### PR TITLE
Export defineConfig helper

### DIFF
--- a/.changeset/quick-islands-call.md
+++ b/.changeset/quick-islands-call.md
@@ -1,0 +1,15 @@
+---
+'astro': patch
+---
+
+Add an `astro/config` entrypoint with a `defineConfig` utility.
+
+Config files can now be easily benefit from Intellisense using the following approach:
+
+```js
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  renderers: []
+})
+```

--- a/examples/blog-multiple-authors/astro.config.mjs
+++ b/examples/blog-multiple-authors/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config';
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Enable the Preact renderer to support Preact JSX components.
 	renderers: ['@astrojs/renderer-preact'],
 });

--- a/examples/blog/astro.config.mjs
+++ b/examples/blog/astro.config.mjs
@@ -1,14 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config';
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
-	// Enable the Preact renderer to support Preact JSX components.
+// https://astro.build/config
+export default defineConfig({
 	renderers: ['@astrojs/renderer-preact'],
 	buildOptions: {
 		site: 'https://example.com/',

--- a/examples/component/demo/astro.config.mjs
+++ b/examples/component/demo/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config';
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Comment out "renderers: []" to enable Astro's default component support.
 	renderers: [],
 });

--- a/examples/docs/astro.config.mjs
+++ b/examples/docs/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config';
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	renderers: [
 		// Enable the Preact renderer to support Preact JSX components.
 		'@astrojs/renderer-preact',

--- a/examples/env-vars/astro.config.mjs
+++ b/examples/env-vars/astro.config.mjs
@@ -1,8 +1,6 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config';
 
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
-	// Comment out "renderers: []" to enable Astro's default component support.
+// https://astro.build/config
+export default defineConfig({
 	renderers: [],
 });

--- a/examples/framework-alpine/astro.config.mjs
+++ b/examples/framework-alpine/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/examples/framework-alpine/astro.config.mjs
+++ b/examples/framework-alpine/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config'
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// No renderers are needed for AlpineJS support, just use Astro components!
 	renderers: [],
 });

--- a/examples/framework-lit/astro.config.mjs
+++ b/examples/framework-lit/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/examples/framework-lit/astro.config.mjs
+++ b/examples/framework-lit/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config'
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Enable the lit renderer to support LitHTML components and templates.
 	renderers: ['@astrojs/renderer-lit'],
 });

--- a/examples/framework-multiple/astro.config.mjs
+++ b/examples/framework-multiple/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/examples/framework-multiple/astro.config.mjs
+++ b/examples/framework-multiple/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config'
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Enable many renderers to support all different kinds of components.
 	renderers: ['@astrojs/renderer-preact', '@astrojs/renderer-react', '@astrojs/renderer-svelte', '@astrojs/renderer-vue', '@astrojs/renderer-solid'],
 });

--- a/examples/framework-preact/astro.config.mjs
+++ b/examples/framework-preact/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/examples/framework-preact/astro.config.mjs
+++ b/examples/framework-preact/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config'
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Enable the Preact renderer to support Preact JSX components.
 	renderers: ['@astrojs/renderer-preact'],
 });

--- a/examples/framework-react/astro.config.mjs
+++ b/examples/framework-react/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/examples/framework-react/astro.config.mjs
+++ b/examples/framework-react/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config'
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Enable the React renderer to support React JSX components.
 	renderers: ['@astrojs/renderer-react'],
 });

--- a/examples/framework-solid/astro.config.mjs
+++ b/examples/framework-solid/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/examples/framework-solid/astro.config.mjs
+++ b/examples/framework-solid/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config'
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Enable the Solid renderer to support Solid JSX components.
 	renderers: ['@astrojs/renderer-solid'],
 });

--- a/examples/framework-svelte/astro.config.mjs
+++ b/examples/framework-svelte/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/examples/framework-svelte/astro.config.mjs
+++ b/examples/framework-svelte/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config'
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Enable the Svelte renderer to support Svelte components.
 	renderers: ['@astrojs/renderer-svelte'],
 });

--- a/examples/framework-vue/astro.config.mjs
+++ b/examples/framework-vue/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/examples/framework-vue/astro.config.mjs
+++ b/examples/framework-vue/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config'
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Enable the Vue renderer to support Vue components.
 	renderers: ['@astrojs/renderer-vue'],
 });

--- a/examples/minimal/astro.config.mjs
+++ b/examples/minimal/astro.config.mjs
@@ -1,8 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config';
 
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Comment out "renderers: []" to enable Astro's default component support.
 	renderers: [],
 });

--- a/examples/non-html-pages/astro.config.mjs
+++ b/examples/non-html-pages/astro.config.mjs
@@ -1,8 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config';
 
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Comment out "renderers: []" to enable Astro's default component support.
 	renderers: [],
 });

--- a/examples/portfolio/astro.config.mjs
+++ b/examples/portfolio/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/examples/portfolio/astro.config.mjs
+++ b/examples/portfolio/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config'
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Enable the Preact renderer to support Preact JSX components.
 	renderers: ['@astrojs/renderer-preact'],
 });

