### PR TITLE
Support objects for `style` attribute

### DIFF
--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -507,7 +507,7 @@ declare namespace astroHTML.JSX {
 		lang?: string | undefined | null;
 		slot?: string | undefined | null;
 		spellcheck?: 'true' | 'false' | boolean | undefined | null;
-		style?: string | undefined | null;
+		style?: string | Record<string, any> | undefined | null;
 		tabindex?: number | string | undefined | null;
 		title?: string | undefined | null;
 		translate?: 'yes' | 'no' | undefined | null;
@@ -1017,7 +1017,7 @@ declare namespace astroHTML.JSX {
 		method?: string | undefined | null;
 		min?: number | string | undefined | null;
 		name?: string | undefined | null;
-		style?: string | undefined | null;
+		style?: string | Record<string, any> | undefined | null;
 		target?: string | undefined | null;
 		type?: string | undefined | null;
 		width?: number | string | undefined | null;

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -542,6 +542,9 @@ export function createAstro(
 const toAttributeString = (value: any, shouldEscape = true) =>
 	shouldEscape ? String(value).replace(/&/g, '&#38;').replace(/"/g, '&#34;') : value;
 
+const kebab = (k: string) => k.toLowerCase() === k ? k : k.replace(/[A-Z]/g, match => `-${match.toLowerCase()}`);
+const toStyleString = (obj: Record<string, any>) => Object.entries(obj).map(([k, v]) => `${kebab(k)}:${v}`).join(';')
+
 const STATIC_DIRECTIVES = new Set(['set:html', 'set:text']);
 
 // A helper used to turn expressions into attribute key/value
@@ -573,6 +576,11 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 			return '';
 		}
 		return markHTMLString(` ${key.slice(0, -5)}="${listValue}"`);
+	}
+
+	// support object styles for better JSX compat
+	if (key === 'style' && typeof value === 'object') {
+		return markHTMLString(` ${key}="${toStyleString(value)}"`);
 	}
 
 	// Boolean values only need the key

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -583,6 +583,11 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 		return markHTMLString(` ${key}="${toStyleString(value)}"`);
 	}
 
+	// support `className` for better JSX compat
+	if (key === 'className') {
+		return markHTMLString(` class="${toAttributeString(value, shouldEscape)}"`);
+	}
+
 	// Boolean values only need the key
 	if (value === true && (key.startsWith('data-') || htmlBooleanAttributes.test(key))) {
 		return markHTMLString(` ${key}`);


### PR DESCRIPTION
## Changes

- Follow-up to https://github.com/withastro/astro/pull/3706
- Adds support for `style={{ color: 'red' }}` props
- Importantly, does not handle number => `px` string conversion for you. The logic in React that handles this is massive, and it's a convenience more than anything. Preact gets away with requiring explicit units.

## Testing

Covered by #4002 

## Docs

Not going to document this as it's a compat feature