### PR TITLE
Add Github Action to automatically push from main to latest when no changeset

### DIFF
--- a/.github/workflows/updatelatest.yml
+++ b/.github/workflows/updatelatest.yml
@@ -44,10 +44,11 @@ jobs:
     if: needs.update.outputs.run_job == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Push
-        uses: Automattic/action-commit-to-branch@master
+      - uses: actions/checkout@v2
         with:
-          branch: 'latest'
-          commit_message: 'Update latest from main'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+      - name: Push
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: latest


### PR DESCRIPTION
## Changes

- Add a github actionsscript to check if a changeset is found. If none is found push to latest branch

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
tested locally on my branch. Works like it should except for the push to `latest` itself. I figured you guys probably know that part better then I do.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Didn't write any docs on the matter, willing to if wanted.