### PR TITLE
Include partytown scripts in SSR manifest

### DIFF
--- a/.changeset/cuddly-llamas-arrive.md
+++ b/.changeset/cuddly-llamas-arrive.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/partytown': patch
+---
+
+Include partytown scripts in SSR manifest

--- a/packages/astro/test/fixtures/ssr-partytown/astro.config.mjs
+++ b/packages/astro/test/fixtures/ssr-partytown/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import partytown from '@astrojs/partytown';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [partytown()],
+});

--- a/packages/astro/test/fixtures/ssr-partytown/package.json
+++ b/packages/astro/test/fixtures/ssr-partytown/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/ssr-partytown",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/partytown": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/ssr-partytown/src/pages/index.astro
+++ b/packages/astro/test/fixtures/ssr-partytown/src/pages/index.astro
@@ -1,0 +1,6 @@
+<html>
+	<head><title>testing</title></head>
+	<body>
+		<h1>testing</h1>
+	</body>
+</html>

--- a/packages/astro/test/ssr-partytown.test.js
+++ b/packages/astro/test/ssr-partytown.test.js
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import { load as cheerioLoad } from 'cheerio';
+import { loadFixture } from './test-utils.js';
+import testAdapter from './test-adapter.js';
+
+describe('Using the Partytown integration in SSR', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/ssr-partytown/',
+			adapter: testAdapter(),
+			experimental: {
+				ssr: true,
+			},
+		});
+		await fixture.build();
+	});
+
+	it('Has the scripts in the page', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		const request = new Request('http://example.com/');
+		const response = await app.render(request);
+		const html = await response.text();
+		const $ = cheerioLoad(html);
+		expect($('script')).to.have.a.lengthOf(1);
+	});
+
+	it('The partytown scripts are in the manifest', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		expect(app.manifest.assets).to.contain('/~partytown/partytown-sw.js');
+	});
+});

--- a/packages/integrations/partytown/src/index.ts
+++ b/packages/integrations/partytown/src/index.ts
@@ -1,8 +1,9 @@
 import { partytownSnippet } from '@builder.io/partytown/integration';
-import { copyLibFiles } from '@builder.io/partytown/utils';
+import { copyLibFiles, libDirPath } from '@builder.io/partytown/utils';
 import type { AstroConfig, AstroIntegration } from 'astro';
 import { createRequire } from 'module';
 import path from 'path';
+import * as fs from 'fs';
 import { fileURLToPath } from 'url';
 import sirv from './sirv.js';
 const resolve = createRequire(import.meta.url).resolve;
@@ -50,6 +51,14 @@ export default function createPlugin(options: PartytownOptions): AstroIntegratio
 					debugDir: false,
 				});
 			},
+			'astro:build:ssr': async ({ manifest }) => {
+				const dirpath = libDirPath({ debugDir: false });
+				const files = await fs.promises.readdir(dirpath);
+				for(const file of files) {
+					if(file === 'debug') continue;
+					manifest.assets.push(`/~partytown/${file}`)
+				}
+			}
 		},
 	};
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1598,6 +1598,14 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/ssr-partytown:
+    specifiers:
+      '@astrojs/partytown': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/partytown': link:../../../../integrations/partytown
+      astro: link:../../..
+
   packages/astro/test/fixtures/ssr-scripts:
     specifiers:
       '@astrojs/preact': 'workspace:'
@@ -8258,11 +8266,6 @@ packages:
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.1.3
     dev: false
@@ -11184,8 +11187,6 @@ packages:
       debug: 3.2.7
       iconv-lite: 0.4.24
       sax: 1.2.4
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /netmask/2.0.2:
@@ -11269,8 +11270,6 @@ packages:
       rimraf: 2.7.1
       semver: 5.7.1
       tar: 4.4.19
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /node-releases/2.0.5:


### PR DESCRIPTION
## Changes

- Closes #3668
- Adding these files to the manifest will cause adapters such as the cloudflare adapter to serve the static files rather than try to render a route.

## Testing

- Test added

## Docs

N/A, bug fix