### PR TITLE
[next] add `@astrojs/render` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "packages/astro/test/fixtures/custom-elements/my-component-lib"
   ],
   "volta": {
-    "node": "14.16.1",
+    "node": "14.18.1",
     "npm": "7.11.2",
     "yarn": "1.22.10"
   },

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@astrojs/render",
+  "version": "0.0.1",
+  "main": "./dist/index.js",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/snowpackjs/astro.git",
+    "directory": "packages/render"
+  },
+  "exports": {
+    ".": "./dist/index.js",
+    "./internal": "./dist/internal/index.js"
+  },
+  "scripts": {
+    "prepublish": "yarn build",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -p tsconfig.json",
+    "postbuild": "del \"dist/@types/**/*.js\"",
+    "dev": "astro-scripts dev \"src/**/*.ts\""
+  },
+  "dependencies": {
+    "serialize-javascript": "^6.0.0",
+    "shorthash": "^0.0.2"
+  },
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0",
+    "npm": ">=6.14.0"
+  },
+  "devDependencies": {
+    "@types/serialize-javascript": "^5.0.1",
+    "del": "^6.0.0"
+  }
+}

--- a/packages/render/src/@types/astro-file.ts
+++ b/packages/render/src/@types/astro-file.ts
@@ -1,0 +1,40 @@
+type AstroRenderedHTML = string;
+
+export type FetchContentResultBase = {
+  astro: {
+    headers: string[];
+    source: string;
+    html: AstroRenderedHTML;
+  };
+  url: URL;
+};
+
+export type FetchContentResult<T> = FetchContentResultBase & T;
+
+export type Params = Record<string, string | undefined>;
+
+interface AstroPageRequest {
+  url: URL;
+  canonicalURL: URL;
+  params: Params;
+}
+
+export interface AstroBuiltinProps {
+  'client:load'?: boolean;
+  'client:idle'?: boolean;
+  'client:media'?: string;
+  'client:visible'?: boolean;
+}
+
+export interface TopLevelAstro {
+  isPage: boolean;
+  fetchContent<T = any>(globStr: string): Promise<FetchContentResult<T>[]>;
+  resolve: (path: string) => string;
+  site: URL;
+}
+
+export interface Astro extends TopLevelAstro {
+  props: Record<string, number | string | any>;
+  request: AstroPageRequest;
+  slots: Record<string, true | undefined>;
+}

