### PR TITLE
Update astro-components.md

### DIFF
--- a/docs/src/pages/core-concepts/astro-components.md
+++ b/docs/src/pages/core-concepts/astro-components.md
@@ -341,7 +341,7 @@ import TwitterTimeline from '../components/TwitterTimeline.astro';
 | Multiple frameworks per-file | Yes                                        | No                                                 |
 | Modifying `<head>`           | Just use `<head>`                          | Per-framework (`<Head>`, `<svelte:head>`, etc)     |
 | Comment Style                | `<!-- HTML -->`                            | `{/* JavaScript */}                                |
-| Special Characters           | `&nbsp;`                                   | `{"&nbsp;"}`                                       |
+| Special Characters           | `&nbsp;`                                   | `&nbsp;`                                           |
 | Attributes                   | `dash-case`                                | `camelCase`                                        |
 
 ## URL resolution

--- a/docs/src/pages/core-concepts/astro-components.md
+++ b/docs/src/pages/core-concepts/astro-components.md
@@ -340,8 +340,8 @@ import TwitterTimeline from '../components/TwitterTimeline.astro';
 | Fragments                    | Automatic top-level, `<>` inside functions | Wrap with `<Fragment>` or `<>`                     |
 | Multiple frameworks per-file | Yes                                        | No                                                 |
 | Modifying `<head>`           | Just use `<head>`                          | Per-framework (`<Head>`, `<svelte:head>`, etc)     |
-| Comment Style                | `<!-- HTML -->`                            | `{/* JavaScript */}`                               |
-| Special Characters           | `&nbsp;`                                   | `&nbsp;`                                           |
+| Comment Style                | `<!-- HTML -->`                            | `{/* JavaScript */}                                |
+| Special Characters           | `&nbsp;`                                   | `{"&nbsp;"}`                                       |
 | Attributes                   | `dash-case`                                | `camelCase`                                        |
 
 ## URL resolution

--- a/docs/src/pages/core-concepts/astro-components.md
+++ b/docs/src/pages/core-concepts/astro-components.md
@@ -341,7 +341,7 @@ import TwitterTimeline from '../components/TwitterTimeline.astro';
 | Multiple frameworks per-file | Yes                                        | No                                                 |
 | Modifying `<head>`           | Just use `<head>`                          | Per-framework (`<Head>`, `<svelte:head>`, etc)     |
 | Comment Style                | `<!-- HTML -->`                            | `{/* JavaScript */}`                               |
-| Special Characters           | `&nbsp;`                                   | `{'\xa0'}` or `{String.fromCharCode(160)}`         |
+| Special Characters           | `&nbsp;`                                   | `&nbsp;`                                           |
 | Attributes                   | `dash-case`                                | `camelCase`                                        |
 
 ## URL resolution


### PR DESCRIPTION
HTML entities are supported in JSX.

## Changes

- What does this change?
Fixes misleading information. It's stated that in .astro files you can use HTML entities (represented by `&nbsp;`), JSX supports HTML entities as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

No test, it's changing doc information. 

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

Yes, that's all this PR is 😄