### PR TITLE
fix: renderer behavior with no children

### DIFF
--- a/.changeset/many-schools-grab.md
+++ b/.changeset/many-schools-grab.md
@@ -1,0 +1,9 @@
+---
+'astro': patch
+'@astrojs/renderer-preact': patch
+'@astrojs/renderer-react': patch
+'@astrojs/renderer-svelte': patch
+'@astrojs/renderer-vue': patch
+---
+
+Fix behavior of renderers when no children are passed in

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -159,7 +159,7 @@ Did you mean to enable ${formatList(probableRendererNames.map((r) => '`' + r + '
   let renderer: Renderer | undefined;
   if (metadata.hydrate !== 'only') {
     for (const r of renderers) {
-      if (await r.ssr.check(Component, props, children)) {
+      if (await r.ssr.check(Component, props, children ? children : undefined)) {
         renderer = r;
         break;
       }
@@ -218,7 +218,7 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
     if (metadata.hydrate === 'only') {
       html = await renderSlot(result, slots?.fallback);
     } else {
-      ({ html } = await renderer.ssr.renderToStaticMarkup(Component, props, children));
+      ({ html } = await renderer.ssr.renderToStaticMarkup(Component, props, children ? children : undefined));
     }
   }
 

--- a/packages/astro/test/fixtures/slots-preact/src/components/Counter.jsx
+++ b/packages/astro/test/fixtures/slots-preact/src/components/Counter.jsx
@@ -1,0 +1,21 @@
+import { h, Fragment } from 'preact';
+import { useState } from 'preact/hooks'
+
+export default function Counter({ children, count: initialCount, case: id }) {
+  const [count, setCount] = useState(initialCount);
+  const add = () => setCount((i) => i + 1);
+  const subtract = () => setCount((i) => i - 1);
+
+  return (
+    <>
+      <div className="counter">
+        <button onClick={subtract}>-</button>
+        <pre>{count}</pre>
+        <button onClick={add}>+</button>
+      </div>
+      <div id={id} className="counter-message">
+        {children || <h1>Fallback</h1>}
+      </div>
+    </>
+  );
+}

--- a/packages/astro/test/fixtures/slots-preact/src/pages/index.astro
+++ b/packages/astro/test/fixtures/slots-preact/src/pages/index.astro
@@ -1,0 +1,8 @@
+---
+import Counter from '../components/Counter.jsx'
+---
+<main>
+  <Counter case="default-self-closing" client:visible/>
+  <Counter case="default-empty" client:visible></Counter>
+  <Counter case="content" client:visible><h1 id="slotted">Hello world!</h1></Counter>
+</main>

--- a/packages/astro/test/fixtures/slots-react/src/components/Counter.jsx
+++ b/packages/astro/test/fixtures/slots-react/src/components/Counter.jsx
@@ -1,0 +1,20 @@
+import React, { useState } from 'react';
+
+export default function Counter({ children, count: initialCount, case: id }) {
+  const [count, setCount] = useState(initialCount);
+  const add = () => setCount((i) => i + 1);
+  const subtract = () => setCount((i) => i - 1);
+
+  return (
+    <>
+      <div className="counter">
+        <button onClick={subtract}>-</button>
+        <pre>{count}</pre>
+        <button onClick={add}>+</button>
+      </div>
+      <div id={id} className="counter-message">
+        {children || <h1>Fallback</h1>}
+      </div>
+    </>
+  );
+}

--- a/packages/astro/test/fixtures/slots-react/src/pages/index.astro
+++ b/packages/astro/test/fixtures/slots-react/src/pages/index.astro
@@ -1,0 +1,8 @@
+---
+import Counter from '../components/Counter.jsx'
+---
+<main>
+  <Counter case="default-self-closing" client:visible/>
+  <Counter case="default-empty" client:visible></Counter>
+  <Counter case="content" client:visible><h1 id="slotted">Hello world!</h1></Counter>
+</main>

--- a/packages/astro/test/fixtures/slots-svelte/src/components/Counter.svelte
+++ b/packages/astro/test/fixtures/slots-svelte/src/components/Counter.svelte
@@ -1,0 +1,36 @@
+<script>
+  let count = 0;
+  export let id;
+
+  function add() {
+    count += 1;
+  }
+
+  function subtract() {
+    count -= 1;
+  }
+</script>
+
+<div class="counter">
+  <button on:click={subtract}>-</button>
+  <pre>{ count }</pre>
+  <button on:click={add}>+</button>
+</div>
+<div id={id}>
+  <slot>
+    <h1 id="fallback">Fallback</h1>
+  </slot>
+</div>
+
+<style>
+  .counter{
+    display: grid;
+    font-size: 2em;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    margin-top: 2em;
+    place-items: center;
+  }
+  .message {
+    text-align: center;
+  }
+</style>

--- a/packages/astro/test/fixtures/slots-svelte/src/pages/index.astro
+++ b/packages/astro/test/fixtures/slots-svelte/src/pages/index.astro
@@ -1,0 +1,8 @@
+---
+import Counter from '../components/Counter.svelte'
+---
+<main>
+  <Counter id="default-self-closing" client:visible/>
+  <Counter id="default-empty" client:visible></Counter>
+  <Counter id="content" client:visible><h1 id="slotted">Hello world!</h1></Counter>
+</main>

--- a/packages/astro/test/fixtures/slots-vue/src/components/Counter.vue
+++ b/packages/astro/test/fixtures/slots-vue/src/components/Counter.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="counter">
+    <button @click="subtract()">-</button>
+    <pre>{{ count }}</pre>
+    <button @click="add()">+</button>
+  </div>
+  <div :id="case" class="counter-message">
+    <slot>
+      <h1>Fallback</h1>
+    </slot>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+export default {
+  props: {
+    case: String,
+  },
+  setup(props) {
+    const count = ref(0);
+    const add = () => (count.value = count.value + 1);
+    const subtract = () => (count.value = count.value - 1);
+
+    return {
+      case: props.case,
+      count,
+      add,
+      subtract,
+    };
+  },
+};
+</script>
+
+<style>
+.counter {
+  display: grid;
+  font-size: 2em;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 2em;
+  place-items: center;
+}
+.counter-message {
+  text-align: center;
+}
+</style>

--- a/packages/astro/test/fixtures/slots-vue/src/pages/index.astro
+++ b/packages/astro/test/fixtures/slots-vue/src/pages/index.astro
@@ -1,0 +1,8 @@
+---
+import Counter from '../components/Counter.vue'
+---
+<main>
+  <Counter case="default-self-closing" client:visible/>
+  <Counter case="default-empty" client:visible></Counter>
+  <Counter case="content" client:visible><h1 id="slotted">Hello world!</h1></Counter>
+</main>

--- a/packages/astro/test/slots-preact.test.js
+++ b/packages/astro/test/slots-preact.test.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Slots: Preact', () => {
+  let fixture;
+
+  before(async () => {
+    fixture = await loadFixture({ projectRoot: './fixtures/slots-preact/', renderers: ['@astrojs/renderer-preact'] });
+    await fixture.build();
+  });
+
+  it('Renders default slot', async () => {
+    const html = await fixture.readFile('/index.html');
+    const $ = cheerio.load(html);
+
+    expect($('#default-self-closing').text().trim()).to.equal('Fallback');
+    expect($('#default-empty').text().trim()).to.equal('Fallback');
+    expect($('#content').text().trim()).to.equal('Hello world!');
+  });
+});

--- a/packages/astro/test/slots-react.test.js
+++ b/packages/astro/test/slots-react.test.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Slots: React', () => {
+  let fixture;
+
+  before(async () => {
+    fixture = await loadFixture({ projectRoot: './fixtures/slots-react/', renderers: ['@astrojs/renderer-react'] });
+    await fixture.build();
+  });
+
+  it('Renders default slot', async () => {
+    const html = await fixture.readFile('/index.html');
+    const $ = cheerio.load(html);
+
+    expect($('#default-self-closing').text().trim()).to.equal('Fallback');
+    expect($('#default-empty').text().trim()).to.equal('Fallback');
+    expect($('#content').text().trim()).to.equal('Hello world!');
+  });
+});

--- a/packages/astro/test/slots-svelte.test.js
+++ b/packages/astro/test/slots-svelte.test.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Slots: Svelte', () => {
+  let fixture;
+
+  before(async () => {
+    fixture = await loadFixture({ projectRoot: './fixtures/slots-svelte/', renderers: ['@astrojs/renderer-svelte'] });
+    await fixture.build();
+  });
+
+  it('Renders default slot', async () => {
+    const html = await fixture.readFile('/index.html');
+    const $ = cheerio.load(html);
+
+    expect($('#default-self-closing').text().trim()).to.equal('Fallback');
+    expect($('#default-empty').text().trim()).to.equal('Fallback');
+    expect($('#content').text().trim()).to.equal('Hello world!');
+  });
+});

