### PR TITLE
Handles all http error code file names the same as 404 files.

### DIFF
--- a/packages/astro/src/core/ssr/sitemap.ts
+++ b/packages/astro/src/core/ssr/sitemap.ts
@@ -1,3 +1,5 @@
+const ERROR_STATUS_CODE_REGEXES = [ /400\/?$/,/401\/?$/,/402\/?$/,/403\/?$/,/404\/?$/,/405\/?$/,/406\/?$/,/407\/?$/,/408\/?$/,/409\/?$/,/410\/?$/,/411\/?$/,/412\/?$/,/413\/?$/,/414\/?$/,/415\/?$/,/416\/?$/,/417\/?$/,/418\/?$/,/421\/?$/,/422\/?$/,/423\/?$/,/424\/?$/,/425\/?$/,/426\/?$/,/428\/?$/,/429\/?$/,/431\/?$/,/451\/?$/,/500\/?$/,/501\/?$/,/502\/?$/,/503\/?$/,/504\/?$/,/505\/?$/,/506\/?$/,/507\/?$/,/508\/?$/,/510\/?$/,/511\/?$/ ];
+
 /** Construct sitemap.xml given a set of URLs */
 export function generateSitemap(pages: string[]): string {
 	// TODO: find way to respect <link rel="canonical"> URLs here
@@ -6,7 +8,8 @@ export function generateSitemap(pages: string[]): string {
 
 	// copy just in case original copy is needed
 	// make sure that 404 page is excluded
-	const urls = [...pages].filter((url) => !/404\/?$/.test(url));
+	// also works for other error pages
+	const urls = [...pages].filter((url) => !ERROR_STATUS_CODE_REGEXES.find((code) => code.test(url)));
 	urls.sort((a, b) => a.localeCompare(b, 'en', { numeric: true })); // sort alphabetically so sitemap is same each time
 	let sitemap = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
 	for (const url of urls) {

--- a/packages/astro/src/vite-plugin-build-html/index.ts
+++ b/packages/astro/src/vite-plugin-build-html/index.ts
@@ -25,7 +25,7 @@ const ASTRO_PAGE_PREFIX = '@astro-page';
 const ASTRO_SCRIPT_PREFIX = '@astro-script';
 
 const ASTRO_EMPTY = '@astro-empty';
-const STATUS_CODE_RE = /^404$/;
+const ERROR_STATUS_CODES = [ '400', '401', '402', '403', '404', '405', '406', '407', '408', '409', '410', '411', '412', '413', '414', '415', '416', '417', '418', '421', '422', '423', '424', '425', '426', '428', '429', '431', '451', '500', '501', '502', '503', '504', '505', '506', '507', '508', '510', '511' ];
 
 interface PluginOptions {
 	astroConfig: AstroConfig;
@@ -481,9 +481,9 @@ export function rollupPluginAstroBuildHTML(options: PluginOptions): VitePlugin {
 				const name = pathname.substr(1);
 				let outPath: string;
 
-				// Output directly to 404.html rather than 400/index.html
+				// Output directly to 404.html rather than 404/index.html
 				// Supports any other status codes, too
-				if (name.match(STATUS_CODE_RE) || astroConfig.buildOptions.pageUrlFormat === 'file') {
+				if (ERROR_STATUS_CODES.find(code =>  code === name) || astroConfig.buildOptions.pageUrlFormat === 'file') {
 					outPath = `${removeEndingForwardSlash(name || 'index')}.html`;
 				} else {
 					outPath = npath.posix.join(name, 'index.html');


### PR DESCRIPTION
## Changes

Handles all http error code file names the same as 404 files.
Fixes #2195.
- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
I don't think test changes are necessary, although if I knew how I would add extra tests to make sure that all of the HTTP status code files are generated correctly.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Bug fix only.
