### PR TITLE
Changed vite.build target to esnext

### DIFF
--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -164,7 +164,7 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 					format: 'esm',
 				},
 			},
-			target: 'es2020', // must match an esbuild target
+			target: 'esnext', // must match an esbuild target
 		},
 		plugins: [
 			vitePluginNewBuild(input, internals, 'mjs'),
@@ -204,7 +204,7 @@ async function clientBuild(opts: StaticBuildOptions, internals: BuildInternals, 
 				},
 				preserveEntrySignatures: 'exports-only',
 			},
-			target: 'es2020', // must match an esbuild target
+			target: 'esnext', // must match an esbuild target
 		},
 		plugins: [
 			vitePluginNewBuild(input, internals, 'js'),


### PR DESCRIPTION
## Changes

- Fixes top-level await and other `es2021`, `es2022`, `esnext` features not working with the static build,

## Testing

Tested locally.

## Docs

Bug fix only
