### PR TITLE
doc: fix "Astro Components" link reference

### DIFF
--- a/docs/src/pages/en/core-concepts/component-hydration.md
+++ b/docs/src/pages/en/core-concepts/component-hydration.md
@@ -92,7 +92,7 @@ If more than one renderer is included in the Astro [config](/en/reference/config
 
 ## Can I Hydrate Astro Components?
 
-[Astro components](./astro-components) (`.astro` files) are HTML-only templating components with no client-side runtime. If you try to hydrate an Astro component with a `client:` modifier, you will get an error.
+[Astro components](/en/core-concepts/astro-components/) (`.astro` files) are HTML-only templating components with no client-side runtime. If you try to hydrate an Astro component with a `client:` modifier, you will get an error.
 
 To make your Astro component interactive, you will need to convert it to the frontend framework of your choice: React, Svelte, Vue, etc. If you have no preference, we recommend React or Preact as they are most similar to Astro's syntax.
 

--- a/docs/src/pages/en/core-concepts/component-hydration.md
+++ b/docs/src/pages/en/core-concepts/component-hydration.md
@@ -92,7 +92,7 @@ If more than one renderer is included in the Astro [config](/en/reference/config
 
 ## Can I Hydrate Astro Components?
 
-[Astro components](/en/core-concepts/astro-components/) (`.astro` files) are HTML-only templating components with no client-side runtime. If you try to hydrate an Astro component with a `client:` modifier, you will get an error.
+[Astro components](/en/core-concepts/astro-components) (`.astro` files) are HTML-only templating components with no client-side runtime. If you try to hydrate an Astro component with a `client:` modifier, you will get an error.
 
 To make your Astro component interactive, you will need to convert it to the frontend framework of your choice: React, Svelte, Vue, etc. If you have no preference, we recommend React or Preact as they are most similar to Astro's syntax.
 


### PR DESCRIPTION
## Changes

Fix "Astro Components" link at "Partial Hydration" documentation

I kept the pattern linking full path instead using relative patter.