### PR TITLE
fix: path error in sample markdown code

### DIFF
--- a/docs/src/pages/en/guides/markdown-content.md
+++ b/docs/src/pages/en/guides/markdown-content.md
@@ -96,7 +96,7 @@ Markdown pages have a special frontmatter property for `layout`. This defines th
 ```markdown
 ---
 # src/pages/index.md
-layout: ../../layouts/BaseLayout.astro
+layout: ../layouts/BaseLayout.astro
 title: My cool page
 ---
 


### PR DESCRIPTION
## Changes

The path denoted in the markdown sample code is
src/pages/index.md
Thus, to refer to a layout component in src/layouts,
we should use ../layouts/ instead of ../../layouts/.

## Testing

This is a documentation change, so no tests are added.

## Docs

This commit itself is an update to docs.
