### PR TITLE
Support non-HTML pages

### DIFF
--- a/.changeset/few-coats-warn.md
+++ b/.changeset/few-coats-warn.md
@@ -2,11 +2,13 @@
 'astro': patch
 ---
 
-RFC 0006: Support for non-HTML pages
+Support for non-HTML pages
 
-This adds support for generating non-HTML pages form `.js` and `.ts` pages during the build.
+> ⚠️ This feature is currently only supported with the `--experimental-static-build` CLI flag. This feature may be refined over the next few weeks/months as SSR support is finalized.
 
-> ⚠️ This API is part of static site generation! Keep an eye out for future releases with SSR support to handle building pages on-demand from an Astro server(less) function.
+This adds support for generating non-HTML pages form `.js` and `.ts` pages during the build. Buitl file and extensions are based on the source file's name, ex: `src/pages/data.json.ts` will be built to `dist/data.json`.
+
+**Is this different from SSR?** Yes! This feature allows JSON, XML, etc. files to be output at build time. Keep an eye out for full SSR support if you need to build similar files when requested, for example as a serverless function in your deployment host.
 
 ## Examples
 

--- a/.changeset/few-coats-warn.md
+++ b/.changeset/few-coats-warn.md
@@ -1,0 +1,42 @@
+---
+'astro': patch
+---
+
+RFC 0006: Support for non-HTML pages
+
+This adds support for generating non-HTML pages form `.js` and `.ts` pages during the build.
+
+> ⚠️ This API is part of static site generation! Keep an eye out for future releases with SSR support to handle building pages on-demand from an Astro server(less) function.
+
+## Examples
+
+```typescript
+// src/pages/company.json.ts
+export async function get() {
+    return {
+        body: JSON.stringify({
+            name: 'Astro Technology Company',
+            url: 'https://astro.build/'
+        })
+    }
+}
+```
+
+What about `getStaticPaths()`?  It **just works**™.
+
+```typescript
+export async function getStaticPaths() {
+    return [
+        { params: { slug: 'thing1' }},
+        { params: { slug: 'thing2' }}
+    ]
+}
+
+export async function get(params) {
+    const { slug } = params
+    
+    return {
+        body: // ...JSON.stringify()
+    }
+}
+```

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -304,6 +304,17 @@ export interface RenderPageOptions {
 	css?: string[];
 }
 
