### PR TITLE
Fix: reintroduce smoke tests across example projects

### DIFF
--- a/.changeset/famous-moons-kick.md
+++ b/.changeset/famous-moons-kick.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/markdown-remark': patch
+---
+
+Tooling: reintroduce smoke test across example projects

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,11 +185,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      
+      - name: Checkout docs
+        uses: actions/checkout@v3
         with:
-          submodules: 'recursive'
+          repository: withastro/docs
+          path: smoke/docs
 
-      - name: Update submodules
-        run: git submodule update --remote
+      - name: Checkout astro.build
+        uses: actions/checkout@v3
+        with:
+          repository: withastro/astro.build
+          path: smoke/astro.build
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v2.2.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node_version: [14]
+        node_version: [16]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         node_version: [14]
     steps:
       - name: Checkout docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node_version: [16]
+        node_version: [14]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install
 
       - name: Build Packages
         run: pnpm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,13 +190,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: withastro/docs
-          path: smoke/docs
 
       - name: Checkout astro.build
         uses: actions/checkout@v3
         with:
           repository: withastro/astro.build
-          path: smoke/astro.build
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v2.2.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         node_version: [14]
     steps:
       - name: Checkout docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,9 +183,6 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         node_version: [14]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      
       - name: Checkout docs
         uses: actions/checkout@v3
         with:
@@ -195,6 +192,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: withastro/astro.build
+
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v2.2.1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,0 @@
-[submodule "smoke/docs"]
-	path = smoke/docs
-	url = git@github.com:withastro/docs.git
-  branch = main
-[submodule "smoke/astro.build"]
-	path = smoke/astro.build
-	url = git@github.com:withastro/astro.build.git
-	branch = main

--- a/examples/with-mdx/src/pages/index.mdx
+++ b/examples/with-mdx/src/pages/index.mdx
@@ -14,4 +14,4 @@ Written by: {new Intl.ListFormat('en').format(authors.map(d => d.name))}.
 
 Published on: {new Intl.DateTimeFormat('en', {dateStyle: 'long'}).format(published)}.
 
-<Counter client:idle>## This is a counter!</Counter>
+<Counter>## This is a counter!</Counter>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "turbo run test --output-logs=new-only --concurrency=1",
     "test:match": "cd packages/astro && pnpm run test:match",
     "test:templates": "turbo run test --filter=create-astro --concurrency=1",
-    "test:smoke": "turbo run build --filter=\"@example/*\" --filter=\"!@example/with-mdx\" --output-logs=new-only",
+    "test:smoke": "turbo run build --filter=\"@example/*\" --output-logs=new-only",
     "test:vite-ci": "turbo run test --output-logs=new-only --no-deps --scope=astro --concurrency=1",
     "test:e2e": "cd packages/astro && pnpm playwright install && pnpm run test:e2e",
     "test:e2e:match": "cd packages/astro && pnpm playwright install && pnpm run test:e2e:match",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "turbo run test --output-logs=new-only --concurrency=1",
     "test:match": "cd packages/astro && pnpm run test:match",
     "test:templates": "turbo run test --filter=create-astro --concurrency=1",
-    "test:smoke": "node scripts/smoke/index.js",
+    "test:smoke": "pnpm run build:examples",
     "test:vite-ci": "turbo run test --output-logs=new-only --no-deps --scope=astro --concurrency=1",
     "test:e2e": "cd packages/astro && pnpm playwright install && pnpm run test:e2e",
     "test:e2e:match": "cd packages/astro && pnpm playwright install && pnpm run test:e2e:match",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "turbo run test --output-logs=new-only --concurrency=1",
     "test:match": "cd packages/astro && pnpm run test:match",
     "test:templates": "turbo run test --filter=create-astro --concurrency=1",
-    "test:smoke": "pnpm run build:examples",
+    "test:smoke": "turbo run build --filter=@example/* --filter=!@example/with-mdx --output-logs=new-only",
     "test:vite-ci": "turbo run test --output-logs=new-only --no-deps --scope=astro --concurrency=1",
     "test:e2e": "cd packages/astro && pnpm playwright install && pnpm run test:e2e",
     "test:e2e:match": "cd packages/astro && pnpm playwright install && pnpm run test:e2e:match",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "turbo run test --output-logs=new-only --concurrency=1",
     "test:match": "cd packages/astro && pnpm run test:match",
     "test:templates": "turbo run test --filter=create-astro --concurrency=1",
