### PR TITLE
Improve “file not found” error display

### DIFF
--- a/.changeset/thirty-fans-know.md
+++ b/.changeset/thirty-fans-know.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'astro-parser': patch
+---
+
+Improve error display for missing local files

--- a/packages/astro-parser/src/interfaces.ts
+++ b/packages/astro-parser/src/interfaces.ts
@@ -1,5 +1,5 @@
 import type { SourceMap } from 'magic-string';
-export type { CompileError } from './utils/error';
+export { CompileError } from './utils/error';
 
 export interface BaseNode {
   start: number;

--- a/packages/astro/src/dev.ts
+++ b/packages/astro/src/dev.ts
@@ -66,6 +66,7 @@ export default async function dev(astroConfig: AstroConfig) {
         break;
       }
       case 500: {
+        res.setHeader('Content-Type', 'text/html;charset=utf-8');
         switch (result.type) {
           case 'parse-error': {
             const err = result.error;

--- a/packages/astro/src/logger.ts
+++ b/packages/astro/src/logger.ts
@@ -131,7 +131,7 @@ export function parseError(opts: LogOptions, err: CompileError) {
     'parse-error',
     `
 
- ${underline(bold(grey(`${err.filename}:${err.start.line}:${err.start.column}`)))}
+ ${underline(bold(grey(`${err.filename || ''}:${err.start.line}:${err.start.column}`)))}
 
  ${bold(red(`𝘅 ${err.message}`))}
 


### PR DESCRIPTION
## Changes

If a user mis-types an import, the error is not very helpful at all:

```
NotFoundError: Not Found (/_astro/src/components/MyComponent.proxy.js)
```

What is `_astro`? What is `.proxy.js`? What file is this in? The error message contains no helpful information for the user to remediate.

However, this error is coming not from Astro, but from Snowpack. But changing that in Snowpack is no small fix; in fact, it would require a very large rewrite (as that error is generated with Snowpack after it has already lost context of what file it was in).

This PR instead is a little hackier, little more brittle solution that saves us from a substantial Snowpack error overhaul. It heavily leans on some assumptions about what Astro is doing. It may break eventually, but it’ll at least be a better dev experience short-term.

**Before**
<img width="777" alt="Screen Shot 2021-06-01 at 16 09 05" src="https://user-images.githubusercontent.com/1369770/120403339-3a929280-c301-11eb-872b-95f0e7c810e4.png">

What is this? Where am I? Hello? Anyone?

**After**
<img width="774" alt="Screen Shot 2021-06-01 at 17 42 06" src="https://user-images.githubusercontent.com/1369770/120403306-2ea6d080-c301-11eb-8d0c-c76b58a25daa.png">

Full code frame complete with exact code that erred

<!-- What does this change, in plain language? Include screenshots or videos if helpful.  -->

## Testing

<!-- How can a reviewer test your code themselves? -->

- [ ] Tests are passing
- [ ] Tests updated where necessary

## Docs

- [ ] Docs / READMEs updated
- [ ] Code comments added where helpful

<!-- Notes, if any -->
