### PR TITLE
Fixes pageUrlFormat: 'file' in static build

### DIFF
--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -395,7 +395,7 @@ function getOutFolder(astroConfig: AstroConfig, pathname: string): URL {
 		case 'directory':
 			return new URL('.' + appendForwardSlash(pathname), outRoot);
 		case 'file':
-			return outRoot;
+			return new URL('.' + appendForwardSlash(npath.dirname(pathname)), outRoot);
 	}
 }
 
@@ -404,7 +404,7 @@ function getOutFile(astroConfig: AstroConfig, outFolder: URL, pathname: string):
 		case 'directory':
 			return new URL('./index.html', outFolder);
 		case 'file':
-			return new URL('.' + pathname + '.html', outFolder);
+			return new URL('./' + npath.basename(pathname) + '.html', outFolder);
 	}
 }
 

--- a/packages/astro/test/fixtures/static-build-page-url-format/src/pages/one.astro
+++ b/packages/astro/test/fixtures/static-build-page-url-format/src/pages/one.astro
@@ -1,0 +1,4 @@
+<html>
+<head><title>One</title></head>
+<body><h1>Testing</h1></body>
+</html>

--- a/packages/astro/test/fixtures/static-build-page-url-format/src/pages/sub/page.astro
+++ b/packages/astro/test/fixtures/static-build-page-url-format/src/pages/sub/page.astro
@@ -1,0 +1,4 @@
+<html>
+<head><title>Subpath</title></head>
+<body><h1>Testing</h1></body>
+</html>

--- a/packages/astro/test/static-build-page-url-format.test.js
+++ b/packages/astro/test/static-build-page-url-format.test.js
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+function addLeadingSlash(path) {
+	return path.startsWith('/') ? path : '/' + path;
+}
+
+describe('Static build - pageUrlFormat: \'file\'', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			projectRoot: './fixtures/static-build-page-url-format/',
+			renderers: [],
+			buildOptions: {
+				experimentalStaticBuild: true,
+				site: 'http://example.com/subpath/',
+				pageUrlFormat: 'file'
+			},
+		});
+		await fixture.build();
+	});
+
+	it('Builds pages in root', async () => {
+		const html = await fixture.readFile('/subpath/one.html');
+		expect(html).to.be.a('string');
+	});
+
+	it('Builds pages in subfolders', async () => {
+		const html = await fixture.readFile('/subpath/sub/page.html');
+		expect(html).to.be.a('string');
+	});
+});


### PR DESCRIPTION
## Changes

- Bug fix for `pageUrlFormat: 'file'` in the static build.

## Testing

Tests added

## Docs

Bug fix only