### PR TITLE
keep publishing to latest, even in pre mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/withastro/astro.git"
   },
   "scripts": {
-    "release": "pnpm run build && changeset publish",
+    "release": "pnpm run build && changeset publish --tag latest",
     "build": "turbo run build --no-deps --scope=astro --scope=create-astro --scope=\"@astrojs/*\"",
     "build:ci": "turbo run build:ci --no-deps --scope=astro --scope=create-astro --scope=\"@astrojs/*\"",
     "build:examples": "turbo run build --scope=\"@example/*\"",


### PR DESCRIPTION
I think that this will fix the npm publish to use `latest`, but maybe only 95% sure. Only one way to find out! :)