### PR TITLE
Fix visibility of focused skip link on docs site

### DIFF
--- a/docs/src/components/Header/SkipToContent.astro
+++ b/docs/src/components/Header/SkipToContent.astro
@@ -1,4 +1,4 @@
-<a href="#article" class="sr-only skiplink"><span>Skip to Content</span></a>
+<a href="#article" class="sr-only focus:not-sr-only skiplink"><span>Skip to Content</span></a>
 
 <style>
 	.skiplink,

--- a/examples/docs/src/components/Header/SkipToContent.astro
+++ b/examples/docs/src/components/Header/SkipToContent.astro
@@ -1,4 +1,4 @@
-<a href="#article" class="sr-only skiplink"><span>Skip to Content</span></a>
+<a href="#article" class="sr-only focus:not-sr-only skiplink"><span>Skip to Content</span></a>
 
 <style>
 	.skiplink,


### PR DESCRIPTION
## Changes

- This PR makes the “Skip to Content” link visible on focus on the docs site and in the docs example project.

| Before (link is focused but not visible) | After (link is focused and visible) |
|---------------------------------------|------|
| ![Screen Shot 2022-01-16 at 15 38 07](https://user-images.githubusercontent.com/357379/149664622-a7e015fb-e06f-4dc2-a4fb-9874568238e3.png) | ![Screen Shot 2022-01-16 at 15 38 47](https://user-images.githubusercontent.com/357379/149664626-80d019e0-60e7-44ac-8c82-885f4aa61545.png) |

This pattern is [recommended by the Institute for Disability Research, Policy, and Practice](https://webaim.org/techniques/skipnav/#hidden) (and was also I think already the intended behaviour given that styling was included for the link when visible).

## Testing

Tested by running `yarn workspace docs dev` and manually checking the skip link was visible when tabbing into the page.

## Docs

Only this tweak in the styling of the skip link.
