### PR TITLE
docs: update some Snowpack references to Vite

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -180,7 +180,7 @@ Astro will generate an RSS 2.0 feed at `/feed/[collection].xml` (for example, `/
 
 ## `import.meta`
 
-All ESM modules include a `import.meta` property. Astro adds `import.meta.env` through [Snowpack](https://www.snowpack.dev/).
+All ESM modules include a `import.meta` property. Astro adds `import.meta.env` through [Vite](https://www.vitejs.dev/).
 
 **import.meta.env.SSR** can be used to know when rendering on the server. Sometimes you might want different logic, for example a component that should only be rendered in the client:
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -180,7 +180,7 @@ Astro will generate an RSS 2.0 feed at `/feed/[collection].xml` (for example, `/
 
 ## `import.meta`
 
-All ESM modules include a `import.meta` property. Astro adds `import.meta.env` through [Vite](https://www.vitejs.dev/).
+All ESM modules include a `import.meta` property. Astro adds `import.meta.env` through [Vite](https://vitejs.dev/guide/env-and-mode.html).
 
 **import.meta.env.SSR** can be used to know when rendering on the server. Sometimes you might want different logic, for example a component that should only be rendered in the client:
 

--- a/docs/src/pages/core-concepts/routing.md
+++ b/docs/src/pages/core-concepts/routing.md
@@ -87,7 +87,7 @@ In this example, a request for `/withastro/astro/tree/main/docs/public/favicon.s
 
 ```js
 {
-	org: 'snowpackjs',
+	org: 'withastro',
 	repo: 'astro',
 	branch: 'main',
 	file: 'docs/public/favicon.svg'

--- a/docs/src/pages/guides/imports.md
+++ b/docs/src/pages/guides/imports.md
@@ -4,7 +4,7 @@ title: Supported Imports
 description: Learn how to import different content types with Astro.
 ---
 
-Astro uses Snowpack as its internal build system. Snowpack provides Astro with built-in support for the following file types, with no configuration required:
+Astro uses Vite as its internal build system. Vite provides Astro with built-in support for the following file types, with no configuration required:
 
 - JavaScript (`.js`, `.mjs`)
 - TypeScript (`.ts`, `.tsx`)
@@ -17,7 +17,7 @@ Astro uses Snowpack as its internal build system. Snowpack provides Astro with 
 - Markdown (`.md`)
 - WASM (`.wasm`)
 
-Any files in your `public/` directory are copied into the final build, untouched by Snowpack or Astro. The following applies to files in your `src/` directory, which Astro is ultimately responsible for.
+Any files in your `public/` directory are copied into the final build, untouched by Vite or Astro. The following applies to files in your `src/` directory, which Astro is ultimately responsible for.
 
 ## JavaScript & ESM
 
@@ -120,7 +120,7 @@ import ReactDOM from 'react-dom';
 
 Astro lets you import npm packages directly in the browser. Even if a package was published using a legacy format, Astro will up-convert the package to ESM before serving it to the browser.
 
-When you start up your dev server or run a new build, you may see a message that Snowpack is "installing dependencies". This means that Snowpack is converting your dependencies to run in the browser. This needs to run only once, or until you next change your dependency tree by adding or removing dependencies.
+When you start up your dev server or run a new build, you may see a message that Vite is "installing dependencies". This means that Vite is converting your dependencies to run in the browser. This needs to run only once, or until you next change your dependency tree by adding or removing dependencies.
 
 ## Node Builtins
 

--- a/docs/src/pages/reference/api-reference.md
+++ b/docs/src/pages/reference/api-reference.md
@@ -277,7 +277,7 @@ interface RSSArgument {
 
 > In this section we use `[dot]` to mean `.`. This is because of a bug in our build engine that is rewriting `import[dot]meta[dot]env` if we use `.` instead of `[dot]`.
 
-All ESM modules include a `import.meta` property. Astro adds `import[dot]meta[dot]env` through [Vite](https://www.vitejs.dev/).
+All ESM modules include a `import.meta` property. Astro adds `import[dot]meta[dot]env` through [Vite](https://vitejs.dev/guide/env-and-mode.html).
 
 **`import[dot]meta[dot]env[dot]SSR`** can be used to know when rendering on the server. Sometimes you might want different logic, for example a component that should only be rendered in the client:
 

--- a/docs/src/pages/reference/api-reference.md
+++ b/docs/src/pages/reference/api-reference.md
@@ -277,7 +277,7 @@ interface RSSArgument {
 
 > In this section we use `[dot]` to mean `.`. This is because of a bug in our build engine that is rewriting `import[dot]meta[dot]env` if we use `.` instead of `[dot]`.
 
-All ESM modules include a `import.meta` property. Astro adds `import[dot]meta[dot]env` through [Snowpack](https://www.snowpack.dev/).
+All ESM modules include a `import.meta` property. Astro adds `import[dot]meta[dot]env` through [Vite](https://www.vitejs.dev/).
 
 **`import[dot]meta[dot]env[dot]SSR`** can be used to know when rendering on the server. Sometimes you might want different logic, for example a component that should only be rendered in the client:
 


### PR DESCRIPTION
Vite has replaced Snowpack in 0.21.

## Changes
* change Snowpack references in English docs to Vite
* change https://snowpack.dev links to https://vitejs.dev
* update a reference to the Astro GitHub organisation 
* I did not update the alias docs because I am not sure how it works :-), but they also are out of date

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Re-reading attentively. Docs-only changes.
## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Yes, the PR only contains documentation updates.