### PR TITLE
remove a bad dev warning from static-build

### DIFF
--- a/.changeset/silver-foxes-bathe.md
+++ b/.changeset/silver-foxes-bathe.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Remove a bad dev warning

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -28,8 +28,11 @@ async function getParamsAndProps(opts: GetParamsAndPropsOptions): Promise<[Param
 			}
 		}
 		let routeCacheEntry = routeCache.get(route);
+		// During build, the route cache should already be populated.
+		// During development, the route cache is filled on-demand and may be empty.
+		// TODO(fks): Can we refactor getParamsAndProps() to receive routeCacheEntry
+		// as a prop, and not do a live lookup/populate inside this lower function call.
 		if (!routeCacheEntry) {
-			warn(logging, 'routeCache', `Internal Warning: getStaticPaths() called twice during the build. (${route.component})`);
 			routeCacheEntry = await callGetStaticPaths(mod, route, true, logging);
 			routeCache.set(route, routeCacheEntry);
 		}


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/2723
- Confirmed that this warning is impossible to happen during build
- left a comment explaining expected behavior, plus some hints on how to refactor

## Testing

- N/A, just a warning removed

## Docs

- N/A