### PR TITLE
Bugfix: CLI selected item spacing

### DIFF
--- a/.changeset/cold-kiwis-arrive.md
+++ b/.changeset/cold-kiwis-arrive.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Bugfix: select component missing space

--- a/packages/create-astro/src/components/Select.tsx
+++ b/packages/create-astro/src/components/Select.tsx
@@ -9,7 +9,7 @@ interface Props {
   label: string;
   description?: string;
 }
-const Indicator: FC<Props> = ({ isSelected }) => (isSelected ? <Text color="#3894FF">[ </Text> : <Text> </Text>);
+const Indicator: FC<Props> = ({ isSelected }) => (isSelected ? <Text color="#3894FF">[ </Text> : <Text>{'  '}</Text>);
 const Item: FC<Props> = ({ isSelected = false, label, description }) => (
   <Box display="flex">
     <Text color={isSelected ? '#3894FF' : 'white'} dimColor={!isSelected}>


### PR DESCRIPTION
## Changes

**Before**

![Screen Shot 2021-05-26 at 14 30 16](https://user-images.githubusercontent.com/1369770/119727207-411b9880-be2f-11eb-99a8-5351f90d0ab5.png)

(look at the unselected item)

**After**

![Screen Shot 2021-05-26 at 14 31 37](https://user-images.githubusercontent.com/1369770/119727226-45e04c80-be2f-11eb-8488-a3145bb11aad.png)


<!-- What does this change, in plain language? Include screenshots or videos if helpful.  -->

## Testing

Manually tested (what a surprise!)

<!-- How can a reviewer test your code themselves? -->

- [ ] Tests are passing
- [ ] Tests updated where necessary

## Docs

No docs

- [ ] Docs / READMEs updated
- [ ] Code comments added where helpful

<!-- Notes, if any -->
