### PR TITLE
Fix APIRoute type

### DIFF
--- a/.changeset/curly-bees-collect.md
+++ b/.changeset/curly-bees-collect.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix for APIRoute type

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -886,7 +886,7 @@ export interface EndpointOutput<Output extends Body = Body> {
 export type APIRoute = (context: APIContext) => EndpointOutput | Response;
 
 export interface EndpointHandler {
-	[method: string]: APIRoute;
+	[method: string]: APIRoute | ((params: Params, request: Request) => EndpointOutput | Response);
 }
 
 export interface AstroRenderer {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -883,15 +883,7 @@ export interface EndpointOutput<Output extends Body = Body> {
 	body: Output;
 }
 
-interface APIRoute {
-	(context: APIContext): EndpointOutput | Response;
-
-	/**
-	 * @deprecated
-	 * Use { context: APIRouteContext } object instead.
-	 */
-	(params: Params, request: Request): EndpointOutput | Response;
-}
+export type APIRoute = (context: APIContext) => EndpointOutput | Response;
 
 export interface EndpointHandler {
 	[method: string]: APIRoute;

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -508,7 +508,7 @@ Update your code to remove this warning.`);
 		},
 	}) as APIContext & Params;
 
-	return await handler.call(mod, proxy, request);
+	return handler.call(mod, proxy, request);
 }
 
 async function replaceHeadInjection(result: SSRResult, html: string): Promise<string> {


### PR DESCRIPTION
<img width="682" alt="Screen Shot 2022-05-11 at 9 09 21 AM" src="https://user-images.githubusercontent.com/361671/167884767-a0c6ff61-231c-4d2a-bba0-ce14977abb1d.png">

## Changes

- Fixes #3343
- Exports `APIRoute`
- Removed deprecated signature which prevents type narrowing.

## Testing

Our TS types are currently not tested :/

## Docs

N/A, this API is already documented.