### PR TITLE
fixed alias path on migration guide.

### DIFF
--- a/docs/src/pages/migration/0.21.0.md
+++ b/docs/src/pages/migration/0.21.0.md
@@ -32,7 +32,7 @@ In Astro v0.21, import aliases can be added from `tsconfig.json` or `jsconfig.js
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/components/*": ["components/*"]
+      "@/components/*": ["src/components/*"]
     }
   }
 }


### PR DESCRIPTION
## Changes

- fixed alias path on the v0.21 migration guide
<img width="1520" alt="Screen Shot 2021-11-27 at 21 29 05" src="https://user-images.githubusercontent.com/82420632/143681335-aa699ebb-42c1-486a-ae37-5b351e50496c.png">

## Testing

<!-- How was this change tested? -->
Tested on [stackblitz](https://stackblitz.com/edit/github-kfnit2?devtoolsheight=33&file=tsconfig.json)

## Docs

<!-- Was public documentation updated? -->
Migration guide on the docs is updated.
