### PR TITLE
Fix renderer-solid (fix #2336)

### DIFF
--- a/.changeset/happy-penguins-wave.md
+++ b/.changeset/happy-penguins-wave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/renderer-solid': patch
+---
+
+fix renderer-solid

--- a/packages/renderers/renderer-solid/server.js
+++ b/packages/renderers/renderer-solid/server.js
@@ -19,7 +19,7 @@ function renderToStaticMarkup(Component, props, children) {
 			children: children != null ? ssr(`<astro-fragment>${children}</astro-fragment>`) : children,
 		})
 	);
-	return { html: html + `<script>window._$HYDRATION||(window._$HYDRATION={events:[],completed:new WeakSet})</script>` };
+	return { html: html + `<script>window._$HY||(_$HY={events:[],completed:new WeakSet,r:{}})</script>` };
 }
 
 export default {


### PR DESCRIPTION
## Changes

in `yarn.lock` file, the resolved `solid-js` version is 1.3.2, `solid-js`'s dependency `dom-expressions` version is 0.31.9

in `dom-expressions` package, the current property name is `_$HY`
cc:
https://github.com/ryansolid/dom-expressions/blob/d6acdfaec8fd29efa9954a56f1f6d068b9b8e528/packages/dom-expressions/src/server.js#L393-L399


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

bug fix only


close #2336;