### PR TITLE
Upgrade language server

### DIFF
--- a/.changeset/quick-pots-hunt.md
+++ b/.changeset/quick-pots-hunt.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `astro check` errors with import.meta usage

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@astrojs/compiler": "^0.7.0",
-    "@astrojs/language-server": "^0.8.2",
+    "@astrojs/language-server": "^0.8.6",
     "@astrojs/markdown-remark": "^0.6.0",
     "@astrojs/prism": "0.4.0",
     "@astrojs/renderer-preact": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -129,10 +129,10 @@
   dependencies:
     typescript "^4.3.5"
 
-"@astrojs/language-server@^0.8.2":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@astrojs/language-server/-/language-server-0.8.5.tgz#f3eb869348d7da802ba88ecb559271abb842a333"
-  integrity sha512-3Ra2HjnJnfKjSsLrZeWuXIvpW/LBtoUOcnSYAR/pqfOcSZDZXHOXLsySLTkS46zQoMJK0F+V+IRUmZ+vTGUQwA==
+"@astrojs/language-server@^0.8.6":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@astrojs/language-server/-/language-server-0.8.6.tgz#72b76429e9100c5b075ef3cd125d77fc36647916"
+  integrity sha512-Ta9v/19bczh9LXOYsRFQU8Rk8K/y6oSo510Jzp5xqJ+miWLQDLvLEL4BsyKpPBVBg2kyMBrpZ7LNSzGhQL4XVQ==
   dependencies:
     lodash "^4.17.21"
     source-map "^0.7.3"


### PR DESCRIPTION
## Changes

- Fixes #2297
- Upgrades the language server, which no longer provides types for import.meta, fixing the above issue.

## Testing

No test added in this repo.

## Docs

N/A, bug fix