### PR TITLE
Make Astro.redirect use a 302 status code

### DIFF
--- a/.changeset/stupid-steaks-hang.md
+++ b/.changeset/stupid-steaks-hang.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Make Astro.redirect use a 302 status code

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -150,7 +150,7 @@ export function createResult(args: CreateResultArgs): SSRResult {
 				redirect: args.ssr
 					? (path: string) => {
 							return new Response(null, {
-								status: 301,
+								status: 302,
 								headers: {
 									Location: path,
 								},

--- a/packages/astro/test/fixtures/ssr-redirect/package.json
+++ b/packages/astro/test/fixtures/ssr-redirect/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/ssr-redirect",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/ssr-redirect/src/pages/secret.astro
+++ b/packages/astro/test/fixtures/ssr-redirect/src/pages/secret.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/login');
+---

--- a/packages/astro/test/ssr-redirect.test.js
+++ b/packages/astro/test/ssr-redirect.test.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { loadFixture } from './test-utils.js';
+import testAdapter from './test-adapter.js';
+
+describe('Astro.redirect', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/ssr-redirect/',
+			experimental: {
+				ssr: true,
+			},
+			adapter: testAdapter(),
+		});
+		await fixture.build();
+	});
+
+	it('Returns a 302 status', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		const request = new Request('http://example.com/secret');
+		const response = await app.render(request);
+		expect(response.status).to.equal(302);
+		expect(response.headers.get('location')).to.equal('/login');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1638,6 +1638,12 @@ importers:
       '@astrojs/partytown': link:../../../../integrations/partytown
       astro: link:../../..
 
+  packages/astro/test/fixtures/ssr-redirect:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/ssr-scripts:
     specifiers:
       '@astrojs/preact': 'workspace:'


### PR DESCRIPTION
## Changes

- Changes Astro.redirect to use a 302 redirect instead of 301.
- 301 is permanent, but the use-case for Astro.redirect is to send someone to a login page, for example, and in that case you want the redirect to be temporary.

## Testing

- New test added.

## Docs

N/A