### PR TITLE
Update styling.md

### DIFF
--- a/docs/src/pages/guides/styling.md
+++ b/docs/src/pages/guides/styling.md
@@ -129,11 +129,9 @@ It’s recommended to only use this in scenarios where a `<link>` tag won’t wo
 ```js
 // postcss.config.cjs
 module.exports = {
-  plugins: {
-    autoprefixer: {
-      /* (optional) autoprefixer settings */
-    },
-  },
+  plugins: [
+    require("autoprefixer")
+  ],
 };
 ```
 
@@ -224,9 +222,9 @@ module.exports = {
 ```js
 // postcss.config.cjs
 module.exports = {
-  plugins: {
-    tailwindcss: {},
-  },
+  plugins: [
+    require("tailwindcss")
+  ],
 };
 ```
 


### PR DESCRIPTION
I found that the require is better way to import postcss plugins: https://github.com/postcss/postcss-load-config/issues/192

## Changes

- What does this change? : The documentation how users need to require postcss plugins in to postcss.config.cjs
- 
## Testing

Own my own project I install some postcss plugins
```
// postcss.config.cjs
module.exports = {
    plugins: [
        require('postcss-nested'),
        require("postcss-nesting"),
        require("tailwindcss"),
        require("autoprefixer"),
    ],
};
```

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
