### PR TITLE
Allow components to return a Response

### DIFF
--- a/.changeset/chatty-cows-attack.md
+++ b/.changeset/chatty-cows-attack.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow components to return a Response

--- a/packages/astro/test/astro-response.test.js
+++ b/packages/astro/test/astro-response.test.js
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import { load as cheerioLoad } from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+// Asset bundling
+describe('Returning responses', () => {
+	let fixture;
+	/** @type {import('./test-utils').DevServer} */
+	let devServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			projectRoot: './fixtures/astro-response/',
+		});
+
+		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer.stop();
+	});
+
+	it('Works from a page', async () => {
+		let response = await fixture.fetch('/not-found');
+		expect(response.status).to.equal(404);
+	});
+
+	it('Works from a component', async () => {
+		let response = await fixture.fetch('/not-found-component');
+		expect(response.status).to.equal(404);
+	});
+});

--- a/packages/astro/test/fixtures/astro-response/src/components/not-found.astro
+++ b/packages/astro/test/fixtures/astro-response/src/components/not-found.astro
@@ -1,0 +1,6 @@
+---
+return new Response(null, {
+	status: 404,
+	statusText: `Not found`
+});
+---

--- a/packages/astro/test/fixtures/astro-response/src/pages/not-found-component.astro
+++ b/packages/astro/test/fixtures/astro-response/src/pages/not-found-component.astro
@@ -1,0 +1,4 @@
+---
+import NotFound from '../components/not-found.astro';
+---
+<NotFound />

--- a/packages/astro/test/fixtures/astro-response/src/pages/not-found.astro
+++ b/packages/astro/test/fixtures/astro-response/src/pages/not-found.astro
@@ -1,0 +1,6 @@
+---
+return new Response(null, {
+	status: 404,
+	statusText: `Not found`
+});
+---


### PR DESCRIPTION
## Changes

- Allows components to return a `Response`, for redirects, etc.
- This is meant so that Layout components can act as gates for auth flows, etc.

## Testing

- Tests added

## Docs

N/A