### PR TITLE
Fixing the new config defaults (docs only)

### DIFF
--- a/.changeset/plenty-suits-happen.md
+++ b/.changeset/plenty-suits-happen.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Updates the @docs default value listed for config.publicDir
+Updates the @docs default value listed for config.publicDir and config.outputDir

--- a/.changeset/plenty-suits-happen.md
+++ b/.changeset/plenty-suits-happen.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates the @docs default value listed for config.publicDir

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -175,7 +175,7 @@ export interface AstroUserConfig {
 	 * @docs
 	 * @name outDir
 	 * @type {string}
-	 * @default `"./outDir"`
+	 * @default `"./out"`
 	 * @description Set the directory that `astro build` writes your final build to.
 	 *
 	 * The value can be either an absolute file system path or a path relative to the project root.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -157,7 +157,7 @@ export interface AstroUserConfig {
 	 * @docs
 	 * @name publicDir
 	 * @type {string}
-	 * @default `"./publicDir"`
+	 * @default `"./public"`
 	 * @description
 	 * Set the directory for your static assets. Files in this directory are served at `/` during dev and copied to your build directory during build. These files are always served or copied as-is, without transform or bundling.
 	 *


### PR DESCRIPTION
Fixes [#2972](https://github.com/withastro/astro/issues/2972)

## Changes

Docs fix only - `config.publicDir` and `config.outDir` were showing the wrong default values

## Testing

None (docs and typedef fix only)

## Docs

None, this will be picked up by the doc's `docgen` script