### PR TITLE
fix: alias astro to @types/astro

### DIFF
--- a/.changeset/calm-queens-study.md
+++ b/.changeset/calm-queens-study.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Alias imports for astro to @types/astro

--- a/.changeset/calm-queens-study.md
+++ b/.changeset/calm-queens-study.md
@@ -1,5 +1,0 @@
----
-'astro': patch
----
-
-Alias imports for astro to @types/astro

--- a/.changeset/spicy-turkeys-clean.md
+++ b/.changeset/spicy-turkeys-clean.md
@@ -1,0 +1,8 @@
+---
+'astro': patch
+'@astrojs/deno': patch
+'@astrojs/netlify': patch
+---
+
+Alias `from 'astro'` imports to `'@astro/types'`
+Update Deno and Netlify integrations to handle vite.resolves.alias as an array

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -96,11 +96,19 @@ export async function createVite(
 			postcss: astroConfig.style.postcss || {},
 		},
 		resolve: {
-			alias: {
-				// This is needed for Deno compatibility, as the non-browser version
-				// of this module depends on Node `crypto`
-				randombytes: 'randombytes/browser',
-			},
+			alias: [
+				{
+					// This is needed for Deno compatibility, as the non-browser version
+					// of this module depends on Node `crypto`
+					find: 'randombytes',
+					replacement: 'randombytes/browser',
+				},
+				{
+					// Typings are imported from 'astro' (e.g. import { Type } from 'astro')
+					find: /^astro$/,
+					replacement: fileURLToPath(new URL('../@types/astro', import.meta.url)),
+				},
+			],
 		},
 		// Note: SSR API is in beta (https://vitejs.dev/guide/ssr.html)
 		ssr: {

--- a/packages/astro/test/fixtures/type-imports/src/pages/index.astro
+++ b/packages/astro/test/fixtures/type-imports/src/pages/index.astro
@@ -1,0 +1,19 @@
+---
+import type { MarkdownInstance } from 'astro'
+---
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>Astro</title>
+		<style is:global>
+			h1 {
+				color: red;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>Astro</h1>
+		<img src="/puppy.png"/>
+	</body>
+</html>

--- a/packages/astro/test/type-imports.test.js
+++ b/packages/astro/test/type-imports.test.js
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import { loadFixture } from './test-utils.js';
+
+describe('Type Imports', async () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/type-imports' });
+		await fixture.build();
+	});
+
+	it('Allows importing types from "astro"', async () => {
+		// if the build passes then the test succeeds
+		expect(true).to.be.true;
+	});
+});

--- a/packages/integrations/deno/src/index.ts
+++ b/packages/integrations/deno/src/index.ts
@@ -25,8 +25,17 @@ export default function createIntegration(args?: Options): AstroIntegration {
 				if (target === 'server') {
 					vite.resolve = vite.resolve || {};
 					vite.resolve.alias = vite.resolve.alias || {};
-					const alias = vite.resolve.alias as Record<string, string>;
-					alias['react-dom/server'] = 'react-dom/server.browser';
+
+					const aliases = [{ find: 'react-dom/server', replacement: 'react-dom/server.browser' }];
+
+					if (Array.isArray(vite.resolve.alias)) {
+						vite.resolve.alias = [...vite.resolve.alias, ...aliases];
+					} else {
+						for (const alias of aliases) {
+							(vite.resolve.alias as Record<string, string>)[alias.find] = alias.replacement;
+						}
+					}
+
 					vite.ssr = {
 						noExternal: true,
 					};

--- a/packages/integrations/netlify/src/integration-edge-functions.ts
+++ b/packages/integrations/netlify/src/integration-edge-functions.ts
@@ -89,8 +89,17 @@ export function netlifyEdgeFunctions({ dist }: NetlifyEdgeFunctionsOptions = {})
 				if (target === 'server') {
 					vite.resolve = vite.resolve || {};
 					vite.resolve.alias = vite.resolve.alias || {};
-					const alias = vite.resolve.alias as Record<string, string>;
-					alias['react-dom/server'] = 'react-dom/server.browser';
+
+					const aliases = [{ find: 'react-dom/server', replacement: 'react-dom/server.browser' }];
+
+					if (Array.isArray(vite.resolve.alias)) {
+						vite.resolve.alias = [...vite.resolve.alias, ...aliases];
+					} else {
+						for (const alias of aliases) {
+							(vite.resolve.alias as Record<string, string>)[alias.find] = alias.replacement;
+						}
+					}
+
 					vite.ssr = {
 						noExternal: true,
 					};


### PR DESCRIPTION
## Changes
fixes: https://github.com/withastro/compiler/issues/378

Aliases imports for `astro` to `@types/astro` c8816d408c6ab92651556559248a9012cfbe9b4f and updates Netlify and Deno integrations to handle `vite.resolve.alias` as an array b15ca78be4483214be6f17e29559df91f206d759

Only the types live under `astro` but without alias vite resolves import to `packages/astro/astro.js` 

## Testing
- Test added to check build passes when `import type { MarkdownInstance } from 'astro'` is present
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
No docs needed, this is fix for expected behaviour
<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->