### PR TITLE
fix: prevent CLI defaults from overriding astro.config.mjs

### DIFF
--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -244,10 +244,10 @@ function resolveFlags(flags: Partial<Flags>): CLIFlags {
 		config: typeof flags.config === 'string' ? flags.config : undefined,
 		hostname: typeof flags.hostname === 'string' ? flags.hostname : undefined,
 		host: typeof flags.host === 'string' || typeof flags.host === 'boolean' ? flags.host : undefined,
-		legacyBuild: typeof flags.legacyBuild === 'boolean' ? flags.legacyBuild : false,
-		experimentalSsr: typeof flags.experimentalSsr === 'boolean' ? flags.experimentalSsr : false,
-		experimentalIntegrations: typeof flags.experimentalIntegrations === 'boolean' ? flags.experimentalIntegrations : false,
-		drafts: typeof flags.drafts === 'boolean' ? flags.drafts : false,
+		legacyBuild: typeof flags.legacyBuild === 'boolean' ? flags.legacyBuild : undefined,
+		experimentalSsr: typeof flags.experimentalSsr === 'boolean' ? flags.experimentalSsr : undefined,
+		experimentalIntegrations: typeof flags.experimentalIntegrations === 'boolean' ? flags.experimentalIntegrations : undefined,
+		drafts: typeof flags.drafts === 'boolean' ? flags.drafts : undefined,
 	};
 }
 


### PR DESCRIPTION
## Changes

These CLI defaults where overriding whatever was inside astro.config.mjs even when no flag were provided! Now, passing a flag overrides the config but passing no flag does nothing.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->