### PR TITLE
Point to the correct page

### DIFF
--- a/docs/src/pages/quick-start.md
+++ b/docs/src/pages/quick-start.md
@@ -74,4 +74,4 @@ We recommend that you to take some time to get more familiar with the way Astro 
 
 📚 Learn more about Astro's component syntax in our [Astro Components guide.](/core-concepts/astro-components)
 
-📚 Learn more about Astro's file-based routing in our [Routing guide.](/core-concepts/astro-pages)
+📚 Learn more about Astro's file-based routing in our [Routing guide.](/core-concepts/routing)


### PR DESCRIPTION
## Changes
- Update the Routing Guide link to point to the correct section of the documentation.

## Testing
Visual inspection.
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
The Routing guide link referenced the Pages section, which I believe is an error.