### PR TITLE
fix(cli): prevent CLI from hanging

### DIFF
--- a/.changeset/soft-dolphins-join.md
+++ b/.changeset/soft-dolphins-join.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent CLI from hanging

--- a/packages/astro/astro.js
+++ b/packages/astro/astro.js
@@ -96,4 +96,6 @@ Please upgrade Node.js to a supported version: "${engines}"\n`);
 	process.exit(1);
 }
 
-main();
+main()
+	.then(() => process.exit(0))
+	.catch(() => process.exit(1));


### PR DESCRIPTION
## Changes

Prevent CLI from hanging. You can see it happening in [this Netlify deploy](https://app.netlify.com/sites/astro-docs-2/deploys/6249c14f8f70250008af2c0f): `astro build` is successful but the process never terminates.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->