### PR TITLE
build: add warning if no public folder found #96

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -275,9 +275,10 @@ export async function build(astroConfig: AstroConfig): Promise<0 | 1> {
     }
     info(logging, 'build', green('✔'), 'public folder copied.');
   } else {
-    info(logging, 'tip', yellow(`! no public folder ${astroConfig.public} found...`));
+    if(path.basename(astroConfig.public.toString()) !=='public'){
+      info(logging, 'tip', yellow(`! no public folder ${astroConfig.public} found...`));
+    }
   }
-
   // build sitemap
   if (astroConfig.buildOptions.sitemap && astroConfig.buildOptions.site) {
     info(logging, 'build', yellow('! creating a sitemap...'));


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? Include screenshots or videos if helpful.  -->
add a tip on `npm run build` if the public folder not found
## Testing

<!-- How can a reviewer test your code themselves? -->

- [ ] Tests are passing
- [ ] Tests updated where necessary

## Docs

- [ ] Docs / READMEs updated
- [ ] Code comments added where helpful

<!-- Notes, if any -->
