### PR TITLE
Fix: update "building for SSR" messaging on SSG

### DIFF
--- a/.changeset/sour-years-scream.md
+++ b/.changeset/sour-years-scream.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Update "building for SSR..." log for SSG users to say "building entrypoints for prerendering..."

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -101,7 +101,13 @@ export async function staticBuild(opts: StaticBuildOptions) {
 
 	// Build your project (SSR application code, assets, client JS, etc.)
 	timer.ssr = performance.now();
-	info(opts.logging, 'build', 'Building for SSR...');
+	info(
+		opts.logging,
+		'build',
+		isBuildingToSSR(astroConfig)
+			? 'Building SSR entrypoints...'
+			: 'Building entrypoints for prerendering...'
+	);
 	const ssrResult = (await ssrBuild(opts, internals, pageInput)) as RollupOutput;
 	info(opts.logging, 'build', dim(`Completed in ${getTimeStat(timer.ssr, performance.now())}.`));
 


### PR DESCRIPTION
## Changes

- A few discord users were confused by the "building for SSR" messaging during SSG. This introduces new messaging:
  - When using SSG: **Build entrypoints for prerendering...**
  - When using an SSR adapter: **Building SSR entrypoints...**

## Testing

N/A

## Docs

N/A