### PR TITLE
Remove unused slot in the "Just the Basics" starter until slot bugs are fixed (fix #3473)

### DIFF
--- a/examples/basics/src/components/Card.astro
+++ b/examples/basics/src/components/Card.astro
@@ -14,7 +14,6 @@ const {href, title, body} = Astro.props;
         </h2>
         <p>
             {body}
-            <slot name="icon" />
         </p>
     </a>
 </li>


### PR DESCRIPTION
Simple fix of "Just the basics" starter for #3473 
This seems to be a bug with named slots. Named slots that are not used will break the build.

## Changes

Remove unused slot in the "Just the Basics" starter:

- this slot is not used in the example
- it fixes the build bug in #3473


## Testing

Tested

- `npm run dev`
- `npm run build` and `npm run preview`

## Docs

No impact on the docs.