### PR TITLE
Improvements to build and dev when building for subpaths

### DIFF
--- a/.changeset/chatty-peas-warn.md
+++ b/.changeset/chatty-peas-warn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds subpath to assets/scripts when statically generating

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -179,7 +179,7 @@ async function generatePath(
 	// If a base path was provided, append it to the site URL. This ensures that
 	// all injected scripts and links are referenced relative to the site and subpath.
 	const site = astroConfig.base && astroConfig.base !== './'
-		? joinPaths(astroConfig.site || 'http://localhost/', astroConfig.base)
+		? joinPaths(astroConfig.site?.toString() || 'http://localhost/', astroConfig.base)
 		: astroConfig.site;
 	const links = createLinkStylesheetElementSet(linkIds.reverse(), site);
 	const scripts = createModuleScriptElementWithSrcSet(hoistedId ? [hoistedId] : [], site);

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -11,7 +11,7 @@ import type {
 } from '../../@types/astro';
 import type { BuildInternals } from '../../core/build/internal.js';
 import { debug, info } from '../logger/core.js';
-import { prependForwardSlash, removeLeadingForwardSlash } from '../../core/path.js';
+import { joinPaths, prependForwardSlash, removeLeadingForwardSlash } from '../../core/path.js';
 import type { RenderOptions } from '../../core/render/core';
 import { BEFORE_HYDRATION_SCRIPT_ID } from '../../vite-plugin-scripts/index.js';
 import { call as callEndpoint } from '../endpoint/index.js';
@@ -176,7 +176,7 @@ async function generatePath(
 
 	debug('build', `Generating: ${pathname}`);
 
-	const site = astroConfig.site;
+	const site = joinPaths(astroConfig.site, astroConfig.base);
 	const links = createLinkStylesheetElementSet(linkIds.reverse(), site);
 	const scripts = createModuleScriptElementWithSrcSet(hoistedId ? [hoistedId] : [], site);
 

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -176,7 +176,9 @@ async function generatePath(
 
 	debug('build', `Generating: ${pathname}`);
 
-	const site = joinPaths(astroConfig.site, astroConfig.base);
+	const site = !astroConfig.base || astroConfig.base === './'
+		? astroConfig.site
+		: joinPaths(astroConfig.site, astroConfig.base);
 	const links = createLinkStylesheetElementSet(linkIds.reverse(), site);
 	const scripts = createModuleScriptElementWithSrcSet(hoistedId ? [hoistedId] : [], site);
 

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -176,9 +176,11 @@ async function generatePath(
 
 	debug('build', `Generating: ${pathname}`);
 
-	const site = !astroConfig.base || astroConfig.base === './'
-		? astroConfig.site
-		: joinPaths(astroConfig.site, astroConfig.base);
+	// If a base path was provided, append it to the site URL. This ensures that
+	// all injected scripts and links are referenced relative to the site and subpath.
+	const site = astroConfig.base && astroConfig.base !== './'
+		? joinPaths(astroConfig.site || 'http://localhost/', astroConfig.base)
+		: astroConfig.site;
 	const links = createLinkStylesheetElementSet(linkIds.reverse(), site);
 	const scripts = createModuleScriptElementWithSrcSet(hoistedId ? [hoistedId] : [], site);
 

--- a/packages/astro/src/core/path.ts
+++ b/packages/astro/src/core/path.ts
@@ -38,3 +38,11 @@ export function startsWithDotSlash(path: string) {
 export function isRelativePath(path: string) {
 	return startsWithDotDotSlash(path) || startsWithDotSlash(path);
 }
+
+function isString(path: unknown): path is string {
+	return typeof path === 'string' || path instanceof String;
+}
+
+export function joinPaths(...paths: (string | undefined)[]) {
+	return paths.filter(isString).map(trimSlashes).join('/');
+}

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -111,6 +111,17 @@ async function handle404Response(
 	if (pathname === '/' && !pathname.startsWith(devRoot)) {
 		html = subpathNotUsedTemplate(devRoot, pathname);
 	} else {
+		// HACK: redirect without the base path for assets in publicDir
+		if (config.base && !pathname.startsWith(config.base)) {
+			const response = new Response(null, {
+				status: 301,
+				headers: {
+					Location: pathname.replace(config.base, ''),
+				},
+			});
+			await writeWebResponse(res, response);
+			return;
+		}
 		html = notFoundTemplate({
 			statusCode: 404,
 			title: 'Not found',

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -119,7 +119,6 @@ async function handle404Response(
 			&& pathname.replace(config.base, '/');
 
 		if (redirectTo && redirectTo !== '/') {
-			console.log('redirecting', pathname, redirectTo);
 			const response = new Response(null, {
 				status: 302,
 				headers: {

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -115,9 +115,11 @@ async function handle404Response(
 		const redirectTo = 
 			req.method === 'GET'
 			&& config.base && config.base !== './'
-			&& pathname.replace(config.base, '');
+			&& pathname.startsWith(config.base)
+			&& pathname.replace(config.base, '/');
 
 		if (redirectTo && redirectTo !== '/') {
+			console.log('redirecting', pathname, redirectTo);
 			const response = new Response(null, {
 				status: 302,
 				headers: {

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -112,20 +112,14 @@ async function handle404Response(
 		html = subpathNotUsedTemplate(devRoot, pathname);
 	} else {
 		// HACK: redirect without the base path for assets in publicDir
-		// Only redirect if:
-		// (1) astroConfig.base was provided
-		// (2) pathname begins with the base path
-		// (3) pathname isn't `{basepath}` or `{basepath}/`
-		const baseRegex = new RegExp(`${config.base}\/\d*$`);
-		const shouldRedirect = config.base && config.base !== './'
-			&& pathname.match(baseRegex);
+		const redirectTo = config.base && config.base !== './'
+			&& pathname.replace(config.base, '');
 
-		if (shouldRedirect) {
+		if (redirectTo && redirectTo !== '/') {
 			const response = new Response(null, {
 				status: 301,
 				headers: {
-					// substring at 1 to maintain the leading /
-					Location: pathname.replace(config.base.substring(1), ''),
+					Location: redirectTo,
 				},
 			});
 			await writeWebResponse(res, response);

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -112,12 +112,14 @@ async function handle404Response(
 		html = subpathNotUsedTemplate(devRoot, pathname);
 	} else {
 		// HACK: redirect without the base path for assets in publicDir
-		const redirectTo = config.base && config.base !== './'
+		const redirectTo = 
+			req.method === 'GET'
+			&& config.base && config.base !== './'
 			&& pathname.replace(config.base, '');
 
 		if (redirectTo && redirectTo !== '/') {
 			const response = new Response(null, {
-				status: 301,
+				status: 302,
 				headers: {
 					Location: redirectTo,
 				},

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -112,7 +112,8 @@ async function handle404Response(
 		html = subpathNotUsedTemplate(devRoot, pathname);
 	} else {
 		// HACK: redirect without the base path for assets in publicDir
-		if (config.base && !pathname.startsWith(config.base)) {
+		if (config.base && config.base !== './' && !pathname.startsWith(config.base)) {
+			console.log('REDIRECT::', pathname, config.base, pathname.replace(config.base, ''));
 			const response = new Response(null, {
 				status: 301,
 				headers: {

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -7,6 +7,7 @@ function addLeadingSlash(path) {
 }
 
 function removeBasePath(path) {
+	// `/subpath` is defined in the test fixture's Astro config
 	return path.replace('/subpath', '')
 }
 
@@ -94,6 +95,14 @@ describe('Static build', () => {
 			const links = $('link[rel=stylesheet]');
 			for (const link of links) {
 				const href = $(link).attr('href');
+
+				/**
+				 * The link should be built with the config's `base` included
+				 * as a subpath.
+				 *
+				 * The test needs to verify that the file will be found once the `/dist`
+				 * output is deployed to a subpath in production by ignoring the subpath here.
+				 */
 				const data = await fixture.readFile(removeBasePath(addLeadingSlash(href)));
 				if (expected.test(data)) {
 					return true;

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -6,6 +6,10 @@ function addLeadingSlash(path) {
 	return path.startsWith('/') ? path : '/' + path;
 }
 
+function removeBasePath(path) {
+	return path.replace('/subpath', '')
+}
+
 /**
  * @typedef {import('../src/core/logger/core').LogMessage} LogMessage
  */
@@ -90,7 +94,7 @@ describe('Static build', () => {
 			const links = $('link[rel=stylesheet]');
 			for (const link of links) {
 				const href = $(link).attr('href');
-				const data = await fixture.readFile(addLeadingSlash(href));
+				const data = await fixture.readFile(removeBasePath(addLeadingSlash(href)));
 				if (expected.test(data)) {
 					return true;
 				}


### PR DESCRIPTION
## Changes

Fixes a bug in `astro build` that was breaking injected links and styles in projects deployed to subpaths
[x] fixes a bug where `astro build` wasn't prepending the base path for injected links and styles
[x] updates the `dev` server to handle the `base` path when assets from `public` are requested

## Testing

Updated static-build test suite to expect injected style links to include the `base` path from `astro.config.js`

## Docs

N/A