### PR TITLE
Encode ampersands in markdown code blocks

### DIFF
--- a/.changeset/pink-pugs-beg.md
+++ b/.changeset/pink-pugs-beg.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Encodes ampersand characters in code blocks

--- a/packages/markdown/remark/src/rehype-escape.ts
+++ b/packages/markdown/remark/src/rehype-escape.ts
@@ -8,7 +8,7 @@ export default function rehypeEscape(): any {
 				// Visit all raw children and escape HTML tags to prevent Markdown code
 				// like "This is a `<script>` tag" from actually opening a script tag
 				visit(el, 'raw', (raw) => {
-					raw.value = raw.value.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+					raw.value = raw.value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 				});
 			}
 			return el;

--- a/packages/markdown/remark/test/expressions.test.js
+++ b/packages/markdown/remark/test/expressions.test.js
@@ -1,5 +1,5 @@
 import { renderMarkdown } from '../dist/index.js';
-import chai from 'chai';
+import chai, { expect } from 'chai';
 
 describe('expressions', () => {
 	it('should be able to serialize bare expression', async () => {
@@ -70,6 +70,33 @@ describe('expressions', () => {
 				`<h6 id={$$slug(\`{} is equivalent to Record&lt;never, never&gt; (at TypeScript v\${frontmatter.version})\`)}><code is:raw>{}</code> is equivalent to <code is:raw>Record&lt;never, never&gt;</code> <small>(at TypeScript v{frontmatter.version})</small></h6>`
 			);
 	});
+
+	it('should be able to encode ampersand characters in code blocks', async () => {
+		const { code } = await renderMarkdown(
+			'The ampersand in `&nbsp;` must be encoded in code blocks.',
+			{}
+		);
+
+		chai
+			.expect(code)
+			.to.equal(
+				'<p>The ampersand in <code is:raw>&amp;nbsp;</code> must be encoded in code blocks.</p>'
+			)
+	});
+
+	it('should be able to encode ampersand characters in pre-code blocks.', async () => {
+		const { code } = await renderMarkdown(`
+		\`\`\`md
+			The ampersand in \`&nbsp;\` must be encoded in code blocks.
+		\`\`\`
+		`);
+
+		chai
+			.expect(code)
+			.to.match(
+				/^<pre is:raw.*<code>.*The ampersand in `&amp;nbsp;`/
+			);
+	})
 
 	it('should be able to serialize function expression', async () => {
 		const { code } = await renderMarkdown(

--- a/packages/markdown/remark/test/expressions.test.js
+++ b/packages/markdown/remark/test/expressions.test.js
@@ -84,7 +84,7 @@ describe('expressions', () => {
 			)
 	});
 
-	it('should be able to encode ampersand characters in pre-code blocks.', async () => {
+	it('should be able to encode ampersand characters in fenced code blocks', async () => {
 		const { code } = await renderMarkdown(`
 		\`\`\`md
 			The ampersand in \`&nbsp;\` must be encoded in code blocks.


### PR DESCRIPTION
Closes #3487 

## Changes

Updates rehype to encode ampersands in code blocks

## Testing

Added tests for markdown `<code>` and fenced code blocks

## Docs

N/A