### PR TITLE
Updates an error handler to expect updated `@astrojs/lit` behavior

### DIFF
--- a/examples/framework-lit/src/components/calc-add.js
+++ b/examples/framework-lit/src/components/calc-add.js
@@ -1,8 +1,6 @@
 import { LitElement, html } from 'lit';
 
-export const tagName = 'calc-add';
-
-class CalcAdd extends LitElement {
+export class CalcAdd extends LitElement {
 	static get properties() {
 		return {
 			num: {
@@ -16,4 +14,4 @@ class CalcAdd extends LitElement {
 	}
 }
 
-customElements.define(tagName, CalcAdd);
+customElements.define('calc-add', CalcAdd);

--- a/examples/framework-lit/src/components/my-counter.js
+++ b/examples/framework-lit/src/components/my-counter.js
@@ -1,8 +1,6 @@
 import { LitElement, html } from 'lit';
 
-export const tagName = 'my-counter';
-
-class Counter extends LitElement {
+export class MyCounter extends LitElement {
 	static get properties() {
 		return {
 			count: {
@@ -31,4 +29,4 @@ class Counter extends LitElement {
 	}
 }
 
-customElements.define(tagName, Counter);
+customElements.define('my-counter', MyCounter);

--- a/examples/framework-lit/src/pages/index.astro
+++ b/examples/framework-lit/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import Lorem from '../components/Lorem.astro';
-import '../components/Test.js';
-import '../components/Counter.js';
+import { CalcAdd } from '../components/calc-add.js';
+import { MyCounter } from '../components/my-counter.js';
 ---
 
 <!DOCTYPE html>
@@ -12,8 +12,8 @@ import '../components/Counter.js';
 	</head>
 	<body>
 		<h1>Test app</h1>
-		<my-counter client:load></my-counter>
+		<MyCounter client:load></MyCounter>
 		<Lorem />
-		<calc-add num={33}></calc-add>
+		<CalcAdd num={33}></CalcAdd>
 	</body>
 </html>

--- a/examples/integrations-playground/src/components/calc-add.js
+++ b/examples/integrations-playground/src/components/calc-add.js
@@ -1,8 +1,6 @@
 import { LitElement, html } from 'lit';
 
-export const tagName = 'calc-add';
-
-class CalcAdd extends LitElement {
+export class CalcAdd extends LitElement {
 	static get properties() {
 		return {
 			num: {
@@ -16,4 +14,4 @@ class CalcAdd extends LitElement {
 	}
 }
 
-customElements.define(tagName, CalcAdd);
+customElements.define('calc-add', CalcAdd);

--- a/examples/integrations-playground/src/components/my-counter.js
+++ b/examples/integrations-playground/src/components/my-counter.js
@@ -1,8 +1,6 @@
 import { LitElement, html } from 'lit';
 
-export const tagName = 'my-counter';
-
-class Counter extends LitElement {
+export class MyCounter extends LitElement {
 	static get properties() {
 		return {
 			count: {
@@ -31,4 +29,4 @@ class Counter extends LitElement {
 	}
 }
 
-customElements.define(tagName, Counter);
+customElements.define('my-counter', MyCounter);

--- a/examples/integrations-playground/src/pages/index.astro
+++ b/examples/integrations-playground/src/pages/index.astro
@@ -2,8 +2,8 @@
 import Lorem from '../components/Lorem.astro';
 import Link from '../components/Link.jsx';
 import SolidCounter from '../components/SolidCounter.jsx';
-import '../components/Test.js';
-import '../components/Counter.js';
+import { CalcAdd } from '../components/calc-add.js';
+import { MyCounter } from '../components/my-counter.js';
 ---
 
 <!DOCTYPE html>
@@ -18,11 +18,11 @@ import '../components/Counter.js';
       <strong>Party Mode!</strong>
       Colors changing = partytown is enabled
     </h2>
-		<my-counter client:load></my-counter>
+		<MyCounter client:load></MyCounter>
     <SolidCounter client:load></SolidCounter>
     <Link to="/foo" text="Go to Page 2" />
 		<Lorem />
-		<calc-add num={33}></calc-add>
+		<CalcAdd num={33}></CalcAdd>
     <script type="text/partytown">
       // Remove `type="text/partytown"` to see this block the page
       // and cause the page to become unresponsive

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -358,7 +358,9 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 		}
 	}
 
-	if (renderer && !renderer.clientEntrypoint && metadata.hydrate) {
+	// HACK! The lit renderer doesn't include a clientEntrypoint for custom elements, allow it
+	// to render here until we find a better way to recognize when a client entrypoint isn't required.
+	if (renderer && !renderer.clientEntrypoint && renderer.name !== '@astrojs/lit' && metadata.hydrate) {
 		throw new Error(
 			`${metadata.displayName} component has a \`client:${metadata.hydrate}\` directive, but no client entrypoint was provided by ${renderer.name}!`
 		);


### PR DESCRIPTION
Closes #3741 

## Changes

Handles an edge case where the `@astrojs/lit` renderer actually doesn't need to include a client entrypoint since it builds plain old custom elements.  It's a one-off check for now, could be interesting to revisit a more general solution if we see a third-party custom element renderer also hit this issue

Also updates example apps that use lit for the newer syntax that removed the `export const tagName` convention

## Testing

All existing tests should pass

## Docs

Bug fix only