### PR TITLE
Fixes external HMR

### DIFF
--- a/packages/astro/vendor/vite/dist/node/chunks/dep-35df7f96.js
+++ b/packages/astro/vendor/vite/dist/node/chunks/dep-35df7f96.js
@@ -67628,7 +67628,9 @@ function clientInjectionsPlugin(config) {
     return {
         name: 'vite:client-inject',
         transform(code, id) {
-            if (id === normalizedClientEntry || id === normalizedEnvEntry) {
+            if (id === normalizedClientEntry || id === normalizedEnvEntry ||
+             // Note that this is only needed for the Astro fork.
+             id.includes('astro_runtime_client_hmr')) {
                 let options = config.server.hmr;
                 options = options && typeof options !== 'boolean' ? options : {};
                 const host = options.host || null;


### PR DESCRIPTION
## Changes

- Hacks Vite fork so that it transforms our own HMR client.
- This is not ideal but I couldn't find any other way.
- Luckily it goes away once we unfork Vite.

## Testing

Nope

## Docs

N/A
