### PR TITLE
Fix unintentional missing type data in `MarkdownInstance`

### DIFF
--- a/.changeset/eleven-planes-deliver.md
+++ b/.changeset/eleven-planes-deliver.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+MarkdownInstance: Persist frontmatter type into the return of `.default()`

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -760,7 +760,7 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 	getHeaders(): Promise<MarkdownHeader[]>;
 	default: () => Promise<{
 		metadata: MarkdownMetadata;
-		frontmatter: MarkdownContent;
+		frontmatter: MarkdownContent & T;
 		$$metadata: Metadata;
 		default: AstroComponentFactory;
 	}>;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -760,7 +760,7 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 	getHeaders(): Promise<MarkdownHeader[]>;
 	default: () => Promise<{
 		metadata: MarkdownMetadata;
-		frontmatter: MarkdownContent & T;
+		frontmatter: MarkdownContent<T>;
 		$$metadata: Metadata;
 		default: AstroComponentFactory;
 	}>;
@@ -815,10 +815,9 @@ export interface MarkdownParserResponse extends MarkdownRenderingResult {
  * The `content` prop given to a Layout
  * https://docs.astro.build/guides/markdown-content/#markdown-layouts
  */
-export interface MarkdownContent {
-	[key: string]: any;
+export type MarkdownContent<T extends Record<string, any> = Record<string, any>> = T & {
 	astro: MarkdownMetadata;
-}
+};
 
 /**
  * paginate() Options


### PR DESCRIPTION
- [x] Don't forget a changeset! `pnpm exec changeset`


## Changes

The return of the `default` function includes the same `frontmatter`
data as the parent object, merged with the `astro` data. The inclusion
of that frontmatter type was previously not recognized by TS, and fell
back to a `Record<string, any>`. This change persists the more accurate
type, as the runtime code does.


|before|after|
|-|-|
|<img width="438" alt="CleanShot 2022-05-18 at 10 36 03@2x" src="https://user-images.githubusercontent.com/3663628/169068138-46efc4f3-3486-4f99-bffd-f0c18dcb77af.png">|<img width="434" alt="CleanShot 2022-05-18 at 10 36 43@2x" src="https://user-images.githubusercontent.com/3663628/169068165-451857dc-c85f-49ac-a296-d2e45e104bcd.png">|



PR NOTE:
**The second commit is optional, and I'd squash it into the first if you want it**

The second commit goes a step farther. It is a slightly deeper change that allows you to optionally pass `T` (frontmatter) into the `MarkdownContent` generic. This allows you to (optionally) make the type of `MarkdownContent` much stricter, and not behave as if any possible string key exists:

<img width="433" alt="CleanShot 2022-05-18 at 11 01 33@2x" src="https://user-images.githubusercontent.com/3663628/169073662-2d869998-98ab-4afc-95ab-440b03c11278.png">


But I don't know if this has deeper ramifications for how the types in this project are being used.

But the first commit by itself should be quite safe. Just let me know which, if either, route you'd like to go.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

It doesn't look like you have type tests for me to add to.

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This doesn't really touch on docs that exist. It just affirms the actual types coming through at runtime.