### PR TITLE
Prevent header plugin from turning code blocks into expressions

### DIFF
--- a/.changeset/tall-cats-hope.md
+++ b/.changeset/tall-cats-hope.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Prevents code blocks containing expression from being evaluated as such

--- a/packages/markdown/remark/src/rehype-collect-headers.ts
+++ b/packages/markdown/remark/src/rehype-collect-headers.ts
@@ -19,9 +19,11 @@ export default function createCollectHeaders() {
 
 				let raw = '';
 				let text = '';
+				let elementTag: string | null = null;
 				let isJSX = false;
 				visit(node, (child) => {
 					if (child.type === 'element') {
+						elementTag = child.tagName;
 						return;
 					}
 					if (child.type === 'raw') {
@@ -34,7 +36,9 @@ export default function createCollectHeaders() {
 					if (child.type === 'text' || child.type === 'raw') {
 						raw += child.value;
 						text += child.value;
-						isJSX = isJSX || child.value.includes('{');
+						if(elementTag !== 'code') {
+							isJSX = isJSX || child.value.includes('{');
+						}
 					}
 				});
 

--- a/packages/markdown/remark/test/expressions.test.js
+++ b/packages/markdown/remark/test/expressions.test.js
@@ -22,6 +22,14 @@ describe('expressions', () => {
 			.to.equal(`<h1 id={$$slug(\`\${frontmatter.title}\`)}>{frontmatter.title}</h1>`);
 	});
 
+	it('should skip expressions inside of backtick blocks', async () => {
+		const { code } = await renderMarkdown(`# \`{frontmatter.title}\` and \`{another}\``, {});
+
+		chai
+			.expect(code)
+			.to.equal(`<h1 id="frontmattertitle-and-another"><code is:raw>{frontmatter.title}</code> and <code is:raw>{another}</code></h1>`);
+	});
+
 	it('should be able to serialize complex expression inside markdown', async () => {
 		const { code } = await renderMarkdown(`# Hello {frontmatter.name}`, {});
 


### PR DESCRIPTION
## Changes

- The markdown plugin which creates ids for headers was causing backtick blocks to be converted to expressions.
- We keep track of what type of element we are in and prevent the expression code from considering it to be within an expression when we are inside of a code block.
- Closes #3491

## Testing

- Test added for this scenario

## Docs

N/A, bug fix.