### PR TITLE
Adds tests for tailwind support in `dev` and `build`

### DIFF
--- a/packages/astro/test/fixtures/tailwindcss/package.json
+++ b/packages/astro/test/fixtures/tailwindcss/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@astrojs/test-tailwindcss",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "postcss": "^8.4.8",
+    "tailwindcss": "^3.0.23"
+  }
+}

--- a/packages/astro/test/fixtures/tailwindcss/package.json
+++ b/packages/astro/test/fixtures/tailwindcss/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "@astrojs/test-tailwindcss",
+  "name": "@test/tailwindcss",
   "version": "0.0.0",
   "private": true,
   "dependencies": {
     "astro": "workspace:*",
+    "autoprefixer": "^10.4.2",
     "postcss": "^8.4.8",
     "tailwindcss": "^3.0.23"
   }

--- a/packages/astro/test/fixtures/tailwindcss/postcss.config.js
+++ b/packages/astro/test/fixtures/tailwindcss/postcss.config.js
@@ -1,0 +1,9 @@
+const path = require('path');
+
+module.exports = {
+	plugins: {
+		tailwindcss: {
+			config: path.join(__dirname, 'tailwind.config.js'), // update this if your path differs!
+		}
+	},
+};

--- a/packages/astro/test/fixtures/tailwindcss/postcss.config.js
+++ b/packages/astro/test/fixtures/tailwindcss/postcss.config.js
@@ -4,6 +4,7 @@ module.exports = {
 	plugins: {
 		tailwindcss: {
 			config: path.join(__dirname, 'tailwind.config.js'), // update this if your path differs!
-		}
+		},
+		autoprefixer: {}
 	},
 };

--- a/packages/astro/test/fixtures/tailwindcss/src/components/Button.astro
+++ b/packages/astro/test/fixtures/tailwindcss/src/components/Button.astro
@@ -1,0 +1,10 @@
+---
+let { type = 'button' } = Astro.props;
+---
+
+<button
+	class="py-2 px-4 lg:py-3 lg:px-5 bg-purple-600 text-white font-[900] rounded-lg shadow-md hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400 focus:ring-opacity-75"
+	{type}
+>
+	<slot />
+</button>

--- a/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
+++ b/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
@@ -1,0 +1,20 @@
+---
+// Component Imports
+import Button from '../components/Button.astro';
+import "../styles/global.css";
+
+// Full Astro Component Syntax:
+// https://docs.astro.build/core-concepts/astro-components/
+---
+
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<title>Astro + TailwindCSS</title>
+	</head>
+
+	<body>
+		<Button>I’m a Tailwind Button!</Button>
+	</body>
+</html>

--- a/packages/astro/test/fixtures/tailwindcss/src/styles/global.css
+++ b/packages/astro/test/fixtures/tailwindcss/src/styles/global.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/packages/astro/test/fixtures/tailwindcss/tailwind.config.js
+++ b/packages/astro/test/fixtures/tailwindcss/tailwind.config.js
@@ -1,0 +1,5 @@
+const path = require('path');
+
+module.exports = {
+	content: [path.join(__dirname, 'src/**/*.{astro,html,js,jsx,svelte,ts,tsx,vue}')],
+};

