### PR TITLE
Fix `*/` breaking HTML comments in Markdown

### DIFF
--- a/.changeset/polite-eels-visit.md
+++ b/.changeset/polite-eels-visit.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent `*/` from breaking HTML comments in Markdown

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -129,10 +129,11 @@ export default function markdown({ config }: AstroPluginOptions): Plugin {
 				// Extract special frontmatter keys
 				let { data: frontmatter, content: markdownContent } = matter(source);
 
-				// Turn HTML comments into JS comments
+				// Turn HTML comments into JS comments while preventing nested `*/` sequences
+				// from ending the JS comment by injecting a zero-width space
 				markdownContent = markdownContent.replace(
 					/<\s*!--([^-->]*)(.*?)-->/gs,
-					(whole) => `{/*${whole}*/}`
+					(whole) => `{/*${whole.replace(/\*\//g, '*\u200b/')}*/}`
 				);
 
 				let renderResult = await renderMarkdown(markdownContent, {

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -72,6 +72,13 @@ describe('Astro Markdown', () => {
 		expect($('h1').text()).to.equal('It works!');
 	});
 
+	it('Prevents `*/` sequences from breaking HTML comments (#3476)', async () => {
+		const html = await fixture.readFile('/comment-with-js/index.html');
+		const $ = cheerio.load(html);
+
+		expect($('h1').text()).to.equal('It still works!');
+	});
+
 	// https://github.com/withastro/astro/issues/3254
 	it('Can handle scripts in markdown pages', async () => {
 		const html = await fixture.readFile('/script/index.html');

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/comment-with-js.md
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/comment-with-js.md
@@ -1,0 +1,17 @@
+<!--
+HTML comments with */ inside!
+-->
+
+<!--
+```js
+/**
+ * It even works inside nested fenced code blocks!
+ */
+function test() {
+	/* Yay */
+	return 'Nice!';
+}
+```
+-->
+
+# It still works!


### PR DESCRIPTION
## Changes

- Fixes #3476.
- Injects a zero-width space character into nested `*/` sequences when wrapping HTML comments to JS comments.

## Testing

- I added a new test case to verify the fixed behavior.

## Docs

- No visible change, just a bugfix.