### PR TITLE
Refactor: remove Deno shim to esbuild "banner"

### DIFF
--- a/packages/integrations/deno/src/index.ts
+++ b/packages/integrations/deno/src/index.ts
@@ -63,6 +63,12 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					format: 'esm',
 					bundle: true,
 					external: ['@astrojs/markdown-remark'],
+					banner: {
+						js: `globalThis.process = {
+									argv: [],
+									env: Deno.env.toObject(),
+								};`
+					}
 				});
 
 				// Remove chunks, if they exist. Since we have bundled via esbuild these chunks are trash.

--- a/packages/integrations/deno/src/server.ts
+++ b/packages/integrations/deno/src/server.ts
@@ -1,8 +1,3 @@
-// NOTE(fks): Side-effect -- shim.js must run first. This isn't guaranteed by
-// the language, but it is a Node.js behavior that we rely on here. Keep this
-// separate from the other imports so that it doesn't get organized & reordered.
-import './shim.js';
-
 // Normal Imports
 import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';

--- a/packages/integrations/deno/src/shim.ts
+++ b/packages/integrations/deno/src/shim.ts
@@ -1,5 +1,0 @@
-(globalThis as any).process = {
-	argv: [],
-	// @ts-ignore
-	env: Deno.env.toObject(),
-};


### PR DESCRIPTION
## Changes
- Add `process` shim using an esbuild banner instead of an ESM import. This guarantees our shim will appear at the top of the file!
- Remove `shim.ts` import

## Testing

Make sure nothing fails 👍 

## Docs

N/A