### PR TITLE
Fix cached inline modules

### DIFF
--- a/.changeset/little-carrots-sleep.md
+++ b/.changeset/little-carrots-sleep.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes dev errors in hydrated components
+
+The errors would occur when there was state changes in hydrated components. This only occurs in dev but does result in the hydrated component not working. This fixes the underlying issue.


### PR DESCRIPTION
## Changes

- Fixes #2004 
- Upstream fix: https://github.com/vitejs/vite/pull/5891
- What was happening was that our astroid is the hash of the HTML produced by a component. If that HTML ever changes the astroid changes. However since Vite's dev HTML plugin turns the inline scripts into external scripts and caches them, the changed astroid was never reflected in the proxy modules.
- Fix is to invalidate the module when the script changes; a bug in Vite. There is an upstream fix listed above.

## Testing

No, we don't have dev tests that change the value of a module, which would be needed to test this.

## Docs

Bug fix only