### PR TITLE
Increases node memory during the CI format workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   format:
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
       - name: Check out code using Git
         uses: actions/checkout@v3


### PR DESCRIPTION
## Changes

Bumps node's memory head size when running the code formatting CI job

## Testing

CI updates only

## Docs

N/A