### PR TITLE
Add support for React 18 in @astrojs/react

### DIFF
--- a/.changeset/ninety-jars-swim.md
+++ b/.changeset/ninety-jars-swim.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': minor
+---
+
+Add support for React v18

--- a/packages/astro/test/fixtures/react-component/package.json
+++ b/packages/astro/test/fixtures/react-component/package.json
@@ -5,6 +5,9 @@
   "dependencies": {
     "@astrojs/react": "workspace:*",
     "@astrojs/vue": "workspace:*",
-    "astro": "workspace:*"
+    "astro": "workspace:*",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "vue": "^3.2.31"
   }
 }

--- a/packages/integrations/react/client-v17.js
+++ b/packages/integrations/react/client-v17.js
@@ -1,13 +1,13 @@
 import { createElement } from 'react';
+import { hydrate } from 'react-dom';
 import StaticHtml from './static-html.js';
-import { hydrateRoot } from 'react-dom/client.js';
 
-export default (element) => async (Component, props, children) =>
-	hydrateRoot(
-		element,
+export default (element) => (Component, props, children) =>
+	hydrate(
 		createElement(
 			Component,
 			{ ...props, suppressHydrationWarning: true },
 			children != null ? createElement(StaticHtml, { value: children, suppressHydrationWarning: true }) : children
-		)
+		),
+		element
 	);

--- a/packages/integrations/react/client.js
+++ b/packages/integrations/react/client.js
@@ -7,7 +7,7 @@ const usingReact18 = version.startsWith('18.');
 // Import the correct hydration method based on the version of React.
 const hydrateFn = (
 	async () => usingReact18
-		? (await import('react-dom/client')).hydrateRoot
+		? (await import('react-dom/client.js')).hydrateRoot
 		: (await import('react-dom')).hydrate
 )();
 

--- a/packages/integrations/react/client.js
+++ b/packages/integrations/react/client.js
@@ -1,15 +1,13 @@
 import { createElement } from 'react';
-import { version } from 'react-dom/package.json';
 import StaticHtml from './static-html.js';
 
-const usingReact18 = version.startsWith('18.');
+const usingReact18 = process.env.REACT_HYDRATION_ENTRYPOINT === 'react-dom/client';
 
 // Import the correct hydration method based on the version of React.
-const hydrateFn = (
-	async () => usingReact18
-		? (await import('react-dom/client.js')).hydrateRoot
-		: (await import('react-dom')).hydrate
-)();
+const hydrateFn = (async () => {
+	const mod = await import(process.env.REACT_HYDRATION_ENTRYPOINT);
+	return mod[usingReact18 ? 'hydrateRoot' : 'hydrate'];
+})();
 
 export default (element) => async (Component, props, children) => {
 	const args = [
@@ -20,9 +18,9 @@ export default (element) => async (Component, props, children) => {
 		),
 		element,
 	];
-	
+
 	// `hydrateRoot` expects [container, component] instead of [component, container].
 	if (usingReact18) args.reverse();
-	
+
 	return (await hydrateFn)(...args);
 };

--- a/packages/integrations/react/client.js
+++ b/packages/integrations/react/client.js
@@ -1,8 +1,8 @@
 import { createElement } from 'react';
-import StaticHtml from './static-html.js';
 import { hydrateRoot } from 'react-dom/client.js';
+import StaticHtml from './static-html.js';
 
