### PR TITLE
Fix mismatched props in `www`

### DIFF
--- a/www/src/components/Note.astro
+++ b/www/src/components/Note.astro
@@ -1,6 +1,6 @@
 ---
 export interface Props {
-  title: string;
+  title?: string;
   type?: 'tip' | 'warning' | 'error'
 }
 const { type = 'tip', title } = Astro.props;

--- a/www/src/pages/blog/astro-repl.astro
+++ b/www/src/pages/blog/astro-repl.astro
@@ -13,7 +13,7 @@ let lang = 'en';
 
 <html lang={ lang ?? 'en' }>
   <head>
-    <BaseHead title={title} description={description} permalink={permalink} image="https://astro.build/assets/blog/astro-repl/astro-repl-social.jpg" />
+    <BaseHead title={title} description={description} canonicalURL={permalink} image="https://astro.build/assets/blog/astro-repl/astro-repl-social.jpg" />
     <link rel="stylesheet" href={Astro.resolve('../../scss/blog.css')} />
   </head>
 

--- a/www/src/pages/blog/index.astro
+++ b/www/src/pages/blog/index.astro
@@ -11,7 +11,7 @@ let lang = 'en';
 
 <html lang={ lang ?? 'en' }>
   <head>
-    <BaseHead title={title} description={description} permalink={permalink} />
+    <BaseHead title={title} description={description} canonicalURL={permalink} />
     <link rel="stylesheet" href={Astro.resolve('../../scss/blog.css')} />
 
     <style>

--- a/www/src/pages/blog/introducing-astro.astro
+++ b/www/src/pages/blog/introducing-astro.astro
@@ -18,7 +18,7 @@ let lang = 'en';
 
 <html lang={ lang ?? 'en' }>
   <head>
-    <BaseHead title={title} description={description} permalink={permalink} />
+    <BaseHead title={title} description={description} canonicalURL={permalink} />
     <link rel="stylesheet" href={Astro.resolve('../../scss/blog.css')} />
   </head>
 


### PR DESCRIPTION
## Changes

- Makes some fixes for Prop mismatches detected by running `astro check` over `www`.
- `docs` passed with flying colors!
- There's also a few lints that exist that are b/c `astro check` was running over embedded code snippets, so there might be an update needed there: https://discord.com/channels/830184174198718474/878341752799494154/899102272326365204

![image](https://user-images.githubusercontent.com/10626596/137606578-3938194b-d51f-49ee-a35b-34dd5d096206.png)


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
