### PR TITLE
Update doc move away from Astro.resolve on styles

### DIFF
--- a/docs/src/pages/de/guides/styling.md
+++ b/docs/src/pages/de/guides/styling.md
@@ -241,7 +241,9 @@ Füge die Datei deiner Astro-Seite (oder deiner Layout-Komponente) hinzu:
 
 ```astro
 <head>
-  <link rel="stylesheet" href={Astro.resolve('../styles/global.css')}>
+  <style global>
+			@import "../styles/global.css";
+	</style>
 </head>
 ```
 

--- a/docs/src/pages/en/guides/styling.md
+++ b/docs/src/pages/en/guides/styling.md
@@ -239,7 +239,9 @@ Lastly, add it to your Astro page (or layout template):
 
 ```astro
 <head>
-  <link rel="stylesheet" href={Astro.resolve('../styles/global.css')}>
+	<style global>
+			@import "../styles/global.css";
+	</style>
 </head>
 ```
 


### PR DESCRIPTION
## Changes

`<link href={Astro.resolve("./X.css")} />` did not work on recent versions of astro.

see also #2393

## Testing

This is a documentation update so no tests are added.

## Docs

This commit itself is a documentation update.
