### PR TITLE
Deprecate unescaped HTML inside of expressions

### DIFF
--- a/.changeset/chatty-spies-wink.md
+++ b/.changeset/chatty-spies-wink.md
@@ -1,0 +1,8 @@
+---
+'astro': minor
+---
+
+Add support for the `set:html` and `set:text` directives. 
+
+With the introduction of these directives, unescaped HTML content in expressions is now deprecated. Please migrate to `set:html` in order to continue injecting unescaped HTML in future versions of Astro—you can use `<Fragment set:html={content}>` to avoid a wrapper element. `set:text` allows you to opt-in to escaping now, but it will soon become the default.
+

--- a/.changeset/mighty-lamps-drive.md
+++ b/.changeset/mighty-lamps-drive.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Bug fix for define:vars with the --experimental-static-build flag
+Bug fix for `define:vars` with the --experimental-static-build flag

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -47,4 +47,4 @@ const _html = highlighter.codeToHtml(code, lang);
 const html = repairShikiTheme(_html);
 ---
 
-{html}
+<Fragment set:html={html} />

--- a/packages/astro/components/Markdown.astro
+++ b/packages/astro/components/Markdown.astro
@@ -41,4 +41,4 @@ if (content) {
 html = htmlContent;
 ---
 
-{html ? html : <slot />}
+{html ? <Fragment set:html={html} /> : <slot />}

--- a/packages/astro/components/Prism.astro
+++ b/packages/astro/components/Prism.astro
@@ -46,4 +46,4 @@ if (grammar) {
 }
 ---
 
-<pre class={[className, classLanguage].join(' ')}><code class={classLanguage}>{html}</code></pre>
+<pre class={[className, classLanguage].join(' ')}><code class={classLanguage}><Fragment set:html={html} /></code></pre>

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -55,7 +55,7 @@
     "test:match": "mocha --timeout 15000 -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.10.0",
+    "@astrojs/compiler": "^0.10.1",
     "@astrojs/language-server": "^0.8.6",
     "@astrojs/markdown-remark": "^0.6.0",
     "@astrojs/prism": "0.4.0",

--- a/packages/astro/src/runtime/server/escape.ts
+++ b/packages/astro/src/runtime/server/escape.ts
@@ -1,9 +1,27 @@
+import { defaultLogOptions, warn } from '../../core/logger.js';
+
 const entities = { '"': 'quot', '&': 'amp', "'": 'apos', '<': 'lt', '>': 'gt' } as const;
 
-export const escapeHTML = (string: any) => string.replace(/["'&<>]/g, (char: keyof typeof entities) => '&' + entities[char] + ';');
+const warned = new Set<string>();
+export const escapeHTML = (string: any, { deprecated = false }: { deprecated?: boolean } = {}) => {
+	const escaped = string.replace(/["'&<>]/g, (char: keyof typeof entities) => '&' + entities[char] + ';');
+	if (!deprecated) return escaped;
+	if (warned.has(string) || !string.match(/[&<>]/g)) return string;
+	warn(defaultLogOptions, 'warning', `Unescaped HTML content found inside expression!
+
+The next minor version of Astro will automatically escape all
+expression content. See https://err.astro.build/0001 for more info.
+
+Expression:
+${string}`);
+	warned.add(string);
+
+	// Return unescaped content for now. To be removed.
+	return string;
+}
 
 /**
- * RawString is a "blessed" version of a String
+ * RawString is a "blessed" version of String
  * that is not subject to escaping.
  */
 export class UnescapedString extends String {}

--- a/packages/astro/src/runtime/server/escape.ts
+++ b/packages/astro/src/runtime/server/escape.ts
@@ -9,9 +9,9 @@ export const escapeHTML = (string: any, { deprecated = false }: { deprecated?: b
 	console.warn(`Unescaped HTML content found inside expression!
 
 The next minor version of Astro will automatically escape all
-expression content. See https://err.astro.build/0001 for more info.
+expression content. Please use the `set:html` directive.
 
-Expression:
+Expression content:
 ${string}`);
 	warned.add(string);
 

--- a/packages/astro/src/runtime/server/escape.ts
+++ b/packages/astro/src/runtime/server/escape.ts
@@ -1,3 +1,11 @@
 const entities = { '"': 'quot', '&': 'amp', "'": 'apos', '<': 'lt', '>': 'gt' } as const;
 
 export const escapeHTML = (string: any) => string.replace(/["'&<>]/g, (char: keyof typeof entities) => '&' + entities[char] + ';');
+
+/**
+ * RawString is a "blessed" version of a String
+ * that is not subject to escaping.
+ */
+export class UnescapedString extends String {}
+
+export const unescapeHTML = (str: any) => new UnescapedString(str);

--- a/packages/astro/src/runtime/server/escape.ts
+++ b/packages/astro/src/runtime/server/escape.ts
@@ -26,4 +26,10 @@ ${string}`);
  */
 export class UnescapedString extends String {}
 
-export const unescapeHTML = (str: any) => new UnescapedString(str);
+/** 
+ * unescapeHTML marks a string as raw, unescaped HTML. 
+ * This should only be generated internally, not a public API.
+ *
+ * Need to cast the return value `as unknown as string` so TS doesn't yell at us.
+ */
+export const unescapeHTML = (str: any) => new UnescapedString(str) as unknown as string;

--- a/packages/astro/src/runtime/server/escape.ts
+++ b/packages/astro/src/runtime/server/escape.ts
@@ -9,7 +9,7 @@ export const escapeHTML = (string: any, { deprecated = false }: { deprecated?: b
 	console.warn(`Unescaped HTML content found inside expression!
 
 The next minor version of Astro will automatically escape all
-expression content. Please use the `set:html` directive.
+expression content. Please use the \`set:html\` directive.
 
 Expression content:
 ${string}`);

--- a/packages/astro/src/runtime/server/escape.ts
+++ b/packages/astro/src/runtime/server/escape.ts
@@ -1,5 +1,3 @@
-import { defaultLogOptions, warn } from '../../core/logger.js';
-
 const entities = { '"': 'quot', '&': 'amp', "'": 'apos', '<': 'lt', '>': 'gt' } as const;
 
 const warned = new Set<string>();
@@ -7,7 +5,8 @@ export const escapeHTML = (string: any, { deprecated = false }: { deprecated?: b
 	const escaped = string.replace(/["'&<>]/g, (char: keyof typeof entities) => '&' + entities[char] + ';');
 	if (!deprecated) return escaped;
 	if (warned.has(string) || !string.match(/[&<>]/g)) return string;
-	warn(defaultLogOptions, 'warning', `Unescaped HTML content found inside expression!
+	// eslint-disable-next-line no-console
+	console.warn(`Unescaped HTML content found inside expression!
 
 The next minor version of Astro will automatically escape all
 expression content. See https://err.astro.build/0001 for more info.

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -93,7 +93,7 @@ export async function renderSlot(_result: any, slotted: string, fallback?: any) 
 	if (slotted) {
 		return unescapeHTML(await _render(slotted));
 	}
-	return unescapeHTML(fallback);
+	return unescapeHTML(await _render(fallback));
 }
 
 export const Fragment = Symbol('Astro.Fragment');

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,10 +130,10 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@astrojs/compiler@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-0.10.0.tgz#6ba2707bf9a91017fd72fb46b1d7865036b71c09"
-  integrity sha512-TbeuITyhRGlQowipNX7Q8o5QczVjSxlE68xKh7i1swTxUhM8K/cnCPSyzTsWiuFWY4C5PDI1GREUaD3BHYfzqQ==
+"@astrojs/compiler@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-0.10.1.tgz#69df1a7e4150c1b0b255154ae716dbc8b24c5dd4"
+  integrity sha512-SUp5auq6jcLmxyOx8Ovd3ebvwR5wnuqsbIi77Ze/ua3+GMcR++rOWiyqyql887U2ajZMwJfHatOwQl67P7o5gg==
   dependencies:
     typescript "^4.3.5"
 


### PR DESCRIPTION
## Changes

- Does not require compiler changes!
- Deprecates passing unescaped HTML inside of an expression (like `{"<style>div { color: red; }</style>"}`, logs a warning when unescaped HTML is encountered
  <img width="533" alt="Screen Shot 2022-01-28 at 2 22 23 PM" src="https://user-images.githubusercontent.com/7118177/151616050-89f838e2-b8c2-4286-95e1-2c4c5b786f0b.png">

- Does **NOT** enable automatic escaping inside of expressions! This is a simple toggle that can be enabled in a follow-up PR to be released in the next minor version.
- Adds an internal `UnescapedString` primitive to power `set:html` and internal rendering 

## Testing

Tested manually in the examples. 

**TODO:** ensure all examples are working as expected.

## Docs

TBD.