### PR TITLE
Prevent sitemap URLs without pathname

### DIFF
--- a/.changeset/large-rings-invite.md
+++ b/.changeset/large-rings-invite.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/sitemap': patch
+---
+
+Prevent sitemap URLs with trimmed paths

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -61,14 +61,22 @@ export default function createPlugin({
 				config = _config;
 			},
 			'astro:build:done': async ({ pages, dir }) => {
-				const finalSiteUrl = canonicalURL || config.site;
-				if (!finalSiteUrl) {
+				let finalSiteUrl: URL;
+				if (canonicalURL) {
+					finalSiteUrl = new URL(canonicalURL);
+					finalSiteUrl.pathname += finalSiteUrl.pathname.endsWith('/') ? '' : '/'; // normalizes the final url since it's provided by user
+				} else if (config.site) {
+					finalSiteUrl = new URL(config.base, config.site);
+				} else {
 					console.warn(
 						'The Sitemap integration requires either the `site` astro.config option or `canonicalURL` integration option. Skipping.'
 					);
 					return;
 				}
-				let pageUrls = pages.map((p) => new URL(p.pathname, finalSiteUrl).href);
+				let pageUrls = pages.map((p) => {
+					const path = finalSiteUrl.pathname + p.pathname
+					return new URL(path, finalSiteUrl).href
+				});
 				if (filter) {
 					pageUrls = pageUrls.filter((page: string) => filter(page));
 				}


### PR DESCRIPTION
## Changes

- Closes #3546
- Handle configured base path or `canonicalURL` pathnames on sitemap generation

## Testing

This change was tested locally

## Docs

It's a small bug fix, we don't need to change the docs  