### PR TITLE
Fix: add "CSS" to noExternal hint

### DIFF
--- a/.changeset/blue-bottles-explode.md
+++ b/.changeset/blue-bottles-explode.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Logs: Add "ssr.noExternal" hint for CSS loaded from npm packages

--- a/packages/astro/src/core/errors.ts
+++ b/packages/astro/src/core/errors.ts
@@ -47,7 +47,7 @@ const incompatiblePackages = {
 const incompatPackageExp = new RegExp(`(${Object.keys(incompatiblePackages).join('|')})`);
 
 function generateHint(err: ErrorWithMetadata): string | undefined {
-	if (/Unknown file extension \"\.(jsx|vue|svelte|astro)\" for /.test(err.message)) {
+	if (/Unknown file extension \"\.(jsx|vue|svelte|astro|css)\" for /.test(err.message)) {
 		return 'You likely need to add this package to `vite.ssr.noExternal` in your astro config file.';
 	} else {
 		const res = incompatPackageExp.exec(err.stack);


### PR DESCRIPTION
## Changes

- Resolves #3226
- Add `.css` extension to `ssr.noExternal` hint

## Testing

N/A

## Docs

https://github.com/withastro/docs/pull/633