### PR TITLE
Check null for props serialization

### DIFF
--- a/.changeset/honest-schools-worry.md
+++ b/.changeset/honest-schools-worry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Check null for props serialization

--- a/packages/astro/src/runtime/server/serialize.ts
+++ b/packages/astro/src/runtime/server/serialize.ts
@@ -48,7 +48,7 @@ function convertToSerializedForm(value: any): [ValueOf<typeof PROP_TYPE>, any] {
 			return [PROP_TYPE.JSON, JSON.stringify(serializeArray(value))];
 		}
 		default: {
-			if (typeof value === 'object') {
+			if (value !== null && typeof value === 'object') {
 				return [PROP_TYPE.Value, serializeObject(value)];
 			} else {
 				return [PROP_TYPE.Value, value];


### PR DESCRIPTION
## Changes

Fixes #3641

Currently, `astro build` fails with client-hydrated-component like below.

```astro
---
import Counter from '../components/Counter.tsx';
---
<html lang="en">
	<head>
		<meta charset="utf-8" />
	</head>
	<body>
		<main>
			<Counter client:visible data={{ x: null }} />
		</main>
	</body>
</html>
```

Because `typeof null` === `object`,

https://github.com/withastro/astro/blob/411af7ae4b0435d740a25fd645380e5bd3949d3a/packages/astro/src/runtime/server/serialize.ts#L50-L52

and `Object.entries(null)` throws.

https://github.com/withastro/astro/blob/411af7ae4b0435d740a25fd645380e5bd3949d3a/packages/astro/src/runtime/server/serialize.ts#L18-L24

## Testing

I'd like to add some tests, but where should it be placed...?

## Docs

Nothing changed.