### PR TITLE
Bugfix: renderer-lit missing files on npm

### DIFF
--- a/packages/renderers/renderer-lit/package.json
+++ b/packages/renderers/renderer-lit/package.json
@@ -10,12 +10,6 @@
     "./client-shim.js": "./client-shim.js",
     "./package.json": "./package.json"
   },
-  "files": [
-    "index.js",
-    "client-shim.js",
-    "server.js",
-    "server-shim.js"
-  ],
   "dependencies": {
     "@lit-labs/ssr": "^1.0.0",
     "@webcomponents/template-shadowroot": "^0.1.0",


### PR DESCRIPTION
## Changes

Tiny change: removes `files` from renderer-lit. This prevented all files from being published to npm.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
