### PR TITLE
Fix declaration of `html` var in `Code.astro`

### DIFF
--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -45,6 +45,6 @@ function repairShikiTheme(html: string): string {
 
 const highlighter = await shiki.getHighlighter({theme});
 const _html = highlighter.codeToHtml(code, lang);
-html = repairShikiTheme(_html);
+const html = repairShikiTheme(_html);
 ---
 {html}


### PR DESCRIPTION


## Changes

- Adds a `const` in front of an undeclared variable. I'm not exactly sure why this worked before... 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
