### PR TITLE
Include outPath in error logging for bad load status, and drop error stack

### DIFF
--- a/packages/astro/src/build.ts
+++ b/packages/astro/src/build.ts
@@ -16,7 +16,6 @@ import { generateSitemap } from './build/sitemap.js';
 import { collectStatics } from './build/static.js';
 import { canonicalURL } from './build/util.js';
 
-
 const { mkdir, readFile, writeFile } = fsPromises;
 
 interface PageBuildOptions {
@@ -68,7 +67,7 @@ async function writeFilep(outPath: URL, bytes: string | Buffer, encoding: 'utf8'
 /** Utility for writing a build result to disk */
 async function writeResult(result: LoadResult, outPath: URL, encoding: null | 'utf8') {
   if (result.statusCode === 500 || result.statusCode === 404) {
-    error(logging, 'build', result.error || result.statusCode, `when generating ${fileURLToPath(outPath)}`);
+    error(logging, 'build', result.error?.toString() || `Unexpected load result (${result.statusCode})`, `(when generating ${fileURLToPath(outPath)})`);
   } else if (result.statusCode !== 200) {
     error(logging, 'build', `Unexpected load result (${result.statusCode}) for ${fileURLToPath(outPath)}`);
   } else {
@@ -199,9 +198,8 @@ export async function build(astroConfig: AstroConfig): Promise<0 | 1> {
   const pages = await allPages(pageRoot);
   let builtURLs: string[] = [];
 
-
   try {
-    info(logging , 'build', yellow('! building pages...'));
+    info(logging, 'build', yellow('! building pages...'));
     // Vue also console.warns, this silences it.
     const release = trapWarn();
     await Promise.all(
@@ -275,7 +273,7 @@ export async function build(astroConfig: AstroConfig): Promise<0 | 1> {
     }
     info(logging, 'build', green('✔'), 'public folder copied.');
   } else {
-    if(path.basename(astroConfig.public.toString()) !=='public'){
+    if (path.basename(astroConfig.public.toString()) !== 'public') {
       info(logging, 'tip', yellow(`! no public folder ${astroConfig.public} found...`));
     }
   }


### PR DESCRIPTION
## Changes

Include `outPath` in error logging during `writeResult` such that the user could track in which file is the error occurring. It might be nicer to actually log the source path instead, but at a first glance seems much more involved due to repeated transformations among different path formats.

Also, remove the error stack from the display since it seems useless. (If necessary I could split it off to another PR though)

Before:
![Screen Shot 2021-05-01 at 8 12 32 PM](https://user-images.githubusercontent.com/15007517/116800967-97a8e780-aaba-11eb-8251-904d0056b658.png)

After:
![Screen Shot 2021-05-01 at 8 10 31 PM](https://user-images.githubusercontent.com/15007517/116800970-9d063200-aaba-11eb-8bd5-a0f5996a1c90.png)


## Testing

Not super sure if I need to add tests for this. The behavior of error logging might change in the future.

- [x] Tests are passing
- [ ] Tests updated where necessary

## Docs

- [ ] Docs / READMEs updated
- [ ] Code comments added where helpful
