### PR TITLE
Allow not specfying section header in sidebar.

### DIFF
--- a/examples/docs/src/components/LeftSidebar/LeftSidebar.astro
+++ b/examples/docs/src/components/LeftSidebar/LeftSidebar.astro
@@ -5,7 +5,14 @@ const { currentPage } = Astro.props;
 const currentPageMatch = currentPage.slice(1);
 const langCode = getLanguageFromURL(currentPage);
 // SIDEBAR is a flat array. Group it by sections to properly render.
-const sidebarSections = SIDEBAR[langCode].reduce((col, item) => {
+const sidebarSections = SIDEBAR[langCode].reduce((col, item, i) => {
+	// If the first item is not a section header, create a new container section.
+	if (i === 0) {
+		if (!item.header) {
+			const pesudoSection = { text: "" };
+			col.push({ ...pesudoSection, children: [] });
+		}
+	}
 	if (item.header) {
 		col.push({ ...item, children: [] });
 	} else {


### PR DESCRIPTION
## Changes

Someone may forget to specify a section header in SIDEBAR,
which would cause build error previously.

## Testing

No tests added.

Manually tested:

```sh
npm i
npm run dev
# check the page rendered in the browser
# delete headers specified in `SIDEBAR`
# refresh the page and check it again in the browser
```

## Docs

Previously examples/docs/README.md did not mention that header is required in `SIDEBAR`,
and this commit make it optional.
Thus no documentation need to change.
