### PR TITLE
Feat: [create-astro] remove online editor configs from output

### DIFF
--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -36,6 +36,7 @@ const { version } = JSON.parse(
 	fs.readFileSync(new URL('../package.json', import.meta.url), 'utf-8')
 );
 
+const FILES_TO_REMOVE = ['.stackblitzrc', 'sandbox.config.json']; // some files are only needed for online editors when using astro.new. Remove for create-astro installs.
 const POSTPROCESS_FILES = ['package.json', 'astro.config.mjs', 'CHANGELOG.md']; // some files need processing after copying.
 
 export async function main() {
@@ -179,8 +180,12 @@ export async function main() {
 	}
 
 	// Post-process in parallel
-	await Promise.all(
-		POSTPROCESS_FILES.map(async (file) => {
+	await Promise.all([
+		...FILES_TO_REMOVE.map(async (file) => {
+			const fileLoc = path.resolve(path.join(cwd, file));
+			return fs.promises.rm(fileLoc);
+		}),
+		...POSTPROCESS_FILES.map(async (file) => {
 			const fileLoc = path.resolve(path.join(cwd, file));
 
 			switch (file) {
@@ -232,8 +237,8 @@ export async function main() {
 					break;
 				}
 			}
-		})
-	);
+		}),
+	]);
 
 	// Inject framework components into starter template
 	if (selectedTemplate?.value === 'starter') {


### PR DESCRIPTION
## Changes

Removes `.stackblitzrc` and `sandbox.config.json` from `create-astro` output. These are helpful when generating from the `astro.new` command, but not necessary for local development with our CLI tool.

## Testing

Debated whether it was worth killing a tree to test this change on our test runner every time. For a small change like this, I decided against it 🙃 

## Docs

N/A