### PR TITLE
Improve CLI & CLI Testing

### DIFF
--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -58,19 +58,6 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 /** Dev server */
 export class AstroDevServer {
   app = connect();
-  httpServer: http.Server | undefined;
-  hostname: string;
-  port: number;
-  private config: AstroConfig;
-  private logging: LogOptions;
-  private manifest: ManifestData;
-  private mostRecentRoute?: RouteData;
-  private site: URL | undefined;
-  private devRoot: string;
-  private url: URL;
-  private origin: string;
-  private routeCache: RouteCache = {};
-  private viteServer: vite.ViteDevServer | undefined;
 
   constructor(config: AstroConfig, options: DevOptions) {
     this.config = config;
@@ -204,7 +191,7 @@ export class AstroDevServer {
   public listen(devStart: number): Promise<void> {
     let showedPortTakenMsg = false;
     return new Promise<void>((resolve, reject) => {
-      const listen = () => {
+      const appListen = () => {
         this.httpServer = this.app.listen(this.port, this.hostname, () => {
           info(this.logging, 'astro', msg.devStart({ startupTime: performance.now() - devStart }));
           info(this.logging, 'astro', msg.devHost({ host: `http://${this.hostname}:${this.port}${this.devRoot}` }));
@@ -220,7 +207,7 @@ export class AstroDevServer {
             showedPortTakenMsg = true; // only print this once
           }
           this.port++;
-          return listen(); // retry
+          return appListen(); // retry
         } else {
           error(this.logging, 'astro', err.stack);
           this.httpServer?.removeListener('error', onError);
@@ -228,7 +215,7 @@ export class AstroDevServer {
         }
       };
 
-      listen();
+      appListen();
     });
   }
 
@@ -395,4 +382,18 @@ export class AstroDevServer {
     res.write(html);
     res.end();
   }
+
+  config: AstroConfig;
+  devRoot: string;
+  hostname: string;
+  httpServer: http.Server | undefined;
+  logging: LogOptions;
+  manifest: ManifestData;
+  mostRecentRoute?: RouteData;
+  origin: string;
+  port: number;
+  routeCache: RouteCache = {};
+  site: URL | undefined;
+  url: URL;
+  viteServer: vite.ViteDevServer | undefined;
 }

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -57,7 +57,20 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 
 /** Dev server */
 export class AstroDevServer {
-  app = connect();
+  app: connect.Server = connect();
+  config: AstroConfig;
+  devRoot: string;
+  hostname: string;
+  httpServer: http.Server | undefined;
+  logging: LogOptions;
+  manifest: ManifestData;
+  mostRecentRoute?: RouteData;
+  origin: string;
+  port: number;
+  routeCache: RouteCache = {};
+  site: URL | undefined;
+  url: URL;
+  viteServer: vite.ViteDevServer | undefined;
 
   constructor(config: AstroConfig, options: DevOptions) {
     this.config = config;
@@ -382,18 +395,4 @@ export class AstroDevServer {
     res.write(html);
     res.end();
   }
-
-  config: AstroConfig;
-  devRoot: string;
-  hostname: string;
-  httpServer: http.Server | undefined;
-  logging: LogOptions;
-  manifest: ManifestData;
-  mostRecentRoute?: RouteData;
-  origin: string;
-  port: number;
-  routeCache: RouteCache = {};
-  site: URL | undefined;
-  url: URL;
-  viteServer: vite.ViteDevServer | undefined;
 }

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -77,7 +77,7 @@ export class AstroDevServer {
     this.hostname = config.devOptions.hostname || 'localhost';
     this.logging = options.logging;
     this.port = config.devOptions.port;
-    this.origin = `http://localhost:${this.port}`;
+    this.origin = `http://${this.hostname}:${this.port}`;
     this.site = config.buildOptions.site ? new URL(config.buildOptions.site) : undefined;
     this.devRoot = this.site ? this.site.pathname : '/';
     this.url = new URL(this.devRoot, this.origin);

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -38,8 +38,8 @@ export default async function preview(config: AstroConfig, { logging }: PreviewO
     }).pipe(res);
   });
 
-  let port = config.devOptions.port;
-  const { hostname } = config.devOptions;
+  let { hostname, port } = config.devOptions;
+
   let httpServer: http.Server;
 
   /** Expose dev server to `port` */

--- a/packages/astro/test/cli.test.js
+++ b/packages/astro/test/cli.test.js
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import { cli } from './test-utils.js';
+import { promises as fs } from 'fs';
+
+describe('astro cli', () => {
+  it('astro', async () => {
+    const proc = await cli();
+
+    expect(proc.stdout).to.include('astro - Futuristic web development tool');
+  });
+
+  it('astro --version', async () => {
+    const pkgURL = new URL('../package.json', import.meta.url);
+    const pkgVersion = await fs.readFile(pkgURL, 'utf8').then((data) => JSON.parse(data).version);
+
+    const proc = await cli('--version');
+
+    expect(proc.stdout).to.equal(pkgVersion);
+  });
+
+  it('astro dev', async () => {
+    const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
+
+    const proc = cli('dev', '--project-root', projectRootURL.pathname);
+
+    let stdout = '';
+
+    for await (const chunk of proc.stdout) {
+      stdout += chunk;
+
+      if (/Server started/.test(chunk)) break;
+    }
+
+    proc.kill();
+
+    expect(stdout).to.include('Server started');
+  });
+
+  it('astro build', async () => {
+    const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
+
+    const proc = await cli('build', '--project-root', projectRootURL.pathname);
+
+    expect(proc.stdout).to.include('Done');
+  });
+});

--- a/packages/astro/test/cli.test.js
+++ b/packages/astro/test/cli.test.js
@@ -29,7 +29,7 @@ describe('astro cli', () => {
     for await (const chunk of proc.stdout) {
       stdout += chunk;
 
-      if (/Server started/.test(chunk)) break;
+      if (chunk.includes('Local:')) break;
     }
 
     proc.kill();

--- a/packages/astro/test/cli.test.js
+++ b/packages/astro/test/cli.test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { cli } from './test-utils.js';
 import { promises as fs } from 'fs';
+import { fileURLToPath } from 'url';
 
 describe('astro cli', () => {
   it('astro', async () => {
@@ -21,7 +22,7 @@ describe('astro cli', () => {
   it('astro dev', async () => {
     const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
 
-    const proc = cli('dev', '--project-root', projectRootURL.pathname);
+    const proc = cli('dev', '--project-root', fileURLToPath(projectRootURL));
 
     let stdout = '';
 
@@ -39,7 +40,7 @@ describe('astro cli', () => {
   it('astro build', async () => {
     const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
 
-    const proc = await cli('build', '--project-root', projectRootURL.pathname);
+    const proc = await cli('build', '--project-root', fileURLToPath(projectRootURL));
 
     expect(proc.stdout).to.include('Done');
   });

--- a/packages/astro/test/config.test.js
+++ b/packages/astro/test/config.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { devCLI, loadFixture } from './test-utils.js';
+import { cli, loadFixture } from './test-utils.js';
 
 describe('config', () => {
   let hostnameFixture;
@@ -15,41 +15,40 @@ describe('config', () => {
     });
 
     it('can be specified via --hostname flag', async () => {
-      const cwd = './fixtures/config-hostname/';
-      const cwdURL = new URL(cwd, import.meta.url);
-      const args = ['--hostname', '127.0.0.1'];
-      const proc = devCLI(cwdURL, args);
+      const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
+      const proc = cli('dev', '--project-root', projectRootURL.pathname, '--hostname', '127.0.0.1');
 
-      proc.stdout.setEncoding('utf8');
+      let stdout = '';
 
       for await (const chunk of proc.stdout) {
-        if (/Local:/.test(chunk)) {
-          expect(chunk).to.include('127.0.0.1');
-          break;
-        }
+        stdout += chunk;
+
+        if (/127\.0\.0\.1/.test(chunk)) break;
       }
 
       proc.kill();
+
+      expect(stdout).to.include('127.0.0.1');
     });
   });
 
   describe('path', () => {
     it('can be passed via --config', async () => {
-      const cwd = './fixtures/config-path/';
-      const cwdURL = new URL(cwd, import.meta.url);
-      const configPath = new URL('./config/my-config.mjs', cwdURL).pathname;
-      const args = ['--config', configPath];
-      const proc = devCLI(cwdURL, args);
+      const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
+      const configFileURL = new URL('./fixtures/config-path/config/my-config.mjs', import.meta.url);
+      const proc = cli('dev', '--project-root', projectRootURL.pathname, '--config', configFileURL.pathname);
 
-      proc.stdout.setEncoding('utf8');
+      let stdout = '';
 
       for await (const chunk of proc.stdout) {
-        if (/Server started/.test(chunk)) {
-          break;
-        }
+        stdout += chunk;
+
+        if (/127\.0\.0\.1/.test(chunk)) break;
       }
 
       proc.kill();
+
+      expect(stdout).to.include('127.0.0.1');
     });
   });
 

--- a/packages/astro/test/config.test.js
+++ b/packages/astro/test/config.test.js
@@ -24,7 +24,7 @@ describe('config', () => {
       for await (const chunk of proc.stdout) {
         stdout += chunk;
 
-        if (/127\.0\.0\.1/.test(chunk)) break;
+        if (chunk.includes('Local:')) break;
       }
 
       proc.kill();
@@ -44,7 +44,7 @@ describe('config', () => {
       for await (const chunk of proc.stdout) {
         stdout += chunk;
 
-        if (/127\.0\.0\.1/.test(chunk)) break;
+        if (chunk.includes('Local:')) break;
       }
 
       proc.kill();

--- a/packages/astro/test/config.test.js
+++ b/packages/astro/test/config.test.js
@@ -37,7 +37,7 @@ describe('config', () => {
     it('can be passed via --config', async () => {
       const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
       const configFileURL = new URL('./fixtures/config-path/config/my-config.mjs', import.meta.url);
-      const proc = cli('dev', '--project-root', fileURLToPath(projectRootURL), '--config', fileURLToPath(configFileURL));
+      const proc = cli('dev', '--project-root', fileURLToPath(projectRootURL), '--config', configFileURL.pathname);
 
       let stdout = '';
 

--- a/packages/astro/test/config.test.js
+++ b/packages/astro/test/config.test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { cli, loadFixture } from './test-utils.js';
+import { fileURLToPath } from 'url';
 
 describe('config', () => {
   let hostnameFixture;
@@ -16,7 +17,7 @@ describe('config', () => {
 
     it('can be specified via --hostname flag', async () => {
       const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
-      const proc = cli('dev', '--project-root', projectRootURL.pathname, '--hostname', '127.0.0.1');
+      const proc = cli('dev', '--project-root', fileURLToPath(projectRootURL), '--hostname', '127.0.0.1');
 
       let stdout = '';
 
@@ -36,7 +37,7 @@ describe('config', () => {
     it('can be passed via --config', async () => {
       const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
       const configFileURL = new URL('./fixtures/config-path/config/my-config.mjs', import.meta.url);
-      const proc = cli('dev', '--project-root', projectRootURL.pathname, '--config', configFileURL.pathname);
+      const proc = cli('dev', '--project-root', fileURLToPath(projectRootURL), '--config', fileURLToPath(configFileURL));
 
       let stdout = '';
 

--- a/packages/astro/test/fixtures/config-path/config/my-config.mjs
+++ b/packages/astro/test/fixtures/config-path/config/my-config.mjs
@@ -1,5 +1,5 @@
 export default {
-  renderers: [
-    '@astrojs/renderer-preact'
-  ]
+  devOptions: {
+    hostname: '127.0.0.1',
+  },
 }

--- a/packages/astro/test/fixtures/config-path/config/my-config.mjs
+++ b/packages/astro/test/fixtures/config-path/config/my-config.mjs
@@ -1,5 +1,6 @@
 export default {
   devOptions: {
     hostname: '127.0.0.1',
+    port: 8080,
   },
 }

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -99,11 +99,13 @@ function merge(a, b) {
   return c;
 }
 
-const cliURL = new URL('../astro.js', import.meta.url);
+const cliPath = fileURLToPath(new URL('../astro.js', import.meta.url));
 
-/** Start Dev server via CLI */
-export function devCLI(root, additionalArgs = []) {
-  const args = [cliURL.pathname, 'dev', '--project-root', root.pathname].concat(additionalArgs);
-  const proc = execa('node', args);
-  return proc;
+/** Returns a process running the Astro CLI. */
+export function cli(/** @type {string[]} */ ...args) {
+  const spawned = execa('node', [cliPath, ...args]);
+
+  spawned.stdout.setEncoding('utf8');
+
+  return spawned;
 }


### PR DESCRIPTION
## Changes

- Fix issue with `astro --version` throwing instead of returning the current version of Astro.
  - Resolves https://github.com/withastro/astro/issues/2143
- Print `astro`, `astro --help`, `astro --version` before loading any configuration 
  - Speeds up those commands which do not require configuration.
- Adds CLI tests
  - Improves CLI testing in the Config tests by ensuring the process has ended.

## Testing

- adds cli tests
- updates config tests

## Docs

bug fix only