### PR TITLE
Cleanup Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           auto_fix: true
           git_name: GitHub Action
           git_email: github-action@users.noreply.github.com
-          commit_message: '[ci] ${linter} fix'
+          commit_message: 'chore(lint): ${linter} fix'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           neutral_check_on_warning: true
 
@@ -72,7 +72,6 @@ jobs:
   # We upload all `dist/` artifacts to GitHub, which can be shared by all dependent jobs.
   build:
     name: Build Packages
-    if: "!contains(github.event.head_commit.message, '[skip-ci]')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -103,7 +102,6 @@ jobs:
   # We also run `yarn install` with the `--prefer-offline` flag to speed things up.
   test:
     name: 'Test: ${{ matrix.os }} (node@${{ matrix.node_version }})'
-    if: "!contains(github.event.head_commit.message, '[skip-ci]')"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -144,7 +142,6 @@ jobs:
   smoke:
     name: 'Smoke Test: ${{ matrix.target }}'
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip-ci]')"
     strategy:
       matrix:
         target: [docs, www]
@@ -179,7 +176,7 @@ jobs:
   # We download all `dist/` artifacts from GitHub to skip the build process.
   changelog:
     name: Changelog PR or Release
-    if: ${{ !contains(github.event.head_commit.message, '[skip-ci]') && github.ref_name == 'main' && github.repository_owner == 'withastro' }}
+    if: ${{ github.ref_name == 'main' && github.repository_owner == 'withastro' }}
     needs: [lint, test, smoke]
     runs-on: ubuntu-latest
     steps:
@@ -209,7 +206,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: yarn changeset publish
-          commit: '[ci] release'
+          commit: 'chore: release'
           title: '[ci] release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   congrats:
     name: congratsbot
-    if: ${{ github.repository_owner == 'withastro' && !contains(github.event.head_commit.message, '[skip-ci]') }}
+    if: ${{ github.repository_owner == 'withastro' }}
     runs-on: ubuntu-latest
     steps:
       - id: setup

--- a/scripts/notify/index.js
+++ b/scripts/notify/index.js
@@ -53,7 +53,7 @@ async function run() {
   } else {
     console.log(`${emoji} Some ${descriptor} ${verb}\n`);
     for (const { name, version, url } of packages) {
-      console.log(`• \`${name}@${version}\` Read the [Release Notes →](<${url}>)`);
+      console.log(`• \`${name}@${version}\` Read the [release notes →](<${url}>)`);
     }
   }
 }

--- a/scripts/notify/index.js
+++ b/scripts/notify/index.js
@@ -3,6 +3,36 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const baseUrl = new URL('https://github.com/withastro/astro/blob/main/');
 
+const emojis = ['🎉', '🥳', '🚀', '🧑‍🚀', '🎊', '🏆', '✅', '🤩', '🤖', '🙌'];
+const descriptors = [
+  'new releases',
+  'fresh new code',
+  'shiny updates',
+  'exciting stuff',
+  'package updates',
+  'awesome updates',
+  'bug fixes and features',
+  'updates'
+];
+const verbs = [
+  'just went out!',
+  'now available!',
+  'in the wild!',
+  'now live!',
+  'hit the registry!',
+  'to share!',
+  'for you!',
+  'for y\'all!',
+  'comin\' your way!',
+  'comin\' atcha!',
+  'comin\' in hot!',
+  ', freshly minted on the blockchain! (jk)',
+];
+
+function item(items) {
+  return items[Math.floor(Math.random() * items.length)];
+}
+
 async function run() {
   const releases = process.argv.slice(2)[0];
   const data = JSON.parse(releases);
@@ -13,13 +43,17 @@ async function run() {
     })
   );
 
+  const emoji = item(emojis);
+  const descriptor = item(descriptors);
+  const verb = item(verbs);
+
   if (packages.length === 1) {
     const { name, version, url } = packages[0];
-    console.log(`\`${name}@${version}\` was just released! Read the [release notes →](<${url}>)`);
+    console.log(`${emoji} \`${name}@${version}\` ${verb}\nRead the [release notes →](<${url}>)`);
   } else {
-    console.log(`**Some new releases just went out!**\n`);
+    console.log(`${emoji} Some ${descriptor} ${verb}\n`);
     for (const { name, version, url } of packages) {
-      console.log(`  • \`${name}@${version}\` ([Release Notes →](<${url}>))`);
+      console.log(`• \`${name}@${version}\` Read the [Release Notes →](<${url}>)`);
     }
   }
 }

--- a/scripts/notify/index.js
+++ b/scripts/notify/index.js
@@ -4,16 +4,7 @@ const require = createRequire(import.meta.url);
 const baseUrl = new URL('https://github.com/withastro/astro/blob/main/');
 
 const emojis = ['🎉', '🥳', '🚀', '🧑‍🚀', '🎊', '🏆', '✅', '🤩', '🤖', '🙌'];
-const descriptors = [
-  'new releases',
-  'fresh new code',
-  'shiny updates',
-  'exciting stuff',
-  'package updates',
-  'awesome updates',
-  'bug fixes and features',
-  'updates'
-];
+const descriptors = ['new releases', 'fresh new code', 'shiny updates', 'exciting stuff', 'package updates', 'awesome updates', 'bug fixes and features', 'updates'];
 const verbs = [
   'just went out!',
   'now available!',
@@ -22,10 +13,10 @@ const verbs = [
   'hit the registry!',
   'to share!',
   'for you!',
-  'for y\'all!',
-  'comin\' your way!',
-  'comin\' atcha!',
-  'comin\' in hot!',
+  "for y'all!",
+  "comin' your way!",
+  "comin' atcha!",
+  "comin' in hot!",
   ', freshly minted on the blockchain! (jk)',
 ];
 


### PR DESCRIPTION
## Changes

- Removes manual `[skip-ci]` checks since [GitHub handles them automatically](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/).
- Removes `[ci]` from automated commit messages since that apparently skips actions

## Testing

This is it!

## Docs

QoL Improvement
