### PR TITLE
Fix loading of styles in static build

### DIFF
--- a/.changeset/fuzzy-drinks-drop.md
+++ b/.changeset/fuzzy-drinks-drop.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes Astro style resolution in the static build

--- a/packages/astro/src/core/path.ts
+++ b/packages/astro/src/core/path.ts
@@ -10,6 +10,10 @@ export function removeEndingForwardSlash(path: string) {
 	return path.endsWith('/') ? path.slice(0, path.length - 1) : path;
 }
 
+export function startsWithForwardSlash(path: string) {
+	return path[0] === '/';
+}
+
 export function startsWithDotDotSlash(path: string) {
 	const c1 = path[0];
 	const c2 = path[1];

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -91,6 +91,15 @@ describe('Static build', () => {
 		};
 	}
 
+	describe('Page CSS', () => {
+		const findEvidence = createFindEvidence(/height:( )*45vw/);
+
+		it('Page level CSS is added', async () => {
+			const found = await findEvidence('/subpath/index.html');
+			expect(found).to.equal(true, 'Did not find page-level CSS on this page');
+		});
+	});
+
 	describe('Shared CSS', () => {
 		const findEvidence = createFindEvidence(/var\(--c\)/);
 


### PR DESCRIPTION
## Changes

- Fixes #2602
- We resolve style ids to be root-relative so that the Vite CSS plugin correctly resolves relative imports. A regression in https://github.com/withastro/astro/commit/ec6f148fc8623c6549885af70512839c08905fdb made it so that the query params were removed.

## Testing

Test added

## Docs

Bug fix only