### PR TITLE
Append to list of HMR modules, don't override

### DIFF
--- a/.changeset/four-mirrors-wonder.md
+++ b/.changeset/four-mirrors-wonder.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes HMR of .astro modules in astro@next

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -49,7 +49,7 @@ export function handleHotUpdate(ctx: HmrContext, config: AstroConfig) {
 
 	// go through each of these modules importers and invalidate any .astro compilation
 	// that needs to be rerun.
-	const filtered = new Set<ModuleNode>();
+	const filtered = new Set<ModuleNode>(ctx.modules);
 	const files = new Set<string>();
 	for (const mod of ctx.modules) {
 		if (mod.file && isCached(config, mod.file)) {


### PR DESCRIPTION
## Changes

- When finding modules that should be HMRed, start with the list that has already been discovered by Vite.
- If you return from `handleHotUpdate` it overrides any existing modules to update. So you must append to the list, not just return new ones.
- Closes https://github.com/withastro/astro/issues/2528

## Testing

Tested via example apps.

## Docs

N/A, bug fix.