### PR TITLE
Replace invalid quote character with standard

### DIFF
--- a/docs/src/pages/guides/rss.md
+++ b/docs/src/pages/guides/rss.md
@@ -21,7 +21,7 @@ export async function getStaticPaths({rss}) {
   // Generate an RSS feed from this collection
   rss({
     // The RSS Feed title, description, and custom metadata.
-    title: 'Don’s Blog',
+    title: 'Don's Blog',
     description: 'An example blog on Astro',
     customData: `<language>en-us</language>`,
     // The list of items for your RSS feed, sorted.

--- a/docs/src/pages/guides/rss.md
+++ b/docs/src/pages/guides/rss.md
@@ -10,7 +10,7 @@ You can create an RSS feed from any Astro page that uses a `getStaticPaths()` fu
 
 > We hope to make this feature available to all other pages before v1.0. As a workaround, you can convert a static route to a dynamic route that only generates a single page. See [Routing](/core-concepts/routing) for more information about dynamic routes.
 
-Create an RSS Feed by calling the `rss()` function that is passed as an argument to `getStaticPaths()`. This will create an `feed.xml` file in your final build based on the data that you provide using the `items` array.
+Create an RSS Feed by calling the `rss()` function that is passed as an argument to `getStaticPaths()`. This will create an `rss.xml` file in your final build based on the data that you provide using the `items` array.
 
 ```js
 // Example: /src/pages/posts/[...page].astro

--- a/docs/src/pages/guides/rss.md
+++ b/docs/src/pages/guides/rss.md
@@ -32,8 +32,8 @@ export async function getStaticPaths({rss}) {
       pubDate: item.date,
     })),
     // Optional: Customize where the file is written to.
-    // Otherwise, defaults to "/rss.xml"
-    dest: "/my/custom/feed.xml",
+    // Otherwise, defaults to "/feed.xml"
+    dest: "/my/custom/rss.xml",
   });
   // Return your paths
   return [...];

--- a/docs/src/pages/guides/rss.md
+++ b/docs/src/pages/guides/rss.md
@@ -21,7 +21,7 @@ export async function getStaticPaths({rss}) {
   // Generate an RSS feed from this collection
   rss({
     // The RSS Feed title, description, and custom metadata.
-    title: 'Don's Blog',
+    title: 'Don\'s Blog',
     description: 'An example blog on Astro',
     customData: `<language>en-us</language>`,
     // The list of items for your RSS feed, sorted.

--- a/docs/src/pages/guides/rss.md
+++ b/docs/src/pages/guides/rss.md
@@ -10,7 +10,7 @@ You can create an RSS feed from any Astro page that uses a `getStaticPaths()` fu
 
 > We hope to make this feature available to all other pages before v1.0. As a workaround, you can convert a static route to a dynamic route that only generates a single page. See [Routing](/core-concepts/routing) for more information about dynamic routes.
 
-Create an RSS Feed by calling the `rss()` function that is passed as an argument to `getStaticPaths()`. This will create an `rss.xml` file in your final build based on the data that you provide using the `items` array.
+Create an RSS Feed by calling the `rss()` function that is passed as an argument to `getStaticPaths()`. This will create an `feed.xml` file in your final build based on the data that you provide using the `items` array.
 
 ```js
 // Example: /src/pages/posts/[...page].astro

--- a/docs/src/pages/guides/rss.md
+++ b/docs/src/pages/guides/rss.md
@@ -32,8 +32,8 @@ export async function getStaticPaths({rss}) {
       pubDate: item.date,
     })),
     // Optional: Customize where the file is written to.
-    // Otherwise, defaults to "/feed.xml"
-    dest: "/my/custom/rss.xml",
+    // Otherwise, defaults to "/rss.xml"
+    dest: "/my/custom/feed.xml",
   });
   // Return your paths
   return [...];


### PR DESCRIPTION
Updated RSS related code-snippet in documentation

## Docs

In its current state the documentation code snippet includes a gremlin-apostrophe character which is patched by this PR.
![image](https://user-images.githubusercontent.com/10339043/144992646-20e12d51-32be-43c6-a0da-0bb174499540.png)

<!-- Was public documentation updated? -->
Updated quote symbol in code-snippet RSS
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
