### PR TITLE
Allows projects to opt out of the base Tailwind styles

### DIFF
--- a/.changeset/tasty-zoos-wink.md
+++ b/.changeset/tasty-zoos-wink.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/tailwind': patch
+---
+
+Adds an option to opt-out of the default base styles for the Tailwind integration

--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -82,6 +82,19 @@ export default {
 }
 ```
 
+We will include `@tailwind` directives for each of Tailwind's layers to enable Tailwind styles by default. If you need to customize this behavior, with Tailwind's [`@layer` directive](https://tailwindcss.com/docs/functions-and-directives#layer) for example, opt-out via the `config.applyBaseStyles` integration option:
+
+__astro.config.mjs__
+
+```js
+export default {
+  // ...
+  integrations: [tailwind({
+    config: { applyBaseStyles: false },
+  })],
+}
+```
+
 You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
 
 [astro-integration]: https://docs.astro.build/en/guides/integrations-guide/

--- a/packages/integrations/tailwind/src/index.ts
+++ b/packages/integrations/tailwind/src/index.ts
@@ -43,12 +43,21 @@ type TailwindOptions =
 				 * @default true
 				 */
 				applyAstroPreset?: boolean;
+				/**
+				 * Apply Tailwind's base styles
+				 * Disabling this is useful when further customization of Tailwind styles
+				 * and directives is required. See {@link https://tailwindcss.com/docs/functions-and-directives#tailwind Tailwind's docs}
+				 * for more details on directives and customization.
+				 * @default: true
+				 */
+				applyBaseStyles?: boolean;
 			};
 	  }
 	| undefined;
 
 export default function tailwindIntegration(options: TailwindOptions): AstroIntegration {
 	const applyAstroConfigPreset = options?.config?.applyAstroPreset ?? true;
+	const applyBaseStyles = options?.config?.applyBaseStyles ?? true;
 	const customConfigPath = options?.config?.path;
 	return {
 		name: '@astrojs/tailwind',
@@ -71,8 +80,10 @@ export default function tailwindIntegration(options: TailwindOptions): AstroInte
 				config.styleOptions.postcss.plugins.push(tailwindPlugin(tailwindConfig));
 				config.styleOptions.postcss.plugins.push(autoprefixerPlugin);
 
-				// Inject the Tailwind base import
-				injectScript('page-ssr', `import '@astrojs/tailwind/base.css';`);
+				if (applyBaseStyles) {
+					// Inject the Tailwind base import
+					injectScript('page-ssr', `import '@astrojs/tailwind/base.css';`);
+				}
 			},
 		},
 	};


### PR DESCRIPTION
## Changes

Fixes [#2950](https://github.com/withastro/astro/issues/2950) - this makes the `base.css` styles in the Tailwind integration opt-out

**Why?** The [`@layer`](https://tailwindcss.com/docs/functions-and-directives#layer) directive is useful for customizing Tailwind's base styles, but `@layer` must be run after `@tailwind` directives. This also allows users to skip built-in tailwind layers in case the project doesn't need `@tailwind components` or `@tailwind utilities`

## Testing

Tested locally against the `with-tailwindcss` starter

## Docs

Integration README updated to describe the new config option and when you may want to opt-out