### PR TITLE
feat: expose pages

### DIFF
--- a/.changeset/mean-donkeys-sin.md
+++ b/.changeset/mean-donkeys-sin.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds pages param to the astro:build:setup integration hook

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -14,6 +14,7 @@ import type { AstroConfigSchema } from '../core/config';
 import type { AstroComponentFactory, Metadata } from '../runtime/server';
 import type { ViteConfigWithSSR } from '../core/create-vite';
 import type { SerializedSSRManifest } from '../core/app/types';
+import type { PageBuildData } from '../core/build/types';
 export type { SSRManifest } from '../core/app/types';
 
 export interface AstroBuiltinProps {
@@ -912,8 +913,9 @@ export interface AstroIntegration {
 		'astro:build:start'?: (options: { buildConfig: BuildConfig }) => void | Promise<void>;
 		'astro:build:setup'?: (options: {
 			vite: ViteConfigWithSSR;
+			pages: Map<string, PageBuildData>;
 			target: 'client' | 'server';
-		}) => void;
+		}) => void | Promise<void>;
 		'astro:build:done'?: (options: {
 			pages: { pathname: string }[];
 			dir: URL;

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -232,7 +232,7 @@ async function clientBuild(
 		base: astroConfig.base,
 	} as ViteConfigWithSSR;
 
-	await runHookBuildSetup({ config: astroConfig, vite: viteBuildConfig, target: 'client' });
+	await runHookBuildSetup({ config: astroConfig, pages: internals.pagesByComponent, vite: viteBuildConfig, target: 'client' });
 
 	const buildResult = await vite.build(viteBuildConfig);
 	info(opts.logging, null, dim(`Completed in ${getTimeStat(timer, performance.now())}.\n`));

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -167,7 +167,7 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 		resolve: viteConfig.resolve,
 	} as ViteConfigWithSSR;
 
-	await runHookBuildSetup({ config: astroConfig, vite: viteBuildConfig, target: 'server' });
+	await runHookBuildSetup({ config: astroConfig, pages: internals.pagesByComponent, vite: viteBuildConfig, target: 'server' });
 
 	// TODO: use vite.mergeConfig() here?
 	return await vite.build(viteBuildConfig);

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -1,6 +1,7 @@
 import type { AddressInfo } from 'net';
 import type { ViteDevServer } from 'vite';
 import type { SerializedSSRManifest } from '../core/app/types';
+import type { PageBuildData } from '../core/build/types';
 import { AstroConfig, AstroRenderer, BuildConfig, RouteData } from '../@types/astro.js';
 import { mergeConfig } from '../core/config.js';
 import ssgAdapter from '../adapter-ssg/index.js';
@@ -123,15 +124,17 @@ export async function runHookBuildStart({
 export async function runHookBuildSetup({
 	config,
 	vite,
+	pages,
 	target,
 }: {
 	config: AstroConfig;
 	vite: ViteConfigWithSSR;
+	pages: Map<string, PageBuildData>;
 	target: 'server' | 'client';
 }) {
 	for (const integration of config.integrations) {
 		if (integration.hooks['astro:build:setup']) {
-			await integration.hooks['astro:build:setup']({ vite, target });
+			await integration.hooks['astro:build:setup']({ vite, pages, target });
 		}
 	}
 }


### PR DESCRIPTION
## Changes

- What does this change?
Exposes a `pages` property in the `astro:build:setup` hook as discussed in: https://github.com/withastro/rfcs/discussions/188#discussioncomment-2682523 The comment suggests to add a new hook, but it seemed like it makes more sense to just add it to the setup hook instead rather than giving it it's entire own special hook.

## Testing

Tested locally

## Docs

The `astro:build:setup` hook wasnt yet documented at all, so I added it here as well: https://github.com/withastro/docs/pull/433