### PR TITLE
Support React 18 in @astrojs/react

### DIFF
--- a/.changeset/slimy-lions-travel.md
+++ b/.changeset/slimy-lions-travel.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': minor
+---
+
+Add support for React v18

--- a/examples/docs/package.json
+++ b/examples/docs/package.json
@@ -14,12 +14,19 @@
     "@docsearch/react": "^3.0.0",
     "@types/react": "^17.0.43",
     "preact": "^10.6.6",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "@astrojs/preact": "^0.0.2",
     "@astrojs/react": "^0.0.2",
     "astro": "^0.25.4"
+  },
+  "pnpm": {
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "react": "*"
+      }
+    }
   }
 }

--- a/examples/framework-multiple/package.json
+++ b/examples/framework-multiple/package.json
@@ -21,8 +21,8 @@
     "@webcomponents/template-shadowroot": "^0.1.0",
     "lit": "^2.2.1",
     "preact": "^10.6.6",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "solid-js": "^1.3.13",
     "svelte": "^3.46.4",
     "vue": "^3.2.31"

--- a/examples/framework-react/package.json
+++ b/examples/framework-react/package.json
@@ -13,7 +13,7 @@
     "astro": "^0.25.4"
   },
   "dependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }

--- a/examples/integrations-playground/package.json
+++ b/examples/integrations-playground/package.json
@@ -21,8 +21,8 @@
     "@webcomponents/template-shadowroot": "^0.1.0",
     "lit": "^2.2.1",
     "preact": "^10.6.6",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "solid-js": "^1.3.13",
     "svelte": "^3.46.4",
     "vue": "^3.2.31"

--- a/examples/subpath/package.json
+++ b/examples/subpath/package.json
@@ -14,7 +14,7 @@
     "sass": "^1.49.9"
   },
   "dependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }

--- a/examples/with-markdown/package.json
+++ b/examples/with-markdown/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "preact": "^10.6.6",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "svelte": "^3.46.4",
     "vue": "^3.2.31"
   }

--- a/examples/with-nanostores/package.json
+++ b/examples/with-nanostores/package.json
@@ -14,8 +14,8 @@
     "@nanostores/vue": "^0.4.1",
     "nanostores": "^0.5.12",
     "preact": "^10.6.6",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "solid-nanostores": "0.0.6",
     "vue": "^3.2.31"
   },

--- a/packages/astro/test/fixtures/react-component/package.json
+++ b/packages/astro/test/fixtures/react-component/package.json
@@ -5,6 +5,9 @@
   "dependencies": {
     "@astrojs/react": "workspace:*",
     "@astrojs/vue": "workspace:*",
-    "astro": "workspace:*"
+    "astro": "workspace:*",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "vue": "^3.2.31"
   }
 }

--- a/packages/astro/test/fixtures/slots-react/package.json
+++ b/packages/astro/test/fixtures/slots-react/package.json
@@ -5,5 +5,9 @@
   "dependencies": {
     "@astrojs/react": "workspace:*",
     "astro": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }

--- a/packages/integrations/react/client-v17.js
+++ b/packages/integrations/react/client-v17.js
@@ -1,13 +1,13 @@
 import { createElement } from 'react';
-import { hydrateRoot } from 'react-dom/client';
+import { hydrate } from 'react-dom';
 import StaticHtml from './static-html.js';
 
 export default (element) => (Component, props, children) =>
