### PR TITLE
docs: unify concepts in Spanish version

### DIFF
--- a/docs/src/pages/es/core-concepts/astro-components.md
+++ b/docs/src/pages/es/core-concepts/astro-components.md
@@ -92,11 +92,11 @@ const thisWorks: number = 42;
 
 ### Importaciones de componentes
 
-Un componente Astro puede reutilizar otros componentes Astro dentro de su plantilla HTML. Esto se convierte en la base de nuestro sistema de componentes: crea nuevos componentes y luego reutilízalos en todo tu proyecto.
+Un componente Astro puede reutilizar otros componentes de Astro dentro de su plantilla HTML. Esto se convierte en la base de nuestro sistema de componentes: crea nuevos componentes y luego reutilízalos en todo tu proyecto.
 
 Para utilizar un componente Astro en tu plantilla, primero debes importarlo en el script preliminar del componente. Un componente Astro es siempre la importación predeterminada del archivo.
 
-Una vez importado, puedes usarlo como cualquier otro elemento HTML en tu plantilla. Ten en cuenta que un componente de Astro **DEBE** comenzar con una letra mayúscula. Astro usará esto para distinguir entre elementos HTML nativos (`from`,` input`, etc.) y tus componentes Astro personalizados.
+Una vez importado, puedes usarlo como cualquier otro elemento HTML en tu plantilla. Ten en cuenta que un componente de Astro **DEBE** comenzar con una letra mayúscula. Astro usará esto para distinguir entre elementos HTML nativos (`from`,` input`, etc.) y tus componentes de Astro personalizados.
 
 ```astro
 ---
@@ -115,7 +115,7 @@ import AlgunComponente from './AlgunComponente.astro';
 
 En lugar de inventar nuestra propia sintaxis personalizada para la creación de plantillas dinámicas, te brindamos acceso directo a los valores de JavaScript dentro de su HTML, utilizando algo que se parece a [JSX](https://reactjs.org/docs/introducing-jsx.html) .
 
-Los componentes Astro pueden definir variables locales dentro del script de Frontmatter. Todas las variables de secuencia de comandos están disponibles automáticamente en la plantilla HTML a continuación.
+Los componentes de Astro pueden definir variables locales dentro del script de Frontmatter. Todas las variables de secuencia de comandos están disponibles automáticamente en la plantilla HTML a continuación.
 
 #### Dynamic Values
 

--- a/docs/src/pages/es/core-concepts/layouts.md
+++ b/docs/src/pages/es/core-concepts/layouts.md
@@ -4,7 +4,7 @@ title: Maquetas
 lang: es
 ---
 
-**Las maquetas** son un tipo especial de [Componente](/es/core-concept/astro-components) que te ayudan a compartir y reutilizar diseños de página comunes dentro de tu proyecto.
+**Las maquetas** son un tipo especial de [Componente](/es/core-concept/astro-components) que te ayudan a compartir y reutilizar maquetas de página comunes dentro de tu proyecto.
 
 Las maquetas son como cualquier otro componente de Astro reutilizable. No hay una nueva sintaxis o API que aprender. Sin embargo, las maquetas de página reutilizables son un patrón tan común en el desarrollo web que creamos esta guía para ayudarte a usarlos.
 
@@ -57,7 +57,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
 
 ## Maquetas anidadas
 
-Puedes anidar diseños cuando desees crear tipos de página más específicos sin copiar y pegar. Es común en Astro tener un `BaseLayout` genérico y luego muchos más diseños específicos (`PostLayout`, `ProductLayout`, etc.) que se reutilizan y construyen sobre él.
+Puedes anidar maquetas cuando desees crear tipos de página más específicos sin copiar y pegar. Es común en Astro tener un `BaseLayout` genérico y luego muchos más maquetas específicas (`PostLayout`, `ProductLayout`, etc.) que se reutilizan y construyen sobre él.
 
 ```astro
 ---
@@ -78,7 +78,7 @@ const {titulo, author} = Astro.props;
 
 A veces, necesitas un control más granular sobre tu página. Por ejemplo, es posible que desees agregar SEO o etiquetas `meta` sociales en algunas páginas, pero no en otras. Puedes implementar esto con un accesorio en su maqueta (`<BaseLayout addMeta={true}...`) pero en algún momento puede ser más fácil componer tus maquetas sin anidar.
 
