### PR TITLE
deprecate the markdown component in SSR

### DIFF
--- a/packages/astro/components/Markdown.astro
+++ b/packages/astro/components/Markdown.astro
@@ -3,6 +3,13 @@ export interface Props {
 	content?: string;
 }
 
+// NOTE(fks): We are most likely moving this component out of Astro core
+// in a few weeks. Checking the name like this is a bit of a hack, but we
+// intentionally don't want to add an SSR flag for others to read from, just yet.
+if (Astro.redirect.name !== '_onlyAvailableInSSR') {
+	console.error(`\x1B[31mThe <Markdown> component is not available in SSR. See https://github.com/withastro/rfcs/discussions/179 for more info.\x1B[39m`);
+}
+
 const dedent = (str: string) => {
 	const _str = str.split('\n').filter(s => s.trimStart().length > 0);
 	if (_str.length === 0) {

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -14,7 +14,7 @@ import { createCanonicalURL, isCSSRequest } from './util.js';
 import { isScriptRequest } from './script.js';
 
 function onlyAvailableInSSR(name: string) {
-	return function () {
+	return function _onlyAvailableInSSR() {
 		// TODO add more guidance when we have docs and adapters.
 		throw new Error(`Oops, you are trying to use ${name}, which is only available with SSR.`);
 	};


### PR DESCRIPTION
## Changes

- Based on https://github.com/withastro/rfcs/discussions/179
- While the RFC is not yet merged, this first step of the adoption plan is needed regardless, to protect users from this broken experience.

## Testing

- Tested manually. 

## Docs

- https://github.com/withastro/docs/pull/411