### PR TITLE
add back dev server host support

### DIFF
--- a/.changeset/grumpy-chefs-judge.md
+++ b/.changeset/grumpy-chefs-judge.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix issue where hostname was not passed to dev server

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -24,7 +24,15 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 		exclude: 'window document',
 	});
 	// start the server
-	const viteUserConfig = vite.mergeConfig({ mode: 'development' }, config.vite || {});
+	const viteUserConfig = vite.mergeConfig(
+		{
+			mode: 'development',
+			server: {
+				host: config.devOptions.hostname,
+			},
+		},
+		config.vite || {}
+	);
 	const viteConfig = await createVite(viteUserConfig, { astroConfig: config, logging: options.logging });
 	const viteServer = await vite.createServer(viteConfig);
 	await viteServer.listen(config.devOptions.port);


### PR DESCRIPTION
## Changes

- Fixes an issue brought up in https://github.com/withastro/rfcs/discussions/80
- In the Vite server refactor we stopped sending the dev's host value to Vite
- @benjaminwy @jonathantneal 

## Testing

- We can't currently test for this since it will fail if the address is not available. Both of our current tests on this do test it _loosely,_ but I can't think of a better way to do it right now.

## Docs

- N/A