### PR TITLE
fix: disable HMR during build

### DIFF
--- a/.changeset/wet-knives-raise.md
+++ b/.changeset/wet-knives-raise.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix issue where HMR could be triggered during `astro build`

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -204,6 +204,7 @@ export default function astro({ config, logging }: AstroPluginOptions): vite.Plu
 			}
 		},
 		async handleHotUpdate(context) {
+			if (context.server.config.isProduction) return;
 			return handleHotUpdate(context, config, logging);
 		},
 	};


### PR DESCRIPTION
## Changes

- Fixes issue reported by @RafidMuhymin on Discord.
- HMR should never fire during `astro build`.

## Testing

Manually

## Docs

Bug fix
