### PR TITLE
Ensure that maybeRenderHead runs last

### DIFF
--- a/.changeset/hip-months-invent.md
+++ b/.changeset/hip-months-invent.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix for putting the <head> into its own component

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -789,7 +789,7 @@ const uniqueElements = (item: any, index: number, all: any[]) => {
 };
 
 const alreadyHeadRenderedResults = new WeakSet<SSRResult>();
-export async function renderHead(result: SSRResult): Promise<string> {
+export function renderHead(result: SSRResult): Promise<string> {
 	alreadyHeadRenderedResults.add(result);
 	const styles = Array.from(result.styles)
 		.filter(uniqueElements)
@@ -811,11 +811,11 @@ export async function renderHead(result: SSRResult): Promise<string> {
 // This accomodates the fact that using a <head> is optional in Astro, so this
 // is called before a component's first non-head HTML element. If the head was
 // already injected it is a noop.
-export function maybeRenderHead(result: SSRResult): string | Promise<string> {
+export async function* maybeRenderHead(result: SSRResult): AsyncIterable<string> {
 	if (alreadyHeadRenderedResults.has(result)) {
-		return '';
+		return;
 	}
-	return renderHead(result);
+	yield renderHead(result);
 }
 
 export async function* renderAstroComponent(

--- a/packages/astro/test/astro-head.test.js
+++ b/packages/astro/test/astro-head.test.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Head in its own component', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/astro-head/',
+			site: 'https://mysite.dev/',
+			base: '/blog',
+		});
+		await fixture.build();
+	});
+
+	it('Styles are appended to the head and not the body', async () => {
+		let html = await fixture.readFile('/head-own-component/index.html');
+		let $ = cheerio.load(html);
+		expect($('link[rel=stylesheet]')).to.have.a.lengthOf(1, 'one stylesheet overall');
+		expect($('head link[rel=stylesheet]')).to.have.a.lengthOf(1, 'stylesheet is in the head');
+	});
+});

--- a/packages/astro/test/fixtures/astro-head/src/components/Head.astro
+++ b/packages/astro/test/fixtures/astro-head/src/components/Head.astro
@@ -1,0 +1,11 @@
+---
+// Head.astro
+const { title } = Astro.props;
+---
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <title>{title}</title>
+</head>

--- a/packages/astro/test/fixtures/astro-head/src/pages/head-own-component.astro
+++ b/packages/astro/test/fixtures/astro-head/src/pages/head-own-component.astro
@@ -1,0 +1,16 @@
+---
+// Layout.astro
+import Head from "../components/Head.astro";
+---
+
+<!DOCTYPE html>
+<html lang="en">
+<Head title="title"/>
+<body>
+	<h1>Title Here</h1>
+	<style>
+		body {
+			background: green;
+		}
+	</style>
+</body>


### PR DESCRIPTION
## Changes

- When putting a `<head>` into its own file, head contents (such as stylesheets) should be appended there.
- We have a `maybeRenderHead` function that exists for components with no head element. This function is intended to cover the case where a page has no explicit head at all.
  - This function intends checks to see if a head has already rendered and if so, bail out.
  - Because this function was synchronous, it would run before components higher in the tree, causing the bug.
  - Maybe it be an async generator, like components are, ensures that it is put *in line* and doesn't run before stuff above it.
- Fixes https://github.com/withastro/astro/issues/3819

## Testing

- Test added

## Docs

N/A, bug fix