### PR TITLE
Add changeset to release `create-astro`

### DIFF
--- a/.changeset/fair-countries-perform.md
+++ b/.changeset/fair-countries-perform.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Remove `astro add` step & tweak wording (PR #3715)


### PR DESCRIPTION
## Changes

Adds a changeset to release `create-astro` which was missed in #3715

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->