### PR TITLE
Fix Astro dev server 408 timeouts

### DIFF
--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -44,7 +44,7 @@ export async function createVite(inlineConfig: ViteConfigWithSSR, { astroConfig,
     clearScreen: false, // we want to control the output, not Vite
     logLevel: 'error', // log errors only
     optimizeDeps: {
-      entries: ['src/**/*'] // Try and scan a user’s project (won’t catch everything),
+      entries: ['src/**/*'], // Try and scan a user’s project (won’t catch everything),
     },
     plugins: [
       astroVitePlugin({ config: astroConfig, devServer }),

--- a/packages/astro/src/core/ssr/css.ts
+++ b/packages/astro/src/core/ssr/css.ts
@@ -33,31 +33,3 @@ export function getStylesForID(id: string, viteServer: vite.ViteDevServer): Set<
 
   return css;
 }
-
-/** add CSS <link> tags to HTML */
-export function addLinkTagsToHTML(html: string, styles: Set<string>): string {
-  let output = html;
-
-  try {
-    // get position of </head>
-    let headEndPos = -1;
-    const parser = new htmlparser2.Parser({
-      onclosetag(tagname) {
-        if (tagname === 'head') {
-          headEndPos = parser.startIndex;
-        }
-      },
-    });
-    parser.write(html);
-    parser.end();
-
-    // update html
-    if (headEndPos !== -1) {
-      output = html.substring(0, headEndPos) + [...styles].map((href) => `<link rel="stylesheet" type="text/css" href="${href}">`).join('') + html.substring(headEndPos);
-    }
-  } catch (err) {
-    // on invalid HTML, do nothing
-  }
-
-  return output;
-}

--- a/packages/astro/src/core/ssr/html.ts
+++ b/packages/astro/src/core/ssr/html.ts
@@ -1,0 +1,112 @@
+import type vite from '../vite';
+
+import htmlparser2 from 'htmlparser2';
+
+/** Inject tags into HTML (note: for best performance, group as many tags as possible into as few calls as you can) */
+export function injectTags(html: string, tags: vite.HtmlTagDescriptor[]): string {
+  // TODO: this usually takes 5ms or less, but if it becomes a bottleneck we can create a WeakMap cache
+  let output = html;
+  if (!tags.length) return output;
+
+  const pos = { 'head-prepend': -1, head: -1, 'body-prepend': -1, body: -1 };
+
+  try {
+    // parse html
+    const parser = new htmlparser2.Parser({
+      onopentag(tagname) {
+        if (tagname === 'head') pos['head-prepend'] = parser.endIndex + 1;
+        if (tagname === 'body') pos['body-prepend'] = parser.endIndex + 1;
+      },
+      onclosetag(tagname) {
+        if (tagname === 'head') pos['head'] = parser.startIndex;
+        if (tagname === 'body') pos['body'] = parser.startIndex;
+      },
+    });
+    parser.write(html);
+    parser.end();
+
+    // inject
+    const lastToFirst = Object.entries(pos).sort((a, b) => b[1] - a[1]);
+    lastToFirst.forEach(([name, i]) => {
+      if (i === -1) {
+        // TODO: warn on missing tag? Is this an HTML partial?
+        return;
+      }
+      let selected = tags.filter(({ injectTo }) => {
+        if (name === 'head-prepend' && !injectTo) {
+          return true; // "head-prepend" is the default
+        } else {
+          return injectTo === name;
+        }
+      });
+      if (!selected.length) return;
+      output = output.substring(0, i) + serializeTags(selected) + html.substring(i);
+    });
+  } catch (err) {
+    // on invalid HTML, do nothing
+  }
+
+  return output;
+}
+
+// Everything below © Vite
+// https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/html.ts
+
+// Vite is released under the MIT license:
+
+// MIT License
+
+// Copyright (c) 2019-present, Yuxi (Evan) You and Vite contributors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+const unaryTags = new Set(['link', 'meta', 'base']);
+
+function serializeTag({ tag, attrs, children }: vite.HtmlTagDescriptor, indent = ''): string {
+  if (unaryTags.has(tag)) {
+    return `<${tag}${serializeAttrs(attrs)}>`;
+  } else {
+    return `<${tag}${serializeAttrs(attrs)}>${serializeTags(children, incrementIndent(indent))}</${tag}>`;
+  }
+}
+
+function serializeTags(tags: vite.HtmlTagDescriptor['children'], indent = ''): string {
+  if (typeof tags === 'string') {
+    return tags;
+  } else if (tags && tags.length) {
+    return tags.map((tag) => `${indent}${serializeTag(tag, indent)}\n`).join('');
+  }
+  return '';
+}
+
+function serializeAttrs(attrs: vite.HtmlTagDescriptor['attrs']): string {
+  let res = '';
+  for (const key in attrs) {
+    if (typeof attrs[key] === 'boolean') {
+      res += attrs[key] ? ` ${key}` : ``;
+    } else {
+      res += ` ${key}=${JSON.stringify(attrs[key])}`;
+    }
+  }
+  return res;
+}
+
+function incrementIndent(indent = '') {
+  return `${indent}${indent[0] === '\t' ? '\t' : '  '}`;
+}

--- a/packages/astro/src/runtime/client/hmr.ts
+++ b/packages/astro/src/runtime/client/hmr.ts
@@ -1,5 +1,3 @@
-import '@vite/client';
-
 if (import.meta.hot) {
   const parser = new DOMParser();
   import.meta.hot.on('astro:reload', async ({ html }: { html: string }) => {

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -103,18 +103,5 @@ export default function astro({ config, devServer }: AstroPluginOptions): vite.P
         return devServer.handleHotUpdate(context);
       }
     },
-    transformIndexHtml() {
-      // note: this runs only in dev
-      return [
-        {
-          injectTo: 'head-prepend',
-          tag: 'script',
-          attrs: {
-            type: 'module',
-            src: '/@astro/runtime/client/hmr',
-          },
-        },
-      ];
-    },
   };
 }


### PR DESCRIPTION
## Changes

In our dev server, before anything else could load, we tried to load our Astro HMR plugin:

```
const url = await this.viteServer.moduleGraph.resolveUrl(spec);
req.url = url[1];
return this.viteServer.middlewares.handle(req, res, next);
```

For some reason this was working fine in the monorepo, but in the npm-installed version of Astro this would cause the Vite dev server to respond with `408: Request Timeout` for the next several requests until the user manually refreshed.

This meant that most of the time, you’d have a broken dev site on initial load 😓.

It might have been creating a recursive lookup or something; I’m not sure. But removing `middlewares.handle()` seemed to fix the `408` responses reliably.

---

This PR moves our Astro HMR from a manually-intercepted route to instead be loaded in Vite’s asset pipeline, at Vite’s discretion.

As a bonus this PR also fixes the “try a new port” behavior if your desired one is taken.

## Testing

This is super hard to test! Tested manually with an npm-installed version.

## Docs

No docs changes necessary.