### PR TITLE
Add meta name="viewport" to portfolio example

### DIFF
--- a/examples/portfolio/src/components/MainHead.astro
+++ b/examples/portfolio/src/components/MainHead.astro
@@ -3,6 +3,7 @@ const { title = 'Jeanine White: Personal Site' } = Astro.props;
 ---
 
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width">
 <title>{title}</title>
 
 <link rel="icon" type="image/x-icon" href="/favicon.ico" />


### PR DESCRIPTION
## Changes

- Adds a `meta name="viewport"` tag to the portfolio example. which optimizes the experience for mobile devices and increases the Lighthouse SEO score by 23.

## Testing

None because only examples were changed.

## Docs

None because only examples were changed.
