### PR TITLE
Rename the `markdownOptions` "parser" property to "render"

### DIFF
--- a/docs/src/pages/guides/markdown-content.md
+++ b/docs/src/pages/guides/markdown-content.md
@@ -14,7 +14,7 @@ Astro lets you use any Markdown parser you want. It just needs to be a function 
 // astro.config.mjs
 export default {
   markdownOptions: {
-    parser: [
+    render: [
       'parser-name', // or import('parser-name') or (contents) => {...}
       {
         // options
@@ -47,7 +47,7 @@ If you want to add a plugin, you need to install the npm package dependency in y
 // astro.config.mjs
 export default {
   markdownOptions: {
-    parser: [
+    render: [
       '@astrojs/markdown-remark',
       {
         remarkPlugins: [
@@ -73,7 +73,7 @@ You can provide names of the plugins as well as import them:
 // astro.config.mjs
 export default {
   markdownOptions: {
-    parser: [
+    render: [
       '@astrojs/markdown-remark',
       {
         remarkPlugins: [


### PR DESCRIPTION
## Changes
The `parser` key isn't valid, `render` needs to be used instead so just updating the docs to save anyone else a headache.

Updates the `/guides/markdown-content/` page to replace instances of  `parser` with `render` as the `markdownOptions` object does not work if you use `parser`.

## Testing
<!-- How was this change tested? -->
Checked rendered markdown in github looks okay.

## Docs
<!-- Was public documentation updated? -->
Yes
