### PR TITLE
Remove `node-fetch`

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -88,7 +88,6 @@
     "magic-string": "^0.25.7",
     "mime": "^3.0.0",
     "morphdom": "^2.6.1",
-    "node-fetch": "^3.0.0",
     "parse5": "^6.0.1",
     "path-to-regexp": "^6.2.0",
     "postcss": "^8.3.8",

--- a/packages/astro/test/fixtures/fetch/src/components/AlreadyImported.astro
+++ b/packages/astro/test/fixtures/fetch/src/components/AlreadyImported.astro
@@ -1,5 +1,1 @@
----
-import fetch from 'node-fetch'
----
-
 <span id="already-imported">{typeof fetch}</span>

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -1,5 +1,5 @@
 import { execa } from 'execa';
-import fetch from 'node-fetch';
+import { fetch } from '@astropub/webapi';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { loadConfig } from '../dist/core/config.js';

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -1,5 +1,5 @@
 import { execa } from 'execa';
-import { fetch } from '@astropub/webapi';
+import { polyfill } from '@astropub/webapi';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { loadConfig } from '../dist/core/config.js';
@@ -7,6 +7,11 @@ import dev from '../dist/core/dev/index.js';
 import build from '../dist/core/build/index.js';
 import preview from '../dist/core/preview/index.js';
 import os from 'os';
+
+// polyfill WebAPIs to globalThis for Node v12, Node v14, and Node v16
+polyfill(globalThis, {
+	exclude: 'window document',
+});
 
 /**
  * @typedef {import('node-fetch').Response} Response


### PR DESCRIPTION
## Changes

- Removes `node-fetch` dependency from `astro`
- Internally, `astro` has been using `@astropub/webapi`

## Testing

- Updates test util to use `fetch` from `@astropub/webapi`
- Updates `AlreadyImported.astro` test to remove `node-fetch` and presume `fetch` is _already imported_.

## Docs

internal change only