### PR TITLE
Pin to the compiler 0.8.1

### DIFF
--- a/.changeset/cold-bottles-eat.md
+++ b/.changeset/cold-bottles-eat.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Pin the compiler to fix obscure Windows bug

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -56,7 +56,7 @@
     "test": "mocha --parallel --timeout 15000"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.8.0",
+    "@astrojs/compiler": "0.8.1",
     "@astrojs/language-server": "^0.8.6",
     "@astrojs/markdown-remark": "^0.6.0",
     "@astrojs/prism": "0.4.0",


### PR DESCRIPTION
This pins to the compiler 0.8.1 version, the last working version for the Windows smoke tests. Currently tracking down what broke in 0.8.2, but this will fix PRs in the meantime.