### PR TITLE
Bugfix: fix getStaticPaths() cache miss

### DIFF
--- a/packages/astro/test/astro-get-static-paths.test.js
+++ b/packages/astro/test/astro-get-static-paths.test.js
@@ -1,7 +1,5 @@
-/**
- * UNCOMMENT: fix "Error: can only be called once!"
 import { expect } from 'chai';
-import { loadFixture } from './test-utils';
+import { loadFixture } from './test-utils.js';
 
 let fixture;
 
@@ -22,6 +20,3 @@ describe('getStaticPaths()', () => {
     expect(true).to.equal(true);
   });
 });
-*/
-
-it.skip('is skipped', () => {});

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/[...test].astro
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/[...test].astro
@@ -1,5 +1,5 @@
 ---
-export function getStaticPaths({paginate}) {
+export function getStaticPaths({ paginate }) {
   if (globalThis.isCalledOnce) {
     throw new Error("Can only be called once!");
   }
@@ -10,7 +10,7 @@ export function getStaticPaths({paginate}) {
     {params: {test: 'c'}},
   ];
 }
-const { params} = Astro.request;
+const { params } = Astro.request;
 ---
 
 <html>


### PR DESCRIPTION
## Changes

Re-enables `getStaticPaths()` test and fixes a bug where a cache hit is missed.

## Testing

Tests should pass

## Docs
No docs needed.