### PR TITLE
Fix tsconfig in `docs` example

### DIFF
--- a/examples/docs/tsconfig.json
+++ b/examples/docs/tsconfig.json
@@ -4,6 +4,6 @@
     "module": "esnext",
     "jsx": "preserve",
     "moduleResolution": "node",
-    "types": ["astro/env"]
+    "types": ["vite/client"]
   },
 }

--- a/examples/docs/tsconfig.json
+++ b/examples/docs/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "esnext",
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "moduleResolution": "node",
+    "types": ["astro/env"]
   },
-  "moduleResolution": "node"
 }


### PR DESCRIPTION
## Changes

- Added `"types": ["vite/client"]` because previosly I was getting rid squigglies everywhere an environment variable was used.
- Moved `moduleResolution` under `compilerOptions`. Previously it had no effect.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Tested manually / in IDE.

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No change in main codebase but it will affect `create-astro` (I think). So it's "visible" in that sense. Not sure if I should still run `pnpm exec changeset`.

