### PR TITLE
move changeset to run after build, no test required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,12 +214,12 @@ jobs:
         run: node ./scripts/smoke/index.js
 
 
-  # Changelog can only run _after_ Build and Test.
+  # Changelog can only run _after_ build.
   # We download all `dist/` artifacts from GitHub to skip the build process.
   changelog:
     name: Changelog PR or Release
     if: ${{ github.ref_name == 'main' && github.repository_owner == 'withastro' }}
-    needs: [lint, test, smoke]
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Changes

- Previously, changeset bot only ran after tests had passed. 
- This can add extra minutes to a release process (especially waiting for the smoke test) and also lead to an outdated/missing release PR if a flakey test happens.
- Because tests will re-run in the `ci release` PR before a release, waiting for tests to run here is unnecessary. 

cc @natemoo-re would love a sanity check on this thinking to make sure it makes sense.
