### PR TITLE
Prevent <Markdown> blocks from locking up vscode extension

### DIFF
--- a/tools/astro-vscode/syntaxes/astro-markdown.tmLanguage.json
+++ b/tools/astro-vscode/syntaxes/astro-markdown.tmLanguage.json
@@ -2201,42 +2201,6 @@
           "name": "comment.block.html"
         },
         {
-          "begin": "(?i)(^|\\G)\\s*(?=<(script|style|pre)(\\s|$|>)(?!.*?</(script|style|pre)>))",
-          "end": "(?i)(.*)((</)(script|style|pre)(>))",
-          "endCaptures": {
-            "1": {
-              "patterns": [
-                {
-                  "include": "text.html.markdown.astro"
-                }
-              ]
-            },
-            "2": {
-              "name": "meta.tag.structure.$4.end.html"
-            },
-            "3": {
-              "name": "punctuation.definition.tag.begin.html"
-            },
-            "4": {
-              "name": "entity.name.tag.html"
-            },
-            "5": {
-              "name": "punctuation.definition.tag.end.html"
-            }
-          },
-          "patterns": [
-            {
-              "begin": "(\\s*|$)",
-              "patterns": [
-                {
-                  "include": "text.html.markdown.astro"
-                }
-              ],
-              "while": "(?i)^(?!.*</(script|style|pre|Markdown)>)"
-            }
-          ]
-        },
-        {
           "begin": "(?i)(?=</?[a-zA-Z]+[^\\s/&gt;]*(\\s|$|/?>))",
           "while": "(?i)^(?!.*</(\\1||\\2)>)",
           "patterns": [

--- a/tools/astro-vscode/syntaxes/astro.tmLanguage.json
+++ b/tools/astro-vscode/syntaxes/astro.tmLanguage.json
@@ -714,39 +714,34 @@
       ]
     },
     "astro-markdown": {
-      "begin": "(?:^\\s+)?(<)(Markdown)\\b(?=[^>]*)",
+      "name": "text.html.astro.markdown",
+      "begin": "(<)(Markdown)(>)",
       "beginCaptures": {
         "1": {
-          "name": "punctuation.definition.tag.begin.html"
+          "name":"punctuation.definition.tag.begin.html"
         },
         "2": {
-          "name": "entity.name.tag.markdown.astro"
+          "name": "entity.name.tag.html"
+        },
+        "3": {
+          "name":"punctuation.definition.tag.end.html"
         }
       },
       "end": "(</)(Markdown)(>)",
       "endCaptures": {
+        "1": {
+          "name":"punctuation.definition.tag.begin.html"
+        },
         "2": {
-          "name": "punctuation.definition.tag.html"
+          "name": "entity.name.tag.html"
+        },
+        "3": {
+          "name":"punctuation.definition.tag.end.html"
         }
       },
-      "name": "text.html.markdown.astro",
       "patterns": [
         {
-          "include": "#tag-stuff"
-        },
-        {
-          "begin": "(>)",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.definition.tag.end.html"
-            }
-          },
-          "end": "(?=</Markdown)",
-          "patterns": [
-            {
-              "include": "text.html.markdown.astro"
-            }
-          ]
+          "include": "text.html.markdown.astro"
         }
       ]
     },


### PR DESCRIPTION
## Changes

Simplifies the grammar a little and gets rid of a block that was causing infinite recursion.

## Testing

<!-- How can a reviewer test your code themselves? -->

- [ ] Tests are passing
- [ ] Tests updated where necessary

## Docs

- [ ] Docs / READMEs updated
- [ ] Code comments added where helpful

<!-- Notes, if any -->
