### PR TITLE
Fix example on `README.md` on @astrojs/node

### DIFF
--- a/.changeset/itchy-bottles-rhyme.md
+++ b/.changeset/itchy-bottles-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/node": patch
+---
+
+Fix example on `README.md`

--- a/packages/integrations/node/README.md
+++ b/packages/integrations/node/README.md
@@ -33,7 +33,7 @@ __astro.config.mjs__
 
 ```js
 import { defineConfig } from 'astro/config';
-import deno from '@astrojs/node';
+import node from '@astrojs/node';
 
 export default defineConfig({
   // ...


### PR DESCRIPTION
The example was suggesting `import deno from '@astrojs/node';` which doesn't work. It needs to be `import node from '@astrojs/node';`.