### PR TITLE
Move client types into Astro

### DIFF
--- a/.changeset/healthy-poems-know.md
+++ b/.changeset/healthy-poems-know.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Replaces vite/client types with astro/client

--- a/examples/basics/tsconfig.json
+++ b/examples/basics/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/basics/tsconfig.json
+++ b/examples/basics/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/blog-multiple-authors/tsconfig.json
+++ b/examples/blog-multiple-authors/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/blog-multiple-authors/tsconfig.json
+++ b/examples/blog-multiple-authors/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/blog/tsconfig.json
+++ b/examples/blog/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/blog/tsconfig.json
+++ b/examples/blog/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/docs/tsconfig.json
+++ b/examples/docs/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/docs/tsconfig.json
+++ b/examples/docs/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/env-vars/src/env.d.ts
+++ b/examples/env-vars/src/env.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="vite/client" />
+/// <reference types="astro/client" />
 
 interface ImportMetaEnv {
 	readonly DB_PASSWORD: string;

--- a/examples/env-vars/tsconfig.json
+++ b/examples/env-vars/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/env-vars/tsconfig.json
+++ b/examples/env-vars/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/framework-alpine/tsconfig.json
+++ b/examples/framework-alpine/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/framework-alpine/tsconfig.json
+++ b/examples/framework-alpine/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/framework-lit/tsconfig.json
+++ b/examples/framework-lit/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/framework-lit/tsconfig.json
+++ b/examples/framework-lit/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/framework-multiple/tsconfig.json
+++ b/examples/framework-multiple/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/framework-multiple/tsconfig.json
+++ b/examples/framework-multiple/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/framework-preact/tsconfig.json
+++ b/examples/framework-preact/tsconfig.json
@@ -13,6 +13,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/framework-preact/tsconfig.json
+++ b/examples/framework-preact/tsconfig.json
@@ -12,7 +12,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/framework-react/tsconfig.json
+++ b/examples/framework-react/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/framework-react/tsconfig.json
+++ b/examples/framework-react/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/framework-solid/tsconfig.json
+++ b/examples/framework-solid/tsconfig.json
@@ -13,6 +13,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/framework-solid/tsconfig.json
+++ b/examples/framework-solid/tsconfig.json
@@ -12,7 +12,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/framework-svelte/tsconfig.json
+++ b/examples/framework-svelte/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/framework-svelte/tsconfig.json
+++ b/examples/framework-svelte/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/framework-vue/tsconfig.json
+++ b/examples/framework-vue/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/framework-vue/tsconfig.json
+++ b/examples/framework-vue/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/integrations-playground/tsconfig.json
+++ b/examples/integrations-playground/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/integrations-playground/tsconfig.json
+++ b/examples/integrations-playground/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/minimal/tsconfig.json
+++ b/examples/minimal/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/minimal/tsconfig.json
+++ b/examples/minimal/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/non-html-pages/tsconfig.json
+++ b/examples/non-html-pages/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/non-html-pages/tsconfig.json
+++ b/examples/non-html-pages/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/portfolio/tsconfig.json
+++ b/examples/portfolio/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/portfolio/tsconfig.json
+++ b/examples/portfolio/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/ssr/tsconfig.json
+++ b/examples/ssr/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/ssr/tsconfig.json
+++ b/examples/ssr/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/starter/tsconfig.json
+++ b/examples/starter/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/starter/tsconfig.json
+++ b/examples/starter/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/subpath/tsconfig.json
+++ b/examples/subpath/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/subpath/tsconfig.json
+++ b/examples/subpath/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/with-markdown-plugins/tsconfig.json
+++ b/examples/with-markdown-plugins/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/with-markdown-plugins/tsconfig.json
+++ b/examples/with-markdown-plugins/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/with-markdown-shiki/tsconfig.json
+++ b/examples/with-markdown-shiki/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/with-markdown-shiki/tsconfig.json
+++ b/examples/with-markdown-shiki/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/with-markdown/tsconfig.json
+++ b/examples/with-markdown/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/with-markdown/tsconfig.json
+++ b/examples/with-markdown/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/with-mdx/tsconfig.json
+++ b/examples/with-mdx/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/with-mdx/tsconfig.json
+++ b/examples/with-mdx/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/with-nanostores/tsconfig.json
+++ b/examples/with-nanostores/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/with-nanostores/tsconfig.json
+++ b/examples/with-nanostores/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/with-tailwindcss/tsconfig.json
+++ b/examples/with-tailwindcss/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/with-tailwindcss/tsconfig.json
+++ b/examples/with-tailwindcss/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/examples/with-vite-plugin-pwa/tsconfig.json
+++ b/examples/with-vite-plugin-pwa/tsconfig.json
@@ -10,6 +10,6 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/examples/with-vite-plugin-pwa/tsconfig.json
+++ b/examples/with-vite-plugin-pwa/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
+    // Add type definitions for our Astro runtime.
     "types": ["astro/client"]
   }
 }

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -1,0 +1,207 @@
+/// <reference types="vite/types/importMeta" />
+
+// CSS modules
+type CSSModuleClasses = { readonly [key: string]: string }
+
+declare module '*.module.css' {
+  const classes: CSSModuleClasses
+  export default classes
+}
+declare module '*.module.scss' {
+  const classes: CSSModuleClasses
+  export default classes
+}
+declare module '*.module.sass' {
+  const classes: CSSModuleClasses
+  export default classes
+}
+declare module '*.module.less' {
+  const classes: CSSModuleClasses
+  export default classes
+}
+declare module '*.module.styl' {
+  const classes: CSSModuleClasses
+  export default classes
+}
+declare module '*.module.stylus' {
+  const classes: CSSModuleClasses
+  export default classes
+}
+declare module '*.module.pcss' {
+  const classes: CSSModuleClasses
+  export default classes
+}
+
+// CSS
+declare module '*.css' {
+  const css: string
+  export default css
+}
+declare module '*.scss' {
+  const css: string
+  export default css
+}
+declare module '*.sass' {
+  const css: string
+  export default css
+}
+declare module '*.less' {
+  const css: string
+  export default css
+}
+declare module '*.styl' {
+  const css: string
+  export default css
+}
+declare module '*.stylus' {
+  const css: string
+  export default css
+}
+declare module '*.pcss' {
+  const css: string
+  export default css
+}
+
+// Built-in asset types
+// see `src/constants.ts`
+
+// images
+declare module '*.jpg' {
+  const src: string
+  export default src
+}
+declare module '*.jpeg' {
+  const src: string
+  export default src
+}
+declare module '*.png' {
+  const src: string
+  export default src
+}
+declare module '*.gif' {
+  const src: string
+  export default src
+}
+declare module '*.svg' {
+  const src: string
+  export default src
+}
+declare module '*.ico' {
+  const src: string
+  export default src
+}
+declare module '*.webp' {
+  const src: string
+  export default src
+}
+declare module '*.avif' {
+  const src: string
+  export default src
+}
+
+// media
+declare module '*.mp4' {
+  const src: string
+  export default src
+}
+declare module '*.webm' {
+  const src: string
+  export default src
+}
+declare module '*.ogg' {
+  const src: string
+  export default src
+}
+declare module '*.mp3' {
+  const src: string
+  export default src
+}
+declare module '*.wav' {
+  const src: string
+  export default src
+}
+declare module '*.flac' {
+  const src: string
+  export default src
+}
+declare module '*.aac' {
+  const src: string
+  export default src
+}
+
+// fonts
+declare module '*.woff' {
+  const src: string
+  export default src
+}
+declare module '*.woff2' {
+  const src: string
+  export default src
+}
+declare module '*.eot' {
+  const src: string
+  export default src
+}
+declare module '*.ttf' {
+  const src: string
+  export default src
+}
+declare module '*.otf' {
+  const src: string
+  export default src
+}
+
+// other
+declare module '*.wasm' {
+  const initWasm: (options: WebAssembly.Imports) => Promise<WebAssembly.Exports>
+  export default initWasm
+}
+declare module '*.webmanifest' {
+  const src: string
+  export default src
+}
+declare module '*.pdf' {
+  const src: string
+  export default src
+}
+declare module '*.txt' {
+  const src: string
+  export default src
+}
+
+// web worker
+declare module '*?worker' {
+  const workerConstructor: {
+    new (): Worker
+  }
+  export default workerConstructor
+}
+
+declare module '*?worker&inline' {
+  const workerConstructor: {
+    new (): Worker
+  }
+  export default workerConstructor
+}
+
+declare module '*?sharedworker' {
+  const sharedWorkerConstructor: {
+    new (): SharedWorker
+  }
+  export default sharedWorkerConstructor
+}
+
+declare module '*?raw' {
+  const src: string
+  export default src
+}
+
+declare module '*?url' {
+  const src: string
+  export default src
+}
+
+declare module '*?inline' {
+  const src: string
+  export default src
+}

