### PR TITLE
Improve error handling

### DIFF
--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -211,6 +211,10 @@ There ${plural ? 'are' : 'is'} ${renderers.length} renderer${plural ? 's' : ''} 
 but ${plural ? 'none were' : 'it was not'} able to server-side render ${metadata.displayName}.
 
 Did you mean to enable ${formatList(probableRendererNames.map((r) => '`' + r + '`'))}?`);
+			} else if (matchingRenderers.length === 1) {
+				// We already know that renderer.ssr.check() has failed
+				// but this will throw a much more descriptive error!
+				renderer = matchingRenderers[0];
 			} else {
 				throw new Error(`Unable to render ${metadata.displayName}!
 

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -215,6 +215,7 @@ Did you mean to enable ${formatList(probableRendererNames.map((r) => '`' + r + '
 				// We already know that renderer.ssr.check() has failed
 				// but this will throw a much more descriptive error!
 				renderer = matchingRenderers[0];
+				({ html } = await renderer.ssr.renderToStaticMarkup(Component, props, children));
 			} else {
 				throw new Error(`Unable to render ${metadata.displayName}!
 


### PR DESCRIPTION
## Changes

- Improves error messages when matching renderers can be guessed, like if there is only a single renderer or a `.vue` file throws when `@astrojs/renderer-vue` is enabled.

**Before**

<img width="1096" alt="Screen Shot 2022-02-04 at 5 35 59 PM" src="https://user-images.githubusercontent.com/7118177/152617181-ef46692c-b795-4ebf-b90b-cbdb2edcf1bb.png">

**After**

<img width="1307" alt="Screen Shot 2022-02-04 at 5 37 13 PM" src="https://user-images.githubusercontent.com/7118177/152617207-3741a7c9-0b58-4398-b800-c70bf71d58a2.png">

## Testing

Manually

## Docs

QoL improvement
