### PR TITLE
Fix build output in static build mode

### DIFF
--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -101,6 +101,7 @@ class AstroBuilder {
 				astroConfig: this.config,
 				logging: this.logging,
 				origin: this.origin,
+				pageNames,
 				routeCache: this.routeCache,
 				viteConfig: this.viteConfig,
 			});

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -25,8 +25,14 @@ export interface StaticBuildOptions {
 	astroConfig: AstroConfig;
 	logging: LogOptions;
 	origin: string;
+	pageNames: string[];
 	routeCache: RouteCache;
 	viteConfig: ViteConfigWithSSR;
+}
+
+function addPageName(pathname: string, opts: StaticBuildOptions): void {
+	const pathrepl = opts.astroConfig.buildOptions.pageUrlFormat === "directory" ? "/index.html" : pathname === "/" ? "index.html" : ".html";
+	opts.pageNames.push(pathname.replace(/\/?$/, pathrepl).replace(/^\//, ""));
 }
 
 export async function staticBuild(opts: StaticBuildOptions) {
@@ -198,8 +204,11 @@ interface GeneratePathOptions {
 }
 
 async function generatePath(pathname: string, opts: StaticBuildOptions, gopts: GeneratePathOptions) {
-	const { astroConfig, logging, origin, routeCache } = opts;
+	const { astroConfig, logging, origin, pageNames, routeCache } = opts;
 	const { Component, internals, linkIds, pageData } = gopts;
+
+	// This adds the page name to the array so it can be shown as part of stats.
+  addPageName(pathname, opts);
 
 	const [renderers, mod] = pageData.preload;
 


### PR DESCRIPTION
## Changes

- Fixes the output when using `--experimental-static-build`. Previously was missing the number of pages, now its fixed:

```
10:02 AM [build] 1001 pages built in 10.58s (11ms/page)
10:02 AM [build] 🚀 Done
```

## Testing

We don't have tests for cli output at the moment.

## Docs

N/A, bug fix only.
