### PR TITLE
Allow changing vite's `MODE` environment variable

### DIFF
--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -71,6 +71,8 @@ class AstroBuilder {
 	private async setup() {
 		debug('build', 'Initial setup...');
 		const { logging } = this;
+		const { mode } = this.config.vite || {};
+		this.mode = mode || this.mode;
 		this.timer.init = performance.now();
 		this.timer.viteStart = performance.now();
 		this.config = await runHookConfigSetup({ config: this.config, command: 'build' });

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -122,7 +122,7 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 
 	const viteBuildConfig = {
 		logLevel: 'error',
-		mode: 'production',
+		mode: viteConfig.mode,
 		css: viteConfig.css,
 		build: {
 			...viteConfig.build,
@@ -203,7 +203,7 @@ async function clientBuild(
 
 	const viteBuildConfig = {
 		logLevel: 'info',
-		mode: 'production',
+		mode: viteConfig.mode,
 		css: viteConfig.css,
 		build: {
 			emptyOutDir: false,


### PR DESCRIPTION
## Changes

- Fixes #3311 
- Adds priority to `vite.mode` value in astro configuration file.

## Testing

The changes were tested locally, I didn't find any test suite related to vite's configuration.

## Docs

TODO

Need to change https://docs.astro.build/en/guides/environment-variables/ so we can specify that changing `vite.mode` values reflects on the respective ENV var only in **astro build** command.