### PR TITLE
Improve API handler export naming

### DIFF
--- a/.changeset/chilly-terms-smoke.md
+++ b/.changeset/chilly-terms-smoke.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Support the "del" API method, because "delete" is a reserved word.

--- a/.changeset/lazy-kangaroos-rush.md
+++ b/.changeset/lazy-kangaroos-rush.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Add support for an "all" API method, to handle all requests


### PR DESCRIPTION
## Changes

- Add support for the `del` export, since `export function delete() {}` is invalid JS (`delete` is a reserved word).
- Add support for a fallback `export function all() {}` handler that handles all requests (if a specific method export was not given).
- See user feedback in https://discord.com/channels/830184174198718474/852168748353060875/963124824111198238

## Testing

- N/A

## Docs

- Docs needed, I think a PR already exists to add. I'll check that out later today.