### PR TITLE
add backlink to blogposts

### DIFF
--- a/www/src/components/BackArrow.astro
+++ b/www/src/components/BackArrow.astro
@@ -1,0 +1,16 @@
+---
+interface Props {
+    url: string
+    title: string
+}
+const { url, title } = Astro.props
+---
+<a href={url}>
+    &leftarrow; {title}
+</a>
+<style>
+a {
+    display: block;
+    margin-top: 2rem;
+}
+</style>

--- a/www/src/components/BlogPost.astro
+++ b/www/src/components/BlogPost.astro
@@ -2,6 +2,7 @@
 import Author from './Author.astro';
 import GithubStarButton from './GithubStarButton.astro';
 import GoogleAnalytics from './GoogleAnalytics.astro';
+import BackArrow from './BackArrow.astro';
 
 export interface Props {
   title: string;
@@ -24,6 +25,7 @@ const { title, author, publishDate, heroImage } = Astro.props;
     </header>
     <main class="content">
       <slot />
+      <BackArrow url={'/blog/'} title={'Back to all blogposts'}/>
     </main>
   </article>
   <GoogleAnalytics />


### PR DESCRIPTION
## Changes

- Add 'back to all blogposts' link under blogposts since `/blog/` is never linked to

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
- no tests added

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
- No docs needed