### PR TITLE
simplify a complex peer semver used by astro add

### DIFF
--- a/.changeset/pink-shirts-mix.md
+++ b/.changeset/pink-shirts-mix.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix a bug with `astro add react` adding a too-complex semver to your package.json

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -407,7 +407,7 @@ async function getInstallIntegrationsCommand({
 		.map<[string, string | null][]>((i) => [[i.packageName, null], ...i.dependencies])
 		.flat(1)
 		.filter((dep, i, arr) => arr.findIndex((d) => d[0] === dep[0]) === i)
-		.map(([name, version]) => (version === null ? name : `${name}@${version}`))
+		.map(([name, version]) => (version === null ? name : `${name}@${version.split(' ').pop()}`))
 		.sort();
 
 	switch (pm.name) {

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -407,7 +407,7 @@ async function getInstallIntegrationsCommand({
 		.map<[string, string | null][]>((i) => [[i.packageName, null], ...i.dependencies])
 		.flat(1)
 		.filter((dep, i, arr) => arr.findIndex((d) => d[0] === dep[0]) === i)
-		.map(([name, version]) => (version === null ? name : `${name}@${version.split(' ').pop()}`))
+		.map(([name, version]) => (version === null ? name : `${name}@${version.split(/\s*\|\|\s*/).pop()}`))
 		.sort();
 
 	switch (pm.name) {


### PR DESCRIPTION
## Changes

- Fixes this odd `astro add` output
- Fixes odd behavior when `astro add react` is run with yarn (reported by @Princesseuh)

<img width="659" alt="Screen Shot 2022-06-17 at 3 31 22 PM" src="https://user-images.githubusercontent.com/622227/174409449-342f9464-05e4-4f7a-abcd-e0f6494d974d.png">

This isn't perfect, but I've never seen a semver string that this wouldn't work for. The next step would be evaluating the semver using a more complex semver-aware parser. I'd rather cross that bridge when we encounter the need.

## Testing

- N/A (code path not currently tested)

## Docs

- N/A (bug fix)