### PR TITLE
Exclude lit-server from being optimized

### DIFF
--- a/packages/renderers/renderer-lit/index.js
+++ b/packages/renderers/renderer-lit/index.js
@@ -20,6 +20,7 @@ export default {
           '@webcomponents/template-shadowroot/template-shadowroot.js',
           'lit/experimental-hydrate-support.js',
         ],
+        exclude: ['@astrojs/renderer-lit/server.js']
       },
       ssr: {
         external: [


### PR DESCRIPTION
This should get the lit example working from `npm`.

## Changes

- Makes it so that Vite doesn't optimize the server.js side of the renderer which has many Node-only deps.

## Testing

Manually

## Docs

N/A