### PR TITLE
Ensure private API is not enumerable

### DIFF
--- a/.changeset/modern-adults-dance.md
+++ b/.changeset/modern-adults-dance.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Ensure private, internal APIs are not enumerable

--- a/packages/astro/components/Markdown.astro
+++ b/packages/astro/components/Markdown.astro
@@ -24,8 +24,6 @@ let { content, class: className } = Astro.props as InternalProps;
 let html = null;
 let htmlContent = '';
 
-const { privateRenderMarkdownDoNotUse: renderMarkdown } = Astro as any;
-
 // If no content prop provided, use the slot.
 if (!content) {
 	content = await Astro.slots.render('default');
@@ -35,7 +33,7 @@ if (!content) {
 }
 
 if (content) {
-	htmlContent = await renderMarkdown(content, {
+	htmlContent = await (Astro as any).__renderMarkdown(content, {
 		mode: 'md',
 		$: {
 			scopedClassName: className,

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -88,7 +88,7 @@ export function createResult(args: CreateResultArgs): SSRResult {
 		createAstro(astroGlobal: AstroGlobalPartial, props: Record<string, any>, slots: Record<string, any> | null) {
 			const astroSlots = new Slots(result, slots);
 
-			return {
+			const Astro = {
 				__proto__: astroGlobal,
 				props,
 				request,
@@ -138,8 +138,14 @@ ${extra}`
 					return astroGlobal.resolve(path);
 				},
 				slots: astroSlots,
+			} as unknown as AstroGlobal;
+
+			Object.defineProperty(Astro, '__renderMarkdown', {
+				// Ensure this API is not exposed to users
+				enumerable: false,
+				writable: false,
 				// <Markdown> also needs the same `astroConfig.markdownOptions.render` as `.md` pages
-				async privateRenderMarkdownDoNotUse(content: string, opts: any) {
+				value: async function(content: string, opts: any) {
 					let [mdRender, renderOpts] = markdownRender;
 					let parser: MarkdownParser | null = null;
 					//let renderOpts = {};
@@ -164,7 +170,9 @@ ${extra}`
 					const { code } = await parser(content, { ...renderOpts, ...(opts ?? {}) });
 					return code;
 				},
-			} as unknown as AstroGlobal;
+			});
+
+			return Astro;
 		},
 		resolve,
 		_metadata: {


### PR DESCRIPTION
## Changes

- Previously, we created a `privateRenderMarkdownDoNotUse` on the `Astro` global.
- This property was enumerable and showed up when users did `console.log(Astro)`.
- This PR makes this value non-enumerable and also makes the name `__renderMarkdown`.

## Testing

Hoping CI doesn't break 🤞🏻 

## Docs

Internal change only
