### PR TITLE
remove docs jsdoc tag from adapter

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -168,7 +168,6 @@ export interface AstroUserConfig {
 	integrations?: Array<AstroIntegration | AstroIntegration[]>;
 
 	/**
-	 * @docs
 	 * @name adapter
 	 * @type {AstroIntegration}
 	 * @default `undefined`


### PR DESCRIPTION
- small change to remove `@docs` from this config
- the docs site uses this to auto-generate the config reference
- safe to add when we're ready to document it on docs.astro.build

cc @matthewp 