### PR TITLE
Update Tailwind docs for path to css

### DIFF
--- a/docs/src/pages/guides/styling.md
+++ b/docs/src/pages/guides/styling.md
@@ -327,7 +327,6 @@ And in your local filesystem, you can even use Sass' [@use][sass-use] to combine
 
 ```
 ├── src/
-│   └── (pages)
 │   └── styles/
 │       ├── _base.scss
 │       ├── _tokens.scss


### PR DESCRIPTION
Closes #1065

## Changes

This is a doc change only for Tailwind.

## Testing

N/A, docs only.

## Docs

This does two things:

1. Changes the location where to put the Tailwind `global.css` file so that it's inside of `src/` since `public/` is no longer processed.
2. Points out that only JIT mode is supported.