### PR TITLE
Update smoke tests to include external docs and www

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 .DS_Store
 .vercel
 _site/
+scripts/smoke/*-main/
 *.log
 package-lock.json
 .turbo/

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "examples/component/demo",
     "examples/component/packages/*",
     "scripts",
+    "scripts/smoke/*",
     "packages/astro/test/fixtures/builtins/packages/*",
     "packages/astro/test/fixtures/builtins-polyfillnode",
     "packages/astro/test/fixtures/custom-elements/my-component-lib",

--- a/scripts/jsconfig.json
+++ b/scripts/jsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "strict": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "target": "esnext"
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,6 +8,7 @@
     "astro-scripts": "./index.js"
   },
   "dependencies": {
+    "adm-zip": "^0.5.9",
     "arg": "^5.0.0",
     "esbuild": "0.13.7",
     "globby": "^12.0.2",

--- a/scripts/smoke/cleanup.js
+++ b/scripts/smoke/cleanup.js
@@ -18,28 +18,11 @@ const scriptDir = new URL('./', import.meta.url);
 /** URL directory containing the entire project. */
 const rootDir = new URL('../../', import.meta.url);
 
-/* Functionality
-/* ========================================================================== */
-
-/** Returns all child directories of the given directory. */
-const getChildDirectories = async (/** @type {URL} */ dir) => {
-	/** @type {URL[]} */
-	const dirs = [];
-
-	for await (const dirent of await fs.opendir(dir)) {
-		if (dirent.isDirectory()) {
-			dirs.push(new URL(dirent.name, dir));
-		}
-	}
-
-	return dirs;
-};
-
 /* Application
 /* ========================================================================== */
 
 /** Runs all smoke tests. */
