### PR TITLE
update `buildOptions.sitemapFilter` jsdoc

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -229,16 +229,20 @@ export interface AstroUserConfig {
 		/**
 		 * @docs
 		 * @name buildOptions.sitemapFilter
-		 * @type {undefined|((page: string) => boolean)}
-		 * @default `undefined`
+		 * @typeraw {(page: string) => boolean}
+		 * @see buildOptions.sitemap
 		 * @description
-		 * Customize sitemap generation for your build by excluding certain pages.
+		 * By default, all pages are included in your generated sitemap.
+		 * You can filter included pages by URL using `buildOptions.sitemapFilter`.
+		 * 
+		 * The `page` function parameter is the full URL of your rendered page, including your `buildOptions.site` domain.
+		 * Return `true` to include a page in your sitemap, and `false` to remove it.
 		 *
 		 * ```js
 		 * {
 		 *   buildOptions: {
 		 * 	   sitemap: true
-		 * 	   sitemapFilter: (page) => !page.includes('secret-page')
+		 * 	   sitemapFilter: (page) => page !== 'http://example.com/secret-page')
 		 *   }
 		 * }
 		 * ```


### PR DESCRIPTION
## Changes

- Updates the docs added in #2755 
- Fixes some invalid JSDoc so that our docs site can continue to generate docs automatically. The fix is to use `@typeraw` if you want to document something that isn't valid JSDoc (like an inline arrow function, which JSDoc is too old to understand).
- Lets keep an eye on this for the future, we probably should add a note about reviewing these JSDoc in the PR for actual content, and could investigate doing JSDoc validation as a part of CI if this happens again.