### PR TITLE
[fix] 2924 Update import in astro config of portfolio starter

### DIFF
--- a/.changeset/stale-walls-whisper.md
+++ b/.changeset/stale-walls-whisper.md
@@ -1,0 +1,5 @@
+---
+'@example/portfolio': patch
+---
+
+fix import in astro config

--- a/examples/portfolio/astro.config.mjs
+++ b/examples/portfolio/astro.config.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from 'astro/config';
-import preact from '@astrojs/render-preact';
+import preact from '@astrojs/preact';
 
 // https://astro.build/config
 export default defineConfig({


### PR DESCRIPTION
## Changes

Update import in the `astro.config.mjs` of the Portfolio starter to address the error raised in #2924 
Closes #2924 

## Testing

Made the same change on the `bug-fix` branch branch of the original repro and the problem was solved [repro here](https://github.com/memarino92/astro-test/tree/bug-fix).

## Docs

No docs change - already covered in the [Getting Started](https://docs.astro.build/en/getting-started/) section of Astro docs