### PR TITLE
Fix: prevent sourcemap warnings in monorepo "dev" mode

### DIFF
--- a/.changeset/eighty-turtles-drive.md
+++ b/.changeset/eighty-turtles-drive.md
@@ -1,0 +1,5 @@
+---
+'astro-scripts': patch
+---
+
+Fix: avoid generating sourcemaps for dev builds of the monorepo - prevents Vite warning logs

--- a/scripts/cmd/build.js
+++ b/scripts/cmd/build.js
@@ -12,7 +12,7 @@ const defaultConfig = {
 	format: 'esm',
 	platform: 'node',
 	target: 'node14',
-	sourcemap: 'inline',
+	sourcemap: false,
 	sourcesContent: false,
 };
 
@@ -61,7 +61,6 @@ export default async function build(...args) {
 	if (!isDev) {
 		await esbuild.build({
 			...config,
-			sourcemap: false,
 			bundle: false,
 			entryPoints,
 			outdir,


### PR DESCRIPTION
## Changes

- Stop generating sourcemaps when building the monorepo in dev mode - prevents Vite console warnings for missing sourcemap files
- Resolves #3403 

## Testing

N/A

## Docs

N/A