### PR TITLE
Bug fix: Order of params for routing has to match

### DIFF
--- a/.changeset/sweet-spoons-cheer.md
+++ b/.changeset/sweet-spoons-cheer.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Dynamic route params should ignore param order when matching paths

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -33,8 +33,7 @@ async function getParamsAndProps(opts: GetParamsAndPropsOptions): Promise<[Param
 			routeCacheEntry = await callGetStaticPaths(mod, route, true, logging);
 			routeCache.set(route, routeCacheEntry);
 		}
-		const paramsKey = JSON.stringify(params);
-		const matchedStaticPath = findPathItemByKey(routeCacheEntry.staticPaths, paramsKey);
+		const matchedStaticPath = findPathItemByKey(routeCacheEntry.staticPaths, params);
 		if (!matchedStaticPath) {
 			throw new Error(`[getStaticPaths] route pattern matched, but no matching static path found. (${pathname})`);
 		}

--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -1,10 +1,15 @@
-import type { ComponentInstance, GetStaticPathsItem, GetStaticPathsResult, GetStaticPathsResultKeyed, RouteData, RSS } from '../../@types/astro';
+import type { ComponentInstance, GetStaticPathsItem, GetStaticPathsResult, GetStaticPathsResultKeyed, Params, RouteData, RSS } from '../../@types/astro';
 import { LogOptions, warn, debug } from '../logger.js';
 
 import { generatePaginateFunction } from './paginate.js';
 import { validateGetStaticPathsModule, validateGetStaticPathsResult } from '../routing/index.js';
 
 type RSSFn = (...args: any[]) => any;
+
+function stringifyParams(params: Params) {
+	// Always sort keys before stringifying to make sure objects match regardless of parameter ordering
+	return JSON.stringify(params, Object.keys(params).sort());
+}
 
 export async function callGetStaticPaths(mod: ComponentInstance, route: RouteData, isValidate: boolean, logging: LogOptions): Promise<RouteCacheEntry> {
 	validateGetStaticPathsModule(mod);
@@ -23,7 +28,7 @@ export async function callGetStaticPaths(mod: ComponentInstance, route: RouteDat
 	const keyedStaticPaths = staticPaths as GetStaticPathsResultKeyed;
 	keyedStaticPaths.keyed = new Map<string, GetStaticPathsItem>();
 	for (const sp of keyedStaticPaths) {
-		const paramsKey = JSON.stringify(sp.params);
+		const paramsKey = stringifyParams(sp.params);
 		keyedStaticPaths.keyed.set(paramsKey, sp);
 	}
 	if (isValidate) {
@@ -73,7 +78,8 @@ export class RouteCache {
 	}
 }
 
-export function findPathItemByKey(staticPaths: GetStaticPathsResultKeyed, paramsKey: string) {
+export function findPathItemByKey(staticPaths: GetStaticPathsResultKeyed, params: Params) {
+	const paramsKey = stringifyParams(params);
 	let matchedStaticPath = staticPaths.keyed.get(paramsKey);
 	if (matchedStaticPath) {
 		return matchedStaticPath;

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/blog/[year]/[slug].astro
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/blog/[year]/[slug].astro
@@ -1,0 +1,17 @@
+---
+export async function getStaticPaths() {
+    return [
+        { params: { year: '2022', slug: 'post-1' } },
+        { params: { slug: 'post-2', year: '2022' } },
+    ]
+}
+
+const { year, slug } = Astro.request.params
+---
+
+<html>
+  <head>
+    <title>{year} | {slug}</title>
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
## Changes

Bug fix for [#2235](https://github.com/withastro/astro/issues/2235) - Order of params for routing has to match

Currently, `src/pages/blog/[year]/[slug].astro` wouldn't match if `getStaticPaths` returned params of `{ slug: 'post-1', year: '2022' }`

## Testing

Tests added to the `astro-get-static-paths` test suite

## Docs

Bug fix only
