### PR TITLE
Fix: refusing to accept `isSelfAccepting` for JSX

### DIFF
--- a/.changeset/long-spies-check.md
+++ b/.changeset/long-spies-check.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix isSelfAccepting errors when hydrating JSX components

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -4,8 +4,6 @@ import type { LogOptions } from './logger/core';
 import { builtinModules } from 'module';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
-import path from 'path';
-import glob from 'fast-glob';
 import * as vite from 'vite';
 import astroVitePlugin from '../vite-plugin-astro/index.js';
 import astroViteServerPlugin from '../vite-plugin-astro-server/index.js';
@@ -48,12 +46,6 @@ export async function createVite(
 	commandConfig: ViteConfigWithSSR,
 	{ astroConfig, logging, mode }: CreateViteOptions
 ): Promise<ViteConfigWithSSR> {
-	const clientRuntimeScripts = await glob(new URL('../runtime/client/*.js', import.meta.url).pathname);
-	const clientRuntimeFilePaths = clientRuntimeScripts
-	.map(script => `astro/client/${path.basename(script)}`)
-	// fixes duplicate dependency issue in monorepo when using astro: "workspace:*"
-	.filter(filePath => filePath !== 'astro/client/hmr.js');
-
 	// Scan for any third-party Astro packages. Vite needs these to be passed to `ssr.noExternal`.
 	const astroPackages = await getAstroPackages(astroConfig);
 	// Start with the Vite configuration that Astro core needs
@@ -63,7 +55,6 @@ export async function createVite(
 		logLevel: 'warn', // log warnings and errors only
 		optimizeDeps: {
 			entries: ['src/**/*'], // Try and scan a user’s project (won’t catch everything),
-			include: clientRuntimeFilePaths,
 			exclude: ['node-fetch'],
 		},
 		plugins: [

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -49,7 +49,11 @@ export async function createVite(
 	{ astroConfig, logging, mode }: CreateViteOptions
 ): Promise<ViteConfigWithSSR> {
 	const clientRuntimeScripts = await glob(new URL('../runtime/client/*.js', import.meta.url).pathname);
-	const clientRuntimeFilePaths = clientRuntimeScripts.map(script => `astro/client/${path.basename(script)}`);
+	const clientRuntimeFilePaths = clientRuntimeScripts
+	.map(script => `astro/client/${path.basename(script)}`)
+	// fixes duplicate dependency issue in monorepo when using astro: "workspace:*"
+	.filter(filePath => filePath !== 'astro/client/hmr.js');
+
 	// Scan for any third-party Astro packages. Vite needs these to be passed to `ssr.noExternal`.
 	const astroPackages = await getAstroPackages(astroConfig);
 	// Start with the Vite configuration that Astro core needs

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -39,9 +39,9 @@ export default async function dev(config: AstroConfig, options: DevOptions): Pro
 	// load client runtime scripts ahead-of-time to fix "isSelfAccepting" bug during HMR
 	const clientRuntimeScripts = await glob(new URL('../../runtime/client/*.js', import.meta.url).pathname);
 	const clientRuntimeFilePaths = clientRuntimeScripts
-	.map(script => `astro/client/${path.basename(script)}`)
-	// fixes duplicate dependency issue in monorepo when using astro: "workspace:*"
-	.filter(filePath => filePath !== 'astro/client/hmr.js');
+		.map(script => `astro/client/${path.basename(script)}`)
+		// fixes duplicate dependency issue in monorepo when using astro: "workspace:*"
+		.filter(filePath => filePath !== 'astro/client/hmr.js');
 	const viteConfig = await createVite(
 		{
 			mode: 'development',

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -36,12 +36,12 @@ export default async function dev(config: AstroConfig, options: DevOptions): Pro
 	config = await runHookConfigSetup({ config, command: 'dev' });
 	const { host, port } = config.server;
 
-
-const clientRuntimeScripts = await glob(new URL('../../runtime/client/*.js', import.meta.url).pathname);
-const clientRuntimeFilePaths = clientRuntimeScripts
-.map(script => `astro/client/${path.basename(script)}`)
-// fixes duplicate dependency issue in monorepo when using astro: "workspace:*"
-.filter(filePath => filePath !== 'astro/client/hmr.js');
+	// load client runtime scripts ahead-of-time to fix "isSelfAccepting" bug during HMR
+	const clientRuntimeScripts = await glob(new URL('../../runtime/client/*.js', import.meta.url).pathname);
+	const clientRuntimeFilePaths = clientRuntimeScripts
+	.map(script => `astro/client/${path.basename(script)}`)
+	// fixes duplicate dependency issue in monorepo when using astro: "workspace:*"
+	.filter(filePath => filePath !== 'astro/client/hmr.js');
 	const viteConfig = await createVite(
 		{
 			mode: 'development',

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -1,3 +1,5 @@
+import glob from 'fast-glob';
+import path from 'path';
 import type { AddressInfo } from 'net';
 import type { AstroTelemetry } from '@astrojs/telemetry';
 import { performance } from 'perf_hooks';
@@ -33,10 +35,20 @@ export default async function dev(config: AstroConfig, options: DevOptions): Pro
 	await options.telemetry.record([]);
 	config = await runHookConfigSetup({ config, command: 'dev' });
 	const { host, port } = config.server;
+
+
+const clientRuntimeScripts = await glob(new URL('../../runtime/client/*.js', import.meta.url).pathname);
+const clientRuntimeFilePaths = clientRuntimeScripts
+.map(script => `astro/client/${path.basename(script)}`)
+// fixes duplicate dependency issue in monorepo when using astro: "workspace:*"
+.filter(filePath => filePath !== 'astro/client/hmr.js');
 	const viteConfig = await createVite(
 		{
 			mode: 'development',
 			server: { host },
+			optimizeDeps: {
+				include: clientRuntimeFilePaths,
+			}
 		},
 		{ astroConfig: config, logging: options.logging, mode: 'dev' }
 	);

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -18,7 +18,6 @@ import { getStylesForURL } from './css.js';
 import { injectTags } from './html.js';
 import { isBuildingToSSR } from '../../util.js';
 import { collectMdMetadata } from '../util.js';
-import { hydrationSpecifier } from '../../../runtime/server/util.js';
 
 export interface SSROptions {
 	/** an instance of the AstroConfig */
@@ -130,17 +129,6 @@ export async function render(
 			},
 			children: '',
 		});
-		// generate client directive scripts to prevent `isSelfAccepting` issues during development
-		await Promise.all([...mod.$$metadata.hydrationDirectives].map(async (hydrationDirective) => {
-      const [, resolvedImport] = await viteServer.moduleGraph.resolveUrl(hydrationSpecifier(hydrationDirective))
-      scripts.add({
-        props: {
-          type: 'module',
-          src: resolvedImport,
-        },
-        children: "",
-      });
-    }))
 	}
 	// TODO: We should allow adding generic HTML elements to the head, not just scripts
 	for (const script of astroConfig._ctx.scripts) {


### PR DESCRIPTION
## Changes

- Resolves #3465 
- Add all client runtime scripts to Vite's `optimizedDeps.include`. We exclude `hmr.js` from this list due to dependency issues in the monorepo when using `workspace:*`. I'm unable to find _exactly_ what's causing this, but the issue seems urgent enough to roll with this temporary solution.

## Testing

N/A

## Docs

N/A