### PR TITLE
Support Prism in the blog template example

### DIFF
--- a/examples/blog/src/layouts/BlogPost.astro
+++ b/examples/blog/src/layouts/BlogPost.astro
@@ -10,6 +10,7 @@ const { title, description, publishDate, author, heroImage, permalink, alt } = c
 
 <html lang={content.lang || 'en'}>
 	<head>
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prism-themes@1.9.0/themes/prism-lucario.css"/>
 		<BaseHead {title} {description} {permalink} />
 	</head>
 

--- a/examples/blog/src/pages/posts/index.md
+++ b/examples/blog/src/pages/posts/index.md
@@ -14,3 +14,13 @@ description: Just a Hello World Post!
 This is so cool!
 
 Do variables work {frontmatter.value * 2}?
+
+```javascript
+// Example JavaScript
+
+const x = 7;
+function returnSeven() {
+  return x;
+}
+
+```

--- a/examples/blog/src/styles/blog.css
+++ b/examples/blog/src/styles/blog.css
@@ -232,7 +232,7 @@ pre {
 	padding: var(--padding-block) var(--padding-inline);
 	padding-right: calc(var(--padding-inline) * 2);
 	margin-left: calc(50vw - var(--padding-inline));
-	transform: translateX(-50vw);
+	transform: translateX(-50);
 
 	line-height: 1.414;
 	width: calc(100vw + (var(--padding-inline) * 2));


### PR DESCRIPTION
The Prism syntax highlighter failed to render properly when Astro was
initialized with the blog template. This was because the Prism CSS
conflicted with the default blog template.

This change-set removes the Viewport Width from the `pre` transform as
this property conflicted with the prism CSS. This change-set also
includes Prism in the Blog Post layout and adds a small javascript
example to the sample post.

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Did you make a user-facing change? You probably need to update docs! -->
<!-- Add a link to your docs PR here. If no docs added, explain why (e.g. "bug fix only") -->
<!-- Link: https://github.com/withastro/docs -->
