### PR TITLE
WIP: pass babel options to solid-js integration

### DIFF
--- a/packages/integrations/solid/src/index.ts
+++ b/packages/integrations/solid/src/index.ts
@@ -1,6 +1,6 @@
 import type { AstroIntegration, AstroRenderer } from 'astro';
 
-function getRenderer(): AstroRenderer {
+function getRenderer(babelConfig): AstroRenderer {
 	return {
 		name: '@astrojs/solid-js',
 		clientEntrypoint: '@astrojs/solid-js/client.js',
@@ -14,7 +14,7 @@ function getRenderer(): AstroRenderer {
 				plugins: [],
 			};
 
-			return options;
+			return babelConfig?.(options) ?? options;
 		},
 	};
 }
@@ -44,12 +44,12 @@ function getViteConfiguration(isDev: boolean) {
 	};
 }
 
-export default function (): AstroIntegration {
+export default function ({babelConfig}): AstroIntegration {
 	return {
 		name: '@astrojs/solid-js',
 		hooks: {
 			'astro:config:setup': ({ command, addRenderer, updateConfig }) => {
-				addRenderer(getRenderer());
+				addRenderer(getRenderer(babelConfig));
 				updateConfig({ vite: getViteConfiguration(command === 'dev') });
 			},
 		},


### PR DESCRIPTION
`babelConfig` will be called with Solid's Babel config object as an arg, allowing modifications to be made by users of the integration

WIP, not tested yet

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

TODO

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

TODO