### PR TITLE
Fix autolinking of URLs inside links in Markdown

### DIFF
--- a/.changeset/afraid-stingrays-sell.md
+++ b/.changeset/afraid-stingrays-sell.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Fix autolinking of URLs inside links

--- a/packages/markdown/remark/src/index.ts
+++ b/packages/markdown/remark/src/index.ts
@@ -99,14 +99,13 @@ export async function renderMarkdown(
 	parser
 		.use(isMDX ? [rehypeJsx, rehypeExpressions] : [rehypeRaw])
 		.use(rehypeEscape)
-		.use(rehypeIslands);
+		.use(rehypeIslands)
+		.use([rehypeCollectHeaders])
+		.use(rehypeStringify, { allowDangerousHtml: true })
 
 	let result: string;
 	try {
-		const vfile = await parser
-			.use([rehypeCollectHeaders])
-			.use(rehypeStringify, { allowDangerousHtml: true })
-			.process(input);
+		const vfile = await parser.process(input);
 		result = vfile.toString();
 	} catch (err) {
 		// Ensure that the error message contains the input filename

--- a/packages/markdown/remark/test/autolinking.test.js
+++ b/packages/markdown/remark/test/autolinking.test.js
@@ -1,0 +1,96 @@
+import { renderMarkdown } from '../dist/index.js';
+import chai from 'chai';
+
+describe('autolinking', () => {
+	it('autolinks URLs starting with a protocol in plain text', async () => {
+		const { code } = await renderMarkdown(
+			`See https://example.com for more.`,
+			{}
+		);
+
+		chai
+			.expect(code.replace(/\n/g, ''))
+			.to.equal(`<p>See <a href="https://example.com">https://example.com</a> for more.</p>`);
+	});
+
+	it('autolinks URLs starting with "www." in plain text', async () => {
+		const { code } = await renderMarkdown(
+			`See www.example.com for more.`,
+			{}
+		);
+
+		chai
+			.expect(code.trim())
+			.to.equal(`<p>See <a href="http://www.example.com">www.example.com</a> for more.</p>`);
+	});
+
+	it('does not autolink URLs in code blocks', async () => {
+		const { code } = await renderMarkdown(
+			'See `https://example.com` or `www.example.com` for more.',
+			{}
+		);
+
+		chai
+			.expect(code.trim())
+			.to.equal(`<p>See <code is:raw>https://example.com</code> or ` +
+				`<code is:raw>www.example.com</code> for more.</p>`);
+	});
+
+	it('does not autolink URLs in fenced code blocks', async () => {
+		const { code } = await renderMarkdown(
+			'Example:\n```\nGo to https://example.com or www.example.com now.\n```',
+			{}
+		);
+
+		chai
+			.expect(code)
+			.to.contain(`<pre is:raw`)
+			.to.contain(`Go to https://example.com or www.example.com now.`);
+	});
+
+	it('does not autolink URLs starting with a protocol when nested inside links', async () => {
+		const { code } = await renderMarkdown(
+			`See [http://example.com](http://example.com) or ` +
+			`<a test href="https://example.com">https://example.com</a>`,
+			{}
+		);
+
+		chai
+			.expect(code.replace(/\n/g, ''))
+			.to.equal(
+				`<p>See <a href="http://example.com">http://example.com</a> or ` +
+				`<a test href="https://example.com">https://example.com</a></p>`
+			);
+	});
+
+	it('does not autolink URLs starting with "www." when nested inside links', async () => {
+		const { code } = await renderMarkdown(
+			`See [www.example.com](https://www.example.com) or ` +
+			`<a test href="https://www.example.com">www.example.com</a>`,
+			{}
+		);
+
+		chai
+			.expect(code.replace(/\n/g, ''))
+			.to.equal(
+				`<p>See <a href="https://www.example.com">www.example.com</a> or ` +
+				`<a test href="https://www.example.com">www.example.com</a></p>`
+			);
+	});
+
+	it('does not autolink URLs when nested several layers deep inside links', async () => {
+		const { code } = await renderMarkdown(
+			`<a href="https://www.example.com">**Visit _our www.example.com or ` +
+			`http://localhost pages_ for more!**</a>`,
+			{}
+		);
+
+		chai
+			.expect(code.replace(/\n/g, ''))
+			.to.equal(
+				`<a href="https://www.example.com"><strong>` +
+				`Visit <em>our www.example.com or http://localhost pages</em> for more!` +
+				`</strong></a>`
+			);
+	});
+});


### PR DESCRIPTION
## Changes

- Fixes #3529.
- Due to the MDX/JSX parsing logic "capturing" `<a>` elements, the remark-gfm plugin mistakingly started adding autolinks to plaintext URLs nested inside links. This PR detects those cases and removes the nested autolinks while still allowing regular links to be used in Markdown.

## Testing

- Added test cases to both test if autolinking works in general, and to test that the unwanted nested autolinking inside links does not happen anymore.
- Ran all tests locally.
- Built Astro Docs without any errors.

## Docs

- Not a visible change, just a bugfix.