### PR TITLE
Fix importing CSS packages in frontmatter

### DIFF
--- a/.changeset/green-ducks-reply.md
+++ b/.changeset/green-ducks-reply.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes imported CSS packages in frontmatter

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -130,7 +130,7 @@
     "strip-ansi": "^7.0.1",
     "supports-esm": "^1.0.0",
     "tsconfig-resolver": "^3.0.1",
-    "vite": "^2.9.9",
+    "vite": "^2.9.10",
     "yargs-parser": "^21.0.1",
     "zod": "^3.17.3"
   },

--- a/packages/astro/src/vite-plugin-build-css/index.ts
+++ b/packages/astro/src/vite-plugin-build-css/index.ts
@@ -198,7 +198,7 @@ export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] 
 							// in order to determine if one of them is a side-effectual web component.
 							// If we ever get rid of that feature, the code below can be removed.
 							for(const [imp, bindings] of Object.entries(output.importedBindings)) {
-								if(imp.startsWith('chunks/') && !bundle[imp]) {
+								if(imp.startsWith('chunks/') && !bundle[imp] && output.code.includes(imp)) {
 									// This just creates an empty chunk module so that the main entry module
 									// that is importing it doesn't break.
 									const depChunk: OutputChunk = {

--- a/packages/astro/src/vite-plugin-build-css/index.ts
+++ b/packages/astro/src/vite-plugin-build-css/index.ts
@@ -14,7 +14,7 @@ interface PluginOptions {
 	target: 'client' | 'server';
 }
 
-export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin {
+export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 	const { internals } = options;
 
 	// This walks up the dependency graph and yields out each ModuleInfo object.
@@ -69,118 +69,129 @@ export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin {
 		}
 	}
 
-	return {
-		name: '@astrojs/rollup-plugin-build-css',
-		enforce: 'post',
+	const CSS_PLUGIN_NAME = '@astrojs/rollup-plugin-build-css';
+	const CSS_MINIFY_PLUGIN_NAME = '@astrojs/rollup-plugin-build-css-minify';
 
-		outputOptions(outputOptions) {
-			const manualChunks = outputOptions.manualChunks || Function.prototype;
-			outputOptions.manualChunks = function (id, ...args) {
-				// Defer to user-provided `manualChunks`, if it was provided.
-				if (typeof manualChunks == 'object') {
-					if (id in manualChunks) {
-						return manualChunks[id];
+	return [
+		{
+			name: CSS_PLUGIN_NAME,
+
+			outputOptions(outputOptions) {
+				const manualChunks = outputOptions.manualChunks || Function.prototype;
+				outputOptions.manualChunks = function (id, ...args) {
+					// Defer to user-provided `manualChunks`, if it was provided.
+					if (typeof manualChunks == 'object') {
+						if (id in manualChunks) {
+							return manualChunks[id];
+						}
+					} else if (typeof manualChunks === 'function') {
+						const outid = manualChunks.call(this, id, ...args);
+						if (outid) {
+							return outid;
+						}
 					}
-				} else if (typeof manualChunks === 'function') {
-					const outid = manualChunks.call(this, id, ...args);
-					if (outid) {
-						return outid;
+
+					// For CSS, create a hash of all of the pages that use it.
+					// This causes CSS to be built into shared chunks when used by multiple pages.
+					if (isCSSRequest(id)) {
+						return createHashOfPageParents(id, args[0]);
 					}
-				}
+				};
+			},
 
-				// For CSS, create a hash of all of the pages that use it.
-				// This causes CSS to be built into shared chunks when used by multiple pages.
-				if (isCSSRequest(id)) {
-					return createHashOfPageParents(id, args[0]);
-				}
-			};
-		},
+			async generateBundle(_outputOptions, bundle) {
+				type ViteMetadata = {
+					importedAssets: Set<string>;
+					importedCss: Set<string>;
+				};
 
-		async generateBundle(_outputOptions, bundle) {
-			type ViteMetadata = {
-				importedAssets: Set<string>;
-				importedCss: Set<string>;
-			};
+				for (const [_, chunk] of Object.entries(bundle)) {
+					if (chunk.type === 'chunk') {
+						const c = chunk;
+						if ('viteMetadata' in chunk) {
+							const meta = chunk['viteMetadata'] as ViteMetadata;
 
-			for (const [_, output] of Object.entries(bundle)) {
-				if (output.type === 'chunk') {
-					const c = output;
-					if ('viteMetadata' in output) {
-						const meta = output['viteMetadata'] as ViteMetadata;
+							// Chunks that have the viteMetadata.importedCss are CSS chunks
+							if (meta.importedCss.size) {
+								// For the client build, client:only styles need to be mapped
+								// over to their page. For this chunk, determine if it's a child of a
+								// client:only component and if so, add its CSS to the page it belongs to.
+								if (options.target === 'client') {
+									for (const [id] of Object.entries(c.modules)) {
+										for (const pageData of getParentClientOnlys(id, this)) {
+											for (const importedCssImport of meta.importedCss) {
+												pageData.css.add(importedCssImport);
+											}
+										}
+									}
+								}
 
-						// Chunks that have the viteMetadata.importedCss are CSS chunks
-						if (meta.importedCss.size) {
-							// For the client build, client:only styles need to be mapped
-							// over to their page. For this chunk, determine if it's a child of a
-							// client:only component and if so, add its CSS to the page it belongs to.
-							if (options.target === 'client') {
+								// For this CSS chunk, walk parents until you find a page. Add the CSS to that page.
 								for (const [id] of Object.entries(c.modules)) {
-									for (const pageData of getParentClientOnlys(id, this)) {
+									for (const pageViteID of getTopLevelPages(id, this)) {
+										const pageData = getPageDataByViteID(internals, pageViteID);
 										for (const importedCssImport of meta.importedCss) {
-											pageData.css.add(importedCssImport);
+											pageData?.css.add(importedCssImport);
 										}
 									}
 								}
 							}
-
-							// For this CSS chunk, walk parents until you find a page. Add the CSS to that page.
-							for (const [id] of Object.entries(c.modules)) {
-								for (const pageViteID of getTopLevelPages(id, this)) {
-									const pageData = getPageDataByViteID(internals, pageViteID);
-									for (const importedCssImport of meta.importedCss) {
-										pageData?.css.add(importedCssImport);
-									}
-								}
-							}
 						}
 					}
 				}
-
+			}
+		},
+		{
+			name: CSS_MINIFY_PLUGIN_NAME,
+			enforce: 'post',
+			async generateBundle(_outputOptions, bundle) {
 				// Minify CSS in each bundle ourselves, since server builds are not minified
 				// so that the JS is debuggable. Since you cannot configure vite:css-post to minify
 				// we need to do it ourselves.
 				if (options.target === 'server') {
-					if (output.type === 'asset') {
-						if (output.name?.endsWith('.css') && typeof output.source === 'string') {
-							const { code: minifiedCSS } = await esbuild.transform(output.source, {
-								loader: 'css',
-								minify: true,
-							});
-							output.source = minifiedCSS;
-						}
-					} else if (output.type === 'chunk') {
-						// vite:css-post removes "pure CSS" JavaScript chunks, that is chunks that only contain a comment
-						// about it being a CSS module. We need to keep these chunks around because Astro
-						// re-imports all modules as their namespace `import * as module1 from 'some/path';
-						// in order to determine if one of them is a side-effectual web component.
-						// If we ever get rid of that feature, the code below can be removed.
-						for(const [imp, bindings] of Object.entries(output.importedBindings)) {
-							if(imp.startsWith('chunks/') && !bundle[imp] && output.code.includes(imp)) {
-								// This just creates an empty chunk module so that the main entry module
-								// that is importing it doesn't break.
-								const depChunk: OutputChunk = {
-									type: 'chunk',
-									fileName: imp,
-									name: imp,
-									facadeModuleId: imp,
-									code: `/* Pure CSS chunk ${imp} */ ${bindings.map(b => `export const ${b} = {};`)}`,
-									dynamicImports: [],
-									implicitlyLoadedBefore: [],
-									importedBindings: {},
-									imports: [],
-									referencedFiles: [],
-									exports: Array.from(bindings),
-									isDynamicEntry: false,
-									isEntry: false,
-									isImplicitEntry: false,
-									modules: {},
-								};
-								bundle[imp] = depChunk;
+					for (const [, output] of Object.entries(bundle)) {
+						if (output.type === 'asset') {
+							if (output.name?.endsWith('.css') && typeof output.source === 'string') {
+								const { code: minifiedCSS } = await esbuild.transform(output.source, {
+									loader: 'css',
+									minify: true,
+								});
+								output.source = minifiedCSS;
+							}
+						} else if (output.type === 'chunk') {
+							// vite:css-post removes "pure CSS" JavaScript chunks, that is chunks that only contain a comment
+							// about it being a CSS module. We need to keep these chunks around because Astro
+							// re-imports all modules as their namespace `import * as module1 from 'some/path';
+							// in order to determine if one of them is a side-effectual web component.
+							// If we ever get rid of that feature, the code below can be removed.
+							for(const [imp, bindings] of Object.entries(output.importedBindings)) {
+								if(imp.startsWith('chunks/') && !bundle[imp] && output.code.includes(imp)) {
+									// This just creates an empty chunk module so that the main entry module
+									// that is importing it doesn't break.
+									const depChunk: OutputChunk = {
+										type: 'chunk',
+										fileName: imp,
+										name: imp,
+										facadeModuleId: imp,
+										code: `/* Pure CSS chunk ${imp} */ ${bindings.map(b => `export const ${b} = {};`)}`,
+										dynamicImports: [],
+										implicitlyLoadedBefore: [],
+										importedBindings: {},
+										imports: [],
+										referencedFiles: [],
+										exports: Array.from(bindings),
+										isDynamicEntry: false,
+										isEntry: false,
+										isImplicitEntry: false,
+										modules: {},
+									};
+									bundle[imp] = depChunk;
+								}
 							}
 						}
 					}
 				}
 			}
 		}
-	};
+	];
 }

--- a/packages/astro/src/vite-plugin-build-css/index.ts
+++ b/packages/astro/src/vite-plugin-build-css/index.ts
@@ -14,7 +14,7 @@ interface PluginOptions {
 	target: 'client' | 'server';
 }
 
-export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
+export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin {
 	const { internals } = options;
 
 	// This walks up the dependency graph and yields out each ModuleInfo object.
@@ -69,162 +69,118 @@ export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] 
 		}
 	}
 
-	const CSS_PLUGIN_NAME = '@astrojs/rollup-plugin-build-css';
-	const CSS_MINIFY_PLUGIN_NAME = '@astrojs/rollup-plugin-build-css-minify';
+	return {
+		name: '@astrojs/rollup-plugin-build-css',
+		enforce: 'post',
 
-	return [
-		{
-			name: CSS_PLUGIN_NAME,
-
-			configResolved(resolvedConfig) {
-				// Our plugin needs to run before `vite:css-post` because we have to modify
-				// The bundles before vite:css-post sees them. We can remove this code
-				// after this bug is fixed: https://github.com/vitejs/vite/issues/8330
-				const plugins = resolvedConfig.plugins as VitePlugin[];
-				const viteCSSPostIndex = resolvedConfig.plugins.findIndex(
-					(p) => p.name === 'vite:css-post'
-				);
-				if (viteCSSPostIndex !== -1) {
-					// Move our plugin to be right before this one.
-					const ourIndex = plugins.findIndex((p) => p.name === CSS_PLUGIN_NAME);
-					const ourPlugin = plugins[ourIndex];
-
-					// Remove us from where we are now and place us right before the viteCSSPost plugin
-					plugins.splice(ourIndex, 1);
-					plugins.splice(viteCSSPostIndex - 1, 0, ourPlugin);
+		outputOptions(outputOptions) {
+			const manualChunks = outputOptions.manualChunks || Function.prototype;
+			outputOptions.manualChunks = function (id, ...args) {
+				// Defer to user-provided `manualChunks`, if it was provided.
+				if (typeof manualChunks == 'object') {
+					if (id in manualChunks) {
+						return manualChunks[id];
+					}
+				} else if (typeof manualChunks === 'function') {
+					const outid = manualChunks.call(this, id, ...args);
+					if (outid) {
+						return outid;
+					}
 				}
-			},
 
-			outputOptions(outputOptions) {
-				const manualChunks = outputOptions.manualChunks || Function.prototype;
-				outputOptions.manualChunks = function (id, ...args) {
-					// Defer to user-provided `manualChunks`, if it was provided.
-					if (typeof manualChunks == 'object') {
-						if (id in manualChunks) {
-							return manualChunks[id];
-						}
-					} else if (typeof manualChunks === 'function') {
-						const outid = manualChunks.call(this, id, ...args);
-						if (outid) {
-							return outid;
-						}
-					}
+				// For CSS, create a hash of all of the pages that use it.
+				// This causes CSS to be built into shared chunks when used by multiple pages.
+				if (isCSSRequest(id)) {
+					return createHashOfPageParents(id, args[0]);
+				}
+			};
+		},
 
-					// For CSS, create a hash of all of the pages that use it.
-					// This causes CSS to be built into shared chunks when used by multiple pages.
-					if (isCSSRequest(id)) {
-						return createHashOfPageParents(id, args[0]);
-					}
-				};
-			},
+		async generateBundle(_outputOptions, bundle) {
+			type ViteMetadata = {
+				importedAssets: Set<string>;
+				importedCss: Set<string>;
+			};
 
-			async generateBundle(_outputOptions, bundle) {
-				type ViteMetadata = {
-					importedAssets: Set<string>;
-					importedCss: Set<string>;
-				};
+			for (const [_, output] of Object.entries(bundle)) {
+				if (output.type === 'chunk') {
+					const c = output;
+					if ('viteMetadata' in output) {
+						const meta = output['viteMetadata'] as ViteMetadata;
 
-				for (const [_, chunk] of Object.entries(bundle)) {
-					if (chunk.type === 'chunk') {
-						const c = chunk;
-						if ('viteMetadata' in chunk) {
-							const meta = chunk['viteMetadata'] as ViteMetadata;
-
-							// Chunks that have the viteMetadata.importedCss are CSS chunks
-							if (meta.importedCss.size) {
-								// For the client build, client:only styles need to be mapped
-								// over to their page. For this chunk, determine if it's a child of a
-								// client:only component and if so, add its CSS to the page it belongs to.
-								if (options.target === 'client') {
-									for (const [id] of Object.entries(c.modules)) {
-										for (const pageData of getParentClientOnlys(id, this)) {
-											for (const importedCssImport of meta.importedCss) {
-												pageData.css.add(importedCssImport);
-											}
+						// Chunks that have the viteMetadata.importedCss are CSS chunks
+						if (meta.importedCss.size) {
+							// For the client build, client:only styles need to be mapped
+							// over to their page. For this chunk, determine if it's a child of a
+							// client:only component and if so, add its CSS to the page it belongs to.
+							if (options.target === 'client') {
+								for (const [id] of Object.entries(c.modules)) {
+									for (const pageData of getParentClientOnlys(id, this)) {
+										for (const importedCssImport of meta.importedCss) {
+											pageData.css.add(importedCssImport);
 										}
 									}
 								}
+							}
 
-								// For this CSS chunk, walk parents until you find a page. Add the CSS to that page.
-								for (const [id] of Object.entries(c.modules)) {
-									for (const pageViteID of getTopLevelPages(id, this)) {
-										const pageData = getPageDataByViteID(internals, pageViteID);
-										for (const importedCssImport of meta.importedCss) {
-											pageData?.css.add(importedCssImport);
-										}
+							// For this CSS chunk, walk parents until you find a page. Add the CSS to that page.
+							for (const [id] of Object.entries(c.modules)) {
+								for (const pageViteID of getTopLevelPages(id, this)) {
+									const pageData = getPageDataByViteID(internals, pageViteID);
+									for (const importedCssImport of meta.importedCss) {
+										pageData?.css.add(importedCssImport);
 									}
 								}
 							}
 						}
 					}
-
-					// TODO remove this code, I think.
-					if (chunk.type === 'chunk') {
-						// This simply replaces single quotes with double quotes because the vite:css-post
-						// plugin only works with single for some reason. This code can be removed
-						// When the Vite bug is fixed: https://github.com/vitejs/vite/issues/8330
-						const exp = new RegExp(
-							`(\\bimport\\s*)[']([^']*(?:[a-z]+\.[0-9a-z]+\.m?js))['](;\n?)`,
-							'g'
-						);
-						chunk.code = chunk.code.replace(exp, (_match, begin, chunkPath, end) => {
-							return begin + '"' + chunkPath + '"' + end;
-						});
-					}
 				}
-			}
-		},
-		{
-			name: CSS_MINIFY_PLUGIN_NAME,
-			enforce: 'post',
-			async generateBundle(_outputOptions, bundle) {
+
 				// Minify CSS in each bundle ourselves, since server builds are not minified
 				// so that the JS is debuggable. Since you cannot configure vite:css-post to minify
 				// we need to do it ourselves.
 				if (options.target === 'server') {
-					for (const [, output] of Object.entries(bundle)) {
-						if (output.type === 'asset') {
-							if (output.name?.endsWith('.css') && typeof output.source === 'string') {
-								const { code: minifiedCSS } = await esbuild.transform(output.source, {
-									loader: 'css',
-									minify: true,
-								});
-								output.source = minifiedCSS;
-							}
-						} else if (output.type === 'chunk') {
-							// vite:css-post removes "pure CSS" JavaScript chunks, that is chunks that only contain a comment
-							// about it being a CSS module. We need to keep these chunks around because Astro
-							// re-imports all modules as their namespace `import * as module1 from 'some/path';
-							// in order to determine if one of them is a side-effectual web component.
-							// If we ever get rid of that feature, the code below can be removed.
-							for(const [imp, bindings] of Object.entries(output.importedBindings)) {
-								if(imp.startsWith('chunks/') && !bundle[imp] && output.code.includes(imp)) {
-									// This just creates an empty chunk module so that the main entry module
-									// that is importing it doesn't break.
-									const depChunk: OutputChunk = {
-										type: 'chunk',
-										fileName: imp,
-										name: imp,
-										facadeModuleId: imp,
-										code: `/* Pure CSS chunk ${imp} */ ${bindings.map(b => `export const ${b} = {};`)}`,
-										dynamicImports: [],
-										implicitlyLoadedBefore: [],
-										importedBindings: {},
-										imports: [],
-										referencedFiles: [],
-										exports: Array.from(bindings),
-										isDynamicEntry: false,
-										isEntry: false,
-										isImplicitEntry: false,
-										modules: {},
-									};
-									bundle[imp] = depChunk;
-								}
+					if (output.type === 'asset') {
+						if (output.name?.endsWith('.css') && typeof output.source === 'string') {
+							const { code: minifiedCSS } = await esbuild.transform(output.source, {
+								loader: 'css',
+								minify: true,
+							});
+							output.source = minifiedCSS;
+						}
+					} else if (output.type === 'chunk') {
+						// vite:css-post removes "pure CSS" JavaScript chunks, that is chunks that only contain a comment
+						// about it being a CSS module. We need to keep these chunks around because Astro
+						// re-imports all modules as their namespace `import * as module1 from 'some/path';
+						// in order to determine if one of them is a side-effectual web component.
+						// If we ever get rid of that feature, the code below can be removed.
+						for(const [imp, bindings] of Object.entries(output.importedBindings)) {
+							if(imp.startsWith('chunks/') && !bundle[imp] && output.code.includes(imp)) {
+								// This just creates an empty chunk module so that the main entry module
+								// that is importing it doesn't break.
+								const depChunk: OutputChunk = {
+									type: 'chunk',
+									fileName: imp,
+									name: imp,
+									facadeModuleId: imp,
+									code: `/* Pure CSS chunk ${imp} */ ${bindings.map(b => `export const ${b} = {};`)}`,
+									dynamicImports: [],
+									implicitlyLoadedBefore: [],
+									importedBindings: {},
+									imports: [],
+									referencedFiles: [],
+									exports: Array.from(bindings),
+									isDynamicEntry: false,
+									isEntry: false,
+									isImplicitEntry: false,
+									modules: {},
+								};
+								bundle[imp] = depChunk;
 							}
 						}
 					}
 				}
 			}
 		}
-	];
+	};
 }

--- a/packages/astro/src/vite-plugin-build-css/index.ts
+++ b/packages/astro/src/vite-plugin-build-css/index.ts
@@ -192,38 +192,39 @@ export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] 
 								output.source = minifiedCSS;
 							}
 						} else if (output.type === 'chunk') {
-						// vite:css-post removes "pure CSS" JavaScript chunks, that is chunks that only contain a comment
-						// about it being a CSS module. We need to keep these chunks around because Astro
-						// re-imports all modules as their namespace `import * as module1 from 'some/path';
-						// in order to determine if one of them is a side-effectual web component.
-						// If we ever get rid of that feature, the code below can be removed.
-						for(const [imp, bindings] of Object.entries(output.importedBindings)) {
-							if(imp.startsWith('chunks/') && !bundle[imp]) {
-								// This just creates an empty chunk module so that the main entry module
-								// that is importing it doesn't break.
-								const depChunk: OutputChunk = {
-									type: 'chunk',
-									fileName: imp,
-									name: imp,
-									facadeModuleId: imp,
-									code: `/* Pure CSS chunk ${imp} */ ${bindings.map(b => `export const ${b} = {};`)}`,
-									dynamicImports: [],
-									implicitlyLoadedBefore: [],
-									importedBindings: {},
-									imports: [],
-									referencedFiles: [],
-									exports: Array.from(bindings),
-									isDynamicEntry: false,
-									isEntry: false,
-									isImplicitEntry: false,
-									modules: {},
-								};
-								bundle[imp] = depChunk;
+							// vite:css-post removes "pure CSS" JavaScript chunks, that is chunks that only contain a comment
+							// about it being a CSS module. We need to keep these chunks around because Astro
+							// re-imports all modules as their namespace `import * as module1 from 'some/path';
+							// in order to determine if one of them is a side-effectual web component.
+							// If we ever get rid of that feature, the code below can be removed.
+							for(const [imp, bindings] of Object.entries(output.importedBindings)) {
+								if(imp.startsWith('chunks/') && !bundle[imp]) {
+									// This just creates an empty chunk module so that the main entry module
+									// that is importing it doesn't break.
+									const depChunk: OutputChunk = {
+										type: 'chunk',
+										fileName: imp,
+										name: imp,
+										facadeModuleId: imp,
+										code: `/* Pure CSS chunk ${imp} */ ${bindings.map(b => `export const ${b} = {};`)}`,
+										dynamicImports: [],
+										implicitlyLoadedBefore: [],
+										importedBindings: {},
+										imports: [],
+										referencedFiles: [],
+										exports: Array.from(bindings),
+										isDynamicEntry: false,
+										isEntry: false,
+										isImplicitEntry: false,
+										modules: {},
+									};
+									bundle[imp] = depChunk;
+								}
 							}
 						}
 					}
 				}
 			}
-		},
-	}];
+		}
+	];
 }

--- a/packages/astro/test/fixtures/fontsource-package/package.json
+++ b/packages/astro/test/fixtures/fontsource-package/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/astro-fontsource-package",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@fontsource/montserrat": "4.5.11",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/fontsource-package/src/pages/index.astro
+++ b/packages/astro/test/fixtures/fontsource-package/src/pages/index.astro
@@ -1,0 +1,13 @@
+---
+import "@fontsource/montserrat";
+---
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>Astro</title>
+	</head>
+	<body>
+		<h1>Astro</h1>
+	</body>
+</html>

--- a/packages/astro/test/fontsource.test.js
+++ b/packages/astro/test/fontsource.test.js
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('@fontsource/* packages', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/fontsource-package/' });
+		await fixture.build();
+	});
+
+	it('can be imported in frontmatter', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerio.load(html);
+		const assetPath = $('link').attr('href');
+		const css = await fixture.readFile(assetPath);
+		expect(css).to.contain('Montserrat');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,7 +542,7 @@ importers:
       strip-ansi: ^7.0.1
       supports-esm: ^1.0.0
       tsconfig-resolver: ^3.0.1
-      vite: ^2.9.9
+      vite: ^2.9.10
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
@@ -599,7 +599,7 @@ importers:
       strip-ansi: 7.0.1
       supports-esm: 1.0.0
       tsconfig-resolver: 3.0.1
-      vite: 2.9.9_sass@1.52.2
+      vite: 2.9.10_sass@1.52.2
       yargs-parser: 21.0.1
       zod: 3.17.3
     devDependencies:
@@ -1365,6 +1365,14 @@ importers:
       '@astrojs/preact': link:../../../../integrations/preact
       '@astrojs/svelte': link:../../../../integrations/svelte
       '@astrojs/vue': link:../../../../integrations/vue
+      astro: link:../../..
+
+  packages/astro/test/fixtures/fontsource-package:
+    specifiers:
+      '@fontsource/montserrat': 4.5.11
+      astro: workspace:*
+    dependencies:
+      '@fontsource/montserrat': 4.5.11
       astro: link:../../..
 
   packages/astro/test/fixtures/legacy-build:
@@ -3894,6 +3902,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@fontsource/montserrat/4.5.11:
+    resolution: {integrity: sha512-XAYZmprnZDVSLIeEiB3evVG2JD+yoR9aT+I6LCOcwZFQ6ro9UPpopDncqoqwv+j5M0/UjyAP6ov70+L/fmP8Gg==}
+    dev: false
 
   /@formatjs/ecma402-abstract/1.11.4:
     resolution: {integrity: sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==}
@@ -13592,6 +13604,31 @@ packages:
       - supports-color
     dev: true
 
+  /vite/2.9.10_sass@1.52.2:
+    resolution: {integrity: sha512-TwZRuSMYjpTurLqXspct+HZE7ONiW9d+wSWgvADGxhDPPyoIcNywY+RX4ng+QpK30DCa1l/oZgi2PLZDibhzbQ==}
+    engines: {node: '>=12.2.0'}
+    hasBin: true
+    peerDependencies:
+      less: '*'
+      sass: '*'
+      stylus: '*'
+    peerDependenciesMeta:
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+    dependencies:
+      esbuild: 0.14.42
+      postcss: 8.4.14
+      resolve: 1.22.0
+      rollup: 2.75.5
+      sass: 1.52.2
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: false
+
   /vite/2.9.9:
     resolution: {integrity: sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==}
     engines: {node: '>=12.2.0'}
@@ -13612,31 +13649,6 @@ packages:
       postcss: 8.4.14
       resolve: 1.22.0
       rollup: 2.75.5
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: false
-
-  /vite/2.9.9_sass@1.52.2:
-    resolution: {integrity: sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==}
-    engines: {node: '>=12.2.0'}
-    hasBin: true
-    peerDependencies:
-      less: '*'
-      sass: '*'
-      stylus: '*'
-    peerDependenciesMeta:
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-    dependencies:
-      esbuild: 0.14.42
-      postcss: 8.4.14
-      resolve: 1.22.0
-      rollup: 2.75.5
-      sass: 1.52.2
     optionalDependencies:
       fsevents: 2.3.2
     dev: false


### PR DESCRIPTION
## Changes

- `vite:css-post` removes JS modules that *only* contain CSS. These modules only exist so that the CSS asset can be created. Vite removes them and updates import statements to also be removed.
- However when you import a package the compiler creates a second import like `import * as $$module from 'some/package';` which is used to discover if the package contains used web components. Because of these namespace imports, those don't get removed by vite:css-post.
- The fix here is to create empty CSS chunks when import statements are left in.
- Fixes #3536

## Testing

- Test added specifically for `@fontsource/*` package since those are a bit popular.

## Docs

N/A, bug fix.