### PR TITLE
fix a bad file URL creation

### DIFF
--- a/packages/astro/src/core/build/scan-based-build.ts
+++ b/packages/astro/src/core/build/scan-based-build.ts
@@ -7,7 +7,7 @@ import type { ViteConfigWithSSR } from '../create-vite.js';
 import { fileURLToPath } from 'url';
 import * as vite from 'vite';
 import { createBuildInternals } from '../../core/build/internal.js';
-import { rollupPluginAstroBuildHTML } from '../../vite-plugin-build-html/index.js';
+import { rollupPluginAstroScanHTML } from '../../vite-plugin-build-html/index.js';
 import { rollupPluginAstroBuildCSS } from '../../vite-plugin-build-css/index.js';
 import { RouteCache } from '../render/route-cache.js';
 
@@ -63,7 +63,7 @@ export async function build(opts: ScanBasedBuildOptions) {
 			target: 'es2020', // must match an esbuild target
 		},
 		plugins: [
-			rollupPluginAstroBuildHTML({
+			rollupPluginAstroScanHTML({
 				astroConfig,
 				internals,
 				logging,

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -273,7 +273,7 @@ export async function loadConfig(configOptions: LoadConfigOptions): Promise<Astr
 
 	if (flags?.config) {
 		userConfigPath = /^\.*\//.test(flags.config) ? flags.config : `./${flags.config}`;
-		userConfigPath = fileURLToPath(new URL(userConfigPath, `file://${root}/`));
+		userConfigPath = fileURLToPath(new URL(userConfigPath, pathToFileURL(root)));
 	}
 	// Automatically load config file using Proload
 	// If `userConfigPath` is `undefined`, Proload will search for `astro.config.[cm]?[jt]s`

--- a/packages/astro/src/vite-plugin-build-html/index.ts
+++ b/packages/astro/src/vite-plugin-build-html/index.ts
@@ -43,7 +43,7 @@ function relativePath(from: string, to: string): string {
 	return prependDotSlash(rel);
 }
 
-export function rollupPluginAstroBuildHTML(options: PluginOptions): VitePlugin {
+export function rollupPluginAstroScanHTML(options: PluginOptions): VitePlugin {
 	const { astroConfig, internals, logging, origin, allPages, routeCache, viteServer, pageNames } = options;
 
 	// The filepath root of the src folder


### PR DESCRIPTION
## Changes

- I wanted to learn why we used `file://${X}` so I audited our usage. It turns out, most of our usage is valid because we're mapping from Rollup IDs (already normalized) to file paths. However, I found one usage that was incorrect based on my understanding of the Node.js docs: https://nodejs.org/api/url.html#urlfileurltopathurl
- Also, this is the second time I've been unsure if the "scan build" plugin was a part of legacy build or not, so I renamed it to make it more clear.
