### PR TITLE
await error reporter

### DIFF
--- a/.changeset/plenty-paws-divide.md
+++ b/.changeset/plenty-paws-divide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix an issue with throwAndExit not awaiting


### PR DESCRIPTION
## Changes

- We were not awaiting the final `throwAndExit()` handler, which caused error telemetry to never run. This didn't impact `DEBUG` mode so I didn't catch it originally 🤦 

## Testing

- N/A

## Docs

- N/A