### PR TITLE
Bump `vite` minimum version

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -132,7 +132,7 @@
     "strip-ansi": "^7.0.1",
     "supports-esm": "^1.0.0",
     "tsconfig-resolver": "^3.0.1",
-    "vite": "^2.9.12",
+    "vite": "^2.9.14",
     "yargs-parser": "^21.0.1",
     "zod": "^3.17.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -563,7 +563,7 @@ importers:
       strip-ansi: ^7.0.1
       supports-esm: ^1.0.0
       tsconfig-resolver: ^3.0.1
-      vite: ^2.9.12
+      vite: ^2.9.14
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
@@ -619,7 +619,7 @@ importers:
       strip-ansi: 7.0.1
       supports-esm: 1.0.0
       tsconfig-resolver: 3.0.1
-      vite: 2.9.13_sass@1.53.0
+      vite: 2.9.14_sass@1.53.0
       yargs-parser: 21.0.1
       zod: 3.17.3
     devDependencies:
@@ -14992,8 +14992,8 @@ packages:
       fsevents: 2.3.2
     dev: false
 
-  /vite/2.9.13_sass@1.53.0:
-    resolution: {integrity: sha512-AsOBAaT0AD7Mhe8DuK+/kE4aWYFMx/i0ZNi98hJclxb4e0OhQcZYUrvLjIaQ8e59Ui7txcvKMiJC1yftqpQoDw==}
+  /vite/2.9.14_sass@1.53.0:
+    resolution: {integrity: sha512-P/UCjSpSMcE54r4mPak55hWAZPlyfS369svib/gpmz8/01L822lMPOJ/RYW6tLCe1RPvMvOsJ17erf55bKp4Hw==}
     engines: {node: '>=12.2.0'}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
## Changes

- Updates our `package.json` file to require `vite` `^2.9.14`
- Came up in discussing https://github.com/withastro/astro/pull/3428 with @userquin

## Testing

CI

## Docs

N/A