### PR TITLE
Updates hydration scripts to use absolute paths

### DIFF
--- a/.changeset/wet-beds-act.md
+++ b/.changeset/wet-beds-act.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates component hydration scripts to use absolute paths for script imports

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -18,7 +18,7 @@ import {
 	createLinkStylesheetElementSet,
 	createModuleScriptElementWithSrcSet,
 } from '../render/ssr-element.js';
-import { prependForwardSlash } from '../path.js';
+import { joinPaths, prependForwardSlash } from '../path.js';
 
 export const pagesVirtualModuleId = '@astrojs-pages-virtual-entry';
 export const resolvedPagesVirtualModuleId = '\0' + pagesVirtualModuleId;
@@ -108,7 +108,7 @@ export class App {
 					throw new Error(`Unable to resolve [${specifier}]`);
 				}
 				const bundlePath = manifest.entryModules[specifier];
-				return bundlePath.startsWith('data:') ? bundlePath : prependForwardSlash(bundlePath);
+				return bundlePath.startsWith('data:') ? bundlePath : prependForwardSlash(joinPaths(manifest.base, bundlePath));
 			},
 			route: routeData,
 			routeCache: this.#routeCache,

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -22,6 +22,7 @@ export type SerializedRouteInfo = Omit<RouteInfo, 'routeData'> & {
 export interface SSRManifest {
 	routes: RouteInfo[];
 	site?: string;
+	base?: string;
 	markdown: MarkdownRenderingOptions;
 	pageMap: Map<ComponentPath, ComponentInstance>;
 	renderers: SSRLoadedRenderer[];

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -219,9 +219,7 @@ async function generatePath(
 				}
 				throw new Error(`Cannot find the built path for ${specifier}`);
 			}
-			const relPath = npath.posix.relative(pathname, '/' + hashedFilePath);
-			const fullyRelativePath = relPath[0] === '.' ? relPath : './' + relPath;
-			return fullyRelativePath;
+			return prependForwardSlash(npath.join(astroConfig.base, hashedFilePath));
 		},
 		request: createRequest({ url, headers: new Headers(), logging, ssr }),
 		route: pageData.route,

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -219,7 +219,7 @@ async function generatePath(
 				}
 				throw new Error(`Cannot find the built path for ${specifier}`);
 			}
