### PR TITLE
Delete robots.txt

### DIFF
--- a/examples/starter/public/robots.txt
+++ b/examples/starter/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /

--- a/examples/starter/src/components/Tour.astro
+++ b/examples/starter/src/components/Tour.astro
@@ -16,8 +16,8 @@ import { Markdown } from 'astro/components';
 			```
 			/
 			├── public/
-			│   ├── robots.txt
 			│   └── favicon.ico
+			│
 			├── src/
 			│   ├── components/
 			│   │   └── Tour.astro

--- a/examples/starter/src/components/Tour.astro
+++ b/examples/starter/src/components/Tour.astro
@@ -17,7 +17,6 @@ import { Markdown } from 'astro/components';
 			/
 			├── public/
 			│   └── favicon.ico
-			│
 			├── src/
 			│   ├── components/
 			│   │   └── Tour.astro


### PR DESCRIPTION
## Changes

Removes `robots.txt` from the starter example. `Disallow: /` is not a great default value, and the file doesn't serve much purpose.
From @Princesseuh:
> Hmm, I feel like the file just shouldn't be there. There's already a `favicon.ico` that shows how the folder work in addition of actually being useful, whereas the `robots.txt` effectively isn't useful to the starter

The file has also been removed from other examples (for example, `minimal`).

## Testing
No testing

## Docs
No docs update required
