### PR TITLE
Fix edge case with slotted children

### DIFF
--- a/.changeset/flat-coats-crash.md
+++ b/.changeset/flat-coats-crash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix edge case where default slots could be rendered too early for Astro components. Slots are now only rendered on demand.

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -150,9 +150,8 @@ export async function renderComponent(
 	slots: any = {}
 ) {
 	Component = await Component;
-	const children = await renderSlot(result, slots?.default);
-
 	if (Component === Fragment) {
+		const children = await renderSlot(result, slots?.default);
 		if (children == null) {
 			return children;
 		}
@@ -197,6 +196,7 @@ Did you mean to add ${formatList(probableRendererNames.map((r) => '`' + r + '`')
 		throw new Error(message);
 	}
 
+	const children = await renderSlot(result, slots?.default);
 	// Call the renderers `check` hook to see if any claim this component.
 	let renderer: SSRLoadedRenderer | undefined;
 	if (metadata.hydrate !== 'only') {


### PR DESCRIPTION
## Changes

- Was building something, found an edge case where slotted children would be rendered before they should be.
- This will unblock utility `function` children for Astro components.

## Testing

Not really possible to test

## Docs

Bug fix only