### PR TITLE
Fix sponsors title contrast

### DIFF
--- a/docs/src/components/LeftSidebar/LeftSidebar.astro
+++ b/docs/src/components/LeftSidebar/LeftSidebar.astro
@@ -141,9 +141,11 @@ const sidebarSections = SIDEBAR[langCode].reduce((col, item) => {
   .sponsor-logo__vercel {
     width: 90px;
   }
-
-  .sponsors-title {
+  :global(:root.theme-dark .sponsors-title) {
     color: hsl(var(--color-base-gray), 75%);
+  }
+  .sponsors-title {
+    color: hsl(var(--color-base-gray), 25%);
     font-size: 0.8em;
     font-weight: 300;
     letter-spacing: 0.0625em;


### PR DESCRIPTION
## Changes

- Small change to the opacity of the sponsors text, making it pass accessibility standards.

## Testing

None because no core code was changed.

## Docs

See changes