--- a/packages/astro/env.d.ts
+++ b/packages/astro/env.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="vite/client" />
+/// <reference path="./client.d.ts" />
 
 type Astro = import('astro').AstroGlobal;
 

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -26,6 +26,7 @@
   "exports": {
     ".": "./astro.js",
     "./env": "./env.d.ts",
+    "./client": "./client.d.ts",
     "./astro-jsx": "./astro-jsx.d.ts",
     "./jsx/*": "./dist/jsx/*",
     "./jsx-runtime": "./dist/jsx-runtime/index.js",
@@ -63,6 +64,7 @@
     "config.d.ts",
     "config.mjs",
     "env.d.ts",
+    "client.d.ts",
     "astro-jsx.d.ts",
     "README.md",
     "vendor"

--- a/packages/astro/src/runtime/client/hmr.ts
+++ b/packages/astro/src/runtime/client/hmr.ts
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 if (import.meta.hot) {
 	import.meta.hot.accept((mod) => mod);
 

--- a/packages/astro/tsconfig.json
+++ b/packages/astro/tsconfig.json
@@ -7,6 +7,6 @@
     "module": "ES2020",
     "outDir": "./dist",
     "target": "ES2020",
-    "types": ["vite/client"]
+    "types": ["astro/client"]
   }
 }

