### PR TITLE
[next] Update compiler

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -52,7 +52,7 @@
     "test": "mocha --parallel --timeout 15000"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.2.18",
+    "@astrojs/compiler": "^0.2.19",
     "@astrojs/language-server": "^0.7.16",
     "@astrojs/markdown-remark": "^0.3.1",
     "@astrojs/markdown-support": "0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,10 +106,10 @@
     "@algolia/logger-common" "4.10.5"
     "@algolia/requester-common" "4.10.5"
 
-"@astrojs/compiler@^0.2.18":
-  version "0.2.18"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-0.2.18.tgz#d274f10506eca194802bde49950f7ed26677e80a"
-  integrity sha512-CQQnzni/3cy1yNWKHllg1xWAbnKnjJ8JSctv/jElS9XmbcZmWgesauAf06rxZ1/CzJ7haaFcLZSivynPXNYSrw==
+"@astrojs/compiler@^0.2.19":
+  version "0.2.19"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-0.2.19.tgz#ba431ea34d94733fe9dd36469f25b788786db263"
+  integrity sha512-GRSZcsYpeXdXmdI/VwiQMuvvc6cBIjT6jIh2OQblC9ce4vQXCtJF+k/ACc74P400S0aS91JoiT4u+qMtzrZUuw==
   dependencies:
     typescript "^4.3.5"
 


### PR DESCRIPTION
## Changes

- Updates `@astrojs/compiler` to [v0.2.19](https://github.com/snowpackjs/astro-compiler-next/blob/main/lib/compiler/CHANGELOG.md#0219).

## Testing

Manual

## Docs

N/A, chore