### PR TITLE
Fix peer deps issue in svelte and vue plugins

### DIFF
--- a/.changeset/violet-bees-camp.md
+++ b/.changeset/violet-bees-camp.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/svelte': patch
+'@astrojs/vue': patch
+---
+
+Fix a vite peer dependency bug

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.41",
     "postcss-load-config": "^3.1.4",
-    "svelte-preprocess": "^4.10.6"
+    "svelte-preprocess": "^4.10.6",
+    "vite": "^2.9.0"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -31,7 +31,8 @@
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {
-    "@vitejs/plugin-vue": "^2.3.1"
+    "@vitejs/plugin-vue": "^2.3.1",
+    "vite": "^2.9.0"
   },
   "devDependencies": {
     "astro": "workspace:*",


### PR DESCRIPTION
## Changes

- Fixes #3032 
- Both plugins use helpers out of the vite plugin, which in yarn/pnpm world means that they must be dependencies somewhere up the chain. Because you as an Astro user aren't also installing Vite, it means that we need to add Vite as a dependency of the integration itself, so that the lower package can find it in its dependency chain.

## Testing

- Tested manually via `pnpm pack`

## Docs

- N/A