### PR TITLE
Conform to API route signature

### DIFF
--- a/.changeset/fast-dolls-eat.md
+++ b/.changeset/fast-dolls-eat.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Implements the Dynamic Route API RFC

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -855,12 +855,27 @@ export interface AstroAdapter {
 	args?: any;
 }
 
+export interface APIContext {
+	params: Params;
+	request: Request;
+}
+
 export interface EndpointOutput<Output extends Body = Body> {
 	body: Output;
 }
 
+interface EndpointHandlerFunction {
+	(context: APIContext, request: Request): EndpointOutput | Response;
+
+	/**
+	 * @deprecated
+	 * Use { context: APIRouteContext } object instead.
+	 */
+	(params: Params, request: Request): EndpointOutput | Response;
+}
+
 export interface EndpointHandler {
-	[method: string]: (params: any, request: Request) => EndpointOutput | Response;
+	[method: string]: EndpointHandlerFunction;
 }
 
 export interface AstroRenderer {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -865,7 +865,7 @@ export interface EndpointOutput<Output extends Body = Body> {
 }
 
 interface APIRoute {
-	(context: APIContext, request: Request): EndpointOutput | Response;
+	(context: APIContext): EndpointOutput | Response;
 
 	/**
 	 * @deprecated

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -864,7 +864,7 @@ export interface EndpointOutput<Output extends Body = Body> {
 	body: Output;
 }
 
-interface EndpointHandlerFunction {
+interface APIRoute {
 	(context: APIContext, request: Request): EndpointOutput | Response;
 
 	/**
@@ -875,7 +875,7 @@ interface EndpointHandlerFunction {
 }
 
 export interface EndpointHandler {
-	[method: string]: EndpointHandlerFunction;
+	[method: string]: APIRoute;
 }
 
 export interface AstroRenderer {

--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -52,6 +52,7 @@ export async function callGetStaticPaths({
 
 	const keyedStaticPaths = staticPaths as GetStaticPathsResultKeyed;
 	keyedStaticPaths.keyed = new Map<string, GetStaticPathsItem>();
+
 	for (const sp of keyedStaticPaths) {
 		const paramsKey = stringifyParams(sp.params);
 		keyedStaticPaths.keyed.set(paramsKey, sp);

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -1,5 +1,6 @@
 import shorthash from 'shorthash';
 import type {
+	APIContext,
 	AstroComponentMetadata,
 	AstroGlobalPartial,
 	EndpointHandler,
@@ -481,7 +482,44 @@ export async function renderEndpoint(mod: EndpointHandler, request: Request, par
 			`Endpoint handler not found! Expected an exported function for "${chosenMethod}"`
 		);
 	}
-	return await handler.call(mod, params, request);
+
+	if(handler.length > 1) {
+		console.warn(`
+API routes with 2 arguments have been deprecated. Instead they take a single argument in the form of:
+
+export function get({ params, request }) {
+	//...
+}
+
+Update your code to remove this warning.`)
+	}
+
+	const context = {
+		request,
+		params
+	};
+
+	const proxy = new Proxy(context, {
+		get(target, prop) {
+			if(prop in target) {
+				return Reflect.get(target, prop);
+			} else if(prop in params) {
+				console.warn(`
+API routes no longer pass params as the first argument. Instead an object containing a params property is provided in the form of:
+
+export function get({ params }) {
+	// ...
+}
+
+Update your code to remove this warning.`);
+				return Reflect.get(params, prop);
+			} else {
+				return undefined;
+			}
+		}
+	}) as APIContext & Params;
+
+	return await handler.call(mod, proxy, request);
 }
 
 async function replaceHeadInjection(result: SSRResult, html: string): Promise<string> {

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -484,6 +484,7 @@ export async function renderEndpoint(mod: EndpointHandler, request: Request, par
 	}
 
 	if(handler.length > 1) {
+		// eslint-disable-next-line no-console
 		console.warn(`
 API routes with 2 arguments have been deprecated. Instead they take a single argument in the form of:
 
@@ -504,6 +505,7 @@ Update your code to remove this warning.`)
 			if(prop in target) {
 				return Reflect.get(target, prop);
 			} else if(prop in params) {
+				// eslint-disable-next-line no-console
 				console.warn(`
 API routes no longer pass params as the first argument. Instead an object containing a params property is provided in the form of:
 

--- a/packages/astro/test/api-routes.test.js
+++ b/packages/astro/test/api-routes.test.js
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('API routes', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/api-routes/' });
+		await fixture.build();
+	});
+
+	describe('Deprecated API', () => {
+		it('two argument supported', async () => {
+			const one = JSON.parse(await fixture.readFile('/old-api/twoarg/one.json'));
+			expect(one).to.deep.equal({
+				param: 'one',
+				pathname: '/old-api/twoarg/one.json'
+			});
+			const two = JSON.parse(await fixture.readFile('/old-api/twoarg/two.json'));
+			expect(two).to.deep.equal({
+				param: 'two',
+				pathname: '/old-api/twoarg/two.json'
+			});
+		});
+
+		it('param first argument is supported', async () => {
+			const one = JSON.parse(await fixture.readFile('/old-api/onearg/one.json'));
+			expect(one).to.deep.equal({
+				param: 'one'
+			});
+		});
+	});
+
+	describe('1.0 API', () => {
+		it('Receives a context argument', async () => {
+			const one = JSON.parse(await fixture.readFile('/context/data/one.json'));
+			expect(one).to.deep.equal({
+				param: 'one',
+				pathname: '/context/data/one.json'
+			});
+		});
+	});
+});

--- a/packages/astro/test/fixtures/api-routes/src/pages/context/data/[param].json.js
+++ b/packages/astro/test/fixtures/api-routes/src/pages/context/data/[param].json.js
@@ -1,0 +1,24 @@
+
+export function getStaticPaths() {
+	return [
+		{
+			params: {
+				param: 'one'
+			}
+		},
+		{
+			params: {
+				param: 'two'
+			}
+		},
+	]
+}
+
+export function get({ params, request }) {
+	return {
+		body: JSON.stringify({
+			param: params.param,
+			pathname: new URL(request.url).pathname
+		})
+	};
+}

--- a/packages/astro/test/fixtures/api-routes/src/pages/old-api/onearg/[param].json.js
+++ b/packages/astro/test/fixtures/api-routes/src/pages/old-api/onearg/[param].json.js
@@ -1,0 +1,23 @@
+
+export function getStaticPaths() {
+	return [
+		{
+			params: {
+				param: 'one'
+			}
+		},
+		{
+			params: {
+				param: 'two'
+			}
+		},
+	]
+}
+
+export function get(params) {
+	return {
+		body: JSON.stringify({
+			param: params.param
+		})
+	};
+}

--- a/packages/astro/test/fixtures/api-routes/src/pages/old-api/twoarg/[param].json.js
+++ b/packages/astro/test/fixtures/api-routes/src/pages/old-api/twoarg/[param].json.js
@@ -1,0 +1,24 @@
+
+export function getStaticPaths() {
+	return [
+		{
+			params: {
+				param: 'one'
+			}
+		},
+		{
+			params: {
+				param: 'two'
+			}
+		},
+	]
+}
+
+export function get(params, request) {
+	return {
+		body: JSON.stringify({
+			param: params.param,
+			pathname: new URL(request.url).pathname
+		})
+	};
+}

--- a/packages/astro/test/fixtures/ssr-dynamic/src/pages/api/products/[id].js
+++ b/packages/astro/test/fixtures/ssr-dynamic/src/pages/api/products/[id].js
@@ -1,5 +1,5 @@
 
-export function get(params) {
+export function get({params}) {
 	return {
 		body: JSON.stringify(params)
 	};

--- a/packages/astro/test/fixtures/ssr-dynamic/src/pages/api/products/[id].js
+++ b/packages/astro/test/fixtures/ssr-dynamic/src/pages/api/products/[id].js
@@ -1,5 +1,5 @@
 
-export function get({params}) {
+export function get({ params }) {
 	return {
 		body: JSON.stringify(params)
 	};


### PR DESCRIPTION
## Changes

- Implements the API Route Change proposal RFC: https://github.com/withastro/rfcs/pull/178
- Retains backwards compatibility, with warnings.
- Provides an `APIContext` to dynamic routes: `{ params, request }` as outlined in the RFC.

## Testing

- Tests added to ensure we retain backwards compatibility on the old signatures.
- Tests added for the new signature.

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->