### PR TITLE
[next] Fix `resolveDependency` on Windows

### DIFF
--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -79,5 +79,6 @@ export function resolveDependency(dep: string, astroConfig: AstroConfig) {
   const resolved = resolve.sync(dep, {
     basedir: fileURLToPath(astroConfig.projectRoot)
   });
+  // For Windows compat, we need a fully resolved `file://` URL string
   return pathToFileURL(resolved).toString();
 }


### PR DESCRIPTION
## Changes

**Reported on Discord**
> error trying to run 0.0.0-compiler-20219270206 (both astro & renderer-react) on Windows:
> ```
> Error: @astrojs/renderer-react: Error 
> [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only file and data URLs are 
> supported by the default ESM loader. On Windows, absolute
> paths must be valid file:// URLs.
> Received protocol 'c:'
> ```

- Fixed this by using `pathToFileURL()` inside of `resolveDependency`
 

## Testing

Not tested, but I'm confused as to why our existing tests didn't catch this!

## Docs

Bug fix only