### PR TITLE
add a new test:match command script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,9 +54,10 @@ DEBUG=vite:[name] astro dev   # debug specific process, e.g. "vite:deps" or "vit
 ```shell
 # run this in the top-level project root to run all tests
 yarn test
-# run only a few tests, great for working on a single feature
-# (example - `yarn test -g "RSS"` runs `astro-rss.test.js`)
-yarn test -g "$STRING_MATCH"
+# run only a few tests, based on describe() or it() string match
+# great for development, and working on a single feature!
+# (example - `yarn test:match "RSS"` runs tests in `astro-rss.test.js`)
+yarn test:match "$STRING_MATCH"
 ```
 
 ### Other useful commands

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:examples": "turbo run build --scope=docs --scope=\"@example/*\"",
     "dev": "turbo run dev --no-deps --no-cache --parallel --scope=astro --scope=create-astro --scope=\"@astrojs/*\"",
     "test": "turbo run test --scope=astro",
+    "test:match": "cd packages/astro && yarn run test:match",
     "test:templates": "turbo run test --scope=create-astro",
     "benchmark": "turbo run benchmark --scope=astro",
     "lint": "eslint \"packages/**/*.ts\"",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -51,7 +51,8 @@
     "dev": "astro-scripts dev \"src/**/*.ts\"",
     "postbuild": "astro-scripts copy \"src/**/*.astro\"",
     "benchmark": "node test/benchmark/dev.bench.js && node test/benchmark/build.bench.js",
-    "test": "mocha --parallel --timeout 15000 --ignore **/lit-element.test.js && mocha **/lit-element.test.js"
+    "test": "mocha --parallel --timeout 15000 --ignore **/lit-element.test.js && mocha **/lit-element.test.js",
+    "test:match": "mocha --timeout 15000 -g"
   },
   "dependencies": {
     "@astrojs/compiler": "^0.9.2",


### PR DESCRIPTION
## Changes

- Our docs were incorrect, and there was no easy way to run a single test since turbo did not support argument passing.
- Adds a new `test:match` command for running specific tests


```shell
# run this in the top-level project root to run all tests
yarn test
# run only a few tests, based on describe() or it() string match
# great for development, and working on a single feature!
# (example - `yarn test:match "RSS"` runs tests in `astro-rss.test.js`)
yarn test:match "$STRING_MATCH"
```


## Testing

- is test

## Docs

- n/a