--- a/packages/astro/test/slots-vue.test.js
+++ b/packages/astro/test/slots-vue.test.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Slots: Vue', () => {
+  let fixture;
+
+  before(async () => {
+    fixture = await loadFixture({ projectRoot: './fixtures/slots-vue/', renderers: ['@astrojs/renderer-vue'] });
+    await fixture.build();
+  });
+
+  it('Renders default slot', async () => {
+    const html = await fixture.readFile('/index.html');
+    const $ = cheerio.load(html);
+
+    expect($('#default-self-closing').text().trim()).to.equal('Fallback');
+    expect($('#default-empty').text().trim()).to.equal('Fallback');
+    expect($('#content').text().trim()).to.equal('Hello world!');
+  });
+});

--- a/packages/renderers/renderer-preact/client.js
+++ b/packages/renderers/renderer-preact/client.js
@@ -1,4 +1,4 @@
 import { h, render } from 'preact';
 import StaticHtml from './static-html.js';
 
-export default (element) => (Component, props, children) => render(h(Component, props, h(StaticHtml, { value: children })), element);
+export default (element) => (Component, props, children) => render(h(Component, props, children ? h(StaticHtml, { value: children }) : undefined), element);

--- a/packages/renderers/renderer-preact/server.js
+++ b/packages/renderers/renderer-preact/server.js
@@ -25,7 +25,7 @@ function check(Component, props, children) {
 }
 
 function renderToStaticMarkup(Component, props, children) {
-  const html = render(h(Component, { ...props, children: h(StaticHtml, { value: children }), innerHTML: children }));
+  const html = render(h(Component, props, children ? h(StaticHtml, { value: children }) : undefined));
   return { html };
 }
 

