### PR TITLE
Make `fetch` injection safe to existing code

### DIFF
--- a/.changeset/wet-insects-dance.md
+++ b/.changeset/wet-insects-dance.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Patch `fetch` support to prioritize authored code. Existing `fetch` imports and declarations are respected.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -76,6 +76,7 @@
     "es-module-lexer": "^0.7.1",
     "esbuild": "0.13.7",
     "estree-util-value-to-estree": "^1.2.0",
+    "estree-walker": "^3.0.0",
     "fast-glob": "^3.2.7",
     "fast-xml-parser": "^3.19.0",
     "html-entities": "^2.3.2",

--- a/packages/astro/src/vite-plugin-fetch/index.ts
+++ b/packages/astro/src/vite-plugin-fetch/index.ts
@@ -52,8 +52,8 @@ export default function pluginFetch(): Plugin {
               fetchDeclared = true;
             }
           }
-        }
-      })
+        },
+      });
 
       // Fetch is already declared, do not inject a re-declaration!
       if (fetchDeclared) {

--- a/packages/astro/src/vite-plugin-fetch/index.ts
+++ b/packages/astro/src/vite-plugin-fetch/index.ts
@@ -1,4 +1,5 @@
 import type { Plugin } from '../core/vite';
+import type { BaseNode, Identifier } from 'estree';
 import MagicString from 'magic-string';
 import { walk } from 'estree-walker';
 
@@ -21,6 +22,10 @@ function isSSR(options: undefined | boolean | { ssr: boolean }): boolean {
 const SUPPORTED_FILES = /\.(astro|svelte|vue|[cm]?js|jsx|[cm]?ts|tsx)$/;
 const IGNORED_MODULES = [/astro\/dist\/runtime\/server/, /\/node-fetch\//];
 const DEFINE_FETCH = `import fetch from 'node-fetch';\n`;
+
+function isIdentifier(node: BaseNode): node is Identifier {
+  return node.type === 'Identifier';
+}
 
 export default function pluginFetch(): Plugin {
   return {
@@ -46,7 +51,7 @@ export default function pluginFetch(): Plugin {
       walk(ast, {
         enter(node, parent) {
           if (fetchDeclared) return this.skip();
-          if (node.type === 'Identifier') {
+          if (isIdentifier(node)) {
             // Identifier is OK in any type of Expression (CallExpression, UnaryExpression, etc)
             if (node.name === 'fetch' && !parent.type.endsWith('Expression')) {
               fetchDeclared = true;

--- a/packages/astro/test/fetch.test.js
+++ b/packages/astro/test/fetch.test.js
@@ -27,4 +27,10 @@ describe('Global Fetch', () => {
     expect($('#svelte').text()).to.equal('function', 'Fetch supported in .svelte');
     expect($('#vue').text()).to.equal('function', 'Fetch supported in .vue');
   });
+  it('Respects existing code', async () => {
+    const html = await fixture.readFile('/index.html');
+    const $ = cheerio.load(html);
+    expect($('#already-imported').text()).to.equal('function', 'Existing fetch imports respected');
+    expect($('#custom-declaration').text()).to.equal('number', 'Custom fetch declarations respected');
+  });
 });

--- a/packages/astro/test/fixtures/fetch/src/components/AlreadyImported.astro
+++ b/packages/astro/test/fixtures/fetch/src/components/AlreadyImported.astro
@@ -1,0 +1,5 @@
+---
+import fetch from 'node-fetch'
+---
+
+<span id="already-imported">{typeof fetch}</span>

--- a/packages/astro/test/fixtures/fetch/src/components/CustomDeclaration.astro
+++ b/packages/astro/test/fixtures/fetch/src/components/CustomDeclaration.astro
@@ -1,0 +1,5 @@
+---
+const fetch = 0;
+---
+
+<span id="custom-declaration">{typeof fetch}</span>

--- a/packages/astro/test/fixtures/fetch/src/pages/index.astro
+++ b/packages/astro/test/fixtures/fetch/src/pages/index.astro
@@ -1,5 +1,7 @@
 ---
 import Test from '../components/AstroComponent.astro';
+import AlreadyImported from '../components/AlreadyImported.astro';
+import CustomDeclaration from '../components/CustomDeclaration.astro';
 import JsxComponent from '../components/JsxComponent.jsx';
 import SvelteComponent from '../components/SvelteComponent.svelte';
 import VueComponent from '../components/VueComponent.vue';
@@ -12,6 +14,8 @@ import VueComponent from '../components/VueComponent.vue';
 <body>
   <span id="astro-page">{typeof fetch}</span>
   <Test />
+  <AlreadyImported />
+  <CustomDeclaration />
   <JsxComponent />
   <SvelteComponent />
   <VueComponent />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5213,6 +5213,11 @@ estree-walker@^2.0.1, estree-walker@^2.0.2:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
+estree-walker@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.0.tgz#ca4b284de9dffb255288c76a44870b360faf14f9"
+  integrity sha512-s6ceX0NFiU/vKPiKvFdR83U1Zffu7upwZsGwpoqfg5rbbq1l50WQ5hCeIvM6E6oD4shUHCYMsiFPns4Jk0YfMQ==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"


### PR DESCRIPTION
## Changes

- Previously, `vite-plugin-fetch` would clobber existing code and _always_ inject a `fetch` import. This would cause `fetch is already declared!` errors.
- Now, we do a quick AST walk to ensure that `fetch` has not already been declared before injecting `fetch`.
- Our migration guide even mentions that you _must remove_ existing `fetch` imports. Now it's optional.

## Testing

Tests added for:

- Existing `fetch` import
- Custom `fetch` variable that could point to something else

## Docs

Bug fix only