### PR TITLE
fix(vercel): `trailingSlash` fix for non-html pages

### DIFF
--- a/.changeset/swift-houses-itch.md
+++ b/.changeset/swift-houses-itch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Fixed `trailingSlash` for non-HTML pages


### PR DESCRIPTION
## Changes

Non-HTML pages (or endpoints) are set to always have its "trailing slash setting" to `never` ([reference](https://github.com/withastro/astro/blob/7ccda57c1d34529446bff99131ded899f1b678ab/packages/astro/src/core/routing/manifest/create.ts#L272)) This PR fixes that case

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->