### PR TITLE
Add link to GOVERNANCE from CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ Understanding in which environment code runs, and at which stage in the process,
 
 ## Releasing Astro
 
-_Note: Only [core contributors (L3+)](https://github.com/withastro/astro/blob/main/GOVERNANCE.md#level-3-l3---core-maintainer) can release new versions of Astro._
+_Note: Only [core maintainers (L3+)](https://github.com/withastro/astro/blob/main/GOVERNANCE.md#level-3-l3---core-maintainer) can release new versions of Astro._
 
 The repo is set up with automatic releases, using the changeset GitHub action & bot.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ Understanding in which environment code runs, and at which stage in the process,
 
 ## Releasing Astro
 
-_Note: Only core contributors (L3+) can release new versions of Astro._
+_Note: Only [core contributors (L3+)](https://github.com/withastro/astro/blob/main/GOVERNANCE.md#level-3-l3---core-maintainer) can release new versions of Astro._
 
 The repo is set up with automatic releases, using the changeset GitHub action & bot.
 


### PR DESCRIPTION
## Changes

- Adds link explaining what core contributors are
- Per [this discussion](https://canary.discord.com/channels/830184174198718474/853350631389265940/933879694749737030) in discord

## Testing

- No code changes

## Docs

- No code changes