### PR TITLE
Render Custom Element Tag

### DIFF
--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -442,11 +442,6 @@ export async function renderHTMLElement(result: SSRResult, constructor: typeof H
 
 	const html = `<${name}${attrHTML}>${children}</${name}>`;
 
-	result.scripts.add({
-		props: { type: 'module' },
-		children: `customElements.define(${JSON.stringify(name)}, ${String(constructor)})`,
-	});
-
 	return html;
 }
 

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -147,7 +147,7 @@ export async function renderComponent(result: SSRResult, displayName: string, Co
 	}
 	const probableRendererNames = guessRenderers(metadata.componentUrl);
 
-	if (Array.isArray(renderers) && renderers.length === 0 && typeof Component !== 'string') {
+	if (Array.isArray(renderers) && renderers.length === 0 && typeof Component !== 'string' && !HTMLElement.isPrototypeOf(Component as object)) {
 		const message = `Unable to render ${metadata.displayName}!
 
 There are no \`renderers\` set in your \`astro.config.mjs\` file.
@@ -163,6 +163,12 @@ Did you mean to enable ${formatList(probableRendererNames.map((r) => '`' + r + '
 				renderer = r;
 				break;
 			}
+		}
+
+		if (!renderer && HTMLElement.isPrototypeOf(Component as object)) {
+			const output = renderHTMLElement(result, Component as typeof HTMLElement, _props, slots);
+
+			return output;
 		}
 	} else {
 		// Attempt: use explicitly passed renderer name
@@ -420,6 +426,36 @@ export async function renderAstroComponent(component: InstanceType<typeof AstroC
 	}
 
 	return template;
+}
+
+export async function renderHTMLElement(result: SSRResult, constructor: typeof HTMLElement, props: any, children: any) {
+	const name = getHTMLElementName(constructor);
+
+	let attrHTML = '';
+
+	for (const attr in props) {
+		attrHTML += ` ${attr}="${toAttributeString(await props[attr])}"`;
+	}
+
+	children = await children;
+	children = children == null ? children : '';
+
+	const html = `<${name}${attrHTML}>${children}</${name}>`;
+
+	result.scripts.add({
+		props: { type: 'module' },
+		children: `customElements.define(${JSON.stringify(name)}, ${String(constructor)})`,
+	});
+
+	return html;
+}
+
+function getHTMLElementName(constructor: typeof HTMLElement) {
+	const definedName = (customElements as CustomElementRegistry & { getName(_constructor: typeof HTMLElement): string }).getName(constructor);
+	if (definedName) return definedName
+
+	const assignedName = constructor.name.replace(/^HTML|Element$/g, '').replace(/[A-Z]/g, '-$&').toLowerCase().replace(/^-/, 'html-')
+	return assignedName
 }
 
 function renderElement(name: string, { props: _props, children = '' }: SSRElement) {


### PR DESCRIPTION
## Changes

- Renders the tag name of a Custom Element (after any renderers).
- Prevents a tag made from an `HTMLElement` from throwing.
- ~Adds a script to register the constructor.~

**Before**:
```astro
<!-- src/components/Button.astro -->
<script hoist>
class Button extends HTMLElement {}
customElements.define('h-button', Button)
</script>
<h-button><slot /></h-button>
```
```astro
---
// src/pages/index.astro
import Button from '../components/Button.astro'
---
<Button>Button</Button>
```

**After**:
```js
// src/components/Button.js
export default class Button extends HTMLElement {}
customElements.define('h-button', Button)
```
```astro
---
// src/pages/index.astro
import Button from '../components/Button.js'
---
<Button>Button</Button>
```

## Testing

testing tbd, if the pr is conceptually acceptable

## Docs

docs tbd