### PR TITLE
Ensure `@vue/server-renderer` is not tree-shaken out

### DIFF
--- a/src/frontend/render/vue.ts
+++ b/src/frontend/render/vue.ts
@@ -4,6 +4,9 @@ import { renderToString } from '@vue/server-renderer';
 import { defineComponent, createSSRApp, h as createElement } from 'vue';
 import { createRenderer } from './renderer';
 
+// This prevents tree-shaking of render.
+Function.prototype(renderToString);
+
 /**
  * Users might attempt to use :vueAttribute syntax to pass primitive values.
  * If so, try to JSON.parse them to get the primitives


### PR DESCRIPTION
## Changes

Previously `@vue/server-renderer` wouldn't be available to `astro dev` due to tree shaking. This fixes that!

## Testing

Our repo structure got in the way again, this has to be tested in a standalone project.

## Docs

N/A (Bugfix)
