### PR TITLE
fix: use defined Props interface

### DIFF
--- a/examples/starter/src/components/Logo.astro
+++ b/examples/starter/src/components/Logo.astro
@@ -4,6 +4,6 @@ export interface Props {
     height?: number,
     width?: number,
 }
-const {height = 80, width = 60 } = Astro.props;
+const {height = 80, width = 60 } = Astro.props as Props;
 ---
 <img height={height} width={width} src="/logo.svg" alt="Astro logo">


### PR DESCRIPTION
A `Props` interface is defined but not used in line 7. Add `as Props` to end of that line. (Note: the comment on line 2 also look incomplete.)

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->