### PR TITLE
test: update error test for vite@2.9.x

### DIFF
--- a/packages/astro/test/errors.test.js
+++ b/packages/astro/test/errors.test.js
@@ -1,4 +1,5 @@
 import { isWindows, loadFixture } from './test-utils.js';
+import { expect } from 'chai';
 
 describe('Error display', () => {
 	if (isWindows) return;
@@ -12,15 +13,20 @@ describe('Error display', () => {
 		});
 	});
 
-	describe('Astro', () => {
-		it('properly detect syntax errors in template', async () => {
-			try {
-				devServer = await fixture.startDevServer();
-			} catch (err) {
-				return;
-			}
-			await devServer.stop();
-			throw new Error('Expected to throw on startup');
-		});
+	describe('Astro', async () => {
+		// This test is skipped because it will hang on vite@2.8.x
+		// TODO: unskip test once vite@2.9.x lands
+		it.skip('properly detect syntax errors in template', async () => {
+				try {
+					devServer = await fixture.startDevServer();
+				} catch (err) {
+					return;
+				}
+
+				// This is new behavior in vite@2.9.x, previously the server would throw on startup
+				const res = await fixture.fetch('/astro-syntax-error');
+				await devServer.stop();
+				expect(res.status).to.equal(500, `Successfully responded with 500 Error for invalid file`);
+			});
 	});
 });


### PR DESCRIPTION
## Changes

- Astro is now part of [`vite-ecosystem-ci`](https://github.com/vitejs/vite-ecosystem-ci/pull/52). **HOORAY!** 🎉 
- But... we're about to fail a test. **BOO!** 😭
- This is due to a change in start-up behavior in `vite@2.9.x`. Instead of failing to start the server because of a syntax error, Vite will start the server immediately and only fail when a malformed file is requested. **HOORAY!** 🎉 
- This PR updates our test to account for the new Vite behavior, but skips the test until we're on the official `vite@2.9.x` release. 
- This really doesn't change our coverage much, we were testing an implementation detail of Vite.

## Testing

Test skip only

## Docs

Test skip only, no docs needed