### PR TITLE
fix(#2753): unescape `define:vars`

### DIFF
--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -391,7 +391,7 @@ export function defineStyleVars(selector: string, vars: Record<any, any>) {
 	for (const [key, value] of Object.entries(vars)) {
 		output += `  --${key}: ${value};\n`;
 	}
-	return `${selector} {${output}}`;
+	return unescapeHTML(`${selector} {${output}}`);
 }
 
 // Adds variables to an inline script.
@@ -400,7 +400,7 @@ export function defineScriptVars(vars: Record<any, any>) {
 	for (const [key, value] of Object.entries(vars)) {
 		output += `let ${key} = ${JSON.stringify(value)};\n`;
 	}
-	return output;
+	return unescapeHTML(output);
 }
 
 // Renders an endpoint request to completion, returning the body.

--- a/packages/astro/test/astro-directives.test.js
+++ b/packages/astro/test/astro-directives.test.js
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Directives', async () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ projectRoot: './fixtures/astro-directives/' });
+		await fixture.build();
+	});
+
+	it('Passes define:vars to script elements', async () => {
+		const html = await fixture.readFile('/define-vars/index.html');
+		const $ = cheerio.load(html);
+
+		expect($('script#inline')).to.have.lengthOf(1);
+		expect($('script#inline').toString()).to.include('let foo = "bar"');
+	});
+});

--- a/packages/astro/test/fixtures/astro-directives/package.json
+++ b/packages/astro/test/fixtures/astro-directives/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@astrojs/test-astro-directives",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/astro-directives/src/pages/define-vars.astro
+++ b/packages/astro/test/fixtures/astro-directives/src/pages/define-vars.astro
@@ -1,0 +1,12 @@
+---
+let foo = 'bar'
+---
+
+<html>
+  <head></head>
+  <body>
+    <script id="inline" define:vars={{ foo }}>
+			console.log(foo);
+		</script>
+  </body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,6 +582,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/astro-directives:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/astro-doctype:
     specifiers:
       astro: workspace:*


### PR DESCRIPTION
## Changes

- Does what it says on the tin.
- Closes #2753

## Testing

Added `astro-directives` test

## Docs

Bug fix only