### PR TITLE
update pages config doc description

### DIFF
--- a/docs/src/pages/en/reference/configuration-reference.md
+++ b/docs/src/pages/en/reference/configuration-reference.md
@@ -49,7 +49,7 @@ The `src` option sets the directory used to resolve source files, like `pages`. 
 
 #### pages
 
-The `pages` option sets the directory used to resolve pages, relative to the `src` option.
+The `pages` option sets the directory used to resolve pages, relative to the `projectRoot` option.
 
 **Default**: The `src/pages` directory within the `projectRoot` directory.
 


### PR DESCRIPTION
## Changes

Forgot to update the description in the pages section. It looks like there's still a bigger issue across the board that `projectRoot` may not be respected. But pages config is now consistently with other config settings

## Testing

Look at first PR, forgot this part

## Docs

This is a docs change