### PR TITLE
Make Non-HTML Pages work for static build

### DIFF
--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -50,10 +50,10 @@ export async function render(renderers: Renderer[], mod: ComponentInstance, ssrO
 	const { astroConfig, filePath, logging, mode, origin, pathname, route, routeCache, viteServer } = ssrOpts;
 
 	// Add hoisted script tags
-	const scripts = createModuleScriptElementWithSrcSet(astroConfig.buildOptions.experimentalStaticBuild ? Array.from(mod.$$metadata.hoistedScriptPaths()) : []);
+	const scripts = createModuleScriptElementWithSrcSet(astroConfig.buildOptions.experimentalStaticBuild && mod.hasOwnProperty('$$metadata') ? Array.from(mod.$$metadata.hoistedScriptPaths()) : []);
 
 	// Inject HMR scripts
-	if (mode === 'development' && astroConfig.buildOptions.experimentalStaticBuild) {
+	if (scripts.length > 0 && mode === 'development' && astroConfig.buildOptions.experimentalStaticBuild) {
 		scripts.add({
 			props: { type: 'module', src: '/@vite/client' },
 			children: '',

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -53,7 +53,7 @@ export async function render(renderers: Renderer[], mod: ComponentInstance, ssrO
 	const scripts = createModuleScriptElementWithSrcSet(astroConfig.buildOptions.experimentalStaticBuild && mod.hasOwnProperty('$$metadata') ? Array.from(mod.$$metadata.hoistedScriptPaths()) : []);
 
 	// Inject HMR scripts
-	if (scripts.length > 0 && mode === 'development' && astroConfig.buildOptions.experimentalStaticBuild) {
+	if (mod.hasOwnProperty('$$metadata') > 0 && mode === 'development' && astroConfig.buildOptions.experimentalStaticBuild) {
 		scripts.add({
 			props: { type: 'module', src: '/@vite/client' },
 			children: '',

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -53,7 +53,7 @@ export async function render(renderers: Renderer[], mod: ComponentInstance, ssrO
 	const scripts = createModuleScriptElementWithSrcSet(astroConfig.buildOptions.experimentalStaticBuild && mod.hasOwnProperty('$$metadata') ? Array.from(mod.$$metadata.hoistedScriptPaths()) : []);
 
 	// Inject HMR scripts
-	if (mod.hasOwnProperty('$$metadata') > 0 && mode === 'development' && astroConfig.buildOptions.experimentalStaticBuild) {
+	if (mod.hasOwnProperty('$$metadata') && mode === 'development' && astroConfig.buildOptions.experimentalStaticBuild) {
 		scripts.add({
 			props: { type: 'module', src: '/@vite/client' },
 			children: '',


### PR DESCRIPTION
If you were to run this Non-HTML Pages example:

https://github.com/withastro/astro/pull/2637

When using ` --experimental-static-build` in `package.json`:

```json
{
  "name": "@example/non-html-pages",
  "version": "0.0.1",
  "private": true,
  "scripts": {
    "dev": "astro dev --experimental-static-build",
    "start": "astro dev --experimental-static-build",
    "build": "astro build --experimental-static-build",
    "preview": "astro preview"
  },
  "devDependencies": {
    "astro": "^0.23.0-next.10"
  }
}
```

Then visit http://localhost:3000/company.json you will see an error like that:

```
Cannot read properties of undefined (reading 'hoistedScriptPaths')
```

This commit resolves the issue and allows the non-html page to load, as well as regular `.astro` pages without issue.