### PR TITLE
fix(examples): incorrect StackBlitz demo URLs

### DIFF
--- a/examples/basics/README.md
+++ b/examples/basics/README.md
@@ -1,6 +1,6 @@
 # Welcome to [Astro](https://astro.build)
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/starter)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/basics)
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 

--- a/examples/integrations-playground/README.md
+++ b/examples/integrations-playground/README.md
@@ -1,7 +1,7 @@
-# Integration Playground
+# Integrations Playground
 
 ```
-npm init astro -- --template integration-playground
+npm init astro -- --template integrations-playground
 ```
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/integration-playground)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/integrations-playground)

--- a/examples/subpath/README.md
+++ b/examples/subpath/README.md
@@ -4,7 +4,7 @@
 npm init astro -- --template subpath
 ```
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/subpath)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/subpath?initialPath=/blog/)
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 

--- a/examples/with-markdown-shiki/README.md
+++ b/examples/with-markdown-shiki/README.md
@@ -4,7 +4,7 @@
 npm init astro -- --template with-markdown-shiki
 ```
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-markdown)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-markdown-shiki)
 
 This example showcases Astro's [built-in Markdown support](https://docs.astro.build/en/guides/markdown-content/).
 

--- a/examples/with-vite-plugin-pwa/README.md
+++ b/examples/with-vite-plugin-pwa/README.md
@@ -4,7 +4,7 @@
 npm init astro -- --template with-vite-plugin-pwa
 ```
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-vite-plugin-pwa)
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 


### PR DESCRIPTION
Fixes https://github.com/stackblitz/core/issues/1896

## Changes

- Fixes a typo in a StackBlitz URL and the corresponding `npm init` snippet, where the example name used didn't match the folder name exactly.
- A few StackBlitz URLs where pointing to another example than the current folder (e.g. `examples/with-vite-plugin-pwa/README.md` pointing to the `minimal` example instead of the `with-vite-plugin-pwa` example). Unless this is a deliberate choice, I suspect this comes from copying an existing example folder to create a new example, and forgetting to update the StackBlitz URL.
- Added a `?initialPath=/blog/` URL parameter for the `subpath` example, so that StackBlitz shows the correct subpath in the preview iframe.

## Testing

This was manually tested by following every StackBlitz URL in `examples/[name]/README.md and verifying that the examples imports correctly in StackBlitz, before and after changes.

Every example loads correctly.

## Docs

Checked the docs and it doesn't seem like they would be impacted in any way.
