### PR TITLE
Typo in code snippet

### DIFF
--- a/docs/src/pages/installation.md
+++ b/docs/src/pages/installation.md
@@ -145,7 +145,7 @@ If you need to share your development progress on the local network or check out
 
 ```js
 devOptions: {
-  hostname: '0.0.0.0';
+  hostname: '0.0.0.0'
 }
 ```
 


### PR DESCRIPTION
Semicolon here will throw an error: `SyntaxError: Unexpected token ';'`

## Changes

This change removes a semicolon `;` in code config for `astro.config.mjs` to prevent an error on config load.

## Testing

Tested by successfully running `npm run dev`.

## Docs

This an update to public documentation.
