### PR TITLE
respect externals in vercel adapter

### DIFF
--- a/packages/integrations/vercel/src/index.ts
+++ b/packages/integrations/vercel/src/index.ts
@@ -63,6 +63,20 @@ export default function vercel(): AstroIntegration {
 					format: 'cjs',
 					platform: 'node',
 					target: 'node14',
+					plugins: [
+						{
+							name: 'make-all-packages-external',
+							setup(build) {
+								build.onResolve(
+									{
+										// Must not start with "/" or "./" or "../"
+										filter: /^[^.\/]|^\.[^.\/]|^\.\.[^\/]/,
+									},
+									(args) => ({ path: args.path, external: true })
+								);
+							},
+						},
+					],
 				});
 
 				await fs.rm(tmpDir, { recursive: true });


### PR DESCRIPTION
## Changes

- I was helping @TheoBr with puppeteer and ran into this issue.
- I marked `"chrome-aws-lambda", "puppeteer-core"` as external in my Astro config, but then the vercel adapter blew this away and bundled them all again.
- This is a quick fix. @JuanM04 is there a reason to use `esbuild.build()` instead of `esbuild.transform()` since we're only ever transforming a single file from ESM -> CJS?
