### PR TITLE
Fix integration name (`prefetch` instead of `lit`)

### DIFF
--- a/.changeset/light-moons-protect.md
+++ b/.changeset/light-moons-protect.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/prefetch': patch
+---
+
+Fix integration name (`prefetch` instead of `lit`)

--- a/packages/integrations/prefetch/src/index.ts
+++ b/packages/integrations/prefetch/src/index.ts
@@ -3,7 +3,7 @@ import type { PrefetchOptions } from './client.js';
 
 export default function (options: PrefetchOptions = {}): AstroIntegration {
 	return {
-		name: '@astrojs/lit',
+		name: '@astrojs/prefetch',
 		hooks: {
 			'astro:config:setup': ({ updateConfig, addRenderer, injectScript }) => {
 				// Inject the necessary polyfills on every page (inlined for speed).


### PR DESCRIPTION
## Changes

- Fixes the `@astrojs/prefetch` integration `name` property that apparently didn't get updated after using the lit integration as a template.

## Testing

- Ran tests locally.

## Docs

- Bugfix only, not a visible change.