### PR TITLE
Add `build:ci` command which skips `tsc`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "release": "pnpm run build && changeset publish",
     "build": "turbo run build --no-deps --scope=astro --scope=create-astro --scope=\"@astrojs/*\"",
+    "build:ci": "turbo run build:ci --no-deps --scope=astro --scope=create-astro --scope=\"@astrojs/*\"",
     "build:examples": "turbo run build --scope=\"@example/*\"",
     "dev": "turbo run dev --no-deps --no-cache --parallel --scope=astro --scope=create-astro --scope=\"@astrojs/*\"",
     "test": "pnpm run test --filter astro --filter @astrojs/webapi",

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
     "test": "rm -rf test/fixtures && mkdir test/fixtures && node --unhandled-rejections=strict test/create-astro.test.js"
   },

--- a/packages/integrations/lit/package.json
+++ b/packages/integrations/lit/package.json
@@ -27,6 +27,7 @@
   },
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {

--- a/packages/integrations/partytown/package.json
+++ b/packages/integrations/partytown/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {

--- a/packages/integrations/preact/package.json
+++ b/packages/integrations/preact/package.json
@@ -28,6 +28,7 @@
   },
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -27,6 +27,7 @@
   },
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {

--- a/packages/integrations/sitemap/package.json
+++ b/packages/integrations/sitemap/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {

--- a/packages/integrations/solid/package.json
+++ b/packages/integrations/solid/package.json
@@ -27,6 +27,7 @@
   },
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -27,6 +27,7 @@
   },
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {

--- a/packages/integrations/tailwind/package.json
+++ b/packages/integrations/tailwind/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {

--- a/packages/integrations/turbolinks/package.json
+++ b/packages/integrations/turbolinks/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -27,6 +27,7 @@
   },
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "prepublish": "pnpm build",
     "build": "astro-scripts build \"src/**/*.ts\" && tsc -p tsconfig.json",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "postbuild": "astro-scripts copy \"src/**/*.js\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },

--- a/packages/webapi/package.json
+++ b/packages/webapi/package.json
@@ -72,6 +72,7 @@
   },
   "scripts": {
     "build": "node run/build.js",
+    "build:ci": "node run/build.js",
     "dev": "node run/build.js",
     "release": "node run/build.js && npm publish --access public",
     "test": "mocha --parallel --timeout 15000"

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,10 @@
       "dependsOn": ["^build"],
       "outputs": ["**/dist/**", "!**/vendor/**"]
     },
+    "build:ci": {
+      "dependsOn": ["^build:ci"],
+      "outputs": ["**/dist/**", "!**/vendor/**"]
+    },
     "dev": {
       "cache": false
     },


### PR DESCRIPTION
## Changes

- Unblocks https://github.com/vitejs/vite-ecosystem-ci/pull/52
- `vite-ecosystem-ci` swaps in a different local version of `vite`, which can lead to TypeScript errors due to mismatching versions. To sidestep this, this PR introduces a `build:ci` command that skips `tsc`.

## Testing

Test after merge

## Docs

N/A
