### PR TITLE
Add label to language selection in docs

### DIFF
--- a/docs/src/components/Header/LanguageSelect.tsx
+++ b/docs/src/components/Header/LanguageSelect.tsx
@@ -26,6 +26,7 @@ const LanguageSelect: FunctionalComponent<{ lang: string }> = ({ lang }) => {
       <select
         class="language-select"
         value={lang}
+        aria-label="Select language"
         onChange={(e) => {
           const newLang = e.target.value;
           if (newLang === 'en') {


### PR DESCRIPTION
## Changes

- Made language selection menu in docs accessible to people using screen readers by adding a label to it.

## Testing

None because no core code was changed.

## Docs

See changes.