-    "test:smoke": "turbo run build --filter=@example/* --filter=!@example/with-mdx --output-logs=new-only",
+    "test:smoke": "turbo run build --filter=\"@example/*\" --filter=\"!@example/with-mdx\" --output-logs=new-only",
     "test:vite-ci": "turbo run test --output-logs=new-only --no-deps --scope=astro --concurrency=1",
     "test:e2e": "cd packages/astro && pnpm playwright install && pnpm run test:e2e",
     "test:e2e:match": "cd packages/astro && pnpm playwright install && pnpm run test:e2e:match",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -108,6 +108,7 @@
     "estree-walker": "^3.0.1",
     "execa": "^6.1.0",
     "fast-glob": "^3.2.11",
+    "github-slugger": "^1.4.0",
     "gray-matter": "^4.0.3",
     "html-entities": "^2.3.3",
     "html-escaper": "^3.0.3",

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -167,6 +167,7 @@ ${components ? `import * from '${components}';` : ''}
 ${hasInjectedScript ? `import '${PAGE_SSR_SCRIPT_ID}';` : ''}
 ${setup}
 
+const slugger = new Slugger();
 function $$slug(value) {
 	return slugger.slug(value);
 }

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -161,7 +161,10 @@ export default function markdown({ config }: AstroPluginOptions): Plugin {
 				const { layout = '', components = '', setup = '', ...content } = frontmatter;
 				content.astro = metadata;
 				const prelude = `---
-import { slug as $$slug } from '@astrojs/markdown-remark/ssr-utils';
+import Slugger from 'github-slugger';
+function $$slug(value: string): string {
+	return slugger.slug(value);
+}
 ${layout ? `import Layout from '${layout}';` : ''}
 ${components ? `import * from '${components}';` : ''}
 ${hasInjectedScript ? `import '${PAGE_SSR_SCRIPT_ID}';` : ''}

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -162,7 +162,7 @@ export default function markdown({ config }: AstroPluginOptions): Plugin {
 				content.astro = metadata;
 				const prelude = `---
 import Slugger from 'github-slugger';
-function $$slug(value: string): string {
+function $$slug(value) {
 	return slugger.slug(value);
 }
 ${layout ? `import Layout from '${layout}';` : ''}

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -162,13 +162,14 @@ export default function markdown({ config }: AstroPluginOptions): Plugin {
 				content.astro = metadata;
 				const prelude = `---
 import Slugger from 'github-slugger';
-function $$slug(value) {
-	return slugger.slug(value);
-}
 ${layout ? `import Layout from '${layout}';` : ''}
 ${components ? `import * from '${components}';` : ''}
 ${hasInjectedScript ? `import '${PAGE_SSR_SCRIPT_ID}';` : ''}
 ${setup}
+
+function $$slug(value) {
+	return slugger.slug(value);
+}
 
 const $$content = ${JSON.stringify(content)}
 ---`;

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -13,8 +13,7 @@
   "homepage": "https://astro.build",
   "main": "./dist/index.js",
   "exports": {
-    ".": "./dist/index.js",
-    "./ssr-utils": "./dist/ssr-utils.js"
+    ".": "./dist/index.js"
   },
   "scripts": {
     "prepublish": "pnpm build",

--- a/packages/markdown/remark/src/ssr-utils.ts
+++ b/packages/markdown/remark/src/ssr-utils.ts
@@ -1,8 +1,0 @@
-/** Utilities used in deployment-ready SSR bundles */
-import Slugger from 'github-slugger';
-
-const slugger = new Slugger();
-/** @see {@link "/packages/astro/vite-plugin-markdown"} */
-export function slug(value: string): string {
-	return slugger.slug(value);
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -515,6 +515,7 @@ importers:
       estree-walker: ^3.0.1
       execa: ^6.1.0
       fast-glob: ^3.2.11
+      github-slugger: ^1.4.0
       gray-matter: ^4.0.3
       html-entities: ^2.3.3
       html-escaper: ^3.0.3
@@ -575,6 +576,7 @@ importers:
       estree-walker: 3.0.1
       execa: 6.1.0
       fast-glob: 3.2.11
+      github-slugger: 1.4.0
       gray-matter: 4.0.3
       html-entities: 2.3.3
       html-escaper: 3.0.3


### PR DESCRIPTION
## Changes

- Remove `no-frozen` requirement from lockfile
- Remove `astro.build` and Astro docs installation. Still checking out via CI, will revisit in a future PR
- Add smoke test across example projects
- Remove `client:` directive from `with-mdx` example. This is causing an infinite build loop to debug separately
- Remove `@astrojs/markdown-remark/ssr-utils` that our generated markdown files directly imported. This caused a missing dependency issue since `@astrojs/markdown` isn't explicitly installed.

## Testing

Testing CI

## Docs

N/A