### PR TITLE
Simplified Response#text() implementation

### DIFF
--- a/.changeset/early-teachers-vanish.md
+++ b/.changeset/early-teachers-vanish.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes build some times breaking in large sites

--- a/packages/astro/src/jsx/renderer.ts
+++ b/packages/astro/src/jsx/renderer.ts
@@ -3,9 +3,9 @@ const renderer = {
 	serverEntrypoint: 'astro/jsx/server.js',
 	jsxImportSource: 'astro',
 	jsxTransformOptions: async () => {
-		// @ts-ignore
 		const {
 			default: { default: jsx },
+			// @ts-ignore
 		} = await import('@babel/plugin-transform-react-jsx');
 		const { default: astroJSX } = await import('./babel.js');
 		return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8554,11 +8554,6 @@ packages:
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.1.3
     dev: false
@@ -11440,8 +11435,6 @@ packages:
       debug: 3.2.7
       iconv-lite: 0.4.24
       sax: 1.2.4
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /netmask/2.0.2:
@@ -11525,8 +11518,6 @@ packages:
       rimraf: 2.7.1
       semver: 5.7.1
       tar: 4.4.19
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /node-releases/2.0.5:


### PR DESCRIPTION
## Changes

- When upgrading to beta.55 on the docs site we were running into a max callstack issue. I assume it's because the page is large and it's possible that our streaming implementation's reader.read() implementation is leaky (or something). This change was tested on the docs site and fixes everything.
- Fixes https://github.com/withastro/astro/issues/3704

## Testing

- Not captured in a unit test, but in the docs site.

## Docs

N/A, bug fix