### PR TITLE
Release bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          # Note: pnpm install after versioning is necessary to refresh lockfile
+          version: pnpm exec changeset version && pnpm install
           publish: pnpm exec changeset publish
           commit: '[ci] release'
           title: '[ci] release'


### PR DESCRIPTION
## Changes

- Fixes release bot notifications by generating `package.json#name` => CHANGELOG link dynamically.
- Also updates our changeset action to handle updating the lockfile after versioning. This has been failing since we switched to PNPM, but it's infrequent enough that it hasn't been a huge pain.

## Testing

Tested manually

## Docs

Nope, internal change only