### PR TITLE
Turbolinks: clean up injected scripts and styles on page navigation

### DIFF
--- a/.changeset/tall-forks-cross.md
+++ b/.changeset/tall-forks-cross.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/turbolinks': patch
+---
+
+Fixes an issue that prevented client components from rehydrating when navigating back to a page

--- a/packages/integrations/turbolinks/client.js
+++ b/packages/integrations/turbolinks/client.js
@@ -2,9 +2,17 @@ import Turbolinks from 'turbolinks';
 export { Turbolinks };
 
 // Before every page navigation, remove any previously added component hydration scripts
-document.addEventListener("turbolinks:before-render", function() {
-	const scripts = document.querySelectorAll("script[data-astro-component-hydration]");
-    for(const script of scripts) {
-        script.remove();
-    }
-})
+document.addEventListener('turbolinks:before-render', function () {
+	const scripts = document.querySelectorAll('script[data-astro-component-hydration]');
+	for (const script of scripts) {
+		script.remove();
+	}
+});
+
+// After every page navigation, move the bundled styles into the body
+document.addEventListener('turbolinks:render', function () {
+	const styles = document.querySelectorAll('link[href^="/assets/asset"][href$=".css"]');
+	for (const style of styles) {
+		document.body.append(style);
+	}
+});

--- a/packages/integrations/turbolinks/client.js
+++ b/packages/integrations/turbolinks/client.js
@@ -1,2 +1,10 @@
 import Turbolinks from 'turbolinks';
 export { Turbolinks };
+
+// Before every page navigation, remove any previously added component hydration scripts
+document.addEventListener("turbolinks:before-render", function() {
+	const scripts = document.querySelectorAll("script[data-astro-component-hydration]");
+    for(const script of scripts) {
+        script.remove();
+    }
+})


### PR DESCRIPTION
## Changes

Closes #3128 

This updates the turbolinks integration to remove any client hydration scripts before page navigation.

By default turbolinks will leave `<head>` scripts in place during page navigation, by manually removing them we leave it up to turbolinks to add them back if needed, triggering a fresh script execution in the browser and re-hydrating the components again 🥳

**styles**

Injected style bundles are also cleaned up on navigation now - after each page navigation they're moved down into the body where Turbolinks will clean them up when diffing the new page

## Testing

Tested locally with the reproduction from #3128 

## Docs

None, bugfix only

### Note

Why two different methods for cleaning up scripts vs styles?  Because it actually works...🤣 If scripts are moved into the body after page navigation it breaks the hydration process.  If styles are removed from the head they're never actually replaced with the new page's link (not sure why, some quirk in Turbolinks diffing 🤷)