-En lugar de definir toda la página `<html>` como un diseño grande, puedes definir los contenidos de `head` y `body` como componentes separados más pequeños. Esto te permite componer varios diseños juntos de formas únicas en cada página.
+En lugar de definir toda la página `<html>` como un diseño grande, puedes definir los contenidos de `head` y `body` como componentes separados más pequeños. Esto te permite componer varias maquetas juntas de formas únicas en cada página.
 
 ```astro
 ---

--- a/docs/src/pages/es/core-concepts/project-structure.md
+++ b/docs/src/pages/es/core-concepts/project-structure.md
@@ -28,7 +28,7 @@ La forma más sencilla de configurar tu nuevo proyecto es con `npm init astro`. 
 
 La carpeta src es donde vive la mayor parte del código fuente de tu proyecto. Esto incluye:
 
-- [Components Astro](/es/core-concepts/astro-components)
+- [Components de Astro](/es/core-concepts/astro-components)
 - [Páginas](/es/core-concepts/astro-pages)
 - [Maquetas](/es/core-concepts/layouts)
 - [Componentes frontend JS](/es/core-concepts/component-hydration)
@@ -45,7 +45,7 @@ Tus componentes de UI que no son de Astro (React, Preact, Svelte, Vue, etc.) tam
 
 ### `src/layouts`
 
-Las [maquetas](/es/core-concepts/layouts) son componentes reutilizables para diseños de páginas HTML. Se recomienda (pero no es obligatorio) que coloques tus componentes de maqueta en este directorio. La forma en que los organices dentro de este directorio depende de ti.
+Las [maquetas](/es/core-concepts/layouts) son componentes reutilizables para maquetar páginas HTML. Se recomienda (pero no es obligatorio) que coloques tus componentes de maqueta en este directorio.  La forma en que los organices dentro de este directorio depende de ti.
 
 ### `src/pages`
 

--- a/docs/src/pages/es/getting-started.md
+++ b/docs/src/pages/es/getting-started.md
@@ -35,7 +35,7 @@ Como cualquier tecnología desconocida, Astro viene con una ligera curva de apre
 
 Cuando comiences a aprender Astro, verás muchos archivos con la extensión `.astro`. Esta es la **sintaxis de componentes de Astro**: un formato de archivo especial similar a HTML que Astro usa para crear templates. Fue diseñado para que resulte familiar a cualquiera que tenga experiencia con HTML o JSX.
 
-Nuestra guía sobre [componentes Astro](https://docs.astro.build/core-concepts/astro-components) presenta la sintaxis de Astro y es la mejor manera de aprender.
+Nuestra guía sobre [componentes de Astro](https://docs.astro.build/core-concepts/astro-components) presenta la sintaxis de Astro y es la mejor manera de aprender.
 
 ### Referencia de la API
 

--- a/docs/src/pages/es/guides/imports.md
+++ b/docs/src/pages/es/guides/imports.md
@@ -37,7 +37,7 @@ Todos los navegadores ahora son compatibles con ESM, por lo que Astro puede envi
 
 ## TypeScript
 
-Astro incluye soporte integrado para crear archivos TypeScript (`*.ts`) en JavaScript. Los componentes Astro también son compatibles con TypeScript en la sección de script preliminar.
+Astro incluye soporte integrado para crear archivos TypeScript (`*.ts`) en JavaScript. Los componentes de Astro también son compatibles con TypeScript en la sección de script preliminar.
 
 Ten en cuenta que este soporte integrado es solo de compilación. De forma predeterminada, Astro no verifica el tipo de su código TypeScript.
 

--- a/docs/src/pages/pt-br/getting-started.md
+++ b/docs/src/pages/pt-br/getting-started.md
@@ -35,7 +35,7 @@ Como qualquer tecnologia emergente, Astro vem com uma leve curva de aprendizado.
 
 Quando você começa a aprender Astro, você verá muitos arquivos usando a extensão `.astro`. Esta é a **Sintaxe de componentes do Astro**: um formato de arquivo HTML especial que o Astro usa para modelagem. Foi projetado para dar o sentimento de familiaridade para qualquer pessoa com experiência HTML ou JSX.
 
-Nosso guia útil em [componentes Astro](/core-concepts/astro-components) apresenta você à sintaxe Astro e é a melhor maneira de aprender.
+Nosso guia útil em [componentes de Astro](/core-concepts/astro-components) apresenta você à sintaxe Astro e é a melhor maneira de aprender.
 
 ### Referência da API
 


### PR DESCRIPTION
## Changes

- docs corrections: Unify the names used for core concepts
- related: #1531

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Just typo corrections

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
docs corrections
