### PR TITLE
fix failing tests on main

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -106,7 +106,7 @@
     "strip-ansi": "^7.0.1",
     "supports-esm": "^1.0.0",
     "tsconfig-resolver": "^3.0.1",
-    "vite": "^2.8.0",
+    "vite": "2.8.4",
     "yargs-parser": "^21.0.0",
     "zod": "^3.8.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9453,10 +9453,10 @@ vite-plugin-pwa@0.11.5:
     workbox-build "^6.4.0"
     workbox-window "^6.4.0"
 
-vite@^2.8.0:
-  version "2.8.5"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.8.5.tgz#afa23aacea91c0ebe77754a807bf74953cafa331"
-  integrity sha512-C/7EGNa1ugWejol6nOcd/0d8PR70Nzd+XXwsPbnNOfzZw0NN2xyXfmw/GNDHgr5fcaTSO4gjxCJCrwNhQUMhmA==
+vite@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.8.4.tgz#4e52a534289b7b4e94e646df2fc5556ceaa7336b"
+  integrity sha512-GwtOkkaT2LDI82uWZKcrpRQxP5tymLnC7hVHHqNkhFNknYr0hJUlDLfhVRgngJvAy3RwypkDCWtTKn1BjO96Dw==
   dependencies:
     esbuild "^0.14.14"
     postcss "^8.4.6"


### PR DESCRIPTION
- In my CI work last night I accidentally merged a bad lockfile change that caused our tests to fail
- Specifically, upgrading vite from `.4` -> `.5` caused a regression being tracked here: #2678 
- This PR pins us to the last working version while the tests are fixed in #2678 