### PR TITLE
Updating how the with-tailwindcss example imports global styles

### DIFF
--- a/examples/with-tailwindcss/src/pages/index.astro
+++ b/examples/with-tailwindcss/src/pages/index.astro
@@ -1,8 +1,6 @@
 ---
 // Component Imports
 import Button from '../components/Button.astro';
-// Imports the global styles to be inlined in the <head>
-import styles from '../styles/global.css';
 
 // Full Astro Component Syntax:
 // https://docs.astro.build/core-concepts/astro-components/
@@ -13,7 +11,8 @@ import styles from '../styles/global.css';
 		<meta charset="UTF-8" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 		<title>Astro + TailwindCSS</title>
-		<style set:html={styles}></style>
+		<!-- Imports the global styles -->
+		<link rel="stylesheet" href="/src/styles/global.css" />
 	</head>
 
 	<body>


### PR DESCRIPTION
## Changes

Fixes [#2629](https://github.com/withastro/astro/issues/2629) by using project relative paths to import the global stylesheet

I had originally updated the example to use `set:html` to avoid HMR issues with the `@import` approach, but that ended up causing an issue in `dev` where the styles were both being inlined and `<link>`d after and HMR update

Once [#2597](https://github.com/withastro/astro/issues/2597) is resolved it might be best to update this to use `import styles from '../styles/global.css?url` since that is the more Vite-ish apporach

## Testing

Tested locally to make sure `astro build` and `astro dev` both include links to compiled tailwind styles, and that HMR updates as expected now in `dev`

## Docs

None yet, but it might be good to update the docs to move away from the `@import` recommendation which doesn't work well with HMR
