### PR TITLE
Feat: markdown `content.raw()` and `content.compiled()` helpers

### DIFF
--- a/.changeset/nasty-tigers-sip.md
+++ b/.changeset/nasty-tigers-sip.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Add "rawContent" helper to imported markdown files. This exposes both the raw markdown content when using rawContent() and the parsed HTML when using rawContent.html()

--- a/.changeset/nasty-tigers-sip.md
+++ b/.changeset/nasty-tigers-sip.md
@@ -2,4 +2,4 @@
 'astro': minor
 ---
 
-Add "rawContent" helper to imported markdown files. This exposes both the raw markdown content when using rawContent() and the parsed HTML when using rawContent.html()
+Add content parsing helpers to imported markdown files. This exposes both the raw markdown content when using rawContent() and the parsed Astro syntax when using compiledContent()

--- a/packages/astro/env.d.ts
+++ b/packages/astro/env.d.ts
@@ -20,7 +20,8 @@ declare module '*.md' {
 	export const url: MD['url'];
 	export const getHeaders: MD['getHeaders'];
 	export const Content: MD['Content'];
-	export const content: MD['content'];
+	export const rawContent: MD['rawContent'];
+	export const compiledContent: MD['compiledContent'];
 
 	const load: MD['default'];
 	export default load;

--- a/packages/astro/env.d.ts
+++ b/packages/astro/env.d.ts
@@ -20,6 +20,7 @@ declare module '*.md' {
 	export const url: MD['url'];
 	export const getHeaders: MD['getHeaders'];
 	export const Content: MD['Content'];
+	export const content: MD['content'];
 
 	const load: MD['default'];
 	export default load;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -753,6 +753,9 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 	file: string;
 	url: string | undefined;
 	Content: AstroComponentFactory;
+	rawContent: () => string & {
+		parseHtml: () => Promise<string>;
+	};
 	getHeaders(): Promise<MarkdownHeader[]>;
 	default: () => Promise<{
 		metadata: MarkdownMetadata;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -753,8 +753,9 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 	file: string;
 	url: string | undefined;
 	Content: AstroComponentFactory;
-	rawContent: () => string & {
-		html: () => Promise<string>;
+	content: {
+		raw: () => string;
+		compiled: () => Promise<string>;
 	};
 	getHeaders(): Promise<MarkdownHeader[]>;
 	default: () => Promise<{

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -754,7 +754,7 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 	url: string | undefined;
 	Content: AstroComponentFactory;
 	rawContent: () => string & {
-		parseHtml: () => Promise<string>;
+		html: () => Promise<string>;
 	};
 	getHeaders(): Promise<MarkdownHeader[]>;
 	default: () => Promise<{

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -753,12 +753,10 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 	file: string;
 	url: string | undefined;
 	Content: AstroComponentFactory;
-	content: {
-		/** raw Markdown file content, excluding frontmatter */
-		raw: () => string;
-		/** Markdown file compiled to valid Astro syntax. Queryable with most HTML parsing libraries */
-		compiled: () => Promise<string>;
-	};
+	/** raw Markdown file content, excluding frontmatter */
+	rawContent(): string;
+	/** Markdown file compiled to valid Astro syntax. Queryable with most HTML parsing libraries */
+	compiledContent(): Promise<string>;
 	getHeaders(): Promise<MarkdownHeader[]>;
 	default: () => Promise<{
 		metadata: MarkdownMetadata;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -754,7 +754,9 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 	url: string | undefined;
 	Content: AstroComponentFactory;
 	content: {
+		/** raw Markdown file content, excluding frontmatter */
 		raw: () => string;
+		/** Markdown file compiled to valid Astro syntax. Queryable with most HTML parsing libraries */
 		compiled: () => Promise<string>;
 	};
 	getHeaders(): Promise<MarkdownHeader[]>;

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -89,13 +89,11 @@ export default function markdown({ config }: AstroPluginOptions): Plugin {
 						export const frontmatter = ${JSON.stringify(frontmatter)};
 						export const file = ${JSON.stringify(fileId)};
 						export const url = ${JSON.stringify(fileUrl)};
-						export const content = {
-							raw() {
-								return ${JSON.stringify(rawContent)};
-							},
-							async compiled() {
-								return load().then((m) => m.content.compiled());
-							}
+						export function rawContent() {
+							return ${JSON.stringify(rawContent)};
+						}
+						export async function compiledContent() {
+							return load().then((m) => m.compiledContent());
 						}
 						export function $$loadMetadata() {
 							return load().then((m) => m.$$metadata);
@@ -178,13 +176,11 @@ ${setup}`.trim();
 
 				tsResult = `\nexport const metadata = ${JSON.stringify(metadata)};
 export const frontmatter = ${JSON.stringify(content)};
-export const content = {
-	raw() {
-		return ${JSON.stringify(markdownContent)};
-	},
-	compiled() {
+export function rawContent() {
+	return ${JSON.stringify(markdownContent)};
+}
+export function compiledContent() {
 		return ${JSON.stringify(renderResult.metadata.html)};
-	}
 }
 ${tsResult}`;
 

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -89,16 +89,16 @@ export default function markdown({ config }: AstroPluginOptions): Plugin {
 						export const frontmatter = ${JSON.stringify(frontmatter)};
 						export const file = ${JSON.stringify(fileId)};
 						export const url = ${JSON.stringify(fileUrl)};
-
+						export const content = {
+							raw() {
+								return ${JSON.stringify(rawContent)};
+							},
+							async compiled() {
+								return load().then((m) => m.content.compiled());
+							}
+						}
 						export function $$loadMetadata() {
 							return load().then((m) => m.$$metadata);
-						}
-
-						export function rawContent() {
-							return ${JSON.stringify(rawContent)};
-						}
-						rawContent.html = async function() {
-							return load().then((m) => m.rawContent.html());
 						}
 						
 						// Deferred
@@ -178,11 +178,13 @@ ${setup}`.trim();
 
 				tsResult = `\nexport const metadata = ${JSON.stringify(metadata)};
 export const frontmatter = ${JSON.stringify(content)};
-export function rawContent() {
-	return ${JSON.stringify(markdownContent)};
-}
-rawContent.html = function() {
-	return ${JSON.stringify(renderResult.metadata.html)};
+export const content = {
+	raw() {
+		return ${JSON.stringify(markdownContent)};
+	},
+	compiled() {
+		return ${JSON.stringify(renderResult.metadata.html)};
+	}
 }
 ${tsResult}`;
 

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -94,14 +94,11 @@ export default function markdown({ config }: AstroPluginOptions): Plugin {
 							return load().then((m) => m.$$metadata);
 						}
 
-						export const rawContent = {
-							toString() {
-								return ${JSON.stringify(rawContent)};
-							},
-							// Deferred
-							async parsedHtml() {
-								return load().then((m) => m.rawContent.html());
-							}
+						export function rawContent() {
+							return ${JSON.stringify(rawContent)};
+						}
+						rawContent.parseHtml = async function() {
+							return load().then((m) => m.rawContent.parseHtml());
 						}
 						
 						// Deferred
@@ -181,13 +178,11 @@ ${setup}`.trim();
 
 				tsResult = `\nexport const metadata = ${JSON.stringify(metadata)};
 export const frontmatter = ${JSON.stringify(content)};
-export const rawContent = {
-	toString() {
-		return ${JSON.stringify(markdownContent)};
-	},
-	parsedHtml() {
-		return ${JSON.stringify(renderResult.metadata.html)};
-	}
+export function rawContent() {
+	return ${JSON.stringify(markdownContent)};
+}
+rawContent.parseHtml = async function() {
+	return ${JSON.stringify(renderResult.metadata.html)};
 }
 ${tsResult}`;
 

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -181,7 +181,7 @@ export const frontmatter = ${JSON.stringify(content)};
 export function rawContent() {
 	return ${JSON.stringify(markdownContent)};
 }
-rawContent.html = async function() {
+rawContent.html = function() {
 	return ${JSON.stringify(renderResult.metadata.html)};
 }
 ${tsResult}`;

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -97,8 +97,8 @@ export default function markdown({ config }: AstroPluginOptions): Plugin {
 						export function rawContent() {
 							return ${JSON.stringify(rawContent)};
 						}
-						rawContent.parseHtml = async function() {
-							return load().then((m) => m.rawContent.parseHtml());
+						rawContent.html = async function() {
+							return load().then((m) => m.rawContent.html());
 						}
 						
 						// Deferred
@@ -181,7 +181,7 @@ export const frontmatter = ${JSON.stringify(content)};
 export function rawContent() {
 	return ${JSON.stringify(markdownContent)};
 }
-rawContent.parseHtml = async function() {
+rawContent.html = async function() {
 	return ${JSON.stringify(renderResult.metadata.html)};
 }
 ${tsResult}`;

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -233,4 +233,16 @@ describe('Astro Markdown', () => {
 		expect($('#target > ol > li').children()).to.have.lengthOf(1);
 		expect($('#target > ol > li > ol > li').text()).to.equal('nested hello');
 	});
+
+	it('Exposes raw markdown content', async () => {
+		const { markdown } = JSON.parse(await fixture.readFile('/raw-content.json'));
+
+		expect(markdown).to.equal(`\n## With components\n\n### Non-hydrated\n\n<Hello name="Astro Naut" />\n\n### Hydrated\n\n<Counter client:load />\n<SvelteButton client:load />\n`);
+	});
+	
+	it('Exposes HTML parser for raw markdown content', async () => {
+		const { html } = JSON.parse(await fixture.readFile('/raw-content.json'));
+	
+		expect(html).to.equal(`<h2 id="with-components">With components</h2>\n<h3 id="non-hydrated">Non-hydrated</h3>\n<Hello name="Astro Naut" />\n<h3 id="hydrated">Hydrated</h3>\n<Counter client:load />\n<SvelteButton client:load />`);
+	})
 });

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
+import { loadFixture, fixLineEndings } from './test-utils.js';
 
 describe('Astro Markdown', () => {
 	let fixture;
@@ -237,12 +237,12 @@ describe('Astro Markdown', () => {
 	it('Exposes raw markdown content', async () => {
 		const { markdown } = JSON.parse(await fixture.readFile('/raw-content.json'));
 
-		expect(markdown).to.equal(`\n## With components\n\n### Non-hydrated\n\n<Hello name="Astro Naut" />\n\n### Hydrated\n\n<Counter client:load />\n<SvelteButton client:load />\n`);
+		expect(fixLineEndings(markdown)).to.equal(`\n## With components\n\n### Non-hydrated\n\n<Hello name="Astro Naut" />\n\n### Hydrated\n\n<Counter client:load />\n<SvelteButton client:load />\n`);
 	});
 	
 	it('Exposes HTML parser for raw markdown content', async () => {
 		const { html } = JSON.parse(await fixture.readFile('/raw-content.json'));
 	
-		expect(html).to.equal(`<h2 id="with-components">With components</h2>\n<h3 id="non-hydrated">Non-hydrated</h3>\n<Hello name="Astro Naut" />\n<h3 id="hydrated">Hydrated</h3>\n<Counter client:load />\n<SvelteButton client:load />`);
+		expect(fixLineEndings(html)).to.equal(`<h2 id="with-components">With components</h2>\n<h3 id="non-hydrated">Non-hydrated</h3>\n<Hello name="Astro Naut" />\n<h3 id="hydrated">Hydrated</h3>\n<Counter client:load />\n<SvelteButton client:load />`);
 	})
 });

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -235,14 +235,14 @@ describe('Astro Markdown', () => {
 	});
 
 	it('Exposes raw markdown content', async () => {
-		const { markdown } = JSON.parse(await fixture.readFile('/raw-content.json'));
+		const { raw } = JSON.parse(await fixture.readFile('/raw-content.json'));
 
-		expect(fixLineEndings(markdown)).to.equal(`\n## With components\n\n### Non-hydrated\n\n<Hello name="Astro Naut" />\n\n### Hydrated\n\n<Counter client:load />\n<SvelteButton client:load />\n`);
+		expect(fixLineEndings(raw)).to.equal(`\n## With components\n\n### Non-hydrated\n\n<Hello name="Astro Naut" />\n\n### Hydrated\n\n<Counter client:load />\n<SvelteButton client:load />\n`);
 	});
 	
 	it('Exposes HTML parser for raw markdown content', async () => {
-		const { html } = JSON.parse(await fixture.readFile('/raw-content.json'));
+		const { compiled } = JSON.parse(await fixture.readFile('/raw-content.json'));
 	
-		expect(fixLineEndings(html)).to.equal(`<h2 id="with-components">With components</h2>\n<h3 id="non-hydrated">Non-hydrated</h3>\n<Hello name="Astro Naut" />\n<h3 id="hydrated">Hydrated</h3>\n<Counter client:load />\n<SvelteButton client:load />`);
+		expect(fixLineEndings(compiled)).to.equal(`<h2 id="with-components">With components</h2>\n<h3 id="non-hydrated">Non-hydrated</h3>\n<Hello name="Astro Naut" />\n<h3 id="hydrated">Hydrated</h3>\n<Counter client:load />\n<SvelteButton client:load />`);
 	})
 });

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.json.js
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.json.js
@@ -1,0 +1,10 @@
+import { rawContent } from '../imported-md/with-components.md';
+
+export async function get() {
+	return {
+		body: JSON.stringify({
+			markdown: rawContent(),
+			html: await rawContent.parseHtml(),
+		}),
+	}
+}

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.json.js
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.json.js
@@ -4,7 +4,7 @@ export async function get() {
 	return {
 		body: JSON.stringify({
 			markdown: rawContent(),
-			html: await rawContent.parseHtml(),
+			html: await rawContent.html(),
 		}),
 	}
 }

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.json.js
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.json.js
@@ -1,10 +1,10 @@
-import { content } from '../imported-md/with-components.md';
+import { rawContent, compiledContent } from '../imported-md/with-components.md';
 
 export async function get() {
 	return {
 		body: JSON.stringify({
-			raw: content.raw(),
-			compiled: await content.compiled(),
+			raw: rawContent(),
+			compiled: await compiledContent(),
 		}),
 	}
 }

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.json.js
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.json.js
@@ -1,10 +1,10 @@
-import { rawContent } from '../imported-md/with-components.md';
+import { content } from '../imported-md/with-components.md';
 
 export async function get() {
 	return {
 		body: JSON.stringify({
-			markdown: rawContent(),
-			html: await rawContent.html(),
+			raw: content.raw(),
+			compiled: await content.compiled(),
 		}),
 	}
 }

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -254,3 +254,7 @@ export async function cliServerLogSetup(flags = [], cmd = 'dev') {
 }
 
 export const isWindows = os.platform() === 'win32';
+
+export function fixLineEndings(str) {
+	return str.replace(/\r\n/g, '\n');
+}


### PR DESCRIPTION
## Changes

Note: I highly recommend [checking the docs PR](https://github.com/withastro/docs/pull/668) to understand the use cases for each of these helpers!

- Resolves #3072 
- Adds 2 new helpers to imported markdown _and_ `?content` markdown:
  - `content.raw()` -> retrieves raw markdown excluding frontmatter block
  - `await content.compiled()` -> retrieves raw markdown parsed to Astro syntax. This excludes JSX, components, and layouts! Note added to docs PR (see Docs section)
- Updates type def for imported markdown

## Testing

New `astro-markdown` tests against a raw content endpoint

## Docs

https://github.com/withastro/docs/pull/668