### PR TITLE
Properly catch falsey components

### DIFF
--- a/.changeset/great-badgers-raise.md
+++ b/.changeset/great-badgers-raise.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Properly catch falsy components

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -172,7 +172,7 @@ export async function renderComponent(
 		return markHTMLString(output);
 	}
 
-	if (Component === null && !_props['client:only']) {
+	if (!Component && !_props['client:only']) {
 		throw new Error(
 			`Unable to render ${displayName} because it is ${Component}!\nDid you forget to import the component or is it possible there is a typo?`
 		);


### PR DESCRIPTION
## Changes

- Fixes issue with bad error message reported on Discord
- We were not catching `undefined` components and throwing an error as expected.

## Testing

N/A

## Docs

N/A