### PR TITLE
fix(core): Issue #2625. error with process.env.LANG larger than 5

### DIFF
--- a/.changeset/twelve-eggs-join.md
+++ b/.changeset/twelve-eggs-join.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix issue when process.env.LANG was longer than 5 characters

--- a/packages/astro/src/core/logger.ts
+++ b/packages/astro/src/core/logger.ts
@@ -18,7 +18,7 @@ function getLoggerLocale(): string {
 		// Check if language code is atleast two characters long (ie. en, es).
 		// NOTE: if "c" locale is encountered, the default locale will be returned.
 		if (extractedLocale.length < 2) return defaultLocale;
-		else return extractedLocale;
+		else return extractedLocale.substring(0, 5);
 	} else return defaultLocale;
 }
 


### PR DESCRIPTION
Solving #2625

## Changes

- npm run dev & npm init astro now works with process.env.LANG larger than 5 characters (ej: "es_ES@euro")

## Testing

No testing added because I can't launch test without this change

## Docs

Bug fix only
