### PR TITLE
Updates the images integration to automatically mark `optimizeDeps` for sharp

### DIFF
--- a/.changeset/neat-yaks-hope.md
+++ b/.changeset/neat-yaks-hope.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Automatically adds the required `vite.optimizeDeps` config for `sharp`. Also ensures that only whole numbers are passed to sharp's resize transform

--- a/packages/integrations/image/components/Image.astro
+++ b/packages/integrations/image/components/Image.astro
@@ -1,8 +1,8 @@
 ---
 // @ts-ignore
 import loader from 'virtual:image-loader';
-import { getImage } from '../src';
-import type { ImageAttributes, ImageMetadata, TransformOptions, OutputFormat } from '../src/types';
+import { getImage } from '../src/index.js';
+import type { ImageAttributes, ImageMetadata, TransformOptions, OutputFormat } from '../src/types.js';
 
 export interface LocalImageProps extends Omit<TransformOptions, 'src'>, Omit<ImageAttributes, 'src'> {
 	src: ImageMetadata | Promise<{ default: ImageMetadata }>;

--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -28,7 +28,8 @@
   },
   "files": [
     "components",
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",

--- a/packages/integrations/image/src/index.ts
+++ b/packages/integrations/image/src/index.ts
@@ -75,7 +75,10 @@ const createIntegration = (options: IntegrationOptions = {}): AstroIntegration =
 	function getViteConfiguration() {
 		return {
 			plugins: [createPlugin(_config, resolvedOptions)],
-		};
+			optimizeDeps: {
+				include: ['image-size', 'sharp']
+			}
+		}
 	}
 
 	return {

--- a/packages/integrations/image/src/loaders/sharp.ts
+++ b/packages/integrations/image/src/loaders/sharp.ts
@@ -84,7 +84,9 @@ class SharpService implements SSRImageService {
 		const sharpImage = sharp(inputBuffer, { failOnError: false });
 
 		if (transform.width || transform.height) {
-			sharpImage.resize(transform.width, transform.height);
+			const width = transform.width && Math.round(transform.width);
+			const height = transform.height && Math.round(transform.height);
+			sharpImage.resize(width, height);
 		}
 
 		if (transform.format) {


### PR DESCRIPTION
## Changes

- Updates the integration to add `sharp` and `image-size` to the `vite.optimizeDeps` config
- Fixes a bug when resizing images - `sharp` requires all dimensions are provided as whole numbers
- Updates the file exports in the NPM package to support the `Image.astro` typescript imports at build time

## Testing

All existing tests should pass

## Docs

Bug fix only