### PR TITLE
chore: integration keywords

### DIFF
--- a/.changeset/tidy-jobs-beg.md
+++ b/.changeset/tidy-jobs-beg.md
@@ -1,0 +1,14 @@
+---
+'@astrojs/lit': patch
+'@astrojs/partytown': patch
+'@astrojs/preact': patch
+'@astrojs/react': patch
+'@astrojs/sitemap': patch
+'@astrojs/solid-js': patch
+'@astrojs/svelte': patch
+'@astrojs/tailwind': patch
+'@astrojs/turbolinks': patch
+'@astrojs/vue': patch
+---
+
+Adds keywords to the official integrations to support discoverability on Astro's Integrations site

--- a/packages/integrations/lit/package.json
+++ b/packages/integrations/lit/package.json
@@ -11,6 +11,11 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/integrations/lit"
   },
+  "keywords": [
+    "astro-component",
+    "renderer",
+    "lit"
+  ],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {

--- a/packages/integrations/partytown/package.json
+++ b/packages/integrations/partytown/package.json
@@ -11,6 +11,11 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/integrations/partytown"
   },
+  "keywords": [
+    "astro-component",
+    "analytics",
+    "performance"
+  ],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {

--- a/packages/integrations/preact/package.json
+++ b/packages/integrations/preact/package.json
@@ -11,6 +11,11 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/integrations/preact"
   },
+  "keywords": [
+    "astro-component",
+    "renderer",
+    "preact"
+  ],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -11,6 +11,11 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/integrations/react"
   },
+  "keywords": [
+    "astro-component",
+    "renderer",
+    "react"
+  ],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {

--- a/packages/integrations/sitemap/package.json
+++ b/packages/integrations/sitemap/package.json
@@ -11,6 +11,10 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/integrations/sitemap"
   },
+  "keywords": [
+    "astro-component",
+    "seo"
+  ],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {

--- a/packages/integrations/solid/package.json
+++ b/packages/integrations/solid/package.json
@@ -11,6 +11,11 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/integrations/solid"
   },
+  "keywords": [
+    "astro-component",
+    "renderer",
+    "solid"
+  ],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -11,6 +11,11 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/integrations/svelte"
   },
+  "keywords": [
+    "astro-component",
+    "renderer",
+    "svelte"
+  ],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {

--- a/packages/integrations/tailwind/package.json
+++ b/packages/integrations/tailwind/package.json
@@ -11,6 +11,9 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/integrations/tailwind"
   },
+  "keywords": [
+    "astro-component"
+  ],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {

--- a/packages/integrations/turbolinks/package.json
+++ b/packages/integrations/turbolinks/package.json
@@ -11,6 +11,10 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/integrations/turbolinks"
   },
+  "keywords": [
+    "astro-component",
+    "performance"
+  ],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -11,6 +11,11 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/integrations/vue"
   },
+  "keywords": [
+    "astro-component",
+    "renderer",
+    "vue"
+  ],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {


### PR DESCRIPTION
## Changes

Adding keywords to the official integration packages

## Testing

None, package metadata updates only

## Docs

None for now.  Before the new integrations page is live, I'll be updating docs with details on what NPM data and keywords we pull down to populate the integrations page


Not part of this PR directly, but here's my current plan for supported keywords

| Integrations Category | NPM Keyword(s) |
| --- | --- |
| all (default) | `astro-component` |
| Accessibility | `a11y`, `accessibility` |
| Analytics | `analytics` |
| CMS | `cms`, `database` |
| CSS + UI | `css`, `ui`, `icons`, `renderer` (maybe framework keywords like `react`?) |
| E-commerce | `ecommerce`, `e-commerce` |
| performance | `performance`, `perf` |
| SEO | `seo` |
