### PR TITLE
fix: Svelte PostCSS config error

### DIFF
--- a/.changeset/large-snakes-lay.md
+++ b/.changeset/large-snakes-lay.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/renderer-svelte': patch
+---
+
+Remove "PostCSS configuration was not passed or is invalid" error when using the Svelte renderer

--- a/packages/renderers/renderer-svelte/index.js
+++ b/packages/renderers/renderer-svelte/index.js
@@ -20,7 +20,6 @@ export default {
 							less: true,
 							sass: { renderSync: true },
 							scss: { renderSync: true },
-							postcss: true,
 							stylus: true,
 							typescript: true,
 						}),


### PR DESCRIPTION
## Changes

- Resolves #2273 
- Removed explicit `postcss: true` on Svelte renderer `preprocess(...)` call. We handle the PostCSS config mapping ourselves, so this opt-in flag is actually unnecessary!

## Testing

Verified existing [postcss.test](https://github.com/withastro/astro/blob/main/packages/astro/test/postcss.test.js) still passes for Svelte.

## Docs

N/A
