### PR TITLE
Governance updates

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -63,7 +63,7 @@ If you're interested in reaching the next level and becoming a **Maintainer**, y
 
 #### Nomination Process
 
-You may self-nominate by sending the message `!contribute` in any Discord channel. If you do this, please share a second message with a link or description of your contribution so that people can recognize you for the contribution,
+You may self-nominate by sending the message `!contribute` in any Discord channel. If you do this, please share a second message with a link or description of your contribution so that people can recognize you for the contribution.
 
 You may also be granted this role automatically if you are active and helpful on Discord.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -209,7 +209,7 @@ Besides our contributor levels described above, there are additional roles and t
 - `@i18n-gang` runs the `#docs-i18n` channel and organizes translations in several languages.
 - `@support-squad` runs the `#support-threads` channel and helps anyone who needs help using Astro.
 
-Many of these team roles can be be browsed and joined automatically by visiting the `#manage-roles` channel in our Discord. Getting involved with a team is a great way to start contributing to Astro!
+Many of these team roles can be browsed and joined automatically by visiting the `#manage-roles` channel in our Discord. Getting involved with a team is a great way to start contributing to Astro!
 
 ### Moderator
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -24,7 +24,7 @@ All types of contribution are meaningful, from code to documentation, even blog 
 
 **Anyone** can become an Astro Contributor (yes, even you!). Regardless of skill, experience or background.
 
-Our goal is too always recognize all of our contributors and their effort given to Astro. 
+Our goal is to always recognize all of our contributors and their effort given to Astro. 
 
 > 🚀 Remember no contribution is too small or too little. 
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -163,7 +163,7 @@ They are seen as leaders in the project and are listened to by the wider Astro c
 
 A Core member is recognized for contributing a significant amount of their time and energy to the project through issues, pull requests, bug fixes, implementing advanced enhancements/features, and is activly posting on Discord. 
 
-Not every contributor will reach this level, and that's okay! L2 Maintainers still have significant responsibility and privileges as is within our community.
+Not every contributor will reach this level, and that's okay! L2 Maintainers still have significant responsibility and privileges within our community.
 
 
 #### Privileges

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,31 +1,70 @@
 # Governance
 
+Herein contains Astro's goverance model. It outlines and describes in detail each role and their subsequent responsibilties. This includes; 
+
+- Nomination Process
+- Duty of Care
+- Code Review Process
+- Code of Conduct Enforcement
+  
 This document outlines the governance model for Astro. This includes detailed descriptions of different roles, nomination processes, code review processes, and Code of Conduct enforcement.
 
