### PR TITLE
Add Accessible Astro Starter to  docs community themes

### DIFF
--- a/docs/src/data/themes.json
+++ b/docs/src/data/themes.json
@@ -49,6 +49,12 @@
       "demo": "https://astro-ink.vercel.app/",
       "sandbox": "https://github.dev/one-aalam/astro-ink",
       "command": "npm init astro -- --template one-aalam/astro-ink"
+    },
+    {
+      "name": "Accessible Astro Starter",
+      "description": "A starter project with accessible features using Astro static site builder",
+      "github": "https://github.com/markteekman/accessible-astro-starter",
+      "demo": "https://accessible-astro.markteekman.nl/"
     }
   ]
 }


### PR DESCRIPTION
This is only a suggestion to get the word out about accessibility BUT, if you guys just want to show one featured theme then I understand and Ink would be better suited 😄 If that's the case just decline the request 🙂

## Changes

- It adds a second theme to the "Featured Theme" (should be Themes in that  case) section on the Themes page in the docs

## Testing

<!-- How was this change tested? -->
I have not tested it, I added another object to the themes.json file assuming that `{themes.community.map((item)=>(<Card data={item} />))}` would then show another item.

## Docs

<!-- Was public documentation updated? -->
Yes, the public documentation is updated with this pull request. It is just a suggestion though 🙂 
