### PR TITLE
fix(integrations): `astro:build:done` dir now matches SSR client output

### DIFF
--- a/.changeset/empty-pens-talk.md
+++ b/.changeset/empty-pens-talk.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+'@astrojs/partytown': patch
+'@astrojs/vercel': patch
+---
+
+Updated integrations' `astro:build:done` hook: now it matches the client dist when using SSR

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -174,6 +174,7 @@ class AstroBuilder {
 		await viteServer.close();
 		await runHookBuildDone({
 			config: this.config,
+			buildConfig,
 			pages: pageNames,
 			routes: Object.values(allPages).map((pd) => pd.route),
 		});

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -4,6 +4,7 @@ import { AstroConfig, AstroRenderer, BuildConfig, RouteData } from '../@types/as
 import { mergeConfig } from '../core/config.js';
 import ssgAdapter from '../adapter-ssg/index.js';
 import type { ViteConfigWithSSR } from '../core/create-vite.js';
+import { isBuildingToSSR } from '../core/util.js';
 
 export async function runHookConfigSetup({
 	config: _config,
@@ -136,18 +137,22 @@ export async function runHookBuildSetup({
 
 export async function runHookBuildDone({
 	config,
+	buildConfig,
 	pages,
 	routes,
 }: {
 	config: AstroConfig;
+	buildConfig: BuildConfig;
 	pages: string[];
 	routes: RouteData[];
 }) {
+	const dir = isBuildingToSSR(config) ? buildConfig.client : config.outDir;
+
 	for (const integration of config.integrations) {
 		if (integration.hooks['astro:build:done']) {
 			await integration.hooks['astro:build:done']({
 				pages: pages.map((p) => ({ pathname: p })),
-				dir: config.outDir,
+				dir,
 				routes,
 			});
 		}

--- a/packages/integrations/partytown/src/index.ts
+++ b/packages/integrations/partytown/src/index.ts
@@ -32,8 +32,8 @@ export default function createPlugin(): AstroIntegration {
 					})
 				);
 			},
-			'astro:build:done': async () => {
-				await copyLibFiles(fileURLToPath(new URL('~partytown', config.outDir)), {
+			'astro:build:done': async ({ dir }) => {
+				await copyLibFiles(fileURLToPath(new URL('~partytown', dir)), {
 					debugDir: false,
 				});
 			},

--- a/packages/integrations/vercel/src/index.ts
+++ b/packages/integrations/vercel/src/index.ts
@@ -35,7 +35,7 @@ export default function vercel(): AstroIntegration {
 				buildConfig.client = new URL('./static/', _config.outDir);
 				buildConfig.server = new URL('./server/tmp/', _config.outDir);
 			},
-			'astro:build:done': async ({ dir, routes }) => {
+			'astro:build:done': async ({ routes }) => {
 				/*
 					Why do we need two folders? Why don't we just generate all inside `server/pages/`?
 					When the app builds, it throws some metadata inside a `chunks/` folder.
@@ -50,8 +50,8 @@ export default function vercel(): AstroIntegration {
 					need to bundle as much as possible in one file. Hence, the following code
 				*/
 
-				const tmpDir = new URL('./server/tmp/', dir);
-				const bundleDir = new URL('./server/pages/', dir);
+				const tmpDir = new URL('./server/tmp/', _config.outDir);
+				const bundleDir = new URL('./server/pages/', _config.outDir);
 
 				await fs.mkdir(bundleDir, { recursive: true });
 
@@ -69,7 +69,7 @@ export default function vercel(): AstroIntegration {
 
 				// Routes Manifest
 				// https://vercel.com/docs/file-system-api#configuration/routes
-				await writeJson(new URL(`./routes-manifest.json`, dir), {
+				await writeJson(new URL(`./routes-manifest.json`, _config.outDir), {
 					version: 3,
 					basePath: '/',
 					pages404: false,


### PR DESCRIPTION
## Changes

In the case of the Vercel integration, the static files are outputted to `.output/static/`, whereas, for example, the Sitemap integration was saving its output inside `.output/`. This PR fixes that case

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->