### PR TITLE
Add Tailwind support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,37 @@ Supports:
 - `lang="scss"`: load as the `.scss` extension
 - `lang="sass"`: load as the `.sass` extension (no brackets; indent-style)
 
-### Autoprefixer
+#### Autoprefixer
 
 We also automatically add browser prefixes using [Autoprefixer][autoprefixer]. By default, Astro loads the default values, but you may also specify your own by placing a [Browserslist][browserslist] file in your project root.
+
+#### Tailwind
+
+Astro can be configured to use [Tailwind][tailwind] easily! Install the dependencies:
+
+```
+npm install @tailwindcss/jit tailwindcss
+```
+
+And also create a `tailwind.config.js` in your project root:
+
+```
+module.exports = {
+  // your options here
+}
+```
+
+_Note: a Tailwind config file is currently required to enable Tailwind in Astro, even if you use the default options._
+
+Then write Tailwind in your project just like you‘re used to:
+
+```astro
+<style>
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+</style>
+```
 
 ## 🚀 Build & Deployment
 
@@ -100,3 +128,4 @@ Now upload the contents of `/_site_` to your favorite static site host.
 [browserslist]: https://github.com/browserslist/browserslist
 [sass]: https://sass-lang.com/
 [svelte]: https://svelte.dev
+[tailwind]: https://tailwindcss.com

--- a/src/@types/postcss-modules.d.ts
+++ b/src/@types/postcss-modules.d.ts
@@ -1,2 +1,0 @@
-// don’t need types; just a plugin
-declare module 'postcss-modules';

--- a/src/@types/tailwind.d.ts
+++ b/src/@types/tailwind.d.ts
@@ -1,0 +1,3 @@
+// we shouldn‘t have this as a dependency for Astro, but we may dynamically import it if a user requests it, so let TS know about it
+declare module 'tailwindcss';
+declare module '@tailwindcss/jit';


### PR DESCRIPTION
## Changes

Adds the Tailwind JIT compiler:

<img width="629" alt="Screen Shot 2021-04-02 at 18 57 57" src="https://user-images.githubusercontent.com/1369770/113463840-931edf80-93e5-11eb-9eaf-34f09231aea4.png">

<img width="973" alt="Screen Shot 2021-04-02 at 18 58 08" src="https://user-images.githubusercontent.com/1369770/113463843-9619d000-93e5-11eb-90d3-79c28c4e3cef.png">

And it clocks in at `11 Kb`! 🎉 (Much better than the raw `tailwindcss` library which took 5s to load and was `4 MB` 😱 )


<!-- What does this change, in plain language? Include screenshots or videos if helpful.  -->

## Testing

<!-- How can a reviewer test your code themselves? -->

This was tested locally, however **tests weren’t added** so we’re not making Tailwind a dependency of this project (even in devDeps). For now, will just continue testing locally, as there may be some change needed as we use this more.

- [ ] Tests are passing
- [ ] Tests updated where necessary

## Docs

- [x] Docs / READMEs updated
- [x] Code comments added where helpful

<!-- Notes, if any -->
