### PR TITLE
fix(#2129): exclude 404 from sitemap

### DIFF
--- a/.changeset/angry-pillows-accept.md
+++ b/.changeset/angry-pillows-accept.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Exclude 404 pages from sitemap generation

--- a/packages/astro/src/core/ssr/sitemap.ts
+++ b/packages/astro/src/core/ssr/sitemap.ts
@@ -6,7 +6,7 @@ export function generateSitemap(pages: string[]): string {
 
   // copy just in case original copy is needed
   // make sure that 404 page is excluded
-  const urls = [...pages].filter(url => !url.endsWith('/404/index.html'));
+  const urls = [...pages].filter((url) => !url.endsWith('/404/index.html'));
   urls.sort((a, b) => a.localeCompare(b, 'en', { numeric: true })); // sort alphabetically so sitemap is same each time
   let sitemap = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
   for (const url of urls) {

--- a/packages/astro/src/core/ssr/sitemap.ts
+++ b/packages/astro/src/core/ssr/sitemap.ts
@@ -4,7 +4,9 @@ export function generateSitemap(pages: string[]): string {
 
   // TODO: find way to exclude pages from sitemap
 
-  const urls = [...pages]; // copy just in case original copy is needed
+  // copy just in case original copy is needed
+  // make sure that 404 page is excluded
+  const urls = [...pages].filter(url => !url.endsWith('/404/index.html'));
   urls.sort((a, b) => a.localeCompare(b, 'en', { numeric: true })); // sort alphabetically so sitemap is same each time
   let sitemap = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
   for (const url of urls) {

--- a/packages/astro/test/astro-sitemap-rss.test.js
+++ b/packages/astro/test/astro-sitemap-rss.test.js
@@ -29,7 +29,7 @@ describe('Sitemaps', () => {
     it('Generates Sitemap correctly', async () => {
       let sitemap = await fixture.readFile('/sitemap.xml');
       expect(sitemap).to.equal(
-        `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://astro.build/404/index.html</loc></url><url><loc>https://astro.build/episode/fazers/index.html</loc></url><url><loc>https://astro.build/episode/rap-snitch-knishes/index.html</loc></url><url><loc>https://astro.build/episode/rhymes-like-dimes/index.html</loc></url><url><loc>https://astro.build/episodes/index.html</loc></url></urlset>\n`
+        `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://astro.build/episode/fazers/index.html</loc></url><url><loc>https://astro.build/episode/rap-snitch-knishes/index.html</loc></url><url><loc>https://astro.build/episode/rhymes-like-dimes/index.html</loc></url><url><loc>https://astro.build/episodes/index.html</loc></url></urlset>\n`
       );
     });
   });


### PR DESCRIPTION
## Changes

- Excludes 404 page from `astro build` sitemap generation.
- Closes #2129 

## Testing

Test was wrong, updated the test to reflect proper output

## Docs

Bug fix only
