### PR TITLE
Adjust TSConfig example files to include compilerOptions

### DIFF
--- a/examples/blog-multiple-authors/tsconfig.json
+++ b/examples/blog-multiple-authors/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }

--- a/examples/blog/tsconfig.json
+++ b/examples/blog/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }

--- a/examples/framework-alpine/tsconfig.json
+++ b/examples/framework-alpine/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }

--- a/examples/framework-lit/tsconfig.json
+++ b/examples/framework-lit/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }

--- a/examples/framework-multiple/tsconfig.json
+++ b/examples/framework-multiple/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }

--- a/examples/framework-preact/tsconfig.json
+++ b/examples/framework-preact/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }

--- a/examples/framework-react/tsconfig.json
+++ b/examples/framework-react/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }

--- a/examples/framework-svelte/tsconfig.json
+++ b/examples/framework-svelte/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }

--- a/examples/framework-vue/tsconfig.json
+++ b/examples/framework-vue/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }

--- a/examples/portfolio-svelte/tsconfig.json
+++ b/examples/portfolio-svelte/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }

--- a/examples/portfolio/tsconfig.json
+++ b/examples/portfolio/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }

--- a/examples/starter/tsconfig.json
+++ b/examples/starter/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }

--- a/examples/with-markdown-plugins/tsconfig.json
+++ b/examples/with-markdown-plugins/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }

--- a/examples/with-markdown/tsconfig.json
+++ b/examples/with-markdown/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }

--- a/examples/with-nanostores/tsconfig.json
+++ b/examples/with-nanostores/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }

--- a/examples/with-tailwindcss/tsconfig.json
+++ b/examples/with-tailwindcss/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "moduleResolution": "node"
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
 }


### PR DESCRIPTION
## Changes

Set `moduleResolution` inside `compilerOptions` object

As per the compiler warning in VSCode
> 'moduleResolution' should be set inside the 'compilerOptions' object of the config json file
![Screen Shot 2021-12-26 at 8 57 37 PM](https://user-images.githubusercontent.com/10026538/147420261-811d670f-f0ac-4814-9c50-be63bb2650d0.png)

And from the TypeScript compiler:
- [error message](https://github.com/microsoft/TypeScript/blob/7a12909ae3f03b1feed19df2082aa84e5c7a5081/src/compiler/diagnosticMessages.json#L4940-L4943)
- [test example](https://github.com/microsoft/TypeScript/blob/main/src/testRunner/unittests/config/convertCompilerOptionsFromJson.ts#L666-L673)

## Testing

Config, no tests

## Docs

Example, no docs
