### PR TITLE
Add Astro.resolve deprecation warning case for script tags

### DIFF
--- a/packages/astro/src/core/ssr/result.ts
+++ b/packages/astro/src/core/ssr/result.ts
@@ -3,6 +3,7 @@ import type { AstroConfig, AstroGlobal, AstroGlobalPartial, Params, Renderer, SS
 import { bold } from 'kleur/colors';
 import { canonicalURL as getCanonicalURL } from '../util.js';
 import { isCSSRequest } from './css.js';
+import { isScriptRequest } from './script.js';
 import { renderSlot } from '../../runtime/server/index.js';
 import { warn, LogOptions } from '../logger.js';
 
@@ -49,6 +50,17 @@ export function createResult(args: CreateResultArgs): SSRResult {
 <style global>
 @import "${path}";
 </style>
+`;
+						} else if (isScriptRequest(path)) {
+							extra = `It looks like you are resolving scripts. If you are adding a script tag, replace with this:
+
+<script type="module" src={(await import("${path}?url")).default}></script>
+
+or consider make it a module like so:
+
+<script type="module" hoist>
+	import MyModule from "${path}";
+</script>
 `;
 						}
 

--- a/packages/astro/src/core/ssr/script.ts
+++ b/packages/astro/src/core/ssr/script.ts
@@ -1,0 +1,8 @@
+export const SCRIPT_EXTENSIONS = new Set(['.js', '.ts']);
+
+const scriptRe = new RegExp(
+	`\\.(${Array.from(SCRIPT_EXTENSIONS)
+		.map((s) => s.slice(1))
+		.join('|')})($|\\?)`
+);
+export const isScriptRequest = (request: string): boolean => scriptRe.test(request);


### PR DESCRIPTION
## Changes

- if `astroConfig.buildOptions.experimentalStaticBuild` is true and file path extension match `.ts` or `.js`, a new message will be presented in the console.

- Adds a file at `packages/astro/src/core/ssr/script.ts` used as util for script detection (same code structure as `css.ts` in the same folder)
  ```ts
  export const SCRIPT_EXTENSIONS = new Set(['.js', '.ts']);
  
  const scriptRe = new RegExp(
	  `\\.(${Array.from(SCRIPT_EXTENSIONS)
		  .map((s) => s.slice(1))
		  .join('|')})($|\\?)`
  );
  export const isScriptRequest = (request: string): boolean => scriptRe.test(request);
  ```
- Shows a suggestion like this when a `.ts` or `.js` file is detected
  ```
  03:20 PM [deprecation] Astro.resolve() is deprecated. We see that you are trying to resolve ./scripts/bar.ts.
  It looks like you are resolving scripts. If you are adding a script tag, replace with this:
  
  <script type="module" src={(await import("./scripts/bar.ts?url")).default}></script>
  
  or consider make it a module like so:
  
  <script type="module" hoist>
	  import MyModule from "./scripts/bar.ts";
  </script>
  ```

## Testing

Code tested in local, works just fine with both `.ts` and `.js` file.
May need some changes for the suggestions as the code evolve, not sure.

## Docs

No migration guides exists for the `--experimental-static-build` as it's still in development, so no docs needed for now.