+type Body = string;
+
+export interface EndpointOutput<Output extends Body = Body> {
+	body: Output;
+}
+
+export interface EndpointHandler {
+	[method: string]: (params: any) => EndpointOutput;
+}
+
+
 /**
  * Astro Renderer
  * Docs: https://docs.astro.build/reference/renderer-reference/
@@ -338,13 +349,15 @@ export interface Renderer {
 	knownEntrypoints?: string[];
 }
 
+export type RouteType = 'page' | 'endpoint';
+
 export interface RouteData {
 	component: string;
 	generate: (data?: any) => string;
 	params: string[];
 	pathname?: string;
 	pattern: RegExp;
-	type: 'page';
+	type: RouteType;
 }
 
 export type SerializedRouteData = Omit<RouteData, 'generate' | 'pattern'> & {

--- a/packages/astro/src/core/build/scan-based-build.ts
+++ b/packages/astro/src/core/build/scan-based-build.ts
@@ -1,6 +1,6 @@
 import type { ViteDevServer } from '../vite.js';
-import type { AstroConfig } from '../../@types/astro';
-import type { AllPagesData } from './types';
+import type { AstroConfig, RouteType } from '../../@types/astro';
+import type { AllPagesData, PageBuildData } from './types';
 import type { LogOptions } from '../logger';
 import type { ViteConfigWithSSR } from '../create-vite.js';
 
@@ -20,6 +20,24 @@ export interface ScanBasedBuildOptions {
 	routeCache: RouteCache;
 	viteConfig: ViteConfigWithSSR;
 	viteServer: ViteDevServer;
+}
+
+// Returns a filter predicate to filter AllPagesData entries by RouteType
+function entryIsType(type: RouteType) {
+	return function withPage([_, pageData]: [string, PageBuildData]) {
+		return pageData.route.type === type;
+	};
+}
+
+// Reducer to combine AllPageData entries back into an object keyed by filepath
+function reduceEntries<U>(acc: { [key: string]: U }, [key, value]: [string, U]) {
+	acc[key] = value;
+	return acc;
+}
+
+// Filters an AllPagesData object to only include routes of a specific RouteType
+function routesOfType(type: RouteType, allPages: AllPagesData) {
+	return Object.entries(allPages).filter(entryIsType(type)).reduce(reduceEntries, {});
 }
 
 export async function build(opts: ScanBasedBuildOptions) {
@@ -50,7 +68,7 @@ export async function build(opts: ScanBasedBuildOptions) {
 				internals,
 				logging,
 				origin,
-				allPages,
+				allPages: routesOfType('page', allPages),
 				pageNames,
 				routeCache,
 				viteServer,

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -1,7 +1,7 @@
-import type { ComponentInstance, MarkdownRenderOptions, Params, Props, Renderer, RouteData, SSRElement } from '../../@types/astro';
+import type { ComponentInstance, EndpointHandler, MarkdownRenderOptions, Params, Props, Renderer, RouteData, SSRElement } from '../../@types/astro';
 import type { LogOptions } from '../logger.js';
 
-import { renderPage } from '../../runtime/server/index.js';
+import { renderEndpoint, renderPage } from '../../runtime/server/index.js';
 import { getParams } from '../routing/index.js';
 import { createResult } from './result.js';
 import { findPathItemByKey, RouteCache, callGetStaticPaths } from './route-cache.js';
@@ -73,6 +73,11 @@ export async function render(opts: RenderOptions): Promise<string> {
 		routeCache,
 		pathname,
 	});
+
+	// For endpoints, render the content immediately without injecting scripts or styles
+	if (route?.type === 'endpoint') {
+		return renderEndpoint(mod as any as EndpointHandler, params);
+	}
 
 	// Validate the page component before rendering the page
 	const Component = await mod.default;

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -64,7 +64,7 @@ export async function render(renderers: Renderer[], mod: ComponentInstance, ssrO
 		});
 	}
 
-	let html = await coreRender({
+	let content = await coreRender({
 		experimentalStaticBuild: astroConfig.buildOptions.experimentalStaticBuild,
 		links: new Set(),
 		logging,
@@ -90,6 +90,11 @@ export async function render(renderers: Renderer[], mod: ComponentInstance, ssrO
 		routeCache,
 		site: astroConfig.buildOptions.site,
 	});
+
+
+	if (route?.type === 'endpoint') {
+		return content;
+	}
 
 	// inject tags
 	const tags: vite.HtmlTagDescriptor[] = [];
@@ -128,20 +133,20 @@ export async function render(renderers: Renderer[], mod: ComponentInstance, ssrO
 	});
 
 	// add injected tags
-	html = injectTags(html, tags);
+	content = injectTags(content, tags);
 
 	// run transformIndexHtml() in dev to run Vite dev transformations
 	if (mode === 'development' && !astroConfig.buildOptions.experimentalStaticBuild) {
 		const relativeURL = filePath.href.replace(astroConfig.projectRoot.href, '/');
-		html = await viteServer.transformIndexHtml(relativeURL, html, pathname);
+		content = await viteServer.transformIndexHtml(relativeURL, content, pathname);
 	}
 
 	// inject <!doctype html> if missing (TODO: is a more robust check needed for comments, etc.?)
-	if (!/<!doctype html/i.test(html)) {
-		html = '<!DOCTYPE html>\n' + html;
+	if (!/<!doctype html/i.test(content)) {
+		content = '<!DOCTYPE html>\n' + content;
 	}
 
-	return html;
+	return content;
 }
 
 export async function ssr(ssrOpts: SSROptions): Promise<string> {

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -1,4 +1,4 @@
-import type { AstroComponentMetadata, Renderer } from '../../@types/astro';
+import type { AstroComponentMetadata, EndpointHandler, Renderer } from '../../@types/astro';
 import type { AstroGlobalPartial, SSRResult, SSRElement } from '../../@types/astro';
 
 import shorthash from 'shorthash';
@@ -410,6 +410,20 @@ const uniqueElements = (item: any, index: number, all: any[]) => {
 	const children = item.children;
 	return index === all.findIndex((i) => JSON.stringify(i.props) === props && i.children == children);
 };
+
+// Renders an endpoint request to completion, returning the body.
+export async function renderEndpoint(mod: EndpointHandler, params: any) {
+	const method = 'get';
+	const handler = mod[method];
+
+	if (!handler || typeof handler !== 'function') {
+		throw new Error(`Endpoint handler not found! Expected an exported function for "${method}"`);
+	}
+
+	const { body } = await mod.get(params);
+
+	return body;
+}
 
 // Renders a page to completion by first calling the factory callback, waiting for its result, and then appending
 // styles and scripts into the head.

--- a/packages/astro/test/dev-routing.test.js
+++ b/packages/astro/test/dev-routing.test.js
@@ -171,4 +171,64 @@ describe('Development Routing', () => {
 			expect(response.status).to.equal(500);
 		});
 	});
+
+	describe('Endpoint routes', () => {
+		/** @type {import('./test-utils').Fixture} */
+		let fixture;
+		/** @type {import('./test-utils').DevServer} */
+		let devServer;
+
+		before(async () => {
+			fixture = await loadFixture({ projectRoot: './fixtures/with-endpoint-routes/' });
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			devServer && (await devServer.stop());
+		});
+
+		it('200 when loading /home.json', async () => {
+			const response = await fixture.fetch('/home.json');
+			expect(response.status).to.equal(200);
+
+			const body = await response.text().then((text) => JSON.parse(text));
+			expect(body.title).to.equal('home');
+		});
+
+		it('200 when loading /thing1.json', async () => {
+			const response = await fixture.fetch('/thing1.json');
+			expect(response.status).to.equal(200);
+
+			const body = await response.text().then((text) => JSON.parse(text));
+			expect(body.slug).to.equal('thing1');
+			expect(body.title).to.equal('[slug]');
+		});
+
+		it('200 when loading /thing2.json', async () => {
+			const response = await fixture.fetch('/thing2.json');
+			expect(response.status).to.equal(200);
+
+			const body = await response.text().then((text) => JSON.parse(text));
+			expect(body.slug).to.equal('thing2');
+			expect(body.title).to.equal('[slug]');
+		});
+
+		it('200 when loading /data/thing3.json', async () => {
+			const response = await fixture.fetch('/data/thing3.json');
+			expect(response.status).to.equal(200);
+
+			const body = await response.text().then((text) => JSON.parse(text));
+			expect(body.slug).to.equal('thing3');
+			expect(body.title).to.equal('data [slug]');
+		});
+
+		it('200 when loading /data/thing4.json', async () => {
+			const response = await fixture.fetch('/data/thing4.json');
+			expect(response.status).to.equal(200);
+
+			const body = await response.text().then((text) => JSON.parse(text));
+			expect(body.slug).to.equal('thing4');
+			expect(body.title).to.equal('data [slug]');
+		});
+	});
 });

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/data/[slug].json.ts
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/data/[slug].json.ts
@@ -1,0 +1,14 @@
+export async function getStaticPaths() {
+    return [
+        { params: { slug: 'thing1' } },
+        { params: { slug: 'thing2' } }
+    ];
+}
+
+export async function get() {
+    return {
+        body: JSON.stringify({
+            title: '[slug]'
+        }, null, 4)
+    };
+}

