### PR TITLE
importing and inlining global.css with set:html

### DIFF
--- a/examples/with-tailwindcss/src/pages/index.astro
+++ b/examples/with-tailwindcss/src/pages/index.astro
@@ -1,6 +1,8 @@
 ---
 // Component Imports
 import Button from '../components/Button.astro';
+// Imports the global styles to be inlined in the <head>
+import styles from '../styles/global.css';
 
 // Full Astro Component Syntax:
 // https://docs.astro.build/core-concepts/astro-components/
@@ -11,9 +13,7 @@ import Button from '../components/Button.astro';
 		<meta charset="UTF-8" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 		<title>Astro + TailwindCSS</title>
-		<style global>
-			@import "../styles/global.css";
-		</style>
+		<style set:html={styles}></style>
 	</head>
 
 	<body>


### PR DESCRIPTION
## Changes

Updates the `with-tailwindcss` example to leverage `set:html` when inlining global CSS in the `<head>`

**Why?**

The `@import "../styles/global.css";` example has a few rough edges with regards to HMR, see #1943 and #2410 for more details

By importing the styles and adding them to the head with `set:html`, vite adds `global.css` to the resource graph and watches the file for changes.

## Testing

Tested the example project locally with `astro dev` and `astro build`.  In `dev`, HMR now works as expected with any changes to `global.css` triggering a rebuild and update.

I also confirmed this fixes #2410.  I'm not 100% sure what the underlying issue here was, but once `global.css` is included in Vite's resource graph any components added after the dev server starts are also picked up and watched for file updates.

## Docs

None right now, but will update the [Tailwind](https://docs.astro.build/en/guides/styling/#-tailwind) integration docs if this updated syntax is approved& merged