--- a/packages/render/src/@types/astro.ts
+++ b/packages/render/src/@types/astro.ts
@@ -1,0 +1,209 @@
+import type { AstroComponentFactory } from '../internal';
+
+export interface AstroComponentMetadata {
+  displayName: string;
+  hydrate?: 'load' | 'idle' | 'visible' | 'media' | 'only';
+  hydrateArgs?: any;
+  componentUrl?: string;
+  componentExport?: { value: string; namespace?: boolean };
+}
+
+export type AsyncRendererComponentFn<U> = (Component: any, props: any, children: string | undefined, metadata?: AstroComponentMetadata) => Promise<U>;
+
+export interface CollectionRSS {
+  /** (required) Title of the RSS Feed */
+  title: string;
+  /** (required) Description of the RSS Feed */
+  description: string;
+  /** Specify arbitrary metadata on opening <xml> tag */
+  xmlns?: Record<string, string>;
+  /** Specify custom data in opening of file */
+  customData?: string;
+  /**
+   * Specify where the RSS xml file should be written.
+   * Relative to final build directory. Example: '/foo/bar.xml'
+   * Defaults to '/rss.xml'.
+   */
+  dest?: string;
+  /** Return data about each item */
+  items: {
+    /** (required) Title of item */
+    title: string;
+    /** (required) Link to item */
+    link: string;
+    /** Publication date of item */
+    pubDate?: Date;
+    /** Item description */
+    description?: string;
+    /** Append some other XML-valid data to this item */
+    customData?: string;
+  }[];
+}
+
+/** Generic interface for a component (Astro, Svelte, React, etc.) */
+export interface ComponentInstance {
+  default: AstroComponentFactory;
+  css?: string[];
+  getStaticPaths?: (options: GetStaticPathsOptions) => GetStaticPathsResult;
+}
+
+export type GetStaticPathsArgs = { paginate: PaginateFunction; rss: RSSFunction };
+
+export interface GetStaticPathsOptions {
+  paginate?: PaginateFunction;
+  rss?: (...args: any[]) => any;
+}
+
+export type GetStaticPathsResult = { params: Params; props?: Props }[] | { params: Params; props?: Props }[];
+
+export interface JSXTransformConfig {
+  /** Babel presets */
+  presets?: babel.PluginItem[];
+  /** Babel plugins */
+  plugins?: babel.PluginItem[];
+}
+
+export type JSXTransformFn = (options: { isSSR: boolean }) => Promise<JSXTransformConfig>;
+
+export interface ManifestData {
+  routes: RouteData[];
+}
+
+export interface PaginatedCollectionProp<T = any> {
+  /** result */
+  data: T[];
+  /** metadata */
+  /** the count of the first item on the page, starting from 0 */
+  start: number;
+  /** the count of the last item on the page, starting from 0 */
+  end: number;
+  /** total number of results */
+  total: number;
+  /** the current page number, starting from 1 */
+  currentPage: number;
+  /** number of items per page (default: 25) */
+  size: number;
+  /** number of last page */
+  lastPage: number;
+  url: {
+    /** url of the current page */
+    current: string;
+    /** url of the previous page (if there is one) */
+    prev: string | undefined;
+    /** url of the next page (if there is one) */
+    next: string | undefined;
+  };
+}
+
+export interface PaginatedCollectionResult<T = any> {
+  /** result */
+  data: T[];
+  /** metadata */
+  /** the count of the first item on the page, starting from 0 */
+  start: number;
+  /** the count of the last item on the page, starting from 0 */
+  end: number;
+  /** total number of results */
+  total: number;
+  /** the current page number, starting from 1 */
+  currentPage: number;
+  /** number of items per page (default: 25) */
+  size: number;
+  /** number of last page */
+  lastPage: number;
+  url: {
+    /** url of the current page */
+    current: string;
+    /** url of the previous page (if there is one) */
+    prev: string | undefined;
+    /** url of the next page (if there is one) */
+    next: string | undefined;
+  };
+}
+
+export type PaginateFunction = (data: [], args?: { pageSize?: number; params?: Params; props?: Props }) => GetStaticPathsResult;
+
+export type Params = Record<string, string | undefined>;
+
+export type Props = Record<string, unknown>;
+
+export interface RenderPageOptions {
+  request: {
+    params?: Params;
+    url: URL;
+    canonicalURL: URL;
+  };
+  children: any[];
+  props: Props;
+  css?: string[];
+}
+
+export interface Renderer {
+  /** Name of the renderer (required) */
+  name: string;
+  polyfills?: string[];
+  /** Utilies for server-side rendering */
+  ssr: {
+    check: AsyncRendererComponentFn<boolean>;
+    renderToStaticMarkup: AsyncRendererComponentFn<{
+      html: string;
+    }>;
+  };
+}
+
+export interface RouteData {
+  component: string;
+  generate: (data?: any) => string;
+  params: string[];
+  pathname?: string;
+  pattern: RegExp;
+  type: 'page';
+}
+
+export type RouteCache = Record<string, GetStaticPathsResult>;
+
+export type RuntimeMode = 'development' | 'production';
+
+export type RSSFunction = (args: RSSFunctionArgs) => void;
+
+export interface RSSFunctionArgs {
+  /** (required) Title of the RSS Feed */
+  title: string;
+  /** (required) Description of the RSS Feed */
+  description: string;
+  /** Specify arbitrary metadata on opening <xml> tag */
+  xmlns?: Record<string, string>;
+  /** Specify custom data in opening of file */
+  customData?: string;
+  /**
+   * Specify where the RSS xml file should be written.
+   * Relative to final build directory. Example: '/foo/bar.xml'
+   * Defaults to '/rss.xml'.
+   */
+  dest?: string;
+  /** Return data about each item */
+  items: {
+    /** (required) Title of item */
+    title: string;
+    /** (required) Link to item */
+    link: string;
+    /** Publication date of item */
+    pubDate?: Date;
+    /** Item description */
+    description?: string;
+    /** Append some other XML-valid data to this item */
+    customData?: string;
+  }[];
+}
+
+export type RSSResult = { url: string; xml?: string };
+
+export type ScriptInfo = ScriptInfoInline | ScriptInfoExternal;
+
+export interface ScriptInfoInline {
+  content: string;
+}
+
+export interface ScriptInfoExternal {
+  src: string;
+}

