### PR TITLE
Fix: `is self accepting` pt 2 module graph boogaloo

### DIFF
--- a/.changeset/wise-garlics-bathe.md
+++ b/.changeset/wise-garlics-bathe.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/preact': patch
+---
+
+Fix `isSelfAccepting` errors when using the Preact integration with the Astro dev server

--- a/packages/integrations/preact/package.json
+++ b/packages/integrations/preact/package.json
@@ -20,9 +20,7 @@
   "homepage": "https://astro.build",
   "exports": {
     ".": "./dist/index.js",
-    "./client": "./client",
     "./client.js": "./client.js",
-    "./server": "./server",
     "./server.js": "./server.js",
     "./package.json": "./package.json"
   },

--- a/packages/integrations/preact/src/index.ts
+++ b/packages/integrations/preact/src/index.ts
@@ -3,8 +3,8 @@ import { AstroIntegration } from 'astro';
 function getRenderer() {
 	return {
 		name: '@astrojs/preact',
-		clientEntrypoint: '@astrojs/preact/client',
-		serverEntrypoint: '@astrojs/preact/server',
+		clientEntrypoint: '@astrojs/preact/client.js',
+		serverEntrypoint: '@astrojs/preact/server.js',
 		jsxImportSource: 'preact',
 		jsxTransformOptions: async () => {
 			const {
@@ -21,8 +21,8 @@ function getRenderer() {
 function getViteConfiguration() {
 	return {
 		optimizeDeps: {
-			include: ['@astrojs/preact/client', 'preact', 'preact/jsx-runtime', 'preact-render-to-string'],
-			exclude: ['@astrojs/preact/server'],
+			include: ['@astrojs/preact/client.js', 'preact', 'preact/jsx-runtime', 'preact-render-to-string'],
+			exclude: ['@astrojs/preact/server.js'],
 		},
 		ssr: {
 			external: ['preact-render-to-string'],


### PR DESCRIPTION
## Changes

- Add `.js` extensions to Preact entrypoints for consistency
- Switch to pulling server renderer IDs from the `urlToModuleMap` directly. This avoids any calls to `ensureEntryFromUrl`, which was causing the module to be loaded twice
- Remove the renderer cache. By pulling from the module map, we get the correct `?v=` version param everytime. This means... no need for a cache 😁 

## Testing

- Tested on a local project using preact in isolation
- Tested on a locacl project with preact, react, and svelte together
- Cannot replicate in fixtures

## Docs

N/A