### PR TITLE
Update util.ts

### DIFF
--- a/packages/astro/src/build/util.ts
+++ b/packages/astro/src/build/util.ts
@@ -17,11 +17,7 @@ export function canonicalURL(url: string, base?: string): URL {
   pathname = pathname.replace(/\/1\/?$/, ''); // neither is a trailing /1/ (impl. detail of collections)
   if (!path.extname(pathname)) pathname = pathname.replace(/(\/+)?$/, '/'); // add trailing slash if there’s no extension
   pathname = pathname.replace(/\/+/g, '/'); // remove duplicate slashes (URL() won’t)
-  if (base) {
-    return new URL('.' + pathname, base);
-  } else {
-    return new URL(pathname, base);
-  }
+  return new URL(pathname, base);
 }
 
 /** Resolve final output URL */


### PR DESCRIPTION
## Changes

Fixed a bug that was adding `.` between the site URL and pathname. For example, instead of `https://domain.tld/pathname`, it was outputting `https://domain.tld/.pathname`

## Testing

## Docs
