### PR TITLE
Fix "Quick-Start guide" href

### DIFF
--- a/docs/src/pages/getting-started.md
+++ b/docs/src/pages/getting-started.md
@@ -9,7 +9,7 @@ Astro is a modern static site builder. Learn what Astro is all about from [our h
 
 The easiest way to try Astro is to run `npm init astro` in a new directory on your machine. Our CLI wizard will assist you in starting a new Astro project.
 
-To get started with Astro in 5 quick and easy steps, visit our [Quick-Start guide](quick-start).
+To get started with Astro in 5 quick and easy steps, visit our [Quick-Start guide](/quick-start).
 
 Alternatively, read our [Installation Guide](/installation) for a full walk-through on getting set up with Astro.
 


### PR DESCRIPTION
Currently in the "Try Astro" section, the link "Quick-Start guide" gets us to https://docs.astro.build/getting-started/quick-start, which is 404.
I guess the correct URL would be: https://docs.astro.build/quick-start

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

bug fix only
