### PR TITLE
Allow pre-generated urls to be passed in rss feeds

### DIFF
--- a/packages/astro/src/core/ssr/rss.ts
+++ b/packages/astro/src/core/ssr/rss.ts
@@ -1,7 +1,7 @@
 import type { RSSFunction, RSS, RSSResult, FeedResult, RouteData } from '../../@types/astro';
 
 import { XMLValidator } from 'fast-xml-parser';
-import { canonicalURL, PRETTY_FEED_V3 } from '../util.js';
+import { canonicalURL, isValidURL, PRETTY_FEED_V3 } from '../util.js';
 
 /** Validates getStaticPaths.rss */
 export function validateRSS(args: GenerateRSSArgs): void {
@@ -47,10 +47,9 @@ export function generateRSS(args: GenerateRSSArgs): string {
 		if (typeof result !== 'object') throw new Error(`[${srcFile}] rss.items expected an object. got: "${JSON.stringify(result)}"`);
 		if (!result.title) throw new Error(`[${srcFile}] rss.items required "title" property is missing. got: "${JSON.stringify(result)}"`);
 		if (!result.link) throw new Error(`[${srcFile}] rss.items required "link" property is missing. got: "${JSON.stringify(result)}"`);
-		let itemLink = result.link;
-		// If the item's link is already a valid URL, don't mess with it.
-		if (!/^(?:https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&//=]*)$/i.test(result.link)) itemLink = canonicalURL(result.link, site).href;
 		xml += `<title><![CDATA[${result.title}]]></title>`;
+		// If the item's link is already a valid URL, don't mess with it.
+		const itemLink = isValidURL(result.link) ? result.link : canonicalURL(result.link, site).href;
 		xml += `<link>${itemLink}</link>`;
 		xml += `<guid>${itemLink}</guid>`;
 		if (result.description) xml += `<description><![CDATA[${result.description}]]></description>`;

--- a/packages/astro/src/core/ssr/rss.ts
+++ b/packages/astro/src/core/ssr/rss.ts
@@ -47,9 +47,12 @@ export function generateRSS(args: GenerateRSSArgs): string {
 		if (typeof result !== 'object') throw new Error(`[${srcFile}] rss.items expected an object. got: "${JSON.stringify(result)}"`);
 		if (!result.title) throw new Error(`[${srcFile}] rss.items required "title" property is missing. got: "${JSON.stringify(result)}"`);
 		if (!result.link) throw new Error(`[${srcFile}] rss.items required "link" property is missing. got: "${JSON.stringify(result)}"`);
+		let itemLink = result.link;
+		// If the item's link is already a valid URL, don't mess with it.
+		if (!/^(?:https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&//=]*)$/i.test(url)) itemLink = canonicalURL(result.link, site).href;
 		xml += `<title><![CDATA[${result.title}]]></title>`;
-		xml += `<link>${canonicalURL(result.link, site).href}</link>`;
-		xml += `<guid>${canonicalURL(result.link, site).href}</guid>`;
+		xml += `<link>${itemLink}</link>`;
+		xml += `<guid>${itemLink}</guid>`;
 		if (result.description) xml += `<description><![CDATA[${result.description}]]></description>`;
 		if (result.pubDate) {
 			// note: this should be a Date, but if user provided a string or number, we can work with that, too.

--- a/packages/astro/src/core/ssr/rss.ts
+++ b/packages/astro/src/core/ssr/rss.ts
@@ -49,7 +49,7 @@ export function generateRSS(args: GenerateRSSArgs): string {
 		if (!result.link) throw new Error(`[${srcFile}] rss.items required "link" property is missing. got: "${JSON.stringify(result)}"`);
 		let itemLink = result.link;
 		// If the item's link is already a valid URL, don't mess with it.
-		if (!/^(?:https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&//=]*)$/i.test(url)) itemLink = canonicalURL(result.link, site).href;
+		if (!/^(?:https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&//=]*)$/i.test(result.link)) itemLink = canonicalURL(result.link, site).href;
 		xml += `<title><![CDATA[${result.title}]]></title>`;
 		xml += `<link>${itemLink}</link>`;
 		xml += `<guid>${itemLink}</guid>`;

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -15,6 +15,15 @@ export function canonicalURL(url: string, base?: string): URL {
 	return new URL(pathname, base);
 }
 
+/** Check if a URL is already valid */
+export function isValidURL(url: string):boolean {
+	try {
+		new URL(url)
+		return true;
+	} catch (e) {}
+	return false;
+}
+
 /** is a specifier an npm package? */
 export function parseNpmName(spec: string): { scope?: string; name: string; subpath?: string } | undefined {
 	// not an npm package

--- a/packages/astro/test/astro-sitemap-rss.test.js
+++ b/packages/astro/test/astro-sitemap-rss.test.js
@@ -23,8 +23,15 @@ describe('Sitemaps', () => {
 ]]></description><pubDate>Tue, 19 Oct 1999 00:00:00 GMT</pubDate><itunes:episodeType>music</itunes:episodeType><itunes:duration>259</itunes:duration><itunes:explicit>true</itunes:explicit></item></channel></rss>`
 			);
 		});
+		it('generates RSS with pregenerated URLs correctly', async () => {
+			const rss = await fixture.readFile('/custom/feed-pregenerated-urls.xml');
+			expect(rss).to.equal(
+				`<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:content="http://purl.org/rss/1.0/modules/content/"><channel><title><![CDATA[MF Doomcast]]></title><description><![CDATA[The podcast about the things you find on a picnic, or at a picnic table]]></description><link>https://astro.build/custom/feed-pregenerated-urls.xml</link><language>en-us</language><itunes:author>MF Doom</itunes:author><item><title><![CDATA[Rap Snitch Knishes (feat. Mr. Fantastik)]]></title><link>https://example.com/episode/rap-snitch-knishes/</link><guid>https://example.com/episode/rap-snitch-knishes/</guid><description><![CDATA[Complex named this song the “22nd funniest rap song of all time.”]]></description><pubDate>Tue, 16 Nov 2004 00:00:00 GMT</pubDate><itunes:episodeType>music</itunes:episodeType><itunes:duration>172</itunes:duration><itunes:explicit>true</itunes:explicit></item><item><title><![CDATA[Fazers]]></title><link>https://example.com/episode/fazers/</link><guid>https://example.com/episode/fazers/</guid><description><![CDATA[Rhapsody ranked Take Me to Your Leader 17th on its list “Hip-Hop’s Best Albums of the Decade”]]></description><pubDate>Thu, 03 Jul 2003 00:00:00 GMT</pubDate><itunes:episodeType>music</itunes:episodeType><itunes:duration>197</itunes:duration><itunes:explicit>true</itunes:explicit></item><item><title><![CDATA[Rhymes Like Dimes (feat. Cucumber Slice)]]></title><link>https://example.com/episode/rhymes-like-dimes/</link><guid>https://example.com/episode/rhymes-like-dimes/</guid><description><![CDATA[Operation: Doomsday has been heralded as an underground classic that established MF Doom's rank within the underground hip-hop scene during the early to mid-2000s.
+]]></description><pubDate>Tue, 19 Oct 1999 00:00:00 GMT</pubDate><itunes:episodeType>music</itunes:episodeType><itunes:duration>259</itunes:duration><itunes:explicit>true</itunes:explicit></item></channel></rss>`
+			);
+		});
 	});
-
+	
 	describe('Sitemap Generation', () => {
 		it('Generates Sitemap correctly', async () => {
 			let sitemap = await fixture.readFile('/sitemap.xml');

--- a/packages/astro/test/fixtures/astro-sitemap-rss/src/pages/episodes/[...page].astro
+++ b/packages/astro/test/fixtures/astro-sitemap-rss/src/pages/episodes/[...page].astro
@@ -21,6 +21,26 @@ export function getStaticPaths({paginate, rss}) {
     })),
     dest: '/custom/feed.xml',
   });
+  rss({
+    title: 'MF Doomcast',
+    description: 'The podcast about the things you find on a picnic, or at a picnic table',
+    xmlns: {
+      itunes: 'http://www.itunes.com/dtds/podcast-1.0.dtd',
+      content: 'http://purl.org/rss/1.0/modules/content/',
+    },
+    customData: `<language>en-us</language>` +
+      `<itunes:author>MF Doom</itunes:author>`,
+    items: episodes.map((episode) => ({
+      title: episode.title,
+      link: `https://example.com/${episode.url}`,
+      description: episode.description,
+      pubDate: episode.pubDate + 'Z',
+      customData: `<itunes:episodeType>${episode.type}</itunes:episodeType>` +
+        `<itunes:duration>${episode.duration}</itunes:duration>` +
+        `<itunes:explicit>${episode.explicit || false}</itunes:explicit>`,
+    })),
+    dest: '/custom/feed-pregenerated-urls.xml',
+  });
   return paginate(episodes);
 }
 


### PR DESCRIPTION
## Changes

- Allows pre-generated URLs to be passed as the link for rss items.
- Previously, passing an already valid URL as the link would result in an invalid URL being generated in the RSS feed.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added extra section to rss feed test to check if pre-generated urls work.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Bug fix only.
