### PR TITLE
feat(vercel): added warning when `ENABLE_FILE_SYSTEM_API=1` is missing

### DIFF
--- a/.changeset/soft-fishes-switch.md
+++ b/.changeset/soft-fishes-switch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Added warning when `ENABLE_FILE_SYSTEM_API` is not found

--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -13,7 +13,7 @@ export default defineConfig({
 });
 ```
 
-After you build your site the `.output/` folder will contain your server-side rendered app. Since this feature is still in beta, you'll **need to add this Enviroment Variable to your Vercel project**: `ENABLE_FILE_SYSTEM_API=1`
+After you build your site the `.output/` folder will contain your server-side rendered app. Since this feature is still in beta, you'll **need to add this Enviroment Variable to your Vercel project**: `ENABLE_FILE_SYSTEM_API=1`. [Learn how to set enviroment variables](https://vercel.com/docs/concepts/projects/environment-variables).
 
 Now you can deploy!
 

--- a/packages/integrations/vercel/src/index.ts
+++ b/packages/integrations/vercel/src/index.ts
@@ -53,6 +53,12 @@ export default function vercel(): AstroIntegration {
 				buildConfig.serverEntry = `${ENTRYFILE}.js`;
 				buildConfig.client = new URL('./static/', _config.outDir);
 				buildConfig.server = new URL('./server/pages/', _config.outDir);
+
+				if (String(process.env.ENABLE_FILE_SYSTEM_API) !== '1') {
+					console.warn(
+						`The enviroment variable "ENABLE_FILE_SYSTEM_API" was not found. Make sure you have it set to "1" in your Vercel project.\nLearn how to set enviroment variables here: https://vercel.com/docs/concepts/projects/environment-variables`
+					);
+				}
 			},
 			'astro:build:done': async ({ routes }) => {
 				// Bundle dependecies


### PR DESCRIPTION
## Changes

Added warning when `ENABLE_FILE_SYSTEM_API=1` is missing. Vercel doesn't fail when it isn't set — the deployment just throws a 404

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->