### PR TITLE
Marking Astro.resolve() as deprecated

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -52,6 +52,9 @@ export interface AstroGlobal extends AstroGlobalPartial {
 
 export interface AstroGlobalPartial {
 	fetchContent<T = any>(globStr: string): Promise<FetchContentResult<T>[]>;
+	/**
+	 * @deprecated since version 0.24. See the {@link https://astro.build/deprecated/resolve upgrade guide} for more details.
+	 */
 	resolve: (path: string) => string;
 	site: URL;
 }


### PR DESCRIPTION
## Changes

Updates type definitions for the Astro global to mark `Astro.resolve()` as deprecated

## Testing

Tested deprecation warning in VS Code locally

## Docs

Migration docs already exist, linking to them in the deprecation warning
