### PR TITLE
Prevent watcher from running during the build

### DIFF
--- a/.changeset/big-ducks-search.md
+++ b/.changeset/big-ducks-search.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Disables file watching during the build

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -83,6 +83,10 @@ export async function createVite(
 			proxy: {
 				// add proxies here
 			},
+			watch: {
+				// Prevent watching during the build to speed it up
+				ignored: mode === 'build' ? ['**'] : undefined,
+			}
 		},
 		css: {
 			postcss: astroConfig.style.postcss || {},


### PR DESCRIPTION
## Changes

- Makes it so that we ignore all file watching during the build.
- This fixtures issues seen in very large projects as reported here: https://discord.com/channels/830184174198718474/966778102401368084
- Also speeds things up, in theory at least.

## Testing

Not really testable unfortunately.

## Docs

N/A, bug fix.