### PR TITLE
Improve build perf

### DIFF
--- a/.changeset/orange-coins-whisper.md
+++ b/.changeset/orange-coins-whisper.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Improve performance by optimizing calls to `getHighlighter`

--- a/.changeset/short-rats-double.md
+++ b/.changeset/short-rats-double.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve build performance by processing `ssrPreload` in serial rather than in parallel


### PR DESCRIPTION
## Changes

While working on the docs repo, I chased down two performance issues related to docs build:

1. `ssrPreload` appears to be mostly serial work, so 142+ pages of of docs inside a `Promise.all()` all blocked each other from completing. This hung the build entirely when I switched the docs parser over to Shiki (see next).
2. Our Shiki markdown plugin and Code component are both unoptimized. After digging into why the build failed once moving over to Shiki, i tracked down the fact that `getHighlighter` is the most expensive part of shiki, and we were calling it once per page. Caching this for later returned improvement to previous Prism-levels.

@sarah11918 FYI both of these together were causing the failing builds you were seeing when we enabled that config change.

## Testing

- Covered by existing tests, all changes were perf based

## Docs

- N/A