### PR TITLE
Fix: make RSS canonicalUrl required

### DIFF
--- a/.changeset/tasty-numbers-destroy.md
+++ b/.changeset/tasty-numbers-destroy.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': minor
+---
+
+Change the optional "canonicalUrl" argument to a required "site" argument. This fixes problems with import.meta.env.SITE. If you want to use your project's "site" field for your RSS feeds, set site: import.meta.env.SITE in the rss function options

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -28,6 +28,8 @@ import rss from '@astrojs/rss';
 export const get = () => rss({
     title: 'Buzz’s Blog',
     description: 'A humble Astronaut’s guide to the stars',
+    // pull in the "site" from your project's astro.config
+    canonicalUrl: import.meta.env.SITE,
     items: import.meta.glob('./blog/**/*.md'),
   });
 ```
@@ -44,6 +46,8 @@ rss({
   title: 'Buzz’s Blog',
   // `<description>` field in output xml
   description: 'A humble Astronaut’s guide to the stars',
+  // provide a base URL for RSS <item> links
+  canonicalUrl: import.meta.env.SITE,
   // list of `<item>`s in output xml
   items: import.meta.glob('./**/*.md'),
   // (optional) absolute path to XSL stylesheet in your project
@@ -52,9 +56,6 @@ rss({
   customData: '<language>en-us</language>',
   // (optional) add arbitrary metadata to opening <rss> tag
   xmlns: { h: 'http://www.w3.org/TR/html4/' },
-  // (optional) provide a canonical URL
-  // defaults to the "site" configured in your project's astro.config
-  canonicalUrl: 'https://stargazers.club',
 });
 ```
 
@@ -69,6 +70,12 @@ The `<title>` attribute of your RSS feed's output xml.
 Type: `string (required)`
 
 The `<description>` attribute of your RSS feed's output xml.
+
+### canonicalUrl
+
+Type: `string (required)`
+
+The base URL to use when generating RSS item links. We recommend using `import.meta.env.SITE` to pull in the "site" from your project's astro.config. Still, feel free to use a custom base URL if necessary.
 
 ### items
 
@@ -135,11 +142,7 @@ Will inject the following XML:
 <rss xmlns:h="http://www.w3.org/TR/html4/"...
 ```
 
-### canonicalUrl
-
-Type: `string (optional)`
-
-The base URL to use when generating RSS item links. This defaults to the [`site` configured in your project's `astro.config`](https://docs.astro.build/en/reference/configuration-reference/#site). We recommend using `site` instead of `canonicalUrl`, though we provide this option if an override is necessary.
+---
 
 For more on building with Astro, [visit the Astro docs][astro-rss].
 

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -29,7 +29,7 @@ export const get = () => rss({
     title: 'Buzz’s Blog',
     description: 'A humble Astronaut’s guide to the stars',
     // pull in the "site" from your project's astro.config
-    canonicalUrl: import.meta.env.SITE,
+    site: import.meta.env.SITE,
     items: import.meta.glob('./blog/**/*.md'),
   });
 ```
