### PR TITLE
internal: deserialized routes now have `generate()`

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -974,6 +974,9 @@ export interface RouteData {
 export type SerializedRouteData = Omit<RouteData, 'generate' | 'pattern'> & {
 	generate: undefined;
 	pattern: string;
+	_meta: {
+		trailingSlash: AstroConfig['trailingSlash'];
+	};
 };
 
 export type RuntimeMode = 'development' | 'production';

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -115,7 +115,7 @@ function buildManifest(
 					.filter((script) => script.stage === 'head-inline')
 					.map(({ stage, content }) => ({ stage, children: content })),
 			],
-			routeData: serializeRouteData(pageData.route),
+			routeData: serializeRouteData(pageData.route, astroConfig.trailingSlash),
 		});
 	}
 

--- a/packages/astro/src/core/routing/manifest/generator.ts
+++ b/packages/astro/src/core/routing/manifest/generator.ts
@@ -1,0 +1,34 @@
+import type { AstroConfig, RoutePart } from '../../../@types/astro';
+
+import { compile } from 'path-to-regexp';
+
+export function getRouteGenerator(
+	segments: RoutePart[][],
+	addTrailingSlash: AstroConfig['trailingSlash']
+) {
+	const template = segments
+		.map((segment) => {
+			return segment[0].spread
+				? `/:${segment[0].content.slice(3)}(.*)?`
+				: '/' +
+						segment
+							.map((part) => {
+								if (part)
+									return part.dynamic
+										? `:${part.content}`
+										: part.content
+												.normalize()
+												.replace(/\?/g, '%3F')
+												.replace(/#/g, '%23')
+												.replace(/%5B/g, '[')
+												.replace(/%5D/g, ']')
+												.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+							})
+							.join('');
+		})
+		.join('');
+
+	const trailing = addTrailingSlash !== 'never' && segments.length ? '/' : '';
+	const toPath = compile(template + trailing);
+	return toPath;
+}


### PR DESCRIPTION
## Changes

Deserialized routes in SSR now have `generate()`. I was trying to figure out other thing saw this TODO

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->