### PR TITLE
Add script for Vite CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:match": "cd packages/astro && pnpm run test:match",
     "test:templates": "turbo run test --filter=create-astro --concurrency=1",
     "test:smoke": "node scripts/smoke/index.js",
+    "test:vite-ci": "turbo run test --no-deps --scope=astro --concurrency=1",
     "benchmark": "turbo run benchmark --scope=astro",
     "lint": "eslint \"packages/**/*.ts\"",
     "format": "prettier -w .",


### PR DESCRIPTION
## Changes

- This adds a script so that the Vite CI project can only target our core tests.

## Testing

N/A

## Docs

N/A