### PR TITLE
Add `content-type` to astro html

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -99,6 +99,7 @@ async function load(config: RuntimeConfig, rawPathname: string | undefined): Pro
 
     return {
       statusCode: 200,
+      contentType: 'text/html; charset=utf-8',
       contents: html,
     };
   } catch (err) {


### PR DESCRIPTION
## Changes

This adds the HTML `content-type` header to astro pages. Without it, the browser may sometimes display an astro-rendered page as plain text.

<!-- What does this change, in plain language? Include screenshots or videos if helpful.  -->

## Testing

Create an astro page without the optional `<html>` tag.

```svelte
---
let cats = [{ name: "Meowser" }, { name: "Catatat" }, { name: "Mr. Kitty" }];
---

<template id="good-kitties">
	{cats.map(cat => (
		<li>{cat.name}</li>
	))}
</template>
<title>Good Kitties</title>
<body>
	<h1>Good Kitties</h1>
	<a href="https://www.youtube.com/watch?v=oHg5SJYRHA0">See more good kitties</a>
</body>
```

<img width="500" alt="screenshot of the above page rendered as plain text" src="https://user-images.githubusercontent.com/188426/114465274-e565ba80-9bb4-11eb-88cf-16a5b78bfa1c.png">

- [ ] Tests are passing (unsure if this applies)
- [ ] Tests updated where necessary (unsure if this applies)

## Docs

- [ ] Docs / READMEs updated (unsure if this is necessary)
- [ ] Code comments added where helpful (unsure if this is necessary)

<!-- Notes, if any -->
