### PR TITLE
Fix `installation` link

### DIFF
--- a/docs/src/pages/quick-start.md
+++ b/docs/src/pages/quick-start.md
@@ -24,7 +24,7 @@ npm run dev
 npm run build
 ```
 
-To learn more about installing and using Astro for the first time, please [read our installation guide.](installation)
+To learn more about installing and using Astro for the first time, please [read our installation guide.](/installation)
 
 If you prefer to learn by example, check out our [complete library of examples](https://github.com/snowpackjs/astro/tree/main/examples) on GitHub. You can check out any of these examples locally by running `npm init astro -- --template "EXAMPLE_NAME"`.
 


### PR DESCRIPTION
From: `https://docs.astro.build/quick-start/installation`
To: `https://docs.astro.build/installation`

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
