### PR TITLE
Update JSDoc comments that get shown in editor

### DIFF
--- a/.changeset/shaggy-pans-buy.md
+++ b/.changeset/shaggy-pans-buy.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Update JSDoc comments that get shown to users through editor integration

--- a/packages/astro/env.d.ts
+++ b/packages/astro/env.d.ts
@@ -4,8 +4,9 @@ type Astro = import('astro').AstroGlobal;
 
 // We duplicate the description here because editors won't show the JSDoc comment from the imported type (but will for its properties, ex: Astro.request will show the AstroGlobal.request description)
 /**
- * Astro.* available in all components
- * Docs: https://docs.astro.build/reference/api-reference/#astro-global
+ * Astro global available in all contexts in .astro files
+ *
+ * [Astro documentation](https://docs.astro.build/reference/api-reference/#astro-global)
  */
 declare const Astro: Readonly<Astro>;
 

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -72,21 +72,69 @@ export interface BuildConfig {
 }
 
 /**
- * Astro.* available in all components
- * Docs: https://docs.astro.build/reference/api-reference/#astro-global
+ * Astro global available in all contexts in .astro files
+ *
+ * [Astro documentation](https://docs.astro.build/reference/api-reference/#astro-global)
  */
 export interface AstroGlobal extends AstroGlobalPartial {
-	/** get the current canonical URL */
+	/** Canonical URL of the current page. If the [site](https://docs.astro.build/en/reference/configuration-reference/#site) config option is set, its origin will be the origin of this URL.
+	 *
+	 * [Astro documentation](https://docs.astro.build/en/reference/api-reference/#astrocanonicalurl)
+	 */
 	canonicalURL: URL;
 	/** get page params (dynamic pages only) */
 	params: Params;
-	/** set props for this astro component (along with default values) */
+	/** List of props passed to this component
+	 *
+	 * A common way to get specific props is through destructuring, ex:
+	 * ```javascript
+	 *  const { name } = Astro.props
+	 * ```
+	 *
+	 * [Astro documentation](https://docs.astro.build/en/core-concepts/astro-components/#component-props)
+	 */
 	props: Record<string, number | string | any>;
-	/** get information about this page */
+	/** Information about the current request. This is a standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object
+	 *
+	 * For example, to get an URL object of the current URL, you can use:
+	 * ```javascript
+	 *  const url = new URL(Astro.request.url);
+	 * ```
+	 *
+	 * [Astro documentation](https://docs.astro.build/en/reference/api-reference/#astrorequest)
+	 */
 	request: Request;
 	/** see if slots are used */
 	slots: Record<string, true | undefined> & {
+		/**
+		 * Check whether content for this slot name exists
+		 *
+		 * Example usage:
+		 * ```typescript
+		 *	if (Astro.slots.has('default')) {
+		 *		// Do something...
+		 *	}
+		 * ```
+		 *
+		 * [Astro documentation](https://docs.astro.build/en/reference/api-reference/#astroslots)
+		 */
 		has(slotName: string): boolean;
+		/**
+		 * Asychronously renders this slot and returns HTML
+		 *
+		 * Example usage:
+		 * ```astro
+		 * ---
+		 * let html: string = '';
+		 * if (Astro.slots.has('default')) {
+		 *		html = await Astro.slots.render('default')
+		 * }
+		 * ---
+		 * <Fragment set:html={html} />
+		 * ```
+		 *
+		 * [Astro documentation](https://docs.astro.build/en/reference/api-reference/#astroslots)
+		 */
 		render(slotName: string, args?: any[]): Promise<string>;
 	};
 }
