### PR TITLE
Fix for allowing space in folder name

### DIFF
--- a/.changeset/grumpy-dancers-smell.md
+++ b/.changeset/grumpy-dancers-smell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix for projects with a folder name containing a space

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'url';
 import { transform } from '@astrojs/compiler';
 import { transformWithVite } from './styles.js';
 import { viteID } from '../core/util.js';
+import { prependForwardSlash } from '../core/path.js';
 
 type CompilationCache = Map<string, CompileResult>;
 type CompileResult = TransformResult & { rawCSSDeps: Set<string> };
@@ -50,7 +51,7 @@ async function compile(config: AstroConfig, filename: string, source: string, vi
 		site: config.buildOptions.site,
 		sourcefile: filename,
 		sourcemap: 'both',
-		internalURL: `/@fs${viteID(new URL('../runtime/server/index.js', import.meta.url))}`,
+		internalURL: `/@fs${prependForwardSlash(viteID(new URL('../runtime/server/index.js', import.meta.url)))}`,
 		experimentalStaticExtraction: !config.buildOptions.legacyBuild,
 		// TODO add experimental flag here
 		preprocessStyle: async (value: string, attrs: Record<string, string>) => {

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -7,6 +7,7 @@ import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { transform } from '@astrojs/compiler';
 import { transformWithVite } from './styles.js';
+import { viteID } from '../core/util.js';
 
 type CompilationCache = Map<string, CompileResult>;
 type CompileResult = TransformResult & { rawCSSDeps: Set<string> };
@@ -49,7 +50,7 @@ async function compile(config: AstroConfig, filename: string, source: string, vi
 		site: config.buildOptions.site,
 		sourcefile: filename,
 		sourcemap: 'both',
-		internalURL: `/@fs${new URL('../runtime/server/index.js', import.meta.url).pathname}`,
+		internalURL: `/@fs${viteID(new URL('../runtime/server/index.js', import.meta.url))}`,
 		experimentalStaticExtraction: !config.buildOptions.legacyBuild,
 		// TODO add experimental flag here
 		preprocessStyle: async (value: string, attrs: Record<string, string>) => {


### PR DESCRIPTION
## Changes

- Fixes #2781

## Testing

- Tested manually with the Stackblitz project.
- Tried adding a Unit test but because of the monorepo the path to the internal astro file does *not* contain a space. So adding a fixture with a space in the folder name doesn't help.
- Would need better integration test infrastructure to do this.

## Docs

N/A, bug fix.