### PR TITLE
Fixes API route compat with Node 14

### DIFF
--- a/.changeset/odd-swans-walk.md
+++ b/.changeset/odd-swans-walk.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes non-GET API routes in dev with Node 14

--- a/packages/astro/test/fixtures/ssr-api-route/src/pages/food.json.js
+++ b/packages/astro/test/fixtures/ssr-api-route/src/pages/food.json.js
@@ -8,3 +8,13 @@ export function get() {
 		])
 	};
 }
+
+export async function post(params, request) {
+	const body = await request.text();
+	return new Response(body === `some data` ? `ok` : `not ok`, {
+		status: 200,
+		headers: {
+			'Content-Type': 'application/x-www-form-urlencoded'
+		}
+	});
+}

--- a/packages/astro/test/ssr-api-route.test.js
+++ b/packages/astro/test/ssr-api-route.test.js
@@ -36,4 +36,25 @@ describe('API routes in SSR', () => {
 		const body = await response.json();
 		expect(body.length).to.equal(3);
 	});
+
+	describe('Dev', () => {
+		let devServer;
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('Can POST to API routes', async () => {
+			const response = await fixture.fetch('/food.json', {
+				method: 'POST',
+				body: `some data`
+			})
+			expect(response.status).to.equal(200);
+			const text = await response.text();
+			expect(text).to.equal(`ok`);
+		});
+	});
 });


### PR DESCRIPTION
## Changes

- Fixes `POST` (and other non-GET) routes in the dev server with Node 14.

## Testing

Test added

## Docs

N/A, bug fix