### PR TITLE
Add sass dev dep to blog-multiple-authors example

### DIFF
--- a/examples/blog-multiple-authors/package.json
+++ b/examples/blog-multiple-authors/package.json
@@ -9,6 +9,7 @@
     "preview": "astro preview"
   },
   "devDependencies": {
-    "astro": "^0.23.0"
+    "astro": "^0.23.0",
+    "sass": "^1.49.8"
   }
 }


### PR DESCRIPTION
https://astro.new/blog-multiple-authors?on=stackblitz

<img width="605" alt="image" src="https://user-images.githubusercontent.com/990216/155259815-d9506c6a-6ae8-4aa7-b45e-15a7bed666b2.png">

```
500: Internal Error
Expected an exported Astro component but received typeof undefined
Error: Expected an exported Astro component but received typeof undefined
    at Module.render (file:///home/projects/bnmipkqmz.github/node_modules/astro/dist/core/render/core.js:58:11)
    at async render (file:///home/projects/bnmipkqmz.github/node_modules/astro/dist/core/render/dev/index.js:41:17)
    at async Module.ssr (file:///home/projects/bnmipkqmz.github/node_modules/astro/dist/core/render/dev/index.js:107:12)
    at async handleRequest (file:///home/projects/bnmipkqmz.github/node_modules/astro/dist/vite-plugin-astro-server/index.js:88:18)
```