### PR TITLE
bump webapi

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -64,7 +64,7 @@
     "@astrojs/renderer-react": "0.4.0",
     "@astrojs/renderer-svelte": "0.3.0",
     "@astrojs/renderer-vue": "0.3.0",
-    "@astropub/webapi": "^0.7.1",
+    "@astropub/webapi": "^0.7.3",
     "@babel/core": "^7.15.8",
     "@babel/traverse": "^7.15.4",
     "@proload/core": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -147,10 +147,10 @@
     vscode-languageserver-types "^3.16.0"
     vscode-uri "^3.0.2"
 
-"@astropub/webapi@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@astropub/webapi/-/webapi-0.7.1.tgz#a82e187b90368ff58ba258036a2f465b44297d4d"
-  integrity sha512-cwyyFTa/PaFsmqieimMocqi0JmWcCzNhvCncEbWCaR8cP47MpWMb+auFztK8hbrZ8UA4Sq/1WF5t5U9Fy2heWQ==
+"@astropub/webapi@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@astropub/webapi/-/webapi-0.7.3.tgz#f83838963416bcaaf407c9f25ab161f605b4ae4c"
+  integrity sha512-HwLMI4GG/a6EgMn8UajCWTJCI3bFEtGf+QdWkVsvkRaRz6OCnJtcV0N++RmJ3gJyMXRQFZcub40StmxglWKThA==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.16.0":
   version "7.16.0"


### PR DESCRIPTION
## Changes

- Bumps `@astropub/webapi` (patch)
- Fixes an issue where StackBlitz would let the browser globals slide into the container globals.
- Credit and thanks to @morritz for reporting the issue and tracking down exactly where it was coming from. 🙏

## Testing

bug fix only

## Docs

bug fix only
