### PR TITLE
Fix: static-build with .md pages

### DIFF
--- a/.changeset/tricky-eagles-enjoy.md
+++ b/.changeset/tricky-eagles-enjoy.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes use of --experimental-static-build with markdown pages

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -41,7 +41,9 @@ function chunkIsPage(output: OutputAsset | OutputChunk, internals: BuildInternal
 		return false;
 	}
 	const chunk = output as OutputChunk;
-	return chunk.facadeModuleId && internals.entrySpecifierToBundleMap.has(chunk.facadeModuleId);
+	return chunk.facadeModuleId &&
+		(internals.entrySpecifierToBundleMap.has(chunk.facadeModuleId) ||
+			internals.entrySpecifierToBundleMap.has('/' + chunk.facadeModuleId));
 }
 
 export async function staticBuild(opts: StaticBuildOptions) {

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -1,4 +1,4 @@
-import type { OutputChunk, PreRenderedChunk, RollupOutput } from 'rollup';
+import type { OutputChunk, OutputAsset, PreRenderedChunk, RollupOutput } from 'rollup';
 import type { Plugin as VitePlugin, UserConfig } from '../vite';
 import type { AstroConfig, RouteCache, SSRElement } from '../../@types/astro';
 import type { AllPagesData } from './types';
@@ -33,6 +33,15 @@ export interface StaticBuildOptions {
 function addPageName(pathname: string, opts: StaticBuildOptions): void {
 	const pathrepl = opts.astroConfig.buildOptions.pageUrlFormat === 'directory' ? '/index.html' : pathname === '/' ? 'index.html' : '.html';
 	opts.pageNames.push(pathname.replace(/\/?$/, pathrepl).replace(/^\//, ''));
+}
+
+// Determines of a Rollup chunk is an entrypoint page.
+function chunkIsPage(output: OutputAsset | OutputChunk, internals: BuildInternals) {
+	if(output.type !== 'chunk') {
+		return false;
+	}
+	const chunk = output as OutputChunk;
+	return chunk.facadeModuleId && internals.entrySpecifierToBundleMap.has(chunk.facadeModuleId);
 }
 
 export async function staticBuild(opts: StaticBuildOptions) {
@@ -158,8 +167,8 @@ async function generatePages(result: RollupOutput, opts: StaticBuildOptions, int
 	debug(opts.logging, 'generate', 'End build step, now generating');
 	const generationPromises = [];
 	for (let output of result.output) {
-		if (output.type === 'chunk' && output.facadeModuleId && output.facadeModuleId.endsWith('.astro')) {
-			generationPromises.push(generatePage(output, opts, internals, facadeIdToPageDataMap));
+		if (chunkIsPage(output, internals)) {
+			generationPromises.push(generatePage(output as OutputChunk, opts, internals, facadeIdToPageDataMap));
 		}
 	}
 	await Promise.all(generationPromises);

--- a/packages/astro/test/fixtures/static-build/src/layouts/Main.astro
+++ b/packages/astro/test/fixtures/static-build/src/layouts/Main.astro
@@ -1,0 +1,6 @@
+<html>
+<head>
+<title>Testing</title>
+</head>
+<body><slot></slot></body>
+</html>

--- a/packages/astro/test/fixtures/static-build/src/pages/index.astro
+++ b/packages/astro/test/fixtures/static-build/src/pages/index.astro
@@ -1,0 +1,6 @@
+<html>
+<head>
+<title>Testing</title>
+</head>
+<body><h1>Testing</h1></body>
+</html>

--- a/packages/astro/test/fixtures/static-build/src/pages/posts/thoughts.md
+++ b/packages/astro/test/fixtures/static-build/src/pages/posts/thoughts.md
@@ -1,0 +1,7 @@
+---
+layout: ../../layouts/Main.astro
+---
+
+# Post
+
+Testing here

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Static build', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			projectRoot: './fixtures/static-build/',
+			renderers: [],
+			buildOptions: {
+				experimentalStaticBuild: true,
+			},
+		});
+		await fixture.build();
+	});
+
+	it('Builds out .astro pags', async () => {
+		const html = await fixture.readFile('/index.html');
+		expect(html).to.be.a('string');
+	});
+
+	it('Builds out .md pages', async () => {
+		const html = await fixture.readFile('/posts/thoughts/index.html');
+		expect(html).to.be.a('string');
+	});
+});


### PR DESCRIPTION
This fixes the `--experimental-static-build` flag to work with markdown
pages.

## Changes

- Correctly check if a Rollup chunk came from one of our entrypoints.

## Testing

Test added

## Docs

Bug fix