### PR TITLE
Remove use of URL module in runtime

### DIFF
--- a/.changeset/empty-oranges-provide.md
+++ b/.changeset/empty-oranges-provide.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes regression in build caused by use of URL module
+
+Using this module breaks the build because Vite tries to shim it, incorrectly.

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -2,7 +2,6 @@ import type { AstroComponentMetadata, Renderer } from '../../@types/astro';
 import type { AstroGlobalPartial, SSRResult, SSRElement } from '../../@types/astro';
 
 import shorthash from 'shorthash';
-import { pathToFileURL } from 'url';
 import { extractDirectives, generateHydrateScript } from './hydration.js';
 import { serializeListValue } from './util.js';
 export { createMetadata } from './metadata.js';
@@ -289,7 +288,7 @@ function createFetchContentFn(url: URL) {
 // Inside of getStaticPaths.
 export function createAstro(fileURLStr: string, site: string, projectRootStr: string): AstroGlobalPartial {
   const url = new URL(fileURLStr);
-  const projectRoot = projectRootStr === '.' ? pathToFileURL(process.cwd()) : new URL(projectRootStr);
+  const projectRoot = new URL(projectRootStr);
   const fetchContent = createFetchContentFn(url);
   return {
     site: new URL(site),


### PR DESCRIPTION


## Changes

- Fixes #2102
- We can't use this module due to Vite not having a shim and this needing to run inside Vite.
- This is not needed anyways because the compiler always passes through `projectRootStr` anyways.

## Testing

Bug only occurs externally

## Docs

Bug fix