### PR TITLE
[astro add] Support adapters and third party packages

### DIFF
--- a/.changeset/lucky-bottles-wait.md
+++ b/.changeset/lucky-bottles-wait.md
@@ -1,0 +1,23 @@
+---
+'astro': patch
+'@astrojs/cloudflare': patch
+'@astrojs/deno': patch
+'@astrojs/image': patch
+'@astrojs/lit': patch
+'@astrojs/mdx': patch
+'@astrojs/netlify': patch
+'@astrojs/node': patch
+'@astrojs/partytown': patch
+'@astrojs/preact': patch
+'@astrojs/prefetch': patch
+'@astrojs/react': patch
+'@astrojs/sitemap': patch
+'@astrojs/solid-js': patch
+'@astrojs/svelte': patch
+'@astrojs/tailwind': patch
+'@astrojs/turbolinks': patch
+'@astrojs/vercel': patch
+'@astrojs/vue': patch
+---
+
+[astro add] Support adapters and third party packages

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -105,8 +105,12 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 
 	// Some packages might have a common alias! We normalize those here.
 	const integrationNames = names.map((name) => (ALIASES.has(name) ? ALIASES.get(name)! : name));
-	const integrations = await validateIntegrations(integrationNames);
+	const integrationsAndAdapters = await validateIntegrations(integrationNames);
+	const integrations = integrationsAndAdapters.filter(isIntegration);
+	const adapters = integrationsAndAdapters.filter(isAdapter);
 
