### PR TITLE
Improve esbuild watch mode

### DIFF
--- a/scripts/cmd/build.js
+++ b/scripts/cmd/build.js
@@ -1,54 +1,65 @@
 import esbuild from 'esbuild';
 import del from 'del';
 import { promises as fs } from 'fs';
-import { resolve } from 'path';
+import { dim, green, red, yellow } from 'kleur/colors';
 import glob from 'tiny-glob';
 
 /** @type {import('esbuild').BuildOptions} */
 const config = {
-    bundle: true,
-    minify: true,
-    sourcemap: 'inline',
-    format: 'esm',
-    platform: 'node',
-    target: 'node14'
-}
+  bundle: true,
+  minify: true,
+  sourcemap: 'inline',
+  format: 'esm',
+  platform: 'node',
+  target: 'node14',
+};
 
 export default async function build(pattern, ...args) {
-    const isDev = args.pop() === 'IS_DEV';
-    const entryPoints = await glob(pattern, { filesOnly: true, absolute: true });
-    const { type = 'module', dependencies = {} } = await fs.readFile('./package.json').then(res => JSON.parse(res.toString()));
-    const format = type === 'module' ? 'esm' : 'cjs';
-    const external = Object.keys(dependencies);
-    const outdir = 'dist';
-    await clean(outdir);
+  const isDev = args.pop() === 'IS_DEV';
+  const entryPoints = await glob(pattern, { filesOnly: true, absolute: true });
+  const { type = 'module', dependencies = {} } = await fs.readFile('./package.json').then((res) => JSON.parse(res.toString()));
+  const format = type === 'module' ? 'esm' : 'cjs';
+  const external = Object.keys(dependencies);
+  const outdir = 'dist';
+  await clean(outdir);
 
-    if (!isDev) {
-        await esbuild.build({
-            ...config,
-            entryPoints,
-            outdir,
-            external,
-            format
-        });
-        return;
-    }
-
-    const builder = await esbuild.build({
-        ...config,
-        watch: true,
-        entryPoints,
-        outdir,
-        external,
-        format
+  if (!isDev) {
+    await esbuild.build({
+      ...config,
+      entryPoints,
+      outdir,
+      external,
+      format,
     });
+    return;
+  }
 
-    process.on('beforeExit', () => {
-        builder.stop?.();
-    })
-    
+  const builder = await esbuild.build({
+    ...config,
+    watch: {
+      onRebuild(error, result) {
+        const date = new Date().toISOString();
+        if (error || (result && result.errors.length)) {
+          console.error(dim(`[${date}] `) + red(error || result.errors.join('\n')));
+        } else {
+          if (result.warnings.length) {
+            console.log(dim(`[${date}] `) + yellow('⚠ updated with warnings:\n' + result.warnings.join('\n')));
+          }
+          console.log(dim(`[${date}] `) + green('✔ updated'));
+        }
+      },
+    },
+    entryPoints,
+    outdir,
+    external,
+    format,
+  });
+
+  process.on('beforeExit', () => {
+    builder.stop?.();
+  });
 }
 
 async function clean(outdir) {
-    return del(`!${outdir}/**/*.d.ts`);
+  return del(`!${outdir}/**/*.d.ts`);
 }


### PR DESCRIPTION
## Changes

I love the new esbuild-powered dev command in Astro! But when building locally I couldn’t tell if it was updating or not, so I added some logging.

![Screen Shot 2021-04-30 at 19 00 20](https://user-images.githubusercontent.com/1369770/116766244-b6d64500-a9e6-11eb-96b0-ed02f3c525e1.png)

Open to styling or changes to this; I’m not particular. I just needed something to show.

<!-- What does this change, in plain language? Include screenshots or videos if helpful.  -->

## Testing

<!-- How can a reviewer test your code themselves? -->

N/A—no tests necessary

- [ ] Tests are passing
- [ ] Tests updated where necessary

## Docs

N/A

- [ ] Docs / READMEs updated
- [ ] Code comments added where helpful

<!-- Notes, if any -->
