### PR TITLE
Fixing bug that could lose Tailwind's default presets

### DIFF
--- a/.changeset/tame-lamps-roll.md
+++ b/.changeset/tame-lamps-roll.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/tailwind': minor
+---
+
+Removes the `applyAstroPreset` integration option. Tailwind presets can be disabled directly from the Tailwind config file by including `presets: []`
+
+See the [Tailwind preset docs](https://tailwindcss.com/docs/presets#disabling-the-default-configuration) for more details.

--- a/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
+++ b/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
@@ -11,7 +11,7 @@ import Complex from '../components/Complex.astro';
 		<title>Astro + TailwindCSS</title>
 	</head>
 
-	<body>
+	<body class="bg-dawn text-midnight">
 		<Button>I’m a Tailwind Button!</Button>
 		<Complex />
 	</body>

--- a/packages/astro/test/fixtures/tailwindcss/tailwind.config.js
+++ b/packages/astro/test/fixtures/tailwindcss/tailwind.config.js
@@ -2,4 +2,11 @@ const path = require('path');
 
 module.exports = {
 	content: [path.join(__dirname, 'src/**/*.{astro,html,js,jsx,svelte,ts,tsx,vue}')],
+	theme: {
+		colors: {
+			dawn: '#f3e9fa',
+			dusk: '#514375',
+			midnight: '#31274a',
+		}
+	}
 };

--- a/packages/astro/test/fixtures/tailwindcss/tailwind.config.js
+++ b/packages/astro/test/fixtures/tailwindcss/tailwind.config.js
@@ -3,10 +3,12 @@ const path = require('path');
 module.exports = {
 	content: [path.join(__dirname, 'src/**/*.{astro,html,js,jsx,svelte,ts,tsx,vue}')],
 	theme: {
-		colors: {
-			dawn: '#f3e9fa',
-			dusk: '#514375',
-			midnight: '#31274a',
+		extend: {
+			colors: {
+				dawn: '#f3e9fa',
+				dusk: '#514375',
+				midnight: '#31274a',
+			}
 		}
 	}
 };

--- a/packages/astro/test/tailwindcss.test.js
+++ b/packages/astro/test/tailwindcss.test.js
@@ -41,6 +41,14 @@ describe('Tailwind', () => {
 			expect(bundledCSS, 'supports arbitrary value classes').to.match(
 				/\.font-\\\[900\\\]{font-weight:900}/
 			);
+
+			// custom theme colors were included
+			expect(bundledCSS, 'includes custom theme colors').to.match(
+				/\.text-midnight{/
+			);
+			expect(bundledCSS, 'includes custom theme colors').to.match(
+				/\.bg-dusk{/
+			);
 		});
 
 		it('maintains classes in HTML', async () => {
@@ -98,6 +106,14 @@ describe('Tailwind', () => {
 
 			// tailwind escapes brackets, `font-[900]` compiles to `font-\[900\]`
 			expect(text, 'supports arbitrary value classes').to.match(/.font-\\[900\\]/);
+
+			// custom theme colors were included
+			expect(bundledCSS, 'includes custom theme colors').to.match(
+				/\.text-midnight/
+			);
+			expect(bundledCSS, 'includes custom theme colors').to.match(
+				/\.bg-dusk/
+			);
 		});
 
 		it('maintains classes in HTML', async () => {

--- a/packages/astro/test/tailwindcss.test.js
+++ b/packages/astro/test/tailwindcss.test.js
@@ -47,7 +47,7 @@ describe('Tailwind', () => {
 				/\.text-midnight{/
 			);
 			expect(bundledCSS, 'includes custom theme colors').to.match(
-				/\.bg-dusk{/
+				/\.bg-dawn{/
 			);
 		});
 
@@ -108,11 +108,11 @@ describe('Tailwind', () => {
 			expect(text, 'supports arbitrary value classes').to.match(/.font-\\[900\\]/);
 
 			// custom theme colors were included
-			expect(bundledCSS, 'includes custom theme colors').to.match(
+			expect(text, 'includes custom theme colors').to.match(
 				/\.text-midnight/
 			);
-			expect(bundledCSS, 'includes custom theme colors').to.match(
-				/\.bg-dusk/
+			expect(text, 'includes custom theme colors').to.match(
+				/\.bg-dawn/
 			);
 		});
 

--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -76,23 +76,6 @@ export default {
 }
 ```
 
-### config.applyAstroPreset
-
-By default, when a custom `tailwind.config.js` file is used this integration will still append some configuration as a `preset` in the final configuration. This default configuration provides the correct `content` property so that Tailwind knows what files to scan in Astro projects (`src/**/*.{astro,html,js,jsx,svelte,ts,tsx,vue}`).
-
-You can disable this by setting `config.applyAstroPreset` to false. enable Tailwind across all Astro files and [UI framework components](https://docs.astro.build/en/core-concepts/framework-components/). To remove this default, opt-out via the `config.applyAstroPreset` integration option:
-
-```js
-// astro.config.mjs
-export default {
-  integrations: [tailwind({
-    // Example: Disable adding Astro configuration as a preset.
-    // Only useful if a custom tailwind.config.js file is used.
-    config: { applyAstroPreset: false },
-  })],
-}
-```
-
 ### config.applyBaseStyles
 
 By default, the integration imports a basic `base.css` file on every page of your project. This basic CSS file includes the three main `@tailwind` directives:

--- a/packages/integrations/tailwind/src/index.ts
+++ b/packages/integrations/tailwind/src/index.ts
@@ -14,6 +14,7 @@ function getDefaultTailwindConfig(srcUrl: URL): TailwindConfig {
 		},
 		plugins: [],
 		content: [path.join(fileURLToPath(srcUrl), `**`, `*.{astro,html,js,jsx,svelte,ts,tsx,vue}`)],
+		presets: undefined // enable Tailwind's default preset
 	});
 }
 
@@ -38,12 +39,6 @@ type TailwindOptions =
 				 */
 				path?: string;
 				/**
-				 * Apply Astro's default Tailwind config as a preset
-				 * This is recommended to enable Tailwind across all components and Astro files
-				 * @default true
-				 */
-				applyAstroPreset?: boolean;
-				/**
 				 * Apply Tailwind's base styles
 				 * Disabling this is useful when further customization of Tailwind styles
 				 * and directives is required. See {@link https://tailwindcss.com/docs/functions-and-directives#tailwind Tailwind's docs}
@@ -56,7 +51,6 @@ type TailwindOptions =
 	| undefined;
 
 export default function tailwindIntegration(options: TailwindOptions): AstroIntegration {
-	const applyAstroConfigPreset = options?.config?.applyAstroPreset ?? true;
 	const applyBaseStyles = options?.config?.applyBaseStyles ?? true;
 	const customConfigPath = options?.config?.path;
 	return {
@@ -76,14 +70,6 @@ export default function tailwindIntegration(options: TailwindOptions): AstroInte
 
 				const tailwindConfig: TailwindConfig =
 					(userConfig?.value as TailwindConfig) ?? getDefaultTailwindConfig(config.srcDir);
-				if (applyAstroConfigPreset && userConfig?.value) {
-					// apply Astro config as a preset to user config
-					// this avoids merging or applying nested spread operators ourselves
-					tailwindConfig.presets = [
-						getDefaultTailwindConfig(config.srcDir),
-						...(tailwindConfig.presets || []),
-					];
-				}
 
 				config.style.postcss.plugins.push(tailwindPlugin(tailwindConfig));
 				config.style.postcss.plugins.push(autoprefixerPlugin);


### PR DESCRIPTION
## Changes

Closes #3043

`@astrojs/tailwind` was defaulting presets to `[]` which actually tells Tailwind to [remove the default presets](https://tailwindcss.com/docs/presets#disabling-the-default-configuration) of colors, sizes, etc.

This change removes the `applyAstroConfigPreset` option, instead of our own custom flag users can disable the built-in preset in the Tailwind config as usual by including `presets: []` themselves

## Testing

- Tailwind test updated to make sure custom colors are included in the build
- Tested locally with astro.build, which has a pretty extensive [tailwind.config.js](https://github.com/withastro/astro.build/blob/main/tailwind.config.js)

## Docs

Updated the integration README (no docs site updates needed)

---

## Bug details

Forcing `presets: undefined` in our default Tailwind config makes sure that the presets are enabled by default.  What was happening in #3043 is that the user config customized the theme and didn't include the `presets` config option (pretty normal not to use that option).  Our integration ended up with a customized theme and `presets: []`, which inadvertantly threw out all Tailwind presets.

With this update, users can use their own Tailwind config file to disable presets if they really need to