### PR TITLE
More comment style changes

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,7 +12,6 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/no-var-requires': 'off',
-    'multiline-comment-style': ['warn', 'starred-block'],
     'no-console': 'warn',
     'no-shadow': 'error',
     'prefer-const': 'off',

--- a/packages/astro/src/@types/astro-core.ts
+++ b/packages/astro/src/@types/astro-core.ts
@@ -106,6 +106,7 @@ export interface AstroUserConfig {
  * export interface AstroUserConfig extends z.input<typeof AstroConfigSchema> {
  * }
  */
+
 export type AstroConfig = z.output<typeof AstroConfigSchema>;
 
 export type AsyncRendererComponentFn<U> = (Component: any, props: any, children: string | undefined, metadata?: AstroComponentMetadata) => Promise<U>;

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -72,10 +72,8 @@ export const AstroConfigSchema = z.object({
 /** Turn raw config values into normalized values */
 export async function validateConfig(userConfig: any, root: string): Promise<AstroConfig> {
   const fileProtocolRoot = pathToFileURL(root + path.sep);
-  /*
-   * We need to extend the global schema to add transforms that are relative to root.
-   * This is type checked against the global schema to make sure we still match.
-   */
+  // We need to extend the global schema to add transforms that are relative to root.
+  // This is type checked against the global schema to make sure we still match.
   const AstroConfigRelativeSchema = AstroConfigSchema.extend({
     projectRoot: z
       .string()

--- a/packages/astro/src/core/logger.ts
+++ b/packages/astro/src/core/logger.ts
@@ -13,10 +13,8 @@ function getLoggerLocale(): string {
   const defaultLocale = 'en-US';
   if (process.env.LANG) {
     const extractedLocale = process.env.LANG.split('.')[0].replace(/_/g, '-');
-    /*
-     * Check if language code is at least two characters long (ie. en, es).
-     * NOTE: if "c" locale is encountered, the default locale will be returned.
-     */
+    // Check if language code is atleast two characters long (ie. en, es).
+    // NOTE: if "c" locale is encountered, the default locale will be returned.
     if (extractedLocale.length < 2) return defaultLocale;
     else return extractedLocale;
   } else return defaultLocale;

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -49,22 +49,18 @@ export function parseNpmName(spec: string): { scope?: string; name: string; subp
 /** generate code frame from esbuild error */
 export function codeFrame(src: string, loc: ErrorPayload['err']['loc']): string {
   if (!loc) return '';
-
   const lines = src.replace(/\r\n/g, '\n').split('\n');
-
   // grab 2 lines before, and 3 lines after focused line
   const visibleLines = [];
   for (let n = -2; n <= 2; n++) {
     if (lines[loc.line + n]) visibleLines.push(loc.line + n);
   }
-
   // figure out gutter width
   let gutterWidth = 0;
   for (const lineNo of visibleLines) {
     let w = `> ${lineNo}`;
     if (w.length > gutterWidth) gutterWidth = w.length;
   }
-
   // print lines
   let output = '';
   for (const lineNo of visibleLines) {

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -10,18 +10,14 @@ export { createMetadata } from './metadata.js';
 
 const { generate, GENERATOR } = astring;
 
-/*
- * A more robust version alternative to `JSON.stringify` that can handle most values
- * See https://github.com/remcohaszing/estree-util-value-to-estree#readme
- */
+// A more robust version alternative to `JSON.stringify` that can handle most values
+// see https://github.com/remcohaszing/estree-util-value-to-estree#readme
 const customGenerator: astring.Generator = {
   ...GENERATOR,
   Literal(node, state) {
     if (node.raw != null) {
-      /*
-       * escape closing script tags in strings so browsers wouldn't interpret them as
-       * closing the actual end tag in HTML
-       */
+      // escape closing script tags in strings so browsers wouldn't interpret them as
+      // closing the actual end tag in HTML
       state.write(node.raw.replace('</script>', '<\\/script>'));
     } else {
       GENERATOR.Literal(node, state);
@@ -39,11 +35,9 @@ async function _render(child: any): Promise<any> {
   if (Array.isArray(child)) {
     return (await Promise.all(child.map((value) => _render(value)))).join('\n');
   } else if (typeof child === 'function') {
-    /*
-     * Special: If a child is a function, call it automatically.
-     * This lets you do {() => ...} without the extra boilerplate
-     * of wrapping it in a function and calling it.
-     */
+    // Special: If a child is a function, call it automatically.
+    // This lets you do {() => ...} without the extra boilerplate
+    // of wrapping it in a function and calling it.
     return _render(child());
   } else if (typeof child === 'string') {
     return child;
@@ -267,7 +261,7 @@ function createFetchContentFn(url: URL) {
           ...mod.frontmatter,
           content: mod.metadata,
           file: new URL(spec, url),
-          url: urlSpec.includes('/pages/') && urlSpec.replace(/^.*\/pages\//, '/').replace(/\.md$/, ''),
+          url: urlSpec.includes('/pages/') && urlSpec.replace(/^.*\/pages\//, '/').replace(/\.md$/, '')
         };
       })
       .filter(Boolean);

--- a/packages/astro/src/vite-plugin-astro-postprocess/index.ts
+++ b/packages/astro/src/vite-plugin-astro-postprocess/index.ts
@@ -11,7 +11,7 @@ interface AstroPluginOptions {
   devServer?: AstroDevServer;
 }
 
-// esbuild transforms the component-scoped Astro into Astro2, so need to check both.
+// esbuild transforms the component-scoped Astro into Astro2, so need to check both. 
 const validAstroGlobalNames = new Set(['Astro', 'Astro2']);
 
 export default function astro({ config, devServer }: AstroPluginOptions): Plugin {
@@ -23,10 +23,8 @@ export default function astro({ config, devServer }: AstroPluginOptions): Plugin
         return null;
       }
 
-      /*
-       * Optimization: only run on a probably match
-       * Open this up if need for post-pass extends past fetchContent
-       */
+      // Optimization: only run on a probably match
+      // Open this up if need for post-pass extends past fetchContent
       if (!code.includes('fetchContent')) {
         return null;
       }

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -28,14 +28,16 @@ export default function astro({ config, devServer }: AstroPluginOptions): Plugin
       let tsResult: TransformResult | undefined;
 
       try {
-        // `.astro` -> `.ts`
+        // Transform from `.astro` to valid `.ts`
+        // use `sourcemap: "both"` so that sourcemap is included in the code
+        // result passed to esbuild, but also available in the catch handler.
         tsResult = await transform(source, {
           site: config.buildOptions.site,
           sourcefile: id,
           sourcemap: 'both',
           internalURL: 'astro/internal',
         });
-        // `.ts` -> `.js`
+        // Compile `.ts` to `.js`
         const { code, map } = await esbuild.transform(tsResult.code, { loader: 'ts', sourcemap: 'external', sourcefile: id });
 
         return {

--- a/packages/astro/src/vite-plugin-fetch/index.ts
+++ b/packages/astro/src/vite-plugin-fetch/index.ts
@@ -15,10 +15,8 @@ function isSSR(options: undefined | boolean | { ssr: boolean }): boolean {
   return false;
 }
 
-/*
- * This matches any JS-like file (that we know of)
- * See https://regex101.com/r/Cgofir/1
- */
+// This matches any JS-like file (that we know of)
+// See https://regex101.com/r/Cgofir/1
 const SUPPORTED_FILES = /\.(astro|svelte|vue|[cm]?js|jsx|[cm]?ts|tsx)$/;
 const DEFINE_FETCH = `import fetch from 'node-fetch';\n`;
 
@@ -28,17 +26,14 @@ export default function pluginFetch(): Plugin {
     enforce: 'post',
     async transform(code, id, opts) {
       const ssr = isSSR(opts);
-
       // If this isn't an SSR pass, `fetch` will already be available!
       if (!ssr) {
         return null;
       }
-
       // Only transform JS-like files
       if (!id.match(SUPPORTED_FILES)) {
         return null;
       }
-
       // Optimization: only run on probable matches
       if (!code.includes('fetch')) {
         return null;
@@ -46,14 +41,11 @@ export default function pluginFetch(): Plugin {
 
       const s = new MagicString(code);
       s.prepend(DEFINE_FETCH);
-
       const result = s.toString();
-
       const map = s.generateMap({
         source: id,
         includeContent: true,
       });
-
       return { code: result, map };
     },
   };

--- a/packages/astro/src/vite-plugin-jsx/index.ts
+++ b/packages/astro/src/vite-plugin-jsx/index.ts
@@ -18,10 +18,8 @@ const IMPORT_STATEMENTS: Record<string, string> = {
   preact: "import { h } from 'preact'",
   'solid-js': "import 'solid-js/web'",
 };
-/*
- * The `tsx` loader in esbuild will remove unused imports, so we need to
- * be careful about esbuild not treating h, React, Fragment, etc. as unused.
- */
+// The `tsx` loader in esbuild will remove unused imports, so we need to
+// be careful about esbuild not treating h, React, Fragment, etc. as unused.
 const PREVENT_UNUSED_IMPORTS = ';;(React,Fragment,h);';
 
 interface AstroPluginJSXOptions {
@@ -55,23 +53,15 @@ export default function jsx({ config, logging }: AstroPluginJSXOptions): Plugin 
         }
       }
 
-      /*
-       * Single JSX renderer
-       * If we only have one renderer, we can skip a bunch of work!
-       */
+      // Attempt: Single JSX renderer 
+      // If we only have one renderer, we can skip a bunch of work!
       if (JSX_RENDERERS.size === 1) {
         return transformJSX({ code, id, renderer: [...JSX_RENDERERS.values()][0], ssr: ssr || false });
       }
 
-      /*
-       * Multiple JSX renderers
-       * Determine for each .jsx or .tsx file what it wants to use to Render
-       */
-
+      // Attempt: Multiple JSX renderers
+      // Determine for each .jsx or .tsx file what it wants to use to Render
       // we need valid JS here, so we can use `h` and `Fragment` as placeholders
-
-      // try and guess renderer from imports (file can’t import React and Preact)
-
       // NOTE(fks, matthewp): Make sure that you're transforming the original contents here.
       const { code: codeToScan } = await esbuild.transform(code + PREVENT_UNUSED_IMPORTS, {
         loader: getLoader(path.extname(id)),

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -20,7 +20,7 @@ export default function markdown({ config }: AstroPluginOptions): Plugin {
       if (id.endsWith('.md')) {
         let source = await fs.promises.readFile(id, 'utf8');
 
-        // `.md` -> `.astro`
+        // Transform from `.md` to valid `.astro`
         let render = config.markdownOptions.render;
         let renderOpts = {};
         if (Array.isArray(render)) {
@@ -46,14 +46,14 @@ ${setup}
           astroResult = `${prelude}\n${astroResult}`;
         }
 
-        // `.astro` -> `.ts`
+        // Transform from `.astro` to valid `.ts`
         let { code: tsResult } = await transform(astroResult, { sourcefile: id, sourcemap: 'inline', internalURL: 'astro/internal' });
 
         tsResult = `\nexport const metadata = ${JSON.stringify(metadata)};
 export const frontmatter = ${JSON.stringify(content)};
 ${tsResult}`;
 
-        // `.ts` -> `.js`
+        // Compile from `.ts` to `.js`
         const { code, map } = await esbuild.transform(tsResult, { loader: 'ts', sourcemap: 'inline', sourcefile: id });
 
         return {


### PR DESCRIPTION
## Changes

Builds on #1611 

I tried my best to be really objective and rule based around these changes. This PR could best be summarized as following the following rules when it comes to comments: 

#### 1. Comments exist to add new context. Remove redundant comments.
This PR removes all comments that re-state what the code already stated. Yes, even JSDoc! I find that this is a really useful rule to follow, especially you're working across larger teams, because getting at the heart of "what does a good comment look like?" is really about answering "why does a comment exist in the first place?". I'd love for us to adopt this rule across Astro!

Example:
```diff
- // Create the timer object.
const timer = {};
- // Create the vite server.
const viteServer = createViteServer(...

class AstroBuilder {
- /** Build all pages */
  async build() { ... }
}
```

#### 2. Revert move from `//` to `/*`

I have no problem with multiline `//`! In fact, I find the switching between `//` and `/*` to be a bit jarring as I read some code. Not a major issue, but since this wasn't really in the scope of the "remove numbering" convo and was merged without convo, I hope no one minds me reverting this new lint rule that was added. @drwpow happy to have a convo about this specifically if you want to see this in the codebase!
 

#### 3. No numbered comments

@drwpow already did the hard work on this one in #1611, but just reiterating that all of this came about because I wanted to remove numbered comments from the codebase!