### PR TITLE
Makes Astro.resolve return root-relative paths

### DIFF
--- a/.changeset/gorgeous-clocks-leave.md
+++ b/.changeset/gorgeous-clocks-leave.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates Astro.resolve to return project-relative paths

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -299,7 +299,7 @@ export function createAstro(fileURLStr: string, site: string, projectRootStr: st
       let resolved = segments.reduce((u, segment) => new URL(segment, u), url).pathname;
       // When inside of project root, remove the leading path so you are
       // left with only `/src/images/tower.png`
-      if(resolved.startsWith(projectRoot.pathname)) {
+      if (resolved.startsWith(projectRoot.pathname)) {
         resolved = '/' + resolved.substr(projectRoot.pathname.length);
       }
       return resolved;

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -2,6 +2,7 @@ import type { AstroComponentMetadata, Renderer } from '../../@types/astro';
 import type { AstroGlobalPartial, SSRResult, SSRElement } from '../../@types/astro';
 
 import shorthash from 'shorthash';
+import { pathToFileURL } from 'url';
 import { extractDirectives, generateHydrateScript } from './hydration.js';
 import { serializeListValue } from './util.js';
 export { createMetadata } from './metadata.js';
@@ -286,15 +287,18 @@ function createFetchContentFn(url: URL) {
 
 // This is used to create the top-level Astro global; the one that you can use
 // Inside of getStaticPaths.
-export function createAstro(fileURLStr: string, site: string): AstroGlobalPartial {
+export function createAstro(fileURLStr: string, site: string, projectRootStr: string): AstroGlobalPartial {
   const url = new URL(fileURLStr);
+  const projectRoot = projectRootStr === '.' ? pathToFileURL(process.cwd()) : new URL(projectRootStr);
   const fetchContent = createFetchContentFn(url);
   return {
     site: new URL(site),
     fetchContent,
     // INVESTIGATE is there a use-case for multi args?
     resolve(...segments: string[]) {
-      return segments.reduce((u, segment) => new URL(segment, u), url).pathname;
+      let resolved = segments.reduce((u, segment) => new URL(segment, u), url).pathname;
+      resolved = '/' + resolved.substr(projectRoot.pathname.length);
+      return resolved;
     },
   };
 }

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -297,7 +297,11 @@ export function createAstro(fileURLStr: string, site: string, projectRootStr: st
     // INVESTIGATE is there a use-case for multi args?
     resolve(...segments: string[]) {
       let resolved = segments.reduce((u, segment) => new URL(segment, u), url).pathname;
-      resolved = '/' + resolved.substr(projectRoot.pathname.length);
+      // When inside of project root, remove the leading path so you are
+      // left with only `/src/images/tower.png`
+      if(resolved.startsWith(projectRoot.pathname)) {
+        resolved = '/' + resolved.substr(projectRoot.pathname.length);
+      }
       return resolved;
     },
   };

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -57,6 +57,7 @@ export default function astro({ config, devServer }: AstroPluginOptions): vite.P
         // result passed to esbuild, but also available in the catch handler.
         tsResult = await transform(source, {
           as: isPage ? 'document' : 'fragment',
+          projectRoot: config.projectRoot.toString(),
           site: config.buildOptions.site,
           sourcefile: id,
           sourcemap: 'both',

--- a/packages/astro/src/vite-plugin-build-html/index.ts
+++ b/packages/astro/src/vite-plugin-build-html/index.ts
@@ -142,8 +142,8 @@ export function rollupPluginAstroBuildHTML(options: PluginOptions): VitePlugin {
                 astroAssetMap.set(src, fs.readFile(new URL(`file://${src}`)));
               } else if(src?.startsWith(srcRootWeb) && !astroAssetMap.has(src)) {
                 const resolved = new URL('.' + src, astroConfig.projectRoot);
-                const id = viteifyURL(resolved);
-                astroAssetMap.set(src, fs.readFile(new URL(`file://${id}`)));
+                const assetId = viteifyURL(resolved);
+                astroAssetMap.set(src, fs.readFile(new URL(`file://${assetId}`)));
               }
             }
 
@@ -154,8 +154,8 @@ export function rollupPluginAstroBuildHTML(options: PluginOptions): VitePlugin {
                   astroAssetMap.set(url, fs.readFile(new URL(`file://${url}`)));
                 } else if(url.startsWith(srcRootWeb) && !astroAssetMap.has(url)) {
                   const resolved = new URL('.' + url, astroConfig.projectRoot);
-                  const id = viteifyURL(resolved);
-                  astroAssetMap.set(url, fs.readFile(new URL(`file://${id}`)));
+                  const assetId = viteifyURL(resolved);
+                  astroAssetMap.set(url, fs.readFile(new URL(`file://${assetId}`)));
                 }
               }
             }

--- a/packages/astro/src/vite-plugin-build-html/index.ts
+++ b/packages/astro/src/vite-plugin-build-html/index.ts
@@ -140,7 +140,7 @@ export function rollupPluginAstroBuildHTML(options: PluginOptions): VitePlugin {
               const src = getAttribute(node, 'src');
               if (src?.startsWith(srcRoot) && !astroAssetMap.has(src)) {
                 astroAssetMap.set(src, fs.readFile(new URL(`file://${src}`)));
-              } else if(src?.startsWith(srcRootWeb) && !astroAssetMap.has(src)) {
+              } else if (src?.startsWith(srcRootWeb) && !astroAssetMap.has(src)) {
                 const resolved = new URL('.' + src, astroConfig.projectRoot);
                 const assetId = viteifyURL(resolved);
                 astroAssetMap.set(src, fs.readFile(new URL(`file://${assetId}`)));
@@ -152,7 +152,7 @@ export function rollupPluginAstroBuildHTML(options: PluginOptions): VitePlugin {
               for (const { url } of candidates) {
                 if (url.startsWith(srcRoot) && !astroAssetMap.has(url)) {
                   astroAssetMap.set(url, fs.readFile(new URL(`file://${url}`)));
-                } else if(url.startsWith(srcRootWeb) && !astroAssetMap.has(url)) {
+                } else if (url.startsWith(srcRootWeb) && !astroAssetMap.has(url)) {
                   const resolved = new URL('.' + url, astroConfig.projectRoot);
                   const assetId = viteifyURL(resolved);
                   astroAssetMap.set(url, fs.readFile(new URL(`file://${assetId}`)));
@@ -359,7 +359,7 @@ export function rollupPluginAstroBuildHTML(options: PluginOptions): VitePlugin {
           } else if (isInSrcDirectory(script, 'src', srcRoot, srcRootWeb)) {
             let src = getAttribute(script, 'src');
             // If this is projectRoot relative, get the fullpath to match the facadeId.
-            if(src?.startsWith(srcRootWeb)) {
+            if (src?.startsWith(srcRootWeb)) {
               src = new URL('.' + src, astroConfig.projectRoot).pathname;
             }
             // On windows the facadeId doesn't start with / but does not Unix :/

--- a/packages/astro/src/vite-plugin-build-html/index.ts
+++ b/packages/astro/src/vite-plugin-build-html/index.ts
@@ -13,7 +13,6 @@ import { findAssets, findExternalScripts, findInlineScripts, findInlineStyles, g
 import { isBuildableImage, isBuildableLink, isHoistedScript, isInSrcDirectory, hasSrcSet } from './util.js';
 import { render as ssrRender } from '../core/ssr/index.js';
 import { getAstroStyleId, getAstroPageStyleId } from '../vite-plugin-build-css/index.js';
-import { viteifyURL } from '../core/util.js';
 
 // This package isn't real ESM, so have to coerce it
 const matchSrcset: typeof srcsetParse = (srcsetParse as any).default;
@@ -142,8 +141,7 @@ export function rollupPluginAstroBuildHTML(options: PluginOptions): VitePlugin {
                 astroAssetMap.set(src, fs.readFile(new URL(`file://${src}`)));
               } else if (src?.startsWith(srcRootWeb) && !astroAssetMap.has(src)) {
                 const resolved = new URL('.' + src, astroConfig.projectRoot);
-                const assetId = viteifyURL(resolved);
-                astroAssetMap.set(src, fs.readFile(new URL(`file://${assetId}`)));
+                astroAssetMap.set(src, fs.readFile(resolved));
               }
             }
 
@@ -154,8 +152,7 @@ export function rollupPluginAstroBuildHTML(options: PluginOptions): VitePlugin {
                   astroAssetMap.set(url, fs.readFile(new URL(`file://${url}`)));
                 } else if (url.startsWith(srcRootWeb) && !astroAssetMap.has(url)) {
                   const resolved = new URL('.' + url, astroConfig.projectRoot);
-                  const assetId = viteifyURL(resolved);
-                  astroAssetMap.set(url, fs.readFile(new URL(`file://${assetId}`)));
+                  astroAssetMap.set(url, fs.readFile(resolved));
                 }
               }
             }

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -57,7 +57,7 @@ ${setup}`.trim();
           site: config.buildOptions.site,
           sourcefile: id,
           sourcemap: 'inline',
-          internalURL: 'astro/internal'
+          internalURL: 'astro/internal',
         });
 
         tsResult = `\nexport const metadata = ${JSON.stringify(metadata)};

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -52,7 +52,13 @@ ${setup}`.trim();
         }
 
         // Transform from `.astro` to valid `.ts`
-        let { code: tsResult } = await transform(astroResult, { sourcefile: id, sourcemap: 'inline', internalURL: 'astro/internal' });
+        let { code: tsResult } = await transform(astroResult, {
+          projectRoot: config.projectRoot.toString(),
+          site: config.buildOptions.site,
+          sourcefile: id,
+          sourcemap: 'inline',
+          internalURL: 'astro/internal'
+        });
 
         tsResult = `\nexport const metadata = ${JSON.stringify(metadata)};
 export const frontmatter = ${JSON.stringify(content)};


### PR DESCRIPTION
## Changes

- Instead of returning a pathname that is the full filesystem URL this will not return `/src/images/penguin.png`, projectRoot relative.
- Depends on https://github.com/withastro/astro-compiler/pull/179
- Closes https://github.com/withastro/astro/issues/2002
- Closes https://github.com/withastro/astro/issues/1968
- Closes https://github.com/withastro/astro/issues/2068

## Testing

No tests needed to be updated, but some code needed to be updated to make them all pass.

## Docs

Bug fix.