### PR TITLE
Fix npm init astro for npm v7

### DIFF
--- a/.changeset/forty-forks-destroy.md
+++ b/.changeset/forty-forks-destroy.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Bugfix: `npm init astro` on npm v7

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -23,7 +23,7 @@
     "ink": "^3.0.8",
     "ink-select-input": "^4.2.0",
     "ink-text-input": "^4.0.1",
-    "react": "~17.0.2",
+    "react": "^16.14.0",
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8392,7 +8392,16 @@ react-reconciler@^0.24.0:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
-react@^17.0.1, react@~17.0.2:
+react@^16.14.0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
+  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+
+react@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==


### PR DESCRIPTION

## Changes

Fixes #183. Locks `react` to v16 for better support with ink & ink components. Fixes `npm init astro` on npm v7:

![Screen Shot 2021-05-26 at 14 12 28](https://user-images.githubusercontent.com/1369770/119724957-999d6680-be2c-11eb-9bde-2259b1ec4696.png)


<!-- What does this change, in plain language? Include screenshots or videos if helpful.  -->

## Testing

<!-- How can a reviewer test your code themselves? -->

Manually tested with a prerelease; not really a test you can write for this.

- [ ] Tests are passing
- [ ] Tests updated where necessary

## Docs

No docs changes necessary.

- [ ] Docs / READMEs updated
- [ ] Code comments added where helpful

<!-- Notes, if any -->
