### PR TITLE
fix(markdown): escape when mode == 'md'

### DIFF
--- a/.changeset/silent-cows-shave.md
+++ b/.changeset/silent-cows-shave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Escape expressions when mode == 'md'

--- a/packages/markdown/remark/src/index.ts
+++ b/packages/markdown/remark/src/index.ts
@@ -50,8 +50,7 @@ export async function renderMarkdown(content: string, opts?: MarkdownRenderingOp
 
 	let parser = unified()
 		.use(markdown)
-		.use(isMDX ? [remarkJsx] : [])
-		.use(isMDX ? [remarkExpressions] : [])
+		.use(isMDX ? [remarkJsx, remarkExpressions] : [])
 		.use([remarkUnwrap]);
 
 	if (remarkPlugins.length === 0 && rehypePlugins.length === 0) {
@@ -91,10 +90,8 @@ export async function renderMarkdown(content: string, opts?: MarkdownRenderingOp
 	});
 
 	parser
-		.use(isMDX ? [rehypeJsx] : [])
-		.use(isMDX ? [rehypeExpressions] : [])
-		.use(isMDX ? [] : [rehypeRaw])
-		.use(isMDX ? [rehypeEscape] : [])
+		.use(isMDX ? [rehypeJsx, rehypeExpressions] : [rehypeRaw])
+		.use(rehypeEscape)
 		.use(rehypeIslands);
 
 	let result: string;


### PR DESCRIPTION
## Changes

I've recently encountered this error when using `mode: 'md'`:

```
 error   Transform failed with 1 error:
  /home/juanm04/dev/projects/portfolio/src/pages/docs/wsl-memory.md:34:164: ERROR: Expected "}" but found "distro"
  File:
    /home/juanm04/dev/projects/portfolio/src/pages/docs/wsl-memory.md
  Code:
      33 | Therefore, in your situation, all you need to include in your file is ⤵
      35 | ```ini:.wslconfig
      36 | [wsl2]
      37 | memory=1GB
```

It turned out, `rehypeEscape` was only being executed when mode was equal to `mdx`, so I've made it so it always get executed. (Plus, I've made some formatting so make it more clear what is being used with MDX and what don't)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->