--- a/packages/render/src/@types/config-minimal.ts
+++ b/packages/render/src/@types/config-minimal.ts
@@ -2,9 +2,7 @@ import type { Renderer } from './astro';
 
 export interface AstroConfigMinimal {
   /** production website, needed for some RSS & Sitemap functions */
-  origin: string;
-  /** the web request (needed for dynamic routes) */
-  pathname?: string;
+  site: string;
   /** Renderers for SSR */
   renderers?: Renderer[];
 }

--- a/packages/render/src/@types/config-minimal.ts
+++ b/packages/render/src/@types/config-minimal.ts
@@ -1,0 +1,10 @@
+import type { Renderer } from './astro';
+
+export interface AstroConfigMinimal {
+  /** production website, needed for some RSS & Sitemap functions */
+  origin: string;
+  /** the web request (needed for dynamic routes) */
+  pathname?: string;
+  /** Renderers for SSR */
+  renderers?: Renderer[];
+}

--- a/packages/render/src/@types/shorthash.d.ts
+++ b/packages/render/src/@types/shorthash.d.ts
@@ -1,0 +1,4 @@
+declare module 'shorthash' {
+  const shorthash: { unique: (string: string) => string; };
+  export default shorthash;
+}

--- a/packages/render/src/@types/ssr.ts
+++ b/packages/render/src/@types/ssr.ts
@@ -1,0 +1,13 @@
+import { Astro as AstroGlobal, TopLevelAstro } from './astro-file';
+import { Renderer } from './astro';
+
+export interface SSRMetadata {
+  renderers: Renderer[];
+}
+
+export interface SSRResult {
+  styles: Set<string>;
+  scripts: Set<string>;
+  createAstro(Astro: TopLevelAstro, props: Record<string, any>, slots: Record<string, any> | null): AstroGlobal;
+  _metadata: SSRMetadata;
+}

--- a/packages/render/src/config/index.ts
+++ b/packages/render/src/config/index.ts
@@ -1,9 +1,11 @@
 import type { AstroConfigMinimal } from '../@types/config-minimal';
 
-export let config: AstroConfigMinimal | null = null;
+export let config: AstroConfigMinimal = {
+  site: 'https://example.com',
+  renderers: []
+};
 
