### PR TITLE
improve debug logs

### DIFF
--- a/.changeset/many-oranges-retire.md
+++ b/.changeset/many-oranges-retire.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve debug logs

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import type { AstroConfig } from '../@types/astro';
-import type { LogOptions } from '../core/logger.js';
+import { enableVerboseLogging, LogOptions } from '../core/logger.js';
 
 import * as colors from 'kleur/colors';
 import fs from 'fs';
@@ -83,9 +83,13 @@ export async function cli(args: string[]) {
 		dest: defaultLogDestination,
 		level: 'info',
 	};
+	if (flags.verbose) {
+		logging.level = 'debug';
+		enableVerboseLogging();
+	} else if (flags.silent) {
+		logging.level = 'silent';
+	}
 
-	if (flags.verbose) logging.level = 'debug';
-	if (flags.silent) logging.level = 'silent';
 	let config: AstroConfig;
 	try {
 		config = await loadConfig({ cwd: projectRoot, flags });

--- a/packages/astro/src/core/logger.ts
+++ b/packages/astro/src/core/logger.ts
@@ -89,6 +89,12 @@ export const levels: Record<LoggerLevel, number> = {
 	silent: 90,
 };
 
+export function enableVerboseLogging() {
+	debugPackage.enable('*,-babel'); 
+	debug('cli', '--verbose flag enabled! Enabling DEBUG="*,-babel"');
+	debug('cli', 'Set the DEBUG env variable directly for more control. Example: "DEBUG=astro:*,vite:* astro build".');
+}
+
 /** Full logging API */
 export function log(opts: LogOptions = {}, level: LoggerLevel, type: string | null, ...args: Array<any>) {
 	const logLevel = opts.level ?? defaultLogOptions.level;
@@ -118,7 +124,7 @@ const debuggers: Record<string, debugPackage.Debugger['log']> = {};
 export function debug(type: string, ...messages: Array<any>) {
 	const namespace = `astro:${type}`;
 	debuggers[namespace] = debuggers[namespace] || debugPackage(namespace);
-	return debuggers[namespace](messages);
+	return debuggers[namespace](...messages);
 }
 
 /** Emit a user-facing message. Useful for UI and other console messages. */

--- a/packages/astro/src/core/logger.ts
+++ b/packages/astro/src/core/logger.ts
@@ -91,8 +91,8 @@ export const levels: Record<LoggerLevel, number> = {
 
 export function enableVerboseLogging() {
 	debugPackage.enable('*,-babel'); 
-	debug('cli', '--verbose flag enabled! Enabling DEBUG="*,-babel"');
-	debug('cli', 'Set the DEBUG env variable directly for more control. Example: "DEBUG=astro:*,vite:* astro build".');
+	debug('cli', '--verbose flag enabled! Enabling: DEBUG="*,-babel"');
+	debug('cli', 'Tip: Set the DEBUG env variable directly for more control. Example: "DEBUG=astro:*,vite:* astro build".');
 }
 
 /** Full logging API */


### PR DESCRIPTION
## Changes

- Hooks up `--verbose` to new debugger, missed this in #2504 
- Improves formatting of debug messages, which previously were all arrays

## Testing

- N/A

## Docs

- N/A