+	logAdapterInstallInstructions(adapters, logging);
+	if (integrations.length) {
 	let ast: t.File | null = null;
 	try {
 		ast = await parseAstroConfig(configURL);
@@ -126,12 +130,8 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 		debug('add', 'Astro config ensured `defineConfig`');
 
 		for (const integration of integrations) {
-			if (integration.type === 'adapter') {
-				await setAdapter(ast, integration);
-			} else {
 				await addIntegration(ast, integration);
-			}
-			debug('add', `Astro config added integration ${integration.id}`);
+				debug('add', `Astro config added ${integration.type} ${integration.id}`);
 		}
 	} catch (err) {
 		debug('add', 'Error parsing/modifying astro config: ', err);
@@ -139,7 +139,6 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 	}
 
 	let configResult: UpdateResult | undefined;
-	let installResult: UpdateResult | undefined;
 
 	if (ast) {
 		try {
@@ -165,7 +164,7 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 				const missingDeps = integrations.filter(
 					(integration) => !deps.includes(integration.packageName)
 				);
-				if (missingDeps.length === 0) {
+					if (missingDeps.length === 0 && !adapters.length) {
 					info(logging, null, msg.success(`Configuration up-to-date.`));
 					return;
 				}
@@ -175,13 +174,19 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 			break;
 		}
 	}
+	}
 
-	installResult = await tryToInstallIntegrations({ integrations, cwd, flags, logging });
+	let installResult = await tryToInstallIntegrations({
+		integrations: integrationsAndAdapters,
+		cwd,
+		flags,
+		logging
+	});
 
 	switch (installResult) {
 		case UpdateResult.updated: {
-			const len = integrations.length;
-			if (integrations.find((integration) => integration.id === 'tailwind')) {
+			const len = integrationsAndAdapters.length;
+			if (integrationsAndAdapters.find((entry) => entry.id === 'tailwind')) {
 				const possibleConfigFiles = [
 					'./tailwind.config.cjs',
 					'./tailwind.config.mjs',
@@ -214,7 +219,7 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 					debug('add', `Using existing Tailwind configuration`);
 				}
 			}
-			const list = integrations.map((integration) => `  - ${integration.packageName}`).join('\n');
+			const list = integrationsAndAdapters.map((entry) => `  - ${entry.packageName}`).join('\n');
 			info(
 				logging,
 				null,
@@ -266,6 +271,29 @@ Reason: ${err.message}
 You will need to add these integration(s) manually.
 Documentation: https://docs.astro.build/en/guides/integrations-guide/`;
 	return err;
+}
+
+function isIntegration(integration: IntegrationInfo): integration is IntegrationInfo & { type: 'integration' } {
+	return integration.type === 'integration';
+}
+
+function isAdapter(integration: IntegrationInfo): integration is IntegrationInfo & { type: 'adapter' } {
+	return integration.type === 'adapter';
+}
+
+function logAdapterInstallInstructions(adapters: (IntegrationInfo & { type: 'adapter' })[], logging: LogOptions) {
+	for (const adapter of adapters) {
+		info(
+			logging,
+			null,
+			`\n  ${cyan(`Check our deployment docs for ${bold(adapter.packageName)} to update your "adapter" config.`)}`
+		);
+	}
+	info(
+		logging,
+		null,
+		`\n  ${bold(cyan('https://docs.astro.build/en/guides/deploy/'))}`
+	);
 }
 
 async function addIntegration(ast: t.File, integration: IntegrationInfo) {
@@ -320,50 +348,6 @@ async function addIntegration(ast: t.File, integration: IntegrationInfo) {
 			if (existingIntegrationCall) return;
 
 			integrationsProp.value.elements.push(integrationCall);
-		},
-	});
-}
-
-async function setAdapter(ast: t.File, adapter: IntegrationInfo) {
-	const adapterId = t.identifier(toIdent(adapter.id));
-
-	ensureImport(
-		ast,
-		t.importDeclaration(
-			[t.importDefaultSpecifier(adapterId)],
-			t.stringLiteral(adapter.packageName)
-		)
-	);
-
-	visit(ast, {
-		// eslint-disable-next-line @typescript-eslint/no-shadow
-		ExportDefaultDeclaration(path) {
-			if (!t.isCallExpression(path.node.declaration)) return;
-
-			const configObject = path.node.declaration.arguments[0];
-			if (!t.isObjectExpression(configObject)) return;
-
-			let adapterProp = configObject.properties.find((prop) => {
-				if (prop.type !== 'ObjectProperty') return false;
-				if (prop.key.type === 'Identifier') {
-					if (prop.key.name === 'adapter') return true;
-				}
-				if (prop.key.type === 'StringLiteral') {
-					if (prop.key.value === 'adapter') return true;
-				}
-				return false;
-			}) as t.ObjectProperty | undefined;
-
-			const adapterCall = t.callExpression(adapterId, []);
-
-			if (!adapterProp) {
-				configObject.properties.push(
-					t.objectProperty(t.identifier('adapter'), adapterCall)
-				);
-				return;
-			}
-
-			adapterProp.value = adapterCall;
 		},
 	});
 }

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -109,7 +109,7 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 	const integrations = integrationsAndAdapters.filter(isIntegration);
 	const adapters = integrationsAndAdapters.filter(isAdapter);
 
-	logAdapterInstallInstructions(adapters, logging);
+	logAdapterConfigInstructions(adapters, logging);
 	if (integrations.length) {
 	let ast: t.File | null = null;
 	try {
@@ -281,7 +281,7 @@ function isAdapter(integration: IntegrationInfo): integration is IntegrationInfo
 	return integration.type === 'adapter';
 }
 
-function logAdapterInstallInstructions(adapters: (IntegrationInfo & { type: 'adapter' })[], logging: LogOptions) {
+function logAdapterConfigInstructions(adapters: (IntegrationInfo & { type: 'adapter' })[], logging: LogOptions) {
 	for (const adapter of adapters) {
 		info(
 			logging,

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -139,7 +139,11 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 				if (officialExportName) {
 					await setAdapter(ast, integration, officialExportName);
 				} else {
-					logAdapterConfigInstructions(integration, logging);
+					info(
+						logging,
+						null,
+						`\n  ${magenta(`Check our deployment docs for ${bold(integration.packageName)} to update your "adapter" config.`)}`
+					);
 				}
 			} else {
 				await addIntegration(ast, integration);
@@ -262,14 +266,6 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 
 function isAdapter(integration: IntegrationInfo): integration is IntegrationInfo & { type: 'adapter' } {
   return integration.type === 'adapter';
-}
-
-function logAdapterConfigInstructions(adapter: (IntegrationInfo & { type: 'adapter' }), logging: LogOptions) {
-	info(
-		logging,
-		null,
-		`\n  ${magenta(`Check our deployment docs for ${bold(adapter.packageName)} to update your "adapter" config.`)}`
-	);
 }
 
 async function parseAstroConfig(configURL: URL): Promise<t.File> {

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -550,7 +550,7 @@ export async function validateIntegrations(integrations: string[]): Promise<Inte
 			integrations.map(async (integration): Promise<IntegrationInfo> => {
 				const parsed = parseIntegrationName(integration);
 				if (!parsed) {
-					throw new Error(`${integration} does not appear to be a valid package name!`);
+					throw new Error(`${bold(integration)} does not appear to be a valid package name!`);
 				}
 
 				let { scope, name, tag } = parsed;

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -3,7 +3,7 @@ import boxen from 'boxen';
 import { diffWords } from 'diff';
 import { execa } from 'execa';
 import { existsSync, promises as fs } from 'fs';
-import { bold, cyan, dim, green, magenta } from 'kleur/colors';
+import { bold, cyan, dim, green, magenta, yellow } from 'kleur/colors';
 import ora from 'ora';
 import path from 'path';
 import preferredPM from 'preferred-pm';
@@ -32,6 +32,7 @@ export interface IntegrationInfo {
 	id: string;
 	packageName: string;
 	dependencies: [name: string, version: string][];
+	type: 'integration' | 'adapter';
 }
 const ALIASES = new Map([
 	['solid', 'solid-js'],
@@ -120,7 +121,11 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 		debug('add', 'Astro config ensured `defineConfig`');
 
 		for (const integration of integrations) {
-			await addIntegration(ast, integration);
+			if (integration.type === 'adapter') {
+				await setAdapter(ast, integration);
+			} else {
+				await addIntegration(ast, integration);
+			}
 			debug('add', `Astro config added integration ${integration.id}`);
 		}
 	} catch (err) {
@@ -314,6 +319,50 @@ async function addIntegration(ast: t.File, integration: IntegrationInfo) {
 	});
 }
 
+async function setAdapter(ast: t.File, adapter: IntegrationInfo) {
+	const adapterId = t.identifier(toIdent(adapter.id));
+
+	ensureImport(
+		ast,
+		t.importDeclaration(
+			[t.importDefaultSpecifier(adapterId)],
+			t.stringLiteral(adapter.packageName)
+		)
+	);
+
+	visit(ast, {
+		// eslint-disable-next-line @typescript-eslint/no-shadow
+		ExportDefaultDeclaration(path) {
+			if (!t.isCallExpression(path.node.declaration)) return;
+
+			const configObject = path.node.declaration.arguments[0];
+			if (!t.isObjectExpression(configObject)) return;
+
+			let adapterProp = configObject.properties.find((prop) => {
+				if (prop.type !== 'ObjectProperty') return false;
+				if (prop.key.type === 'Identifier') {
+					if (prop.key.name === 'adapter') return true;
+				}
+				if (prop.key.type === 'StringLiteral') {
+					if (prop.key.value === 'adapter') return true;
+				}
+				return false;
+			}) as t.ObjectProperty | undefined;
+
+			const adapterCall = t.callExpression(adapterId, []);
+
+			if (!adapterProp) {
+				configObject.properties.push(
+					t.objectProperty(t.identifier('adapter'), adapterCall)
+				);
+				return;
+			}
+
+			adapterProp.value = adapterCall;
+		},
+	});
+}
+
 const enum UpdateResult {
 	none,
 	updated,
@@ -479,46 +528,98 @@ async function tryToInstallIntegrations({
 	}
 }
 
+async function fetchPackageJson(scope: string | undefined, name: string, tag: string): Promise<object | Error> {
+	const packageName = `${scope ? `@${scope}/` : ''}${name}`;
+	const res = await fetch(`https://registry.npmjs.org/${packageName}/${tag}`)
+	if (res.status === 404) {
+		return new Error();
+	} else {
+		return await res.json();
+	}
+}
+
 export async function validateIntegrations(integrations: string[]): Promise<IntegrationInfo[]> {
-	const spinner = ora('Resolving integrations...').start();
-	const integrationEntries = await Promise.all(
-		integrations.map(async (integration): Promise<IntegrationInfo> => {
-			const parsed = parseIntegrationName(integration);
-			if (!parsed) {
-				spinner.fail();
-				throw new Error(`${integration} does not appear to be a valid package name!`);
-			}
-
-			let { scope = '', name, tag } = parsed;
-			// Allow third-party integrations starting with `astro-` namespace
-			if (!name.startsWith('astro-')) {
-				scope = `astrojs`;
-			}
-			const packageName = `${scope ? `@${scope}/` : ''}${name}`;
-
-			const result = await fetch(`https://registry.npmjs.org/${packageName}/${tag}`).then((res) => {
-				if (res.status === 404) {
-					spinner.fail();
-					throw new Error(`Unable to fetch ${packageName}. Does this package exist?`);
+	const spinner = ora('Resolving packages...').start();
+	try {
+		const integrationEntries = await Promise.all(
+			integrations.map(async (integration): Promise<IntegrationInfo> => {
+				const parsed = parseIntegrationName(integration);
+				if (!parsed) {
+					throw new Error(`${integration} does not appear to be a valid package name!`);
 				}
-				return res.json();
-			});
 
-			let dependencies: IntegrationInfo['dependencies'] = [
-				[result['name'], `^${result['version']}`],
-			];
+				let { scope, name, tag } = parsed;
+				let pkgJson = null;
+				let pkgType: 'first-party' | 'third-party' = 'first-party';
 
-			if (result['peerDependencies']) {
-				for (const peer in result['peerDependencies']) {
-					dependencies.push([peer, result['peerDependencies'][peer]]);
+				if (!scope) {
+					const firstPartyPkgCheck = await fetchPackageJson('astrojs', name, tag);
+					if (firstPartyPkgCheck instanceof Error) {
+						spinner.warn(yellow(`${bold(integration)} is not an official Astro package. Use at your own risk!`));
+						const response = await prompts({
+							type: 'confirm',
+							name: 'askToContinue',
+							message: 'Continue?',
+							initial: true,
+						});
+						if (!response.askToContinue) {
+							throw new Error('No problem! Find our official integrations at https://astro.build/integrations');
+						}
+						spinner.start('Resolving with third party packages...');
+						pkgType = 'third-party';
+					} else {
+						pkgJson = firstPartyPkgCheck as any;
+					}
 				}
-			}
+				if (pkgType === 'third-party') {
+					const thirdPartyPkgCheck = await fetchPackageJson(scope, name, tag);
+					if (thirdPartyPkgCheck instanceof Error) {
+						throw new Error(
+							`Unable to fetch ${bold(integration)}. Does the package exist?`,
+						);
+					} else {
+						pkgJson = thirdPartyPkgCheck as any;
+					}
+				}
 
-			return { id: integration, packageName, dependencies };
-		})
-	);
-	spinner.succeed();
-	return integrationEntries;
+				const resolvedScope = pkgType === 'first-party' ? 'astrojs' : scope;
+				const packageName = `${resolvedScope ? `@${resolvedScope}/` : ''}${name}`;
+
+				let dependencies: IntegrationInfo['dependencies'] = [
+					[pkgJson['name'], `^${pkgJson['version']}`],
+				];
+
+				if (pkgJson['peerDependencies']) {
+					for (const peer in pkgJson['peerDependencies']) {
+						dependencies.push([peer, pkgJson['peerDependencies'][peer]]);
+					}
+				}
+
+				let integrationType: IntegrationInfo['type'];
+				const keywords = Array.isArray(pkgJson['keywords']) ? pkgJson['keywords'] : [];
+				if (keywords.includes('astro-integration')) {
+					integrationType = 'integration';
+				} else if (keywords.includes('astro-adapter')) {
+					integrationType = 'adapter';
+				} else {
+					throw new Error(
+						`${bold(packageName)} doesn't appear to be an integration or an adapter. Find our official integrations at https://astro.build/integrations`
+					);
+				}
+
+				return { id: integration, packageName, dependencies, type: integrationType };
+			})
+		);
+		spinner.succeed();
+		return integrationEntries;
+	} catch (e) {
+		if (e instanceof Error) {
+			spinner.fail(e.message);
+			process.exit(0);
+		} else {
+			throw e;
+		}
+	}
 }
 
 function parseIntegrationName(spec: string) {

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -52,7 +52,7 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 	if (flags.help || names.length === 0) {
 		printHelp({
 			commandName: 'astro add',
-			usage: '[...integrations]',
+			usage: '[...integrations/adapters]',
 			tables: {
 				Flags: [
 					['--yes', 'Accept all prompts.'],
@@ -70,6 +70,11 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 					['tailwind', 'astro add tailwind'],
 					['partytown', 'astro add partytown'],
 					['sitemap', 'astro add sitemap'],
+				],
+				'Example: Add an Adapter': [
+					['netlify', 'astro add netlify'],
+					['vercel', 'astro add vercel'],
+					['deno', 'astro add deno'],
 				],
 			},
 			description: `Check out the full integration catalog: ${cyan(

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -52,7 +52,7 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 	if (flags.help || names.length === 0) {
 		printHelp({
 			commandName: 'astro add',
-			usage: '[...integrations/adapters]',
+			usage: '[...integrations] [...adapters]',
 			tables: {
 				Flags: [
 					['--yes', 'Accept all prompts.'],

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -568,7 +568,7 @@ export async function validateIntegrations(integrations: string[]): Promise<Inte
 							initial: true,
 						});
 						if (!response.askToContinue) {
-							throw new Error('No problem! Find our official integrations at https://astro.build/integrations');
+							throw new Error(`No problem! Find our official integrations at ${cyan('https://astro.build/integrations')}`);
 						}
 						spinner.start('Resolving with third party packages...');
 						pkgType = 'third-party';
@@ -608,7 +608,7 @@ export async function validateIntegrations(integrations: string[]): Promise<Inte
 					integrationType = 'adapter';
 				} else {
 					throw new Error(
-						`${bold(packageName)} doesn't appear to be an integration or an adapter. Find our official integrations at https://astro.build/integrations`
+						`${bold(packageName)} doesn't appear to be an integration or an adapter. Find our official integrations at ${cyan('https://astro.build/integrations')}`
 					);
 				}
 

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -620,7 +620,7 @@ export async function validateIntegrations(integrations: string[]): Promise<Inte
 	} catch (e) {
 		if (e instanceof Error) {
 			spinner.fail(e.message);
-			process.exit(0);
+			process.exit(1);
 		} else {
 			throw e;
 		}

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/integrations/cloudflare"
   },
+  "keywords": ["astro-adapter"],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {

--- a/packages/integrations/deno/package.json
+++ b/packages/integrations/deno/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/integrations/deno"
   },
+  "keywords": ["astro-adapter"],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {

--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/image"
   },
   "keywords": [
+    "astro-integration",
     "astro-component",
     "withastro",
     "image"

--- a/packages/integrations/lit/package.json
+++ b/packages/integrations/lit/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/lit"
   },
   "keywords": [
+    "astro-integration",
     "astro-component",
     "renderer",
     "lit"

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/mdx"
   },
   "keywords": [
+    "astro-integration",
     "astro-component",
     "renderer",
     "mdx"

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/integrations/netlify"
   },
+  "keywords": ["astro-adapter"],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/integrations/node"
   },
+  "keywords": ["astro-adapter"],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {

--- a/packages/integrations/partytown/package.json
+++ b/packages/integrations/partytown/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/partytown"
   },
   "keywords": [
+    "astro-integration",
     "astro-component",
     "analytics",
     "performance"

--- a/packages/integrations/preact/package.json
+++ b/packages/integrations/preact/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/preact"
   },
   "keywords": [
+    "astro-integration",
     "astro-component",
     "renderer",
     "preact"

--- a/packages/integrations/prefetch/package.json
+++ b/packages/integrations/prefetch/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/astro-prefetch"
   },
+  "keywords": ["astro-integration"],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/react"
   },
   "keywords": [
+    "astro-integration",
     "astro-component",
     "renderer",
     "react"

--- a/packages/integrations/sitemap/package.json
+++ b/packages/integrations/sitemap/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/sitemap"
   },
   "keywords": [
+    "astro-integration",
     "astro-component",
     "seo",
     "sitemap"

--- a/packages/integrations/solid/package.json
+++ b/packages/integrations/solid/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/solid"
   },
   "keywords": [
+    "astro-integration",
     "astro-component",
     "renderer",
     "solid"

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/svelte"
   },
   "keywords": [
+    "astro-integration",
     "astro-component",
     "renderer",
     "svelte"

--- a/packages/integrations/tailwind/package.json
+++ b/packages/integrations/tailwind/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/tailwind"
   },
   "keywords": [
+    "astro-integration",
     "astro-component"
   ],
   "bugs": "https://github.com/withastro/astro/issues",

--- a/packages/integrations/turbolinks/package.json
+++ b/packages/integrations/turbolinks/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/turbolinks"
   },
   "keywords": [
+    "astro-integration",
     "astro-component",
     "performance"
   ],

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/integrations/vercel"
   },
+  "keywords": ["astro-adapter"],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
   "exports": {

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/vue"
   },
   "keywords": [
+    "astro-integration",
     "astro-component",
     "renderer",
     "vue"


### PR DESCRIPTION
## Changes

- Detect adapters and integrations by `package.json` keywords!
  - `astro-integration` -> valid Astro integration
  - `astro-adapter` -> valid Astro adapter
- Add `package.json` keywords across all official integrations and adapters
- Correctly set the adapter in your astro config instead of blindly adding to integrations
- Add warning + "continue?" prompt when installing third party integrations and adapters
- Remove `astro-` package naming requirement for third party integrations

## Testing

TODO

## Docs

Document magic "keywords" in the integrations API and adapter API references for package authors ❤️ 
https://github.com/withastro/docs/pull/946