### PR TITLE
Fix build missing styles (affecting docs)

### DIFF
--- a/.changeset/popular-roses-ring.md
+++ b/.changeset/popular-roses-ring.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Bugfix: fix missing styles in build

--- a/docs/src/config.ts
+++ b/docs/src/config.ts
@@ -135,6 +135,7 @@ export const SIDEBAR = {
     { text: '新手上路', link: 'zh-TW/getting-started' },
     { text: '快速開始', link: 'zh-TW/quick-start' },
     { text: '安裝', link: 'zh-TW/installation' },
+    { text: '佈景主題', link: 'zh-TW/themes' },
   ],
   bg: [
     { text: 'Главни', header: true },

--- a/docs/src/pages/es/guides/markdown-content.astro
+++ b/docs/src/pages/es/guides/markdown-content.astro
@@ -1,0 +1,13 @@
+---
+import { Markdown } from 'astro/components';
+import MainLayout from '~/layouts/MainLayout.astro';
+const [content] = Astro.fetchContent('/src/pages/guides/markdown-content.md');
+---
+
+<MainLayout content="{content}">
+  <Markdown>
+    > Esta página todavía no está disponible en Español. Se muestra la versión en inglés.
+  </Markdown>
+  {content.astro.html}
+</MainLayout>
+

--- a/docs/src/pages/es/guides/pagination.astro
+++ b/docs/src/pages/es/guides/pagination.astro
@@ -1,0 +1,13 @@
+---
+import { Markdown } from 'astro/components';
+import MainLayout from '~/layouts/MainLayout.astro';
+const [content] = Astro.fetchContent('/src/pages/guides/pagination.md');
+---
+
+<MainLayout content="{content}">
+  <Markdown>
+    > Esta página todavía no está disponible en Español. Se muestra la versión en inglés.
+  </Markdown>
+  {content.astro.html}
+</MainLayout>
+

--- a/docs/src/pages/es/guides/publish-to-npm.astro
+++ b/docs/src/pages/es/guides/publish-to-npm.astro
@@ -1,0 +1,13 @@
+---
+import { Markdown } from 'astro/components';
+import MainLayout from '~/layouts/MainLayout.astro';
+const [content] = Astro.fetchContent('/src/pages/guides/publish-to-npm.md');
+---
+
+<MainLayout content="{content}">
+  <Markdown>
+    > Esta página todavía no está disponible en Español. Se muestra la versión en inglés.
+  </Markdown>
+  {content.astro.html}
+</MainLayout>
+

--- a/docs/src/pages/es/guides/styling.astro
+++ b/docs/src/pages/es/guides/styling.astro
@@ -1,0 +1,13 @@
+---
+import { Markdown } from 'astro/components';
+import MainLayout from '~/layouts/MainLayout.astro';
+const [content] = Astro.fetchContent('/src/pages/guides/styling.md');
+---
+
+<MainLayout content="{content}">
+  <Markdown>
+    > Esta página todavía no está disponible en Español. Se muestra la versión en inglés.
+  </Markdown>
+  {content.astro.html}
+</MainLayout>
+

--- a/docs/src/pages/es/reference/renderer-reference.astro
+++ b/docs/src/pages/es/reference/renderer-reference.astro
@@ -1,0 +1,13 @@
+---
+import { Markdown } from 'astro/components';
+import MainLayout from '~/layouts/MainLayout.astro';
+const [content] = Astro.fetchContent('/src/pages/reference/renderer-reference.md');
+---
+
+<MainLayout content="{content}">
+  <Markdown>
+    > Esta página todavía no está disponible en Español. Se muestra la versión en inglés.
+  </Markdown>
+  {content.astro.html}
+</MainLayout>
+

--- a/docs/src/pages/zh-TW/themes.astro
+++ b/docs/src/pages/zh-TW/themes.astro
@@ -1,0 +1,52 @@
+---
+import Layout from '../../layouts/MainLayout.astro';
+import Card from '../../components/Card.astro';
+import {Markdown} from 'astro/components';
+import themes from '../../data/themes.json';
+import components from '../../data/components.json';
+---
+<style>
+    .card-grid {
+        display: grid;
+        grid-column-gap: 15px;
+        grid-row-gap: 15px;
+        grid-auto-flow: dense;
+        grid-template-columns: repeat(auto-fit,minmax(300px,1fr))
+    }
+</style>
+<Layout content={{title: 'Themes'}} hideRightSidebar>
+    <Markdown>
+        ## 精選佈景主題
+    </Markdown>
+    <div class="card-grid">
+        {themes.featured.map((item)=>(<Card data={item} />))}
+    </div>
+    <Markdown>
+        ## 官方佈景主題
+
+        Astro 維護的文件網站、作品集⋯等官方佈景主題。
+    </Markdown>
+    <div class="card-grid">
+        {themes.official.map((item)=>(<Card data={item} />))}
+    </div>
+    <Markdown>
+        ## 社群佈景主題
+
+        趕緊來看看社群開發的佈景主題！
+    </Markdown>
+    <div class="card-grid">
+        {themes.community.map((item)=>(<Card data={item} />))}
+    </div>
+    <Markdown>
+        ## 精選套件
+
+        我們的套件生態持續成長！所有精選社群套件都可以在 [npm](https://www.npmjs.com/search?q=keywords%3Aastro-component) 發掘。
+    </Markdown>
+    <div class="card-grid">
+        {components.community.map((item)=>(<Card data={item} />))}
+    </div>
+    <Markdown>
+        > 想要讓自己的作品成為精選嗎？[在 Discord 分享！](https://astro.build/chat)
+        我們常在 `#showcase` 頻道取材，把深受喜愛的在這裡發布。
+    </Markdown>
+</Layout>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  ignore = "git diff --quiet $COMMIT_REF $CACHED_COMMIT_REF -- docs/ www/"
+  ignore = "git diff --quiet $COMMIT_REF $CACHED_COMMIT_REF -- packages/astro/src docs/ www/"

--- a/packages/astro/src/core/ssr/index.ts
+++ b/packages/astro/src/core/ssr/index.ts
@@ -23,7 +23,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { renderPage, renderSlot } from '../../runtime/server/index.js';
-import { canonicalURL as getCanonicalURL, codeFrame, resolveDependency, viteifyURL } from '../util.js';
+import { canonicalURL as getCanonicalURL, codeFrame, resolveDependency } from '../util.js';
 import { getStylesForURL } from './css.js';
 import { injectTags } from './html.js';
 import { generatePaginateFunction } from './paginate.js';
@@ -133,7 +133,7 @@ export async function preload({ astroConfig, filePath, viteServer }: SSROptions)
   // Important: This needs to happen first, in case a renderer provides polyfills.
   const renderers = await resolveRenderers(viteServer, astroConfig);
   // Load the module from the Vite SSR Runtime.
-  const mod = (await viteServer.ssrLoadModule(viteifyURL(filePath))) as ComponentInstance;
+  const mod = (await viteServer.ssrLoadModule(fileURLToPath(filePath))) as ComponentInstance;
 
   return [renderers, mod];
 }

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -74,12 +74,11 @@ export function resolveDependency(dep: string, astroConfig: AstroConfig) {
 }
 
 /**
- * Vite-ify URL
- * Given a file URL, return an ID that matches Vite’s module graph. Needed for resolution and stack trace fixing.
- * Must match the following format:
- * Linux/Mac:  /@fs/Users/astro/code/my-project/src/pages/index.astro
- * Windows:    /@fs/C:/Users/astro/code/my-project/src/pages/index.astro
+ * Convert file URL to ID for viteServer.moduleGraph.idToModuleMap.get(:viteID)
+ * Format:
+ *   Linux/Mac:  /Users/astro/code/my-project/src/pages/index.astro
+ *   Windows:    C:/Users/astro/code/my-project/src/pages/index.astro
  */
-export function viteifyURL(filePath: URL): string {
-  return `/@fs${slash(fileURLToPath(filePath)).replace(/^\/?/, '/')}`;
+export function viteID(filePath: URL): string {
+  return slash(fileURLToPath(filePath));
 }


### PR DESCRIPTION
## Changes

Fixes #2101

The issue is that looking up modules through Vite’s moduleGraph requires a specific ID lookup to pull up dependencies. In resolving other moduleGraph issues on Windows it seems we’ve had a regression with styles.

**Before**

![Publish_to_NPM_🚀_Astro_Documentation](https://user-images.githubusercontent.com/1369770/144689454-87b0d883-7906-4507-b3f8-6d5c3d1145f6.jpg)

**After**

<img width="1440" alt="Screen Shot 2021-12-06 at 14 19 09" src="https://user-images.githubusercontent.com/1369770/144924245-94c0d6aa-e18c-425c-ab32-0b024af5b062.png">


## Testing

This is very hard to write a test for! This is very Vite implementation-specific and so even if a test was written, it might be a false positive if Vite’s internals ever changed. No tests were added, unfortunately.

But testing has been done manually on the docs: https://deploy-preview-2112--astro-docs-2.netlify.app/ (make sure **every page has header styles**)

## Docs

Bugfix only.