-	hydrateRoot(
-		element,
+	hydrate(
 		createElement(
 			Component,
 			{ ...props, suppressHydrationWarning: true },
 			children != null ? createElement(StaticHtml, { value: children, suppressHydrationWarning: true }) : children
 		),
+		element
 	);

--- a/packages/integrations/react/jsx-runtime.js
+++ b/packages/integrations/react/jsx-runtime.js
@@ -1,5 +1,5 @@
-// This module is a simple wrapper around react/jsx-runtime so that
-// it can run in Node ESM. 'react' doesn't declare this module as an export map
+// This module is a simple wrapper around react/jsx-runtime so that React v17
+// it can run in Node ESM. 'react' (v17) doesn't declare this module as an export map
 // So we have to use the .js. The .js is not added via the babel automatic JSX transform
 // hence this module as a workaround.
 import jsxr from 'react/jsx-runtime.js';

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -21,6 +21,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./client.js": "./client.js",
+    "./client-v17.js": "./client-v17.js",
     "./server.js": "./server.js",
     "./package.json": "./package.json",
     "./jsx-runtime": "./jsx-runtime.js"
@@ -34,14 +35,16 @@
     "@babel/plugin-transform-react-jsx": "^7.17.3"
   },
   "devDependencies": {
+    "@types/react": "^17.0.43",
+    "@types/react-dom": "^17.0.14",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^17.0.2 || ^18.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0"
   },
   "engines": {
     "node": "^14.15.0 || >=16.0.0"

--- a/packages/integrations/react/server.js
+++ b/packages/integrations/react/server.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom/server.js';
+import ReactDOM from 'react-dom/server';
 import StaticHtml from './static-html.js';
 
 const reactTypeof = Symbol.for('react.element');

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -1,9 +1,9 @@
 import { AstroIntegration } from 'astro';
 
-function getRenderer() {
+function getRenderer({reactVersion}: {reactVersion: 17 | 18}) {
 	return {
 		name: '@astrojs/react',
-		clientEntrypoint: '@astrojs/react/client.js',
+		clientEntrypoint: reactVersion >= 18 ? '@astrojs/react/client.js' : '@astrojs/react/client-v17.js',
 		serverEntrypoint: '@astrojs/react/server.js',
 		jsxImportSource: 'react',
 		jsxTransformOptions: async () => {
@@ -17,7 +17,7 @@ function getRenderer() {
 						{},
 						{
 							runtime: 'automatic',
-							importSource: '@astrojs/react',
+							importSource: reactVersion >= 18 ? 'react' : '@astrojs/react',
 						}
 					),
 				],
@@ -41,12 +41,13 @@ function getViteConfiguration() {
 	};
 }
 
-export default function (): AstroIntegration {
+export default function (options = {}): AstroIntegration {
 	return {
 		name: '@astrojs/react',
 		hooks: {
-			'astro:config:setup': ({ addRenderer, updateConfig }) => {
-				addRenderer(getRenderer());
+			'astro:config:setup': async ({ addRenderer, updateConfig }) => {
+				const reactVersion = await (import('react-dom/client').then(() => 18 as 18).catch(() => 17 as 17));
+				addRenderer(getRenderer({reactVersion}));
 				updateConfig({ vite: getViteConfiguration() });
 			},
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,16 +92,16 @@ importers:
       '@types/react': ^17.0.43
       astro: ^0.25.4
       preact: ^10.6.6
-      react: ^17.0.2
-      react-dom: ^17.0.2
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@algolia/client-search': 4.13.0
       '@docsearch/css': 3.0.0
-      '@docsearch/react': 3.0.0_73997327e0ab5ab2aaf50785071cd6bd
+      '@docsearch/react': 3.0.0_9e0989ed96c3582fc46f3bba1f5ac769
       '@types/react': 17.0.43
       preact: 10.6.6
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: 18.0.0
+      react-dom: 18.0.0_react@18.0.0
     devDependencies:
       '@astrojs/preact': link:../../packages/integrations/preact
       '@astrojs/react': link:../../packages/integrations/react
@@ -144,8 +144,8 @@ importers:
       astro: ^0.25.4
       lit: ^2.2.1
       preact: ^10.6.6
-      react: ^17.0.2
-      react-dom: ^17.0.2
+      react: ^18.0.0
+      react-dom: ^18.0.0
       solid-js: ^1.3.13
       svelte: ^3.46.4
       vue: ^3.2.31
@@ -153,8 +153,8 @@ importers:
       '@webcomponents/template-shadowroot': 0.1.0
       lit: 2.2.1
       preact: 10.6.6
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: 18.0.0
+      react-dom: 18.0.0_react@18.0.0
       solid-js: 1.3.13
       svelte: 3.46.4
       vue: 3.2.31
@@ -182,11 +182,11 @@ importers:
     specifiers:
       '@astrojs/react': ^0.0.2
       astro: ^0.25.4
-      react: ^17.0.2
-      react-dom: ^17.0.2
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: 18.0.0
+      react-dom: 18.0.0_react@18.0.0
     devDependencies:
       '@astrojs/react': link:../../packages/integrations/react
       astro: link:../../packages/astro
@@ -236,8 +236,8 @@ importers:
       astro: ^0.25.4
       lit: ^2.2.1
       preact: ^10.6.6
-      react: ^17.0.2
-      react-dom: ^17.0.2
+      react: ^18.0.0
+      react-dom: ^18.0.0
       solid-js: ^1.3.13
       svelte: ^3.46.4
       vue: ^3.2.31
@@ -245,8 +245,8 @@ importers:
       '@webcomponents/template-shadowroot': 0.1.0
       lit: 2.2.1
       preact: 10.6.6
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: 18.0.0
+      react-dom: 18.0.0_react@18.0.0
       solid-js: 1.3.13
       svelte: 3.46.4
       vue: 3.2.31
@@ -315,12 +315,12 @@ importers:
     specifiers:
       '@astrojs/react': ^0.0.2
       astro: ^0.25.4
-      react: ^17.0.2
-      react-dom: ^17.0.2
+      react: ^18.0.0
+      react-dom: ^18.0.0
       sass: ^1.49.9
     dependencies:
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: 18.0.0
+      react-dom: 18.0.0_react@18.0.0
     devDependencies:
       '@astrojs/react': link:../../packages/integrations/react
       astro: link:../../packages/astro
@@ -335,14 +335,14 @@ importers:
       '@astrojs/vue': ^0.0.2
       astro: ^0.25.4
       preact: ^10.6.6
-      react: ^17.0.2
-      react-dom: ^17.0.2
+      react: ^18.0.0
+      react-dom: ^18.0.0
       svelte: ^3.46.4
       vue: ^3.2.31
     dependencies:
       preact: 10.6.6
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: 18.0.0
+      react-dom: 18.0.0_react@18.0.0
       svelte: 3.46.4
       vue: 3.2.31
     devDependencies:
@@ -392,18 +392,18 @@ importers:
       astro: ^0.25.4
       nanostores: ^0.5.12
       preact: ^10.6.6
-      react: ^17.0.2
-      react-dom: ^17.0.2
+      react: ^18.0.0
+      react-dom: ^18.0.0
       solid-nanostores: 0.0.6
       vue: ^3.2.31
     dependencies:
       '@nanostores/preact': 0.1.3_nanostores@0.5.12+preact@10.6.6
-      '@nanostores/react': 0.1.5_f66e5a41ef8212ca2b6be35009893a5b
+      '@nanostores/react': 0.1.5_33de46f26c75888291546388c72611d1
       '@nanostores/vue': 0.4.1_nanostores@0.5.12+vue@3.2.31
       nanostores: 0.5.12
       preact: 10.6.6
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: 18.0.0
+      react-dom: 18.0.0_react@18.0.0
       solid-nanostores: 0.0.6
       vue: 3.2.31
     devDependencies:
@@ -1011,10 +1011,16 @@ importers:
       '@astrojs/react': workspace:*
       '@astrojs/vue': workspace:*
       astro: workspace:*
+      react: ^18.0.0
+      react-dom: ^18.0.0
+      vue: ^3.2.31
     dependencies:
       '@astrojs/react': link:../../../../integrations/react
       '@astrojs/vue': link:../../../../integrations/vue
       astro: link:../../..
+      react: 18.0.0
+      react-dom: 18.0.0_react@18.0.0
+      vue: 3.2.31
 
   packages/astro/test/fixtures/remote-css:
     specifiers:
@@ -1276,17 +1282,21 @@ importers:
   packages/integrations/react:
     specifiers:
       '@babel/plugin-transform-react-jsx': ^7.17.3
+      '@types/react': ^17.0.43
+      '@types/react-dom': ^17.0.14
       astro: workspace:*
       astro-scripts: workspace:*
-      react: ^17.0.2
-      react-dom: ^17.0.2
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/plugin-transform-react-jsx': 7.17.3
     devDependencies:
+      '@types/react': 17.0.43
+      '@types/react-dom': 17.0.14
       astro: link:../../astro
       astro-scripts: link:../../../scripts
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: 18.0.0
+      react-dom: 18.0.0_react@18.0.0
 
   packages/integrations/sitemap:
     specifiers:
@@ -1529,10 +1539,6 @@ importers:
 
   scripts:
     specifiers:
-      '@astrojs/renderer-preact': workspace:*
-      '@astrojs/renderer-react': workspace:*
-      '@astrojs/renderer-svelte': workspace:*
-      '@astrojs/renderer-vue': workspace:*
       '@astrojs/webapi': workspace:*
       adm-zip: ^0.5.9
       arg: ^5.0.1
@@ -1542,10 +1548,6 @@ importers:
       svelte: ^3.46.4
       tar: ^6.1.11
     dependencies:
-      '@astrojs/renderer-preact': link:../packages/renderers/renderer-preact
-      '@astrojs/renderer-react': link:../packages/renderers/renderer-react
-      '@astrojs/renderer-svelte': link:../packages/renderers/renderer-svelte
-      '@astrojs/renderer-vue': link:../packages/renderers/renderer-vue
       '@astrojs/webapi': link:../packages/webapi
       adm-zip: 0.5.9
       arg: 5.0.1
@@ -3291,7 +3293,7 @@ packages:
     resolution: {integrity: sha512-1kkV7tkAsiuEd0shunYRByKJe3xQDG2q7wYg24SOw1nV9/2lwEd4WrUYRJC/ukGTl2/kHeFxsaUvtiOy0y6fFA==}
     dev: false
 
-  /@docsearch/react/3.0.0_73997327e0ab5ab2aaf50785071cd6bd:
+  /@docsearch/react/3.0.0_9e0989ed96c3582fc46f3bba1f5ac769:
     resolution: {integrity: sha512-yhMacqS6TVQYoBh/o603zszIb5Bl8MIXuOc6Vy617I74pirisDzzcNh0NEaYQt50fVVR3khUbeEhUEWEWipESg==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 18.0.0'
@@ -3303,8 +3305,8 @@ packages:
       '@docsearch/css': 3.0.0
       '@types/react': 17.0.43
       algoliasearch: 4.13.0
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: 18.0.0
+      react-dom: 18.0.0_react@18.0.0
     transitivePeerDependencies:
       - '@algolia/client-search'
     dev: false
@@ -3456,7 +3458,7 @@ packages:
       preact: 10.6.6
     dev: false
 
-  /@nanostores/react/0.1.5_f66e5a41ef8212ca2b6be35009893a5b:
+  /@nanostores/react/0.1.5_33de46f26c75888291546388c72611d1:
     resolution: {integrity: sha512-1XEsszpCDcxNeX21QJ+4mFROdn45ulahJ9oLJEo0IA2HZPkwfjSzG+iSXImqFU5nzo0earvlD09z4C9olf8Sxw==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     peerDependencies:
@@ -3465,8 +3467,8 @@ packages:
       react-dom: '>=16.8.0'
     dependencies:
       nanostores: 0.5.12
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: 18.0.0
+      react-dom: 18.0.0_react@18.0.0
     dev: false
 
   /@nanostores/vue/0.4.1_nanostores@0.5.12+vue@3.2.31:
@@ -4009,11 +4011,16 @@ packages:
 
   /@types/prop-types/15.7.4:
     resolution: {integrity: sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==}
-    dev: false
 
   /@types/pug/2.0.6:
     resolution: {integrity: sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==}
     dev: false
+
+  /@types/react-dom/17.0.14:
+    resolution: {integrity: sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==}
+    dependencies:
+      '@types/react': 17.0.43
+    dev: true
 
   /@types/react/17.0.43:
     resolution: {integrity: sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==}
@@ -4021,7 +4028,6 @@ packages:
       '@types/prop-types': 15.7.4
       '@types/scheduler': 0.16.2
       csstype: 3.0.11
-    dev: false
 
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
@@ -4053,7 +4059,6 @@ packages:
 
   /@types/scheduler/0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
-    dev: false
 
   /@types/semver/6.2.3:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
@@ -5236,7 +5241,6 @@ packages:
 
   /csstype/3.0.11:
     resolution: {integrity: sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==}
-    dev: false
 
   /csv-generate/3.4.3:
     resolution: {integrity: sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==}
@@ -8794,6 +8798,16 @@ packages:
       object-assign: 4.1.1
       react: 17.0.2
       scheduler: 0.20.2
+    dev: false
+
+  /react-dom/18.0.0_react@18.0.0:
+    resolution: {integrity: sha512-XqX7uzmFo0pUceWFCt7Gff6IyIMzFUn7QMZrbrQfGxtaxXZIcGQzoNpRLE3fQLnS4XzLLPMZX2T9TRcSrasicw==}
+    peerDependencies:
+      react: ^18.0.0
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.0.0
+      scheduler: 0.21.0
 
   /react/17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
@@ -8801,6 +8815,13 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+    dev: false
+
+  /react/18.0.0:
+    resolution: {integrity: sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
 
   /read-pkg-up/7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -9198,6 +9219,12 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+    dev: false
+
+  /scheduler/0.21.0:
+    resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
+    dependencies:
+      loose-envify: 1.4.0
 
   /section-matter/1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,10 +8,6 @@
     "astro-scripts": "./index.js"
   },
   "dependencies": {
-    "@astrojs/renderer-preact": "workspace:*",
-    "@astrojs/renderer-react": "workspace:*",
-    "@astrojs/renderer-svelte": "workspace:*",
-    "@astrojs/renderer-vue": "workspace:*",
     "@astrojs/webapi": "workspace:*",
     "adm-zip": "^0.5.9",
     "arg": "^5.0.1",


### PR DESCRIPTION
## Changes

- Support both React 17 & 18 in the same integration
- If tests pass, #2939 should be closed
- @delucis would still love your help getting this over the line!

## Testing

- None yet, but I think we'll have to fix this with a fixture that uses `react@17` as a dependency, and then updated all of our current react fixtures to use `react@18`

## Docs

- N/A