### PR TITLE
Fix: Make Congratsbot link to actual commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           # DISCORD_AVATAR: ${{ github.event.pull_request.user.avatar_url }}
         uses: Ilshidur/action-discord@0.3.2
         with:
-          args: "**Merged!** ${{ github.event.commits[0].author.name }}: [`${{ steps.setup.outputs.COMMIT_MSG }}`](<https://github.com/withastro/astro/commits/main>)"
+          args: "**Merged!** ${{ github.event.commits[0].author.name }}: [`${{ steps.setup.outputs.COMMIT_MSG }}`](<https://github.com/withastro/astro/commit/${{ github.event.commits[0].id }}>)"
 
   check_for_update:
     name: Check for Updates


### PR DESCRIPTION
## Changes

When Congratsbot posts new commits to our `#dev` channel on Discord, the commit message always linked to the general `withastro/astro` commit history page. This PR changes this and makes it link to the actual commit, just like our new Docsbot does.

No changeset as this doesn't change any packages, only the GitHub workflow.

## Testing

Docsbot uses the same code and it was just tested in production.

## Docs

Not a visible change.