### PR TITLE
Missing '&' in example of scoped styles

### DIFF
--- a/docs/src/pages/en/guides/styling.md
+++ b/docs/src/pages/en/guides/styling.md
@@ -355,7 +355,7 @@ const { theme } = Astro.props;
 <style lang="scss">
   .btn {
     /* ✅  <Button> is now back in control of its own styling again! */
-    [data-theme='nav'] {
+    &[data-theme='nav'] {
       // nav-friendly styles here…
     }
   }


### PR DESCRIPTION
Style is written in SCSS, so there is missing '&' in nesting data-theme

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
