### PR TITLE
Ci: improve times, reduce delay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,9 @@ jobs:
         node_version: [14, 16]
         include:
           - os: windows-latest
-            node_version: 16
+            node_version: 14
           - os: macos-latest
-            node_version: 16
+            node_version: 14
       fail-fast: false
     needs:
       - build
@@ -151,17 +151,14 @@ jobs:
         run: pnpm run test
 
   e2e:
-    name: 'E2E: ${{ matrix.os }} (node@${{ matrix.node_version }})'
+    name: 'Test (E2E): ${{ matrix.os }} (node@${{ matrix.node_version }})'
     runs-on: ${{ matrix.os }}
     env:
       ASTRO_TELEMETRY_DISABLED: true
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         node_version: [14]
-        include:
-          - os: windows-latest
-            node_version: 16
       fail-fast: false
     needs:
       - build
@@ -191,11 +188,12 @@ jobs:
         run: pnpm run test:e2e
 
   smoke:
-    name: 'Test (Smoke) ${{ matrix.os }}'
+    name: 'Test (Smoke): ${{ matrix.os }} (node@${{ matrix.node_version }})'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
+        node_version: [14]
     needs:
       - build
     steps:
@@ -210,10 +208,10 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v2.2.1
 
-      - name: Setup Node
+      - name: Setup node@${{ matrix.node_version }}
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: ${{ matrix.node_version }}
           cache: 'pnpm'
 
       - name: Download Build Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,11 +158,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [14, 16]
+        node_version: [14]
         include:
           - os: windows-latest
-            node_version: 16
-          - os: macos-latest
             node_version: 16
       fail-fast: false
     needs:


### PR DESCRIPTION
## Changes

- I'm seeing PRs taking 15, 20+ minutes to complete CI
- This can be a huge efficiency loss when we're waiting around for CI to complete
- E2E tests seem to be a big contributor to this
- This change reduces E2E runs to just basic covers: 1 ubuntu and 1 windows 
- This is something we had to do to smoke tests in the past for the exact same reason

<img width="271" alt="Screen Shot 2022-06-30 at 11 10 42 AM" src="https://user-images.githubusercontent.com/622227/176749112-321ac421-475d-4073-86bc-b621715d9cc3.png">


## Testing

- Is test.

## Docs

- N/A