### PR TITLE
fix: locale handling for logger

### DIFF
--- a/.changeset/thirty-drinks-shout.md
+++ b/.changeset/thirty-drinks-shout.md
@@ -1,5 +1,6 @@
 ---
 'astro': patch
+'create-astro': patch
 ---
 
 Fix [#3309](https://github.com/withastro/astro/issues/3309) default logger locale behavior.

--- a/.changeset/thirty-drinks-shout.md
+++ b/.changeset/thirty-drinks-shout.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix [#3309](https://github.com/withastro/astro/issues/3309) default logger locale behavior.

--- a/packages/astro/src/core/logger/core.ts
+++ b/packages/astro/src/core/logger/core.ts
@@ -14,18 +14,16 @@ export interface LogOptions {
 	level: LoggerLevel;
 }
 
-function getLoggerLocale(): string {
-	const defaultLocale = 'en-US';
-	if (process.env.LANG) {
-		const extractedLocale = process.env.LANG.split('.')[0].replace(/_/g, '-');
-		// Check if language code is atleast two characters long (ie. en, es).
-		// NOTE: if "c" locale is encountered, the default locale will be returned.
-		if (extractedLocale.length < 2) return defaultLocale;
-		else return extractedLocale.substring(0, 5);
-	} else return defaultLocale;
-}
-
-export const dateTimeFormat = new Intl.DateTimeFormat(getLoggerLocale(), {
+// Hey, locales are pretty complicated! Be careful modifying this logic...
+// If we throw at the top-level, international users can't use Astro.
+// 
+// Using `[]` sets the default locale properly from the system!
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#parameters
+// 
+// Here be the dragons we've slain:
+// https://github.com/withastro/astro/issues/2625
+// https://github.com/withastro/astro/issues/3309
+export const dateTimeFormat = new Intl.DateTimeFormat([], {
 	hour: '2-digit',
 	minute: '2-digit',
 	second: '2-digit',

--- a/packages/astro/test/cli.test.js
+++ b/packages/astro/test/cli.test.js
@@ -25,6 +25,18 @@ describe('astro cli', () => {
 		expect(proc.stdout).to.include(pkgVersion);
 	});
 
+	const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+	const LOCALES = ['en_US', 'sv_SE', 'es_419.UTF-8', 'es_ES@euro', 'C'];
+	LOCALES.forEach((locale) => {
+		it(`astro does NOT throw on "${locale}" locales`, async () => {
+			const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
+			const proc = cli('dev', '--root', fileURLToPath(projectRootURL), { extendEnv: false, env: { LANG: locale }});
+
+			await Promise.race([proc, sleep(5000).then(() => proc.kill(0))]);
+			expect(proc.exitCode).to.equal(0, ``);
+		});
+	})
+
 	it('astro build', async () => {
 		const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
 		const proc = await cli('build', '--root', fileURLToPath(projectRootURL));

--- a/packages/astro/test/cli.test.js
+++ b/packages/astro/test/cli.test.js
@@ -25,18 +25,6 @@ describe('astro cli', () => {
 		expect(proc.stdout).to.include(pkgVersion);
 	});
 
-	const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
-	const LOCALES = ['en_US', 'sv_SE', 'es_419.UTF-8', 'es_ES@euro', 'C'];
-	LOCALES.forEach((locale) => {
-		it(`astro does NOT throw on "${locale}" locales`, async () => {
-			const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
-			const proc = cli('dev', '--root', fileURLToPath(projectRootURL), { extendEnv: false, env: { LANG: locale }});
-
-			await Promise.race([proc, sleep(5000).then(() => proc.kill(0))]);
-			expect(proc.exitCode).to.equal(0, ``);
-		});
-	})
-
 	it('astro build', async () => {
 		const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
 		const proc = await cli('build', '--root', fileURLToPath(projectRootURL));
@@ -122,3 +110,21 @@ describe('astro cli', () => {
 		});
 	});
 });
+
+describe('astro cli i18n', () => {
+	const LOCALES = ['en_US', 'sv_SE', 'es_419.UTF-8', 'es_ES@euro', 'C'];
+	LOCALES.forEach((locale) => {
+		it(`astro does NOT throw on "${locale}" locales`, async () => {
+			const projectRootURL = new URL('./fixtures/astro-basic/', import.meta.url);
+			let error = null;
+			try {
+				const proc = cli('dev', '--root', fileURLToPath(projectRootURL), { env: { LANG: locale }});
+				await parseCliDevStart(proc)
+			} catch (e) {
+				console.log(e);
+				error = e.message;
+			}
+			expect(error).to.be.null;
+		});
+	})
+})

--- a/packages/create-astro/src/logger.ts
+++ b/packages/create-astro/src/logger.ts
@@ -6,20 +6,19 @@ type ConsoleStream = Writable & {
 	fd: 1 | 2;
 };
 
-function getLoggerLocale(): string {
-	const defaultLocale = 'en-US';
-	if (process.env.LANG) {
-		const extractedLocale = process.env.LANG.split('.')[0].replace(/_/g, '-');
-		// Check if language code is atleast two characters long (ie. en, es).
-		// NOTE: if "c" locale is encountered, the default locale will be returned.
-		if (extractedLocale.length < 2) return defaultLocale;
-		else return extractedLocale;
-	} else return defaultLocale;
-}
-
-const dt = new Intl.DateTimeFormat(getLoggerLocale(), {
+// Hey, locales are pretty complicated! Be careful modifying this logic...
+// If we throw at the top-level, international users can't use Astro.
+// 
+// Using `[]` sets the default locale properly from the system!
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#parameters
+// 
+// Here be the dragons we've slain:
+// https://github.com/withastro/astro/issues/2625
+// https://github.com/withastro/astro/issues/3309
+const dt = new Intl.DateTimeFormat([], {
 	hour: '2-digit',
 	minute: '2-digit',
+	second: '2-digit',
 });
 
 export const defaultLogDestination = new Writable({


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/3309
- Use default locale based on `process.env.LANG` without implementing our own logic
- Adds a warning for future devs

## Testing

- Regression tests added

## Docs

Bug fix only