### PR TITLE
Fix: support `FormData` object on fetch body

### DIFF
--- a/.changeset/serious-vans-smell.md
+++ b/.changeset/serious-vans-smell.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/webapi': patch
+'@astrojs/webapi': minor
 'astro': patch
 ---
 

--- a/.changeset/serious-vans-smell.md
+++ b/.changeset/serious-vans-smell.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/webapi': patch
+'astro': patch
+---
+
+Fix: support FormData object on fetch body

--- a/packages/webapi/package.json
+++ b/packages/webapi/package.json
@@ -49,6 +49,9 @@
   ],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://github.com/withastro/astro/tree/main/packages/webapi#readme",
+  "dependencies": {
+    "node-fetch": "^3.2.4"
+  },
   "devDependencies": {
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-inject": "^4.0.4",
@@ -65,7 +68,6 @@
     "formdata-polyfill": "^4.0.10",
     "magic-string": "^0.25.9",
     "mocha": "^9.2.2",
-    "node-fetch": "^3.2.4",
     "rollup": "^2.74.1",
     "rollup-plugin-terser": "^7.0.2",
     "tslib": "^2.4.0",

--- a/packages/webapi/run/build.js
+++ b/packages/webapi/run/build.js
@@ -178,6 +178,7 @@ async function build() {
 			inputOptions: {
 				input: 'src/polyfill.ts',
 				plugins: plugins,
+				external: ['node-fetch'],
 				onwarn(warning, warn) {
 					if (warning.code !== 'UNRESOLVED_IMPORT') warn(warning)
 				},

--- a/packages/webapi/src/lib/fetch.ts
+++ b/packages/webapi/src/lib/fetch.ts
@@ -3,7 +3,8 @@ import {
 	Headers,
 	Request,
 	Response,
-} from 'node-fetch/src/index.js'
+} from 'node-fetch'
+import type { RequestInit } from 'node-fetch'
 import Stream from 'node:stream'
 import * as _ from './utils'
 
@@ -11,7 +12,7 @@ export { Headers, Request, Response }
 
 export const fetch = {
 	fetch(
-		resource: string | URL | Request,
+		resource: string | Request,
 		init?: Partial<FetchInit>
 	): Promise<Response> {
 		const resourceURL = new URL(
@@ -62,13 +63,7 @@ export const fetch = {
 type USVString = {} & string
 
 interface FetchInit {
-	body:
-		| Blob
-		| BufferSource
-		| FormData
-		| URLSearchParams
-		| ReadableStream
-		| USVString
+	body: RequestInit['body']
 	cache:
 		| 'default'
 		| 'no-store'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1687,6 +1687,8 @@ importers:
       typescript: ^4.6.4
       urlpattern-polyfill: ^1.0.0-rc5
       web-streams-polyfill: ^3.2.1
+    dependencies:
+      node-fetch: 3.2.4
     devDependencies:
       '@rollup/plugin-alias': 3.1.9_rollup@2.74.1
       '@rollup/plugin-inject': 4.0.4_rollup@2.74.1
@@ -1703,7 +1705,6 @@ importers:
       formdata-polyfill: 4.0.10
       magic-string: 0.25.9
       mocha: 9.2.2
-      node-fetch: 3.2.4
       rollup: 2.74.1
       rollup-plugin-terser: 7.0.2_rollup@2.74.1
       tslib: 2.4.0
@@ -7745,6 +7746,7 @@ packages:
   /data-uri-to-buffer/4.0.0:
     resolution: {integrity: sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==}
     engines: {node: '>= 12'}
+    dev: false
 
   /dataloader/1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
@@ -7757,11 +7759,6 @@ packages:
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.1.3
     dev: false
@@ -9628,7 +9625,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 14.18.18
+      '@types/node': 17.0.35
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: true
@@ -10583,8 +10580,6 @@ packages:
       debug: 3.2.7
       iconv-lite: 0.4.24
       sax: 1.2.4
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /netmask/2.0.2:
@@ -10646,6 +10641,7 @@ packages:
       data-uri-to-buffer: 4.0.0
       fetch-blob: 3.1.5
       formdata-polyfill: 4.0.10
+    dev: false
 
   /node-gyp-build/4.4.0:
     resolution: {integrity: sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==}
@@ -10667,8 +10663,6 @@ packages:
       rimraf: 2.7.1
       semver: 5.7.1
       tar: 4.4.19
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /node-releases/2.0.4:


### PR DESCRIPTION
## Changes

- Resolves #2741 
- Move `node-fetch` to external dependency for `@astrojs/webapi` bundle. This was causing strange issues with body parsing that I still haven't figured out. Still, since `@astrojs/telemetry` already pulls in `node-fetch` as a standard dependency, this shouldn't be a problem!
- moving away from using `node-fetch/src/index.js` exposed type issues. A few pieces to resolve:
  - `fetch` no longer accepts `URL` as a resource type. Funny enough, you _can_ still pass a `URL` for node-fetch to run `toString()` implicitly. Still, you get red squigglies in VS Code using URL today, so removing this type option is for consistency if anything.
  - `FetchInit` now uses node-fetch's body type in its type signature

### Why not switch to undici like all the cool kids?

@FredKSchott (a cool kid) suggested using [undici](https://www.npmjs.com/package/undici) since it mirrors Node's incoming fetch standard. This seemed possible at first... until I discovered their node versioning requirements. In short: **they[ don't expose `fetch` or `Request` for node versions below 16.5.](https://github.com/nodejs/undici#undicifetchinput-init-promise)** Also poked the source code to confirm. This would mean dropping Node 14.X support, which feels a bit _too_ far as we approach 1.0. Keep it in mind for the future though!

## Testing

N/A

## Docs

N/A