### PR TITLE
Add runtime mode

### DIFF
--- a/src/@types/astro.ts
+++ b/src/@types/astro.ts
@@ -33,3 +33,5 @@ export interface CompileResult {
   contents: string;
   css?: string;
 }
+
+export type RuntimeMode = 'development' | 'production';

--- a/src/@types/compiler.ts
+++ b/src/@types/compiler.ts
@@ -1,9 +1,10 @@
 import type { LogOptions } from '../logger';
-import type { AstroConfig, ValidExtensionPlugins } from './astro';
+import type { AstroConfig, RuntimeMode, ValidExtensionPlugins } from './astro';
 
 export interface CompileOptions {
   logging: LogOptions;
   resolve: (p: string) => Promise<string>;
   astroConfig: AstroConfig;
   extensions?: Record<string, ValidExtensionPlugins>;
+  mode: RuntimeMode;
 }

--- a/src/@types/optimizer.ts
+++ b/src/@types/optimizer.ts
@@ -1,4 +1,5 @@
 import type { TemplateNode } from '../parser/interfaces';
+import type { CompileOptions } from './compiler';
 
 export type VisitorFn = (node: TemplateNode, parent: TemplateNode, type: string, index: number) => void;
 
@@ -13,4 +14,10 @@ export interface Optimizer {
     css?: Record<string, NodeVisitor>;
   };
   finalize: () => Promise<void>;
+}
+
+export interface OptimizeOptions {
+  compileOptions: CompileOptions;
+  filename: string;
+  fileID: string;
 }

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,4 +1,4 @@
-import type { AstroConfig } from './@types/astro';
+import type { AstroConfig, RuntimeMode } from './@types/astro';
 import type { LogOptions } from './logger';
 import type { LoadResult } from './runtime';
 
@@ -60,14 +60,15 @@ export async function build(astroConfig: AstroConfig): Promise<0 | 1> {
     dest: defaultLogDestination,
   };
 
-  const runtime = await createRuntime(astroConfig, { logging: runtimeLogging });
+  const mode: RuntimeMode = 'production';
+  const runtime = await createRuntime(astroConfig, { mode, logging: runtimeLogging });
   const { runtimeConfig } = runtime;
   const { backendSnowpack: snowpack } = runtimeConfig;
   const resolve = (pkgName: string) => snowpack.getUrlForPackage(pkgName);
 
   const imports = new Set<string>();
   const statics = new Set<string>();
-  const collectImportsOptions = { astroConfig, logging, resolve };
+  const collectImportsOptions = { astroConfig, logging, resolve, mode };
 
   for (const pathname of await allPages(pageRoot)) {
     const filepath = new URL(`file://${pathname}`);

--- a/src/build/bundle.ts
+++ b/src/build/bundle.ts
@@ -1,4 +1,4 @@
-import type { AstroConfig, ValidExtensionPlugins } from '../@types/astro';
+import type { AstroConfig, RuntimeMode, ValidExtensionPlugins } from '../@types/astro';
 import type { ImportDeclaration } from '@babel/types';
 import type { InputOptions, OutputOptions } from 'rollup';
 import type { AstroRuntime } from '../runtime';
@@ -62,9 +62,10 @@ interface CollectDynamic {
   astroConfig: AstroConfig;
   resolve: (s: string) => Promise<string>;
   logging: LogOptions;
+  mode: RuntimeMode;
 }
 
-export async function collectDynamicImports(filename: URL, { astroConfig, logging, resolve }: CollectDynamic) {
+export async function collectDynamicImports(filename: URL, { astroConfig, logging, resolve, mode }: CollectDynamic) {
   const imports = new Set<string>();
 
   // Only astro files
@@ -89,6 +90,7 @@ export async function collectDynamicImports(filename: URL, { astroConfig, loggin
       astroConfig,
       resolve,
       logging,
+      mode,
     },
   });
 

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -1,5 +1,5 @@
-import type { LogOptions } from '../logger.js';
-import type { AstroConfig, CompileResult, TransformResult } from '../@types/astro';
+import type { CompileResult, TransformResult } from '../@types/astro';
+import type { CompileOptions } from '../@types/compiler.js';
 
 import path from 'path';
 import micromark from 'micromark';
@@ -12,12 +12,6 @@ import { createMarkdownHeadersCollector } from '../micromark-collect-headers.js'
 import { encodeMarkdown } from '../micromark-encode.js';
 import { optimize } from './optimize/index.js';
 import { codegen } from './codegen.js';
-
-interface CompileOptions {
-  astroConfig: AstroConfig;
-  logging: LogOptions;
-  resolve: (p: string) => Promise<string>;
-}
 
 function internalImport(internalPath: string) {
   return `/_astro_internal/${internalPath}`;

--- a/src/compiler/optimize/index.ts
+++ b/src/compiler/optimize/index.ts
@@ -1,6 +1,5 @@
 import type { Ast, TemplateNode } from '../../parser/interfaces';
-import type { CompileOptions } from '../../@types/compiler';
-import type { NodeVisitor, Optimizer, VisitorFn } from '../../@types/optimizer';
+import type { NodeVisitor, OptimizeOptions, Optimizer, VisitorFn } from '../../@types/optimizer';
 
 import { walk } from 'estree-walker';
 
@@ -67,12 +66,6 @@ function walkAstWithVisitors(tmpl: TemplateNode, collection: VisitorCollection) 
       }
     },
   });
