### PR TITLE
Exclude `node-fetch` from vite.optimizeDeps

### DIFF
--- a/.changeset/funny-poets-walk.md
+++ b/.changeset/funny-poets-walk.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Update default `vite.optimizeDeps.exclude` to keep `node-fetch` from being optimized

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -55,7 +55,7 @@ export async function createVite(
 		logLevel: 'warn', // log warnings and errors only
 		optimizeDeps: {
 			entries: ['src/**/*'], // Try and scan a user’s project (won’t catch everything),
-      exclude: ['node-fetch'],
+			exclude: ['node-fetch'],
 		},
 		plugins: [
 			configAliasVitePlugin({ config: astroConfig }),

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -55,6 +55,7 @@ export async function createVite(
 		logLevel: 'warn', // log warnings and errors only
 		optimizeDeps: {
 			entries: ['src/**/*'], // Try and scan a user’s project (won’t catch everything),
+      exclude: ['node-fetch'],
 		},
 		plugins: [
 			configAliasVitePlugin({ config: astroConfig }),


### PR DESCRIPTION
## Changes

- Related to https://github.com/withastro/astro/issues/3338
- Adds `node-fetch` to default `vite.optimizeDeps.exclude`.
- Changeset added ✅

## Testing

Manually

## Docs

N/A