### PR TITLE
Add Astro Blog RSS feed

### DIFF
--- a/www/src/components/BaseHead.astro
+++ b/www/src/components/BaseHead.astro
@@ -14,6 +14,7 @@ const { title, description, image = 'https://astro.build/social.jpg?v=1', canoni
 <meta name="theme-color" content="#ff5e00" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <link rel="alternate icon" type="image/x-icon" href="/favicon.ico" />
+<link rel="alternate" type="application/rss+xml" href="/rss.xml" title="RSS" />
 <link rel="sitemap" href="/sitemap.xml" />
 
 <!-- Primary Meta Tags -->

--- a/www/src/pages/blog/[slug].astro
+++ b/www/src/pages/blog/[slug].astro
@@ -4,10 +4,26 @@ import BlogHeader from '../../components/BlogHeader.astro';
 import BlogPost from '../../components/BlogPost.astro';
 import GoogleAnalytics from '../../components/GoogleAnalytics.astro';
 
-export function getStaticPaths() {
-	const posts = Astro.fetchContent('../../data/blog-posts/*.md');
+export function getPostSlug(post) {
+	return post.file.pathname.split('/').pop().split('.').shift();
+}
+
+export function getStaticPaths({rss}) {
+	const posts = Astro.fetchContent('../../data/blog-posts/*.md').sort((a, b) => new Date(b.publishDate) - new Date(a.publishDate));
+
+	rss({
+		title: 'Astro Blog',
+		description: 'Everything you need to know about Astro, direct from mission control.',
+		items: posts.map(p => ({
+			title: p.title,
+			description: p.description,
+			link: `blog/${getPostSlug(p)}`,
+			pubDate: p.publishDate,
+		}))
+	});
+
 	return posts.map((p) => ({
-		params: { slug: p.file.pathname.split('/').pop().split('.').shift() },
+		params: { slug: getPostSlug(p) },
 		props: { post: p },
 	}));
 }


### PR DESCRIPTION
## Changes

Generate a RSS feed for Astro Blog posts, and add an alternate link to the `<head>` for discoverability.

## Testing

Build and serve locally, then check `/rss.xml`.

Or check deploy preview feed: https://deploy-preview-2301--astro-www.netlify.app/rss.xml

## Docs

No documentation updates, blog changes only.

Closes #1009.