### PR TITLE
Add `@nanostores/preact` to ALWAYS_NOEXTERNAL

### DIFF
--- a/.changeset/famous-icons-pull.md
+++ b/.changeset/famous-icons-pull.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix: add @nanostores/preact to ALWAYS_NOEXTERNAL list for easier onboarding

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -28,7 +28,11 @@ const ALWAYS_EXTERNAL = new Set([
 	'whatwg-url',
 ]);
 const ALWAYS_NOEXTERNAL = new Set([
-	'astro', // This is only because Vite's native ESM doesn't resolve "exports" correctly.
+	// This is only because Vite's native ESM doesn't resolve "exports" correctly.
+	'astro',
+	// Handle recommended nanostores. Only @nanostores/preact is required from our testing!
+	// Related issue on Preact-as-subdependency with Vite bundling - https://github.com/withastro/astro/issues/3449
+	'@nanostores/preact', 
 ]);
 
 // note: ssr is still an experimental API hence the type omission from `vite`

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -31,7 +31,7 @@ const ALWAYS_NOEXTERNAL = new Set([
 	// This is only because Vite's native ESM doesn't resolve "exports" correctly.
 	'astro',
 	// Handle recommended nanostores. Only @nanostores/preact is required from our testing!
-	// Related issue on Preact-as-subdependency with Vite bundling - https://github.com/withastro/astro/issues/3449
+	// Full explanation and related bug report: https://github.com/withastro/astro/pull/3667
 	'@nanostores/preact', 
 ]);
 


### PR DESCRIPTION
## Changes

Adds `@nanostores/preact` to the dreaded `ALWAYS_NOEXTERNAL` list.

It seems `noExternal` is required for any utility package relying on Preact hooks. From testing, this is likely due to a duplicate Preact getting bundled when used in a component, with a separate Preact coming from your `node_modules` inside the offending package.

### Why not `@nanostores/react`?

React is a UMD package, while Preact is a true ESM package. This means React will _always_ be bundled due to Vite's heuristics, while Preact will be ignored. This is why `resolve.dedupe` does _not_ solve the issue for Preact 😓 

## Testing

N/A, though a "nanostores" E2E test suite is on my list!

## Docs

N/A