### PR TITLE
Fix Sass WASM crashes

### DIFF
--- a/.changeset/honest-knives-bake.md
+++ b/.changeset/honest-knives-bake.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Bugfix: Sass compile errors cause compiler panic

--- a/packages/astro/test/fixtures/sass/src/pages/error.astro
+++ b/packages/astro/test/fixtures/sass/src/pages/error.astro
@@ -1,0 +1,7 @@
+<style lang="scss">
+  $blue: blue;
+
+  .h1 {
+    color: $red; // undefined!
+  }
+</style>

--- a/packages/astro/test/sass.test.js
+++ b/packages/astro/test/sass.test.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import { loadFixture } from './test-utils.js';
+
+// note: many Sass tests live in 0-css.test.js to test within context of a framework.
+// these tests are independent of framework.
+describe('Sass', () => {
+  let fixture;
+  let devServer;
+
+  before(async () => {
+    fixture = await loadFixture({ projectRoot: './fixtures/sass/' });
+    devServer = await fixture.startDevServer();
+  });
+
+  after(async () => {
+    devServer && (await devServer.stop());
+  });
+
+  it('shows helpful error on failure', async () => {
+    const res = await fixture.fetch('/error').then((res) => res.text());
+    expect(res).to.include('Undefined variable');
+  });
+});


### PR DESCRIPTION
## Changes

Partially addresses #2032. When Sass encounters a compile error, we don’t properly stop WASM from trying to process the broken CSS, resulting in the error never being shown.

**Before**
😵 (no screenshot; it just crashes)

**After**

![Screen Shot 2021-11-29 at 14 32 45](https://user-images.githubusercontent.com/1369770/143946580-ff182a7b-2c6b-4a2d-b838-696488f783a6.png)

Helpful error shown

## Testing

Test added

## Docs

No docs needed