### PR TITLE
Add base config option to partytown snippet generation

### DIFF
--- a/.changeset/orange-colts-march.md
+++ b/.changeset/orange-colts-march.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/partytown': patch
+---
+
+Fix partytown script generation to get astro base config option

--- a/packages/integrations/partytown/src/index.ts
+++ b/packages/integrations/partytown/src/index.ts
@@ -25,7 +25,7 @@ export default function createPlugin(options: PartytownOptions): AstroIntegratio
 		name: '@astrojs/partytown',
 		hooks: {
 			'astro:config:setup': ({ config: _config, command, injectScript }) => {
-				const lib = path.join(_config.base || '/', '~partytown');
+				const lib = `${_config.base}~partytown/`;
 				const forward = options?.config?.forward || [];
 				const debug = options?.config?.debug || command === 'dev';
 				partytownSnippetHtml = partytownSnippet({ lib, debug, forward });
@@ -35,9 +35,10 @@ export default function createPlugin(options: PartytownOptions): AstroIntegratio
 				config = _config;
 			},
 			'astro:server:setup': ({ server }) => {
+				const lib = `${config.base}~partytown/`;
 				server.middlewares.use(
 					sirv(partytownLibDirectory, {
-						mount: '/~partytown',
+						mount: lib,
 						dev: true,
 						etag: true,
 						extensions: [],

--- a/packages/integrations/partytown/src/index.ts
+++ b/packages/integrations/partytown/src/index.ts
@@ -25,9 +25,10 @@ export default function createPlugin(options: PartytownOptions): AstroIntegratio
 		name: '@astrojs/partytown',
 		hooks: {
 			'astro:config:setup': ({ config: _config, command, injectScript }) => {
+				const lib = path.join(_config.base || '/', '~partytown');
 				const forward = options?.config?.forward || [];
 				const debug = options?.config?.debug || command === 'dev';
-				partytownSnippetHtml = partytownSnippet({ debug, forward });
+				partytownSnippetHtml = partytownSnippet({ lib, debug, forward });
 				injectScript('head-inline', partytownSnippetHtml);
 			},
 			'astro:config:done': ({ config: _config }) => {


### PR DESCRIPTION
## Changes
- Closes #3432 
- It adds the `lib` option so the partytown scritpt can resolve the correct path if the `base` config option is provided.

## Testing
Tested locally

## Docs
There's no need to update the docs.