-}
-
-interface OptimizeOptions {
-  compileOptions: CompileOptions;
-  filename: string;
-  fileID: string;
 }
 
 export async function optimize(ast: Ast, opts: OptimizeOptions) {

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -21,7 +21,7 @@ const logging: LogOptions = {
 export default async function (astroConfig: AstroConfig) {
   const { projectRoot } = astroConfig;
 
-  const runtime = await createRuntime(astroConfig, { logging });
+  const runtime = await createRuntime(astroConfig, { mode: 'development', logging });
 
   const server = http.createServer(async (req, res) => {
     const result = await runtime.load(req.url);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,5 +1,5 @@
 import type { SnowpackDevServer, ServerRuntime as SnowpackServerRuntime, SnowpackConfig } from 'snowpack';
-import type { AstroConfig } from './@types/astro';
+import type { AstroConfig, RuntimeMode } from './@types/astro';
 import type { LogOptions } from './logger';
 import type { CompileError } from './parser/utils/error.js';
 import { debug, info } from './logger.js';
@@ -10,6 +10,7 @@ import { loadConfiguration, logger as snowpackLogger, startServer as startSnowpa
 interface RuntimeConfig {
   astroConfig: AstroConfig;
   logging: LogOptions;
+  mode: RuntimeMode;
   backendSnowpack: SnowpackDevServer;
   backendSnowpackRuntime: SnowpackServerRuntime;
   backendSnowpackConfig: SnowpackConfig;
@@ -129,6 +130,7 @@ export interface AstroRuntime {
 }
 
 interface RuntimeOptions {
+  mode: RuntimeMode;
   logging: LogOptions;
 }
 
@@ -187,7 +189,7 @@ async function createSnowpack(astroConfig: AstroConfig, env: Record<string, any>
   return { snowpack, snowpackRuntime, snowpackConfig };
 }
 
-export async function createRuntime(astroConfig: AstroConfig, { logging }: RuntimeOptions): Promise<AstroRuntime> {
+export async function createRuntime(astroConfig: AstroConfig, { mode, logging }: RuntimeOptions): Promise<AstroRuntime> {
   const { snowpack: backendSnowpack, snowpackRuntime: backendSnowpackRuntime, snowpackConfig: backendSnowpackConfig } = await createSnowpack(astroConfig, {
     astro: true,
   });
@@ -199,6 +201,7 @@ export async function createRuntime(astroConfig: AstroConfig, { logging }: Runti
   const runtimeConfig: RuntimeConfig = {
     astroConfig,
     logging,
+    mode,
     backendSnowpack,
     backendSnowpackRuntime,
     backendSnowpackConfig,


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? Include screenshots or videos if helpful.  -->

Adds `mode: 'development'` or `mode: 'production'` to the Astro runtime. This can get passed through `compileOptions` to everything that needs it.

## Testing

<!-- How can a reviewer test your code themselves? -->

TODO: testing (still looking for feedback though)

- [x] Tests are passing
- [x] Tests updated where necessary

## Docs

- [ ] Docs / READMEs updated
- [ ] Code comments added where helpful

<!-- Notes, if any -->

This is an internal flag. We could expose this as a config option down-the-road, but I personally just like handling this automatically for the user for now.