### PR TITLE
Supports hoisted scripts in the static build

### DIFF
--- a/.changeset/sour-games-boil.md
+++ b/.changeset/sour-games-boil.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds support for hoisted scripts to the static build

--- a/examples/fast-build/package.json
+++ b/examples/fast-build/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "astro": "^0.22.16",
-    "preact": "^10.6.4",
+    "preact": "~10.5.15",
     "unocss": "^0.15.5",
     "vite-imagetools": "^4.0.1"
   }

--- a/examples/fast-build/package.json
+++ b/examples/fast-build/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "astro": "^0.22.16",
+    "preact": "^10.6.4",
     "unocss": "^0.15.5",
     "vite-imagetools": "^4.0.1"
   }

--- a/examples/fast-build/src/components/ExternalHoisted.astro
+++ b/examples/fast-build/src/components/ExternalHoisted.astro
@@ -1,0 +1,2 @@
+<div id="external-hoist"></div>
+<script type="module" hoist src="/src/scripts/external-hoist"></script>

--- a/examples/fast-build/src/components/InlineHoisted.astro
+++ b/examples/fast-build/src/components/InlineHoisted.astro
@@ -1,0 +1,13 @@
+<script type="module" hoist>
+	import { h, render } from 'preact';
+
+
+	const mount = document.querySelector('#inline-hoist');
+
+	function App() {
+		return h('strong', null, 'Hello again');
+	}
+
+	render(h(App), mount);
+</script>
+<div id="inline-hoist"></div>

--- a/examples/fast-build/src/pages/index.astro
+++ b/examples/fast-build/src/pages/index.astro
@@ -4,6 +4,8 @@ import grayscaleUrl from '../images/random.jpg?grayscale=true';
 import Greeting from '../components/Greeting.vue';
 import Counter from '../components/Counter.vue';
 import { Code } from 'astro/components';
+import InlineHoisted from '../components/InlineHoisted.astro';
+import ExternalHoisted from '../components/ExternalHoisted.astro';
 ---
 
 <html>
@@ -44,5 +46,11 @@ import { Code } from 'astro/components';
     <h1>Hydrated component</h1>
     <Counter client:idle />
   </section>
+
+	<section>
+		<h1>Hoisted scripts</h1>
+		<InlineHoisted />
+		<ExternalHoisted />
+	</section>
 </body>
 </html>

--- a/examples/fast-build/src/scripts/external-hoist.ts
+++ b/examples/fast-build/src/scripts/external-hoist.ts
@@ -1,0 +1,2 @@
+const el = document.querySelector('#external-hoist');
+el.textContent = `This was loaded externally`;

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -56,7 +56,7 @@
     "test": "mocha --parallel --timeout 15000"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.8.3-pre.0",
+    "@astrojs/compiler": "^0.8.2",
     "@astrojs/language-server": "^0.8.6",
     "@astrojs/markdown-remark": "^0.6.0",
     "@astrojs/prism": "0.4.0",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -56,7 +56,7 @@
     "test": "mocha --parallel --timeout 15000"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.8.2",
