### PR TITLE
Fix `<link>` tag not being self-closing

### DIFF
--- a/.changeset/new-knives-raise.md
+++ b/.changeset/new-knives-raise.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix issue where generated `link` tags would have an invalid closing tag

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -715,5 +715,8 @@ function renderElement(
 			children = defineScriptVars(defineVars) + '\n' + children;
 		}
 	}
+	if ((children == null || children == '') && voidElementNames.test(name)) {
+		return `<${name}${internalSpreadAttributes(props, shouldEscape)} />`;
+	}
 	return `<${name}${internalSpreadAttributes(props, shouldEscape)}>${children}</${name}>`;
 }

--- a/packages/astro/test/0-css.test.js
+++ b/packages/astro/test/0-css.test.js
@@ -18,6 +18,7 @@ describe('CSS', function () {
 	// test HTML and CSS contents for accuracy
 	describe('build', () => {
 		let $;
+		let html;
 		let bundledCSS;
 
 		before(async () => {
@@ -25,7 +26,7 @@ describe('CSS', function () {
 			await fixture.build();
 
 			// get bundled CSS (will be hashed, hence DOM query)
-			const html = await fixture.readFile('/index.html');
+			html = await fixture.readFile('/index.html');
 			$ = cheerio.load(html);
 			const bundledCSSHREF = $('link[rel=stylesheet][href^=/assets/]').attr('href');
 			bundledCSS = (await fixture.readFile(bundledCSSHREF.replace(/^\/?/, '/')))
@@ -47,6 +48,10 @@ describe('CSS', function () {
 				// 2. check CSS
 				const expected = `.blue.${scopedClass}{color:#b0e0e6}.color\\\\:blue.${scopedClass}{color:#b0e0e6}.visible.${scopedClass}{display:block}`;
 				expect(bundledCSS).to.include(expected);
+			});
+
+			it('Generated link tags are void elements', async () => {
+				expect(html).to.not.include("</link>");
 			});
 
 			it('No <style> skips scoping', async () => {


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/compiler/issues/392
- Ensures our generated `link` tags are self-closing
- [x] Don't forget a changeset! `pnpm exec changeset`

## Testing

Test added to CSS tests

## Docs

Bug fix only