### PR TITLE
[next] Fix node-fetch injecting into node-fetch

### DIFF
--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -12,7 +12,16 @@ import fetchVitePlugin from '../vite-plugin-fetch/index.js';
 import { getPackageJSON, resolveDependency } from './util.js';
 
 // Some packages are just external, and that’s the way it goes.
-const ALWAYS_EXTERNAL = new Set(['@sveltejs/vite-plugin-svelte', 'estree-util-value-to-estree', 'micromark-util-events-to-acorn', 'prismjs', 'shorthash', 'unified']);
+const ALWAYS_EXTERNAL = new Set([
+  '@sveltejs/vite-plugin-svelte',
+  'estree-util-value-to-estree',
+  'micromark-util-events-to-acorn',
+  'node-fetch',
+  'prismjs',
+  'shorthash',
+  'unified',
+  'whatwg-url',
+]);
 const ALWAYS_NOEXTERNAL = new Set([
   'astro', // This is only because Vite's native ESM doesn't resolve "exports" correctly.
 ]);


### PR DESCRIPTION
## Changes

Our internal plugin injects `node-fetch` into files so `fetch()` runs smoothly on SSR and in the browser. But on the npm installed version, it was also catching `node-fetch` itself, which resulted in an error.

This just adds a check to `node-fetch` so it doesn’t inject into itself.

This PR unblocks the portfolio example from the npm installed version of the next branch.

## Testing

Very difficult to test because it’s not behavior in the monorepo! Tested manually though.

## Docs
No docs needed