### PR TITLE
Add missing is:raw in AstroBuiltinAttributes

### DIFF
--- a/.changeset/happy-sheep-chew.md
+++ b/.changeset/happy-sheep-chew.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add `is:raw` to AstroBuiltinAttributes

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -25,6 +25,7 @@ export interface AstroBuiltinAttributes {
 		| string;
 	'set:html'?: any;
 	'set:text'?: any;
+	'is:raw'?: boolean;
 }
 
 export interface AstroDefineVarsAttribute {


### PR DESCRIPTION
## Changes

`is:raw` was missing from the types of allowed attributes

## Testing

No tests needed

## Docs

No docs needed