### PR TITLE
Allow special characters in filenames

### DIFF
--- a/.changeset/proud-yaks-smile.md
+++ b/.changeset/proud-yaks-smile.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Bugfix: allow special characters in filenames

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -81,5 +81,5 @@ export function resolveDependency(dep: string, astroConfig: AstroConfig) {
  * Windows:    /@fs/C:/Users/astro/code/my-project/src/pages/index.astro
  */
 export function viteifyURL(filePath: URL): string {
-  return `/@fs${filePath.pathname}`;
+  return `/@fs${slash(fileURLToPath(filePath)).replace(/^\/?/, '/')}`;
 }

--- a/packages/astro/test/astro-basic.test.js
+++ b/packages/astro/test/astro-basic.test.js
@@ -81,6 +81,11 @@ describe('Astro basics', () => {
       // will be 1 if element rendered correctly
       expect($('#one')).to.have.lengthOf(1);
     });
+
+    it('supports special chars in filename', async () => {
+      // will have already erred by now, but add test anyway
+      expect(await fixture.readFile('/special-“characters” -in-file/index.html')).to.be.ok;
+    });
   });
 
   it('Supports void elements whose name is a string (#2062)', async () => {

--- a/packages/astro/test/fixtures/astro-basic/src/pages/special-“characters” -in-file.md
+++ b/packages/astro/test/fixtures/astro-basic/src/pages/special-“characters” -in-file.md
@@ -1,0 +1,5 @@
+---
+title: Special chars
+---
+
+# I have special characters


### PR DESCRIPTION
## Changes

Fixes #2089. Files with special characters won’t build

## Testing

Adds test

## Docs

Bugfix