### PR TITLE
fix: remove extra meta title from complex blog template

### DIFF
--- a/examples/blog-multiple-authors/src/pages/index.astro
+++ b/examples/blog-multiple-authors/src/pages/index.astro
@@ -24,7 +24,6 @@ let firstPage = allPosts.slice(0, 2);
 
 <html lang="en">
 	<head>
-		<title>{title}</title>
 		<MainHead {title} {description} image={allPosts[0].frontmatter.image} {canonicalURL} />
 	</head>
 


### PR DESCRIPTION
## Changes


Removes extra meta title from blog complex template
issue: #3270 

**Before** 
<img width="450" alt="image" src="https://user-images.githubusercontent.com/46791833/166514894-a8d54755-6683-4ba6-86a0-8627662e339a.png">

**After**
<img width="443" alt="image" src="https://user-images.githubusercontent.com/46791833/166515174-f7da793e-2f3d-4839-94c0-541727075091.png">

## Testing
No testing needed
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

No docs update
<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->