### PR TITLE
Use noExternal config on 'astro'

### DIFF
--- a/.changeset/soft-mayflies-warn.md
+++ b/.changeset/soft-mayflies-warn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes bug with astro/components not loading in the next release

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -25,6 +25,9 @@ const ALWAYS_EXTERNAL = new Set([
 	'unified',
 	'whatwg-url',
 ]);
+const ALWAYS_NOEXTERNAL = new Set([
+	'astro', // This is only because Vite's native ESM doesn't resolve "exports" correctly.
+]);
 
 // note: ssr is still an experimental API hence the type omission
 export type ViteConfigWithSSR = vite.InlineConfig & { ssr?: { external?: string[]; noExternal?: string[] } };
@@ -69,7 +72,7 @@ export async function createVite(inlineConfig: ViteConfigWithSSR, { astroConfig,
 		// Note: SSR API is in beta (https://vitejs.dev/guide/ssr.html)
 		ssr: {
 			external: [...ALWAYS_EXTERNAL],
-			noExternal: [],
+			noExternal: [...ALWAYS_NOEXTERNAL],
 		},
 	};
 


### PR DESCRIPTION
## Changes

- Reverts the change that happened here: https://github.com/withastro/astro/commit/1abb9ed0800989f47351cc916f19fd8e0672e2c0#diff-025f8338e5be413b0f65c74bc50d6484c6bc9bb4f78847da0ba896b8e9569390L28-L30
- Fixes #2567
- 'astro' has to be set to `noExternal` because we cannot set just `astro/components` to noExternal. astro/components must be noExternal so that it's built with Vite.

## Testing

Not testable as this only happens outside of the monorepo.

## Docs

Bug fix
