### PR TITLE
Add `build:ci` script to integrations

### DIFF
--- a/packages/integrations/deno/package.json
+++ b/packages/integrations/deno/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
     "test": "deno test --allow-run --allow-read --allow-net ./test/"
   },

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
     "test": "mocha --exit --timeout 20000"
   },

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {


### PR DESCRIPTION
## Changes

- Adds required `build:ci` command that Vite Ecosystem CI needs

## Testing

Will see once merged

## Docs

N/A