### PR TITLE
Add render page hook

### DIFF
--- a/.changeset/warm-cherries-brush.md
+++ b/.changeset/warm-cherries-brush.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Add `astro:render:page` hook to Integration API

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -890,6 +890,13 @@ export interface AstroIntegration {
 			dir: URL;
 			routes: RouteData[];
 		}) => void | Promise<void>;
+		/** Allows processing and modification of all rendered page/endpoint HTML code. */
+		'astro:render:page'?: (options: {
+			config: AstroConfig;
+			routeType: RouteType;
+			pathname: string;
+			html: string;
+		}) => void | Promise<void> | string | Promise<string>;
 	};
 }
 

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -100,6 +100,7 @@ export class App {
 			site: this.#manifest.site,
 			ssr: true,
 			request,
+			astroConfig: this.#manifest.astroConfig,
 		});
 
 		if (result.type === 'response') {
@@ -132,6 +133,7 @@ export class App {
 			route: routeData,
 			routeCache: this.#routeCache,
 			ssr: true,
+			astroConfig: this.#manifest.astroConfig,
 		});
 
 		if (result.type === 'response') {

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -4,6 +4,7 @@ import type {
 	MarkdownRenderOptions,
 	ComponentInstance,
 	SSRLoadedRenderer,
+	AstroConfig,
 } from '../../@types/astro';
 
 export type ComponentPath = string;
@@ -28,6 +29,7 @@ export interface SSRManifest {
 	pageMap: Map<ComponentPath, ComponentInstance>;
 	renderers: SSRLoadedRenderer[];
 	entryModules: Record<string, string>;
+	astroConfig: AstroConfig;
 }
 
 export type SerializedSSRManifest = Omit<SSRManifest, 'routes'> & {

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -227,6 +227,7 @@ async function generatePath(
 			? new URL(astroConfig.base, astroConfig.site).toString()
 			: astroConfig.site,
 		ssr,
+		astroConfig: astroConfig,
 	};
 
 	let body: string;

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -116,6 +116,7 @@ function buildManifest(opts: StaticBuildOptions, internals: BuildInternals): Ser
 		pageMap: null as any,
 		renderers: [],
 		entryModules,
+		astroConfig,
 	};
 
 	return ssrManifest;

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -189,6 +189,7 @@ export async function render(
 		routeCache,
 		site: astroConfig.site ? new URL(astroConfig.base, astroConfig.site).toString() : undefined,
 		ssr: isBuildingToSSR(astroConfig),
+		astroConfig,
 	});
 
 	if (route?.type === 'endpoint' || content.type === 'response') {

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -1,6 +1,6 @@
 import type { AddressInfo } from 'net';
 import type { ViteDevServer } from 'vite';
-import { AstroConfig, AstroRenderer, BuildConfig, RouteData } from '../@types/astro.js';
+import { AstroConfig, AstroRenderer, BuildConfig, RouteData, RouteType } from '../@types/astro.js';
 import { mergeConfig } from '../core/config.js';
 import ssgAdapter from '../adapter-ssg/index.js';
 import type { ViteConfigWithSSR } from '../core/create-vite.js';
@@ -157,4 +157,32 @@ export async function runHookBuildDone({
 			});
 		}
 	}
+}
+
+export async function runHookRenderPage({
+	config,
+	routeType,
+	pathname,
+	html,
+}: {
+	config: AstroConfig;
+	routeType: RouteType;
+	pathname: string;
+	html: string;
+}): Promise<string> {
+	for (const integration of config.integrations) {
+		if (integration.hooks['astro:render:page']) {
+			let newHtml = await integration.hooks['astro:render:page']({
+				config,
+				routeType,
+				pathname,
+				html,
+			});
+			if (newHtml) {
+				html = newHtml;
+			}
+		}
+	}
+	
+	return html;
 }


### PR DESCRIPTION
## Changes

- Add `astro:render:page` hook to Integration API (see https://github.com/withastro/rfcs/discussions/169)

## Testing

No tests have been added yet as this PR is meant to help the RFC discussion. I will gladly add tests if the RFC discussion leads to a positive outcome. I have tested this locally on my machine both in `dev` and `build` without any issues.

## Docs

As this adds a new Integration API hook, the docs would also need to be updated. I can do that if the feature is given a go.