### PR TITLE
Fix dev resolution of client modules on Windows

### DIFF
--- a/.changeset/strange-kings-add.md
+++ b/.changeset/strange-kings-add.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes loading astro/client/\* on Windows in dev

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -8,6 +8,7 @@ import { RouteCache } from '../route-cache.js';
 import { resolveRenderers } from './renderers.js';
 import { errorHandler } from './error.js';
 import { getHmrScript } from './hmr.js';
+import { prependForwardSlash } from '../../path.js';
 import { render as coreRender } from '../core.js';
 import { createModuleScriptElementWithSrcSet } from '../ssr-element.js';
 
@@ -103,7 +104,7 @@ export async function render(renderers: Renderer[], mod: ComponentInstance, ssrO
 			// broken in the legacy build. This can be removed once the legacy build is removed.
 			if (!astroConfig.buildOptions.legacyBuild) {
 				const [, resolvedPath] = await viteServer.moduleGraph.resolveUrl(s);
-				return resolvedPath;
+				return '/@fs' + prependForwardSlash(resolvedPath);
 			} else {
 				return s;
 			}


### PR DESCRIPTION
## Changes

- When we create the dynamic script tags for components, in dev we use Vite to get the file path for a module id like `astro/client/idle.js`. 
- On Windows this was generating file:// paths which of course do not work. Fix is to prepend `/@fs` which is a resolution that Vite understands.

## Testing

Tested manually in the example apps only :/

## Docs

N/A