### PR TITLE
Logic for opening example projects

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ tasks:
       pnpm install
       pnpm run build
     command: |
-      [[ ! -z "$ASTRO_NEW" ]] && gp await-port 23000 && cd "$GITPOD_REPO_ROOT"/examples/"$ASTRO_NEW" && code src/pages/index.astro && pnpm start
+      .gitpod/gitpod-setup.sh
 vscode:
   extensions:
     - astro-build.astro-vscode

--- a/.gitpod/gitpod-setup.sh
+++ b/.gitpod/gitpod-setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Convert context URL to an array
+mapfile -t CONTEXT_URL_ITEMS < <(echo "$GITPOD_WORKSPACE_CONTEXT_URL" | tr '/' '\n')
+
+# Check if Gitpod started from a specific example directory in the repository
+if [ "${CONTEXT_URL_ITEMS[7]}" = "examples" ]; then
+    EXAMPLE_PROJECT=${CONTEXT_URL_ITEMS[8]}
+# Check it Gitpod started with $ASTRO_NEW environment variable
+elif [ -n "$ASTRO_NEW" ]; then
+    EXAMPLE_PROJECT="$ASTRO_NEW"
+# Otherwise, set the default example project - 'starter'
+else
+    EXAMPLE_PROJECT="starter"
+fi
+
+# Wait for VSCode to be ready (port 23000)
+gp await-port 23000 > /dev/null 2>&1
+
+echo "Loading example project:" $EXAMPLE_PROJECT
+
+# Go to the requested example project
+cd "$GITPOD_REPO_ROOT"/examples/"$EXAMPLE_PROJECT" || exit
+# Open the main page in VSCode
+code src/pages/index.astro
+# Start Astro
+pnpm start


### PR DESCRIPTION
## Changes

When opening this Astro repo in Gitpod, an example project would open in the following logic:
* If Gitpod workspace was opened from a specific example project - that project would open
* If $ASTRO_NEW environment variable was set - open that project
* Otherwise, be default, open `starter` example project

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
* Go to https://github.com/shaal/astro/tree/gitpod--open-examples/examples
(that's a fork of Astro on my user account, with the branch that is the base of this PR. It will include the information of which directory Gitpod workspace was opened from
* Click on any example project.
* Either use Gitpod browser extension, or add `https://gitpod.io/#` before the full URL, for example -
https://gitpod.io/#https://github.com/shaal/astro/tree/gitpod--open-examples/examples/framework-lit
* Confirm that the correct example project opened.

Confirm that ASTRO_NEW is still working, by adding
https://gitpod.io/#ASTRO_NEW=blog/https://github.com/shaal/astro/tree/gitpod--open-examples

Confirm that `starter` project starting when just opening the branch without any additions -
https://gitpod.io/#https://github.com/shaal/astro/tree/gitpod--open-examples

## Docs

<!-- Did you make a user-facing change? You probably need to update docs! -->
<!-- Add a link to your docs PR here. If no docs added, explain why (e.g. "bug fix only") -->
<!-- Link: https://github.com/withastro/docs -->