--- a/packages/astro/tsconfig.json
+++ b/packages/astro/tsconfig.json
@@ -7,6 +7,6 @@
     "module": "ES2020",
     "outDir": "./dist",
     "target": "ES2020",
-    "types": ["astro/client"]
+    "types": ["./client"]
   }
 }

--- a/packages/integrations/tailwind/src/index.ts
+++ b/packages/integrations/tailwind/src/index.ts
@@ -3,7 +3,6 @@ import type { AstroIntegration } from 'astro';
 import autoprefixerPlugin from 'autoprefixer';
 import path from 'path';
 import tailwindPlugin, { Config as TailwindConfig } from 'tailwindcss';
-// @ts-expect-error "resolveConfig.js" isn't typed
 import resolveConfig from 'tailwindcss/resolveConfig.js';
 import { fileURLToPath } from 'url';
 

--- a/packages/integrations/tailwind/src/index.ts
+++ b/packages/integrations/tailwind/src/index.ts
@@ -3,6 +3,7 @@ import type { AstroIntegration } from 'astro';
 import autoprefixerPlugin from 'autoprefixer';
 import path from 'path';
 import tailwindPlugin, { Config as TailwindConfig } from 'tailwindcss';
+// @ts-expect-error "resolveConfig.js" isn't typed
 import resolveConfig from 'tailwindcss/resolveConfig.js';
 import { fileURLToPath } from 'url';
 


### PR DESCRIPTION
## Changes

- Replaces `vite/client` with `astro/client`.
- `astro/client` doesn't contain DOM references, so you don't get weird DOM types in your frontmatter.

## Testing

- No new ones, but existing tests would break if this was incorrect.

## Docs

- https://github.com/withastro/docs/pull/953