### PR TITLE
fix markdown page script injection

### DIFF
--- a/.changeset/cyan-pigs-ring.md
+++ b/.changeset/cyan-pigs-ring.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix a bug where tailwind integration wouldn't apply to markdown pages

--- a/examples/with-tailwindcss/src/pages/index.astro
+++ b/examples/with-tailwindcss/src/pages/index.astro
@@ -14,8 +14,9 @@ import Button from '../components/Button.astro';
 	</head>
 
 	<body>
-		<div class="grid place-items-center h-screen">
-			<Button>Click Me!</Button>
+		<div class="grid place-items-center h-screen content-center">
+			<Button>Tailwind Button in Astro!</Button>
+			<a href="/markdown-page" class="p-4 underline">Markdown is also supported...</a>
 		</div>
 	</body>
 </html>

--- a/examples/with-tailwindcss/src/pages/markdown-page.md
+++ b/examples/with-tailwindcss/src/pages/markdown-page.md
@@ -1,0 +1,10 @@
+---
+title: "Markdown + Tailwind"
+setup: |
+    import Button from '../components/Button.astro';
+---
+
+<div class="grid place-items-center h-screen content-center">
+    <Button>Tailwind Button in Markdown!</Button>
+    <a href="/" class="p-4 underline">Go home...</a>
+</div>

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -465,7 +465,7 @@ export interface AstroUserConfig {
  * - "page": Injected into the JavaScript bundle of every page. Processed & resolved by Vite.
  * - "page-ssr": Injected into the frontmatter of every Astro page. Processed & resolved by Vite.
  */
-type InjectedScriptStage = 'before-hydration' | 'head-inline' | 'page' | 'page-ssr';
+export type InjectedScriptStage = 'before-hydration' | 'head-inline' | 'page' | 'page-ssr';
 
 /**
  * Resolved Astro Config

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -1,22 +1,22 @@
-import type { OutputAsset, OutputChunk, RollupOutput } from 'rollup';
-import type { PageBuildData } from './types';
-import type { AstroConfig, AstroRenderer, ComponentInstance, EndpointHandler, SSRLoadedRenderer } from '../../@types/astro';
-import type { StaticBuildOptions } from './types';
-import type { BuildInternals } from '../../core/build/internal.js';
-import type { RenderOptions } from '../../core/render/core';
-
 import fs from 'fs';
+import { bgMagenta, black, cyan, dim, magenta } from 'kleur/colors';
 import npath from 'path';
+import type { OutputAsset, OutputChunk, RollupOutput } from 'rollup';
 import { fileURLToPath } from 'url';
+import type { AstroConfig, AstroRenderer, ComponentInstance, EndpointHandler, SSRLoadedRenderer } from '../../@types/astro';
+import type { BuildInternals } from '../../core/build/internal.js';
 import { debug, error, info } from '../../core/logger.js';
 import { prependForwardSlash } from '../../core/path.js';
+import type { RenderOptions } from '../../core/render/core';
 import { resolveDependency } from '../../core/util.js';
+import { BEFORE_HYDRATION_SCRIPT_ID } from '../../vite-plugin-scripts/index.js';
 import { call as callEndpoint } from '../endpoint/index.js';
 import { render } from '../render/core.js';
 import { createLinkStylesheetElementSet, createModuleScriptElementWithSrcSet } from '../render/ssr-element.js';
-import { getOutRoot, getOutFolder, getOutFile } from './common.js';
-import { bgMagenta, black, cyan, dim, magenta } from 'kleur/colors';
+import { getOutFile, getOutFolder, getOutRoot } from './common.js';
+import type { PageBuildData, StaticBuildOptions } from './types';
 import { getTimeStat } from './util.js';
+
 
 // Render is usually compute, which Node.js can't parallelize well.
 // In real world testing, dropping from 10->1 showed a notiable perf
@@ -214,7 +214,7 @@ async function generatePath(pathname: string, opts: StaticBuildOptions, gopts: G
 					// Return this as placeholder, which will be ignored by the browser.
 					// TODO: In the future, we hope to run this entire script through Vite,
 					// removing the need to maintain our own custom Vite-mimic resolve logic.
-					if (specifier === 'astro:scripts/before-hydration.js') {
+					if (specifier === BEFORE_HYDRATION_SCRIPT_ID) {
 						return 'data:text/javascript;charset=utf-8,//[no before-hydration script]';
 					}
 					throw new Error(`Cannot find the built path for ${specifier}`);

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -7,6 +7,7 @@ import type { SerializedRouteInfo, SerializedSSRManifest } from '../app/types';
 
 import { chunkIsPage, rootRelativeFacadeId, getByFacadeId } from './generate.js';
 import { serializeRouteData } from '../routing/index.js';
+import { BEFORE_HYDRATION_SCRIPT_ID } from '../../vite-plugin-scripts/index.js';
 
 const virtualModuleId = '@astrojs-ssr-virtual-entry';
 const resolvedVirtualModuleId = '\0' + virtualModuleId;
@@ -107,7 +108,7 @@ function buildManifest(bundle: OutputBundle, opts: StaticBuildOptions, internals
 
 	// HACK! Patch this special one.
 	const entryModules = Object.fromEntries(internals.entrySpecifierToBundleMap.entries());
-	entryModules['astro:scripts/before-hydration.js'] = 'data:text/javascript;charset=utf-8,//[no before-hydration script]';
+	entryModules[BEFORE_HYDRATION_SCRIPT_ID] = 'data:text/javascript;charset=utf-8,//[no before-hydration script]';
 
 	const ssrManifest: SerializedSSRManifest = {
 		routes,

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -107,7 +107,8 @@ export async function generateHydrateScript(scriptOptions: HydrateScriptOptions,
 		: `await import("${await result.resolve(componentUrl)}");
   return () => {};
 `;
-
+	// TODO: If we can figure out tree-shaking in the final SSR build, we could safely
+	// use BEFORE_HYDRATION_SCRIPT_ID instead of 'astro:scripts/before-hydration.js'.
 	const hydrationScript = {
 		props: { type: 'module', 'data-astro-component-hydration': true },
 		children: `import setup from '${await result.resolve(hydrationSpecifier(hydrate))}';

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -13,6 +13,7 @@ import { cachedCompilation } from './compile.js';
 import ancestor from 'common-ancestor-path';
 import { trackCSSDependencies, handleHotUpdate } from './hmr.js';
 import { isRelativePath, startsWithForwardSlash } from '../core/path.js';
+import { PAGE_SCRIPT_ID, PAGE_SSR_SCRIPT_ID } from '../vite-plugin-scripts/index.js';
 
 const FRONTMATTER_PARSE_REGEXP = /^\-\-\-(.*)^\-\-\-/ms;
 interface AstroPluginOptions {
@@ -93,9 +94,9 @@ export default function astro({ config, logging }: AstroPluginOptions): vite.Plu
 			const filename = normalizeFilename(parsedId.filename);
 			const fileUrl = new URL(`file://${filename}`);
 			let source = await fs.promises.readFile(fileUrl, 'utf-8');
-			const isPage = filename.startsWith(config.pages.pathname);
+			const isPage = fileUrl.pathname.startsWith(config.pages.pathname);
 			if (isPage && config._ctx.scripts.some((s) => s.stage === 'page')) {
-				source += `\n<script hoist src="astro:scripts/page.js" />`;
+				source += `\n<script hoist src="${PAGE_SCRIPT_ID}" />`;
 			}
 			if (query.astro) {
 				if (query.type === 'style') {
@@ -152,7 +153,7 @@ export default function astro({ config, logging }: AstroPluginOptions): vite.Plu
 				}
 				// Add handling to inject scripts into each page JS bundle, if needed.
 				if (isPage) {
-					SUFFIX += `\nimport "astro:scripts/page-ssr.js";`;
+					SUFFIX += `\nimport "${PAGE_SSR_SCRIPT_ID}";`;
 				}
 				return {
 					code: `${code}${SUFFIX}`,

--- a/packages/astro/src/vite-plugin-scripts/index.ts
+++ b/packages/astro/src/vite-plugin-scripts/index.ts
@@ -1,13 +1,13 @@
 import { Plugin as VitePlugin } from 'vite';
-import { AstroConfig } from '../@types/astro.js';
+import { AstroConfig, InjectedScriptStage } from '../@types/astro.js';
 
 // NOTE: We can't use the virtual "\0" ID convention because we need to
 // inject these as ESM imports into actual code, where they would not
 // resolve correctly.
 const SCRIPT_ID_PREFIX = `astro:scripts/`;
-const BEFORE_HYDRATION_SCRIPT_ID = `${SCRIPT_ID_PREFIX}before-hydration.js`;
-const PAGE_SCRIPT_ID = `${SCRIPT_ID_PREFIX}page.js`;
-const PAGE_SSR_SCRIPT_ID = `${SCRIPT_ID_PREFIX}page-ssr.js`;
+export const BEFORE_HYDRATION_SCRIPT_ID = `${SCRIPT_ID_PREFIX}${'before-hydration' as InjectedScriptStage}.js`;
+export const PAGE_SCRIPT_ID = `${SCRIPT_ID_PREFIX}${'page' as InjectedScriptStage}.js`;
+export const PAGE_SSR_SCRIPT_ID = `${SCRIPT_ID_PREFIX}${'page-ssr' as InjectedScriptStage}.js`;
 
 export default function astroScriptsPlugin({ config }: { config: AstroConfig }): VitePlugin {
 	return {

--- a/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
+++ b/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
@@ -2,11 +2,6 @@
 // Component Imports
 import Button from '../components/Button.astro';
 import Complex from '../components/Complex.astro';
-
-import "../styles/global.css";
-
-// Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
 ---
 
 <html lang="en">

--- a/packages/astro/test/fixtures/tailwindcss/src/pages/markdown-page.md
+++ b/packages/astro/test/fixtures/tailwindcss/src/pages/markdown-page.md
@@ -1,0 +1,11 @@
+---
+title: "Markdown + Tailwind"
+setup: |
+    import Button from '../components/Button.astro';
+    import Complex from '../components/Complex.astro';
+---
+
+<div class="grid place-items-center h-screen content-center">
+    <Button>Tailwind Button in Markdown!</Button>
+    <Complex />
+</div>

--- a/packages/astro/test/fixtures/tailwindcss/src/styles/global.css
+++ b/packages/astro/test/fixtures/tailwindcss/src/styles/global.css
@@ -1,3 +1,0 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;

--- a/packages/astro/test/tailwindcss.test.js
+++ b/packages/astro/test/tailwindcss.test.js
@@ -55,6 +55,14 @@ describe('Tailwind', () => {
 			expect(button.hasClass('w-10/12'), 'solidus').to.be.true;
 			expect(button.hasClass('2xl:w-[80%]'), 'complex class').to.be.true;
 		});
+
+		it('handles Markdown pages', async () => {
+			const html = await fixture.readFile('/markdown-page/index.html');
+			const $ = cheerio.load(html);
+			const bundledCSSHREF = $('link[rel=stylesheet][href^=/assets/]').attr('href');
+			const bundledCSS = await fixture.readFile(bundledCSSHREF.replace(/^\/?/, '/'));
+			expect(bundledCSS, 'includes used component classes').to.match(/\.bg-purple-600{/);
+		});
 	});
 
 	// with "build" handling CSS checking, the dev tests are mostly testing the paths resolve in dev
@@ -73,8 +81,8 @@ describe('Tailwind', () => {
 		});
 
 		it('resolves CSS in src/styles', async () => {
-			const href = $(`link[href$="/src/styles/global.css"]`).attr('href');
-			const res = await fixture.fetch(href);
+			const bundledCSSHREF = $('link[rel=stylesheet]').attr('href');
+			const res = await fixture.fetch(bundledCSSHREF);
 			expect(res.status).to.equal(200);
 
 			const text = await res.text();


### PR DESCRIPTION
## Changes

- Markdown script injection was broken in a couple of small ways.
- This PR hardens our script injection to use TS types better.
- This PR also adds a Markdown example page to the with-tailwindcss example project
- Last, we add a test to the test suite and make some small improvements to the tailwind test suite.

## Testing

- Manually confirmed and tests added.

## Docs

- N/A