### PR TITLE
Remove second smoke test 

### DIFF
--- a/scripts/smoke/index.js
+++ b/scripts/smoke/index.js
@@ -52,20 +52,6 @@ async function run() {
 			console.log(err);
 			process.exit(1);
 		}
-
-		// Run with the static build too (skip for remote repos)
-		if (isExternal) {
-			continue;
-		}
-
-		try {
-			await execa('pnpm', ['run', 'build', '--', '--experimental-static-build'], { cwd: fileURLToPath(directory), stdout: 'inherit', stderr: 'inherit' });
-		} catch (err) {
-			console.log(err);
-			process.exit(1);
-		}
-
-		console.log();
 	}
 }
 


### PR DESCRIPTION
## Changes

- `--experimental-static-build` is the default, don't need a second pass on smoke tests

## Testing

CI

## Docs

N/A