-export function setConfig(options: AstroConfigMinimal): void {
-  validateConfig(options);
+export function configure(options: AstroConfigMinimal): void {
   if (!config) {
     config = {} as any;
   }
@@ -12,11 +14,3 @@ export function setConfig(options: AstroConfigMinimal): void {
   }
 }
 
-export function validateConfig(config: unknown) {
-  if (!config) {
-    throw new Error(`[Astro]: You must call \`setConfig(value)\` before rendering!`)
-  }
-  if (typeof config !== 'object') {
-    throw new Error(`[Astro]: \`config\` must be of type "object". Found typeof "${typeof config}"!`)
-  }
-}

--- a/packages/render/src/config/index.ts
+++ b/packages/render/src/config/index.ts
@@ -1,0 +1,22 @@
+import type { AstroConfigMinimal } from '../@types/config-minimal';
+
+export let config: AstroConfigMinimal | null = null;
+
+export function setConfig(options: AstroConfigMinimal): void {
+  validateConfig(options);
+  if (!config) {
+    config = {} as any;
+  }
+  for (const [key, value] of Object.entries(options)) {
+    config![key as keyof AstroConfigMinimal] = value && typeof value === 'object' ? Object.assign({}, value) : value;
+  }
+}
+
+export function validateConfig(config: unknown) {
+  if (!config) {
+    throw new Error(`[Astro]: You must call \`setConfig(value)\` before rendering!`)
+  }
+  if (typeof config !== 'object') {
+    throw new Error(`[Astro]: \`config\` must be of type "object". Found typeof "${typeof config}"!`)
+  }
+}

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -1,0 +1,5 @@
+export type { AstroConfigMinimal } from './@types/config-minimal';
+export type { RenderResult } from './render';
+
+export { setConfig } from './config/index.js';
+export { render } from './render/index.js';

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -1,5 +1,5 @@
 export type { AstroConfigMinimal } from './@types/config-minimal';
 export type { RenderResult } from './render';
 
-export { setConfig } from './config/index.js';
+export { configure } from './config/index.js';
 export { render } from './render/index.js';

--- a/packages/render/src/internal/hydration-map.ts
+++ b/packages/render/src/internal/hydration-map.ts
@@ -1,0 +1,67 @@
+import { pathToFileURL } from 'url';
+
+interface ModuleInfo {
+  module: Record<string, any>,
+  specifier: string;
+}
+
+interface ComponentMetadata {
+  componentExport: string;
+  componentUrl: string
+}
+
+class HydrationMap {
+  public fileURL: URL;
+  private metadataCache: Map<any, ComponentMetadata | null>;
+  constructor(fileURL: string, public modules: ModuleInfo[], components: any[]) {
+    this.fileURL = pathToFileURL(fileURL);
+    this.metadataCache = new Map<any, ComponentMetadata | null>();
+  }
+
+  getPath(Component: any): string | null {
+    const metadata = this.getComponentMetadata(Component);
+    return metadata?.componentUrl || null;
+  }
+
+  getExport(Component: any): string | null {
+    const metadata = this.getComponentMetadata(Component);
+    return metadata?.componentExport || null;
+  }
+
+  private getComponentMetadata(Component: any): ComponentMetadata | null {
+    if(this.metadataCache.has(Component)) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return this.metadataCache.get(Component)!;
+    }
+    const metadata = this.findComponentMetadata(Component);
+    this.metadataCache.set(Component, metadata);
+    return metadata;
+  }
+
+  private findComponentMetadata(Component: any): ComponentMetadata | null {
+    const isCustomElement = typeof Component === 'string';
+    for (const { module, specifier }  of this.modules) {
+      const id = specifier.startsWith('.') ? new URL(specifier, this.fileURL).pathname : specifier;
+      for (const [key, value] of Object.entries(module)) {
+        if(isCustomElement) {
+          if (key === 'tagName' && Component === value) {
+            return {
+              componentExport: key,
+              componentUrl: id
+            };
+          }
+        } else if(Component === value) {
+          return {
+            componentExport: key,
+            componentUrl: id
+          };
+        }
+      }
+    }
+    return null;
+  }
+}
+
+export function createHydrationMap(fileURL: string, modules: ModuleInfo[], components: any[]) {
+  return new HydrationMap(fileURL, modules, components);
+}

