### PR TITLE
fix(runtime): Issue #2589 - returning an empty Fragment renders undefined

### DIFF
--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -131,6 +131,9 @@ export async function renderComponent(result: SSRResult, displayName: string, Co
 	const children = await renderSlot(result, slots?.default);
 
 	if (Component === Fragment) {
+		if (children == null) {
+			return children;
+		}
 		return unescapeHTML(children);
 	}
 


### PR DESCRIPTION
Fixes #2589 

## Changes

This PR fixes the bug when returning an empty Fragment. The problem is because unescapeHTML will create a String object with an 'undefined' string. 

```js
new String(undefined) // String { "undefined" }
```

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Did you make a user-facing change? You probably need to update docs! -->
<!-- Add a link to your docs PR here. If no docs added, explain why (e.g. "bug fix only") -->
<!-- Link: https://github.com/withastro/docs -->
