### PR TITLE
Fix type error in blog-multiple-authors example

### DIFF
--- a/examples/blog-multiple-authors/src/components/MainHead.astro
+++ b/examples/blog-multiple-authors/src/components/MainHead.astro
@@ -6,7 +6,7 @@ export interface Props {
   type?: string;
   next?: string;
   prev?: string;
-  canonicalURL?: string;
+  canonicalURL?: string | URL;
 }
 
 const { title, description, image, type, next, prev, canonicalURL } = Astro.props as Props;

--- a/examples/blog-multiple-authors/src/layouts/post.astro
+++ b/examples/blog-multiple-authors/src/layouts/post.astro
@@ -4,12 +4,13 @@ import Nav from '../components/Nav.astro';
 import authorData from '../data/authors.json';
 
 const { content } = Astro.props;
+let canonicalURL = Astro.request.canonicalURL;
 ---
 
 <html lang={ content.lang || 'en' }>
   <head>
     <title>{content.title}</title>
-    <MainHead title={content.title} description={content.description} image={content.image} canonicalURL={Astro.request.canonicalURL} />
+    <MainHead title={content.title} description={content.description} image={content.image} canonicalURL={canonicalURL} />
     <style lang="scss">
       .title {
         margin-top: 4rem;

--- a/examples/blog-multiple-authors/src/pages/about.astro
+++ b/examples/blog-multiple-authors/src/pages/about.astro
@@ -3,14 +3,15 @@ import MainHead from '../components/MainHead.astro';
 import Nav from '../components/Nav.astro';
 
 let title = "About";
-let description = "About page of an example blog on Astro"
+let description = "About page of an example blog on Astro";
+let canonicalURL = Astro.request.canonicalURL;
 ---
 <html lang="en">
   <head>
     <MainHead
       title={title}
       description={description}
-      canonicalURL={Astro.request.canonicalURL}
+      canonicalURL={canonicalURL}
     />
     <style lang="scss">
 

--- a/examples/blog-multiple-authors/src/pages/index.astro
+++ b/examples/blog-multiple-authors/src/pages/index.astro
@@ -18,6 +18,7 @@ interface MarkdownFrontmatter {
 // All variables are available to use in the HTML template below.
 let title = 'Don’s Blog';
 let description = 'An example blog on Astro';
+let canonicalURL = Astro.request.canonicalURL;
 
 // Data Fetching: List all Markdown posts in the repo.
 let allPosts = Astro.fetchContent<MarkdownFrontmatter>('./post/*.md');
@@ -34,7 +35,7 @@ let firstPage = allPosts.slice(0, 2);
       title={title}
       description={description}
       image={allPosts[0].image}
-      canonicalURL={Astro.request.canonicalURL.href}
+      canonicalURL={canonicalURL}
     />
   </head>
 


### PR DESCRIPTION
## Changes
Fixed type of canonical URL to avoid type error
<img width="482" alt="スクリーンショット 2021-10-14 23 12 27" src="https://user-images.githubusercontent.com/62130798/137341220-864fc8cf-43f7-4ff2-9a76-601611087d8a.png">


## Testing
type fix only

## Docs

type fix only
