### PR TITLE
fix: HTML/SVG boolean attributes

### DIFF
--- a/.changeset/shy-brooms-tell.md
+++ b/.changeset/shy-brooms-tell.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fix rendering of HTML boolean attributes like `open` and `async`. 
+
+Fix rendering of HTML and SVG enumerated attributes like `contenteditable` and `spellcheck`.

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -11,8 +11,9 @@ export { createMetadata } from './metadata.js';
 export { escapeHTML, unescapeHTML } from './escape.js';
 
 const voidElementNames = /^(area|base|br|col|command|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)$/i;
-const htmlBooleanAttributes = /^(allowfullscreen|async|autofocus|autoplay|controls|default|defer|disabled|disablepictureinpicture|disableremoteplayback|formnovalidate|hidden|loop|nomodule|novalidate|open|playsinline|readonly|required|reversed|scoped|seamless|itemscope)$/;
-const htmlEnumAttributes = /^(contenteditable|draggable|spellcheck|value)$/;
+const htmlBooleanAttributes = /^(allowfullscreen|async|autofocus|autoplay|controls|default|defer|disabled|disablepictureinpicture|disableremoteplayback|formnovalidate|hidden|loop|nomodule|novalidate|open|playsinline|readonly|required|reversed|scoped|seamless|itemscope)$/i;
+const htmlEnumAttributes = /^(contenteditable|draggable|spellcheck|value)$/i;
+// Note: SVG is case-sensitive!
 const svgEnumAttributes = /^(autoReverse|externalResourcesRequired|focusable|preserveAlpha)$/;
 
 // INVESTIGATE:

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -11,6 +11,9 @@ export { createMetadata } from './metadata.js';
 export { escapeHTML, unescapeHTML } from './escape.js';
 
 const voidElementNames = /^(area|base|br|col|command|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)$/i;
+const htmlBooleanAttributes = /^(allowfullscreen|async|autofocus|autoplay|controls|default|defer|disabled|disablepictureinpicture|disableremoteplayback|formnovalidate|hidden|loop|nomodule|novalidate|open|playsinline|readonly|required|reversed|scoped|seamless|itemscope)$/;
+const htmlEnumAttributes = /^(contenteditable|draggable|spellcheck|value)$/;
+const svgEnumAttributes = /^(autoReverse|externalResourcesRequired|focusable|preserveAlpha)$/;
 
 // INVESTIGATE:
 // 2. Less anys when possible and make it well known when they are needed.
@@ -327,8 +330,15 @@ const STATIC_DIRECTIVES = new Set(['set:html', 'set:text']);
 
 // A helper used to turn expressions into attribute key/value
 export function addAttribute(value: any, key: string) {
-	if (value == null || value === false) {
+	if (value == null) {
 		return '';
+	}
+
+	if (value === false) {
+		if (htmlEnumAttributes.test(key) || svgEnumAttributes.test(key)) {
+			return unescapeHTML(` ${key}="false"`);
+		}
+		return ''
 	}
 
 	// compiler directives cannot be applied dynamically, log a warning and ignore.
@@ -345,8 +355,8 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 		return unescapeHTML(` ${key.slice(0, -5)}="${toAttributeString(serializeListValue(value))}"`);
 	}
 
-	// Boolean only needs the key
-	if (value === true && key.startsWith('data-')) {
+	// Boolean values only need the key
+	if (value === true && (key.startsWith('data-') || htmlBooleanAttributes.test(key))) {
 		return unescapeHTML(` ${key}`);
 	} else {
 		return unescapeHTML(` ${key}="${toAttributeString(value)}"`);

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -14,7 +14,7 @@ const voidElementNames = /^(area|base|br|col|command|embed|hr|img|input|keygen|l
 const htmlBooleanAttributes = /^(allowfullscreen|async|autofocus|autoplay|controls|default|defer|disabled|disablepictureinpicture|disableremoteplayback|formnovalidate|hidden|loop|nomodule|novalidate|open|playsinline|readonly|required|reversed|scoped|seamless|itemscope)$/i;
 const htmlEnumAttributes = /^(contenteditable|draggable|spellcheck|value)$/i;
 // Note: SVG is case-sensitive!
-const svgEnumAttributes = /^(autoReverse|externalResourcesRequired|focusable|preserveAlpha)$/;
+const svgEnumAttributes = /^(autoReverse|externalResourcesRequired|focusable|preserveAlpha)$/i;
 
 // INVESTIGATE:
 // 2. Less anys when possible and make it well known when they are needed.


### PR DESCRIPTION
## Changes

- HTML has a number of attributes that should be treated as booleans. That is, if passed a value of `true`, they should be present with just the key. Examples include `open` and `async`, among others.
- HTML and SVG also have a number of attributes that should be coerced to strings. That is, if passed a value of `true`, they should have a value of `"true"`. If passed a value of `false`, they should have a literal value of `"false"`.
- This PR updates our attribute rendering logic to account for these.

## Testing

No tests added, but I should!

## Docs

Bug fix only
