### PR TITLE
Fix: markdown JSX expression inconsistencies

### DIFF
--- a/.changeset/purple-timers-speak.md
+++ b/.changeset/purple-timers-speak.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/markdown-remark': patch
+---
+
+Fix JSX expression inconsistencies within markdown files

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -23,6 +23,17 @@ describe('Astro Markdown', () => {
 		expect($('#test').length).to.be.ok;
 	});
 
+	it('Can parse JSX expressions in markdown pages', async () => {
+		const html = await fixture.readFile('/jsx-expressions/index.html');
+		const $ = cheerio.load(html);
+
+		expect($('h2').html()).to.equal('Blog Post with JSX expressions')
+		expect($('p').first().html()).to.equal('JSX at the start of the line!')
+		for (let listItem of ['test-1', 'test-2', 'test-3']) {
+			expect($(`#${listItem}`).html()).to.equal(`\n${listItem}\n`)
+		}
+	})
+
 	it('Can load more complex jsxy stuff', async () => {
 		const html = await fixture.readFile('/complex/index.html');
 		const $ = cheerio.load(html);

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/jsx-expressions.md
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/jsx-expressions.md
@@ -1,0 +1,11 @@
+---
+title: Blog Post with JSX expressions
+paragraph: JSX at the start of the line!
+list: ['test-1', 'test-2', 'test-3']
+---
+
+## {frontmatter.title}
+
+{frontmatter.paragraph}
+
+{frontmatter.list.map(item => <p id={item}>{item}</p>)}

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -29,7 +29,6 @@
     "mdast-util-mdx-expression": "^1.2.0",
     "mdast-util-mdx-jsx": "^1.2.0",
     "mdast-util-to-string": "^3.1.0",
-    "micromark-extension-mdx-expression": "^1.0.3",
     "micromark-extension-mdx-jsx": "^1.0.3",
     "prismjs": "^1.27.0",
     "rehype-raw": "^6.1.1",

--- a/packages/markdown/remark/src/remark-expressions.ts
+++ b/packages/markdown/remark/src/remark-expressions.ts
@@ -1,5 +1,4 @@
 // Vite bug: dynamically import() modules needed for CJS. Cache in memory to keep side effects
-let mdxExpression: any;
 let mdxExpressionFromMarkdown: any;
 let mdxExpressionToMarkdown: any;
 
@@ -7,7 +6,6 @@ export function remarkExpressions(this: any, options: any) {
 	let settings = options || {};
 	let data = this.data();
 
-	add('micromarkExtensions', mdxExpression({}));
 	add('fromMarkdownExtensions', mdxExpressionFromMarkdown);
 	add('toMarkdownExtensions', mdxExpressionToMarkdown);
 
@@ -19,10 +17,6 @@ export function remarkExpressions(this: any, options: any) {
 }
 
 export async function loadRemarkExpressions() {
-	if (!mdxExpression) {
-		const micromarkMdxExpression = await import('micromark-extension-mdx-expression');
-		mdxExpression = micromarkMdxExpression.mdxExpression;
-	}
 	if (!mdxExpressionFromMarkdown || !mdxExpressionToMarkdown) {
 		const mdastUtilMdxExpression = await import('mdast-util-mdx-expression');
 		mdxExpressionFromMarkdown = mdastUtilMdxExpression.mdxExpressionFromMarkdown;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1444,7 +1444,6 @@ importers:
       mdast-util-mdx-expression: ^1.2.0
       mdast-util-mdx-jsx: ^1.2.0
       mdast-util-to-string: ^3.1.0
-      micromark-extension-mdx-expression: ^1.0.3
       micromark-extension-mdx-jsx: ^1.0.3
       prismjs: ^1.27.0
       rehype-raw: ^6.1.1
@@ -1465,7 +1464,6 @@ importers:
       mdast-util-mdx-expression: 1.2.0
       mdast-util-mdx-jsx: 1.2.0
       mdast-util-to-string: 3.1.0
-      micromark-extension-mdx-expression: 1.0.3
       micromark-extension-mdx-jsx: 1.0.3
       prismjs: 1.27.0
       rehype-raw: 6.1.1
@@ -7687,18 +7685,6 @@ packages:
       micromark-extension-gfm-task-list-item: 1.0.3
       micromark-util-combine-extensions: 1.0.0
       micromark-util-types: 1.0.2
-    dev: false
-
-  /micromark-extension-mdx-expression/1.0.3:
-    resolution: {integrity: sha512-TjYtjEMszWze51NJCZmhv7MEBcgYRgb3tJeMAJ+HQCAaZHHRBaDCccqQzGizR/H4ODefP44wRTgOn2vE5I6nZA==}
-    dependencies:
-      micromark-factory-mdx-expression: 1.0.6
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-events-to-acorn: 1.0.4
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      uvu: 0.5.3
     dev: false
 
   /micromark-extension-mdx-jsx/1.0.3:


### PR DESCRIPTION
## Changes

- Resolves #2886 
- Removes the `micromark-extension-mdx-expression` dependency. This was removing the curlies `{}` from our JSX expressions, causing some variables to remain unparsed by the Astro parser.

## Testing

- added JSX expressions test to `packages/astro/test/astro-markdown.test.js`

## Docs

N/A