### PR TITLE
Fix: React - Use "createRoot" instead of "hydrateRoot" for `client:only`

### DIFF
--- a/.changeset/small-maps-cough.md
+++ b/.changeset/small-maps-cough.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/react': patch
+---
+
+Fix: remove hydration failures on React v18 by exposing the "client" directive from Astro core.

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -110,15 +110,15 @@ export async function generateHydrateScript(
 		);
 	}
 
-	let hydrationSource = ``;
-
-	hydrationSource += renderer.clientEntrypoint
+	const hydrationSource = renderer.clientEntrypoint
 		? `const [{ ${
 				componentExport.value
 		  }: Component }, { default: hydrate }] = await Promise.all([import("${await result.resolve(
 				componentUrl
 		  )}"), import("${await result.resolve(renderer.clientEntrypoint)}")]);
-  return (el, children) => hydrate(el)(Component, ${serializeProps(props)}, children);
+  return (el, children) => hydrate(el)(Component, ${serializeProps(
+		props
+	)}, children, ${JSON.stringify(hydrate)});
 `
 		: `await import("${await result.resolve(componentUrl)}");
   return () => {};

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -118,7 +118,7 @@ export async function generateHydrateScript(
 		  )}"), import("${await result.resolve(renderer.clientEntrypoint)}")]);
   return (el, children) => hydrate(el)(Component, ${serializeProps(
 		props
-	)}, children, ${JSON.stringify(hydrate)});
+	)}, children, ${JSON.stringify({ client: hydrate })});
 `
 		: `await import("${await result.resolve(componentUrl)}");
   return () => {};

--- a/packages/integrations/react/client-v17.js
+++ b/packages/integrations/react/client-v17.js
@@ -1,15 +1,18 @@
 import { createElement } from 'react';
-import { hydrate } from 'react-dom';
+import { render, hydrate } from 'react-dom';
 import StaticHtml from './static-html.js';
 
 export default (element) => (Component, props, children) =>
-	hydrate(
-		createElement(
+	{
+		const componentEl = createElement(
 			Component,
-			{ ...props, suppressHydrationWarning: true },
+			props,
 			children != null
-				? createElement(StaticHtml, { value: children, suppressHydrationWarning: true })
+				? createElement(StaticHtml, { value: children })
 				: children
-		),
-		element
-	);
+		);
+		if (client === 'only') {
+			return render(componentEl, element);
+		}
+		return hydrate(componentEl, element);
+	};

--- a/packages/integrations/react/client-v17.js
+++ b/packages/integrations/react/client-v17.js
@@ -2,7 +2,7 @@ import { createElement } from 'react';
 import { render, hydrate } from 'react-dom';
 import StaticHtml from './static-html.js';
 
-export default (element) => (Component, props, children) =>
+export default (element) => (Component, props, children, { client }) =>
 	{
 		const componentEl = createElement(
 			Component,

--- a/packages/integrations/react/client.js
+++ b/packages/integrations/react/client.js
@@ -1,15 +1,18 @@
 import { createElement } from 'react';
-import { hydrateRoot } from 'react-dom/client';
+import { createRoot, hydrateRoot } from 'react-dom/client';
 import StaticHtml from './static-html.js';
 
-export default (element) => (Component, props, children) =>
-	hydrateRoot(
-		element,
-		createElement(
+export default (element) => (Component, props, children, client) =>
+	{
+		const componentEl = createElement(
 			Component,
-			{ ...props, suppressHydrationWarning: true },
+			props,
 			children != null
-				? createElement(StaticHtml, { value: children, suppressHydrationWarning: true })
+				? createElement(StaticHtml, { value: children })
 				: children
-		)
-	);
+		);
+		if (client === 'only') {
+			return createRoot(element).render(componentEl);
+		}
+		return hydrateRoot(element, componentEl);
+	};

--- a/packages/integrations/react/client.js
+++ b/packages/integrations/react/client.js
@@ -2,7 +2,7 @@ import { createElement } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import StaticHtml from './static-html.js';
 
-export default (element) => (Component, props, children, client) =>
+export default (element) => (Component, props, children, { client }) =>
 	{
 		const componentEl = createElement(
 			Component,


### PR DESCRIPTION
## Changes
- Resolves #3010
- Update Astro core to surface `client` directive to client renderers
- Update React `client.js` to use `createRoot` on `client:only` instead of suppressing hydration warnings (spoiler: they aren't suppressed!)
- Update React `client-17.js` to use `render` on `client:only` instead of suppressing hydration warnings

## Testing

N/A, check your console 😉 

## Docs

N/A