### PR TITLE
Fix: Check node version and find acceptable host accordingly

### DIFF
--- a/.changeset/kind-feet-double.md
+++ b/.changeset/kind-feet-double.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix: find a hosting network differently based on Node version

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -86,7 +86,9 @@ export function devStart({
 		const ipv4Networks = Object.values(os.networkInterfaces())
 			.flatMap((networkInterface) => networkInterface ?? [])
 			.filter(
-				(networkInterface) => networkInterface?.address && networkInterface?.family === 'IPv4'
+				(networkInterface) =>
+					networkInterface?.address &&
+					networkInterface?.family === (Number(process.version.substring(1, 5)) < 18.1 ? 'IPv4' : 4)
 			);
 		for (let { address } of ipv4Networks) {
 			if (address.includes('127.0.0.1')) {


### PR DESCRIPTION
## Changes

- Resolves #3598 
- Ensures that Astro finds an appropriate network to host `dev` or `preview` on Node 18.1+
- Checks for appropriate network differently dependent on Node version

## Testing

As mentioned by @bholmesdev on #3547, this kind of change is hard to test because we have to manipulate the Node's `os` response. However, for what it's worth, adding this fix locally fixed my issue (#3598)

## Docs

This change is not visible, meaning that documentation does not need to be updated.