### PR TITLE
fix: no canonicalURL option now

### DIFF
--- a/.changeset/rich-books-dress.md
+++ b/.changeset/rich-books-dress.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/sitemap': patch
+---
+
+The `canonocalURL` option was deleted in the previous commit. But its validation still exists.

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -63,32 +63,28 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 				const logger = new Logger(PKG_NAME);
 
 				try {
-					const opts = validateOptions(config.site, options);
+					const opts = validateOptions(options);
 
 					const { filter, customPages, serialize, entryLimit } = opts;
 
-					let finalSiteUrl: URL;
-					if (config.site) {
-						finalSiteUrl = new URL(config.base, config.site);
-					} else {
-						console.warn(
-							'The Sitemap integration requires the `site` astro.config option. Skipping.'
-						);
+					if (!config.site) {
+						logger.warn('The Sitemap integration requires the `site` astro.config option.');
 						return;
 					}
+					const finalSiteUrl = new URL(config.base, config.site);
 
 					let pageUrls = pages.map((p) => {
 						const path = finalSiteUrl.pathname + p.pathname;
 						return new URL(path, finalSiteUrl).href;
 					});
-
-					try {
-						if (filter) {
+					
+					if (filter) {
+						try {
 							pageUrls = pageUrls.filter(filter);
+						} catch (err) {
+							logger.error(`Error filtering pages\n${(err as any).toString()}`);
+							return;
 						}
-					} catch (err) {
-						logger.error(`Error filtering pages\n${(err as any).toString()}`);
-						return;
 					}
 
 					if (customPages) {
@@ -102,7 +98,7 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 								`No pages found! We can only detect sitemap routes for "static" projects. Since you are using an SSR adapter, we recommend manually listing your sitemap routes using the "customPages" integration option.\n\nExample: \`sitemap({ customPages: ['https://example.com/route'] })\``
 							);
 						} else {
-							logger.warn(`No pages found!\n\`${OUTFILE}\` not created.`);
+							logger.warn('No pages found!');
 						}
 						return;
 					}

--- a/packages/integrations/sitemap/src/schema.ts
+++ b/packages/integrations/sitemap/src/schema.ts
@@ -8,7 +8,6 @@ export const SitemapOptionsSchema = z
 	.object({
 		filter: z.function().args(z.string()).returns(z.boolean()).optional(),
 		customPages: z.string().url().array().optional(),
-		canonicalURL: z.string().url().optional(),
 
 		i18n: z
 			.object({

--- a/packages/integrations/sitemap/src/validate-options.ts
+++ b/packages/integrations/sitemap/src/validate-options.ts
@@ -1,22 +1,8 @@
-import { z } from 'zod';
 import type { SitemapOptions } from './index.js';
 import { SitemapOptionsSchema } from './schema.js';
 
 // @internal
-export const validateOptions = (site: string | undefined, opts: SitemapOptions) => {
+export const validateOptions = (opts: SitemapOptions) => {
 	const result = SitemapOptionsSchema.parse(opts);
-
-	z.object({
-		site: z.string().optional(), // Astro takes care of `site`: how to validate, transform and refine
-		canonicalURL: z.string().optional(), // `canonicalURL` is already validated in prev step
-	})
-		.refine((options) => options.site || options.canonicalURL, {
-			message: 'Required `site` astro.config option or `canonicalURL` integration option',
-		})
-		.parse({
-			site,
-			canonicalURL: result.canonicalURL,
-		});
-
 	return result;
 };


### PR DESCRIPTION
## Changes

The `canonicalURL` option doesn't longer exist after last commit. 
I've deleted it from the schema and validation too. 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->