### PR TITLE
Fix Markdown errors missing source filename

### DIFF
--- a/.changeset/hot-waves-jump.md
+++ b/.changeset/hot-waves-jump.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Fix Markdown errors missing source filename


### PR DESCRIPTION
## Changes

- Adds a proper source filename to Markdown errors that fail the build.
- Reason: Questions where users did not know which Markdown file was causing a build failure were asked multiple times in our Discord support channel in the last few days.
- Old error message example:
  ```
  Expected a closing tag for `<br>` (2:74-2:78) before the end of `paragraph
  ```
- New error message example:
  ```
  Failed to parse Markdown file "D:\Dev\astro-docs\src\pages\en\core-concepts\routing.md":
  Expected a closing tag for `<br>` (2:74-2:78) before the end of `paragraph
  ```
- Works in `build`, `dev`, and SSR modes.

## Testing

- Ran all tests locally.
- Performed multiple builds of the Astro Docs repo, inserting test errors in various MD files.

## Docs

- Not a visible change, just a bugfix.