### PR TITLE
Add Astro attributes to svg elements

### DIFF
--- a/.changeset/metal-doors-rhyme.md
+++ b/.changeset/metal-doors-rhyme.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Added Astro attributes to SVG elements in JSX definition

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -621,7 +621,10 @@ declare namespace astroHTML.JSX {
 	//   - "number | string"
 	//   - "string"
 	//   - union of string literals
-	interface SVGAttributes<T extends EventTarget> extends AriaAttributes, DOMAttributes<T> {
+	interface SVGAttributes<T extends EventTarget>
+		extends AriaAttributes,
+			DOMAttributes<T>,
+			AstroBuiltinAttributes {
 		// Attributes which also defined in HTMLAttributes
 		className?: string | undefined | null;
 		class?: string | undefined | null;


### PR DESCRIPTION
## Changes

Add Astro attributes (`class:list`, `set:html` etc) to SVG elements

Fix https://github.com/withastro/language-tools/issues/260

## Testing

No tests needed (if we have to, we'll test this in the language server itself)

## Docs

No docs needed