-export default (element) => async (Component, props, children) =>
+export default (element) => (Component, props, children) =>
 	hydrateRoot(
 		element,
 		createElement(

--- a/packages/integrations/react/client.js
+++ b/packages/integrations/react/client.js
@@ -1,13 +1,28 @@
 import { createElement } from 'react';
-import { hydrate } from 'react-dom';
+import { version } from 'react-dom/package.json';
 import StaticHtml from './static-html.js';
 
-export default (element) => (Component, props, children) =>
-	hydrate(
+const usingReact18 = version.startsWith('18.');
+
+// Import the correct hydration method based on the version of React.
+const hydrateFn = (
+	async () => usingReact18
+		? (await import('react-dom/client')).hydrateRoot
+		: (await import('react-dom')).hydrate
+)();
+
+export default (element) => async (Component, props, children) => {
+	const args = [
 		createElement(
 			Component,
 			{ ...props, suppressHydrationWarning: true },
 			children != null ? createElement(StaticHtml, { value: children, suppressHydrationWarning: true }) : children
 		),
-		element
-	);
+		element,
+	];
+	
+	// `hydrateRoot` expects [container, component] instead of [component, container].
+	if (usingReact18) args.reverse();
+	
+	return (await hydrateFn)(...args);
+};

--- a/packages/integrations/react/client.js
+++ b/packages/integrations/react/client.js
@@ -1,5 +1,5 @@
 import { createElement } from 'react';
-import { hydrateRoot } from 'react-dom/client.js';
+import { hydrateRoot } from 'react-dom/client';
 import StaticHtml from './static-html.js';
 
 export default (element) => (Component, props, children) =>

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -40,8 +40,8 @@
     "react-dom": "^17.0.2"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^17.0.2 || ^18.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0"
   },
   "engines": {
     "node": "^14.15.0 || >=16.0.0"

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -20,7 +20,8 @@
   "homepage": "https://astro.build",
   "exports": {
     ".": "./dist/index.js",
-    "./client.js": "./client-v17.js",
+    "./client.js": "./client.js",
+    "./client-v17.js": "./client-v17.js",
     "./server.js": "./server.js",
     "./package.json": "./package.json",
     "./jsx-runtime": "./jsx-runtime.js"

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -23,6 +23,7 @@
     "./client.js": "./client.js",
     "./client-v17.js": "./client-v17.js",
     "./server.js": "./server.js",
+    "./server-v17.js": "./server-v17.js",
     "./package.json": "./package.json",
     "./jsx-runtime": "./jsx-runtime.js"
   },

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -34,6 +34,8 @@
     "@babel/plugin-transform-react-jsx": "^7.17.3"
   },
   "devDependencies": {
+    "@types/react": "^17.0.43",
+    "@types/react-dom": "^17.0.14",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "react": "^17.0.2",

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://astro.build",
   "exports": {
     ".": "./dist/index.js",
-    "./client.js": "./client.js",
+    "./client.js": "./client-v17.js",
     "./server.js": "./server.js",
     "./package.json": "./package.json",
     "./jsx-runtime": "./jsx-runtime.js"

--- a/packages/integrations/react/server-v17.js
+++ b/packages/integrations/react/server-v17.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom/server';
+import ReactDOM from 'react-dom/server.js';
 import StaticHtml from './static-html.js';
 
 const reactTypeof = Symbol.for('react.element');

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -1,4 +1,5 @@
 import { AstroIntegration } from 'astro';
+import { version as ReactVersion } from 'react-dom/package.json';
 
 function getRenderer() {
 	return {
@@ -28,6 +29,9 @@ function getRenderer() {
 
 function getViteConfiguration() {
 	return {
+		define: {
+			'process.env.REACT_HYDRATION_ENTRYPOINT': ReactVersion.startsWith('18.') ? 'react-dom/client' : 'react-dom',
+		},
 		optimizeDeps: {
 			include: ['@astrojs/react/client.js', 'react', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'react-dom'],
 			exclude: ['@astrojs/react/server.js'],

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -30,7 +30,7 @@ function getRenderer() {
 function getViteConfiguration() {
 	return {
 		optimizeDeps: {
-			include: ['@astrojs/react/client.js', 'react', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'react-dom'],
+			include: [ReactVersion.startsWith('18.') ? '@astrojs/react/client.js' : '@astrojs/react/client-v17.js', 'react', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'react-dom'],
 			exclude: ['@astrojs/react/server.js'],
 		},
 		resolve: {

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -5,7 +5,7 @@ function getRenderer() {
 	return {
 		name: '@astrojs/react',
 		clientEntrypoint: ReactVersion.startsWith('18.') ? '@astrojs/react/client.js' : '@astrojs/react/client-v17.js',
-		serverEntrypoint: '@astrojs/react/server.js',
+		serverEntrypoint: ReactVersion.startsWith('18.') ? '@astrojs/react/server.js' : '@astrojs/react/server-v17.js',
 		jsxImportSource: 'react',
 		jsxTransformOptions: async () => {
 			const {
@@ -18,7 +18,7 @@ function getRenderer() {
 						{},
 						{
 							runtime: 'automatic',
-							importSource: '@astrojs/react',
+							importSource: ReactVersion.startsWith('18.') ? 'react' : '@astrojs/react',
 						}
 					),
 				],
@@ -31,13 +31,13 @@ function getViteConfiguration() {
 	return {
 		optimizeDeps: {
 			include: [ReactVersion.startsWith('18.') ? '@astrojs/react/client.js' : '@astrojs/react/client-v17.js', 'react', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'react-dom'],
-			exclude: ['@astrojs/react/server.js'],
+			exclude: [ReactVersion.startsWith('18.') ? '@astrojs/react/server.js' : '@astrojs/react/server-v17.js'], 
 		},
 		resolve: {
 			dedupe: ['react', 'react-dom'],
 		},
 		ssr: {
-			external: ['react-dom/server.js', 'react-dom/client.js'],
+			external: ReactVersion.startsWith('18.') ? ['react-dom/server', 'react-dom/client'] : ['react-dom/server.js', 'react-dom/client.js'],
 		},
 	};
 }

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -18,6 +18,10 @@ function getRenderer() {
 						{},
 						{
 							runtime: 'automatic',
+							// This option tells the JSX transform how to construct the "*/jsx-runtime" import.
+							// In React v17, we had to shim this due to an export map issue in React.
+							// In React v18, this issue was fixed and we can import "react/jsx-runtime" directly.
+							// See `./jsx-runtime.js` for more details.
 							importSource: ReactVersion.startsWith('18.') ? 'react' : '@astrojs/react',
 						}
 					),

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -1,10 +1,10 @@
 import { AstroIntegration } from 'astro';
-import { version as ReactVersion } from 'react-dom/package.json';
+import { version as ReactVersion } from 'react-dom';
 
 function getRenderer() {
 	return {
 		name: '@astrojs/react',
-		clientEntrypoint: '@astrojs/react/client.js',
+		clientEntrypoint: ReactVersion.startsWith('18.') ? '@astrojs/react/client.js' : '@astrojs/react/client-v17.js',
 		serverEntrypoint: '@astrojs/react/server.js',
 		jsxImportSource: 'react',
 		jsxTransformOptions: async () => {
@@ -29,9 +29,6 @@ function getRenderer() {
 
 function getViteConfiguration() {
 	return {
-		define: {
-			'process.env.REACT_HYDRATION_ENTRYPOINT': ReactVersion.startsWith('18.') ? 'react-dom/client' : 'react-dom',
-		},
 		optimizeDeps: {
 			include: ['@astrojs/react/client.js', 'react', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'react-dom'],
 			exclude: ['@astrojs/react/server.js'],

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -36,7 +36,7 @@ function getViteConfiguration() {
 			dedupe: ['react', 'react-dom'],
 		},
 		ssr: {
-			external: ['react-dom/server.js'],
+			external: ['react-dom/server.js', 'react-dom/client.js'],
 		},
 	};
 }

--- a/packages/integrations/react/tsconfig.json
+++ b/packages/integrations/react/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "module": "ES2020",
     "outDir": "./dist",
+    "resolveJsonModule": true,
     "target": "ES2020"
   }
 }

--- a/packages/integrations/react/tsconfig.json
+++ b/packages/integrations/react/tsconfig.json
@@ -5,7 +5,6 @@
     "allowJs": true,
     "module": "ES2020",
     "outDir": "./dist",
-    "resolveJsonModule": true,
     "target": "ES2020"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1256,6 +1256,8 @@ importers:
   packages/integrations/react:
     specifiers:
       '@babel/plugin-transform-react-jsx': ^7.17.3
+      '@types/react': ^17.0.43
+      '@types/react-dom': ^17.0.14
       astro: workspace:*
       astro-scripts: workspace:*
       react: ^17.0.2
@@ -1263,6 +1265,8 @@ importers:
     dependencies:
       '@babel/plugin-transform-react-jsx': 7.17.3
     devDependencies:
+      '@types/react': 17.0.43
+      '@types/react-dom': 17.0.14
       astro: link:../../astro
       astro-scripts: link:../../../scripts
       react: 17.0.2
@@ -3985,11 +3989,16 @@ packages:
 
   /@types/prop-types/15.7.4:
     resolution: {integrity: sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==}
-    dev: false
 
   /@types/pug/2.0.6:
     resolution: {integrity: sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==}
     dev: false
+
+  /@types/react-dom/17.0.14:
+    resolution: {integrity: sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==}
+    dependencies:
+      '@types/react': 17.0.43
+    dev: true
 
   /@types/react/17.0.43:
     resolution: {integrity: sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==}
@@ -3997,7 +4006,6 @@ packages:
       '@types/prop-types': 15.7.4
       '@types/scheduler': 0.16.2
       csstype: 3.0.11
-    dev: false
 
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
@@ -4029,7 +4037,6 @@ packages:
 
   /@types/scheduler/0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
-    dev: false
 
   /@types/semver/6.2.3:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
@@ -5212,7 +5219,6 @@ packages:
 
   /csstype/3.0.11:
     resolution: {integrity: sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==}
-    dev: false
 
   /csv-generate/3.4.3:
     resolution: {integrity: sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1007,10 +1007,16 @@ importers:
       '@astrojs/react': workspace:*
       '@astrojs/vue': workspace:*
       astro: workspace:*
+      react: ^17.0.2
+      react-dom: ^17.0.2
+      vue: ^3.2.31
     dependencies:
       '@astrojs/react': link:../../../../integrations/react
       '@astrojs/vue': link:../../../../integrations/vue
       astro: link:../../..
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      vue: 3.2.31
 
   packages/astro/test/fixtures/remote-css:
     specifiers:


### PR DESCRIPTION
## Changes

- Adds support for v18 to `@astrojs/react`
- React v17 remains the same
- Monorepo stays on v17 to confirm that this doesn't break
- Follow up PR to update Monorepo to v18

## Testing

- Tested manually
- I believe this is impossible to test in our monorepo, due to how we use peer deps. In the monorepo, the peer dep is hard-coded do whatever the actual dep is of the integration. Because its a symlink, it can't follow the import the way it would in a normal project. This shouldn't impact all monorepos, just ours where the integration source code itself is literally the thing being mono-repo'd.

## Docs

- N/A