### PR TITLE
improve memory leak test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,8 +208,8 @@ jobs:
 
       - name: Memory Leak Test
         run: |
-          node ./scripts/memory/mk.js
-          node ./scripts/memory/index.js
+          node ./scripts/memory/mk.js 
+          node --expose-gc ./scripts/memory/index.js --ci
 
 
   # Changelog can only run _after_ build.

--- a/scripts/memory/index.js
+++ b/scripts/memory/index.js
@@ -1,42 +1,18 @@
-import { execa } from 'execa';
 import { fileURLToPath } from 'url';
 import v8 from 'v8';
 import dev from '../../packages/astro/dist/core/dev/index.js';
 import { loadConfig } from '../../packages/astro/dist/core/config.js';
 import prettyBytes from 'pretty-bytes';
 
+if (!global.gc) {
+	console.error('ERROR: Node must be run with --expose-gc');
+	process.exit(1);
+}
+
+const isCI = process.argv.includes('--ci');
+
 /** URL directory containing the entire project. */
 const projDir = new URL('./project/', import.meta.url);
-
-function mean(numbers) {
-	var total = 0,
-		i;
-	for (i = 0; i < numbers.length; i += 1) {
-		total += numbers[i];
-	}
-	return total / numbers.length;
-}
-
-function median(numbers) {
-	// median of [3, 5, 4, 4, 1, 1, 2, 3] = 3
-	var median = 0,
-		numsLen = numbers.length;
-	numbers.sort();
-
-	if (
-		numsLen % 2 ===
-		0 // is even
-	) {
-		// average of two middle numbers
-		median = (numbers[numsLen / 2 - 1] + numbers[numsLen / 2]) / 2;
-	} else {
-		// is odd
-		// middle number only
-		median = numbers[(numsLen - 1) / 2];
-	}
-
-	return median;
-}
 
 let config = await loadConfig({
 	cwd: fileURLToPath(projDir),
@@ -44,44 +20,53 @@ let config = await loadConfig({
 
 config.buildOptions.experimentalStaticBuild = true;
 
-const server = await dev(config, { logging: 'error' });
+const server = await dev(config, { logging: { level: 'error' } });
 
 // Prime the server so initial memory is created
 await fetch(`http://localhost:3000/page-0`);
 
-const sizes = [];
-
-function addSize() {
-	sizes.push(v8.getHeapStatistics().total_heap_size);
-}
-
 async function run() {
-	addSize();
 	for (let i = 0; i < 100; i++) {
 		let path = `/page-${i}`;
 		await fetch(`http://localhost:3000${path}`);
 	}
-	addSize();
 }
 
-for (let i = 0; i < 100; i++) {
-	await run();
-}
+global.gc();
+const startSize = v8.getHeapStatistics().used_heap_size;
 
-let lastThirthy = sizes.slice(sizes.length - 30);
-let averageOfLastThirty = mean(lastThirthy);
-let medianOfAll = median(sizes);
-
-// If the trailing average is higher than the median, see if it's more than 5% higher
-if (averageOfLastThirty > medianOfAll) {
-	let percentage = Math.abs(averageOfLastThirty - medianOfAll) / medianOfAll;
-	if (percentage > 0.1) {
-		throw new Error(
-			`The average towards the end (${prettyBytes(averageOfLastThirty)}) is more than 10% higher than the median of all runs (${prettyBytes(
-				medianOfAll
-			)}). This tells us that memory continues to grow and a leak is likely.`
-		);
+// HUMAN mode: Runs forever. Optimized for accurate results on each snapshot Slower than CI.
+if (!isCI) {
+	console.log(`Greetings, human. This test will run forever. Run with the "--ci" flag to finish with a result.`);
+	let i = 1;
+	while (i++) {
+		await run();
+		global.gc();
+		const checkpoint = v8.getHeapStatistics().used_heap_size;
+		console.log(`Snapshot ${String(i).padStart(3, '0')}: ${(checkpoint / startSize) * 100}%`);
 	}
 }
 
+// CI mode: Runs 100 times. Optimized for speed with an accurate final result.
+for (let i = 0; i < 100; i++) {
+	await run();
+	const checkpoint = v8.getHeapStatistics().used_heap_size;
+	console.log(`Estimate ${String(i).padStart(3, '0')}/100: ${(checkpoint / startSize) * 100}%`);
+}
+
+console.log(`Test complete. Running final garbage collection...`);
+global.gc();
+const endSize = v8.getHeapStatistics().used_heap_size;
+
+// If the trailing average is higher than the median, see if it's more than 5% higher
+let percentage = endSize / startSize;
+const TEST_THRESHOLD = 1.2;
+const isPass = percentage < TEST_THRESHOLD;
+console.log(``);
+console.log(`Result: ${isPass ? 'PASS' : 'FAIL'} (${percentage * 100}%)`);
+console.log(`Memory usage began at ${prettyBytes(startSize)} and finished at ${prettyBytes(endSize)}.`);
+console.log(`The threshold for a probable memory leak is ${TEST_THRESHOLD * 100}%`);
+console.log(``);
+console.log(`Exiting...`);
 await server.stop();
+process.exit(isPass ? 0 : 1);


### PR DESCRIPTION
## Changes

**tldr: Uncovered a memory leak test bug that causes it to pass/fail unreliably. I may get this merged asap so that our CI goes back to reliable + green for any weekend PRs.**

A bit of fun to end the day: I was seeing some flakiness in the memory test and ended up refactoring a bit of it. There's a mix of usability changes (`--ci` mode if you want a final pass/fail, otherwise it will run forever and let you spot the trend in the output over time) and actual test reliability improvements. Mainly:

- Added `--expose-gc` support so that we can guarantee that garbage collection runs
- Switched `total_head_size -> used_heap_size`. `total` is the total reserved, which is largely up to Node.js. Used is actual memory used by the application. 

With these two changes I now see reliable results across every run, locally.




```
$ node scripts/memory/index.js
ERROR: Node must be run with --expose-gc
```         


```
$ node --expose-gc scripts/memory/index.js
Greetings, human. This test will run forever. Run with the "--ci" flag to finish with a result.
Snapshot 001: 106.69290329060044%
Snapshot 002: 106.3646071611346%
Snapshot 003: 106.62807742564124%
Snapshot 004: 106.76272397910616%
Snapshot 005: 107.130898566085%
...
Snapshot 121: 109.18502642715731%
Snapshot 122: 109.2200169022692%
Snapshot 123: 109.21072172262116%
```


```
$ node --expose-gc scripts/memory/index.js --ci
Estimate 000/100: 155.98816145873386%
Estimate 001/100: 144.71746216879%
Estimate 002/100: 129.19713350080747%
...
Estimate 097/100: 150.28960848649527%
Estimate 098/100: 140.2301594422086%
Estimate 099/100: 169.27028594498987%
Test complete. Running final garbage collection...

Result: PASS (110.47501025351825%)
Memory usage began at 33.1 MB and finished at 33.1 MB.
The threshold for a probable memory leak is 120%

Exiting...
```