### PR TITLE
build-css resolve should return false instead of undefined

### DIFF
--- a/packages/astro/src/vite-plugin-build-css/index.ts
+++ b/packages/astro/src/vite-plugin-build-css/index.ts
@@ -86,7 +86,7 @@ export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin {
 			if (isStyleVirtualModule(id)) {
 				return id;
 			}
-			return undefined;
+			return false;
 		},
 
 		async load(id) {


### PR DESCRIPTION
## Changes

Resolve function of vite plugin build-css should return false instead of undefined in case an id can not be resolved.

This allows for some vite plugins to function on astro build. Working eg windicss. 
Not working: unocss (caused by how unocss is setup)

## Testing

Run regular ci tests

Manually verified using windicss and unocss plugins.
Unclear yet how to add proper test

## Docs

No feature change.