### PR TITLE
Improve third-party Astro package compatability

### DIFF
--- a/.changeset/dry-geese-speak.md
+++ b/.changeset/dry-geese-speak.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve compatability with third-party Astro packages

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -153,7 +153,7 @@ export interface AstroUserConfig {
 		trailingSlash?: 'always' | 'never' | 'ignore';
 	};
 	/** Pass configuration options to Vite */
-	vite?: vite.InlineConfig;
+	vite?: vite.InlineConfig & { ssr?: vite.SSROptions };
 }
 
 // NOTE(fks): We choose to keep our hand-generated AstroUserConfig interface so that


### PR DESCRIPTION
## Changes

- Improves support for third-party `.astro` packages.
- Vite now automatically does NOT process any third-party packages, which is the right approach in most cases. For Astro community packages, we reccomend exporting `.astro` files which means Vite needs to process the package.
- This PR scans a project's dependencies on startup to filter any third-party Astro packages to treat as `ssr.noExternal`.

## Testing

Manually. Not sure there's a great way to test this.

## Docs

N/A
