### PR TITLE
Make 'lit' always be bundled in SSR

### DIFF
--- a/.changeset/old-plants-glow.md
+++ b/.changeset/old-plants-glow.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/lit': patch
+---
+
+Fixes lit when running in SSR

--- a/packages/astro/src/core/build/vite-plugin-pages.ts
+++ b/packages/astro/src/core/build/vite-plugin-pages.ts
@@ -40,7 +40,9 @@ export function vitePluginPages(opts: StaticBuildOptions, internals: BuildIntern
 				let rendererItems = '';
 				for (const renderer of opts.astroConfig._ctx.renderers) {
 					const variable = `_renderer${i}`;
-					imports.push(`import ${variable} from '${renderer.serverEntrypoint}';`);
+					// Use unshift so that renderers are imported before user code, in case they set globals
+					// that user code depends on.
+					imports.unshift(`import ${variable} from '${renderer.serverEntrypoint}';`);
 					rendererItems += `Object.assign(${JSON.stringify(renderer)}, { ssr: ${variable} }),`;
 					i++;
 				}

--- a/packages/astro/test/ssr-lit.test.js
+++ b/packages/astro/test/ssr-lit.test.js
@@ -27,6 +27,7 @@ describe('Lit integration in SSR', () => {
 	}
 
 	it('Is able to load', async () => {
+		delete globalThis.window;
 		const html = await fetchHTML('/');
 		const $ = cheerioLoad(html);
 		expect($('#win').text()).to.equal('function');

--- a/packages/integrations/lit/src/index.ts
+++ b/packages/integrations/lit/src/index.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import type { AstroIntegration } from 'astro';
+import type { AstroConfig, AstroIntegration } from 'astro';
 
 function getViteConfiguration() {
 	return {
@@ -44,6 +44,19 @@ export default function (): AstroIntegration {
 				updateConfig({
 					vite: getViteConfiguration(),
 				});
+			},
+			'astro:build:setup': ({ vite, target }) => {
+				if (target === 'server') {
+					if(!vite.ssr) {
+						vite.ssr = {};
+					}
+					if(!vite.ssr.noExternal) {
+						vite.ssr.noExternal = [];
+					}
+					if(Array.isArray(vite.ssr.noExternal)) {
+						vite.ssr.noExternal.push('lit')
+					}
+				}
 			},
 		},
 	};


### PR DESCRIPTION
## Changes

- Fixes #3126
- Makes it so that renderers are imported first, since framework components depend on them implicitly.
- Makes it so that the lit integration sets `lit` to be noExternal, forcing it into the bundle so that the globals set up by the renderer are applied by the time lit runs.

## Testing

- Test updated.

## Docs

N/A