### PR TITLE
Added: reminder to update docs if create-astro flow or wording changes

### DIFF
--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -45,6 +45,7 @@ const { version } = JSON.parse(
 
 const FILES_TO_REMOVE = ['.stackblitzrc', 'sandbox.config.json', 'CHANGELOG.md']; // some files are only needed for online editors when using astro.new. Remove for create-astro installs.
 
+// Please also update the installation instructions in the docs at https://github.com/withastro/docs/blob/main/src/pages/en/install/auto.md if you make any changes to the flow or wording here.
 export async function main() {
 	const pkgManager = pkgManagerFromUserAgent(process.env.npm_config_user_agent);
 


### PR DESCRIPTION
## Changes

- Adds a code comment before the `main()` function where `create-astro` "messages" are defined.
- Directs to [installation instructions file in docs repo](https://github.com/withastro/docs/blob/main/src/pages/en/install/auto.md) which will mirror the exact flow and wording of `create-astro` wizard when https://github.com/withastro/docs/pull/867 is merged
- instructs anyone changing the steps or wording of `create-astro` to make a corresponding change in the docs if necessary

## Testing
No test

## Docs
Does not require a change to docs.