### PR TITLE
Docs: add adapter heading for configuration docs

### DIFF
--- a/.changeset/funny-masks-yawn.md
+++ b/.changeset/funny-masks-yawn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Docs: add complete "adapter" configuration reference

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -590,7 +590,17 @@ export interface AstroUserConfig {
 	 * @name Adapter
 	 * @description
 	 * 
-	 * Deploy to your favorite server, serverless, or edge host with deployment adapters. Import a first-party adapter for [Netlify](https://docs.astro.build/en/guides/deploy/netlify/#adapter-for-ssredge), [Vercel](https://docs.astro.build/en/guides/deploy/vercel/#adapter-for-ssr), and more to engage Astro SSR. [See our Server-side Rendering docs](https://docs.astro.build/en/guides/server-side-rendering/) for full details.
+	 * Deploy to your favorite server, serverless, or edge host with build adapters. Import one of our first-party adapters for [Netlify](https://docs.astro.build/en/guides/deploy/netlify/#adapter-for-ssredge), [Vercel](https://docs.astro.build/en/guides/deploy/vercel/#adapter-for-ssr), and more to engage Astro SSR.
+	 * 
+	 * [See our Server-side Rendering guide](https://docs.astro.build/en/guides/server-side-rendering/) for more on SSR, and [our deployment guides](https://docs.astro.build/en/guides/deploy/) for a complete list of hosts.
+	 * 
+	 * ```js
+	 * import netlify from '@astrojs/netlify/functions';
+	 * {
+	 *   // Example: Build for Netlify serverless deployment
+	 * 	 adapter: netlify(),
+	 * }
+	 * ```
 	 */
 	adapter?: AstroIntegration;
 

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -585,11 +585,12 @@ export interface AstroUserConfig {
 	};
 
 	/**
-	 * @name adapter
-	 * @type {AstroIntegration}
-	 * @default `undefined`
+	 * @docs
+	 * @kind heading
+	 * @name Adapter
 	 * @description
-	 * Add an adapter to build for SSR (server-side rendering). An adapter makes it easy to connect a deployed Astro app to a hosting provider or runtime environment.
+	 * 
+	 * Deploy to your favorite server, serverless, or edge host with deployment adapters. Import a first-party adapter for [Netlify](https://docs.astro.build/en/guides/deploy/netlify/#adapter-for-ssredge), [Vercel](https://docs.astro.build/en/guides/deploy/vercel/#adapter-for-ssr), and more to engage Astro SSR. [See our Server-side Rendering docs](https://docs.astro.build/en/guides/server-side-rendering/) for full details.
 	 */
 	adapter?: AstroIntegration;
 


### PR DESCRIPTION
## Changes

- Resolves #3691 
- Adds Adapter documentation heading for docs.astro.build. Also beefed up with links to relevant docs and more sell-y language 😉 

## Testing

N/A

## Docs

Need a redeploy to re-run docgen!