--- a/packages/astro/test/fixtures/static build/src/pages/company.json.ts
+++ b/packages/astro/test/fixtures/static build/src/pages/company.json.ts
@@ -1,0 +1,8 @@
+export async function get() {
+    return {
+        body: JSON.stringify({
+            name: 'Astro Technology Company',
+            url: 'https://astro.build/'
+        })
+    }
+}

--- a/packages/astro/test/fixtures/static build/src/pages/data/[slug].json.ts
+++ b/packages/astro/test/fixtures/static build/src/pages/data/[slug].json.ts
@@ -1,0 +1,16 @@
+export async function getStaticPaths() {
+    return [
+        { params: { slug: 'thing1' }},
+        { params: { slug: 'thing2' }}
+    ]
+}
+
+export async function get(params) {
+    return {
+        body: JSON.stringify({
+            slug: params.slug,
+            name: 'Astro Technology Company',
+            url: 'https://astro.build/'
+        })
+    }
+}

--- a/packages/astro/test/fixtures/static build/src/pages/posts.json.js
+++ b/packages/astro/test/fixtures/static build/src/pages/posts.json.js
@@ -1,0 +1,22 @@
+async function fetchPosts() {
+    const files = import.meta.glob('./posts/**/*.md');
+    
+    const posts = await Promise.all(
+        Object.entries(files).map(([filename, load]) => load().then(({ frontmatter }) => {
+            return {
+                filename,
+                title: frontmatter.title,
+            };
+        })),
+    );
+
+    return posts.sort((a, b) => a.title.localeCompare(b.title));
+}
+
+export async function get() {
+    const posts = await fetchPosts();
+
+    return {
+        body: JSON.stringify(posts, null, 4),
+    };
+}

--- a/packages/astro/test/fixtures/static build/src/pages/posts/nested/more.md
+++ b/packages/astro/test/fixtures/static build/src/pages/posts/nested/more.md
@@ -1,5 +1,6 @@
 ---
 layout: ../../../layouts/Main.astro
+title: More post
 ---
 
 # Post

