### PR TITLE
[next] Add `fragment` support for Components

### DIFF
--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -22,6 +22,11 @@ export const AstroConfigSchema = z.object({
     .optional()
     .default('./src/pages')
     .transform((val) => new URL(val)),
+  layouts: z
+    .string()
+    .optional()
+    .default('./src/layouts')
+    .transform((val) => new URL(val)),
   public: z
     .string()
     .optional()
@@ -86,6 +91,10 @@ export async function validateConfig(userConfig: any, root: string): Promise<Ast
     pages: z
       .string()
       .default('./src/pages')
+      .transform((val) => new URL(addTrailingSlash(val), fileProtocolRoot)),
+    layouts: z
+      .string()
+      .default('./src/layouts')
       .transform((val) => new URL(addTrailingSlash(val), fileProtocolRoot)),
     public: z
       .string()


### PR DESCRIPTION
## Changes

- Uses the `as` mode in the compiler to switch between `document` (pages, layouts) and `fragment` (components that are anywhere else) mode

## Testing

Manually, no tests added but would be good to add some

## Docs

Should document the addition of `layouts` to the config. These are special page-level components that should be considered full documents, but aren't used in the File System routing.