### PR TITLE
Prevent unknown keys in markdownOptions

### DIFF
--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -47,6 +47,7 @@ export const AstroConfigSchema = z.object({
       gfm: z.boolean().optional(),
       render: z.any().optional().default(['@astrojs/markdown-remark', {}]),
     })
+    .strict()
     .optional()
     .default({}),
   buildOptions: z

--- a/packages/astro/test/config-validate.test.js
+++ b/packages/astro/test/config-validate.test.js
@@ -13,6 +13,12 @@ describe('Config Validation', () => {
     expect(configError instanceof z.ZodError).to.equal(true);
   });
 
+  it('errors when an older markdownOptions format is used', async () => {
+    const configError = await validateConfig({ markdownOptions: { rehypePlugins: ["rehype-autolink-headings"] } }, process.cwd()).catch((err) => err);
+    expect(configError instanceof z.ZodError).to.equal(true);
+    expect(configError.issues[0].message).to.equal("Unrecognized key(s) in object: 'rehypePlugins'")
+  });
+
   it('A validation error can be formatted correctly', async () => {
     const configError = await validateConfig({ buildOptions: { sitemap: 42 } }, process.cwd()).catch((err) => err);
     expect(configError instanceof z.ZodError).to.equal(true);


### PR DESCRIPTION
## Changes

Closes #2072 

## Testing

Added test to `config-validate.test.js`.

## Docs

No, although I do have https://github.com/withastro/astro/pull/2070 open to change the migration guide docs.
