### PR TITLE
Corrected package name in warning message

### DIFF
--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -140,7 +140,7 @@ export async function validateConfig(userConfig: any, root: string): Promise<Ast
 		console.error('Update your configuration and install new dependencies:');
 		try {
 			const rendererKeywords = userConfig.renderers.map((r: string) => r.replace('@astrojs/renderer-', ''));
-			const rendererImports = rendererKeywords.map((r: string) => `  import ${r} from '@astrojs/${r}';`).join('\n');
+      const rendererImports = rendererKeywords.map((r) => `  import ${r} from '@astrojs/${r === "solid" ? "solid-js" : r}';`).join("\n");
 			const rendererIntegrations = rendererKeywords.map((r: string) => `    ${r}(),`).join('\n');
 			console.error('');
 			console.error(colors.dim('  // astro.config.js'));

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -140,7 +140,7 @@ export async function validateConfig(userConfig: any, root: string): Promise<Ast
 		console.error('Update your configuration and install new dependencies:');
 		try {
 			const rendererKeywords = userConfig.renderers.map((r: string) => r.replace('@astrojs/renderer-', ''));
-      const rendererImports = rendererKeywords.map((r) => `  import ${r} from '@astrojs/${r === "solid" ? "solid-js" : r}';`).join("\n");
+      const rendererImports = rendererKeywords.map((r: string) => `  import ${r} from '@astrojs/${r === "solid" ? "solid-js" : r}';`).join("\n");
 			const rendererIntegrations = rendererKeywords.map((r: string) => `    ${r}(),`).join('\n');
 			console.error('');
 			console.error(colors.dim('  // astro.config.js'));


### PR DESCRIPTION
## Changes

Corrected a package name (from `@astrojs/solid` to `@astrojs/solid-js`) in the error message which is shown if the `renderers` array is used.

## Testing

The change was tested locally and it's working.

## Docs