### PR TITLE
Allow importing of rehype plugins

### DIFF
--- a/.changeset/wise-icons-tell.md
+++ b/.changeset/wise-icons-tell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Bugfix: allow dynamic importing of rehype plugins

--- a/packages/astro/src/core/ssr/index.ts
+++ b/packages/astro/src/core/ssr/index.ts
@@ -209,8 +209,13 @@ export async function render(renderers: Renderer[], mod: ComponentInstance, ssrO
             renderOpts = mdRender[1];
             mdRender = mdRender[0];
           }
+          // ['rehype-toc', opts]
           if (typeof mdRender === 'string') {
             ({ default: mdRender } = await import(mdRender));
+          }
+          // [import('rehype-toc'), opts]
+          else if (mdRender instanceof Promise) {
+            ({ default: mdRender } = await mdRender);
           }
           const { code } = await mdRender(content, { ...renderOpts, ...(opts ?? {}) });
           return code;

--- a/packages/astro/test/astro-markdown-plugins.test.js
+++ b/packages/astro/test/astro-markdown-plugins.test.js
@@ -15,7 +15,7 @@ describe('Astro Markdown plugins', () => {
           markdownRemark,
           {
             remarkPlugins: ['remark-code-titles', ['rehype-autolink-headings', { behavior: 'prepend' }]],
-            rehypePlugins: [['rehype-toc', { headings: ['h2', 'h3'] }], ['rehype-add-classes', { 'h1,h2,h3': 'title' }], 'rehype-slug'],
+            rehypePlugins: [[import('rehype-toc'), { headings: ['h2', 'h3'] }], ['rehype-add-classes', { 'h1,h2,h3': 'title' }], 'rehype-slug'],
           },
         ],
       },


### PR DESCRIPTION
## Changes

Fixes #2061. [Our own docs](https://docs.astro.build/guides/markdown-content/#add-a-markdown-plugin-in-astro) say that `import()`-ing a plugin works, so this adds a fix + test for that.

## Testing

Test added

## Docs

Bug fix