--- a/examples/ssr/astro.config.mjs
+++ b/examples/ssr/astro.config.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 
-export default /** @type {import('astro').AstroUserConfig} */ ({
+export default defineConfig({
 	renderers: ['@astrojs/renderer-svelte'],
 	vite: {
 		server: {

--- a/examples/starter/astro.config.mjs
+++ b/examples/starter/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/examples/starter/astro.config.mjs
+++ b/examples/starter/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config'
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Set "renderers" to "[]" to disable all default, builtin component support.
 	renderers: [],
 });

--- a/examples/subpath/astro.config.mjs
+++ b/examples/subpath/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/examples/subpath/astro.config.mjs
+++ b/examples/subpath/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config'
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Comment out "renderers: []" to enable Astro's default component support.
 	buildOptions: {
 		site: 'http://example.com/blog',

--- a/examples/with-markdown-plugins/astro.config.mjs
+++ b/examples/with-markdown-plugins/astro.config.mjs
@@ -1,15 +1,9 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
-
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
+import { defineConfig } from 'astro/config';
 import astroRemark from '@astrojs/markdown-remark';
 import addClasses from './add-classes.mjs';
 
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Enable Custom Markdown options, plugins, etc.
 	renderers: [],
 	markdownOptions: {

--- a/examples/with-markdown-shiki/astro.config.mjs
+++ b/examples/with-markdown-shiki/astro.config.mjs
@@ -1,14 +1,8 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
-
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
+import { defineConfig } from 'astro/config';
 import astroRemark from '@astrojs/markdown-remark';
 
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Enable Custom Markdown options, plugins, etc.
 	renderers: [],
 	markdownOptions: {

--- a/examples/with-markdown/astro.config.mjs
+++ b/examples/with-markdown/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/examples/with-markdown/astro.config.mjs
+++ b/examples/with-markdown/astro.config.mjs
@@ -1,12 +1,6 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config'
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	renderers: ['@astrojs/renderer-preact', '@astrojs/renderer-react', '@astrojs/renderer-svelte', '@astrojs/renderer-vue'],
 });

--- a/examples/with-nanostores/astro.config.mjs
+++ b/examples/with-nanostores/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/examples/with-nanostores/astro.config.mjs
+++ b/examples/with-nanostores/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config'
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Enable many renderers to support all different kinds of components.
 	renderers: ['@astrojs/renderer-preact', '@astrojs/renderer-react', '@astrojs/renderer-svelte', '@astrojs/renderer-vue', '@astrojs/renderer-solid'],
 });

--- a/examples/with-tailwindcss/astro.config.mjs
+++ b/examples/with-tailwindcss/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/examples/with-tailwindcss/astro.config.mjs
+++ b/examples/with-tailwindcss/astro.config.mjs
@@ -1,13 +1,7 @@
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config'
 
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	// Enable the Preact renderer to support Preact JSX components.
 	renderers: ['@astrojs/renderer-preact'],
 });

--- a/examples/with-vite-plugin-pwa/astro.config.mjs
+++ b/examples/with-vite-plugin-pwa/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig } from 'astro/config';
 import { VitePWA } from 'vite-plugin-pwa';
 
 // https://astro.build/config

--- a/examples/with-vite-plugin-pwa/astro.config.mjs
+++ b/examples/with-vite-plugin-pwa/astro.config.mjs
@@ -1,15 +1,8 @@
+import { defineConfig } from 'astro/config'
 import { VitePWA } from 'vite-plugin-pwa';
 
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
-
-// @type-check enabled!
-// VSCode and other TypeScript-enabled text editors will provide auto-completion,
-// helpful tooltips, and warnings if your exported object is invalid.
-// You can disable this by removing "@ts-check" and `@type` comments below.
-
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
+// https://astro.build/config
+export default defineConfig({
 	renderers: [],
 	vite: {
 		plugins: [VitePWA()],

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -1,0 +1,7 @@
+type AstroUserConfig = import('./dist/types/@types/astro').AstroUserConfig;
+
+/**
+ * See the full Astro Configuration API Documentation
+ * https://astro.build/config
+ */
+export function defineConfig(config: AstroUserConfig): AstroUserConfig;

--- a/packages/astro/config.mjs
+++ b/packages/astro/config.mjs
@@ -1,0 +1,3 @@
+export function defineConfig(config) {
+	return config;
+}

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": "./astro.js",
     "./env": "./env.d.ts",
+    "./config": "./config.mjs",
     "./internal": "./internal.js",
     "./app/node": "./dist/core/app/node.js",
     "./client/*": "./dist/runtime/client/*",
@@ -45,6 +46,8 @@
     "components",
     "dist",
     "astro.js",
+    "config.d.ts",
+    "config.mjs",
     "env.d.ts",
     "README.md",
     "vendor"


### PR DESCRIPTION
## Changes

- Simplifies the authoring experience for `astro.config.mjs` files
- Adds a `defineConfig` export to `astro/config` that provides intellisense (even in JS files!)
- Pairs with https://github.com/withastro/astro.build/pull/46 to add https://astro.build/config shortlink to docs
- Cleans up `astro.config.mjs` files in examples

**Before**
```js
// Full Astro Configuration API Documentation:
// https://docs.astro.build/reference/configuration-reference

// @type-check enabled!
// VSCode and other TypeScript-enabled text editors will provide auto-completion,
// helpful tooltips, and warnings if your exported object is invalid.
// You can disable this by removing "@ts-check" and `@type` comments below.

// @ts-check
export default /** @type {import('astro').AstroUserConfig} */ ({
	// Enable the Preact renderer to support Preact JSX components.
	renderers: ['@astrojs/renderer-preact'],
});
```

**After**
```js
import { defineConfig } from 'astro/config';

// https://astro.build/config
export default defineConfig({
	// Enable the Preact renderer to support Preact JSX components.
	renderers: ['@astrojs/renderer-preact'],
});
```

## Testing

No surface area for breakage, `defineConfig` is just for types

## Docs

No docs needed, QoL improvement only
