### PR TITLE
Add document to global

### DIFF
--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -23,7 +23,7 @@ export interface BuildOptions {
 export default async function build(config: AstroConfig, options: BuildOptions = { logging: defaultLogOptions }): Promise<void> {
 	// polyfill WebAPIs to globalThis for Node v12, Node v14, and Node v16
 	polyfill(globalThis, {
-		exclude: 'window document',
+		exclude: 'window',
 	});
 
 	const builder = new AstroBuilder(config, options);

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -38,7 +38,7 @@ export interface DevServer {
 export default async function dev(config: AstroConfig, options: DevOptions = { logging: defaultLogOptions }): Promise<DevServer> {
 	// polyfill WebAPIs to globalThis for Node v12, Node v14, and Node v16
 	polyfill(globalThis, {
-		exclude: 'window document',
+		exclude: 'window',
 	});
 
 	// start dev server


### PR DESCRIPTION
## Changes

- Adds `document` to the global scope.
- Unlocks enough WebAPIs to import Web Components server-side.

Reviews are welcome, but this is only for discussion for now.

## Testing

we should discuss this

## Docs

we should discuss this