### PR TITLE
Fix: show correct error log on 5xx error

### DIFF
--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -128,7 +128,7 @@ async function handle500Response(
 	res: http.ServerResponse,
 	err: any
 ) {
-	const pathname = decodeURI(new URL(origin + req.url).pathname);
+	const pathname = decodeURI(new URL('./index.html', origin + req.url).pathname);
 	const html = serverErrorTemplate({
 		statusCode: 500,
 		title: 'Internal Error',
@@ -137,7 +137,7 @@ async function handle500Response(
 		url: err.url || undefined,
 		stack: stripAnsi(err.stack),
 	});
-	const transformedHtml = await viteServer.transformIndexHtml(pathname, html, pathname);
+	const transformedHtml = await viteServer.transformIndexHtml(pathname, html);
 	writeHtmlResponse(res, 500, transformedHtml);
 }
 


### PR DESCRIPTION
## Changes

- Resolves #3049 
- Appends `index.html` to path when rendering any `5xx` error page. Without this, Vite will incorrectly resolve included resources on the page (like our CSS files). This was throwing _another_ error on top of the user's error!

## Testing

N/A

## Docs

N/A