### PR TITLE
fix(#3843): move @babel/types to dependencies

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -87,6 +87,7 @@
     "@astrojs/telemetry": "^0.2.4",
     "@astrojs/webapi": "^0.12.0",
     "@babel/core": "^7.18.2",
+    "@babel/types": "^7.18.4",
     "@babel/generator": "^7.18.2",
     "@babel/parser": "^7.18.4",
     "@babel/plugin-transform-react-jsx": "^7.17.12",
@@ -137,7 +138,6 @@
     "zod": "^3.17.3"
   },
   "devDependencies": {
-    "@babel/types": "^7.18.4",
     "@playwright/test": "^1.22.2",
     "@types/babel__core": "^7.1.19",
     "@types/babel__generator": "^7.6.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -578,6 +578,7 @@ importers:
       '@babel/parser': 7.18.8
       '@babel/plugin-transform-react-jsx': 7.18.6_@babel+core@7.18.6
       '@babel/traverse': 7.18.8
+      '@babel/types': 7.18.8
       '@proload/core': 0.3.2
       '@proload/plugin-tsm': 0.2.1_@proload+core@0.3.2
       ast-types: 0.14.2
@@ -623,7 +624,6 @@ importers:
       yargs-parser: 21.0.1
       zod: 3.17.3
     devDependencies:
-      '@babel/types': 7.18.8
       '@playwright/test': 1.23.2
       '@types/babel__core': 7.1.19
       '@types/babel__generator': 7.6.4


### PR DESCRIPTION
## Changes

- Move `@babel/types` to `dependencies`
- Closes #3843

## Testing

N/A

## Docs

Bug fix only