### PR TITLE
Fix: component styles within imported markdown files

### DIFF
--- a/.changeset/tidy-poems-occur.md
+++ b/.changeset/tidy-poems-occur.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix: Astro components used in dynamically imported markdown (ex. Astro.glob('\*.md') will now retain their CSS styles in dev and production builds

--- a/packages/astro/src/core/render/dev/css.ts
+++ b/packages/astro/src/core/render/dev/css.ts
@@ -36,7 +36,7 @@ export async function getStylesForURL(
 				let upToDateEntry = entry;
 				if (!entry.ssrTransformResult) {
 					await viteServer.ssrLoadModule(entry.id);
-					upToDateEntry = viteServer.moduleGraph.getModuleById(id)!;
+					upToDateEntry = viteServer.moduleGraph.getModuleById(id) ?? entry;
 				}
 				scanned.add(id);
 				for (const importedModule of upToDateEntry.importedModules) {

--- a/packages/astro/src/core/render/dev/css.ts
+++ b/packages/astro/src/core/render/dev/css.ts
@@ -44,8 +44,12 @@ export async function getStylesForURL(
 					// some dynamically imported modules are *not* server rendered in time
 					// to only SSR modules that we can safely transform, we check against
 					// a list of file extensions based on our built-in vite plugins
-					if (importedModule.id && fileExtensionsToSSR.has(path.extname(importedModule.id))) {
-						await viteServer.ssrLoadModule(importedModule.id);
+					if (importedModule.id) {
+						// use URL to strip special query params like "?content"
+						const { pathname } = new URL(`file://${importedModule.id}`);
+						if (fileExtensionsToSSR.has(path.extname(pathname))) {
+							await viteServer.ssrLoadModule(importedModule.id);
+						}
 					}
 					importedModules.add(importedModule);
 				}

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -139,7 +139,7 @@ export async function render(
 	// Pass framework CSS in as link tags to be appended to the page.
 	let links = new Set<SSRElement>();
 	if (!isLegacyBuild) {
-		[...getStylesForURL(filePath, viteServer)].forEach((href) => {
+		[...(await getStylesForURL(filePath, viteServer))].forEach((href) => {
 			if (mode === 'development' && svelteStylesRE.test(href)) {
 				scripts.add({
 					props: { type: 'module', src: href },
@@ -211,7 +211,7 @@ export async function render(
 
 	// inject CSS
 	if (isLegacyBuild) {
-		[...getStylesForURL(filePath, viteServer)].forEach((href) => {
+		[...(await getStylesForURL(filePath, viteServer))].forEach((href) => {
 			if (mode === 'development' && svelteStylesRE.test(href)) {
 				tags.push({
 					tag: 'script',

--- a/packages/astro/src/vite-plugin-build-css/index.ts
+++ b/packages/astro/src/vite-plugin-build-css/index.ts
@@ -72,7 +72,7 @@ export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin {
 
 		const info = ctx.getModuleInfo(id);
 		if (info) {
-			for (const importedId of info.importedIds) {
+			for (const importedId of [...info.importedIds, ...info.dynamicallyImportedIds]) {
 				if (!seen.has(importedId) && !isRawOrUrlModule(importedId)) {
 					yield* walkStyles(ctx, importedId, seen);
 				}

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -66,7 +66,7 @@ export default function markdown({ config }: AstroPluginOptions): Plugin {
 			if (id.endsWith('.md') && !isRootImport(importer)) {
 				const resolvedId = await this.resolve(id, importer, { skipSelf: true, ...options });
 				if (resolvedId) {
-					return resolvedId?.id + IMPORTED_MODULE_FLAG;
+					return resolvedId.id + IMPORTED_MODULE_FLAG;
 				}
 			}
 			// In all other cases, we do nothing and rely on normal Vite resolution.

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -16,7 +16,7 @@ interface AstroPluginOptions {
 	config: AstroConfig;
 }
 
-const IMPORTED_MODULE_FLAG = '?astro:markdown:imported';
+const IMPORTED_MODULE_FLAG = '?astroMarkdownImported';
 
 // TODO: Clean up some of the shared logic between this Markdown plugin and the Astro plugin.
 // Both end up connecting a `load()` hook to the Astro compiler, and share some copy-paste

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -17,7 +17,6 @@ interface AstroPluginOptions {
 }
 
 const VIRTUAL_MODULE_ID_PREFIX = 'astro:markdown';
-const VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID_PREFIX;
 
 // TODO: Clean up some of the shared logic between this Markdown plugin and the Astro plugin.
 // Both end up connecting a `load()` hook to the Astro compiler, and share some copy-paste

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -16,6 +16,9 @@ interface AstroPluginOptions {
 	config: AstroConfig;
 }
 
+// We avoid the "\0" prefix convention that Vite recommends for virtual modules:
+// https://vitejs.dev/guide/api-plugin.html#virtual-modules-convention
+// this broke crawling of sub-modules within the Vite module graph
 const VIRTUAL_MODULE_ID_PREFIX = 'astro:markdown';
 
 // TODO: Clean up some of the shared logic between this Markdown plugin and the Astro plugin.

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -10,7 +10,7 @@ import type { AstroConfig } from '../@types/astro';
 import { PAGE_SSR_SCRIPT_ID } from '../vite-plugin-scripts/index.js';
 import { virtualModuleId as pagesVirtualModuleId } from '../core/build/vite-plugin-pages.js';
 import { appendForwardSlash } from '../core/path.js';
-import { resolvePages } from '../core/util.js';
+import { resolvePages, VALID_ID_PREFIX } from '../core/util.js';
 
 interface AstroPluginOptions {
 	config: AstroConfig;
@@ -56,7 +56,10 @@ export default function markdown({ config }: AstroPluginOptions): Plugin {
 		enforce: 'pre',
 		async resolveId(id, importer, options) {
 			// Resolve virtual modules as-is.
-			if (id.startsWith(VIRTUAL_MODULE_ID_PREFIX)) {
+			if (
+				id.startsWith(VIRTUAL_MODULE_ID_PREFIX) ||
+				id.startsWith(VALID_ID_PREFIX + VIRTUAL_MODULE_ID_PREFIX)
+			) {
 				return id;
 			}
 			// Resolve any .md files with the `?content` cache buster. This should only come from

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -80,10 +80,7 @@ export default function markdown({ config }: AstroPluginOptions): Plugin {
 			// A markdown file has been imported via ESM!
 			// Return the file's JS representation, including all Markdown
 			// frontmatter and a deferred `import() of the compiled markdown content.
-			if (
-				id.startsWith(VIRTUAL_MODULE_ID_PREFIX) ||
-				id.startsWith('/@id/' + VIRTUAL_MODULE_ID_PREFIX)
-			) {
+			if (id.startsWith(VIRTUAL_MODULE_ID_PREFIX)) {
 				const sitePathname = config.site
 					? appendForwardSlash(new URL(config.base, config.site).pathname)
 					: '/';

--- a/packages/astro/test/astro-markdown-css.js
+++ b/packages/astro/test/astro-markdown-css.js
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+let fixture;
+const IMPORTED_ASTRO_COMPONENT_ID = 'imported-astro-component'
+
+describe('Imported markdown CSS', function () {
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/astro-markdown-css/' });
+	});
+	describe('build', () => {
+		let $;
+		let bundledCSS;
+
+		before(async () => {
+			this.timeout(45000); // test needs a little more time in CI
+			await fixture.build();
+
+			// get bundled CSS (will be hashed, hence DOM query)
+			const html = await fixture.readFile('/index.html');
+			$ = cheerio.load(html);
+			const bundledCSSHREF = $('link[rel=stylesheet][href^=/assets/]').attr('href');
+			bundledCSS = await fixture.readFile(bundledCSSHREF.replace(/^\/?/, '/'));
+		});
+
+		it('Compiles styles for Astro components within imported markdown', () => {
+			const importedAstroComponent = $(`#${IMPORTED_ASTRO_COMPONENT_ID}`)?.[0]
+			expect(importedAstroComponent?.name).to.equal('h2')
+			const cssClass = $(importedAstroComponent).attr('class')?.split(/\s+/)?.[0]
+
+			expect(bundledCSS).to.match(new RegExp(`h2.${cssClass}{color:#00f}`))
+		});
+	});
+	describe('dev', () => {
+		let devServer;
+		let $;
+
+		before(async () => {
+			devServer = await fixture.startDevServer();
+			const html = await fixture.fetch('/').then((res) => res.text());
+			$ = cheerio.load(html);
+		});
+		
+		after(async () => {
+			await devServer.stop();
+		});
+		
+		it('Compiles styles for Astro components within imported markdown', async () => {
+			const importedAstroComponent = $(`#${IMPORTED_ASTRO_COMPONENT_ID}`)?.[0]
+			expect(importedAstroComponent?.name).to.equal('h2')
+			const cssClass = $(importedAstroComponent).attr('class')?.split(/\s+/)?.[0]
+
+			const astroCSSHREF = $('link[rel=stylesheet][href^=/src/components/Visual.astro]').attr('href');
+			const css = await fixture.fetch(astroCSSHREF.replace(/^\/?/, '/')).then((res) => res.text());
+			expect(css).to.match(new RegExp(`h2.${cssClass}{color:#00f}`));
+		});
+	});
+});

--- a/packages/astro/test/fixtures/astro-markdown-css/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-markdown-css/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+  integrations: []
+});

--- a/packages/astro/test/fixtures/astro-markdown-css/package.json
+++ b/packages/astro/test/fixtures/astro-markdown-css/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@test/astro-markdown-css",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "astro build",
+    "dev": "astro dev"
+  },
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/astro-markdown-css/src/components/Visual.astro
+++ b/packages/astro/test/fixtures/astro-markdown-css/src/components/Visual.astro
@@ -1,0 +1,7 @@
+<h2 id="imported-astro-component">I'm a visual!</h2>
+
+<style>
+	h2 {
+		color: #00f;
+	}
+</style>

--- a/packages/astro/test/fixtures/astro-markdown-css/src/markdown/article.md
+++ b/packages/astro/test/fixtures/astro-markdown-css/src/markdown/article.md
@@ -1,0 +1,9 @@
+---
+setup: import Visual from '../components/Visual.astro'
+---
+
+# Example markdown document, with a Visual
+
+<Visual />
+<Visual />
+<Visual />

--- a/packages/astro/test/fixtures/astro-markdown-css/src/markdown/article2.md
+++ b/packages/astro/test/fixtures/astro-markdown-css/src/markdown/article2.md
@@ -1,0 +1,9 @@
+---
+setup: import Visual from '../components/Visual.astro'
+---
+
+# Example markdown document, with a more Visuals
+
+<Visual />
+<Visual />
+<Visual />

--- a/packages/astro/test/fixtures/astro-markdown-css/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-markdown-css/src/pages/index.astro
@@ -1,0 +1,15 @@
+---
+const markdownDocs = await Astro.glob('../markdown/*.md')
+const article2 = await import('../markdown/article2.md')
+---
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>Astro</title>
+	</head>
+	<body>
+		{markdownDocs.map(markdownDoc => <><h2>{markdownDoc.url}</h2><markdownDoc.Content /></>)}
+		<article2.Content />
+	</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -798,6 +798,12 @@ importers:
       '@astrojs/preact': link:../../../../integrations/preact
       astro: link:../../..
 
+  packages/astro/test/fixtures/astro-markdown-css:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/astro-markdown-drafts:
     specifiers:
       astro: workspace:*


### PR DESCRIPTION
## Changes
- resolves #3054 
- Instead of applying a path prefix on imported markdown files, apply a flag to the suffix. This allows Vite to resolve the markdown file in the module graph, so we can parse imported styles on our end

## Testing

TODO

## Docs

N/A