### PR TITLE
Update .degit cache path in error message

### DIFF
--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -108,7 +108,7 @@ export async function main() {
 
 		// Warning for issue #655
 		if (err.message === 'zlib: unexpected end of file') {
-			console.log(yellow("This seems to be a cache related problem. Remove the folder '~/.degit/github/snowpackjs' to fix this error."));
+			console.log(yellow("This seems to be a cache related problem. Remove the folder '~/.degit/github/withastro' to fix this error."));
 			console.log(yellow('For more information check out this issue: https://github.com/withastro/astro/issues/655'));
 		}
 


### PR DESCRIPTION
## Changes

astro's repo changed from snowpack/astro to withastro/astro,
so I updated the error message accordingly.

## Testing

No tests added since the update is meant for a human to read.

## Docs

This is only a error message fix, so there is no need to update the public documentation.
Currently the public documentation did not mention this error message.
