### PR TITLE
Fix: `astro add` generating config outside project root

### DIFF
--- a/.changeset/warm-days-wash.md
+++ b/.changeset/warm-days-wash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix: astro add generating "astro.config.mjs" outside project root

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -19,6 +19,7 @@ import { parseNpmName } from '../util.js';
 import { wrapDefaultExport } from './wrapper.js';
 import { ensureImport } from './imports.js';
 import { t, parse, visit, generate } from './babel.js';
+import { appendForwardSlash } from '../path.js';
 
 export interface AddOptions {
 	logging: LogOptions;
@@ -91,7 +92,7 @@ export default async function add(names: string[], { cwd, flags, logging }: AddO
 		debug('add', `Found config at ${configURL}`);
 	} else {
 		info(logging, 'add', `Unable to locate a config file, generating one for you.`);
-		configURL = new URL('./astro.config.mjs', root);
+		configURL = new URL('./astro.config.mjs', appendForwardSlash(root.href));
 		await fs.writeFile(fileURLToPath(configURL), CONSTS.CONFIG_STUB, { encoding: 'utf-8' });
 	}
 


### PR DESCRIPTION
## Changes

Append trailing slash to project `root` to fix `astro.config.mjs` path resolution

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->