### PR TITLE
Use `error` log level since warnings are irrelevant and noisy

### DIFF
--- a/.changeset/fair-bananas-camp.md
+++ b/.changeset/fair-bananas-camp.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Respect user's configured vite logLevel during build, changes default to `info`.
+Respect user's configured vite logLevel during build

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -127,8 +127,7 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 	const out = ssr ? opts.buildConfig.server : astroConfig.outDir;
 
 	const viteBuildConfig: ViteConfigWithSSR = {
-		// use default Vite's logLevel if not configured
-		logLevel: opts.viteConfig.logLevel ?? 'info',
+		logLevel: opts.viteConfig.logLevel ?? 'error',
 		mode: 'production',
 		css: viteConfig.css,
 		build: {


### PR DESCRIPTION
## Changes

- Sets `logLevel` for `astro build` back to `error`. We get a LOT of warnings from using so many framework plugins and they are mostly irrelevant.

## Testing

New output reflected in test logs

## Docs

N/A