-👉 **All community members must follow the [Code of Conduct (CoC)](CODE_OF_CONDUCT.md).**  
+> 🚨 **All community members must follow the [Code of Conduct (CoC)](CODE_OF_CONDUCT.md).**  
 Consequences for CoC violations are detailed in [Moderation](#moderation).
 
-👉 **Want to trigger a vote, nomination, or perform some other action?**  
+> 👉 **Want to trigger a vote, nomination, or perform some other action?**  
 Scroll down to [Playbook](#governance-playbook).
 
 ## Get Involved
 
-**Anything that supports the Astro community is a valuable contribution.** All types of contribution are meaningful, from code to documentation to blog posts. Anyone can become an Astro Contributor (yes, even you!). Our goal is to recognize all contributors to Astro regardless of skill, experience or background.
+**Any contribution that helps support or further the Astro project and its wider community is always welcome and greatly appreciated.**
+ 
+
+All types of contribution are meaningful, from code to documentation, even blog posts. 
+
+**Anyone** can become an Astro Contributor (yes, even you!). Regardless of skill, experience or background.
+
+Our goal is too always recognize all of our contributors and their effort given to Astro. 
+
+> 🚀 Remember no contribution is too small or too little. 
+
+We will always recognise and value all our contributors and their effort that they bring to the Astro project. 
+
+Most importantly we are eternally grateful for the vast and diverse impact that they bring to our community.
 
 ## Contributor Levels
 
-We recognize different degrees of contribution to the Astro project as **Contributor Levels** (also referred to as **Contributor Roles**). Contributor levels are available to all Astro community members, regardless of coding skill or experience. The two most important things that we look for in contributors are:
+We recognize different degrees of contributions made to the Astro project as **Contributor Levels** also referred to as **Contributor Roles**. 
+
+Contributor levels are available to **all members** within the Astro Community, regardless of coding skill or experience. 
+
+The two off the most important things that we look from our contributors is:
 
 - **Being here** - Everyone's time is valuable, and the fact that you're here and contributing to Astro is amazing! Thank you for being a part of this project with us.
-- **Being a positive member of our community** - Go above and beyond our [Code of Conduct](CODE_OF_CONDUCT.md) and commit to healthy communication in pull requests, issue discussions, Discord conversations, and interactions outside of our community (ex: no Twitter bullies allowed :)
+  
+- **Being a positive member of our community**  
+  Strive to go above and beyond our [Code of Conduct](CODE_OF_CONDUCT.md) and commit to a healthy, honest discourse when communicating: 
+  - Within our Github Project and its wider umbrella groups and projects.
+    - Pull Requests, 
+    - Issue's 
+    - Discussions,
+    - RFC process, 
+  - Discord conversations, 
+  - Any public and outward interactions conducted outside of our community (ex: no Twitter bullies allowed 🤼‍♂️)
 
-All Contributor roles are granted for as long as the person wishes to engage with the project. A Contributor can voluntarily leave the project at any time (see [Retiring a Role](#retiring-a-role-alumni) below). In extreme cases -- such as a Code of Conduct violation -- this role may be revoked by a project Steward at their discretion.
+All Contributor roles are granted for as long as the individual wishes to engage with the project. 
 
-Each level unlocks new privileges and responsibilities on Discord and GitHub. Below is a summary of each contributor level:
+Contributor's can voluntarily leave the project at any time (see [Retiring a Role](#retiring-a-role-alumni) below). 
+
+In extreme cases such as a *Code of Conduct violation* this role may be revoked by a project Steward at their discretion.
+
+Each new Contributor level unlocks new privileges and responsibilities both on Discord and on GitHub. Below is a summary of each contributor level:
 
 ### Level 1 - Contributor
 
-Have you done something (big or small) to contribute to the health, success, or growth of Astro? Congratulations, you're officially recognized as a contributor to the project!
+> **Done something (big or small) to contribute to the health, success, or growth of Astro?** 
+
+Congratulations, you're officially recognized as a contributor to the project!
 
 #### Examples of recognized contributions
 
@@ -43,11 +82,12 @@ Have you done something (big or small) to contribute to the health, success, or 
 - New name color on Discord: **light blue**.
 - Invitations to contributor-only events, sticker drops, and the occasional swag drop.
 
+
 #### Responsibilities
 
-This role does not require any extra responsibilities or time commitment. We hope you stick around and keep participating!
+This role does not require any extra responsibilities nor time commitment. We hope you stick around and keep participating!
 
-If you're interested in reaching the next level and becoming a Maintainer, you can begin to explore some of those responsibilities in the next section.
+If you're interested in reaching the next level and becoming a **Maintainer**, you can begin to explore some of those responsibilities in the [next section](#level-2-l2---maintainer).
 
 #### Nomination Process
 
@@ -61,13 +101,19 @@ The **Maintainer** role is available to contributors who want to join the team a
 
 The Maintainer role is critical to the long-term health of Astro. Maintainers act as the first line of defense when it comes to new issues, pull requests and Discord activity. Maintainers are most likely the first people that a user will interact with on Discord or GitHub.
 
-**A Maintainer is not required to write code!** Some Maintainers spend most of their time inside of Discord, maintaining a healthy community there.
+**A Maintainer is not required to write code!** 
 
-**A Maintainer has moderation privileges!** All maintainers are trusted with the ability to help moderate our Discord and GitHub communities for things like spam. There is also a special (optional, opt-in) `@mods` role open to maintainers who are also interested in helping out when a community member reaches out for moderation help.
+Some Maintainers spend most of their time inside of Discord, maintaining the health of our strong and vibriant community.
+
+**A Maintainer has moderation privileges!** 
+
+All maintainers are trusted with the ability to help moderate our Discord and GitHub communities for things like spam. 
+
+There is also a special (optional, opt-in) `@mods` role open to maintainers who are also interested in helping out when a community member reaches out for moderation help.
 
 #### Recognized Contributions
 
-There is no strict minimum number of contributions needed to reach this level, as long as you can show **sustained** involvement over some amount of time (at least a couple of weeks).
+There is no strict minimum number of contributions needed to reach this level, as long as you can show **sustained** involvement over some amount of time (at least a few months).
 
 - **GitHub:** Submitting multiple non-trivial pull requests and RFCs
 - **GitHub:** Reviewing multiple non-trivial pull requests and RFCs
@@ -81,11 +127,12 @@ There is no strict minimum number of contributions needed to reach this level, a
 - All privileges of the [Contributor role](#level-1---contributor), plus...
 - Invitation to the `@maintainer` role on [Discord](https://astro.build/chat)
 - Invitation to the private `#maintainers` channel on Discord.
+- Invitation to the `withastro` organisation on GitHub.
 - Invitation to the `@maintainers` team on GitHub.
 - New name color on Discord: **blue**.
 - Ability to moderate Discord to remove spam, harmful speech, etc.
 - Ability to join the `@mods` role on Discord (optional, opt-in).
-- Ability to push branches directly to the `astro` GitHub repo (No more personal fork needed).
+- Ability to push branches directly to the `withastro` GitHub organisation (No more personal fork needed).
 - Ability to review GitHub PRs.
 - Ability to merge _some_ GitHub PRs.
 - Ability to vote on _some_ initiatives (see [Voting](#voting) below).
@@ -102,17 +149,21 @@ There is no strict minimum number of contributions needed to reach this level, a
 
 #### Nomination
 
-- To be nominated, a nominee is expected to already be performing some of the responsibilities of a Maintainer.
-- You can be nominated by any existing Maintainer (L2 or above). 
+- To be nominated, a nominee is expected to already be performing some of the duties and responsibilities of a Maintainer.
+- You can only be nominated by any existing Maintainer (L2 or above). 
 - Once nominated, there will be a vote by existing Maintainers. 
 - See [vote rules & requirements](#voting) for info on how the vote works.
 
 
 ### Level 3 (L3) - Core
 
-The **Core** role is available to community members who have a larger-than-usual impact on the Astro project and community. They are seen as leaders in the project and are listened to by the wider Astro community, often before they have even reached this level. A Core member is recognized for contributing a significant amount of time and energy to the project through issues, pull requests, bug fixes, implementing advanced enhancements/features, and/or actively posting on Discord. 
+The **Core** role is available to community members who have a larger-than-usual impact on the Astro project and community. 
 
-Not every contributor will reach this level, and that's okay! L2 Maintainers still have significant responsibility and privileges in our community.
+They are seen as leaders in the project and are listened to by the wider Astro community, often before they have even reached this level. 
+
+A Core member is recognized for contributing a significant amount of their time and energy to the project through issues, pull requests, bug fixes, implementing advanced enhancements/features, and is activly posting on Discord. 
+
+Not every contributor will reach this level, and that's okay! L2 Maintainers still have significant responsibility and privileges as is within our community.
 
 
 #### Privileges
@@ -156,9 +207,15 @@ If a Core Residency member has their membership revoked, the project Steward may
 
 ### Level 4 - Project Steward
 
-The **Steward** is an additional role bestowed to 1 (or more) Core member of the project. The role of Steward is mainly an administrative one. Stewards control and maintain sensitive project assets, assist in resolving conflicts, and act as tiebreakers in the event of disagreements.
+The **Steward** is an additional role bestowed to one (or more) Core members of the project. 
 
-In extremely rare cases, a Steward can act unilaterally when they believe it is in the project's best interest and can prove that the issue cannot be resolved through normal governance procedure. The steward must publicly state their reason for unilateral action before taking it.
+The role of Steward is mainly an administrative one. 
+
+Stewards control and maintain sensitive project assets, assist in resolving conflicts, and act as tiebreakers in the event of disagreements.
+
+In extremely rare cases, a Steward can act unilaterally when they believe it is in the project's best interest and can prove that the issue cannot be resolved through Astro's normal governance process. 
+
+The steward must publicly state their reason for unilateral action before taking it.
 
 The project Steward is currently: **@FredKSchott**
 
@@ -193,7 +250,9 @@ Besides our contributor levels described above, there are additional roles and t
 - `@i18n-gang` runs the `#docs-i18n` channel and organizes translations in several languages.
 - `@support-squad` runs the `#support-threads` channel and helps anyone who needs help using Astro.
 
-Many of these team roles can be be browsed and joined automatically by visiting the `#manage-roles` channel in our Discord. Getting involved with a team is a great way to start contributing to Astro!
+Many of these team roles can be be browsed and joined automatically by visiting the `#manage-roles` channel from within our Discord. 
+
+Getting involved with a team is a great way to start contributing to Astro!
 
 ### Moderator
 
@@ -215,7 +274,9 @@ Any Maintainer (L2 and above) can self-nominate by messaging the project Steward
 
 The **TSC** is a special role available to Core members (L3 and above). TSC members are responsible for the growth and maintenance of the Astro codebase. 
 
-TSC members are watchdogs over the codebase who ensure code quality, correctness and security. A TSC member guides the direction of the project and ensures a healthy future for the Astro codebase. TSC members are ultimately responsible for technical decision making when it comes to any changes to the Astro codebase.
+TSC members are guardians over the Astro codebase. Their duty is to ensure code quality, correctness and security. 
+
+A TSC member guides the direction of the project and ensures a healthy future for the Astro codebase. TSC members are ultimately responsible for technical decision making when it comes to any changes to the Astro codebase.
 
 A TSC member has significant sway in software design decisions. For this reason, coding experience is critical for this role. TSC membership is one of the only roles that requires a significant contribution history of code to the Astro project on GitHub.
 
@@ -270,7 +331,9 @@ Staff membership does not grant any additional abilities when it comes to voting
 
 ## Retiring a Role (Alumni)
 
-Contributor roles are granted for as long as the person wishes to engage with the project. However, over time an active community member may choose to step away from the Astro project to work on other things. This is a natural and well-understood part of any open source community, and we celebrate it! 
+Contributor roles are granted for as long as the person wishes to engage with the project. However, over time an active community member may choose to step away from the Astro project to work on other things. 
+
+This is a natural and well-understood part of any open source community, and we celebrate it! 
 
 **Alumni** is a special designation and role for any person who was once an active maintainer (L2 or above) but is now no longer actively involved. By retiring and joining Alumni you trade-in your current set of roles, privileges, and responsibilities for a new, special Alumni role (which comes with its own set of Privileges, as described above).
 
@@ -355,7 +418,15 @@ This process kicks off once a valid nomination has been made. See ["Core Member 
 ```
 Hey $NAME!
 
-I have some exciting news—you’ve been nominated and accepted as a member of the Astro Core team! The Core team held a vote and overwhelmingly agree that you would be a great addition to the team. Congratulations! Thanks for all of your significant contributions to Astro to date and your continued dedication to this project and our community. We would be thrilled to have your help ensuring a healthy future for Astro!
+I have some exciting news!
+
+You’ve been nominated and accepted as a member of the Astro Core team! The Core team held a vote and overwhelmingly agree that you would be a great addition to the team. 
+
+Congratulations! 
+
+Thanks for all of your significant contributions to Astro to date and your continued dedication to this project and our community. 
+
+We would be thrilled to have your help ensuring a healthy future for Astro!
 
 Please let me know if you’re interested in accepting this invitation. If so, we’ll start getting your roles and permissions up to date.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -138,6 +138,22 @@ Not every contributor will reach this level, and that's okay! L2 Maintainers sti
 - Once nominated, there will be a vote by existing Core members. 
 - See [vote rules & requirements](#voting) for info on how the vote works.
 
+#### Special Membership Type: Core Residency
+
+**Core Residency** is a special type of Core membership that is limited in the following way(s):
+
+- No voting abilities.
+- No nomination abilities.
+- Can be revoked at any time by the project Steward.
+
+Because of these limitations, this type of Core membership is useful for anyone who has been brought in to work on or contribute to the Astro project without rising through our normal contributor levels. For example: an Astro designer or developer advocate hired by The Astro Technology Company to assist the community could be nominated for a Core Residency role without having a previously earned contributor level.
+
+A Core Residency nomination must still be approved through the normal Core nomination and voting process. During the nomination, the Project Steward will state that the nomination is for the Core Residency designation. The project Steward is the only one who can officially make this designation during the nomination process.
+
+A Core Residency member can become a full Core member (with all limitations removed) through the normal Core nomination and voting procedure. 
+
+If a Core Residency member has their membership revoked, the project Steward may choose to impose a waiting period of some number of days, during which the member can not be re-nominated to become a full Core member.
+
 ### Level 4 - Project Steward
 
 The **Steward** is an additional role bestowed to 1 (or more) Core member of the project. The role of Steward is mainly an administrative one. Stewards control and maintain sensitive project assets, assist in resolving conflicts, and act as tiebreakers in the event of disagreements.
@@ -230,9 +246,7 @@ A TSC member has significant sway in software design decisions. For this reason,
 
 ### Staff
 
-**Staff** is a special designation for employees of [The Astro Technology Company](https://astro.build/company) that lives outside of our Governance model. The staff role was designed to help those of us working full-time on Astro to work productively without "skipping the line" and circumventing our governance model entirely.
-
-The staff role was designed to offer instant **visibility** and **trust**, but not instant **authority.**
+**Staff** is a special designation for employees of [The Astro Technology Company](https://astro.build/company). 
 
 #### Privileges
 
@@ -241,11 +255,7 @@ The staff role was designed to offer instant **visibility** and **trust**, but n
 - Invitation to some private channels on Discord, at the discretion of the project Steward.
 - Invitation to the `staff` team on GitHub.
 
-Staff membership does not grant any additional abilities when it comes to voting and project governance. However, a Staff member is still eligible for other roles in the community and may still still vote as defined by their other roles. For example, a Staff member who is also a part of `@core` will be able to vote as any other `@core` member would.
-
-#### Nomination
-
-There is no nomination process for this role. The project steward is responsible for granting and revoking the `@staff` role. This usually coincides with someone joining or departing from [The Astro Technology Company](https://astro.build/blog/the-astro-technology-company/).
+Staff membership does not grant any additional abilities when it comes to voting and project governance. A Staff member is still eligible for other roles in the community and may still vote as defined by their other roles. For example, a Staff member who is also a part of `@core` will be able to vote as any other `@core` member would.
 
 ### Alumni
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -46,7 +46,7 @@ The two off the most important things that we look from our contributors is:
   Strive to go above and beyond our [Code of Conduct](CODE_OF_CONDUCT.md) and commit to a healthy, honest discourse when communicating: 
   - Within our Github Project and its wider umbrella groups and projects.
     - Pull Requests, 
-    - Issue's 
+    - Issues 
     - Discussions,
     - RFC process, 
   - Discord conversations, 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # Governance
 
-This document outlines the governance model for Astro. This includes detailed descriptions of the contributor levels, nomination process, code review process, pull request merge process, and the consequences of Code of Conduct violations.
+This document outlines the governance model for Astro. This includes detailed descriptions of different roles, nomination processes, code review processes, and Code of Conduct enforcement.
 
 👉 **All community members must follow the [Code of Conduct (CoC)](CODE_OF_CONDUCT.md).**  
 Consequences for CoC violations are detailed in [Moderation](#moderation).
@@ -14,10 +14,12 @@ Scroll down to [Playbook](#governance-playbook).
 
 ## Contributor Levels
 
-We recognize different degrees of contribution as **levels**, and most levels can be reached regardless of coding skill or years of experience. The two most important things that we look for in contributors are:
+We recognize different degrees of contribution to the Astro project as **Contributor Levels** (also referred to as **Contributor Roles**). Contributor levels are available to all Astro community members, regardless of coding skill or experience. The two most important things that we look for in contributors are:
 
-- **Being here** - Everyone's time is valuable, and the fact that you're here and contributing to Astro is amazing! Thank you for being a part of this journey with us.
-- **Being a positive member of our community** - Go above and beyond our Code of Conduct, and commit to healthy communication in pull requests, issue discussions, Discord conversations, and interactions outside of our community (ex: no Twitter bullies allowed :)
+- **Being here** - Everyone's time is valuable, and the fact that you're here and contributing to Astro is amazing! Thank you for being a part of this project with us.
+- **Being a positive member of our community** - Go above and beyond our [Code of Conduct](CODE_OF_CONDUCT.md) and commit to healthy communication in pull requests, issue discussions, Discord conversations, and interactions outside of our community (ex: no Twitter bullies allowed :)
+
+All Contributor roles are granted for as long as the person wishes to engage with the project. A Contributor can voluntarily leave the project at any time (see [Retiring a Role](#retiring-a-role-alumni) below). In extreme cases -- such as a Code of Conduct violation -- this role may be revoked by a project Steward at their discretion.
 
 Each level unlocks new privileges and responsibilities on Discord and GitHub. Below is a summary of each contributor level:
 
@@ -49,11 +51,13 @@ If you're interested in reaching the next level and becoming a Maintainer, you c
 
 #### Nomination Process
 
-If you contributed to Astro outside of Discord, you may self-nominate by sending `!contribute` in any Discord channel, accompanied by a link or description of your contribution. You may also gain this role if you are active and helpful on Discord.
+You may self-nominate by sending the message `!contribute` in any Discord channel. If you do this, please share a second message with a link or description of your contribution so that people can recognize you for the contribution,
+
+You may also be granted this role automatically if you are active and helpful on Discord.
 
 ### Level 2 (L2) - Maintainer
 
-The **Maintainer** role is available to any contributor who wants to join the team and take part in the long-term maintenance of Astro.
+The **Maintainer** role is available to contributors who want to join the team and take part in the long-term maintenance and growth of Astro.
 
 The Maintainer role is critical to the long-term health of Astro. Maintainers act as the first line of defense when it comes to new issues, pull requests and Discord activity. Maintainers are most likely the first people that a user will interact with on Discord or GitHub.
 
@@ -65,8 +69,8 @@ The Maintainer role is critical to the long-term health of Astro. Maintainers ac
 
 There is no strict minimum number of contributions needed to reach this level, as long as you can show **sustained** involvement over some amount of time (at least a couple of weeks).
 
-- **GitHub:** Submitting non-trivial pull requests and RFCs
-- **GitHub:** Reviewing non-trivial pull requests and RFCs
+- **GitHub:** Submitting multiple non-trivial pull requests and RFCs
+- **GitHub:** Reviewing multiple non-trivial pull requests and RFCs
 - **Discord:** Supporting users in Discord, especially in the #support channel
 - **Discord:** Active participation in RFC calls and other events
 - **GitHub + Discord:** Triaging and confirming user issues
@@ -76,12 +80,12 @@ There is no strict minimum number of contributions needed to reach this level, a
 
 - All privileges of the [Contributor role](#level-1---contributor), plus...
 - Invitation to the `@maintainer` role on [Discord](https://astro.build/chat)
+- Invitation to the private `#maintainers` channel on Discord.
 - Invitation to the `@maintainers` team on GitHub.
 - New name color on Discord: **blue**.
-- Invitation to the private #maintainers channel on Discord.
 - Ability to moderate Discord to remove spam, harmful speech, etc.
 - Ability to join the `@mods` role on Discord (optional, opt-in).
-- Ability to push branches to the repo (No more personal fork needed).
+- Ability to push branches directly to the `astro` GitHub repo (No more personal fork needed).
 - Ability to review GitHub PRs.
 - Ability to merge _some_ GitHub PRs.
 - Ability to vote on _some_ initiatives (see [Voting](#voting) below).
@@ -98,61 +102,45 @@ There is no strict minimum number of contributions needed to reach this level, a
 
 #### Nomination
 
-To be nominated, a nominee is expected to already be performing some of the responsibilities of a Maintainer over the course of at least a couple of weeks.
-
-In some rare cases, this role may be revoked by a project Steward. However, under normal circumstances this role is granted for as long as the contributor wishes to engage with the project.
-
-#### Nomination Process
-
-- You can be nominated by any existing Maintainer (L2 or above).
-- Once nominated, there will be a vote by existing Maintainers (L2 and above).
+- To be nominated, a nominee is expected to already be performing some of the responsibilities of a Maintainer.
+- You can be nominated by any existing Maintainer (L2 or above). 
+- Once nominated, there will be a vote by existing Maintainers. 
 - See [vote rules & requirements](#voting) for info on how the vote works.
 
-### Level 3 (L3) - Core Maintainer
 
-**Core Maintainers** are community members who have contributed a significant amount of time and energy to the project through issues, bug fixes, implementing enhancements/features, and engagement with the community. A Core Maintainer is considered a trusted leader within the community.
+### Level 3 (L3) - Core
 
-A Core Maintainer has significant sway in software design decisions. For this reason, coding experience is critical for this role. Core Maintainer is the only level of contributor that does require a significant contribution history on GitHub.
+The **Core** role is available to community members who have a larger-than-usual impact on the Astro project and community. They are seen as leaders in the project and are listened to by the wider Astro community, often before they have even reached this level. A Core member is recognized for contributing a significant amount of time and energy to the project through issues, pull requests, bug fixes, implementing advanced enhancements/features, and/oractivly posting on Discord. 
 
-Core maintainers are watchdogs over the code, ensuring code quality, correctness and security. A Core Maintainer helps to set the direction of the project and ensure a healthy future for Astro.
+Not every contributor will reach this level, and that's okay! L2 Maintainers still have significant responsibility and privileges in our community.
 
-Some contributors will not reach this level, and that's okay! L2 Maintainers still have significant responsibility and privileges in our community.
 
 #### Privileges
 
 - All privileges of the [Maintainer role](#level-2---maintainer), plus...
 - `@core` role on [Discord](https://astro.build/chat)
 - New name color on Discord: **yellow**.
-- Invitation to the private #core channel on Discord.
+- Invitation to the private `#core` channel on Discord.
 - Invitation to the `core` team on GitHub.
-- Ability to merge all GitHub PRs.
-- Ability to vote on all initiatives (see [Voting](#voting) below).
+- Ability to vote on most initiatives (see [Voting](#voting) below).
 
 #### Responsibilities
 
 - All of the responsibilities of L2, including...
-- Ownership over specific parts of the project.
-- Maintaining and improving overall architecture.
-- Tracking and ensuring progress of open pull requests.
-- Reviewing and merging larger, non-trivial PRs.
+- Ownership over specific part(s) of the project.
+- Ownership over the long-term health and success of Astro.
+- Leadership as a role-model to other maintainers and community members.
 
 #### Nomination
 
-To be nominated, a nominee is expected to already be performing some of the responsibilities of a Core Maintainer. This could include showing expertise over some larger section of the codebase, championing RFCs through ideation and implementation, reviewing non-trivial PRs and providing critical feedback, or some combination of those responsibilities listed above.
-
-If a Core Maintainer steps away from the project for a significant amount of time, they may be removed as a Core Maintainer (L3 -> L2) until they choose to return.
-
-In some rare cases, this role may be revoked by a project Steward. However, under normal circumstances this role is granted for as long as the contributor wishes to engage with the project.
-
-#### Nomination Process
-
-- You can be nominated by any existing Core Maintainer (L3 or above).
-- Once nominated, there will be a vote by existing Core Maintainers (L3 and above).
+- To be nominated, a nominee is expected to already be performing some of the responsibilities of a Core member.
+- You can be nominated by any existing Core member (L3 or above). 
+- Once nominated, there will be a vote by existing Core members. 
 - See [vote rules & requirements](#voting) for info on how the vote works.
 
-### Steward
+### Level 4 - Project Steward
 
-Steward is an additional privilege bestowed to 1 (or more) Core Maintainers. The role of Steward is mainly an administrative one. Stewards control and maintain sensitive project assets, and act as tiebreakers in the event of disagreements.
+The **Steward** is an additional role bestowed to 1 (or more) Core member of the project. The role of Steward is mainly an administrative one. Stewards control and maintain sensitive project assets, assist in resolving conflicts, and act as tiebreakers in the event of disagreements.
 
 In extremely rare cases, a Steward can act unilaterally when they believe it is in the project's best interest and can prove that the issue cannot be resolved through normal governance procedure. The steward must publicly state their reason for unilateral action before taking it.
 
@@ -175,39 +163,112 @@ The project Steward is currently: **@FredKSchott**
 #### Nomination
 
 - Stewards cannot be self-nominated.
-- Only Core Maintainers are eligible.
-- New stewards will be added based on a unanimous vote by the existing Steward(s).
+- Only Core members are eligible.
+- New Stewards will be added based on a unanimous vote by the existing Steward(s).
 - In the event that someone is unreachable then the decision will be deferred.
 
 ## Other Roles
 
+### Project Teams
+
+Besides our contributor levels described above, there are additional roles and teams available that community members are welcome to join. Roles are a great way to organize around different projects and initiatives in our community. For example:
+
+- `@team-docs` runs the `#docs` channel and organizes the growth and development of Astro documentation.
+- `@i18n-gang` runs the `#docs-i18n` channel and organizes translations in several languages.
+- `@support-squad` runs the `#support-threads` channel and helps anyone who needs help using Astro.
+
+Many of these team roles can be be browsed and joined automatically by visiting the `#manage-roles` channel in our Discord. Getting involved with a team is a great way to start contributing to Astro!
+
+### Moderator
+
+**Moderator** is a special role available to Maintainers (L2 and above). While all maintainers are granted permissions to moderate for bad behavior across our community, a Moderator actively takes on this the responsibility. For example, a community member may ping moderators (via the `@mods` role) to resolve spam posts or Code of Conduct violations.
+
+Trivial tasks (like removing spam) can be acted on unilaterally by a Moderator. Other non-trivial tasks (like assisting with or resolving a Code of Conduct violation) should involve the entire Moderator team (and in some cases, the project Steward).
+
+#### Privileges
+
+- `@mods` role on [Discord](https://astro.build/chat)
+- Invitation to the private `#moderators` channel on Discord
+- Invitation to the `staff` team on GitHub.
+
+#### Nomination
+
+Any Maintainer (L2 and above) can self-nominate by messaging the project Steward (`@steward`) on Discord.
+
+### Technical Steering Committee (TSC)
+
+The **TSC** is a special role available to Core members (L3 and above). TSC members are responsible for the growth and maintenance of the Astro codebase. 
+
+TSC members are watchdogs over the codebase who ensure code quality, correctness and security. A TSC member guides the direction of the project and ensures a healthy future for the Astro codebase. TSC members are ultimately responsible for technical decision making when it comes to any changes to the Astro codebase.
+
+A TSC member has significant sway in software design decisions. For this reason, coding experience is critical for this role. TSC membership is one of the only roles that requires a significant contribution history of code to the Astro project on GitHub.
+
+#### Privileges
+
+- `@tsc` role on [Discord](https://astro.build/chat)
+- Invitation to the private `#tsc` channel on Discord
+- Invitation to the `tsc` team on GitHub.
+- Ability to merge all GitHub PRs.
+- Ability to vote on RFCs and technical initiatives (see [Voting](#voting) below).
+
+#### Responsibilities 
+
+- Participating in RFC discussions and technical meetings.
+- Assisting with design and implementation of non-trivial GitHub PRs.
+- Reviewing and merging larger, non-trivial PRs.
+- Maintaining and improving overall codebase architecture.
+- Tracking and ensuring progress of open pull requests.
+- Mentoring and guiding other community contributors.
+
+#### Nomination
+
+- To be nominated, a nominee is expected to already be active in technical discussions and performing some of the responsibilities of a TSC member.
+- You can be nominated by any existing Core member (L3 or above). Note: This includes all existing TSC members as well.
+- Once nominated, there will be a vote by existing Core members.
+- See [vote rules & requirements](#voting) for info on how this vote works.
+
+
 ### Staff
 
-Staff is a special designation for employees of [The Astro Technology Company](https://astro.build/company) that lives outside of our Governance model. The staff role was designed to help those of us working full-time on Astro to work productively without "skipping the line" and circumventing our governance model entirely.
+**Staff** is a special designation for employees of [The Astro Technology Company](https://astro.build/company) that lives outside of our Governance model. The staff role was designed to help those of us working full-time on Astro to work productively without "skipping the line" and circumventing our governance model entirely.
 
 The staff role was designed to offer instant **visibility** and **trust**, but not instant **authority.**
 
 #### Privileges
 
-All privileges of the [Core Maintainer role](#level-3---core-mainainer), except...
+- `@staff` role on [Discord](https://astro.build/chat)
+- New name color on Discord: **yellow**.
+- Invitation to some private channels on Discord, at the discretion of the project Steward.
+- Invitation to the `staff` team on GitHub.
 
-- Instead of gaining Discord contributor roles (`@contributor`, `@maintainer`, `@core`) you will receive a special `@staff` role in Discord and GitHub that grants equivalent visibility and permissions as `@core`.
-- No voting abilities for the first 3 months of staff membership. Then, the role grants equivalent voting permissions as `@core` (see [Voting](#voting) below).
-- Not eligible for additional contributor levels while acting as `@staff`. You can retain all current contributor levels and can request a new nomination upon leaving `@staff` (See [Leaving Staff](#leaving-staff) below). This rule is designed to prevent a team of contributors/maintainers that is overwhelmingly ex-staff members.
-
-#### Responsibilities
-
-Responsibilities will vary. Most often, a staff member will regularly meet the responsibilites of either the [Maintainer (L2)](#level-2---maintainer) or [Core Maintainer (L3)](#level-3---core-mainainer) role.
+Staff membership does not grant any additional abilities when it comes to voting and project governance. However, a Staff member is still eligible for other roles in the community and may still still vote as defined by their other roles. For example, a Staff member who is also a part of `@core` will be able to vote as any other `@core` member would.
 
 #### Nomination
 
-There is no nomination process for this role. The project steward is responsible for granting and revoking the `@staff` role.
+There is no nomination process for this role. The project steward is responsible for granting and revoking the `@staff` role. This usually coincides with someone joining or departing from [The Astro Technology Company](https://astro.build/blog/the-astro-technology-company/).
 
-#### Leaving Staff
+### Alumni
 
-When someone leaves the Astro Technology Company, they lose staff privileges and return to their original membership level in our governance structure (whatever level they were at before joining staff).
+**Alumni** is a special designation for Maintainers (L2 and above) who have stepped away from the project and no longer contribute regularly. See [Retiring a Role](#retiring-a-role-alumni) below for more information.
 
-If that person wishes to continue working on Astro after leaving, they may request a nomination to become an official L2 or L3 contributor. This nomination would follow the normal voting rules & procedure for that role (see [Voting](#voting) below).
+#### Privileges
+
+- `@alumni` role on [Discord](https://astro.build/chat)
+- New name color on Discord: **light blue**.
+- Invitation to the private `#alumni` channel on Discord.
+
+
+## Retiring a Role (Alumni)
+
+Contributor roles are granted for as long as the person wishes to engage with the project. However, over time an active community member may choose to step away from the Astro project to work on other things. This is a natural and well-understood part of any open source community, and we celebrate it! 
+
+**Alumni** is a special designation and role for any person who was once an active maintainer (L2 or above) but is now no longer actively involved. By retiring and joining Alumni you trade-in your current set of roles, privileges, and responsibilities for a new, special Alumni role (which comes with its own set of Privileges, as described above).
+
+As a Maintainer (L2 or above) you can retire your role at any time by pinging the project Steward and requesting Alumni status. You can initiate this action yourself if you know ahead-of-time that you need to step away from the project. Or, if you have gone several months without interacting with the Astro community, the project Steward may actively reach out to you to discuss retiring as a way to make room for new contributors.
+
+As an Alumni member, you are still a part of the Astro community and can continue to be a part of our Discord, GitHub, and anywhere else. You may also request to have your old roles reinstated at any time through the normal nomination & voting process for that role.
+
+Rejoining the project as a contributor (L1 or above) will automatically remove you from the Alumni role.
 
 # Governance Playbook
 
@@ -231,14 +292,14 @@ This process kicks off once a valid nomination has been made. See ["Maintainer -
 **Who can vote:** All Maintainers (L2 and above).
 
 1. A vote thread should be created in Discord #maintainers channel (the private channel for all maintainers).
-2. A vote thread can be created by any maintainer, core maintainer, or the Steward.
+2. A vote thread can be created by any Maintainer, Core member, or the Steward.
 3. Once a vote thread is created, existing Maintainers can discuss the nomination in private.
 4. The normal 3 day voting & discussion window begins with the thread creation.
 5. Voting can be done in the thread (visible to other voters) or in a private DM to the project Steward.
 6. Once the vote is complete, the thread is deleted.
 7. The vote must receive an overwhelming majority (70%+) to pass.
 8. **If the vote passes:** the nominee will be made a Maintainer and all privileges will be made available to them.
-9. **If the vote fails:** the project Steward is responsible for informing the nominee with constructive, actionable feedback. (Note: this is not required if the nomination was made in the #core channel, or if the nominee was otherwise not made aware of their nomination).
+9. **If the vote fails:** the project Steward is responsible for informing the nominee with constructive, actionable feedback. (Note: this is not required if the nomination was made in the `#core` channel, or if the nominee was otherwise not made aware of their nomination).
 
 #### Draft message to send to accepted maintainer, informing them of the decision:
 
@@ -263,20 +324,20 @@ ${MY_NAME}
 *PS: As a reminder, our Governance document describes the following privileges and responsibilities for the  **L2 - Maintainer** role: https://github.com/withastro/astro/blob/main/GOVERNANCE.md*
 ```
 
-## Voting: Core Maintainer (L3) Nomination
+## Voting: Core Member (L3) Nomination
 
-This process kicks off once a valid nomination has been made. See ["Core Maintainer - Nomination Process"](#nomination-process) above for more details on nomination.
+This process kicks off once a valid nomination has been made. See ["Core Member - Nomination Process"](#nomination-process) above for more details on nomination.
 
-**Who can vote:** All Core Maintainers (L3 and above).
+**Who can vote:** All Core members (L3 and above).
 
-1. A vote thread should be created in Discord #core channel (the private channel for core maintainers).
-2. A vote thread can be created by any core maintainer, or the Steward.
-3. Once a vote thread is created, existing Core Maintainers can discuss the nomination in private.
+1. A vote thread should be created in Discord `#core` channel (the private channel for Core members).
+2. A vote thread can be created by any Core member, or the Steward.
+3. Once a vote thread is created, existing Core members can discuss the nomination in private.
 4. The normal 3 day voting & discussion window begins with the thread creation.
 5. Voting can be done in the thread (visible to other voters) or in a private DM to the project Steward.
 6. Once the vote is complete, the thread is deleted.
 7. The vote must receive an overwhelming majority (70%+) to pass.
-8. **If the vote passes:** the nominee will be made a Core Maintainer and all privileges will be made available to them.
+8. **If the vote passes:** the nominee will be made a Core Member and all privileges will be made available to them.
 9. **If the vote fails:** the project Steward is responsible for informing the nominee with constructive, actionable feedback. (Note: this is not required if the nomination was made in the #core channel, or if the nominee was otherwise not made aware of their nomination).
 
 #### Draft message to send to accepted maintainer, informing them of the decision:
@@ -284,11 +345,11 @@ This process kicks off once a valid nomination has been made. See ["Core Maintai
 ```
 Hey $NAME!
 
-I have some exciting news—you’ve been nominated and accepted as a core maintainer of Astro! The core maintainer group held a vote and overwhelmingly agree that you would be a great addition to the team. Congratulations! Thanks for all of your significant contributions to Astro to date and your continued dedication to this project and our community. We would be thrilled to have your help ensuring a healthy future for Astro!
+I have some exciting news—you’ve been nominated and accepted as a member of the Astro Core team! The Core team held a vote and overwhelmingly agree that you would be a great addition to the team. Congratulations! Thanks for all of your significant contributions to Astro to date and your continued dedication to this project and our community. We would be thrilled to have your help ensuring a healthy future for Astro!
 
 Please let me know if you’re interested in accepting this invitation. If so, we’ll start getting your roles and permissions up to date.
 
-As a reminder, our Governance document describes the following privileges and responsibilities for a **Core Maintainer**:
+As a reminder, our Governance document describes the following privileges and responsibilities for a **Core Member**:
 
 #### Privileges
 
@@ -301,11 +362,11 @@ $COPY_AND_PASTE_FROM_ABOVE
 
 ## Voting: Governance Change
 
-A vote is initiated once a pull request to the GOVERNANCE.md file is submitted by a Core Maintainer.
+A vote is initiated once a pull request to the GOVERNANCE.md file is submitted by a Core Member.
 
-If the pull request submitter is not a Core Maintainer, the PR can be closed by any Maintainer without a vote. However, any Core Maintainer may request a vote on that PR, in which case a vote is initiated.
+If the pull request submitter is not a Core Member, the PR can be closed by any Maintainer without a vote. However, any Core Member may request a vote on that PR, in which case a vote is initiated.
 
-**Who can vote:** Core Maintainers (L3 and above). All Maintainers are encouraged to discuss and voice their opinion in the pull request discussion. Core Maintainers should take the opinions of others into consideration when voting.
+**Who can vote:** Core members (L3 and above). All Maintainers are encouraged to discuss and voice their opinion in the pull request discussion. Core members should take the opinions of Maintainers into consideration when voting.
 
 1. The pull request discussion thread is used to discuss the governance change.
 2. The normal 3 day voting & discussion window begins with either the PR creation or the removal of `WIP:` from the PR title if the PR was created as a draft.
@@ -318,17 +379,17 @@ If the pull request submitter is not a Core Maintainer, the PR can be closed by 
 
 Astro features are discussed using a model called [Consensus-seeking decision-making](https://en.wikipedia.org/wiki/Consensus-seeking_decision-making). This model attempts to achieve consensus on all significant changes to Astro, but has a fallback voting procedure in place if consensus appears unattainable.
 
-**Who can vote:** All Maintainers (L2 and above).
+**Who can vote:** All [TSC](#technical-steering-committee-tsc) members.
 
 1. Anyone can submit an RFC to suggest changes to Astro.
-2. A trivial change can be discussed and approved entirely within the RFC GitHub issue, as long as there are no objections from Maintainers or Core Maintainers. This is not considered a formal vote.
-3. A non-trivial, significant change should be discussed within the RFC GitHub issue and approved during an RFC meeting call.
-4. During an RFC meeting, the moderator will attempt to achieve consensus on the RFC proposal.
+2. A trivial change can be discussed and approved entirely within the RFC GitHub issue, as long as there are no objections from Core or TSC members. This is not considered a formal vote.
+3. A non-trivial, significant change should be discussed within the RFC and approved during an RFC meeting call. In some cases, an RFC may be approved outside of an RFC meeting using Pull Request reviews as a proxy for votes.
+4. During an RFC meeting, the person leading the call will attempt to achieve consensus on the RFC proposal.
 5. **If consensus is reached:** the RFC is approved.
-6. **If consensus is not reached:** Maintainers must make all reasonable attempts to resolve issues and reach consensus in GitHub or a follow-up RFC meeting. The process of reaching consensus can take time, and should not be rushed as long as all participants are making a reasonable effort to respond.
-7. **If consensus still cannot be reached:** The project Steward may initiate the first fallback mechanism by limiting the vote to Core Maintainers.
-8. **If consensus still cannot be reached:** The project Steward may initiate a final fallback vote of Core Maintainers, of which an overwhelming majority (80%+) is required to pass.
-9. **If consensus still cannot be reached:** The RFC is closed without approval.
+6. **If consensus is not reached:** The RFC author and TSC members must make all reasonable attempts to resolve issues and reach consensus in GitHub or a follow-up RFC meeting. The process of reaching consensus can take time, and should not be rushed as long as all participants are making a reasonable effort to respond.
+7. **If consensus still cannot be reached:** The project Steward may invoke [rough consensus](https://en.wikipedia.org/wiki/Rough_consensus) to resolve an RFC that has not achieved absolute consensus, as described below (borrowed from the [IETF](https://datatracker.ietf.org/doc/html/rfc2418)):
+
+> Working groups make decisions through a "rough consensus" process. Astro consensus does not require that all participants agree although this is, of course, preferred. In general, the dominant view of the TSC shall prevail. (However, "dominance" is not to be determined on the basis of volume or persistence, but rather a more general sense of agreement). Consensus can be determined by a show of hands, humming, or any other means on which the TSC agrees (by rough consensus, of course). Note that 51% of the TSC does not qualify as "rough consensus" and 99% is better than rough. It is up to the project Steward to determine if rough consensus has been reached.
 
 ## Moderation
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -110,7 +110,7 @@ There is no strict minimum number of contributions needed to reach this level, a
 
 ### Level 3 (L3) - Core
 
-The **Core** role is available to community members who have a larger-than-usual impact on the Astro project and community. They are seen as leaders in the project and are listened to by the wider Astro community, often before they have even reached this level. A Core member is recognized for contributing a significant amount of time and energy to the project through issues, pull requests, bug fixes, implementing advanced enhancements/features, and/oractivly posting on Discord. 
+The **Core** role is available to community members who have a larger-than-usual impact on the Astro project and community. They are seen as leaders in the project and are listened to by the wider Astro community, often before they have even reached this level. A Core member is recognized for contributing a significant amount of time and energy to the project through issues, pull requests, bug fixes, implementing advanced enhancements/features, and/or actively posting on Discord. 
 
 Not every contributor will reach this level, and that's okay! L2 Maintainers still have significant responsibility and privileges in our community.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,79 +1,52 @@
 # Governance
 
-Herein contains Astro's goverance model. It outlines and describes in detail each role and their subsequent responsibilties. This includes; 
-
-- Nomination Process
-- Duty of Care
-- Code Review Process
-- Code of Conduct Enforcement
-  
 This document outlines the governance model for Astro. This includes detailed descriptions of different roles, nomination processes, code review processes, and Code of Conduct enforcement.
 
-> 🚨 **All community members must follow the [Code of Conduct (CoC)](CODE_OF_CONDUCT.md).**  
+👉 **All community members must follow the [Code of Conduct (CoC)](CODE_OF_CONDUCT.md).**  
 Consequences for CoC violations are detailed in [Moderation](#moderation).
 
-> 👉 **Want to trigger a vote, nomination, or perform some other action?**  
+👉 **Want to trigger a vote, nomination, or perform some other action?**  
 Scroll down to [Playbook](#governance-playbook).
 
 ## Get Involved
 
-**Any contribution that helps support or further the Astro project and its wider community is always welcome and greatly appreciated.**
- 
+**Anything that supports the Astro community is a valuable contribution!** 
 
-All types of contribution are meaningful, from code to documentation, even blog posts. 
+All types of contribution are meaningful. This can include code changes, type fixes, Discord activity, and even posting about Astro to your personal blog. No contribution is too small!
 
-**Anyone** can become an Astro Contributor (yes, even you!). Regardless of skill, experience or background.
-
-Our goal is to always recognize all of our contributors and their effort given to Astro. 
-
-> 🚀 Remember no contribution is too small or too little. 
-
-We will always recognise and value all our contributors and their effort that they bring to the Astro project. 
-
-Most importantly we are eternally grateful for the vast and diverse impact that they bring to our community.
+Anyone can become an Astro contributor (yes, even you!). Engineering ability is not required. Our goal is to recognize all contributors to the project regardless of skill, experience or background. 
 
 ## Contributor Levels
 
-We recognize different degrees of contributions made to the Astro project as **Contributor Levels** also referred to as **Contributor Roles**. 
+We recognize different levels of contribution as four different **Contributor Levels.** Because each level comes with a new set of privileges and responsibilities, you may also see these levels referred to as **Contributor Roles**. 
 
-Contributor levels are available to **all members** within the Astro Community, regardless of coding skill or experience. 
+Contributor levels are available to **all members** of the Astro community, regardless of coding skill or experience. 
 
-The two off the most important things that we look from our contributors is:
+Two important things that we look for in a contributor are:
 
 - **Being here** - Everyone's time is valuable, and the fact that you're here and contributing to Astro is amazing! Thank you for being a part of this project with us.
-  
-- **Being a positive member of our community**  
-  Strive to go above and beyond our [Code of Conduct](CODE_OF_CONDUCT.md) and commit to a healthy, honest discourse when communicating: 
-  - Within our Github Project and its wider umbrella groups and projects.
-    - Pull Requests, 
-    - Issues 
-    - Discussions,
-    - RFC process, 
-  - Discord conversations, 
-  - Any public and outward interactions conducted outside of our community (ex: no Twitter bullies allowed 🤼‍♂️)
+- **Being a positive member of our community** - Go above and beyond our [Code of Conduct](CODE_OF_CONDUCT.md) and commit to healthy communication across pull requests, issue discussions, Discord conversations, and any interactions outside of our community (ex: no Twitter bullies allowed :)
 
 All Contributor roles are granted for as long as the individual wishes to engage with the project. 
 
-Contributors can voluntarily leave the project at any time (see [Retiring a Role](#retiring-a-role-alumni) below). 
+Contributors can voluntarily leave the project at any time. See [Retiring a Role](#retiring-a-role-alumni) below for more information.
+ 
+In extreme cases -- such as a Code of Conduct violation -- a role may be revoked by a project Steward at their discretion.
 
-In extreme cases such as a *Code of Conduct violation* this role may be revoked by a project Steward at their discretion.
-
-Each new Contributor level unlocks new privileges and responsibilities both on Discord and on GitHub. Below is a summary of each contributor level:
+Each new Contributor level unlocks new privileges and responsibilities both on Discord and on GitHub. Below is a summary of each level.
 
 ### Level 1 - Contributor
 
-> **Done something (big or small) to contribute to the health, success, or growth of Astro?** 
-
-Congratulations, you're officially recognized as a contributor to the project!
+Have you done something (big or small) to contribute to the health, success, or growth of Astro? **Congratulations, you're officially recognized as a contributor to the project!**
 
 #### Examples of recognized contributions
 
-- **GitHub:** Submitting a merged pull request
-- **GitHub:** Filing a detailed bug report or RFC
-- **GitHub:** Updating documentation!
+- **GitHub:** Submitting a merged pull request.
+- **GitHub:** Filing a detailed bug report or RFC.
+- **GitHub:** Updating documentation or fixing a typo.
 - Helping people on GitHub, Discord, etc.
 - Answering questions on Stack Overflow, Twitter, etc.
-- Blogging, Vlogging, Podcasting, and Livestreaming about Astro
+- Blogging, Vlogging, Podcasting, and Livestreaming about Astro.
 - This list is incomplete! Similar contributions are also recognized.
 
 #### Privileges
@@ -82,12 +55,11 @@ Congratulations, you're officially recognized as a contributor to the project!
 - New name color on Discord: **light blue**.
 - Invitations to contributor-only events, sticker drops, and the occasional swag drop.
 
-
 #### Responsibilities
 
-This role does not require any extra responsibilities nor time commitment. We hope you stick around and keep participating!
+This role does not require any extra responsibilities nor time commitment. We hope you stick around and keep participating in our community!
 
-If you're interested in reaching the next level and becoming a **Maintainer**, you can begin to explore some of those responsibilities in the [next section](#level-2-l2---maintainer).
+If you're interested in reaching the next level and becoming a **Maintainer**, you can explore some of those responsibilities in the [next section](#level-2-l2---maintainer).
 
 #### Nomination Process
 
@@ -101,15 +73,9 @@ The **Maintainer** role is available to contributors who want to join the team a
 
 The Maintainer role is critical to the long-term health of Astro. Maintainers act as the first line of defense when it comes to new issues, pull requests and Discord activity. Maintainers are most likely the first people that a user will interact with on Discord or GitHub.
 
-**A Maintainer is not required to write code!** 
+**Maintainers are not required to write code!** Some Maintainers spend most of their time inside of Discord, maintaining a healthy community there. Others work on technical documentation, support, or design.
 
-Some Maintainers spend most of their time inside of Discord, maintaining the health of our strong and vibriant community.
-
-**A Maintainer has moderation privileges!** 
-
-All maintainers are trusted with the ability to help moderate our Discord and GitHub communities for things like spam. 
-
-There is also a special (optional, opt-in) `@mods` role open to maintainers who are also interested in helping out when a community member reaches out for moderation help.
+**A Maintainer has moderation privileges!** All maintainers are trusted with the ability to help moderate our Discord and GitHub communities for things like spam. There is also a special (optional, opt-in) `@mods` role open to maintainers who are also interested in helping out when a community member reaches out for moderation help.
 
 #### Recognized Contributions
 
@@ -127,12 +93,12 @@ There is no strict minimum number of contributions needed to reach this level, a
 - All privileges of the [Contributor role](#level-1---contributor), plus...
 - Invitation to the `@maintainer` role on [Discord](https://astro.build/chat)
 - Invitation to the private `#maintainers` channel on Discord.
-- Invitation to the `withastro` organisation on GitHub.
+- Invitation to the `withastro` organization on GitHub.
 - Invitation to the `@maintainers` team on GitHub.
 - New name color on Discord: **blue**.
 - Ability to moderate Discord to remove spam, harmful speech, etc.
 - Ability to join the `@mods` role on Discord (optional, opt-in).
-- Ability to push branches directly to the `withastro` GitHub organisation (No more personal fork needed).
+- Ability to push branches directly to the `withastro` GitHub organization (personal forks no longer needed).
 - Ability to review GitHub PRs.
 - Ability to merge _some_ GitHub PRs.
 - Ability to vote on _some_ initiatives (see [Voting](#voting) below).
@@ -149,19 +115,15 @@ There is no strict minimum number of contributions needed to reach this level, a
 
 #### Nomination
 
-- To be nominated, a nominee is expected to already be performing some of the duties and responsibilities of a Maintainer.
-- You can only be nominated by any existing Maintainer (L2 or above). 
+- To be nominated, a nominee is expected to already be performing some of the responsibilities of a Maintainer.
+- You can be nominated by any existing Maintainer (L2 or above). 
 - Once nominated, there will be a vote by existing Maintainers. 
 - See [vote rules & requirements](#voting) for info on how the vote works.
 
 
 ### Level 3 (L3) - Core
 
-The **Core** role is available to community members who have a larger-than-usual impact on the Astro project and community. 
-
-They are seen as leaders in the project and are listened to by the wider Astro community, often before they have even reached this level. 
-
-A Core member is recognized for contributing a significant amount of their time and energy to the project through issues, pull requests, bug fixes, implementing advanced enhancements/features, and is activly posting on Discord. 
+The **Core** role is available to community members who have a larger-than-usual impact on the Astro project and community. They are seen as leaders in the project and are listened to by the wider Astro community, often before they have even reached this level. A Core member is recognized for contributing a significant amount of time and energy to the project through issues, pull requests, bug fixes, implementing advanced enhancements/features, and/or actively posting on Discord. 
 
 Not every contributor will reach this level, and that's okay! L2 Maintainers still have significant responsibility and privileges within our community.
 
@@ -207,15 +169,12 @@ If a Core Residency member has their membership revoked, the project Steward may
 
 ### Level 4 - Project Steward
 
-The **Steward** is an additional role bestowed to one (or more) Core members of the project. 
+The **Steward** is an additional role bestowed to 1 (or more) Core member of the project. 
 
-The role of Steward is mainly an administrative one. 
+The role of Steward is mainly an administrative one. Stewards control and maintain sensitive project assets, assist in resolving conflicts, and act as tiebreakers in the event of disagreements.
 
-Stewards control and maintain sensitive project assets, assist in resolving conflicts, and act as tiebreakers in the event of disagreements.
 
-In extremely rare cases, a Steward can act unilaterally when they believe it is in the project's best interest and can prove that the issue cannot be resolved through Astro's normal governance process. 
-
-The steward must publicly state their reason for unilateral action before taking it.
+In extremely rare cases, a Steward can act unilaterally when they believe it is in the project's best interest and can prove that the issue cannot be resolved through normal governance procedure. The steward must publicly state their reason for unilateral action before taking it.
 
 The project Steward is currently: **@FredKSchott**
 
@@ -250,9 +209,7 @@ Besides our contributor levels described above, there are additional roles and t
 - `@i18n-gang` runs the `#docs-i18n` channel and organizes translations in several languages.
 - `@support-squad` runs the `#support-threads` channel and helps anyone who needs help using Astro.
 
-Many of these team roles can be be browsed and joined automatically by visiting the `#manage-roles` channel from within our Discord. 
-
-Getting involved with a team is a great way to start contributing to Astro!
+Many of these team roles can be be browsed and joined automatically by visiting the `#manage-roles` channel in our Discord. Getting involved with a team is a great way to start contributing to Astro!
 
 ### Moderator
 
@@ -331,9 +288,7 @@ Staff membership does not grant any additional abilities when it comes to voting
 
 ## Retiring a Role (Alumni)
 
-Contributor roles are granted for as long as the person wishes to engage with the project. However, over time an active community member may choose to step away from the Astro project to work on other things. 
-
-This is a natural and well-understood part of any open source community, and we celebrate it! 
+Contributor roles are granted for as long as the person wishes to engage with the project. However, over time an active community member may choose to step away from the Astro project to work on other things. Moving on from a project is a natural and well-understood part of any open source community, and we celebrate it!
 
 **Alumni** is a special designation and role for any person who was once an active maintainer (L2 or above) but is now no longer actively involved. By retiring and joining Alumni you trade-in your current set of roles, privileges, and responsibilities for a new, special Alumni role (which comes with its own set of Privileges, as described above).
 
@@ -418,15 +373,7 @@ This process kicks off once a valid nomination has been made. See ["Core Member 
 ```
 Hey $NAME!
 
-I have some exciting news!
-
-You’ve been nominated and accepted as a member of the Astro Core team! The Core team held a vote and overwhelmingly agree that you would be a great addition to the team. 
-
-Congratulations! 
-
-Thanks for all of your significant contributions to Astro to date and your continued dedication to this project and our community. 
-
-We would be thrilled to have your help ensuring a healthy future for Astro!
+I have some exciting news—you’ve been nominated and accepted as a member of the Astro Core team! The Core team held a vote and overwhelmingly agree that you would be a great addition to the team. Congratulations! Thanks for all of your significant contributions to Astro to date and your continued dedication to this project and our community. We would be thrilled to have your help ensuring a healthy future for Astro!
 
 Please let me know if you’re interested in accepting this invitation. If so, we’ll start getting your roles and permissions up to date.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -54,7 +54,7 @@ The two off the most important things that we look from our contributors is:
 
 All Contributor roles are granted for as long as the individual wishes to engage with the project. 
 
-Contributor's can voluntarily leave the project at any time (see [Retiring a Role](#retiring-a-role-alumni) below). 
+Contributors can voluntarily leave the project at any time (see [Retiring a Role](#retiring-a-role-alumni) below). 
 
 In extreme cases such as a *Code of Conduct violation* this role may be revoked by a project Steward at their discretion.
 


### PR DESCRIPTION
## Changes

This PR serves to implement several governance changes that will help our project as it continues to grow into its second year. The biggest changes (and the rationale behind them) are highlighted below:

1. **Remove technical requirement from Core.** This will let us recognize the contributions of more amazing leaders in our community who are not necessarily focused on technical contributions.
2. **Form a new Technical Steering Committee (TSC).** This group will take on the responsibility of technical decision making, RFC approvals, etc. that Core currently performs. Initially, current core members will become the founding TSC members.
3. **Simplify TSC consensus model.** Replace our current multi-stage consensus resolution flow with a simpler "rough consensus" model (made popular by the IETF). This is similar in practice to what we use today, but with more history, documentation and precedent.
4. **Move staff privileges to a new, more limited core membership.** This lets us empower anyone brought in to work on Astro full- or part-time, without letting them "skip the line" of our normal contributor ladder.
5. **Document additional project roles.** This lets us recognize teams like `@team-docs` and `@support-squad` more officially, and provide even more resources to them from a project governance perspective.
6. **Document the alumni role & process.** This will let us guide some absent maintainers into a new `@alumni` role (voluntarily), making room for new maintainers and core members.