### PR TITLE
Update examples to move away from Astro.resolve on styles

### DIFF
--- a/.changeset/flat-tips-happen.md
+++ b/.changeset/flat-tips-happen.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prepends site subpath when using --experimental-static-build

--- a/examples/blog-multiple-authors/src/components/MainHead.astro
+++ b/examples/blog-multiple-authors/src/components/MainHead.astro
@@ -18,7 +18,9 @@ const { title, description, image, type, next, prev, canonicalURL } = Astro.prop
 <meta name="description" content={description} />
 <link rel="preconnect" href="https://fonts.gstatic.com" />
 <link href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" />
-<link rel="stylesheet" href={Astro.resolve('../styles/global.css')} />
+<style global>
+	@import "../styles/global.css";
+</style>
 <!-- Sitemap -->
 <link rel="sitemap" href="/sitemap.xml" />
 <!-- RSS -->

--- a/examples/docs/src/components/HeadCommon.astro
+++ b/examples/docs/src/components/HeadCommon.astro
@@ -8,9 +8,11 @@
 <link rel="sitemap" href="/sitemap.xml" />
 
 <!-- Global CSS -->
-<link rel="stylesheet" href={Astro.resolve('../styles/theme.css')} />
-<link rel="stylesheet" href={Astro.resolve('../styles/code.css')} />
-<link rel="stylesheet" href={Astro.resolve('../styles/index.css')} />
+<style global>
+	@import "../styles/theme.css";
+	@import "../styles/code.css";
+	@import "../styles/index.css";
+</style>
 
 <!-- Preload Fonts -->
 <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/examples/framework-multiple/src/pages/index.astro
+++ b/examples/framework-multiple/src/pages/index.astro
@@ -17,7 +17,9 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
-		<link rel="stylesheet" type="text/css" href={Astro.resolve('../styles/global.css')} />
+		<style global>
+			@import "../styles/global.css";
+		</style>
 	</head>
 	<body>
 		<main>

--- a/examples/starter/src/pages/index.astro
+++ b/examples/starter/src/pages/index.astro
@@ -20,8 +20,10 @@ let title = 'My Astro Site';
 	<title>{title}</title>
 
 	<link rel="icon" type="image/x-icon" href="/favicon.ico" />
-	<link rel="stylesheet" href={Astro.resolve('../styles/global.css')}>
-	<link rel="stylesheet" href={Astro.resolve('../styles/home.css')}>
+	<style global>
+		@import "../styles/global.css";
+		@import "../styles/home.css";
+	</style>
 
 	<style>
 		header {

--- a/examples/with-markdown-plugins/src/layouts/main.astro
+++ b/examples/with-markdown-plugins/src/layouts/main.astro
@@ -9,7 +9,9 @@ const { content } = Astro.props;
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 
 		<title>{content.title}</title>
-		<link rel="stylesheet" href={Astro.resolve('../styles/global.css')} />
+		<style global>
+			@import "../styles/global.css";
+		</style>
 		<style>
 			.nav {
 				border-bottom: 1px solid #ccc;

--- a/examples/with-markdown/src/layouts/main.astro
+++ b/examples/with-markdown/src/layouts/main.astro
@@ -9,7 +9,9 @@ const { content } = Astro.props;
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 
 		<title>{content.title}</title>
-		<link rel="stylesheet" href={Astro.resolve('../styles/global.css')} />
+		<style global>
+			@import "../styles/global.css";
+		</style>
 	</head>
 	<body>
 		<slot />

--- a/examples/with-nanostores/src/pages/index.astro
+++ b/examples/with-nanostores/src/pages/index.astro
@@ -18,8 +18,10 @@ import AdminsSolid from '../components/AdminsSolid.jsx';
 
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 
-		<link rel="stylesheet" href={Astro.resolve('../styles/global.css')} />
-		<link rel="stylesheet" href={Astro.resolve('../styles/home.css')} />
+		<style global>
+			@import "../styles/global.css";
+			@import "../styles/home.css";
+		</style>
 
 		<style>
 			header {

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -280,12 +280,13 @@ async function generatePath(pathname: string, opts: StaticBuildOptions, gopts: G
 
 		debug(logging, 'generate', `Generating: ${pathname}`);
 
+		const rootpath = new URL(astroConfig.buildOptions.site || 'http://localhost/').pathname;
 		const result = createResult({ astroConfig, origin, params, pathname, renderers });
 		result.links = new Set<SSRElement>(
 			linkIds.map((href) => ({
 				props: {
 					rel: 'stylesheet',
-					href,
+					href: npath.posix.join(rootpath, href)
 				},
 				children: '',
 			}))


### PR DESCRIPTION
## Changes

- Updates the examples to use `<style global>@import "..."</style>` where they used to use Astro.resolve.
  - Based on https://github.com/withastro/rfcs/blob/main/active-rfcs/0000-style-unification.md

## Testing

Tested to verify they work both in the normal and static build.

## Docs

N/A
