### PR TITLE
chore(.gitignore): remove pnpm error logs from git

### DIFF
--- a/examples/blog-multiple-authors/.gitignore
+++ b/examples/blog-multiple-authors/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/blog/.gitignore
+++ b/examples/blog/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/component/.gitignore
+++ b/examples/component/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/docs/.gitignore
+++ b/examples/docs/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/env-vars/.gitignore
+++ b/examples/env-vars/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/framework-alpine/.gitignore
+++ b/examples/framework-alpine/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/framework-lit/.gitignore
+++ b/examples/framework-lit/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/framework-multiple/.gitignore
+++ b/examples/framework-multiple/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/framework-preact/.gitignore
+++ b/examples/framework-preact/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/framework-react/.gitignore
+++ b/examples/framework-react/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/framework-solid/.gitignore
+++ b/examples/framework-solid/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/framework-svelte/.gitignore
+++ b/examples/framework-svelte/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/framework-vue/.gitignore
+++ b/examples/framework-vue/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/integrations-playground/.gitignore
+++ b/examples/integrations-playground/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/minimal/.gitignore
+++ b/examples/minimal/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/non-html-pages/.gitignore
+++ b/examples/non-html-pages/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/portfolio/.gitignore
+++ b/examples/portfolio/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/starter/.gitignore
+++ b/examples/starter/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/subpath/.gitignore
+++ b/examples/subpath/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/with-markdown-plugins/.gitignore
+++ b/examples/with-markdown-plugins/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/with-markdown-shiki/.gitignore
+++ b/examples/with-markdown-shiki/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/with-markdown/.gitignore
+++ b/examples/with-markdown/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/with-nanostores/.gitignore
+++ b/examples/with-nanostores/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/with-tailwindcss/.gitignore
+++ b/examples/with-tailwindcss/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env

--- a/examples/with-vite-plugin-pwa/.gitignore
+++ b/examples/with-vite-plugin-pwa/.gitignore
@@ -8,6 +8,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+
 
 # environment variables
 .env


### PR DESCRIPTION
## Changes

This change adds `pnpm-debug.log*` to `.gitignore` following with the `npm-debug.log*` that is already in the `.gitignore`.
I got annoyed that I had to add this section to the .gitignore so I thought why not create a PR for it.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
No, docs necessary