### PR TITLE
update image reference path

### DIFF
--- a/docs/src/pages/en/guides/markdown-content.md
+++ b/docs/src/pages/en/guides/markdown-content.md
@@ -156,7 +156,7 @@ For Markdown files, the `content` prop also has an `astro` property which holds 
 Using images or videos follows Astro's normal import rules:
 
 - Place them in the `public/` as explained on the [project-structure page](/en/core-concepts/project-structure/#public)
-  - Example: Image is located at `/public/assets/img/astonaut.png` → Markdown: `![Astronaut](assets/img/astronaut.png)`
+  - Example: Image is located at `/public/assets/img/astonaut.png` → Markdown: `![Astronaut](/assets/img/astronaut.png)`
 - Or use `import` as explained on the [imports page](/en/guides/imports#other-assets) (when using Astro's Markdown Component)
 
 ## Astro's Markdown Component


### PR DESCRIPTION
## Changes

- image reference path to the assets folder in public directors needs to begin with `/`. Example: Image is located at /public/assets/img/astonaut.png → Markdown: ![Astronaut](/assets/img/astronaut.png)

## Testing

<!-- How was this change tested? --> Local testing. 
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. --> No Tests as it’s a doc update

## Docs

<!-- Was public documentation updated? --> Yes
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") --> N/A
