### PR TITLE
Chore: fix examples/blog template generate sitemap.xml

### DIFF
--- a/examples/blog/astro.config.mjs
+++ b/examples/blog/astro.config.mjs
@@ -10,4 +10,7 @@
 export default /** @type {import('astro').AstroUserConfig} */ ({
 	// Enable the Preact renderer to support Preact JSX components.
 	renderers: ['@astrojs/renderer-preact'],
+	buildOptions: {
+		site: 'https://example.com/',
+	},
 });


### PR DESCRIPTION
## Changes

- Fixes: #2288 
- As reported in #2288 , `examples/blog` template currently does not generate `sitemap.xml` nor `rss.xml`
- I configure `buildOptions.site` to generate `sitemap.xml`
  - as far as I understand, to generate `rss.xml` with astro needs a dynamic page(`[page].astro`), and the way to generate `rss.xml` on the static page has not been supported yet
  -  should I fix static page `posts/index.md` into dynamic page to generate `rss.xml`?
  - or should I wait for astro supporting to generate `rss.xml` with static pages?
- this is a tiny fix, but I would be happy if this helps you.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I did not add any additional tests because this is the fix in the example showcase.

## Docs

<!-- Did you make a user-facing change? You probably need to update docs! -->
<!-- Add a link to your docs PR here. If no docs added, explain why (e.g. "bug fix only") -->
<!-- Link: https://github.com/withastro/docs -->

Not needed, this is the fix in the example showcase.
