### PR TITLE
Fix running the VSCode extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,16 +3,12 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "pwa-extensionHost",
-      "request": "launch",
       "name": "Launch Client",
+      "type": "extensionHost",
+      "request": "launch",
       "runtimeExecutable": "${execPath}",
-      "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
-      "outFiles": ["${workspaceRoot}/tools/astro-vscode/dist/**/*.js"],
-      "preLaunchTask": {
-        "type": "npm",
-        "script": "build:vscode"
-      }
+      "args": ["--extensionDevelopmentPath=${workspaceRoot}/tools/astro-vscode"],
+      "outFiles": ["${workspaceRoot}/tools/astro-vscode/dist/**/*.js"]
     },
     {
       "type": "node",
@@ -20,7 +16,8 @@
       "name": "Attach to Server",
       "port": 6040,
       "restart": true,
-      "outFiles": ["${workspaceRoot}/tools/astro-languageserver/dist/**/*.js"]
+      "outFiles": ["${workspaceRoot}/tools/astro-languageserver/dist/**/*.js"],
+      "skipFiles": ["<node_internals>/**"]
     }
   ],
   "compounds": [

--- a/tools/astro-languageserver/bin/server.js
+++ b/tools/astro-languageserver/bin/server.js
@@ -1,0 +1,6 @@
+#! /usr/bin/env node
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { startServer } = require('../dist/index');
+
+startServer();

--- a/tools/astro-languageserver/tsconfig.json
+++ b/tools/astro-languageserver/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "target": "ES2020"
   },
   "include": ["src"],
   "exclude": ["node_modules"]

--- a/tools/astro-vscode/contributing.md
+++ b/tools/astro-vscode/contributing.md
@@ -1,0 +1,20 @@
+# Contributing
+
+## Development workflow
+
+In the monorepo first install and build Astro:
+
+```shell
+yarn install
+yarn build
+```
+
+To start the development server run:
+
+```shell
+yarn dev:vscode
+```
+
+Then in the __Debug__ panel select __Launch Extension__ from the dropdown and click the run button.
+
+<img width="558" alt="Screen Shot 2021-05-07 at 8 51 37 AM" src="https://user-images.githubusercontent.com/361671/117452223-807e5580-af11-11eb-8404-dd615784408a.png">

--- a/tools/astro-vscode/src/index.ts
+++ b/tools/astro-vscode/src/index.ts
@@ -17,7 +17,7 @@ export async function activate(context: vscode.ExtensionContext) {
 /**  */
 function createLanguageService(context: vscode.ExtensionContext, mode: 'doc', id: string, name: string, port: number) {
   const { workspace } = vscode;
-  const serverModule = context.asAbsolutePath(require.resolve('astro-languageserver'));
+  const serverModule = require.resolve('astro-languageserver/bin/server.js');
   const debugOptions = { execArgv: ['--nolazy', '--inspect=' + port] };
   const serverOptions: lsp.ServerOptions = {
     run: { module: 'astro-languageserver', transport: lsp.TransportKind.ipc },
@@ -60,6 +60,8 @@ function createLanguageService(context: vscode.ExtensionContext, mode: 'doc', id
     };
     const disposable = activateTagClosing(tagRequestor, { astro: true }, 'html.autoClosingTags');
     context.subscriptions.push(disposable);
+  }).catch(err => {
+    console.error('Astro, unable to load language server.', err);
   });
 
   return client;


### PR DESCRIPTION
## Changes

I'm not sure how my setup was different but I was unable to get the extension to run locally without adding a binary. This mirrors what Svelte does so I'm assuming it's the way it's supposed to be loaded.

## Testing

n/a

## Docs

Added a Contributing.md file to the vscode extension explaining how to get development running.