--- a/packages/render/src/internal/index.ts
+++ b/packages/render/src/internal/index.ts
@@ -1,0 +1,290 @@
+import type { AstroComponentMetadata } from '../@types/astro';
+import type { SSRResult } from '../@types/ssr';
+import type { TopLevelAstro } from '../@types/astro-file';
+
+import { pathToFileURL } from 'url';
+import shorthash from 'shorthash';
+import serialize from 'serialize-javascript';
+import { renderToString, renderAstroComponent } from '../render/utils.js';
+
+export { createHydrationMap } from './hydration-map.js';
+
+async function _render(child: any): Promise<any> {
+  child = await child;
+  if (Array.isArray(child)) {
+    return (await Promise.all(child.map((value) => _render(value)))).join('\n');
+  } else if (typeof child === 'function') {
+    // Special: If a child is a function, call it automatically.
+    // This lets you do {() => ...} without the extra boilerplate
+    // of wrapping it in a function and calling it.
+    return _render(child());
+  } else if (typeof child === 'string') {
+    return child;
+  } else if (!child && child !== 0) {
+    // do nothing, safe to ignore falsey values.
+  } else if (child instanceof AstroComponent) {
+    return await renderAstroComponent(child);
+  } else {
+    return child;
+  }
+}
+
+export class AstroComponent {
+  private htmlParts: TemplateStringsArray;
+  private expressions: any[];
+
+  constructor(htmlParts: TemplateStringsArray, expressions: any[]) {
+    this.htmlParts = htmlParts;
+    this.expressions = expressions;
+  }
+
+  *[Symbol.iterator]() {
+    const { htmlParts, expressions } = this;
+
+    for (let i = 0; i < htmlParts.length; i++) {
+      const html = htmlParts[i];
+      const expression = expressions[i];
+
+      yield _render(html);
+      yield _render(expression);
+    }
+  }
+}
+
+export async function render(htmlParts: TemplateStringsArray, ...expressions: any[]) {
+  return new AstroComponent(htmlParts, expressions);
+}
+
+export interface AstroComponentFactory {
+  (result: any, props: any, slots: any): ReturnType<typeof render>;
+  isAstroComponentFactory?: boolean;
+}
+
+export function createComponent(cb: AstroComponentFactory) {
+  // Add a flag to this callback to mark it as an Astro component
+  (cb as any).isAstroComponentFactory = true;
+  return cb;
+}
+
+interface ExtractedHydration {
+  hydration: {
+    directive: string;
+    value: string;
+    componentUrl: string;
+    componentExport: { value: string };
+  } | null;
+  props: Record<string | number, any>;
+}
+
+function extractHydrationDirectives(inputProps: Record<string | number, any>): ExtractedHydration {
+  let extracted: ExtractedHydration = {
+    hydration: null,
+    props: {},
+  };
+  for (const [key, value] of Object.entries(inputProps)) {
+    if (key.startsWith('client:')) {
+      if (!extracted.hydration) {
+        extracted.hydration = {
+          directive: '',
+          value: '',
+          componentUrl: '',
+          componentExport: { value: '' },
+        };
+      }
+      switch (key) {
+        case 'client:component-path': {
+          extracted.hydration.componentUrl = value;
+          break;
+        }
+        case 'client:component-export': {
+          extracted.hydration.componentExport.value = value;
+          break;
+        }
+        default: {
+          extracted.hydration.directive = key.split(':')[1];
+          extracted.hydration.value = value;
+          break;
+        }
+      }
+    } else {
+      extracted.props[key] = value;
+    }
+  }
+  return extracted;
+}
+
+interface HydrateScriptOptions {
+  renderer: any;
+  astroId: string;
+  props: any;
+}
+
+/** For hydrated components, generate a <script type="module"> to load the component */
+async function generateHydrateScript(scriptOptions: HydrateScriptOptions, metadata: Required<AstroComponentMetadata>) {
+  const { renderer, astroId, props } = scriptOptions;
+  const { hydrate, componentUrl, componentExport } = metadata;
+
+  if (!componentExport) {
+    throw new Error(`Unable to resolve a componentExport for "${metadata.displayName}"! Please open an issue.`);
+  }
+
+  let hydrationSource = '';
+  if (renderer.hydrationPolyfills) {
+    hydrationSource += `await Promise.all([${renderer.hydrationPolyfills.map((src: string) => `\n  import("${src}")`).join(', ')}]);\n`;
+  }
+
+  hydrationSource += renderer.source
+    ? `const [{ ${componentExport.value}: Component }, { default: hydrate }] = await Promise.all([import("${componentUrl}"), import("${renderer.source}")]);
+  return (el, children) => hydrate(el)(Component, ${serialize(props)}, children);
+`
+    : `await import("${componentUrl}");
+  return () => {};
+`;
+
+  const hydrationScript = `<script type="module">
+import setup from 'astro/client/${hydrate}.js';
+setup("${astroId}", {${metadata.hydrateArgs ? `value: ${JSON.stringify(metadata.hydrateArgs)}` : ''}}, async () => {
+  ${hydrationSource}
+});
+</script>
+`;
+
+  return hydrationScript;
+}
+
+export async function renderSlot(result: any, slotted: string, fallback?: any) {
+  if (slotted) {
+    return _render(slotted);
+  }
+  return fallback;
+}
+
+export async function renderComponent(result: SSRResult, displayName: string, Component: unknown, _props: Record<string | number, any>, slots: any = {}) {
+  Component = await Component;
+  const children = await renderSlot(result, slots?.default);
+  const { renderers } = result._metadata;
+
+  if (Component && (Component as any).isAstroComponentFactory) {
+    const output = await renderToString(result, Component as any, _props, slots);
+    return output;
+  }
+
+  let metadata: AstroComponentMetadata = { displayName };
+
+  if (Component == null) {
+    throw new Error(`Unable to render ${metadata.displayName} because it is ${Component}!\nDid you forget to import the component or is it possible there is a typo?`);
+  }
+
+  const { hydration, props } = extractHydrationDirectives(_props);
+  let html = '';
+
+  if (hydration) {
+    metadata.hydrate = hydration.directive as AstroComponentMetadata['hydrate'];
+    metadata.hydrateArgs = hydration.value;
+    metadata.componentExport = hydration.componentExport;
+    metadata.componentUrl = hydration.componentUrl;
+  }
+
+  let renderer = null;
+  for (const r of renderers) {
+    if (await r.ssr.check(Component, props, children)) {
+      renderer = r;
+    }
+  }
+
+  if (renderer === null) {
+    if (typeof Component === 'string') {
+      html = await renderAstroComponent(await render`<${Component}${spreadAttributes(props)}>${children}</${Component}>`);
+    } else {
+      throw new Error(`Astro is unable to render ${metadata.displayName}!\nIs there a renderer to handle this type of component defined in your Astro config?`);
+    }
+  } else {
+    ({ html } = await renderer.ssr.renderToStaticMarkup(Component, props, children));
+  }
+
+  if (renderer?.polyfills?.length) {
+    let polyfillScripts = renderer.polyfills.map((src) => `<script type="module">import "${src}";</script>`).join('');
+    html = html + polyfillScripts;
+  }
+
+  if (!hydration) {
+    return html.replace(/\<\/?astro-fragment\>/g, '');
+  }
+
+  const astroId = shorthash.unique(html);
+
+  result.scripts.add(await generateHydrateScript({ renderer, astroId, props }, metadata as Required<AstroComponentMetadata>));
+
+  return `<astro-root uid="${astroId}">${html}</astro-root>`;
+}
+
+/** Create the Astro.fetchContent() runtime function. */
+function createFetchContentFn(url: URL) {
+  const fetchContent = (importMetaGlobResult: Record<string, any>) => {
+    let allEntries = [...Object.entries(importMetaGlobResult)];
+    if (allEntries.length === 0) {
+      throw new Error(`[${url.pathname}] Astro.fetchContent() no matches found.`);
+    }
+    return allEntries
+      .map(([spec, mod]) => {
+        // Only return Markdown files for now.
+        if (!mod.frontmatter) {
+          return;
+        }
+        const urlSpec = new URL(spec, url).pathname.replace(/[\\/\\\\]/, '/');
+        return {
+          content: mod.metadata,
+          metadata: mod.frontmatter,
+          file: new URL(spec, url),
+          url: urlSpec.includes('/pages/') && urlSpec.replace(/^.*\/pages\//, '/').replace(/\.md$/, ''),
+        };
+      })
+      .filter(Boolean);
+  };
+  return fetchContent;
+}
+
+export function createAstro(fileURLStr: string|URL, site: string): TopLevelAstro {
+  const url = fileURLStr instanceof URL ? fileURLStr : pathToFileURL(fileURLStr);
+  const fetchContent = createFetchContentFn(url) as unknown as TopLevelAstro['fetchContent'];
+  return {
+    // TODO I think this is no longer needed.
+    isPage: false,
+    site: new URL(site),
+    fetchContent,
+    resolve(...segments) {
+      return segments.reduce((u, segment) => new URL(segment, u), url).pathname;
+    },
+  };
+}
+
+export function addAttribute(value: any, key: string) {
+  if (value == null || value === false) {
+    return '';
+  }
+  return ` ${key}="${value}"`;
+}
+
+export function spreadAttributes(values: Record<any, any>) {
+  let output = '';
+  for (const [key, value] of Object.entries(values)) {
+    output += addAttribute(value, key);
+  }
+  return output;
+}
+
+export function defineStyleVars(astroId: string, vars: Record<any, any>) {
+  let output = '\n';
+  for (const [key, value] of Object.entries(vars)) {
+    output += `  --${key}: ${value};\n`;
+  }
+  return `.${astroId} {${output}}`;
+}
+
+export function defineScriptVars(vars: Record<any, any>) {
+  let output = '';
+  for (const [key, value] of Object.entries(vars)) {
+    output += `let ${key} = ${JSON.stringify(value)};\n`;
+  }
+  return output;
+}

--- a/packages/render/src/render/index.ts
+++ b/packages/render/src/render/index.ts
@@ -1,0 +1,25 @@
+import type { AstroComponentFactory } from '../internal'
+
+import { createResult, renderToString, AstroElement } from './utils.js';
+import { config, validateConfig } from '../config/index.js';
+
+export interface RenderResult {
+  html: { code: string };
+  css: AstroElement[];
+  js: AstroElement[];
+}
+
+export async function render(Component: AstroComponentFactory, props: Record<string, any>): Promise<RenderResult> {
+  validateConfig(config);
+  const result = createResult(config!)
+  const template = await renderToString(result, Component, props);
+  const styles = Array.from(result.styles).map(({ props, children }: any) => new AstroElement('style', props, children));
+  const scripts = Array.from(result.scripts).map(({ props, children }: any) => new AstroElement('script', props, children));
+  const html = template.replace('</head>', styles.join('\n') + scripts.join('\n') + '</head>');
+
+  return {
+    html: { code: html },
+    css: styles,
+    js: scripts,
+  };
+}

--- a/packages/render/src/render/index.ts
+++ b/packages/render/src/render/index.ts
@@ -1,7 +1,7 @@
 import type { AstroComponentFactory } from '../internal'
 
 import { createResult, renderToString, AstroElement } from './utils.js';
-import { config, validateConfig } from '../config/index.js';
+import { config } from '../config/index.js';
 
 export interface RenderResult {
   html: { code: string };
@@ -9,9 +9,8 @@ export interface RenderResult {
   js: AstroElement[];
 }
 
-export async function render(Component: AstroComponentFactory, props: Record<string, any>): Promise<RenderResult> {
-  validateConfig(config);
-  const result = createResult(config!)
+export async function render(Component: AstroComponentFactory, props: Record<string, any>, req: { url: string }): Promise<RenderResult> {
+  const result = createResult(config!, req);
   const template = await renderToString(result, Component, props);
   const styles = Array.from(result.styles).map(({ props, children }: any) => new AstroElement('style', props, children));
   const scripts = Array.from(result.scripts).map(({ props, children }: any) => new AstroElement('script', props, children));

--- a/packages/render/src/render/utils.ts
+++ b/packages/render/src/render/utils.ts
@@ -1,0 +1,99 @@
+import type { TopLevelAstro, Astro as AstroGlobal } from '../@types/astro-file'
+import type { SSRResult } from '../@types/ssr';
+import type { Renderer } from '../@types/astro';
+import type { AstroConfigMinimal } from '../@types/config-minimal'
+import type { AstroComponentFactory, AstroComponent } from '../internal';
+
+import { defineStyleVars, defineScriptVars, spreadAttributes } from '../internal';
+
+export interface CreateResultOptions {
+  /** production website, needed for some RSS & Sitemap functions */
+  origin: string;
+  /** the web request (needed for dynamic routes) */
+  pathname: string;
+  renderers?: Renderer[];
+}
+
+export function createResult({ origin, pathname = '/', renderers = [] }: AstroConfigMinimal): SSRResult {
+  const result: SSRResult = {
+      styles: new Set(),
+      scripts: new Set(),
+      /** This function returns the `Astro` faux-global */
+      createAstro(astroGlobal: TopLevelAstro, props: Record<string, any>, slots: Record<string, any> | null) {
+        const site = new URL(origin);
+        const url = new URL('.' + pathname, site);
+        const canonicalURL = getCanonicalURL('.' + pathname, origin);
+
+        return {
+          __proto__: astroGlobal,
+          props,
+          request: {
+            canonicalURL,
+            params: {},
+            url,
+          },
+          slots: Object.fromEntries(Object.entries(slots || {}).map(([slotName]) => [slotName, true])),
+        } as unknown as AstroGlobal;
+      },
+      _metadata: { renderers },
+    };
+    return result;
+}
+
+// Polyfill `path.extname` for non-Node environments
+function extname(path: string) {
+  const tmp = /(\.[^.\/]*|)(?:[\/]*)$/.exec(path) || [path, ''];
+  return tmp.slice(1)[0];
+}
+
+/** Normalize URL to its canonical form */
+function getCanonicalURL(url: string, base?: string): URL {
+  let pathname = url.replace(/\/index.html$/, ''); // index.html is not canonical
+  pathname = pathname.replace(/\/1\/?$/, ''); // neither is a trailing /1/ (impl. detail of collections)
+  if (!extname(pathname)) pathname = pathname.replace(/(\/+)?$/, '/'); // add trailing slash if there’s no extension
+  pathname = pathname.replace(/\/+/g, '/'); // remove duplicate slashes (URL() won’t)
+  return new URL(pathname, base);
+}
+
+export class AstroElement {
+  private attributes: Record<string|number, any>;
+  private code: string;
+
+  constructor(private name: string, _props: Record<string|number, any>, children: string = '') {
+    const { hoist: _, 'define:vars': defineVars, ...props } = _props;
+    this.attributes = props;
+
+    if (defineVars) {
+      if (name === 'style') {
+        children = defineStyleVars(props['data-astro-id'], defineVars) + '\n' + children;
+      }
+      if (name === 'script') {
+        children = defineScriptVars(defineVars) + '\n' + children;
+      }
+    }
+
+    this.code = children;
+  }
+
+  toString() {
+    return `<${this.name}${spreadAttributes(this.attributes)}>${this.code}</${this.name}>`
+  }
+}
+
+export async function renderAstroComponent(component: InstanceType<typeof AstroComponent>) {
+  let template = '';
+
+  for await (const value of component) {
+    if (value || value === 0) {
+      template += value;
+    }
+  }
+
+  return template;
+}
+
+export async function renderToString(result: SSRResult, componentFactory: AstroComponentFactory, props: Record<string|number, any>, slots: Record<string, AstroComponentFactory>|null = null) {
+  const Component = await componentFactory(result, props, slots);
+  let template = await renderAstroComponent(Component);
+  return template;
+}

--- a/packages/render/tsconfig.json
+++ b/packages/render/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src", "src/@types"],
+  "compilerOptions": {
+    "allowJs": true,
+    "target": "ES2019",
+    "module": "ES2020",
+    "outDir": "./dist"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1991,6 +1991,11 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
+"@types/serialize-javascript@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/serialize-javascript/-/serialize-javascript-5.0.1.tgz#2c32e0626734a02a83b94cb924699c4bdcb6fd94"
+  integrity sha512-QqgTcm7IgIt/oWNFQMlpVv5Z3saYtxWK9yFrAUkk3jxvjbqIG835xNNoOYq12mXKQMuWGc+PgOXwXy92eax5BA==
+
 "@types/trusted-types@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
@@ -9644,7 +9649,7 @@ send@^0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@6.0.0:
+serialize-javascript@6.0.0, serialize-javascript@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
   integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==


### PR DESCRIPTION
## Changes

This PR is meant to kick off a discussion!

Currently, rendering an Astro component requires quite a bit of knowledge about Astro's internals. The goal of this new `@astrojs/render` package would be to provide a straightforward interface for rendering Astro components in server environments. 

```
import { render } from '@astrojs/render';
// precompiled Astro file
import Component from '../pages/index.astro.js';

const { html, css, js } = await render(Component, { /* props */ }, { url: '/index' })
```

**Non-goals**
- Compilation. Instead, use `@astrojs/compiler` and run through a build pipeline.
- Loading. This part is up to you... write to disk or use `import()` with a base-64 encoded URL.

**Todo**
- Migrate `astro` rendering logic to use `@astrojs/render`

## Testing

I should add tests.

## Docs

TBD.