### PR TITLE
Invalidate based on modulePath

### DIFF
--- a/.changeset/dull-parents-speak.md
+++ b/.changeset/dull-parents-speak.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes invalidation of proxy module (inline script modules)

--- a/packages/astro/vendor/vite/dist/node/chunks/dep-35df7f96.js
+++ b/packages/astro/vendor/vite/dist/node/chunks/dep-35df7f96.js
@@ -56984,7 +56984,10 @@ const devHtmlHook = async (html, { path: htmlPath, server, originalUrl }) => {
                 addToHTMLProxyCache(config, url, scriptModuleIndex, contents);
                 const modulePath = `${config.base + htmlPath.slice(1)}?html-proxy&index=${scriptModuleIndex}.js`;
                 // invalidate the module so the newly cached contents will be served
-                server === null || server === void 0 ? void 0 : server.moduleGraph.invalidateId(config.root + modulePath);
+                const module = server === null || server === void 0 ? void 0 : server.moduleGraph.getModuleById(modulePath);
+                if (module) {
+                    server === null || server === void 0 ? void 0 : server.moduleGraph.invalidateModule(module);
+                }
                 s.overwrite(node.loc.start.offset, node.loc.end.offset, `<script type="module" src="${modulePath}"></script>`);
             }
         }
@@ -57114,12 +57117,6 @@ class ModuleGraph {
         mod.transformResult = null;
         mod.ssrTransformResult = null;
         invalidateSSRModule(mod, seen);
-    }
-    invalidateId(id) {
-        const mod = this.idToModuleMap.get(id);
-        if (mod) {
-            this.invalidateModule(mod);
-        }
     }
     invalidateAll() {
         const seen = new Set();


### PR DESCRIPTION
Note that this is the compiled output of Vite's build. See https://github.com/vitejs/vite/pull/5891 for the real changes.

## Changes

- Updates code based on Vite PR review.
- Removes unused `invalidateId` method.
- Fixes #2004

## Testing

Not really possible.

## Docs

Bug fix only