### PR TITLE
Perf: reuse Shiki highlighters per theme/lang

### DIFF
--- a/.changeset/eleven-guests-rhyme.md
+++ b/.changeset/eleven-guests-rhyme.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates `<Code />` component to cache and reuse Shiki highlighters

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -1,6 +1,6 @@
 ---
 import type * as shiki from 'shiki';
-import { getHighlighter } from 'shiki';
+import { getHighlighter } from './Shiki.js';
 
 export interface Props {
 	/** The code to highlight. Required. */

--- a/packages/astro/components/Shiki.js
+++ b/packages/astro/components/Shiki.js
@@ -1,0 +1,22 @@
+import { getHighlighter as getShikiHighlighter } from 'shiki';
+
+// Caches Promise<Highligher> for reuse when the same theme and langs are provided
+const _resolvedHighlighters = new Map();
+
+function stringify(opts) {
+    // Always sort keys before stringifying to make sure objects match regardless of parameter ordering
+    return JSON.stringify(opts, Object.keys(opts).sort());
+}
+
+export function getHighlighter(opts) {
+    const key = stringify(opts);
+
+    // Highlighter has already been requested, reuse the same instance
+    if (_resolvedHighlighters.has(key)) { return _resolvedHighlighters.get(key) }
+
+    // Start the async getHighlighter call and cache the Promise
+    const highlighter = getShikiHighlighter(opts);
+    _resolvedHighlighters.set(key, highlighter);
+
+    return highlighter;
+}


### PR DESCRIPTION
## Changes

Fixes #3110 

This updates the built-in `<Code>` component to reuse Shiki highlighters based on the `theme` and `lang` properties

## Testing

Tested locally against the [astro-imagetools docs](https://github.com/RafidMuhymin/astro-imagetools/) site

**Before**

`Error: fail to memory allocation`

![Screen Shot 2022-04-18 at 10 49 22 AM](https://user-images.githubusercontent.com/15836226/163783283-f875226f-1318-48a9-8e5f-babd1017add2.png)

**After**
![Screen Shot 2022-04-18 at 10 46 48 AM](https://user-images.githubusercontent.com/15836226/163783112-30fe7c4c-e00f-4cd5-b9b8-9d881b7b584f.png)

## Docs

N/A