### PR TITLE
Ignore test fixture for changesets

### DIFF
--- a/.changeset/chilled-masks-kneel.md
+++ b/.changeset/chilled-masks-kneel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Test

--- a/.changeset/chilled-masks-kneel.md
+++ b/.changeset/chilled-masks-kneel.md
@@ -1,5 +1,0 @@
----
-'astro': patch
----
-
-Test

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@example/*"]
+  "ignore": ["@example/*", "@test/*"]
 }

--- a/packages/astro/test/custom-elements.test.js
+++ b/packages/astro/test/custom-elements.test.js
@@ -8,7 +8,7 @@ describe('Custom Elements', () => {
 	before(async () => {
 		fixture = await loadFixture({
 			projectRoot: './fixtures/custom-elements/',
-			renderers: ['@astrojs/test-custom-element-renderer'],
+			renderers: ['@test/custom-element-renderer'],
 		});
 		await fixture.build();
 	});

--- a/packages/astro/test/fixtures/0-css/package.json
+++ b/packages/astro/test/fixtures/0-css/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-0-css",
+  "name": "@test/0-css",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-assets/package.json
+++ b/packages/astro/test/fixtures/astro-assets/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-assets",
+  "name": "@test/astro-assets",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-attrs/package.json
+++ b/packages/astro/test/fixtures/astro-attrs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-attrs",
+  "name": "@test/astro-attrs",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-basic/package.json
+++ b/packages/astro/test/fixtures/astro-basic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-basic",
+  "name": "@test/astro-basic",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-children/package.json
+++ b/packages/astro/test/fixtures/astro-children/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-children",
+  "name": "@test/astro-children",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-class-list/package.json
+++ b/packages/astro/test/fixtures/astro-class-list/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-class-list",
+  "name": "@test/astro-class-list",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-client-only/package.json
+++ b/packages/astro/test/fixtures/astro-client-only/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-client-only",
+  "name": "@test/astro-client-only",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-component-code/package.json
+++ b/packages/astro/test/fixtures/astro-component-code/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-component-code",
+  "name": "@test/astro-component-code",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-components/package.json
+++ b/packages/astro/test/fixtures/astro-components/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-components",
+  "name": "@test/astro-components",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-css-bundling-import/package.json
+++ b/packages/astro/test/fixtures/astro-css-bundling-import/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-css-bundling-import",
+  "name": "@test/astro-css-bundling-import",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-css-bundling-nested-layouts/package.json
+++ b/packages/astro/test/fixtures/astro-css-bundling-nested-layouts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-css-bundling-nested-layouts",
+  "name": "@test/astro-css-bundling-nested-layouts",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-css-bundling/package.json
+++ b/packages/astro/test/fixtures/astro-css-bundling/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-css-bundling",
+  "name": "@test/astro-css-bundling",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-directives/package.json
+++ b/packages/astro/test/fixtures/astro-directives/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-directives",
+  "name": "@test/astro-directives",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-doctype/package.json
+++ b/packages/astro/test/fixtures/astro-doctype/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-doctype",
+  "name": "@test/astro-doctype",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-dynamic/package.json
+++ b/packages/astro/test/fixtures/astro-dynamic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-dynamic",
+  "name": "@test/astro-dynamic",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-envs/package.json
+++ b/packages/astro/test/fixtures/astro-envs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-envs",
+  "name": "@test/astro-envs",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-expr/package.json
+++ b/packages/astro/test/fixtures/astro-expr/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-expr",
+  "name": "@test/astro-expr",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-external-files/package.json
+++ b/packages/astro/test/fixtures/astro-external-files/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-external-files",
+  "name": "@test/astro-external-files",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-fallback/package.json
+++ b/packages/astro/test/fixtures/astro-fallback/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-fallback",
+  "name": "@test/astro-fallback",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-get-static-paths/package.json
+++ b/packages/astro/test/fixtures/astro-get-static-paths/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-get-static-paths",
+  "name": "@test/astro-get-static-paths",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-global/package.json
+++ b/packages/astro/test/fixtures/astro-global/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-global",
+  "name": "@test/astro-global",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-jsx/package.json
+++ b/packages/astro/test/fixtures/astro-jsx/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-jsx",
+  "name": "@test/astro-jsx",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-markdown-drafts/package.json
+++ b/packages/astro/test/fixtures/astro-markdown-drafts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-markdown-drafts",
+  "name": "@test/astro-markdown-drafts",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-markdown-plugins/package.json
+++ b/packages/astro/test/fixtures/astro-markdown-plugins/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-markdown-plugins",
+  "name": "@test/astro-markdown-plugins",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-markdown-shiki/langs/package.json
+++ b/packages/astro/test/fixtures/astro-markdown-shiki/langs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-markdown-skiki-langs",
+  "name": "@test/astro-markdown-skiki-langs",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-markdown-shiki/normal/package.json
+++ b/packages/astro/test/fixtures/astro-markdown-shiki/normal/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-markdown-skiki-normal",
+  "name": "@test/astro-markdown-skiki-normal",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-markdown-shiki/themes-custom/package.json
+++ b/packages/astro/test/fixtures/astro-markdown-shiki/themes-custom/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-markdown-skiki-themes-custom",
+  "name": "@test/astro-markdown-skiki-themes-custom",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-markdown-shiki/themes-integrated/package.json
+++ b/packages/astro/test/fixtures/astro-markdown-shiki/themes-integrated/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-markdown-skiki-themes-integrated",
+  "name": "@test/astro-markdown-skiki-themes-integrated",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-markdown-shiki/wrap-false/package.json
+++ b/packages/astro/test/fixtures/astro-markdown-shiki/wrap-false/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-markdown-skiki-wrap-false",
+  "name": "@test/astro-markdown-skiki-wrap-false",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-markdown-shiki/wrap-null/package.json
+++ b/packages/astro/test/fixtures/astro-markdown-shiki/wrap-null/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-markdown-skiki-wrap-null",
+  "name": "@test/astro-markdown-skiki-wrap-null",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-markdown-shiki/wrap-true/package.json
+++ b/packages/astro/test/fixtures/astro-markdown-shiki/wrap-true/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-markdown-skiki-wrap-true",
+  "name": "@test/astro-markdown-skiki-wrap-true",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-markdown/package.json
+++ b/packages/astro/test/fixtures/astro-markdown/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-markdown",
+  "name": "@test/astro-markdown",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-page-directory-url/package.json
+++ b/packages/astro/test/fixtures/astro-page-directory-url/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-page-directory-url",
+  "name": "@test/astro-page-directory-url",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-pages/package.json
+++ b/packages/astro/test/fixtures/astro-pages/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-pages",
+  "name": "@test/astro-pages",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-pagination/package.json
+++ b/packages/astro/test/fixtures/astro-pagination/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-pagination",
+  "name": "@test/astro-pagination",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-partial-html/package.json
+++ b/packages/astro/test/fixtures/astro-partial-html/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-partial-html",
+  "name": "@test/astro-partial-html",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-public/package.json
+++ b/packages/astro/test/fixtures/astro-public/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-public",
+  "name": "@test/astro-public",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-scripts/package.json
+++ b/packages/astro/test/fixtures/astro-scripts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-scripts",
+  "name": "@test/astro-scripts",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-sitemap-rss/package.json
+++ b/packages/astro/test/fixtures/astro-sitemap-rss/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-sitemap-rss",
+  "name": "@test/astro-sitemap-rss",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-slots/package.json
+++ b/packages/astro/test/fixtures/astro-slots/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-astro-slots",
+  "name": "@test/astro-slots",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/config-host/package.json
+++ b/packages/astro/test/fixtures/config-host/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-config-host",
+  "name": "@test/config-host",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/config-hostname/package.json
+++ b/packages/astro/test/fixtures/config-hostname/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-config-hostname",
+  "name": "@test/config-hostname",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/config-path/package.json
+++ b/packages/astro/test/fixtures/config-path/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-config-path",
+  "name": "@test/config-path",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/config-port/package.json
+++ b/packages/astro/test/fixtures/config-port/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-config-port",
+  "name": "@test/config-port",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/custom-elements/my-component-lib/CHANGELOG.md
+++ b/packages/astro/test/fixtures/custom-elements/my-component-lib/CHANGELOG.md
@@ -1,8 +1,0 @@
-# @astrojs/test-custom-element-renderer
-
-## 0.1.0
-### Minor Changes
-
-
-
-- [#2202](https://github.com/withastro/astro/pull/2202) [`45cea6ae`](https://github.com/withastro/astro/commit/45cea6aec5a310fed4cb8da0d96670d6b99a2539) Thanks [@jonathantneal](https://github.com/jonathantneal)! - Officially drop support for Node v12. The minimum supported version is now Node v14.15+,

--- a/packages/astro/test/fixtures/custom-elements/my-component-lib/index.js
+++ b/packages/astro/test/fixtures/custom-elements/my-component-lib/index.js
@@ -1,5 +1,5 @@
 export default {
-  name: '@astrojs/test-custom-element-renderer',
+  name: '@test/custom-element-renderer',
   server: './server.js',
   polyfills: [
     './polyfill.js'
@@ -10,8 +10,8 @@ export default {
   viteConfig() {
     return {
       optimizeDeps: {
-        include: ['@astrojs/test-custom-element-renderer/polyfill.js', '@astrojs/test-custom-element-renderer/hydration-polyfill.js'],
-				exclude: ['@astrojs/test-custom-element-renderer/server.js']
+        include: ['@test/custom-element-renderer/polyfill.js', '@test/custom-element-renderer/hydration-polyfill.js'],
+				exclude: ['@test/custom-element-renderer/server.js']
       }
     }
   }

--- a/packages/astro/test/fixtures/custom-elements/my-component-lib/package.json
+++ b/packages/astro/test/fixtures/custom-elements/my-component-lib/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-custom-element-renderer",
+  "name": "@test/custom-element-renderer",
   "version": "0.1.0",
   "private": true,
   "main": "index.js",

--- a/packages/astro/test/fixtures/custom-elements/package.json
+++ b/packages/astro/test/fixtures/custom-elements/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@astrojs/test-custom-elements",
+  "name": "@test/custom-elements",
   "version": "0.0.0",
   "private": true,
   "dependencies": {
     "astro": "workspace:*",
-    "@astrojs/test-custom-element-renderer": "workspace:*"
+    "@test/custom-element-renderer": "workspace:*"
   }
 }

--- a/packages/astro/test/fixtures/debug-component/package.json
+++ b/packages/astro/test/fixtures/debug-component/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-debug-component",
+  "name": "@test/debug-component",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/errors/package.json
+++ b/packages/astro/test/fixtures/errors/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-errors",
+  "name": "@test/errors",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/fetch/package.json
+++ b/packages/astro/test/fixtures/fetch/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-fetch",
+  "name": "@test/fetch",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/legacy-build/package.json
+++ b/packages/astro/test/fixtures/legacy-build/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/legacy-build",
+  "name": "@test/legacy-build",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/lit-element/package.json
+++ b/packages/astro/test/fixtures/lit-element/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-lit-element",
+  "name": "@test/lit-element",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/markdown/package.json
+++ b/packages/astro/test/fixtures/markdown/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-markdown",
+  "name": "@test/markdown",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/postcss/package.json
+++ b/packages/astro/test/fixtures/postcss/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-postcss",
+  "name": "@test/postcss",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/preact-component/package.json
+++ b/packages/astro/test/fixtures/preact-component/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-preact-component",
+  "name": "@test/preact-component",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/react-component/package.json
+++ b/packages/astro/test/fixtures/react-component/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-react-component",
+  "name": "@test/react-component",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/remote-css/package.json
+++ b/packages/astro/test/fixtures/remote-css/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-remote-css",
+  "name": "@test/remote-css",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/route-manifest/package.json
+++ b/packages/astro/test/fixtures/route-manifest/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-route-manifest",
+  "name": "@test/route-manifest",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/sass/package.json
+++ b/packages/astro/test/fixtures/sass/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-sass",
+  "name": "@test/sass",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/slots-preact/package.json
+++ b/packages/astro/test/fixtures/slots-preact/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-slots-preact",
+  "name": "@test/slots-preact",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/slots-react/package.json
+++ b/packages/astro/test/fixtures/slots-react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-slots-react",
+  "name": "@test/slots-react",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/slots-solid/package.json
+++ b/packages/astro/test/fixtures/slots-solid/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-slots-solid",
+  "name": "@test/slots-solid",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/slots-svelte/package.json
+++ b/packages/astro/test/fixtures/slots-svelte/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-slots-svelte",
+  "name": "@test/slots-svelte",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/slots-vue/package.json
+++ b/packages/astro/test/fixtures/slots-vue/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-slots-vue",
+  "name": "@test/slots-vue",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/solid-component/package.json
+++ b/packages/astro/test/fixtures/solid-component/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-solid-component",
+  "name": "@test/solid-component",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/static build/package.json
+++ b/packages/astro/test/fixtures/static build/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@astrojs/test-static-build",
+  "name": "@test/static-build",
   "version": "0.0.0",
   "dependencies": {
-    "@astrojs/test-static-build-pkg": "link:pkg",
+    "@test/static-build-pkg": "link:pkg",
     "astro": "workspace:*"
   }
 }

--- a/packages/astro/test/fixtures/static build/pkg/package.json
+++ b/packages/astro/test/fixtures/static build/pkg/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-static-build-pkg",
+  "name": "@test/static-build-pkg",
   "main": "./oops.cjs",
   "version": "0.0.3",
   "exports": {

--- a/packages/astro/test/fixtures/static build/src/pages/index.astro
+++ b/packages/astro/test/fixtures/static build/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import MainHead from '../components/MainHead.astro';
 import Nav from '../components/Nav/index.jsx';
-import { test as ssrConfigTest } from '@astrojs/test-static-build-pkg';
+import { test as ssrConfigTest } from '@test/static-build-pkg';
 let allPosts = await Astro.fetchContent('./posts/*.md');
 ---
 <html>

--- a/packages/astro/test/fixtures/static-build-code-component/package.json
+++ b/packages/astro/test/fixtures/static-build-code-component/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-static-build-code-component",
+  "name": "@test/static-build-code-component",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/static-build-frameworks/package.json
+++ b/packages/astro/test/fixtures/static-build-frameworks/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-static-build-frameworks",
+  "name": "@test/static-build-frameworks",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/static-build-page-url-format/package.json
+++ b/packages/astro/test/fixtures/static-build-page-url-format/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-static-build-page-url-format",
+  "name": "@test/static-build-page-url-format",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/svelte-component/package.json
+++ b/packages/astro/test/fixtures/svelte-component/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-svelte-component",
+  "name": "@test/svelte-component",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/vue-component/package.json
+++ b/packages/astro/test/fixtures/vue-component/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-vue-component",
+  "name": "@test/vue-component",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/with-endpoint-routes/package.json
+++ b/packages/astro/test/fixtures/with-endpoint-routes/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-with-endpoint-routes",
+  "name": "@test/with-endpoint-routes",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/with-subpath-no-trailing-slash/package.json
+++ b/packages/astro/test/fixtures/with-subpath-no-trailing-slash/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-with-subpath-no-trailing-slash",
+  "name": "@test/with-subpath-no-trailing-slash",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/with-subpath-trailing-slash/package.json
+++ b/packages/astro/test/fixtures/with-subpath-trailing-slash/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-with-subpath-trailing-slash",
+  "name": "@test/with-subpath-trailing-slash",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/without-site-config/package.json
+++ b/packages/astro/test/fixtures/without-site-config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-without-site-config",
+  "name": "@test/without-site-config",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/without-subpath/package.json
+++ b/packages/astro/test/fixtures/without-subpath/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astrojs/test-without-subpath",
+  "name": "@test/without-subpath",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -17,7 +17,7 @@ describe('Static build', () => {
 				site: 'http://example.com/subpath/',
 			},
 			ssr: {
-				noExternal: ['@astrojs/test-static-build-pkg'],
+				noExternal: ['@test/static-build-pkg'],
 			},
 		});
 		await fixture.build();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -770,10 +770,10 @@ importers:
 
   packages/astro/test/fixtures/custom-elements:
     specifiers:
-      '@astrojs/test-custom-element-renderer': workspace:*
+      '@test/custom-element-renderer': workspace:*
       astro: workspace:*
     dependencies:
-      '@astrojs/test-custom-element-renderer': link:my-component-lib
+      '@test/custom-element-renderer': link:my-component-lib
       astro: link:../../..
 
   packages/astro/test/fixtures/custom-elements/my-component-lib:
@@ -909,10 +909,10 @@ importers:
 
   packages/astro/test/fixtures/static build:
     specifiers:
-      '@astrojs/test-static-build-pkg': link:pkg
+      '@test/static-build-pkg': link:pkg
       astro: workspace:*
     dependencies:
-      '@astrojs/test-static-build-pkg': link:pkg
+      '@test/static-build-pkg': link:pkg
       astro: link:../../..
 
   packages/astro/test/fixtures/static build/pkg:


### PR DESCRIPTION
## Changes

- Moves test fixture packages to `@test/*` namespace.
- Ignores `@test/*` packages for changesets.

**Before**
<img width="594" alt="Screen Shot 2022-03-15 at 3 32 06 PM" src="https://user-images.githubusercontent.com/7118177/158467090-972ac17c-b8bf-460a-8dab-0f7638781d65.png">


**After**
<img width="639" alt="Screen Shot 2022-03-15 at 3 31 10 PM" src="https://user-images.githubusercontent.com/7118177/158466971-806cbdd4-1adc-4859-a6bf-b9ab61efe5f7.png">



## Testing

This is the test

## Docs

N/A