### PR TITLE
Refactor/clean create astro logs

### DIFF
--- a/.changeset/curly-cobras-kneel.md
+++ b/.changeset/curly-cobras-kneel.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Simplify logging during welcome message and directory selection

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -66,8 +66,7 @@ export async function main() {
 	}
 
 	if (!cwd || !isEmpty(cwd)) {
-		const notEmptyMsg = (dirPath: string) =>
-			`"${bold(dirPath)}" is not empty. Please clear contents or choose a different path.`;
+		const notEmptyMsg = (dirPath: string) => `"${bold(dirPath)}" is not empty!`;
 
 		if (!isEmpty(cwd)) {
 			let rejectProjectDir = ora({ color: 'red', text: notEmptyMsg(cwd) });

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -45,11 +45,6 @@ export async function main() {
 
 	logger.debug('Verbose logging turned on');
 	console.log(`\n${bold('Welcome to Astro!')} ${gray(`(create-astro v${version})`)}`);
-	console.log(
-		`If you encounter a problem, visit ${cyan(
-			'https://github.com/withastro/astro/issues'
-		)} to search or file a new issue.\n`
-	);
 
 	let spinner = ora({ color: 'green', text: 'Prepare for liftoff.' });
 

--- a/packages/create-astro/test/directory-step.test.js
+++ b/packages/create-astro/test/directory-step.test.js
@@ -58,7 +58,7 @@ describe('[create-astro] select directory', function () {
 		return promiseWithTimeout((resolve) => {
 			const { stdout, stdin } = setup();
 			stdout.on('data', (chunk) => {
-				if (chunk.includes('Please clear contents or choose a different path.')) {
+				if (chunk.includes('is not empty!')) {
 					resolve();
 				}
 				if (chunk.includes(PROMPT_MESSAGES.directory)) {


### PR DESCRIPTION
## Changes

- Remove "issue" callout from the start of the script. We prompt users to join our discord after installing, which is our preferred forum for feedback anyways.
- Shorten the empty directory log for simplicity. This also prevents longer messages from wrapping to a newline, which reveals a bug in the prompt library's line clearing setup

## Testing

N/A

## Docs

N/A