### PR TITLE
Fix/2177/log missing local network ip

### DIFF
--- a/.changeset/yellow-trees-clean.md
+++ b/.changeset/yellow-trees-clean.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Update server start message to use localhost for local hostnames

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -41,12 +41,10 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 	const viteServer = await vite.createServer(viteConfig);
 	await viteServer.listen(config.devOptions.port);
 	const address = viteServer.httpServer!.address() as AddressInfo;
-	const localHostname = isLocalHost(address.address, config.devOptions.hostname) ? 'localhost' : address.address
+	const localAddress = isLocalHost(address.address, config.devOptions.hostname) ? 'localhost' : address.address
 	// Log to console
 	const site = config.buildOptions.site ? new URL(config.buildOptions.site) : undefined;
-	info(options.logging, 'astro', msg.devStart({ startupTime: performance.now() - devStart }));
-	info(options.logging, 'astro', msg.devLocalHost({ port: address.port, hostname: localHostname, site, https: !!viteUserConfig.server?.https }));
-	info(options.logging, 'astro', msg.devNetworkHost({ port: address.port, hostname: address.address, site, https: !!viteUserConfig.server?.https }));
+	info(options.logging, 'astro', msg.devStart({ startupTime: performance.now() - devStart, port: address.port, localAddress, networkAddress: address.address, site, https: !!viteUserConfig.server?.https }));
 
 	return {
 		address,

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -6,6 +6,7 @@ import { createVite } from '../create-vite.js';
 import { defaultLogOptions, info, LogOptions } from '../logger.js';
 import * as vite from 'vite';
 import * as msg from '../messages.js';
+import { getLocalAddress } from './util.js';
 
 export interface DevOptions {
 	logging: LogOptions;
@@ -14,10 +15,6 @@ export interface DevOptions {
 export interface DevServer {
 	address: AddressInfo;
 	stop(): Promise<void>;
-}
-
-function isLocalHost(serverAddress: string, configHostname: string): boolean {
-	return configHostname === 'localhost' || serverAddress === '127.0.0.1' || serverAddress === '0.0.0.0'
 }
 
 /** `astro dev` */
@@ -41,7 +38,7 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 	const viteServer = await vite.createServer(viteConfig);
 	await viteServer.listen(config.devOptions.port);
 	const address = viteServer.httpServer!.address() as AddressInfo;
-	const localAddress = isLocalHost(address.address, config.devOptions.hostname) ? 'localhost' : address.address
+	const localAddress = getLocalAddress(address.address, config.devOptions.hostname)
 	// Log to console
 	const site = config.buildOptions.site ? new URL(config.buildOptions.site) : undefined;
 	info(options.logging, null, msg.devStart({ startupTime: performance.now() - devStart, port: address.port, localAddress, networkAddress: address.address, site, https: !!viteUserConfig.server?.https }));

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -41,7 +41,7 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 	const localAddress = getLocalAddress(address.address, config.devOptions.hostname)
 	// Log to console
 	const site = config.buildOptions.site ? new URL(config.buildOptions.site) : undefined;
-	info(options.logging, null, msg.devStart({ startupTime: performance.now() - devStart, port: address.port, localAddress, networkAddress: address.address, site, https: !!viteUserConfig.server?.https }));
+	info(options.logging, null, await msg.devStart({ startupTime: performance.now() - devStart, port: address.port, localAddress, networkAddress: address.address, site, https: !!viteUserConfig.server?.https }));
 
 	return {
 		address,

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -41,7 +41,7 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 	const localAddress = getLocalAddress(address.address, config.devOptions.hostname)
 	// Log to console
 	const site = config.buildOptions.site ? new URL(config.buildOptions.site) : undefined;
-	info(options.logging, null, await msg.devStart({ startupTime: performance.now() - devStart, port: address.port, localAddress, networkAddress: address.address, site, https: !!viteUserConfig.server?.https }));
+	info(options.logging, null, msg.devStart({ startupTime: performance.now() - devStart, port: address.port, localAddress, networkAddress: address.address, site, https: !!viteUserConfig.server?.https }));
 
 	return {
 		address,

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -44,7 +44,7 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 	const localAddress = isLocalHost(address.address, config.devOptions.hostname) ? 'localhost' : address.address
 	// Log to console
 	const site = config.buildOptions.site ? new URL(config.buildOptions.site) : undefined;
-	info(options.logging, 'astro', msg.devStart({ startupTime: performance.now() - devStart, port: address.port, localAddress, networkAddress: address.address, site, https: !!viteUserConfig.server?.https }));
+	info(options.logging, null, msg.devStart({ startupTime: performance.now() - devStart, port: address.port, localAddress, networkAddress: address.address, site, https: !!viteUserConfig.server?.https }));
 
 	return {
 		address,

--- a/packages/astro/src/core/dev/util.ts
+++ b/packages/astro/src/core/dev/util.ts
@@ -8,7 +8,7 @@ export function pad(input: string, minLength: number, dir?: 'left' | 'right'): s
 }
 
 export function emoji(char: string, fallback: string) {
-	return process.platform !== 'win32' ? char + ' ' : fallback;
+	return process.platform !== 'win32' ? char : fallback;
 }
 
 export function getLocalAddress(serverAddress: string, configHostname: string): string {

--- a/packages/astro/src/core/dev/util.ts
+++ b/packages/astro/src/core/dev/util.ts
@@ -6,3 +6,7 @@ export function pad(input: string, minLength: number, dir?: 'left' | 'right'): s
 	}
 	return output;
 }
+
+export function emoji(char: string, fallback: string) {
+	return process.platform !== 'win32' ? char + ' ' : fallback;
+}

--- a/packages/astro/src/core/dev/util.ts
+++ b/packages/astro/src/core/dev/util.ts
@@ -10,3 +10,11 @@ export function pad(input: string, minLength: number, dir?: 'left' | 'right'): s
 export function emoji(char: string, fallback: string) {
 	return process.platform !== 'win32' ? char + ' ' : fallback;
 }
+
+export function getLocalAddress(serverAddress: string, configHostname: string): string {
+	if (configHostname === 'localhost' || serverAddress === '127.0.0.1' || serverAddress === '0.0.0.0') {
+		return 'localhost'
+	} else {
+		return serverAddress
+	}
+}

--- a/packages/astro/src/core/logger.ts
+++ b/packages/astro/src/core/logger.ts
@@ -35,10 +35,11 @@ export const defaultLogDestination = new Writable({
 			dest = process.stdout;
 		}
 
-		dest.write(dim(dt.format(new Date()) + ' '));
 
 		let type = event.type;
 		if (type) {
+			// hide timestamp when type is undefined
+			dest.write(dim(dt.format(new Date()) + ' '));
 			if (event.level === 'info') {
 				type = bold(blue(type));
 			} else if (event.level === 'warn') {

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -5,7 +5,6 @@
 import type { AddressInfo } from 'net';
 import { bold, dim, green, magenta, yellow, cyan } from 'kleur/colors';
 import { pad, emoji } from './dev/util.js';
-import fs from 'fs';
 
 /** Display  */
 export function req({ url, statusCode, reqTime }: { url: string; statusCode: number; reqTime?: number }): string {
@@ -24,10 +23,9 @@ export function reload({ url, reqTime }: { url: string; reqTime: number }): stri
 }
 
 /** Display dev server host and startup time */
-export async function devStart({ startupTime, port, localAddress, networkAddress, https, site }: { startupTime: number; port: number; localAddress: string; networkAddress: string; https: boolean; site: URL | undefined }): Promise<string> {
-	const pkgURL = new URL('../../package.json', import.meta.url);
-	const pkg = JSON.parse(await fs.promises.readFile(pkgURL, 'utf8'));
-	const pkgVersion = pkg.version;
+export function devStart({ startupTime, port, localAddress, networkAddress, https, site }: { startupTime: number; port: number; localAddress: string; networkAddress: string; https: boolean; site: URL | undefined }): string {
+	// PACAKGE_VERSION is injected at build-time
+	const pkgVersion = process.env.PACKAGE_VERSION;
 
 	const rootPath = site ? site.pathname : '/';
 	const toDisplayUrl = (hostname: string) => `${https ? 'https' : 'http'}://${hostname}:${port}${rootPath}`

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -34,6 +34,20 @@ export function devHost({ address, https, site }: { address: AddressInfo; https:
 	return `Local: ${bold(magenta(displayUrl))}`;
 }
 
+/** Display local server host */
+export function devLocalHost({ port, hostname, https, site }: { port: number; hostname: string; https: boolean; site: URL | undefined }): string {
+	const rootPath = site ? site.pathname : '/';
+	const displayUrl = `${https ? 'https' : 'http'}://${hostname}:${port}${rootPath}`;
+	return `Local: ${bold(magenta(displayUrl))}`;
+}
+
+/** Display local server host */
+export function devNetworkHost({ port, hostname, https, site }: { port: number; hostname: string; https: boolean; site: URL | undefined }): string {
+	const rootPath = site ? site.pathname : '/';
+	const displayUrl = `${https ? 'https' : 'http'}://${hostname}:${port}${rootPath}`;
+	return `Network: ${bold(magenta(displayUrl))}`;
+}
+
 /** Display port in use */
 export function portInUse({ port }: { port: number }): string {
 	return `Port ${port} in use. Trying a new one…`;

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -24,7 +24,7 @@ export function reload({ url, reqTime }: { url: string; reqTime: number }): stri
 }
 
 /** Display dev server host and startup time */
-export async function devStart({ startupTime, port, localAddress, networkAddress, https, site }: { startupTime: number; port: number; localAddress: string; networkAddress: string; https: boolean; site: URL | undefined }): string {
+export async function devStart({ startupTime, port, localAddress, networkAddress, https, site }: { startupTime: number; port: number; localAddress: string; networkAddress: string; https: boolean; site: URL | undefined }): Promise<string> {
 	const pkgURL = new URL('../../package.json', import.meta.url);
 	const pkg = JSON.parse(await fs.promises.readFile(pkgURL, 'utf8'));
 	const pkgVersion = pkg.version;

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -5,6 +5,7 @@
 import type { AddressInfo } from 'net';
 import { bold, dim, green, magenta, yellow, cyan } from 'kleur/colors';
 import { pad, emoji } from './dev/util.js';
+import fs from 'fs';
 
 /** Display  */
 export function req({ url, statusCode, reqTime }: { url: string; statusCode: number; reqTime?: number }): string {
@@ -23,7 +24,11 @@ export function reload({ url, reqTime }: { url: string; reqTime: number }): stri
 }
 
 /** Display dev server host and startup time */
-export function devStart({ startupTime, port, localAddress, networkAddress, https, site }: { startupTime: number; port: number; localAddress: string; networkAddress: string; https: boolean; site: URL | undefined }): string {
+export async function devStart({ startupTime, port, localAddress, networkAddress, https, site }: { startupTime: number; port: number; localAddress: string; networkAddress: string; https: boolean; site: URL | undefined }): string {
+	const pkgURL = new URL('../../package.json', import.meta.url);
+	const pkg = JSON.parse(await fs.promises.readFile(pkgURL, 'utf8'));
+	const pkgVersion = pkg.version;
+
 	const rootPath = site ? site.pathname : '/';
 	const toDisplayUrl = (hostname: string) => `${https ? 'https' : 'http'}://${hostname}:${port}${rootPath}`
 	const messages = [

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -3,8 +3,8 @@
  */
 
 import type { AddressInfo } from 'net';
-import { bold, dim, green, magenta, yellow } from 'kleur/colors';
-import { pad } from './dev/util.js';
+import { bold, dim, green, magenta, yellow, cyan } from 'kleur/colors';
+import { pad, emoji } from './dev/util.js';
 
 /** Display  */
 export function req({ url, statusCode, reqTime }: { url: string; statusCode: number; reqTime?: number }): string {
@@ -26,11 +26,15 @@ export function reload({ url, reqTime }: { url: string; reqTime: number }): stri
 export function devStart({ startupTime, port, localAddress, networkAddress, https, site }: { startupTime: number; port: number; localAddress: string; networkAddress: string; https: boolean; site: URL | undefined }): string {
 	const rootPath = site ? site.pathname : '/';
 	const toDisplayUrl = (hostname: string) => `${https ? 'https' : 'http'}://${hostname}:${port}${rootPath}`
-	const addressMessages = [
-		`> Local: ${bold(magenta(toDisplayUrl(localAddress)))}`,
-		`> Network: ${bold(magenta(toDisplayUrl(networkAddress)))}`,
+	const messages = [
+		``,
+		`${emoji('🚀', ' ')} ${magenta('astro v0.23.1')} ${dim(`started in ${Math.round(startupTime)}ms`)}`,
+		``,
+		`${emoji('👉', '>')} Local:   ${bold(cyan(toDisplayUrl(localAddress)))}`,
+		`${emoji('👉', '>')} Network: ${bold(cyan(toDisplayUrl(networkAddress)))}`,
+		``,
 	]
-	return `${pad(`Server started`, 44)} ${dim(`${Math.round(startupTime)}ms`)}\n\n${addressMessages.join('\n')}\n`;
+	return messages.join('\n')
 }
 
 /** Display dev server host */

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -33,10 +33,10 @@ export async function devStart({ startupTime, port, localAddress, networkAddress
 	const toDisplayUrl = (hostname: string) => `${https ? 'https' : 'http'}://${hostname}:${port}${rootPath}`
 	const messages = [
 		``,
-		`${emoji('🚀', ' ')} ${magenta('astro v0.23.1')} ${dim(`started in ${Math.round(startupTime)}ms`)}`,
+		`${emoji('🚀 ', '')}${magenta(`astro ${pkgVersion}`)} ${dim(`started in ${Math.round(startupTime)}ms`)}`,
 		``,
-		`${emoji('👉', '>')} Local:   ${bold(cyan(toDisplayUrl(localAddress)))}`,
-		`${emoji('👉', '>')} Network: ${bold(cyan(toDisplayUrl(networkAddress)))}`,
+		`Local:   ${bold(cyan(toDisplayUrl(localAddress)))}`,
+		`Network: ${bold(cyan(toDisplayUrl(networkAddress)))}`,
 		``,
 	]
 	return messages.join('\n')

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -23,8 +23,14 @@ export function reload({ url, reqTime }: { url: string; reqTime: number }): stri
 }
 
 /** Display dev server host and startup time */
-export function devStart({ startupTime }: { startupTime: number }): string {
-	return `${pad(`Server started`, 44)} ${dim(`${Math.round(startupTime)}ms`)}`;
+export function devStart({ startupTime, port, localAddress, networkAddress, https, site }: { startupTime: number; port: number; localAddress: string; networkAddress: string; https: boolean; site: URL | undefined }): string {
+	const rootPath = site ? site.pathname : '/';
+	const toDisplayUrl = (hostname: string) => `${https ? 'https' : 'http'}://${hostname}:${port}${rootPath}`
+	const addressMessages = [
+		`> Local: ${bold(magenta(toDisplayUrl(localAddress)))}`,
+		`> Network: ${bold(magenta(toDisplayUrl(networkAddress)))}`,
+	]
+	return `${pad(`Server started`, 44)} ${dim(`${Math.round(startupTime)}ms`)}\n\n${addressMessages.join('\n')}\n`;
 }
 
 /** Display dev server host */
@@ -32,20 +38,6 @@ export function devHost({ address, https, site }: { address: AddressInfo; https:
 	const rootPath = site ? site.pathname : '/';
 	const displayUrl = `${https ? 'https' : 'http'}://${address.address}:${address.port}${rootPath}`;
 	return `Local: ${bold(magenta(displayUrl))}`;
-}
-
-/** Display local server host */
-export function devLocalHost({ port, hostname, https, site }: { port: number; hostname: string; https: boolean; site: URL | undefined }): string {
-	const rootPath = site ? site.pathname : '/';
-	const displayUrl = `${https ? 'https' : 'http'}://${hostname}:${port}${rootPath}`;
-	return `Local: ${bold(magenta(displayUrl))}`;
-}
-
-/** Display local server host */
-export function devNetworkHost({ port, hostname, https, site }: { port: number; hostname: string; https: boolean; site: URL | undefined }): string {
-	const rootPath = site ? site.pathname : '/';
-	const displayUrl = `${https ? 'https' : 'http'}://${hostname}:${port}${rootPath}`;
-	return `Network: ${bold(magenta(displayUrl))}`;
 }
 
 /** Display port in use */

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -130,7 +130,7 @@ export default async function preview(config: AstroConfig, { logging }: PreviewO
 						const { address: networkAddress } = server.address() as AddressInfo;
 						const localAddress = getLocalAddress(networkAddress, hostname)
 
-						info(logging, null, await msg.devStart({ startupTime: performance.now() - timerStart, port, localAddress, networkAddress, https: false, site: baseURL }));
+						info(logging, null, msg.devStart({ startupTime: performance.now() - timerStart, port, localAddress, networkAddress, https: false, site: baseURL }));
 					}
 					showedListenMsg = true;
 					resolve();

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -1,6 +1,7 @@
 import type { AstroConfig } from '../../@types/astro';
 import type { LogOptions } from '../logger';
 import type { Stats } from 'fs';
+import type { AddressInfo } from 'net';
 
 import http from 'http';
 import { performance } from 'perf_hooks';
@@ -11,6 +12,7 @@ import * as msg from '../messages.js';
 import { error, info } from '../logger.js';
 import { subpathNotUsedTemplate, notFoundTemplate, default as template } from '../../template/4xx.js';
 import { appendForwardSlash, trimSlashes } from '../path.js';
+import { getLocalAddress } from '../dev/util.js';
 
 interface PreviewOptions {
 	logging: LogOptions;
@@ -125,8 +127,10 @@ export default async function preview(config: AstroConfig, { logging }: PreviewO
 			const listen = () => {
 				httpServer = server.listen(port, hostname, () => {
 					if (!showedListenMsg) {
-						info(logging, 'astro', msg.devStart({ startupTime: performance.now() - timerStart }));
-						info(logging, 'astro', msg.devHost({ address: { family: 'ipv4', address: hostname, port }, https: false, site: baseURL }));
+						const { address: networkAddress } = server.address() as AddressInfo;
+						const localAddress = getLocalAddress(networkAddress, hostname)
+
+						info(logging, null, msg.devStart({ startupTime: performance.now() - timerStart, port, localAddress, networkAddress, https: false, site: baseURL }));
 					}
 					showedListenMsg = true;
 					resolve();

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -125,12 +125,12 @@ export default async function preview(config: AstroConfig, { logging }: PreviewO
 		let showedListenMsg = false;
 		return new Promise<void>((resolve, reject) => {
 			const listen = () => {
-				httpServer = server.listen(port, hostname, () => {
+				httpServer = server.listen(port, hostname, async () => {
 					if (!showedListenMsg) {
 						const { address: networkAddress } = server.address() as AddressInfo;
 						const localAddress = getLocalAddress(networkAddress, hostname)
 
-						info(logging, null, msg.devStart({ startupTime: performance.now() - timerStart, port, localAddress, networkAddress, https: false, site: baseURL }));
+						info(logging, null, await msg.devStart({ startupTime: performance.now() - timerStart, port, localAddress, networkAddress, https: false, site: baseURL }));
 					}
 					showedListenMsg = true;
 					resolve();

--- a/packages/astro/test/cli.test.js
+++ b/packages/astro/test/cli.test.js
@@ -19,22 +19,26 @@ describe('astro cli', () => {
 		expect(proc.stdout).to.equal(pkgVersion);
 	});
 
-	it('astro dev', async () => {
-		const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
+	[undefined, '0.0.0.0', '127.0.0.1'].forEach(hostname => {
+		it(`astro dev --hostname=${hostname}`, async () => {
+			const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
 
-		const proc = cli('dev', '--project-root', fileURLToPath(projectRootURL));
+			const hostnameArgs = hostname ? ['--hostname', hostname] : []
+			const proc = cli('dev', '--project-root', fileURLToPath(projectRootURL), ...hostnameArgs);
 
-		let stdout = '';
+			let stdout = '';
 
-		for await (const chunk of proc.stdout) {
-			stdout += chunk;
+			for await (const chunk of proc.stdout) {
+				stdout += chunk;
 
-			if (chunk.includes('Local:')) break;
-		}
+				if (chunk.includes('Local:')) break;
+			}
 
-		proc.kill();
+			proc.kill();
 
-		expect(stdout).to.include('Server started');
+			expect(stdout).to.include('Local:   http://localhost:3000');
+			expect(stdout).to.include(`Network: http://${hostname ?? '127.0.0.1'}:3000`);
+		});
 	});
 
 	it('astro build', async () => {

--- a/scripts/cmd/build.js
+++ b/scripts/cmd/build.js
@@ -28,7 +28,9 @@ export default async function build(...args) {
 		.map((f) => f.replace(/^'/, '').replace(/'$/, '')); // Needed for Windows: glob strings contain surrounding string chars??? remove these
 	let entryPoints = [].concat(...(await Promise.all(patterns.map((pattern) => glob(pattern, { filesOnly: true, absolute: true })))));
 
-	const { type = 'module', dependencies = {} } = await fs.readFile('./package.json').then((res) => JSON.parse(res.toString()));
+	const { type = 'module', version, dependencies = {} } = await fs.readFile('./package.json').then((res) => JSON.parse(res.toString()));
+	// expose PACKAGE_VERSION on process.env for CLI utils 
+	config.define = { 'process.env.PACKAGE_VERSION': JSON.stringify(version) };
 	const format = type === 'module' ? 'esm' : 'cjs';
 	const outdir = 'dist';
 	await clean(outdir);


### PR DESCRIPTION
## Changes
<img width="413" alt="Screen Shot 2022-03-08 at 2 07 36 PM" src="https://user-images.githubusercontent.com/51384119/157307814-d831f4f5-401a-46e4-acf5-b60d9088b6c9.png">

- Resolves #2177
- Display "localhost" for local IPs: `--hostname=127.0.0.1`, `--hostname=0.0.0.0`, no hostname provided
- Replace with `--hostname` IP for all other IPs
- Add some ✨ nice emojis ✨ and formatting tweaks to mirror Vite more closely

## Testing

Manually tested with different `--hostname` arguments.

## Docs

N/A
