### PR TITLE
Fixed shiki import to work with "type": "module"

### DIFF
--- a/.changeset/great-hotels-breathe.md
+++ b/.changeset/great-hotels-breathe.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/markdown-remark': patch
+---
+
+Fixed shiki to work with `{ "type": "module" }`

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -1,5 +1,6 @@
 ---
-import * as shiki from 'shiki';
+import type shiki from 'shiki';
+import { getHighlighter } from 'shiki';
 
 export interface Props {
 	/** The code to highlight. Required. */
@@ -49,7 +50,7 @@ function repairShikiTheme(html: string): string {
 	return html;
 }
 
-const highlighter = await shiki.getHighlighter({
+const highlighter = await getHighlighter({
 	theme,
 	// Load custom lang if passed an object, otherwise load the default
 	langs: typeof lang !== 'string' ? [lang] : undefined,

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -1,5 +1,5 @@
 ---
-import shiki from 'shiki';
+import * as shiki from 'shiki';
 
 export interface Props {
 	/** The code to highlight. Required. */
@@ -49,10 +49,10 @@ function repairShikiTheme(html: string): string {
 	return html;
 }
 
-const highlighter = await shiki.getHighlighter({ 
+const highlighter = await shiki.getHighlighter({
 	theme,
 	// Load custom lang if passed an object, otherwise load the default
-	langs: typeof lang !== 'string' ? [lang] : undefined
+	langs: typeof lang !== 'string' ? [lang] : undefined,
 });
 const _html = highlighter.codeToHtml(code, { lang: typeof lang === 'string' ? lang : lang.id });
 const html = repairShikiTheme(_html);

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -1,5 +1,5 @@
 ---
-import type shiki from 'shiki';
+import type * as shiki from 'shiki';
 import { getHighlighter } from 'shiki';
 
 export interface Props {

--- a/packages/markdown/remark/src/remark-shiki.ts
+++ b/packages/markdown/remark/src/remark-shiki.ts
@@ -1,4 +1,4 @@
-import type shiki from 'shiki';
+import type * as shiki from 'shiki';
 import { getHighlighter } from 'shiki';
 import { visit } from 'unist-util-visit';
 

--- a/packages/markdown/remark/src/remark-shiki.ts
+++ b/packages/markdown/remark/src/remark-shiki.ts
@@ -1,4 +1,5 @@
-import * as shiki from 'shiki';
+import type shiki from 'shiki';
+import { getHighlighter } from 'shiki';
 import { visit } from 'unist-util-visit';
 
 export interface ShikiConfig {
@@ -30,7 +31,7 @@ export interface ShikiConfig {
 }
 
 const remarkShiki = async ({ langs = [], theme = 'github-dark', wrap = false }: ShikiConfig) => {
-	const highlighter = await shiki.getHighlighter({ theme });
+	const highlighter = await getHighlighter({ theme });
 
 	for (const lang of langs) {
 		await highlighter.loadLanguage(lang);

--- a/packages/markdown/remark/src/remark-shiki.ts
+++ b/packages/markdown/remark/src/remark-shiki.ts
@@ -1,4 +1,4 @@
-import shiki from 'shiki';
+import * as shiki from 'shiki';
 import { visit } from 'unist-util-visit';
 
 export interface ShikiConfig {


### PR DESCRIPTION
## Changes

With a package.json with `{ "type": "module" }`, shiki doesn't work. That because it doesn't have a default export (although their `index.d.ts` says the opposite)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Did you make a user-facing change? You probably need to update docs! -->
<!-- Add a link to your docs PR here. If no docs added, explain why (e.g. "bug fix only") -->
<!-- Link: https://github.com/withastro/docs -->
