### PR TITLE
Fix resolve of scss/css-file in Starter Example

### DIFF
--- a/examples/starter/src/pages/index.astro
+++ b/examples/starter/src/pages/index.astro
@@ -21,8 +21,8 @@ let title = 'My Astro Site';
 
         <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     
-    <link rel="stylesheet" href={Astro.resolve('../styles/global.scss')}>
-    <link rel="stylesheet" href={Astro.resolve('../styles/home.scss')}>
+    <link rel="stylesheet" href={Astro.resolve('../styles/global.css')}>
+    <link rel="stylesheet" href={Astro.resolve('../styles/home.css')}>
 
     <style>
         header {


### PR DESCRIPTION
## Changes
I can't find the section in the documentation anymore about resolving SCSS-files (maybe it's gone since v0.21) but the Starter Example doesn't load the SCSS/CSS file anymore.

- Change: `{Astro.resolve('../styles/XXX.scss')}` → `{Astro.resolve('../styles/XXX.css')}`

#### Starter out of the box:
<img width="1280" alt="Screenshot 2021-11-25 at 09 14 17" src="https://user-images.githubusercontent.com/7897006/143404589-d09dcbb7-f02b-4b14-bcc0-f4473742c98e.png">

#### Starter after the change:
<img width="1280" alt="Screenshot 2021-11-25 at 09 14 04" src="https://user-images.githubusercontent.com/7897006/143404641-a7104600-4695-4134-8493-36a7a46ce940.png">

## Testing
Didn't add any tests, not sure if there should be for this.

## Docs
Don't think this requires documentation – except for the section that I think existed at some point, but is now gone? 🤷 
