### PR TITLE
small lockfile update after #2771

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,16 +199,6 @@ importers:
       astro: link:../../packages/astro
       sass: 1.49.9
 
-  examples/portfolio-svelte:
-    specifiers:
-      '@astrojs/renderer-svelte': ^0.5.1
-      astro: ^0.24.0
-      sass: ^1.49.9
-    devDependencies:
-      '@astrojs/renderer-svelte': link:../../packages/renderers/renderer-svelte
-      astro: link:../../packages/astro
-      sass: 1.49.9
-
   examples/ssr:
     specifiers:
       '@astrojs/renderer-svelte': ^0.5.1


### PR DESCRIPTION
## Changes

- #2771 made a change to the workspace but didn't re-run `pnpm install`, causing an out of date lockfile. This should fix that issue.