### PR TITLE
run lit test separately to prevent error

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -53,7 +53,7 @@
     "dev": "astro-scripts dev \"src/**/*.ts\"",
     "postbuild": "astro-scripts copy \"src/**/*.astro\"",
     "benchmark": "node test/benchmark/dev.bench.js && node test/benchmark/build.bench.js",
-    "test": "mocha --timeout 15000 --ignore **/lit-element.test.js && mocha **/lit-element.test.js"
+    "test": "mocha --parallel --timeout 15000 --ignore **/lit-element.test.js && mocha **/lit-element.test.js"
   },
   "dependencies": {
     "@astrojs/compiler": "^0.9.2",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -53,7 +53,7 @@
     "dev": "astro-scripts dev \"src/**/*.ts\"",
     "postbuild": "astro-scripts copy \"src/**/*.astro\"",
     "benchmark": "node test/benchmark/dev.bench.js && node test/benchmark/build.bench.js",
-    "test": "mocha --timeout 15000 --bail"
+    "test": "mocha --timeout 15000 --exclude lit-element.test.js"
   },
   "dependencies": {
     "@astrojs/compiler": "^0.9.2",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -53,7 +53,7 @@
     "dev": "astro-scripts dev \"src/**/*.ts\"",
     "postbuild": "astro-scripts copy \"src/**/*.astro\"",
     "benchmark": "node test/benchmark/dev.bench.js && node test/benchmark/build.bench.js",
-    "test": "mocha --timeout 15000 --exclude lit-element.test.js"
+    "test": "mocha --timeout 15000 --ignore **/lit-element.test.js && mocha **/lit-element.test.js"
   },
   "dependencies": {
     "@astrojs/compiler": "^0.9.2",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -53,7 +53,7 @@
     "dev": "astro-scripts dev \"src/**/*.ts\"",
     "postbuild": "astro-scripts copy \"src/**/*.astro\"",
     "benchmark": "node test/benchmark/dev.bench.js && node test/benchmark/build.bench.js",
-    "test": "mocha --parallel --timeout 15000"
+    "test": "mocha --timeout 15000 --bail"
   },
   "dependencies": {
     "@astrojs/compiler": "^0.9.2",


### PR DESCRIPTION
## Changes

- Runs `lit-element.test.js` separately to prevent the test suite from erroring out.

Resolves https://github.com/withastro/astro/issues/2445

## Testing

bug test only

## Docs

bug test only