### PR TITLE
Allow an adapter to export default

### DIFF
--- a/.changeset/forty-boats-remain.md
+++ b/.changeset/forty-boats-remain.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/vercel': patch
+---
+
+Allows adapters to export default

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -45,8 +45,14 @@ const _args = ${adapter.args ? JSON.stringify(adapter.args) : 'undefined'};
 ${
 	adapter.exports
 		? `const _exports = adapter.createExports(_manifest, _args);
-${adapter.exports.map((name) => `export const ${name} = _exports['${name}'];`).join('\n')}
-${adapter.exports.includes('_default') ? `export default _default` : ''}
+${adapter.exports.map((name) => {
+	if(name === 'default') {
+		return `const _default = _exports['default'];
+export { _default as default };`;
+	} else {
+		return `export const ${name} = _exports['${name}'];`
+	}
+}).join('\n')}
 `
 		: ''
 }

--- a/packages/integrations/vercel/src/index.ts
+++ b/packages/integrations/vercel/src/index.ts
@@ -13,7 +13,7 @@ export function getAdapter(): AstroAdapter {
 	return {
 		name: '@astrojs/vercel',
 		serverEntrypoint: '@astrojs/vercel/server-entrypoint',
-		exports: ['_default'],
+		exports: ['default'],
 	};
 }
 

--- a/packages/integrations/vercel/src/server-entrypoint.ts
+++ b/packages/integrations/vercel/src/server-entrypoint.ts
@@ -12,7 +12,7 @@ polyfill(globalThis, {
 export const createExports = (manifest: SSRManifest) => {
 	const app = new App(manifest);
 
-	const _default = async (req: IncomingMessage, res: ServerResponse) => {
+	const handler = async (req: IncomingMessage, res: ServerResponse) => {
 		let request: Request;
 
 		try {
@@ -30,5 +30,5 @@ export const createExports = (manifest: SSRManifest) => {
 		await setResponse(res, await app.render(request));
 	};
 
-	return { _default };
+	return { 'default': handler };
 };


### PR DESCRIPTION
## Changes

- Adapters were not able to export `default` and some need to.
- A workaround was added for Vercel where `_default` became the default export.
- This was not obvious and not documented, so better just to allow a default export. This fixes that.

## Testing

- Test adapter exports a default which exposed the bug.

## Docs

N/A, already covered by the adapter docs (just fixes a bug).