### PR TITLE
Add option "none" to Astro init framework question

### DIFF
--- a/packages/create-astro/src/frameworks.ts
+++ b/packages/create-astro/src/frameworks.ts
@@ -109,6 +109,10 @@ export default {
 
 export const FRAMEWORKS = [
   {
+    title: 'None',
+    value: '',
+  },
+  {
     title: 'Preact',
     value: '@astrojs/renderer-preact',
   },


### PR DESCRIPTION
## Changes

Should add an option "none" to the question "✔ Which frameworks would you like to use?" during Astro init (on the commandline), which passes no value but generates a clean version of Astro in the folder. Currently if you don't select an answer to this question, you get the same result, but I felt that was unclear. 

## Testing

I'm not quite sure how to test this, honestly, so I could use some help. I will ask on Discord.

## Docs

No, I will gladly update documentation but looking at it I saw no mention of the steps of the init script, where it would be logical to add/make changes.