### PR TITLE
Make UVU tests time out

### DIFF
--- a/packages/astro/test/config-path.test.js
+++ b/packages/astro/test/config-path.test.js
@@ -3,8 +3,17 @@ import * as assert from 'uvu/assert';
 import { runDevServer } from './helpers.js';
 
 const ConfigPath = suite('Config path');
+const MAX_TEST_TIME = 10000; // max time this test suite may take
 
 const root = new URL('./fixtures/config-path/', import.meta.url);
+const timers = {};
+
+ConfigPath.before.each(({ __test__ }) => {
+  timers[__test__] = setTimeout(() => {
+    throw new Error(`Test "${__test__}" did not finish within allowed time`);
+  }, MAX_TEST_TIME);
+});
+
 ConfigPath('can be passed via --config', async (context) => {
   const configPath = new URL('./config/my-config.mjs', root).pathname;
   const args = ['--config', configPath];
@@ -19,6 +28,10 @@ ConfigPath('can be passed via --config', async (context) => {
 
   process.kill();
   assert.ok(true, 'Server started');
+});
+
+ConfigPath.after.each(({ __test__ }) => {
+  clearTimeout(timers[__test__]);
 });
 
 ConfigPath.run();


### PR DESCRIPTION
## Changes

Our test suites have been caught running for **3 hours or more** 😱 so it’s time they timed out. This adds timeouts to `uvu`, since that will likely never be implemented in the library itself (https://github.com/lukeed/uvu/issues/33).

There may be some GitHub Action that simply stops tests after n minutes, but I’d prefer this way for 2 reasons:

1. It makes debugging much simpler. This exposes the exact line of code where the hangup is, whereas an Action would require investigation.
2. This is more efficient. A stuck test will be killed within seconds rather than waiting 20 minutes, or whatever we’d set an action to.

<!-- What does this change, in plain language? Include screenshots or videos if helpful.  -->

## Testing

![Screen Shot 2021-05-27 at 12 36 45](https://user-images.githubusercontent.com/1369770/119882558-c95f7380-beeb-11eb-865a-e45f00ffbbe0.png)

Note you can still see the individual test file that erred (`astro-expr.test.js`), along with the specific test that took too long.

<!-- How can a reviewer test your code themselves? -->

- [x] Tests are passing
- [x] Tests updated where necessary

## Docs

- [ ] Docs / READMEs updated
- [ ] Code comments added where helpful

<!-- Notes, if any -->
