### PR TITLE
Pass user's viteConfig.ssr to the build

### DIFF
--- a/.changeset/neat-seals-fold.md
+++ b/.changeset/neat-seals-fold.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow setting ssr Vite config in the static build

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "docs",
     "packages/astro/test/fixtures/builtins/packages/*",
     "packages/astro/test/fixtures/builtins-polyfillnode",
-    "packages/astro/test/fixtures/custom-elements/my-component-lib"
+    "packages/astro/test/fixtures/custom-elements/my-component-lib",
+    "packages/astro/test/fixtures/static-build/pkg"
   ],
   "volta": {
     "node": "14.17.0",

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -178,7 +178,8 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 		envPrefix: 'PUBLIC_',
 		server: viteConfig.server,
 		base: astroConfig.buildOptions.site ? new URL(astroConfig.buildOptions.site).pathname : '/',
-	});
+		ssr: viteConfig.ssr,
+	} as ViteConfigWithSSR);
 }
 
 async function clientBuild(opts: StaticBuildOptions, internals: BuildInternals, input: Set<string>) {

--- a/packages/astro/test/fixtures/static-build/package.json
+++ b/packages/astro/test/fixtures/static-build/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@astrojs/test-static-build",
+  "version": "0.0.1",
+  "dependencies": {
+    "@astrojs/test-static-build-pkg": "file:./pkg"
+  }
+}

--- a/packages/astro/test/fixtures/static-build/pkg/package.json
+++ b/packages/astro/test/fixtures/static-build/pkg/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@astrojs/test-static-build-pkg",
+  "main": "./oops.js",
+  "version": "0.0.1",
+  "exports": {
+    ".": {
+      "import": "./pkg.js",
+      "require": "./oops.js"
+    }
+  }
+}

--- a/packages/astro/test/fixtures/static-build/pkg/pkg.js
+++ b/packages/astro/test/fixtures/static-build/pkg/pkg.js
@@ -1,0 +1,1 @@
+export const test = 'testing';

--- a/packages/astro/test/fixtures/static-build/src/pages/index.astro
+++ b/packages/astro/test/fixtures/static-build/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import MainHead from '../components/MainHead.astro';
 import Nav from '../components/Nav/index.jsx';
+import { test as ssrConfigTest } from '@astrojs/test-static-build-pkg';
 let allPosts = await Astro.fetchContent('./posts/*.md');
 ---
 <html>
@@ -27,5 +28,6 @@ let allPosts = await Astro.fetchContent('./posts/*.md');
 		<li><a href={post.url}>post.title</a></li>
 	))}
 </ul>
+<div id="ssr-config">{ssrConfigTest}</div>
 </body>
 </html>

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -16,6 +16,9 @@ describe('Static build', () => {
 			buildOptions: {
 				experimentalStaticBuild: true,
 			},
+			ssr: {
+				noExternal: ['@astrojs/test-static-build-pkg'],
+			},
 		});
 		await fixture.build();
 	});
@@ -93,5 +96,11 @@ describe('Static build', () => {
 			const $$ = cheerio.load(indexHTML);
 			expect($$(`script[src="${href}"]`).length).to.equal(0, 'no script added to different page');
 		});
+	});
+
+	it('honors ssr config', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerio.load(html);
+		expect($('#ssr-config').text()).to.equal('testing');
 	});
 });


### PR DESCRIPTION
## Changes

- In the static build, include a user's own `vite.ssr` configuration, so they can control `external` and `noExternal` config.

## Testing

Test added

## Docs

Bug fix