### PR TITLE
Add client:only CSS to their pages

### DIFF
--- a/.changeset/forty-goats-warn.md
+++ b/.changeset/forty-goats-warn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes client:only CSS

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -1,7 +1,8 @@
-import type { RouteData } from '../../@types/astro';
+import type { AstroConfig, RouteData } from '../../@types/astro';
 import type { RenderedChunk } from 'rollup';
 import type { PageBuildData, ViteID } from './types';
 
+import { fileURLToPath } from 'url';
 import { viteID } from '../util.js';
 
 export interface BuildInternals {
@@ -24,6 +25,11 @@ export interface BuildInternals {
 	 * A map for page-specific information by Vite ID (a path-like string)
 	 */
 	pagesByViteID: Map<ViteID, PageBuildData>;
+
+	/**
+	 * A map for page-specific information by a client:only component
+	 */
+	pagesByClientOnly: Map<string, Set<PageBuildData>>;
 
 	/**
 	 * chunkToReferenceIdMap maps them to a hash id used to find the final file.
@@ -73,6 +79,7 @@ export function createBuildInternals(): BuildInternals {
 
 		pagesByComponent: new Map(),
 		pagesByViteID: new Map(),
+		pagesByClientOnly: new Map(),
 	};
 }
 
@@ -88,6 +95,30 @@ export function trackPageData(
 	internals.pagesByViteID.set(viteID(componentURL), pageData);
 }
 
+/**
+ * Tracks client-only components to the pages they are associated with.
+ */
+export function trackClientOnlyPageDatas(
+	internals: BuildInternals,
+	pageData: PageBuildData,
+	clientOnlys: string[],
+	astroConfig: AstroConfig,
+) {
+	for(const clientOnlyComponent of clientOnlys) {
+		const coPath = fileURLToPath(new URL('.' + clientOnlyComponent, astroConfig.root));
+		let pageDataSet: Set<PageBuildData>;
+		if(internals.pagesByClientOnly.has(coPath)) {
+			pageDataSet = internals.pagesByClientOnly.get(coPath)!;
+		} else {
+			pageDataSet = new Set<PageBuildData>();
+			internals.pagesByClientOnly.set(coPath, pageDataSet);
+		}
+		pageDataSet.add(pageData);
+	}
+}
+
+
+
 export function* getPageDatasByChunk(
 	internals: BuildInternals,
 	chunk: RenderedChunk
@@ -96,6 +127,22 @@ export function* getPageDatasByChunk(
 	for (const [modulePath] of Object.entries(chunk.modules)) {
 		if (pagesByViteID.has(modulePath)) {
 			yield pagesByViteID.get(modulePath)!;
+		}
+	}
+}
+
+export function* getPageDatasByClientOnlyChunk(
+	internals: BuildInternals,
+	chunk: RenderedChunk
+): Generator<PageBuildData, void, unknown> {
+	const pagesByClientOnly = internals.pagesByClientOnly;
+	if(pagesByClientOnly.size) {
+		for (const [modulePath] of Object.entries(chunk.modules)) {
+			if (pagesByClientOnly.has(modulePath)) {
+				for(const pageData of pagesByClientOnly.get(modulePath)!) {
+					yield pageData;
+				}
+			}
 		}
 	}
 }

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -105,7 +105,7 @@ export function trackClientOnlyPageDatas(
 	astroConfig: AstroConfig,
 ) {
 	for(const clientOnlyComponent of clientOnlys) {
-		const coPath = fileURLToPath(new URL('.' + clientOnlyComponent, astroConfig.root));
+		const coPath = viteID(new URL('.' + clientOnlyComponent, astroConfig.root));
 		let pageDataSet: Set<PageBuildData>;
 		if(internals.pagesByClientOnly.has(coPath)) {
 			pageDataSet = internals.pagesByClientOnly.get(coPath)!;

--- a/packages/astro/test/astro-client-only.test.js
+++ b/packages/astro/test/astro-client-only.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import cheerio from 'cheerio';
+import { load as cheerioLoad } from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Client only components', () => {
@@ -14,7 +14,7 @@ describe('Client only components', () => {
 
 	it('Loads pages using client:only hydrator', async () => {
 		const html = await fixture.readFile('/index.html');
-		const $ = cheerio.load(html);
+		const $ = cheerioLoad(html);
 
 		// test 1: <astro-root> is empty
 		expect($('astro-root').html()).to.equal('');
@@ -24,4 +24,10 @@ describe('Client only components', () => {
 		// test 2: svelte renderer is on the page
 		expect(/import\(".\/entry.*/g.test(script)).to.be.ok;
 	});
+
+	it('Adds the CSS to the page', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerioLoad(html);
+		expect($('link[rel=stylesheet]')).to.have.lengthOf(2);
+	})
 });

--- a/packages/astro/test/fixtures/astro-client-only/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-client-only/astro.config.mjs
@@ -1,7 +1,8 @@
 import { defineConfig } from 'astro/config';
 import svelte from '@astrojs/svelte';
+import react from '@astrojs/react';
 
 // https://astro.build/config
 export default defineConfig({
-	integrations: [svelte()],
+	integrations: [svelte(), react()],
 });

--- a/packages/astro/test/fixtures/astro-client-only/package.json
+++ b/packages/astro/test/fixtures/astro-client-only/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@astrojs/svelte": "workspace:*",
+    "@astrojs/react": "workspace:*",
     "astro": "workspace:*"
   }
 }

--- a/packages/astro/test/fixtures/astro-client-only/src/components/JSXComponent.jsx
+++ b/packages/astro/test/fixtures/astro-client-only/src/components/JSXComponent.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import './global.css';
+
+export default function() {
+	return <div>i am react</div>
+}

--- a/packages/astro/test/fixtures/astro-client-only/src/components/PersistentCounter.svelte
+++ b/packages/astro/test/fixtures/astro-client-only/src/components/PersistentCounter.svelte
@@ -12,7 +12,11 @@
     count -= 1;
   }
 </script>
-
+<style>
+	button {
+		background: yellowgreen;
+	}
+</style>
 <div class="counter">
   <button on:click={subtract}>-</button>
   <pre>{ count }</pre>

--- a/packages/astro/test/fixtures/astro-client-only/src/components/global.css
+++ b/packages/astro/test/fixtures/astro-client-only/src/components/global.css
@@ -1,0 +1,3 @@
+body {
+	font-family: 'Courier New', Courier, monospace;
+}

--- a/packages/astro/test/fixtures/astro-client-only/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-client-only/src/pages/index.astro
@@ -1,9 +1,11 @@
 ---
 import PersistentCounter from '../components/PersistentCounter.svelte';
+import ReactComponent from '../components/JSXComponent.jsx';
 ---
 <html>
 <head><title>Client only pages</title></head>
 <body>
   <PersistentCounter client:only />
+	<ReactComponent client:only="react" />
 </body>
 </html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,9 +684,11 @@ importers:
 
   packages/astro/test/fixtures/astro-client-only:
     specifiers:
+      '@astrojs/react': workspace:*
       '@astrojs/svelte': workspace:*
       astro: workspace:*
     dependencies:
+      '@astrojs/react': link:../../../../integrations/react
       '@astrojs/svelte': link:../../../../integrations/svelte
       astro: link:../../..
 


### PR DESCRIPTION
## Changes

- Adds tracking for client:only usage and adds their CSS to pages they belong to
- Thanks to @bholmesdev for pairing with me on this!
- Fixes #2966
- Fixes #2225

## Testing

- Added a test case to our css:only test

## Docs

N/A, bug fix