### PR TITLE
Fix flakey windows CI: eperm, totalist

### DIFF
--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -33,6 +33,7 @@ export default async function preview(config: AstroConfig, { logging }: PreviewO
 	/** Base request URL. */
 	let baseURL = new URL(config.buildOptions.site || '/', defaultOrigin);
 	const staticFileServer = sirv(fileURLToPath(config.dist), {
+		dev: true,
 		etag: true,
 		maxAge: 0,
 	});


### PR DESCRIPTION
## Changes

- Stops hitting the code-path inside of `sirv` that calls totalist, fixing the last (?!) windows CI issue.
- This means that preview will hit the file system for requests instead of caching them for long-term speed. I think this is acceptable and maybe even desired for the testing use-case, if I was using preview and making changes to `dist/` I think I'd expect those changes to be reflected on page refresh.
