### PR TITLE
Fixes dynamic API routes in SSR

### DIFF
--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -119,7 +119,7 @@ export class App {
 
 	async #callEndpoint(
 		request: Request,
-		_routeData: RouteData,
+		routeData: RouteData,
 		mod: ComponentInstance
 	): Promise<Response> {
 		const url = new URL(request.url);
@@ -129,6 +129,7 @@ export class App {
 			origin: url.origin,
 			pathname: url.pathname,
 			request,
+			route: routeData,
 			routeCache: this.#routeCache,
 			ssr: true,
 		});

--- a/packages/astro/test/fixtures/ssr-dynamic/src/pages/api/products/[id].js
+++ b/packages/astro/test/fixtures/ssr-dynamic/src/pages/api/products/[id].js
@@ -1,0 +1,6 @@
+
+export function get(params) {
+	return {
+		body: JSON.stringify(params)
+	};
+}

--- a/packages/astro/test/ssr-dynamic.test.js
+++ b/packages/astro/test/ssr-dynamic.test.js
@@ -27,6 +27,14 @@ describe('Dynamic pages in SSR', () => {
 		return html;
 	}
 
+	async function fetchJSON(path) {
+		const app = await fixture.loadTestAdapterApp();
+		const request = new Request('http://example.com' + path);
+		const response = await app.render(request);
+		const json = await response.json();
+		return json;
+	}
+
 	it('Do not have to implement getStaticPaths', async () => {
 		const html = await fetchHTML('/123');
 		const $ = cheerioLoad(html);
@@ -37,5 +45,10 @@ describe('Dynamic pages in SSR', () => {
 		const html = await fetchHTML('/123');
 		const $ = cheerioLoad(html);
 		expect($('link').length).to.equal(1);
+	});
+
+	it('Dynamic API routes work', async () => {
+		const json = await fetchJSON('/api/products/33');
+		expect(json.id).to.equal('33');
 	});
 });


### PR DESCRIPTION
## Changes

- Passes the `routeData` into endpoints, so it can get the params to pass into the API route.

## Testing

- Test added

## Docs

N/A, bug fix