### PR TITLE
Fix Vite race condition

### DIFF
--- a/packages/astro/vendor/vite/dist/node/chunks/dep-35df7f96.js
+++ b/packages/astro/vendor/vite/dist/node/chunks/dep-35df7f96.js
@@ -66472,13 +66472,14 @@ async function instantiateModule(url, server, context = { global }, urlStack = [
             if (pendingDeps.length === 1) {
                 pendingImports.set(url, pendingDeps);
             }
-            await ssrLoadModule(dep, server, context, urlStack);
+            let val = await ssrLoadModule(dep, server, context, urlStack);
             if (pendingDeps.length === 1) {
                 pendingImports.delete(url);
             }
             else {
                 pendingDeps.splice(pendingDeps.indexOf(dep), 1);
             }
+          return val;
         }
         return (_b = moduleGraph.urlToModuleMap.get(dep)) === null || _b === void 0 ? void 0 : _b.ssrModule;
     };


### PR DESCRIPTION
## Changes

- This fixes a race condition in Vite where, when it encounters a package dep that needs to be built it invalidates the module graph. This means that any in-flight modules being loaded can receive invalid module instances.
- The fix is to prevent reading from global state to find the module instance.
- Explained more here: https://discord.com/channels/804011606160703521/831456449632534538/902934189119266836

## Testing

Give me a break.

## Docs

nah