### PR TITLE
Netlify Edge: forward requests for static assets

### DIFF
--- a/packages/astro/src/core/app/common.ts
+++ b/packages/astro/src/core/app/common.ts
@@ -13,8 +13,11 @@ export function deserializeManifest(serializedManifest: SerializedSSRManifest): 
 		route.routeData = deserializeRouteData(serializedRoute.routeData);
 	}
 
+	const assets = new Set<string>(serializedManifest.assets);
+
 	return {
 		...serializedManifest,
+		assets,
 		routes,
 	};
 }

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -26,10 +26,12 @@ export interface SSRManifest {
 	pageMap: Map<ComponentPath, ComponentInstance>;
 	renderers: SSRLoadedRenderer[];
 	entryModules: Record<string, string>;
+	assets: Set<string>;
 }
 
-export type SerializedSSRManifest = Omit<SSRManifest, 'routes'> & {
+export type SerializedSSRManifest = Omit<SSRManifest, 'routes' | 'assets'> & {
 	routes: SerializedRouteInfo[];
+	assets: string[];
 };
 
 export type AdapterCreateExports<T = any> = (

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from 'url';
 import * as vite from 'vite';
 import { createBuildInternals } from '../../core/build/internal.js';
 import { info } from '../logger/core.js';
-import { appendForwardSlash, prependForwardSlash } from '../../core/path.js';
+import { prependForwardSlash } from '../../core/path.js';
 import { emptyDir, removeDir } from '../../core/util.js';
 import { rollupPluginAstroBuildCSS } from '../../vite-plugin-build-css/index.js';
 import { vitePluginHoistedScripts } from './vite-plugin-hoisted-scripts.js';

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -27,12 +27,13 @@
     "dev": "astro-scripts dev \"src/**/*.ts\"",
     "test-fn": "mocha --exit --timeout 20000 test/functions/",
     "test-edge": "deno test --allow-run --allow-read --allow-net ./test/edge-functions/",
-    "test": "npm run test-fn"
+    "test": "npm run test-fn && npm run test-edge"
   },
   "dependencies": {
     "@astrojs/webapi": "^0.11.1"
   },
   "devDependencies": {
+    "@netlify/edge-handler-types": "^0.34.1",
     "@netlify/functions": "^1.0.0",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*"

--- a/packages/integrations/netlify/src/netlify-edge-functions.ts
+++ b/packages/integrations/netlify/src/netlify-edge-functions.ts
@@ -5,7 +5,14 @@ import { App } from 'astro/app';
 export function createExports(manifest: SSRManifest) {
 	const app = new App(manifest);
 
-	const handler = async (request: Request): Promise<Response> => {
+	const handler = async (request: Request): Promise<Response | void> => {
+		const url = new URL(request.url);
+
+		// If this matches a static asset, just return and Netlify will forward it
+		// to its static asset handler.
+		if(manifest.assets.has(url.pathname)) {
+			return;
+		}
 		if (app.match(request)) {
 			return app.render(request);
 		}

--- a/packages/integrations/netlify/test/edge-functions/fixtures/root-dynamic/astro.config.mjs
+++ b/packages/integrations/netlify/test/edge-functions/fixtures/root-dynamic/astro.config.mjs
@@ -1,0 +1,11 @@
+import { defineConfig } from 'astro/config';
+import { netlifyEdgeFunctions } from '@astrojs/netlify';
+
+export default defineConfig({
+	adapter: netlifyEdgeFunctions({
+		dist: new URL('./dist/', import.meta.url),
+	}),
+	experimental: {
+		ssr: true
+	}
+})

--- a/packages/integrations/netlify/test/edge-functions/fixtures/root-dynamic/package.json
+++ b/packages/integrations/netlify/test/edge-functions/fixtures/root-dynamic/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/netlify-edge-root-dynamic",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/netlify": "workspace:*"
+  }
+}

--- a/packages/integrations/netlify/test/edge-functions/fixtures/root-dynamic/public/styles.css
+++ b/packages/integrations/netlify/test/edge-functions/fixtures/root-dynamic/public/styles.css
@@ -1,0 +1,3 @@
+body {
+	background: blue;
+}

--- a/packages/integrations/netlify/test/edge-functions/fixtures/root-dynamic/src/pages/[...all].astro
+++ b/packages/integrations/netlify/test/edge-functions/fixtures/root-dynamic/src/pages/[...all].astro
@@ -1,0 +1,9 @@
+<html>
+<head>
+	<title>Testing</title>
+	<link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+	<h1>Testing</h1>
+</body>
+</html>

--- a/packages/integrations/netlify/test/edge-functions/root-dynamic.test.ts
+++ b/packages/integrations/netlify/test/edge-functions/root-dynamic.test.ts
@@ -1,0 +1,16 @@
+// @ts-ignore
+import { runBuild } from './test-utils.ts';
+// @ts-ignore
+import { assertEquals, assert, DOMParser } from './deps.ts';
+
+// @ts-ignore
+Deno.test({
+	name: 'Assets are preferred over HTML routes',
+	async fn() {
+		let close = await runBuild('./fixtures/root-dynamic/');
+		const { default: handler } = await import('./fixtures/root-dynamic/dist/edge-functions/entry.js');
+		const response = await handler(new Request('http://example.com/styles.css'));
+		assertEquals(response, undefined, 'No response because this is an asset');
+		await close();
+	},
+});

--- a/packages/integrations/netlify/tsconfig.json
+++ b/packages/integrations/netlify/tsconfig.json
@@ -5,6 +5,10 @@
     "allowJs": true,
     "module": "ES2020",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2020",
+    "typeRoots": [
+      "node_modules/@types",
+      "node_modules/@netlify"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1259,12 +1259,14 @@ importers:
   packages/integrations/netlify:
     specifiers:
       '@astrojs/webapi': ^0.11.1
+      '@netlify/edge-handler-types': ^0.34.1
       '@netlify/functions': ^1.0.0
       astro: workspace:*
       astro-scripts: workspace:*
     dependencies:
       '@astrojs/webapi': link:../../webapi
     devDependencies:
+      '@netlify/edge-handler-types': 0.34.1
       '@netlify/functions': 1.0.0
       astro: link:../../astro
       astro-scripts: link:../../../scripts
@@ -1277,6 +1279,14 @@ importers:
     dependencies:
       '@astrojs/netlify': link:../../../..
       '@astrojs/react': link:../../../../../react
+      astro: link:../../../../../../astro
+
+  packages/integrations/netlify/test/edge-functions/fixtures/root-dynamic:
+    specifiers:
+      '@astrojs/netlify': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/netlify': link:../../../..
       astro: link:../../../../../../astro
 
   packages/integrations/node:
@@ -3476,6 +3486,12 @@ packages:
       nanostores: 0.5.12
       vue: 3.2.33
     dev: false
+
+  /@netlify/edge-handler-types/0.34.1:
+    resolution: {integrity: sha512-YTwn8cw89M4lRTmoUhl9s8ljSGMDt7FOIsxsrx7YrRz/RZlbh4Yuh4RU13DDafDRBEVuRbjGo93cnN621ZfBjA==}
+    dependencies:
+      web-streams-polyfill: 3.2.1
+    dev: true
 
   /@netlify/functions/1.0.0:
     resolution: {integrity: sha512-7fnJv3vr8uyyyOYPChwoec6MjzsCw1CoRUO2DhQ1BD6bOyJRlD4DUaOOGlMILB2LCT8P24p5LexEGx8AJb7xdA==}


### PR DESCRIPTION
## Changes

- This includes static assets in the SSR manifest so that adapters can use that.
- Netlify Edge is called *before* static assets are handled, so we need to know what static assets exist and not respond. This is in case you have something like `[...stuff].astro` as a root page, which would capture all requests.

## Testing

- Test added!

## Docs

N/A, bug fix