### PR TITLE
Fix `client:visible` directive in safari

### DIFF
--- a/.changeset/twenty-meals-train.md
+++ b/.changeset/twenty-meals-train.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `client:visible` directive in safari

--- a/packages/astro/src/runtime/server/astro-island.ts
+++ b/packages/astro/src/runtime/server/astro-island.ts
@@ -41,16 +41,16 @@ declare const Astro: {
 				public Component: any;
 				public hydrator: any;
 				static observedAttributes = ['props'];
-				async connectedCallback() {
+				connectedCallback() {
 					if(this.getAttribute('client') === 'only' || this.firstChild) {
-						await this.childrenConnectedCallback();
+						this.childrenConnectedCallback();
 					} else {
 						// connectedCallback may run *before* children are rendered (ex. HTML streaming)
 						// If SSR children are expected, but not yet rendered,
 						// Wait with a mutation observer
-						new MutationObserver(async (_, mo) => {
+						new MutationObserver((_, mo) => {
 							mo.disconnect();
-							await this.childrenConnectedCallback();
+							this.childrenConnectedCallback();
 						}).observe(this, { childList: true });
 					}
 				}

--- a/packages/astro/src/runtime/server/astro-island.ts
+++ b/packages/astro/src/runtime/server/astro-island.ts
@@ -42,14 +42,10 @@ declare const Astro: {
 				public hydrator: any;
 				static observedAttributes = ['props'];
 				async connectedCallback() {
-					// connectedCallback may run *before* children are rendered (ex. HTML streaming)
-					if (this.getAttribute('client') === 'only') {
-						// If no SSR children will be rendered,
-						// setTimeout to wait until children exist - needed for client:visible
-						setTimeout(() => this.childrenConnectedCallback(), 0);
-					} else if(this.firstChild) {
+					if(this.getAttribute('client') === 'only' || this.firstChild) {
 						await this.childrenConnectedCallback();
 					} else {
+						// connectedCallback may run *before* children are rendered (ex. HTML streaming)
 						// If SSR children are expected, but not yet rendered,
 						// Wait with a mutation observer
 						new MutationObserver(async (_, mo) => {

--- a/packages/astro/src/runtime/server/astro-island.ts
+++ b/packages/astro/src/runtime/server/astro-island.ts
@@ -42,23 +42,27 @@ declare const Astro: {
 				public hydrator: any;
 				static observedAttributes = ['props'];
 				async connectedCallback() {
-					window.addEventListener('astro:hydrate', this.hydrate);
-					await import(this.getAttribute('before-hydration-url')!);
-					const opts = JSON.parse(this.getAttribute('opts')!) as Record<string, any>;
-					Astro[this.getAttribute('client') as directiveAstroKeys](
-						async () => {
-							const rendererUrl = this.getAttribute('renderer-url');
-							const [componentModule, { default: hydrator }] = await Promise.all([
-								import(this.getAttribute('component-url')!),
-								rendererUrl ? import(rendererUrl) : () => () => {},
-							]);
-							this.Component = componentModule[this.getAttribute('component-export') || 'default'];
-							this.hydrator = hydrator;
-							return this.hydrate;
-						},
-						opts,
-						this
-					);
+					// Hack: connectedCallback may run in Safari *before* children are rendered
+					// Use setTimeout to wait until children exist (needed for client:visible)
+					setTimeout(async () => {
+						window.addEventListener('astro:hydrate', this.hydrate);
+						await import(this.getAttribute('before-hydration-url')!);
+						const opts = JSON.parse(this.getAttribute('opts')!) as Record<string, any>;
+						Astro[this.getAttribute('client') as directiveAstroKeys](
+							async () => {
+								const rendererUrl = this.getAttribute('renderer-url');
+								const [componentModule, { default: hydrator }] = await Promise.all([
+									import(this.getAttribute('component-url')!),
+									rendererUrl ? import(rendererUrl) : () => () => {},
+								]);
+								this.Component = componentModule[this.getAttribute('component-export') || 'default'];
+								this.hydrator = hydrator;
+								return this.hydrate;
+							},
+							opts,
+							this,
+						);
+					}, 0);
 				}
 				hydrate = () => {
 					if (!this.hydrator || this.parentElement?.closest('astro-island[ssr]')) {


### PR DESCRIPTION
## Changes

Wraps our island `connectedCallback` in a 0ms timeout. This delays hydrate scripts until the component's children are fully mounted. `connectedCallback` _should_ handle this by definition, but safari has other ideas 😓 

## Testing

N/A

## Docs

N/A