### PR TITLE
feat: better behavior for 'undefined' return values from 'serialize…

### DIFF
--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -222,7 +222,9 @@ The `LinkItem` type has two required fields: `url` (the fully-qualified URL for 
 
 The `serialize` function should return `SitemapItem`, touched or not.  
 
-The example below shows the ability to add the sitemap specific properties individually.
+To exclude the passed entry from sitemap it should return `undefined`.
+
+The example below shows the ability to exclude certain entries and add the sitemap specific properties individually.
 
 __astro.config.mjs__
 
@@ -234,6 +236,9 @@ export default {
   integrations: [
     sitemap({
       serialize(item) {
+        if (/exclude-from-sitemap/.test(item.url)) {
+          return undefined;
+        }
         if (/your-special-page/.test(item.url)) {
           item.changefreq = 'daily';
           item.lastmod = new Date();

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -38,7 +38,7 @@ export type SitemapOptions =
 			priority?: number;
 
 			// called for each sitemap item just before to save them on disk, sync or async
-			serialize?(item: SitemapItem): SitemapItem | Promise<SitemapItem>;
+			serialize?(item: SitemapItem): SitemapItem | Promise<SitemapItem | undefined> | undefined;
 	  }
 	| undefined;
 
@@ -117,8 +117,14 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 							const serializedUrls: SitemapItem[] = [];
 							for (const item of urlData) {
 								const serialized = await Promise.resolve(serialize(item));
-								serializedUrls.push(serialized);
+                if (serialized) {
+                  serializedUrls.push(serialized);
+                }
 							}
+              if (serializedUrls.length === 0) {
+                logger.warn('No pages found!');
+                return;
+              }							
 							urlData = serializedUrls;
 						} catch (err) {
 							logger.error(`Error serializing pages\n${(err as any).toString()}`);


### PR DESCRIPTION
## Changes

If `serialize` function returns `undefined` value for the passed entry, such entry will be excluded from sitemap

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->