### PR TITLE
fix handled git error output accidentally being piped to the user

### DIFF
--- a/.changeset/rare-elephants-add.md
+++ b/.changeset/rare-elephants-add.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/telemetry': patch
+---
+
+Fix an issue where handled error output was piped to the user

--- a/packages/telemetry/src/project-info.ts
+++ b/packages/telemetry/src/project-info.ts
@@ -67,7 +67,7 @@ function getProjectIdFromGit(): string | null {
 	try {
 		const originBuffer = execSync(`git rev-list --max-parents=0 HEAD`, {
 			timeout: 500,
-			stdio: [0, 'pipe', 0],
+			stdio: ['ignore', 'pipe', 'ignore'],
 		});
 		return String(originBuffer).trim();
 	} catch (_) {


### PR DESCRIPTION
## Changes

- An error that was meant to be handled was accidentally piped to the user


## Testing

- N/A

## Docs

- N/A