### PR TITLE
Matching custom 404 pages using the manifest's route patterns

### DIFF
--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -165,9 +165,8 @@ async function handle500Response(
 	writeHtmlResponse(res, 500, transformedHtml);
 }
 
-function getCustom404Route(config: AstroConfig, manifest: ManifestData) {
-	const relPages = resolvePages(config).href.replace(config.root.href, '');
-	return manifest.routes.find((r) => r.component === appendForwardSlash(relPages) + '404.astro');
+function getCustom404Route(manifest: ManifestData) {
+	return manifest.routes.find((r) => '/404'.match(r.pattern));
 }
 
 function log404(logging: LogOptions, pathname: string) {
@@ -235,7 +234,7 @@ async function handleRequest(
 
 		if (!route) {
 			log404(logging, pathname);
-			const custom404 = getCustom404Route(config, manifest);
+			const custom404 = getCustom404Route(manifest);
 			if (custom404) {
 				route = custom404;
 			} else {
@@ -263,7 +262,7 @@ async function handleRequest(
 				`Route pattern matched, but no matching static path found. (${pathname})`
 			);
 			log404(logging, pathname);
-			const routeCustom404 = getCustom404Route(config, manifest);
+			const routeCustom404 = getCustom404Route(manifest);
 			if (routeCustom404) {
 				const filePathCustom404 = new URL(`./${routeCustom404.component}`, config.root);
 				const preloadedCompCustom404 = await preload({

--- a/packages/astro/test/custom-404-md.test.js
+++ b/packages/astro/test/custom-404-md.test.js
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Custom 404 Markdown', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/custom-404-md/',
+		});
+	});
+
+	describe('dev', () => {
+		let devServer;
+		let $;
+
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('renders /', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			$ = cheerio.load(html);
+
+			expect($('h1').text()).to.equal('Home');
+		});
+
+		it('renders 404 for /abc', async () => {
+			const html = await fixture.fetch('/a').then((res) => res.text());
+			$ = cheerio.load(html);
+
+			expect($('h1').text()).to.equal('Page not found');
+		});
+	});
+});

--- a/packages/astro/test/fixtures/custom-404-md/astro.config.mjs
+++ b/packages/astro/test/fixtures/custom-404-md/astro.config.mjs
@@ -1,0 +1,4 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({});

--- a/packages/astro/test/fixtures/custom-404-md/package.json
+++ b/packages/astro/test/fixtures/custom-404-md/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/custom-404-md",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/custom-404-md/src/layouts/Base.astro
+++ b/packages/astro/test/fixtures/custom-404-md/src/layouts/Base.astro
@@ -1,0 +1,12 @@
+---
+const { content } = Astro.props;
+---
+
+<html lang="en">
+<head>
+  <title>{content.title}</title>
+</head>
+<body>
+	<slot />
+</body>
+</html>

--- a/packages/astro/test/fixtures/custom-404-md/src/pages/404.md
+++ b/packages/astro/test/fixtures/custom-404-md/src/pages/404.md
@@ -1,0 +1,6 @@
+---
+layout: '../layouts/Base.astro'
+title: 'Not Found - Custom 404'
+---
+
+# Page not found

--- a/packages/astro/test/fixtures/custom-404-md/src/pages/index.astro
+++ b/packages/astro/test/fixtures/custom-404-md/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+---
+
+<html lang="en">
+<head>
+  <title>Custom 404</title>
+</head>
+<body>
+  <h1>Home</h1>
+</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1017,6 +1017,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/custom-404-md:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/custom-elements:
     specifiers:
       '@test/custom-element-renderer': workspace:*


### PR DESCRIPTION
Closes #3389 

## Changes

Updates the dev server to support using markdown pages for custom 404 routes (this already works in `astro preview`)

## Testing

Added a test fixture for custom `404.md` pages

## Docs

Related to [PR #554](https://github.com/withastro/docs/pull/554)