### PR TITLE
Consolidate hydration scripts into just one

### DIFF
--- a/packages/astro/e2e/fixtures/pass-js/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/pass-js/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [react()],
+});

--- a/packages/astro/e2e/fixtures/pass-js/package.json
+++ b/packages/astro/e2e/fixtures/pass-js/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@e2e/pass-js",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@astrojs/react": "workspace:*",
+    "astro": "workspace:*"
+  },
+  "dependencies": {
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0"
+  }
+}

--- a/packages/astro/e2e/fixtures/pass-js/src/components/React.tsx
+++ b/packages/astro/e2e/fixtures/pass-js/src/components/React.tsx
@@ -1,0 +1,29 @@
+import type { BigNestedObject } from '../types';
+import { useState } from 'react';
+
+interface Props {
+	obj: BigNestedObject;
+	num: bigint;
+}
+
+const isNode = typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]';
+
+/** a counter written in React */
+export default function Component({ obj, num, arr }: Props) {
+	// We are testing hydration, so don't return anything in the server.
+	if(isNode) {
+		return <div></div>
+	}
+
+	return (
+		<div>
+			<span id="nested-date">{obj.nested.date.toUTCString()}</span>
+			<span id="regexp-type">{Object.prototype.toString.call(obj.more.another.exp)}</span>
+			<span id="regexp-value">{obj.more.another.exp.source}</span>
+			<span id="bigint-type">{Object.prototype.toString.call(num)}</span>
+			<span id="bigint-value">{num.toString()}</span>
+			<span id="arr-type">{Object.prototype.toString.call(arr)}</span>
+			<span id="arr-value">{arr.join(',')}</span>
+		</div>
+	);
+}

--- a/packages/astro/e2e/fixtures/pass-js/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/pass-js/src/pages/index.astro
@@ -1,0 +1,28 @@
+---
+import Component from '../components/React';
+import { BigNestedObject } from '../types';
+
+const obj: BigNestedObject = {
+	nested: {
+		date: new Date('Thu, 09 Jun 2022 14:18:27 GMT')
+	},
+	more: {
+		another: {
+			exp: /ok/
+		}
+	}
+};
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width" />
+		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+	</head>
+	<body>
+		<main>
+			<Component client:load obj={obj} num={11n} arr={[0, "foo"]} />
+		</main>
+	</body>
+</html>

--- a/packages/astro/e2e/fixtures/pass-js/src/types.ts
+++ b/packages/astro/e2e/fixtures/pass-js/src/types.ts
@@ -1,0 +1,11 @@
+
+export interface BigNestedObject {
+	nested: {
+		date: Date;
+	};
+	more: {
+		another: {
+			exp: RegExp;
+		}
+	}
+}

