### PR TITLE
feat(vercel): Support `trailingSlash`

### DIFF
--- a/.changeset/thirty-boxes-shave.md
+++ b/.changeset/thirty-boxes-shave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Support trailingSlash


### PR DESCRIPTION
## Changes

When using the Vercel adapter, setting the `trailingSlash` option will result in the same behavior as the `trailingSlash` setting inside `vercel.json`:
- `always` redirects `/foo` to `/foo/`
- `never` redirects `/foo/` to `/foo`
- `ignore` doesn't redirect

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->