### PR TITLE
Update svelte version in renderer-svelte

### DIFF
--- a/.changeset/swift-cherries-rule.md
+++ b/.changeset/swift-cherries-rule.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/renderer-svelte': patch
+---
+
+Update Svelte to 3.44.3 to get rid of console warning that component receives an unexpected slot "default".

--- a/packages/renderers/renderer-svelte/package.json
+++ b/packages/renderers/renderer-svelte/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@sveltejs/vite-plugin-svelte": "1.0.0-next.30",
-    "svelte": "^3.44.2",
+    "svelte": "^3.44.3",
     "svelte-preprocess": "^4.9.8"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8804,7 +8804,7 @@ svelte-preprocess@^4.9.8:
     sorcery "^0.10.0"
     strip-indent "^3.0.0"
 
-svelte@^3.44.2:
+svelte@^3.44.3:
   version "3.44.3"
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.44.3.tgz#795b1ced6ed3da44969099e5061b850c93c95e9a"
   integrity sha512-aGgrNCip5PQFNfq9e9tmm7EYxWLVHoFsEsmKrtOeRD8dmoGDdyTQ+21xd7qgFd8MNdKGSYvg7F9dr+Tc0yDymg==


### PR DESCRIPTION
I am having funny console logs saying that my svelte component `received an unexpected slot "default".`. This issue is described [here](https://github.com/sveltejs/kit/issues/981).

## Changes

Supposedly, updating svelte to version 3.44.3 solves this issue.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Sorry, I was unable to fork the renderer and test it locally. 

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
bug fix only
