### PR TITLE
fix: `@astrojs/cloudflare` 404 handling

### DIFF
--- a/.changeset/five-zoos-look.md
+++ b/.changeset/five-zoos-look.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+fix custom 404 pages not rendering

--- a/packages/integrations/cloudflare/src/server.ts
+++ b/packages/integrations/cloudflare/src/server.ts
@@ -24,6 +24,11 @@ export function createExports(manifest: SSRManifest) {
 		}
 
 		// 404
+		const _404Request = new Request(`${origin}/404`, request);
+		if (app.match(_404Request)) {
+			return app.render(_404Request);
+		}
+
 		return new Response(null, {
 			status: 404,
 			statusText: 'Not found',


### PR DESCRIPTION
## Changes

perviously requests that we're 404'ing would fall through and not render a custom 404 page if one existed.

This change rectifies that.

- if a request does not match a route check if 404 matches a route
- if 404 matches render that
- else default as before

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->