### PR TITLE
adding test coverage for boolean and enum HTML attributes

### DIFF
--- a/packages/astro/test/astro-attrs.test.js
+++ b/packages/astro/test/astro-attrs.test.js
@@ -15,18 +15,25 @@ describe('Attributes', async () => {
 		const $ = cheerio.load(html);
 
 		const attrs = {
-			'false-str': 'false',
-			'true-str': 'true',
-			false: undefined,
-			true: 'true',
-			empty: '',
-			null: undefined,
-			undefined: undefined,
+			'false-str': { attribute: 'attr', value: 'false' },
+			'true-str': { attribute: 'attr', value: 'true' },
+			false: { attribute: 'attr', value: undefined },
+			true: { attribute: 'attr', value: 'true' },
+			empty: { attribute: 'attr', value: '' },
+			null: { attribute: 'attr', value: undefined },
+			undefined: { attribute: 'attr', value: undefined },
+			'html-boolean': { attribute: 'async', value: 'async' },
+			'html-boolean-true': { attribute: 'async', value: 'async' },
+			'html-boolean-false': { attribute: 'async', value: undefined },
+			'html-enum': { attribute: 'draggable', value: 'true' },
+			'html-enum-true': { attribute: 'draggable', value: 'true' },
+			'html-enum-false': { attribute: 'draggable', value: 'false' },
 		};
 
-		for (const [k, v] of Object.entries(attrs)) {
-			const attr = $(`#${k}`).attr('attr');
-			expect(attr).to.equal(v);
+		for (const id of Object.keys(attrs)) {
+			const { attribute, value } = attrs[id]
+			const attr = $(`#${id}`).attr(attribute);
+			expect(attr).to.equal(value);
 		}
 	});
 

--- a/packages/astro/test/fixtures/astro-attrs/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-attrs/src/pages/index.astro
@@ -5,4 +5,17 @@
 <span id="empty" attr="" />
 <span id="null" attr={null} />
 <span id="undefined" attr={undefined} />
-
+<!--
+    Per HTML spec, some attributes should be treated as booleans
+    These should always render <span async /> or <span /> (without a string value)
+-->
+<span id='html-boolean' async />
+<span id='html-boolean-true' async={true} />
+<span id='html-boolean-false' async={false} />
+<!--
+    Other attributes should be treated as string enums
+    These should always render <span draggable="true" /> or <span draggable="false" />
+-->
+<span id='html-enum' draggable='true' />
+<span id='html-enum-true' draggable={true} />
+<span id='html-enum-false' draggable={false} />


### PR DESCRIPTION
## Changes

Adds a few test cases to cover the fix for PR #2538, no production code updates

## Testing

Adds a handful of tests to verify that boolean and enum HTML attributes are being serialized properly

## Docs

test updates only (no docs changes)
