### PR TITLE
Fix an issue with unfriendly config validation errors

### DIFF
--- a/.changeset/sour-clocks-unite.md
+++ b/.changeset/sour-clocks-unite.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix an issue with unfriendly config validation error output


### PR DESCRIPTION
## Changes

- Config parsing was accidentally moved outside of a try-catch, so that config errors are no longer shown with a user-friendly presentation. This was just introduced in #3713.
- This PR fixes that specific problem, and also refactors the code to remove the need for individual try-catch blocks. The `throwAndExit()` function is meant to be a global handler, so now it handles all errors that come out of the CLI with a single try-catch.

## Testing

- We already do unit test for config validation errors, but not through the CLI.
- I'm not sure if this is worth adding an entire fixture for, so I didn't touch tests for now.

## Docs

- N/A