--- a/packages/astro/test/tailwindcss.test.js
+++ b/packages/astro/test/tailwindcss.test.js
@@ -6,7 +6,6 @@ let fixture;
 
 describe('Tailwind', () => {
 	let fixture;
-	let devServer;
 
     before(async () => {
 		fixture = await loadFixture({
@@ -35,24 +34,26 @@ describe('Tailwind', () => {
 			bundledCSS = await fixture.readFile(bundledCSSHREF.replace(/^\/?/, '/'));
 		});
 
-        it('includes used component classes', async () => {
-            expect(bundledCSS).to.match(/\.bg-purple-600{/);
-        });
+		it('resolves CSS in src/styles', async () => {
+			expect(bundledCSS, 'includes used component classes').to.match(/\.bg-purple-600{/);
 
-        it('purges unused classes', async () => {
             // tests a random tailwind class that isn't used on the page
-            expect(bundledCSS).not.to.match(/\.bg-blue-600{/);
-        });
+            expect(bundledCSS, 'purges unused classes').not.to.match(/\.bg-blue-600{/);
 
-        it('includes responsive classes', async () => {
             // tailwind escapes colons, `lg:py-3` compiles to `lg\:py-3`
-            expect(bundledCSS).to.match(/\.lg\\:py-3{/)
-        })
+            expect(bundledCSS, 'includes responsive classes').to.match(/\.lg\\:py-3{/);
 
-        it('supports arbitrary value classes', async () => {
             // tailwind escapes brackets, `font-[900]` compiles to `font-\[900\]`
-            expect(bundledCSS).to.match(/\.font-\\\[900\\\]{font-weight:900}/)
-        })
+            expect(bundledCSS, 'supports arbitrary value classes').to.match(/\.font-\\\[900\\\]{font-weight:900}/)
+		});
+
+		it('maintains classes in HTML', async () => {
+			const button = $('button');
+
+			expect(button.hasClass('text-white'), 'basic class').to.be.true;
+			expect(button.hasClass('lg:py-3'), 'responsive class').to.be.true;
+			expect(button.hasClass('font-[900]', 'arbitrary value')).to.be.true;
+		});
     });
 
     // with "build" handling CSS checking, the dev tests are mostly testing the paths resolve in dev
@@ -78,9 +79,23 @@ describe('Tailwind', () => {
             const text = await res.text()
             
             expect(text, 'includes used component classes').to.match(/\.bg-purple-600/);
+
+			// tests a random tailwind class that isn't used on the page
             expect(text, 'purges unused classes').not.to.match(/\.bg-blue-600/);
+
+			// tailwind escapes colons, `lg:py-3` compiles to `lg\:py-3`
             expect(text, 'includes responsive classes').to.match(/\.lg\\\\:py-3/);
+
+			// tailwind escapes brackets, `font-[900]` compiles to `font-\[900\]`
             expect(text, 'supports arbitrary value classes').to.match(/.font-\\[900\\]/)
+		});
+
+		it('maintains classes in HTML', async () => {
+			const button = $('button');
+
+			expect(button.hasClass('text-white'), 'basic class').to.be.true;
+			expect(button.hasClass('lg:py-3'), 'responsive class').to.be.true;
+			expect(button.hasClass('font-[900]', 'arbitrary value')).to.be.true;
 		});
     })
 });

--- a/packages/astro/test/tailwindcss.test.js
+++ b/packages/astro/test/tailwindcss.test.js
@@ -7,7 +7,7 @@ let fixture;
 describe('Tailwind', () => {
 	let fixture;
 
-    before(async () => {
+	before(async () => {
 		fixture = await loadFixture({
 			projectRoot: './fixtures/tailwindcss/',
 			renderers: [],
@@ -19,12 +19,12 @@ describe('Tailwind', () => {
 		});
 	});
 
-    // test HTML and CSS contents for accuracy
-    describe('build', () => {
+	// test HTML and CSS contents for accuracy
+	describe('build', () => {
 		let $;
 		let bundledCSS;
 
-        before(async () => {
+		before(async () => {
 			await fixture.build();
 
 			// get bundled CSS (will be hashed, hence DOM query)
@@ -37,14 +37,14 @@ describe('Tailwind', () => {
 		it('resolves CSS in src/styles', async () => {
 			expect(bundledCSS, 'includes used component classes').to.match(/\.bg-purple-600{/);
 
-            // tests a random tailwind class that isn't used on the page
-            expect(bundledCSS, 'purges unused classes').not.to.match(/\.bg-blue-600{/);
+			// tests a random tailwind class that isn't used on the page
+			expect(bundledCSS, 'purges unused classes').not.to.match(/\.bg-blue-600{/);
 
-            // tailwind escapes colons, `lg:py-3` compiles to `lg\:py-3`
-            expect(bundledCSS, 'includes responsive classes').to.match(/\.lg\\:py-3{/);
+			// tailwind escapes colons, `lg:py-3` compiles to `lg\:py-3`
+			expect(bundledCSS, 'includes responsive classes').to.match(/\.lg\\:py-3{/);
 
-            // tailwind escapes brackets, `font-[900]` compiles to `font-\[900\]`
-            expect(bundledCSS, 'supports arbitrary value classes').to.match(/\.font-\\\[900\\\]{font-weight:900}/)
+			// tailwind escapes brackets, `font-[900]` compiles to `font-\[900\]`
+			expect(bundledCSS, 'supports arbitrary value classes').to.match(/\.font-\\\[900\\\]{font-weight:900}/);
 		});
 
 		it('maintains classes in HTML', async () => {
@@ -54,11 +54,11 @@ describe('Tailwind', () => {
 			expect(button.hasClass('lg:py-3'), 'responsive class').to.be.true;
 			expect(button.hasClass('font-[900]', 'arbitrary value')).to.be.true;
 		});
-    });
+	});
 
-    // with "build" handling CSS checking, the dev tests are mostly testing the paths resolve in dev
-    describe('dev', () => {
-        let devServer;
+	// with "build" handling CSS checking, the dev tests are mostly testing the paths resolve in dev
+	describe('dev', () => {
+		let devServer;
 		let $;
 
 		before(async () => {
@@ -73,21 +73,21 @@ describe('Tailwind', () => {
 
 		it('resolves CSS in src/styles', async () => {
 			const href = $(`link[href$="/src/styles/global.css"]`).attr('href');
-            const res = await fixture.fetch(href);
-            expect(res.status).to.equal(200);
+			const res = await fixture.fetch(href);
+			expect(res.status).to.equal(200);
 
-            const text = await res.text()
-            
-            expect(text, 'includes used component classes').to.match(/\.bg-purple-600/);
+			const text = await res.text();
+
+			expect(text, 'includes used component classes').to.match(/\.bg-purple-600/);
 
 			// tests a random tailwind class that isn't used on the page
-            expect(text, 'purges unused classes').not.to.match(/\.bg-blue-600/);
+			expect(text, 'purges unused classes').not.to.match(/\.bg-blue-600/);
 
 			// tailwind escapes colons, `lg:py-3` compiles to `lg\:py-3`
-            expect(text, 'includes responsive classes').to.match(/\.lg\\\\:py-3/);
+			expect(text, 'includes responsive classes').to.match(/\.lg\\\\:py-3/);
 
 			// tailwind escapes brackets, `font-[900]` compiles to `font-\[900\]`
-            expect(text, 'supports arbitrary value classes').to.match(/.font-\\[900\\]/)
+			expect(text, 'supports arbitrary value classes').to.match(/.font-\\[900\\]/);
 		});
 
 		it('maintains classes in HTML', async () => {
@@ -97,5 +97,5 @@ describe('Tailwind', () => {
 			expect(button.hasClass('lg:py-3'), 'responsive class').to.be.true;
 			expect(button.hasClass('font-[900]', 'arbitrary value')).to.be.true;
 		});
-    })
+	});
 });

--- a/packages/astro/test/tailwindcss.test.js
+++ b/packages/astro/test/tailwindcss.test.js
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+let fixture;
+
+describe('Tailwind', () => {
+	let fixture;
+	let devServer;
+
+    before(async () => {
+		fixture = await loadFixture({
+			projectRoot: './fixtures/tailwindcss/',
+			renderers: [],
+			vite: {
+				build: {
+					assetsInlineLimit: 0,
+				},
+			},
+		});
+	});
+
+    // test HTML and CSS contents for accuracy
+    describe('build', () => {
+		let $;
+		let bundledCSS;
+
+        before(async () => {
+			await fixture.build();
+
+			// get bundled CSS (will be hashed, hence DOM query)
+			const html = await fixture.readFile('/index.html');
+			$ = cheerio.load(html);
+			const bundledCSSHREF = $('link[rel=stylesheet][href^=/assets/]').attr('href');
+			bundledCSS = await fixture.readFile(bundledCSSHREF.replace(/^\/?/, '/'));
+		});
+
+        it('includes used component classes', async () => {
+            expect(bundledCSS).to.match(/\.bg-purple-600{/);
+        });
+
+        it('purges unused classes', async () => {
+            // tests a random tailwind class that isn't used on the page
+            expect(bundledCSS).not.to.match(/\.bg-blue-600{/);
+        });
+
+        it('includes responsive classes', async () => {
+            // tailwind escapes colons, `lg:py-3` compiles to `lg\:py-3`
+            expect(bundledCSS).to.match(/\.lg\\:py-3{/)
+        })
+
+        it('supports arbitrary value classes', async () => {
+            // tailwind escapes brackets, `font-[900]` compiles to `font-\[900\]`
+            expect(bundledCSS).to.match(/\.font-\\\[900\\\]{font-weight:900}/)
+        })
+    });
+
+    // with "build" handling CSS checking, the dev tests are mostly testing the paths resolve in dev
+    describe('dev', () => {
+        let devServer;
+		let $;
+
+		before(async () => {
+			devServer = await fixture.startDevServer();
+			const html = await fixture.fetch('/').then((res) => res.text());
+			$ = cheerio.load(html);
+		});
+
+		after(async () => {
+			devServer && (await devServer.stop());
+		});
+
+		it('resolves CSS in src/styles', async () => {
+			const href = $(`link[href$="/src/styles/global.css"]`).attr('href');
+            const res = await fixture.fetch(href);
+            expect(res.status).to.equal(200);
+
+            const text = await res.text()
+            
+            expect(text, 'includes used component classes').to.match(/\.bg-purple-600/);
+            expect(text, 'purges unused classes').not.to.match(/\.bg-blue-600/);
+            expect(text, 'includes responsive classes').to.match(/\.lg\\\\:py-3/);
+            expect(text, 'supports arbitrary value classes').to.match(/.font-\\[900\\]/)
+		});
+    })
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -953,12 +953,14 @@ importers:
   packages/astro/test/fixtures/tailwindcss:
     specifiers:
       astro: workspace:*
+      autoprefixer: ^10.4.2
       postcss: ^8.4.8
       tailwindcss: ^3.0.23
     dependencies:
       astro: link:../../..
+      autoprefixer: 10.4.2_postcss@8.4.8
       postcss: 8.4.8
-      tailwindcss: 3.0.23
+      tailwindcss: 3.0.23_autoprefixer@10.4.2
 
   packages/astro/test/fixtures/vue-component:
     specifiers:
@@ -9217,7 +9219,6 @@ packages:
       resolve: 1.22.0
     transitivePeerDependencies:
       - ts-node
-    dev: true
 
   /tar-fs/2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1214,7 +1214,7 @@ packages:
       '@algolia/autocomplete-shared': 1.5.2
     dev: false
 
-  /@algolia/autocomplete-preset-algolia/1.5.2_7938c62af9e2e3908b5b052ce2305b13:
+  /@algolia/autocomplete-preset-algolia/1.5.2_0e7d0fa1316a1da795248855ef6c22d0:
     resolution: {integrity: sha512-3MRYnYQFJyovANzSX2CToS6/5cfVjbLLqFsZTKcvF3abhQzxbqwwaMBlJtt620uBUOeMzhdfasKhCc40+RHiZw==}
     peerDependencies:
       '@algolia/client-search': ^4.9.1
@@ -1222,44 +1222,55 @@ packages:
     dependencies:
       '@algolia/autocomplete-shared': 1.5.2
       '@algolia/client-search': 4.13.0
-      algoliasearch: 4.13.0
+      algoliasearch: 4.12.2
     dev: false
 
   /@algolia/autocomplete-shared/1.5.2:
     resolution: {integrity: sha512-ylQAYv5H0YKMfHgVWX0j0NmL8XBcAeeeVQUmppnnMtzDbDnca6CzhKj3Q8eF9cHCgcdTDdb5K+3aKyGWA0obug==}
     dev: false
 
-  /@algolia/cache-browser-local-storage/4.13.0:
-    resolution: {integrity: sha512-nj1vHRZauTqP/bluwkRIgEADEimqojJgoTRCel5f6q8WCa9Y8QeI4bpDQP28FoeKnDRYa3J5CauDlN466jqRhg==}
+  /@algolia/cache-browser-local-storage/4.12.2:
+    resolution: {integrity: sha512-z8LjFsQc0B6h6LEE3pkUGM4ErVktn6bkFbhnYbTccjmFVQ+wXFJd/D63e0WtaC+hwRB1xq8uKhkz9oojEKEsGA==}
     dependencies:
-      '@algolia/cache-common': 4.13.0
+      '@algolia/cache-common': 4.12.2
+    dev: false
+
+  /@algolia/cache-common/4.12.2:
+    resolution: {integrity: sha512-r//r7MF0Na0HxD2BHnjWsDKuI72Z5UEf/Rb/8MC08XKBsjCwBihGxWxycjRcNGjNEIxJBsvRMIEOipcd9qD54g==}
     dev: false
 
   /@algolia/cache-common/4.13.0:
     resolution: {integrity: sha512-f9mdZjskCui/dA/fA/5a+6hZ7xnHaaZI5tM/Rw9X8rRB39SUlF/+o3P47onZ33n/AwkpSbi5QOyhs16wHd55kA==}
     dev: false
 
-  /@algolia/cache-in-memory/4.13.0:
-    resolution: {integrity: sha512-hHdc+ahPiMM92CQMljmObE75laYzNFYLrNOu0Q3/eyvubZZRtY2SUsEEgyUEyzXruNdzrkcDxFYa7YpWBJYHAg==}
+  /@algolia/cache-in-memory/4.12.2:
+    resolution: {integrity: sha512-opWpbBUloP1fcTG3wBDnAfcoyNXW5GFDgGtLXrSANdfnelPKkr3O8j01ZTkRlPIuBDR0izGZG8MVWMDlTf71Bw==}
     dependencies:
-      '@algolia/cache-common': 4.13.0
+      '@algolia/cache-common': 4.12.2
     dev: false
 
-  /@algolia/client-account/4.13.0:
-    resolution: {integrity: sha512-FzFqFt9b0g/LKszBDoEsW+dVBuUe1K3scp2Yf7q6pgHWM1WqyqUlARwVpLxqyc+LoyJkTxQftOKjyFUqddnPKA==}
+  /@algolia/client-account/4.12.2:
+    resolution: {integrity: sha512-HZqEyeVVjzOlfoSUyc+7+ueEJmRgqSuC+hqQOGECYa5JVno4d8eRVuDAMOb87I2LOdg/WoFMcAtaaRq2gpfV/w==}
     dependencies:
-      '@algolia/client-common': 4.13.0
-      '@algolia/client-search': 4.13.0
-      '@algolia/transporter': 4.13.0
+      '@algolia/client-common': 4.12.2
+      '@algolia/client-search': 4.12.2
+      '@algolia/transporter': 4.12.2
     dev: false
 
-  /@algolia/client-analytics/4.13.0:
-    resolution: {integrity: sha512-klmnoq2FIiiMHImkzOm+cGxqRLLu9CMHqFhbgSy9wtXZrqb8BBUIUE2VyBe7azzv1wKcxZV2RUyNOMpFqmnRZA==}
+  /@algolia/client-analytics/4.12.2:
+    resolution: {integrity: sha512-7ktimzesu+vk3l+eG9w/nQh6/9AoIieCKmoiRIguKh6okGsaSBrcTHvUwIQEIiliqPuAFBk2M8eXYFqOZzwCZw==}
     dependencies:
-      '@algolia/client-common': 4.13.0
-      '@algolia/client-search': 4.13.0
-      '@algolia/requester-common': 4.13.0
-      '@algolia/transporter': 4.13.0
+      '@algolia/client-common': 4.12.2
+      '@algolia/client-search': 4.12.2
+      '@algolia/requester-common': 4.12.2
+      '@algolia/transporter': 4.12.2
+    dev: false
+
+  /@algolia/client-common/4.12.2:
+    resolution: {integrity: sha512-+dTicT1lklwOpeoiDspUoRSQYHhrr2IzllrX89/WuTPEBm2eww1xurqrSTQYC0MuVeX1s9/i4k34Q0ZnspypWg==}
+    dependencies:
+      '@algolia/requester-common': 4.12.2
+      '@algolia/transporter': 4.12.2
     dev: false
 
   /@algolia/client-common/4.13.0:
@@ -1269,12 +1280,20 @@ packages:
       '@algolia/transporter': 4.13.0
     dev: false
 
-  /@algolia/client-personalization/4.13.0:
-    resolution: {integrity: sha512-KneLz2WaehJmNfdr5yt2HQETpLaCYagRdWwIwkTqRVFCv4DxRQ2ChPVW9jeTj4YfAAhfzE6F8hn7wkQ/Jfj6ZA==}
+  /@algolia/client-personalization/4.12.2:
+    resolution: {integrity: sha512-JBW3vYFGIm5sAAy3cLUdmUCpmSAdreo5S1fERg7xgF6KyxGrwyy5BViTNWrOKG+av2yusk1wKydOYJ1Fbpbaxw==}
     dependencies:
-      '@algolia/client-common': 4.13.0
-      '@algolia/requester-common': 4.13.0
-      '@algolia/transporter': 4.13.0
+      '@algolia/client-common': 4.12.2
+      '@algolia/requester-common': 4.12.2
+      '@algolia/transporter': 4.12.2
+    dev: false
+
+  /@algolia/client-search/4.12.2:
+    resolution: {integrity: sha512-JIqi14TgfEqAooNbSPBC1ZCk3Pnviqlaz9KofAqWBxSRTpPUFnU/XQCU5ihR0PC68SFVDnU/Y9cak/XotXPUeg==}
+    dependencies:
+      '@algolia/client-common': 4.12.2
+      '@algolia/requester-common': 4.12.2
+      '@algolia/transporter': 4.12.2
     dev: false
 
   /@algolia/client-search/4.13.0:
@@ -1285,30 +1304,46 @@ packages:
       '@algolia/transporter': 4.13.0
     dev: false
 
+  /@algolia/logger-common/4.12.2:
+    resolution: {integrity: sha512-iOiJAymLjq137G7+8EQuUEkrgta0cZGMg6scp8s4hJ+X6k+6By4nyptdkCWYwKLsW/Xy927QcIhGlkWV78vQIQ==}
+    dev: false
+
   /@algolia/logger-common/4.13.0:
     resolution: {integrity: sha512-8yqXk7rMtmQJ9wZiHOt/6d4/JDEg5VCk83gJ39I+X/pwUPzIsbKy9QiK4uJ3aJELKyoIiDT1hpYVt+5ia+94IA==}
     dev: false
 
-  /@algolia/logger-console/4.13.0:
-    resolution: {integrity: sha512-YepRg7w2/87L0vSXRfMND6VJ5d6699sFJBRWzZPOlek2p5fLxxK7O0VncYuc/IbVHEgeApvgXx0WgCEa38GVuQ==}
+  /@algolia/logger-console/4.12.2:
+    resolution: {integrity: sha512-veuQZyTSqHoHJtr9mLMnYeal9Mee6hCie4eqY+645VbeOrgT9p/kCMbKg5GLJGoLPlXGu7C0XpHyUj5k7/NQyw==}
     dependencies:
-      '@algolia/logger-common': 4.13.0
+      '@algolia/logger-common': 4.12.2
     dev: false
 
-  /@algolia/requester-browser-xhr/4.13.0:
-    resolution: {integrity: sha512-Dj+bnoWR5MotrnjblzGKZ2kCdQi2cK/VzPURPnE616NU/il7Ypy6U6DLGZ/ZYz+tnwPa0yypNf21uqt84fOgrg==}
+  /@algolia/requester-browser-xhr/4.12.2:
+    resolution: {integrity: sha512-FpFdHNd81tS3zj6Glqd+lt+RV0ljPExKtx+QB+gani6HWZ9YlSCM+Zl82T4ibxN+hmkrMeAyT+TMzS0jiGhGyQ==}
     dependencies:
-      '@algolia/requester-common': 4.13.0
+      '@algolia/requester-common': 4.12.2
+    dev: false
+
+  /@algolia/requester-common/4.12.2:
+    resolution: {integrity: sha512-4szj/lvDQf/u8EyyRBBRZD1ZkKDyLBbckLj7meQDlnbfwnW1UpLwpB2l3XJ9wDmDSftGxUCeTl5oMFe4z9OEvQ==}
     dev: false
 
   /@algolia/requester-common/4.13.0:
     resolution: {integrity: sha512-BRTDj53ecK+gn7ugukDWOOcBRul59C4NblCHqj4Zm5msd5UnHFjd/sGX+RLOEoFMhetILAnmg6wMrRrQVac9vw==}
     dev: false
 
-  /@algolia/requester-node-http/4.13.0:
-    resolution: {integrity: sha512-9b+3O4QFU4azLhGMrZAr/uZPydvzOR4aEZfSL8ZrpLZ7fbbqTO0S/5EVko+QIgglRAtVwxvf8UJ1wzTD2jvKxQ==}
+  /@algolia/requester-node-http/4.12.2:
+    resolution: {integrity: sha512-UXfJNZt2KMwjBjiOa3cJ/PyoXWZa/F1vy6rdyG4xQeZDcLbqKP3O2b+bOJcGPmFbmdwBhtAyMVLt+hvAvAVfOw==}
     dependencies:
-      '@algolia/requester-common': 4.13.0
+      '@algolia/requester-common': 4.12.2
+    dev: false
+
+  /@algolia/transporter/4.12.2:
+    resolution: {integrity: sha512-PUq79if4CukXsm27ymTQ3eD3juSvMcyJmt6mxCkSFE0zQRL4ert61HBlNH6S9y/quUVe3g7oggfHq3d5pdpqZA==}
+    dependencies:
+      '@algolia/cache-common': 4.12.2
+      '@algolia/logger-common': 4.12.2
+      '@algolia/requester-common': 4.12.2
     dev: false
 
   /@algolia/transporter/4.13.0:
@@ -1381,9 +1416,38 @@ packages:
     dependencies:
       '@babel/highlight': 7.16.10
 
+  /@babel/compat-data/7.17.0:
+    resolution: {integrity: sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/compat-data/7.17.7:
     resolution: {integrity: sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==}
     engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@babel/core/7.17.5:
+    resolution: {integrity: sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.1.2
+      '@babel/code-frame': 7.16.7
+      '@babel/generator': 7.17.3
+      '@babel/helper-compilation-targets': 7.16.7_@babel+core@7.17.5
+      '@babel/helper-module-transforms': 7.17.6
+      '@babel/helpers': 7.17.2
+      '@babel/parser': 7.17.3
+      '@babel/template': 7.16.7
+      '@babel/traverse': 7.17.3
+      '@babel/types': 7.17.0
+      convert-source-map: 1.8.0
+      debug: 4.3.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.0
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@babel/core/7.17.7:
     resolution: {integrity: sha512-djHlEfFHnSnTAcPb7dATbiM5HxGOP98+3JLBZtjRb5I7RXrw7kFRoG2dXM8cm3H+o11A8IFH/uprmJpwFynRNQ==}
@@ -1406,6 +1470,15 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /@babel/generator/7.17.3:
+    resolution: {integrity: sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.17.0
+      jsesc: 2.5.2
+      source-map: 0.5.7
 
   /@babel/generator/7.17.7:
     resolution: {integrity: sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==}
@@ -1414,6 +1487,7 @@ packages:
       '@babel/types': 7.17.0
       jsesc: 2.5.2
       source-map: 0.5.7
+    dev: false
 
   /@babel/helper-annotate-as-pure/7.16.7:
     resolution: {integrity: sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==}
@@ -1427,6 +1501,22 @@ packages:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.16.7
       '@babel/types': 7.17.0
+    dev: true
+
+  /@babel/helper-compilation-targets/7.16.7_@babel+core@7.17.5:
+    resolution: {integrity: sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+    dependencies:
+      '@babel/compat-data': 7.17.0
+      '@babel/core': 7.17.5
+      '@babel/helper-validator-option': 7.16.7
+      browserslist: 4.20.0
+      semver: 6.3.0
     dev: true
 
   /@babel/helper-compilation-targets/7.17.7_@babel+core@7.17.7:
@@ -1443,8 +1533,9 @@ packages:
       '@babel/helper-validator-option': 7.16.7
       browserslist: 4.20.2
       semver: 6.3.0
+    dev: false
 
-  /@babel/helper-create-class-features-plugin/7.17.6_@babel+core@7.17.7:
+  /@babel/helper-create-class-features-plugin/7.17.6_@babel+core@7.17.5:
     resolution: {integrity: sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1453,11 +1544,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-environment-visitor': 7.16.7
       '@babel/helper-function-name': 7.16.7
-      '@babel/helper-member-expression-to-functions': 7.17.7
+      '@babel/helper-member-expression-to-functions': 7.16.7
       '@babel/helper-optimise-call-expression': 7.16.7
       '@babel/helper-replace-supers': 7.16.7
       '@babel/helper-split-export-declaration': 7.16.7
@@ -1465,7 +1556,7 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-create-regexp-features-plugin/7.17.0_@babel+core@7.17.7:
+  /@babel/helper-create-regexp-features-plugin/7.17.0_@babel+core@7.17.5:
     resolution: {integrity: sha512-awO2So99wG6KnlE+TPs6rn83gCz5WlEePJDTnLEqbchMVrBeAujURVphRdigsk094VhvZehFoNOihSlcBjwsXA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1474,12 +1565,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-annotate-as-pure': 7.16.7
       regexpu-core: 5.0.1
     dev: true
 
-  /@babel/helper-define-polyfill-provider/0.3.1_@babel+core@7.17.7:
+  /@babel/helper-define-polyfill-provider/0.3.1_@babel+core@7.17.5:
     resolution: {integrity: sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==}
     peerDependencies:
       '@babel/core': ^7.4.0-0
@@ -1487,8 +1578,8 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
-      '@babel/helper-compilation-targets': 7.17.7_@babel+core@7.17.7
+      '@babel/core': 7.17.5
+      '@babel/helper-compilation-targets': 7.16.7_@babel+core@7.17.5
       '@babel/helper-module-imports': 7.16.7
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/traverse': 7.17.3
@@ -1533,8 +1624,8 @@ packages:
     dependencies:
       '@babel/types': 7.17.0
 
-  /@babel/helper-member-expression-to-functions/7.17.7:
-    resolution: {integrity: sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==}
+  /@babel/helper-member-expression-to-functions/7.16.7:
+    resolution: {integrity: sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.17.0
@@ -1553,6 +1644,22 @@ packages:
     dependencies:
       '@babel/types': 7.17.0
 
+  /@babel/helper-module-transforms/7.17.6:
+    resolution: {integrity: sha512-2ULmRdqoOMpdvkbT8jONrZML/XALfzxlb052bldftkicAUy8AxSCkD5trDPQcwHNmolcl7wP6ehNqMlyUw6AaA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-environment-visitor': 7.16.7
+      '@babel/helper-module-imports': 7.16.7
+      '@babel/helper-simple-access': 7.16.7
+      '@babel/helper-split-export-declaration': 7.16.7
+      '@babel/helper-validator-identifier': 7.16.7
+      '@babel/template': 7.16.7
+      '@babel/traverse': 7.17.3
+      '@babel/types': 7.17.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/helper-module-transforms/7.17.7:
     resolution: {integrity: sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==}
     engines: {node: '>=6.9.0'}
@@ -1567,6 +1674,7 @@ packages:
       '@babel/types': 7.17.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/helper-optimise-call-expression/7.16.7:
     resolution: {integrity: sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==}
@@ -1595,7 +1703,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-environment-visitor': 7.16.7
-      '@babel/helper-member-expression-to-functions': 7.17.7
+      '@babel/helper-member-expression-to-functions': 7.16.7
       '@babel/helper-optimise-call-expression': 7.16.7
       '@babel/traverse': 7.17.3
       '@babel/types': 7.17.0
@@ -1603,11 +1711,19 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helper-simple-access/7.16.7:
+    resolution: {integrity: sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.17.0
+    dev: true
+
   /@babel/helper-simple-access/7.17.7:
     resolution: {integrity: sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.17.0
+    dev: false
 
   /@babel/helper-skip-transparent-expression-wrappers/7.16.0:
     resolution: {integrity: sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==}
@@ -1642,6 +1758,17 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helpers/7.17.2:
+    resolution: {integrity: sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.16.7
+      '@babel/traverse': 7.17.3
+      '@babel/types': 7.17.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/helpers/7.17.7:
     resolution: {integrity: sha512-TKsj9NkjJfTBxM7Phfy7kv6yYc4ZcOo+AaWGqQOKTPDOmcGkIFb5xNA746eKisQkm4yavUYh4InYM9S+VnO01w==}
     engines: {node: '>=6.9.0'}
@@ -1651,6 +1778,7 @@ packages:
       '@babel/types': 7.17.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/highlight/7.16.10:
     resolution: {integrity: sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==}
@@ -1660,12 +1788,18 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
+  /@babel/parser/7.17.3:
+    resolution: {integrity: sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   /@babel/parser/7.17.7:
     resolution: {integrity: sha512-bm3AQf45vR4gKggRfvJdYJ0gFLoCbsPxiFLSH6hTVYABptNHY6l9NrhnucVjQ/X+SPtLANT9lc0fFhikj+VBRA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dev: false
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-anv/DObl7waiGEnC24O9zqL0pSuI9hljihqiDuFHC8d7/bjr/4RLGPWuc8rYOff/QPzbEPSkzG8wGG9aDuhHRg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1674,11 +1808,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-di8vUHRdf+4aJ7ltXhaDbPoszdkh59AQtJM5soLsuHpQJdFQZOA4uGj0V2u/CZ8bJ/u8ULDL5yq6FO/bCXnKHw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1687,13 +1821,13 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.16.0
-      '@babel/plugin-proposal-optional-chaining': 7.16.7_@babel+core@7.17.7
+      '@babel/plugin-proposal-optional-chaining': 7.16.7_@babel+core@7.17.5
     dev: true
 
-  /@babel/plugin-proposal-async-generator-functions/7.16.8_@babel+core@7.17.7:
+  /@babel/plugin-proposal-async-generator-functions/7.16.8_@babel+core@7.17.5:
     resolution: {integrity: sha512-71YHIvMuiuqWJQkebWJtdhQTfd4Q4mF76q2IX37uZPkG9+olBxsX+rH1vkhFto4UeJZ9dPY2s+mDvhDm1u2BGQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1702,15 +1836,15 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/helper-remap-async-to-generator': 7.16.8
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.17.7
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.17.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-class-properties/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-proposal-class-properties/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1719,14 +1853,14 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
-      '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.17.7
+      '@babel/core': 7.17.5
+      '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-class-static-block/7.17.6_@babel+core@7.17.7:
+  /@babel/plugin-proposal-class-static-block/7.17.6_@babel+core@7.17.5:
     resolution: {integrity: sha512-X/tididvL2zbs7jZCeeRJ8167U/+Ac135AM6jCAx6gYXDUviZV5Ku9UDvWS2NCuWlFjIRXklYhwo6HhAC7ETnA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1735,15 +1869,15 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
-      '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.17.7
+      '@babel/core': 7.17.5
+      '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.17.7
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.17.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-dynamic-import/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-proposal-dynamic-import/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1752,12 +1886,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.17.7
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.17.5
     dev: true
 
-  /@babel/plugin-proposal-export-namespace-from/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-proposal-export-namespace-from/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1766,12 +1900,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.17.7
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.17.5
     dev: true
 
-  /@babel/plugin-proposal-json-strings/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-proposal-json-strings/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-lNZ3EEggsGY78JavgbHsK9u5P3pQaW7k4axlgFLYkMd7UBsiNahCITShLjNQschPyjtO6dADrL24757IdhBrsQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1780,12 +1914,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.17.7
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.17.5
     dev: true
 
-  /@babel/plugin-proposal-logical-assignment-operators/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-proposal-logical-assignment-operators/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1794,12 +1928,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.17.7
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.17.5
     dev: true
 
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-aUOrYU3EVtjf62jQrCj63pYZ7k6vns2h/DQvHPWGmsJRYzWXZ6/AsfgpiRy6XiuIDADhJzP2Q9MwSMKauBQ+UQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1808,12 +1942,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.17.7
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.17.5
     dev: true
 
-  /@babel/plugin-proposal-numeric-separator/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-proposal-numeric-separator/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1822,12 +1956,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.17.7
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.17.5
     dev: true
 
-  /@babel/plugin-proposal-object-rest-spread/7.17.3_@babel+core@7.17.7:
+  /@babel/plugin-proposal-object-rest-spread/7.17.3_@babel+core@7.17.5:
     resolution: {integrity: sha512-yuL5iQA/TbZn+RGAfxQXfi7CNLmKi1f8zInn4IgobuCWcAb7i+zj4TYzQ9l8cEzVyJ89PDGuqxK1xZpUDISesw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1836,15 +1970,15 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/compat-data': 7.17.7
-      '@babel/core': 7.17.7
-      '@babel/helper-compilation-targets': 7.17.7_@babel+core@7.17.7
+      '@babel/compat-data': 7.17.0
+      '@babel/core': 7.17.5
+      '@babel/helper-compilation-targets': 7.16.7_@babel+core@7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.17.7
-      '@babel/plugin-transform-parameters': 7.16.7_@babel+core@7.17.7
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.17.5
+      '@babel/plugin-transform-parameters': 7.16.7_@babel+core@7.17.5
     dev: true
 
-  /@babel/plugin-proposal-optional-catch-binding/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-proposal-optional-catch-binding/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1853,12 +1987,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.17.7
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.17.5
     dev: true
 
-  /@babel/plugin-proposal-optional-chaining/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-proposal-optional-chaining/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-eC3xy+ZrUcBtP7x+sq62Q/HYd674pPTb/77XZMb5wbDPGWIdUbSr4Agr052+zaUPSb+gGRnjxXfKFvx5iMJ+DA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1867,13 +2001,13 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.16.0
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.17.7
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.17.5
     dev: true
 
-  /@babel/plugin-proposal-private-methods/7.16.11_@babel+core@7.17.7:
+  /@babel/plugin-proposal-private-methods/7.16.11_@babel+core@7.17.5:
     resolution: {integrity: sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1882,14 +2016,14 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
-      '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.17.7
+      '@babel/core': 7.17.5
+      '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-private-property-in-object/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-proposal-private-property-in-object/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-rMQkjcOFbm+ufe3bTZLyOfsOUOxyvLXZJCTARhJr+8UMSoZmqTe1K1BgkFcrW37rAchWg57yI69ORxiWvUINuQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1898,16 +2032,16 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-annotate-as-pure': 7.16.7
-      '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.17.7
+      '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.17.7
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.17.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-unicode-property-regex/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-proposal-unicode-property-regex/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-QRK0YI/40VLhNVGIjRNAAQkEHws0cswSdFFjpFyt943YmJIU1da9uW63Iu6NFV6CxTZW5eTDCrwZUstBWgp/Rg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -1916,12 +2050,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
-      '@babel/helper-create-regexp-features-plugin': 7.17.0_@babel+core@7.17.7
+      '@babel/core': 7.17.5
+      '@babel/helper-create-regexp-features-plugin': 7.17.0_@babel+core@7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.17.7:
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.17.5:
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1929,11 +2063,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.17.7:
+  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.17.5:
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1941,11 +2075,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.17.7:
+  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.17.5:
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -1954,11 +2088,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.17.7:
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.17.5:
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1966,11 +2100,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.17.7:
+  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.17.5:
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1978,11 +2112,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.17.7:
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.17.5:
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1990,7 +2124,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
@@ -2006,7 +2140,7 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.17.7:
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.17.5:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2014,11 +2148,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.17.7:
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.17.5:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2026,11 +2160,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.17.7:
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.17.5:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2038,11 +2172,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.17.7:
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.17.5:
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2050,11 +2184,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.17.7:
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.17.5:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2062,11 +2196,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.17.7:
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.17.5:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2074,11 +2208,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.17.7:
+  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.17.5:
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2087,11 +2221,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.17.7:
+  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.17.5:
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2100,11 +2234,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-arrow-functions/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-arrow-functions/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-9ffkFFMbvzTvv+7dTp/66xvZAWASuPD5Tl9LK3Z9vhOmANo6j94rik+5YMBt4CwHVMWLWpMsriIc2zsa3WW3xQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2113,11 +2247,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-async-to-generator/7.16.8_@babel+core@7.17.7:
+  /@babel/plugin-transform-async-to-generator/7.16.8_@babel+core@7.17.5:
     resolution: {integrity: sha512-MtmUmTJQHCnyJVrScNzNlofQJ3dLFuobYn3mwOTKHnSCMtbNsqvF71GQmJfFjdrXSsAA7iysFmYWw4bXZ20hOg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2126,7 +2260,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-module-imports': 7.16.7
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/helper-remap-async-to-generator': 7.16.8
@@ -2134,7 +2268,7 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-block-scoped-functions/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-block-scoped-functions/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2143,11 +2277,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-block-scoping/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-block-scoping/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-ObZev2nxVAYA4bhyusELdo9hb3H+A56bxH3FZMbEImZFiEDYVHXQSJ1hQKFlDnlt8G9bBrCZ5ZpURZUrV4G5qQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2156,11 +2290,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-classes/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-classes/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-WY7og38SFAGYRe64BrjKf8OrE6ulEHtr5jEYaZMwox9KebgqPi67Zqz8K53EKk1fFEJgm96r32rkKZ3qA2nCWQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2169,7 +2303,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-environment-visitor': 7.16.7
       '@babel/helper-function-name': 7.16.7
@@ -2182,7 +2316,7 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-computed-properties/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-computed-properties/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-gN72G9bcmenVILj//sv1zLNaPyYcOzUho2lIJBMh/iakJ9ygCo/hEF9cpGb61SCMEDxbbyBoVQxrt+bWKu5KGw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2191,12 +2325,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-destructuring/7.17.7_@babel+core@7.17.7:
-    resolution: {integrity: sha512-XVh0r5yq9sLR4vZ6eVZe8FKfIcSgaTBxVBRSYokRj2qksf6QerYnTxz9/GTuKTH/n/HwLP7t6gtlybHetJ/6hQ==}
+  /@babel/plugin-transform-destructuring/7.17.3_@babel+core@7.17.5:
+    resolution: {integrity: sha512-dDFzegDYKlPqa72xIlbmSkly5MluLoaC1JswABGktyt6NTXSBcUuse/kWE/wvKFWJHPETpi158qJZFS3JmykJg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2204,11 +2338,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-dotall-regex/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-dotall-regex/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-Lyttaao2SjZF6Pf4vk1dVKv8YypMpomAbygW+mU5cYP3S5cWTfCJjG8xV6CFdzGFlfWK81IjL9viiTvpb6G7gQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2217,12 +2351,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
-      '@babel/helper-create-regexp-features-plugin': 7.17.0_@babel+core@7.17.7
+      '@babel/core': 7.17.5
+      '@babel/helper-create-regexp-features-plugin': 7.17.0_@babel+core@7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-duplicate-keys/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-duplicate-keys/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-03DvpbRfvWIXyK0/6QiR1KMTWeT6OcQ7tbhjrXyFS02kjuX/mu5Bvnh5SDSWHxyawit2g5aWhKwI86EE7GUnTw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2231,11 +2365,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-exponentiation-operator/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-exponentiation-operator/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-8UYLSlyLgRixQvlYH3J2ekXFHDFLQutdy7FfFAMm3CPZ6q9wHCwnUyiXpQCe3gVVnQlHc5nsuiEVziteRNTXEA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2244,12 +2378,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.16.7
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-for-of/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-for-of/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2258,11 +2392,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-function-name/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-function-name/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2271,13 +2405,13 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
-      '@babel/helper-compilation-targets': 7.17.7_@babel+core@7.17.7
+      '@babel/core': 7.17.5
+      '@babel/helper-compilation-targets': 7.16.7_@babel+core@7.17.5
       '@babel/helper-function-name': 7.16.7
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-literals/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-literals/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2286,11 +2420,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-member-expression-literals/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-member-expression-literals/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2299,11 +2433,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-modules-amd/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-modules-amd/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-KaaEtgBL7FKYwjJ/teH63oAmE3lP34N3kshz8mm4VMAw7U3PxjVwwUmxEFksbgsNUaO3wId9R2AVQYSEGRa2+g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2312,16 +2446,16 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
-      '@babel/helper-module-transforms': 7.17.7
+      '@babel/core': 7.17.5
+      '@babel/helper-module-transforms': 7.17.6
       '@babel/helper-plugin-utils': 7.16.7
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-commonjs/7.17.7_@babel+core@7.17.7:
-    resolution: {integrity: sha512-ITPmR2V7MqioMJyrxUo2onHNC3e+MvfFiFIR0RP21d3PtlVb6sfzoxNKiphSZUOM9hEIdzCcZe83ieX3yoqjUA==}
+  /@babel/plugin-transform-modules-commonjs/7.16.8_@babel+core@7.17.5:
+    resolution: {integrity: sha512-oflKPvsLT2+uKQopesJt3ApiaIS2HW+hzHFcwRNtyDGieAeC/dIHZX8buJQ2J2X1rxGPy4eRcUijm3qcSPjYcA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2329,16 +2463,16 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
-      '@babel/helper-module-transforms': 7.17.7
+      '@babel/core': 7.17.5
+      '@babel/helper-module-transforms': 7.17.6
       '@babel/helper-plugin-utils': 7.16.7
-      '@babel/helper-simple-access': 7.17.7
+      '@babel/helper-simple-access': 7.16.7
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-systemjs/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-modules-systemjs/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-DuK5E3k+QQmnOqBR9UkusByy5WZWGRxfzV529s9nPra1GE7olmxfqO2FHobEOYSPIjPBTr4p66YDcjQnt8cBmw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2347,9 +2481,9 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-hoist-variables': 7.16.7
-      '@babel/helper-module-transforms': 7.17.7
+      '@babel/helper-module-transforms': 7.17.6
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/helper-validator-identifier': 7.16.7
       babel-plugin-dynamic-import-node: 2.3.3
@@ -2357,7 +2491,7 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-umd/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-modules-umd/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-EMh7uolsC8O4xhudF2F6wedbSHm1HHZ0C6aJ7K67zcDNidMzVcxWdGr+htW9n21klm+bOn+Rx4CBsAntZd3rEQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2366,14 +2500,14 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
-      '@babel/helper-module-transforms': 7.17.7
+      '@babel/core': 7.17.5
+      '@babel/helper-module-transforms': 7.17.6
       '@babel/helper-plugin-utils': 7.16.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-named-capturing-groups-regex/7.16.8_@babel+core@7.17.7:
+  /@babel/plugin-transform-named-capturing-groups-regex/7.16.8_@babel+core@7.17.5:
     resolution: {integrity: sha512-j3Jw+n5PvpmhRR+mrgIh04puSANCk/T/UA3m3P1MjJkhlK906+ApHhDIqBQDdOgL/r1UYpz4GNclTXxyZrYGSw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2382,11 +2516,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
-      '@babel/helper-create-regexp-features-plugin': 7.17.0_@babel+core@7.17.7
+      '@babel/core': 7.17.5
+      '@babel/helper-create-regexp-features-plugin': 7.17.0_@babel+core@7.17.5
     dev: true
 
-  /@babel/plugin-transform-new-target/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-new-target/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-xiLDzWNMfKoGOpc6t3U+etCE2yRnn3SM09BXqWPIZOBpL2gvVrBWUKnsJx0K/ADi5F5YC5f8APFfWrz25TdlGg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2395,11 +2529,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-object-super/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-object-super/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2408,14 +2542,14 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/helper-replace-supers': 7.16.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-parameters/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-parameters/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2424,11 +2558,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-property-literals/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-property-literals/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2437,7 +2571,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
@@ -2457,7 +2591,7 @@ packages:
       '@babel/types': 7.17.0
     dev: false
 
-  /@babel/plugin-transform-regenerator/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-regenerator/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-mF7jOgGYCkSJagJ6XCujSQg+6xC1M77/03K2oBmVJWoFGNUtnVJO4WHKJk3dnPC8HCcj4xBQP1Egm8DWh3Pb3Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2466,11 +2600,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       regenerator-transform: 0.14.5
     dev: true
 
-  /@babel/plugin-transform-reserved-words/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-reserved-words/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-KQzzDnZ9hWQBjwi5lpY5v9shmm6IVG0U9pB18zvMu2i4H90xpT4gmqwPYsn8rObiadYe2M0gmgsiOIF5A/2rtg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2479,11 +2613,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-shorthand-properties/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-shorthand-properties/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2492,11 +2626,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-spread/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-spread/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2505,12 +2639,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.16.0
     dev: true
 
-  /@babel/plugin-transform-sticky-regex/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-sticky-regex/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-NJa0Bd/87QV5NZZzTuZG5BPJjLYadeSZ9fO6oOUoL4iQx+9EEuw/eEM92SrsT19Yc2jgB1u1hsjqDtH02c3Drw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2519,11 +2653,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-template-literals/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-template-literals/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2532,11 +2666,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-typeof-symbol/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-typeof-symbol/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-p2rOixCKRJzpg9JB4gjnG4gjWkWa89ZoYUnl9snJ1cWIcTH/hvxZqfO+WjG6T8DRBpctEol5jw1O5rA8gkCokQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2545,11 +2679,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-unicode-escapes/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-unicode-escapes/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-TAV5IGahIz3yZ9/Hfv35TV2xEm+kaBDaZQCn2S/hG9/CZ0DktxJv9eKfPc7yYCvOYR4JGx1h8C+jcSOvgaaI/Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2558,11 +2692,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-transform-unicode-regex/7.16.7_@babel+core@7.17.7:
+  /@babel/plugin-transform-unicode-regex/7.16.7_@babel+core@7.17.5:
     resolution: {integrity: sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2571,12 +2705,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
-      '@babel/helper-create-regexp-features-plugin': 7.17.0_@babel+core@7.17.7
+      '@babel/core': 7.17.5
+      '@babel/helper-create-regexp-features-plugin': 7.17.0_@babel+core@7.17.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/preset-env/7.16.11_@babel+core@7.17.7:
+  /@babel/preset-env/7.16.11_@babel+core@7.17.5:
     resolution: {integrity: sha512-qcmWG8R7ZW6WBRPZK//y+E3Cli151B20W1Rv7ln27vuPaXU/8TKms6jFdiJtF7UDTxcrb7mZd88tAeK9LjdT8g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -2585,86 +2719,86 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/compat-data': 7.17.7
-      '@babel/core': 7.17.7
-      '@babel/helper-compilation-targets': 7.17.7_@babel+core@7.17.7
+      '@babel/compat-data': 7.17.0
+      '@babel/core': 7.17.5
+      '@babel/helper-compilation-targets': 7.16.7_@babel+core@7.17.5
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/helper-validator-option': 7.16.7
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-proposal-async-generator-functions': 7.16.8_@babel+core@7.17.7
-      '@babel/plugin-proposal-class-properties': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-proposal-class-static-block': 7.17.6_@babel+core@7.17.7
-      '@babel/plugin-proposal-dynamic-import': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-proposal-export-namespace-from': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-proposal-json-strings': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-proposal-logical-assignment-operators': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-proposal-numeric-separator': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-proposal-object-rest-spread': 7.17.3_@babel+core@7.17.7
-      '@babel/plugin-proposal-optional-catch-binding': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-proposal-optional-chaining': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-proposal-private-methods': 7.16.11_@babel+core@7.17.7
-      '@babel/plugin-proposal-private-property-in-object': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-proposal-unicode-property-regex': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.17.7
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.17.7
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.17.7
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.17.7
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.17.7
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.17.7
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.17.7
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.17.7
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.17.7
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.17.7
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.17.7
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.17.7
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.17.7
-      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.17.7
-      '@babel/plugin-transform-arrow-functions': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-async-to-generator': 7.16.8_@babel+core@7.17.7
-      '@babel/plugin-transform-block-scoped-functions': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-block-scoping': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-classes': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-computed-properties': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-destructuring': 7.17.7_@babel+core@7.17.7
-      '@babel/plugin-transform-dotall-regex': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-duplicate-keys': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-exponentiation-operator': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-for-of': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-function-name': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-literals': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-member-expression-literals': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-modules-amd': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-modules-commonjs': 7.17.7_@babel+core@7.17.7
-      '@babel/plugin-transform-modules-systemjs': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-modules-umd': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.16.8_@babel+core@7.17.7
-      '@babel/plugin-transform-new-target': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-object-super': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-parameters': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-property-literals': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-regenerator': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-reserved-words': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-shorthand-properties': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-spread': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-sticky-regex': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-template-literals': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-typeof-symbol': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-unicode-escapes': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-unicode-regex': 7.16.7_@babel+core@7.17.7
-      '@babel/preset-modules': 0.1.5_@babel+core@7.17.7
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-proposal-async-generator-functions': 7.16.8_@babel+core@7.17.5
+      '@babel/plugin-proposal-class-properties': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-proposal-class-static-block': 7.17.6_@babel+core@7.17.5
+      '@babel/plugin-proposal-dynamic-import': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-proposal-export-namespace-from': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-proposal-json-strings': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-proposal-logical-assignment-operators': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-proposal-numeric-separator': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-proposal-object-rest-spread': 7.17.3_@babel+core@7.17.5
+      '@babel/plugin-proposal-optional-catch-binding': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-proposal-optional-chaining': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-proposal-private-methods': 7.16.11_@babel+core@7.17.5
+      '@babel/plugin-proposal-private-property-in-object': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-proposal-unicode-property-regex': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.17.5
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.17.5
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.17.5
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.17.5
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.17.5
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.17.5
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.17.5
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.17.5
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.17.5
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.17.5
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.17.5
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.17.5
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.17.5
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.17.5
+      '@babel/plugin-transform-arrow-functions': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-async-to-generator': 7.16.8_@babel+core@7.17.5
+      '@babel/plugin-transform-block-scoped-functions': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-block-scoping': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-classes': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-computed-properties': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-destructuring': 7.17.3_@babel+core@7.17.5
+      '@babel/plugin-transform-dotall-regex': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-duplicate-keys': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-exponentiation-operator': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-for-of': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-function-name': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-literals': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-member-expression-literals': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-modules-amd': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-modules-commonjs': 7.16.8_@babel+core@7.17.5
+      '@babel/plugin-transform-modules-systemjs': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-modules-umd': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.16.8_@babel+core@7.17.5
+      '@babel/plugin-transform-new-target': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-object-super': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-parameters': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-property-literals': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-regenerator': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-reserved-words': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-shorthand-properties': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-spread': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-sticky-regex': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-template-literals': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-typeof-symbol': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-unicode-escapes': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-unicode-regex': 7.16.7_@babel+core@7.17.5
+      '@babel/preset-modules': 0.1.5_@babel+core@7.17.5
       '@babel/types': 7.17.0
-      babel-plugin-polyfill-corejs2: 0.3.1_@babel+core@7.17.7
-      babel-plugin-polyfill-corejs3: 0.5.2_@babel+core@7.17.7
-      babel-plugin-polyfill-regenerator: 0.3.1_@babel+core@7.17.7
+      babel-plugin-polyfill-corejs2: 0.3.1_@babel+core@7.17.5
+      babel-plugin-polyfill-corejs3: 0.5.2_@babel+core@7.17.5
+      babel-plugin-polyfill-regenerator: 0.3.1_@babel+core@7.17.5
       core-js-compat: 3.21.1
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/preset-modules/0.1.5_@babel+core@7.17.7:
+  /@babel/preset-modules/0.1.5_@babel+core@7.17.5:
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2672,16 +2806,16 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-      '@babel/plugin-proposal-unicode-property-regex': 7.16.7_@babel+core@7.17.7
-      '@babel/plugin-transform-dotall-regex': 7.16.7_@babel+core@7.17.7
+      '@babel/plugin-proposal-unicode-property-regex': 7.16.7_@babel+core@7.17.5
+      '@babel/plugin-transform-dotall-regex': 7.16.7_@babel+core@7.17.5
       '@babel/types': 7.17.0
       esutils: 2.0.3
     dev: true
 
-  /@babel/runtime/7.17.7:
-    resolution: {integrity: sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==}
+  /@babel/runtime/7.17.2:
+    resolution: {integrity: sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.9
@@ -2692,7 +2826,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.16.7
-      '@babel/parser': 7.17.7
+      '@babel/parser': 7.17.3
       '@babel/types': 7.17.0
 
   /@babel/traverse/7.17.3:
@@ -2700,12 +2834,12 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.17.7
+      '@babel/generator': 7.17.3
       '@babel/helper-environment-visitor': 7.16.7
       '@babel/helper-function-name': 7.16.7
       '@babel/helper-hoist-variables': 7.16.7
       '@babel/helper-split-export-declaration': 7.16.7
-      '@babel/parser': 7.17.7
+      '@babel/parser': 7.17.3
       '@babel/types': 7.17.0
       debug: 4.3.3
       globals: 11.12.0
@@ -2722,7 +2856,7 @@ packages:
   /@changesets/apply-release-plan/5.0.5:
     resolution: {integrity: sha512-CxL9dkhzjHiVmXCyHgsLCQj7i/coFTMv/Yy0v6BC5cIWZkQml+lf7zvQqAcFXwY7b54HxRWZPku02XFB53Q0Uw==}
     dependencies:
-      '@babel/runtime': 7.17.7
+      '@babel/runtime': 7.17.2
       '@changesets/config': 1.7.0
       '@changesets/get-version-range-type': 0.3.2
       '@changesets/git': 1.3.1
@@ -2740,7 +2874,7 @@ packages:
   /@changesets/assemble-release-plan/5.1.1:
     resolution: {integrity: sha512-TQRZnK1sqYuoibJdSwpqE81rfDh0Xrkkr/M6bCQZ1ogGoRJNVbNYDWvNfkNvR4rEdRylri8cfKzffo/ruoy8QA==}
     dependencies:
-      '@babel/runtime': 7.17.7
+      '@babel/runtime': 7.17.2
       '@changesets/errors': 0.1.4
       '@changesets/get-dependents-graph': 1.3.1
       '@changesets/types': 4.1.0
@@ -2768,7 +2902,7 @@ packages:
     resolution: {integrity: sha512-4AJKo/UW0P217m2VHjiuhZy+CstLw54eu9I1fsY7tst76GeEN7mX0mVrTNEisR6CvOH7wLav3ITqvDcKVPbKsw==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.17.7
+      '@babel/runtime': 7.17.2
       '@changesets/apply-release-plan': 5.0.5
       '@changesets/assemble-release-plan': 5.1.1
       '@changesets/changelog-git': 0.1.10
@@ -2841,7 +2975,7 @@ packages:
   /@changesets/get-release-plan/3.0.7:
     resolution: {integrity: sha512-zDp6RIEKvERIF4Osy8sJ5BzqTiiLMhPWBO02y6w3nzTQJ0VBMaTs4hhwImQ/54O9I34eUHR3D0DwmwGQ27ifaw==}
     dependencies:
-      '@babel/runtime': 7.17.7
+      '@babel/runtime': 7.17.2
       '@changesets/assemble-release-plan': 5.1.1
       '@changesets/config': 1.7.0
       '@changesets/pre': 1.0.10
@@ -2857,7 +2991,7 @@ packages:
   /@changesets/git/1.3.1:
     resolution: {integrity: sha512-yg60QUi38VA0XGXdBy9SRYJhs8xJHE97Z1CaB/hFyByBlh5k1i+avFNBvvw66MsoT/aiml6y9scIG6sC8R5mfg==}
     dependencies:
-      '@babel/runtime': 7.17.7
+      '@babel/runtime': 7.17.2
       '@changesets/errors': 0.1.4
       '@changesets/types': 4.1.0
       '@manypkg/get-packages': 1.1.3
@@ -2881,7 +3015,7 @@ packages:
   /@changesets/pre/1.0.10:
     resolution: {integrity: sha512-cZC1C1wTSC17/TcTWivAQ4LAXz5jEYDuy3UeZiBz1wnTTzMHyTHLLwJi60juhl4hawXunDLw0mwZkcpS8Ivitg==}
     dependencies:
-      '@babel/runtime': 7.17.7
+      '@babel/runtime': 7.17.2
       '@changesets/errors': 0.1.4
       '@changesets/types': 4.1.0
       '@manypkg/get-packages': 1.1.3
@@ -2891,7 +3025,7 @@ packages:
   /@changesets/read/0.5.4:
     resolution: {integrity: sha512-12dTx+p5ztFs9QgJDGHRHR6HzTIbHct9S4lK2I/i6Qkz1cNfAPVIbdoMCdbPIWeLank9muMUjiiFmCWJD7tQIg==}
     dependencies:
-      '@babel/runtime': 7.17.7
+      '@babel/runtime': 7.17.2
       '@changesets/git': 1.3.1
       '@changesets/logger': 0.0.5
       '@changesets/parse': 0.3.12
@@ -2908,7 +3042,7 @@ packages:
   /@changesets/write/0.1.7:
     resolution: {integrity: sha512-6r+tc6u2l5BBIwEAh7ivRYWFir+XKiw0q/6Hx6NJA4dSN5fNu9uyWRQ+IMHCllD9dBcsh+e79sOepc+xT8l28g==}
     dependencies:
-      '@babel/runtime': 7.17.7
+      '@babel/runtime': 7.17.2
       '@changesets/types': 4.1.0
       fs-extra: 7.0.1
       human-id: 1.0.2
@@ -2927,10 +3061,10 @@ packages:
       react-dom: '>= 16.8.0 < 18.0.0'
     dependencies:
       '@algolia/autocomplete-core': 1.5.2
-      '@algolia/autocomplete-preset-algolia': 1.5.2_7938c62af9e2e3908b5b052ce2305b13
+      '@algolia/autocomplete-preset-algolia': 1.5.2_0e7d0fa1316a1da795248855ef6c22d0
       '@docsearch/css': 3.0.0
       '@types/react': 17.0.40
-      algoliasearch: 4.13.0
+      algoliasearch: 4.12.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     transitivePeerDependencies:
@@ -2960,7 +3094,7 @@ packages:
       ajv: 6.12.6
       debug: 4.3.3
       espree: 9.3.1
-      globals: 13.13.0
+      globals: 13.12.1
       ignore: 5.2.0
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -2989,8 +3123,8 @@ packages:
     resolution: {integrity: sha512-6er6wSGF3hgc1JEZqiGpg21CTCjHBYOUwqLmb2Idzkjiw6ogalGP0ZMLVutCzah+0WB4yP+Zd2oVPN8jvJ+Ftg==}
     dev: true
 
-  /@iconify/utils/1.0.24:
-    resolution: {integrity: sha512-SxnUyoLqlB2HGncZIFgZsR3O7gvpdwODi7A7J7udKAXTAkA8ZzQ7cG/PzBuGWA7s67VJtKFyl/scGZB8c759qQ==}
+  /@iconify/utils/1.0.23:
+    resolution: {integrity: sha512-Ktdmpe4mkMXQAnnDUz3s6s5aY/BeVPwHC1d5IhG1bgrWVNWFQNUj8cQPMbHpNCSD9MRC5yGxm9/PGPpOWGJLAg==}
     dependencies:
       '@antfu/install-pkg': 0.1.0
       '@antfu/utils': 0.3.0
@@ -3023,9 +3157,9 @@ packages:
   /@lit-labs/ssr-client/1.0.1:
     resolution: {integrity: sha512-rr/UVhxbKWNUr+3qRyvZk+glC7v7ph8Gk/W0z96YG64COJKf9ilnWY6JGW77TRqhrRMmS2nsvAXOyQgcF+4jrA==}
     dependencies:
-      '@lit/reactive-element': 1.3.1
+      '@lit/reactive-element': 1.3.0
       lit: 2.2.1
-      lit-html: 2.2.1
+      lit-html: 2.2.0
     dev: false
 
   /@lit-labs/ssr/2.0.4:
@@ -3033,11 +3167,11 @@ packages:
     engines: {node: '>=13.9.0'}
     dependencies:
       '@lit-labs/ssr-client': 1.0.1
-      '@lit/reactive-element': 1.3.1
+      '@lit/reactive-element': 1.3.0
       '@types/node': 16.11.26
       lit: 2.2.1
       lit-element: 3.2.0
-      lit-html: 2.2.1
+      lit-html: 2.2.0
       node-fetch: 2.6.7
       parse5: 6.0.1
       resolve: 1.22.0
@@ -3045,8 +3179,8 @@ packages:
       - encoding
     dev: false
 
-  /@lit/reactive-element/1.3.1:
-    resolution: {integrity: sha512-nOJARIr3pReqK3hfFCSW2Zg/kFcFsSAlIE7z4a0C9D2dPrgD/YSn3ZP2ET/rxKB65SXyG7jJbkynBRm+tGlacw==}
+  /@lit/reactive-element/1.3.0:
+    resolution: {integrity: sha512-0TKSIuJHXNLM0k98fi0AdMIdUoHIYlDHTP+0Vruc2SOs4T6vU1FinXgSvYd8mSrkt+8R+qdRAXvjpqrMXMyBgw==}
     dev: false
 
   /@ljharb/has-package-exports-patterns/0.0.1:
@@ -3056,7 +3190,7 @@ packages:
   /@manypkg/find-root/1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
-      '@babel/runtime': 7.17.7
+      '@babel/runtime': 7.17.2
       '@types/node': 12.20.47
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -3065,7 +3199,7 @@ packages:
   /@manypkg/get-packages/1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
     dependencies:
-      '@babel/runtime': 7.17.7
+      '@babel/runtime': 7.17.2
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -3268,7 +3402,7 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@rollup/plugin-babel/5.3.1_@babel+core@7.17.7+rollup@2.70.1:
+  /@rollup/plugin-babel/5.3.1_@babel+core@7.17.5+rollup@2.70.1:
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -3281,7 +3415,7 @@ packages:
       '@types/babel__core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
+      '@babel/core': 7.17.5
       '@babel/helper-module-imports': 7.16.7
       '@rollup/pluginutils': 3.1.0_rollup@2.70.1
       rollup: 2.70.1
@@ -3428,7 +3562,7 @@ packages:
   /@types/babel__core/7.1.18:
     resolution: {integrity: sha512-S7unDjm/C7z2A2R9NzfKCK1I+BAALDtxEmsJBwlB3EzNfb929ykjL++1CK9LO++EIp2fQrC8O+BwjKvz6UeDyQ==}
     dependencies:
-      '@babel/parser': 7.17.7
+      '@babel/parser': 7.17.3
       '@babel/types': 7.17.0
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
@@ -3444,7 +3578,7 @@ packages:
   /@types/babel__template/7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.17.7
+      '@babel/parser': 7.17.3
       '@babel/types': 7.17.0
     dev: true
 
@@ -3846,7 +3980,7 @@ packages:
   /@unocss/preset-icons/0.15.6:
     resolution: {integrity: sha512-o5NWtOu3OKVaWYVieQ1pVmsj7jvWvMgE5TXPKRr3OTRR2u8M5wo+yRX4+m1sVjAtWiUz8e49TpbbsQTM42Lv7A==}
     dependencies:
-      '@iconify/utils': 1.0.24
+      '@iconify/utils': 1.0.23
       '@unocss/core': 0.15.6
       local-pkg: 0.4.1
     transitivePeerDependencies:
@@ -3909,7 +4043,7 @@ packages:
   /@vue/compiler-core/3.2.31:
     resolution: {integrity: sha512-aKno00qoA4o+V/kR6i/pE+aP+esng5siNAVQ422TkBNM6qA4veXiZbSe8OTXHXquEi/f6Akc+nLfB4JGfe4/WQ==}
     dependencies:
-      '@babel/parser': 7.17.7
+      '@babel/parser': 7.17.3
       '@vue/shared': 3.2.31
       estree-walker: 2.0.2
       source-map: 0.6.1
@@ -3925,7 +4059,7 @@ packages:
   /@vue/compiler-sfc/3.2.31:
     resolution: {integrity: sha512-748adc9msSPGzXgibHiO6T7RWgfnDcVQD+VVwYgSsyyY8Ans64tALHZANrKtOzvkwznV/F4H7OAod/jIlp/dkQ==}
     dependencies:
-      '@babel/parser': 7.17.7
+      '@babel/parser': 7.17.3
       '@vue/compiler-core': 3.2.31
       '@vue/compiler-dom': 3.2.31
       '@vue/compiler-ssr': 3.2.31
@@ -3933,7 +4067,7 @@ packages:
       '@vue/shared': 3.2.31
       estree-walker: 2.0.2
       magic-string: 0.25.9
-      postcss: 8.4.12
+      postcss: 8.4.8
       source-map: 0.6.1
     dev: false
 
@@ -3947,7 +4081,7 @@ packages:
   /@vue/reactivity-transform/3.2.31:
     resolution: {integrity: sha512-uS4l4z/W7wXdI+Va5pgVxBJ345wyGFKvpPYtdSgvfJfX/x2Ymm6ophQlXXB6acqGHtXuBqNyyO3zVp9b1r0MOA==}
     dependencies:
-      '@babel/parser': 7.17.7
+      '@babel/parser': 7.17.3
       '@vue/compiler-core': 3.2.31
       '@vue/shared': 3.2.31
       estree-walker: 2.0.2
@@ -4082,23 +4216,23 @@ packages:
       uri-js: 4.4.1
     dev: true
 
-  /algoliasearch/4.13.0:
-    resolution: {integrity: sha512-oHv4faI1Vl2s+YC0YquwkK/TsaJs79g2JFg5FDm2rKN12VItPTAeQ7hyJMHarOPPYuCnNC5kixbtcqvb21wchw==}
+  /algoliasearch/4.12.2:
+    resolution: {integrity: sha512-bn1P9+V415zeDQJtXn+1SwuwedEAv9/LJAxt8XwR6ygH/sMwaHSm2hpkz8wIbCBt/tKQ43TL672Kyxzv5PwGgQ==}
     dependencies:
-      '@algolia/cache-browser-local-storage': 4.13.0
-      '@algolia/cache-common': 4.13.0
-      '@algolia/cache-in-memory': 4.13.0
-      '@algolia/client-account': 4.13.0
-      '@algolia/client-analytics': 4.13.0
-      '@algolia/client-common': 4.13.0
-      '@algolia/client-personalization': 4.13.0
-      '@algolia/client-search': 4.13.0
-      '@algolia/logger-common': 4.13.0
-      '@algolia/logger-console': 4.13.0
-      '@algolia/requester-browser-xhr': 4.13.0
-      '@algolia/requester-common': 4.13.0
-      '@algolia/requester-node-http': 4.13.0
-      '@algolia/transporter': 4.13.0
+      '@algolia/cache-browser-local-storage': 4.12.2
+      '@algolia/cache-common': 4.12.2
+      '@algolia/cache-in-memory': 4.12.2
+      '@algolia/client-account': 4.12.2
+      '@algolia/client-analytics': 4.12.2
+      '@algolia/client-common': 4.12.2
+      '@algolia/client-personalization': 4.12.2
+      '@algolia/client-search': 4.12.2
+      '@algolia/logger-common': 4.12.2
+      '@algolia/logger-console': 4.12.2
+      '@algolia/requester-browser-xhr': 4.12.2
+      '@algolia/requester-common': 4.12.2
+      '@algolia/requester-node-http': 4.12.2
+      '@algolia/transporter': 4.12.2
     dev: false
 
   /ansi-colors/4.1.1:
@@ -4211,6 +4345,22 @@ packages:
     engines: {node: '>= 4.0.0'}
     dev: true
 
+  /autoprefixer/10.4.2_postcss@8.4.8:
+    resolution: {integrity: sha512-9fOPpHKuDW1w/0EKfRmVnxTDt8166MAnLI3mgZ1JCnhNtYWxcJ6Ud5CO/AVOZi/AvFa8DY9RTy3h3+tFBlrrdQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+    dependencies:
+      browserslist: 4.20.0
+      caniuse-lite: 1.0.30001316
+      fraction.js: 4.2.0
+      normalize-range: 0.1.2
+      picocolors: 1.0.0
+      postcss: 8.4.8
+      postcss-value-parser: 4.2.0
+    dev: false
+
   /autoprefixer/10.4.4_postcss@8.4.12:
     resolution: {integrity: sha512-Tm8JxsB286VweiZ5F0anmbyGiNI3v3wGv3mz9W+cxEDYB/6jbnj6GM9H9mK3wIL8ftgl+C07Lcwb8PG5PCCPzA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4237,8 +4387,8 @@ packages:
       object.assign: 4.1.2
     dev: true
 
-  /babel-plugin-jsx-dom-expressions/0.32.10:
-    resolution: {integrity: sha512-vtCYhvKnkGwuiiFN/56/4BGXchu8ju7TTay3A8wlkIWI5CsEaJD0ztGoGKlq/clQzuqm0hQtQAq5glCVHVuGGQ==}
+  /babel-plugin-jsx-dom-expressions/0.32.9:
+    resolution: {integrity: sha512-6wvUZU+2oxRC4M5UyOMr3/x176NC5nbeDOXqckubCQkDr0mljpoRiLR5M0EXj3Jn2tiW6qVsQ3o4kKnjq8/kTA==}
     dependencies:
       '@babel/helper-module-imports': 7.16.0
       '@babel/plugin-syntax-jsx': 7.16.7
@@ -4248,7 +4398,7 @@ packages:
       - '@babel/core'
     dev: false
 
-  /babel-plugin-polyfill-corejs2/0.3.1_@babel+core@7.17.7:
+  /babel-plugin-polyfill-corejs2/0.3.1_@babel+core@7.17.5:
     resolution: {integrity: sha512-v7/T6EQcNfVLfcN2X8Lulb7DjprieyLWJK/zOWH5DUYcAgex9sP3h25Q+DLsX9TloXe3y1O8l2q2Jv9q8UVB9w==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4256,15 +4406,15 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/compat-data': 7.17.7
-      '@babel/core': 7.17.7
-      '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.17.7
+      '@babel/compat-data': 7.17.0
+      '@babel/core': 7.17.5
+      '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.17.5
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-corejs3/0.5.2_@babel+core@7.17.7:
+  /babel-plugin-polyfill-corejs3/0.5.2_@babel+core@7.17.5:
     resolution: {integrity: sha512-G3uJih0XWiID451fpeFaYGVuxHEjzKTHtc9uGFEjR6hHrvNzeS/PX+LLLcetJcytsB5m4j+K3o/EpXJNb/5IEQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4272,14 +4422,14 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
-      '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.17.7
+      '@babel/core': 7.17.5
+      '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.17.5
       core-js-compat: 3.21.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-regenerator/0.3.1_@babel+core@7.17.7:
+  /babel-plugin-polyfill-regenerator/0.3.1_@babel+core@7.17.5:
     resolution: {integrity: sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4287,8 +4437,8 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.17.7
-      '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.17.7
+      '@babel/core': 7.17.5
+      '@babel/helper-define-polyfill-provider': 0.3.1_@babel+core@7.17.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4296,7 +4446,7 @@ packages:
   /babel-preset-solid/1.3.12:
     resolution: {integrity: sha512-2/ggNVrYoZ/XMGB5ap9G5qoCXfYxm6GJ9NDhPz3+G4f4kSNQ1CMqZbQAfuKpUqEmtvcOM2riIgNsgeAdUiiGMw==}
     dependencies:
-      babel-plugin-jsx-dom-expressions: 0.32.10
+      babel-plugin-jsx-dom-expressions: 0.32.9
     transitivePeerDependencies:
       - '@babel/core'
     dev: false
@@ -4361,6 +4511,17 @@ packages:
   /browser-stdout/1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
     dev: true
+
+  /browserslist/4.20.0:
+    resolution: {integrity: sha512-bnpOoa+DownbciXj0jVGENf8VYQnE2LNWomhYuCsMmmx9Jd9lwq0WXODuwpSsp8AVdKM2/HorrzxAfbKvWTByQ==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001316
+      electron-to-chromium: 1.4.82
+      escalade: 3.1.1
+      node-releases: 2.0.2
+      picocolors: 1.0.0
 
   /browserslist/4.20.2:
     resolution: {integrity: sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==}
@@ -4435,6 +4596,9 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
     dev: true
+
+  /caniuse-lite/1.0.30001316:
+    resolution: {integrity: sha512-JgUdNoZKxPZFzbzJwy4hDSyGuH/gXz2rN51QmoR8cBQsVo58llD3A0vlRKKRt8FGf5u69P9eQyIH8/z9vN/S0Q==}
 
   /caniuse-lite/1.0.30001317:
     resolution: {integrity: sha512-xIZLh8gBm4dqNX0gkzrBeyI86J2eCjWzYAs40q88smG844YIrN4tVQl/RhquHvKEKImWWFIVh1Lxe5n1G/N+GQ==}
@@ -4673,7 +4837,7 @@ packages:
   /core-js-compat/3.21.1:
     resolution: {integrity: sha512-gbgX5AUvMb8gwxC7FLVWYT7Kkgu/y7+h/h1X43yJkNqhlK2fuYyQimqvKGNZFAY6CKii/GFKJ2cp/1/42TN36g==}
     dependencies:
-      browserslist: 4.20.2
+      browserslist: 4.20.0
       semver: 7.0.0
     dev: true
 
@@ -5020,6 +5184,9 @@ packages:
       jake: 10.8.2
     dev: true
 
+  /electron-to-chromium/1.4.82:
+    resolution: {integrity: sha512-Ks+ANzLoIrFDUOJdjxYMH6CMKB8UQo5modAwvSZTxgF+vEs/U7G5IbWFUp6dS4klPkTDVdxbORuk8xAXXhMsWw==}
+
   /electron-to-chromium/1.4.85:
     resolution: {integrity: sha512-K9AsQ41WS2bjZUFpRWfvaS4RjEcRCamEkBJN1Z1TQILBfP1H8QnJ9ti0wiLiMv0sRjX3EHKzgs9jDnmGFx2jXg==}
 
@@ -5121,8 +5288,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-android-64/0.14.27:
-    resolution: {integrity: sha512-LuEd4uPuj/16Y8j6kqy3Z2E9vNY9logfq8Tq+oTE2PZVuNs3M1kj5Qd4O95ee66yDGb3isaOCV7sOLDwtMfGaQ==}
+  /esbuild-android-64/0.14.26:
+    resolution: {integrity: sha512-HIyJ3VvigHfseaI0D+vsD8zKQ4roDUD962/vtO/KXzav6wR//Y//Qx1HUX8k5bQeQ7/0yCXlltY9VBw1MFnWFQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -5138,8 +5305,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-android-arm64/0.14.27:
-    resolution: {integrity: sha512-E8Ktwwa6vX8q7QeJmg8yepBYXaee50OdQS3BFtEHKrzbV45H4foMOeEE7uqdjGQZFBap5VAqo7pvjlyA92wznQ==}
+  /esbuild-android-arm64/0.14.26:
+    resolution: {integrity: sha512-TxRCLxyU5yj3U8Bud9fCg3IxzIXXKaWcmDbvURm8JkRr0WvCAmwZBdLi5T8BasT1v5vrVE//M0KSHZod6HC6lA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -5155,8 +5322,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-darwin-64/0.14.27:
-    resolution: {integrity: sha512-czw/kXl/1ZdenPWfw9jDc5iuIYxqUxgQ/Q+hRd4/3udyGGVI31r29LCViN2bAJgGvQkqyLGVcG03PJPEXQ5i2g==}
+  /esbuild-darwin-64/0.14.26:
+    resolution: {integrity: sha512-oZJBN+CkR47Fc7KB1vowZy2kb5r+WSnsBjVEw7aI8HmR6louAgTr4bs1NwzaF6MbLi41ajaw6RdipfsM1H9PvQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -5172,8 +5339,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-darwin-arm64/0.14.27:
-    resolution: {integrity: sha512-BEsv2U2U4o672oV8+xpXNxN9bgqRCtddQC6WBh4YhXKDcSZcdNh7+6nS+DM2vu7qWIWNA4JbRG24LUUYXysimQ==}
+  /esbuild-darwin-arm64/0.14.26:
+    resolution: {integrity: sha512-eYW+cmP3BGVPDp+wd9bRI5CN5HjkZnrMQtj46Mj//UsSh4SRvflAp3pjs3ooA+MCpIa9xZ8091HqLqpYi7KFWA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -5189,8 +5356,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-freebsd-64/0.14.27:
-    resolution: {integrity: sha512-7FeiFPGBo+ga+kOkDxtPmdPZdayrSzsV9pmfHxcyLKxu+3oTcajeZlOO1y9HW+t5aFZPiv7czOHM4KNd0tNwCA==}
+  /esbuild-freebsd-64/0.14.26:
+    resolution: {integrity: sha512-Q+Hs27fSBkNfUHNhphSyWfF5lxl3o9S6LFlzkC5KofxLCnCESP+7YTzAWTosYGANsPT2mvYFOraFeYEokG+5DA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -5206,8 +5373,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-freebsd-arm64/0.14.27:
-    resolution: {integrity: sha512-8CK3++foRZJluOWXpllG5zwAVlxtv36NpHfsbWS7TYlD8S+QruXltKlXToc/5ZNzBK++l6rvRKELu/puCLc7jA==}
+  /esbuild-freebsd-arm64/0.14.26:
+    resolution: {integrity: sha512-MT+FuC/63oz6j/jvWOMCNqnHBYm/bNhGPArUgQX8GRhofFCeqe0NRmJbhtlHZaEeErIIjHPZQ/nXs34mfiqo/Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -5223,8 +5390,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-32/0.14.27:
-    resolution: {integrity: sha512-qhNYIcT+EsYSBClZ5QhLzFzV5iVsP1YsITqblSaztr3+ZJUI+GoK8aXHyzKd7/CKKuK93cxEMJPpfi1dfsOfdw==}
+  /esbuild-linux-32/0.14.26:
+    resolution: {integrity: sha512-9gqSfJ8qMDvz7wXZoinNoe9/ekPpbT+/ZgVfZEeB72ETITVPHvMbG8i0E12wG366G01vMXtlxbD9IYJsMVhe6w==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -5240,8 +5407,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-64/0.14.27:
-    resolution: {integrity: sha512-ESjck9+EsHoTaKWlFKJpPZRN26uiav5gkI16RuI8WBxUdLrrAlYuYSndxxKgEn1csd968BX/8yQZATYf/9+/qg==}
+  /esbuild-linux-64/0.14.26:
+    resolution: {integrity: sha512-aPku1lCxxXmBr5LkENSlGIbY33jjQExDzaSrNV+dDA5bHXhFnpI9UkSe+vQzrSkxgO66vNjSTNDcxg3pOXBaBw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -5257,8 +5424,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-arm/0.14.27:
-    resolution: {integrity: sha512-JnnmgUBdqLQO9hoNZQqNHFWlNpSX82vzB3rYuCJMhtkuaWQEmQz6Lec1UIxJdC38ifEghNTBsF9bbe8dFilnCw==}
+  /esbuild-linux-arm/0.14.26:
+    resolution: {integrity: sha512-m7ozLQozfgBmh9l3HWxDEVYEEG8GuTqzRoFuf9iX0xAlbtqmhhlm7M4zNMa2eyPEG+ejgHndAuvuB1hcOWvdJw==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -5274,8 +5441,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-arm64/0.14.27:
-    resolution: {integrity: sha512-no6Mi17eV2tHlJnqBHRLekpZ2/VYx+NfGxKcBE/2xOMYwctsanCaXxw4zapvNrGE9X38vefVXLz6YCF8b1EHiQ==}
+  /esbuild-linux-arm64/0.14.26:
+    resolution: {integrity: sha512-S0boyzv5Yx+IN1A8253nEPzHqn/W/y+CRcLYFZ1E5DscqkY7EvBao6rhff3ZxaHU9Zrkn0pLVqlJdMx3rm6D4Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -5291,8 +5458,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-mips64le/0.14.27:
-    resolution: {integrity: sha512-NolWP2uOvIJpbwpsDbwfeExZOY1bZNlWE/kVfkzLMsSgqeVcl5YMen/cedRe9mKnpfLli+i0uSp7N+fkKNU27A==}
+  /esbuild-linux-mips64le/0.14.26:
+    resolution: {integrity: sha512-TyMRc2ctQV1g9ruHg1Y793e18uDigKKsgzcZPzfxZi2z+hGK1uaSdaejGdULEJBJVMXt3/NC1T1yq0vCTiYYgg==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -5308,8 +5475,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-ppc64le/0.14.27:
-    resolution: {integrity: sha512-/7dTjDvXMdRKmsSxKXeWyonuGgblnYDn0MI1xDC7J1VQXny8k1qgNp6VmrlsawwnsymSUUiThhkJsI+rx0taNA==}
+  /esbuild-linux-ppc64le/0.14.26:
+    resolution: {integrity: sha512-aOJPP80m2gV8CyDqEMGbwZaGKuR45tZU1qYZ0+Cy8lWV4CWmd9iBWhCLP3eI9d7163m6t+0YO/6N3iLSVlNnpA==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -5325,8 +5492,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-riscv64/0.14.27:
-    resolution: {integrity: sha512-D+aFiUzOJG13RhrSmZgrcFaF4UUHpqj7XSKrIiCXIj1dkIkFqdrmqMSOtSs78dOtObWiOrFCDDzB24UyeEiNGg==}
+  /esbuild-linux-riscv64/0.14.26:
+    resolution: {integrity: sha512-2E5xK7SNZFXhFzRbZGtUqg3MbHnrx5XzqHaGLOLdHBqOSWIAdJKB3w6WtjpLkZvPuWrKeh51XnRpk1jm0TsUjQ==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -5342,8 +5509,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-s390x/0.14.27:
-    resolution: {integrity: sha512-CD/D4tj0U4UQjELkdNlZhQ8nDHU5rBn6NGp47Hiz0Y7/akAY5i0oGadhEIg0WCY/HYVXFb3CsSPPwaKcTOW3bg==}
+  /esbuild-linux-s390x/0.14.26:
+    resolution: {integrity: sha512-kfSuFea857mTYMp/RAFmMp9TBjf1T8F/dTRqLn2p+g8Ok30Cp1+mI2+YCmxz5Uw2JOfxyvpND0Ek1PGPMo1UsQ==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -5359,8 +5526,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-netbsd-64/0.14.27:
-    resolution: {integrity: sha512-h3mAld69SrO1VoaMpYl3a5FNdGRE/Nqc+E8VtHOag4tyBwhCQXxtvDDOAKOUQexBGca0IuR6UayQ4ntSX5ij1Q==}
+  /esbuild-netbsd-64/0.14.26:
+    resolution: {integrity: sha512-tWhLwfOOqdZRwvaSYIWuic9Cj+WRRCLHe//Bmlf0ThBur9/EssRTtVh6/rC2Okp7Eb4QcerA/1wjWLYLECYD7g==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -5376,8 +5543,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-openbsd-64/0.14.27:
-    resolution: {integrity: sha512-xwSje6qIZaDHXWoPpIgvL+7fC6WeubHHv18tusLYMwL+Z6bEa4Pbfs5IWDtQdHkArtfxEkIZz77944z8MgDxGw==}
+  /esbuild-openbsd-64/0.14.26:
+    resolution: {integrity: sha512-Xj7IWpsPn/hgKNzwjLpnf6wMtV0lfw5bzn7N9vmiCKx9TBA28L2hI8G15O0s9atLKny4HpmCGwZWmReNF1Ui6g==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -5393,8 +5560,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-sunos-64/0.14.27:
-    resolution: {integrity: sha512-/nBVpWIDjYiyMhuqIqbXXsxBc58cBVH9uztAOIfWShStxq9BNBik92oPQPJ57nzWXRNKQUEFWr4Q98utDWz7jg==}
+  /esbuild-sunos-64/0.14.26:
+    resolution: {integrity: sha512-5odPsuhghCUYc3c1gEtz6pGq9cuGRDq1+iNdLBjZcz6IUebd0ay/AVORWchs5WddzyJA9hguxrKsPjECxX6OzQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -5410,8 +5577,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-windows-32/0.14.27:
-    resolution: {integrity: sha512-Q9/zEjhZJ4trtWhFWIZvS/7RUzzi8rvkoaS9oiizkHTTKd8UxFwn/Mm2OywsAfYymgUYm8+y2b+BKTNEFxUekw==}
+  /esbuild-windows-32/0.14.26:
+    resolution: {integrity: sha512-xSVyGV6xGQlAC/K+oBXC9YiGGqoKqQGXVEFQKlDGXD6rxHGK5Fch0ynuvkjaYWW/p8OWqxGVYcof5BvGjY49RA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -5427,8 +5594,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-windows-64/0.14.27:
-    resolution: {integrity: sha512-b3y3vTSl5aEhWHK66ngtiS/c6byLf6y/ZBvODH1YkBM+MGtVL6jN38FdHUsZasCz9gFwYs/lJMVY9u7GL6wfYg==}
+  /esbuild-windows-64/0.14.26:
+    resolution: {integrity: sha512-Q0Bm42+wIqHJ8yF96T7nXosILXROegRtMmuI1L0kry0YBHnCFMtjNRTyUwv8yi7o2XvVYh7DF0NHLDL4N34MuA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -5444,8 +5611,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-windows-arm64/0.14.27:
-    resolution: {integrity: sha512-I/reTxr6TFMcR5qbIkwRGvldMIaiBu2+MP0LlD7sOlNXrfqIl9uNjsuxFPGEG4IRomjfQ5q8WT+xlF/ySVkqKg==}
+  /esbuild-windows-arm64/0.14.26:
+    resolution: {integrity: sha512-+l0DB0VV4LiSoDfNsGviK/2M88IR+/fOUfQoQx08RPu7OZ7gv9BqhRLZCSCT4qHT351OTH1nPv7avRXX6JRQcg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -5480,32 +5647,32 @@ packages:
       esbuild-windows-64: 0.14.25
       esbuild-windows-arm64: 0.14.25
 
-  /esbuild/0.14.27:
-    resolution: {integrity: sha512-MZQt5SywZS3hA9fXnMhR22dv0oPGh6QtjJRIYbgL1AeqAoQZE+Qn5ppGYQAoHv/vq827flj4tIJ79Mrdiwk46Q==}
+  /esbuild/0.14.26:
+    resolution: {integrity: sha512-v0zIYlFB9NZ82/hFljhvpA7f8rob66r68ymB7juMz6TYAAMYjKGoW+hrMfRRvic5MAOI2wE/SuykFvsELLa6eA==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      esbuild-android-64: 0.14.27
-      esbuild-android-arm64: 0.14.27
-      esbuild-darwin-64: 0.14.27
-      esbuild-darwin-arm64: 0.14.27
-      esbuild-freebsd-64: 0.14.27
-      esbuild-freebsd-arm64: 0.14.27
-      esbuild-linux-32: 0.14.27
-      esbuild-linux-64: 0.14.27
-      esbuild-linux-arm: 0.14.27
-      esbuild-linux-arm64: 0.14.27
-      esbuild-linux-mips64le: 0.14.27
-      esbuild-linux-ppc64le: 0.14.27
-      esbuild-linux-riscv64: 0.14.27
-      esbuild-linux-s390x: 0.14.27
-      esbuild-netbsd-64: 0.14.27
-      esbuild-openbsd-64: 0.14.27
-      esbuild-sunos-64: 0.14.27
-      esbuild-windows-32: 0.14.27
-      esbuild-windows-64: 0.14.27
-      esbuild-windows-arm64: 0.14.27
+      esbuild-android-64: 0.14.26
+      esbuild-android-arm64: 0.14.26
+      esbuild-darwin-64: 0.14.26
+      esbuild-darwin-arm64: 0.14.26
+      esbuild-freebsd-64: 0.14.26
+      esbuild-freebsd-arm64: 0.14.26
+      esbuild-linux-32: 0.14.26
+      esbuild-linux-64: 0.14.26
+      esbuild-linux-arm: 0.14.26
+      esbuild-linux-arm64: 0.14.26
+      esbuild-linux-mips64le: 0.14.26
+      esbuild-linux-ppc64le: 0.14.26
+      esbuild-linux-riscv64: 0.14.26
+      esbuild-linux-s390x: 0.14.26
+      esbuild-netbsd-64: 0.14.26
+      esbuild-openbsd-64: 0.14.26
+      esbuild-sunos-64: 0.14.26
+      esbuild-windows-32: 0.14.26
+      esbuild-windows-64: 0.14.26
+      esbuild-windows-arm64: 0.14.26
     dev: false
 
   /escalade/3.1.1:
@@ -5624,7 +5791,7 @@ packages:
       file-entry-cache: 6.0.1
       functional-red-black-tree: 1.0.1
       glob-parent: 6.0.2
-      globals: 13.13.0
+      globals: 13.12.1
       ignore: 5.2.0
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
@@ -6060,8 +6227,8 @@ packages:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
 
-  /globals/13.13.0:
-    resolution: {integrity: sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==}
+  /globals/13.12.1:
+    resolution: {integrity: sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
@@ -6865,12 +7032,12 @@ packages:
   /lit-element/3.2.0:
     resolution: {integrity: sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==}
     dependencies:
-      '@lit/reactive-element': 1.3.1
-      lit-html: 2.2.1
+      '@lit/reactive-element': 1.3.0
+      lit-html: 2.2.0
     dev: false
 
-  /lit-html/2.2.1:
-    resolution: {integrity: sha512-AiJ/Rs0awjICs2FioTnHSh+Np5dhYSkyRczKy3wKjp8qjLhr1Ov+GiHrUQNdX8ou1LMuznpIME990AZsa/tR8g==}
+  /lit-html/2.2.0:
+    resolution: {integrity: sha512-dJnevgV8VkCuOXLWrjQopDE8nSy8CzipZ/ATfYQv7z7Dct4abblcKecf50gkIScuwCTzKvRLgvTgV0zzagW4gA==}
     dependencies:
       '@types/trusted-types': 2.0.2
     dev: false
@@ -6878,9 +7045,9 @@ packages:
   /lit/2.2.1:
     resolution: {integrity: sha512-dSe++R50JqrvNGXmI9OE13de1z5U/Y3J2dTm/9GC86vedI8ILoR8ZGnxfThFpvQ9m0lR0qRnIR4IiKj/jDCfYw==}
     dependencies:
-      '@lit/reactive-element': 1.3.1
+      '@lit/reactive-element': 1.3.0
       lit-element: 3.2.0
-      lit-html: 2.2.1
+      lit-html: 2.2.0
     dev: false
 
   /load-yaml-file/0.2.0:
@@ -7057,14 +7224,11 @@ packages:
       mdast-util-to-markdown: 1.3.0
     dev: false
 
-  /mdast-util-gfm-table/1.0.4:
-    resolution: {integrity: sha512-aEuoPwZyP4iIMkf2cLWXxx3EQ6Bmh2yKy9MVCg4i6Sd3cX80dcLEfXO/V4ul3pGH9czBK4kp+FAl+ZHmSUt9/w==}
+  /mdast-util-gfm-table/1.0.3:
+    resolution: {integrity: sha512-B/tgpJjND1qIZM2WZst+NYnb0notPE6m0J+YOe3NOHXyEmvK38ytxaOsgz4BvrRPQQcNbRrTzSHMPnBkj1fCjg==}
     dependencies:
       markdown-table: 3.0.2
-      mdast-util-from-markdown: 1.2.0
       mdast-util-to-markdown: 1.3.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /mdast-util-gfm-task-list-item/1.0.1:
@@ -7074,18 +7238,14 @@ packages:
       mdast-util-to-markdown: 1.3.0
     dev: false
 
-  /mdast-util-gfm/2.0.1:
-    resolution: {integrity: sha512-42yHBbfWIFisaAfV1eixlabbsa6q7vHeSPY+cg+BBjX51M8xhgMacqH9g6TftB/9+YkcI0ooV4ncfrJslzm/RQ==}
+  /mdast-util-gfm/2.0.0:
+    resolution: {integrity: sha512-wMwejlTN3EQADPFuvxe8lmGsay3+f6gSJKdAHR6KBJzpcxvsjJSILB9K6u6G7eQLC7iOTyVIHYGui9uBc9r1Tg==}
     dependencies:
-      mdast-util-from-markdown: 1.2.0
       mdast-util-gfm-autolink-literal: 1.0.2
       mdast-util-gfm-footnote: 1.0.1
       mdast-util-gfm-strikethrough: 1.0.1
-      mdast-util-gfm-table: 1.0.4
+      mdast-util-gfm-table: 1.0.3
       mdast-util-gfm-task-list-item: 1.0.1
-      mdast-util-to-markdown: 1.3.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /mdast-util-mdx-expression/1.2.0:
@@ -8005,15 +8165,14 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /postcss-js/4.0.0_postcss@8.4.12:
+  /postcss-js/4.0.0_postcss@8.4.8:
     resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
       postcss: ^8.3.3
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.12
-    dev: true
+      postcss: 8.4.8
 
   /postcss-load-config/3.1.3:
     resolution: {integrity: sha512-5EYgaM9auHGtO//ljHH+v/aC/TQ5LHXtL7bQajNAUBKUVKiYE8rYpFms7+V26D9FncaGe2zwCoPQsFKb5zF/Hw==}
@@ -8027,13 +8186,13 @@ packages:
       lilconfig: 2.0.4
       yaml: 1.10.2
 
-  /postcss-nested/5.0.6_postcss@8.4.12:
+  /postcss-nested/5.0.6_postcss@8.4.8:
     resolution: {integrity: sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
-      postcss: 8.4.12
+      postcss: 8.4.8
       postcss-selector-parser: 6.0.9
 
   /postcss-selector-parser/6.0.9:
@@ -8048,6 +8207,14 @@ packages:
 
   /postcss/8.4.12:
     resolution: {integrity: sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.1
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+
+  /postcss/8.4.8:
+    resolution: {integrity: sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.1
@@ -8342,7 +8509,7 @@ packages:
   /regenerator-transform/0.14.5:
     resolution: {integrity: sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==}
     dependencies:
-      '@babel/runtime': 7.17.7
+      '@babel/runtime': 7.17.2
     dev: true
 
   /regexp.prototype.flags/1.4.1:
@@ -8437,11 +8604,9 @@ packages:
     resolution: {integrity: sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==}
     dependencies:
       '@types/mdast': 3.0.10
-      mdast-util-gfm: 2.0.1
+      mdast-util-gfm: 2.0.0
       micromark-extension-gfm: 2.0.1
       unified: 10.1.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /remark-parse/10.0.1:
@@ -8565,7 +8730,7 @@ packages:
       jest-worker: 26.6.2
       rollup: 2.70.1
       serialize-javascript: 4.0.0
-      terser: 5.12.1
+      terser: 5.12.0
     dev: true
 
   /rollup/2.70.1:
@@ -9188,6 +9353,39 @@ packages:
     engines: {node: '>= 8'}
     dev: false
 
+  /tailwindcss/3.0.23_autoprefixer@10.4.2:
+    resolution: {integrity: sha512-+OZOV9ubyQ6oI2BXEhzw4HrqvgcARY38xv3zKcjnWtMIZstEsXdI9xftd1iB7+RbOnj2HOEzkA0OyB5BaSxPQA==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+    peerDependencies:
+      autoprefixer: ^10.0.2
+    dependencies:
+      arg: 5.0.1
+      autoprefixer: 10.4.2_postcss@8.4.8
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      color-name: 1.1.4
+      cosmiconfig: 7.0.1
+      detective: 5.2.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.11
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      object-hash: 2.2.0
+      postcss: 8.4.8
+      postcss-js: 4.0.0_postcss@8.4.8
+      postcss-load-config: 3.1.3
+      postcss-nested: 5.0.6_postcss@8.4.8
+      postcss-selector-parser: 6.0.9
+      postcss-value-parser: 4.2.0
+      quick-lru: 5.1.1
+      resolve: 1.22.0
+    transitivePeerDependencies:
+      - ts-node
+    dev: false
+
   /tailwindcss/3.0.23_autoprefixer@10.4.4:
     resolution: {integrity: sha512-+OZOV9ubyQ6oI2BXEhzw4HrqvgcARY38xv3zKcjnWtMIZstEsXdI9xftd1iB7+RbOnj2HOEzkA0OyB5BaSxPQA==}
     engines: {node: '>=12.13.0'}
@@ -9209,16 +9407,17 @@ packages:
       is-glob: 4.0.3
       normalize-path: 3.0.0
       object-hash: 2.2.0
-      postcss: 8.4.12
-      postcss-js: 4.0.0_postcss@8.4.12
+      postcss: 8.4.8
+      postcss-js: 4.0.0_postcss@8.4.8
       postcss-load-config: 3.1.3
-      postcss-nested: 5.0.6_postcss@8.4.12
+      postcss-nested: 5.0.6_postcss@8.4.8
       postcss-selector-parser: 6.0.9
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1
       resolve: 1.22.0
     transitivePeerDependencies:
       - ts-node
+    dev: true
 
   /tar-fs/2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
@@ -9272,8 +9471,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /terser/5.12.1:
-    resolution: {integrity: sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==}
+  /terser/5.12.0:
+    resolution: {integrity: sha512-R3AUhNBGWiFc77HXag+1fXpAxTAFRQTJemlJKjAgD9r8xXTpjNKqIXwHM/o7Rh+O0kUJtS3WQVdBeMKFk5sw9A==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -9879,8 +10078,8 @@ packages:
       stylus:
         optional: true
     dependencies:
-      esbuild: 0.14.27
-      postcss: 8.4.12
+      esbuild: 0.14.26
+      postcss: 8.4.8
       resolve: 1.22.0
       rollup: 2.70.1
     optionalDependencies:
@@ -9903,8 +10102,8 @@ packages:
       stylus:
         optional: true
     dependencies:
-      esbuild: 0.14.27
-      postcss: 8.4.12
+      esbuild: 0.14.26
+      postcss: 8.4.8
       resolve: 1.22.0
       rollup: 2.70.1
       sass: 1.49.9
@@ -10124,10 +10323,10 @@ packages:
     engines: {node: '>=10.0.0'}
     dependencies:
       '@apideck/better-ajv-errors': 0.3.3_ajv@8.10.0
-      '@babel/core': 7.17.7
-      '@babel/preset-env': 7.16.11_@babel+core@7.17.7
-      '@babel/runtime': 7.17.7
-      '@rollup/plugin-babel': 5.3.1_@babel+core@7.17.7+rollup@2.70.1
+      '@babel/core': 7.17.5
+      '@babel/preset-env': 7.16.11_@babel+core@7.17.5
+      '@babel/runtime': 7.17.2
+      '@rollup/plugin-babel': 5.3.1_@babel+core@7.17.5+rollup@2.70.1
       '@rollup/plugin-node-resolve': 11.2.1_rollup@2.70.1
       '@rollup/plugin-replace': 2.4.2_rollup@2.70.1
       '@surma/rollup-plugin-off-main-thread': 2.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -950,6 +950,16 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/tailwindcss:
+    specifiers:
+      astro: workspace:*
+      postcss: ^8.4.8
+      tailwindcss: ^3.0.23
+    dependencies:
+      astro: link:../../..
+      postcss: 8.4.8
+      tailwindcss: 3.0.23
+
   packages/astro/test/fixtures/vue-component:
     specifiers:
       astro: workspace:*
@@ -3575,7 +3585,6 @@ packages:
 
   /@types/parse-json/4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
-    dev: true
 
   /@types/parse5/6.0.3:
     resolution: {integrity: sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==}
@@ -4011,12 +4020,10 @@ packages:
       acorn: 7.4.1
       acorn-walk: 7.2.0
       xtend: 4.0.2
-    dev: true
 
   /acorn-walk/7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /acorn-walk/8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
@@ -4027,7 +4034,6 @@ packages:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: true
 
   /acorn/8.7.0:
     resolution: {integrity: sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==}
@@ -4124,7 +4130,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /anymatch/3.1.2:
     resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}
@@ -4405,12 +4410,10 @@ packages:
   /callsites/3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
-    dev: true
 
   /camelcase-css/2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
-    dev: true
 
   /camelcase-keys/6.2.2:
     resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
@@ -4473,7 +4476,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: true
 
   /character-entities-html4/2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -4593,14 +4595,12 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name/1.1.3:
     resolution: {integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=}
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
 
   /color-string/1.9.0:
     resolution: {integrity: sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==}
@@ -4688,7 +4688,6 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
-    dev: true
 
   /cross-spawn/5.1.0:
     resolution: {integrity: sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=}
@@ -4734,7 +4733,6 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /csstype/2.6.20:
     resolution: {integrity: sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==}
@@ -4873,7 +4871,6 @@ packages:
 
   /defined/1.0.0:
     resolution: {integrity: sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=}
-    dev: true
 
   /defu/5.0.1:
     resolution: {integrity: sha512-EPS1carKg+dkEVy3qNTqIdp2qV7mUP08nIsupfwQpz++slCVRw7qbQyWvSTig+kFPwz2XXp5/kIIkH+CwrJKkQ==}
@@ -4949,11 +4946,9 @@ packages:
       acorn-node: 1.8.2
       defined: 1.0.0
       minimist: 1.2.5
-    dev: true
 
   /didyoumean/1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
-    dev: true
 
   /diff/5.0.0:
     resolution: {integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==}
@@ -4971,7 +4966,6 @@ packages:
 
   /dlv/1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
-    dev: true
 
   /doctrine/3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -5071,7 +5065,6 @@ packages:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
       is-arrayish: 0.2.1
-    dev: true
 
   /es-abstract/1.19.1:
     resolution: {integrity: sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==}
@@ -6050,7 +6043,6 @@ packages:
     engines: {node: '>=10.13.0'}
     dependencies:
       is-glob: 4.0.3
-    dev: true
 
   /glob/7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
@@ -6149,7 +6141,6 @@ packages:
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /has-package-exports/1.2.3:
     resolution: {integrity: sha512-lkLLwrNNaRsmwj+TylZJh1o3YlzLfgrl9fZKOAMj4MHjbvt7wy1J0icE6jD36dzkA0aQGoNuqY0hVN2uuPfPBA==}
@@ -6422,7 +6413,6 @@ packages:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-    dev: true
 
   /imurmurhash/0.1.4:
     resolution: {integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=}
@@ -6484,7 +6474,6 @@ packages:
 
   /is-arrayish/0.2.1:
     resolution: {integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=}
-    dev: true
 
   /is-arrayish/0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
@@ -6771,7 +6760,6 @@ packages:
 
   /json-parse-even-better-errors/2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
-    dev: true
 
   /json-schema-traverse/0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -6868,11 +6856,9 @@ packages:
   /lilconfig/2.0.4:
     resolution: {integrity: sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==}
     engines: {node: '>=10'}
-    dev: true
 
   /lines-and-columns/1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-    dev: true
 
   /lit-element/3.2.0:
     resolution: {integrity: sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==}
@@ -7756,7 +7742,6 @@ packages:
   /object-hash/2.2.0:
     resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
     engines: {node: '>= 6'}
-    dev: true
 
   /object-inspect/1.12.0:
     resolution: {integrity: sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==}
@@ -7917,7 +7902,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
-    dev: true
 
   /parse-entities/4.0.0:
     resolution: {integrity: sha512-5nk9Fn03x3rEhGaX1FU6IDwG/k+GxLXlFAkgrbM1asuAFl3BhdQWvASaIsmwWypRNcZKHPYnIuOSfIWEyEQnPQ==}
@@ -7940,7 +7924,6 @@ packages:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-    dev: true
 
   /parse-latin/5.0.0:
     resolution: {integrity: sha512-Ht+4/+AUySMS5HKGAiQpBmkFsHSoGrj6Y83flLCa5OIBdtsVkO3UD4OtboJ0O0vZiOznH02x8qlwg9KLUVXuNg==}
@@ -8041,7 +8024,6 @@ packages:
     dependencies:
       lilconfig: 2.0.4
       yaml: 1.10.2
-    dev: true
 
   /postcss-nested/5.0.6_postcss@8.4.12:
     resolution: {integrity: sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==}
@@ -8051,7 +8033,6 @@ packages:
     dependencies:
       postcss: 8.4.12
       postcss-selector-parser: 6.0.9
-    dev: true
 
   /postcss-selector-parser/6.0.9:
     resolution: {integrity: sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==}
@@ -8059,7 +8040,6 @@ packages:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-    dev: true
 
   /postcss-value-parser/4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -8224,7 +8204,6 @@ packages:
   /quick-lru/5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
-    dev: true
 
   /randombytes/2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -8508,7 +8487,6 @@ packages:
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-    dev: true
 
   /resolve-from/5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -9125,7 +9103,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-color/8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
@@ -9803,7 +9780,6 @@ packages:
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
-    dev: true
 
   /util/0.12.4:
     resolution: {integrity: sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==}
@@ -10307,7 +10283,6 @@ packages:
   /xtend/4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
-    dev: true
 
   /y18n/4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -10332,7 +10307,6 @@ packages:
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
-    dev: true
 
   /yargs-parser/18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}


### PR DESCRIPTION
Follow-up to [#2791](https://github.com/withastro/astro/pull/2791) - adding test coverage now that Tailwind is working properly in `astro dev` 🎉 

## Changes

Test coverage only, no feature changes

## Testing

Adds tests to verify tailwind in `astro dev` and `astro build` to make sure classes are kept in HTML and styles are available in rendered CSS

## Docs

Test coverage only, no docs updates
