### PR TITLE
Post-Tailwind cleanup: revert stylegen

### DIFF
--- a/examples/portfolio/src/pages/index.astro
+++ b/examples/portfolio/src/pages/index.astro
@@ -5,7 +5,7 @@ import Nav from '../components/Nav/index.jsx';
 import Footer from '../components/Footer/index.jsx';
 import PorfolioPreview from '../components/PortfolioPreview/index.jsx';
 
-const projects = Astro.fetchContent('./project/*.md');
+const projects = Astro.fetchContent('./project/**/*.md');
 const featuredProject = projects[0];
 ---
 


### PR DESCRIPTION
## Changes

Reverts change made in [#222](https://github.com/snowpackjs/astro/pull/222#discussion_r637085620). Turns out it’s bad to have backend & frontend disagree. This just reverts the code back to where it was before; doesn’t affect Tailwind support or anything else for that matter.

<!-- What does this change, in plain language? Include screenshots or videos if helpful.  -->

## Testing

No tests changed; this just comes up when trying to build or run our examples

<!-- How can a reviewer test your code themselves? -->

- [ ] Tests are passing
- [ ] Tests updated where necessary

## Docs

- [ ] Docs / READMEs updated
- [ ] Code comments added where helpful

<!-- Notes, if any -->
