### PR TITLE
[docs] fix typo in portfolio-svelte example

### DIFF
--- a/examples/portfolio-svelte/README.md
+++ b/examples/portfolio-svelte/README.md
@@ -1,7 +1,7 @@
-# Astro Starter Kit: Portfolio
+# Astro Starter Kit: Portfolio + Svelte
 
 ```
-npm init astro -- --template portfolio
+npm init astro -- --template portfolio-svelte
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/portfolio-svelte)


### PR DESCRIPTION
Currently, the `portfolio-svelte` example uses the same installation command as `portfolio`.

As a result, `npm init astro -- --template portfolio` does not install the `portfolio-svelte` example.

## Changes

- [docs] fix typo in portfolio-svelte installation command

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
