### PR TITLE
Added descriptions to example

### DIFF
--- a/examples/docs/src/pages/en/introduction.md
+++ b/examples/docs/src/pages/en/introduction.md
@@ -1,5 +1,6 @@
 ---
 title: Introduction
+description: Docs intro
 layout: ../../layouts/MainLayout.astro
 ---
 

--- a/examples/docs/src/pages/en/page-2.md
+++ b/examples/docs/src/pages/en/page-2.md
@@ -1,5 +1,6 @@
 ---
 title: Page 2
+description: Lorem ipsum dolor sit amet - 2
 layout: ../../layouts/MainLayout.astro
 ---
 

--- a/examples/docs/src/pages/en/page-3.md
+++ b/examples/docs/src/pages/en/page-3.md
@@ -1,5 +1,6 @@
 ---
 title: Page 3
+description: Lorem ipsum dolor sit amet - 3
 layout: ../../layouts/MainLayout.astro
 ---
 

--- a/examples/docs/src/pages/en/page-4.md
+++ b/examples/docs/src/pages/en/page-4.md
@@ -1,5 +1,6 @@
 ---
 title: Page 4
+description: Lorem ipsum dolor sit amet - 4
 layout: ../../layouts/MainLayout.astro
 ---
 


### PR DESCRIPTION
It would be better if the doc example pages included a description to show users of the docs example how to create a description for a page, so I added a description to all pages in the docs example.

## Changes

- All pages in the docs example had a short description added.

## Testing

None because no core code was changed.

## Docs

None because it is an example.
