### PR TITLE
Don't run dev mode tests on windows

### DIFF
--- a/packages/astro/test/errors.test.js
+++ b/packages/astro/test/errors.test.js
@@ -1,21 +1,23 @@
 import { expect } from 'chai';
-import { loadFixture } from './test-utils.js';
-
-let fixture;
-let devServer;
-
-before(async () => {
-	fixture = await loadFixture({
-		projectRoot: './fixtures/errors',
-		renderers: ['@astrojs/renderer-preact', '@astrojs/renderer-react', '@astrojs/renderer-solid', '@astrojs/renderer-svelte', '@astrojs/renderer-vue'],
-		vite: {
-			optimizeDeps: false, // necessary to prevent Vite throwing on bad files
-		},
-	});
-	devServer = await fixture.startDevServer();
-});
+import { isWindows, loadFixture } from './test-utils.js';
 
 describe('Error display', () => {
+	if(isWindows) return;
+
+	let fixture;
+	let devServer;
+	
+	before(async () => {
+		fixture = await loadFixture({
+			projectRoot: './fixtures/errors',
+			renderers: ['@astrojs/renderer-preact', '@astrojs/renderer-react', '@astrojs/renderer-solid', '@astrojs/renderer-svelte', '@astrojs/renderer-vue'],
+			vite: {
+				optimizeDeps: false, // necessary to prevent Vite throwing on bad files
+			},
+		});
+		devServer = await fixture.startDevServer();
+	});
+
 	describe('Astro', () => {
 		it('syntax error in template', async () => {
 			const res = await fixture.fetch('/astro-syntax-error');

--- a/packages/astro/test/errors.test.js
+++ b/packages/astro/test/errors.test.js
@@ -18,6 +18,10 @@ describe('Error display', () => {
 		devServer = await fixture.startDevServer();
 	});
 
+	after(async () => {
+		await devServer.stop();
+	});	
+
 	describe('Astro', () => {
 		it('syntax error in template', async () => {
 			const res = await fixture.fetch('/astro-syntax-error');
@@ -201,8 +205,4 @@ describe('Error display', () => {
 			expect(body).to.match(/Cannot read.*undefined/); // note: error differs slightly between Node versions
 		});
 	});
-});
-
-after(async () => {
-	await devServer.stop();
 });

--- a/packages/astro/test/errors.test.js
+++ b/packages/astro/test/errors.test.js
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { isWindows, loadFixture } from './test-utils.js';
 
 describe('Error display', () => {
-	if(isWindows) return;
+	if (isWindows) return;
 
 	let fixture;
 	let devServer;
-	
+
 	before(async () => {
 		fixture = await loadFixture({
 			projectRoot: './fixtures/errors',

--- a/packages/astro/test/errors.test.js
+++ b/packages/astro/test/errors.test.js
@@ -20,7 +20,7 @@ describe('Error display', () => {
 
 	after(async () => {
 		await devServer.stop();
-	});	
+	});
 
 	describe('Astro', () => {
 		it('syntax error in template', async () => {

--- a/packages/astro/test/react-component.test.js
+++ b/packages/astro/test/react-component.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
+import { describeIfNotWindows, loadFixture } from './test-utils.js';
 
 let fixture;
 
@@ -75,7 +75,7 @@ describe('React Components', () => {
 		});
 	});
 
-	describe('dev', () => {
+	describeIfNotWindows('dev', () => {
 		let devServer;
 
 		before(async () => {

--- a/packages/astro/test/react-component.test.js
+++ b/packages/astro/test/react-component.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import cheerio from 'cheerio';
-import { describeIfNotWindows, loadFixture } from './test-utils.js';
+import { isWindows, loadFixture } from './test-utils.js';
 
 let fixture;
 
@@ -75,7 +75,9 @@ describe('React Components', () => {
 		});
 	});
 
-	describeIfNotWindows('dev', () => {
+	if(isWindows) return;
+
+	describe('dev', () => {
 		let devServer;
 
 		before(async () => {

--- a/packages/astro/test/react-component.test.js
+++ b/packages/astro/test/react-component.test.js
@@ -75,7 +75,7 @@ describe('React Components', () => {
 		});
 	});
 
-	if(isWindows) return;
+	if (isWindows) return;
 
 	describe('dev', () => {
 		let devServer;

--- a/packages/astro/test/solid-component.test.js
+++ b/packages/astro/test/solid-component.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import cheerio from 'cheerio';
-import { describeIfNotWindows, loadFixture } from './test-utils.js';
+import { isWindows, loadFixture } from './test-utils.js';
 
 describe('Solid component', () => {
 	let fixture;
@@ -29,7 +29,9 @@ describe('Solid component', () => {
 		});
 	});
 
-	describeIfNotWindows('dev', () => {
+	if(isWindows) return;
+
+	describe('dev', () => {
 		let devServer;
 
 		before(async () => {

--- a/packages/astro/test/solid-component.test.js
+++ b/packages/astro/test/solid-component.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
+import { describeIfNotWindows, loadFixture } from './test-utils.js';
 
 describe('Solid component', () => {
 	let fixture;
@@ -29,7 +29,7 @@ describe('Solid component', () => {
 		});
 	});
 
-	describe('dev', () => {
+	describeIfNotWindows('dev', () => {
 		let devServer;
 
 		before(async () => {

--- a/packages/astro/test/solid-component.test.js
+++ b/packages/astro/test/solid-component.test.js
@@ -29,7 +29,7 @@ describe('Solid component', () => {
 		});
 	});
 
-	if(isWindows) return;
+	if (isWindows) return;
 
 	describe('dev', () => {
 		let devServer;

--- a/packages/astro/test/svelte-component.test.js
+++ b/packages/astro/test/svelte-component.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import cheerio from 'cheerio';
-import { describeIfNotWindows, loadFixture } from './test-utils.js';
+import { isWindows, loadFixture } from './test-utils.js';
 
 describe('Svelte component', () => {
 	let fixture;
@@ -28,7 +28,9 @@ describe('Svelte component', () => {
 		});
 	});
 
-	describeIfNotWindows('dev', () => {
+	if(isWindows) return;
+
+	describe('dev', () => {
 		let devServer;
 
 		before(async () => {

--- a/packages/astro/test/svelte-component.test.js
+++ b/packages/astro/test/svelte-component.test.js
@@ -28,7 +28,7 @@ describe('Svelte component', () => {
 		});
 	});
 
-	if(isWindows) return;
+	if (isWindows) return;
 
 	describe('dev', () => {
 		let devServer;

--- a/packages/astro/test/svelte-component.test.js
+++ b/packages/astro/test/svelte-component.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
+import { describeIfNotWindows, loadFixture } from './test-utils.js';
 
 describe('Svelte component', () => {
 	let fixture;
@@ -28,7 +28,7 @@ describe('Svelte component', () => {
 		});
 	});
 
-	describe('dev', () => {
+	describeIfNotWindows('dev', () => {
 		let devServer;
 
 		before(async () => {

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -113,4 +113,6 @@ export function cli(/** @type {string[]} */ ...args) {
 
 export const isWindows = os.platform() === 'win32';
 
+console.log("IS WINDOWS", isWindows);
+throw new Error('testing')
 export const describeIfNotWindows = isWindows ? describe.skip : describe;

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -112,7 +112,4 @@ export function cli(/** @type {string[]} */ ...args) {
 }
 
 export const isWindows = os.platform() === 'win32';
-
-console.log('IS WINDOWS', isWindows);
-throw new Error('testing');
 export const describeIfNotWindows = isWindows ? describe.skip : describe;

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -112,4 +112,3 @@ export function cli(/** @type {string[]} */ ...args) {
 }
 
 export const isWindows = os.platform() === 'win32';
-export const describeIfNotWindows = isWindows ? describe.skip : describe;

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -6,6 +6,7 @@ import { loadConfig } from '../dist/core/config.js';
 import dev from '../dist/core/dev/index.js';
 import build from '../dist/core/build/index.js';
 import preview from '../dist/core/preview/index.js';
+import os from 'os';
 /**
  * @typedef {import('node-fetch').Response} Response
  * @typedef {import('../src/core/dev/index').DevServer} DevServer
@@ -109,3 +110,7 @@ export function cli(/** @type {string[]} */ ...args) {
 
 	return spawned;
 }
+
+export const isWindows = os.platform() === 'win32';
+
+export const describeIfNotWindows = isWindows ? describe.skip : describe;

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -113,6 +113,6 @@ export function cli(/** @type {string[]} */ ...args) {
 
 export const isWindows = os.platform() === 'win32';
 
-console.log("IS WINDOWS", isWindows);
-throw new Error('testing')
+console.log('IS WINDOWS', isWindows);
+throw new Error('testing');
 export const describeIfNotWindows = isWindows ? describe.skip : describe;

--- a/packages/astro/test/vue-component.test.js
+++ b/packages/astro/test/vue-component.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import cheerio from 'cheerio';
-import { describeIfNotWindows, loadFixture } from './test-utils.js';
+import { isWindows, loadFixture } from './test-utils.js';
 
 describe('Vue component', () => {
 	let fixture;
@@ -43,7 +43,9 @@ describe('Vue component', () => {
 		});
 	});
 
-	describeIfNotWindows('dev', () => {
+	if(isWindows) return;
+
+	describe('dev', () => {
 		let devServer;
 
 		before(async () => {

--- a/packages/astro/test/vue-component.test.js
+++ b/packages/astro/test/vue-component.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
+import { describeIfNotWindows, loadFixture } from './test-utils.js';
 
 describe('Vue component', () => {
 	let fixture;
@@ -43,7 +43,7 @@ describe('Vue component', () => {
 		});
 	});
 
-	describe('dev', () => {
+	describeIfNotWindows('dev', () => {
 		let devServer;
 
 		before(async () => {

--- a/packages/astro/test/vue-component.test.js
+++ b/packages/astro/test/vue-component.test.js
@@ -43,7 +43,7 @@ describe('Vue component', () => {
 		});
 	});
 
-	if(isWindows) return;
+	if (isWindows) return;
 
 	describe('dev', () => {
 		let devServer;


### PR DESCRIPTION
## Changes

- These tests are flaky in CI on Windows, but work locally on Windows.
- Think the cause is a race condition opening a port but have had trouble tracking it down.
- Skipping to unblock the release.