### PR TITLE
Deprecate @astrojs/turbolinks

### DIFF
--- a/.changeset/smart-bananas-kick.md
+++ b/.changeset/smart-bananas-kick.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/turbolinks': patch
+---
+
+The @astrojs/turbolinks integration has been deprecated

--- a/packages/integrations/turbolinks/README.md
+++ b/packages/integrations/turbolinks/README.md
@@ -1,3 +1,11 @@
+# This integration is no longer actively supported
+
+[Turbolinks](https://github.com/turbolinks/turbolinks) is no longer under active development. The `@astrojs/turbolinks` integration has been deprecated.
+
+## Looking for an alternative?
+
+Check out [swup](https://swup.js.org/)! If you are using any `client:*` script for partial hydration, make sure to install the `@swup/scripts-plugin` to ensure components are rehydrated after a page navigation.
+
 # @astrojs/turbolinks ⚡️
 
 This **[Astro integration][astro-integration]** brings [Turbo](https://github.com/hotwired/turbo) to your Astro project.


### PR DESCRIPTION
## Changes

Adding a deprecation warning to the `@astrojs/turbolinks` package.  [Turbolinks](@swup/scripts-plugin) is no longer actively maintained and unfortunately it doesn't work well with islands architecture.

## Testing

N/A

## Docs

Docs [PR #574](https://github.com/withastro/docs/pull/574) removing references to the integration