### PR TITLE
feat(markdown): Improved types

### DIFF
--- a/.changeset/cool-experts-shake.md
+++ b/.changeset/cool-experts-shake.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Added better types to importing Markdown

--- a/packages/astro/env.d.ts
+++ b/packages/astro/env.d.ts
@@ -11,3 +11,16 @@ type Astro = import('astro').AstroGlobal;
 declare const Astro: Readonly<Astro>;
 
 declare const Fragment: any;
+
+declare module '*.md' {
+	type MD = import('astro').MarkdownInstance<Record<string, any>>;
+
+	export const frontmatter: MD['frontmatter'];
+	export const file: MD['file'];
+	export const url: MD['url'];
+	export const getHeaders: MD['getHeaders'];
+	export const Content: MD['Content'];
+
+	const load: MD['default'];
+	export default load;
+}

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -725,7 +725,13 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 	file: string;
 	url: string | undefined;
 	Content: AstroComponentFactory;
-	getHeaders(): Promise<{ depth: number; slug: string; text: string }[]>;
+	getHeaders(): Promise<MarkdownHeader[]>;
+	default: () => Promise<{
+		metadata: MarkdownMetadata;
+		frontmatter: MarkdownContent;
+		$$metadata: Metadata;
+		default: AstroComponentFactory;
+	}>;
 }
 
 export type GetHydrateCallback = () => Promise<
@@ -767,16 +773,37 @@ export interface ManifestData {
 	routes: RouteData[];
 }
 
+export interface MarkdownHeader {
+	depth: number;
+	slug: string;
+	text: string;
+}
+
+export interface MarkdownMetadata {
+	headers: MarkdownHeader[];
+	source: string;
+	html: string;
+}
+
 export interface MarkdownParserResponse {
 	frontmatter: {
 		[key: string]: any;
 	};
-	metadata: {
-		headers: any[];
+	metadata: MarkdownMetadata;
+	code: string;
+}
+
+/**
+ * The `content` prop given to a Layout
+ * https://docs.astro.build/guides/markdown-content/#markdown-layouts
+ */
+export interface MarkdownContent {
+	[key: string]: any;
+	astro: {
+		headers: MarkdownHeader[];
 		source: string;
 		html: string;
 	};
-	code: string;
 }
 
 /**

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -799,11 +799,7 @@ export interface MarkdownParserResponse {
  */
 export interface MarkdownContent {
 	[key: string]: any;
-	astro: {
-		headers: MarkdownHeader[];
-		source: string;
-		html: string;
-	};
+	astro: MarkdownMetadata;
 }
 
 /**


### PR DESCRIPTION
## Changes

- Added types `MarkdownHeader`, `MarkdownMetadata` and `MarkdownContent`
- Types for importing `.md` files

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->