### PR TITLE
Fixes a bug in how `injectRoute` parses route patterns on Windows

### DIFF
--- a/.changeset/seven-rocks-sort.md
+++ b/.changeset/seven-rocks-sort.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes how `injectRoute` parses route patterns on Windows

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import slash from 'slash';
 import { fileURLToPath } from 'url';
 import { warn } from '../../logger/core.js';
+import { removeLeadingForwardSlash } from '../../path.js';
 import { resolvePages } from '../../util.js';
 import { getRouteGenerator } from './generator.js';
 const require = createRequire(import.meta.url);
@@ -294,7 +295,7 @@ export function createRouteManifest(
 		const isDynamic = (str: string) => str?.[0] === '[';
 		const normalize = (str: string) => str?.substring(1, str?.length - 1);
 
-		const segments = name
+		const segments = removeLeadingForwardSlash(name)
 			.split(path.sep)
 			.filter(Boolean)
 			.map((s: string) => {


### PR DESCRIPTION
## Changes

Quick bug fix after running into this with the `@astrojs/image` integration - on Windows the route `/_image` was being parsed and injected as `//_image`

This change strips the leading slash when adding injected routes to the manifest (the leading slash is always added back in anyway)

## Testing

None yet!  I opened [#3762](https://github.com/withastro/astro/issues/3762) tagged as a chore to add `injectRoute` coverage

## Docs

Bug fix only