### PR TITLE
Fix webapi build script on windows

### DIFF
--- a/packages/webapi/run/build.js
+++ b/packages/webapi/run/build.js
@@ -1,6 +1,6 @@
 import { rollup } from 'rollup'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
-import { posix as path } from 'node:path'
+import path from 'node:path'
 import { createRequire } from 'node:module'
 import {
 	readFile as nodeReadFile,


### PR DESCRIPTION
## Changes

- Ran into a problem when debugging with Antony.
- Fixes `pnpm run build` on Windows.
- CI doesn't catch this because the build only runs on Linux and the generated artifacts are shared with Windows.

## Testing

Manually

## Docs

N/A, bugfix