### PR TITLE
feat: add shim option to adapters

### DIFF
--- a/.changeset/flat-rocks-laugh.md
+++ b/.changeset/flat-rocks-laugh.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds shim option to adapters to simplify polyfilling/shimming of multiple environments

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -870,6 +870,7 @@ type Body = string;
 export interface AstroAdapter {
 	name: string;
 	serverEntrypoint?: string;
+	shim?: string[];
 	exports?: string[];
 	args?: any;
 }

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -36,7 +36,8 @@ export function vitePluginSSR(
 		},
 		load(id) {
 			if (id === resolvedVirtualModuleId) {
-				return `import * as adapter from '${adapter.serverEntrypoint}';
+				return `${adapter?.shim?.map(i => `import '${i}'`).join('\n')}
+import * as adapter from '${adapter.serverEntrypoint}';
 import * as _main from '${pagesVirtualModuleId}';
 import { deserializeManifest as _deserializeManifest } from 'astro/app';
 const _manifest = Object.assign(_deserializeManifest('${manifestReplace}'), {


### PR DESCRIPTION
## Changes

- What does this change?
Adds a `shim` option to adapters.

**Usecase:** Arguably, an adapter could just shim whatever is required for the provider in the `adapter.serverEntrypoint`. However, I'm creating an adapter for providers/hosting based on the service worker API, which may be supported by different environments; cloudflare, deno deploy, browser, ([JS containers](https://tinyclouds.org/javascript_containers)?), where each of these environments will likely support API's like `fetch`, `Response`, etc, but may have slight differences in environment-specific details, like for example static asset handling. In this case, I would still like to have 1 `adapter.serverEntrypoint` file  (e.g. `worker-entrypoint.js`), without having to read the output of Astro's build through the filesystem, add some shim-imports, and run another build to bundle the shims I need. Consider the following example:

```js
export default defineConfig({
  adapter: worker({
    // cloudflare specific handling
    shim: [
      '@worker-tools/location-polyfill',
      '@cloudflare/kv-asset-handler',
    ]
  }),
});
```

Where the `adapter` would look something like:
```js
export function getAdapter(options) {
  return {
    name: "astro-worker-adapter",
    shim: options?.shim ?? [],
    serverEntrypoint: 'astro-worker',
    exports: ['handler'],
    args: {}
  }
}
```

Which then could even be abstracted to: `worker(cloudFlare)`, `worker(denoDeploy)`, `worker(browser)`, etc


## Testing

Ran tests locally, tested in a local project

## Docs

https://github.com/withastro/docs/pull/479