### PR TITLE
Set the correct content-type for CSS HMR

### DIFF
--- a/.changeset/fifty-mice-bow.md
+++ b/.changeset/fifty-mice-bow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Forces the correct mime type for CSS in HMR

--- a/packages/astro/test/fixtures/hmr-css/src/pages/index.astro
+++ b/packages/astro/test/fixtures/hmr-css/src/pages/index.astro
@@ -1,0 +1,11 @@
+<html>
+	<head>
+		<title>Testing</title>
+		<style>
+			background { background: brown; }
+		</style>
+	</head>
+	<body>
+		<h1>Testing</h1>
+	</body>
+</html>

--- a/packages/astro/test/hmr-css.test.js
+++ b/packages/astro/test/hmr-css.test.js
@@ -1,0 +1,29 @@
+import { isWindows, loadFixture } from './test-utils.js';
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+
+describe('HMR - CSS', () => {
+	if (isWindows) return;
+
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	/** @type {import('./test-utils').DevServer} */
+	let devServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/hmr-css/',
+		});
+		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer.stop();
+	});
+
+	it('Timestamp URL used by Vite gets the right mime type', async () => {
+		let res = await fixture.fetch('/src/pages/index.astro?astro=&type=style&index=0&lang.css=&t=1653657441095');
+		let headers = res.headers;
+		expect(headers.get('content-type')).to.equal('text/css');
+	});
+});


### PR DESCRIPTION
## Changes

- In the dev server detect requests for `lang.css` which is a search param added for Astro, Vue, and Svelte styles. Set the correct content-type for these (`text/css`).
- Closes #3219
- Closes #3370

## Testing

- Test added which mimics what Vite does in HMR.

## Docs

N/A, bug fix.