### PR TITLE
Fix hmr updating

### DIFF
--- a/.changeset/two-radios-visit.md
+++ b/.changeset/two-radios-visit.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed an HMR bug. Possibly resolves issue #2707

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -81,9 +81,9 @@ export async function handleHotUpdate(ctx: HmrContext, config: AstroConfig, logg
 
 	const mod = ctx.modules.find((m) => m.file === ctx.file);
 	const file = ctx.file.replace(config.projectRoot.pathname, '/');
-	if (ctx.file.endsWith('.astro')) {
-		ctx.server.ws.send({ type: 'custom', event: 'astro:update', data: { file } });
-	}
+	
+	ctx.server.ws.send({ type: 'custom', event: 'astro:update', data: { file } });
+	
 	if (mod?.isSelfAccepting) {
 		info(logging, 'astro', msg.hmr({ file }));
 	} else {


### PR DESCRIPTION
## Changes

This fixes an HMR bug where changes non-.astro files would not send an HMR update. Possibly resolves issue #2707.

## Testing

Tested manually using the Astro example projects.

## Docs

No documentation changes needed, just a bug fix.

