### PR TITLE
Fix flakey windows tests, attempt number 127

### DIFF
--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -14,6 +14,7 @@ import { collectPagesData } from './page-data.js';
 import { build as scanBasedBuild } from './scan-based-build.js';
 import { staticBuild } from './static-build.js';
 import { RouteCache } from '../render/route-cache.js';
+import { emptyDir } from '../util.js';
 
 export interface BuildOptions {
 	mode?: string;
@@ -56,10 +57,16 @@ class AstroBuilder {
 	}
 
 	async build() {
-		const { logging, origin } = this;
+		const { logging, config, origin } = this;
 		const timer: Record<string, number> = {};
 		timer.init = performance.now();
 		timer.viteStart = performance.now();
+
+		// Empty out the dist folder, if needed. Vite has a config for doing this
+		// but because we are running 2 vite builds in parallel, that would cause a race
+		// condition, so we are doing it ourselves.
+		await emptyDir(config.dist, new Set('.git'));
+
 		const viteConfig = await createVite(
 			vite.mergeConfig(
 				{

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -15,7 +15,7 @@ import glob from 'fast-glob';
 import * as vite from 'vite';
 import { debug, error } from '../../core/logger.js';
 import { prependForwardSlash, appendForwardSlash } from '../../core/path.js';
-import { emptyDir, removeDir, resolveDependency } from '../../core/util.js';
+import { removeDir, resolveDependency } from '../../core/util.js';
 import { createBuildInternals } from '../../core/build/internal.js';
 import { rollupPluginAstroBuildCSS } from '../../vite-plugin-build-css/index.js';
 import { vitePluginHoistedScripts } from './vite-plugin-hoisted-scripts.js';
@@ -159,11 +159,6 @@ export async function staticBuild(opts: StaticBuildOptions) {
 		pageInput.add(astroModuleId);
 		facadeIdToPageDataMap.set(fileURLToPath(astroModuleURL), pageData);
 	}
-
-	// Empty out the dist folder, if needed. Vite has a config for doing this
-	// but because we are running 2 vite builds in parallel, that would cause a race
-	// condition, so we are doing it ourselves
-	emptyDir(astroConfig.dist, new Set('.git'));
 
 	// Build your project (SSR application code, assets, client JS, etc.)
 	const ssrResult = (await ssrBuild(opts, internals, pageInput)) as RollupOutput;


### PR DESCRIPTION
## Changes

- Make emptyDir async, run in parallel to improve perf and also maybe fix the Windows issue
- Move the emptyDir up into the main build, further away from file creation (I'm iffy on if this is the issue, but it also might not be a bad idea to delete this directory sooner i the build, before Vite has started, in case you've accidentally referenced a `dist` asset in your application).


## Testing

- Existing tests

## Docs

- N/A