### PR TITLE
Disable sourcemaps for build

### DIFF
--- a/.changeset/spicy-chicken-pump.md
+++ b/.changeset/spicy-chicken-pump.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix a warning from Vite regarding internal sourcemaps

--- a/scripts/cmd/build.js
+++ b/scripts/cmd/build.js
@@ -38,6 +38,7 @@ export default async function build(...args) {
 	if (!isDev) {
 		await esbuild.build({
 			...config,
+			sourcemap: false,
 			bundle: entryPoints.length === 1, // Note: only use `bundle` with a single entrypoint!
 			entryPoints,
 			outdir,


### PR DESCRIPTION
## Changes

- Disables sourcemaps for built `astro` files, since they point to missing files.
- Hopefully fixes issue where Vite would yell at users.

## Testing

Not possible to test in monorepo

## Docs

N/A