### PR TITLE
Fix use of preprocessors with the static build

### DIFF
--- a/.changeset/hungry-dots-reply.md
+++ b/.changeset/hungry-dots-reply.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix for CSS preprocessing using the static build

--- a/examples/fast-build/src/pages/index.astro
+++ b/examples/fast-build/src/pages/index.astro
@@ -16,6 +16,12 @@ import ExternalHoisted from '../components/ExternalHoisted.astro';
 				color: salmon;
 			}
 		</style>
+		<style lang="scss">
+			$color: purple;
+			h2 {
+				color: purple;
+			}
+		</style>
 	</head>
 	<body>
 		<section>


### PR DESCRIPTION
## Changes

- In order to fix HMR a change was made to the static build which prevented preprocessing, thinking that the module would be preprocessed later.
- This was a mistake, we have to preprocess because scoping happens in the compiler. So this restores preprocessing for the static build.

## Testing

Updated the example app.

## Docs

Bug fix
