### PR TITLE
Fix: Infer content type with charset in dev and prod

### DIFF
--- a/.changeset/ten-radios-rush.md
+++ b/.changeset/ten-radios-rush.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix: add default content type to endpoints with { body } shorthand

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -149,7 +149,9 @@ export class App {
 			const headers = new Headers();
 			const mimeType = mime.getType(url.pathname);
 			if (mimeType) {
-				headers.set('Content-Type', mimeType);
+				headers.set('Content-Type', `${mimeType};charset=utf-8`);
+			} else {
+				headers.set('Content-Type', 'text/plain;charset=utf-8');
 			}
 			const bytes = this.#encoder.encode(body);
 			headers.set('Content-Length', bytes.byteLength.toString());

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -315,7 +315,8 @@ async function handleRequest(
 			if (result.type === 'response') {
 				await writeWebResponse(res, result.response);
 			} else {
-				res.writeHead(200);
+				// mirrors SvelteKit's default when using { body: ... } shorthand
+				res.writeHead(200, { 'Content-Type': 'text/plain;charset=utf-8' });
 				res.end(result.body);
 			}
 		} else {

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -1,5 +1,6 @@
 import type http from 'http';
 import type * as vite from 'vite';
+import mime from 'mime';
 import type { AstroConfig, ManifestData } from '../@types/astro';
 import type { SSROptions } from '../core/render/dev/index';
 
@@ -315,8 +316,12 @@ async function handleRequest(
 			if (result.type === 'response') {
 				await writeWebResponse(res, result.response);
 			} else {
-				// mirrors SvelteKit's default when using { body: ... } shorthand
-				res.writeHead(200, { 'Content-Type': 'text/plain;charset=utf-8' });
+				let contentType = 'text/plain';
+				const computedMimeType = route.pathname ? mime.getType(route.pathname) : null;
+				if (computedMimeType) {
+					contentType = computedMimeType;
+				}
+				res.writeHead(200, { 'Content-Type': `${contentType};charset=utf-8` });
 				res.end(result.body);
 			}
 		} else {

--- a/packages/astro/test/ssr-api-route.test.js
+++ b/packages/astro/test/ssr-api-route.test.js
@@ -56,11 +56,11 @@ describe('API routes in SSR', () => {
 			expect(text).to.equal(`ok`);
 		});
 
-		it('Has default content type with charset for { body } shorthand', async () => {
+		it('Infer content type with charset for { body } shorthand', async () => {
 			const response = await fixture.fetch('/food.json', {
 				method: 'GET',
 			});
-			expect(response.headers.get('Content-Type')).to.equal('text/plain;charset=utf-8');
+			expect(response.headers.get('Content-Type')).to.equal('application/json;charset=utf-8');
 		});
 
 		it('Can set multiple headers of the same type', async () => {

--- a/packages/astro/test/ssr-api-route.test.js
+++ b/packages/astro/test/ssr-api-route.test.js
@@ -56,6 +56,13 @@ describe('API routes in SSR', () => {
 			expect(text).to.equal(`ok`);
 		});
 
+		it('Has default content type with charset for { body } shorthand', async () => {
+			const response = await fixture.fetch('/food.json', {
+				method: 'GET',
+			});
+			expect(response.headers.get('Content-Type')).to.equal('text/plain;charset=utf-8');
+		});
+
 		it('Can set multiple headers of the same type', async () => {
 			const response = await fixture.fetch('/login', {
 				method: 'POST',

--- a/packages/astro/test/ssr-api-route.test.js
+++ b/packages/astro/test/ssr-api-route.test.js
@@ -30,7 +30,7 @@ describe('API routes in SSR', () => {
 		const request = new Request('http://example.com/food.json');
 		const response = await app.render(request);
 		expect(response.status).to.equal(200);
-		expect(response.headers.get('Content-Type')).to.equal('application/json');
+		expect(response.headers.get('Content-Type')).to.equal('application/json;charset=utf-8');
 		expect(response.headers.get('Content-Length')).to.not.be.empty;
 		const body = await response.json();
 		expect(body.length).to.equal(3);


### PR DESCRIPTION
## Context and open questions

Discord comment:

> Okay, I hit a snag with our UTF-8 issue: after a triage call, we decided we should assign "charset=UTF-8" to the header of all API endpoints (in dev only) that use the { body } shorthand. Unfortunately, you can't assign a charset without also assigning a content type. 
> We could use text/plain; charset=utf-8, but this wouldn't seem valid .json endpoints. We could also infer application/json for the .json extension specifically, but this is a slippery slope for other content types we'd need to support 
> So yeah... not sure what behavior we want here 🤷‍♂️
> Oh interesting, sveltekit just says text/plain;charset=UTF-8 for any {body} shorthand, even for .json files in production 


## Changes

- Resolves #3573
- Infer content type in dev and prod for `{ body }` shorthand using [mine package](https://www.npmjs.com/package/mime) (no, this isn't a new dependency)
- Set `text/plain;charset=utf-8` content type when mime can't be inferred

## Testing

Add content type test to `ssr-api-route.test.js`

## Docs

N/A