### PR TITLE
Ensure import.meta.env.SSR is true in SSR mode

### DIFF
--- a/.changeset/moody-crabs-stare.md
+++ b/.changeset/moody-crabs-stare.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Ensure import.meta.env.SSR is true in SSR mode

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -122,6 +122,7 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 					entryFileNames: opts.buildConfig.serverEntry,
 				},
 			},
+
 			ssr: true,
 			// must match an esbuild target
 			target: 'esnext',
@@ -150,6 +151,9 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 		base: astroConfig.base,
 		ssr: viteConfig.ssr,
 		resolve: viteConfig.resolve,
+		define: {
+			'import.meta.env.SSR': JSON.stringify(true),
+		},
 	};
 
 	await runHookBuildSetup({

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -151,9 +151,6 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 		base: astroConfig.base,
 		ssr: viteConfig.ssr,
 		resolve: viteConfig.resolve,
-		define: {
-			'import.meta.env.SSR': JSON.stringify(true),
-		},
 	};
 
 	await runHookBuildSetup({

--- a/packages/astro/src/vite-plugin-env/index.ts
+++ b/packages/astro/src/vite-plugin-env/index.ts
@@ -78,6 +78,7 @@ export default function envVitePlugin({
 				privateEnv = getPrivateEnv(config, astroConfig);
 				if (privateEnv) {
 					privateEnv.SITE = astroConfig.site ? `'${astroConfig.site}'` : 'undefined';
+					privateEnv.SSR = JSON.stringify(true);
 					const entries = Object.entries(privateEnv).map(([key, value]) => [
 						`import.meta.env.${key}`,
 						value,
@@ -86,6 +87,7 @@ export default function envVitePlugin({
 					// These additional replacements are needed to match Vite
 					replacements = Object.assign(replacements, {
 						'import.meta.env.SITE': astroConfig.site ? `'${astroConfig.site}'` : 'undefined',
+						'import.meta.env.SSR': JSON.stringify(true),
 						// This catches destructed `import.meta.env` calls,
 						// BUT we only want to inject private keys referenced in the file.
 						// We overwrite this value on a per-file basis.

--- a/packages/astro/test/fixtures/ssr-env/astro.config.mjs
+++ b/packages/astro/test/fixtures/ssr-env/astro.config.mjs
@@ -1,0 +1,5 @@
+import preact from '@astrojs/preact';
+
+export default {
+	integrations: [preact()]
+}

--- a/packages/astro/test/fixtures/ssr-env/package.json
+++ b/packages/astro/test/fixtures/ssr-env/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/ssr-env",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/preact": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/ssr-env/src/components/Env.jsx
+++ b/packages/astro/test/fixtures/ssr-env/src/components/Env.jsx
@@ -1,0 +1,7 @@
+
+export default function() {
+	const ssr = import.meta.env.SSR;
+	return (
+		<div id="ssr">{'' + ssr }</div>
+	)
+}

--- a/packages/astro/test/fixtures/ssr-env/src/pages/ssr.astro
+++ b/packages/astro/test/fixtures/ssr-env/src/pages/ssr.astro
@@ -1,0 +1,9 @@
+---
+import Env from '../components/Env.jsx';
+---
+<html>
+<head><title>Test</title></head>
+<body>
+	<Env />
+</body>
+</html>

--- a/packages/astro/test/ssr-env.test.js
+++ b/packages/astro/test/ssr-env.test.js
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+import testAdapter from './test-adapter.js';
+
+describe('SSR Environment Variables', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/ssr-env/',
+			experimental: {
+				ssr: true,
+			},
+			adapter: testAdapter(),
+		});
+		await fixture.build();
+	});
+
+	it('import.meta.env.SSR is true', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		const request = new Request('http://example.com/ssr');
+		const response = await app.render(request);
+		const html = await response.text();
+		const $ = cheerio.load(html);
+		expect($('#ssr').text()).to.equal('true');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1622,6 +1622,14 @@ importers:
       '@astrojs/solid-js': link:../../../../integrations/solid
       astro: link:../../..
 
+  packages/astro/test/fixtures/ssr-env:
+    specifiers:
+      '@astrojs/preact': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/preact': link:../../../../integrations/preact
+      astro: link:../../..
+
   packages/astro/test/fixtures/ssr-markdown:
     specifiers:
       astro: workspace:*


### PR DESCRIPTION
## Changes

- Defines `import.meta.env.SSR` to always be true. This ensures it's locked in during the build (in SSR mode that is).
- Fixes #3688

## Testing

- Test added

## Docs

N/A, bug fix only