### PR TITLE
Adjustments for Netlify Edge Functions

### DIFF
--- a/.changeset/small-radios-whisper.md
+++ b/.changeset/small-radios-whisper.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Outputs manifest.json in correct folder for Netlify Edge Functions


### PR DESCRIPTION
## Changes

- Puts the manifest file in `.netlify/edge-functions/manifest.json`
- Fixes dynamic routes manifest output.
- Use `entry.js` (no mjs) as the function root, as .mjs isn't picked up.

## Testing

Verified manually as this requires deployment.

<img width="1405" alt="Screen Shot 2022-04-19 at 12 44 19 PM" src="https://user-images.githubusercontent.com/361671/164054958-f7425759-e383-47f9-9abe-e0bf95cb2808.png">


## Docs

N/A, bug fix