### PR TITLE
Add migration guide for markdownOptions

### DIFF
--- a/docs/src/pages/migration/0.21.0.md
+++ b/docs/src/pages/migration/0.21.0.md
@@ -193,6 +193,29 @@ To learn more about Vite plugins, please visit their [plugin guide](https://vite
 
 > In prior releases, these were configured with `snowpackPlugin` or `snowpackPluginOptions`.
 
+## Markdown Options
+
+The configuration of markdown options has changed slightly in Astro v0.21. There's now a `render` property, which should include `@astrojs/markdown-remark`:
+
+```diff
+// astro.config.mjs
+export default {
+  markdownOptions: {
++    render: [
++      '@astrojs/markdown-remark',
++      {
+        remarkPlugins: [
+          // Add a Remark plugin that you want to enable for your project.
+        ],
+        rehypePlugins: [
+          // Add a Rehype plugin that you want to enable for your project.
+        ],
++      },
++    ],
+  },
+};
+```
+
 ## Styling Changes
 
 ### Autoprefixer


### PR DESCRIPTION
## Changes

I found that the configuration changed a little for `markdownOptions` in 0.21, so here's a short guide to hopefully help others realize it changed as well.

## Testing

Docs only

## Docs

Docs only
