### PR TITLE
Feat: `create astro` add install step

### DIFF
--- a/.changeset/strong-seals-grow.md
+++ b/.changeset/strong-seals-grow.md
@@ -1,0 +1,5 @@
+---
+'create-astro': minor
+---
+
+Feat: add option to install dependencies during setup. This respects the package manager used to run create-astro (ex. "yarn create astro" vs "pnpm create astro@latest").

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -31,6 +31,7 @@
     "@types/degit": "^2.8.3",
     "@types/prompts": "^2.0.14",
     "degit": "^2.8.4",
+    "execa": "^6.1.0",
     "kleur": "^4.1.4",
     "node-fetch": "^3.2.3",
     "ora": "^6.1.0",

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -326,10 +326,6 @@ function emojiWithFallback(char: string, fallback: string) {
 	return process.platform !== 'win32' ? char : fallback;
 }
 
-/**
- * Politely stolen from ViteJS
- * @see https://github.com/vitejs/vite/blob/fc89057b406fc85e01a1d4fd08f128e9b6bcba5a/packages/create-vite/index.js#L339
- */
 function pkgManagerFromUserAgent(userAgent?: string) {
 	if (!userAgent) return 'npm';
 	const pkgSpec = userAgent.split(' ')[0];

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -309,13 +309,16 @@ export async function main() {
 		console.log(`  ${i++}: ${bold(cyan(`cd ${relative}`))}`);
 	}
 
-	console.log(`  ${i++}: ${bold(cyan('npm install'))} (or pnpm install, yarn, etc)`);
+	if (!installResponse.install) {
+		console.log(`  ${i++}: ${bold(cyan(`${pkgManager} install`))}`);
+	}
 	console.log(
 		`  ${i++}: ${bold(
 			cyan('git init && git add -A && git commit -m "Initial commit"')
 		)} (optional step)`
 	);
-	console.log(`  ${i++}: ${bold(cyan('npm run dev'))} (or pnpm, yarn, etc)`);
+	const runCommand = pkgManager === 'npm' ? 'npm run dev' : `${pkgManager} dev`;
+	console.log(`  ${i++}: ${bold(cyan(runCommand))}`);
 
 	console.log(`\nTo close the dev server, hit ${bold(cyan('Ctrl-C'))}`);
 	console.log(`\nStuck? Visit us at ${cyan('https://astro.build/chat')}\n`);

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -288,12 +288,13 @@ export async function main() {
 
 	if (installResponse.install) {
 		const installExec = exec(`cd ${cwd} && ${pkgManager} install`);
-		spinner = ora({ color: 'green', text: 'Installing packages...' }).start();
+		const installingPackagesMsg = `Installing packages${emojiWithFallback(' 📦', '...')}`;
+		spinner = ora({ color: 'green', text: installingPackagesMsg }).start();
 		await new Promise<void>((resolve, reject) => {
 			installExec.stdout?.on('data', function (data) {
 				// remove newlines from data stream for nicer formatting
 				const oneLiner = data.replace('\n', '');
-				spinner.text = `Installing packages...\n${bold(`[${pkgManager}]`)} ${oneLiner}`;
+				spinner.text = `${installingPackagesMsg}\n${bold(`[${pkgManager}]`)} ${oneLiner}`;
 			});
 			installExec.on('error', (error) => reject(error));
 			installExec.on('close', () => resolve());
@@ -318,6 +319,10 @@ export async function main() {
 
 	console.log(`\nTo close the dev server, hit ${bold(cyan('Ctrl-C'))}`);
 	console.log(`\nStuck? Visit us at ${cyan('https://astro.build/chat')}\n`);
+}
+
+function emojiWithFallback(char: string, fallback: string) {
+	return process.platform !== 'win32' ? char : fallback;
 }
 
 /**

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -141,135 +141,137 @@ export async function main() {
 	spinner = ora({ color: 'green', text: 'Copying project files...' }).start();
 
 	// Copy
-	try {
-		emitter.on('info', (info) => {
-			logger.debug(info.message);
-		});
-		await emitter.clone(cwd);
-	} catch (err: any) {
-		// degit is compiled, so the stacktrace is pretty noisy. Only report the stacktrace when using verbose mode.
-		logger.debug(err);
-		console.error(red(err.message));
+	if (!args.dryrun) {
+		try {
+			emitter.on('info', (info) => {
+				logger.debug(info.message);
+			});
+			await emitter.clone(cwd);
+		} catch (err: any) {
+			// degit is compiled, so the stacktrace is pretty noisy. Only report the stacktrace when using verbose mode.
+			logger.debug(err);
+			console.error(red(err.message));
 
-		// Warning for issue #655
-		if (err.message === 'zlib: unexpected end of file') {
-			console.log(
-				yellow(
-					"This seems to be a cache related problem. Remove the folder '~/.degit/github/withastro' to fix this error."
-				)
-			);
-			console.log(
-				yellow(
-					'For more information check out this issue: https://github.com/withastro/astro/issues/655'
-				)
-			);
+			// Warning for issue #655
+			if (err.message === 'zlib: unexpected end of file') {
+				console.log(
+					yellow(
+						"This seems to be a cache related problem. Remove the folder '~/.degit/github/withastro' to fix this error."
+					)
+				);
+				console.log(
+					yellow(
+						'For more information check out this issue: https://github.com/withastro/astro/issues/655'
+					)
+				);
+			}
+
+			// Helpful message when encountering the "could not find commit hash for ..." error
+			if (err.code === 'MISSING_REF') {
+				console.log(
+					yellow(
+						"This seems to be an issue with degit. Please check if you have 'git' installed on your system, and install it if you don't have (https://git-scm.com)."
+					)
+				);
+				console.log(
+					yellow(
+						"If you do have 'git' installed, please run this command with the --verbose flag and file a new issue with the command output here: https://github.com/withastro/astro/issues"
+					)
+				);
+			}
+			spinner.fail();
+			process.exit(1);
 		}
 
-		// Helpful message when encountering the "could not find commit hash for ..." error
-		if (err.code === 'MISSING_REF') {
-			console.log(
-				yellow(
-					"This seems to be an issue with degit. Please check if you have 'git' installed on your system, and install it if you don't have (https://git-scm.com)."
-				)
-			);
-			console.log(
-				yellow(
-					"If you do have 'git' installed, please run this command with the --verbose flag and file a new issue with the command output here: https://github.com/withastro/astro/issues"
-				)
-			);
-		}
-		spinner.fail();
-		process.exit(1);
-	}
+		// Post-process in parallel
+		await Promise.all([
+			...FILES_TO_REMOVE.map(async (file) => {
+				const fileLoc = path.resolve(path.join(cwd, file));
+				return fs.promises.rm(fileLoc);
+			}),
+			...POSTPROCESS_FILES.map(async (file) => {
+				const fileLoc = path.resolve(path.join(cwd, file));
 
-	// Post-process in parallel
-	await Promise.all([
-		...FILES_TO_REMOVE.map(async (file) => {
-			const fileLoc = path.resolve(path.join(cwd, file));
-			return fs.promises.rm(fileLoc);
-		}),
-		...POSTPROCESS_FILES.map(async (file) => {
-			const fileLoc = path.resolve(path.join(cwd, file));
-
-			switch (file) {
-				case 'CHANGELOG.md': {
-					if (fs.existsSync(fileLoc)) {
-						await fs.promises.unlink(fileLoc);
-					}
-					break;
-				}
-				case 'astro.config.mjs': {
-					if (selectedTemplate?.integrations !== true) {
+				switch (file) {
+					case 'CHANGELOG.md': {
+						if (fs.existsSync(fileLoc)) {
+							await fs.promises.unlink(fileLoc);
+						}
 						break;
 					}
-					await fs.promises.writeFile(fileLoc, createConfig({ integrations }));
-					break;
-				}
-				case 'package.json': {
-					const packageJSON = JSON.parse(await fs.promises.readFile(fileLoc, 'utf8'));
-					delete packageJSON.snowpack; // delete snowpack config only needed in monorepo (can mess up projects)
-					// Fetch latest versions of selected integrations
-					const integrationEntries = (
-						await Promise.all(
-							integrations.map((integration) =>
-								fetch(`https://registry.npmjs.org/${integration.packageName}/latest`)
-									.then((res) => res.json())
-									.then((res: any) => {
-										let dependencies: [string, string][] = [[res['name'], `^${res['version']}`]];
+					case 'astro.config.mjs': {
+						if (selectedTemplate?.integrations !== true) {
+							break;
+						}
+						await fs.promises.writeFile(fileLoc, createConfig({ integrations }));
+						break;
+					}
+					case 'package.json': {
+						const packageJSON = JSON.parse(await fs.promises.readFile(fileLoc, 'utf8'));
+						delete packageJSON.snowpack; // delete snowpack config only needed in monorepo (can mess up projects)
+						// Fetch latest versions of selected integrations
+						const integrationEntries = (
+							await Promise.all(
+								integrations.map((integration) =>
+									fetch(`https://registry.npmjs.org/${integration.packageName}/latest`)
+										.then((res) => res.json())
+										.then((res: any) => {
+											let dependencies: [string, string][] = [[res['name'], `^${res['version']}`]];
 
-										if (res['peerDependencies']) {
-											for (const peer in res['peerDependencies']) {
-												dependencies.push([peer, res['peerDependencies'][peer]]);
+											if (res['peerDependencies']) {
+												for (const peer in res['peerDependencies']) {
+													dependencies.push([peer, res['peerDependencies'][peer]]);
+												}
 											}
-										}
 
-										return dependencies;
-									})
+											return dependencies;
+										})
+								)
 							)
-						)
-					).flat(1);
-					// merge and sort dependencies
-					packageJSON.devDependencies = {
-						...(packageJSON.devDependencies ?? {}),
-						...Object.fromEntries(integrationEntries),
-					};
-					packageJSON.devDependencies = Object.fromEntries(
-						Object.entries(packageJSON.devDependencies).sort((a, b) => a[0].localeCompare(b[0]))
-					);
-					await fs.promises.writeFile(fileLoc, JSON.stringify(packageJSON, undefined, 2));
-					break;
+						).flat(1);
+						// merge and sort dependencies
+						packageJSON.devDependencies = {
+							...(packageJSON.devDependencies ?? {}),
+							...Object.fromEntries(integrationEntries),
+						};
+						packageJSON.devDependencies = Object.fromEntries(
+							Object.entries(packageJSON.devDependencies).sort((a, b) => a[0].localeCompare(b[0]))
+						);
+						await fs.promises.writeFile(fileLoc, JSON.stringify(packageJSON, undefined, 2));
+						break;
+					}
 				}
-			}
-		}),
-	]);
+			}),
+		]);
 
-	// Inject framework components into starter template
-	if (selectedTemplate?.value === 'starter') {
-		let importStatements: string[] = [];
-		let components: string[] = [];
-		await Promise.all(
-			integrations.map(async (integration) => {
-				const component = COUNTER_COMPONENTS[integration.id as keyof typeof COUNTER_COMPONENTS];
-				const componentName = path.basename(component.filename, path.extname(component.filename));
-				const absFileLoc = path.resolve(cwd, component.filename);
-				importStatements.push(
-					`import ${componentName} from '${component.filename.replace(/^src/, '..')}';`
-				);
-				components.push(`<${componentName} client:visible />`);
-				await fs.promises.writeFile(absFileLoc, component.content);
-			})
-		);
+		// Inject framework components into starter template
+		if (selectedTemplate?.value === 'starter') {
+			let importStatements: string[] = [];
+			let components: string[] = [];
+			await Promise.all(
+				integrations.map(async (integration) => {
+					const component = COUNTER_COMPONENTS[integration.id as keyof typeof COUNTER_COMPONENTS];
+					const componentName = path.basename(component.filename, path.extname(component.filename));
+					const absFileLoc = path.resolve(cwd, component.filename);
+					importStatements.push(
+						`import ${componentName} from '${component.filename.replace(/^src/, '..')}';`
+					);
+					components.push(`<${componentName} client:visible />`);
+					await fs.promises.writeFile(absFileLoc, component.content);
+				})
+			);
 
-		const pageFileLoc = path.resolve(path.join(cwd, 'src', 'pages', 'index.astro'));
-		const content = (await fs.promises.readFile(pageFileLoc)).toString();
-		const newContent = content
-			.replace(/^(\s*)\/\* ASTRO\:COMPONENT_IMPORTS \*\//gm, (_, indent) => {
-				return indent + importStatements.join('\n');
-			})
-			.replace(/^(\s*)<!-- ASTRO:COMPONENT_MARKUP -->/gm, (_, indent) => {
-				return components.map((ln) => indent + ln).join('\n');
-			});
-		await fs.promises.writeFile(pageFileLoc, newContent);
+			const pageFileLoc = path.resolve(path.join(cwd, 'src', 'pages', 'index.astro'));
+			const content = (await fs.promises.readFile(pageFileLoc)).toString();
+			const newContent = content
+				.replace(/^(\s*)\/\* ASTRO\:COMPONENT_IMPORTS \*\//gm, (_, indent) => {
+					return indent + importStatements.join('\n');
+				})
+				.replace(/^(\s*)<!-- ASTRO:COMPONENT_MARKUP -->/gm, (_, indent) => {
+					return components.map((ln) => indent + ln).join('\n');
+				});
+			await fs.promises.writeFile(pageFileLoc, newContent);
+		}
 	}
 
 	spinner.succeed();
@@ -290,13 +292,15 @@ export async function main() {
 		const installExec = execa(pkgManager, ['install'], { cwd });
 		const installingPackagesMsg = `Installing packages${emojiWithFallback(' 📦', '...')}`;
 		spinner = ora({ color: 'green', text: installingPackagesMsg }).start();
-		await new Promise<void>((resolve, reject) => {
-			installExec.stdout?.on('data', function (data) {
-				spinner.text = `${installingPackagesMsg}\n${bold(`[${pkgManager}]`)} ${data}`;
+		if (!args.dryrun) {
+			await new Promise<void>((resolve, reject) => {
+				installExec.stdout?.on('data', function (data) {
+					spinner.text = `${installingPackagesMsg}\n${bold(`[${pkgManager}]`)} ${data}`;
+				});
+				installExec.on('error', (error) => reject(error));
+				installExec.on('close', () => resolve());
 			});
-			installExec.on('error', (error) => reject(error));
-			installExec.on('close', () => resolve());
-		});
+		}
 		spinner.succeed();
 	}
 

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -292,7 +292,6 @@ export async function main() {
 		spinner = ora({ color: 'green', text: installingPackagesMsg }).start();
 		await new Promise<void>((resolve, reject) => {
 			installExec.stdout?.on('data', function (data) {
-				// remove newlines from data stream for nicer formatting
 				spinner.text = `${installingPackagesMsg}\n${bold(`[${pkgManager}]`)} ${data}`;
 			});
 			installExec.on('error', (error) => reject(error));

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -10,7 +10,7 @@ import { FRAMEWORKS, COUNTER_COMPONENTS, Integration } from './frameworks.js';
 import { TEMPLATES } from './templates.js';
 import { createConfig } from './config.js';
 import { logger, defaultLogLevel } from './logger.js';
-import { exec } from 'child_process';
+import { execa } from 'execa';
 
 // NOTE: In the v7.x version of npm, the default behavior of `npm init` was changed
 // to no longer require `--` to pass args and instead pass `--` directly to us. This
@@ -287,14 +287,13 @@ export async function main() {
 	}
 
 	if (installResponse.install) {
-		const installExec = exec(`cd ${cwd} && ${pkgManager} install`);
+		const installExec = execa(pkgManager, ['install'], { cwd });
 		const installingPackagesMsg = `Installing packages${emojiWithFallback(' 📦', '...')}`;
 		spinner = ora({ color: 'green', text: installingPackagesMsg }).start();
 		await new Promise<void>((resolve, reject) => {
 			installExec.stdout?.on('data', function (data) {
 				// remove newlines from data stream for nicer formatting
-				const oneLiner = data.replace('\n', '');
-				spinner.text = `${installingPackagesMsg}\n${bold(`[${pkgManager}]`)} ${oneLiner}`;
+				spinner.text = `${installingPackagesMsg}\n${bold(`[${pkgManager}]`)} ${data}`;
 			});
 			installExec.on('error', (error) => reject(error));
 			installExec.on('close', () => resolve());

--- a/packages/create-astro/test/directory-step.test.js
+++ b/packages/create-astro/test/directory-step.test.js
@@ -8,7 +8,7 @@ const inputs = {
 	nonexistentDir: './fixtures/select-directory/banana-dir',
 };
 
-describe.skip('[create-astro] select directory', function () {
+describe('[create-astro] select directory', function () {
 	this.timeout(timeout);
 	it('should prompt for directory when none is provided', function () {
 		return promiseWithTimeout((resolve) => {

--- a/packages/create-astro/test/directory-step.test.js
+++ b/packages/create-astro/test/directory-step.test.js
@@ -1,24 +1,20 @@
 import { resolve } from 'path';
 import { promises, existsSync } from 'fs';
-import { testDir, setup, promiseWithTimeout, timeout } from './utils.js'
+import { PROMPT_MESSAGES, testDir, setup, promiseWithTimeout, timeout } from './utils.js';
 
-const instructions = {
-	directory: 'Where would you like to create your app?',
-	template: 'Which app template would you like to use?',
-};
 const inputs = {
 	nonEmptyDir: './fixtures/select-directory/nonempty-dir',
 	emptyDir: './fixtures/select-directory/empty-dir',
 	nonexistentDir: './fixtures/select-directory/banana-dir',
 };
 
-describe('[create-astro] select directory', function () {
+describe.skip('[create-astro] select directory', function () {
 	this.timeout(timeout);
 	it('should prompt for directory when none is provided', function () {
 		return promiseWithTimeout((resolve) => {
 			const { stdout } = setup();
 			stdout.on('data', (chunk) => {
-				if (chunk.includes(instructions.directory)) {
+				if (chunk.includes(PROMPT_MESSAGES.directory)) {
 					resolve();
 				}
 			});
@@ -28,7 +24,7 @@ describe('[create-astro] select directory', function () {
 		return promiseWithTimeout((resolve) => {
 			const { stdout } = setup([inputs.nonEmptyDir]);
 			stdout.on('data', (chunk) => {
-				if (chunk.includes(instructions.directory)) {
+				if (chunk.includes(PROMPT_MESSAGES.directory)) {
 					resolve();
 				}
 			});
@@ -42,7 +38,7 @@ describe('[create-astro] select directory', function () {
 		return promiseWithTimeout((resolve) => {
 			const { stdout } = setup([inputs.emptyDir]);
 			stdout.on('data', (chunk) => {
-				if (chunk.includes(instructions.template)) {
+				if (chunk.includes(PROMPT_MESSAGES.template)) {
 					resolve();
 				}
 			});
@@ -52,7 +48,7 @@ describe('[create-astro] select directory', function () {
 		return promiseWithTimeout((resolve) => {
 			const { stdout } = setup([inputs.nonexistentDir]);
 			stdout.on('data', (chunk) => {
-				if (chunk.includes(instructions.template)) {
+				if (chunk.includes(PROMPT_MESSAGES.template)) {
 					resolve();
 				}
 			});
@@ -65,7 +61,7 @@ describe('[create-astro] select directory', function () {
 				if (chunk.includes('Please clear contents or choose a different path.')) {
 					resolve();
 				}
-				if (chunk.includes(instructions.directory)) {
+				if (chunk.includes(PROMPT_MESSAGES.directory)) {
 					stdin.write(`${inputs.nonEmptyDir}\x0D`);
 				}
 			});

--- a/packages/create-astro/test/directory-step.test.js
+++ b/packages/create-astro/test/directory-step.test.js
@@ -1,15 +1,6 @@
-import { execa } from 'execa';
-import { fileURLToPath } from 'url';
-import { dirname, resolve } from 'path';
+import { resolve } from 'path';
 import { promises, existsSync } from 'fs';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const createAstroError = new Error(
-	'Timed out waiting for create-astro to respond with expected output.'
-);
-const timeout = 5000;
+import { testDir, setup, promiseWithTimeout, timeout } from './utils.js'
 
 const instructions = {
 	directory: 'Where would you like to create your app?',
@@ -20,27 +11,6 @@ const inputs = {
 	emptyDir: './fixtures/select-directory/empty-dir',
 	nonexistentDir: './fixtures/select-directory/banana-dir',
 };
-
-function promiseWithTimeout(testFn) {
-	return new Promise((resolve, reject) => {
-		const timeoutEvent = setTimeout(() => {
-			reject(createAstroError);
-		}, timeout);
-		function resolver() {
-			clearTimeout(timeoutEvent);
-			resolve();
-		}
-		testFn(resolver);
-	});
-}
-
-function setup(args = []) {
-	const { stdout, stdin } = execa('../create-astro.mjs', args, { cwd: __dirname });
-	return {
-		stdin,
-		stdout,
-	};
-}
 
 describe('[create-astro] select directory', function () {
 	this.timeout(timeout);
@@ -65,7 +35,7 @@ describe('[create-astro] select directory', function () {
 		});
 	});
 	it('should proceed on an empty directory', async function () {
-		const resolvedEmptyDirPath = resolve(__dirname, inputs.emptyDir);
+		const resolvedEmptyDirPath = resolve(testDir, inputs.emptyDir);
 		if (!existsSync(resolvedEmptyDirPath)) {
 			await promises.mkdir(resolvedEmptyDirPath);
 		}

--- a/packages/create-astro/test/install-step.test.js
+++ b/packages/create-astro/test/install-step.test.js
@@ -1,0 +1,60 @@
+import { setup, promiseWithTimeout, timeout, PROMPT_MESSAGES } from './utils.js';
+import { sep } from 'path';
+import fs from 'fs';
+import os from 'os';
+
+const FAKE_PACKAGE_MANAGER = 'banana';
+
+describe('[create-astro] install', function () {
+	this.timeout(timeout);
+	let tempDir = '';
+	beforeEach(async () => {
+		tempDir = await fs.promises.mkdtemp(`${os.tmpdir()}${sep}`);
+	});
+	process.env.npm_config_user_agent = FAKE_PACKAGE_MANAGER;
+	it('should respect package manager in prompt', function() {
+		const { stdout, stdin } = setup([tempDir]);
+		return promiseWithTimeout((resolve) => {
+			const seen = new Set();
+			stdout.on('data', (chunk) => {
+				if (!seen.has(PROMPT_MESSAGES.template) && chunk.includes(PROMPT_MESSAGES.template)) {
+					seen.add(PROMPT_MESSAGES.template);
+					stdin.write('\x0D');
+				}
+				if (!seen.has(PROMPT_MESSAGES.frameworks) && chunk.includes(PROMPT_MESSAGES.frameworks)) {
+					seen.add(PROMPT_MESSAGES.frameworks);
+					stdin.write('\x0D');
+				}
+				if (chunk.includes(PROMPT_MESSAGES.install(FAKE_PACKAGE_MANAGER))) {
+					resolve();
+				}
+			});
+		});
+	});
+
+	it('should respect package manager in next steps', function() {
+		const { stdout, stdin } = setup([tempDir]);
+		return promiseWithTimeout((resolve) => {
+			const seen = new Set();
+			const installPrompt = PROMPT_MESSAGES.install(FAKE_PACKAGE_MANAGER);
+			stdout.on('data', (chunk) => {
+				if (!seen.has(PROMPT_MESSAGES.template) && chunk.includes(PROMPT_MESSAGES.template)) {
+					seen.add(PROMPT_MESSAGES.template);
+					stdin.write('\x0D');
+				}
+				if (!seen.has(PROMPT_MESSAGES.frameworks) && chunk.includes(PROMPT_MESSAGES.frameworks)) {
+					seen.add(PROMPT_MESSAGES.frameworks);
+					stdin.write('\x0D');
+				}
+				
+				if (!seen.has(installPrompt) && chunk.includes(installPrompt)) {
+					seen.add(installPrompt)
+					stdin.write('n\x0D');
+				}
+				if (chunk.includes('banana dev')) {
+					resolve();
+				}
+			});
+		});
+	});
+})

--- a/packages/create-astro/test/install-step.test.js
+++ b/packages/create-astro/test/install-step.test.js
@@ -21,15 +21,15 @@ describe('[create-astro] install', function () {
 	})
 
 	it('should respect package manager in prompt', function() {
-		console.log({tempDir})
-		const { stdout, stdin } = setup([tempDir]);
+		const { stdout, stdin } = setup([tempDir, '--dryrun']);
 		return promiseWithTimeout((resolve) => {
 			const seen = new Set();
 			const installPrompt = PROMPT_MESSAGES.install(FAKE_PACKAGE_MANAGER);
 			stdout.on('data', (chunk) => {
-				console.log({ chunk: chunk.toString() });
 				if (!seen.has(PROMPT_MESSAGES.template) && chunk.includes(PROMPT_MESSAGES.template)) {
+					fs.promises.rmdir('~/.degit/github')
 					seen.add(PROMPT_MESSAGES.template);
+					console.log('temp')
 					stdin.write('\x0D');
 				}
 				if (!seen.has(PROMPT_MESSAGES.frameworks) && chunk.includes(PROMPT_MESSAGES.frameworks)) {
@@ -47,7 +47,7 @@ describe('[create-astro] install', function () {
 
 	it('should respect package manager in next steps', function() {
 		console.log({tempDir})
-		const { stdout, stdin } = setup([tempDir]);
+		const { stdout, stdin } = setup([tempDir, '--dryrun']);
 		return promiseWithTimeout((resolve) => {
 			const seen = new Set();
 			const installPrompt = PROMPT_MESSAGES.install(FAKE_PACKAGE_MANAGER);

--- a/packages/create-astro/test/install-step.test.js
+++ b/packages/create-astro/test/install-step.test.js
@@ -21,11 +21,13 @@ describe('[create-astro] install', function () {
 	})
 
 	it('should respect package manager in prompt', function() {
+		console.log({tempDir})
 		const { stdout, stdin } = setup([tempDir]);
 		return promiseWithTimeout((resolve) => {
 			const seen = new Set();
 			const installPrompt = PROMPT_MESSAGES.install(FAKE_PACKAGE_MANAGER);
 			stdout.on('data', (chunk) => {
+				console.log({ chunk: chunk.toString() });
 				if (!seen.has(PROMPT_MESSAGES.template) && chunk.includes(PROMPT_MESSAGES.template)) {
 					seen.add(PROMPT_MESSAGES.template);
 					stdin.write('\x0D');
@@ -44,6 +46,7 @@ describe('[create-astro] install', function () {
 	});
 
 	it('should respect package manager in next steps', function() {
+		console.log({tempDir})
 		const { stdout, stdin } = setup([tempDir]);
 		return promiseWithTimeout((resolve) => {
 			const seen = new Set();

--- a/packages/create-astro/test/install-step.test.js
+++ b/packages/create-astro/test/install-step.test.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import os from 'os';
 
 const FAKE_PACKAGE_MANAGER = 'banana';
+let initialEnvValue = null;
 
 describe('[create-astro] install', function () {
 	this.timeout(timeout);
@@ -11,7 +12,14 @@ describe('[create-astro] install', function () {
 	beforeEach(async () => {
 		tempDir = await fs.promises.mkdtemp(`${os.tmpdir()}${sep}`);
 	});
-	process.env.npm_config_user_agent = FAKE_PACKAGE_MANAGER;
+	this.beforeAll(() => {
+		initialEnvValue = process.env.npm_config_user_agent;
+		process.env.npm_config_user_agent = FAKE_PACKAGE_MANAGER;
+	})
+	this.afterAll(() => {
+		process.env.npm_config_user_agent = initialEnvValue;
+	})
+
 	it('should respect package manager in prompt', function() {
 		const { stdout, stdin } = setup([tempDir]);
 		return promiseWithTimeout((resolve) => {

--- a/packages/create-astro/test/install-step.test.js
+++ b/packages/create-astro/test/install-step.test.js
@@ -24,6 +24,7 @@ describe('[create-astro] install', function () {
 		const { stdout, stdin } = setup([tempDir]);
 		return promiseWithTimeout((resolve) => {
 			const seen = new Set();
+			const installPrompt = PROMPT_MESSAGES.install(FAKE_PACKAGE_MANAGER);
 			stdout.on('data', (chunk) => {
 				if (!seen.has(PROMPT_MESSAGES.template) && chunk.includes(PROMPT_MESSAGES.template)) {
 					seen.add(PROMPT_MESSAGES.template);
@@ -33,7 +34,9 @@ describe('[create-astro] install', function () {
 					seen.add(PROMPT_MESSAGES.frameworks);
 					stdin.write('\x0D');
 				}
-				if (chunk.includes(PROMPT_MESSAGES.install(FAKE_PACKAGE_MANAGER))) {
+				
+				if (!seen.has(installPrompt) && chunk.includes(installPrompt)) {
+					seen.add(installPrompt);
 					resolve();
 				}
 			});

--- a/packages/create-astro/test/install-step.test.js
+++ b/packages/create-astro/test/install-step.test.js
@@ -27,7 +27,6 @@ describe('[create-astro] install', function () {
 			const installPrompt = PROMPT_MESSAGES.install(FAKE_PACKAGE_MANAGER);
 			stdout.on('data', (chunk) => {
 				if (!seen.has(PROMPT_MESSAGES.template) && chunk.includes(PROMPT_MESSAGES.template)) {
-					fs.promises.rmdir('~/.degit/github')
 					seen.add(PROMPT_MESSAGES.template);
 					stdin.write('\x0D');
 				}

--- a/packages/create-astro/test/install-step.test.js
+++ b/packages/create-astro/test/install-step.test.js
@@ -29,7 +29,6 @@ describe('[create-astro] install', function () {
 				if (!seen.has(PROMPT_MESSAGES.template) && chunk.includes(PROMPT_MESSAGES.template)) {
 					fs.promises.rmdir('~/.degit/github')
 					seen.add(PROMPT_MESSAGES.template);
-					console.log('temp')
 					stdin.write('\x0D');
 				}
 				if (!seen.has(PROMPT_MESSAGES.frameworks) && chunk.includes(PROMPT_MESSAGES.frameworks)) {
@@ -46,7 +45,6 @@ describe('[create-astro] install', function () {
 	});
 
 	it('should respect package manager in next steps', function() {
-		console.log({tempDir})
 		const { stdout, stdin } = setup([tempDir, '--dryrun']);
 		return promiseWithTimeout((resolve) => {
 			const seen = new Set();

--- a/packages/create-astro/test/utils.js
+++ b/packages/create-astro/test/utils.js
@@ -1,0 +1,32 @@
+import { execa } from 'execa'
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+export const testDir = dirname(__filename);
+export const timeout = 5000;
+
+const createAstroError = new Error(
+	'Timed out waiting for create-astro to respond with expected output.'
+);
+
+export function promiseWithTimeout(testFn) {
+	return new Promise((resolve, reject) => {
+		const timeoutEvent = setTimeout(() => {
+			reject(createAstroError);
+		}, timeout);
+		function resolver() {
+			clearTimeout(timeoutEvent);
+			resolve();
+		}
+		testFn(resolver);
+	});
+}
+
+export function setup(args = []) {
+	const { stdout, stdin } = execa('../create-astro.mjs', args, { cwd: testDir });
+	return {
+		stdin,
+		stdout,
+	};
+}

--- a/packages/create-astro/test/utils.js
+++ b/packages/create-astro/test/utils.js
@@ -23,6 +23,14 @@ export function promiseWithTimeout(testFn) {
 	});
 }
 
+export const PROMPT_MESSAGES = {
+	directory: 'Where would you like to create your app?',
+	template: 'Which app template would you like to use?',
+	// TODO: remove when framework selector is removed
+	frameworks: 'Which frameworks would you like to use?',
+	install: (pkgManager) => `Would you like us to run "${pkgManager} install?"`,
+};
+
 export function setup(args = []) {
 	const { stdout, stdin } = execa('../create-astro.mjs', args, { cwd: testDir });
 	return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1210,6 +1210,7 @@ importers:
       astro-scripts: workspace:*
       chai: ^4.3.6
       degit: ^2.8.4
+      execa: ^6.1.0
       kleur: ^4.1.4
       mocha: ^9.2.2
       node-fetch: ^3.2.3
@@ -1221,6 +1222,7 @@ importers:
       '@types/degit': 2.8.3
       '@types/prompts': 2.0.14
       degit: 2.8.4
+      execa: 6.1.0
       kleur: 4.1.4
       node-fetch: 3.2.3
       ora: 6.1.0
@@ -1234,6 +1236,12 @@ importers:
       chai: 4.3.6
       mocha: 9.2.2
       uvu: 0.5.3
+
+  packages/create-astro/test/fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir./fixtures/select-directory/nonempty-dir:
+    specifiers:
+      astro: ^1.0.0-beta.17
+    devDependencies:
+      astro: link:../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../astro
 
   packages/integrations/deno:
     specifiers:


### PR DESCRIPTION
## Changes

- Add new step to `create astro` - Would you like us to run "MY_PACKAGE_MANAGER install?"
- Update "next steps" section to recommend `pnpm dev`, `yarn dev`, or `npm run dev`.
- Infers MY_PACKAGE_MANAGER based on how you ran the command: `yarn create astro` vs `pnpm create astro`, etc.

## Testing

Add super fancy unit tests to walk through the CLI: `install-step.test.js` 🔥 

## Watch it go 🏃‍♂️ 

https://user-images.githubusercontent.com/51384119/164801565-70004c92-01d2-472f-9dec-ded1a382fa5e.mov

## Docs

N/A