### PR TITLE
[WIP] new content, setup APIs

### DIFF
--- a/docs/src/pages/[...slug].astro
+++ b/docs/src/pages/[...slug].astro
@@ -1,19 +1,30 @@
 ---
-export async function getStaticPaths() {
+
+// NOTE: This should be setup(), however the compiler currently only hoists
+// getStaticPaths(). So we're using getStaticPaths() for the moment.
+export async function getStaticPaths({content, buildStaticPaths, rss}) {
+    // content() instructions:
+        // To fetch via glob:
+        // console.log(await content('./en/**/*.md'));
+        // To fetch via glob + filter (filtering improves HMR):
+        // console.log(await content('./en/**/*.md', (f) => f.file.includes('getting-started')));
+
     // get english pages that moved from `/` to `/en/`
-    const englishPages = Astro.fetchContent('./en/**/*.md');
+    const englishPages = await content('./en/**/*.md');
 
     // add pages that are `*.astro` files as well
     const otherPages = [{ url: "/en/themes" }];
-    return [...englishPages, ...otherPages].map((page) => ({
+    buildStaticPaths([...englishPages, ...otherPages].map((page) => ({
         params: {
-            slug: page.url.slice(4),
+            slug: page.url ? page.url.slice(4) : page.file.replace(/^.*src.pages.en/, ''),
         },
         props: {
-            englishSlug: page.url,
+            englishSlug: page.url ? page.url : page.file.replace(/^.*src.pages/, ''),
         }
-    }));
+    })));
 }
 ---
-
-<meta http-equiv="refresh" content={`0;url=${Astro.props.englishSlug}`} />
+<!-- 
+    Commented out so that the page doesn't redirect while testing.
+    <meta http-equiv="refresh" content={`0;url=${Astro.props.englishSlug}`} /> 
+-->

--- a/packages/astro/src/core/ssr/route-cache.ts
+++ b/packages/astro/src/core/ssr/route-cache.ts
@@ -1,47 +1,48 @@
-import type { ComponentInstance, GetStaticPathsItem, GetStaticPathsResult, GetStaticPathsResultKeyed, RouteCache, RouteData } from '../../@types/astro';
+import type { ComponentInstance, GetStaticPathsOptions, GetStaticPathsResult, RouteCache, RouteData, GetStaticPathsItem, GetStaticPathsResultKeyed, GetStaticPathsResultObject } from '../../@types/astro';
 import type { LogOptions } from '../logger';
 
 import { debug } from '../logger.js';
 import { generatePaginateFunction } from '../ssr/paginate.js';
+import { createNewFetchContentFn } from '../../runtime/server/content.js';
 
-type RSSFn = (...args: any[]) => any;
-
-export async function callGetStaticPaths(mod: ComponentInstance, route: RouteData, rssFn?: RSSFn): Promise<GetStaticPathsResultKeyed> {
-	const staticPaths: GetStaticPathsResult = await (
+export async function callGetStaticPaths(filePath: URL, mod: ComponentInstance, route: RouteData, loadContent: (filePath: string) => Promise<any>): Promise<GetStaticPathsResultObject> {
+	let result: GetStaticPathsResultObject = {
+		filePath,
+		rss: undefined,
+		// @ts-expect-error
+		staticPaths: undefined,
+		linkedContent: [],
+	};
+	let staticPaths: GetStaticPathsResult = [];
+	const newFetchContentFn = createNewFetchContentFn(filePath, mod, loadContent);
+	await (
 		await mod.getStaticPaths!({
+			content: async (globStr, filter) => {
+				const [fetchContentResults, linkedContentIds] = await newFetchContentFn(globStr, filter);
+				result.linkedContent.push(...linkedContentIds);
+				return fetchContentResults;
+			},
 			paginate: generatePaginateFunction(route),
-			rss:
-				rssFn ||
-				(() => {
-					/* noop */
-				}),
+			buildStaticPaths: (result) => {
+				staticPaths = result;
+			},
+			rss: (fn) => {
+				result.rss = fn;
+			},
 		})
-	).flat();
+	);
 
-	const keyedStaticPaths = staticPaths as GetStaticPathsResultKeyed;
+	const keyedStaticPaths: GetStaticPathsResultKeyed = (staticPaths || []) as any;
 	keyedStaticPaths.keyed = new Map<string, GetStaticPathsItem>();
 	for (const sp of keyedStaticPaths) {
 		const paramsKey = JSON.stringify(sp.params);
 		keyedStaticPaths.keyed.set(paramsKey, sp);
 	}
+	result.staticPaths = keyedStaticPaths;
 
-	return keyedStaticPaths;
+	return result;
 }
 
-export async function assignStaticPaths(routeCache: RouteCache, route: RouteData, mod: ComponentInstance, rssFn?: RSSFn): Promise<void> {
-	const staticPaths = await callGetStaticPaths(mod, route, rssFn);
-	routeCache[route.component] = staticPaths;
-}
-
-export async function ensureRouteCached(routeCache: RouteCache, route: RouteData, mod: ComponentInstance, rssFn?: RSSFn): Promise<GetStaticPathsResultKeyed> {
-	if (!routeCache[route.component]) {
-		const staticPaths = await callGetStaticPaths(mod, route, rssFn);
-		routeCache[route.component] = staticPaths;
-		return staticPaths;
-	} else {
-		return routeCache[route.component];
-	}
-}
 
 export function findPathItemByKey(staticPaths: GetStaticPathsResultKeyed, paramsKey: string, logging: LogOptions) {
 	let matchedStaticPath = staticPaths.keyed.get(paramsKey);

--- a/packages/astro/src/core/ssr/routing.ts
+++ b/packages/astro/src/core/ssr/routing.ts
@@ -1,4 +1,4 @@
-import type { AstroConfig, ComponentInstance, GetStaticPathsResult, ManifestData, Params, RouteData } from '../../@types/astro';
+import type { AstroConfig, ComponentInstance, GetStaticPathsResult, GetStaticPathsResultObject, ManifestData, Params, RouteData } from '../../@types/astro';
 import type { LogOptions } from '../logger';
 
 import fs from 'fs';
@@ -45,7 +45,8 @@ export function validateGetStaticPathsModule(mod: ComponentInstance) {
 }
 
 /** Throw error for malformed getStaticPaths() response */
-export function validateGetStaticPathsResult(result: GetStaticPathsResult, logging: LogOptions) {
+export function validateGetStaticPathsResult(resultObj: GetStaticPathsResultObject, logging: LogOptions) {
+	const result = resultObj.staticPaths;
 	if (!Array.isArray(result)) {
 		throw new Error(`[getStaticPaths] invalid return value. Expected an array of path objects, but got \`${JSON.stringify(result)}\`.`);
 	}

--- a/packages/astro/src/runtime/server/content.ts
+++ b/packages/astro/src/runtime/server/content.ts
@@ -1,0 +1,73 @@
+import type { AstroComponentMetadata, Renderer, AstroGlobalPartial, SSRResult, SSRElement, GetStaticPathsOptions, ComponentInstance } from '../../@types/astro';
+import glob from 'fast-glob';
+import { pathToFileURL, fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+/** Create the Astro.content() runtime function. */
+export function createNewFetchContentFn(fileUrl: URL, mod: ComponentInstance, loadContent: (filePath: string) => Promise<any>): any  {
+  const fetchResults: string[][] = [];
+  const filePath = fileURLToPath(fileUrl);
+  const cwd = dirname(filePath);
+  console.log(filePath, cwd, mod);
+	return (async (pattern: string, filter?: (data: any) => boolean) => {
+		const files = await glob(pattern, {
+			cwd,
+      absolute: true,
+			// Ignore node_modules by default unless explicitly indicated in the pattern
+			ignore: /(^|\/)node_modules\//.test(pattern) ? [] : ['**/node_modules/**'],
+		});
+
+		// for each file, import it and pass it to filter
+		const modules = 
+      (await Promise.all(files.map((f) => loadContent(f))))
+        .map((mod, i) => {
+          // Only return Markdown files for now.
+          if (!mod.frontmatter) {
+            return;
+          }
+          const filePath = files[i];
+          return {
+            file: filePath,
+            data: mod.frontmatter,
+            Content: mod.default,
+            content: mod.metadata,
+            // TODO: figure out if we want to do the url property
+            // We would need to use some Vite resolution logic, I think 
+            // but we may not even want to bring this along
+            // url: urlSpec.includes('/pages/') ? urlSpec.replace(/^.*\/pages\//, site.pathname).replace(/(\/index)?\.md$/, '') : undefined,
+          };
+        })
+        .filter(Boolean)
+        .filter(filter || (() => true));
+    console.log(files, modules);
+    
+		return [modules as any[], files];
+	});
+
+	// 	PREVIOUS CODE - to be deleted before merging
+	// 	let allEntries = [...Object.entries(importMetaGlobResult)];
+	// 	if (allEntries.length === 0) {
+	// 		throw new Error(`[${url.pathname}] Astro.fetchContent() no matches found.`);
+	// 	}
+	// 	return allEntries
+	// 		.map(([spec, mod]) => {
+	// 			// Only return Markdown files for now.
+	// 			if (!mod.frontmatter) {
+	// 				return;
+	// 			}
+	// 			const urlSpec = new URL(spec, url).pathname;
+	// 			return {
+	// 				...mod.frontmatter,
+	// 				Content: mod.default,
+	// 				content: mod.metadata,
+	// 				file: new URL(spec, url),
+	// 				url: urlSpec.includes('/pages/') ? urlSpec.replace(/^.*\/pages\//, site.pathname).replace(/(\/index)?\.md$/, '') : undefined,
+	// 			};
+	// 		})
+	// 		.filter(Boolean);
+	// };
+	// // This has to be cast because the type of fetchContent is the type of the function
+	// // that receives the import.meta.glob result, but the user is using it as
+	// // another type.
+	// return fetchContent as unknown as AstroGlobalPartial['fetchContent'];
+}

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -1,5 +1,4 @@
-import type { AstroComponentMetadata, Renderer } from '../../@types/astro';
-import type { AstroGlobalPartial, SSRResult, SSRElement } from '../../@types/astro';
+import type { AstroComponentMetadata, Renderer, AstroGlobalPartial, SSRResult, SSRElement } from '../../@types/astro';
 
 import shorthash from 'shorthash';
 import { extractDirectives, generateHydrateScript } from './hydration.js';
@@ -264,6 +263,7 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 /** Create the Astro.fetchContent() runtime function. */
 function createFetchContentFn(url: URL, site: URL) {
 	const fetchContent = (importMetaGlobResult: Record<string, any>) => {
+		// 	
 		let allEntries = [...Object.entries(importMetaGlobResult)];
 		if (allEntries.length === 0) {
 			throw new Error(`[${url.pathname}] Astro.fetchContent() no matches found.`);


### PR DESCRIPTION
## Changes

_**Note:** This is a work in progress! The purpose is to explore a few API cleanup proposals in parallel, as a part of the RFC process. When an RFC is created, it will be linked here._

- [ ] `getStaticPaths()` -> `export function setup() {}` 
- [x] `Astro.fetchContent()` -> `content()` 
- [ ] A way to pass data from `setup()` to the component (pass as prop?)

## Testing

- TODO

## Docs

- TODO