### PR TITLE
Defer head injection until `renderPage`

### DIFF
--- a/.changeset/fluffy-wolves-sneeze.md
+++ b/.changeset/fluffy-wolves-sneeze.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix hydration when rendering `<head>` elements inside of a component

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -544,7 +544,7 @@ export async function renderToString(
 	}
 
 	let template = await renderAstroComponent(Component);
-	return replaceHeadInjection(result, template);
+	return template;
 }
 
 export async function renderPage(

--- a/packages/astro/test/astro-partial-html.test.js
+++ b/packages/astro/test/astro-partial-html.test.js
@@ -48,3 +48,24 @@ describe('Partial HTML', async () => {
 		expect(href).to.be.ok;
 	});
 });
+
+describe('Head Component', async () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/astro-partial-html/',
+		});
+		await fixture.build();
+	});
+
+	it('injects Astro hydration scripts', async () => {
+		const html = await fixture.readFile('/head/index.html');
+		const $ = cheerio.load(html);
+
+		const hydrationId = $('astro-root').attr('uid');
+
+		const script = $('script').html();
+		expect(script).to.match(new RegExp(hydrationId));
+	});
+});

--- a/packages/astro/test/fixtures/astro-partial-html/src/components/Head.astro
+++ b/packages/astro/test/fixtures/astro-partial-html/src/components/Head.astro
@@ -1,0 +1,3 @@
+<head>
+	<title>Hello world!</title>
+</head>

--- a/packages/astro/test/fixtures/astro-partial-html/src/pages/head.astro
+++ b/packages/astro/test/fixtures/astro-partial-html/src/pages/head.astro
@@ -1,0 +1,15 @@
+---
+import Head from '../components/Head.astro';
+import Component from '../components/Component.jsx';
+---
+
+<html>
+	<!-- <head> element delegated to component -->
+	<Head />
+	<body>
+		<Component client:load>
+			<h1>JSX Partial HTML</h1>
+		</Component>
+	</body>
+</html>
+


### PR DESCRIPTION
## Changes

- Closes #3195, #3197
- We had a bug where `<!--astro:head-->` would be replaced too early, before any scripts were ready to be inserted. This meant that if you put `<head>` inside of a component, hydration would never work.
- We've discussed removing the head injection logic all together—this PR opts to fix the immediate bug, and we can circle back to exploring different techniques in the future.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

Test added

## Docs

Bug fix only