### PR TITLE
small tailwind example config fix

### DIFF
--- a/.changeset/shaggy-bulldogs-beam.md
+++ b/.changeset/shaggy-bulldogs-beam.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+tailwind: add a default "contents" configuration that works for most Astro projects

--- a/examples/with-tailwindcss/tailwind.config.cjs
+++ b/examples/with-tailwindcss/tailwind.config.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-	content: [],
+	content: ['./src/**/*.{astro,html,js,jsx,svelte,ts,tsx,vue}'],
 	theme: {
 		extend: {},
 	},

--- a/packages/astro/src/core/add/consts.ts
+++ b/packages/astro/src/core/add/consts.ts
@@ -18,7 +18,7 @@ export const ALIASES = new Map([
 ]);
 export const CONFIG_STUB = `import { defineConfig } from 'astro/config';\n\nexport default defineConfig({});`;
 export const TAILWIND_CONFIG_STUB = `module.exports = {
-	content: [],
+	content: ['./src/**/*.{astro,html,js,jsx,svelte,ts,tsx,vue}'],
 	theme: {
 		extend: {},
 	},


### PR DESCRIPTION
## Changes

- Tailwind example has an empty `content` in its `tailwind.config.js`
- This causes it to fail to find any src files. (Example: https://stackblitz.com/edit/github-nkk41y?file=tailwind.config.cjs&on=stackblitz)
- I think we want to merge our default config with the user's config to prevent this bug? That's what Nuxt does, but I'm not sure. Regardless, that can be left for another PR :)
