### PR TITLE
Fix double <pre> tag

### DIFF
--- a/.changeset/olive-jars-grab.md
+++ b/.changeset/olive-jars-grab.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Bugfix: fixes double <pre> tags generated from markdown code blocks

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": "./astro.mjs",
     "./snowpack-plugin": "./snowpack-plugin.cjs",
-    "./components/*.astro": "./components/*.astro",
+    "./components/*": "./components/*",
     "./runtime/svelte": "./dist/frontend/runtime/svelte.js"
   },
   "imports": {

--- a/packages/astro/src/compiler/transform/prism.ts
+++ b/packages/astro/src/compiler/transform/prism.ts
@@ -19,8 +19,11 @@ export default function (module: Script): Transformer {
       html: {
         Element: {
           enter(node) {
-            if (node.name !== 'code') return;
-            const className = getAttrValue(node.attributes, 'class') || '';
+            if (node.name !== 'pre') return;
+            const codeEl = node.children && node.children[0];
+            if (!codeEl || codeEl.name !== 'code') return;
+
+            const className = getAttrValue(codeEl.attributes, 'class') || '';
             const classes = className.split(' ');
 
             let lang;
@@ -33,10 +36,9 @@ export default function (module: Script): Transformer {
 
             if (!lang) return;
 
-            let code;
-            if (node.children?.length) {
-              code = node.children[0].data;
-            }
+            let codeData = codeEl.children && codeEl.children[0];
+            if (!codeData) return;
+            let code = codeData.data as string;
 
             const repl = {
               start: 0,


### PR DESCRIPTION
## Changes

Fixes accidental nested `<pre>` tags, visible in Snowpack docs.

**Before**

![Screen Shot 2021-05-07 at 14 50 25](https://user-images.githubusercontent.com/1369770/117506937-a3c1f880-af43-11eb-9b56-11a343b90c8d.png)


**After**

![Screen Shot 2021-05-07 at 14 48 51](https://user-images.githubusercontent.com/1369770/117506952-a886ac80-af43-11eb-83dd-aacc05154a4e.png)


<!-- What does this change, in plain language? Include screenshots or videos if helpful.  -->

## Testing

I tested this manually, but when I try to add a test within `packages/astro/test` I get an error from Snowpack about it not being able to load `astro/components/Prism.astro`? Not sure if that’s just within our test suite or what. I figured we could at least add this now, and add tests for that later (I’m sure there are others we’d like to add.)

<!-- How can a reviewer test your code themselves? -->

- [x] Tests are passing
- [ ] Tests updated where necessary

## Docs

- [ ] Docs / READMEs updated
- [ ] Code comments added where helpful

<!-- Notes, if any -->
