### PR TITLE
Don't overwrite the stack when using verbose logging

### DIFF
--- a/.changeset/soft-frogs-tap.md
+++ b/.changeset/soft-frogs-tap.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Preserve wasm stack trace when verbose logging is enabled

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -50,7 +50,7 @@ export async function createVite(inlineConfig: ViteConfigWithSSR, { astroConfig,
 		},
 		plugins: [
 			configAliasVitePlugin({ config: astroConfig }),
-			astroVitePlugin({ config: astroConfig, devServer }),
+			astroVitePlugin({ config: astroConfig, devServer, logging }),
 			markdownVitePlugin({ config: astroConfig, devServer }),
 			jsxVitePlugin({ config: astroConfig, logging }),
 			astroPostprocessVitePlugin({ config: astroConfig, devServer }),

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -1,5 +1,6 @@
 import type vite from '../core/vite';
 import type { AstroConfig } from '../@types/astro';
+import type { LogOptions } from '../core/logger';
 
 import esbuild from 'esbuild';
 import { fileURLToPath } from 'url';
@@ -11,11 +12,12 @@ import { cachedCompilation, invalidateCompilation } from './compile.js';
 const FRONTMATTER_PARSE_REGEXP = /^\-\-\-(.*)^\-\-\-/ms;
 interface AstroPluginOptions {
 	config: AstroConfig;
+	logging: LogOptions;
 	devServer?: AstroDevServer;
 }
 
 /** Transform .astro files for Vite */
-export default function astro({ config }: AstroPluginOptions): vite.Plugin {
+export default function astro({ config, logging }: AstroPluginOptions): vite.Plugin {
 	let viteTransform: TransformHook;
 	return {
 		name: '@astrojs/vite-plugin-astro',
@@ -118,8 +120,11 @@ export default function astro({ config }: AstroPluginOptions): vite.Plugin {
     Please open
     a GitHub issue using the link below:
     ${err.url}`;
-					// TODO: remove stack replacement when compiler throws better errors
-					err.stack = `    at ${id}`;
+
+					if(logging.level !== 'debug') {
+						// TODO: remove stack replacement when compiler throws better errors
+						err.stack = `    at ${id}`;
+					}
 				}
 
 				throw err;


### PR DESCRIPTION
## Changes

- This makes it so that if the compiler panics and `--verbose` logging is
on (debug level), we don't replace the stack trace.
- This allows you to debug the panic.

## Testing

No

## Docs

No