### PR TITLE
Pass `optimizeDeps.include` to silence build warning

### DIFF
--- a/.changeset/hip-jars-swim.md
+++ b/.changeset/hip-jars-swim.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Silence noisy build warnings about `optimizeDeps.include`

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -152,6 +152,10 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 		logLevel: opts.viteConfig.logLevel ?? 'error',
 		mode: 'production',
 		css: viteConfig.css,
+		optimizeDeps: {
+			include: [...(viteConfig.optimizeDeps?.include ?? [])],
+			exclude: [...(viteConfig.optimizeDeps?.exclude ?? [])]
+		},
 		build: {
 			...viteConfig.build,
 			emptyOutDir: false,
@@ -234,6 +238,10 @@ async function clientBuild(
 		logLevel: 'info',
 		mode: 'production',
 		css: viteConfig.css,
+		optimizeDeps: {
+			include: [...(viteConfig.optimizeDeps?.include ?? [])],
+			exclude: [...(viteConfig.optimizeDeps?.exclude ?? [])]
+		},
 		build: {
 			emptyOutDir: false,
 			minify: 'esbuild',


### PR DESCRIPTION
## Changes

- Silences Vite warning that runs for every build
- Warning states...
  ```
  (!) Could not auto-determine entry point from rollupOptions or html files and there are no explicit optimizeDeps.include patterns. Skipping dependency pre-bundling.
  ```
- Fix was to add an explicit `optimizeDeps.include` (by default `[]`)
- [x] Don't forget a changeset! `pnpm exec changeset`

## Testing

Manually, we don't test build logs right now

## Docs

N/A, QoL improvement only