### PR TITLE
Enable ci on `next`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - next
   pull_request:
     paths-ignore:
       - '.vscode/**'


### PR DESCRIPTION
## Changes

- Allows CI to publish from [`next`](https://github.com/withastro/astro/pull/2705) branch, which is in `pre` mode.

## Testing

N/A

## Docs

N/A