### PR TITLE
Fix(component): align starting position in Markdown slot

### DIFF
--- a/packages/astro/components/Markdown.astro
+++ b/packages/astro/components/Markdown.astro
@@ -3,11 +3,17 @@ export interface Props {
 	content?: string;
 }
 
-const dedent = (str: string) =>
-	str
+const dedent = (str: string) => {
+	const _str = str.split('\n').filter(s => s.trimStart().length > 0);
+	if (_str.length === 0) {
+		return str.trimStart();
+	}
+	const trimmedSpace = _str[0].replace(_str[0].trimStart(), '');
+	return str
 		.split('\n')
-		.map((ln) => ln.trimStart())
+		.map((ln) => ln.replace(trimmedSpace, ''))
 		.join('\n');
+}
 
 // Internal props that should not be part of the external interface.
 interface InternalProps extends Props {

--- a/packages/astro/components/Markdown.astro
+++ b/packages/astro/components/Markdown.astro
@@ -11,7 +11,7 @@ const dedent = (str: string) => {
 	const trimmedSpace = _str[0].replace(_str[0].trimStart(), '');
 	return str
 		.split('\n')
-		.map((ln) => ln.replace(trimmedSpace, ''))
+		.map((ln) => ln.startsWith(trimmedSpace) ? ln.replace(trimmedSpace, '') : ln)
 		.join('\n');
 }
 

--- a/packages/astro/test/astro-markdown-shiki.test.js
+++ b/packages/astro/test/astro-markdown-shiki.test.js
@@ -118,9 +118,9 @@ describe('Astro Markdown Shiki', () => {
 			const $ = cheerio.load(html);
 
 			const segments = $('.line').get(6).children;
-			expect(segments).to.have.lengthOf(2);
-			expect(segments[0].attribs.style).to.be.equal('color: #79C0FF');
-			expect(segments[1].attribs.style).to.be.equal('color: #C9D1D9');
+			expect(segments).to.have.lengthOf(3);
+			expect(segments[0].attribs.style).to.be.equal('color: #C9D1D9');
+			expect(segments[1].attribs.style).to.be.equal('color: #79C0FF');
 		});
 	});
 

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -146,4 +146,21 @@ describe('Astro Markdown', () => {
 		// render html without error
 		expect(html).to.be.ok;
 	});
+
+	it('can render nested list correctly', async () => {
+		const html = await fixture.readFile('/nested-list/index.html');
+		const $ = cheerio.load(html);
+		/**
+		 * - list
+		 *  - list
+		 */
+		expect($('#target > ul > li').children()).to.have.lengthOf(1);
+		expect($('#target > ul > li > ul > li').text()).to.equal('nested list');
+		/**
+		 * 1. Hello
+		 *  1. nested hello
+		 */
+		expect($('#target > ol > li').children()).to.have.lengthOf(1);
+		expect($('#target > ol > li > ol > li').text()).to.equal('nested hello');
+	});
 });

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/nested-list.astro
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/nested-list.astro
@@ -1,0 +1,32 @@
+---
+// Component imports and setup JavaScript go here!
+import { Markdown } from 'astro/components';
+const content = `
+- list 1
+  - list 2
+- list
+	- - list
+1. Hello
+	1. Hello`
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>Welcome to Astro</title>
+	</head>
+
+	<body>
+		<h1>Welcome to <a href="https://astro.build/">Astro</a></h1>
+        <div id="target">
+            <Markdown>
+            - list
+                - nested list 
+
+            1. Hello
+                1. nested hello
+            </Markdown>
+        </div>
+	</body>
+</html>


### PR DESCRIPTION
## Changes

Fixes: #2610 

- in the current implementation, `<Markdown />` trims the start of the content in each line of slot of `<Markdown />`
- However, some markdown grammar, such as nested list, have the meaning on the tab or space of the start of the line, so #2610 happens.
- I fixed this behavior to trim just the same amount of tab or space from the start of line

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

simply, add the test case to test about nested list

## Docs

<!-- Did you make a user-facing change? You probably need to update docs! -->
<!-- Add a link to your docs PR here. If no docs added, explain why (e.g. "bug fix only") -->
<!-- Link: https://github.com/withastro/docs -->

no need, this is a tiny bug fix

## Note

This is my secound contribution to astro, so there may be something I missed(testing, coding style, context, etc…). If there is something I missed, please be free to point out or close this PR 🙇 
