### PR TITLE
Docs: fix typo on pagination page

### DIFF
--- a/docs/src/pages/guides/pagination.md
+++ b/docs/src/pages/guides/pagination.md
@@ -60,7 +60,7 @@ const { page } = Astro.props;
 ---
 <h1>Page {page.currentPage}</h1>
 <ul>
-  {page.data.map(item => <li>{item.title}</h1>)}
+  {page.data.map(item => <li>{item.title}</li>)}
 </ul>
 ```
 


### PR DESCRIPTION
## Changes

- Change `</h1>` to `</li>` on example using `page` props 

## Testing

It's only a documentation change.

## Docs

It's only a documentation change.