### PR TITLE
feat: use Vite's `logLevel` on SSR build

### DIFF
--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -127,7 +127,8 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 	const out = ssr ? opts.buildConfig.server : astroConfig.outDir;
 
 	const viteBuildConfig: ViteConfigWithSSR = {
-		logLevel: 'error',
+		// use default Vite's logLevel if not configured
+		logLevel: opts.viteConfig.logLevel ?? 'info',
 		mode: 'production',
 		css: viteConfig.css,
 		build: {


### PR DESCRIPTION
Instead using `error` as default value, use the Vite's default `logLevel`: `info`

## Changes

- What does this change?
Use the `levelLog` provided by the user or the Vite's default `levelLog`: `info`
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->