### PR TITLE
fix(#2981): keeps `astro preview` server alive

### DIFF
--- a/.changeset/big-yaks-invite.md
+++ b/.changeset/big-yaks-invite.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix bug causing `astro preview` server to close immediately

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -138,8 +138,8 @@ export async function cli(args: string[]) {
 
 		case 'preview': {
 			try {
-				await preview(config, { logging });
-				return await new Promise(() => {}); // lives forever
+				const server = await preview(config, { logging });
+				return await server.closed(); // keep alive until the server is closed
 			} catch (err) {
 				return throwAndExit(err);
 			}

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -138,7 +138,8 @@ export async function cli(args: string[]) {
 
 		case 'preview': {
 			try {
-				return await preview(config, { logging }); // this will keep running
+				await preview(config, { logging });
+				return await new Promise(() => {}); // lives forever
 			} catch (err) {
 				return throwAndExit(err);
 			}

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -18,6 +18,7 @@ export interface PreviewServer {
 	host?: string;
 	port: number;
 	server: http.Server;
+	closed(): Promise<void>;
 	stop(): Promise<void>;
 }
 
@@ -133,9 +134,18 @@ export default async function preview(
 	// Start listening on `hostname:port`.
 	await startServer(startServerTime);
 
+	// Resolves once the server is closed
+	function closed() {
+		return new Promise<void>((resolve, reject) => {
+			httpServer!.addListener('close', resolve);
+			httpServer!.addListener('error', reject);
+		})
+	}
+
 	return {
 		host,
 		port,
+		closed,
 		server: httpServer!,
 		stop: async () => {
 			await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Changes

Fixes a bug that was preventing the `astro preview` server from staying alive

## Testing

Tested locally

## Docs

Bug fix only