### PR TITLE
Chore: bump Astro core to expose new starter template

### DIFF
--- a/.changeset/tiny-guests-stare.md
+++ b/.changeset/tiny-guests-stare.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix: bump Astro core to update available starter templates. Find new "Just the Basics" option in create-astro!


### PR DESCRIPTION
## Changes

To expose [our new "Just the Basics" template](https://github.com/withastro/astro/pull/3206) from `create-astro`, we need to bump Astro core. This is because we rely on the `#latest` version flag in degit to fetch templates.

## Testing

N/A

## Docs

N/A