### PR TITLE
Fixing mobile header for docs example

### DIFF
--- a/examples/docs/src/components/Header/Header.astro
+++ b/examples/docs/src/components/Header/Header.astro
@@ -18,8 +18,8 @@ const lang = currentPage && getLanguageFromURL(currentPage);
 			<SidebarToggle client:idle />
 		</div>
 		<div class="logo flex">
-			<AstroLogo size={40} />
 			<a href="/">
+				<AstroLogo size={40} />
 				<h1>{CONFIG.SITE.title ?? "Documentation"}</h1>
 			</a>
 		</div>
@@ -48,6 +48,7 @@ const lang = currentPage && getLanguageFromURL(currentPage);
 	}
 
 	.logo {
+		flex: 1;
 		display: flex;
 		overflow: hidden;
 		width: 30px;
@@ -61,6 +62,7 @@ const lang = currentPage && getLanguageFromURL(currentPage);
 	}
 
 	.logo a {
+		display: flex;
 		padding: 0.5em 0.25em;
 		margin: -0.5em -0.25em;
 		text-decoration: none;
@@ -78,6 +80,7 @@ const lang = currentPage && getLanguageFromURL(currentPage);
 	}
 
 	.logo h1 {
+		display: none;
 		font: inherit;
 		color: inherit;
 		margin: 0;
@@ -103,11 +106,11 @@ const lang = currentPage && getLanguageFromURL(currentPage);
 			margin: 0;
 			z-index: 0;
 		}
+		.logo h1 {
+			display: initial;
+		}
 		.menu-toggle {
 			display: none;
-		}
-		.logo {
-			width: auto;
 		}
 	}
 

--- a/examples/docs/src/config.ts
+++ b/examples/docs/src/config.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-	title: 'Your Documentation Website',
+	title: 'Documentation',
 	description: 'Your website description.',
 	defaultLanguage: 'en_US',
 };


### PR DESCRIPTION
## Changes

Updating the docs example to fix the mobile header layout

**Before**
![Screen Shot 2022-05-10 at 21 13 31](https://user-images.githubusercontent.com/15836226/167722896-f846030c-4473-4064-83ac-f1b16b02a921.png)

**After**
![Screen Shot 2022-05-10 at 21 12 48](https://user-images.githubusercontent.com/15836226/167722929-59bcebfd-0b17-451f-b5e8-a5dd01e03d26.png)

## Testing

NA

## Docs

NA