### PR TITLE
Update index.js

### DIFF
--- a/packages/renderers/renderer-svelte/index.js
+++ b/packages/renderers/renderer-svelte/index.js
@@ -20,6 +20,7 @@ export default {
               less: true,
               sass: { renderSync: true },
               scss: { renderSync: true },
+              postcss: true,
               stylus: true,
               typescript: true,
             }),


### PR DESCRIPTION
Enables PostCSS in Svelte components. Fixes #2211

## Changes

Enables PostCSS in Svelte components. Fixes #2211.

## Testing

Tested by initalizing a new Astro project and manually adding the change to `node_modules/@astrojs/renderer-svelte/index.js`.

## Docs

Documentation already suggests that PostCSS is enabled in Astro, thus this basically just fixes a bug.
