### PR TITLE
Fix "Island Architecture" phrase attribution

### DIFF
--- a/docs/src/pages/de/core-concepts/component-hydration.md
+++ b/docs/src/pages/de/core-concepts/component-hydration.md
@@ -41,9 +41,8 @@ _Beachte: Partial Hydration (Partielle Anreicherung) wird manchmal auch als “P
 
 **Islands Architecture** ist die Idee Partial Hydration zu verwenden, um komplette Websites zu erzeugen. Islands Architecture ist eine Alternative zu der beliebten Idee deine gesamte Website in eine Client-seitige JavaScript-Anwendung zu packen, welche von den Nutzerinnen und Nutzern heruntergeladen werden muss.
 
-Um Jason Miller zu zitieren, der [den Begriff aufgebracht hat](https://jasonformat.com/islands-architecture/):
-
 > In einem Modell aus "Inseln" ist Server-seitiges Rendering nicht die angeflanschte Optimierung, die darauf abzielt die SEO- oder UX-Werte zu verbessern. Stattdessen ist es die grundlegende Methode mit der Seiten an den Browser ausgeliefert werden. Das HTML das als Antwort auf eine Navigation zurückgegeben wird, enthält eine bedeutsame und unmittelbar gerenderte Repräsentation des Inhaltes, den die Nutzerin oder der Nutzer angefordert hat.
+> <br/> -- [Jason Miller](https://jasonformat.com/islands-architecture/)
 
 Neben den offensichtlichen Leistungsvorteilen, wenn weniger JavaScript an den Browser geschickt und dort ausgeführt wird, verfügt eine Islands Architecture über zwei wesentliche Vorteile:
 

--- a/docs/src/pages/en/core-concepts/component-hydration.md
+++ b/docs/src/pages/en/core-concepts/component-hydration.md
@@ -41,9 +41,8 @@ _Note: Partial hydration is sometimes called "progressive enhancement" or "progr
 
 **Island architecture** is the idea of using partial hydration to build entire websites. Island architecture is an alternative to the popular idea of building your website into a client-side JavaScript bundle that must be shipped to the user.
 
-To quote Jason Miller, who [coined the phrase](https://jasonformat.com/islands-architecture/):
-
 > In an "islands" model, server rendering is not a bolt-on optimization aimed at improving SEO or UX. Instead, it is a fundamental part of how pages are delivered to the browser. The HTML returned in response to navigation contains a meaningful and immediately renderable representation of the content the user requested.
+> <br/> -- [Jason Miller](https://jasonformat.com/islands-architecture/)
 
 Besides the obvious performance benefits of sending less JavaScript down to the browser, there are two key benefits to island architecture:
 

--- a/docs/src/pages/es/core-concepts/component-hydration.md
+++ b/docs/src/pages/es/core-concepts/component-hydration.md
@@ -41,9 +41,8 @@ En Astro, depende de ti, como desarrollador, "habilitar" explícitamente cualqui
 
 **La arquitectura de la isla** es la idea de utilizar la hidratación parcial para construir sitios web completos. La arquitectura de la isla es una alternativa a la idea popular de construir su sitio web en un paquete de JavaScript del lado del cliente que debe enviarse al usuario.
 
-Para citar a Jason Miller, quien [acuñó la frase](https://jasonformat.com/islands-architecture/):
-
 > En un modelo de "islas", la representación del servidor no es una optimización complementaria destinada a mejorar el SEO o la UX. En cambio, es una parte fundamental de cómo se envían las páginas al navegador. El HTML devuelto en respuesta a la navegación contiene una representación significativa e inmediatamente renderizable del contenido solicitado por el usuario.
+> <br/> -- [Jason Miller](https://jasonformat.com/islands-architecture/)
 
 Además de los obvios beneficios de rendimiento de enviar menos JavaScript al navegador, existen dos beneficios clave para la arquitectura de la isla:
 


### PR DESCRIPTION
Fixes #2407 🚀 

## Changes

Remove incorrect statement in the [Partial Hydration section](https://docs.astro.build/en/core-concepts/component-hydration/#concept-island-architecture) of the docs that Jason Miller coined the phrase "Island Architecture." See issue #2407 for a short discussion of possible replacement phrases. Any of the suggested phrases there also seem fine as alternatives to this PR.

## Testing

N/A -- docs only change