### PR TITLE
Add .js to imports in the sitemap package

### DIFF
--- a/.changeset/gold-walls-pretend.md
+++ b/.changeset/gold-walls-pretend.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/sitemap': patch
+---
+
+Fixes the last build

--- a/packages/integrations/sitemap/package.json
+++ b/packages/integrations/sitemap/package.json
@@ -28,7 +28,8 @@
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
-    "dev": "astro-scripts dev \"src/**/*.ts\""
+    "dev": "astro-scripts dev \"src/**/*.ts\"",
+    "test": "mocha --timeout 20000"
   },
   "dependencies": {
     "sitemap": "^7.1.1",

--- a/packages/integrations/sitemap/src/config-defaults.ts
+++ b/packages/integrations/sitemap/src/config-defaults.ts
@@ -1,4 +1,4 @@
-import type { SitemapOptions } from './index';
+import type { SitemapOptions } from './index.js';
 
 export const SITEMAP_CONFIG_DEFAULTS: SitemapOptions & any = {
 	entryLimit: 45000,

--- a/packages/integrations/sitemap/src/generate-sitemap.ts
+++ b/packages/integrations/sitemap/src/generate-sitemap.ts
@@ -1,5 +1,5 @@
-import type { SitemapItem, SitemapOptions } from './index';
-import { parseUrl } from './utils/parse-url';
+import type { SitemapItem, SitemapOptions } from './index.js';
+import { parseUrl } from './utils/parse-url.js';
 
 const STATUS_CODE_PAGE_REGEXP = /\/[0-9]{3}\/?$/;
 

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -8,9 +8,9 @@ import {
 import { fileURLToPath } from 'url';
 import { ZodError } from 'zod';
 
-import { generateSitemap } from './generate-sitemap';
-import { Logger } from './utils/logger';
-import { validateOptions } from './validate-options';
+import { generateSitemap } from './generate-sitemap.js';
+import { Logger } from './utils/logger.js';
+import { validateOptions } from './validate-options.js';
 
 export type ChangeFreq = EnumChangefreq;
 export type SitemapItem = Pick<

--- a/packages/integrations/sitemap/src/schema.ts
+++ b/packages/integrations/sitemap/src/schema.ts
@@ -1,6 +1,6 @@
 import { EnumChangefreq as ChangeFreq } from 'sitemap';
 import { z } from 'zod';
-import { SITEMAP_CONFIG_DEFAULTS } from './config-defaults';
+import { SITEMAP_CONFIG_DEFAULTS } from './config-defaults.js';
 
 const localeKeySchema = z.string().min(1);
 

--- a/packages/integrations/sitemap/src/validate-options.ts
+++ b/packages/integrations/sitemap/src/validate-options.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import type { SitemapOptions } from './index';
-import { SitemapOptionsSchema } from './schema';
+import type { SitemapOptions } from './index.js';
+import { SitemapOptionsSchema } from './schema.js';
 
 // @internal
 export const validateOptions = (site: string | undefined, opts: SitemapOptions) => {

--- a/packages/integrations/sitemap/test/smoke.test.js
+++ b/packages/integrations/sitemap/test/smoke.test.js
@@ -1,0 +1,3 @@
+import '../dist/index.js';
+
+// Just a smoke test, this would fail if there's a problem.


### PR DESCRIPTION
## Changes

- Fixes #3660
- Regression caused by https://github.com/withastro/astro/pull/3579/files, didn't include .js at the end.

## Testing

- Basic smoke test, make sure the package can be imported.

## Docs

N/A, bug fix