### PR TITLE
[next] Clear Vite dependency cache

### DIFF
--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -50,14 +50,14 @@ export async function createVite(inlineConfig: ViteConfigWithSSR, { astroConfig,
     publicDir: fileURLToPath(astroConfig.public),
     root: fileURLToPath(astroConfig.projectRoot),
     server: {
-      /** disable HMR for test */
-      hmr: process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'production' ? false : undefined,
-      /** handle Vite URLs */
+      force: true, // force dependency rebuild (TODO: enabled only while next is unstable; eventually only call in "production" mode?)
+      hmr: process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'production' ? false : undefined, // disable HMR for test
+      // handle Vite URLs
       proxy: {
         // add proxies here
       },
     },
-    /** Note: SSR API is in beta (https://vitejs.dev/guide/ssr.html) */
+    // Note: SSR API is in beta (https://vitejs.dev/guide/ssr.html)
     ssr: {
       external: [...ALWAYS_EXTERNAL],
       noExternal: [...ALWAYS_NOEXTERNAL],


### PR DESCRIPTION
## Changes

Minor improvement for users: when testing from npm, I found that sometimes all it took to get an example working was deleting the Vite client dep cache and restarting. This PR enables this for both dev and build.

Eventually I think we’d want to only run this in build, but while we’re still testing dev I think it will only help.

## Testing

No tests needed.

## Docs

No docs needed