### PR TITLE
make sure anonymousProjectId is hashed in fallback, non-git case

### DIFF
--- a/.changeset/lemon-fireants-film.md
+++ b/.changeset/lemon-fireants-film.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/telemetry': patch
+---
+
+Fix issue where project id fallback was not getting hashed

--- a/packages/telemetry/src/project-info.ts
+++ b/packages/telemetry/src/project-info.ts
@@ -85,6 +85,6 @@ export function getProjectInfo(isCI: boolean): ProjectInfo {
 	}
 	return {
 		isGit: false,
-		anonymousProjectId: isCI ? '' : process.cwd(),
+		anonymousProjectId: isCI ? '' : createAnonymousValue(process.cwd()),
 	};
 }


### PR DESCRIPTION
## Changes

- Missed the `createAnonymousValue()` call when telemetry runs outside of a git repo

## Testing

- N/A

## Docs

- N/A