### PR TITLE
feat: expose route dist URL on SSG

### DIFF
--- a/.changeset/ten-hounds-fry.md
+++ b/.changeset/ten-hounds-fry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Expose route dist URL on SSG

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ package-lock.json
 
 !packages/astro/vendor/vite/dist
 packages/integrations/**/.netlify/
+
+# exclude IntelliJ/WebStorm stuff
+.idea

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -973,6 +973,8 @@ export interface RouteData {
 	generate: (data?: any) => string;
 	params: string[];
 	pathname?: string;
+	// expose the real path name on SSG
+	distURL?: URL;
 	pattern: RegExp;
 	segments: RoutePart[][];
 	type: RouteType;

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -250,6 +250,7 @@ async function generatePath(
 
 	const outFolder = getOutFolder(astroConfig, pathname, pageData.route.type);
 	const outFile = getOutFile(astroConfig, outFolder, pathname, pageData.route.type);
+	pageData.route.distURL = outFile;
 	await fs.promises.mkdir(outFolder, { recursive: true });
 	await fs.promises.writeFile(outFile, body, 'utf-8');
 }

--- a/packages/astro/test/static-build-page-dist-url.test.js
+++ b/packages/astro/test/static-build-page-dist-url.test.js
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+import { loadFixture } from './test-utils.js';
+
+describe('Static build: pages routes have distURL', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	/** @type {RouteData[]} */
+	let checkRoutes
+	before(async () => {
+		const fixture = await loadFixture({
+			root: './fixtures/astro pages/',
+			integrations: [{
+				name: '@astrojs/distURL',
+				hooks: {
+					'astro:build:done': ({ routes }) => {
+						console.log(routes)
+						checkRoutes = routes.filter(p => p.type === 'page')
+					},
+				},
+			}]
+		});
+		await fixture.build();
+	})
+	it('Pages routes have distURL', async () => {
+		expect(checkRoutes).to.have.lengthOf.above(0, 'Pages not found: build end hook not being called')
+		checkRoutes.forEach(p => expect(p).to.have.property(
+			'distURL'
+		).that.is.a(
+			'URL', `${p.pathname} doesn't include distURL`
+		));
+	});
+});
+
+
+

--- a/packages/astro/test/static-build-page-dist-url.test.js
+++ b/packages/astro/test/static-build-page-dist-url.test.js
@@ -13,7 +13,6 @@ describe('Static build: pages routes have distURL', () => {
 				name: '@astrojs/distURL',
 				hooks: {
 					'astro:build:done': ({ routes }) => {
-						console.log(routes)
 						checkRoutes = routes.filter(p => p.type === 'page')
 					},
 				},


### PR DESCRIPTION
## Changes

- Just exposes a `distURL` path on routes for use in integrations
- Also excludes IntelliJ/WebStorm internal stuff from the `.gitignore` root file

## Testing

Tested manually on PWA integration

## Docs

Is there docs for this? If so, just add a hint for the `distURL` prop