### PR TITLE
Include server CSS in the manifest assets

### DIFF
--- a/.changeset/good-humans-sniff.md
+++ b/.changeset/good-humans-sniff.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Include server CSS in the SSR manifest assets

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -69,11 +69,18 @@ if(_start in adapter) {
 			return void 0;
 		},
 		async generateBundle(_opts, bundle) {
-			const staticFiles = await glob('**/*', {
+			const staticFiles = new Set(await glob('**/*', {
 				cwd: fileURLToPath(buildOpts.buildConfig.client),
-			});
+			}));
 
-			const manifest = buildManifest(buildOpts, internals, staticFiles);
+			// Add assets from this SSR chunk as well.
+			for(const [_chunkName, chunk] of Object.entries(bundle)) {
+				if(chunk.type === 'asset') {
+					staticFiles.add(chunk.fileName);
+				}
+			}
+
+			const manifest = buildManifest(buildOpts, internals, Array.from(staticFiles));
 			await runHookBuildSsr({ config: buildOpts.astroConfig, manifest });
 
 			for (const [_chunkName, chunk] of Object.entries(bundle)) {

--- a/packages/astro/test/fixtures/ssr-assets/src/pages/index.astro
+++ b/packages/astro/test/fixtures/ssr-assets/src/pages/index.astro
@@ -1,0 +1,19 @@
+---
+
+---
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>Astro</title>
+		<style is:global>
+			h1 {
+				color: red;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>Astro</h1>
+		<img src="/puppy.png"/>
+	</body>
+</html>

--- a/packages/astro/test/ssr-assets.test.js
+++ b/packages/astro/test/ssr-assets.test.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { loadFixture } from './test-utils.js';
+import testAdapter from './test-adapter.js';
+
+describe('SSR Assets', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/ssr-assets/',
+			experimental: {
+				ssr: true,
+			},
+			adapter: testAdapter(),
+		});
+		await fixture.build();
+	});
+
+	it('Do not have to implement getStaticPaths', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		/** @type {Set<string>} */
+		const assets = app.manifest.assets;
+		expect(assets.size).to.equal(1);
+		expect(Array.from(assets)[0].endsWith('.css')).to.be.true;
+	});
+});

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -137,8 +137,10 @@ export async function loadFixture(inlineConfig) {
 		clean: () => fs.promises.rm(config.outDir, { maxRetries: 10, recursive: true, force: true }),
 		loadTestAdapterApp: async () => {
 			const url = new URL('./server/entry.mjs', config.outDir);
-			const { createApp } = await import(url);
-			return createApp();
+			const { createApp, manifest } = await import(url);
+			const app =createApp();
+			app.manifest = manifest;
+			return app;
 		},
 		editFile: async (filePath, newContents) => {
 			const fileUrl = new URL(filePath.replace(/^\//, ''), config.root);


### PR DESCRIPTION
## Changes

- Makes it so that the SSR manifest `assets` field includes server CSS. This is so that an edge function can forward those requests back to the CDN.
- Closes #3324

## Testing

- New test added

## Docs

N/a, bug fix