### PR TITLE
add error hints

### DIFF
--- a/.changeset/dry-glasses-guess.md
+++ b/.changeset/dry-glasses-guess.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve error hints for packages that should be added to `vite.ssr.noExternal`

--- a/packages/astro/src/core/errors.ts
+++ b/packages/astro/src/core/errors.ts
@@ -9,6 +9,7 @@ export interface ErrorWithMetadata {
 	[name: string]: any;
 	message: string;
 	stack: string;
+	hint?: string;
 	id?: string;
 	frame?: string;
 	plugin?: string;
@@ -38,6 +39,13 @@ export function fixViteErrorMessage(_err: unknown, server: ViteDevServer) {
 		err.message = 'Astro.glob() and import.meta.glob() can only accept string literals.';
 	}
 	return err;
+}
+
+function generateHint(err: ErrorWithMetadata): string | undefined {
+	if (/Unknown file extension \"\.(jsx|vue|svelte|astro)\" for /.test(err.message)) {
+		return 'You likely need to add this package to `vite.ssr.noExternal` in your astro config file.';
+	}
+	return undefined;
 }
 
 /**
@@ -70,9 +78,11 @@ export function collectErrorMetadata(e: any): ErrorWithMetadata {
 		if (pluginName) {
 			err.plugin = pluginName;
 		}
+		err.hint = generateHint(err);
 		return err;
 	}
 
 	// Generic error (probably from Vite, and already formatted)
+		e.hint = generateHint(e);
 	return e;
 }

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -212,6 +212,10 @@ export function formatConfigErrorMessage(err: ZodError) {
 export function formatErrorMessage(_err: Error, args: string[] = []): string {
 	const err = collectErrorMetadata(_err);
 	args.push(`${bgRed(black(` error `))}${red(bold(padMultilineString(err.message)))}`);
+	if (err.hint) {
+		args.push(`  ${bold('Hint:')}`);
+    	args.push(yellow(padMultilineString(err.hint, 4)));
+	}
 	if (err.id) {
 		args.push(`  ${bold('File:')}`);
 		args.push(red(`    ${err.id}`));


### PR DESCRIPTION
## Changes

- Solves a DX issue that the Solid + Builder teams were seeing, where it was unclear how to resolve a `noExternal` issue based on the console output. 
- Adds a larger "Hint" error metadata + formatter that you can use to report hints alongside errors.

## Testing

- TODO

## Docs

- N/A