### PR TITLE
Parse --renderers flag correctly when passed to the create-astro cli

### DIFF
--- a/.changeset/spicy-bats-search.md
+++ b/.changeset/spicy-bats-search.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Parse --renderers flag correctly when passed to the create-astro cli

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -14,7 +14,7 @@ import { createConfig } from './config.js';
 // broke our arg parser, since `--` is a special kind of flag. Filtering for `--` here
 // fixes the issue so that create-astro now works on all npm version.
 const cleanArgv = process.argv.filter((arg) => arg !== '--');
-const args = yargs(cleanArgv);
+const args = yargs(cleanArgv, { array: ['renderers'] });
 prompts.override(args);
 
 export function mkdirp(dir: string) {


### PR DESCRIPTION
## Changes

Fixes #2045. Make sure the `--renderers` flag is parsed correctly as an array when passed.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
I tested it manually since I tried running `yarn test:templates` locally but it fails even without any changes. I saw the `create-astro` package tests are not being run as part of CI, is that because they are broken or slow? 🤷🏻  

If I'm missing something, I'd be happy to amend the tests for it. We just need to pass the renderers for templates with `renderers: true` and it should succeed.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Bug fix only