### PR TITLE
Adjust layout imports in `docs` example

### DIFF
--- a/examples/docs/src/pages/en/introduction.md
+++ b/examples/docs/src/pages/en/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-layout: ~/layouts/MainLayout.astro
+layout: ../../layouts/MainLayout.astro
 ---
 
 **Welcome to Astro!**

--- a/examples/docs/src/pages/en/page-2.md
+++ b/examples/docs/src/pages/en/page-2.md
@@ -1,6 +1,6 @@
 ---
 title: Page 2
-layout: ~/layouts/MainLayout.astro
+layout: ../../layouts/MainLayout.astro
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/examples/docs/src/pages/en/page-3.md
+++ b/examples/docs/src/pages/en/page-3.md
@@ -1,6 +1,6 @@
 ---
 title: Page 3
-layout: ~/layouts/MainLayout.astro
+layout: ../../layouts/MainLayout.astro
 ---
 
 This is a fully-featured page, written in Markdown!

--- a/examples/docs/src/pages/en/page-4.md
+++ b/examples/docs/src/pages/en/page-4.md
@@ -1,6 +1,6 @@
 ---
 title: Page 4
-layout: ~/layouts/MainLayout.astro
+layout: ../../layouts/MainLayout.astro
 ---
 
 This is a fully-featured page, written in Markdown!


### PR DESCRIPTION
Fixes #1249 
Adjust the layout imports in all `md` files so that they can be resolved.

## Changes

- Change all `md` to reference `../../layouts/MainLayout.astro`

## Testing

Not sure how to test the CLI / `npm init astro` command. I did test the fix in terms of changing the previous layout path to this new one in a fresh install.

## Docs

Just a bugfix that creates the behaviour described in the documentation.