--- a/packages/astro/test/fixtures/static build/src/pages/posts/thoughts.md
+++ b/packages/astro/test/fixtures/static build/src/pages/posts/thoughts.md
@@ -1,5 +1,6 @@
 ---
 layout: ../../layouts/Main.astro
+title: Thoughts post
 ---
 
 # Post

--- a/packages/astro/test/fixtures/with-endpoint-routes/astro.config.mjs
+++ b/packages/astro/test/fixtures/with-endpoint-routes/astro.config.mjs
@@ -1,0 +1,6 @@
+
+export default {
+  buildOptions: {
+    site: 'http://example.com/'
+  }
+}

--- a/packages/astro/test/fixtures/with-endpoint-routes/src/pages/[slug].json.ts
+++ b/packages/astro/test/fixtures/with-endpoint-routes/src/pages/[slug].json.ts
@@ -1,0 +1,15 @@
+export async function getStaticPaths() {
+    return [
+        { params: { slug: 'thing1' } },
+        { params: { slug: 'thing2' } }
+    ];
+}
+
+export async function get(params) {
+    return {
+        body: JSON.stringify({
+            slug: params.slug,
+            title: '[slug]'
+        })
+    };
+}

--- a/packages/astro/test/fixtures/with-endpoint-routes/src/pages/data/[slug].json.ts
+++ b/packages/astro/test/fixtures/with-endpoint-routes/src/pages/data/[slug].json.ts
@@ -1,0 +1,15 @@
+export async function getStaticPaths() {
+    return [
+        { params: { slug: 'thing3' } },
+        { params: { slug: 'thing4' } }
+    ];
+}
+
+export async function get(params) {
+    return {
+        body: JSON.stringify({
+            slug: params.slug,
+            title: 'data [slug]'
+        })
+    };
+}

--- a/packages/astro/test/fixtures/with-endpoint-routes/src/pages/home.json.ts
+++ b/packages/astro/test/fixtures/with-endpoint-routes/src/pages/home.json.ts
@@ -1,0 +1,7 @@
+export async function get() {
+    return {
+        body: JSON.stringify({
+            title: 'home'
+        })
+    };
+}

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -42,6 +42,23 @@ describe('Static build', () => {
 		expect(html).to.be.a('string');
 	});
 
+	it('Builds out .json files', async () => {
+		const content = await fixture.readFile('/subpath/company.json').then((text) => JSON.parse(text));
+		expect(content.name).to.equal('Astro Technology Company');
+		expect(content.url).to.equal('https://astro.build/');
+	});
+
+	it('Builds out dynamic .json files', async () => {
+		const slugs = ['thing1', 'thing2'];
+
+		for (const slug of slugs) {
+			const content = await fixture.readFile(`/subpath/data/${slug}.json`).then((text) => JSON.parse(text));
+			expect(content.name).to.equal('Astro Technology Company');
+			expect(content.url).to.equal('https://astro.build/');
+			expect(content.slug).to.equal(slug);
+		}
+	});
+
 	function createFindEvidence(expected) {
 		return async function findEvidence(pathname) {
 			const html = await fixture.readFile(pathname);

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -48,6 +48,21 @@ describe('Static build', () => {
 		expect(content.url).to.equal('https://astro.build/');
 	});
 
+	it ('Builds out async .json files', async () => {
+		const content = await fixture.readFile('/subpath/posts.json').then((text) => JSON.parse(text));
+		expect(Array.isArray(content)).to.equal(true);
+		expect(content).deep.equal([
+			{
+				filename: './posts/nested/more.md',
+				title: 'More post',
+			},
+			{
+				filename: './posts/thoughts.md',
+				title: 'Thoughts post',
+			},
+		]);
+	});
+
 	it('Builds out dynamic .json files', async () => {
 		const slugs = ['thing1', 'thing2'];
 


### PR DESCRIPTION
## Changes

[RFC 0006](https://github.com/withastro/rfcs/blob/main/proposals/0006-support-non-html-files.md)

This adds support for building non-HTML files from `src/pages`, hidden behind the `--experimental-static-build` flag

- Built filenames/extensions follow the existing file-based routing behavior (`src/pages/data.json.ts` -> `dist/data.json`)
- `getStaticPaths()` works to support dynamic routes

## Testing

[x] supports static files, ex: `src/pages/data.json.ts`
[x] supports dynamic files, ex: `src/pages/posts/[post].json.js`
[x] these files are excluded from the sitemap
[x] works with `astro dev`
[x] ignored for the current scan-based build process

## Docs

WIP: I still need to finish up docs for this feature and open a PR on the docs repo
