### PR TITLE
Updates integration package READMES to remove "experimental" warning from astro add command

### DIFF
--- a/packages/integrations/lit/README.md
+++ b/packages/integrations/lit/README.md
@@ -6,7 +6,7 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 There are two ways to add integrations to your project. Let's try the most convenient option first!
 
-### (experimental) `astro add` command
+### `astro add` command
 
 Astro includes a CLI tool for adding first party integrations: `astro add`. This command will:
 1. (Optionally) Install all necessary dependencies and peer dependencies

--- a/packages/integrations/preact/README.md
+++ b/packages/integrations/preact/README.md
@@ -6,7 +6,7 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 There are two ways to add integrations to your project. Let's try the most convenient option first!
 
-### (experimental) `astro add` command
+### `astro add` command
 
 Astro includes a CLI tool for adding first party integrations: `astro add`. This command will:
 1. (Optionally) Install all necessary dependencies and peer dependencies

--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -6,7 +6,7 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 There are two ways to add integrations to your project. Let's try the most convenient option first!
 
-### (experimental) `astro add` command
+### `astro add` command
 
 Astro includes a CLI tool for adding first party integrations: `astro add`. This command will:
 1. (Optionally) Install all necessary dependencies and peer dependencies

--- a/packages/integrations/solid/README.md
+++ b/packages/integrations/solid/README.md
@@ -6,7 +6,7 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 There are two ways to add integrations to your project. Let's try the most convenient option first!
 
-### (experimental) `astro add` command
+### `astro add` command
 
 Astro includes a CLI tool for adding first party integrations: `astro add`. This command will:
 1. (Optionally) Install all necessary dependencies and peer dependencies

--- a/packages/integrations/svelte/README.md
+++ b/packages/integrations/svelte/README.md
@@ -6,7 +6,7 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 There are two ways to add integrations to your project. Let's try the most convenient option first!
 
-### (experimental) `astro add` command
+### `astro add` command
 
 Astro includes a CLI tool for adding first party integrations: `astro add`. This command will:
 1. (Optionally) Install all necessary dependencies and peer dependencies

--- a/packages/integrations/vue/README.md
+++ b/packages/integrations/vue/README.md
@@ -6,7 +6,7 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 There are two ways to add integrations to your project. Let's try the most convenient option first!
 
-### (experimental) `astro add` command
+### `astro add` command
 
 Astro includes a CLI tool for adding first party integrations: `astro add`. This command will:
 1. (Optionally) Install all necessary dependencies and peer dependencies


### PR DESCRIPTION
## Changes
Updates READMEs for Lit, Preact, React, Solid, Svelte, Vue integration packages

- `astro add` is still marked as "experimental" in these files. 
- In the Docs, we no longer refer to official Astro integrations as experimental, and instead reference an experimental flag or config option only for enabling third-party extensions.

This removes the warning "(experimental)" from the installation instructions for the Astro renderer integration packages to be more consistent with Docs.

From: (experimental) `astro add` command
To: `astro add` command

## Testing
No tests.

## Docs
Does not change Docs.