### PR TITLE
add injected scripts to markdown pages

### DIFF
--- a/.changeset/twenty-kiwis-tease.md
+++ b/.changeset/twenty-kiwis-tease.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+add missing injected "page" scripts into markdown pages


### PR DESCRIPTION
## Changes

From LukeWilson in Discord:

> Hey everybody, testing out the the new tailwind integration in astro@next here, running into a problem. It works great for pages/index.astro, but for a pages/test.md, the base.css is not injected.

- Fixes that bug, and cleans up a few small edge cases where the Markdown and Astro page differ to bring Markdown back in line with Astro.

## Testing

- Not covered by existing tests. Realizing that while integrations are covered by test suite, the specific hooks aren't really covered. I'll try to get to that by the end of the day but feel free to review this before then.