### PR TITLE
ensure utf8 encoding when serving html

### DIFF
--- a/.changeset/spicy-tomatoes-act.md
+++ b/.changeset/spicy-tomatoes-act.md
@@ -1,0 +1,6 @@
+---
+"astro": patch
+"@example/ssr": patch
+---
+
+Fix an issue where utf8 encoding was skipped in the dev server.

--- a/.changeset/spicy-tomatoes-act.md
+++ b/.changeset/spicy-tomatoes-act.md
@@ -1,6 +1,5 @@
 ---
 "astro": patch
-"@example/ssr": patch
 ---
 
 Fix an issue where utf8 encoding was skipped in the dev server.

--- a/examples/ssr/server/server.mjs
+++ b/examples/ssr/server/server.mjs
@@ -18,7 +18,8 @@ async function handle(req, res) {
 		const html = await app.render(req, route);
 
 		res.writeHead(200, {
-			'Content-Type': 'text/html',
+			'Content-Type': 'text/html; charset=utf-8',
+			'Content-Length': Buffer.byteLength(html, 'utf-8'),
 		});
 		res.end(html);
 	} else if (/^\/api\//.test(req.url)) {

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -3,7 +3,6 @@ import type http from 'http';
 import type { AstroConfig, ManifestData, RouteData } from '../@types/astro';
 import { info, LogOptions } from '../core/logger.js';
 import { createRouteManifest, matchRoute } from '../core/routing/index.js';
-import mime from 'mime';
 import stripAnsi from 'strip-ansi';
 import { createSafeError } from '../core/util.js';
 import { ssr } from '../core/render/dev/index.js';
@@ -30,8 +29,8 @@ function removeViteHttpMiddleware(server: vite.Connect.Server) {
 
 function writeHtmlResponse(res: http.ServerResponse, statusCode: number, html: string) {
 	res.writeHead(statusCode, {
-		'Content-Type': mime.getType('.html') as string,
-		'Content-Length': Buffer.byteLength(html, 'utf8'),
+		'Content-Type': 'text/html; charset=utf-8',
+		'Content-Length': Buffer.byteLength(html, 'utf-8'),
 	});
 	res.write(html);
 	res.end();


### PR DESCRIPTION
## Changes
- Fixes a small bug that was causing utf-8 encoding issues. For example, we were seeing `Donâ€:tm:s Blog` instead of `Don's Blog`.
- Fixed the same bug in the ssr example directory.

## Testing

- Tested manually, too small to add a test for imo but happy to add if anyone feels strongly!

## Docs

- N/A