### PR TITLE
Update out directories for Netlify Functions

### DIFF
--- a/.changeset/eight-feet-reflect.md
+++ b/.changeset/eight-feet-reflect.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': minor
+---
+
+Updating out directories for Netlify Functions

--- a/packages/integrations/netlify/README.md
+++ b/packages/integrations/netlify/README.md
@@ -39,7 +39,7 @@ export default defineConfig({
 
 ### dist
 
-For Netlify Functions, we build to a `netlify` directory at the base of your project. In the case of Netlify Edge Functions, we build to a `dist` directory at the base of your project. To change this, use the `dist` option:
+We build to a `dist` directory at the base of your project. To change this, use the `dist` option:
 
 ```js
 import { defineConfig } from 'astro/config';

--- a/packages/integrations/netlify/src/integration-functions.ts
+++ b/packages/integrations/netlify/src/integration-functions.ts
@@ -24,7 +24,7 @@ function netlifyFunctions({ dist }: NetlifyFunctionsOptions = {}): AstroIntegrat
 				if (dist) {
 					config.outDir = dist;
 				} else {
-					config.outDir = new URL('./netlify/', config.root);
+					config.outDir = new URL('./dist/', config.root);
 				}
 			},
 			'astro:config:done': ({ config, setAdapter }) => {
@@ -34,7 +34,7 @@ function netlifyFunctions({ dist }: NetlifyFunctionsOptions = {}): AstroIntegrat
 			'astro:build:start': async ({ buildConfig }) => {
 				entryFile = buildConfig.serverEntry.replace(/\.m?js/, '');
 				buildConfig.client = _config.outDir;
-				buildConfig.server = new URL('./functions/', _config.outDir);
+				buildConfig.server = new URL('./.netlify/functions-internal/', _config.root);
 			},
 			'astro:build:done': async ({ routes, dir }) => {
 				await createRedirects(routes, dir, entryFile, false);


### PR DESCRIPTION
## Changes

Changes the outDir to /dist/ for regular Netlify Functions (not Edge Functions) - as /netlify/ is a directory that Netlify users [add their own Edge Functions to](https://docs.netlify.com/netlify-labs/experimental-features/edge-functions/get-started/#create-an-edge-function), and we don't want to overwrite them when building.
Modifies the out directory for the entry.js file to ./.netlify/functions-internal (used for integration functions) as we do not want this file in the dist directory.

## Testing

This change was tested against an astro project, set up with the @astro/netlify package, with the `import netlify from '@astrojs/netlify/functions';` configuration.. I have confirmed that it builds the site to the dist directory, and puts the relevant server file in ./.netlify/functions-internal

## Docs

Updated documentation in package README.md