### PR TITLE
CLI: add prerelease warning

### DIFF
--- a/.changeset/stupid-pots-give.md
+++ b/.changeset/stupid-pots-give.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add CLI warnings when running a prerelease or outdated version of Astro

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -6,7 +6,7 @@ import { createVite } from '../create-vite.js';
 import { defaultLogOptions, info, warn, LogOptions } from '../logger.js';
 import * as vite from 'vite';
 import * as msg from '../messages.js';
-import { getLocalAddress, getLatestVersion } from './util.js';
+import { getLocalAddress } from './util.js';
 
 export interface DevOptions {
 	logging: LogOptions;
@@ -55,16 +55,7 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 			null,
 			msg.prerelease({ currentVersion })
 		);
-	} else {
-		const latestVersion = await getLatestVersion();
-		if (latestVersion && currentVersion !== latestVersion) {
-			warn(
-				options.logging,
-				null,
-				msg.outdated({ currentVersion, latestVersion })
-			);
-		}
-	}
+	} 
 	
 	return {
 		address,

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -24,8 +24,6 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 	polyfill(globalThis, {
 		exclude: 'window document',
 	});
-	// Checks for a new version of Astro, but do NOT block with `await`
-	let latestVersionPromise = getLatestVersion();
 	// start the server
 	const viteUserConfig = vite.mergeConfig(
 		{
@@ -39,8 +37,8 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 	const viteConfig = await createVite(viteUserConfig, { astroConfig: config, logging: options.logging, mode: 'dev' });
 	const viteServer = await vite.createServer(viteConfig);
 	await viteServer.listen(config.devOptions.port);
-	// Now we should wait for a response
-	const latestVersion = await latestVersionPromise;
+
+	const latestVersion = await getLatestVersion();
 	const address = viteServer.httpServer!.address() as AddressInfo;
 	const localAddress = getLocalAddress(address.address, config.devOptions.hostname);
 	// Log to console

--- a/packages/astro/src/core/dev/util.ts
+++ b/packages/astro/src/core/dev/util.ts
@@ -18,3 +18,10 @@ export function getLocalAddress(serverAddress: string, configHostname: string): 
 		return serverAddress;
 	}
 }
+
+export async function getLatestVersion(): Promise<string|undefined> {
+	try {
+		const pkg = await fetch(`https://registry.npmjs.org/astro/latest`).then(res => res.json())
+		return pkg.version;
+	} catch (e) {}
+}

--- a/packages/astro/src/core/dev/util.ts
+++ b/packages/astro/src/core/dev/util.ts
@@ -18,10 +18,3 @@ export function getLocalAddress(serverAddress: string, configHostname: string): 
 		return serverAddress;
 	}
 }
