### PR TITLE
Broken link to Solid package

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Join us on [Discord](https://astro.build/chat) to meet other maintainers. We'll 
 | [create-astro](packages/create-astro)                   | [![create-astro version](https://img.shields.io/npm/v/create-astro.svg?label=%20)](packages/create-astro/CHANGELOG.md)            |
 | [@astrojs/react](packages/integrations/react)           | [![astro version](https://img.shields.io/npm/v/@astrojs/react.svg?label=%20)](packages/integrations/react/CHANGELOG.md)           |
 | [@astrojs/preact](packages/integrations/preact)         | [![astro version](https://img.shields.io/npm/v/@astrojs/preact.svg?label=%20)](packages/integrations/preact/CHANGELOG.md)         |
-| [@astrojs/solid-js](packages/integrations/solid-js)     | [![astro version](https://img.shields.io/npm/v/@astrojs/solid-js.svg?label=%20)](packages/integrations/solid-js/CHANGELOG.md)     |
+| [@astrojs/solid-js](packages/integrations/solid)        | [![astro version](https://img.shields.io/npm/v/@astrojs/solid-js.svg?label=%20)](packages/integrations/solid-js/CHANGELOG.md)     |
 | [@astrojs/svelte](packages/integrations/svelte)         | [![astro version](https://img.shields.io/npm/v/@astrojs/svelte.svg?label=%20)](packages/integrations/svelte/CHANGELOG.md)         |
 | [@astrojs/vue](packages/integrations/vue)               | [![astro version](https://img.shields.io/npm/v/@astrojs/vue.svg?label=%20)](packages/integrations/vue/CHANGELOG.md)               |
 | [@astrojs/lit](packages/integrations/lit)               | [![astro version](https://img.shields.io/npm/v/@astrojs/lit.svg?label=%20)](packages/integrations/lit/CHANGELOG.md)               |


### PR DESCRIPTION
The link to the `solid` package was pointing to `solid-js` instead of `solid`

## Changes

- Fixes a link to Solid integration in the README

## Testing

N/A - Only README changed

## Docs

Only applies to the README.md as far as I can tell