### PR TITLE
Improve static build performance on large sites

### DIFF
--- a/.changeset/metal-pens-decide.md
+++ b/.changeset/metal-pens-decide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improvements performance for building sites with thousands of pages with the static build

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -177,7 +177,11 @@ export type GetHydrateCallback = () => Promise<(element: Element, innerHTML: str
 	rss?: (...args: any[]) => any;
 }
 
-export type GetStaticPathsResult = { params: Params; props?: Props }[];
+export type GetStaticPathsItem = { params: Params; props?: Props };
+export type GetStaticPathsResult = GetStaticPathsItem[];
+export type GetStaticPathsResultKeyed = GetStaticPathsResult & {
+	keyed: Map<string, GetStaticPathsItem>
+};
 
 export interface HydrateOptions {
 	value?: string;
@@ -313,7 +317,7 @@ export interface RouteData {
 	type: 'page';
 }
 
-export type RouteCache = Record<string, GetStaticPathsResult>;
+export type RouteCache = Record<string, GetStaticPathsResultKeyed>;
 
 export type RuntimeMode = 'development' | 'production';
 

--- a/packages/astro/src/core/build/page-data.ts
+++ b/packages/astro/src/core/build/page-data.ts
@@ -10,6 +10,7 @@ import { preload as ssrPreload } from '../ssr/index.js';
 import { validateGetStaticPathsModule, validateGetStaticPathsResult } from '../ssr/routing.js';
 import { generatePaginateFunction } from '../ssr/paginate.js';
 import { generateRssFunction } from '../ssr/rss.js';
+import { assignStaticPaths } from '../ssr/route-cache.js';
 
 export interface CollectPagesDataOptions {
 	astroConfig: AstroConfig;
@@ -112,8 +113,8 @@ async function getStaticPathsForRoute(opts: CollectPagesDataOptions, route: Rout
 	const mod = (await viteServer.ssrLoadModule(fileURLToPath(filePath))) as ComponentInstance;
 	validateGetStaticPathsModule(mod);
 	const rss = generateRssFunction(astroConfig.buildOptions.site, route);
-	const staticPaths: GetStaticPathsResult = (await mod.getStaticPaths!({ paginate: generatePaginateFunction(route), rss: rss.generator })).flat();
-	routeCache[route.component] = staticPaths;
+	await assignStaticPaths(routeCache, route, mod, rss.generator);
+	const staticPaths = routeCache[route.component];
 	validateGetStaticPathsResult(staticPaths, logging);
 	return {
 		paths: staticPaths.map((staticPath) => staticPath.params && route.generate(staticPath.params)).filter(Boolean),

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -31,6 +31,8 @@ export interface StaticBuildOptions {
 	viteConfig: ViteConfigWithSSR;
 }
 
+const MAX_CONCURRENT_RENDERS = 10;
+
 function addPageName(pathname: string, opts: StaticBuildOptions): void {
 	const pathrepl = opts.astroConfig.buildOptions.pageUrlFormat === 'directory' ? '/index.html' : pathname === '/' ? 'index.html' : '.html';
 	opts.pageNames.push(pathname.replace(/\/?$/, pathrepl).replace(/^\//, ''));
@@ -43,6 +45,29 @@ function chunkIsPage(output: OutputAsset | OutputChunk, internals: BuildInternal
 	}
 	const chunk = output as OutputChunk;
 	return chunk.facadeModuleId && (internals.entrySpecifierToBundleMap.has(chunk.facadeModuleId) || internals.entrySpecifierToBundleMap.has('/' + chunk.facadeModuleId));
+}
+
+// Throttle the rendering a paths to prevents creating too many Promises on the microtask queue.
+function *throttle(max: number, inPaths: string[]) {
+  let tmp = [];
+  let i = 0;
+  for(let path of inPaths) {
+    tmp.push(path);
+    if(i === max) {
+      yield tmp;
+			// Empties the array, to avoid allocating a new one.
+      tmp.length = 0;
+      i = 0;
+    } else {
+      i++;
+    }
+  }
+
+	// If tmp has items in it, that means there were less than {max} paths remaining
+	// at the end, so we need to yield these too.
+  if(tmp.length) {
+    yield tmp;
+  }
 }
 
 export async function staticBuild(opts: StaticBuildOptions) {
@@ -232,10 +257,17 @@ async function generatePage(output: OutputChunk, opts: StaticBuildOptions, inter
 		renderers,
 	};
 
-	const renderPromises = pageData.paths.map((path) => {
-		return generatePath(path, opts, generationOptions);
-	});
-	return await Promise.all(renderPromises);
+	const renderPromises = [];
+	// Throttle the paths to avoid overloading the CPU with too many tasks.
+	for(const paths of throttle(MAX_CONCURRENT_RENDERS, pageData.paths)) {
+		for(const path of paths) {
+			renderPromises.push(generatePath(path, opts, generationOptions));
+		}
+		// This blocks generating more paths until these 10 complete.
+		await Promise.all(renderPromises);
+		// This empties the array without allocating a new one.
+		renderPromises.length = 0;
+  }
 }
 
 interface GeneratePathOptions {
@@ -262,6 +294,7 @@ async function generatePath(pathname: string, opts: StaticBuildOptions, gopts: G
 			logging,
 			pathname,
 			mod,
+			validate: false
 		});
 
 		debug(logging, 'generate', `Generating: ${pathname}`);

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -294,6 +294,8 @@ async function generatePath(pathname: string, opts: StaticBuildOptions, gopts: G
 			logging,
 			pathname,
 			mod,
+			// Do not validate as validation already occurred for static routes
+			// and validation is relatively expensive.
 			validate: false
 		});
 

--- a/packages/astro/src/core/ssr/route-cache.ts
+++ b/packages/astro/src/core/ssr/route-cache.ts
@@ -27,13 +27,13 @@ export async function callGetStaticPaths(mod: ComponentInstance, route: RouteDat
 }
 
 export async function assignStaticPaths(routeCache: RouteCache, route: RouteData, mod: ComponentInstance, rssFn?: RSSFn): Promise<void> {
-	const staticPaths = await callGetStaticPaths(mod, route);
+	const staticPaths = await callGetStaticPaths(mod, route, rssFn);
 	routeCache[route.component] = staticPaths;
 }
 
 export async function ensureRouteCached(routeCache: RouteCache, route: RouteData, mod: ComponentInstance, rssFn?: RSSFn): Promise<GetStaticPathsResultKeyed> {
 	if (!routeCache[route.component]) {
-		const staticPaths = await callGetStaticPaths(mod, route);
+		const staticPaths = await callGetStaticPaths(mod, route, rssFn);
 		routeCache[route.component] = staticPaths;
 		return staticPaths;
 	} else {

--- a/packages/astro/src/core/ssr/route-cache.ts
+++ b/packages/astro/src/core/ssr/route-cache.ts
@@ -1,0 +1,59 @@
+import type { ComponentInstance, GetStaticPathsItem, GetStaticPathsResult, GetStaticPathsResultKeyed, RouteCache, RouteData } from '../../@types/astro';
+import type { LogOptions } from '../logger';
+
+import { debug } from '../logger.js';
+import { generatePaginateFunction } from '../ssr/paginate.js';
+
+type RSSFn = (...args: any[]) => any;
+
+export async function callGetStaticPaths(mod: ComponentInstance, route: RouteData, rssFn?: RSSFn): Promise<GetStaticPathsResultKeyed> {
+	const staticPaths: GetStaticPathsResult = await (
+		await mod.getStaticPaths!({
+			paginate: generatePaginateFunction(route),
+			rss: rssFn || (() => {
+				/* noop */
+			}),
+		})
+	).flat();
+
+	const keyedStaticPaths = staticPaths as GetStaticPathsResultKeyed;
+	keyedStaticPaths.keyed = new Map<string, GetStaticPathsItem>();
+	for(const sp of keyedStaticPaths) {
+		const paramsKey = JSON.stringify(sp.params);
+		keyedStaticPaths.keyed.set(paramsKey, sp);
+	}
+
+	return keyedStaticPaths;
+}
+
+export async function assignStaticPaths(routeCache: RouteCache, route: RouteData, mod: ComponentInstance, rssFn?: RSSFn): Promise<void> {
+	const staticPaths = await callGetStaticPaths(mod, route);
+	routeCache[route.component] = staticPaths;
+}
+
+export async function ensureRouteCached(routeCache: RouteCache, route: RouteData, mod: ComponentInstance, rssFn?: RSSFn): Promise<GetStaticPathsResultKeyed> {
+	if (!routeCache[route.component]) {
+		const staticPaths = await callGetStaticPaths(mod, route);
+		routeCache[route.component] = staticPaths;
+		return staticPaths;
+	} else {
+		return routeCache[route.component];
+	}
+}
+
+export function findPathItemByKey(staticPaths: GetStaticPathsResultKeyed, paramsKey: string, logging: LogOptions) {
+	let matchedStaticPath = staticPaths.keyed.get(paramsKey);
+	if(matchedStaticPath) {
+		return matchedStaticPath;
+	}
+
+	debug(logging, 'findPathItemByKey', `Unexpected cache miss looking for ${paramsKey}`);
+	matchedStaticPath = staticPaths.find(({ params: _params }) => JSON.stringify(_params) === paramsKey);
+}
+
+/*
+export function doAThing() {
+	const staticPaths: GetStaticPathsResult = (await mod.getStaticPaths!({ paginate: generatePaginateFunction(route), rss: rss.generator })).flat();
+	routeCache[route.component] = staticPaths;
+})
+*/

--- a/packages/astro/src/core/ssr/route-cache.ts
+++ b/packages/astro/src/core/ssr/route-cache.ts
@@ -50,10 +50,3 @@ export function findPathItemByKey(staticPaths: GetStaticPathsResultKeyed, params
 	debug(logging, 'findPathItemByKey', `Unexpected cache miss looking for ${paramsKey}`);
 	matchedStaticPath = staticPaths.find(({ params: _params }) => JSON.stringify(_params) === paramsKey);
 }
-
-/*
-export function doAThing() {
-	const staticPaths: GetStaticPathsResult = (await mod.getStaticPaths!({ paginate: generatePaginateFunction(route), rss: rss.generator })).flat();
-	routeCache[route.component] = staticPaths;
-})
-*/


### PR DESCRIPTION
## Changes

- On large sites that are thousands of pages rendering all pages in parallel becomes a bottleneck as it adds a lot of tasks to the microtask queue. This change throttles rendering so that there are only 10 simultaneous renders. This prevents the build from choking on very large sites.
- This also optimizes `getParamsAndProps` which was taking almost as much time as rendering, due to looping over paths frequently and validating when validation had already occurred.
- Closes https://github.com/withastro/astro/issues/1711

## Testing

Manually tested against the example app in https://github.com/withastro/astro/issues/1711

## Docs

Bug fix
