### PR TITLE
Skip flaky macOS Sass test

### DIFF
--- a/packages/astro/test/sass.test.js
+++ b/packages/astro/test/sass.test.js
@@ -17,6 +17,7 @@ describe('Sass', () => {
     devServer && (await devServer.stop());
   });
 
+  // TODO: Sass cannot be found on macOS for some reason... Vite issue?
   const test = os.platform() === 'darwin' ? it.skip : it;
   test('shows helpful error on failure', async () => {
     const res = await fixture.fetch('/error').then((res) => res.text());

--- a/packages/astro/test/sass.test.js
+++ b/packages/astro/test/sass.test.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import os from 'os';
 import { loadFixture } from './test-utils.js';
 
 // note: many Sass tests live in 0-css.test.js to test within context of a framework.
@@ -16,7 +17,8 @@ describe('Sass', () => {
     devServer && (await devServer.stop());
   });
 
-  it('shows helpful error on failure', async () => {
+  const test = os.platform() === 'darwin' ? it.skip : it;
+  test('shows helpful error on failure', async () => {
     const res = await fixture.fetch('/error').then((res) => res.text());
     expect(res).to.include('Undefined variable');
   });


### PR DESCRIPTION
## Changes

We have been plagued by 🔴 for too long! This PR skips the failing Sass test on macOS only.

## Testing

This is it, the tests!

## Docs

QoL improvement only