### PR TITLE
unused dependency 'sitemap', 'filter' option should return boolean

### DIFF
--- a/packages/integrations/sitemap/package.json
+++ b/packages/integrations/sitemap/package.json
@@ -27,7 +27,6 @@
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {
-    "sitemap": "^7.1.1"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -15,7 +15,7 @@ type SitemapOptions =
 			 * filter: (page) => page !== 'http://example.com/secret-page'
 			 * ```
 			 */
-			filter?(page: string): string;
+			filter?(page: string): boolean;
 
 			/**
 			 * If you have any URL, not rendered by Astro, that you want to include in your sitemap,


### PR DESCRIPTION
## Changes

- remove unused dependency 'sitemap'. it is not used, but it exists in package dependencies;
- better typings for SitemapOptions: filter?(page: string):  it should return Boolean instead of String.
