### PR TITLE
fest(create-astro): autoinstall dependencies

### DIFF
--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -32,10 +32,13 @@
     "degit": "^2.8.4",
     "kleur": "^4.1.4",
     "node-fetch": "^3.2.3",
+    "ora": "^6.1.0",
     "prompts": "^2.4.2",
+    "which-pm-runs": "^1.1.0",
     "yargs-parser": "^21.0.1"
   },
   "devDependencies": {
+    "@types/which-pm-runs": "^1.0.0",
     "@types/yargs-parser": "^21.0.0",
     "astro-scripts": "workspace:*",
     "uvu": "^0.5.3"

--- a/packages/create-astro/src/config.ts
+++ b/packages/create-astro/src/config.ts
@@ -1,4 +1,6 @@
-export const createConfig = ({ integrations }: { integrations: string[] }) => {
+import type { Integration } from './frameworks';
+
+export const createConfig = ({ integrations }: { integrations: Integration[] }) => {
 	if (integrations.length === 0) {
 		return `import { defineConfig } from 'astro/config';
 // https://astro.build/config
@@ -6,8 +8,8 @@ export default defineConfig({});
 `;
 	}
 
-	const rendererImports = integrations.map((r: string) => `  import ${r} from '@astrojs/${r === 'solid' ? 'solid-js' : r}';`);
-	const rendererIntegrations = integrations.map((r: string) => `    ${r}(),`);
+	const rendererImports = integrations.map((r) => `  import ${r.id} from '${r.packageName}';`);
+	const rendererIntegrations = integrations.map((r) => `    ${r.id}(),`);
 	return [
 		`import { defineConfig } from 'astro/config';`,
 		...rendererImports,

--- a/packages/create-astro/src/frameworks.ts
+++ b/packages/create-astro/src/frameworks.ts
@@ -107,25 +107,30 @@ export default {
 	},
 };
 
-export const FRAMEWORKS = [
+export interface Integration {
+	id: string;
+	packageName: string;
+}
+
+export const FRAMEWORKS: { title: string; value: Integration }[] = [
 	{
-		title: 'preact',
-		value: '@astrojs/preact',
+		title: 'Preact',
+		value: { id: 'preact', packageName: '@astrojs/preact' },
 	},
 	{
-		title: 'react',
-		value: 'react',
+		title: 'React',
+		value: { id: 'react', packageName: '@astrojs/react' },
 	},
 	{
-		title: 'solid',
-		value: 'solid',
+		title: 'Solid.js',
+		value: { id: 'solid', packageName: '@astrojs/solid-js' },
 	},
 	{
-		title: 'svelte',
-		value: 'svelte',
+		title: 'Svelte',
+		value: { id: 'svelte', packageName: '@astrojs/svelte' },
 	},
 	{
-		title: 'vue',
-		value: 'vue',
+		title: 'Vue',
+		value: { id: 'vue', packageName: '@astrojs/vue' },
 	},
 ];


### PR DESCRIPTION
## Changes

- Autoinstalls dependencies with the same package manager used to run `create-astro`
- Adds peer dependencies of integrations to `package.json`
- Added spinners

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Did you make a user-facing change? You probably need to update docs! -->
<!-- Add a link to your docs PR here. If no docs added, explain why (e.g. "bug fix only") -->
<!-- Link: https://github.com/withastro/docs -->
