### PR TITLE
Improved HMR

### DIFF
--- a/.changeset/cyan-dots-admire.md
+++ b/.changeset/cyan-dots-admire.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+General HMR Improvements, including new HMR support for framework components that are only server-side rendered (do not have a `client:*` directive)

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -84,16 +84,13 @@ export async function handleHotUpdate(ctx: HmrContext, config: AstroConfig, logg
 
 	const mod = ctx.modules.find((m) => m.file === ctx.file);
 
-	// Note: this intentionally ONLY applies to Astro components
-	// HMR is handled for other file types by their respective plugins
 	const file = ctx.file.replace(config.root.pathname, '/');
-	if (ctx.file.endsWith('.astro')) {
-		ctx.server.ws.send({ type: 'custom', event: 'astro:update', data: { file } });
-	}
 	if (mod?.isSelfAccepting) {
 		info(logging, 'astro', msg.hmr({ file }));
 	} else {
 		info(logging, 'astro', msg.reload({ file }));
 	}
-	return Array.from(filtered);
+
+	// TODO: filter down `.astro` updates to ignore style updates
+	// because they are not self-accepting
 }

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -82,15 +82,17 @@ export async function handleHotUpdate(ctx: HmrContext, config: AstroConfig, logg
 		invalidateCompilation(config, file);
 	}
 
-	const mod = ctx.modules.find((m) => m.file === ctx.file);
+	// Bugfix: sometimes style URLs get normalized and end with `lang.css=`
+	// These will cause full reloads, so filter them out here
+	const mods = ctx.modules.filter(m => !m.url.endsWith('='));
+	const isSelfAccepting = mods.every(m => m.isSelfAccepting || m.url.endsWith('.svelte'));
 
 	const file = ctx.file.replace(config.root.pathname, '/');
-	if (mod?.isSelfAccepting) {
+	if (isSelfAccepting) {
 		info(logging, 'astro', msg.hmr({ file }));
 	} else {
 		info(logging, 'astro', msg.reload({ file }));
 	}
 
-	// TODO: filter down `.astro` updates to ignore style updates
-	// because they are not self-accepting
+	return mods
 }


### PR DESCRIPTION
## Changes

- Removes our fully-custom HMR and leans on the built-in `vite:beforeUpdate` event instead.
- Fixes SSR-only HMR by tracking file dependencies in `vite-plugin-astro`
- Fixes edge case with Astro/Svelte styles triggering a full reload because duplicate URLs were present and one was not being picked up as self-accepting.

## Testing

Still looking into HMR tests

## Docs

Bugfixes only