### PR TITLE
Fix remarkMdxish performance issue on huge sites

### DIFF
--- a/.changeset/proud-forks-hammer.md
+++ b/.changeset/proud-forks-hammer.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Fix remarkMdxish performance issue on huge sites

--- a/packages/markdown/remark/src/remark-mdxish.ts
+++ b/packages/markdown/remark/src/remark-mdxish.ts
@@ -3,12 +3,17 @@ import type { Tag } from 'mdast-util-mdx-jsx';
 import { mdxFromMarkdown, mdxToMarkdown } from './mdast-util-mdxish.js';
 import { mdxjs } from './mdxjs.js';
 
-export default function remarkMdxish(this: any, options = {}) {
+// Prepare markdown extensions once to prevent performance issues
+const extMdxJs = mdxjs({});
+const extMdxFromMarkdown = makeFromMarkdownLessStrict(mdxFromMarkdown());
+const extMdxToMarkdown = mdxToMarkdown();
+
+export default function remarkMdxish(this: any) {
 	const data = this.data();
 
-	add('micromarkExtensions', mdxjs(options));
-	add('fromMarkdownExtensions', makeFromMarkdownLessStrict(mdxFromMarkdown()));
-	add('toMarkdownExtensions', mdxToMarkdown());
+	add('micromarkExtensions', extMdxJs);
+	add('fromMarkdownExtensions', extMdxFromMarkdown);
+	add('toMarkdownExtensions', extMdxToMarkdown);
 
 	function add(field: string, value: unknown) {
 		const list = data[field] ? data[field] : (data[field] = []);


### PR DESCRIPTION
## Changes

- Fixes an issue reported by `JamesScheller` in our Discord support channel that causes a `Maximum call stack size exceeded` error when building sites with hundreds of Markdown pages.
- Background: The `makeFromMarkdownLessStrict` fix introduced in beta 41 was applied once per page render, inadvertently wrapping the extension function in multiple layers of fix functions. This caused the call stack to grow indefinitely.
- This PR changes this behavior by preparing all extensions (including the fix) just once and then reusing the prepared extensions later.

## Testing

- Ran all tests.
- Successfully built the private example repo provided by the original issue reporter.

## Docs

- Not a visible change, just a bugfix.