### PR TITLE
Only resolve inline script specifiers in the static build

### DIFF
--- a/.changeset/soft-sloths-impress.md
+++ b/.changeset/soft-sloths-impress.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix to allow the static build to build hydrated components

--- a/examples/fast-build/package.json
+++ b/examples/fast-build/package.json
@@ -6,6 +6,7 @@
     "dev": "astro dev --experimental-static-build",
     "start": "astro dev",
     "build": "astro build --experimental-static-build",
+    "scan-build": "astro build",
     "preview": "astro preview"
   },
   "devDependencies": {

--- a/examples/fast-build/src/components/Counter.vue
+++ b/examples/fast-build/src/components/Counter.vue
@@ -1,0 +1,24 @@
+<template>
+	<div id="vue" class="counter">
+		<button @click="subtract()">-</button>
+		<pre>{{ count }}</pre>
+		<button @click="add()">+</button>
+	</div>
+</template>
+
+<script>
+import { ref } from 'vue';
+export default {
+	setup() {
+		const count = ref(0);
+		const add = () => (count.value = count.value + 1);
+		const subtract = () => (count.value = count.value - 1);
+
+		return {
+			count,
+			add,
+			subtract,
+		};
+	},
+};
+</script>

--- a/examples/fast-build/src/pages/[pokemon].astro
+++ b/examples/fast-build/src/pages/[pokemon].astro
@@ -1,0 +1,20 @@
+---
+import Greeting from '../components/Greeting.vue';
+
+export async function getStaticPaths() {
+  const response = await fetch(`https://pokeapi.co/api/v2/pokemon?limit=2000`);
+  const result = await response.json();
+  const allPokemon = result.results;
+  return allPokemon.map(pokemon => ({params: {pokemon: pokemon.name}, props: {pokemon}}));
+}
+---
+<html lang="en">
+  <head>
+    <title>Hello</title>
+  </head>
+
+  <body>
+    <h1>{Astro.props.pokemon.name}</h1>
+    <Greeting client:load />
+  </body>
+</html>

--- a/examples/fast-build/src/pages/index.astro
+++ b/examples/fast-build/src/pages/index.astro
@@ -2,6 +2,7 @@
 import imgUrl from '../images/penguin.jpg';
 import grayscaleUrl from '../images/random.jpg?grayscale=true';
 import Greeting from '../components/Greeting.vue';
+import Counter from '../components/Counter.vue';
 ---
 
 <html>
@@ -26,9 +27,14 @@ import Greeting from '../components/Greeting.vue';
 			<Greeting />
 		</section>
 
-		<section>
-			<h1>ImageTools</h1>
-			<img src={grayscaleUrl} />
-		</section>
-	</body>
+  <section>
+    <h1>ImageTools</h1>
+    <img src={grayscaleUrl} />
+  </section>
+
+  <section>
+    <h1>Hydrated component</h1>
+    <Counter client:idle />
+  </section>
+</body>
 </html>

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -56,7 +56,7 @@
     "test": "mocha --parallel --timeout 15000"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.6.0",
+    "@astrojs/compiler": "^0.7.0",
     "@astrojs/language-server": "^0.8.2",
     "@astrojs/markdown-remark": "^0.6.0",
     "@astrojs/prism": "0.4.0",

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -371,5 +371,6 @@ export interface SSRResult {
 	scripts: Set<SSRElement>;
 	links: Set<SSRElement>;
 	createAstro(Astro: AstroGlobalPartial, props: Record<string, any>, slots: Record<string, any> | null): AstroGlobal;
+	resolve: (s: string) => Promise<string>;
 	_metadata: SSRMetadata;
 }

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -14,6 +14,10 @@ export interface BuildInternals {
 
 	// A mapping to entrypoints (facadeId) to assets (styles) that are added.
 	facadeIdToAssetsMap: Map<string, string[]>;
+
+	// A mapping of specifiers like astro/client/idle.js to the hashed bundled name.
+	// Used to render pages with the correct specifiers.
+	entrySpecifierToBundleMap: Map<string, string>;
 }
 
 /**
@@ -41,5 +45,6 @@ export function createBuildInternals(): BuildInternals {
 		astroStyleMap,
 		astroPageStyleMap,
 		facadeIdToAssetsMap,
+		entrySpecifierToBundleMap: new Map<string, string>(),
 	};
 }

--- a/packages/astro/src/core/ssr/index.ts
+++ b/packages/astro/src/core/ssr/index.ts
@@ -1,34 +1,19 @@
 import type { BuildResult } from 'esbuild';
 import type vite from '../vite';
-import type {
-	AstroConfig,
-	AstroGlobal,
-	AstroGlobalPartial,
-	ComponentInstance,
-	GetStaticPathsResult,
-	Params,
-	Props,
-	Renderer,
-	RouteCache,
-	RouteData,
-	RuntimeMode,
-	SSRElement,
-	SSRError,
-	SSRResult,
-} from '../../@types/astro';
+import type { AstroConfig, ComponentInstance, GetStaticPathsResult, Params, Props, Renderer, RouteCache, RouteData, RuntimeMode, SSRElement, SSRError } from '../../@types/astro';
 import type { LogOptions } from '../logger';
-import type { AstroComponentFactory } from '../../runtime/server/index';
 
 import eol from 'eol';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { renderPage, renderSlot } from '../../runtime/server/index.js';
-import { canonicalURL as getCanonicalURL, codeFrame, resolveDependency } from '../util.js';
+import { renderPage } from '../../runtime/server/index.js';
+import { codeFrame, resolveDependency } from '../util.js';
 import { getStylesForURL } from './css.js';
 import { injectTags } from './html.js';
 import { generatePaginateFunction } from './paginate.js';
 import { getParams, validateGetStaticPathsModule, validateGetStaticPathsResult } from './routing.js';
+import { createResult } from './result.js';
 
 const svelteStylesRE = /svelte\?svelte&type=style/;
 
@@ -139,75 +124,6 @@ export async function preload({ astroConfig, filePath, viteServer }: SSROptions)
 	return [renderers, mod];
 }
 
-export async function renderComponent(
-	renderers: Renderer[],
-	Component: AstroComponentFactory,
-	astroConfig: AstroConfig,
-	pathname: string,
-	origin: string,
-	params: Params,
-	pageProps: Props,
-	links: string[] = []
-): Promise<string> {
-	const _links = new Set<SSRElement>(
-		links.map((href) => ({
-			props: {
-				rel: 'stylesheet',
-				href,
-			},
-			children: '',
-		}))
-	);
-	const result: SSRResult = {
-		styles: new Set<SSRElement>(),
-		scripts: new Set<SSRElement>(),
-		links: _links,
-		/** This function returns the `Astro` faux-global */
-		createAstro(astroGlobal: AstroGlobalPartial, props: Record<string, any>, slots: Record<string, any> | null) {
-			const site = new URL(origin);
-			const url = new URL('.' + pathname, site);
-			const canonicalURL = getCanonicalURL('.' + pathname, astroConfig.buildOptions.site || origin);
-			return {
-				__proto__: astroGlobal,
-				props,
-				request: {
-					canonicalURL,
-					params,
-					url,
-				},
-				slots: Object.fromEntries(Object.entries(slots || {}).map(([slotName]) => [slotName, true])),
-				// This is used for <Markdown> but shouldn't be used publicly
-				privateRenderSlotDoNotUse(slotName: string) {
-					return renderSlot(result, slots ? slots[slotName] : null);
-				},
-				// <Markdown> also needs the same `astroConfig.markdownOptions.render` as `.md` pages
-				async privateRenderMarkdownDoNotUse(content: string, opts: any) {
-					let mdRender = astroConfig.markdownOptions.render;
-					let renderOpts = {};
-					if (Array.isArray(mdRender)) {
-						renderOpts = mdRender[1];
-						mdRender = mdRender[0];
-					}
-					if (typeof mdRender === 'string') {
-						({ default: mdRender } = await import(mdRender));
-					}
-					const { code } = await mdRender(content, { ...renderOpts, ...(opts ?? {}) });
-					return code;
-				},
-			} as unknown as AstroGlobal;
-		},
-		_metadata: {
-			renderers,
-			pathname,
-			experimentalStaticBuild: astroConfig.buildOptions.experimentalStaticBuild,
-		},
-	};
-
-	let html = await renderPage(result, Component, pageProps, null);
-
-	return html;
-}
-
 export async function getParamsAndProps({
 	route,
 	routeCache,
@@ -292,57 +208,10 @@ export async function render(renderers: Renderer[], mod: ComponentInstance, ssrO
 	if (!Component) throw new Error(`Expected an exported Astro component but received typeof ${typeof Component}`);
 	if (!Component.isAstroComponentFactory) throw new Error(`Unable to SSR non-Astro component (${route?.component})`);
 
-	// Create the result object that will be passed into the render function.
-	// This object starts here as an empty shell (not yet the result) but then
-	// calling the render() function will populate the object with scripts, styles, etc.
-	const result: SSRResult = {
-		styles: new Set<SSRElement>(),
-		scripts: new Set<SSRElement>(),
-		links: new Set<SSRElement>(),
-		/** This function returns the `Astro` faux-global */
-		createAstro(astroGlobal: AstroGlobalPartial, props: Record<string, any>, slots: Record<string, any> | null) {
-			const site = new URL(origin);
-			const url = new URL('.' + pathname, site);
-			const canonicalURL = getCanonicalURL('.' + pathname, astroConfig.buildOptions.site || origin);
-			return {
-				__proto__: astroGlobal,
-				props,
-				request: {
-					canonicalURL,
-					params,
-					url,
-				},
-				slots: Object.fromEntries(Object.entries(slots || {}).map(([slotName]) => [slotName, true])),
-				// This is used for <Markdown> but shouldn't be used publicly
-				privateRenderSlotDoNotUse(slotName: string) {
-					return renderSlot(result, slots ? slots[slotName] : null);
-				},
-				// <Markdown> also needs the same `astroConfig.markdownOptions.render` as `.md` pages
-				async privateRenderMarkdownDoNotUse(content: string, opts: any) {
-					let mdRender = astroConfig.markdownOptions.render;
-					let renderOpts = {};
-					if (Array.isArray(mdRender)) {
-						renderOpts = mdRender[1];
-						mdRender = mdRender[0];
-					}
-					// ['rehype-toc', opts]
-					if (typeof mdRender === 'string') {
-						({ default: mdRender } = await import(mdRender));
-					}
-					// [import('rehype-toc'), opts]
-					else if (mdRender instanceof Promise) {
-						({ default: mdRender } = await mdRender);
-					}
-					const { code } = await mdRender(content, { ...renderOpts, ...(opts ?? {}) });
-					return code;
-				},
-			} as unknown as AstroGlobal;
-		},
-		_metadata: {
-			renderers,
-			pathname,
-			experimentalStaticBuild: astroConfig.buildOptions.experimentalStaticBuild,
-		},
+	const result = createResult({ astroConfig, origin, params, pathname, renderers });
+	result.resolve = async (s: string) => {
+		const [, resolvedPath] = await viteServer.moduleGraph.resolveUrl(s);
+		return resolvedPath;
 	};
 
 	let html = await renderPage(result, Component, pageProps, null);
@@ -387,7 +256,7 @@ export async function render(renderers: Renderer[], mod: ComponentInstance, ssrO
 	html = injectTags(html, tags);
 
 	// run transformIndexHtml() in dev to run Vite dev transformations
-	if (mode === 'development') {
+	if (mode === 'development' && !astroConfig.buildOptions.experimentalStaticBuild) {
 		const relativeURL = filePath.href.replace(astroConfig.projectRoot.href, '/');
 		html = await viteServer.transformIndexHtml(relativeURL, html, pathname);
 	}

--- a/packages/astro/src/core/ssr/result.ts
+++ b/packages/astro/src/core/ssr/result.ts
@@ -1,0 +1,75 @@
+import type { AstroConfig, AstroGlobal, AstroGlobalPartial, Params, Renderer, SSRElement, SSRResult } from '../../@types/astro';
+
+import { canonicalURL as getCanonicalURL } from '../util.js';
+import { renderSlot } from '../../runtime/server/index.js';
+
+export interface CreateResultArgs {
+	astroConfig: AstroConfig;
+	origin: string;
+	params: Params;
+	pathname: string;
+	renderers: Renderer[];
+}
+
+export function createResult(args: CreateResultArgs): SSRResult {
+	const { astroConfig, origin, params, pathname, renderers } = args;
+
+	// Create the result object that will be passed into the render function.
+	// This object starts here as an empty shell (not yet the result) but then
+	// calling the render() function will populate the object with scripts, styles, etc.
+	const result: SSRResult = {
+		styles: new Set<SSRElement>(),
+		scripts: new Set<SSRElement>(),
+		links: new Set<SSRElement>(),
+		/** This function returns the `Astro` faux-global */
+		createAstro(astroGlobal: AstroGlobalPartial, props: Record<string, any>, slots: Record<string, any> | null) {
+			const site = new URL(origin);
+			const url = new URL('.' + pathname, site);
+			const canonicalURL = getCanonicalURL('.' + pathname, astroConfig.buildOptions.site || origin);
+			return {
+				__proto__: astroGlobal,
+				props,
+				request: {
+					canonicalURL,
+					params,
+					url,
+				},
+				slots: Object.fromEntries(Object.entries(slots || {}).map(([slotName]) => [slotName, true])),
+				// This is used for <Markdown> but shouldn't be used publicly
+				privateRenderSlotDoNotUse(slotName: string) {
+					return renderSlot(result, slots ? slots[slotName] : null);
+				},
+				// <Markdown> also needs the same `astroConfig.markdownOptions.render` as `.md` pages
+				async privateRenderMarkdownDoNotUse(content: string, opts: any) {
+					let mdRender = astroConfig.markdownOptions.render;
+					let renderOpts = {};
+					if (Array.isArray(mdRender)) {
+						renderOpts = mdRender[1];
+						mdRender = mdRender[0];
+					}
+					// ['rehype-toc', opts]
+					if (typeof mdRender === 'string') {
+						({ default: mdRender } = await import(mdRender));
+					}
+					// [import('rehype-toc'), opts]
+					else if (mdRender instanceof Promise) {
+						({ default: mdRender } = await mdRender);
+					}
+					const { code } = await mdRender(content, { ...renderOpts, ...(opts ?? {}) });
+					return code;
+				},
+			} as unknown as AstroGlobal;
+		},
+		// This is a stub and will be implemented by dev and build.
+		async resolve(s: string): Promise<string> {
+			return '';
+		},
+		_metadata: {
+			renderers,
+			pathname,
+			experimentalStaticBuild: astroConfig.buildOptions.experimentalStaticBuild,
+		},
+	};
+
+	return result;
+}

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -1,8 +1,8 @@
 import type { AstroComponentMetadata } from '../../@types/astro';
-import type { SSRElement } from '../../@types/astro';
+import type { SSRElement, SSRResult } from '../../@types/astro';
 import { valueToEstree } from 'estree-util-value-to-estree';
 import * as astring from 'astring';
-import { serializeListValue } from './util.js';
+import { hydrationSpecifier, serializeListValue } from './util.js';
 
 const { generate, GENERATOR } = astring;
 
@@ -69,6 +69,11 @@ export function extractDirectives(inputProps: Record<string | number, any>): Ext
 					extracted.hydration.componentExport.value = value;
 					break;
 				}
+				// This is a special prop added to prove that the client hydration method
+				// was added statically.
+				case 'client:component-hydration': {
+					break;
+				}
 				default: {
 					extracted.hydration.directive = key.split(':')[1];
 					extracted.hydration.value = value;
@@ -93,18 +98,20 @@ export function extractDirectives(inputProps: Record<string | number, any>): Ext
 			extracted.props[key] = value;
 		}
 	}
+
 	return extracted;
 }
 
 interface HydrateScriptOptions {
 	renderer: any;
+	result: SSRResult;
 	astroId: string;
 	props: Record<string | number, any>;
 }
 
 /** For hydrated components, generate a <script type="module"> to load the component */
 export async function generateHydrateScript(scriptOptions: HydrateScriptOptions, metadata: Required<AstroComponentMetadata>): Promise<SSRElement> {
-	const { renderer, astroId, props } = scriptOptions;
+	const { renderer, result, astroId, props } = scriptOptions;
 	const { hydrate, componentUrl, componentExport } = metadata;
 
 	if (!componentExport) {
@@ -117,7 +124,9 @@ export async function generateHydrateScript(scriptOptions: HydrateScriptOptions,
 	}
 
 	hydrationSource += renderer.source
-		? `const [{ ${componentExport.value}: Component }, { default: hydrate }] = await Promise.all([import("${componentUrl}"), import("${renderer.source}")]);
+		? `const [{ ${componentExport.value}: Component }, { default: hydrate }] = await Promise.all([import("${await result.resolve(componentUrl)}"), import("${await result.resolve(
+				renderer.source
+		  )}")]);
   return (el, children) => hydrate(el)(Component, ${serializeProps(props)}, children);
 `
 		: `await import("${componentUrl}");
@@ -126,7 +135,7 @@ export async function generateHydrateScript(scriptOptions: HydrateScriptOptions,
 
 	const hydrationScript = {
 		props: { type: 'module', 'data-astro-component-hydration': true },
-		children: `import setup from 'astro/client/${hydrate}.js';
+		children: `import setup from '${await result.resolve(hydrationSpecifier(hydrate))}';
 setup("${astroId}", {${metadata.hydrateArgs ? `value: ${JSON.stringify(metadata.hydrateArgs)}` : ''}}, async () => {
   ${hydrationSource}
 });

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -249,7 +249,7 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 
 	// Rather than appending this inline in the page, puts this into the `result.scripts` set that will be appended to the head.
 	// INVESTIGATE: This will likely be a problem in streaming because the `<head>` will be gone at this point.
-	result.scripts.add(await generateHydrateScript({ renderer, astroId, props }, metadata as Required<AstroComponentMetadata>));
+	result.scripts.add(await generateHydrateScript({ renderer, result, astroId, props }, metadata as Required<AstroComponentMetadata>));
 
 	return `<astro-root uid="${astroId}">${html ?? ''}</astro-root>`;
 }

--- a/packages/astro/src/runtime/server/util.ts
+++ b/packages/astro/src/runtime/server/util.ts
@@ -1,3 +1,10 @@
+function formatList(values: string[]): string {
+	if (values.length === 1) {
+		return values[0];
+	}
+	return `${values.slice(0, -1).join(', ')} or ${values[values.length - 1]}`;
+}
+
 export function serializeListValue(value: any) {
 	const hash: Record<string, any> = {};
 
@@ -26,4 +33,13 @@ export function serializeListValue(value: any) {
 			}
 		}
 	}
+}
+
+/**
+ * Get the import specifier for a given hydration directive.
+ * @param hydrate The hydration directive such as `idle` or `visible`
+ * @returns
+ */
+export function hydrationSpecifier(hydrate: string) {
+	return `astro/client/${hydrate}.js`;
 }

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -29,8 +29,10 @@ function isSSR(options: undefined | boolean | { ssr: boolean }): boolean {
 async function compile(config: AstroConfig, filename: string, source: string, viteTransform: TransformHook, opts: boolean | undefined) {
 	// pages and layouts should be transformed as full documents (implicit <head> <body> etc)
 	// everything else is treated as a fragment
-	const normalizedID = fileURLToPath(new URL(`file://${filename}`));
+	const filenameURL = new URL(`file://${filename}`);
+	const normalizedID = fileURLToPath(filenameURL);
 	const isPage = normalizedID.startsWith(fileURLToPath(config.pages)) || normalizedID.startsWith(fileURLToPath(config.layouts));
+	const pathname = filenameURL.pathname.substr(config.projectRoot.pathname.length - 1);
 
 	let cssTransformError: Error | undefined;
 
@@ -39,6 +41,7 @@ async function compile(config: AstroConfig, filename: string, source: string, vi
 	// result passed to esbuild, but also available in the catch handler.
 	const transformResult = await transform(source, {
 		as: isPage ? 'document' : 'fragment',
+		pathname,
 		projectRoot: config.projectRoot.toString(),
 		site: config.buildOptions.site,
 		sourcefile: filename,

--- a/packages/astro/src/vite-plugin-build-html/index.ts
+++ b/packages/astro/src/vite-plugin-build-html/index.ts
@@ -69,7 +69,7 @@ export function rollupPluginAstroBuildHTML(options: PluginOptions): VitePlugin {
 				const [renderers, mod] = pageData.preload;
 
 				// Hydrated components are statically identified.
-				for (const path of mod.$$metadata.getAllHydratedComponentPaths()) {
+				for (const path of mod.$$metadata.hydratedComponentPaths()) {
 					jsInput.add(path);
 				}
 

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -51,8 +51,12 @@ ${setup}`.trim();
 					astroResult = `${prelude}\n${astroResult}`;
 				}
 
+				const filenameURL = new URL(`file://${id}`);
+				const pathname = filenameURL.pathname.substr(config.projectRoot.pathname.length - 1);
+
 				// Transform from `.astro` to valid `.ts`
 				let { code: tsResult } = await transform(astroResult, {
+					pathname,
 					projectRoot: config.projectRoot.toString(),
 					site: config.buildOptions.site,
 					sourcefile: id,

--- a/packages/astro/test/astro-client-only.test.js
+++ b/packages/astro/test/astro-client-only.test.js
@@ -20,7 +20,7 @@ describe('Client only components', () => {
 
 		const script = await fixture.readFile(src);
 		// test 2: svelte renderer is on the page
-		const exp = /import\("(.\/client.*)"\)/g;
+		const exp = /import\("(.\/@astrojs_renderer-svelte_client.*)"\)/g;
 		let match, svelteRenderer;
 		while ((match = exp.exec(script))) {
 			svelteRenderer = match[1].replace(/^\./, '/assets/');

--- a/packages/astro/test/astro-client-only.test.js
+++ b/packages/astro/test/astro-client-only.test.js
@@ -20,7 +20,7 @@ describe('Client only components', () => {
 
 		const script = await fixture.readFile(src);
 		// test 2: svelte renderer is on the page
-		const exp = /import\("(.\/@astrojs_renderer-svelte_client.*)"\)/g;
+		const exp = /import\("(.\/client.*)"\)/g;
 		let match, svelteRenderer;
 		while ((match = exp.exec(script))) {
 			svelteRenderer = match[1].replace(/^\./, '/assets/');

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,10 +122,10 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@astrojs/compiler@^0.6.0":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-0.6.2.tgz#f9f6d2bfabc70921fa2be9da49767f878a1bc1e4"
-  integrity sha512-okzco1cwAPC1Fs1EovCckQpZFLAkuysTM+0qVXQ41fE6mLxmq/4i7fFR7l0Wy/0JapgcRQbK5xN4Y08ku4EPQg==
+"@astrojs/compiler@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-0.7.0.tgz#b2c93c0df6cfe84360043918bb581f8cec1fac31"
+  integrity sha512-lnEdXsGSCMbUfVfXewvYKzTOyHYxsiZHmePNc5YBGjNUvJsFljr4ttMAE958gvwRWltOuaVqc4HuNSx6ylL/hQ==
   dependencies:
     typescript "^4.3.5"
 


### PR DESCRIPTION
## Changes

- The 5c98456028df94aa2edef62512b24e6936d4c0b8 commit is the new code here.
- The other commit is a revert of a revert. Had to revert the new static build enhancements due to it breaking the docs site.
- In order to not rely on vite HTML post-processing the static build resolves inline script specifiers by mapping them to the hashed built file. This doesn't work for the legacy build as Vite-HTML doesn't use the same underlying API. We will want to ask Vite to expose their API, but for now since it's not needed by the legacy build, we can just not resolve the specifiers at render-time.
