### PR TITLE
Add .d.ts file to astro package for language-tools consumption

### DIFF
--- a/packages/astro/app.d.ts
+++ b/packages/astro/app.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+type Astro = import('./dist/types/@types/astro').AstroGlobal;
+
+// We duplicate the description here because editors won't show the JSDoc comment from the imported type (but will for its properties, ex: Astro.request will show the AstroGlobal.request description)
+/**
+ * Astro.* available in all components
+ * Docs: https://docs.astro.build/reference/api-reference/#astro-global
+ */
+declare let Astro: Astro;
+
+declare let Fragment: any;

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -44,6 +44,7 @@
     "components",
     "dist",
     "astro.js",
+    "app.d.ts",
     "README.md",
     "vendor"
   ],


### PR DESCRIPTION
## Changes

This adds a .d.ts file to the Astro package describing the global Astro object. It's intended to be used by the language-server and the ts-plugin to provide typechecking without needing to maintain separate (and often outdated) .d.ts files there. This will be followed by a PR in the language-tools to remove the outdated .d.ts files (fixing https://github.com/withastro/language-tools/issues/170) and import this file instead

This bring many advantages, notably the types we can now provide to the users being based on our own internal types, they're always up to date and we can show the JSDoc comments to our users. Additionally, I added a reference to `vite/client` in it since we depends on it for many of our features (importMeta, assets imports etc)

![image](https://user-images.githubusercontent.com/3019731/156593771-b7cfd08d-e30f-413c-82d0-6665dfb4b52b.png)

Side note: I tried to type getStaticPaths but it didn't work. It seems like since getStaticPaths gets exported, TypeScript doesn't apply the types to it. That's unfortunate, if anyone has a solution, I'll gladly add it to this PR

## Testing

No tests needed

## Docs

No docs needed