### PR TITLE
Add external PR lint support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
   # We also run `yarn install` with the `--prefer-offline` flag to speed things up.
   lint:
     name: Lint
-    # Lint cannot run on forks, so just skip those! See https://github.com/wearerequired/lint-action/issues/13
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -46,7 +44,14 @@ jobs:
       - name: Status
         run: git status
 
+      # Lint autofix cannot run on forks, so just skip those! See https://github.com/wearerequired/lint-action/issues/13
+      - name: Lint (External)
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != github.repository_owner }}
+        run: yarn lint
+        
+      # Otherwise, run lint autofixer
       - name: Lint
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}
         uses: wearerequired/lint-action@v1.10.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

- Add support for a lower-powered lint CI command that can run on external PRs

## Testing

Works on internal PRs: 

<img width="213" alt="Screen Shot 2021-12-01 at 1 59 33 PM" src="https://user-images.githubusercontent.com/622227/144320988-9a2c1991-41ae-49e1-baa7-067741c1a397.png">

@jonathantneal might need you to test on your fork to confirm!