### PR TITLE
First pass at supporting React 18 in @astrojs/react

### DIFF
--- a/packages/integrations/react/client.js
+++ b/packages/integrations/react/client.js
@@ -1,13 +1,28 @@
 import { createElement } from 'react';
-import { hydrate } from 'react-dom';
+import { version } from 'react-dom/package.json';
 import StaticHtml from './static-html.js';
 
-export default (element) => (Component, props, children) =>
-	hydrate(
+const usingReact18 = version.startsWith('18.');
+
+// Import the correct hydration method based on the version of React.
+const hydrateFn = (
+	async () => usingReact18
+		? (await import('react-dom/client')).hydrateRoot
+		: (await import('react-dom')).hydrate
+)();
+
+export default (element) => async (Component, props, children) => {
+	const args = [
 		createElement(
 			Component,
 			{ ...props, suppressHydrationWarning: true },
 			children != null ? createElement(StaticHtml, { value: children, suppressHydrationWarning: true }) : children
 		),
-		element
-	);
+		element,
+	];
+	
+	// `hydrateRoot` expects [container, component] instead of [component, container].
+	if (usingReact18) args.reverse();
+	
+	return (await hydrateFn)(...args);
+};

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -40,8 +40,8 @@
     "react-dom": "^17.0.2"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^17.0.2 || ^18.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0"
   },
   "engines": {
     "node": "^14.15.0 || >=16.0.0"


### PR DESCRIPTION
## Changes

Tries to use the correct hydration method (`hydrate` vs `hydrateRoot`) based on the installed version of `react-dom`.

Details of how these APIs differ can be found [on the React blog](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis).

## Testing

I’m having trouble running the test suite locally (with or without these changes), so partially opening this PR to see how CI responds. I found a similar approach worked in a different context, but am not sure if there are any special considerations for Vite, or if the `optimizeDeps` array in the integration needs updating.

I’m guessing React tests should ideally be run against both 17 and 18. Do you already have strategies for testing against multiple dependency versions?

## Docs

- [ ] Todo? Not sure if React 18 support needs mentioning.