### PR TITLE
Update markdown.remark/rehypePlugins defaults for docs

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -563,7 +563,7 @@ export interface AstroUserConfig {
 		 * {
 		 *   markdown: {
 		 *     // Example: The default set of remark plugins used by Astro
-		 *     remarkPlugins: ['remark-code-titles', ['rehype-autolink-headings', { behavior: 'prepend' }]],
+		 *     remarkPlugins: ['remark-gfm', 'remark-smartypants'],
 		 *   },
 		 * };
 		 * ```
@@ -582,7 +582,7 @@ export interface AstroUserConfig {
 		 * {
 		 *   markdown: {
 		 *     // Example: The default set of rehype plugins used by Astro
-		 *     rehypePlugins: ['rehype-slug', ['rehype-toc', { headings: ['h2', 'h3'] }], [addClasses, { 'h1,h2,h3': 'title' }]],
+		 *     rehypePlugins: [],
 		 *   },
 		 * };
 		 * ```


### PR DESCRIPTION


## Changes

- aligns the documentation of Astro's default `markdown.remarkPlugins` and `markdown.rehypePlugins` with the defaults used in https://github.com/withastro/astro/blob/main/packages/markdown/remark/src/index.ts#L24
- as requested by @RafidMuhymin in [this message on Discord](https://discord.com/channels/830184174198718474/853350631389265940/970743012214841414)

## Testing

No tests.

## Docs
Updates defaults shown in [Configurations Reference page in docs](https://docs.astro.build/en/reference/configuration-reference/#markdownremarkplugins) 