### PR TITLE
Add test react component children attribute

### DIFF
--- a/packages/astro/test/fixtures/astro-components/src/components/Component.astro
+++ b/packages/astro/test/fixtures/astro-components/src/components/Component.astro
@@ -5,7 +5,7 @@ import SvelteComponent from './Component.svelte';
 ---
 
 <div id="astro">
-  <ReactComponent />
+  <ReactComponent children="ReactComponent"/>
   <VueComponent />
   <SvelteComponent />
 </div>


### PR DESCRIPTION
## Changes
`ReactComponent` add a `children` attribute. If missing,  this will have a error and show the tip like below
`Property 'children' is missing in type '{}' but required in type '{ children: any; }'`.

## Testing
None because no core code was changed.
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
None.
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