+    "@astrojs/compiler": "^0.8.3-pre.0",
     "@astrojs/language-server": "^0.8.6",
     "@astrojs/markdown-remark": "^0.6.0",
     "@astrojs/prism": "0.4.0",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -56,7 +56,7 @@
     "test": "mocha --parallel --timeout 15000"
   },
   "dependencies": {
-    "@astrojs/compiler": "0.8.1",
+    "@astrojs/compiler": "^0.8.2",
     "@astrojs/language-server": "^0.8.6",
     "@astrojs/markdown-remark": "^0.6.0",
     "@astrojs/prism": "0.4.0",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -56,7 +56,7 @@
     "test": "mocha --parallel --timeout 15000"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.8.2",
+    "@astrojs/compiler": "^0.9.2",
     "@astrojs/language-server": "^0.8.6",
     "@astrojs/markdown-remark": "^0.6.0",
     "@astrojs/prism": "0.4.0",

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -15,6 +15,10 @@ export interface BuildInternals {
 	// A mapping to entrypoints (facadeId) to assets (styles) that are added.
 	facadeIdToAssetsMap: Map<string, string[]>;
 
+	hoistedScriptIdToHoistedMap: Map<string, Set<string>>;
+
+	facadeIdToHoistedEntryMap: Map<string, string>;
+
 	// A mapping of specifiers like astro/client/idle.js to the hashed bundled name.
 	// Used to render pages with the correct specifiers.
 	entrySpecifierToBundleMap: Map<string, string>;
@@ -39,12 +43,18 @@ export function createBuildInternals(): BuildInternals {
 	// A mapping to entrypoints (facadeId) to assets (styles) that are added.
 	const facadeIdToAssetsMap = new Map<string, string[]>();
 
+	// These are for tracking hoisted script bundling
+	const hoistedScriptIdToHoistedMap = new Map<string, Set<string>>();
+	const facadeIdToHoistedEntryMap = new Map<string, string>();
+
 	return {
 		pureCSSChunks,
 		chunkToReferenceIdMap,
 		astroStyleMap,
 		astroPageStyleMap,
 		facadeIdToAssetsMap,
+		hoistedScriptIdToHoistedMap,
+		facadeIdToHoistedEntryMap,
 		entrySpecifierToBundleMap: new Map<string, string>(),
 	};
 }

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -16,7 +16,6 @@ export interface BuildInternals {
 	facadeIdToAssetsMap: Map<string, string[]>;
 
 	hoistedScriptIdToHoistedMap: Map<string, Set<string>>;
-
 	facadeIdToHoistedEntryMap: Map<string, string>;
 
 	// A mapping of specifiers like astro/client/idle.js to the hashed bundled name.

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -117,8 +117,6 @@ export async function staticBuild(opts: StaticBuildOptions) {
 			internals.hoistedScriptIdToHoistedMap.set(moduleId, hoistedScripts);
 			topLevelImports.add(moduleId);
 		}
-		
-		//internals.facadeIdToHoistedMap.set(astroModuleId, );
 
 		for (const specifier of topLevelImports) {
 			jsInput.add(specifier);

--- a/packages/astro/src/core/build/vite-plugin-hoisted-scripts.ts
+++ b/packages/astro/src/core/build/vite-plugin-hoisted-scripts.ts
@@ -1,0 +1,43 @@
+import type { Plugin as VitePlugin } from '../vite';
+import type { BuildInternals } from '../../core/build/internal.js';
+
+function virtualHoistedEntry(id: string) {
+	return id.endsWith('.astro/hoisted.js') || id.endsWith('.md/hoisted.js');
+}
+
+export function vitePluginHoistedScripts(internals: BuildInternals): VitePlugin {
+	return {
+		name: '@astro/rollup-plugin-astro-hoisted-scripts',
+
+		resolveId(id) {
+			if(virtualHoistedEntry(id)) {
+				return id;
+			}
+		},
+
+		load(id) {
+			if(virtualHoistedEntry(id)) {
+				let code = '';
+				for(let path of internals.hoistedScriptIdToHoistedMap.get(id)!) {
+					code += `import "${path}";`
+				}
+				return {
+					code
+				};
+			}
+			return void 0;
+		},
+
+		async generateBundle(_options, bundle) {
+			// Find all page entry points and create a map of the entry point to the hashed hoisted script.
+			// This is used when we render so that we can add the script to the head.
+			for(const [id, output] of Object.entries(bundle)) {
+				if(output.type === 'chunk' && output.facadeModuleId && virtualHoistedEntry(output.facadeModuleId)) {
+					const facadeId = output.facadeModuleId!;
+					const filename = facadeId.slice(0, facadeId.length - "/hoisted.js".length);
+					internals.facadeIdToHoistedEntryMap.set(filename, id);
+				}
+			}
+		}
+	};
+}

--- a/packages/astro/src/core/ssr/index.ts
+++ b/packages/astro/src/core/ssr/index.ts
@@ -219,7 +219,14 @@ export async function render(renderers: Renderer[], mod: ComponentInstance, ssrO
 	if (!Component) throw new Error(`Expected an exported Astro component but received typeof ${typeof Component}`);
 	if (!Component.isAstroComponentFactory) throw new Error(`Unable to SSR non-Astro component (${route?.component})`);
 
-	const result = createResult({ astroConfig, logging, origin, params, pathname, renderers });
+	// Add hoisted script tags
+	const scripts = astroConfig.buildOptions.experimentalStaticBuild ?
+		new Set<SSRElement>(Array.from(mod.$$metadata.hoistedScriptPaths()).map(src => ({
+			props: { type: 'module', src },
+			children: ''
+		}))) : new Set<SSRElement>();
+
+	const result = createResult({ astroConfig, logging, origin, params, pathname, renderers, scripts });
 	// Resolves specifiers in the inline hydrated scripts, such as "@astrojs/renderer-preact/client.js"
 	result.resolve = async (s: string) => {
 		// The legacy build needs these to remain unresolved so that vite HTML

--- a/packages/astro/src/core/ssr/result.ts
+++ b/packages/astro/src/core/ssr/result.ts
@@ -13,6 +13,8 @@ export interface CreateResultArgs {
 	params: Params;
 	pathname: string;
 	renderers: Renderer[];
+	links?: Set<SSRElement>;
+	scripts?: Set<SSRElement>;
 }
 
 export function createResult(args: CreateResultArgs): SSRResult {
@@ -23,8 +25,8 @@ export function createResult(args: CreateResultArgs): SSRResult {
 	// calling the render() function will populate the object with scripts, styles, etc.
 	const result: SSRResult = {
 		styles: new Set<SSRElement>(),
-		scripts: new Set<SSRElement>(),
-		links: new Set<SSRElement>(),
+		scripts: args.scripts ?? new Set<SSRElement>(),
+		links: args.links ?? new Set<SSRElement>(),
 		/** This function returns the `Astro` faux-global */
 		createAstro(astroGlobal: AstroGlobalPartial, props: Record<string, any>, slots: Record<string, any> | null) {
 			const site = new URL(origin);

--- a/packages/astro/src/runtime/server/metadata.ts
+++ b/packages/astro/src/runtime/server/metadata.ts
@@ -18,7 +18,7 @@ interface CreateMetadataOptions {
 }
 
 export class Metadata {
-	public fileURL: URL;
+	public mockURL: URL;
 	public modules: ModuleInfo[];
 	public hoisted: any[];
 	public hydratedComponents: any[];
@@ -31,12 +31,12 @@ export class Metadata {
 		this.hoisted = opts.hoisted;
 		this.hydratedComponents = opts.hydratedComponents;
 		this.hydrationDirectives = opts.hydrationDirectives;
-		this.fileURL = new URL(filePathname, 'http://example.com');
+		this.mockURL = new URL(filePathname, 'http://example.com');
 		this.metadataCache = new Map<any, ComponentMetadata | null>();
 	}
 
 	resolvePath(specifier: string): string {
-		return specifier.startsWith('.') ? new URL(specifier, this.fileURL).pathname : specifier;
+		return specifier.startsWith('.') ? new URL(specifier, this.mockURL).pathname : specifier;
 	}
 
 	getPath(Component: any): string | null {
@@ -77,6 +77,16 @@ export class Metadata {
 					found.add(directive);
 					yield hydrationSpecifier(directive);
 				}
+			}
+		}
+	}
+
+	* hoistedScriptPaths() {
+		for(const metadata of this.deepMetadata()) {
+			let i = 0, pathname = metadata.mockURL.pathname;
+			while(i < metadata.hoisted.length) {
+				yield `${pathname}?astro&type=script&index=${i}`;
+				i++;
 			}
 		}
 	}

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -66,16 +66,16 @@ export default function astro({ config, logging }: AstroPluginOptions): vite.Plu
 					const transformResult = await cachedCompilation(config,
 						normalizeFilename(filename), null, viteTransform, opts);
 					const scripts = transformResult.scripts;
-					const r = scripts[query.index];
+					const hoistedScript = scripts[query.index];
 
-					if(!r) {
-						throw new Error(`No hoisted script at index ${query.index}`);
+					if(!hoistedScript) {
+						throw new Error(`No hoisted script at index ${i}`);
 					}
 
 					return {
-						code: r.type === 'inline' ?
-							r.code! :
-							`import "${r.src!}";`
+						code: hoistedScript.type === 'inline' ?
+							hoistedScript.code :
+							`import "${hoistedScript.src}";`
 					};
 				}
 			}

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -69,13 +69,13 @@ export default function astro({ config, logging }: AstroPluginOptions): vite.Plu
 					const hoistedScript = scripts[query.index];
 
 					if(!hoistedScript) {
-						throw new Error(`No hoisted script at index ${i}`);
+						throw new Error(`No hoisted script at index ${query.index}`);
 					}
 
 					return {
 						code: hoistedScript.type === 'inline' ?
-							hoistedScript.code :
-							`import "${hoistedScript.src}";`
+							hoistedScript.code! :
+							`import "${hoistedScript.src!}";`
 					};
 				}
 			}

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -19,6 +19,15 @@ interface AstroPluginOptions {
 
 /** Transform .astro files for Vite */
 export default function astro({ config, logging }: AstroPluginOptions): vite.Plugin {
+	function normalizeFilename(filename: string) {
+		if (filename.startsWith('/@fs')) {
+			filename = filename.slice('/@fs'.length);
+		} else if (filename.startsWith('/') && !ancestor(filename, config.projectRoot.pathname)) {
+			filename = new URL('.' + filename, config.projectRoot).pathname;
+		}
+		return filename;
+	}
+
 	let viteTransform: TransformHook;
 	return {
 		name: '@astrojs/vite-plugin-astro',
@@ -37,22 +46,36 @@ export default function astro({ config, logging }: AstroPluginOptions): vite.Plu
 			let { filename, query } = parseAstroRequest(id);
 			if (query.astro) {
 				if (query.type === 'style') {
-					if (filename.startsWith('/@fs')) {
-						filename = filename.slice('/@fs'.length);
-					} else if (filename.startsWith('/') && !ancestor(filename, config.projectRoot.pathname)) {
-						filename = new URL('.' + filename, config.projectRoot).pathname;
-					}
-					const transformResult = await cachedCompilation(config, filename, null, viteTransform, opts);
-
 					if (typeof query.index === 'undefined') {
 						throw new Error(`Requests for Astro CSS must include an index.`);
 					}
 
+					const transformResult = await cachedCompilation(config,
+						normalizeFilename(filename), null, viteTransform, opts);
 					const csses = transformResult.css;
 					const code = csses[query.index];
 
 					return {
 						code,
+					};
+				} else if(query.type === 'script') {
+					if(typeof query.index === 'undefined') {
+						throw new Error(`Requests for hoisted scripts must include an index`);
+					}
+
+					const transformResult = await cachedCompilation(config,
+						normalizeFilename(filename), null, viteTransform, opts);
+					const scripts = transformResult.scripts;
+					const r = scripts[query.index];
+
+					if(!r) {
+						throw new Error(`No hoisted script at index ${query.index}`);
+					}
+
+					return {
+						code: r.type === 'inline' ?
+							r.code! :
+							`import "${r.src!}";`
 					};
 				}
 			}

--- a/packages/astro/test/fixtures/static-build/src/components/ExternalHoisted.astro
+++ b/packages/astro/test/fixtures/static-build/src/components/ExternalHoisted.astro
@@ -1,0 +1,2 @@
+<div id="external-hoist"></div>
+<script type="module" hoist src="/src/scripts/external-hoist"></script>

--- a/packages/astro/test/fixtures/static-build/src/components/InlineHoisted.astro
+++ b/packages/astro/test/fixtures/static-build/src/components/InlineHoisted.astro
@@ -1,0 +1,13 @@
+<script type="module" hoist>
+	import { h, render } from 'preact';
+
+
+	const mount = document.querySelector('#inline-hoist');
+
+	function App() {
+		return h('strong', null, 'Hello again');
+	}
+
+	render(h(App), mount);
+</script>
+<div id="inline-hoist"></div>

--- a/packages/astro/test/fixtures/static-build/src/pages/hoisted.astro
+++ b/packages/astro/test/fixtures/static-build/src/pages/hoisted.astro
@@ -1,0 +1,17 @@
+---
+import InlineHoisted from '../components/InlineHoisted.astro';
+import ExternalHoisted from '../components/ExternalHoisted.astro';
+---
+
+<html>
+	<head>
+		<title>Demo app</title>
+	</head>
+	<body>
+	<section>
+		<h1>Hoisted scripts</h1>
+		<InlineHoisted />
+		<ExternalHoisted />
+	</section>
+</body>
+</html>

--- a/packages/astro/test/fixtures/static-build/src/scripts/external-hoist.ts
+++ b/packages/astro/test/fixtures/static-build/src/scripts/external-hoist.ts
@@ -1,0 +1,2 @@
+const element: HTMLElement = document.querySelector('#external-hoist');
+element.textContent = `This was loaded externally`;

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -77,4 +77,21 @@ describe('Static build', () => {
 			expect(found).to.equal(true, 'Did not find shared CSS module code');
 		});
 	});
+
+	describe('Hoisted scripts', () => {
+		it('Get bundled together on the page', async () => {
+			const html = await fixture.readFile('/hoisted/index.html');
+			const $ = cheerio.load(html);
+			expect($('script[type="module"]').length).to.equal(1, 'hoisted script added');
+		});
+
+		it('Do not get added to the wrong page', async () => {
+			const hoistedHTML = await fixture.readFile('/hoisted/index.html');
+			const $ = cheerio.load(hoistedHTML);
+			const href = $('script[type="module"]').attr('src');
+			const indexHTML = await fixture.readFile('/index.html');
+			const $$ = cheerio.load(indexHTML);
+			expect($$(`script[src="${href}"]`).length).to.equal(0, 'no script added to different page');
+		})
+	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,10 +130,10 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@astrojs/compiler@^0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-0.8.2.tgz#4aebb1c75bdfebbdaf920fa5a47bac5a9b406684"
-  integrity sha512-DnEjHlGzLaZDZ/uDdU1cmx8Hvair9fB1SmIj6yQCNIPqfKs/ZyUDyRrIzvHxri8xkaBTynL7cpzENJF99ub4Gg==
+"@astrojs/compiler@^0.8.3-pre.0":
+  version "0.8.3-pre.0"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-0.8.3-pre.0.tgz#601ff0e27c4d310e76b1e0641df6c18ac01c8e5d"
+  integrity sha512-KiDyo3IQObngrDub5F0P+AoYnaONzspTtj8l5POL9/weiBVv7Y59nf5YxbZE9EaIyrOEZieIhW65Mpne5EeBqQ==
   dependencies:
     typescript "^4.3.5"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7443,6 +7443,11 @@ preact-render-to-string@^5.1.19:
   dependencies:
     pretty-format "^3.8.0"
 
+preact@^10.6.4:
+  version "10.6.4"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.6.4.tgz#ad12c409ff1b4316158486e0a7b8d43636f7ced8"
+  integrity sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ==
+
 preact@~10.5.15:
   version "10.5.15"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,7 +130,7 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@astrojs/compiler@^0.8.0":
+"@astrojs/compiler@^0.8.2":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-0.8.2.tgz#4aebb1c75bdfebbdaf920fa5a47bac5a9b406684"
   integrity sha512-DnEjHlGzLaZDZ/uDdU1cmx8Hvair9fB1SmIj6yQCNIPqfKs/ZyUDyRrIzvHxri8xkaBTynL7cpzENJF99ub4Gg==
@@ -7442,11 +7442,6 @@ preact-render-to-string@^5.1.19:
   integrity sha512-bj8sn/oytIKO6RtOGSS/1+5CrQyRSC99eLUnEVbqUa6MzJX5dYh7wu9bmT0d6lm/Vea21k9KhCQwvr2sYN3rrQ==
   dependencies:
     pretty-format "^3.8.0"
-
-preact@^10.6.4:
-  version "10.6.4"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.6.4.tgz#ad12c409ff1b4316158486e0a7b8d43636f7ced8"
-  integrity sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ==
 
 preact@~10.5.15:
   version "10.5.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,10 +130,10 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@astrojs/compiler@^0.8.3-pre.0":
-  version "0.8.3-pre.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-0.8.3-pre.0.tgz#601ff0e27c4d310e76b1e0641df6c18ac01c8e5d"
-  integrity sha512-KiDyo3IQObngrDub5F0P+AoYnaONzspTtj8l5POL9/weiBVv7Y59nf5YxbZE9EaIyrOEZieIhW65Mpne5EeBqQ==
+"@astrojs/compiler@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-0.9.2.tgz#aea226472046cb88c0ff20661be34af84d983feb"
+  integrity sha512-8yxdyokSNmTbcDfW75k5NcPKMBnPTfzLHVxhdiUrII7Zqh/OG9SaOZWFCnvFhU8dkQBUU6B1eh/ABAHwnxZWGw==
   dependencies:
     typescript "^4.3.5"
 


### PR DESCRIPTION
## Changes

- Adds support for hoisted scripts to the static build. This will add hoisted scripts as external in dev like `/src/components/Nav.astro?astro&type=script&index=0`.
- During the static build these are bundled at the page level and then the result is rendered out to the final HTML.

## Testing

Tests added

## Docs

N/A