### PR TITLE
Add new markdown.frontmatterPlugins config option

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -6,6 +6,7 @@ import type {
 	ShikiConfig,
 	RemarkPlugins,
 	RehypePlugins,
+	FrontmatterPlugins,
 	MarkdownHeader,
 	MarkdownMetadata,
 	MarkdownRenderingResult,
@@ -592,6 +593,23 @@ export interface AstroUserConfig {
 		 * ```
 		 */
 		rehypePlugins?: RehypePlugins;
+		/**
+		 * @docs
+		 * @name markdown.frontmatterPlugins
+		 * @type {FrontmatterPlugins}
+		 * @description
+		 * Pass a custom Frontmatter plugin to customize Markdown frontmatter.
+		 *
+		 * ```js
+		 * {
+		 *   markdown: {
+		 *     // Example: The default set of frontmatter plugins used by Astro
+		 *     frontmatterPlugins: [],
+		 *   },
+		 * };
+		 * ```
+		 */
+		frontmatterPlugins?: FrontmatterPlugins;
 	};
 
 	/**

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -2,7 +2,7 @@ import type { AstroConfig, AstroUserConfig, CLIFlags, ViteUserConfig } from '../
 import type { Arguments as Flags } from 'yargs-parser';
 import type * as Postcss from 'postcss';
 import type { ILanguageRegistration, IThemeRegistration, Theme } from 'shiki';
-import type { RemarkPlugin, RehypePlugin } from '@astrojs/markdown-remark';
+import type { RemarkPlugin, RehypePlugin, FrontmatterPlugin } from '@astrojs/markdown-remark';
 
 import * as colors from 'kleur/colors';
 import path from 'path';
@@ -177,6 +177,15 @@ export const AstroConfigSchema = z.object({
 					z.tuple([z.string(), z.any()]),
 					z.custom<RehypePlugin>((data) => typeof data === 'function'),
 					z.tuple([z.custom<RehypePlugin>((data) => typeof data === 'function'), z.any()]),
+				])
+				.array()
+				.default([]),
+			frontmatterPlugins: z
+				.union([
+					z.string(),
+					z.tuple([z.string(), z.any()]),
+					z.custom<FrontmatterPlugin>((data) => typeof data === 'function'),
+					z.tuple([z.custom<FrontmatterPlugin>((data) => typeof data === 'function'), z.any()]),
 				])
 				.array()
 				.default([]),

--- a/packages/astro/test/astro-markdown-plugins.test.js
+++ b/packages/astro/test/astro-markdown-plugins.test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 import addClasses from './fixtures/astro-markdown-plugins/add-classes.mjs';
+import updateFrontmatter from './fixtures/astro-markdown-plugins/update-frontmatter.mjs';
 
 describe('Astro Markdown plugins', () => {
 	let fixture;
@@ -19,6 +20,7 @@ describe('Astro Markdown plugins', () => {
 					['rehype-toc', { headings: ['h2', 'h3'] }],
 					[addClasses, { 'h1,h2,h3': 'title' }],
 				],
+				frontmatterPlugins: [updateFrontmatter],
 			},
 		});
 		await fixture.build();
@@ -32,7 +34,7 @@ describe('Astro Markdown plugins', () => {
 		expect($('.toc')).to.have.lengthOf(1);
 
 		// teste 2: Added .title to h1
-		expect($('#hello-world').hasClass('title')).to.equal(true);
+		expect($('#hello-world-from-page').hasClass('title')).to.equal(true);
 	});
 
 	it('Can render Astro <Markdown> with plugins', async () => {
@@ -43,6 +45,15 @@ describe('Astro Markdown plugins', () => {
 		expect($('.toc')).to.have.lengthOf(1);
 
 		// teste 2: Added .title to h1
-		expect($('#hello-world').hasClass('title')).to.equal(true);
+		expect($('#hello-world-from-component').hasClass('title')).to.equal(true);
+	});
+
+	it('Can update Markdown frontmatter from config', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerio.load(html);
+
+		// test 1: Switched layout
+		expect($('.container-alt')).to.have.lengthOf(1);
+		expect($('.container')).to.have.lengthOf(0);
 	});
 });

--- a/packages/astro/test/fixtures/astro-markdown-plugins/src/layouts/content-alt.astro
+++ b/packages/astro/test/fixtures/astro-markdown-plugins/src/layouts/content-alt.astro
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <!-- Head Stuff -->
+  </head>
+  <body>
+    <div class="container-alt">
+      <slot></slot>
+    </div>
+  </body>
+</html>

--- a/packages/astro/test/fixtures/astro-markdown-plugins/src/pages/astro.astro
+++ b/packages/astro/test/fixtures/astro-markdown-plugins/src/pages/astro.astro
@@ -5,6 +5,6 @@ import Layout from '../layouts/content.astro';
 
 <Layout>
 	<Markdown>
-		# Hello world
+		# Hello world from component
 	</Markdown>
 </Layout>

--- a/packages/astro/test/fixtures/astro-markdown-plugins/src/pages/index.md
+++ b/packages/astro/test/fixtures/astro-markdown-plugins/src/pages/index.md
@@ -2,4 +2,4 @@
 layout: ../layouts/content.astro
 ---
 
-# Hello world
+# Hello world from page

--- a/packages/astro/test/fixtures/astro-markdown-plugins/update-frontmatter.mjs
+++ b/packages/astro/test/fixtures/astro-markdown-plugins/update-frontmatter.mjs
@@ -1,0 +1,5 @@
+export default (frontmatter, {fileId, fileUrl}) => {
+	let newFrontmatter = Object.assign({}, frontmatter)
+	newFrontmatter.layout = "../layouts/content-alt.astro";
+	return newFrontmatter;
+};

--- a/packages/markdown/remark/src/index.ts
+++ b/packages/markdown/remark/src/index.ts
@@ -21,6 +21,8 @@ import rehypeRaw from 'rehype-raw';
 
 export * from './types.js';
 
+export { loadPlugins };
+
 export const DEFAULT_REMARK_PLUGINS = ['remark-gfm', 'remark-smartypants'];
 export const DEFAULT_REHYPE_PLUGINS = [];
 

--- a/packages/markdown/remark/src/types.ts
+++ b/packages/markdown/remark/src/types.ts
@@ -19,6 +19,18 @@ export type RehypePlugin<PluginParameters extends any[] = any[]> = unified.Plugi
 
 export type RehypePlugins = (string | [string, any] | RehypePlugin | [RehypePlugin, any])[];
 
+export type FrontmatterPlugin<PluginParameters extends any[] = any[]> = unified.Plugin<
+	PluginParameters,
+	hast.Root
+>;
+
+export type FrontmatterPlugins = (
+	| string
+	| [string, any]
+	| FrontmatterPlugin
+	| [FrontmatterPlugin, any]
+)[];
+
 export interface ShikiConfig {
 	langs: ILanguageRegistration[];
 	theme: Theme | IThemeRegistration;
@@ -32,6 +44,7 @@ export interface AstroMarkdownOptions {
 	shikiConfig: ShikiConfig;
 	remarkPlugins: RemarkPlugins;
 	rehypePlugins: RehypePlugins;
+	frontmatterPlugins: FrontmatterPlugins;
 }
 
 export interface MarkdownRenderingOptions extends AstroMarkdownOptions {


### PR DESCRIPTION
Hello!

Currently, when importing Markdown files, one can modify their content via the `markdown.remarkPlugins` and `markdown.rehypePlugins` config options.

However there is currently no supported way to do the same with their frontmatter. This could open up interesting usecases:
 - Auto-registering components in imported Markdown files (just append the imports to `frontmatter.setup`!)
 - Provide a more generic solution to the `frontmatterDefaults` suggestion here: https://github.com/withastro/rfcs/discussions/172#discussioncomment-2558676
 - Probably more that I'm missing!

This patch adds a prototype implementation of a new `frontmatterPlugins` config option.

Let me know what you think!

Thanks,
