### PR TITLE
Fix comparison heading order

### DIFF
--- a/docs/src/pages/comparing-astro-vs-other-tools.md
+++ b/docs/src/pages/comparing-astro-vs-other-tools.md
@@ -20,13 +20,13 @@ A few features are still missing from Astro, and several APIs are not yet finali
 
 Docusaurus was designed to build documentation websites and has some built-in, documentation-specific website features that Astro does not. Instead, Astro offers documentation-specific features through an official [`docs`](https://github.com/snowpackjs/astro/tree/main/examples/docs) theme that you can use for your site. This website was built using that template!
 
-#### Comparing Docusaurus vs. Astro Performance
+### Comparing Docusaurus vs. Astro Performance
 
 In most cases, Astro websites will load significantly faster than Docusaurus websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/core-concepts/component-hydration).
 
 Docusaurus doesn't support partial hydration, and instead makes the user load and rehydrate the entire page in the browser, even if most of the page content is static. This creates a slower page load and worse performance for your website. There is no way to disable this behavior in Docusaurus.
 
-#### Case Study: Building a Documentation Website
+### Case Study: Building a Documentation Website
 
 [docusaurus.io/docs](https://docusaurus.io/docs) is the official Docusaurus documentation website, built with Docusaurus. The website offers a similar enough design and featureset to compare against the official Astro documentation website. This gives us a **_rough, real-world_** comparison between the two site builders.
 
@@ -55,7 +55,7 @@ Elder.js supports both Static Site Generation (SSG) and Server-Side Rendering (S
 
 Eleventy uses several [older HTML templating languages](https://www.11ty.dev/docs/languages/) to render your website: Nunjucks, Liquid, Pug, EJS, and others. Astro lets you create pages using your favorite UI component libraries (React, Preact, Vue, Svelte, and others) or a built-in component syntax which is similar to HTML + JSX. Eleventy does not support using modern UI components for HTML templating.
 
-#### Comparing Eleventy vs. Astro Performance
+### Comparing Eleventy vs. Astro Performance
 
 Conceptually, Eleventy is aligned with Astro's "minimal client-side JavaScript" approach to web development. Eleventy and Astro both offer similar, zero-JavaScript-by-default performance baselines.
 
@@ -73,7 +73,7 @@ Gatsby v4 supports both Static Site Generation (SSG) with incremental rebuilds, 
 
 Gatsby requires a custom GraphQL API for working with all of your site content. While some developers enjoy this model, a common criticism of Gatsby is that this model becomes too complex and difficult to maintain over time, especially as sites grow. Astro has no GraphQL requirement, and instead provides familiar APIs (like `fetch()` and top-level `await`) for data loading close to where the data is needed.
 
-#### Comparing Gastby vs. Astro Performance
+### Comparing Gastby vs. Astro Performance
 
 In most cases, Astro websites will load significantly faster than Gatsby websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/core-concepts/component-hydration).
 
@@ -81,7 +81,7 @@ Gatsby doesn't support partial hydration, and instead makes the user load and re
 
 Gatsby has a great plugin ecosystem, which could make Gatsby a better choice for your project depending on your needs. [gatsby-plugin-image](https://www.gatsbyjs.com/plugins/gatsby-plugin-image/) is a popular plugin for image optimizations, which could make Gatsby a better choice for some image-heavy websites.
 
-#### Case Study: Building a Documentation Website
+### Case Study: Building a Documentation Website
 
 [gatsbyjs.com/docs](https://www.gatsbyjs.com/docs/quick-start/) is the official Gatsby documentation website, built with Gatsby. The website offers a similar enough design and feature-set to compare against the official Astro documentation website. This gives us a **_rough, real-world_** comparison between the two site builders for this common use-case.
 
@@ -96,7 +96,7 @@ One big reason behind this performance difference is Astro's smaller JavaScript 
 
 Hugo uses a custom [templating language](https://gohugo.io/templates/introduction/) to render your website. Astro lets you create pages using your favorite UI component libraries (React, Preact, Vue, Svelte, and others) or a built-in component syntax which is similar to HTML + JSX. Hugo does not support using modern UI components for HTML templating.
 
-#### Comparing Hugo vs. Astro Performance
+### Comparing Hugo vs. Astro Performance
 
 Conceptually, Hugo is aligned with Astro's "minimal client-side JavaScript" approach to web development. Hugo and Astro both offer similar, zero-JavaScript-by-default performance baselines.
 
@@ -108,7 +108,7 @@ Both Hugo and Astro offer built-in support for building, bundling and minifying 
 
 Jekyll uses an older [templating language](https://jekyllrb.com/docs/liquid/) to render your website called Liquid. Astro lets you create pages using your favorite UI component libraries (React, Preact, Vue, Svelte, and others) or a built-in component syntax which is similar to HTML + JSX. Jekyll does not support using modern UI components for HTML templating.
 
-#### Comparing Jekyll vs. Astro Performance
+### Comparing Jekyll vs. Astro Performance
 
 Conceptually, Jekyll is aligned with Astro's "minimal client-side JavaScript" approach to web development. Jekyll and Astro both offer similar, zero-JavaScript-by-default performance baselines.
 
@@ -126,13 +126,13 @@ Both SvelteKit and Astro are frameworks for building websites. SvelteKit does be
 
 SvelteKit supports both Static Site Generation (SSG) and Server-Side Rendering (SSR). Today, Astro only supports Static Site Generation (SSG).
 
-#### Comparing SvelteKit vs. Astro Performance
+### Comparing SvelteKit vs. Astro Performance
 
 In most cases, Astro websites will load faster than SvelteKit websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/core-concepts/component-hydration).
 
 SvelteKit doesn't support partial hydration, and instead makes the user load and rehydrate the entire page in the browser, even if most of the page content is static. This creates a slower page load and worse performance for your website. SvelteKit does offer support for [page-level static, zero-JavaScript pages](https://kit.svelte.dev/docs#ssr-and-javascript-hydrate). However, there is no planned support for hydrating individual components on the page. This leaves you with an all-or-nothing decision for interactivity on each page.
 
-#### Case Study: Building a Documentation Website
+### Case Study: Building a Documentation Website
 
 [kit.svelte.dev](https://kit.svelte.dev/docs#ssr-and-javascript-hydrate) is the official SvelteKit documentation website, built with SvelteKit. The website offers a similar enough design and featureset to compare against the official Astro documentation website. This gives us a **_rough, real-world_** comparison between the two site builders for this common use-case.
 
@@ -153,7 +153,7 @@ Both Next.js and Astro are frameworks for building websites. Next.js does best w
 
 Next.js supports both Static Site Generation (SSG) and Server-Side Rendering (SSR). Today, Astro only supports Static Site Generation (SSG).
 
-#### Comparing Next.js vs. Astro Performance
+### Comparing Next.js vs. Astro Performance
 
 In most cases, Astro websites will load significantly faster than Next.js websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/core-concepts/component-hydration).
 
@@ -161,7 +161,7 @@ Next.js doesn't support partial hydration, and instead makes the user load and r
 
 Next.js has great built-in image optimizations, which could make Next.js a better choice for some image-heavy websites.
 
-#### Case Study: Building a Documentation Website
+### Case Study: Building a Documentation Website
 
 [nextjs.org/docs](https://nextjs.org/docs/getting-started) is the official Next.js documentation website, built with Next.js. The website offers a similar enough design and featureset to compare against the official Astro documentation website. This gives us a **_rough, real-world_** comparison between the two site builders for this common use-case.
 
@@ -180,7 +180,7 @@ Both Nuxt and Astro are frameworks for building websites. Nuxt does best with hi
 
 Nuxt supports both Static Site Generation (SSG) and Server-Side Rendering (SSR). Today, Astro only supports Static Site Generation (SSG).
 
-#### Comparing Nuxt vs. Astro Performance
+### Comparing Nuxt vs. Astro Performance
 
 In most cases, Astro websites will load significantly faster than Nuxt websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/core-concepts/component-hydration).
 
@@ -188,7 +188,7 @@ Nuxt doesn't support partial hydration, and instead makes the user load and rehy
 
 Nuxt has great built-in image optimizations, which could make Nuxt a better choice for some image-heavy websites.
 
-#### Case Study: Building a Documentation Website
+### Case Study: Building a Documentation Website
 
 [nuxtjs.org/docs](https://nuxtjs.org/docs/2.x/get-started/installation) is the official Nuxt documentation website, built with Nuxt. The website offers a similar enough design and featureset to compare against the official Astro documentation website. This gives us a **_rough, real-world_** comparison between the two site builders for this common use-case.
 
@@ -205,13 +205,13 @@ VuePress was designed for documentation websites and has some built-in, document
 
 Evan You (creator of Vue.js) is currently working on a new version of Vuepress called [VitePress.](https://vitepress.vuejs.org/). If you want a modern alternative to VuePress, [check out Evan's post](https://github.com/snowpackjs/astro/issues/1159#issue-974035962) on why VitePress may be a better option.
 
-#### Comparing VuePress vs. Astro Performance
+### Comparing VuePress vs. Astro Performance
 
 In most cases, Astro websites will load significantly faster than VuePress websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/core-concepts/component-hydration).
 
 VuePress doesn't support partial hydration, and instead makes the user load and rehydrate the entire page in the browser, even if most of the page content is static. This creates a slower page load and worse performance for your website. There is no way to disable this behavior in VuePress.
 
-#### Case Study: Building a Documentation Website
+### Case Study: Building a Documentation Website
 
 [vuepress.vuejs.org](https://vuepress.vuejs.org/guide/) is the official VuePress documentation website, built with VuePress. The website offers a similar enough design and featureset to compare against the official Astro documentation website. This gives us a **_rough, real-world_** comparison between the two site builders for this common use-case.
 
@@ -226,7 +226,7 @@ One big reason behind this performance difference is Astro's smaller JavaScript 
 
 Zola uses [Tera](https://tera.netlify.app/) to render your website. Astro lets you create pages using your favorite UI component libraries (React, Preact, Vue, Svelte, and others) or a built-in component syntax which is similar to HTML + JSX. Zola does not support using modern UI components for HTML templating.
 
-#### Comparing Zola vs. Astro Performance
+### Comparing Zola vs. Astro Performance
 
 Conceptually, Zola is aligned with Astro's "minimal client-side JavaScript" approach to web development. Zola and Astro both offer similar, zero-JavaScript-by-default performance baselines.
 


### PR DESCRIPTION
## Changes

- The comparison page was updated to use H3s instead of H4s, which fixes the accessibility audit [https://web.dev/heading-order](https://web.dev/heading-order).

## Testing

None because no core code was changed.

## Docs

See changes
