### PR TITLE
Fix formatting issues caused by release

### DIFF
--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -1029,10 +1029,10 @@ For convenience, you may now also move your `astro.config.js` file to a top-leve
 
   ```js
   export default {
-  	markdownOptions: {
-  		remarkPlugins: ['remark-slug', ['remark-autolink-headings', { behavior: 'prepend' }]],
-  		rehypePlugins: ['rehype-slug', ['rehype-autolink-headings', { behavior: 'prepend' }]],
-  	},
+    markdownOptions: {
+      remarkPlugins: ['remark-slug', ['remark-autolink-headings', { behavior: 'prepend' }]],
+      rehypePlugins: ['rehype-slug', ['rehype-autolink-headings', { behavior: 'prepend' }]],
+    },
   };
   ```
 
@@ -1052,10 +1052,10 @@ For convenience, you may now also move your `astro.config.js` file to a top-leve
 
   ```js
   export default {
-  	name: '@matthewp/my-renderer',
-  	server: './server.js',
-  	client: './client.js',
-  	hydrationPolyfills: ['./my-polyfill.js'],
+    name: '@matthewp/my-renderer',
+    server: './server.js',
+    client: './client.js',
+    hydrationPolyfills: ['./my-polyfill.js'],
   };
   ```
 

--- a/packages/astro/test/builtins.test.js
+++ b/packages/astro/test/builtins.test.js
@@ -15,7 +15,7 @@ describe('Node builtins', () => {
 		const $ = cheerio.load(html);
 
 		expect($('#version').text()).to.equal('1.2.0');
-		expect($('#dep-version').text()).to.equal('0.0.1');
+		expect($('#dep-version').text()).to.equal('0.1.0');
 	});
 
 	it('Can also be used with the non-prefixed version', async () => {

--- a/packages/markdown/remark/CHANGELOG.md
+++ b/packages/markdown/remark/CHANGELOG.md
@@ -105,10 +105,10 @@
 
   ```js
   export default {
-  	markdownOptions: {
-  		remarkPlugins: ['remark-slug', ['remark-autolink-headings', { behavior: 'prepend' }]],
-  		rehypePlugins: ['rehype-slug', ['rehype-autolink-headings', { behavior: 'prepend' }]],
-  	},
+    markdownOptions: {
+      remarkPlugins: ['remark-slug', ['remark-autolink-headings', { behavior: 'prepend' }]],
+      rehypePlugins: ['rehype-slug', ['rehype-autolink-headings', { behavior: 'prepend' }]],
+    },
   };
   ```
 


### PR DESCRIPTION
## Changes

- The formatting change caused some issues where the open release PR hadn't been updated and therefore had old formatting which caused `main` to fail once merged.

I think this won't happen in the future due to new PRs all being formatted.