### PR TITLE
fix: Nested hydration with Solid

### DIFF
--- a/.changeset/ten-rice-unite.md
+++ b/.changeset/ten-rice-unite.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/solid-js": patch
+"@astrojs/renderer-solid": patch
+---
+
+Improve nested hydration with Solid

--- a/packages/integrations/solid/client.js
+++ b/packages/integrations/solid/client.js
@@ -1,14 +1,25 @@
+import { sharedConfig } from 'solid-js';
 import { hydrate, createComponent } from 'solid-js/web';
 
 export default (element) => (Component, props, childHTML) => {
 	let children;
-	if (childHTML != null) {
-		children = document.createElement('astro-fragment');
-		children.innerHTML = childHTML;
-	}
+	hydrate(
+		() =>
+			createComponent(Component, {
+				...props,
+				get children() {
+					if (childHTML != null) {
+						// hydrating
+						if (sharedConfig.context) children = element.querySelector('astro-fragment');
 
-	// Using Solid's `hydrate` method ensures that a `root` is created
-	// in order to properly handle reactivity. It also handles
-	// components that are not native HTML elements.
-	hydrate(() => createComponent(Component, { ...props, children }), element);
+						if (children == null) {
+							children = document.createElement('astro-fragment');
+							children.innerHTML = childHTML;
+						}
+					}
+					return children;
+				},
+			}),
+		element
+	);
 };

--- a/packages/renderers/renderer-solid/client.js
+++ b/packages/renderers/renderer-solid/client.js
@@ -1,14 +1,25 @@
+import { sharedConfig } from 'solid-js';
 import { hydrate, createComponent } from 'solid-js/web';
 
 export default (element) => (Component, props, childHTML) => {
 	let children;
-	if (childHTML != null) {
-		children = document.createElement('astro-fragment');
-		children.innerHTML = childHTML;
-	}
+	hydrate(
+		() =>
+			createComponent(Component, {
+				...props,
+				get children() {
+					if (childHTML != null) {
+						// hydrating
+						if (sharedConfig.context) children = element.querySelector('astro-fragment');
 
-	// Using Solid's `hydrate` method ensures that a `root` is created
-	// in order to properly handle reactivity. It also handles
-	// components that are not native HTML elements.
-	hydrate(() => createComponent(Component, { ...props, children }), element);
+						if (children == null) {
+							children = document.createElement('astro-fragment');
+							children.innerHTML = childHTML;
+						}
+					}
+					return children;
+				},
+			}),
+		element
+	);
 };


### PR DESCRIPTION
## Changes

Updated Solid's client renderer and integration to fix issue with nested hydration, like you'd find in the recursive comments in Hackernews.

Previous behavior recreated static children as DOM elements and inserted them during hydration. This reset hydration state messing with Solid's hydration when nested.

Solid treats any `undefined` value inserted as skip during hydration assuming client will match server eventually, so I just removed the children and it will skip hydration of static children.

This also appears to improve the Solid integration's hydration performance by about 200%.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->