### PR TITLE
Preoptimize renderers and hydration directives

### DIFF
--- a/.changeset/modern-toes-glow.md
+++ b/.changeset/modern-toes-glow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes race condition causing the "self accepting" error message

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -130,7 +130,7 @@
     "strip-ansi": "^7.0.1",
     "supports-esm": "^1.0.0",
     "tsconfig-resolver": "^3.0.1",
-    "vite": "^2.9.10",
+    "vite": "^2.9.12",
     "yargs-parser": "^21.0.1",
     "zod": "^3.17.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,7 +542,7 @@ importers:
       strip-ansi: ^7.0.1
       supports-esm: ^1.0.0
       tsconfig-resolver: ^3.0.1
-      vite: ^2.9.10
+      vite: ^2.9.12
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
@@ -599,7 +599,7 @@ importers:
       strip-ansi: 7.0.1
       supports-esm: 1.0.0
       tsconfig-resolver: 3.0.1
-      vite: 2.9.10_sass@1.52.2
+      vite: 2.9.12_sass@1.52.2
       yargs-parser: 21.0.1
       zod: 3.17.3
     devDependencies:
@@ -13621,8 +13621,8 @@ packages:
       fsevents: 2.3.2
     dev: false
 
-  /vite/2.9.10_sass@1.52.2:
-    resolution: {integrity: sha512-TwZRuSMYjpTurLqXspct+HZE7ONiW9d+wSWgvADGxhDPPyoIcNywY+RX4ng+QpK30DCa1l/oZgi2PLZDibhzbQ==}
+  /vite/2.9.12_sass@1.52.2:
+    resolution: {integrity: sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==}
     engines: {node: '>=12.2.0'}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
## Changes

- Adds all of the hydration directive scripts and renderer client entrypoints to optimized deps.
- This prevents a race condition where Vite assigns a unique hash for all of the deps it has optimized. When it encounters an unknown dep that hash changes. The changing of the hash causes it to need to rebuild some modules, and any modules that are in the process of being loaded are in a unexpected state at the point.
- The fix is to tell Vite about things that it will need to optimize later, which is everything in runtime/hydration.ts, so just the renderers and client directives.
- Discussed with @patak-dev (thanks!) here: https://discord.com/channels/804011606160703521/831456449632534538/984795370955616287

## Testing

- Tested manually, this is a race condition that's hard to capture in a unit test.

## Docs

N/A, bug fix.