### PR TITLE
Support alias use with hydration scripts

### DIFF
--- a/.changeset/tiny-donuts-own.md
+++ b/.changeset/tiny-donuts-own.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow using aliases for hydrated scripts

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -195,7 +195,6 @@ class AstroBuilder {
 		try {
 			await this.build(setupData);
 		} catch (_err) {
-			debugger;
 			throw fixViteErrorMessage(createSafeError(_err), setupData.viteServer);
 		}
 	}

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -160,18 +160,11 @@ export async function render(
 		pathname,
 		scripts,
 		// Resolves specifiers in the inline hydrated scripts, such as "@astrojs/preact/client.js"
-		// TODO: Can we pass the hydration code more directly through Vite, so that we
-		// don't need to copy-paste and maintain Vite's import resolution here?
 		async resolve(s: string) {
-			const [resolvedUrl, resolvedPath] = await viteServer.moduleGraph.resolveUrl(s);
-			if (resolvedPath.includes('node_modules/.vite')) {
-				return resolvedPath.replace(/.*?node_modules\/\.vite/, '/node_modules/.vite');
+			if(s.startsWith('/@fs')) {
+				return s;
 			}
-			// NOTE: This matches the same logic that Vite uses to add the `/@id/` prefix.
-			if (!resolvedUrl.startsWith('.') && !resolvedUrl.startsWith('/')) {
-				return '/@id' + prependForwardSlash(resolvedUrl);
-			}
-			return '/@fs' + prependForwardSlash(resolvedPath);
+			return '/@id' + prependForwardSlash(s);
 		},
 		renderers,
 		request,

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -603,10 +603,7 @@ export async function renderHead(result: SSRResult): Promise<string> {
 			if ('data-astro-component-hydration' in script.props) {
 				needsHydrationStyles = true;
 			}
-			return renderElement('script', {
-				...script,
-				props: { ...script.props, 'astro-script': result._metadata.pathname + '/script-' + i },
-			});
+			return renderElement('script', script);
 		});
 	if (needsHydrationStyles) {
 		styles.push(

--- a/packages/astro/test/alias.test.js
+++ b/packages/astro/test/alias.test.js
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { isWindows, loadFixture } from './test-utils.js';
+
+describe('Aliases', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/alias/',
+		});
+	});
+
+	if (isWindows) return;
+
+	describe('dev', () => {
+		let devServer;
+
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it.only('can load client components', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			const $ = cheerio.load(html);
+
+			// Should render aliased element
+			expect($('#client').text()).to.equal('test');
+
+			const scripts = $('script').toArray();
+			expect(scripts.length).to.be.greaterThan(0);
+		});
+	});
+});

--- a/packages/astro/test/fixtures/alias/astro.config.mjs
+++ b/packages/astro/test/fixtures/alias/astro.config.mjs
@@ -1,0 +1,14 @@
+import { defineConfig } from 'astro/config';
+import svelte from '@astrojs/svelte';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [svelte()],
+	vite: {
+		resolve: {
+			alias: [
+				{ find:/^component:(.*)$/, replacement: '/src/components/$1' }
+			]
+		}
+	}
+});

--- a/packages/astro/test/fixtures/alias/package.json
+++ b/packages/astro/test/fixtures/alias/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/aliases",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/svelte": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/alias/src/components/Client.svelte
+++ b/packages/astro/test/fixtures/alias/src/components/Client.svelte
@@ -1,0 +1,2 @@
+<script></script>
+<div id="client">test</div>

--- a/packages/astro/test/fixtures/alias/src/pages/index.astro
+++ b/packages/astro/test/fixtures/alias/src/pages/index.astro
@@ -1,0 +1,25 @@
+---
+import Client from 'component:Client.svelte'
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Svelte Client</title>
+    <style>
+      html,
+      body {
+        font-family: system-ui;
+        margin: 0;
+      }
+      body {
+        padding: 2rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <Client  client:load />
+    </main>
+  </body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -671,6 +671,14 @@ importers:
       '@astrojs/vue': link:../../../../integrations/vue
       astro: link:../../..
 
+  packages/astro/test/fixtures/alias:
+    specifiers:
+      '@astrojs/svelte': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/svelte': link:../../../../integrations/svelte
+      astro: link:../../..
+
   packages/astro/test/fixtures/astro-assets:
     specifiers:
       astro: workspace:*
@@ -5487,6 +5495,11 @@ packages:
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
     dev: false
@@ -8280,6 +8293,8 @@ packages:
       debug: 3.2.7
       iconv-lite: 0.4.24
       sax: 1.2.4
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /netmask/2.0.2:
@@ -8362,6 +8377,8 @@ packages:
       rimraf: 2.7.1
       semver: 5.7.1
       tar: 4.4.19
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /node-releases/2.0.4:


### PR DESCRIPTION
## Changes

- Fixes #2921
- Simplifies hydration id resolution in dev, now we just defer to `/@id`, an internal Vite resolution, unless it's already `/@fs`.

## Testing

Test added

## Docs

N/A, bug fix.