### PR TITLE
Fix dynamic routes for sites with subpath

### DIFF
--- a/.changeset/dry-brooms-care.md
+++ b/.changeset/dry-brooms-care.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix dynamic routes for sites with subpath

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -319,7 +319,7 @@ export class AstroDevServer {
 				logging: this.logging,
 				mode: 'development',
 				origin: this.origin,
-				pathname,
+				pathname: routePathname,
 				route,
 				routeCache: this.routeCache,
 				viteServer: this.viteServer,

--- a/packages/astro/test/dev-routing.test.js
+++ b/packages/astro/test/dev-routing.test.js
@@ -32,6 +32,16 @@ describe('Development Routing', () => {
 			const response = await fixture.fetch('/another');
 			expect(response.status).to.equal(200);
 		});
+
+		it('200 when loading dynamic route', async () => {
+			const response = await fixture.fetch('/1');
+			expect(response.status).to.equal(200);
+		});
+
+		it('500 when loading invalid dynamic route', async () => {
+			const response = await fixture.fetch('/2');
+			expect(response.status).to.equal(500);
+		});
 	});
 
 	describe('No subpath used', () => {
@@ -57,6 +67,16 @@ describe('Development Routing', () => {
 		it('200 when loading non-root page', async () => {
 			const response = await fixture.fetch('/another');
 			expect(response.status).to.equal(200);
+		});
+
+		it('200 when loading dynamic route', async () => {
+			const response = await fixture.fetch('/1');
+			expect(response.status).to.equal(200);
+		});
+
+		it('500 when loading invalid dynamic route', async () => {
+			const response = await fixture.fetch('/2');
+			expect(response.status).to.equal(500);
 		});
 	});
 
@@ -94,6 +114,16 @@ describe('Development Routing', () => {
 			const response = await fixture.fetch('/blog/another/');
 			expect(response.status).to.equal(200);
 		});
+
+		it('200 when loading dynamic route', async () => {
+			const response = await fixture.fetch('/blog/1/');
+			expect(response.status).to.equal(200);
+		});
+
+		it('500 when loading invalid dynamic route', async () => {
+			const response = await fixture.fetch('/blog/2/');
+			expect(response.status).to.equal(500);
+		});
 	});
 
 	describe('Subpath without trailing slash', () => {
@@ -129,6 +159,16 @@ describe('Development Routing', () => {
 		it('200 when loading another page with subpath used', async () => {
 			const response = await fixture.fetch('/blog/another/');
 			expect(response.status).to.equal(200);
+		});
+
+		it('200 when loading dynamic route', async () => {
+			const response = await fixture.fetch('/blog/1/');
+			expect(response.status).to.equal(200);
+		});
+
+		it('500 when loading invalid dynamic route', async () => {
+			const response = await fixture.fetch('/blog/2/');
+			expect(response.status).to.equal(500);
 		});
 	});
 });

--- a/packages/astro/test/fixtures/with-subpath-no-trailing-slash/src/pages/[id].astro
+++ b/packages/astro/test/fixtures/with-subpath-no-trailing-slash/src/pages/[id].astro
@@ -1,0 +1,6 @@
+---
+export function getStaticPaths() {
+  return [{ params: { id: '1' } }];
+}
+---
+<h1>Post #1</h1>

--- a/packages/astro/test/fixtures/with-subpath-trailing-slash/src/pages/[id].astro
+++ b/packages/astro/test/fixtures/with-subpath-trailing-slash/src/pages/[id].astro
@@ -1,0 +1,6 @@
+---
+export function getStaticPaths() {
+  return [{ params: { id: '1' } }];
+}
+---
+<h1>Post #1</h1>

--- a/packages/astro/test/fixtures/without-site-config/src/pages/[id].astro
+++ b/packages/astro/test/fixtures/without-site-config/src/pages/[id].astro
@@ -1,0 +1,6 @@
+---
+export function getStaticPaths() {
+  return [{ params: { id: '1' } }];
+}
+---
+<h1>Post #1</h1>

--- a/packages/astro/test/fixtures/without-subpath/src/pages/[id].astro
+++ b/packages/astro/test/fixtures/without-subpath/src/pages/[id].astro
@@ -1,0 +1,6 @@
+---
+export function getStaticPaths() {
+  return [{ params: { id: '1' } }];
+}
+---
+<h1>Post #1</h1>


### PR DESCRIPTION
## Changes

The route being passed into `ssrOptions` included the configured site pathname and therefore failed to match any patterns in the available routes when trying to extract parameters. This made it so that every valid dynamic route would error with `route pattern matched, but no matching static path found.`

## Testing

I added tests for all the scenarios currently being tested under `Dynamic Routing` for both valid and invalid dynamic routes.

## Docs

No documentation changes should be required since it's only a bug fix.