@@ -95,12 +143,29 @@ export interface AstroGlobalPartial {
 	/**
 	 * @deprecated since version 0.24. See the {@link https://astro.build/deprecated/resolve upgrade guide} for more details.
 	 */
-	resolve: (path: string) => string;
-	/** @deprecated Use `Astro.glob()` instead. */
+	resolve(path: string): string;
+	/** @deprecated since version 0.26. Use [Astro.glob()](https://docs.astro.build/en/reference/api-reference/#astroglob) instead. */
 	fetchContent(globStr: string): Promise<any[]>;
+	/**
+	 * Fetch local files into your static site setup
+	 *
+	 * Example usage:
+	 * ```typescript
+	 * const posts = await Astro.glob('../pages/post/*.md'); // returns an array of posts that live at ./src/pages/post/*.md
+	 * ```
+	 *
+	 * [Astro documentation](https://docs.astro.build/en/reference/api-reference/#astroglob)
+	 */
 	glob(globStr: `${any}.astro`): Promise<ComponentInstance[]>;
 	glob<T extends Record<string, any>>(globStr: `${any}.md`): Promise<MarkdownInstance<T>[]>;
 	glob<T extends Record<string, any>>(globStr: string): Promise<T[]>;
+	/**
+	 * Returns an [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) object built from the [site](https://docs.astro.build/en/reference/configuration-reference/#site) config option
+	 *
+	 * If `site` is undefined, the URL object will instead be built from `localhost`
+	 *
+	 * [Astro documentation](https://docs.astro.build/en/reference/api-reference/#astrosite)
+	 */
 	site: URL;
 }
 

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -104,7 +104,7 @@ export interface AstroGlobal extends AstroGlobalPartial {
 	/** List of props passed to this component
 	 *
 	 * A common way to get specific props is through [destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment), ex:
-	 * ```javascript
+	 * ```typescript
 	 * const { name } = Astro.props
 	 * ```
 	 *
@@ -113,8 +113,8 @@ export interface AstroGlobal extends AstroGlobalPartial {
 	props: Record<string, number | string | any>;
 	/** Information about the current request. This is a standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object
 	 *
-	 * For example, to get an URL object of the current URL, you can use:
-	 * ```javascript
+	 * For example, to get a URL object of the current URL, you can use:
+	 * ```typescript
 	 * const url = new URL(Astro.request.url);
 	 * ```
 	 *
@@ -192,7 +192,7 @@ export interface AstroGlobalPartial {
 	glob<T extends Record<string, any>>(globStr: `${any}.md`): Promise<MarkdownInstance<T>[]>;
 	glob<T extends Record<string, any>>(globStr: string): Promise<T[]>;
 	/**
-	 * Returns an [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) object built from the [site](https://docs.astro.build/en/reference/configuration-reference/#site) config option
+	 * Returns a [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) object built from the [site](https://docs.astro.build/en/reference/configuration-reference/#site) config option
 	 *
 	 * If `site` is undefined, the URL object will instead be built from `localhost`
 	 *

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -82,13 +82,30 @@ export interface AstroGlobal extends AstroGlobalPartial {
 	 * [Astro documentation](https://docs.astro.build/en/reference/api-reference/#astrocanonicalurl)
 	 */
 	canonicalURL: URL;
-	/** get page params (dynamic pages only) */
+	/** Parameters passed to a dynamic page generated using [getStaticPaths](https://docs.astro.build/en/reference/api-reference/#getstaticpaths)
+	 *
+	 * Example usage:
+	 * ```astro
+	 * ---
+	 * export async function getStaticPaths() {
+	 *    return [
+	 *     { params: { id: '1' } },
+	 *   ];
+	 * }
+	 *
+	 * const { id } = Astro.params;
+	 * ---
+	 * <h1>{id}</h1>
+	 * ```
+	 *
+	 * [Astro documentation](https://docs.astro.build/en/reference/api-reference/#params)
+	 */
 	params: Params;
 	/** List of props passed to this component
 	 *
-	 * A common way to get specific props is through destructuring, ex:
+	 * A common way to get specific props is through [destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment), ex:
 	 * ```javascript
-	 *  const { name } = Astro.props
+	 * const { name } = Astro.props
 	 * ```
 	 *
 	 * [Astro documentation](https://docs.astro.build/en/core-concepts/astro-components/#component-props)
@@ -98,13 +115,28 @@ export interface AstroGlobal extends AstroGlobalPartial {
 	 *
 	 * For example, to get an URL object of the current URL, you can use:
 	 * ```javascript
-	 *  const url = new URL(Astro.request.url);
+	 * const url = new URL(Astro.request.url);
 	 * ```
 	 *
 	 * [Astro documentation](https://docs.astro.build/en/reference/api-reference/#astrorequest)
 	 */
 	request: Request;
-	/** see if slots are used */
+	/** Redirect to another page (**SSR Only**)
+	 *
+	 * Example usage:
+	 * ```typescript
+	 * if(!isLoggedIn) {
+	 *   return Astro.redirect('/login');
+	 * }
+	 * ```
+	 *
+	 * [Astro documentation](https://docs.astro.build/en/guides/server-side-rendering/#astroredirect)
+	 */
+	redirect(path: string): Response;
+	/** Utility functions for modifying an Astro component’s slotted children
+	 *
+	 * [Astro documentation](https://docs.astro.build/en/reference/api-reference/#astroslots)
+	 */
 	slots: Record<string, true | undefined> & {
 		/**
 		 * Check whether content for this slot name exists
@@ -112,7 +144,7 @@ export interface AstroGlobal extends AstroGlobalPartial {
 		 * Example usage:
 		 * ```typescript
 		 *	if (Astro.slots.has('default')) {
-		 *		// Do something...
+		 *   // Do something...
 		 *	}
 		 * ```
 		 *
@@ -127,7 +159,7 @@ export interface AstroGlobal extends AstroGlobalPartial {
 		 * ---
 		 * let html: string = '';
 		 * if (Astro.slots.has('default')) {
-		 *		html = await Astro.slots.render('default')
+		 *   html = await Astro.slots.render('default')
 		 * }
 		 * ---
 		 * <Fragment set:html={html} />
@@ -151,7 +183,7 @@ export interface AstroGlobalPartial {
 	 *
 	 * Example usage:
 	 * ```typescript
-	 * const posts = await Astro.glob('../pages/post/*.md'); // returns an array of posts that live at ./src/pages/post/*.md
+	 * const posts = await Astro.glob('../pages/post/*.md');
 	 * ```
 	 *
 	 * [Astro documentation](https://docs.astro.build/en/reference/api-reference/#astroglob)


### PR DESCRIPTION
## Changes

This updates all of our JSDoc comments on public-facing API in Astro files (so, Astro global, its methods etc) in order to improve the hover info we provide to users in the editor

It is not necessary to document client directives and other Astro-attributes as the language-server provides its own description for those using another mechanism (because those kinda lives in "HTML" land)

Example:

**Before** 
![image](https://user-images.githubusercontent.com/3019731/161829542-8064f2d3-9d00-483f-8263-ed0154cdbdc7.png)

**After**
![image](https://user-images.githubusercontent.com/3019731/161829573-eb12302e-9f40-4f2f-a822-965ed54d2703.png)

I am not the best writer in the world regarding those short snippets so really, suggestions are very much welcome!

## Testing

No tests needed

## Docs

I guess, this is technically docs itself..