### PR TITLE
Manually correcting import ordering to unblock CI

### DIFF
--- a/packages/integrations/image/src/endpoints/dev.ts
+++ b/packages/integrations/image/src/endpoints/dev.ts
@@ -1,6 +1,6 @@
-// @ts-ignore
 import type { APIRoute } from 'astro';
 import { lookup } from 'mrmime';
+// @ts-ignore
 import loader from 'virtual:image-loader';
 import { loadImage } from '../utils.js';
 

--- a/packages/integrations/image/src/endpoints/prod.ts
+++ b/packages/integrations/image/src/endpoints/prod.ts
@@ -1,7 +1,7 @@
-// @ts-ignore
 import type { APIRoute } from 'astro';
 import etag from 'etag';
 import { lookup } from 'mrmime';
+// @ts-ignore
 import loader from 'virtual:image-loader';
 import { isRemoteImage, loadRemoteImage } from '../utils.js';
 


### PR DESCRIPTION
## Changes

The CI `format` job gets stuck with a build break when the imports are reordered but the `@ts-ignore` comment isn't also moved to match

## Testing

NA

## Docs

NA