### PR TITLE
Update Configuration Reference documentation

### DIFF
--- a/docs/src/pages/reference/configuration-reference.md
+++ b/docs/src/pages/reference/configuration-reference.md
@@ -27,7 +27,7 @@ The `projectRoot` option sets the working directory used by Astro. All other pat
 
 The `public` option sets the directory used to resolve public assets. By default, this is the `public` directory.
 
-The `dist` option sets the directory used to write the production build of the project.
+The `dist` option sets the directory used to output the final build of the project.
 
 The `src` option sets the directory used to resolve source files, like `pages`. By default, this is the `src` directory.
 

--- a/docs/src/pages/reference/configuration-reference.md
+++ b/docs/src/pages/reference/configuration-reference.md
@@ -3,22 +3,44 @@ layout: ~/layouts/MainLayout.astro
 title: Configuration Reference
 ---
 
-To configure Astro, add an `astro.config.mjs` file in the root of your project. All settings are optional.
-
-You can view the full configuration API (including information about default configuration) on [GitHub.](https://github.com/withastro/astro/blob/latest/packages/astro/src/%40types/astro.ts)
+To configure Astro, add an `astro.config.mjs` file to the root of your project.
 
 ```js
-// Example: astro.config.mjs
-
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ (
-  {
-    // ...
-  }
-);
+export default /** @type {import('astro').AstroUserConfig} */ ({
+  projectRoot: './',
+  public: './public/',
+  dist: './dist/',
+  src: './src/',
+  pages: './pages/',
+  renderers: [
+    '@astrojs/renderer-svelte',
+    '@astrojs/renderer-vue',
+    '@astrojs/renderer-react',
+    '@astrojs/renderer-preact',
+  ],
+});
 ```
+
+All settings are optional.
+
+The `projectRoot` option sets the working directory used by Astro. All other paths will be resolved from this. By default, this is the current working directory.
+
+The `public` option sets the directory used to resolve public assets. By default, this is the `public` directory.
+
+The `dist` option sets the directory used to write the production build of the project.
+
+The `src` option sets the directory used to resolve source files, like `pages`. By default, this is the `src` directory.
+
+The `pages` option sets the directory used to resolve pages, relative to the `src` option. By default, this is the `pages` directory.
+
+The `renderers` option assigns the framework renderers to be used by Astro. By default, Astro provides renderers for Svelte, Vue, React, and Preact. To assign no renderers at all, provide an empty array (`[]`).
+
+The `buildOptions` option configures your site, including the site URL (`buildOptions.site`), whether it should generate a sitemap (`buildOptions.sitemap`), and whether pages should be written as `path.html` or `path/index.html` (`buildOptions.pageUrlFormat`).
+
+The `devOptions` option configures your site for development, including the hostname (`devOptions.hostname`), the default port (`devOptions.port`), and whether urls should include a trailing slash (`devOptions.trailingSlash`).
+
+The `vite` option configures the internals of Vite. These options can be explored on [ViteJS.dev](https://vitejs.dev/config/).
+
+The `markdownOptions` option assigns options to the Markdown parser. These options can be explored on [GitHub](https://github.com/withastro/astro/blob/latest/packages/astro/src/@types/astro.ts).
+
+You can view the full configuration API (including information about default configuration) on [GitHub](https://github.com/withastro/astro/blob/latest/packages/astro/src/@types/astro.ts).

--- a/docs/src/pages/reference/configuration-reference.md
+++ b/docs/src/pages/reference/configuration-reference.md
@@ -23,26 +23,58 @@ export default /** @type {import('astro').AstroUserConfig} */ ({
 });
 ```
 
-All settings are optional.
+#### projectRoot
 
-The `projectRoot` option sets the working directory used by Astro. All other paths will be resolved from this. By default, this is the current working directory.
+The `projectRoot` option sets the working directory used by Astro. Astro will resolve all other directory options from this path.
 
-The `public` option sets the directory used to resolve public assets. By default, this is the `public` directory.
+**Default**: The current working directory.
 
-The `dist` option sets the directory used to output the final build of the project.
+#### public
 
-The `src` option sets the directory used to resolve source files, like `pages`. By default, this is the `src` directory.
+The `public` option sets the directory used to resolve public assets. Astro does not process any files within this directory.
 
-The `pages` option sets the directory used to resolve pages, relative to the `src` option. By default, this is the `pages` directory within `src`.
+**Default**: The `public` directory within the `projectRoot` directory.
 
-The `renderers` option assigns the framework renderers to be used by Astro. By default, Astro provides renderers for Svelte, Vue, React, and Preact. To assign no renderers at all, provide an empty array (`[]`).
+#### dist
 
-The `buildOptions` option configures your site, including the site URL (`buildOptions.site`), whether it should generate a sitemap (`buildOptions.sitemap`), and whether pages should be written as `path.html` or `path/index.html` (`buildOptions.pageUrlFormat`).
+The `dist` option sets the directory used to output the final build of the project. Contents of the `public` directory are also copied into this directory.
 
-The `devOptions` option configures your site for development, including the hostname (`devOptions.hostname`), the default port (`devOptions.port`), and whether urls should include a trailing slash (`devOptions.trailingSlash`).
+**Default**: The `dist` directory within the `projectRoot` directory.
+
+#### src
+
+The `src` option sets the directory used to resolve source files, like `pages`. Astro may process, optimize, and bundle any files in this directory.
+
+**Default**: The `src` directory within the `projectRoot` directory.
+
+#### pages
+
+The `pages` option sets the directory used to resolve pages, relative to the `src` option.
+
+**Default**: The `pages` directory within the `src` directory.
+
+#### renderers
+
+The `renderers` option defines the framework renderers to be used by Astro.
+
+**Default**: An array of `@astrojs/renderer-svelte`, `@astrojs/renderer-vue`, `@astrojs/renderer-react`, and `@astrojs/renderer-preact`. To assign no renderers at all, you must provide an empty array (`[]`).
+
+#### buildOptions
+
+The `buildOptions` option configures how a site is built, including its base URL (`buildOptions.site`), whether it includes a sitemap (`buildOptions.sitemap`), and whether its pages should be files (`path.html`) or directories (`path/index.html`) (`buildOptions.pageUrlFormat`).
+
+#### devOptions
+
+The `devOptions` option configures features used during development, including the server hostname (`devOptions.hostname`), the server port (`devOptions.port`), and whether urls should include a trailing slash (`devOptions.trailingSlash`).
+
+#### vite
 
 The `vite` option configures the internals of Vite. These options can be explored on [ViteJS.dev](https://vitejs.dev/config/).
 
+#### markdownOptions
+
 The `markdownOptions` option assigns options to the Markdown parser. These options can be explored on [GitHub](https://github.com/withastro/astro/blob/latest/packages/astro/src/@types/astro.ts).
 
-You can view the full configuration API (including information about default configuration) on [GitHub](https://github.com/withastro/astro/blob/latest/packages/astro/src/@types/astro.ts).
+---
+
+You can view the entire configuration API on [GitHub](https://github.com/withastro/astro/blob/latest/packages/astro/src/@types/astro.ts).

--- a/docs/src/pages/reference/configuration-reference.md
+++ b/docs/src/pages/reference/configuration-reference.md
@@ -33,7 +33,7 @@ The `dist` option sets the directory used to output the final build of the proje
 
 The `src` option sets the directory used to resolve source files, like `pages`. By default, this is the `src` directory.
 
-The `pages` option sets the directory used to resolve pages, relative to the `src` option. By default, this is the `pages` directory.
+The `pages` option sets the directory used to resolve pages, relative to the `src` option. By default, this is the `pages` directory within `src`.
 
 The `renderers` option assigns the framework renderers to be used by Astro. By default, Astro provides renderers for Svelte, Vue, React, and Preact. To assign no renderers at all, provide an empty array (`[]`).
 

--- a/docs/src/pages/reference/configuration-reference.md
+++ b/docs/src/pages/reference/configuration-reference.md
@@ -7,6 +7,7 @@ To configure Astro, add an `astro.config.mjs` file to the root of your project.
 
 ```js
 export default /** @type {import('astro').AstroUserConfig} */ ({
+  // all options are optional, and these values represent their defaults
   projectRoot: './',
   public: './public/',
   dist: './dist/',

--- a/docs/src/pages/reference/configuration-reference.md
+++ b/docs/src/pages/reference/configuration-reference.md
@@ -7,7 +7,7 @@ To configure Astro, add an `astro.config.mjs` file to the root of your project.
 
 ```js
 export default /** @type {import('astro').AstroUserConfig} */ ({
-  // all options are optional, and these values represent their defaults
+  // all options are optional; these values are the defaults
   projectRoot: './',
   public: './public/',
   dist: './dist/',
@@ -19,6 +19,7 @@ export default /** @type {import('astro').AstroUserConfig} */ ({
     '@astrojs/renderer-react',
     '@astrojs/renderer-preact',
   ],
+  vite: {},
 });
 ```
 


### PR DESCRIPTION
## Changes

- This updates the configuration reference documentation to be much more useful to users who either cannot or do not wish to analyze our typescript definitions file.

[Preview](https://deploy-preview-2239--astro-docs-2.netlify.app/reference/configuration-reference/)

## Testing

doc fix only

## Docs

doc fix only