### PR TITLE
WIP:  Triggers HMR for server-only components

### DIFF
--- a/packages/astro/src/runtime/client/hmr.ts
+++ b/packages/astro/src/runtime/client/hmr.ts
@@ -2,7 +2,7 @@ if (import.meta.hot) {
 	// signal to Vite that we accept HMR
 	import.meta.hot.accept((mod) => mod);
 	const parser = new DOMParser();
-	import.meta.hot.on('astro:update', async ({ file }) => {
+	async function onUpdate(file: string) {
 		const { default: diff } = await import('micromorph');
 		// eslint-disable-next-line no-console
 		console.log(`[vite] hot updated: ${file}`);
@@ -18,5 +18,14 @@ if (import.meta.hot) {
 			}
 		}
 		diff(document, doc);
+	}
+	import.meta.hot.on('astro:update', async ({ file }) => {
+		await onUpdate(file);
+	});
+	import.meta.hot.on('vite:beforeUpdate', async ({ updates }) => {
+		const astroUpdate = Array.from(updates)
+			.find((update) => update.acceptedPath.endsWith('.astro'));
+		if (!astroUpdate) { return; }
+		await onUpdate(astroUpdate.acceptedPath);
 	});
 }


### PR DESCRIPTION
## Changes

Closes #3069  and #3097 

For server-only components (i.e. components not using `client:` directives) we never ship the JS to the browser and HMR is never aware of those module dependencies

This updates our HMR script to watch for Vite's HMR events and force a page reload when only astro pages are updated

## Testing

None, would be excellent to find a clean way to test HMR though

## Docs

None, bug fix only