### PR TITLE
Fix issue rendering content within HTMLElement

### DIFF
--- a/.changeset/calm-suns-give.md
+++ b/.changeset/calm-suns-give.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix an issue rendering content within HTMLElement

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -441,7 +441,7 @@ export async function renderAstroComponent(component: InstanceType<typeof AstroC
 	return template;
 }
 
-export async function renderHTMLElement(result: SSRResult, constructor: typeof HTMLElement, props: any, children: any) {
+export async function renderHTMLElement(result: SSRResult, constructor: typeof HTMLElement, props: any, slots: any) {
 	const name = getHTMLElementName(constructor);
 
 	let attrHTML = '';
@@ -450,12 +450,7 @@ export async function renderHTMLElement(result: SSRResult, constructor: typeof H
 		attrHTML += ` ${attr}="${toAttributeString(await props[attr])}"`;
 	}
 
-	children = await children;
-	children = children == null ? children : '';
-
-	const html = `<${name}${attrHTML}>${children}</${name}>`;
-
-	return html;
+	return `<${name}${attrHTML}>${await renderSlot(result, slots?.default)}</${name}>`;
 }
 
 function getHTMLElementName(constructor: typeof HTMLElement) {


### PR DESCRIPTION
## Changes

- Updates `renderHTMLElement` method to support children like `renderComponent`.

## Testing

bug fix only

## Docs

bug fix only