### PR TITLE
Changed docs TOC buttons to be better touch targets

### DIFF
--- a/docs/public/index.css
+++ b/docs/public/index.css
@@ -337,6 +337,7 @@ h2.heading {
   display: inline-flex;
   gap: 0.5em;
   width: 100%;
+  padding: 0.15em 0 0.15em 0;
 }
 
 .header-link.depth-3 {

--- a/examples/docs/public/index.css
+++ b/examples/docs/public/index.css
@@ -341,6 +341,7 @@ h2.heading {
   display: inline-flex;
   gap: 0.5em;
   width: 100%;
+  padding: 0.15em 0 0.15em 0;
 }
 
 .header-link.depth-3 {


### PR DESCRIPTION
According to the Lighthouse audit [https://web.dev/tap-targets/](https://web.dev/tap-targets/), tap targets in Astro doc's table of contents were not sizes appropriately. Padding was added to each anchor element to fix this, improving mobile user's experience and giving Astro docs an 100 in SEO with Lighthouse.

## Changes

- Padding was added to the anchor elements in the table of contents of the docs to make them big enough touch targets for users on mobile devices.

## Testing

None because it was just a small CSS change.

## Docs

See changes.