-			return prependForwardSlash(npath.join(astroConfig.base, hashedFilePath));
+			return prependForwardSlash(npath.posix.join(astroConfig.base, hashedFilePath));
 		},
 		request: createRequest({ url, headers: new Headers(), logging, ssr }),
 		route: pageData.route,

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -136,6 +136,7 @@ function buildManifest(
 	const ssrManifest: SerializedSSRManifest = {
 		routes,
 		site: astroConfig.site,
+		base: astroConfig.base,
 		markdown: astroConfig.markdown,
 		pageMap: null as any,
 		renderers: [],

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -110,29 +110,24 @@ export async function generateHydrateScript(
 		);
 	}
 
-	const resolveAbsolute = async (path: string) => {
-		const relative = await result.resolve(path);
-		return relative.replace(/((\.*)\/)*/, '/');
-	}
-
 	const hydrationSource = renderer.clientEntrypoint
 		? `const [{ ${
 				componentExport.value
-		  }: Component }, { default: hydrate }] = await Promise.all([import("${await resolveAbsolute(
+		  }: Component }, { default: hydrate }] = await Promise.all([import("${await result.resolve(
 				componentUrl
-		  )}"), import("${await resolveAbsolute(renderer.clientEntrypoint)}")]);
+		  )}"), import("${await result.resolve(renderer.clientEntrypoint)}")]);
   return (el, children) => hydrate(el)(Component, ${serializeProps(
 		props
 	)}, children, ${JSON.stringify({ client: hydrate })});
 `
-		: `await import("${await resolveAbsolute(componentUrl)}");
+		: `await import("${await result.resolve(componentUrl)}");
   return () => {};
 `;
 	// TODO: If we can figure out tree-shaking in the final SSR build, we could safely
 	// use BEFORE_HYDRATION_SCRIPT_ID instead of 'astro:scripts/before-hydration.js'.
 	const hydrationScript = {
 		props: { type: 'module', 'data-astro-component-hydration': true },
-		children: `import setup from '${await resolveAbsolute(hydrationSpecifier(hydrate))}';
+		children: `import setup from '${await result.resolve(hydrationSpecifier(hydrate))}';
 ${`import '${await result.resolve('astro:scripts/before-hydration.js')}';`}
 setup("${astroId}", {name:"${metadata.displayName}",${
 			metadata.hydrateArgs ? `value: ${JSON.stringify(metadata.hydrateArgs)}` : ''

--- a/packages/astro/test/astro-client-only.test.js
+++ b/packages/astro/test/astro-client-only.test.js
@@ -22,7 +22,7 @@ describe('Client only components', () => {
 		const script = $script.html();
 
 		// test 2: svelte renderer is on the page
-		expect(/import\(".\/entry.*/g.test(script)).to.be.ok;
+		expect(/import\("\/entry.*/g.test(script)).to.be.ok;
 	});
 
 	it('Adds the CSS to the page', async () => {

--- a/packages/astro/test/astro-client-only.test.js
+++ b/packages/astro/test/astro-client-only.test.js
@@ -31,3 +31,35 @@ describe('Client only components', () => {
 		expect($('link[rel=stylesheet]')).to.have.lengthOf(2);
 	});
 });
+
+describe('Client only components subpath', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			site: 'https://site.com',
+			base: '/blog',
+			root: './fixtures/astro-client-only/',
+		});
+		await fixture.build();
+	});
+
+	it('Loads pages using client:only hydrator', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerioLoad(html);
+
+		// test 1: <astro-root> is empty
+		expect($('astro-root').html()).to.equal('');
+		const $script = $('script');
+		const script = $script.html();
+
+		// test 2: svelte renderer is on the page
+		expect(/import\("\/blog\/entry.*/g.test(script)).to.be.ok;
+	});
+
+	it('Adds the CSS to the page', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerioLoad(html);
+		expect($('link[rel=stylesheet]')).to.have.lengthOf(2);
+	});
+});

--- a/packages/astro/test/astro-dynamic.test.js
+++ b/packages/astro/test/astro-dynamic.test.js
@@ -37,6 +37,6 @@ describe('Dynamic components', () => {
 		// test 2: correct script is being loaded.
 		// because of bundling, we don't have access to the source import,
 		// only the bundled import.
-		expect($('script').html()).to.include(`import setup from '../entry`);
+		expect($('script').html()).to.include(`import setup from '/entry`);
 	});
 });

--- a/packages/astro/test/astro-dynamic.test.js
+++ b/packages/astro/test/astro-dynamic.test.js
@@ -40,3 +40,44 @@ describe('Dynamic components', () => {
 		expect($('script').html()).to.include(`import setup from '/entry`);
 	});
 });
+
+describe('Dynamic components subpath', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			site: 'https://site.com',
+			base: '/blog',
+			root: './fixtures/astro-dynamic/',
+		});
+		await fixture.build();
+	});
+
+	it('Loads packages that only run code in client', async () => {
+		const html = await fixture.readFile('/index.html');
+
+		const $ = cheerio.load(html);
+		expect($('script').length).to.eq(2);
+	});
+
+	it('Loads pages using client:media hydrator', async () => {
+		const root = new URL('http://example.com/media/index.html');
+		const html = await fixture.readFile('/media/index.html');
+		const $ = cheerio.load(html);
+
+		// test 1: static value rendered
+		expect($('script').length).to.equal(2); // One for each
+	});
+
+	it('Loads pages using client:only hydrator', async () => {
+		const html = await fixture.readFile('/client-only/index.html');
+		const $ = cheerio.load(html);
+
+		// test 1: <astro-root> is empty.
+		expect($('<astro-root>').html()).to.equal('');
+		// test 2: correct script is being loaded.
+		// because of bundling, we don't have access to the source import,
+		// only the bundled import.
+		expect($('script').html()).to.include(`import setup from '/blog/entry`);
+	});
+});


### PR DESCRIPTION
Closes #2561 

## Changes

This updates hydration scripts to use absolute paths when importing scripts.  This is necessary to make sure any client-hydrated scripts on a custom 404 page are loaded properly

## Testing

Updated existing tests and added two new ones to confirm this behavior when `config.base` is used to deploy to subpaths

## Docs

None, bug fix only