### PR TITLE
Bugfix: add missing import for build profiling

### DIFF
--- a/packages/astro/src/build/util.ts
+++ b/packages/astro/src/build/util.ts
@@ -1,4 +1,5 @@
 import type { AstroConfig } from '../@types/astro';
+import { performance } from 'perf_hooks';
 
 import path from 'path';
 import { fileURLToPath, URL } from 'url';


### PR DESCRIPTION
## Changes

Accidentally omitted an import. Worked for build (TypeScript assumed it was defined), but at runtime the build would fail because `performance` wasn’t defined.

<!-- What does this change, in plain language? Include screenshots or videos if helpful.  -->

## Testing

<!-- How can a reviewer test your code themselves? -->

- [x] Tests are passing
- [x] Tests updated where necessary

## Docs

- [x] Docs / READMEs updated
- [x] Code comments added where helpful

<!-- Notes, if any -->
