### PR TITLE
Add missing licenses to published packages

### DIFF
--- a/packages/astro-parser/package.json
+++ b/packages/astro-parser/package.json
@@ -1,16 +1,18 @@
 {
   "name": "@astrojs/parser",
   "version": "0.20.3",
-  "author": "Skypack",
-  "license": "MIT",
   "type": "commonjs",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "author": "withastro",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/astro-parser"
   },
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://astro.build",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/astro-prism/package.json
+++ b/packages/astro-prism/package.json
@@ -1,21 +1,23 @@
 {
   "name": "@astrojs/prism",
   "version": "0.3.0",
-  "description": "IYKYK",
-  "main": "index.mjs",
+  "description": "Supports Prism highlighting in Astro projects",
+  "author": "withastro",
+  "license": "MIT",
+  "bugs": "https://github.com/withastro/astro/issues",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/astro-prism"
   },
+  "homepage": "https://astro.build",
+  "main": "index.mjs",
   "scripts": {},
   "exports": {
     ".": "./index.mjs"
   },
   "types": "./index.d.ts",
   "keywords": [],
-  "author": "Skypack",
-  "license": "MIT",
   "devDependencies": {
     "prismjs": "^1.23.0"
   },

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -2,16 +2,17 @@
   "name": "astro",
   "version": "0.21.12",
   "description": "Astro is a modern site builder with web best practices, performance, and DX front-of-mind.",
+  "type": "module",
   "author": "withastro",
   "license": "MIT",
-  "homepage": "https://astro.build",
-  "type": "module",
-  "types": "./dist/types/@types/astro.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/astro"
   },
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://astro.build",
+  "types": "./dist/types/@types/astro.d.ts",
   "exports": {
     ".": "./astro.js",
     "./client/*": "./dist/runtime/client/*",

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -2,11 +2,15 @@
   "name": "create-astro",
   "version": "0.6.10",
   "type": "module",
+  "author": "withastro",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/create-astro"
   },
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://astro.build",
   "exports": {
     ".": "./create-astro.mjs"
   },

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@astrojs/markdown-remark",
   "version": "0.5.0",
+  "license": "MIT",
   "main": "./dist/index.js",
   "type": "module",
   "repository": {

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -1,14 +1,17 @@
 {
   "name": "@astrojs/markdown-remark",
   "version": "0.5.0",
-  "license": "MIT",
-  "main": "./dist/index.js",
   "type": "module",
+  "author": "withastro",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/markdown/remark"
   },
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://astro.build",
+  "main": "./dist/index.js",
   "exports": {
     ".": "./dist/index.js"
   },

--- a/packages/renderers/renderer-lit/package.json
+++ b/packages/renderers/renderer-lit/package.json
@@ -2,6 +2,7 @@
   "name": "@astrojs/renderer-lit",
   "version": "0.2.1",
   "description": "Use Lit components within Astro",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",

--- a/packages/renderers/renderer-lit/package.json
+++ b/packages/renderers/renderer-lit/package.json
@@ -2,13 +2,16 @@
   "name": "@astrojs/renderer-lit",
   "version": "0.2.1",
   "description": "Use Lit components within Astro",
+  "type": "module",
+  "author": "withastro",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/renderers/renderer-lit"
   },
-  "type": "module",
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://astro.build",
   "exports": {
     ".": "./index.js",
     "./*": "./*",

--- a/packages/renderers/renderer-preact/package.json
+++ b/packages/renderers/renderer-preact/package.json
@@ -2,6 +2,7 @@
   "name": "@astrojs/renderer-preact",
   "description": "Use Preact components within Astro",
   "version": "0.3.2",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",

--- a/packages/renderers/renderer-preact/package.json
+++ b/packages/renderers/renderer-preact/package.json
@@ -2,13 +2,16 @@
   "name": "@astrojs/renderer-preact",
   "description": "Use Preact components within Astro",
   "version": "0.3.2",
+  "type": "module",
+  "author": "withastro",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/renderers/renderer-preact"
   },
-  "type": "module",
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://astro.build",
   "exports": {
     ".": "./index.js",
     "./*": "./*",

--- a/packages/renderers/renderer-react/package.json
+++ b/packages/renderers/renderer-react/package.json
@@ -2,13 +2,16 @@
   "name": "@astrojs/renderer-react",
   "description": "Use React components within Astro",
   "version": "0.3.1",
+  "type": "module",
+  "author": "withastro",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/renderers/renderer-react"
   },
-  "type": "module",
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://astro.build",
   "exports": {
     ".": "./index.js",
     "./*": "./*",

--- a/packages/renderers/renderer-react/package.json
+++ b/packages/renderers/renderer-react/package.json
@@ -2,6 +2,7 @@
   "name": "@astrojs/renderer-react",
   "description": "Use React components within Astro",
   "version": "0.3.1",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",

--- a/packages/renderers/renderer-solid/package.json
+++ b/packages/renderers/renderer-solid/package.json
@@ -2,13 +2,16 @@
   "name": "@astrojs/renderer-solid",
   "version": "0.2.1",
   "description": "Use Solid components within Astro",
+  "type": "module",
+  "author": "withastro",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/renderers/renderer-solid"
   },
-  "type": "module",
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://astro.build",
   "exports": {
     ".": "./index.js",
     "./*": "./*",

--- a/packages/renderers/renderer-solid/package.json
+++ b/packages/renderers/renderer-solid/package.json
@@ -2,6 +2,7 @@
   "name": "@astrojs/renderer-solid",
   "version": "0.2.1",
   "description": "Use Solid components within Astro",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",

--- a/packages/renderers/renderer-svelte/package.json
+++ b/packages/renderers/renderer-svelte/package.json
@@ -2,13 +2,16 @@
   "name": "@astrojs/renderer-svelte",
   "version": "0.2.2",
   "description": "Use Svelte components within Astro",
+  "type": "module",
+  "author": "withastro",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/renderers/renderer-svelte"
   },
-  "type": "module",
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://astro.build",
   "exports": {
     ".": "./index.js",
     "./*": "./*",

--- a/packages/renderers/renderer-svelte/package.json
+++ b/packages/renderers/renderer-svelte/package.json
@@ -2,6 +2,7 @@
   "name": "@astrojs/renderer-svelte",
   "version": "0.2.2",
   "description": "Use Svelte components within Astro",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",

--- a/packages/renderers/renderer-vue/package.json
+++ b/packages/renderers/renderer-vue/package.json
@@ -2,13 +2,16 @@
   "name": "@astrojs/renderer-vue",
   "version": "0.2.1",
   "description": "Use Vue components within Astro",
+  "type": "module",
+  "author": "withastro",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/renderers/renderer-vue"
   },
-  "type": "module",
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://astro.build",
   "exports": {
     ".": "./index.js",
     "./*": "./*",

--- a/packages/renderers/renderer-vue/package.json
+++ b/packages/renderers/renderer-vue/package.json
@@ -2,6 +2,7 @@
   "name": "@astrojs/renderer-vue",
   "version": "0.2.1",
   "description": "Use Vue components within Astro",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/withastro/astro.git",


### PR DESCRIPTION
## Changes

- add MIT license to package.json which were missing it
- adds info on published npm: https://www.npmjs.com/package/@astrojs/markdown-remark (currently: none)
- automated license checking tooling will complain

## Testing

not covered

## Docs

self documented