### PR TITLE
docs: add link to renderer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Astro uses __[Snowpack](https://www.snowpack.dev/)__ for module resolution. You 
 
 Astro is able to render [React](https://npm.im/@astrojs/renderer-react), [Svelte](https://npm.im/@astrojs/renderer-svelte), [Vue](https://npm.im/@astrojs/renderer-vue), and [Preact](https://npm.im/@astrojs/renderer-preact) components out of the box. If you'd like to add support for another framework, you can build a **renderer** plugin using the same interface as Astro's official renderers.
 
-👉 [**Learn more about Renderers**][docs-renderer]
+👉 [**Renderer Docs**][docs-renderer]
 
 ## 📚 API
 


### PR DESCRIPTION
## Changes

Adds a link to the Renderer documentation from the README.

## Testing

N/A

## Docs

N/A