### PR TITLE
Fix a regression in vite.build() base option

### DIFF
--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -263,6 +263,10 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 
 /** Create the Astro.fetchContent() runtime function. */
 function createFetchContentFn(url: URL, site: URL) {
+	let sitePathname = site.pathname;
+	if(!sitePathname.endsWith('/')) {
+		sitePathname += '/';
+	}
 	const fetchContent = (importMetaGlobResult: Record<string, any>) => {
 		let allEntries = [...Object.entries(importMetaGlobResult)];
 		if (allEntries.length === 0) {
@@ -280,7 +284,7 @@ function createFetchContentFn(url: URL, site: URL) {
 					Content: mod.default,
 					content: mod.metadata,
 					file: new URL(spec, url),
-					url: urlSpec.includes('/pages/') ? urlSpec.replace(/^.*\/pages\//, site.pathname).replace(/(\/index)?\.md$/, '') : undefined,
+					url: urlSpec.includes('/pages/') ? urlSpec.replace(/^.*\/pages\//, sitePathname).replace(/(\/index)?\.md$/, '') : undefined,
 				};
 			})
 			.filter(Boolean);

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -264,9 +264,6 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 /** Create the Astro.fetchContent() runtime function. */
 function createFetchContentFn(url: URL, site: URL) {
 	let sitePathname = site.pathname;
-	if(!sitePathname.endsWith('/')) {
-		sitePathname += '/';
-	}
 	const fetchContent = (importMetaGlobResult: Record<string, any>) => {
 		let allEntries = [...Object.entries(importMetaGlobResult)];
 		if (allEntries.length === 0) {

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -15,7 +15,7 @@ describe('Static build', () => {
 			renderers: ['@astrojs/renderer-preact'],
 			buildOptions: {
 				experimentalStaticBuild: true,
-				site: 'http://example.com/subpath',
+				site: 'http://example.com/subpath/',
 			},
 			ssr: {
 				noExternal: ['@astrojs/test-static-build-pkg'],

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -15,6 +15,7 @@ describe('Static build', () => {
 			renderers: ['@astrojs/renderer-preact'],
 			buildOptions: {
 				experimentalStaticBuild: true,
+				site: 'http://example.com/subpath',
 			},
 			ssr: {
 				noExternal: ['@astrojs/test-static-build-pkg'],
@@ -24,20 +25,20 @@ describe('Static build', () => {
 	});
 
 	it('Builds out .astro pages', async () => {
-		const html = await fixture.readFile('/index.html');
+		const html = await fixture.readFile('/subpath/index.html');
 		expect(html).to.be.a('string');
 	});
 
 	it('can build pages using fetchContent', async () => {
-		const html = await fixture.readFile('/index.html');
+		const html = await fixture.readFile('/subpath/index.html');
 		const $ = cheerio.load(html);
 		const link = $('.posts a');
 		const href = link.attr('href');
-		expect(href).to.be.equal('/posts/thoughts');
+		expect(href).to.be.equal('/subpath/posts/thoughts');
 	});
 
 	it('Builds out .md pages', async () => {
-		const html = await fixture.readFile('/posts/thoughts/index.html');
+		const html = await fixture.readFile('/subpath/posts/thoughts/index.html');
 		expect(html).to.be.a('string');
 	});
 
@@ -62,12 +63,12 @@ describe('Static build', () => {
 		const findEvidence = createFindEvidence(/var\(--c\)/);
 
 		it('Included on the index page', async () => {
-			const found = await findEvidence('/index.html');
+			const found = await findEvidence('/subpath/index.html');
 			expect(found).to.equal(true, 'Did not find shared CSS on this page');
 		});
 
 		it('Included on a md page', async () => {
-			const found = await findEvidence('/posts/thoughts/index.html');
+			const found = await findEvidence('/subpath/posts/thoughts/index.html');
 			expect(found).to.equal(true, 'Did not find shared CSS on this page');
 		});
 	});
@@ -76,30 +77,30 @@ describe('Static build', () => {
 		const findEvidence = createFindEvidence(/var\(--c-black\)/);
 
 		it('Is included in the index CSS', async () => {
-			const found = await findEvidence('/index.html');
+			const found = await findEvidence('/subpath/index.html');
 			expect(found).to.equal(true, 'Did not find shared CSS module code');
 		});
 	});
 
 	describe('Hoisted scripts', () => {
 		it('Get bundled together on the page', async () => {
-			const html = await fixture.readFile('/hoisted/index.html');
+			const html = await fixture.readFile('/subpath/hoisted/index.html');
 			const $ = cheerio.load(html);
 			expect($('script[type="module"]').length).to.equal(1, 'hoisted script added');
 		});
 
 		it('Do not get added to the wrong page', async () => {
-			const hoistedHTML = await fixture.readFile('/hoisted/index.html');
+			const hoistedHTML = await fixture.readFile('/subpath/hoisted/index.html');
 			const $ = cheerio.load(hoistedHTML);
 			const href = $('script[type="module"]').attr('src');
-			const indexHTML = await fixture.readFile('/index.html');
+			const indexHTML = await fixture.readFile('/subpath/index.html');
 			const $$ = cheerio.load(indexHTML);
 			expect($$(`script[src="${href}"]`).length).to.equal(0, 'no script added to different page');
 		});
 	});
 
 	it('honors ssr config', async () => {
-		const html = await fixture.readFile('/index.html');
+		const html = await fixture.readFile('/subpath/index.html');
 		const $ = cheerio.load(html);
 		expect($('#ssr-config').text()).to.equal('testing');
 	});


### PR DESCRIPTION
## Changes

- Fixes this regression: https://github.com/withastro/astro/pull/2486/files#r795260099
- no changeset needed since this regression hasn't gone out yet

## Testing

- Does this need a test? Odd that none of our build tests caught this, since it feels like any buildOptions.site value would break this.

## Docs

- N/A