### PR TITLE
feat(vercel): remove `nodeVersion`

### DIFF
--- a/.changeset/silver-toes-retire.md
+++ b/.changeset/silver-toes-retire.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Remove `nodeVersion` option for `serverless` target. Now it is inferred from Vercel

--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -59,19 +59,6 @@ import vercel from '@astrojs/vercel/serverless';
 import vercel from '@astrojs/vercel/static';
 ```
 
-### Node.js version
-
-When deploying to `serverless` you can choose what version of Node.js you want to target: `12.x`, `14.x` or `16.x` (default).
-
-```js
-import { defineConfig } from 'astro/config';
-import vercel from '@astrojs/vercel/serverless';
-
-export default defineConfig({
-	adapter: vercel({ nodeVersion: '14.x' })
-});
-```
-
 ## Limitations
 
 **A few known complex packages (example: [puppeteer](https://github.com/puppeteer/puppeteer)) do not support bundling and therefore will not work properly with this adapter.** By default, Vercel doesn't include npm installed files & packages from your project's `./node_modules` folder. To address this, the `@astrojs/vercel` adapter automatically bundles your final build output using `esbuild`.

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -14,11 +14,7 @@ function getAdapter(): AstroAdapter {
 	};
 }
 
-export interface Options {
-	nodeVersion?: '12.x' | '14.x' | '16.x';
-}
-
-export default function vercelEdge({ nodeVersion = '16.x' }: Options = {}): AstroIntegration {
+export default function vercelEdge(): AstroIntegration {
 	let _config: AstroConfig;
 	let functionFolder: URL;
 	let serverEntry: string;
@@ -57,7 +53,7 @@ export default function vercelEdge({ nodeVersion = '16.x' }: Options = {}): Astr
 				// Serverless function config
 				// https://vercel.com/docs/build-output-api/v3#vercel-primitives/serverless-functions/configuration
 				await writeJson(new URL(`./.vc-config.json`, functionFolder), {
-					runtime: `nodejs${nodeVersion}`,
+					runtime: getRuntime(),
 					handler: serverEntry,
 					launcherType: 'Nodejs',
 				});
@@ -75,4 +71,10 @@ export default function vercelEdge({ nodeVersion = '16.x' }: Options = {}): Astr
 			},
 		},
 	};
+}
+
+function getRuntime() {
+	const version = process.version.slice(1); // 'v16.5.0' --> '16.5.0'
+	const major = version.split('.')[0]; // '16.5.0' --> '16'
+	return `nodejs${major}.x`;
 }


### PR DESCRIPTION
## Changes

Remove `nodeVersion` option for `serverless` target. Now it is inferred from Vercel

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->