### PR TITLE
Fix: Allow self-closing tags in Markdown again

### DIFF
--- a/.changeset/late-swans-impress.md
+++ b/.changeset/late-swans-impress.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Fix: Allow self-closing tags in Markdown

--- a/packages/markdown/remark/src/remark-mdxish.ts
+++ b/packages/markdown/remark/src/remark-mdxish.ts
@@ -1,15 +1,50 @@
 import { mdxjs } from 'micromark-extension-mdxjs';
 import { mdxFromMarkdown, mdxToMarkdown } from './mdast-util-mdxish.js';
+import type * as fromMarkdown from 'mdast-util-from-markdown';
+import type { Tag } from 'mdast-util-mdx-jsx';
 
 export default function remarkMdxish(this: any, options = {}) {
 	const data = this.data();
 
 	add('micromarkExtensions', mdxjs(options));
-	add('fromMarkdownExtensions', mdxFromMarkdown());
+	add('fromMarkdownExtensions', makeFromMarkdownLessStrict(mdxFromMarkdown()));
 	add('toMarkdownExtensions', mdxToMarkdown());
 
 	function add(field: string, value: unknown) {
 		const list = data[field] ? data[field] : (data[field] = []);
 		list.push(value);
 	}
+}
+
+function makeFromMarkdownLessStrict(extensions: fromMarkdown.Extension[]) {
+	extensions.forEach(extension => {
+		// Fix exit handlers that are too strict
+		['mdxJsxFlowTag', 'mdxJsxTextTag'].forEach(exitHandler => {
+			if (!extension.exit || !extension.exit[exitHandler])
+				return;
+			extension.exit[exitHandler] = chainHandlers(
+				fixSelfClosing,
+				extension.exit[exitHandler]
+			);
+		});
+	});
+
+	return extensions;
+}
+
+const selfClosingTags = new Set([
+	'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'source',
+	'track', 'wbr'
+]);
+
+function fixSelfClosing(this: fromMarkdown.CompileContext) {
+	const tag = this.getData('mdxJsxTag') as Tag;
+	if (tag.name && selfClosingTags.has(tag.name))
+		tag.selfClosing = true;
+}
+
+function chainHandlers(...handlers: fromMarkdown.Handle[]) {
+	return function handlerChain (this: fromMarkdown.CompileContext, token: fromMarkdown.Token) {
+		handlers.forEach(handler => handler.call(this, token));
+	};
 }

--- a/packages/markdown/remark/test/strictness.test.js
+++ b/packages/markdown/remark/test/strictness.test.js
@@ -1,0 +1,16 @@
+import { renderMarkdown } from '../dist/index.js';
+import chai from 'chai';
+
+describe('strictness', () => {
+	it('should allow self-closing HTML tags (void elements)', async () => {
+		const { code } = await renderMarkdown(
+			`Use self-closing void elements<br>like word<wbr>break and images: <img src="hi.jpg">`,
+			{}
+		);
+
+		chai.expect(code).to.equal(
+			`<p>Use self-closing void elements<br />like word<wbr />break and images: ` +
+			`<img src="hi.jpg" /></p>`
+		);
+	});
+});


### PR DESCRIPTION
## Changes

- After our switch to the MDX-like parsing logic in Beta 33 (PR https://github.com/withastro/astro/pull/3410), Markdown parsing has become a lot more strict. This caused commonly used syntax in Markdown to become invalid.
- This PR fixes one of the most common issues concerning self-closing tags like `<br>`. They are now considered valid again by wrapping the MDX JSX tag parsing logic.
- Fixes #3458.

## Testing

- Added a new test case to `@astrojs/markdown-remark`.
- Ran all tests locally.
- Performed a full build of Astro Docs without issues.

## Docs

- Not a visible change, just a bugfix.