### PR TITLE
Add two missing blog posts to blog index

### DIFF
--- a/www/src/pages/blog/index.astro
+++ b/www/src/pages/blog/index.astro
@@ -75,6 +75,14 @@ let lang = 'en';
             <span>Astro September Demo Day was today and we had 4 amazing talks, including one with big announcements on the future direction of Astro.</span>
           </BlogPostPreview>
 
+          <BlogPostPreview title="Introducing the Astro REPL" publishDate="September 17, 2021" href="/blog/astro-repl">
+            <span>The power of Astro, right in your browser.</span>
+          </BlogPostPreview>
+
+          <BlogPostPreview title="Netlify Becomes Astro's Official Hosting Partner" publishDate="September 9, 2021" href="/blog/netlify-astro-hosting-sponsorship">
+            <span>We are happy to announce that Netlify has become Astro’s first corporate sponsor and exclusive hosting partner, donating $2,500 each month towards the ongoing open source maintenance and development of Astro.</span>
+          </BlogPostPreview>
+
           <BlogPostPreview title="Astro 0.19" publishDate="Wednesday, August 18 2021" href="/blog/astro-019">
             <span>Introducing: Next.js-inspired file routing • Astro.resolve() • client:only components • translations.</span>
           </BlogPostPreview>


### PR DESCRIPTION
## Changes

- Two missing blog posts about Astro's repl and Astro's Netlify sponsorship have been added to the blog index

## Testing

None because no core code was changed.

## Docs

None because no public APIs were changed.
