### PR TITLE
Upgrade `@astrojs/compiler`

### DIFF
--- a/.changeset/eighty-cows-wink.md
+++ b/.changeset/eighty-cows-wink.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Update `@astrojs/compiler` to [`v0.11.0`](https://github.com/withastro/compiler/blob/main/lib/compiler/CHANGELOG.md#0110), which moves from TinyGo to Go's built-in WASM output. This will be a significant improvement for stability and memory safety.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -56,7 +56,7 @@
     "test:match": "mocha --timeout 15000 -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.10.2",
+    "@astrojs/compiler": "^0.11.0",
     "@astrojs/language-server": "^0.8.6",
     "@astrojs/markdown-remark": "^0.6.1-next.2",
     "@astrojs/prism": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,10 +130,10 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@astrojs/compiler@^0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-0.10.2.tgz#231a3ba822a8919921543b105eca7a978aaaceea"
-  integrity sha512-2uh1diCmOhdm4M3I0UJ8/GT1Nu43+jtlX3olN/AQtCx85xh2ri3gf7pAN1fyeMqMPaMrYxT7islRX9hQtC0SQQ==
+"@astrojs/compiler@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-0.11.0.tgz#8a15b0dcca8fba3343e3c6aad1f58c035aa1aa46"
+  integrity sha512-mCrY+e74YXnPsCERLk7Vgm/XIccalcMsSrEE+LOTRKsTU5R3eHEXrUc32bpsIiWO7Rbspf14uYtFQ6ErrGybsA==
   dependencies:
     typescript "^4.3.5"
 


### PR DESCRIPTION
## Changes

- Upgrade `@astrojs/compiler` to [`v0.11.0`](https://github.com/withastro/compiler/blob/main/lib/compiler/CHANGELOG.md#0110).
- At the cost of a larger `.wasm` file, this is a significant improvement for stability and memory safety.

## Testing

CI passing, third-party reproductions passing

## Docs

Bug fix only
