### PR TITLE
[next] exclude renderer server entrypoints

### DIFF
--- a/packages/renderers/renderer-preact/index.js
+++ b/packages/renderers/renderer-preact/index.js
@@ -15,6 +15,7 @@ export default {
     return {
       optimizeDeps: {
         include: ['@astrojs/renderer-preact/client.js', 'preact', 'preact/jsx-runtime', 'preact-render-to-string'],
+        exclude: ['@astrojs/renderer-preact/server.js'],
       },
       ssr: {
         external: ['preact-render-to-string'],

--- a/packages/renderers/renderer-react/index.js
+++ b/packages/renderers/renderer-react/index.js
@@ -15,6 +15,7 @@ export default {
     return {
       optimizeDeps: {
         include: ['@astrojs/renderer-react/client.js', 'react', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'react-dom'],
+        exclude: ['@astrojs/renderer-react/server.js'],
       },
       resolve: {
         dedupe: ['react', 'react-dom'],

--- a/packages/renderers/renderer-solid/index.js
+++ b/packages/renderers/renderer-solid/index.js
@@ -47,6 +47,7 @@ export default {
       },
       optimizeDeps: {
         include: nestedDeps,
+        exclude: ['@astrojs/renderer-solid/server.js'],
       },
       ssr: {
         external: ['solid-js/web/dist/server.js', 'solid-js/store/dist/server.js', 'solid-js/dist/server.js', 'babel-preset-solid'],

--- a/packages/renderers/renderer-svelte/index.js
+++ b/packages/renderers/renderer-svelte/index.js
@@ -8,6 +8,7 @@ export default {
     return {
       optimizeDeps: {
         include: ['@astrojs/renderer-svelte/client.js', 'svelte', 'svelte/internal'],
+        exclude: ['@astrojs/renderer-svelte/server.js'],
       },
       plugins: [
         svelte({

--- a/packages/renderers/renderer-vue/index.js
+++ b/packages/renderers/renderer-vue/index.js
@@ -8,6 +8,7 @@ export default {
     return {
       optimizeDeps: {
         include: ['@astrojs/renderer-vue/client.js', 'vue'],
+        exclude: ['@astrojs/renderer-vue/server.js'],
       },
       plugins: [vue()],
       ssr: {


### PR DESCRIPTION
## Changes

- Updates renderers to exclude their own server entrypoints from `optimizeDeps`.

## Testing

Manual

## Docs

Bug fix only