### PR TITLE
Make Netlify adapter actually append redirects

### DIFF
--- a/.changeset/lemon-elephants-sell.md
+++ b/.changeset/lemon-elephants-sell.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Make Netlify adapter actually append redirects

--- a/packages/integrations/netlify/src/index.ts
+++ b/packages/integrations/netlify/src/index.ts
@@ -53,11 +53,10 @@ ${pattern}    /.netlify/functions/${entryFile}    200`;
 					}
 				}
 
-				if (fs.existsSync(_redirects)) {
-					await fs.promises.appendFile(_redirectsURL, _redirects, 'utf-8');
-				} else {
-					await fs.promises.writeFile(_redirectsURL, _redirects, 'utf-8');
-				}
+				// Always use appendFile() because the redirects file could already exist,
+				// e.g. due to a `/public/_redirects` file that got copied to the output dir.
+				// If the file does not exist yet, appendFile() automatically creates it.
+				await fs.promises.appendFile(_redirectsURL, _redirects, 'utf-8');
 			},
 		},
 	};


### PR DESCRIPTION
## Changes

The previous code in the `astro:build:done` hook called `fs.existsSync(_redirects)` to check if the redirects target file already exists, before deciding to either call appendFile or writeFile. Unfortunately, `_redirects` is not the file name/URL, but the contents, so this check always failed. The code therefore always used writeFile, effectively overwriting any existing contents of the `_redirects` file.

My code eliminates this check and always uses `appendFile`, which will automatically create the file if it doesn't exist yet (as per the Node.js docs).

If you put your own custom redirects in a `/public/_redirects` file, they will get copied to the build output directory and Astro will now add its own redirects to the end instead of always overwriting the file.

## Testing

The new code was tested locally on Windows 10 by building an example site using the fixed Netlify adapter, both with and without an existing `/public/_redirects` file.

I also ran `pnpm run test --filter @astrojs/netlify` without any errors.

## Docs

This is just a fix, so no documentation is needed per se. It however allows the use case outlined above (putting custom redirects in a `/public/_redirects` file), which wasn't possible before due to the buggy check. Adding custom redirects could optionally be documented as an advanced usage scenario.
