### PR TITLE
updated comment 'threw' to 'through'

### DIFF
--- a/packages/astro/src/external.ts
+++ b/packages/astro/src/external.ts
@@ -21,7 +21,7 @@ const isAstroRenderer = (name: string) => {
 const denyList = ['prismjs/components/index.js', '@astrojs/markdown-support', 'node:fs/promises', ...nodeBuiltinsMap.values()];
 
 export default Object.keys(pkg.dependencies)
-  // Filter out packages that should be loaded threw Snowpack
+  // Filter out packages that should be loaded through Snowpack
   .filter((name) => {
     // Explicitly allowed packages should NOT be external
     if (allowList.has(name)) return false;


### PR DESCRIPTION
## Changes

Just a typo in the comments threw->through

## Testing

No test as just a comment typo fix

## Docs

comment typo fix only
