### PR TITLE
Update volta node engine to 16.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "packages/astro/test/fixtures/static build/pkg"
   ],
   "volta": {
-    "node": "14.17.0",
+    "node": "16.14.0",
     "npm": "7.11.2",
     "yarn": "1.22.10"
   },


### PR DESCRIPTION
## Changes
Bump Volta node engine, Node.js 16 has stabilized quite well I think.

## Testing
Locally everything runs as expected.
