### PR TITLE
Add first contributors guide to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 
 We welcome contributions of any size and skill level. As an open source project, we believe in giving back to our contributors and are happy to help with guidance on PRs, technical writing, and turning any feature idea into a reality.
 
+> **Tip for new contributors:**
+> Take a look at [https://github.com/firstcontributions/first-contributions](https://github.com/firstcontributions/first-contributions) for helpful information on contributing
+
 ## Prerequisite
 
 ```shell


### PR DESCRIPTION
## Changes

- CONTRIBUTING.md now has a tip at the top to look at https://github.com/firstcontributions/first-contributions if you are a new OSS contributor.

## Testing

None because no core code was changed

## Docs

Refer to changes
