### PR TITLE
Gitpod setup improvements

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,4 @@
+FROM gitpod/workspace-node
+
+# Install latest pnpm
+RUN pnpm i -g pnpm

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ tasks:
       pnpm install
       pnpm run build
     command: |
-      [[ ! -z "$ASTRO_NEW" ]] && cd "$GITPOD_REPO_ROOT"/examples/"$ASTRO_NEW" && pnpm start
+      [[ ! -z "$ASTRO_NEW" ]] && cd "$GITPOD_REPO_ROOT"/examples/"$ASTRO_NEW" && code src/pages/index.astro && pnpm start
 vscode:
   extensions:
     - astro-build.astro-vscode

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ tasks:
       pnpm install
       pnpm run build
     command: |
-      cd examples/starter && pnpm start
+      [[ ! -z "$ASTRO_NEW" ]] && cd "$GITPOD_REPO_ROOT"/examples/"$ASTRO_NEW" && pnpm start
 vscode:
   extensions:
     - astro-build.astro-vscode

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,6 +10,9 @@ vscode:
     - astro-build.astro-vscode
     - esbenp.prettier-vscode
     - dbaeumer.vscode-eslint
+ports:
+  - port: 3000
+    onOpen: open-preview
 github:
   prebuilds:
     # enable for the master/default branch (defaults to true)

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ tasks:
       pnpm install
       pnpm run build
     command: |
-      [[ ! -z "$ASTRO_NEW" ]] && cd "$GITPOD_REPO_ROOT"/examples/"$ASTRO_NEW" && code src/pages/index.astro && pnpm start
+      [[ ! -z "$ASTRO_NEW" ]] && sleep 1 && cd "$GITPOD_REPO_ROOT"/examples/"$ASTRO_NEW" && code src/pages/index.astro && pnpm start
 vscode:
   extensions:
     - astro-build.astro-vscode

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ tasks:
       pnpm install
       pnpm run build
     command: |
-      [[ ! -z "$ASTRO_NEW" ]] && sleep 1 && cd "$GITPOD_REPO_ROOT"/examples/"$ASTRO_NEW" && code src/pages/index.astro && pnpm start
+      [[ ! -z "$ASTRO_NEW" ]] && gp await-port 23000 && cd "$GITPOD_REPO_ROOT"/examples/"$ASTRO_NEW" && code src/pages/index.astro && pnpm start
 vscode:
   extensions:
     - astro-build.astro-vscode

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,13 +1,13 @@
 ---
+image:
+  file: .gitpod.Dockerfile
 # Commands to start on workspace startup
 tasks:
   - init: pnpm install
     command: pnpm run build
 vscode:
   extensions:
-    # TODO Once astro is on [vsx](https://open-vsx.org/), we should be able to specify it as an extension as well!
-    # https://www.gitpod.io/docs/vscode-extensions
-    - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/astro-build/vsextensions/astro-vscode/0.7.13/vspackage
+    - astro-build.astro-vscode
     - esbenp.prettier-vscode
     - dbaeumer.vscode-eslint
 github:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,8 +3,9 @@ image:
   file: .gitpod.Dockerfile
 # Commands to start on workspace startup
 tasks:
-  - init: pnpm install
-    command: pnpm run build
+  - init: |
+      pnpm install
+      pnpm run build
 vscode:
   extensions:
     - astro-build.astro-vscode

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,6 +6,8 @@ tasks:
   - init: |
       pnpm install
       pnpm run build
+    command: |
+      cd examples/starter && pnpm start
 vscode:
   extensions:
     - astro-build.astro-vscode


### PR DESCRIPTION
## Changes
Various Gitpod setup improvements:
* Install the latest `pnpm` in workspace
* Add Astro-build VSCode extension (from open-vsx)
* Run `pnpm run build` during prebuild (user doesn't have to wait)
* Automatically open preview browser when port 3000 is active
* Run `starter` demo when workspace starts

## Testing
1. Open this PR in Gitpod - https://gitpod.io/#https://github.com/withastro/astro/pull/2789
1. `pnpm run build` should be ready by the time the workspace open (ran during prebuild)
1. Confirm you can see Astro's `starter` demo
1. Open `.astro` file, and confirm syntax highlighting works

* Open `blog` example from this PR in Gitpod -
https://gitpod.io/#ASTRO_NEW=blog/https://github.com/withastro/astro/pull/2789
* Open `starter` example from this PR in Gitpod -
https://gitpod.io/#ASTRO_NEW=starter/https://github.com/withastro/astro/pull/2789

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Did you make a user-facing change? You probably need to update docs! -->
<!-- Add a link to your docs PR here. If no docs added, explain why (e.g. "bug fix only") -->
<!-- Link: https://github.com/withastro/docs -->