--- a/packages/astro/e2e/pass-js.test.js
+++ b/packages/astro/e2e/pass-js.test.js
@@ -1,0 +1,61 @@
+import { test as base, expect } from '@playwright/test';
+import { loadFixture } from './test-utils.js';
+
+const test = base.extend({
+	astro: async ({}, use) => {
+		const fixture = await loadFixture({ root: './fixtures/pass-js/' });
+		await use(fixture);
+	},
+});
+
+let devServer;
+
+test.beforeEach(async ({ astro }) => {
+	devServer = await astro.startDevServer();
+});
+
+test.afterEach(async () => {
+	await devServer.stop();
+});
+
+test.describe('Passing JS into client components', () => {
+	test('Complex nested objects', async ({ astro, page }) => {
+		await page.goto('/');
+
+		const nestedDate = await page.locator('#nested-date');
+		await expect(nestedDate, 'component is visible').toBeVisible();
+		await expect(nestedDate).toHaveText('Thu, 09 Jun 2022 14:18:27 GMT');
+
+		const regeExpType = await page.locator('#regexp-type');
+		await expect(regeExpType, 'is visible').toBeVisible();
+		await expect(regeExpType).toHaveText('[object RegExp]');
+
+		const regExpValue = await page.locator('#regexp-value');
+		await expect(regExpValue, 'is visible').toBeVisible();
+		await expect(regExpValue).toHaveText('ok');
+	});
+
+	test('BigInts', async ({ page }) => {
+		await page.goto('/');
+
+		const bigIntType = await page.locator('#bigint-type');
+		await expect(bigIntType, 'is visible').toBeVisible();
+		await expect(bigIntType).toHaveText('[object BigInt]');
+
+		const bigIntValue = await page.locator('#bigint-value');
+		await expect(bigIntValue, 'is visible').toBeVisible();
+		await expect(bigIntValue).toHaveText('11');
+	});
+
+	test('Arrays that look like the serialization format', async ({ page }) => {
+		await page.goto('/');
+
+		const arrType = await page.locator('#arr-type');
+		await expect(arrType, 'is visible').toBeVisible();
+		await expect(arrType).toHaveText('[object Array]');
+
+		const arrValue = await page.locator('#arr-value');
+		await expect(arrValue, 'is visible').toBeVisible();
+		await expect(arrValue).toHaveText('0,foo');
+	});
+});

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -66,6 +66,7 @@
     "vendor"
   ],
   "scripts": {
+    "prebuild": "astro-scripts prebuild --to-string \"src/runtime/server/astro-island.ts\"",
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
@@ -121,7 +122,6 @@
     "resolve": "^1.22.0",
     "rollup": "^2.75.5",
     "semver": "^7.3.7",
-    "serialize-javascript": "^6.0.0",
     "shiki": "^0.10.1",
     "sirv": "^2.0.2",
     "slash": "^4.0.0",

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -998,6 +998,7 @@ export interface SSRElement {
 export interface SSRMetadata {
 	renderers: SSRLoadedRenderer[];
 	pathname: string;
+	needsHydrationStyles: boolean;
 }
 
 export interface SSRResult {

--- a/packages/astro/src/@types/serialize-javascript.d.ts
+++ b/packages/astro/src/@types/serialize-javascript.d.ts
@@ -1,3 +1,0 @@
-declare module 'serialize-javascript' {
-	export default function serialize(value: any): string;
-}

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -21,7 +21,6 @@ const ALWAYS_EXTERNAL = new Set([
 	'@sveltejs/vite-plugin-svelte',
 	'micromark-util-events-to-acorn',
 	'@astrojs/markdown-remark',
-	'serialize-javascript',
 	'node-fetch',
 	'prismjs',
 	'shiki',

--- a/packages/astro/src/runtime/client/idle.ts
+++ b/packages/astro/src/runtime/client/idle.ts
@@ -6,7 +6,7 @@ import { listen, notify } from './events';
  * (or after a short delay, if `requestIdleCallback`) isn't supported
  */
 export default async function onIdle(
-	astroId: string,
+	root: HTMLElement,
 	options: HydrateOptions,
 	getHydrateCallback: GetHydrateCallback
 ) {
@@ -16,14 +16,12 @@ export default async function onIdle(
 	async function idle() {
 		listen(idle);
 		const cb = async () => {
-			const roots = document.querySelectorAll(`astro-root[ssr][uid="${astroId}"]`);
-			if (roots.length === 0) return;
 			if (typeof innerHTML !== 'string') {
-				let fragment = roots[0].querySelector(`astro-fragment`);
-				if (fragment == null && roots[0].hasAttribute('tmpl')) {
+				let fragment = root.querySelector(`astro-fragment`);
+				if (fragment == null && root.hasAttribute('tmpl')) {
 					// If there is no child fragment, check to see if there is a template.
 					// This happens if children were passed but the client component did not render any.
-					let template = roots[0].querySelector(`template[data-astro-template]`);
+					let template = root.querySelector(`template[data-astro-template]`);
 					if (template) {
 						innerHTML = template.innerHTML;
 						template.remove();
@@ -35,8 +33,7 @@ export default async function onIdle(
 			if (!hydrate) {
 				hydrate = await getHydrateCallback();
 			}
-			for (const root of roots) {
-				if (root.parentElement?.closest('astro-root[ssr]')) continue;
+			if (!root.parentElement?.closest('astro-root[ssr]')) {
 				await hydrate(root, innerHTML);
 				root.removeAttribute('ssr');
 			}

--- a/packages/astro/src/runtime/client/load.ts
+++ b/packages/astro/src/runtime/client/load.ts
@@ -5,7 +5,7 @@ import { listen, notify } from './events';
  * Hydrate this component immediately
  */
 export default async function onLoad(
-	astroId: string,
+	root: HTMLElement,
 	options: HydrateOptions,
 	getHydrateCallback: GetHydrateCallback
 ) {
@@ -14,14 +14,12 @@ export default async function onLoad(
 
 	async function load() {
 		listen(load);
-		const roots = document.querySelectorAll(`astro-root[ssr][uid="${astroId}"]`);
-		if (roots.length === 0) return;
 		if (typeof innerHTML !== 'string') {
-			let fragment = roots[0].querySelector(`astro-fragment`);
-			if (fragment == null && roots[0].hasAttribute('tmpl')) {
+			let fragment = root.querySelector(`astro-fragment`);
+			if (fragment == null && root.hasAttribute('tmpl')) {
 				// If there is no child fragment, check to see if there is a template.
 				// This happens if children were passed but the client component did not render any.
-				let template = roots[0].querySelector(`template[data-astro-template]`);
+				let template = root.querySelector(`template[data-astro-template]`);
 				if (template) {
 					innerHTML = template.innerHTML;
 					template.remove();
@@ -33,8 +31,7 @@ export default async function onLoad(
 		if (!hydrate) {
 			hydrate = await getHydrateCallback();
 		}
-		for (const root of roots) {
-			if (root.parentElement?.closest('astro-root[ssr]')) continue;
+		if (!root.parentElement?.closest('astro-root[ssr]')) {
 			await hydrate(root, innerHTML);
 			root.removeAttribute('ssr');
 		}

--- a/packages/astro/src/runtime/client/media.ts
+++ b/packages/astro/src/runtime/client/media.ts
@@ -5,7 +5,7 @@ import { listen, notify } from './events';
  * Hydrate this component when a matching media query is found
  */
 export default async function onMedia(
-	astroId: string,
+	root: HTMLElement,
 	options: HydrateOptions,
 	getHydrateCallback: GetHydrateCallback
 ) {
@@ -15,14 +15,12 @@ export default async function onMedia(
 	async function media() {
 		listen(media);
 		const cb = async () => {
-			const roots = document.querySelectorAll(`astro-root[ssr][uid="${astroId}"]`);
-			if (roots.length === 0) return;
 			if (typeof innerHTML !== 'string') {
-				let fragment = roots[0].querySelector(`astro-fragment`);
-				if (fragment == null && roots[0].hasAttribute('tmpl')) {
+				let fragment = root.querySelector(`astro-fragment`);
+				if (fragment == null && root.hasAttribute('tmpl')) {
 					// If there is no child fragment, check to see if there is a template.
 					// This happens if children were passed but the client component did not render any.
-					let template = roots[0].querySelector(`template[data-astro-template]`);
+					let template = root.querySelector(`template[data-astro-template]`);
 					if (template) {
 						innerHTML = template.innerHTML;
 						template.remove();
@@ -34,8 +32,7 @@ export default async function onMedia(
 			if (!hydrate) {
 				hydrate = await getHydrateCallback();
 			}
-			for (const root of roots) {
-				if (root.parentElement?.closest('astro-root[ssr]')) continue;
+			if (!root.parentElement?.closest('astro-root[ssr]')) {
 				await hydrate(root, innerHTML);
 				root.removeAttribute('ssr');
 			}

--- a/packages/astro/src/runtime/client/only.ts
+++ b/packages/astro/src/runtime/client/only.ts
@@ -5,7 +5,7 @@ import { listen, notify } from './events';
  * Hydrate this component only on the client
  */
 export default async function onOnly(
-	astroId: string,
+	root: HTMLElement,
 	options: HydrateOptions,
 	getHydrateCallback: GetHydrateCallback
 ) {
@@ -14,14 +14,12 @@ export default async function onOnly(
 
 	async function only() {
 		listen(only);
-		const roots = document.querySelectorAll(`astro-root[ssr][uid="${astroId}"]`);
-		if (roots.length === 0) return;
 		if (typeof innerHTML !== 'string') {
-			let fragment = roots[0].querySelector(`astro-fragment`);
-			if (fragment == null && roots[0].hasAttribute('tmpl')) {
+			let fragment = root.querySelector(`astro-fragment`);
+			if (fragment == null && root.hasAttribute('tmpl')) {
 				// If there is no child fragment, check to see if there is a template.
 				// This happens if children were passed but the client component did not render any.
-				let template = roots[0].querySelector(`template[data-astro-template]`);
+				let template = root.querySelector(`template[data-astro-template]`);
 				if (template) {
 					innerHTML = template.innerHTML;
 					template.remove();
@@ -33,8 +31,7 @@ export default async function onOnly(
 		if (!hydrate) {
 			hydrate = await getHydrateCallback();
 		}
-		for (const root of roots) {
-			if (root.parentElement?.closest('astro-root[ssr]')) continue;
+		if (!root.parentElement?.closest('astro-root[ssr]')) {
 			await hydrate(root, innerHTML);
 			root.removeAttribute('ssr');
 		}

--- a/packages/astro/src/runtime/server/astro-island.prebuilt.ts
+++ b/packages/astro/src/runtime/server/astro-island.prebuilt.ts
@@ -1,0 +1,7 @@
+/**
+ * This file is prebuilt from packages/astro/src/runtime/server/astro-island.ts
+ * Do not edit this directly, but instead edit that file and rerun the prebuild
+ * to generate this file.
+ */
+
+export default `{const i={0:t=>t,1:t=>JSON.parse(t,r),2:t=>new RegExp(t),3:t=>new Date(t),4:t=>new Map(JSON.parse(t,r)),5:t=>new Set(JSON.parse(t,r)),6:t=>BigInt(t),7:t=>new URL(t)},r=(t,e)=>{if(t===""||!Array.isArray(e))return e;const[n,s]=e;return n in i?i[n](s):void 0};customElements.define("astro-island",class extends HTMLElement{async connectedCallback(){const[{default:t}]=await Promise.all([import(this.getAttribute("directive-url")),import(this.getAttribute("before-hydration-url"))]),e=JSON.parse(this.getAttribute("opts"));t(this,e,async()=>{const n=this.hasAttribute("props")?JSON.parse(this.getAttribute("props"),r):{},s=this.getAttribute("renderer-url"),[{default:o},{default:a}]=await Promise.all([import(this.getAttribute("component-url")),s?import(s):()=>()=>{}]);return(p,l)=>a(p)(o,n,l,{client:this.getAttribute("client")})})}})}`;

--- a/packages/astro/src/runtime/server/astro-island.ts
+++ b/packages/astro/src/runtime/server/astro-island.ts
@@ -1,6 +1,12 @@
-/*
+// Note that this file is prebuilt to astro-island.prebuilt.ts
+// Do not import this file directly, instead import the prebuilt one instead.
+
 {
-	const propTypes = {
+	interface PropTypeSelector {
+		[k: string]: (value: any) => any;
+	}
+
+	const propTypes: PropTypeSelector = {
 		0: value => value,
 		1: value => JSON.parse(value, reviver),
 		2: value => new RegExp(value),
@@ -11,7 +17,7 @@
 		7: value => new URL(value),
 	};
 
-	const reviver = (propKey, raw) => {
+	const reviver = (propKey: string, raw: string): any => {
 		if(propKey === '' || !Array.isArray(raw)) return raw;
 		const [type, value] = raw;
 		return (type in propTypes) ? propTypes[type](value) : undefined;
@@ -20,32 +26,22 @@
 	customElements.define('astro-island', class extends HTMLElement {
 		async connectedCallback(){
 			const [ { default: setup } ] = await Promise.all([
-				import(this.getAttribute('directive-url')),
-				import(this.getAttribute('before-hydration-url'))
+				import(this.getAttribute('directive-url')!),
+				import(this.getAttribute('before-hydration-url')!)
 			]);
-			const opts = JSON.parse(this.getAttribute('opts'));
+			const opts = JSON.parse(this.getAttribute('opts')!);
 			setup(this, opts, async () => {
-				const props = this.hasAttribute('props') ? JSON.parse(this.getAttribute('props'), reviver) : {};
+				const props = this.hasAttribute('props') ? JSON.parse(this.getAttribute('props')!, reviver) : {};
 				const rendererUrl = this.getAttribute('renderer-url');
 				const [
 					{ default: Component },
 					{ default: hydrate }
 				] = await Promise.all([
-					import(this.getAttribute('component-url')),
+					import(this.getAttribute('component-url')!),
 					rendererUrl ? import(rendererUrl) : () => () => {}
 				]);
-				return (el, children) => hydrate(el)(Component, props, children, { client: this.getAttribute('client') });
+				return (el: HTMLElement, children: string) => hydrate(el)(Component, props, children, { client: this.getAttribute('client') });
 			});
 		}
 	});
 }
-*/
-
-/**
- * This is a minified version of the above. If you modify the above you need to
- * copy/paste it into a .js file and then run:
- * > node_modules/.bin/terser --mangle --compress -- file.js
- * 
- * And copy/paste the result below
- */
-export const islandScript = `{const t={0:t=>t,1:t=>JSON.parse(t,e),2:t=>new RegExp(t),3:t=>new Date(t),4:t=>new Map(JSON.parse(t,e)),5:t=>new Set(JSON.parse(t,e)),6:t=>BigInt(t),7:t=>new URL(t)},e=(e,r)=>{if(""===e||!Array.isArray(r))return r;const[i,s]=r;return i in t?t[i](s):void 0};customElements.define("astro-island",class extends HTMLElement{async connectedCallback(){const[{default:t}]=await Promise.all([import(this.getAttribute("directive-url")),import(this.getAttribute("before-hydration-url"))]);t(this,JSON.parse(this.getAttribute("opts")),(async()=>{const t=this.hasAttribute("props")?JSON.parse(this.getAttribute("props"),e):{},r=this.getAttribute("renderer-url"),[{default:i},{default:s}]=await Promise.all([import(this.getAttribute("component-url")),r?import(r):()=>()=>{}]);return(e,r)=>s(e)(i,t,r,{client:this.getAttribute("client")})}))}})}`;

--- a/packages/astro/src/runtime/server/astro-island.ts
+++ b/packages/astro/src/runtime/server/astro-island.ts
@@ -1,0 +1,51 @@
+/*
+{
+	const propTypes = {
+		0: value => value,
+		1: value => JSON.parse(value, reviver),
+		2: value => new RegExp(value),
+		3: value => new Date(value),
+		4: value => new Map(JSON.parse(value, reviver)),
+		5: value => new Set(JSON.parse(value, reviver)),
+		6: value => BigInt(value),
+		7: value => new URL(value),
+	};
+
+	const reviver = (propKey, raw) => {
+		if(propKey === '' || !Array.isArray(raw)) return raw;
+		const [type, value] = raw;
+		return (type in propTypes) ? propTypes[type](value) : undefined;
+	};
+
+	customElements.define('astro-island', class extends HTMLElement {
+		async connectedCallback(){
+			const [ { default: setup } ] = await Promise.all([
+				import(this.getAttribute('directive-url')),
+				import(this.getAttribute('before-hydration-url'))
+			]);
+			const opts = JSON.parse(this.getAttribute('opts'));
+			setup(this, opts, async () => {
+				const props = this.hasAttribute('props') ? JSON.parse(this.getAttribute('props'), reviver) : {};
+				const rendererUrl = this.getAttribute('renderer-url');
+				const [
+					{ default: Component },
+					{ default: hydrate }
+				] = await Promise.all([
+					import(this.getAttribute('component-url')),
+					rendererUrl ? import(rendererUrl) : () => () => {}
+				]);
+				return (el, children) => hydrate(el)(Component, props, children, { client: this.getAttribute('client') });
+			});
+		}
+	});
+}
+*/
+
+/**
+ * This is a minified version of the above. If you modify the above you need to
+ * copy/paste it into a .js file and then run:
+ * > node_modules/.bin/terser --mangle --compress -- file.js
+ * 
+ * And copy/paste the result below
+ */
+export const islandScript = `{const t={0:t=>t,1:t=>JSON.parse(t,e),2:t=>new RegExp(t),3:t=>new Date(t),4:t=>new Map(JSON.parse(t,e)),5:t=>new Set(JSON.parse(t,e)),6:t=>BigInt(t),7:t=>new URL(t)},e=(e,r)=>{if(""===e||!Array.isArray(r))return r;const[i,s]=r;return i in t?t[i](s):void 0};customElements.define("astro-island",class extends HTMLElement{async connectedCallback(){const[{default:t}]=await Promise.all([import(this.getAttribute("directive-url")),import(this.getAttribute("before-hydration-url"))]);t(this,JSON.parse(this.getAttribute("opts")),(async()=>{const t=this.hasAttribute("props")?JSON.parse(this.getAttribute("props"),e):{},r=this.getAttribute("renderer-url"),[{default:i},{default:s}]=await Promise.all([import(this.getAttribute("component-url")),r?import(r):()=>()=>{}]);return(e,r)=>s(e)(i,t,r,{client:this.getAttribute("client")})}))}})}`;

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -5,13 +5,9 @@ import type {
 	SSRLoadedRenderer,
 	SSRResult,
 } from '../../@types/astro';
+import { escapeHTML } from './escape.js';
 import { hydrationSpecifier, serializeListValue } from './util.js';
-
-// Serializes props passed into a component so that they can be reused during hydration.
-// The value is any
-export function serializeProps(value: any) {
-	return serializeJavaScript(value);
-}
+import { serializeProps } from './serialize.js';
 
 const HydrationDirectives = ['load', 'idle', 'media', 'visible', 'only'];
 
@@ -100,6 +96,11 @@ interface HydrateScriptOptions {
 	props: Record<string | number, any>;
 }
 
+
+
+
+
+
 /** For hydrated components, generate a <script type="module"> to load the component */
 export async function generateHydrateScript(
 	scriptOptions: HydrateScriptOptions,
@@ -114,32 +115,31 @@ export async function generateHydrateScript(
 		);
 	}
 
-	const hydrationSource = renderer.clientEntrypoint
-		? `const [{ ${
-				componentExport.value
-		  }: Component }, { default: hydrate }] = await Promise.all([import("${await result.resolve(
-				componentUrl
-		  )}"), import("${await result.resolve(renderer.clientEntrypoint)}")]);
-  return (el, children) => hydrate(el)(Component, ${serializeProps(
-		props
-	)}, children, ${JSON.stringify({ client: hydrate })});
-`
-		: `await import("${await result.resolve(componentUrl)}");
-  return () => {};
-`;
-	// TODO: If we can figure out tree-shaking in the final SSR build, we could safely
-	// use BEFORE_HYDRATION_SCRIPT_ID instead of 'astro:scripts/before-hydration.js'.
-	const hydrationScript = {
-		props: { type: 'module', 'data-astro-component-hydration': true },
-		children: `import setup from '${await result.resolve(hydrationSpecifier(hydrate))}';
-${`import '${await result.resolve('astro:scripts/before-hydration.js')}';`}
-setup("${astroId}", {name:"${metadata.displayName}",${
-			metadata.hydrateArgs ? `value: ${JSON.stringify(metadata.hydrateArgs)}` : ''
-		}}, async () => {
-  ${hydrationSource}
-});
-`,
+	const island: SSRElement = {
+		children: '',
+		props: {
+			// This is for HMR, probably can avoid it in prod
+			uid: astroId
+		}
 	};
 
-	return hydrationScript;
+	// Add component url
+	island.props['component-url'] = await result.resolve(componentUrl);
+
+	// Add renderer url
+	if(renderer.clientEntrypoint) {
+		island.props['renderer-url'] = await result.resolve(renderer.clientEntrypoint);
+		island.props['props'] = escapeHTML(serializeProps(props));
+	}
+
+	island.props['ssr'] = '';
+	island.props['client'] = hydrate;
+	island.props['directive-url'] = await result.resolve(hydrationSpecifier(hydrate));
+	island.props['before-hydration-url'] = await result.resolve('astro:scripts/before-hydration.js');
+	island.props['opts'] = escapeHTML(JSON.stringify({
+		name: metadata.displayName,
+		value: metadata.hydrateArgs || ''
+	}))
+
+	return island;
 }

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -1,4 +1,3 @@
-import serializeJavaScript from 'serialize-javascript';
 import type {
 	AstroComponentMetadata,
 	SSRElement,

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -9,9 +9,11 @@ import type {
 	SSRResult,
 } from '../../@types/astro';
 import { escapeHTML, HTMLString, markHTMLString } from './escape.js';
-import { extractDirectives, generateHydrateScript, serializeProps } from './hydration.js';
+import { extractDirectives, generateHydrateScript } from './hydration.js';
 import { shorthash } from './shorthash.js';
 import { serializeListValue } from './util.js';
+import { islandScript } from './astro-island.js';
+import { serializeProps } from './serialize.js';
 
 export { markHTMLString, markHTMLString as unescapeHTML } from './escape.js';
 export type { Metadata } from './metadata';
@@ -24,6 +26,11 @@ const htmlBooleanAttributes =
 const htmlEnumAttributes = /^(contenteditable|draggable|spellcheck|value)$/i;
 // Note: SVG is case-sensitive!
 const svgEnumAttributes = /^(autoReverse|externalResourcesRequired|focusable|preserveAlpha)$/i;
+
+// This is used to keep track of which requests (pages) have had the hydration script
+// appended. We only add the hydration script once per page, and since the SSRResult
+// object corresponds to one page request, we are using it as a key to know.
+const resultsWithHydrationScript = new WeakSet<SSRResult>();
 
 // INVESTIGATE:
 // 2. Less anys when possible and make it well known when they are needed.
@@ -316,23 +323,40 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 		)}`
 	);
 
-	// Rather than appending this inline in the page, puts this into the `result.scripts` set that will be appended to the head.
-	// INVESTIGATE: This will likely be a problem in streaming because the `<head>` will be gone at this point.
-	result.scripts.add(
-		await generateHydrateScript(
-			{ renderer: renderer!, result, astroId, props },
-			metadata as Required<AstroComponentMetadata>
-		)
+	const island = await generateHydrateScript(
+		{ renderer: renderer!, result, astroId, props },
+		metadata as Required<AstroComponentMetadata>
 	);
+	result._metadata.needsHydrationStyles = true;
 
 	// Render a template if no fragment is provided.
 	const needsAstroTemplate = children && !/<\/?astro-fragment\>/.test(html);
 	const template = needsAstroTemplate ? `<template data-astro-template>${children}</template>` : '';
 
+	if(needsAstroTemplate) {
+		island.props.tmpl = '';
+	}
+
+	island.children = `${
+		html ?? ''
+	}${template}`;
+
+	// Add the astro-island definition only once. Since the SSRResult object
+	// is scoped to a page renderer we can use it as a key to know if the script
+	// has been rendered or not.
+	let script = '';
+	if(!resultsWithHydrationScript.has(result)) {
+		resultsWithHydrationScript.add(result);
+		// Note that this is a class script, not a module script.
+		// This is so that it executes immediate, and when the browser encounters
+		// an astro-island element the callbacks will fire immediately, causing the JS
+		// deps to be loaded immediately.
+		script = `<script>${islandScript}</script>`;
+	}
+
 	return markHTMLString(
-		`<astro-root ssr uid="${astroId}"${needsAstroTemplate ? ' tmpl' : ''}>${
-			html ?? ''
-		}${template}</astro-root>`
+		script +
+		renderElement('astro-island', island, false)
 	);
 }
 
@@ -619,7 +643,7 @@ export async function renderHead(result: SSRResult): Promise<string> {
 	const styles = Array.from(result.styles)
 		.filter(uniqueElements)
 		.map((style) => renderElement('style', style));
-	let needsHydrationStyles = false;
+	let needsHydrationStyles = result._metadata.needsHydrationStyles;
 	const scripts = Array.from(result.scripts)
 		.filter(uniqueElements)
 		.map((script, i) => {
@@ -632,7 +656,7 @@ export async function renderHead(result: SSRResult): Promise<string> {
 		styles.push(
 			renderElement('style', {
 				props: {},
-				children: 'astro-root, astro-fragment { display: contents; }',
+				children: 'astro-island, astro-fragment { display: contents; }',
 			})
 		);
 	}

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -12,7 +12,7 @@ import { escapeHTML, HTMLString, markHTMLString } from './escape.js';
 import { extractDirectives, generateHydrateScript } from './hydration.js';
 import { shorthash } from './shorthash.js';
 import { serializeListValue } from './util.js';
-import { islandScript } from './astro-island.js';
+import islandScript from './astro-island.prebuilt.js';
 import { serializeProps } from './serialize.js';
 
 export { markHTMLString, markHTMLString as unescapeHTML } from './escape.js';

--- a/packages/astro/src/runtime/server/serialize.ts
+++ b/packages/astro/src/runtime/server/serialize.ts
@@ -1,0 +1,60 @@
+type ValueOf<T> = T[keyof T];
+
+const PROP_TYPE = {
+	Value: 0,
+	JSON: 1,
+	RegExp: 2,
+	Date: 3,
+	Map: 4,
+	Set: 5,
+	BigInt: 6,
+	URL: 7,
+};
+
+function serializeArray(value: any[]): any[] {
+	return value.map((v) => convertToSerializedForm(v));
+}
+
+function serializeObject(value: Record<any, any>): Record<any, any> {
+	return Object.fromEntries(Object.entries(value).map(([k, v]) => {
+		return [k, convertToSerializedForm(v)];
+	}));
+}
+
+function convertToSerializedForm(value: any): [ValueOf<typeof PROP_TYPE>, any] {
+	const tag = Object.prototype.toString.call(value);
+	switch(tag) {
+		case '[object Date]': {
+			return [PROP_TYPE.Date, (value as Date).toISOString()];
+		}
+		case '[object RegExp]': {
+			return [PROP_TYPE.RegExp, (value as RegExp).source];
+		}
+		case '[object Map]': {
+			return [PROP_TYPE.Map, Array.from(value as Map<any, any>)];
+		}
+		case '[object Set]': {
+			return [PROP_TYPE.Set, Array.from(value as Set<any>)];
+		}
+		case '[object BigInt]': {
+			return [PROP_TYPE.BigInt, (value as bigint).toString()];
+		}
+		case '[object URL]': {
+			return [PROP_TYPE.URL, (value as URL).toString()];
+		}
+		case '[object Array]': {
+			return [PROP_TYPE.JSON, JSON.stringify(serializeArray(value))];
+		}
+		default: {
+			if(typeof value === 'object') {
+				return [PROP_TYPE.Value, serializeObject(value)];
+			} else {
+				return [PROP_TYPE.Value, value];
+			}
+		}
+	}
+}
+
+export function serializeProps(props: any) {
+	return JSON.stringify(serializeObject(props));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -894,6 +894,19 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/e2e/fixtures/pass-js:
+    specifiers:
+      '@astrojs/react': workspace:*
+      astro: workspace:*
+      react: ^18.1.0
+      react-dom: ^18.1.0
+    dependencies:
+      react: 18.1.0
+      react-dom: 18.1.0_react@18.1.0
+    devDependencies:
+      '@astrojs/react': link:../../../../integrations/react
+      astro: link:../../..
+
   packages/astro/e2e/fixtures/preact-component:
     specifiers:
       '@astrojs/preact': workspace:*
@@ -8119,6 +8132,11 @@ packages:
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
     dev: false
@@ -11059,6 +11077,8 @@ packages:
       debug: 3.2.7
       iconv-lite: 0.4.24
       sax: 1.2.4
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /netmask/2.0.2:
@@ -11142,6 +11162,8 @@ packages:
       rimraf: 2.7.1
       semver: 5.7.1
       tar: 4.4.19
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /node-releases/2.0.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,7 +532,6 @@ importers:
       rollup: ^2.75.5
       sass: ^1.52.2
       semver: ^7.3.7
-      serialize-javascript: ^6.0.0
       shiki: ^0.10.1
       sirv: ^2.0.2
       slash: ^4.0.0
@@ -590,7 +589,6 @@ importers:
       resolve: 1.22.0
       rollup: 2.75.5
       semver: 7.3.7
-      serialize-javascript: 6.0.0
       shiki: 0.10.1
       sirv: 2.0.2
       slash: 4.0.0
@@ -11843,6 +11841,7 @@ packages:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
     dependencies:
       safe-buffer: 5.2.1
+    dev: true
 
   /raw-body/2.5.1:
     resolution: {integrity: sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==}
@@ -12375,6 +12374,7 @@ packages:
     resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
     dependencies:
       randombytes: 2.1.0
+    dev: true
 
   /set-blocking/2.0.0:
     resolution: {integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=}

--- a/scripts/cmd/prebuild.js
+++ b/scripts/cmd/prebuild.js
@@ -1,0 +1,49 @@
+import * as terser from 'terser';
+import esbuild from 'esbuild';
+import glob from 'tiny-glob';
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL, fileURLToPath } from 'url';
+
+export default async function prebuild(...args) {
+	let buildToString = args.indexOf('--to-string');
+	if(buildToString !== -1) {
+		args.splice(buildToString, 1);
+		buildToString = true;
+	}
+
+	let patterns = args;
+	let entryPoints = [].concat(
+		...(await Promise.all(
+			patterns.map((pattern) => glob(pattern, { filesOnly: true, absolute: true }))
+		))
+	);
+
+	function getPrebuildURL(entryfilepath) {
+		const entryURL = pathToFileURL(entryfilepath);
+		const basename = path.basename(entryfilepath);
+		const ext = path.extname(entryfilepath);
+		const name = basename.slice(0, basename.indexOf(ext));
+		const outname = `${name}.prebuilt${ext}`;
+		const outURL = new URL('./' + outname, entryURL);
+		return outURL;
+	}
+
+	async function prebuildFile(filepath) {
+		const tscode = await fs.promises.readFile(filepath, 'utf-8');
+		const esbuildresult = await esbuild.transform(tscode, { loader: 'ts', minify: true });
+		const rootURL = new URL('../../', import.meta.url);
+		const rel = path.relative(fileURLToPath(rootURL), filepath)
+		const mod = `/**
+ * This file is prebuilt from ${rel}
+ * Do not edit this directly, but instead edit that file and rerun the prebuild
+ * to generate this file.
+ */
+
+export default \`${esbuildresult.code.trim()}\`;`;
+		const url = getPrebuildURL(filepath);
+		await fs.promises.writeFile(url, mod, 'utf-8');
+	}
+
+	await Promise.all(entryPoints.map(prebuildFile));
+}

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -13,6 +13,11 @@ export default async function run() {
 			await copy(...args);
 			break;
 		}
+		case 'prebuild': {
+			const { default: prebuild } = await import('./cmd/prebuild.js');
+			await prebuild(...args);
+			break;
+		}
 	}
 }
 


### PR DESCRIPTION
## Changes

- This is a repeat of something we previously did, but had to revert: https://github.com/withastro/astro/pull/3275
- New change is that there is a small serializer/deserializer that supports:
  - Date
  - RegExp
  - Map
  - Set
  - BigInt
  - URL
  - Everything that can be JSON.stringified.
- How this works is:
  1. The first time we encounter a hydrated component in a page a small script is inlined.
  2. This script defines a custom element, `astro-island`.
  3. Each island contains attributes for things that need to be loaded (directive script, renderer script, component, etc) and its props.
  4. The custom element does the loading and rendering; essentially the same thing that happened in the individual scripts previously.

## Testing

- New E2E test added to ensure complex objects would be serialized correctly.
- Previous tests updated.

## Docs

N/A, perf improvement.