### PR TITLE
folder-level special frontmatter for MD files

### DIFF
--- a/.changeset/good-mangos-work.md
+++ b/.changeset/good-mangos-work.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Enable MD files to grab layout|components|setup special frontmatter from a shared folder-level config


### PR DESCRIPTION
## Changes

vite markdown plugin was updated to enable reading special frontmatter `layout`, `components`, `setup` from a special file `_config.json` that exists in the same folder as the MD file. All MD files in the same folder will load this frontmatter fields.

```json
{
  "layout": "../../layouts/BlogPost.astro",
  "components": "",
  "setup": ""
}
```

Specifying the fields in the MD frontmatter will override values in the shared JSON file.


## Testing

This was tested in the Blog template, by replacing the updated file (minus the TypeScript because it is a `.js` instead of `.ts`)

## Docs

If PR is accepted, I can work on the docs site to document how this new functionality is enabled and used.