### PR TITLE
Add new configKeys prop for telemetry

### DIFF
--- a/.changeset/sweet-vans-begin.md
+++ b/.changeset/sweet-vans-begin.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/telemetry': patch
+---
+
+Update to telemetry to include AstroConfig keys used

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -139,10 +139,12 @@ export async function cli(args: string[]) {
 		case 'dev': {
 			try {
 				const { astroConfig, userConfig } = await openConfig({ cwd: root, flags, cmd });
+
 				telemetry.record(
 					event.eventCliSession(
 						{ astroVersion: process.env.PACKAGE_VERSION ?? '', cliCommand: 'dev' },
-						userConfig
+						userConfig,
+						flags
 					)
 				);
 				await devServer(astroConfig, { logging, telemetry });
@@ -158,7 +160,8 @@ export async function cli(args: string[]) {
 				telemetry.record(
 					event.eventCliSession(
 						{ astroVersion: process.env.PACKAGE_VERSION ?? '', cliCommand: 'build' },
-						userConfig
+						userConfig,
+						flags
 					)
 				);
 				return await build(astroConfig, { logging, telemetry });
@@ -172,7 +175,8 @@ export async function cli(args: string[]) {
 			telemetry.record(
 				event.eventCliSession(
 					{ astroVersion: process.env.PACKAGE_VERSION ?? '', cliCommand: 'check' },
-					userConfig
+					userConfig,
+					flags,
 				)
 			);
 			const ret = await check(astroConfig);
@@ -185,7 +189,8 @@ export async function cli(args: string[]) {
 				telemetry.record(
 					event.eventCliSession(
 						{ astroVersion: process.env.PACKAGE_VERSION ?? '', cliCommand: 'preview' },
-						userConfig
+						userConfig,
+						flags
 					)
 				);
 				const server = await preview(astroConfig, { logging, telemetry });

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -17,7 +17,7 @@ import preview from '../core/preview/index.js';
 import { check } from './check.js';
 import { openInBrowser } from './open.js';
 import * as telemetryHandler from './telemetry.js';
-import { loadConfig } from '../core/config.js';
+import { openConfig } from '../core/config.js';
 import { printHelp, formatErrorMessage, formatConfigErrorMessage } from '../core/messages.js';
 import { createSafeError } from '../core/util.js';
 
@@ -138,14 +138,14 @@ export async function cli(args: string[]) {
 		}
 		case 'dev': {
 			try {
-				const config = await loadConfig({ cwd: root, flags, cmd });
+				const { astroConfig, userConfig } = await openConfig({ cwd: root, flags, cmd });
 				telemetry.record(
 					event.eventCliSession(
 						{ astroVersion: process.env.PACKAGE_VERSION ?? '', cliCommand: 'dev' },
-						config
+						userConfig
 					)
 				);
-				await devServer(config, { logging, telemetry });
+				await devServer(astroConfig, { logging, telemetry });
 				return await new Promise(() => {}); // lives forever
 			} catch (err) {
 				return throwAndExit(err);
@@ -154,41 +154,41 @@ export async function cli(args: string[]) {
 
 		case 'build': {
 			try {
-				const config = await loadConfig({ cwd: root, flags, cmd });
+				const { astroConfig, userConfig } = await openConfig({ cwd: root, flags, cmd });
 				telemetry.record(
 					event.eventCliSession(
 						{ astroVersion: process.env.PACKAGE_VERSION ?? '', cliCommand: 'build' },
-						config
+						userConfig
 					)
 				);
-				return await build(config, { logging, telemetry });
+				return await build(astroConfig, { logging, telemetry });
 			} catch (err) {
 				return throwAndExit(err);
 			}
 		}
 
 		case 'check': {
-			const config = await loadConfig({ cwd: root, flags, cmd });
+			const { astroConfig, userConfig } = await openConfig({ cwd: root, flags, cmd });
 			telemetry.record(
 				event.eventCliSession(
 					{ astroVersion: process.env.PACKAGE_VERSION ?? '', cliCommand: 'check' },
-					config
+					userConfig
 				)
 			);
-			const ret = await check(config);
+			const ret = await check(astroConfig);
 			return process.exit(ret);
 		}
 
 		case 'preview': {
 			try {
-				const config = await loadConfig({ cwd: root, flags, cmd });
+				const { astroConfig, userConfig } = await openConfig({ cwd: root, flags, cmd });
 				telemetry.record(
 					event.eventCliSession(
 						{ astroVersion: process.env.PACKAGE_VERSION ?? '', cliCommand: 'preview' },
-						config
+						userConfig
 					)
 				);
-				const server = await preview(config, { logging, telemetry });
+				const server = await preview(astroConfig, { logging, telemetry });
 				return await server.closed(); // keep alive until the server is closed
 			} catch (err) {
 				return throwAndExit(err);

--- a/packages/telemetry/test/session-event.test.js
+++ b/packages/telemetry/test/session-event.test.js
@@ -1,241 +1,389 @@
 import { expect } from 'chai';
 import * as events from '../dist/events/index.js';
-import { resolveConfig } from '../../astro/dist/core/config.js';
-
-async function mockConfig(userConfig) {
-	return await resolveConfig(userConfig, import.meta.url, {}, 'dev');
-}
 
 describe('Session event', () => {
-	it('top-level keys are captured', async () => {
-		const config = await mockConfig({
-			vite: {
-				css: { modules: [] },
-				base: 'a',
-				mode: 'b',
-				define: {
-					a: 'b',
+	describe('top-level', () => {
+		it('All top-level keys added', () => {
+			const config = {
+				root: 1,
+				srcDir: 2,
+				publicDir: 3,
+				outDir: 4,
+				site: 5,
+				base: 6,
+				trailingSlash: 7,
+				experimental: 8,
+			};
+			const expected = Object.keys(config);
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0',
 				},
-				publicDir: 'some/dir',
-			},
+				config
+			);
+			expect(payload.config.configKeys).to.deep.equal(expected);
 		});
-
-		const [{ payload }] = events.eventCliSession(
-			{
-				cliCommand: 'dev',
-				astroVersion: '0.0.0',
-			},
-			config
-		);
-		expect(payload.config.viteKeys).is.deep.equal([
-			'css',
-			'css.modules',
-			'base',
-			'mode',
-			'define',
-			'publicDir',
-		]);
 	});
 
-	it('vite.resolve keys are captured', async () => {
-		const config = await mockConfig({
-			vite: {
-				resolve: {
-					alias: {
-						a: 'b',
-					},
-					dedupe: ['one', 'two'],
+	describe('config.build', () => {
+		it('configKeys includes format', () => {
+			const config = {
+				srcDir: 1,
+				build: {
+					format: 'file',
+				}
+			};
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0'
 				},
-			},
+				config
+			);
+			expect(payload.config.configKeys).to.deep.equal(['srcDir', 'build', 'build.format']);
 		});
 
-		const [{ payload }] = events.eventCliSession(
-			{
-				cliCommand: 'dev',
-				astroVersion: '0.0.0',
-			},
-			config
-		);
-		expect(payload.config.viteKeys).is.deep.equal(['resolve', 'resolve.alias', 'resolve.dedupe']);
-	});
-
-	it('vite.css keys are captured', async () => {
-		const config = await mockConfig({
-			vite: {
-				resolve: {
-					dedupe: ['one', 'two'],
+		it('config.build.format', () => {
+			const config = {
+				srcDir: 1,
+				build: {
+					format: 'file',
+				}
+			};
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0'
 				},
-				css: {
-					modules: [],
-					postcss: {},
-				},
-			},
+				config
+			);
+			expect(payload.config.build.format).to.equal('file');
 		});
-
-		const [{ payload }] = events.eventCliSession(
-			{
-				cliCommand: 'dev',
-				astroVersion: '0.0.0',
-			},
-			config
-		);
-		expect(payload.config.viteKeys).is.deep.equal([
-			'resolve',
-			'resolve.dedupe',
-			'css',
-			'css.modules',
-			'css.postcss',
-		]);
 	});
 
-	it('vite.server keys are captured', async () => {
-		const config = await mockConfig({
-			vite: {
+	describe('config.server', () => {
+		it('configKeys includes server props', () => {
+			const config = {
+				srcDir: 1,
 				server: {
 					host: 'example.com',
-					open: true,
-					fs: {
-						strict: true,
-						allow: ['a', 'b'],
-					},
+					port: 8033
+				}
+			};
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0'
 				},
-			},
+				config
+			);
+			expect(payload.config.configKeys).to.deep.equal(['srcDir', 'server', 'server.host', 'server.port']);
 		});
-
-		const [{ payload }] = events.eventCliSession(
-			{
-				cliCommand: 'dev',
-				astroVersion: '0.0.0',
-			},
-			config
-		);
-		expect(payload.config.viteKeys).is.deep.equal([
-			'server',
-			'server.host',
-			'server.open',
-			'server.fs',
-			'server.fs.strict',
-			'server.fs.allow',
-		]);
 	});
 
-	it('vite.build keys are captured', async () => {
-		const config = await mockConfig({
-			vite: {
-				build: {
-					target: 'one',
-					outDir: 'some/dir',
-					cssTarget: {
-						one: 'two',
+	describe('config.markdown', () => {
+		it('configKeys is deep', () => {
+			const config = {
+				publicDir: 1,
+				markdown: {
+					drafts: true,
+					mode: 'mdx',
+					shikiConfig: {
+						lang: 1,
+						theme: 2,
+						wrap: 3
 					},
+					syntaxHighlight: 'shiki',
+					remarkPlugins: [],
+					rehypePlugins: [],
+				}
+			};
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0'
 				},
-			},
+				config
+			);
+			expect(payload.config.configKeys).to.deep.equal(['publicDir', 'markdown',
+				'markdown.drafts', 'markdown.mode', 'markdown.shikiConfig',
+				'markdown.shikiConfig.lang', 'markdown.shikiConfig.theme', 'markdown.shikiConfig.wrap',
+				'markdown.syntaxHighlight', 'markdown.remarkPlugins', 'markdown.rehypePlugins']);
 		});
 
-		const [{ payload }] = events.eventCliSession(
-			{
-				cliCommand: 'dev',
-				astroVersion: '0.0.0',
-			},
-			config
-		);
-		expect(payload.config.viteKeys).is.deep.equal([
-			'build',
-			'build.target',
-			'build.outDir',
-			'build.cssTarget',
-		]);
+		it('mode', () => {
+			const config = {
+				markdown: {
+					mode: 'mdx',
+				}
+			};
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0'
+				},
+				config
+			);
+			expect(payload.config.markdown.mode).to.equal('mdx');
+		});
+
+		it('syntaxHighlight', () => {
+			const config = {
+				markdown: {
+					syntaxHighlight: 'shiki',
+				}
+			};
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0'
+				},
+				config
+			);
+			expect(payload.config.markdown.syntaxHighlight).to.equal('shiki');
+		});
 	});
 
-	it('vite.preview keys are captured', async () => {
-		const config = await mockConfig({
-			vite: {
-				preview: {
-					host: 'example.com',
-					port: 8080,
-					another: {
+	describe('config.vite', () => {
+		it('top-level keys are captured', async () => {
+			const config = {
+				root: 'some/thing',
+				vite: {
+					css: { modules: [] },
+					base: 'a',
+					mode: 'b',
+					define: {
 						a: 'b',
 					},
+					publicDir: 'some/dir',
 				},
-			},
-		});
-
-		const [{ payload }] = events.eventCliSession(
-			{
-				cliCommand: 'dev',
-				astroVersion: '0.0.0',
-			},
-			config
-		);
-		expect(payload.config.viteKeys).is.deep.equal([
-			'preview',
-			'preview.host',
-			'preview.port',
-			'preview.another',
-		]);
-	});
-
-	it('vite.optimizeDeps keys are captured', async () => {
-		const config = await mockConfig({
-			vite: {
-				optimizeDeps: {
-					entries: ['one', 'two'],
-					exclude: ['secret', 'name'],
+			};
+	
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0',
 				},
-			},
+				config
+			);
+			expect(payload.config.configKeys).is.deep.equal([
+				'root',
+				'vite',
+				'vite.css',
+				'vite.css.modules',
+				'vite.base',
+				'vite.mode',
+				'vite.define',
+				'vite.publicDir',
+			]);
 		});
-
-		const [{ payload }] = events.eventCliSession(
-			{
-				cliCommand: 'dev',
-				astroVersion: '0.0.0',
-			},
-			config
-		);
-		expect(payload.config.viteKeys).is.deep.equal([
-			'optimizeDeps',
-			'optimizeDeps.entries',
-			'optimizeDeps.exclude',
-		]);
-	});
-
-	it('vite.ssr keys are captured', async () => {
-		const config = await mockConfig({
-			vite: {
-				ssr: {
-					external: ['a'],
-					target: { one: 'two' },
+	
+		it('vite.resolve keys are captured', async () => {
+			const config = {
+				vite: {
+					resolve: {
+						alias: {
+							a: 'b',
+						},
+						dedupe: ['one', 'two'],
+					},
 				},
-			},
-		});
-
-		const [{ payload }] = events.eventCliSession(
-			{
-				cliCommand: 'dev',
-				astroVersion: '0.0.0',
-			},
-			config
-		);
-		expect(payload.config.viteKeys).is.deep.equal(['ssr', 'ssr.external', 'ssr.target']);
-	});
-
-	it('vite.worker keys are captured', async () => {
-		const config = await mockConfig({
-			vite: {
-				worker: {
-					format: { a: 'b' },
-					plugins: ['a', 'b'],
+			};
+	
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0',
 				},
-			},
+				config
+			);
+			expect(payload.config.configKeys).is.deep.equal(['vite', 'vite.resolve', 'vite.resolve.alias', 'vite.resolve.dedupe']);
 		});
-
-		const [{ payload }] = events.eventCliSession(
-			{
-				cliCommand: 'dev',
-				astroVersion: '0.0.0',
-			},
-			config
-		);
-		expect(payload.config.viteKeys).is.deep.equal(['worker', 'worker.format', 'worker.plugins']);
+	
+		it('vite.css keys are captured', async () => {
+			const config = {
+				vite: {
+					resolve: {
+						dedupe: ['one', 'two'],
+					},
+					css: {
+						modules: [],
+						postcss: {},
+					},
+				},
+			};
+	
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0',
+				},
+				config
+			);
+			expect(payload.config.configKeys).is.deep.equal([
+				'vite',
+				'vite.resolve',
+				'vite.resolve.dedupe',
+				'vite.css',
+				'vite.css.modules',
+				'vite.css.postcss',
+			]);
+		});
+	
+		it('vite.server keys are captured', async () => {
+			const config = {
+				vite: {
+					server: {
+						host: 'example.com',
+						open: true,
+						fs: {
+							strict: true,
+							allow: ['a', 'b'],
+						},
+					},
+				},
+			};
+	
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0',
+				},
+				config
+			);
+			expect(payload.config.configKeys).is.deep.equal([
+				'vite',
+				'vite.server',
+				'vite.server.host',
+				'vite.server.open',
+				'vite.server.fs',
+				'vite.server.fs.strict',
+				'vite.server.fs.allow',
+			]);
+		});
+	
+		it('vite.build keys are captured', async () => {
+			const config = {
+				vite: {
+					build: {
+						target: 'one',
+						outDir: 'some/dir',
+						cssTarget: {
+							one: 'two',
+						},
+					},
+				},
+			};
+	
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0',
+				},
+				config
+			);
+			expect(payload.config.configKeys).is.deep.equal([
+				'vite',
+				'vite.build',
+				'vite.build.target',
+				'vite.build.outDir',
+				'vite.build.cssTarget',
+			]);
+		});
+	
+		it('vite.preview keys are captured', async () => {
+			const config = {
+				vite: {
+					preview: {
+						host: 'example.com',
+						port: 8080,
+						another: {
+							a: 'b',
+						},
+					},
+				},
+			};
+	
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0',
+				},
+				config
+			);
+			expect(payload.config.configKeys).is.deep.equal([
+				'vite',
+				'vite.preview',
+				'vite.preview.host',
+				'vite.preview.port',
+				'vite.preview.another',
+			]);
+		});
+	
+		it('vite.optimizeDeps keys are captured', async () => {
+			const config = {
+				vite: {
+					optimizeDeps: {
+						entries: ['one', 'two'],
+						exclude: ['secret', 'name'],
+					},
+				},
+			};
+	
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0',
+				},
+				config
+			);
+			expect(payload.config.configKeys).is.deep.equal([
+				'vite',
+				'vite.optimizeDeps',
+				'vite.optimizeDeps.entries',
+				'vite.optimizeDeps.exclude',
+			]);
+		});
+	
+		it('vite.ssr keys are captured', async () => {
+			const config = {
+				vite: {
+					ssr: {
+						external: ['a'],
+						target: { one: 'two' },
+					},
+				},
+			};
+	
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0',
+				},
+				config
+			);
+			expect(payload.config.configKeys).is.deep.equal(['vite', 'vite.ssr', 'vite.ssr.external', 'vite.ssr.target']);
+		});
+	
+		it('vite.worker keys are captured', async () => {
+			const config = {
+				vite: {
+					worker: {
+						format: { a: 'b' },
+						plugins: ['a', 'b'],
+					},
+				},
+			};
+	
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0',
+				},
+				config
+			);
+			expect(payload.config.configKeys).is.deep.equal(['vite', 'vite.worker', 'vite.worker.format', 'vite.worker.plugins']);
+		});
 	});
 });

--- a/packages/telemetry/test/session-event.test.js
+++ b/packages/telemetry/test/session-event.test.js
@@ -22,7 +22,7 @@ describe('Session event', () => {
 				},
 				config
 			);
-			expect(payload.config.configKeys).to.deep.equal(expected);
+			expect(payload.configKeys).to.deep.equal(expected);
 		});
 	});
 
@@ -41,7 +41,7 @@ describe('Session event', () => {
 				},
 				config
 			);
-			expect(payload.config.configKeys).to.deep.equal(['srcDir', 'build', 'build.format']);
+			expect(payload.configKeys).to.deep.equal(['srcDir', 'build', 'build.format']);
 		});
 
 		it('config.build.format', () => {
@@ -78,7 +78,7 @@ describe('Session event', () => {
 				},
 				config
 			);
-			expect(payload.config.configKeys).to.deep.equal(['srcDir', 'server', 'server.host', 'server.port']);
+			expect(payload.configKeys).to.deep.equal(['srcDir', 'server', 'server.host', 'server.port']);
 		});
 	});
 
@@ -106,7 +106,7 @@ describe('Session event', () => {
 				},
 				config
 			);
-			expect(payload.config.configKeys).to.deep.equal(['publicDir', 'markdown',
+			expect(payload.configKeys).to.deep.equal(['publicDir', 'markdown',
 				'markdown.drafts', 'markdown.mode', 'markdown.shikiConfig',
 				'markdown.shikiConfig.lang', 'markdown.shikiConfig.theme', 'markdown.shikiConfig.wrap',
 				'markdown.syntaxHighlight', 'markdown.remarkPlugins', 'markdown.rehypePlugins']);
@@ -167,7 +167,7 @@ describe('Session event', () => {
 				},
 				config
 			);
-			expect(payload.config.configKeys).is.deep.equal([
+			expect(payload.configKeys).is.deep.equal([
 				'root',
 				'vite',
 				'vite.css',
@@ -198,7 +198,7 @@ describe('Session event', () => {
 				},
 				config
 			);
-			expect(payload.config.configKeys).is.deep.equal(['vite', 'vite.resolve', 'vite.resolve.alias', 'vite.resolve.dedupe']);
+			expect(payload.configKeys).is.deep.equal(['vite', 'vite.resolve', 'vite.resolve.alias', 'vite.resolve.dedupe']);
 		});
 	
 		it('vite.css keys are captured', async () => {
@@ -221,7 +221,7 @@ describe('Session event', () => {
 				},
 				config
 			);
-			expect(payload.config.configKeys).is.deep.equal([
+			expect(payload.configKeys).is.deep.equal([
 				'vite',
 				'vite.resolve',
 				'vite.resolve.dedupe',
@@ -252,7 +252,7 @@ describe('Session event', () => {
 				},
 				config
 			);
-			expect(payload.config.configKeys).is.deep.equal([
+			expect(payload.configKeys).is.deep.equal([
 				'vite',
 				'vite.server',
 				'vite.server.host',
@@ -283,7 +283,7 @@ describe('Session event', () => {
 				},
 				config
 			);
-			expect(payload.config.configKeys).is.deep.equal([
+			expect(payload.configKeys).is.deep.equal([
 				'vite',
 				'vite.build',
 				'vite.build.target',
@@ -312,7 +312,7 @@ describe('Session event', () => {
 				},
 				config
 			);
-			expect(payload.config.configKeys).is.deep.equal([
+			expect(payload.configKeys).is.deep.equal([
 				'vite',
 				'vite.preview',
 				'vite.preview.host',
@@ -338,7 +338,7 @@ describe('Session event', () => {
 				},
 				config
 			);
-			expect(payload.config.configKeys).is.deep.equal([
+			expect(payload.configKeys).is.deep.equal([
 				'vite',
 				'vite.optimizeDeps',
 				'vite.optimizeDeps.entries',
@@ -363,7 +363,7 @@ describe('Session event', () => {
 				},
 				config
 			);
-			expect(payload.config.configKeys).is.deep.equal(['vite', 'vite.ssr', 'vite.ssr.external', 'vite.ssr.target']);
+			expect(payload.configKeys).is.deep.equal(['vite', 'vite.ssr', 'vite.ssr.external', 'vite.ssr.target']);
 		});
 	
 		it('vite.worker keys are captured', async () => {
@@ -383,7 +383,41 @@ describe('Session event', () => {
 				},
 				config
 			);
-			expect(payload.config.configKeys).is.deep.equal(['vite', 'vite.worker', 'vite.worker.format', 'vite.worker.plugins']);
+			expect(payload.configKeys).is.deep.equal(['vite', 'vite.worker', 'vite.worker.format', 'vite.worker.plugins']);
 		});
 	});
+
+	describe('flags', () => {
+		it('includes cli flags in payload', () => {
+			const config = {};
+			const flags = {
+				root: 'root',
+				site: 'http://example.com',
+				host: true,
+				port: 8080,
+				config: 'path/to/config.mjs',
+				experimentalSsr: true,
+				experimentalIntegrations: true,
+				drafts: true,
+			}
+			const [{ payload }] = events.eventCliSession(
+				{
+					cliCommand: 'dev',
+					astroVersion: '0.0.0',
+				},
+				config,
+				flags
+			);
+			expect(payload.flags).to.deep.equal([
+				'root',
+				'site',
+				'host',
+				'port',
+				'config',
+				'experimentalSsr',
+				'experimentalIntegrations',
+				'drafts'
+			]);
+		})
+	})
 });


### PR DESCRIPTION
## Changes

- This updates the telemetry so that the shallow AstroConfig keys are tracked. We have found the existing vite key data to be very valuable and intend on sharing it with other maintainers. Adding the rest of these config keys will give us better data on which features are being used.

## Testing

Tests updated to reflect the new data structure.

## Docs

N/A