### PR TITLE
Add italian to language selector

### DIFF
--- a/docs/src/components/Header/LanguageSelect.tsx
+++ b/docs/src/components/Header/LanguageSelect.tsx
@@ -95,6 +95,9 @@ const LanguageSelect: FunctionalComponent<{ lang: string }> = ({ lang }) => {
         <option value="ru">
           <span>Русский</span>
         </option>
+        <option value="it">
+          <span>Italiano</span>
+        </option>
       </select>
     </div>
   );


### PR DESCRIPTION
## Changes

Italian language in docs selector

## Testing

Build with no errors. Italian language shown as last item of the list.

## Docs

This is docs page update
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
