### PR TITLE
Add function-based slot support to `Astro.slots.render()`

### DIFF
--- a/.changeset/light-apricots-sort.md
+++ b/.changeset/light-apricots-sort.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Improve `Astro.slots` API to support passing arguments to function-based slots. 
+
+This allows for more ergonomic utility components that accept a callback function as a child.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -60,7 +60,7 @@ export interface AstroGlobal extends AstroGlobalPartial {
 	/** get information about this page */
 	request: Request;
 	/** see if slots are used */
-	slots: Record<string, true | undefined> & { has(slotName: string): boolean; render(slotName: string): Promise<string> };
+	slots: Record<string, true | undefined> & { has(slotName: string): boolean; render(slotName: string, args?: any[]): Promise<string> };
 }
 
 export interface AstroGlobalPartial {

--- a/packages/astro/test/astro-slots.test.js
+++ b/packages/astro/test/astro-slots.test.js
@@ -112,4 +112,33 @@ describe('Slots', () => {
 			expect($('#default')).to.have.lengthOf(1); // the default slot is filled
 		}
 	});
+
+	it('Slots.render() API', async () => {
+		// Simple imperative slot render
+		{
+			const html = await fixture.readFile('/slottedapi-render/index.html');
+			const $ = cheerio.load(html);
+
+			expect($('#render')).to.have.lengthOf(1);
+			expect($('#render').text()).to.equal('render');
+		}
+
+		// Child function render without args
+		{
+			const html = await fixture.readFile('/slottedapi-render/index.html');
+			const $ = cheerio.load(html);
+
+			expect($('#render-fn')).to.have.lengthOf(1);
+			expect($('#render-fn').text()).to.equal('render-fn');
+		}
+
+		// Child function render with args
+		{
+			const html = await fixture.readFile('/slottedapi-render/index.html');
+			const $ = cheerio.load(html);
+
+			expect($('#render-args')).to.have.lengthOf(1);
+			expect($('#render-args').text()).to.equal('render-args');
+		}
+	});
 });

--- a/packages/astro/test/fixtures/astro-slots/src/components/Render.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/components/Render.astro
@@ -1,0 +1,6 @@
+---
+const { id } = Astro.props;
+const content = await Astro.slots.render('default');
+---
+
+<div id={id} set:html={content} />

--- a/packages/astro/test/fixtures/astro-slots/src/components/RenderArgs.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/components/RenderArgs.astro
@@ -1,0 +1,6 @@
+---
+const { id, text } = Astro.props;
+const content = await Astro.slots.render('default', [text]);
+---
+
+<div id={id} set:html={content} />

--- a/packages/astro/test/fixtures/astro-slots/src/components/RenderFn.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/components/RenderFn.astro
@@ -1,0 +1,6 @@
+---
+const { id } = Astro.props;
+const content = await Astro.slots.render('default');
+---
+
+<div id={id} set:html={content} />

--- a/packages/astro/test/fixtures/astro-slots/src/pages/slottedapi-render.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/pages/slottedapi-render.astro
@@ -1,0 +1,20 @@
+---
+import Render from '../components/Render.astro';
+import RenderFn from '../components/RenderFn.astro';
+import RenderArgs from '../components/RenderArgs.astro';
+---
+
+<html>
+  <head>
+    <!--
+      Test Astro.slots.render behavior.
+      - `Render` is basic imperative `render` call
+			- `RenderFn` is `render` that calls child function with arguments
+    -->
+  </head>
+  <body>
+    <Render id="render">render</Render>
+		<RenderFn id="render-fn">{() => "render-fn"}</RenderFn>
+		<RenderArgs id="render-args" text="render-args">{(text: string) => text}</RenderArgs>
+  </body>
+</html>


### PR DESCRIPTION
## Changes

- Previously, `Astro.slots.render("default")` could only render Astro components.
- Now, `Astro.slots.render("default", [...args])` can render a function child, passing `args` into the function correctly.
- This allows users to build more ergonomic utility components like `For`.

```astro
<For each={items}>
  {(item) => <li>{item}</li>}
</For>
```

## Testing

Test suite added for `Astro.slots.render('default')` and `Astro.slots.render('default', [args])`

## Docs

TBD