### PR TITLE
[WIP] Implement new markdown plugin with deferred markdown rendering

### DIFF
--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -296,11 +296,17 @@ function createFetchContentFn(url: URL, site: URL) {
 				}
 				const urlSpec = new URL(spec, url).pathname;
 				return {
-					...mod.frontmatter,
-					Content: mod.default,
-					content: mod.metadata,
 					file: new URL(spec, url),
 					url: urlSpec.includes('/pages/') ? urlSpec.replace(/^.*\/pages\//, sitePathname).replace(/(\/index)?\.md$/, '') : undefined,
+					data: mod.frontmatter,
+					getContent: () => mod.default().then((m: any) => m.default),
+					getHeaders: () => mod.default().then((m: any) => m.metadata.headers),
+					Content: () => {
+						throw new Error('Astro.fetchContent() ".Content" property is no longer supported. Use `.getContent()` instead.');
+					},
+					content: () => {
+						throw new Error('Astro.fetchContent() ".content" property is no longer supported. Use `.getMetadata()` instead.');
+					},
 				};
 			})
 			.filter(Boolean);

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -1,24 +1,84 @@
 import type { Plugin } from 'vite';
 import type { AstroConfig } from '../@types/astro';
-
 import esbuild from 'esbuild';
 import fs from 'fs';
 import { transform } from '@astrojs/compiler';
+import { fileURLToPath } from 'url';
+import matter from 'gray-matter';
 
 interface AstroPluginOptions {
 	config: AstroConfig;
 }
 
+const virtualModuleId = '@astro-markdown-import';
+const resolvedVirtualModuleId = '\0' + virtualModuleId;
+
 /** Transform .astro files for Vite */
 export default function markdown({ config }: AstroPluginOptions): Plugin {
+	// Weird vite behavior: Vite seems to use a fake "index.html" importer when you
+	// have `enforce: pre`. This can probably be removed once the vite issue is fixed.
+	// see: https://github.com/vitejs/vite/issues/5981
+	const fakeRootImporter = fileURLToPath(new URL('index.html', config.projectRoot));
+	function isRootImport(importer: string | undefined) {
+		if (!importer) {
+			return true;
+		}
+		if (importer === fakeRootImporter) {
+			return true;
+		}
+		return false;
+	}
+
 	return {
 		name: 'astro:markdown',
-		enforce: 'pre', // run transforms before other plugins can
+		enforce: 'pre',
+		async resolveId(id, importer, options) {
+			// Resolve virtual modules.
+			if (id.startsWith(resolvedVirtualModuleId)) {
+				return id;
+			}
+			// If the markdown file is imported from another file via ESM, resolve a JS representation
+			// that defers the markdown -> HTML rendering until it is needed. This is especially useful
+			// when fetching and then filtering many markdown files, like via Astro.fetchContent().
+			// Otherwise, resolve directly to the actual component.
+			if (id.endsWith('.md') && !isRootImport(importer)) {
+				const resolvedId = await this.resolve(id, importer, { skipSelf: true, ...options });
+				if (resolvedId) {
+					return resolvedVirtualModuleId + resolvedId.id;
+				}
+			}
+			// Resolve any .md files with the `?content` cache buster. This should only come from
+			// an already-resolved JS module wrapper. Needed to prevent infinite loops in Vite.
+			if (id.endsWith('.md?content')) {
+				const resolvedId = await this.resolve(id, importer, { skipSelf: true, ...options });
+				return resolvedId?.id.replace('?content', '');
+			}
+			return undefined;
+		},
 		async load(id) {
-			if (id.endsWith('.md')) {
-				let source = await fs.promises.readFile(id, 'utf8');
+			// A markdown file has been imported via ESM!
+			// Return the file's JS representation, which includes all Markdown frontmatter data
+			// and a deferred render of the markdown contents.
+			if (id.startsWith(resolvedVirtualModuleId)) {
+				const fileId = id.substring(resolvedVirtualModuleId.length);
+				let source = await fs.promises.readFile(fileId, 'utf8');
+				const { data: frontmatter } = matter(source);
+				return {
+					code: `
+						export const frontmatter = ${JSON.stringify(frontmatter)};
+						export default async function load(...args) {
+							return (await import(${JSON.stringify(fileId + '?content')}));
+						};`,
+					map: null,
+				};
+			}
 
-				// Transform from `.md` to valid `.astro`
+			// A markdown file is being rendered! This markdown file was either imported
+			// directly as a page in Vite, or it was a deferred render from a JS module.
+			// This returns the compiled markdown -> astro component that renders to HTML.
+			if (id.endsWith('.md') || id.endsWith('.md?content')) {
+				const fileId = id.endsWith('?content') ? id.substring(0, id.length - '?content'.length) : id;
+				let source = await fs.promises.readFile(fileId, 'utf8');
 				let render = config.markdownOptions.render;
 				let renderOpts = {};
 				if (Array.isArray(render)) {
@@ -28,10 +88,9 @@ export default function markdown({ config }: AstroPluginOptions): Plugin {
 				if (typeof render === 'string') {
 					({ default: render } = await import(render));
 				}
-				let renderResult = await render(source, renderOpts);
-				let { frontmatter, metadata, code: astroResult } = renderResult;
-
-				// Extract special frontmatter keys
+				const { data: frontmatter, content: markdownContent } = matter(source);
+				let renderResult = await render(markdownContent, renderOpts);
+				let { code: astroResult, metadata } = renderResult;
 				const { layout = '', components = '', setup = '', ...content } = frontmatter;
 				content.astro = metadata;
 				const prelude = `---
@@ -49,9 +108,8 @@ ${setup}`.trim();
 					astroResult = `${prelude}\n${astroResult}`;
 				}
 
-				const filenameURL = new URL(`file://${id}`);
+				const filenameURL = new URL(`file://${fileId}`);
 				const pathname = filenameURL.pathname.substr(config.projectRoot.pathname.length - 1);
-
 				// Transform from `.astro` to valid `.ts`
 				let { code: tsResult } = await transform(astroResult, {
 					pathname,
@@ -63,12 +121,10 @@ ${setup}`.trim();
 				});
 
 				tsResult = `\nexport const metadata = ${JSON.stringify(metadata)};
-export const frontmatter = ${JSON.stringify(content)};
 ${tsResult}`;
 
 				// Compile from `.ts` to `.js`
-				const { code, map } = await esbuild.transform(tsResult, { loader: 'ts', sourcemap: 'inline', sourcefile: id });
-
+				const { code } = await esbuild.transform(tsResult, { loader: 'ts', sourcemap: false, sourcefile: id });
 				return {
 					code,
 					map: null,


### PR DESCRIPTION
## Changes

- **Still proof of concept!** Still thinking through whether this can be implemented in a backwards-compatible way, or whether this will need to be a new API (`Astro.content()`?). Will want to create an RFC if we go that route.
- Implements a new experimental Astro.fetchContent() interface that is significantly faster than markdown plugin with deferred rendering. 
- The biggest performance impact felt is that a large `Astro.fetchContent()` no longer blocks the dev server due to rendering every imported page in parallel.
- Also, fixes an infinite loop bug where `fetchContent()` couldn't be called inside of a layout.

## Testing

TODO

## Docs

TODO