### PR TITLE
Fixed netlify and sentry logo srcs

### DIFF
--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -31,7 +31,7 @@ You can sponsor Astro's development on [Open Collective][oc]. Astro is generousl
 <table>
   <tbody>
     <tr>
-      <td align="center"><a href="https://www.netlify.com/" target="_blank"><img width="147" height="40" src="./.github/assets/netlify.svg" alt="Netlify" /></a></td>
+      <td align="center"><a href="https://www.netlify.com/" target="_blank"><img width="147" height="40" src="https://raw.githubusercontent.com/snowpackjs/astro/main/.github/assets/netlify.svg" alt="Netlify" /></a></td>
     </tr>
   </tbody>
 </table>
@@ -41,7 +41,7 @@ You can sponsor Astro's development on [Open Collective][oc]. Astro is generousl
 <table>
   <tbody>
     <tr>
-      <td align="center"><a href="https://sentry.io" target="_blank"><img width="147" height="40" src="./.github/assets/sentry.svg" alt="Sentry" /></a></td>
+      <td align="center"><a href="https://sentry.io" target="_blank"><img width="147" height="40" src="https://raw.githubusercontent.com/snowpackjs/astro/main/.github/assets/sentry.svg" alt="Sentry" /></a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Changes

The Netlify and Sentry logos are being displayed when visiting https://github.com/snowpackjs/astro and https://github.com/snowpackjs/astro/tree/main. But they aren't working at https://www.npmjs.com/package/astro and https://github.com/snowpackjs/astro/tree/main/packages/astro. This PR changes the relative URLs in the `src` attributes to absolute URLs to fix the issue.

## Testing

## Docs

