### PR TITLE
Load environment variables in deno SSR

### DIFF
--- a/.changeset/chilly-sheep-doubt.md
+++ b/.changeset/chilly-sheep-doubt.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/deno': patch
+---
+
+Deno integration now loads environment variables in server runtime

--- a/packages/integrations/deno/package.json
+++ b/packages/integrations/deno/package.json
@@ -22,7 +22,7 @@
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "deno test --allow-run --allow-read --allow-net ./test/"
+    "test": "deno test --allow-run --allow-read --allow-env --allow-net ./test/"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/packages/integrations/deno/src/shim.ts
+++ b/packages/integrations/deno/src/shim.ts
@@ -1,4 +1,5 @@
 (globalThis as any).process = {
 	argv: [],
-	env: {},
+	// @ts-ignore
+	env: Deno.env.toObject(),
 };

--- a/packages/integrations/deno/test/basics.test.js
+++ b/packages/integrations/deno/test/basics.test.js
@@ -5,6 +5,12 @@ async function startApp(cb) {
 	await runBuildAndStartApp('./fixtures/basics/', cb);
 }
 
+// this needs to be here and not in the specific test case, because
+// the variables are loaded in the global scope of the built server
+// module, which is only executed once upon the first load
+const varContent = 'this is a value stored in env variable';
+Deno.env.set('SOME_VARIABLE', varContent);
+
 Deno.test({
 	name: 'Basics',
 	async fn() {
@@ -36,6 +42,20 @@ Deno.test({
 			const ct = resp.headers.get('content-type');
 			assertEquals(ct, 'text/css');
 			await resp.body.cancel();
+		});
+	},
+});
+
+Deno.test({
+	name: 'Correctly loads run-time env variables',
+	async fn() {
+		await startApp(async () => {
+			const resp = await fetch('http://127.0.0.1:8085/');
+			const html = await resp.text();
+
+			const doc = new DOMParser().parseFromString(html, `text/html`);
+			const p = doc.querySelector('p#env-value');
+			assertEquals(p.innerText, varContent);
 		});
 	},
 });

--- a/packages/integrations/deno/test/fixtures/basics/src/pages/index.astro
+++ b/packages/integrations/deno/test/fixtures/basics/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import ReactComponent from '../components/React.jsx';
+const envValue = import.meta.env.SOME_VARIABLE;
 ---
 <html>
 <head>
@@ -8,6 +9,7 @@ import ReactComponent from '../components/React.jsx';
 </head>
 <body>
 	<h1>Basic App on Deno</h1>
+	<p id="env-value">{envValue}</p>
 	<ReactComponent />
 </body>
 </html>


### PR DESCRIPTION
## Changes

Uses Deno.env to mock process.env

## Testing

A test is added

## Docs

One would expect this to work, but IMO doesn't need to be documented separately