### PR TITLE
Handle `301` and `302` redirects in dev server

### DIFF
--- a/packages/astro/src/dev.ts
+++ b/packages/astro/src/dev.ts
@@ -47,6 +47,13 @@ export default async function dev(astroConfig: AstroConfig) {
         res.end();
         break;
       }
+      case 301:
+      case 302: {
+        res.statusCode = result.statusCode;
+        res.setHeader('Location', result.location);
+        res.end();
+        break;
+      }
       case 404: {
         const fullurl = new URL(req.url || '/', astroConfig.buildOptions.site || `http://localhost${astroConfig.devOptions.port}`);
         const reqPath = decodeURI(fullurl.pathname);


### PR DESCRIPTION
## Changes

The `runtime` was correctly returning `301` redirects for `nested/index.astro` files, but we weren't handling these in the dev server! Whoops.

## Testing

We're not testing the dev server directly, we're testing the runtime. This behavior is already covered by `astro-search.test.js`.

- [x] Tests are passing

## Docs

Bug fix only