### PR TITLE
fix create-astro export map entry

### DIFF
--- a/.changeset/purple-paws-shave.md
+++ b/.changeset/purple-paws-shave.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fix create-astro export map entry

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/create-astro"
   },
   "exports": {
-    ".": "./create-astro.js"
+    ".": "./create-astro.mjs"
   },
   "bin": {
     "create-astro": "./create-astro.mjs"


### PR DESCRIPTION
## Changes

- Fixes a bad path in the package.json exports map

## Testing

Tested by CI releasebot failure: https://github.com/withastro/astro/runs/4437407032?check_suite_focus=true

## Docs

N/A