### PR TITLE
Move SASS to devDependencies

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -92,7 +92,6 @@
     "rehype-slug": "^5.0.0",
     "resolve": "^1.20.0",
     "rollup": "^2.64.0",
-    "sass": "^1.49.0",
     "semver": "^7.3.5",
     "send": "^0.17.1",
     "serialize-javascript": "^6.0.0",
@@ -125,7 +124,8 @@
     "chai": "^4.3.4",
     "cheerio": "^1.0.0-rc.10",
     "execa": "^6.0.0",
-    "mocha": "^9.1.3"
+    "mocha": "^9.1.3",
+    "sass": "^1.49.0"
   },
   "engines": {
     "node": "^14.15.0 || >=16.0.0",


### PR DESCRIPTION
## Changes

Move SASS to be a devDependency instead of a normal dependency. The reason for this change is that we shouldn't be shipping SASS ourselves, not only does both the Astro and the Vite documentation says to manually add it to your project but I also think that it's useless to be shipping it ourselves when in reality, probably only a minority of our users uses it (this makes Astro about 5mb smaller for most people!)

For context, here's what the current docs says about it:

> Sass: Run npm install -D sass and use <style lang="scss"> or <style lang="sass"> (indented) in .astro files
Stylus: Run npm install -D stylus and use <style lang="styl"> or <style lang="stylus"> in .astro files
Less: Run npm install -D less and use <style lang="less"> in .astro files.

Users who don't have it installed will simply get an error saying to install SASS, so users experiencing issues due to this will easily be able to migrate to the new setup needed to get SASS working

It's still needed as a DevDependency however as we have a test that uses it

## Testing

Ran tests and everything worked, including the SASS test

## Docs

No docs needed as the current docs are accurate on this
