### PR TITLE
chore: add publish script for `vscode`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .vercel
 _site/
 *.log
+package-lock.json

--- a/tools/astro-vscode/package.json
+++ b/tools/astro-vscode/package.json
@@ -10,10 +10,10 @@
   },
   "version": "0.4.2",
   "author": "Astro",
-  "publisher": "astro-build",
   "license": "MIT",
+  "publisher": "astro-build",
   "scripts": {
-    "vscode:prepublish": "yarn build",
+    "vscode:publish": "node ./scripts/publish.mjs",
     "build": "astro-scripts build 'src/index.ts'",
     "dev": "astro-scripts dev 'src/index.ts'"
   },
@@ -24,14 +24,15 @@
     "onLanguage:astro"
   ],
   "dependencies": {
-    "astro-languageserver": "0.4.0"
+    "astro-languageserver": "file:../astro-languageserver"
   },
   "devDependencies": {
-    "vscode-html-languageservice": "^3.0.3",
+    "@types/vscode": "^1.52.0",
+    "astro-scripts": "file:../../scripts",
+    "execa": "^5.0.0",
     "vscode-emmet-helper": "2.1.2",
-    "vscode-languageclient": "~7.0.0",
-    "astro-scripts": "0.0.1",
-    "@types/vscode": "^1.52.0"
+    "vscode-html-languageservice": "^3.0.3",
+    "vscode-languageclient": "~7.0.0"
   },
   "main": "./dist/index.js",
   "files": [

--- a/tools/astro-vscode/scripts/publish.mjs
+++ b/tools/astro-vscode/scripts/publish.mjs
@@ -1,0 +1,41 @@
+import { promises as fs } from 'fs';
+import { fileURLToPath } from 'url';
+import execa from 'execa';
+
+/** Copies `astro-languageserver` to our file */
+async function publish() {
+  const p0 = execa('yarn', ['lerna', 'run', 'build', '--scope', 'astro-vscode', '--scope', 'astro-languageserver'], { all: true });
+  p0.all.setEncoding('utf8');
+  for await (const chunk of p0.all) {
+    console.log(chunk);
+
+    if (/lerna success/g.test(chunk)) {
+      break;
+    }
+
+    if (/ERROR/g.test(chunk)) {
+      process.exit(1);
+    }
+  }
+
+  await execa('npm', ['install']);
+
+  const p1 = execa('vsce', ['publish'], { all: true });
+
+  p1.all.setEncoding('utf8');
+  for await (const chunk of p1.all) {
+    console.log(chunk);
+
+    if (/DONE/g.test(chunk)) {
+      break;
+    }
+
+    if (/ERROR/g.test(chunk)) {
+      process.exit(1);
+    }
+  }
+
+  p1.kill();
+}
+
+publish();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,7 +2087,7 @@ are-we-there-yet@~1.1.2:
 
 arg@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.npmjs.org/arg/-/arg-5.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.0.tgz#a20e2bb5710e82950a516b3f933fee5ed478be90"
   integrity sha512-4P8Zm2H+BRS+c/xX1LrHw0qKpEhdlZjLCgWy+d78T9vqa2Z2SiD2wMrYuWIAFy5IZUD7nnNXroRttz+0RzlrzQ==
 
 argparse@^1.0.7:
@@ -2215,6 +2215,17 @@ astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+
+"astro-languageserver@file:tools/astro-languageserver":
+  version "0.4.0"
+
+"astro-scripts@file:scripts":
+  version "0.0.1"
+  dependencies:
+    arg "^5.0.0"
+    esbuild "^0.11.16"
+    globby "^11.0.3"
+    tar "^6.1.0"
 
 async-each-series@0.1.1:
   version "0.1.1"
@@ -4467,7 +4478,7 @@ execa@^0.7.0:
 
 execa@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.0.0.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376"
   integrity sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==
   dependencies:
     cross-spawn "^7.0.3"


### PR DESCRIPTION
## Changes

This adds a publish script to `astro-vscode` to manage some weirdness with the `vsce` CLI.

It also renames our extension to `astro-build.astro-vscode` because `yarn` yells at you when multiple packages have the same name.