### PR TITLE
Fix: Support .html requests in dev

### DIFF
--- a/.changeset/lemon-insects-smash.md
+++ b/.changeset/lemon-insects-smash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adding support for config.build.format to the dev server

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -50,7 +50,7 @@ function getParts(part: string, file: string) {
 	return result;
 }
 
-function getPattern(segments: RoutePart[][], addTrailingSlash: AstroConfig['trailingSlash'], buildFormat: AstroConfig['build']['format']) {
+function getPattern(segments: RoutePart[][], addTrailingSlash: AstroConfig['trailingSlash']) {
 	const pathname = segments
 		.map((segment) => {
 			return segment[0].spread
@@ -73,20 +73,9 @@ function getPattern(segments: RoutePart[][], addTrailingSlash: AstroConfig['trai
 		})
 		.join('');
 
-	const format = getFormatPattern(pathname, buildFormat);
 	const trailing =
 		addTrailingSlash && segments.length ? getTrailingSlashPattern(addTrailingSlash) : '$';
-	return new RegExp(`^${pathname || '\\/'}${format}${trailing}`);
-}
-
-function getFormatPattern(pathname: string, format: AstroConfig['build']['format']) {
-	if (format === 'directory') {
-		return '';
-	}
-	if (!pathname) {
-		return '(index.html)?';
-	}
-	return '(.html)?';
+	return new RegExp(`^${pathname || '\\/'}${trailing}`);
 }
 
 function getTrailingSlashPattern(addTrailingSlash: AstroConfig['trailingSlash']): string {
@@ -253,8 +242,7 @@ export function createRouteManifest(
 				components.push(item.file);
 				const component = item.file;
 				const trailingSlash = item.isPage ? config.trailingSlash : 'never';
-				const format = config.build.format;
-				const pattern = getPattern(segments, trailingSlash, format);
+				const pattern = getPattern(segments, trailingSlash);
 				const generate = getRouteGenerator(segments, trailingSlash);
 				const pathname = segments.every((segment) => segment.length === 1 && !segment[0].dynamic)
 					? `/${segments.map((segment) => segment[0].content).join('/')}`

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -191,7 +191,7 @@ async function handleRequest(
 	const devRoot = site ? site.pathname : '/';
 	const origin = `${viteServer.config.server.https ? 'https' : 'http'}://${req.headers.host}`;
 	const buildingToSSR = isBuildingToSSR(config);
-	const url = new URL(origin + req.url);
+	const url = new URL(origin + req.url?.replace(/(index)?\.html$/, ''));
 	const pathname = decodeURI(url.pathname);
 	const rootRelativeUrl = pathname.substring(devRoot.length - 1);
 	if (!buildingToSSR) {

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -191,7 +191,12 @@ async function handleRequest(
 	const devRoot = site ? site.pathname : '/';
 	const origin = `${viteServer.config.server.https ? 'https' : 'http'}://${req.headers.host}`;
 	const buildingToSSR = isBuildingToSSR(config);
-	const url = new URL(origin + req.url?.replace(/(index)?\.html$/, ''));
+	// When file-based build format is used, pages will be built to `/blog.html`
+	// rather than `/blog/index.html`. The dev server should handle this as well
+	// to match production deployments.
+	const url = config.build.format === 'file'
+		? new URL(origin + req.url?.replace(/(index)?\.html$/, ''))
+		: new URL(origin + req.url);
 	const pathname = decodeURI(url.pathname);
 	const rootRelativeUrl = pathname.substring(devRoot.length - 1);
 	if (!buildingToSSR) {

--- a/packages/astro/test/dev-routing.test.js
+++ b/packages/astro/test/dev-routing.test.js
@@ -265,8 +265,33 @@ describe('Development Routing', () => {
 			devServer = await fixture.startDevServer();
 		});
 
-		it('200 when loading /blog.html', async () => {
-			const response = await fixture.fetch('/blog.html');
+		it('200 when loading /index.html', async () => {
+			const response = await fixture.fetch('/index.html');
+			expect(response.status).to.equal(200);
+		});
+
+		it('200 when loading /', async () => {
+			const response = await fixture.fetch('/');
+			expect(response.status).to.equal(200);
+		});
+
+		it('200 when loading /another.html', async () => {
+			const response = await fixture.fetch('/another.html');
+			expect(response.status).to.equal(200);
+		});
+
+		it('200 when loading /another', async () => {
+			const response = await fixture.fetch('/another');
+			expect(response.status).to.equal(200);
+		});
+
+		it('200 when loading /1.html', async () => {
+			const response = await fixture.fetch('/1.html');
+			expect(response.status).to.equal(200);
+		});
+		
+		it('200 when loading /1', async () => {
+			const response = await fixture.fetch('/1');
 			expect(response.status).to.equal(200);
 		});
 	});

--- a/packages/astro/test/dev-routing.test.js
+++ b/packages/astro/test/dev-routing.test.js
@@ -247,4 +247,27 @@ describe('Development Routing', () => {
 			expect(body.title).to.equal('data [slug]');
 		});
 	});
+
+	describe('file format routing', () => {
+		/** @type {import('./test-utils').Fixture} */
+		let fixture;
+		/** @type {import('./test-utils').DevServer} */
+		let devServer;
+
+		before(async () => {
+			fixture = await loadFixture({
+				build: {
+					format: 'file',
+				},
+				root: './fixtures/without-site-config/',
+				site: 'http://example.com/',
+			});
+			devServer = await fixture.startDevServer();
+		});
+
+		it('200 when loading /blog.html', async () => {
+			const response = await fixture.fetch('/blog.html');
+			expect(response.status).to.equal(200);
+		});
+	});
 });


### PR DESCRIPTION
## Changes

This updates the dev server to support `.html` requests, currently only `/blog` is matched and `/blog.html` would 404

## Testing

Added a test to verify `.html` is supported in dev when `config.build.format === 'file'`

## Docs

None, bug fix only