-export default async function run() {
+async function run() {
 	const dirs = await getChildDirectories(scriptDir)
 
 	if (dirs.length) {
@@ -58,5 +41,25 @@ export default async function run() {
 
 	await execa('yarn', [], { cwd: fileURLToPath(rootDir), stdout: 'inherit', stderr: 'inherit' });
 }
+
+/* Functionality
+/* ========================================================================== */
+
+/** Returns all child directories of the given directory. */
+const getChildDirectories = async (/** @type {URL} */ dir) => {
+	/** @type {URL[]} */
+	const dirs = [];
+
+	for await (const dirent of await fs.opendir(dir)) {
+		if (dirent.isDirectory()) {
+			dirs.push(new URL(dirent.name, dir));
+		}
+	}
+
+	return dirs;
+};
+
+/* Execution
+/* -------------------------------------------------------------------------- */
 
 run();

--- a/scripts/smoke/cleanup.js
+++ b/scripts/smoke/cleanup.js
@@ -1,0 +1,62 @@
+/** @file Remove all smoke tests and may remove extra smoke-test dependencies from `yarn.lock`. */
+
+// @ts-check
+
+import { execa } from 'execa';
+import { polyfill } from '@astropub/webapi';
+import { fileURLToPath } from 'node:url';
+import { promises as fs } from 'node:fs';
+
+polyfill(globalThis, { exclude: 'window document' });
+
+/* Configuration
+/* ========================================================================== */
+
+/** URL directory containing this current script. */
+const scriptDir = new URL('./', import.meta.url);
+
+/** URL directory containing the entire project. */
+const rootDir = new URL('../../', import.meta.url);
+
+/* Functionality
+/* ========================================================================== */
+
+/** Returns all child directories of the given directory. */
+const getChildDirectories = async (/** @type {URL} */ dir) => {
+	/** @type {URL[]} */
+	const dirs = [];
+
+	for await (const dirent of await fs.opendir(dir)) {
+		if (dirent.isDirectory()) {
+			dirs.push(new URL(dirent.name, dir));
+		}
+	}
+
+	return dirs;
+};
+
+/* Application
+/* ========================================================================== */
+
+/** Runs all smoke tests. */
+export default async function run() {
+	const dirs = await getChildDirectories(scriptDir)
+
+	if (dirs.length) {
+		console.log()
+
+		for (const dir of await getChildDirectories(scriptDir)) {
+			console.log('🤖', 'Removing', dir.pathname.split('/').at(-1));
+
+			fs.rm(dir, { force: true, recursive: true })
+		}
+	}
+
+	console.log()
+
+	console.log('🤖', 'Resetting', 'yarn');
+
+	await execa('yarn', [], { cwd: fileURLToPath(rootDir), stdout: 'inherit', stderr: 'inherit' });
+}
+
+run();

--- a/scripts/smoke/index.js
+++ b/scripts/smoke/index.js
@@ -1,34 +1,93 @@
 /** @todo migrate these to use the independent docs repository at https://github.com/withastro/docs */
 
-import fs from 'fs';
-import { execa } from 'execa';
-import { fileURLToPath } from 'url';
-import path from 'path';
-
 // NOTE: Only needed for Windows, due to a Turbo bug.
 // Once Turbo works on Windows, we can remove this script
 // and update our CI to run through Turbo.
 
-export default async function run() {
-	const examplesUrl = new URL('../../examples/', import.meta.url);
-	const examplesToTest = fs
-		.readdirSync(examplesUrl)
-		.map((filename) => new URL(filename, examplesUrl))
-		.filter((fileUrl) => fs.statSync(fileUrl).isDirectory());
-	const allProjectsToTest = [...examplesToTest, new URL('../../docs', import.meta.url)];
+// @ts-check
 
+import Zip from 'adm-zip';
+import { execa } from 'execa';
+import { polyfill } from '@astropub/webapi';
+import { fileURLToPath } from 'node:url';
+import { promises as fs } from 'node:fs';
+
+polyfill(globalThis, { exclude: 'window document' });
+
+const currentDir = new URL('./', import.meta.url);
+
+/** Returns the URL to the ZIP of the given GitHub project. */
+const getGitHubZipURL = (/** @type {GitHubZipOpts} */ opts) => `https://github.com/${opts.org}/${opts.name}/archive/refs/heads/${opts.branch}.zip`;
+
+/** Returns the awaited ZIP Buffer from the given GitHub project. */
+const fetchGitHubZip = (/** @type {GitHubZipOpts} */ opts) =>
+	fetch(getGitHubZipURL(opts))
+		.then((response) => response.arrayBuffer())
+		.then((arrayBuffer) => Buffer.from(arrayBuffer));
+
+/** Downloads a ZIP from the given GitHub project. */
+const downloadGitHubZip = async (/** @type {GitHubZipOpts} */ opts) => {
+	/** Expected directory when the zip is downloaded. */
+	const expectedDir = new URL(`${opts.name}-${opts.branch}`, currentDir);
+
+	/** Whether the expected directory is already available */
+	const hasExpectedDir = await fs.stat(expectedDir).then(
+		(stats) => stats.isDirectory(),
+		() => false
+	);
+
+	if (!hasExpectedDir) {
+		console.log('🤖', 'Downloading', `${opts.org}/${opts.name}#${opts.branch}`);
+
+		const buffer = await fetchGitHubZip(opts);
+
+		console.log('🤖', 'Extracting', `${opts.org}/${opts.name}#${opts.branch}`);
+
+		new Zip(buffer).extractAllTo(fileURLToPath(currentDir), true);
+
+		console.log('🤖', 'Preparing', `${opts.org}/${opts.name}#${opts.branch}`);
+		await execa('yarn', [], { cwd: fileURLToPath(expectedDir), stdout: 'inherit', stderr: 'inherit' });
+	}
+
+	return expectedDir;
+};
+
+/** Returns all child directories of the given directory. */
+const getDirectories = async (/** @type {URL} */ dir) => {
+	/** @type {URL[]} */
+	const dirs = [];
+
+	for await (const dirent of await fs.opendir(dir)) {
+		if (dirent.isDirectory()) {
+			dirs.push(new URL(dirent.name, dir));
+		}
+	}
+
+	return dirs;
+};
+
+/** Runs all smoke tests. */
+export default async function run() {
 	console.log('');
-	for (const projectToTest of allProjectsToTest) {
-		const filePath = fileURLToPath(projectToTest);
-		console.log('  🤖 Testing', filePath, '\n');
+
+	const directories = await getDirectories(new URL('../../examples/', import.meta.url));
+
+	directories.push(await downloadGitHubZip({ org: 'withastro', name: 'docs', branch: 'main' }), await downloadGitHubZip({ org: 'withastro', name: 'astro.build', branch: 'main' }));
+
+	for (const directory of directories) {
+		console.log('🤖', 'Testing', directory.pathname.split('/').at(-1));
+
 		try {
-			await execa('yarn', ['build'], { cwd: fileURLToPath(projectToTest), stdout: 'inherit', stderr: 'inherit' });
+			await execa('yarn', ['build'], { cwd: fileURLToPath(directory), stdout: 'inherit', stderr: 'inherit' });
 		} catch (err) {
 			console.log(err);
 			process.exit(1);
 		}
-		console.log('\n  🤖 Test complete.');
+
+		console.log();
 	}
 }
 
 run();
+
+/** @typedef {{ org: string, name: string, branch: string }} GitHubZipOpts */

--- a/scripts/smoke/index.js
+++ b/scripts/smoke/index.js
@@ -1,4 +1,4 @@
-/** @todo migrate these to use the independent docs repository at https://github.com/withastro/docs */
+/** @file Runs all smoke tests and may add extra smoke-test dependencies to `yarn.lock`. */
 
 // @ts-check
 
@@ -10,46 +10,91 @@ import { promises as fs } from 'node:fs';
 
 polyfill(globalThis, { exclude: 'window document' });
 
-const currentDir = new URL('./', import.meta.url);
+/* Configuration
+/* ========================================================================== */
+
+/** URL directory containing this current script. */
+const scriptDir = new URL('./', import.meta.url);
+
+/** URL directory containing the entire project. */
+const rootDir = new URL('../../', import.meta.url);
+
+/** URL directory containing the example subdirectories. */
+const exampleDir = new URL('examples/', rootDir);
+
+/** URL directory containing the Astro package. */
+const astroDir = new URL('packages/astro/', rootDir);
+
+/** GitHub configuration for the external "docs" Astro project. */
+const docGithubConfig = { org: 'withastro', name: 'docs', branch: 'main' };
+
+/** GitHub configuration for the external "astro.build" Astro project. */
+const wwwGithubConfig = { org: 'withastro', name: 'astro.build', branch: 'main' };
+
+/* Functionality
+/* ========================================================================== */
 
 /** Returns the URL to the ZIP of the given GitHub project. */
-const getGitHubZipURL = (/** @type {GitHubZipOpts} */ opts) => `https://github.com/${opts.org}/${opts.name}/archive/refs/heads/${opts.branch}.zip`;
+const getGithubZipURL = (/** @type {GithubOpts} */ opts) => `https://github.com/${opts.org}/${opts.name}/archive/refs/heads/${opts.branch}.zip`;
 
 /** Returns the awaited ZIP Buffer from the given GitHub project. */
-const fetchGitHubZip = (/** @type {GitHubZipOpts} */ opts) =>
-	fetch(getGitHubZipURL(opts))
+const fetchGithubZip = (/** @type {GithubOpts} */ opts) =>
+	fetch(getGithubZipURL(opts))
 		.then((response) => response.arrayBuffer())
 		.then((arrayBuffer) => Buffer.from(arrayBuffer));
 
 /** Downloads a ZIP from the given GitHub project. */
-const downloadGitHubZip = async (/** @type {GitHubZipOpts} */ opts) => {
+const downloadGithubZip = async (/** @type {GithubOpts} */ opts) => {
 	/** Expected directory when the zip is downloaded. */
-	const expectedDir = new URL(`${opts.name}-${opts.branch}`, currentDir);
+	const githubDir = new URL(`${opts.name}-${opts.branch}`, scriptDir);
 
 	/** Whether the expected directory is already available */
-	const hasExpectedDir = await fs.stat(expectedDir).then(
+	const hasGithubDir = await fs.stat(githubDir).then(
 		(stats) => stats.isDirectory(),
 		() => false
 	);
 
-	if (!hasExpectedDir) {
+	if (!hasGithubDir) {
 		console.log('🤖', 'Downloading', `${opts.org}/${opts.name}#${opts.branch}`);
 
-		const buffer = await fetchGitHubZip(opts);
+		const buffer = await fetchGithubZip(opts);
 
 		console.log('🤖', 'Extracting', `${opts.org}/${opts.name}#${opts.branch}`);
 
-		new Zip(buffer).extractAllTo(fileURLToPath(currentDir), true);
+		new Zip(buffer).extractAllTo(fileURLToPath(scriptDir), true);
 
 		console.log('🤖', 'Preparing', `${opts.org}/${opts.name}#${opts.branch}`);
-		await execa('yarn', [], { cwd: fileURLToPath(expectedDir), stdout: 'inherit', stderr: 'inherit' });
+
+		const astroPackage = await readDirectoryPackage(astroDir);
+
+		const githubPackage = await readDirectoryPackage(githubDir);
+
+		if ('astro' in Object(githubPackage.dependencies)) {
+			githubPackage.dependencies['astro'] = astroPackage.version;
+		}
+
+		if ('astro' in Object(githubPackage.devDependencies)) {
+			githubPackage.devDependencies['astro'] = astroPackage.version;
+		}
+
+		if ('astro' in Object(githubPackage.peerDependencies)) {
+			githubPackage.peerDependencies['astro'] = astroPackage.version;
+		}
+
+		await writeDirectoryPackage(githubDir, githubPackage);
 	}
 
-	return expectedDir;
+	return githubDir;
 };
 
+/** Returns the parsed package.json of the given directory. */
+const readDirectoryPackage = async (/** @type {URL} */ dir) => JSON.parse(await fs.readFile(new URL('package.json', dir + '/'), 'utf-8'));
+
+/** Returns upon completion of writing a package.json to the given directory. */
+const writeDirectoryPackage = async (/** @type {URL} */ dir, /** @type {any} */ data) => await fs.writeFile(new URL('package.json', dir + '/'), JSON.stringify(data, null, '  ') + '\n');
+
 /** Returns all child directories of the given directory. */
-const getDirectories = async (/** @type {URL} */ dir) => {
+const getChildDirectories = async (/** @type {URL} */ dir) => {
 	/** @type {URL[]} */
 	const dirs = [];
 
@@ -62,13 +107,20 @@ const getDirectories = async (/** @type {URL} */ dir) => {
 	return dirs;
 };
 
+/* Application
+/* ========================================================================== */
+
 /** Runs all smoke tests. */
 export default async function run() {
 	console.log('');
 
-	const directories = await getDirectories(new URL('../../examples/', import.meta.url));
+	const directories = await getChildDirectories(exampleDir);
 
-	directories.push(await downloadGitHubZip({ org: 'withastro', name: 'docs', branch: 'main' }), await downloadGitHubZip({ org: 'withastro', name: 'astro.build', branch: 'main' }));
+	directories.push(await downloadGithubZip(docGithubConfig), await downloadGithubZip(wwwGithubConfig));
+
+	console.log('🤖', 'Preparing', 'yarn');
+
+	await execa('yarn', [], { cwd: fileURLToPath(rootDir), stdout: 'inherit', stderr: 'inherit' });
 
 	for (const directory of directories) {
 		console.log('🤖', 'Testing', directory.pathname.split('/').at(-1));
@@ -77,6 +129,7 @@ export default async function run() {
 			await execa('yarn', ['build'], { cwd: fileURLToPath(directory), stdout: 'inherit', stderr: 'inherit' });
 		} catch (err) {
 			console.log(err);
+
 			process.exit(1);
 		}
 
@@ -86,4 +139,4 @@ export default async function run() {
 
 run();
 
-/** @typedef {{ org: string, name: string, branch: string }} GitHubZipOpts */
+/** @typedef {{ org: string, name: string, branch: string }} GithubOpts */

--- a/scripts/smoke/index.js
+++ b/scripts/smoke/index.js
@@ -1,9 +1,5 @@
 /** @todo migrate these to use the independent docs repository at https://github.com/withastro/docs */
 
-// NOTE: Only needed for Windows, due to a Turbo bug.
-// Once Turbo works on Windows, we can remove this script
-// and update our CI to run through Turbo.
-
 // @ts-check
 
 import Zip from 'adm-zip';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2286,6 +2286,11 @@ acorn@^8.6.0, acorn@^8.7.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
+adm-zip@^0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.9.tgz#b33691028333821c0cf95c31374c5462f2905a83"
+  integrity sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==
+
 agent-base@6, agent-base@^6.0.0, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"


### PR DESCRIPTION
## Changes

- Updates smoke tests to include external `docs` and `www`.

## Testing

Adds tests for the externalized `docs` and `www` main branches.

## Docs

testing only