### PR TITLE
Fix HTMLElement expression warning

### DIFF
--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -495,7 +495,7 @@ export async function renderHTMLElement(result: SSRResult, constructor: typeof H
 		attrHTML += ` ${attr}="${toAttributeString(await props[attr])}"`;
 	}
 
-	return `<${name}${attrHTML}>${await renderSlot(result, slots?.default)}</${name}>`;
+	return unescapeHTML(`<${name}${attrHTML}>${await renderSlot(result, slots?.default)}</${name}>`);
 }
 
 function getHTMLElementName(constructor: typeof HTMLElement) {


### PR DESCRIPTION
## Changes

- In a prior version of astro, the `unescapeHTML` method was introduced to mark a string as raw, unescaped HTML.
- This method was not applied to the `renderHTMLElement` method.
- This PR applies the `unescapeHTML` method to the result of the `renderHTMLElement` method.

Resolves https://github.com/withastro/astro/issues/2664

## Testing

- There are no tests for `unescapeHTML`, which applies to many other places.
- A followup PR should address the overall missing tests.

## Docs

bug fix only