### PR TITLE
Add a warning when passing the --experimental-static-build flag

### DIFF
--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -113,6 +113,10 @@ function addTrailingSlash(str: string): string {
 
 /** Convert the generic "yargs" flag object into our own, custom TypeScript object. */
 function resolveFlags(flags: Partial<Flags>): CLIFlags {
+	if(flags.experimentalStaticBuild) {
+		console.warn(`Passing --experimental-static-build is no longer necessary and is now the default. The flag will be removed in a future version of Astro.`)
+	}
+
 	return {
 		projectRoot: typeof flags.projectRoot === 'string' ? flags.projectRoot : undefined,
 		site: typeof flags.site === 'string' ? flags.site : undefined,

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -114,6 +114,7 @@ function addTrailingSlash(str: string): string {
 /** Convert the generic "yargs" flag object into our own, custom TypeScript object. */
 function resolveFlags(flags: Partial<Flags>): CLIFlags {
 	if(flags.experimentalStaticBuild) {
+		// eslint-disable-next-line no-console
 		console.warn(`Passing --experimental-static-build is no longer necessary and is now the default. The flag will be removed in a future version of Astro.`)
 	}
 


### PR DESCRIPTION
## Changes

- Adds a warning when passing the flag, since that's no longer necessary.

<img width="997" alt="Image of the new warning" src="https://user-images.githubusercontent.com/361671/156797651-3d490883-52d0-4772-93c7-d4702803b916.png">


## Testing

Not tested.

## Docs

Nope