### PR TITLE
Fix: Relative imports inside of hosited script on windows

### DIFF
--- a/.changeset/friendly-ways-collect.md
+++ b/.changeset/friendly-ways-collect.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix relative inline scripts on Windows

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -62,8 +62,9 @@ export default function astro({ config, logging }: AstroPluginOptions): vite.Plu
 			// If resolving from an astro subresource such as a hoisted script,
 			// we need to resolve relative paths ourselves.
 			if (from) {
-				const { query: fromQuery, filename } = parseAstroRequest(from);
-				if (fromQuery.astro && isRelativePath(id) && fromQuery.type === 'script') {
+				const parsedFrom = parseAstroRequest(from);
+				if (parsedFrom.query.astro && isRelativePath(id) && parsedFrom.query.type === 'script') {
+					const filename = normalizeFilename(parsedFrom.filename);
 					const resolvedURL = new URL(id, `file://${filename}`);
 					const resolved = resolvedURL.pathname;
 					if (isBrowserPath(resolved)) {

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -64,6 +64,7 @@ export default function astro({ config, logging }: AstroPluginOptions): vite.Plu
 			if (from) {
 				const { query: fromQuery, filename } = parseAstroRequest(from);
 				if (fromQuery.astro && isRelativePath(id) && fromQuery.type === 'script') {
+					console.log("FROM", from, filename);
 					const resolvedURL = new URL(id, `file://${filename}`);
 					const resolved = resolvedURL.pathname;
 					if (isBrowserPath(resolved)) {

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -62,9 +62,10 @@ export default function astro({ config, logging }: AstroPluginOptions): vite.Plu
 			// If resolving from an astro subresource such as a hoisted script,
 			// we need to resolve relative paths ourselves.
 			if (from) {
-				const { query: fromQuery, filename } = parseAstroRequest(from);
-				if (fromQuery.astro && isRelativePath(id) && fromQuery.type === 'script') {
-					console.log("FROM", from, filename);
+				const parsedFrom = parseAstroRequest(from);
+				//const { query: fromQuery, filename } );
+				if (parsedFrom.query.astro && isRelativePath(id) && parsedFrom.query.type === 'script') {
+					const filename = normalizeFilename(parsedFrom.filename);
 					const resolvedURL = new URL(id, `file://${filename}`);
 					const resolved = resolvedURL.pathname;
 					if (isBrowserPath(resolved)) {

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -62,10 +62,8 @@ export default function astro({ config, logging }: AstroPluginOptions): vite.Plu
 			// If resolving from an astro subresource such as a hoisted script,
 			// we need to resolve relative paths ourselves.
 			if (from) {
-				const parsedFrom = parseAstroRequest(from);
-				//const { query: fromQuery, filename } );
-				if (parsedFrom.query.astro && isRelativePath(id) && parsedFrom.query.type === 'script') {
-					const filename = normalizeFilename(parsedFrom.filename);
+				const { query: fromQuery, filename } = parseAstroRequest(from);
+				if (fromQuery.astro && isRelativePath(id) && fromQuery.type === 'script') {
 					const resolvedURL = new URL(id, `file://${filename}`);
 					const resolved = resolvedURL.pathname;
 					if (isBrowserPath(resolved)) {

--- a/packages/astro/test/astro-scripts.test.js
+++ b/packages/astro/test/astro-scripts.test.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
-import path from 'path';
 import { loadFixture } from './test-utils.js';
 
 describe('Scripts (hoisted and not)', () => {
@@ -50,6 +49,9 @@ describe('Scripts (hoisted and not)', () => {
 
 		// test 3: the JS exists
 		expect(inlineEntryJS).to.be.ok;
+
+		// test 4: Inline imported JS is included
+		expect(inlineEntryJS).to.contain("I AM IMPORTED INLINE", "The inline imported JS is included in the bundle");
 	});
 
 	it('External page builds the hoisted scripts to a single bundle', async () => {

--- a/packages/astro/test/astro-scripts.test.js
+++ b/packages/astro/test/astro-scripts.test.js
@@ -26,7 +26,7 @@ describe('Scripts (hoisted and not)', () => {
 		expect($('body script')).to.have.lengthOf(0);
 	});
 
-	it.only('Moves inline scripts up', async () => {
+	it('Moves inline scripts up', async () => {
 		const html = await fixture.readFile('/inline/index.html');
 		const $ = cheerio.load(html);
 

--- a/packages/astro/test/astro-scripts.test.js
+++ b/packages/astro/test/astro-scripts.test.js
@@ -26,7 +26,7 @@ describe('Scripts (hoisted and not)', () => {
 		expect($('body script')).to.have.lengthOf(0);
 	});
 
-	it('Moves inline scripts up', async () => {
+	it.only('Moves inline scripts up', async () => {
 		const html = await fixture.readFile('/inline/index.html');
 		const $ = cheerio.load(html);
 

--- a/packages/astro/test/fixtures/astro-scripts/src/components/Inline.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/components/Inline.astro
@@ -1,5 +1,3 @@
 <script>
-	// This must be relative for the test
-	import '../scripts/hoist_external_imported_inline.js';
   console.log('some content here.');
 </script>

--- a/packages/astro/test/fixtures/astro-scripts/src/components/Inline.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/components/Inline.astro
@@ -1,3 +1,5 @@
 <script>
+	// This must be relative for the test
+	import '../scripts/hoist_external_imported_inline.js';
   console.log('some content here.');
 </script>

--- a/packages/astro/test/fixtures/astro-scripts/src/pages/inline.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/pages/inline.astro
@@ -12,5 +12,9 @@ import Inline from '../components/Inline.astro';
   <Inline />
   <Inline />
   <Inline />
+	<script>
+		// This must be relative for the test
+		import '../scripts/hoist_external_imported_inline.js';
+	</script>
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-scripts/src/scripts/hoist_external_imported_inline.js
+++ b/packages/astro/test/fixtures/astro-scripts/src/scripts/hoist_external_imported_inline.js
@@ -1,0 +1,1 @@
+console.log("I AM IMPORTED INLINE");


### PR DESCRIPTION
## Changes

- Uses `normalizeFilename` which removes the `@fs` previous which was preventing us from resolving on Windows.
- Fixes https://github.com/withastro/astro/issues/3387

## Testing

- Test added in the astro-scripts package. The test passing shows this is now fixed.

## Docs

N/A