@@ -47,7 +47,7 @@ rss({
   // `<description>` field in output xml
   description: 'A humble Astronaut’s guide to the stars',
   // provide a base URL for RSS <item> links
-  canonicalUrl: import.meta.env.SITE,
+  site: import.meta.env.SITE,
   // list of `<item>`s in output xml
   items: import.meta.glob('./**/*.md'),
   // (optional) absolute path to XSL stylesheet in your project
@@ -71,7 +71,7 @@ Type: `string (required)`
 
 The `<description>` attribute of your RSS feed's output xml.
 
-### canonicalUrl
+### site
 
 Type: `string (required)`
 

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -13,7 +13,7 @@ type RSSOptions = {
 	 * We recommend "import.meta.env.SITE" to pull in the "site"
 	 * from your project's astro.config.
 	 */
-	canonicalUrl: string;
+	site: string;
 	/**
 	 * List of RSS feed items to render. Accepts either:
 	 * a) list of RSSFeedItems
@@ -90,7 +90,7 @@ export default async function getRSS(rssOptions: RSSOptions) {
 
 /** Generate RSS 2.0 feed */
 export async function generateRSS({ rssOptions, items }: GenerateRSSArgs): Promise<string> {
-	const { canonicalUrl } = rssOptions;
+	const { site } = rssOptions;
 	let xml = `<?xml version="1.0" encoding="UTF-8"?>`;
 	if (typeof rssOptions.stylesheet === 'string') {
 		xml += `<?xml-stylesheet href="${rssOptions.stylesheet}" type="text/xsl"?>`;
@@ -109,7 +109,7 @@ export async function generateRSS({ rssOptions, items }: GenerateRSSArgs): Promi
 	// title, description, customData
 	xml += `<title><![CDATA[${rssOptions.title}]]></title>`;
 	xml += `<description><![CDATA[${rssOptions.description}]]></description>`;
-	xml += `<link>${createCanonicalURL(canonicalUrl).href}</link>`;
+	xml += `<link>${createCanonicalURL(site).href}</link>`;
 	if (typeof rssOptions.customData === 'string') xml += rssOptions.customData;
 	// items
 	for (const result of items) {
@@ -118,7 +118,7 @@ export async function generateRSS({ rssOptions, items }: GenerateRSSArgs): Promi
 		// If the item's link is already a valid URL, don't mess with it.
 		const itemLink = isValidURL(result.link)
 			? result.link
-			: createCanonicalURL(result.link, canonicalUrl).href;
+			: createCanonicalURL(result.link, site).href;
 		xml += `<link>${itemLink}</link>`;
 		xml += `<guid>${itemLink}</guid>`;
 		if (result.description) xml += `<description><![CDATA[${result.description}]]></description>`;

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -9,6 +9,12 @@ type RSSOptions = {
 	/** (required) Description of the RSS Feed */
 	description: string;
 	/**
+	 * Specify the base URL to use for RSS feed links.
+	 * We recommend "import.meta.env.SITE" to pull in the "site"
+	 * from your project's astro.config.
+	 */
+	canonicalUrl: string;
+	/**
 	 * List of RSS feed items to render. Accepts either:
 	 * a) list of RSSFeedItems
 	 * b) import.meta.glob result. You can only glob ".md" files within src/pages/ when using this method!
@@ -22,11 +28,6 @@ type RSSOptions = {
 	stylesheet?: string | boolean;
 	/** Specify custom data in opening of file */
 	customData?: string;
-	/**
-	 * Specify the base URL to use for RSS feed links.
-	 * Defaults to "site" in your project's astro.config
-	 */
-	canonicalUrl?: string;
 };
 
 type RSSFeedItem = {
@@ -43,7 +44,6 @@ type RSSFeedItem = {
 };
 
 type GenerateRSSArgs = {
-	site: string;
 	rssOptions: RSSOptions;
 	items: RSSFeedItem[];
 };
@@ -76,19 +76,12 @@ function mapGlobResult(items: GlobResult): Promise<RSSFeedItem[]> {
 }
 
 export default async function getRSS(rssOptions: RSSOptions) {
-	const site = rssOptions.canonicalUrl ?? (import.meta as any).env.SITE;
-	if (!site) {
-		throw new Error(
-			`RSS requires a canonical URL. Either add a "site" to your project's astro.config, or supply the canonicalUrl argument.`
-		);
-	}
 	let { items } = rssOptions;
 	if (isGlobResult(items)) {
 		items = await mapGlobResult(items);
 	}
 	return {
 		body: await generateRSS({
-			site,
 			rssOptions,
 			items,
 		}),
@@ -96,7 +89,8 @@ export default async function getRSS(rssOptions: RSSOptions) {
 }
 
 /** Generate RSS 2.0 feed */
-export async function generateRSS({ site, rssOptions, items }: GenerateRSSArgs): Promise<string> {
+export async function generateRSS({ rssOptions, items }: GenerateRSSArgs): Promise<string> {
+	const { canonicalUrl } = rssOptions;
 	let xml = `<?xml version="1.0" encoding="UTF-8"?>`;
 	if (typeof rssOptions.stylesheet === 'string') {
 		xml += `<?xml-stylesheet href="${rssOptions.stylesheet}" type="text/xsl"?>`;
@@ -115,7 +109,7 @@ export async function generateRSS({ site, rssOptions, items }: GenerateRSSArgs):
 	// title, description, customData
 	xml += `<title><![CDATA[${rssOptions.title}]]></title>`;
 	xml += `<description><![CDATA[${rssOptions.description}]]></description>`;
-	xml += `<link>${createCanonicalURL(site).href}</link>`;
+	xml += `<link>${createCanonicalURL(canonicalUrl).href}</link>`;
 	if (typeof rssOptions.customData === 'string') xml += rssOptions.customData;
 	// items
 	for (const result of items) {
@@ -124,7 +118,7 @@ export async function generateRSS({ site, rssOptions, items }: GenerateRSSArgs):
 		// If the item's link is already a valid URL, don't mess with it.
 		const itemLink = isValidURL(result.link)
 			? result.link
-			: createCanonicalURL(result.link, site).href;
+			: createCanonicalURL(result.link, canonicalUrl).href;
 		xml += `<link>${itemLink}</link>`;
 		xml += `<guid>${itemLink}</guid>`;
 		if (result.description) xml += `<description><![CDATA[${result.description}]]></description>`;

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -6,7 +6,7 @@ chai.use(chaiPromises);
 
 const title = 'My RSS feed';
 const description = 'This sure is a nice RSS feed';
-const canonicalUrl = 'https://example.com';
+const site = 'https://example.com';
 
 const phpFeedItem = {
 	link: '/php',
@@ -34,7 +34,7 @@ describe('rss', () => {
 			title,
 			description,
 			items: [phpFeedItem, web1FeedItem],
-			canonicalUrl,
+			site,
 		});
 
 		chai.expect(body).to.equal(validXmlResult);
@@ -71,7 +71,7 @@ describe('rss', () => {
 				title,
 				description,
 				items: globResult,
-				canonicalUrl,
+				site,
 			});
 
 			chai.expect(body).to.equal(validXmlResult);
@@ -95,7 +95,7 @@ describe('rss', () => {
 					title,
 					description,
 					items: globResult,
-					canonicalUrl,
+					site,
 				})
 			).to.be.rejected;
 		});
@@ -118,7 +118,7 @@ describe('rss', () => {
 					title,
 					description,
 					items: globResult,
-					canonicalUrl,
+					site,
 				})
 			).to.be.rejected;
 		});

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -29,16 +29,6 @@ const web1FeedItem = {
 const validXmlResult = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title><![CDATA[My RSS feed]]></title><description><![CDATA[This sure is a nice RSS feed]]></description><link>https://example.com/</link><item><title><![CDATA[Remember PHP?]]></title><link>https://example.com/php/</link><guid>https://example.com/php/</guid><description><![CDATA[PHP is a general-purpose scripting language geared toward web development. It was originally created by Danish-Canadian programmer Rasmus Lerdorf in 1994.]]></description><pubDate>Tue, 03 May 1994 00:00:00 GMT</pubDate></item><item><title><![CDATA[Web 1.0]]></title><link>https://example.com/web1/</link><guid>https://example.com/web1/</guid><description><![CDATA[Web 1.0 is the term used for the earliest version of the Internet as it emerged from its origins with Defense Advanced Research Projects Agency (DARPA) and became, for the first time, a global network representing the future of digital communications.]]></description><pubDate>Sat, 03 May 1997 00:00:00 GMT</pubDate></item></channel></rss>`;
 
 describe('rss', () => {
-	it('should fail on missing "site" and/or "canonicalUrl"', () => {
-		return chai.expect(
-			rss({
-				title,
-				description,
-				items: [],
-			})
-		).to.be.rejected;
-	});
-
 	it('should generate on valid RSSFeedItem array', async () => {
 		const { body } = await rss({
 			title,


### PR DESCRIPTION
We discovered that canonicalUrl did not work as expected in the `@astrojs/rss` package. So, we're asking users to apply this value manually as a required prop.

## Changes
- Rename `canonicalUrl` to `site` per @fredkshott's suggestion
- Make `site` a required argument to `@astrojs/rss`
- Remove any logic pulling in `site` from the environment

## Testing

Remove test for `site` validation

## Docs

- Update README
- Update docs.astro.build https://github.com/withastro/docs/pull/453