### PR TITLE
Fix tailwind integration in markdown files

### DIFF
--- a/examples/with-tailwindcss/tailwind.config.cjs
+++ b/examples/with-tailwindcss/tailwind.config.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-	content: ['./src/**/*.{astro,html,js,jsx,svelte,ts,tsx,vue}'],
+	content: ['./src/**/*.{astro,html,js,jsx,md,svelte,ts,tsx,vue}'],
 	theme: {
 		extend: {},
 	},

--- a/packages/astro/src/core/add/consts.ts
+++ b/packages/astro/src/core/add/consts.ts
@@ -18,7 +18,7 @@ export const ALIASES = new Map([
 ]);
 export const CONFIG_STUB = `import { defineConfig } from 'astro/config';\n\nexport default defineConfig({});`;
 export const TAILWIND_CONFIG_STUB = `module.exports = {
-	content: ['./src/**/*.{astro,html,js,jsx,svelte,ts,tsx,vue}'],
+	content: ['./src/**/*.{astro,html,js,jsx,md,svelte,ts,tsx,vue}'],
 	theme: {
 		extend: {},
 	},

--- a/packages/astro/test/fixtures/tailwindcss/tailwind.config.js
+++ b/packages/astro/test/fixtures/tailwindcss/tailwind.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 module.exports = {
-	content: [path.join(__dirname, 'src/**/*.{astro,html,js,jsx,svelte,ts,tsx,vue}')],
+	content: [path.join(__dirname, 'src/**/*.{astro,html,js,jsx,md,svelte,ts,tsx,vue}')],
 	theme: {
 		extend: {
 			colors: {


### PR DESCRIPTION
## Changes

Add markdown to the default content files in the tailwind integration. This fixes an issue I was having (if you add a tailwind class to a `div` or other html component in markdown, tailwind wouldn't generate the new class).

## Testing

So far, it works fine in my own project.

## Docs

Doesn't need docs