### PR TITLE
Create .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Switch to tabs (Use Accessible Indentation #2253)
+6ddd7678ffb6598ae6e263706813cb5e94535f02

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,12 @@ yarn install
 yarn build
 ```
 
+In [#2254](https://github.com/withastro/astro/pull/2254) a `.git-blame-ignore-revs` file was added to ignore repo-wide formatting changes. To improve your experience, you should run the following command locally.
+
+```shell
+git config --local blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
 ### Development
 
 ```shell


### PR DESCRIPTION
## Changes

- Adds a `.git-blame-ignore-revs` file.
- Useful for ignoring mass reformatting commits. <sup>[ref](https://www.moxio.com/blog/43/ignoring-bulk-change-commits-with-git-blame)</sup>
- Supported in GitLens. <sup>[ref](https://github.com/gitkraken/vscode-gitlens/issues/947#issuecomment-583703079)</sup>
- Support coming to GitHub (_recently given high priority_). <sup>[ref](https://github.com/github/feedback/discussions/5033#discussioncomment-1549036)</sup>
- Works with `git config blame.ignoreRevsFile .git-blame-ignore-revs`

## Testing

git config only

## Docs

git config only