### PR TITLE
Include all client build artifacts in SSRManifest

### DIFF
--- a/.changeset/unlucky-otters-agree.md
+++ b/.changeset/unlucky-otters-agree.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix regression with SSRManifest and client assets

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -70,12 +70,6 @@ if(_start in adapter) {
 			return void 0;
 		},
 		async generateBundle(_opts, bundle) {
-			internals.staticFiles = new Set(
-				await glob('**/*', {
-					cwd: fileURLToPath(buildOpts.buildConfig.client),
-				})
-			);
-
 			// Add assets from this SSR chunk as well.
 			for (const [_chunkName, chunk] of Object.entries(bundle)) {
 				if (chunk.type === 'asset') {
@@ -99,6 +93,16 @@ if(_start in adapter) {
 export async function injectManifest(buildOpts: StaticBuildOptions, internals: BuildInternals) {
 	if (!internals.ssrEntryChunk) {
 		throw new Error(`Did not generate an entry chunk for SSR`);
+	}
+
+	// Add assets from the client build.
+	const clientStatics = new Set(
+		await glob('**/*', {
+			cwd: fileURLToPath(buildOpts.buildConfig.client),
+		})
+	);
+	for(const file of clientStatics) {
+		internals.staticFiles.add(file);
 	}
 
 	const staticFiles = internals.staticFiles;

--- a/packages/astro/test/fixtures/ssr-scripts/astro.config.mjs
+++ b/packages/astro/test/fixtures/ssr-scripts/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import preact from '@astrojs/preact';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [preact()],
+});

--- a/packages/astro/test/fixtures/ssr-scripts/package.json
+++ b/packages/astro/test/fixtures/ssr-scripts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/ssr-scripts",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/preact": "workspace:",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/ssr-scripts/src/components/Hello.jsx
+++ b/packages/astro/test/fixtures/ssr-scripts/src/components/Hello.jsx
@@ -1,0 +1,6 @@
+
+export default function() {
+	return (
+		<div>Hello world</div>
+	)
+}

--- a/packages/astro/test/fixtures/ssr-scripts/src/pages/index.astro
+++ b/packages/astro/test/fixtures/ssr-scripts/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+import Hello from '../components/Hello.jsx';
+---
+<html lang="en">
+	<head>
+		<title>Astro</title>
+	</head>
+	<body>
+		<Hello client:load />
+	</body>
+</html>

--- a/packages/astro/test/ssr-scripts.test.js
+++ b/packages/astro/test/ssr-scripts.test.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { loadFixture } from './test-utils.js';
+import testAdapter from './test-adapter.js';
+
+describe('SSR Hydrated component scripts', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/ssr-scripts/',
+			experimental: {
+				ssr: true,
+			},
+			adapter: testAdapter(),
+		});
+		await fixture.build();
+	});
+
+	it('Are included in the manifest.assets so that an adapter can know to serve static', async () => {
+		const app = await fixture.loadTestAdapterApp();
+
+		/** @type {Set<string>} */
+		const assets = app.manifest.assets;
+		expect(assets.size).to.be.greaterThan(0);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1588,6 +1588,14 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/ssr-scripts:
+    specifiers:
+      '@astrojs/preact': 'workspace:'
+      astro: workspace:*
+    dependencies:
+      '@astrojs/preact': link:../../../../integrations/preact
+      astro: link:../../..
+
   packages/astro/test/fixtures/static-build:
     specifiers:
       '@astrojs/preact': workspace:*


### PR DESCRIPTION
## Changes

- Fixes #3670
- Regression caused by the fact that the order of the client and ssr builds flipped. Because of this we need to collect client assets when we inject the manifest.

## Testing

- Test added

## Docs

N/A, bug fix