### PR TITLE
Use CONFIG.SITE.title for h1 in doc theme header

### DIFF
--- a/examples/docs/src/components/Header/Header.astro
+++ b/examples/docs/src/components/Header/Header.astro
@@ -20,7 +20,7 @@ const lang = currentPage && getLanguageFromURL(currentPage);
 		<div class="logo flex">
 			<AstroLogo size={40} />
 			<a href="/">
-				<h1>Documentation</h1>
+				<h1>{CONFIG.SITE.title ?? "Documentation"}</h1>
 			</a>
 		</div>
 		<div style="flex-grow: 1;"></div>


### PR DESCRIPTION
## Changes

Use SITE.title specified in config.ts as the h1 heading in Header.astro
of doc theme.
When SITE.title is null, use "Documentation" as the fallback value.
Previously the h1 heading in doc theme header is hardcoded
as "Documentation".

## Testing

I run `npm run dev` and manually checked the rendered page.

Given the following config:

```
export const SITE = {
	title: 'Your Documentation Website',
	// omitted
};
```

The page is rendered as expected:

![image](https://user-images.githubusercontent.com/114114/150636618-15cf16b2-6e29-40ce-8b1f-59c73de181ad.png)

Then I removed the title:

```diff
export const SITE = {
-	title: 'Your Documentation Website',
};
``` 

And the page is rendered as below:

![image](https://user-images.githubusercontent.com/114114/150636680-ce9a3a1d-f49c-4f36-92af-d5032594267c.png)


## Docs

Previously `examples/docs/README.md` did not mention that the Documentation h1 heading is hard-coded in `Header.astro` and just changing `SITE.title` would not change the h1 heading.
Thus I think no documentation need to update.
