### PR TITLE
Add `devOptions.tailwindConfig`  for Tailwind setup

### DIFF
--- a/docs/src/pages/guides/styling.md
+++ b/docs/src/pages/guides/styling.md
@@ -224,6 +224,18 @@ module.exports = {
 };
 ```
 
+Then in the `astro.config.mjs` file, point to the Tailwind config file:
+
+```js
+export default /** @type {import('astro').AstroUserConfig} */ ({
+  // Comment out "renderers: []" to enable Astro's default component support.
+  renderers: [],
+  devOptions: {
+    tailwindConfig: './tailwind.config.cjs'
+  }
+})
+```
+
 Now you're ready to write Tailwind! Our recommended approach is to create a `src/styles/global.css` file (or whatever you‘d like to name your global stylesheet) with [Tailwind utilities][tailwind-utilities] like so:
 
 ```css


### PR DESCRIPTION
(Docs site) I had an issue setting up Tailwind, I missed this piece I found explained on https://daily-dev-tips.com/posts/how-to-use-tailwind-css-in-astro/
