### PR TITLE
Allow importing .ts files with .js extension

### DIFF
--- a/.changeset/hungry-ears-clap.md
+++ b/.changeset/hungry-ears-clap.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow importing .ts files with .js extension

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -216,6 +216,13 @@ export default function astro({ config, logging }: AstroPluginOptions): vite.Plu
 				return {
 					code: `${code}${SUFFIX}`,
 					map,
+					meta: {
+						vite: {
+							// Setting this vite metadata to `ts` causes Vite to resolve .js
+							// extensions to .ts files.
+							lang: 'ts'
+						}
+					}
 				};
 			} catch (err: any) {
 				// Verify frontmatter: a common reason that this plugin fails is that

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -194,6 +194,11 @@ ${tsResult}`;
 				return {
 					code: escapeViteEnvReferences(code),
 					map: null,
+					meta: {
+						vite: {
+							lang: 'ts'
+						}
+					}
 				};
 			}
 

--- a/packages/astro/test/fixtures/import-ts-with-js/src/bar.ts
+++ b/packages/astro/test/fixtures/import-ts-with-js/src/bar.ts
@@ -1,0 +1,3 @@
+export default function() {
+	return 'bar';
+}

--- a/packages/astro/test/fixtures/import-ts-with-js/src/foo.ts
+++ b/packages/astro/test/fixtures/import-ts-with-js/src/foo.ts
@@ -1,0 +1,3 @@
+import bar from './bar.js';
+
+export default bar;

--- a/packages/astro/test/fixtures/import-ts-with-js/src/pages/index.astro
+++ b/packages/astro/test/fixtures/import-ts-with-js/src/pages/index.astro
@@ -1,0 +1,9 @@
+---
+import foo from '../foo.js';
+---
+<html>
+	<head><title></title></head>
+	<body>
+		<h1>{ foo() }</h1>
+	</body>
+</html>

--- a/packages/astro/test/fixtures/import-ts-with-js/src/pages/post.md
+++ b/packages/astro/test/fixtures/import-ts-with-js/src/pages/post.md
@@ -1,0 +1,8 @@
+---
+setup: |
+  import foo from '../foo.js'
+---
+
+# Testing
+
+## { foo() }

--- a/packages/astro/test/import-ts-with-js.test.js
+++ b/packages/astro/test/import-ts-with-js.test.js
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Using .js extension on .ts file', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/import-ts-with-js/' });
+		await fixture.build();
+	});
+
+	it('works', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerio.load(html);
+		expect($('h1').text()).to.equal('bar');
+	});
+});

--- a/packages/astro/test/import-ts-with-js.test.js
+++ b/packages/astro/test/import-ts-with-js.test.js
@@ -11,9 +11,15 @@ describe('Using .js extension on .ts file', () => {
 		await fixture.build();
 	});
 
-	it('works', async () => {
+	it('works in .astro files', async () => {
 		const html = await fixture.readFile('/index.html');
 		const $ = cheerio.load(html);
 		expect($('h1').text()).to.equal('bar');
+	});
+
+	it('works in .md files', async () => {
+		const html = await fixture.readFile('/post/index.html');
+		const $ = cheerio.load(html);
+		expect($('h2').text()).to.equal('bar');
 	});
 });


### PR DESCRIPTION
## Changes

- Allowing doing `import './foo.js'` where a foo.ts file exists.
- Closes #3415
- Implementation is that Vite allows this scenario when a parent is a typescript module. When compiling Astro we can provide metadata to allow this.

## Testing

Test added

## Docs

N/A, bug fix.