### PR TITLE
Fixes adding set-cookie headers multiple times

### DIFF
--- a/.changeset/calm-dolphins-remain.md
+++ b/.changeset/calm-dolphins-remain.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix for adding set-cookie multiple times

--- a/packages/astro/test/fixtures/ssr-api-route/src/pages/login.js
+++ b/packages/astro/test/fixtures/ssr-api-route/src/pages/login.js
@@ -1,0 +1,11 @@
+
+export function post() {
+  const headers = new Headers();
+  headers.append('Set-Cookie', `foo=foo; HttpOnly`);
+  headers.append('Set-Cookie', `bar=bar; HttpOnly`);
+
+  return new Response('', {
+    status: 201,
+    headers,
+  });
+}

--- a/packages/astro/test/ssr-api-route.test.js
+++ b/packages/astro/test/ssr-api-route.test.js
@@ -56,5 +56,13 @@ describe('API routes in SSR', () => {
 			const text = await response.text();
 			expect(text).to.equal(`ok`);
 		});
+
+		it('Can set multiple headers of the same type', async () => {
+			const response = await fixture.fetch('/login', {
+				method: 'POST',
+			});
+			const setCookie = response.headers.get('set-cookie');
+			expect(setCookie).to.equal('foo=foo; HttpOnly, bar=bar; HttpOnly');
+		});
 	});
 });


### PR DESCRIPTION
## Changes

- Fixes #3024
- Turns out the fetch standard doesn't provide a way to get multiple of the same header. Even though you can `.append()` them, you can't read out each value.
- Luckily node-fetch has a workaround, which is being used here.

## Testing

Test added

## Docs

N/A, bug fix.