### PR TITLE
Fixes for blog and docs examples

### DIFF
--- a/examples/blog/src/layouts/BlogPost.astro
+++ b/examples/blog/src/layouts/BlogPost.astro
@@ -2,6 +2,7 @@
 import BaseHead from '../components/BaseHead.astro';
 import BlogHeader from '../components/BlogHeader.astro';
 import BlogPost from '../components/BlogPost.astro';
+import '../styles/blog.css';
 
 const { content } = Astro.props;
 const { title, description, publishDate, author, heroImage, permalink, alt } = content;
@@ -10,7 +11,6 @@ const { title, description, publishDate, author, heroImage, permalink, alt } = c
 <html lang={content.lang || 'en'}>
 	<head>
 		<BaseHead {title} {description} {permalink} />
-		<link rel="stylesheet" href={Astro.resolve('../styles/blog.css')} />
 	</head>
 
 	<body>

--- a/examples/blog/src/pages/index.astro
+++ b/examples/blog/src/pages/index.astro
@@ -3,6 +3,7 @@
 import BaseHead from '../components/BaseHead.astro';
 import BlogHeader from '../components/BlogHeader.astro';
 import BlogPostPreview from '../components/BlogPostPreview.astro';
+import '../styles/blog.css';
 
 interface MarkdownFrontmatter {
 	publishDate: number;
@@ -28,7 +29,6 @@ allPosts = allPosts.sort((a, b) => new Date(b.publishDate).valueOf() - new Date(
 <html lang="en">
 	<head>
 		<BaseHead {title} {description} {permalink} />
-		<link rel="stylesheet" href={Astro.resolve('../styles/blog.css')} />
 
 		<style>
 			header {

--- a/examples/docs/src/components/Header/Search.tsx
+++ b/examples/docs/src/components/Header/Search.tsx
@@ -1,10 +1,12 @@
 /* jsxImportSource: react */
 import { useState, useCallback, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { DocSearchModal, useDocSearchKeyboardEvents } from '@docsearch/react';
+import * as docSearchReact from '@docsearch/react';
 import * as CONFIG from '../../config';
 import '@docsearch/css/dist/style.css';
 import './Search.css';
+
+const { DocSearchModal, useDocSearchKeyboardEvents } = docSearchReact.default;
 
 export default function Search() {
 	const [isOpen, setIsOpen] = useState(false);

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -286,8 +286,8 @@ function createFetchContentFn(url: URL) {
 
 // This is used to create the top-level Astro global; the one that you can use
 // Inside of getStaticPaths.
-export function createAstro(fileURLStr: string, site: string, projectRootStr: string): AstroGlobalPartial {
-	const url = new URL(fileURLStr);
+export function createAstro(filePathname: string, site: string, projectRootStr: string): AstroGlobalPartial {
+	const url = new URL(filePathname, site);
 	const projectRoot = new URL(projectRootStr);
 	const fetchContent = createFetchContentFn(url);
 	return {

--- a/packages/astro/src/runtime/server/metadata.ts
+++ b/packages/astro/src/runtime/server/metadata.ts
@@ -57,7 +57,7 @@ export class Metadata {
 		const found = new Set<string>();
 		for (const metadata of this.deepMetadata()) {
 			for (const component of metadata.hydratedComponents) {
-				const path = this.getPath(component);
+				const path = metadata.getPath(component);
 				if (path && !found.has(path)) {
 					found.add(path);
 					yield path;
@@ -70,8 +70,14 @@ export class Metadata {
 	 * Gets all of the hydration specifiers used within this component.
 	 */
 	*hydrationDirectiveSpecifiers() {
-		for (const directive of this.hydrationDirectives) {
-			yield hydrationSpecifier(directive);
+		const found = new Set<string>();
+		for(const metadata of this.deepMetadata()) {
+			for (const directive of metadata.hydrationDirectives) {
+				if(!found.has(directive)) {
+					found.add(directive);
+					yield hydrationSpecifier(directive);
+				}
+			}
 		}
 	}
 

--- a/packages/astro/test/fixtures/static-build-frameworks/src/components/Nested.astro
+++ b/packages/astro/test/fixtures/static-build-frameworks/src/components/Nested.astro
@@ -1,0 +1,7 @@
+---
+import NestedCounter from './Nested.jsx';
+---
+
+<div class="nested-counter">
+	<NestedCounter client:idle />
+</div>

--- a/packages/astro/test/fixtures/static-build-frameworks/src/components/Nested.jsx
+++ b/packages/astro/test/fixtures/static-build-frameworks/src/components/Nested.jsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+export default function Counter({ children }) {
+	const [count, setCount] = useState(0);
+	const add = () => setCount((i) => i + 1);
+	const subtract = () => setCount((i) => i - 1);
+
+	return (
+		<>
+			<div className="counter">
+				<button onClick={subtract}>-</button>
+				<pre>{count}</pre>
+				<button onClick={add}>+</button>
+			</div>
+			<div className="counter-message">{children}</div>
+		</>
+	);
+}

--- a/packages/astro/test/fixtures/static-build-frameworks/src/pages/nested.astro
+++ b/packages/astro/test/fixtures/static-build-frameworks/src/pages/nested.astro
@@ -1,0 +1,13 @@
+---
+import Nested from '../components/Nested.astro';
+---
+
+<html>
+<head>
+<title>Nested</title>
+</head>
+<body>
+<h1>Testing</h1>
+<Nested />
+</body>
+</html>

--- a/packages/astro/test/fixtures/static-build/src/pages/index.astro
+++ b/packages/astro/test/fixtures/static-build/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import MainHead from '../components/MainHead.astro';
 import Nav from '../components/Nav/index.jsx';
+let allPosts = await Astro.fetchContent('./posts/*.md');
 ---
 <html>
 <head>
@@ -21,5 +22,10 @@ import Nav from '../components/Nav/index.jsx';
 <body>
 <Nav />
 <h1>Testing</h1>
+<ul class="posts">
+	{allPosts.map(post => (
+		<li><a href={post.url}>post.title</a></li>
+	))}
+</ul>
 </body>
 </html>

--- a/packages/astro/test/static-build-frameworks.test.js
+++ b/packages/astro/test/static-build-frameworks.test.js
@@ -28,4 +28,11 @@ describe('Static build - frameworks', () => {
 		const html = await fixture.readFile('/react/index.html');
 		expect(html).to.be.a('string');
 	});
+
+	it('can build nested framework usage', async () => {
+		const html = await fixture.readFile('/nested/index.html');
+		const $ = cheerio.load(html);
+		const counter = $('.nested-counter .counter');
+		expect(counter.length).to.equal(1, 'Found the counter');
+	});
 });

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -20,9 +20,17 @@ describe('Static build', () => {
 		await fixture.build();
 	});
 
-	it('Builds out .astro pags', async () => {
+	it('Builds out .astro pages', async () => {
 		const html = await fixture.readFile('/index.html');
 		expect(html).to.be.a('string');
+	});
+
+	it('can build pages using fetchContent', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerio.load(html);
+		const link = $('.posts a');
+		const href = link.attr('href');
+		expect(href).to.be.equal('/posts/thoughts');
 	});
 
 	it('Builds out .md pages', async () => {


### PR DESCRIPTION
## Changes

- Gets the blog and docs examples working in the static build.
- Fixes using hydrated components within nested components.
- Fixes correctly resolving URLs with fetchContent.
  - Depends on https://github.com/withastro/compiler/pull/243

## Testing

Tests added

## Docs

Bug fix