### PR TITLE
fix: `paginate()` didn't have the correct canonicalURL for page `/1/`

### DIFF
--- a/packages/astro/src/core/render/util.ts
+++ b/packages/astro/src/core/render/util.ts
@@ -3,7 +3,6 @@ import npath from 'path-browserify';
 /** Normalize URL to its canonical form */
 export function createCanonicalURL(url: string, base?: string): URL {
 	let pathname = url.replace(/\/index.html$/, ''); // index.html is not canonical
-	pathname = pathname.replace(/\/1\/?$/, ''); // neither is a trailing /1/ (impl. detail of collections)
 	if (!npath.extname(pathname)) pathname = pathname.replace(/(\/+)?$/, '/'); // add trailing slash if there’s no extension
 	pathname = pathname.replace(/\/+/g, '/'); // remove duplicate slashes (URL() won’t)
 	return new URL(pathname, base);

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -53,7 +53,7 @@ describe('Astro.*', () => {
 			const canonicalURLs = {
 				'/index.html': 'https://mysite.dev/blog/',
 				'/post/post/index.html': 'https://mysite.dev/blog/post/post/',
-				'/posts/1/index.html': 'https://mysite.dev/blog/posts/',
+				'/posts/1/index.html': 'https://mysite.dev/blog/posts/1/',
 				'/posts/2/index.html': 'https://mysite.dev/blog/posts/2/',
 			};
 

--- a/packages/astro/test/astro-pagination.test.js
+++ b/packages/astro/test/astro-pagination.test.js
@@ -50,4 +50,16 @@ describe('Pagination', () => {
 			})
 		);
 	});
+
+	it('canonical URLs', async () => {
+		for (const [file, canonicalURL] of [
+			['/posts/red/1/index.html', 'https://mysite.dev/blog/posts/red/1/'],
+			['/posts/blue/1/index.html', 'https://mysite.dev/blog/posts/blue/1/'],
+			['/posts/blue/2/index.html', 'https://mysite.dev/blog/posts/blue/2/'],
+		]) {
+			const html = await fixture.readFile(file);
+			const $ = cheerio.load(html);
+			expect($('link[rel="canonical"]').attr('href')).to.equal(canonicalURL);
+		}
+	});
 });


### PR DESCRIPTION
## Changes

`paginate()` will build the first page with a URL similar to `/1/` but this was being stripped out of `Astro.canonicalURL`

## Testing

pagination test updated to validate canonical URLs

## Docs

None, bug fix only