### PR TITLE
fix: set maxRetries for fs utils

### DIFF
--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -101,7 +101,7 @@ export function viteID(filePath: URL): string {
 /** An fs utility, similar to `rimraf` or `rm -rf` */
 export function removeDir(_dir: URL): void {
 	const dir = fileURLToPath(_dir);
-	fs.rmSync(dir, { recursive: true, force: true });
+	fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3 });
 }
 
 export function emptyDir(_dir: URL, skip?: Set<string>): void {
@@ -111,7 +111,7 @@ export function emptyDir(_dir: URL, skip?: Set<string>): void {
 		if (skip?.has(file)) {
 			continue;
 		}
-		fs.rmSync(path.resolve(dir, file), { recursive: true, force: true });
+		fs.rmSync(path.resolve(dir, file), { recursive: true, force: true, maxRetries: 3 });
 	}
 }
 

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -100,16 +100,16 @@ export function viteID(filePath: URL): string {
 
 /** An fs utility, similar to `rimraf` or `rm -rf` */
 export function removeDir(dir: URL): void {
-	fs.rmSync(`${dir}`, { recursive: true, force: true, maxRetries: 3 });
+	fs.rmSync(dir.toString(), { recursive: true, force: true, maxRetries: 3 });
 }
 
 export function emptyDir(dir: URL, skip?: Set<string>): void {
-	if (!fs.existsSync(`${dir}`)) return undefined;
-	for (const file of fs.readdirSync(`${dir}`)) {
+	if (!fs.existsSync(dir.toString())) return undefined;
+	for (const file of fs.readdirSync(dir.toString())) {
 		if (skip?.has(file)) {
 			continue;
 		}
-		fs.rmSync(new URL(file, `${dir}`), { recursive: true, force: true, maxRetries: 3 });
+		fs.rmSync(new URL(file, dir).toString(), { recursive: true, force: true, maxRetries: 3 });
 	}
 }
 

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -99,19 +99,17 @@ export function viteID(filePath: URL): string {
 }
 
 /** An fs utility, similar to `rimraf` or `rm -rf` */
-export function removeDir(_dir: URL): void {
-	const dir = fileURLToPath(_dir);
+export function removeDir(dir: URL): void {
 	fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3 });
 }
 
-export function emptyDir(_dir: URL, skip?: Set<string>): void {
-	const dir = fileURLToPath(_dir);
+export function emptyDir(dir: URL, skip?: Set<string>): void {
 	if (!fs.existsSync(dir)) return undefined;
 	for (const file of fs.readdirSync(dir)) {
 		if (skip?.has(file)) {
 			continue;
 		}
-		fs.rmSync(path.resolve(dir, file), { recursive: true, force: true, maxRetries: 3 });
+		fs.rmSync(new URL(file, dir), { recursive: true, force: true, maxRetries: 3 });
 	}
 }
 

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -100,16 +100,16 @@ export function viteID(filePath: URL): string {
 
 /** An fs utility, similar to `rimraf` or `rm -rf` */
 export function removeDir(dir: URL): void {
-	fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3 });
+	fs.rmSync(`${dir}`, { recursive: true, force: true, maxRetries: 3 });
 }
 
 export function emptyDir(dir: URL, skip?: Set<string>): void {
-	if (!fs.existsSync(dir)) return undefined;
-	for (const file of fs.readdirSync(dir)) {
+	if (!fs.existsSync(`${dir}`)) return undefined;
+	for (const file of fs.readdirSync(`${dir}`)) {
 		if (skip?.has(file)) {
 			continue;
 		}
-		fs.rmSync(new URL(file, dir), { recursive: true, force: true, maxRetries: 3 });
+		fs.rmSync(new URL(file, `${dir}`), { recursive: true, force: true, maxRetries: 3 });
 	}
 }
 


### PR DESCRIPTION
## Changes

- Follow-up to #2749. Fixes failure in https://github.com/withastro/astro/pull/2758 (I HOPE!)
- Should fix flakey windows tests (I SWEAR!) by using Node's built-in `maxRetries` feature. `retryDelay` defaults to `100` but `maxRetries` defaults to 0. See [Node's `fs.rmSync` docs](https://nodejs.org/api/fs.html#fsrmsyncpath-options).

## Testing

CI

## Docs

N/A
