### PR TITLE
Only run `.github/workflows/stats.yml` locally, not on forks

### DIFF
--- a/.github/workflows/stat.yml
+++ b/.github/workflows/stat.yml
@@ -10,6 +10,7 @@ env:
 
 jobs:
   stat:
+    if: github.repository == 'snowpackjs/astro'
     runs-on: ubuntu-latest
     steps:
       # Check out code using git


### PR DESCRIPTION
## Changes

- Prevents the stats github action from running on forks of the repo!

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
