### PR TITLE
Corrected the default value of the trailingSlash config

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -380,7 +380,7 @@ export interface AstroUserConfig {
 	 * @docs
 	 * @name trailingSlash
 	 * @type {('always' | 'never' | 'ignore')}
-	 * @default `'always'`
+	 * @default `'ignore'`
 	 * @see buildOptions.pageUrlFormat
 	 * @description
 	 *


### PR DESCRIPTION
## Changes

Corrected the default value of the `trailingSlash` config.

## Testing

## Docs

This is for correcting the documentation and the documentation is built automatically from the `astro.ts` file.