### PR TITLE
fix(preact): use updateConfig hook

### DIFF
--- a/.changeset/thick-beds-flow.md
+++ b/.changeset/thick-beds-flow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/preact': patch
+---
+
+Fix integration to use updateConfig rather than returning a partial config object

--- a/packages/integrations/preact/src/index.ts
+++ b/packages/integrations/preact/src/index.ts
@@ -39,11 +39,11 @@ export default function (): AstroIntegration {
 	return {
 		name: '@astrojs/preact',
 		hooks: {
-			'astro:config:setup': ({ addRenderer }) => {
+			'astro:config:setup': ({ addRenderer, updateConfig }) => {
 				addRenderer(getRenderer());
-				return {
+				updateConfig({
 					vite: getViteConfiguration(),
-				};
+				})
 			},
 		},
 	};


### PR DESCRIPTION
## Changes

- Previously, the Preact integration returned a partial Vite config.
- Every other integration uses the `updateConfig` helper, so now Preact does too.

## Testing

CI

## Docs

N/A