### PR TITLE
Add filter for sitemap

### DIFF
--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -148,7 +148,7 @@ class AstroBuilder {
 		// Build your final sitemap.
 		if (this.config.buildOptions.sitemap && this.config.buildOptions.site) {
 			timer.sitemapStart = performance.now();
-			const sitemap = generateSitemap(pageNames.map((pageName) => new URL(pageName, this.config.buildOptions.site).href));
+			const sitemap = generateSitemap(pageNames.map((pageName) => new URL(pageName, this.config.buildOptions.site).href), this.config.buildOptions.sitemapFilter);
 			const sitemapPath = new URL('./sitemap.xml', this.config.dist);
 			await fs.promises.mkdir(new URL('./', sitemapPath), { recursive: true });
 			await fs.promises.writeFile(sitemapPath, sitemap, 'utf8');

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -57,6 +57,7 @@ export const AstroConfigSchema = z.object({
 				.string()
 				.optional()
 				.transform((val) => (val ? addTrailingSlash(val) : val)),
+			sitemapFilter: z.function().optional(),
 			sitemap: z.boolean().optional().default(true),
 			pageUrlFormat: z
 				.union([z.literal('file'), z.literal('directory')])

--- a/packages/astro/src/core/ssr/sitemap.ts
+++ b/packages/astro/src/core/ssr/sitemap.ts
@@ -1,15 +1,18 @@
 const STATUS_CODE_PAGE_REGEXP = /\/[0-9]{3}\/?$/;
 
 /** Construct sitemap.xml given a set of URLs */
-export function generateSitemap(pages: string[]): string {
+export function generateSitemap(pages: string[], filter: (page: string) => boolean): string {
 	// TODO: find way to respect <link rel="canonical"> URLs here
-
-	// TODO: find way to exclude pages from sitemap
 
 	// copy just in case original copy is needed
 	// make sure that 404 page is excluded
 	// also works for other error pages
-	const urls = [...pages].filter((url) => !STATUS_CODE_PAGE_REGEXP.test(url));
+	let urls = [...pages].filter((url) => !STATUS_CODE_PAGE_REGEXP.test(url));
+
+	if (filter) {
+		urls = urls.filter(url => filter(url));
+	}
+
 	urls.sort((a, b) => a.localeCompare(b, 'en', { numeric: true })); // sort alphabetically so sitemap is same each time
 	let sitemap = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
 	for (const url of urls) {


### PR DESCRIPTION
## Changes

Allows to filter the results in the sitemap.xml, configured via astro.config.mjs

```
export default /** @type {import('astro').AstroUserConfig} */ ({
    ...
    buildOptions: {
        sitemap: true,
        siteMapFilter: (page) => !page.includes('secret-page')
    },
    ...
```

## Testing

No existing sitemap tests found
Known issue in [config.ts](https://github.com/withastro/astro/compare/main...davidrot:main#diff-376630862e295fd5d974f4fff5419d9cb97c8f88f1a180092917500fb62b28ff) zod is not allowing undefined. What is the value to define it correct? 

## Docs

No user facing change
