### PR TITLE
Prevent minifying server JS

### DIFF
--- a/.changeset/three-news-cry.md
+++ b/.changeset/three-news-cry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent minifying server JS


### PR DESCRIPTION
## Changes

- Previous issue fixing `__VITE_ASSET__` bug included us turning on minification just for the `vite:css-post` plugin, so that CSS would be minified. However this inadvertently caused all server JS to be minified, which we do not want.
- The change is to remove the monkey patching and to instead create a post plugin just for doing CSS minification for the server build.
- Fixes #3500

## Testing

Existing tests should cover this change.

## Docs

N/A, bug fix.