### PR TITLE
Fix location of SolidJS pre-hydration code

### DIFF
--- a/.changeset/eight-pumas-repeat.md
+++ b/.changeset/eight-pumas-repeat.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/solid-js': patch
+---
+
+Fix location of SolidJS pre-hydration code

--- a/packages/integrations/solid/client.js
+++ b/packages/integrations/solid/client.js
@@ -2,6 +2,11 @@ import { sharedConfig } from 'solid-js';
 import { hydrate, createComponent } from 'solid-js/web';
 
 export default (element) => (Component, props, childHTML) => {
+	// Prepare global object expected by Solid's hydration logic
+	if (!window._$HY) {
+		window._$HY = { events: [], completed: new WeakSet, r: {} };
+	}
+	// Perform actual hydration
 	let children;
 	hydrate(
 		() =>

--- a/packages/integrations/solid/server.js
+++ b/packages/integrations/solid/server.js
@@ -20,7 +20,7 @@ function renderToStaticMarkup(Component, props, children) {
 		})
 	);
 	return {
-		html: html + `<script>window._$HY||(_$HY={events:[],completed:new WeakSet,r:{}})</script>`,
+		html: html,
 	};
 }
 


### PR DESCRIPTION
## Changes

- Makes the SolidJS pre-hydration code actually run before hydration.
- Before this fix, we were inlining a <script> block after each component, no matter if it was supposed to get hydrated or not.
- Fixes #3132.

## Testing

Tested locally on Windows 10 in dev mode, build, and SSR using Netlify adapter.

## Docs

This is not a visible change, just a code fix/refactor.