### PR TITLE
fix: typo

### DIFF
--- a/docs/src/pages/core-concepts/routing.md
+++ b/docs/src/pages/core-concepts/routing.md
@@ -87,7 +87,7 @@ In this example, a request for `/withastro/astro/tree/main/docs/public/favicon.s
 
 ```js
 {
-	org: 'snowpackjs',
+	org: 'withastro',
 	repo: 'astro',
 	branch: 'main',
 	file: 'docs/public/favicon.svg'


### PR DESCRIPTION
The example showed a different org in the source URL from the parsed URL. This makes it consistent.