### PR TITLE
Feat/expose pages

### DIFF
--- a/.changeset/twelve-onions-warn.md
+++ b/.changeset/twelve-onions-warn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds astro:build:ssr integration hook

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -13,6 +13,7 @@ import type {
 import type { AstroConfigSchema } from '../core/config';
 import type { AstroComponentFactory, Metadata } from '../runtime/server';
 import type { ViteConfigWithSSR } from '../core/create-vite';
+import type { SerializedSSRManifest } from '../core/app/types';
 export type { SSRManifest } from '../core/app/types';
 
 export interface AstroBuiltinProps {
@@ -907,6 +908,7 @@ export interface AstroIntegration {
 		'astro:server:setup'?: (options: { server: vite.ViteDevServer }) => void | Promise<void>;
 		'astro:server:start'?: (options: { address: AddressInfo }) => void | Promise<void>;
 		'astro:server:done'?: () => void | Promise<void>;
+		'astro:build:ssr'?: (options: { manifest: SerializedSSRManifest }) => void | Promise<void>;
 		'astro:build:start'?: (options: { buildConfig: BuildConfig }) => void | Promise<void>;
 		'astro:build:setup'?: (options: {
 			vite: ViteConfigWithSSR;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -14,6 +14,7 @@ import type { AstroConfigSchema } from '../core/config';
 import type { AstroComponentFactory, Metadata } from '../runtime/server';
 import type { ViteConfigWithSSR } from '../core/create-vite';
 import type { SerializedSSRManifest } from '../core/app/types';
+import type { PageBuildData } from '../core/build/types';
 export type { SSRManifest } from '../core/app/types';
 
 export interface AstroBuiltinProps {
@@ -912,8 +913,9 @@ export interface AstroIntegration {
 		'astro:build:start'?: (options: { buildConfig: BuildConfig }) => void | Promise<void>;
 		'astro:build:setup'?: (options: {
 			vite: ViteConfigWithSSR;
+			pages: Map<string, PageBuildData>;
 			target: 'client' | 'server';
-		}) => void;
+		}) => void | Promise<void>;
 		'astro:build:done'?: (options: {
 			pages: { pathname: string }[];
 			dir: URL;

--- a/packages/astro/src/core/app/common.ts
+++ b/packages/astro/src/core/app/common.ts
@@ -1,9 +1,6 @@
 import type { SSRManifest, SerializedSSRManifest, RouteInfo } from './types';
 import { deserializeRouteData } from '../routing/manifest/serialization.js';
 
-export const pagesVirtualModuleId = '@astrojs-pages-virtual-entry';
-export const resolvedPagesVirtualModuleId = '\0' + pagesVirtualModuleId;
-
 export function deserializeManifest(serializedManifest: SerializedSSRManifest): SSRManifest {
 	const routes: RouteInfo[] = [];
 	for (const serializedRoute of serializedManifest.routes) {

--- a/packages/astro/src/core/app/common.ts
+++ b/packages/astro/src/core/app/common.ts
@@ -1,6 +1,9 @@
 import type { SSRManifest, SerializedSSRManifest, RouteInfo } from './types';
 import { deserializeRouteData } from '../routing/manifest/serialization.js';
 
+export const pagesVirtualModuleId = '@astrojs-pages-virtual-entry';
+export const resolvedPagesVirtualModuleId = '\0' + pagesVirtualModuleId;
+
 export function deserializeManifest(serializedManifest: SerializedSSRManifest): SSRManifest {
 	const routes: RouteInfo[] = [];
 	for (const serializedRoute of serializedManifest.routes) {

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -20,6 +20,9 @@ import {
 } from '../render/ssr-element.js';
 import { prependForwardSlash } from '../path.js';
 
+export const pagesVirtualModuleId = '@astrojs-pages-virtual-entry';
+export const resolvedPagesVirtualModuleId = '\0' + pagesVirtualModuleId;
+
 export class App {
 	#manifest: Manifest;
 	#manifestData: ManifestData;

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -167,7 +167,7 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 		resolve: viteConfig.resolve,
 	} as ViteConfigWithSSR;
 
-	await runHookBuildSetup({ config: astroConfig, vite: viteBuildConfig, target: 'server' });
+	await runHookBuildSetup({ config: astroConfig, pages: internals.pagesByComponent, vite: viteBuildConfig, target: 'server' });
 
 	// TODO: use vite.mergeConfig() here?
 	return await vite.build(viteBuildConfig);

--- a/packages/astro/src/core/build/vite-plugin-pages.ts
+++ b/packages/astro/src/core/build/vite-plugin-pages.ts
@@ -4,7 +4,7 @@ import type { StaticBuildOptions } from './types';
 import { addRollupInput } from './add-rollup-input.js';
 import { eachPageData } from './internal.js';
 import { isBuildingToSSR } from '../util.js';
-import { resolvedPagesVirtualModuleId, pagesVirtualModuleId } from '../app/common';
+import { resolvedPagesVirtualModuleId, pagesVirtualModuleId } from '../app/common.js';
 
 export function vitePluginPages(opts: StaticBuildOptions, internals: BuildInternals): VitePlugin {
 	return {

--- a/packages/astro/src/core/build/vite-plugin-pages.ts
+++ b/packages/astro/src/core/build/vite-plugin-pages.ts
@@ -4,7 +4,7 @@ import type { StaticBuildOptions } from './types';
 import { addRollupInput } from './add-rollup-input.js';
 import { eachPageData } from './internal.js';
 import { isBuildingToSSR } from '../util.js';
-import { resolvedPagesVirtualModuleId, pagesVirtualModuleId } from '../app/common.js';
+import { resolvedPagesVirtualModuleId, pagesVirtualModuleId } from '../app/index.js';
 
 export function vitePluginPages(opts: StaticBuildOptions, internals: BuildInternals): VitePlugin {
 	return {

--- a/packages/astro/src/core/build/vite-plugin-pages.ts
+++ b/packages/astro/src/core/build/vite-plugin-pages.ts
@@ -4,9 +4,7 @@ import type { StaticBuildOptions } from './types';
 import { addRollupInput } from './add-rollup-input.js';
 import { eachPageData } from './internal.js';
 import { isBuildingToSSR } from '../util.js';
-
-export const virtualModuleId = '@astrojs-pages-virtual-entry';
-export const resolvedVirtualModuleId = '\0' + virtualModuleId;
+import { resolvedPagesVirtualModuleId, pagesVirtualModuleId } from '../app/common';
 
 export function vitePluginPages(opts: StaticBuildOptions, internals: BuildInternals): VitePlugin {
 	return {
@@ -14,18 +12,18 @@ export function vitePluginPages(opts: StaticBuildOptions, internals: BuildIntern
 
 		options(options) {
 			if (!isBuildingToSSR(opts.astroConfig)) {
-				return addRollupInput(options, [virtualModuleId]);
+				return addRollupInput(options, [pagesVirtualModuleId]);
 			}
 		},
 
 		resolveId(id) {
-			if (id === virtualModuleId) {
-				return resolvedVirtualModuleId;
+			if (id === pagesVirtualModuleId) {
+				return resolvedPagesVirtualModuleId;
 			}
 		},
 
 		load(id) {
-			if (id === resolvedVirtualModuleId) {
+			if (id === resolvedPagesVirtualModuleId) {
 				let importMap = '';
 				let imports = [];
 				let i = 0;

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -9,7 +9,7 @@ import { eachPageData } from './internal.js';
 import { addRollupInput } from './add-rollup-input.js';
 import { fileURLToPath } from 'url';
 import glob from 'fast-glob';
-import { pagesVirtualModuleId } from '../app/common.js';
+import { pagesVirtualModuleId } from '../app/index.js';
 import { BEFORE_HYDRATION_SCRIPT_ID } from '../../vite-plugin-scripts/index.js';
 import { runHookBuildSsr } from '../../integrations/index.js';
 

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -9,8 +9,9 @@ import { eachPageData } from './internal.js';
 import { addRollupInput } from './add-rollup-input.js';
 import { fileURLToPath } from 'url';
 import glob from 'fast-glob';
-import { virtualModuleId as pagesVirtualModuleId } from './vite-plugin-pages.js';
+import { pagesVirtualModuleId } from '../app/common';
 import { BEFORE_HYDRATION_SCRIPT_ID } from '../../vite-plugin-scripts/index.js';
+import { runHookBuildSsr } from '../../integrations/index';
 
 export const virtualModuleId = '@astrojs-ssr-virtual-entry';
 const resolvedVirtualModuleId = '\0' + virtualModuleId;
@@ -73,6 +74,7 @@ if(_start in adapter) {
 			});
 
 			const manifest = buildManifest(buildOpts, internals, staticFiles);
+			await runHookBuildSsr({config: buildOpts.astroConfig, manifest});
 
 			for (const [_chunkName, chunk] of Object.entries(bundle)) {
 				if (chunk.type === 'asset') {

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -9,9 +9,9 @@ import { eachPageData } from './internal.js';
 import { addRollupInput } from './add-rollup-input.js';
 import { fileURLToPath } from 'url';
 import glob from 'fast-glob';
-import { pagesVirtualModuleId } from '../app/common';
+import { pagesVirtualModuleId } from '../app/common.js';
 import { BEFORE_HYDRATION_SCRIPT_ID } from '../../vite-plugin-scripts/index.js';
-import { runHookBuildSsr } from '../../integrations/index';
+import { runHookBuildSsr } from '../../integrations/index.js';
 
 export const virtualModuleId = '@astrojs-ssr-virtual-entry';
 const resolvedVirtualModuleId = '\0' + virtualModuleId;

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -1,5 +1,6 @@
 import type { AddressInfo } from 'net';
 import type { ViteDevServer } from 'vite';
+import type { SerializedSSRManifest } from '../core/app/types';
 import { AstroConfig, AstroRenderer, BuildConfig, RouteData } from '../@types/astro.js';
 import { mergeConfig } from '../core/config.js';
 import ssgAdapter from '../adapter-ssg/index.js';
@@ -131,6 +132,20 @@ export async function runHookBuildSetup({
 	for (const integration of config.integrations) {
 		if (integration.hooks['astro:build:setup']) {
 			await integration.hooks['astro:build:setup']({ vite, target });
+		}
+	}
+}
+
+export async function runHookBuildSsr({
+	config,
+	manifest,
+}: {
+	config: AstroConfig;
+	manifest: SerializedSSRManifest;
+}) {
+	for (const integration of config.integrations) {
+		if (integration.hooks['astro:build:ssr']) {
+			await integration.hooks['astro:build:ssr']({ manifest });
 		}
 	}
 }

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -1,6 +1,7 @@
 import type { AddressInfo } from 'net';
 import type { ViteDevServer } from 'vite';
 import type { SerializedSSRManifest } from '../core/app/types';
+import type { PageBuildData } from '../core/build/types';
 import { AstroConfig, AstroRenderer, BuildConfig, RouteData } from '../@types/astro.js';
 import { mergeConfig } from '../core/config.js';
 import ssgAdapter from '../adapter-ssg/index.js';
@@ -124,14 +125,16 @@ export async function runHookBuildSetup({
 	config,
 	vite,
 	target,
+	pages,
 }: {
 	config: AstroConfig;
 	vite: ViteConfigWithSSR;
+	pages: Map<string, PageBuildData>;
 	target: 'server' | 'client';
 }) {
 	for (const integration of config.integrations) {
 		if (integration.hooks['astro:build:setup']) {
-			await integration.hooks['astro:build:setup']({ vite, target });
+			await integration.hooks['astro:build:setup']({ vite, pages, target });
 		}
 	}
 }

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url';
 import type { Plugin } from 'vite';
 import type { AstroConfig } from '../@types/astro';
 import { PAGE_SSR_SCRIPT_ID } from '../vite-plugin-scripts/index.js';
-import { pagesVirtualModuleId } from '../core/app/common';
+import { pagesVirtualModuleId } from '../core/app/common.js';
 import { appendForwardSlash } from '../core/path.js';
 import { resolvePages } from '../core/util.js';
 

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url';
 import type { Plugin } from 'vite';
 import type { AstroConfig } from '../@types/astro';
 import { PAGE_SSR_SCRIPT_ID } from '../vite-plugin-scripts/index.js';
-import { virtualModuleId as pagesVirtualModuleId } from '../core/build/vite-plugin-pages.js';
+import { pagesVirtualModuleId } from '../core/app/common';
 import { appendForwardSlash } from '../core/path.js';
 import { resolvePages } from '../core/util.js';
 

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url';
 import type { Plugin } from 'vite';
 import type { AstroConfig } from '../@types/astro';
 import { PAGE_SSR_SCRIPT_ID } from '../vite-plugin-scripts/index.js';
-import { pagesVirtualModuleId } from '../core/app/common.js';
+import { pagesVirtualModuleId } from '../core/app/index.js';
 import { appendForwardSlash } from '../core/path.js';
 import { resolvePages } from '../core/util.js';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -28,13 +28,13 @@ importers:
       '@changesets/changelog-github': 0.4.4
       '@changesets/cli': 2.22.0
       '@octokit/action': 3.18.0
-      '@typescript-eslint/eslint-plugin': 5.20.0_b9ac9b5656ce5dffade639fcf5e491bf
-      '@typescript-eslint/parser': 5.20.0_eslint@8.13.0+typescript@4.6.3
+      '@typescript-eslint/eslint-plugin': 5.20.0_xgwjwvswzzo77lpghh6plzerx4
+      '@typescript-eslint/parser': 5.20.0_jzhokl4shvj5szf5bgr66kln2a
       del: 6.0.0
       esbuild: 0.14.38
       eslint: 8.13.0
       eslint-config-prettier: 8.5.0_eslint@8.13.0
-      eslint-plugin-prettier: 4.0.0_1815ac95b7fb26c13c7d48a8eef62d0f
+      eslint-plugin-prettier: 4.0.0_dak2zfnx7mtmcpd5jcuo55rnb4
       execa: 6.1.0
       patch-package: 6.4.7
       prettier: 2.6.2
@@ -105,7 +105,7 @@ importers:
     dependencies:
       '@algolia/client-search': 4.13.0
       '@docsearch/css': 3.0.0
-      '@docsearch/react': 3.0.0_5377e26b52c02809078cfcbfa66845b0
+      '@docsearch/react': 3.0.0_kn36e22syauasb4m7s72m2cfwa
       '@types/react': 17.0.44
       preact: 10.7.1
       react: 17.0.2
@@ -412,9 +412,9 @@ importers:
       solid-nanostores: 0.0.6
       vue: ^3.2.33
     dependencies:
-      '@nanostores/preact': 0.1.3_nanostores@0.5.12+preact@10.7.1
-      '@nanostores/react': 0.1.5_33de46f26c75888291546388c72611d1
-      '@nanostores/vue': 0.4.1_nanostores@0.5.12+vue@3.2.33
+      '@nanostores/preact': 0.1.3_szcmxo7i5hx4oviopihqnbgbg4
+      '@nanostores/react': 0.1.5_gppen4tmoweifekumoemojqr2e
+      '@nanostores/vue': 0.4.1_vboeo7axrmyjwprm7hcgpjx6rm
       nanostores: 0.5.12
       preact: 10.7.1
       react: 18.0.0
@@ -1406,7 +1406,7 @@ importers:
     dependencies:
       '@sveltejs/vite-plugin-svelte': 1.0.0-next.41_svelte@3.47.0
       postcss-load-config: 3.1.4
-      svelte-preprocess: 4.10.6_1402eb22fee660bb6c891bb9c1bca0d1
+      svelte-preprocess: 4.10.6_ouvyccvykwltmjwugnola6eovq
     devDependencies:
       astro: link:../../astro
       astro-scripts: link:../../../scripts
@@ -1548,7 +1548,7 @@ importers:
       '@rollup/plugin-alias': 3.1.9_rollup@2.70.2
       '@rollup/plugin-inject': 4.0.4_rollup@2.70.2
       '@rollup/plugin-node-resolve': 13.2.1_rollup@2.70.2
-      '@rollup/plugin-typescript': 8.3.2_056aba5e56e0ab5307259a29131f3fbe
+      '@rollup/plugin-typescript': 8.3.2_rollup@2.70.2+tslib@2.4.0
       '@types/chai': 4.3.1
       '@types/mocha': 9.1.1
       '@types/node': 14.18.13
@@ -1595,7 +1595,7 @@ packages:
       '@algolia/autocomplete-shared': 1.5.2
     dev: false
 
-  /@algolia/autocomplete-preset-algolia/1.5.2_7938c62af9e2e3908b5b052ce2305b13:
+  /@algolia/autocomplete-preset-algolia/1.5.2_pe4mmkxz4lrzbc23auwoemc3cm:
     resolution: {integrity: sha512-3MRYnYQFJyovANzSX2CToS6/5cfVjbLLqFsZTKcvF3abhQzxbqwwaMBlJtt620uBUOeMzhdfasKhCc40+RHiZw==}
     peerDependencies:
       '@algolia/client-search': ^4.9.1
@@ -1764,7 +1764,7 @@ packages:
     resolution: {integrity: sha512-sXCe9FBgn31HAlBwimT2RfveNrYP6/j+XT/YHlj15tdlYqqcEQUj3IP43wSWwkIKwtKVrHWUjY+SOk+MeD+eow==}
     dependencies:
       svelte: 3.47.0
-      svelte2tsx: 0.5.9_svelte@3.47.0+typescript@4.6.3
+      svelte2tsx: 0.5.9_ucc3fdkrl6lb7lhnlfimbouujy
     transitivePeerDependencies:
       - typescript
     dev: false
@@ -3316,7 +3316,7 @@ packages:
     resolution: {integrity: sha512-1kkV7tkAsiuEd0shunYRByKJe3xQDG2q7wYg24SOw1nV9/2lwEd4WrUYRJC/ukGTl2/kHeFxsaUvtiOy0y6fFA==}
     dev: false
 
-  /@docsearch/react/3.0.0_5377e26b52c02809078cfcbfa66845b0:
+  /@docsearch/react/3.0.0_kn36e22syauasb4m7s72m2cfwa:
     resolution: {integrity: sha512-yhMacqS6TVQYoBh/o603zszIb5Bl8MIXuOc6Vy617I74pirisDzzcNh0NEaYQt50fVVR3khUbeEhUEWEWipESg==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 18.0.0'
@@ -3324,7 +3324,7 @@ packages:
       react-dom: '>= 16.8.0 < 18.0.0'
     dependencies:
       '@algolia/autocomplete-core': 1.5.2
-      '@algolia/autocomplete-preset-algolia': 1.5.2_7938c62af9e2e3908b5b052ce2305b13
+      '@algolia/autocomplete-preset-algolia': 1.5.2_pe4mmkxz4lrzbc23auwoemc3cm
       '@docsearch/css': 3.0.0
       '@types/react': 17.0.44
       algoliasearch: 4.13.0
@@ -3470,7 +3470,7 @@ packages:
       read-yaml-file: 1.1.0
     dev: true
 
-  /@nanostores/preact/0.1.3_nanostores@0.5.12+preact@10.7.1:
+  /@nanostores/preact/0.1.3_szcmxo7i5hx4oviopihqnbgbg4:
     resolution: {integrity: sha512-uiX1ned0LrzASot+sPUjyJzr8Js3pX075omazgsSdLf0zPp4ss8xwTiuNh5FSKigTSQEVqZFiS+W8CnHIrX62A==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     peerDependencies:
@@ -3481,7 +3481,7 @@ packages:
       preact: 10.7.1
     dev: false
 
-  /@nanostores/react/0.1.5_33de46f26c75888291546388c72611d1:
+  /@nanostores/react/0.1.5_gppen4tmoweifekumoemojqr2e:
     resolution: {integrity: sha512-1XEsszpCDcxNeX21QJ+4mFROdn45ulahJ9oLJEo0IA2HZPkwfjSzG+iSXImqFU5nzo0earvlD09z4C9olf8Sxw==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     peerDependencies:
@@ -3494,7 +3494,7 @@ packages:
       react-dom: 18.0.0_react@18.0.0
     dev: false
 
-  /@nanostores/vue/0.4.1_nanostores@0.5.12+vue@3.2.33:
+  /@nanostores/vue/0.4.1_vboeo7axrmyjwprm7hcgpjx6rm:
     resolution: {integrity: sha512-b0nNzKD2fTi8R48Jrlg6j+/InPH9r1HOl0iOnpNmL84BOxl+jQnbgyzNlf+3VWAEQSD955hJ/HTl/N1bjJSz5g==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     peerDependencies:
@@ -3678,7 +3678,7 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@rollup/plugin-babel/5.3.1_@babel+core@7.17.9+rollup@2.70.2:
+  /@rollup/plugin-babel/5.3.1_6m6vi5xreq5wlqqwvo3xvcrttm:
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -3748,7 +3748,7 @@ packages:
       rollup: 2.70.2
     dev: true
 
-  /@rollup/plugin-typescript/8.3.2_056aba5e56e0ab5307259a29131f3fbe:
+  /@rollup/plugin-typescript/8.3.2_rollup@2.70.2+tslib@2.4.0:
     resolution: {integrity: sha512-MtgyR5LNHZr3GyN0tM7gNO9D0CS+Y+vflS4v/PHmrX17JCkHUYKvQ5jN5o3cz1YKllM3duXUqu3yOHwMPUxhDg==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -3760,7 +3760,6 @@ packages:
       resolve: 1.22.0
       rollup: 2.70.2
       tslib: 2.4.0
-      typescript: 4.6.3
     dev: true
 
   /@rollup/pluginutils/3.1.0_rollup@2.70.2:
@@ -4100,7 +4099,7 @@ packages:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.20.0_b9ac9b5656ce5dffade639fcf5e491bf:
+  /@typescript-eslint/eslint-plugin/5.20.0_xgwjwvswzzo77lpghh6plzerx4:
     resolution: {integrity: sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4111,10 +4110,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.20.0_eslint@8.13.0+typescript@4.6.3
+      '@typescript-eslint/parser': 5.20.0_jzhokl4shvj5szf5bgr66kln2a
       '@typescript-eslint/scope-manager': 5.20.0
-      '@typescript-eslint/type-utils': 5.20.0_eslint@8.13.0+typescript@4.6.3
-      '@typescript-eslint/utils': 5.20.0_eslint@8.13.0+typescript@4.6.3
+      '@typescript-eslint/type-utils': 5.20.0_jzhokl4shvj5szf5bgr66kln2a
+      '@typescript-eslint/utils': 5.20.0_jzhokl4shvj5szf5bgr66kln2a
       debug: 4.3.4
       eslint: 8.13.0
       functional-red-black-tree: 1.0.1
@@ -4127,7 +4126,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.20.0_eslint@8.13.0+typescript@4.6.3:
+  /@typescript-eslint/parser/5.20.0_jzhokl4shvj5szf5bgr66kln2a:
     resolution: {integrity: sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4155,7 +4154,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.20.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.20.0_eslint@8.13.0+typescript@4.6.3:
+  /@typescript-eslint/type-utils/5.20.0_jzhokl4shvj5szf5bgr66kln2a:
     resolution: {integrity: sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4165,7 +4164,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.20.0_eslint@8.13.0+typescript@4.6.3
+      '@typescript-eslint/utils': 5.20.0_jzhokl4shvj5szf5bgr66kln2a
       debug: 4.3.4
       eslint: 8.13.0
       tsutils: 3.21.0_typescript@4.6.3
@@ -4200,7 +4199,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.20.0_eslint@8.13.0+typescript@4.6.3:
+  /@typescript-eslint/utils/5.20.0_jzhokl4shvj5szf5bgr66kln2a:
     resolution: {integrity: sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5864,7 +5863,7 @@ packages:
       eslint: 8.13.0
     dev: true
 
-  /eslint-plugin-prettier/4.0.0_1815ac95b7fb26c13c7d48a8eef62d0f:
+  /eslint-plugin-prettier/4.0.0_dak2zfnx7mtmcpd5jcuo55rnb4:
     resolution: {integrity: sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -9644,7 +9643,7 @@ packages:
       svelte: 3.47.0
     dev: false
 
-  /svelte-preprocess/4.10.6_1402eb22fee660bb6c891bb9c1bca0d1:
+  /svelte-preprocess/4.10.6_ouvyccvykwltmjwugnola6eovq:
     resolution: {integrity: sha512-I2SV1w/AveMvgIQlUF/ZOO3PYVnhxfcpNyGt8pxpUVhPfyfL/CZBkkw/KPfuFix5FJ9TnnNYMhACK3DtSaYVVQ==}
     engines: {node: '>= 9.11.2'}
     requiresBuild: true
@@ -9693,14 +9692,13 @@ packages:
       sorcery: 0.10.0
       strip-indent: 3.0.0
       svelte: 3.47.0
-      typescript: 4.6.3
     dev: false
 
   /svelte/3.47.0:
     resolution: {integrity: sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==}
     engines: {node: '>= 8'}
 
-  /svelte2tsx/0.5.9_svelte@3.47.0+typescript@4.6.3:
+  /svelte2tsx/0.5.9_ucc3fdkrl6lb7lhnlfimbouujy:
     resolution: {integrity: sha512-xTDASjlh+rKo4QRhTRYSH87sS7fRoyX67xhGIMPKa3FYqftRHRmMes6nVgEskiuhBovslNHYYpMMg5YM5n/STg==}
     peerDependencies:
       svelte: ^3.24
@@ -10615,7 +10613,7 @@ packages:
       '@babel/core': 7.17.9
       '@babel/preset-env': 7.16.11_@babel+core@7.17.9
       '@babel/runtime': 7.17.9
-      '@rollup/plugin-babel': 5.3.1_@babel+core@7.17.9+rollup@2.70.2
+      '@rollup/plugin-babel': 5.3.1_6m6vi5xreq5wlqqwvo3xvcrttm
       '@rollup/plugin-node-resolve': 11.2.1_rollup@2.70.2
       '@rollup/plugin-replace': 2.4.2_rollup@2.70.2
       '@surma/rollup-plugin-off-main-thread': 2.2.3


### PR DESCRIPTION
## Changes

- What does this change?
Exposes a `pages` property in the `astro:build:setup` hook as discussed in: https://github.com/withastro/rfcs/discussions/188#discussioncomment-2682523 The comment suggests to add a new hook, but it seems like it makes more sense to just add it to the setup hook instead.

## Testing

Tested locally

## Docs

