### PR TITLE
Bump `@astropub/webapi`

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -64,7 +64,7 @@
     "@astrojs/renderer-react": "0.3.1",
     "@astrojs/renderer-svelte": "0.2.3",
     "@astrojs/renderer-vue": "0.2.1",
-    "@astropub/webapi": "^0.4.0",
+    "@astropub/webapi": "^0.6.0",
     "@babel/core": "^7.15.8",
     "@babel/traverse": "^7.15.4",
     "@proload/core": "^0.2.1",

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -28,7 +28,7 @@ export interface BuildOptions {
 export default async function build(config: AstroConfig, options: BuildOptions = { logging: defaultLogOptions }): Promise<void> {
   // polyfill WebAPIs to globalThis for Node v12, Node v14, and Node v16
   polyfill(globalThis, {
-    exclude: 'window document'
+    exclude: 'window document',
   });
 
   const builder = new AstroBuilder(config, options);

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -27,7 +27,9 @@ export interface BuildOptions {
 /** `astro build` */
 export default async function build(config: AstroConfig, options: BuildOptions = { logging: defaultLogOptions }): Promise<void> {
   // polyfill WebAPIs to globalThis for Node v12, Node v14, and Node v16
-  polyfill(globalThis);
+  polyfill(globalThis, {
+    exclude: 'window document'
+  });
 
   const builder = new AstroBuilder(config, options);
   await builder.build();

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -38,7 +38,7 @@ export interface DevServer {
 export default async function dev(config: AstroConfig, options: DevOptions = { logging: defaultLogOptions }): Promise<DevServer> {
   // polyfill WebAPIs to globalThis for Node v12, Node v14, and Node v16
   polyfill(globalThis, {
-    exclude: 'window document'
+    exclude: 'window document',
   });
 
   // start dev server

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -37,7 +37,9 @@ export interface DevServer {
 /** `astro dev` */
 export default async function dev(config: AstroConfig, options: DevOptions = { logging: defaultLogOptions }): Promise<DevServer> {
   // polyfill WebAPIs to globalThis for Node v12, Node v14, and Node v16
-  polyfill(globalThis);
+  polyfill(globalThis, {
+    exclude: 'window document'
+  });
 
   // start dev server
   const server = new AstroDevServer(config, options);

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,10 +140,10 @@
     vscode-languageserver-types "^3.16.0"
     vscode-uri "^3.0.2"
 
-"@astropub/webapi@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@astropub/webapi/-/webapi-0.4.0.tgz#ce03357e562758fe8ac9b461fec4206a888c8e56"
-  integrity sha512-KpHOH9WsIJk2E3Z/suAZri3a6I9GrkZnmm+BHAZp4OBAXUUyNTIid9mIC8tiiHNbY2A6OLbBvfteuD+BYQfcrw==
+"@astropub/webapi@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@astropub/webapi/-/webapi-0.6.0.tgz#a56ef240e7e2ff7a47c2e7d6f0a8c048441f6399"
+  integrity sha512-V/McrfI3BjzqESNDyL75Z1Xj7gPny5x0j1+v1+XO8fxS8QMuEhNX11GD0TFJPS7JZcQKTM6sZBNihm7oDIWDKA==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.16.0":
   version "7.16.0"


### PR DESCRIPTION
## Changes

- Update `@astropub/webapi` from v0.4.0 to v0.6.0
- Exclude polyfills for `window` and `document`

## Testing

dependency bump only

## Docs

dependency bump only