### PR TITLE
fix: show build errors during Preact build

### DIFF
--- a/.changeset/mighty-deers-teach.md
+++ b/.changeset/mighty-deers-teach.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/preact': patch
+---
+
+Build errors should now be shown properly

--- a/packages/integrations/preact/server.js
+++ b/packages/integrations/preact/server.js
@@ -28,7 +28,8 @@ function check(Component, props, children) {
 
 			return !/\<undefined\>/.test(html);
 		} catch (err) {
-			return false;
+			// This is done intentionally in order to show errors that are thrown during a build process.
+			throw err;
 		}
 	} finally {
 		finishUsingConsoleFilter();


### PR DESCRIPTION
## Changes

This PR introduces a change that forces Preact to properly report the error code when trying to build a project with a bug in Preact


### Before:


<details>
<summary>The error before this change</summary>

```
   git  Astro  unicorn-astro-site  main  ≡  ?3 ~14 
↳  yarn dev
yarn run v1.22.19
$ astro dev
   astro  v1.0.0-beta.63 started in 170ms

  ┃ Local    http://localhost:3000/
  ┃ Network  use --host to expose

  ▶ This is a  beta  prerelease build
    Feedback? https://astro.build/issues

Error: Unable to render PostBody!

This component likely uses @astrojs/react or @astrojs/preact,
but Astro encountered an error during server-side rendering.

Please ensure that PostBody:
1. Does not unconditionally access browser-specific globals like `window` or `document`.
   If this is unavoidable, use the `client:only` hydration directive.
2. Does not conditionally return `null` or `undefined` when rendered on the server.

If you're still stuck, please open an issue on GitHub or join us at https://astro.build/chat.
    at Module.renderComponent (/node_modules/astro/dist/runtime/server/index.js:221:15)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

</details>

### After

<details>
<summary>The error after this change</summary>

```
   git  Astro  unicorn-astro-site  main  ≡  ?3 ~14 
↳  yarn dev
yarn run v1.22.19
$ astro dev
   astro  v1.0.0-beta.63 started in 122ms

  ┃ Local    http://localhost:3000/
  ┃ Network  use --host to expose

  ▶ This is a  beta  prerelease build
    Feedback? https://astro.build/issues

C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\react\cjs\react.development.js:1622
  return dispatcher.useState(initialState);
                    ^

TypeError: Cannot read properties of null (reading 'useState')
    at useState (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\react\cjs\react.development.js:1622:21)
    at Object.Tabs (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\react-tabs\lib\components\Tabs.js:78:39)
    at m (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\preact-render-to-string\dist\commonjs.js:1:2609)
    at m (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\preact-render-to-string\dist\commonjs.js:1:2724)
    at m (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\preact-render-to-string\dist\commonjs.js:1:1586)
    at m (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\preact-render-to-string\dist\commonjs.js:1:1777)
    at m (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\preact-render-to-string\dist\commonjs.js:1:2724)
    at m (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\preact-render-to-string\dist\commonjs.js:1:1586)
    at m (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\preact-render-to-string\dist\commonjs.js:1:1777)
    at m (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\preact-render-to-string\dist\commonjs.js:1:2724)
    at m (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\preact-render-to-string\dist\commonjs.js:1:1586)
    at m (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\preact-render-to-string\dist\commonjs.js:1:1777)
    at m (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\preact-render-to-string\dist\commonjs.js:1:1586)
    at m (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\preact-render-to-string\dist\commonjs.js:1:1777)
    at m (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\preact-render-to-string\dist\commonjs.js:1:2724)
    at Proxy.y (C:\Users\crutchcorn\git\Astro\unicorn-astro-site\node_modules\preact-render-to-string\dist\commonjs.js:1:1288)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

</details>



## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I used this change inside of an application which had build errors inside of a Preact component. I then changed the LOC relevant to this PR and suddenly was able to see the build errors.

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This should not be a visible change to most users, and should generally be regarded as a bug fix.