### PR TITLE
[next] Fix `define:vars` style scoping

### DIFF
--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -339,7 +339,7 @@ export function defineStyleVars(astroId: string, vars: Record<any, any>) {
   for (const [key, value] of Object.entries(vars)) {
     output += `  --${key}: ${value};\n`;
   }
-  return `.${astroId} {${output}}`;
+  return `.astro-${astroId} {${output}}`;
 }
 
 export function defineScriptVars(vars: Record<any, any>) {


### PR DESCRIPTION
## Changes

- Small bugfix for `define:vars` in styles

## Testing

Manually

## Docs

Bug fix only
