### PR TITLE
Static build - fixes path to HMR script

### DIFF
--- a/.changeset/cool-months-deliver.md
+++ b/.changeset/cool-months-deliver.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes 404 to HMR script in the static build

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -59,7 +59,7 @@ export async function render(renderers: Renderer[], mod: ComponentInstance, ssrO
 			children: '',
 		});
 		scripts.add({
-			props: { type: 'module', src: new URL('../../runtime/client/hmr.js', import.meta.url).pathname },
+			props: { type: 'module', src: new URL('../../../runtime/client/hmr.js', import.meta.url).pathname },
 			children: '',
 		});
 	}


### PR DESCRIPTION
## Changes

- Fixes #2603
- In the core refactor this file was moved around but the path was not changed.
- This only applies to the static build

## Testing

We don't have tests for HMR yet :(

## Docs

Bug fix.
