### PR TITLE
Fix: React hydration failure

### DIFF
--- a/.changeset/clean-cherries-bow.md
+++ b/.changeset/clean-cherries-bow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Expose "metadata" to component integrations renderToStaticMarkup function

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -260,7 +260,7 @@ Did you mean to enable ${formatList(probableRendererNames.map((r) => '`' + r + '
 				// We already know that renderer.ssr.check() has failed
 				// but this will throw a much more descriptive error!
 				renderer = matchingRenderers[0];
-				({ html } = await renderer.ssr.renderToStaticMarkup(Component, props, children));
+				({ html } = await renderer.ssr.renderToStaticMarkup(Component, props, children, metadata));
 			} else {
 				throw new Error(`Unable to render ${metadata.displayName}!
 
@@ -279,7 +279,7 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 		if (metadata.hydrate === 'only') {
 			html = await renderSlot(result, slots?.fallback);
 		} else {
-			({ html } = await renderer.ssr.renderToStaticMarkup(Component, props, children));
+			({ html } = await renderer.ssr.renderToStaticMarkup(Component, props, children, metadata));
 		}
 	}
 


### PR DESCRIPTION
## Changes
- resolves #3047
- resolves #3086
- `metadata` was no longer exposed to our SSR `renderToStaticMarkup` functions. This restores the object for our React integration to use

## Testing

N/A

## Docs

N/A