### PR TITLE
Correcting the link to docs on Just the Basics starter README

### DIFF
--- a/examples/basics/README.md
+++ b/examples/basics/README.md
@@ -39,4 +39,4 @@ All commands are run from the root of the project, from a terminal:
 
 ## 👀 Want to learn more?
 
-Feel free to check [our documentation](https://github.com/withastro/astro) or jump into our [Discord server](https://astro.build/chat).
+Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/examples/blog-multiple-authors/README.md
+++ b/examples/blog-multiple-authors/README.md
@@ -51,4 +51,4 @@ All commands are run from the root of the project, from a terminal:
 
 ## 👀 Want to learn more?
 
-Feel free to check [our documentation](https://github.com/withastro/astro) or jump into our [Discord server](https://astro.build/chat).
+Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -51,4 +51,4 @@ All commands are run from the root of the project, from a terminal:
 
 ## 👀 Want to learn more?
 
-Feel free to check [our documentation](https://github.com/withastro/astro) or jump into our [Discord server](https://astro.build/chat).
+Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/examples/component/README.md
+++ b/examples/component/README.md
@@ -42,4 +42,4 @@ All commands are run from the root of the project, from a terminal:
 
 ## 👀 Want to learn more?
 
-Feel free to check [our documentation](https://github.com/withastro/astro) or jump into our [Discord server](https://astro.build/chat).
+Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -32,7 +32,7 @@ To deploy your site to production, check out our [Deploy an Astro Website](https
 
 ## New to Astro?
 
-Welcome! Check out [our documentation](https://github.com/withastro/astro) or jump into our [Discord server](https://astro.build/chat).
+Welcome! Check out [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
 
 ## Customize This Theme
 

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -40,4 +40,4 @@ All commands are run from the root of the project, from a terminal:
 
 ## 👀 Want to learn more?
 
-Feel free to check [our documentation](https://github.com/withastro/astro) or jump into our [Discord server](https://astro.build/chat).
+Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/examples/non-html-pages/README.md
+++ b/examples/non-html-pages/README.md
@@ -45,4 +45,4 @@ All commands are run from the root of the project, from a terminal:
 
 ## 👀 Want to learn more?
 
-Feel free to check [our documentation](https://github.com/withastro/astro) or jump into our [Discord server](https://astro.build/chat).
+Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/examples/portfolio/README.md
+++ b/examples/portfolio/README.md
@@ -21,4 +21,4 @@ All commands are run from the root of the project, from a terminal:
 
 ## 👀 Want to learn more?
 
-Feel free to check [our documentation](https://github.com/withastro/astro) or jump into our [Discord server](https://astro.build/chat).
+Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/examples/starter/README.md
+++ b/examples/starter/README.md
@@ -40,4 +40,4 @@ All commands are run from the root of the project, from a terminal:
 
 ## 👀 Want to learn more?
 
-Feel free to check [our documentation](https://github.com/withastro/astro) or jump into our [Discord server](https://astro.build/chat).
+Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/examples/subpath/README.md
+++ b/examples/subpath/README.md
@@ -42,4 +42,4 @@ All commands are run from the root of the project, from a terminal:
 
 ## 👀 Want to learn more?
 
-Feel free to check [our documentation](https://github.com/withastro/astro) or jump into our [Discord server](https://astro.build/chat).
+Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/examples/with-vite-plugin-pwa/README.md
+++ b/examples/with-vite-plugin-pwa/README.md
@@ -40,4 +40,4 @@ All commands are run from the root of the project, from a terminal:
 
 ## 👀 Want to learn more?
 
-Feel free to check [our documentation](https://github.com/withastro/astro) or jump into our [Discord server](https://astro.build/chat).
+Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).


### PR DESCRIPTION
## Changes

The link to documentation in the Just the Basics starter template README did not actually go to Docs. Now it does!

## Testing

No test, only link.

## Docs

Does not affect Docs site itself.