### PR TITLE
Fix: `isSelfAccepting`? More like `isBanishedToTheShadowRealm`

### DIFF
--- a/.changeset/forty-badgers-relate.md
+++ b/.changeset/forty-badgers-relate.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix "isSelfAccepting" exception when using the new @astrojs/react integration in development

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -83,7 +83,7 @@ export async function render(renderers: SSRLoadedRenderer[], mod: ComponentInsta
 			children: '',
 		});
 		scripts.add({
-			props: { type: 'module', src: '/@id/astro/client/hmr.js' },
+			props: { type: 'module', src: new URL('../../../runtime/client/hmr.js', import.meta.url).pathname },
 			children: '',
 		});
 	}

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -40,6 +40,9 @@ export type ComponentPreload = [SSRLoadedRenderer[], ComponentInstance];
 export type RenderResponse = { type: 'html'; html: string } | { type: 'response'; response: Response };
 
 const svelteStylesRE = /svelte\?svelte&type=style/;
+// Cache renderers to avoid re-resolving the module using Vite's `ssrLoadModule`
+// This prevents an odd exception trying to resolve the same server-side module
+// Multiple times. See `isSelfAccepting` issue: https://github.com/withastro/astro/pull/2852
 const rendererCache = new Map<string, SSRLoadedRenderer['ssr']>();
 
 async function loadRenderer(viteServer: vite.ViteDevServer, renderer: AstroRenderer): Promise<SSRLoadedRenderer> {

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -51,11 +51,11 @@ async function loadRenderer(viteServer: vite.ViteDevServer, renderer: AstroRende
 	const cachedRenderer = rendererCache.get(url);
 	if (cachedRenderer) {
 		return { ...renderer, ssr: cachedRenderer };
-	} else {
-		const mod = (await viteServer.ssrLoadModule(url)) as { default: SSRLoadedRenderer['ssr'] };
-		rendererCache.set(url, mod.default);
-		return { ...renderer, ssr: mod.default };
 	}
+
+	const mod = (await viteServer.ssrLoadModule(url)) as { default: SSRLoadedRenderer['ssr'] };
+	rendererCache.set(url, mod.default);
+	return { ...renderer, ssr: mod.default };
 }
 
 export async function loadRenderers(viteServer: vite.ViteDevServer, astroConfig: AstroConfig): Promise<SSRLoadedRenderer[]> {


### PR DESCRIPTION
## Changes

- Restore [our old caching strategy](https://github.com/withastro/astro/pull/2820/files#diff-61d8e7069b52b4ecd47d6e43210ba31015b3902bac58a8110790c15462ab0703L7-L22) for renderers instead of re-fetching from `ssrLoadModule`
- Restore [our old, not-so-fun URL constructor](https://github.com/withastro/astro/pull/2820/files#diff-3083ab6e9fa53c9fb3348d84342281e812a7d216f0cd5f947080dba2feabe855R78) for HMR scripts

## Testing

Had to test by hand, manually copying the `dist` to a `node_modules` folder to avoid false positives. I encourage other devs to do the same, or install directly from this GitHub branch!

## Docs

N/A
