### PR TITLE
[chore] improve some github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/---01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/---01-bug-report.yml
@@ -39,7 +39,13 @@ body:
   - type: input
     attributes:
       label: Link to Minimal Reproducible Example
-      description: 'Please use the following link to create a reproduction: https://astro.new'
+      description: 'Use [astro.new](https://astro.new) to create a minimal reproduction of the problem. **A minimal reproduction is required** so that others can help debug your issue. If a report is vague (e.g. just a generic error message) and has no reproduction, it may be auto-closed.'
       placeholder: 'https://stackblitz.com/abcd1234'
     validations:
       required: true
+  - type: checkboxes
+    attributes:
+      label: Participation
+      options:
+        - label:  I am willing to submit a pull request for this issue.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,8 @@
 
 - What does this change?
 - Be short and concise. Bullet points can help!
-- Before/after screenshots can be helpful as well.
+- Before/after screenshots can help as well.
+- Don't forget a changeset! `pnpm exec changeset`
 
 ## Testing
 
@@ -11,6 +12,6 @@
 
 ## Docs
 
-<!-- Did you make a user-facing change? You probably need to update docs! -->
-<!-- Add a link to your docs PR here. If no docs added, explain why (e.g. "bug fix only") -->
-<!-- Link: https://github.com/withastro/docs -->
+<!-- Is this a visible change? You probably need to update docs! -->
+<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
+<!-- https://github.com/withastro/docs -->


### PR DESCRIPTION
## Changes

- Bug report: Improve docs around minimal reproduction item, stress importance.
- Bug report: Add a "participation" checkbox. This is something that seemed to really make a difference in Snowpack, that I'd love to bring back to this repo.
- PR template: Add an entry to remind someone to create a changeset, since we keep having this problem :)