### PR TITLE
Add docs for `renderer` plugins

### DIFF
--- a/docs/renderers.md
+++ b/docs/renderers.md
@@ -1,6 +1,6 @@
 # 🪄 Renderers
 
-Astro is able to render React, Svelte, Vue, and Preact components out of the box. This is because Astro's [default configuration][astro-config] relies on the following **renderers**.
+Astro is able to render [React](https://npm.im/@astrojs/renderer-react), [Svelte](https://npm.im/@astrojs/renderer-svelte), [Vue](https://npm.im/@astrojs/renderer-vue), and [Preact](https://npm.im/@astrojs/renderer-preact) components out of the box. This is because Astro's [default configuration][astro-config] relies on **renderers** for those frameworks.
 
 If you'd like to add support for another framework, you can build a **renderer** plugin using the same interface as Astro's official renderers.
 


### PR DESCRIPTION
## Changes

Just adding a doc to outline how renderer plugins are architected. Hopefully this clarifies things for people looking to build their own renderers!

## Testing

N/A

## Docs

N/A