### PR TITLE
Skip the docs-main smoke test

### DIFF
--- a/scripts/smoke/index.js
+++ b/scripts/smoke/index.js
@@ -40,7 +40,8 @@ async function run() {
 
 	const directories = await getChildDirectories(exampleDir);
 
-	directories.push(await downloadGithubZip(docGithubConfig), await downloadGithubZip(wwwGithubConfig));
+	// TODO Skipped the docs-main test since it is failing at the moment.
+	directories.push(/*await downloadGithubZip(docGithubConfig), */await downloadGithubZip(wwwGithubConfig));
 
 	console.log('🤖', 'Preparing', 'yarn');
 


### PR DESCRIPTION
Skipping this test which is causing all PRs to fail. We should follow-up with a fix to the underlying issue shortly.