-
-export async function getLatestVersion(): Promise<string|undefined> {
-	try {
-		const pkg = await fetch(`https://registry.npmjs.org/astro/latest`).then(res => res.json())
-		return pkg.version;
-	} catch (e) {}
-}

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -62,7 +62,7 @@ export function prerelease({ currentVersion }: { currentVersion: string }) {
 	const tag = currentVersion.split('-').slice(1).join('-').replace(/\..*$/, '');
 	const badge = bgYellow(black(` ${tag} `));
 	const headline = yellow(`▶ This is a ${badge} prerelease build`);
-	const warning = dim(`  Leave feedback/report bugs at ${underline('https://astro.build/issues')}`)
+	const warning = dim(`  Share feedback at ${underline('https://astro.build/issues')}`)
 	return [headline, warning, ''].map((msg) => `  ${msg}`).join('\n');
 }
 

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -43,7 +43,7 @@ export function devStart({
 	networkAddress: string;
 	https: boolean;
 	site: URL | undefined;
-	latestVersion: string | undefined;
+	latestVersion?: string;
 }): string {
 	// PACAKGE_VERSION is injected at build-time
 	const version = process.env.PACKAGE_VERSION ?? '0.0.0';

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -4,7 +4,7 @@
 
 import type { AddressInfo } from 'net';
 import stripAnsi from 'strip-ansi';
-import { bold, dim, red, green, magenta, yellow, cyan, bgGreen, black } from 'kleur/colors';
+import { bold, dim, red, green, underline, yellow, cyan, bgGreen, black } from 'kleur/colors';
 import { pad, emoji } from './dev/util.js';
 
 const PREFIX_PADDING = 6;
@@ -35,6 +35,7 @@ export function devStart({
 	networkAddress,
 	https,
 	site,
+	latestVersion,
 }: {
 	startupTime: number;
 	port: number;
@@ -42,18 +43,28 @@ export function devStart({
 	networkAddress: string;
 	https: boolean;
 	site: URL | undefined;
+	latestVersion: string | undefined;
 }): string {
 	// PACAKGE_VERSION is injected at build-time
 	const version = process.env.PACKAGE_VERSION ?? '0.0.0';
+	const isPre = Boolean(version.split('-')[1]);
+	const bg = bgGreen;
+	const fg = green;
 	const rootPath = site ? site.pathname : '/';
 	const toDisplayUrl = (hostname: string) => `${https ? 'https' : 'http'}://${hostname}:${port}${rootPath}`;
+
 	const messages = [
-		`${emoji('🚀 ', '')}${bgGreen(black(` astro `))} ${green(`v${version}`)} ${dim(`started in ${Math.round(startupTime)}ms`)}`,
+		`${emoji('🚀 ', '')}${bg(black(` astro `))} ${fg(`v${version}`)} ${dim(`started in ${Math.round(startupTime)}ms`)}`,
 		'',
 		`${dim('┃')} Local    ${bold(cyan(toDisplayUrl(localAddress)))}`,
 		`${dim('┃')} Network  ${bold(cyan(toDisplayUrl(networkAddress)))}`,
 		'',
 	];
+	if (isPre) {
+		messages.push(yellow('▶ This is a prerelease build.'), yellow('  Undocumented changes may happen at any time!'), '');
+	} else if (latestVersion && version !== latestVersion) {
+		messages.push(`${yellow('▶ Update available!')} ${dim(pad(version, 12, 'left'))} → ${green(latestVersion)}`, `  See ${underline(`https://astro.build/releases/${latestVersion}`)}`, '');
+	}
 	return messages.map((msg) => `  ${msg}`).join('\n');
 }
 

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -4,7 +4,7 @@
 
 import type { AddressInfo } from 'net';
 import stripAnsi from 'strip-ansi';
-import { bold, dim, red, green, underline, yellow, cyan, bgGreen, black } from 'kleur/colors';
+import { bold, dim, red, green, underline, yellow, bgYellow, cyan, bgGreen, black } from 'kleur/colors';
 import { pad, emoji } from './dev/util.js';
 
 const PREFIX_PADDING = 6;
@@ -35,7 +35,6 @@ export function devStart({
 	networkAddress,
 	https,
 	site,
-	latestVersion,
 }: {
 	startupTime: number;
 	port: number;
@@ -43,11 +42,9 @@ export function devStart({
 	networkAddress: string;
 	https: boolean;
 	site: URL | undefined;
-	latestVersion?: string;
 }): string {
 	// PACAKGE_VERSION is injected at build-time
 	const version = process.env.PACKAGE_VERSION ?? '0.0.0';
-	const isPrerelease = version.includes('-');
 	const rootPath = site ? site.pathname : '/';
 	const toDisplayUrl = (hostname: string) => `${https ? 'https' : 'http'}://${hostname}:${port}${rootPath}`;
 
@@ -58,12 +55,23 @@ export function devStart({
 		`${dim('┃')} Network  ${bold(cyan(toDisplayUrl(networkAddress)))}`,
 		'',
 	];
-	if (isPrerelease) {
-		messages.push(yellow('▶ This is a prerelease build.'), yellow('  Undocumented changes may happen at any time!'), '');
-	} else if (latestVersion && version !== latestVersion) {
-		messages.push(`${yellow('▶ Update available!')} ${dim(pad(version, 12, 'left'))} → ${green(latestVersion)}`, `  See ${underline(`https://astro.build/releases/${latestVersion}`)}`, '');
-	}
 	return messages.map((msg) => `  ${msg}`).join('\n');
+}
+
+export function prerelease({ currentVersion }: { currentVersion: string }) {
+	const tag = currentVersion.split('-').slice(1).join('-').replace(/\..*$/, '');
+	const badge = bgYellow(black(` ${tag} `));
+	const headline = yellow(`▶ This is a ${badge} prerelease build`);
+	const warning = dim(yellow(`  Undocumented changes may happen at any time!`))
+	return [headline, warning, ''].map((msg) => `  ${msg}`).join('\n');
+}
+
+export function outdated({ currentVersion, latestVersion }: { currentVersion: string, latestVersion: string }) {
+	return [
+			`${yellow('▶ Update available!')} ${dim(pad(currentVersion, 12, 'left'))} → ${green(latestVersion)}`,
+			`  See ${underline(`https://astro.build/releases/${latestVersion}`)}`,
+			''
+	].map((msg) => `  ${msg}`).join('\n')
 }
 
 /** Display port in use */

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -47,20 +47,18 @@ export function devStart({
 }): string {
 	// PACAKGE_VERSION is injected at build-time
 	const version = process.env.PACKAGE_VERSION ?? '0.0.0';
-	const isPre = Boolean(version.split('-')[1]);
-	const bg = bgGreen;
-	const fg = green;
+	const isPrerelease = version.includes('-');
 	const rootPath = site ? site.pathname : '/';
 	const toDisplayUrl = (hostname: string) => `${https ? 'https' : 'http'}://${hostname}:${port}${rootPath}`;
 
 	const messages = [
-		`${emoji('🚀 ', '')}${bg(black(` astro `))} ${fg(`v${version}`)} ${dim(`started in ${Math.round(startupTime)}ms`)}`,
+		`${emoji('🚀 ', '')}${bgGreen(black(` astro `))} ${green(`v${version}`)} ${dim(`started in ${Math.round(startupTime)}ms`)}`,
 		'',
 		`${dim('┃')} Local    ${bold(cyan(toDisplayUrl(localAddress)))}`,
 		`${dim('┃')} Network  ${bold(cyan(toDisplayUrl(networkAddress)))}`,
 		'',
 	];
-	if (isPre) {
+	if (isPrerelease) {
 		messages.push(yellow('▶ This is a prerelease build.'), yellow('  Undocumented changes may happen at any time!'), '');
 	} else if (latestVersion && version !== latestVersion) {
 		messages.push(`${yellow('▶ Update available!')} ${dim(pad(version, 12, 'left'))} → ${green(latestVersion)}`, `  See ${underline(`https://astro.build/releases/${latestVersion}`)}`, '');

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -62,7 +62,7 @@ export function prerelease({ currentVersion }: { currentVersion: string }) {
 	const tag = currentVersion.split('-').slice(1).join('-').replace(/\..*$/, '');
 	const badge = bgYellow(black(` ${tag} `));
 	const headline = yellow(`▶ This is a ${badge} prerelease build`);
-	const warning = dim(`  Share feedback at ${underline('https://astro.build/issues')}`)
+	const warning = `  Feedback? ${underline('https://astro.build/issues')}`
 	return [headline, warning, ''].map((msg) => `  ${msg}`).join('\n');
 }
 

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -62,16 +62,8 @@ export function prerelease({ currentVersion }: { currentVersion: string }) {
 	const tag = currentVersion.split('-').slice(1).join('-').replace(/\..*$/, '');
 	const badge = bgYellow(black(` ${tag} `));
 	const headline = yellow(`▶ This is a ${badge} prerelease build`);
-	const warning = dim(yellow(`  Undocumented changes may happen at any time!`))
+	const warning = dim(`  Leave feedback/report bugs at ${underline('https://astro.build/issues')}`)
 	return [headline, warning, ''].map((msg) => `  ${msg}`).join('\n');
-}
-
-export function outdated({ currentVersion, latestVersion }: { currentVersion: string, latestVersion: string }) {
-	return [
-			`${yellow('▶ Update available!')} ${dim(pad(currentVersion, 12, 'left'))} → ${green(latestVersion)}`,
-			`  See ${underline(`https://astro.build/releases/${latestVersion}`)}`,
-			''
-	].map((msg) => `  ${msg}`).join('\n')
 }
 
 /** Display port in use */


### PR DESCRIPTION
## Changes

- Adds a warning on dev startup when Astro is in a pre-release mode.

<img width="640" alt="Screen Shot 2022-03-10 at 4 58 12 PM" src="https://user-images.githubusercontent.com/7118177/157769191-0b152957-3b1d-49f0-9695-254fb67e0c88.png">


## Testing

Tested manually, we need snapshot tests to properly cover this

## Docs

N/A but added Netlify redirect for https://astro.build/issues
