### PR TITLE
Resolve component URLs during compilation

### DIFF
--- a/snowpack-plugin.cjs
+++ b/snowpack-plugin.cjs
@@ -3,7 +3,7 @@ const { readFile } = require('fs').promises;
 // Snowpack plugins must be CommonJS :(
 const transformPromise = import('./lib/compiler/index.js');
 
-module.exports = function (snowpackConfig, { resolve, extensions } = {}) {
+module.exports = function (snowpackConfig, { resolve, extensions, astroConfig } = {}) {
   return {
     name: 'snowpack-astro',
     knownEntrypoints: ['deepmerge'],
@@ -16,6 +16,7 @@ module.exports = function (snowpackConfig, { resolve, extensions } = {}) {
       const projectRoot = snowpackConfig.root;
       const contents = await readFile(filePath, 'utf-8');
       const compileOptions = {
+        astroConfig,
         resolve,
         extensions,
       };

--- a/src/@types/compiler.ts
+++ b/src/@types/compiler.ts
@@ -1,8 +1,9 @@
 import type { LogOptions } from '../logger';
-import type { ValidExtensionPlugins } from './astro';
+import type { AstroConfig, ValidExtensionPlugins } from './astro';
 
 export interface CompileOptions {
   logging: LogOptions;
   resolve: (p: string) => Promise<string>;
+  astroConfig: AstroConfig;
   extensions?: Record<string, ValidExtensionPlugins>;
 }

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -1,4 +1,5 @@
 import type { LogOptions } from '../logger.js';
+import type { AstroConfig } from '../@types/astro';
 
 import path from 'path';
 import micromark from 'micromark';
@@ -14,14 +15,10 @@ import { optimize } from './optimize/index.js';
 import { codegen } from './codegen.js';
 
 interface CompileOptions {
+  astroConfig: AstroConfig;
   logging: LogOptions;
   resolve: (p: string) => Promise<string>;
 }
-
-const defaultCompileOptions: CompileOptions = {
-  logging: defaultLogOptions,
-  resolve: (p: string) => Promise.resolve(p),
-};
 
 function internalImport(internalPath: string) {
   return `/_astro_internal/${internalPath}`;
@@ -107,7 +104,7 @@ async function transformFromSource(
 
 export async function compileComponent(
   source: string,
-  { compileOptions = defaultCompileOptions, filename, projectRoot }: { compileOptions: CompileOptions; filename: string; projectRoot: string }
+  { compileOptions, filename, projectRoot }: { compileOptions: CompileOptions; filename: string; projectRoot: string }
 ): Promise<CompileResult> {
   const sourceJsx = await transformFromSource(source, { compileOptions, filename, projectRoot });
   const isPage = path.extname(filename) === '.md' || sourceJsx.items.some((item) => item.name === 'html');

--- a/src/frontend/render/renderer.ts
+++ b/src/frontend/render/renderer.ts
@@ -23,7 +23,7 @@ export function createRenderer(renderer: Renderer) {
         return [...acc, `import("${context.frameworkUrls[lib as any]}")`];
       }, [])
       .join(',');
-    return `const [{${context.componentExport}: Component}, ${values}] = await Promise.all([import(${context.componentUrl})${renderer.imports ? ', ' + libs : ''}]);`;
+    return `const [{${context.componentExport}: Component}, ${values}] = await Promise.all([import("${context.componentUrl}")${renderer.imports ? ', ' + libs : ''}]);`;
   };
   const serializeProps = (props: Record<string, any>) => JSON.stringify(props);
   const createContext = () => {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -126,7 +126,9 @@ export async function createRuntime(astroConfig: AstroConfig, { logging }: Runti
   const astroPlugOptions: {
     resolve?: (s: string) => Promise<string>;
     extensions?: Record<string, string>;
+    astroConfig: AstroConfig;
   } = {
+    astroConfig,
     extensions,
     resolve: async (pkgName: string) => snowpack.getUrlForPackage(pkgName),
   };


### PR DESCRIPTION
Previously dynamic component URLs were being resolved client-side in a weird way that only worked during dev. This change makes them handle during compilation, so it works in both (and improves readability of the dynamic import output).
