### PR TITLE
Only run CI on pull requests and merges, not every commit

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,15 +1,35 @@
 name: Node CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
+  skip_test:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          concurrent_skipping: 'never'
+          skip_after_successful_duplicate: 'true'
+          paths_ignore: '["**/README.md", "**/docs/**"]'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
   test:
+    needs: skip_test # allow skip_test to cancel this job if it’s not needed
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
         node-version: [14.x, 15.x]
-
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
@@ -27,7 +47,7 @@ jobs:
 
           cd prettier-plugin-astro
           npm ci
-          
+
           cd ../examples/kitchen-sink
           npm ci
           npm run build


### PR DESCRIPTION
## Changes

Before, we were running CI on every commit. Now we only run on PR and on merge.

Also, adds the [Skip Duplicate Actions](https://github.com/marketplace/actions/skip-duplicate-actions) GH Action, which cancels unnecessary runs (GitHub Actions unfortunately doesn’t have this natively built in).

<!-- What does this change, in plain language? Include screenshots or videos if helpful.  -->

## Testing

<!-- How can a reviewer test your code themselves? -->

- [ ] Tests are passing
- [ ] Tests updated where necessary

## Docs

- [ ] Docs / READMEs updated
- [ ] Code comments added where helpful

<!-- Notes, if any -->
