### PR TITLE
Fix SSR static build public file copying. fixes #3016

### DIFF
--- a/.changeset/metal-grapes-tickle.md
+++ b/.changeset/metal-grapes-tickle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix SSR static build public files copying

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -257,8 +257,8 @@ async function copyFiles(fromFolder: URL, toFolder: URL) {
 		files.map(async (filename) => {
 			const from = new URL(filename, fromFolder);
 			const to = new URL(filename, toFolder);
-			const toSubPath = new URL(npath.dirname(filename), toFolder)
-			return fs.promises.mkdir(toSubPath, {recursive: true})
+			const lastFolder = new URL('./', to)
+			return fs.promises.mkdir(lastFolder, {recursive: true})
 							.then(()=>fs.promises.copyFile(from, to) )
 			})
 	);

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -253,15 +253,14 @@ async function copyFiles(fromFolder: URL, toFolder: URL) {
 		cwd: fileURLToPath(fromFolder),
 	});
 
-	// Make the directory
-	await fs.promises.mkdir(toFolder, { recursive: true });
-
 	await Promise.all(
 		files.map(async (filename) => {
 			const from = new URL(filename, fromFolder);
 			const to = new URL(filename, toFolder);
-			return fs.promises.copyFile(from, to);
-		})
+			const toSubPath = new URL(npath.dirname(filename), toFolder)
+			return fs.promises.mkdir(toSubPath, {recursive: true})
+							.then(()=>fs.promises.copyFile(from, to) )
+			})
 	);
 }
 

--- a/packages/astro/test/fixtures/static build SSR/astro.config.mjs
+++ b/packages/astro/test/fixtures/static build SSR/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+import nodejs from '@astrojs/node';
+
+export default defineConfig({
+	adapter: nodejs(),
+});

--- a/packages/astro/test/fixtures/static build SSR/package.json
+++ b/packages/astro/test/fixtures/static build SSR/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/static-build",
+  "version": "0.0.0",
+  "dependencies": {
+    "@astrojs/node": "workspace:*",
+    "@test/static-build-pkg": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/static build SSR/public/asset.txt
+++ b/packages/astro/test/fixtures/static build SSR/public/asset.txt
@@ -1,0 +1,1 @@
+test asset

--- a/packages/astro/test/fixtures/static build SSR/public/nested/asset2.txt
+++ b/packages/astro/test/fixtures/static build SSR/public/nested/asset2.txt
@@ -1,0 +1,1 @@
+test asset

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -138,3 +138,16 @@ describe('Static build', () => {
 		expect($('#ssr-config').text()).to.equal('testing');
 	});
 });
+
+describe('Static build SSR', () => {
+
+	it('Copies public files', async () => {
+		const fixture2 = await loadFixture({
+			root: './fixtures/static build SSR/',
+		});
+		return fixture2.build()	
+			.then(() => { expect('build fulfilled').to.be.ok; })
+			.catch((e) => { expect(`build rejected with :${e}`).to.not.be.ok })
+	});
+
+});

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -142,12 +142,11 @@ describe('Static build', () => {
 describe('Static build SSR', () => {
 
 	it('Copies public files', async () => {
-		const fixture2 = await loadFixture({
+		const fixture = await loadFixture({
 			root: './fixtures/static build SSR/',
 		});
-		return fixture2.build()	
-			.then(() => { expect('build fulfilled').to.be.ok; })
-			.catch((e) => { expect(`build rejected with :${e}`).to.not.be.ok })
+		await fixture.build()
+			const asset = await fixture.readFile('/client/nested/asset2.txt');
 	});
 
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1100,6 +1100,16 @@ importers:
       '@test/static-build-pkg': link:pkg
       astro: link:../../..
 
+  packages/astro/test/fixtures/static build SSR:
+    specifiers:
+      '@astrojs/node': workspace:*
+      '@test/static-build-pkg': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/node': link:../../../../integrations/node
+      '@test/static-build-pkg': link:../static build/pkg
+      astro: link:../../..
+
   packages/astro/test/fixtures/static build/pkg:
     specifiers: {}
 


### PR DESCRIPTION
## Changes

- When SSR is enabled and it's a static build the copying of public files is broken with sub folders
- - fix is to create subfolders as required

## Testing

Test added to static -build.test.js

## Docs

none