### PR TITLE
Fix GitHub Issue creation link

### DIFF
--- a/.changeset/hungry-elephants-smash.md
+++ b/.changeset/hungry-elephants-smash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix GitHub Issues issue creation link.

--- a/.github/ISSUE_TEMPLATE/---01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/---01-bug-report.yml
@@ -13,36 +13,42 @@ body:
         ✅ I am using the **latest version of Astro** and all plugins.
         ✅ I am using a version of Node that supports ESM (`v14.15.0+`, or `v16.0.0+`)
   - type: input
+    id: astro-version
     attributes:
       label: What version of `astro` are you using?
       placeholder: 0.0.0
     validations:
       required: true
   - type: input
+    id: ssr-adapter
     attributes:
       label: Are you using an SSR adapter? If so, which one?
       placeholder: None, or Netlify, Vercel, Cloudflare, etc.
     validations:
       required: true
   - type: input
+    id: package-manager
     attributes:
       label: What package manager are you using?
       placeholder: npm, yarn, pnpm
     validations:
       required: true
   - type: input
+    id: os
     attributes:
       label: What operating system are you using?
       placeholder: Mac, Windows, Linux
     validations:
       required: true
   - type: textarea
+    id: bug-description
     attributes:
       label: Describe the Bug
       description: A clear and concise description of what the bug is.
     validations:
       required: true
   - type: input
+    id: bug-reproduction
     attributes:
       label: Link to Minimal Reproducible Example
       description: 'Use [astro.new](https://astro.new) to create a minimal reproduction of the problem. **A minimal reproduction is required** so that others can help debug your issue. If a report is vague (e.g. just a generic error message) and has no reproduction, it may be auto-closed.'
@@ -50,6 +56,7 @@ body:
     validations:
       required: true
   - type: checkboxes
+    id: will-pr
     attributes:
       label: Participation
       options:

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -251,19 +251,17 @@ export default function astro({ config, logging }: AstroPluginOptions): vite.Plu
 					const search = new URLSearchParams({
 						labels: 'compiler',
 						title: '🐛 BUG: `@astrojs/compiler` panic',
-						body: `### Describe the Bug
-    
-    \`@astrojs/compiler\` encountered an unrecoverable error when compiling the following file.
-    
-    **${id.replace(fileURLToPath(config.root), '')}**
-    \`\`\`astro
-    ${source}
-    \`\`\`
-    `,
+						template: '---01-bug-report.yml',
+						'bug-description': `\`@astrojs/compiler\` encountered an unrecoverable error when compiling the following file.
+
+**${id.replace(fileURLToPath(config.root), '')}**
+\`\`\`astro
+${source}
+\`\`\``,
 					});
 					err.url = `https://github.com/withastro/astro/issues/new?${search.toString()}`;
 					err.message = `Error: Uh oh, the Astro compiler encountered an unrecoverable error!
-    
+
     Please open
     a GitHub issue using the link below:
     ${err.url}`;


### PR DESCRIPTION
This PR closes #3257

## Changes

* Add IDs to bug report issue form
* Replace 'body' with correct input id for prefilling form

## Testing

This approach was tested by creating a fresh repository, creating an issue template with `id`s for each input box in the form, constructing a URL and opening it to see if it works. It worked.

Additional information: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys

## Docs

No docs required

## Additional information (unrelated)

I don't know why but this commit is falsely shown as "Unverified" even if I signed it with one of my GPG keys. Maybe it is because I uploaded the public key to GitHub after making this commit, and the fact that I was using GitHub Codespaces and not my local computer.