### PR TITLE
Validate Astro frontmatter JS/TS on compiler error

### DIFF
--- a/.changeset/dirty-guests-wash.md
+++ b/.changeset/dirty-guests-wash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve error message on bad JS/TS frontmatter

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -111,7 +111,7 @@ export default function astro({ config, devServer }: AstroPluginOptions): vite.P
             await esbuild.transform(scannedFrontmatter[1], { loader: 'ts', sourcemap: false, sourcefile: id });
           } catch (frontmatterErr: any) {
             // Improve the error by replacing the phrase "unexpected end of file"
-            // with the word "frontmatter" in the error message.
+            // with "unexpected end of frontmatter" in the esbuild error message.
             if (frontmatterErr && frontmatterErr.message) {
               frontmatterErr.message = frontmatterErr.message.replace('end of file', 'end of frontmatter');
             }

--- a/packages/astro/test/errors.test.js
+++ b/packages/astro/test/errors.test.js
@@ -21,10 +21,9 @@ before(async () => {
 
 describe('Error display', () => {
   describe('Astro', () => {
-
     it('syntax error in template', async () => {
       // if (isMacOS) return;
-      const res = await fixture.fetch('/astro-syntax-error')
+      const res = await fixture.fetch('/astro-syntax-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
       console.log(res.body);

--- a/packages/astro/test/errors.test.js
+++ b/packages/astro/test/errors.test.js
@@ -21,90 +21,64 @@ before(async () => {
 
 describe('Error display', () => {
   describe('Astro', () => {
-    // This test is redundant w/ runtime error since it no longer produces an Astro syntax error
-    it.skip('syntax error', async () => {
-      if (isMacOS) return;
 
-      const res = await fixture.fetch('/astro-syntax-error');
-
-      // 500 returned
+    it('syntax error in template', async () => {
+      // if (isMacOS) return;
+      const res = await fixture.fetch('/astro-syntax-error')
       expect(res.status).to.equal(500);
-
-      // error message includes "unrecoverable error"
       const body = await res.text();
       console.log(res.body);
-      expect(body).to.include('unrecoverable error');
+      expect(body).to.include('Unexpected &quot;}&quot;');
+    });
+
+    it('syntax error in frontmatter', async () => {
+      // if (isMacOS) return;
+      const res = await fixture.fetch('/astro-frontmatter-syntax-error');
+      expect(res.status).to.equal(500);
+      const body = await res.text();
+      console.log(res.body);
+      expect(body).to.include('Unexpected end of frontmatter');
     });
 
     it('runtime error', async () => {
-      if (isMacOS) return;
-
+      // if (isMacOS) return;
       const res = await fixture.fetch('/astro-runtime-error');
-
-      // 500 returned
       expect(res.status).to.equal(500);
-
-      // error message contains error
       const body = await res.text();
       expect(body).to.include('ReferenceError: title is not defined');
-
-      // TODO: improve stacktrace
+      // TODO: improve and test stacktrace
     });
 
     it('hydration error', async () => {
-      if (isMacOS) return;
-
+      // if (isMacOS) return;
       const res = await fixture.fetch('/astro-hydration-error');
-
-      // 500 returned
       expect(res.status).to.equal(500);
-
-      // error message contains error
       const body = await res.text();
-
-      // error message contains error
       expect(body).to.include('Error: invalid hydration directive');
     });
 
     it('client:media error', async () => {
-      if (isMacOS) return;
-
+      // if (isMacOS) return;
       const res = await fixture.fetch('/astro-client-media-error');
-
-      // 500 returned
       expect(res.status).to.equal(500);
-
-      // error message contains error
       const body = await res.text();
-
-      // error message contains error
       expect(body).to.include('Error: Media query must be provided');
     });
   });
 
   describe('JS', () => {
     it('syntax error', async () => {
-      if (isMacOS) return;
-
+      // if (isMacOS) return;
       const res = await fixture.fetch('/js-syntax-error');
-
-      // 500 returnd
       expect(res.status).to.equal(500);
-
-      // error message is helpful
       const body = await res.text();
       expect(body).to.include('Parse failure');
     });
 
     it('runtime error', async () => {
-      if (isMacOS) return;
-
+      // if (isMacOS) return;
       const res = await fixture.fetch('/js-runtime-error');
-
-      // 500 returnd
       expect(res.status).to.equal(500);
-
-      // error message is helpful
       const body = await res.text();
       expect(body).to.include('ReferenceError: undefinedvar is not defined');
     });
@@ -112,27 +86,17 @@ describe('Error display', () => {
 
   describe('Preact', () => {
     it('syntax error', async () => {
-      if (isMacOS) return;
-
+      // if (isMacOS) return;
       const res = await fixture.fetch('/preact-syntax-error');
-
-      // 500 returned
       expect(res.status).to.equal(500);
-
-      // error message is helpful
       const body = await res.text();
       expect(body).to.include('Syntax error');
     });
 
     it('runtime error', async () => {
-      if (isMacOS) return;
-
+      // if (isMacOS) return;
       const res = await fixture.fetch('/preact-runtime-error');
-
-      // 500 returned
       expect(res.status).to.equal(500);
-
-      // error message is helpful
       const body = await res.text();
       expect(body).to.include('Error: PreactRuntimeError');
     });
@@ -140,27 +104,17 @@ describe('Error display', () => {
 
   describe('React', () => {
     it('syntax error', async () => {
-      if (isMacOS) return;
-
+      // if (isMacOS) return;
       const res = await fixture.fetch('/react-syntax-error');
-
-      // 500 returned
       expect(res.status).to.equal(500);
-
-      // error message is helpful
       const body = await res.text();
       expect(body).to.include('Syntax error');
     });
 
     it('runtime error', async () => {
-      if (isMacOS) return;
-
+      // if (isMacOS) return;
       const res = await fixture.fetch('/react-runtime-error');
-
-      // 500 returned
       expect(res.status).to.equal(500);
-
-      // error message is helpful
       const body = await res.text();
       expect(body).to.include('Error: ReactRuntimeError');
     });
@@ -168,27 +122,17 @@ describe('Error display', () => {
 
   describe('Solid', () => {
     it('syntax error', async () => {
-      if (isMacOS) return;
-
+      // if (isMacOS) return;
       const res = await fixture.fetch('/solid-syntax-error');
-
-      // 500 returned
       expect(res.status).to.equal(500);
-
-      // error message is helpful
       const body = await res.text();
       expect(body).to.include('Syntax error');
     });
 
     it('runtime error', async () => {
-      if (isMacOS) return;
-
+      // if (isMacOS) return;
       const res = await fixture.fetch('/solid-runtime-error');
-
-      // 500 returned
       expect(res.status).to.equal(500);
-
-      // error message is helpful
       const body = await res.text();
       expect(body).to.include('Error: SolidRuntimeError');
     });
@@ -196,27 +140,17 @@ describe('Error display', () => {
 
   describe('Svelte', () => {
     it('syntax error', async () => {
-      if (isMacOS) return;
-
+      // if (isMacOS) return;
       const res = await fixture.fetch('/svelte-syntax-error');
-
-      // 500 returned
       expect(res.status).to.equal(500);
-
-      // error message is helpful
       const body = await res.text();
       expect(body).to.include('ParseError');
     });
 
     it('runtime error', async () => {
-      if (isMacOS) return;
-
+      // if (isMacOS) return;
       const res = await fixture.fetch('/svelte-runtime-error');
-
-      // 500 returned
       expect(res.status).to.equal(500);
-
-      // error message is helpful
       const body = await res.text();
       expect(body).to.include('Error: SvelteRuntimeError');
     });
@@ -224,28 +158,17 @@ describe('Error display', () => {
 
   describe('Vue', () => {
     it('syntax error', async () => {
-      if (isMacOS) return;
-
+      // if (isMacOS) return;
       const res = await fixture.fetch('/vue-syntax-error');
-
       const body = await res.text();
-
-      // 500 returned
       expect(res.status).to.equal(500);
-
-      // error message is helpful
       expect(body).to.include('Parse failure');
     });
 
     it('runtime error', async () => {
-      if (isMacOS) return;
-
+      // if (isMacOS) return;
       const res = await fixture.fetch('/vue-runtime-error');
-
-      // 500 returned
       expect(res.status).to.equal(500);
-
-      // error message is helpful
       const body = await res.text();
       expect(body).to.match(/Cannot read.*undefined/); // note: error differs slightly between Node versions
     });

--- a/packages/astro/test/errors.test.js
+++ b/packages/astro/test/errors.test.js
@@ -1,9 +1,5 @@
 import { expect } from 'chai';
-import os from 'os';
 import { loadFixture } from './test-utils.js';
-
-// TODO: fix these tests on macOS
-const isMacOS = os.platform() === 'darwin';
 
 let fixture;
 let devServer;
@@ -22,7 +18,6 @@ before(async () => {
 describe('Error display', () => {
   describe('Astro', () => {
     it('syntax error in template', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/astro-syntax-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
@@ -31,7 +26,6 @@ describe('Error display', () => {
     });
 
     it('syntax error in frontmatter', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/astro-frontmatter-syntax-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
@@ -40,7 +34,6 @@ describe('Error display', () => {
     });
 
     it('runtime error', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/astro-runtime-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
@@ -49,7 +42,6 @@ describe('Error display', () => {
     });
 
     it('hydration error', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/astro-hydration-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
@@ -57,7 +49,6 @@ describe('Error display', () => {
     });
 
     it('client:media error', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/astro-client-media-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
@@ -67,7 +58,6 @@ describe('Error display', () => {
 
   describe('JS', () => {
     it('syntax error', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/js-syntax-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
@@ -75,7 +65,6 @@ describe('Error display', () => {
     });
 
     it('runtime error', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/js-runtime-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
@@ -85,7 +74,6 @@ describe('Error display', () => {
 
   describe('Preact', () => {
     it('syntax error', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/preact-syntax-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
@@ -93,7 +81,6 @@ describe('Error display', () => {
     });
 
     it('runtime error', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/preact-runtime-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
@@ -103,7 +90,6 @@ describe('Error display', () => {
 
   describe('React', () => {
     it('syntax error', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/react-syntax-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
@@ -111,7 +97,6 @@ describe('Error display', () => {
     });
 
     it('runtime error', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/react-runtime-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
@@ -121,7 +106,6 @@ describe('Error display', () => {
 
   describe('Solid', () => {
     it('syntax error', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/solid-syntax-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
@@ -129,7 +113,6 @@ describe('Error display', () => {
     });
 
     it('runtime error', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/solid-runtime-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
@@ -139,7 +122,6 @@ describe('Error display', () => {
 
   describe('Svelte', () => {
     it('syntax error', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/svelte-syntax-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
@@ -147,7 +129,6 @@ describe('Error display', () => {
     });
 
     it('runtime error', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/svelte-runtime-error');
       expect(res.status).to.equal(500);
       const body = await res.text();
@@ -157,7 +138,6 @@ describe('Error display', () => {
 
   describe('Vue', () => {
     it('syntax error', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/vue-syntax-error');
       const body = await res.text();
       expect(res.status).to.equal(500);
@@ -165,7 +145,6 @@ describe('Error display', () => {
     });
 
     it('runtime error', async () => {
-      // if (isMacOS) return;
       const res = await fixture.fetch('/vue-runtime-error');
       expect(res.status).to.equal(500);
       const body = await res.text();

--- a/packages/astro/test/fixtures/errors/src/pages/astro-frontmatter-syntax-error.astro
+++ b/packages/astro/test/fixtures/errors/src/pages/astro-frontmatter-syntax-error.astro
@@ -1,0 +1,4 @@
+---
+{
+---
+<h1>Testing bad JS in frontmatter</h1>


### PR DESCRIPTION
## Changes

- Before passing a component to the compiler, use esbuild to validate the frontmatter against JS/TS syntax.
- This will prevent a class of bug where bad front-matter syntax can break the compiled output in very obscure ways (for example, an unclosed parenthesis).
- Once the compiler can handle this better, we can remove this.

### Before
```
---
import Layout from '../layouts/MainLayout.astro';
{
--- 
```

Unclear error output.

<img width="1127" alt="Screen Shot 2021-12-03 at 11 58 30 AM" src="https://user-images.githubusercontent.com/622227/144665246-94cbe7ee-ac89-4d80-9914-53bb09f39213.png">

### After

Clear error output, with the correct bug location. "end of file" is still a little odd wording (it should say "end of frontmatter", which we can fix by re-writing this error message if that makes sense) but this is already a nice improvement over broken output, compiler panics, etc.

<img width="1096" alt="Screen Shot 2021-12-03 at 11 58 49 AM" src="https://user-images.githubusercontent.com/622227/144665308-91c41110-4ce7-4dfe-a78e-8171c6c632b0.png">




## Testing

- Still TODO

## Docs

- Not needed