### PR TITLE
rename dts to ts file

### DIFF
--- a/.changeset/new-carrots-cough.md
+++ b/.changeset/new-carrots-cough.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix an `import from '../core/build/types';` error

--- a/packages/astro/src/core/build/types.ts
+++ b/packages/astro/src/core/build/types.ts
@@ -7,9 +7,9 @@ import type {
 	ComponentInstance,
 	SSRLoadedRenderer,
 } from '../../@types/astro';
-import type { ViteConfigWithSSR } from '../../create-vite';
-import type { LogOptions } from '../../logger';
-import type { RouteCache } from '../../render/route-cache.js';
+import { LogOptions } from '../logger/core';
+import { RouteCache } from '../render/route-cache';
+import { ViteConfigWithSSR } from '../create-vite';
 
 export type ComponentPath = string;
 export type ViteID = string;

--- a/packages/astro/src/core/build/types.ts
+++ b/packages/astro/src/core/build/types.ts
@@ -7,9 +7,9 @@ import type {
 	ComponentInstance,
 	SSRLoadedRenderer,
 } from '../../@types/astro';
-import { LogOptions } from '../logger/core';
-import { RouteCache } from '../render/route-cache';
-import { ViteConfigWithSSR } from '../create-vite';
+import type { LogOptions } from '../logger/core';
+import type { RouteCache } from '../render/route-cache';
+import type { ViteConfigWithSSR } from '../create-vite';
 
 export type ComponentPath = string;
 export type ViteID = string;


### PR DESCRIPTION
## Changes

- Fixes #3320
- `.d.ts` files don't get built in the final package, it should be `.ts`
- Also, looks like `.d.ts` files aren't checked with TS, so renaming it also triggered some TS errors to solve.

## Testing

- Should this be tested? I guess we could add a test that no `.d.ts` bugs
- Update: looks like eslint really isn't designed for file name checks, and we don't have `package/astro` specific eslint rules. I think we can skip a test given how infrequent this will be.

## Docs

- N/A