### PR TITLE
Fix typing of `integrations` array in user config

### DIFF
--- a/.changeset/real-starfishes-turn.md
+++ b/.changeset/real-starfishes-turn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix typing of `integrations` array in user config

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -161,7 +161,7 @@ export interface AstroUserConfig {
 	 * }
 	 * ```
 	 */
-	integrations?: AstroIntegration[];
+	integrations?: Array<AstroIntegration | AstroIntegration[]>;
 
 	/**
 	 * @docs


### PR DESCRIPTION
## Changes

As per [docs](https://docs.astro.build/en/reference/integrations-reference/#combining-plugins), an integration can return an array of `AstroIntegration` objects to support bundling a collection of integrations as a preset. This change reflects that usage in the typing for the user config object.

## Testing

I think this is just fixing the existing expected type, so I haven’t added any tests.

## Docs

I left the JSDoc `@type` tag as is (`AstroIntegration[]`) as the technically correct type (`Array<AstroIntegration | AstroIntegration[]>`) doesn’t feel like it adds a huge amount to user comprehension.