### PR TITLE
Remove extra newlines around components in Markdown

### DIFF
--- a/.changeset/wild-phones-work.md
+++ b/.changeset/wild-phones-work.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/markdown-remark': patch
+---
+
+Remove extra newlines around Markdown components

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -291,12 +291,16 @@ describe('Astro Markdown', () => {
 		expect(slots.find('> .fragmentSlot > div').text()).to.contain('1:');
 		expect(slots.find('> .fragmentSlot > div + p').text()).to.contain('2:');
 		expect(slots.find('> .pSlot > p[title="hello"]').text()).to.contain('3:');
-		expect(slots.find('> .defaultSlot').text().replace(/\s+/g, ' ')).to.equal(
-			`
-			4: Div in default slot
-			5: Paragraph in fragment in default slot
-			6: Regular text in default slot
-		`.replace(/\s+/g, ' ')
+		expect(slots.find('> .defaultSlot').html()).to.match(
+			new RegExp(
+				`<div>4: Div in default slot</div>` +
+					// Optional extra paragraph due to the line breaks between components
+					`(<p></p>)?` +
+					`<p>5: Paragraph in fragment in default slot</p>` +
+					// Optional whitespace due to the line breaks between components
+					`[\s\n]*` +
+					`6: Regular text in default slot`
+			)
 		);
 
 		const nestedSlots = $('article').eq(1);

--- a/packages/markdown/remark/src/rehype-collect-headers.ts
+++ b/packages/markdown/remark/src/rehype-collect-headers.ts
@@ -25,7 +25,7 @@ export default function createCollectHeaders() {
 						return;
 					}
 					if (child.type === 'raw') {
-						if (child.value.startsWith('\n<') || child.value.endsWith('>\n')) {
+						if (child.value.match(/^\n?<.*>\n?$/)) {
 							return;
 						}
 					}

--- a/packages/markdown/remark/src/rehype-jsx.ts
+++ b/packages/markdown/remark/src/rehype-jsx.ts
@@ -53,11 +53,11 @@ export default function rehypeJsx(): ReturnType<RehypePlugin> {
 			// wrapped by raw opening and closing tags
 			const openingTag = {
 				type: 'raw',
-				value: `\n<${node.name}${attrs}>`,
+				value: `<${node.name}${attrs}>`,
 			};
 			const closingTag = {
 				type: 'raw',
-				value: `</${node.name}>\n`,
+				value: `</${node.name}>`,
 			};
 			parent.children.splice(index, 1, openingTag, ...node.children, closingTag);
 		});

--- a/packages/markdown/remark/test/components.test.js
+++ b/packages/markdown/remark/test/components.test.js
@@ -49,7 +49,7 @@ describe('components', () => {
 	it('should normalize children', async () => {
 		const { code } = await renderMarkdown(`<Component bool={true}>Hello world!</Component>`, {});
 
-		chai.expect(code).to.equal(`\n<Component bool={true}>Hello world!</Component>\n`);
+		chai.expect(code).to.equal(`<Component bool={true}>Hello world!</Component>`);
 	});
 
 	it('should be able to nest components', async () => {
@@ -60,7 +60,7 @@ describe('components', () => {
 
 		chai
 			.expect(code)
-			.to.equal(`\n<Component bool={true}>\n<Component>Hello world!</Component>\n</Component>\n`);
+			.to.equal(`<Component bool={true}><Component>Hello world!</Component></Component>`);
 	});
 
 	it('should allow markdown without many spaces', async () => {
@@ -71,6 +71,6 @@ describe('components', () => {
 			{}
 		);
 
-		chai.expect(code).to.equal(`\n<Component><h1 id="hello-world">Hello world!</h1></Component>\n`);
+		chai.expect(code).to.equal(`<Component><h1 id="hello-world">Hello world!</h1></Component>`);
 	});
 });

--- a/packages/markdown/remark/test/expressions.test.js
+++ b/packages/markdown/remark/test/expressions.test.js
@@ -11,7 +11,7 @@ describe('expressions', () => {
 	it('should be able to serialize expression inside component', async () => {
 		const { code } = await renderMarkdown(`<Component>{a}</Component>`, {});
 
-		chai.expect(code).to.equal(`\n<Component>{a}</Component>\n`);
+		chai.expect(code).to.equal(`<Component>{a}</Component>`);
 	});
 
 	it('should be able to serialize expression inside markdown', async () => {


### PR DESCRIPTION
## Changes

- Fixes #3493.
- Removes the extra newlines that the previous code wrapped around `mdxJsxFlowElement` and `mdxJsxTextElement` elements with children in Markdown. These extra newlines caused unwanted whitespace to be introduced into the resulting HTML output.

## Testing

- Updated test cases to reflect the new correct output.
- Ran all tests locally.
- Built Astro Docs using the new code without apparent issues.

## Docs

- Just a bugfix.