### PR TITLE
Improve the contributing docs for the documentation!

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,10 +8,17 @@ Every pull request needs to be reviewed by another contributor to the documentat
 
 ## Running this project
 
-- Clone/Fork the project
-- This project uses yarn to manage dependencies. [Make sure that you have yarn v1 installed.](https://classic.yarnpkg.com/)
-- Run `yarn install` to install latest dependencies.
-- Run `yarn dev` to start the dev server.
-- Run `yarn build` to build the final site for production.
+- Clone the Project
 
-The environment variable `SNOWPACK_PUBLIC_GITHUB_TOKEN` must be set to a personal access token with `public_repo` permissions to prevent rate-limiting.
+  `git clone git@github.com:withastro/astro.git`
+- Run `yarn install` to install latest dependencies.
+  > This project uses yarn to manage dependencies. [Make sure that you have yarn v1 installed.](https://classic.yarnpkg.com/)
+- Run `yarn workspace docs dev` to start the dev server.
+- Run `yarn workspace docs build` to build the final site for production.
+  > The environment variable `SNOWPACK_PUBLIC_GITHUB_TOKEN` must be set to a personal access token with `public_repo` permissions to prevent rate-limiting.
+
+## Deploying
+
+The site is automatically deployed when commits land in `latest`, via Netlify.
+
+The "next" docs are automatically deployed when commits land in `main`, via Netlify at <https://main--astro-docs-2.netlify.app/getting-started/>.


### PR DESCRIPTION
## Changes

- Fixes #2272 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

- Updates the contributing docs under `docs/README.md` 
  > I feel like there should be a link to contributing in both `README.md`, `CONTRIBUTING.md`, and on the docs website 🤔