### PR TITLE
Feat: expose server on local network with new --host flag

### DIFF
--- a/.changeset/breezy-walls-guess.md
+++ b/.changeset/breezy-walls-guess.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Introduce a new --host flag + host devOption to expose your server on a network IP

--- a/examples/minimal/astro.config.mjs
+++ b/examples/minimal/astro.config.mjs
@@ -5,7 +5,4 @@
 export default /** @type {import('astro').AstroUserConfig} */ ({
 	// Comment out "renderers: []" to enable Astro's default component support.
 	renderers: [],
-	devOptions: {
-		host: false,
-	},
 });

--- a/examples/minimal/astro.config.mjs
+++ b/examples/minimal/astro.config.mjs
@@ -5,4 +5,7 @@
 export default /** @type {import('astro').AstroUserConfig} */ ({
 	// Comment out "renderers: []" to enable Astro's default component support.
 	renderers: [],
+	devOptions: {
+		host: false,
+	},
 });

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -320,8 +320,12 @@ export interface AstroUserConfig {
 		 * @name devOptions.hostname
 		 * @type {string | boolean}
 		 * @default `false`
+		 * @version 0.24.0
 		 * @description
-		 * Set which IP addresses the dev server should listen on. Set this to "true" to expose a default local network, or 0.0.0.0 to listen on all addresses (including LAN and public addresses).
+		 * Set which network IP addresses the dev server should listen on (i.e. 	non-localhost IPs).
+		 * - `false` - do not expose on a network IP address
+		 * - `true` - listen on all addresses, including LAN and public addresses
+		 * - `[custom-address]` - expose on a network IP address at `[custom-address]`
 		 */
 		host?: string | boolean;
 

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -24,7 +24,8 @@ export interface CLIFlags {
 	projectRoot?: string;
 	site?: string;
 	sitemap?: boolean;
-	hostname?: string | boolean;
+	host?: string | boolean;
+	hostname?: string;
 	port?: number;
 	config?: string;
 	/** @deprecated */
@@ -322,7 +323,18 @@ export interface AstroUserConfig {
 		 * @description
 		 * Set which IP addresses the dev server should listen on. Set this to "true" to expose a default local network, or 0.0.0.0 to listen on all addresses (including LAN and public addresses).
 		 */
-		hostname?: string | boolean;
+		host?: string | boolean;
+
+		/**
+		 * @docs
+		 * @name devOptions.host
+		 * @type {string}
+		 * @default `localhost`
+		 * @deprecated Use --host instead
+		 * @description
+		 * Set which IP addresses the dev server should listen on. Set this to 0.0.0.0 to listen on all addresses, including LAN and public addresses.
+		 */
+		hostname?: string;
 
 		/**
 		 * @docs

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -317,7 +317,7 @@ export interface AstroUserConfig {
 	devOptions?: {
 		/**
 		 * @docs
-		 * @name devOptions.hostname
+		 * @name devOptions.host
 		 * @type {string | boolean}
 		 * @default `false`
 		 * @version 0.24.0
@@ -331,11 +331,13 @@ export interface AstroUserConfig {
 
 		/**
 		 * @docs
-		 * @name devOptions.host
+		 * @name devOptions.hostname
 		 * @type {string}
-		 * @default `localhost`
-		 * @deprecated Use --host instead
+		 * @default `'localhost'`
+		 * @deprecated Use `host` instead
 		 * @description
+		 * > **This option is deprecated.** Consider using `host` instead.
+		 *
 		 * Set which IP addresses the dev server should listen on. Set this to 0.0.0.0 to listen on all addresses, including LAN and public addresses.
 		 */
 		hostname?: string;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -317,7 +317,7 @@ export interface AstroUserConfig {
 		/**
 		 * @docs
 		 * @name devOptions.hostname
-		 * @type {string}
+		 * @type {string | boolean}
 		 * @default `false`
 		 * @description
 		 * Set which IP addresses the dev server should listen on. Set this to "true" to expose a default local network, or 0.0.0.0 to listen on all addresses (including LAN and public addresses).

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -24,7 +24,7 @@ export interface CLIFlags {
 	projectRoot?: string;
 	site?: string;
 	sitemap?: boolean;
-	hostname?: string;
+	hostname?: string | boolean;
 	port?: number;
 	config?: string;
 	/** @deprecated */
@@ -318,11 +318,11 @@ export interface AstroUserConfig {
 		 * @docs
 		 * @name devOptions.hostname
 		 * @type {string}
-		 * @default `'localhost'`
+		 * @default `false`
 		 * @description
-		 * Set which IP addresses the dev server should listen on. Set this to 0.0.0.0 to listen on all addresses, including LAN and public addresses.
+		 * Set which IP addresses the dev server should listen on. Set this to "true" to expose a default local network, or 0.0.0.0 to listen on all addresses (including LAN and public addresses).
 		 */
-		hostname?: string;
+		hostname?: string | boolean;
 
 		/**
 		 * @docs

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -38,7 +38,7 @@ function printHelp() {
 	title('Flags');
 	table(
 		[
-			['--host [optional host address]', 'Expose server on network'],
+			['--host [optional IP]', 'Expose server on network'],
 			['--config <path>', 'Specify the path to the Astro config file.'],
 			['--project-root <path>', 'Specify the path to the project root folder.'],
 			['--no-sitemap', 'Disable sitemap generation (build only).'],

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -38,6 +38,7 @@ function printHelp() {
 	title('Flags');
 	table(
 		[
+			['--host [optional host address]', 'Expose server on network'],
 			['--config <path>', 'Specify the path to the Astro config file.'],
 			['--project-root <path>', 'Specify the path to the project root folder.'],
 			['--no-sitemap', 'Disable sitemap generation (build only).'],

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -65,7 +65,7 @@ export const AstroConfigSchema = z.object({
 		.default({}),
 	devOptions: z
 		.object({
-			hostname: z.string().optional().default('localhost'),
+			hostname: z.union([z.string(), z.boolean()]).optional().default(false),
 			port: z.number().optional().default(3000),
 			trailingSlash: z
 				.union([z.literal('always'), z.literal('never'), z.literal('ignore')])
@@ -124,7 +124,7 @@ function resolveFlags(flags: Partial<Flags>): CLIFlags {
 		sitemap: typeof flags.sitemap === 'boolean' ? flags.sitemap : undefined,
 		port: typeof flags.port === 'number' ? flags.port : undefined,
 		config: typeof flags.config === 'string' ? flags.config : undefined,
-		hostname: typeof flags.hostname === 'string' ? flags.hostname : undefined,
+		hostname: typeof flags.hostname === 'string' || typeof flags.hostname === 'boolean' ? flags.hostname : undefined,
 		legacyBuild: typeof flags.legacyBuild === 'boolean' ? flags.legacyBuild : false,
 		experimentalSsr: typeof flags.experimentalSsr === 'boolean' ? flags.experimentalSsr : false,
 		drafts: typeof flags.drafts === 'boolean' ? flags.drafts : false,
@@ -138,7 +138,7 @@ function mergeCLIFlags(astroConfig: AstroUserConfig, flags: CLIFlags) {
 	if (typeof flags.sitemap === 'boolean') astroConfig.buildOptions.sitemap = flags.sitemap;
 	if (typeof flags.site === 'string') astroConfig.buildOptions.site = flags.site;
 	if (typeof flags.port === 'number') astroConfig.devOptions.port = flags.port;
-	if (typeof flags.hostname === 'string') astroConfig.devOptions.hostname = flags.hostname;
+	if (typeof flags.hostname === 'string' || typeof flags.hostname === 'boolean') astroConfig.devOptions.hostname = flags.hostname;
 	if (typeof flags.legacyBuild === 'boolean') astroConfig.buildOptions.legacyBuild = flags.legacyBuild;
 	if (typeof flags.experimentalSsr === 'boolean') {
 		astroConfig.buildOptions.experimentalSsr = flags.experimentalSsr;

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -65,7 +65,8 @@ export const AstroConfigSchema = z.object({
 		.default({}),
 	devOptions: z
 		.object({
-			hostname: z.union([z.string(), z.boolean()]).optional().default(false),
+			host: z.union([z.string(), z.boolean()]).optional().default(false),
+			hostname: z.string().optional().default('localhost'),
 			port: z.number().optional().default(3000),
 			trailingSlash: z
 				.union([z.literal('always'), z.literal('never'), z.literal('ignore')])
@@ -124,7 +125,8 @@ function resolveFlags(flags: Partial<Flags>): CLIFlags {
 		sitemap: typeof flags.sitemap === 'boolean' ? flags.sitemap : undefined,
 		port: typeof flags.port === 'number' ? flags.port : undefined,
 		config: typeof flags.config === 'string' ? flags.config : undefined,
-		hostname: typeof flags.hostname === 'string' || typeof flags.hostname === 'boolean' ? flags.hostname : undefined,
+		hostname: typeof flags.hostname === 'string' ? flags.hostname : undefined,
+		host: typeof flags.host === 'string' || typeof flags.host === 'boolean' ? flags.host : undefined,
 		legacyBuild: typeof flags.legacyBuild === 'boolean' ? flags.legacyBuild : false,
 		experimentalSsr: typeof flags.experimentalSsr === 'boolean' ? flags.experimentalSsr : false,
 		drafts: typeof flags.drafts === 'boolean' ? flags.drafts : false,
@@ -138,7 +140,8 @@ function mergeCLIFlags(astroConfig: AstroUserConfig, flags: CLIFlags) {
 	if (typeof flags.sitemap === 'boolean') astroConfig.buildOptions.sitemap = flags.sitemap;
 	if (typeof flags.site === 'string') astroConfig.buildOptions.site = flags.site;
 	if (typeof flags.port === 'number') astroConfig.devOptions.port = flags.port;
-	if (typeof flags.hostname === 'string' || typeof flags.hostname === 'boolean') astroConfig.devOptions.hostname = flags.hostname;
+	if (typeof flags.host === 'string' || typeof flags.host === 'boolean') astroConfig.devOptions.host = flags.host;
+	if (typeof flags.hostname === 'string') astroConfig.devOptions.hostname = flags.hostname;
 	if (typeof flags.legacyBuild === 'boolean') astroConfig.buildOptions.legacyBuild = flags.legacyBuild;
 	if (typeof flags.experimentalSsr === 'boolean') {
 		astroConfig.buildOptions.experimentalSsr = flags.experimentalSsr;

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -42,10 +42,11 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 	const localAddress = getLocalAddress(address.address, config.devOptions.hostname);
 	// Log to console
 	const site = config.buildOptions.site ? new URL(config.buildOptions.site) : undefined;
+	const isNetworkExposed = config.devOptions.hostname === true || typeof config.devOptions.hostname === 'string';
 	info(
 		options.logging,
 		null,
-		msg.devStart({ startupTime: performance.now() - devStart, port: address.port, localAddress, networkAddress: address.address, site, https: !!viteUserConfig.server?.https })
+		msg.devStart({ startupTime: performance.now() - devStart, port: address.port, localAddress, isNetworkExposed, site, https: !!viteUserConfig.server?.https })
 	);
 
 	const currentVersion = process.env.PACKAGE_VERSION ?? '0.0.0';

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -6,7 +6,7 @@ import { createVite } from '../create-vite.js';
 import { defaultLogOptions, info, warn, LogOptions } from '../logger.js';
 import * as vite from 'vite';
 import * as msg from '../messages.js';
-import { getLocalAddress, getResolvedHostForVite, shouldNetworkBeExposed } from './util.js';
+import { getResolvedHostForVite } from './util.js';
 
 export interface DevOptions {
 	logging: LogOptions;
@@ -38,15 +38,9 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 	const viteServer = await vite.createServer(viteConfig);
 	await viteServer.listen(config.devOptions.port);
 
-	const address = viteServer.httpServer!.address() as AddressInfo;
-	const localAddress = getLocalAddress(address.address, config);
-	const isNetworkExposed = shouldNetworkBeExposed(config);
+	const devServerAddressInfo = viteServer.httpServer!.address() as AddressInfo;
 	const site = config.buildOptions.site ? new URL(config.buildOptions.site) : undefined;
-	info(
-		options.logging,
-		null,
-		msg.devStart({ startupTime: performance.now() - devStart, port: address.port, localAddress, isNetworkExposed, site, https: !!viteUserConfig.server?.https })
-	);
+	info(options.logging, null, msg.devStart({ startupTime: performance.now() - devStart, config, devServerAddressInfo, site, https: !!viteUserConfig.server?.https }));
 
 	const currentVersion = process.env.PACKAGE_VERSION ?? '0.0.0';
 	if (currentVersion.includes('-')) {
@@ -54,7 +48,7 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 	}
 
 	return {
-		address,
+		address: devServerAddressInfo,
 		stop: () => viteServer.close(),
 	};
 }

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -6,7 +6,7 @@ import { createVite } from '../create-vite.js';
 import { defaultLogOptions, info, warn, LogOptions } from '../logger.js';
 import * as vite from 'vite';
 import * as msg from '../messages.js';
-import { getLocalAddress, getResolvedHostForVite } from './util.js';
+import { getLocalAddress, getResolvedHostForVite, shouldNetworkBeExposed } from './util.js';
 
 export interface DevOptions {
 	logging: LogOptions;
@@ -40,9 +40,7 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 
 	const address = viteServer.httpServer!.address() as AddressInfo;
 	const localAddress = getLocalAddress(address.address, config);
-	// true - Vite exposes server on default network
-	// string - Vite exposes server on specified network
-	const isNetworkExposed = host === true || typeof host === 'string';
+	const isNetworkExposed = shouldNetworkBeExposed(config);
 	const site = config.buildOptions.site ? new URL(config.buildOptions.site) : undefined;
 	info(
 		options.logging,

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -6,7 +6,7 @@ import { createVite } from '../create-vite.js';
 import { defaultLogOptions, info, warn, LogOptions } from '../logger.js';
 import * as vite from 'vite';
 import * as msg from '../messages.js';
-import { getLocalAddress } from './util.js';
+import { getLocalAddress, getResolvedHostForVite } from './util.js';
 
 export interface DevOptions {
 	logging: LogOptions;
@@ -25,13 +25,8 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 		exclude: 'window document',
 	});
 
-	let host: string | boolean = '';
-	// TODO: remove "hostname" check once flag is baselined
-	if (config.devOptions.host === false && config.devOptions.hostname !== 'localhost') {
-		host = config.devOptions.hostname;
-	} else {
-		host = config.devOptions.host;
-	}
+	// TODO: remove call once --hostname is baselined
+	const host = getResolvedHostForVite(config);
 	const viteUserConfig = vite.mergeConfig(
 		{
 			mode: 'development',
@@ -44,7 +39,7 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 	await viteServer.listen(config.devOptions.port);
 
 	const address = viteServer.httpServer!.address() as AddressInfo;
-	const localAddress = getLocalAddress(address.address, host);
+	const localAddress = getLocalAddress(address.address, config);
 	// true - Vite exposes server on default network
 	// string - Vite exposes server on specified network
 	const isNetworkExposed = host === true || typeof host === 'string';

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -24,13 +24,18 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 	polyfill(globalThis, {
 		exclude: 'window document',
 	});
-	// start the server
+
+	let host: string | boolean = '';
+	// TODO: remove "hostname" check once flag is baselined
+	if (config.devOptions.host === false && config.devOptions.hostname !== 'localhost') {
+		host = config.devOptions.hostname;
+	} else {
+		host = config.devOptions.host;
+	}
 	const viteUserConfig = vite.mergeConfig(
 		{
 			mode: 'development',
-			server: {
-				host: config.devOptions.hostname,
-			},
+			server: { host },
 		},
 		config.vite || {}
 	);
@@ -39,10 +44,11 @@ export default async function dev(config: AstroConfig, options: DevOptions = { l
 	await viteServer.listen(config.devOptions.port);
 
 	const address = viteServer.httpServer!.address() as AddressInfo;
-	const localAddress = getLocalAddress(address.address, config.devOptions.hostname);
-	// Log to console
+	const localAddress = getLocalAddress(address.address, host);
+	// true - Vite exposes server on default network
+	// string - Vite exposes server on specified network
+	const isNetworkExposed = host === true || typeof host === 'string';
 	const site = config.buildOptions.site ? new URL(config.buildOptions.site) : undefined;
-	const isNetworkExposed = config.devOptions.hostname === true || typeof config.devOptions.hostname === 'string';
 	info(
 		options.logging,
 		null,

--- a/packages/astro/src/core/dev/util.ts
+++ b/packages/astro/src/core/dev/util.ts
@@ -1,5 +1,7 @@
 import type { AstroConfig } from '../../@types/astro';
 
+const localIps = new Set(['localhost', '127.0.0.1']);
+
 /** Pad string () */
 export function pad(input: string, minLength: number, dir?: 'left' | 'right'): string {
 	let output = input;
@@ -25,7 +27,7 @@ export function getResolvedHostForVite(config: AstroConfig) {
 export function getLocalAddress(serverAddress: string, config: AstroConfig): string {
 	// TODO: remove once --hostname is baselined
 	const host = getResolvedHostForVite(config);
-	if (typeof host === 'boolean' || host === 'localhost' || serverAddress === '127.0.0.1' || serverAddress === '0.0.0.0') {
+	if (typeof host === 'boolean' || localIps.has(host) || serverAddress === '0.0.0.0') {
 		return 'localhost';
 	} else {
 		return serverAddress;
@@ -35,5 +37,7 @@ export function getLocalAddress(serverAddress: string, config: AstroConfig): str
 export function shouldNetworkBeExposed(config: AstroConfig) {
 	// TODO: remove once --hostname is baselined
 	const host = getResolvedHostForVite(config);
-	return host === true || typeof host === 'string';
+	// true - Vite exposes server on default network
+	// non-local string - Vite exposes server on specified network
+	return host === true || (typeof host === 'string' && !localIps.has(host));
 }

--- a/packages/astro/src/core/dev/util.ts
+++ b/packages/astro/src/core/dev/util.ts
@@ -11,8 +11,8 @@ export function emoji(char: string, fallback: string) {
 	return process.platform !== 'win32' ? char : fallback;
 }
 
-export function getLocalAddress(serverAddress: string, configHostname: string): string {
-	if (configHostname === 'localhost' || serverAddress === '127.0.0.1' || serverAddress === '0.0.0.0') {
+export function getLocalAddress(serverAddress: string, configHostname: string | boolean): string {
+	if (configHostname === false || configHostname === 'localhost' || serverAddress === '127.0.0.1' || serverAddress === '0.0.0.0') {
 		return 'localhost';
 	} else {
 		return serverAddress;

--- a/packages/astro/src/core/dev/util.ts
+++ b/packages/astro/src/core/dev/util.ts
@@ -1,6 +1,6 @@
 import type { AstroConfig } from '../../@types/astro';
 
-const localIps = new Set(['localhost', '127.0.0.1']);
+export const localIps = new Set(['localhost', '127.0.0.1']);
 
 /** Pad string () */
 export function pad(input: string, minLength: number, dir?: 'left' | 'right'): string {
@@ -27,17 +27,24 @@ export function getResolvedHostForVite(config: AstroConfig) {
 export function getLocalAddress(serverAddress: string, config: AstroConfig): string {
 	// TODO: remove once --hostname is baselined
 	const host = getResolvedHostForVite(config);
-	if (typeof host === 'boolean' || localIps.has(host) || serverAddress === '0.0.0.0') {
+	if (typeof host === 'boolean' || host === 'localhost') {
 		return 'localhost';
 	} else {
 		return serverAddress;
 	}
 }
 
-export function shouldNetworkBeExposed(config: AstroConfig) {
+export type NetworkLogging = 'none' | 'host-to-expose' | 'visible';
+
+export function getNetworkLogging(config: AstroConfig): NetworkLogging {
 	// TODO: remove once --hostname is baselined
 	const host = getResolvedHostForVite(config);
-	// true - Vite exposes server on default network
-	// non-local string - Vite exposes server on specified network
-	return host === true || (typeof host === 'string' && !localIps.has(host));
+
+	if (host === false) {
+		return 'host-to-expose';
+	} else if (typeof host === 'string' && localIps.has(host)) {
+		return 'none';
+	} else {
+		return 'visible';
+	}
 }

--- a/packages/astro/src/core/dev/util.ts
+++ b/packages/astro/src/core/dev/util.ts
@@ -1,3 +1,5 @@
+import type { AstroConfig } from '../../@types/astro';
+
 /** Pad string () */
 export function pad(input: string, minLength: number, dir?: 'left' | 'right'): string {
 	let output = input;
@@ -11,10 +13,27 @@ export function emoji(char: string, fallback: string) {
 	return process.platform !== 'win32' ? char : fallback;
 }
 
-export function getLocalAddress(serverAddress: string, configHostname: string | boolean): string {
-	if (typeof configHostname === 'boolean' || configHostname === 'localhost' || serverAddress === '127.0.0.1' || serverAddress === '0.0.0.0') {
+// TODO: remove once --hostname is baselined
+export function getResolvedHostForVite(config: AstroConfig) {
+	if (config.devOptions.host === false && config.devOptions.hostname !== 'localhost') {
+		return config.devOptions.hostname;
+	} else {
+		return config.devOptions.host;
+	}
+}
+
+export function getLocalAddress(serverAddress: string, config: AstroConfig): string {
+	// TODO: remove once --hostname is baselined
+	const host = getResolvedHostForVite(config);
+	if (typeof host === 'boolean' || host === 'localhost' || serverAddress === '127.0.0.1' || serverAddress === '0.0.0.0') {
 		return 'localhost';
 	} else {
 		return serverAddress;
 	}
+}
+
+export function shouldNetworkBeExposed(config: AstroConfig) {
+	// TODO: remove once --hostname is baselined
+	const host = getResolvedHostForVite(config);
+	return host === true || typeof host === 'string';
 }

--- a/packages/astro/src/core/dev/util.ts
+++ b/packages/astro/src/core/dev/util.ts
@@ -12,7 +12,7 @@ export function emoji(char: string, fallback: string) {
 }
 
 export function getLocalAddress(serverAddress: string, configHostname: string | boolean): string {
-	if (configHostname === false || configHostname === 'localhost' || serverAddress === '127.0.0.1' || serverAddress === '0.0.0.0') {
+	if (typeof configHostname === 'boolean' || configHostname === 'localhost' || serverAddress === '127.0.0.1' || serverAddress === '0.0.0.0') {
 		return 'localhost';
 	} else {
 		return serverAddress;

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -47,11 +47,13 @@ export function devStart({
 	// PACKAGE_VERSION is injected at build-time
 	const version = process.env.PACKAGE_VERSION ?? '0.0.0';
 	const rootPath = site ? site.pathname : '/';
+	const localPrefix = `${dim('┃')} Local    `;
+	const networkPrefix = `${dim('┃')} Network  `;
 	const toDisplayUrl = (hostname: string) => `${https ? 'https' : 'http'}://${hostname}:${port}${rootPath}`;
 	let addresses = [];
 
 	if (!isNetworkExposed) {
-		addresses = [`${dim('┃')} Local    ${bold(cyan(toDisplayUrl(localAddress)))}`, `${dim('┃')} Network  ${dim('use --hostname to expose')}`];
+		addresses = [`${localPrefix}${bold(cyan(toDisplayUrl(localAddress)))}`, `${networkPrefix}${dim('use --hostname to expose')}`];
 	} else {
 		addresses = Object.values(os.networkInterfaces())
 			.flatMap((networkInterface) => networkInterface ?? [])
@@ -59,9 +61,9 @@ export function devStart({
 			.map(({ address }) => {
 				if (address.includes('127.0.0.1')) {
 					const displayAddress = address.replace('127.0.0.1', localAddress);
-					return `${dim('┃')} Local    ${bold(cyan(toDisplayUrl(displayAddress)))}`;
+					return `${localPrefix}${bold(cyan(toDisplayUrl(displayAddress)))}`;
 				} else {
-					return `${dim('┃')} Network  ${bold(cyan(toDisplayUrl(address)))}`;
+					return `${networkPrefix}${bold(cyan(toDisplayUrl(address)))}`;
 				}
 			});
 	}

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -2,7 +2,6 @@
  * Dev server messages (organized here to prevent clutter)
  */
 
-import type { AddressInfo } from 'net';
 import stripAnsi from 'strip-ansi';
 import { bold, dim, red, green, underline, yellow, bgYellow, cyan, bgGreen, black } from 'kleur/colors';
 import { pad, emoji } from './dev/util.js';

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -53,7 +53,7 @@ export function devStart({
 	let addresses = [];
 
 	if (!isNetworkExposed) {
-		addresses = [`${localPrefix}${bold(cyan(toDisplayUrl(localAddress)))}`, `${networkPrefix}${dim('use --hostname to expose')}`];
+		addresses = [`${localPrefix}${bold(cyan(toDisplayUrl(localAddress)))}`, `${networkPrefix}${dim('use --host to expose')}`];
 	} else {
 		addresses = Object.values(os.networkInterfaces())
 			.flatMap((networkInterface) => networkInterface ?? [])

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -64,7 +64,9 @@ export function devStart({
 				} else {
 					return `${networkPrefix}${bold(cyan(toDisplayUrl(address)))}`;
 				}
-			});
+			})
+			// ensure Local logs come before Network
+			.sort((msg) => (msg.startsWith(localPrefix) ? -1 : 1));
 	}
 
 	const messages = [`${emoji('🚀 ', '')}${bgGreen(black(` astro `))} ${green(`v${version}`)} ${dim(`started in ${Math.round(startupTime)}ms`)}`, '', ...addresses, ''];

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -7,7 +7,6 @@ import { performance } from 'perf_hooks';
 import { fileURLToPath } from 'url';
 import * as msg from '../messages.js';
 import { error, info } from '../logger.js';
-import { getLocalAddress, shouldNetworkBeExposed } from '../dev/util.js';
 import { subpathNotUsedTemplate, notFoundTemplate } from '../../template/4xx.js';
 import { getResolvedHostForHttpServer } from './util.js';
 
@@ -87,11 +86,8 @@ export default async function preview(config: AstroConfig, { logging }: PreviewO
 			const listen = () => {
 				httpServer = server.listen(port, host, async () => {
 					if (!showedListenMsg) {
-						const { address: networkAddress } = server.address() as AddressInfo;
-						const localAddress = getLocalAddress(networkAddress, config);
-						const isNetworkExposed = shouldNetworkBeExposed(config);
-
-						info(logging, null, msg.devStart({ startupTime: performance.now() - timerStart, port, localAddress, isNetworkExposed, https: false, site: baseURL }));
+						const devServerAddressInfo = server.address() as AddressInfo;
+						info(logging, null, msg.devStart({ startupTime: performance.now() - timerStart, config, devServerAddressInfo, https: false, site: baseURL }));
 					}
 					showedListenMsg = true;
 					resolve();

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -1,6 +1,5 @@
 import type { AstroConfig } from '../../@types/astro';
 import type { LogOptions } from '../logger';
-import type { Stats } from 'fs';
 import type { AddressInfo } from 'net';
 import http from 'http';
 import sirv from 'sirv';
@@ -8,16 +7,16 @@ import { performance } from 'perf_hooks';
 import { fileURLToPath } from 'url';
 import * as msg from '../messages.js';
 import { error, info } from '../logger.js';
-import { appendForwardSlash, trimSlashes } from '../path.js';
-import { getLocalAddress } from '../dev/util.js';
+import { getLocalAddress, shouldNetworkBeExposed } from '../dev/util.js';
 import { subpathNotUsedTemplate, notFoundTemplate } from '../../template/4xx.js';
+import { getResolvedHostForHttpServer } from './util.js';
 
 interface PreviewOptions {
 	logging: LogOptions;
 }
 
 export interface PreviewServer {
-	hostname: string;
+	host?: string;
 	port: number;
 	server: http.Server;
 	stop(): Promise<void>;
@@ -75,7 +74,8 @@ export default async function preview(config: AstroConfig, { logging }: PreviewO
 		}
 	});
 
-	let { hostname, port } = config.devOptions;
+	let { port } = config.devOptions;
+	const host = getResolvedHostForHttpServer(config);
 
 	let httpServer: http.Server;
 
@@ -85,12 +85,13 @@ export default async function preview(config: AstroConfig, { logging }: PreviewO
 		let showedListenMsg = false;
 		return new Promise<void>((resolve, reject) => {
 			const listen = () => {
-				httpServer = server.listen(port, hostname, async () => {
+				httpServer = server.listen(port, host, async () => {
 					if (!showedListenMsg) {
 						const { address: networkAddress } = server.address() as AddressInfo;
-						const localAddress = getLocalAddress(networkAddress, hostname);
+						const localAddress = getLocalAddress(networkAddress, config);
+						const isNetworkExposed = shouldNetworkBeExposed(config);
 
-						info(logging, null, msg.devStart({ startupTime: performance.now() - timerStart, port, localAddress, networkAddress, https: false, site: baseURL }));
+						info(logging, null, msg.devStart({ startupTime: performance.now() - timerStart, port, localAddress, isNetworkExposed, https: false, site: baseURL }));
 					}
 					showedListenMsg = true;
 					resolve();
@@ -121,7 +122,7 @@ export default async function preview(config: AstroConfig, { logging }: PreviewO
 	await startServer(startServerTime);
 
 	return {
-		hostname,
+		host,
 		port,
 		server: httpServer!,
 		stop: async () => {

--- a/packages/astro/src/core/preview/util.ts
+++ b/packages/astro/src/core/preview/util.ts
@@ -1,0 +1,17 @@
+import type { AstroConfig } from '../../@types/astro';
+
+export function getResolvedHostForHttpServer(config: AstroConfig) {
+	const { host, hostname } = config.devOptions;
+
+	if (host === false && hostname === 'localhost') {
+		// Use a secure default
+		return '127.0.0.1';
+	} else if (host === true) {
+		// If passed --host in the CLI without arguments
+		return undefined; // undefined typically means 0.0.0.0 or :: (listen on all IPs)
+	} else if (typeof host === 'string') {
+		return host;
+	} else {
+		return hostname;
+	}
+}

--- a/packages/astro/test/cli.test.js
+++ b/packages/astro/test/cli.test.js
@@ -38,28 +38,12 @@ describe('astro cli', () => {
 		expect(messages[0]).to.contain('started in');
 	});
 
-	['dev', 'preview'].forEach((cmd) => {
-		it(`astro ${cmd} (no --host)`, async () => {
-			const { local, network } = await cliServerLogSetupWithFixture([], cmd);
-
-			expect(local).to.not.be.undefined;
-			expect(network).to.not.be.undefined;
-
-			const localURL = new URL(local);
-			expect(localURL.hostname).to.be.equal('localhost', `Expected local URL to be on localhost`);
-			// should not print a network URL when --host is missing!
-			expect(() => new URL(network)).to.throw();
-		});
-	});
-
-	const hostnameFlags = [
-		['--hostname', '0.0.0.0'],
-		['--hostname', '127.0.0.1'],
-	];
-
 	// TODO: remove once --hostname is baselined
-	hostnameFlags.forEach((flags) => {
-		['dev', 'preview'].forEach((cmd) => {
+	['dev', 'preview'].forEach((cmd) => {
+		const hostnameFlags = [
+			['--hostname', '0.0.0.0'],
+		];
+		hostnameFlags.forEach((flags) => {
 			it(`astro ${cmd} ${flags.join(' ')}`, async () => {
 				const { local, network } = await cliServerLogSetupWithFixture(flags, cmd);
 
@@ -76,10 +60,9 @@ describe('astro cli', () => {
 		});
 	});
 
-	const hostFlags = [['--host'], ['--host', '0.0.0.0'], ['--host', '127.0.0.1']];
-
-	hostFlags.forEach((flags) => {
-		['dev', 'preview'].forEach((cmd) => {
+	['dev', 'preview'].forEach((cmd) => {
+		const hostFlags = [['--host'], ['--host', '0.0.0.0']];
+		hostFlags.forEach((flags) => {
 			it(`astro ${cmd} ${flags.join(' ')}`, async () => {
 				const { local, network } = await cliServerLogSetupWithFixture(flags);
 
@@ -94,6 +77,25 @@ describe('astro cli', () => {
 				expect(Number.parseInt(localURL.port)).to.be.greaterThanOrEqual(3000, `Expected Port to be >= 3000`);
 				expect(networkURL.port).to.be.equal(localURL.port, `Expected local and network ports to be equal`);
 				expect(isIPv4(networkURL.hostname)).to.be.equal(true, `Expected network URL to respect --host flag`);
+			});
+		});
+
+		const localFlags = [
+			[],
+			['--host', 'localhost'],
+			['--host', '127.0.0.1'],
+		];
+		localFlags.forEach((flags) => {
+			it(`astro ${cmd} ${flags.length ? flags.join(' ') : '(no --host)'}`, async () => {
+				const { local, network } = await cliServerLogSetupWithFixture([], cmd);
+
+				expect(local).to.not.be.undefined;
+				expect(network).to.not.be.undefined;
+
+				const localURL = new URL(local);
+				expect(localURL.hostname).to.be.equal('localhost', `Expected local URL to be on localhost`);
+				// should not print a network URL
+				expect(() => new URL(network)).to.throw();
 			});
 		});
 	});

--- a/packages/astro/test/cli.test.js
+++ b/packages/astro/test/cli.test.js
@@ -7,12 +7,8 @@ import { isIPv4 } from 'net';
 describe('astro cli', () => {
 	const cliServerLogSetupWithFixture = (flags, cmd) => {
 		const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
-		return cliServerLogSetup([
-			'--project-root',
-			fileURLToPath(projectRootURL),
-			...flags,
-		], cmd);
-	}
+		return cliServerLogSetup(['--project-root', fileURLToPath(projectRootURL), ...flags], cmd);
+	};
 
 	it('astro', async () => {
 		const proc = await cli();
@@ -43,12 +39,12 @@ describe('astro cli', () => {
 	});
 
 	['dev', 'preview'].forEach((cmd) => {
-		it (`astro ${cmd} (no --host)`, async () => {
+		it(`astro ${cmd} (no --host)`, async () => {
 			const { local, network } = await cliServerLogSetupWithFixture([], cmd);
-	
+
 			expect(local).to.not.be.undefined;
 			expect(network).to.not.be.undefined;
-	
+
 			const localURL = new URL(local);
 			expect(localURL.hostname).to.be.equal('localhost', `Expected local URL to be on localhost`);
 			// should not print a network URL when --host is missing!
@@ -80,11 +76,7 @@ describe('astro cli', () => {
 		});
 	});
 
-	const hostFlags = [
-		['--host'],
-		['--host', '0.0.0.0'],
-		['--host', '127.0.0.1'],
-	];
+	const hostFlags = [['--host'], ['--host', '0.0.0.0'], ['--host', '127.0.0.1']];
 
 	hostFlags.forEach((flags) => {
 		['dev', 'preview'].forEach((cmd) => {

--- a/packages/astro/test/cli.test.js
+++ b/packages/astro/test/cli.test.js
@@ -40,9 +40,7 @@ describe('astro cli', () => {
 
 	// TODO: remove once --hostname is baselined
 	['dev', 'preview'].forEach((cmd) => {
-		const hostnameFlags = [
-			['--hostname', '0.0.0.0'],
-		];
+		const hostnameFlags = [['--hostname', '0.0.0.0']];
 		hostnameFlags.forEach((flags) => {
 			it(`astro ${cmd} ${flags.join(' ')}`, async () => {
 				const { local, network } = await cliServerLogSetupWithFixture(flags, cmd);
@@ -80,11 +78,7 @@ describe('astro cli', () => {
 			});
 		});
 
-		const localFlags = [
-			[],
-			['--host', 'localhost'],
-			['--host', '127.0.0.1'],
-		];
+		const localFlags = [[], ['--host', 'localhost'], ['--host', '127.0.0.1']];
 		localFlags.forEach((flags) => {
 			it(`astro ${cmd} ${flags.length ? flags.join(' ') : '(no --host)'}`, async () => {
 				const { local, network } = await cliServerLogSetupWithFixture([], cmd);

--- a/packages/astro/test/config.test.js
+++ b/packages/astro/test/config.test.js
@@ -1,15 +1,22 @@
 import { expect } from 'chai';
-import { cli, loadFixture } from './test-utils.js';
+import { cli, loadFixture, cliServerLogSetup } from './test-utils.js';
 import { fileURLToPath } from 'url';
+import { isIPv4 } from 'net';
 
 describe('config', () => {
 	let hostnameFixture;
+	let hostFixture;
 	let portFixture;
 
 	before(async () => {
-		[hostnameFixture, portFixture] = await Promise.all([loadFixture({ projectRoot: './fixtures/config-hostname/' }), loadFixture({ projectRoot: './fixtures/config-port/' })]);
+		[hostnameFixture, hostFixture, portFixture] = await Promise.all([
+			loadFixture({ projectRoot: './fixtures/config-hostname/' }),
+			loadFixture({ projectRoot: './fixtures/config-host/' }),
+			loadFixture({ projectRoot: './fixtures/config-port/' }),
+		]);
 	});
 
+	// TODO: remove test once --hostname is baselined
 	describe('hostname', () => {
 		it('can be specified in astro.config.mjs', async () => {
 			expect(hostnameFixture.config.devOptions.hostname).to.equal('0.0.0.0');
@@ -17,19 +24,33 @@ describe('config', () => {
 
 		it('can be specified via --hostname flag', async () => {
 			const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
-			const proc = cli('dev', '--project-root', fileURLToPath(projectRootURL), '--hostname', '127.0.0.1');
+			const { network } = await cliServerLogSetup([
+				'--project-root',
+				fileURLToPath(projectRootURL),
+				'--hostname',
+				'127.0.0.1',
+			]);
+	
+			const networkURL = new URL(network);
+			expect(isIPv4(networkURL.hostname)).to.be.equal(true, `Expected network URL to respect --hostname flag`);
+		});
+	});
 
-			let stdout = '';
+	describe('host', () => {
+		it('can be specified in astro.config.mjs', async () => {
+			expect(hostFixture.config.devOptions.host).to.equal(true);
+		});
 
-			for await (const chunk of proc.stdout) {
-				stdout += chunk;
-
-				if (chunk.includes('Local')) break;
-			}
-
-			proc.kill();
-
-			expect(stdout).to.include('127.0.0.1');
+		it('can be specified via --host flag', async () => {
+			const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
+			const { network } = await cliServerLogSetup([
+				'--project-root',
+				fileURLToPath(projectRootURL),
+				'--host',
+			]);
+	
+			const networkURL = new URL(network);
+			expect(isIPv4(networkURL.hostname)).to.be.equal(true, `Expected network URL to respect --hostname flag`);
 		});
 	});
 

--- a/packages/astro/test/config.test.js
+++ b/packages/astro/test/config.test.js
@@ -24,7 +24,7 @@ describe('config', () => {
 
 		it('can be specified via --hostname flag', async () => {
 			const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
-			const { network } = await cliServerLogSetup(['--project-root', fileURLToPath(projectRootURL), '--hostname', '127.0.0.1']);
+			const { network } = await cliServerLogSetup(['--project-root', fileURLToPath(projectRootURL), '--hostname', '0.0.0.0']);
 
 			const networkURL = new URL(network);
 			expect(isIPv4(networkURL.hostname)).to.be.equal(true, `Expected network URL to respect --hostname flag`);

--- a/packages/astro/test/config.test.js
+++ b/packages/astro/test/config.test.js
@@ -24,13 +24,8 @@ describe('config', () => {
 
 		it('can be specified via --hostname flag', async () => {
 			const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
-			const { network } = await cliServerLogSetup([
-				'--project-root',
-				fileURLToPath(projectRootURL),
-				'--hostname',
-				'127.0.0.1',
-			]);
-	
+			const { network } = await cliServerLogSetup(['--project-root', fileURLToPath(projectRootURL), '--hostname', '127.0.0.1']);
+
 			const networkURL = new URL(network);
 			expect(isIPv4(networkURL.hostname)).to.be.equal(true, `Expected network URL to respect --hostname flag`);
 		});
@@ -43,12 +38,8 @@ describe('config', () => {
 
 		it('can be specified via --host flag', async () => {
 			const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
-			const { network } = await cliServerLogSetup([
-				'--project-root',
-				fileURLToPath(projectRootURL),
-				'--host',
-			]);
-	
+			const { network } = await cliServerLogSetup(['--project-root', fileURLToPath(projectRootURL), '--host']);
+
 			const networkURL = new URL(network);
 			expect(isIPv4(networkURL.hostname)).to.be.equal(true, `Expected network URL to respect --hostname flag`);
 		});

--- a/packages/astro/test/config.test.js
+++ b/packages/astro/test/config.test.js
@@ -49,19 +49,10 @@ describe('config', () => {
 		it('can be passed via --config', async () => {
 			const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
 			const configFileURL = new URL('./fixtures/config-path/config/my-config.mjs', import.meta.url);
-			const proc = cli('dev', '--project-root', fileURLToPath(projectRootURL), '--config', configFileURL.pathname);
+			const { network } = await cliServerLogSetup(['--project-root', fileURLToPath(projectRootURL), '--config', configFileURL.pathname]);
 
-			let stdout = '';
-
-			for await (const chunk of proc.stdout) {
-				stdout += chunk;
-
-				if (chunk.includes('Local')) break;
-			}
-
-			proc.kill();
-
-			expect(stdout).to.include('127.0.0.1');
+			const networkURL = new URL(network);
+			expect(isIPv4(networkURL.hostname)).to.be.equal(true, `Expected network URL to respect --hostname flag`);
 		});
 	});
 

--- a/packages/astro/test/fixtures/config-host/astro.config.mjs
+++ b/packages/astro/test/fixtures/config-host/astro.config.mjs
@@ -1,0 +1,6 @@
+
+export default {
+  devOptions: {
+    host: true
+  }
+}

--- a/packages/astro/test/fixtures/config-host/package.json
+++ b/packages/astro/test/fixtures/config-host/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@astrojs/test-config-host",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/config-path/config/my-config.mjs
+++ b/packages/astro/test/fixtures/config-path/config/my-config.mjs
@@ -1,6 +1,6 @@
 export default {
   devOptions: {
-    hostname: '127.0.0.1',
+    host: true,
     port: 8080,
   },
 }

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -143,4 +143,15 @@ export async function parseCliDevStart(proc) {
 	return { messages };
 }
 
+export async function cliServerLogSetup(flags = [], cmd = 'dev') {
+	const proc = cli(cmd, ...flags);
+
+	const { messages } = await parseCliDevStart(proc);
+
+	const local = messages[1].replace(/Local\s*/g, '');
+	const network = messages[2].replace(/Network\s*/g, '');
+
+	return { local, network };
+}
+
 export const isWindows = os.platform() === 'win32';

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -148,8 +148,8 @@ export async function cliServerLogSetup(flags = [], cmd = 'dev') {
 
 	const { messages } = await parseCliDevStart(proc);
 
-	const local = messages[1].replace(/Local\s*/g, '');
-	const network = messages[2].replace(/Network\s*/g, '');
+	const local = messages[1]?.replace(/Local\s*/g, '');
+	const network = messages[2]?.replace(/Network\s*/g, '');
 
 	return { local, network };
 }

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -148,8 +148,11 @@ export async function cliServerLogSetup(flags = [], cmd = 'dev') {
 
 	const { messages } = await parseCliDevStart(proc);
 
-	const local = messages[1]?.replace(/Local\s*/g, '');
-	const network = messages[2]?.replace(/Network\s*/g, '');
+	const localRaw = (messages[1] ?? '').includes('Local') ? messages[1] : undefined;
+	const networkRaw = (messages[2] ?? '').includes('Network') ? messages[2] : undefined;
+
+	const local = localRaw?.replace(/Local\s*/g, '');
+	const network = networkRaw?.replace(/Network\s*/g, '');
 
 	return { local, network };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -754,6 +754,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/config-host:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/config-hostname:
     specifiers:
       astro: workspace:*


### PR DESCRIPTION
## Changes

- Introduce new `--host` flag to mirror [Vite's config option](https://vitejs.dev/config/#server-host)
  - When `--host` is absent, the network URL is _not_ exposed on your network
  - When `--host` is present, the network URL is exposed at a default URL
  - When `--host [custom host]` is present, the network URL is exposed at [custom host]
  - (deprecated) When `--hostname [custom host]` is present, the network URL is also exposed at [custom host]
- Deprecate `--hostname` while maintaining functionality

## Testing

- Added unit tests for current and legacy flags
- Added unit tests for `preview` command alongside `dev`

## Docs

Updated configuration and CLI references on docs.
**[PR here!](https://github.com/withastro/docs/pull/207)**