--- a/packages/renderers/renderer-react/client.js
+++ b/packages/renderers/renderer-react/client.js
@@ -3,4 +3,4 @@ import { hydrate } from 'react-dom';
 import StaticHtml from './static-html.js';
 
 export default (element) => (Component, props, children) =>
-  hydrate(createElement(Component, { ...props, suppressHydrationWarning: true }, createElement(StaticHtml, { value: children, suppressHydrationWarning: true })), element);
+  hydrate(createElement(Component, { ...props, suppressHydrationWarning: true }, children ? createElement(StaticHtml, { value: children, suppressHydrationWarning: true }) : undefined), element);

--- a/packages/renderers/renderer-react/server.js
+++ b/packages/renderers/renderer-react/server.js
@@ -50,7 +50,7 @@ function renderToStaticMarkup(Component, props, children, metadata) {
   delete props['class'];
   const vnode = React.createElement(Component, {
     ...props,
-    children: React.createElement(StaticHtml, { value: children }),
+    children: children ? React.createElement(StaticHtml, { value: children }) : undefined,
   });
   let html;
   if (metadata && metadata.hydrate) {

--- a/packages/renderers/renderer-svelte/Wrapper.svelte.ssr.js
+++ b/packages/renderers/renderer-svelte/Wrapper.svelte.ssr.js
@@ -3,14 +3,16 @@ import { create_ssr_component, missing_component, validate_component } from 'sve
 
 const App = create_ssr_component(($$result, $$props, $$bindings, slots) => {
   const { __astro_component: Component, __astro_children, ...props } = $$props;
+  const children = {};
+  if (__astro_children) {
+    children.default = () => `<astro-fragment>${__astro_children}</astro-fragment>`;
+  }
 
   return `${validate_component(Component || missing_component, 'svelte:component').$$render(
     $$result,
     Object.assign(props),
     {},
-    {
-      default: () => `${__astro_children ? `<astro-fragment>${__astro_children}</astro-fragment>` : ``}`,
-    }
+    children
   )}`;
 });
 

--- a/packages/renderers/renderer-vue/client.js
+++ b/packages/renderers/renderer-vue/client.js
@@ -5,6 +5,10 @@ export default (element) => (Component, props, children) => {
   delete props['class'];
   // Expose name on host component for Vue devtools
   const name = Component.name ? `${Component.name} Host` : undefined;
-  const app = createSSRApp({ name, render: () => h(Component, props, { default: () => h(StaticHtml, { value: children }) }) });
+  const slots = {};
+  if (children) {
+    slots.default = () => h(StaticHtml, { value: children });
+  }
+  const app = createSSRApp({ name, render: () => h(Component, props, slots) });
   app.mount(element, true);
 };

--- a/packages/renderers/renderer-vue/server.js
+++ b/packages/renderers/renderer-vue/server.js
@@ -7,7 +7,11 @@ function check(Component) {
 }
 
 async function renderToStaticMarkup(Component, props, children) {
-  const app = createSSRApp({ render: () => h(Component, props, { default: () => h(StaticHtml, { value: children }) }) });
+  const slots = {};
+  if (children) {
+    slots.default = () => h(StaticHtml, { value: children });
+  }
+  const app = createSSRApp({ render: () => h(Component, props, slots) });
   const html = await renderToString(app);
   return { html };
 }


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/astro/issues/2056
- Renderers previously did not conditionally inject children, they injected a child element even if it was empty.
- This was causing default slots to be overwritten, even though they should have been displayed.
- This PR makes our renderers smarter about injecting `children`!

## Testing

Tests added for each framework renderer

## Docs

Bug fix only