### PR TITLE
Fix broken link to quick-start guide

### DIFF
--- a/docs/src/pages/getting-started.md
+++ b/docs/src/pages/getting-started.md
@@ -9,7 +9,7 @@ Astro is a modern static site builder. Learn what Astro is all about from [our h
 
 The easiest way to try Astro is to run `npm init astro` in a new directory on your machine. Our CLI wizard will assist you in starting a new Astro project.
 
-To get started with Astro in 5 quick and easy steps, visit our [Quick-Start guide](quick-start).
+To get started with Astro in 5 quick and easy steps, visit our [Quick-Start guide](/quick-start).
 
 Alternatively, read our [Installation Guide](/installation) for a full walk-through on getting set up with Astro.
 


### PR DESCRIPTION
## Changes

- This is a simple URL typo fix.
- Making sure the URL is now prepended by a `/` so `Quick-Start guide` links to `/quick-start` and not `/getting-started/quick-start`

## Testing

This code has been tested to work locally. 

There seems to be an issue with the local development environment (or browser interpretation) that doesn't reflect the public site. Locally, the link with no slash `/` prepended seems to resolve fine, but on the live website it does not. That is probably its own issue though.

The other links on in the document are prepended with a slash, so it makes sense to keep this pattern for all similar links.

The rendered output should now be `<a href="/quick-start">Quick-Start guide</a>` and not `<a href="quick-start">Quick-Start guide</a>` as the current branch renders.

See live page https://docs.astro.build/getting-started/ and follow link to quick start guide, which takes you to https://docs.astro.build/getting-started/quick-start

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

This is part of the documentation.

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
