### PR TITLE
Add console warning on fs.strict=false

### DIFF
--- a/.changeset/olive-cobras-bow.md
+++ b/.changeset/olive-cobras-bow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add warning on startup when `vite.server.fs.strict` is disabled

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -12,7 +12,6 @@ import {
 } from '../../integrations/index.js';
 import { createVite } from '../create-vite.js';
 import { info, LogOptions, warn, warnIfUsingExperimentalSSR } from '../logger/core.js';
-import { nodeLogOptions } from '../logger/node.js';
 import * as msg from '../messages.js';
 import { apply as applyPolyfill } from '../polyfill.js';
 
@@ -64,6 +63,9 @@ export default async function dev(config: AstroConfig, options: DevOptions): Pro
 	const currentVersion = process.env.PACKAGE_VERSION ?? '0.0.0';
 	if (currentVersion.includes('-')) {
 		warn(options.logging, null, msg.prerelease({ currentVersion }));
+	}
+	if (viteConfig.server?.fs?.strict === false) {
+		warn(options.logging, null, msg.fsStrictWarning());
 	}
 
 	await runHookServerStart({ config, address: devServerAddressInfo });

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -145,6 +145,10 @@ export function telemetryReset() {
 	)}. You may be prompted again.\n`;
 }
 
+export function fsStrictWarning() {
+	return yellow('⚠️ Serving with vite.server.fs.strict: false. Note that all files on your machine will be accessible to anyone on your network!')
+}
+
 export function prerelease({ currentVersion }: { currentVersion: string }) {
 	const tag = currentVersion.split('-').slice(1).join('-').replace(/\..*$/, '');
 	const badge = bgYellow(black(` ${tag} `));


### PR DESCRIPTION
## Changes

Add warning log when `vite.server.fs.strict` is `false` to [follow SvelteKit's lead](https://github.com/sveltejs/kit/blob/7f958dd49cfbbc4712001b1b21ce1474b44da69e/packages/kit/src/cli.js#L232-L241). Don't worry, this value [is `true` by default](https://vitejs.dev/config/#server-fs-strict) in Vite!

## Testing

N/A

## Docs

N/A