### PR TITLE
Fix missing `postcss-load-config` dependency

### DIFF
--- a/.changeset/moody-trees-allow.md
+++ b/.changeset/moody-trees-allow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix missing `postcss-load-config` dependency

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -90,6 +90,7 @@
     "parse5": "^6.0.1",
     "path-to-regexp": "^6.2.0",
     "postcss": "^8.4.12",
+    "postcss-load-config": "^3.1.1",
     "prismjs": "^1.27.0",
     "rehype-slug": "^5.0.1",
     "resolve": "^1.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -405,6 +405,7 @@ importers:
       parse5: ^6.0.1
       path-to-regexp: ^6.2.0
       postcss: ^8.4.12
+      postcss-load-config: ^3.1.1
       prismjs: ^1.27.0
       rehype-slug: ^5.0.1
       resolve: ^1.22.0
@@ -455,6 +456,7 @@ importers:
       parse5: 6.0.1
       path-to-regexp: 6.2.0
       postcss: 8.4.12
+      postcss-load-config: 3.1.3
       prismjs: 1.27.0
       rehype-slug: 5.0.1
       resolve: 1.22.0


### PR DESCRIPTION
## Changes

- Does what it says on the tin.

## Testing

Caught during post-release testing

## Docs

N/A
