### PR TITLE
Allow specifying entryFileNames for client JS

### DIFF
--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -116,10 +116,10 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 				input: [],
 				output: {
 					format: 'esm',
-					entryFileNames: opts.buildConfig.serverEntry,
 					chunkFileNames: 'chunks/chunk.[hash].mjs',
 					assetFileNames: 'assets/asset.[hash][extname]',
 					...viteConfig.build?.rollupOptions?.output,
+					entryFileNames: opts.buildConfig.serverEntry,
 				},
 			},
 			ssr: true,

--- a/packages/astro/test/entry-file-names.test.js
+++ b/packages/astro/test/entry-file-names.test.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('vite.build.rollupOptions.entryFileNames', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/entry-file-names',
+		});
+		await fixture.build();
+	});
+
+	it('Renders correctly', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerio.load(html);
+		expect($('#hello')).to.have.a.lengthOf(1);
+	});
+
+	it('Outputs a client module that was specified by the config', async () => {
+		const js = await fixture.readFile('/assets/js/Hello.js');
+		expect(js).to.be.a('string');
+		expect(js.length).to.be.greaterThan(0);
+	})
+});

--- a/packages/astro/test/fixtures/entry-file-names/astro.config.mjs
+++ b/packages/astro/test/fixtures/entry-file-names/astro.config.mjs
@@ -1,0 +1,16 @@
+import { defineConfig } from 'astro/config';
+import preact from '@astrojs/preact';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [preact()],
+  vite: {
+    build: {
+      rollupOptions: {
+        output: {
+          entryFileNames: `assets/js/[name].js`,
+        },
+      },
+    },
+  },
+});

--- a/packages/astro/test/fixtures/entry-file-names/package.json
+++ b/packages/astro/test/fixtures/entry-file-names/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/entry-file-names",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/preact": "workspace:",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/entry-file-names/src/components/Hello.jsx
+++ b/packages/astro/test/fixtures/entry-file-names/src/components/Hello.jsx
@@ -1,0 +1,6 @@
+
+export default function() {
+	return (
+		<div id="hello">Hello world</div>
+	)
+}

--- a/packages/astro/test/fixtures/entry-file-names/src/pages/index.astro
+++ b/packages/astro/test/fixtures/entry-file-names/src/pages/index.astro
@@ -1,0 +1,10 @@
+---
+import Hello from '../components/Hello.jsx';
+---
+
+<html>
+	<head><title>Test</title></head>
+	<body>
+		<Hello client:load />
+	</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1348,6 +1348,14 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/entry-file-names:
+    specifiers:
+      '@astrojs/preact': 'workspace:'
+      astro: workspace:*
+    dependencies:
+      '@astrojs/preact': link:../../../../integrations/preact
+      astro: link:../../..
+
   packages/astro/test/fixtures/error-react-spectrum:
     specifiers:
       '@adobe/react-spectrum': ^3.18.0


### PR DESCRIPTION
## Changes

- Fixes #3672
- We need to specify the server entry point, so when you try to define `entryFileNames` in your own config that causes the build to fail.
- Fix is to make sure our entryFileNames is used for the server code, but not for client.

## Testing

- Tests added

## Docs

N/A, bug fix