### PR TITLE
Integration README fixes

### DIFF
--- a/.changeset/breezy-ravens-sort.md
+++ b/.changeset/breezy-ravens-sort.md
@@ -1,0 +1,11 @@
+---
+'@astrojs/deno': patch
+'@astrojs/image': patch
+'@astrojs/netlify': patch
+'@astrojs/node': patch
+'@astrojs/prefetch': patch
+'@astrojs/sitemap': patch
+'@astrojs/vercel': patch
+---
+
+Small README fixes

--- a/packages/integrations/deno/README.md
+++ b/packages/integrations/deno/README.md
@@ -42,7 +42,7 @@ export default defineConfig({
   
 ## Usage
 
-After [performing a build](https://docs.astro.build/en/guides/deploy/#building-the-app) there will be a `dist/server/entry.mjs` module. You can start a server by importing this module in your Deno app:
+After [performing a build](https://docs.astro.build/en/guides/deploy/#building-your-site-locally) there will be a `dist/server/entry.mjs` module. You can start a server by importing this module in your Deno app:
 
 ```js
 import './dist/entry.mjs';

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -4,7 +4,7 @@
 
 This **[Astro integration][astro-integration]** makes it easy to optimize images in your [Astro project](https://astro.build), with full support for SSG builds and server-side rendering!
 
-- <strong>[Why `@astrojs/image`?](#why-astrojs-image)</strong>
+- <strong>[Why `@astrojs/image`?](#why-astrojsimage)</strong>
 - <strong>[Installation](#installation)</strong>
 - <strong>[Usage](#usage)</strong>
 - <strong>[Configuration](#configuration)</strong>

--- a/packages/integrations/netlify/README.md
+++ b/packages/integrations/netlify/README.md
@@ -56,9 +56,9 @@ export default defineConfig({
 ```
 ## Usage
 
-[Read the full deployment guide here.](https://docs.astro.build/en/guides/deploy/vercel)
+[Read the full deployment guide here.](https://docs.astro.build/en/guides/deploy/netlify/)
 
-After [performing a build](https://docs.astro.build/en/guides/deploy/#building-the-app) the `netlify/` folder will contain [Netlify Functions](https://docs.netlify.com/functions/overview/) in the `netlify/functions/` folder.
+After [performing a build](https://docs.astro.build/en/guides/deploy/#building-your-site-locally) the `netlify/` folder will contain [Netlify Functions](https://docs.netlify.com/functions/overview/) in the `netlify/functions/` folder.
 
 Now you can deploy. Install the [Netlify CLI](https://docs.netlify.com/cli/get-started/) and run:
 

--- a/packages/integrations/node/README.md
+++ b/packages/integrations/node/README.md
@@ -43,7 +43,7 @@ export default defineConfig({
 
 ## Usage
 
-After [performing a build](https://docs.astro.build/en/guides/deploy/#building-the-app) there will be a `dist/server/entry.mjs` module that exposes a `handler` function. This works like a [middleware](https://expressjs.com/en/guide/using-middleware.html) function: it can handle incoming requests and respond accordingly. 
+After [performing a build](https://docs.astro.build/en/guides/deploy/#building-your-site-locally) there will be a `dist/server/entry.mjs` module that exposes a `handler` function. This works like a [middleware](https://expressjs.com/en/guide/using-middleware.html) function: it can handle incoming requests and respond accordingly. 
 
 
 ### Using a middleware framework

--- a/packages/integrations/prefetch/README.md
+++ b/packages/integrations/prefetch/README.md
@@ -7,7 +7,6 @@
 - <strong>[Examples](#examples)</strong>
 - <strong>[Troubleshooting](#troubleshooting)</strong>
 - <strong>[Contributing](#contributing)</strong>
-- <strong>[Changelog](#changelog)</strong>
 
 ## Why Prefetch?
 

--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -109,7 +109,6 @@ Example of generated sitemap content for a two-page website:
 ```
 
 **sitemap-0.xml**
-<?xml version="1.0" encoding="UTF-8"?>
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -59,7 +59,7 @@ import vercel from '@astrojs/vercel/static';
 
 ## Usage
 
-📚 **[Read the full deployment guide here.](https://docs.astro.build/en/guides/deploy/vercel)**
+📚 **[Read the full deployment guide here.](https://docs.astro.build/en/guides/deploy/vercel/)**
 
 You can deploy by CLI (`vercel deploy`) or by connecting your new repo in the [Vercel Dashboard](https://vercel.com/). Alternatively, you can create a production build locally:
 


### PR DESCRIPTION
## Changes

Miscellaneous small fixes caught while building the new system for showing the integration READMEs on the docs site.

- Remove a stray XML tag in the sitemap integration README. This stray tag crashes builds because micromark doesn’t expect tags to start with `<?`.

- Fix some broken links caught by the docs link checker

These are fairly minor changes to READMEs, so I haven’t included a changeset, but can do if you think these fixes should trigger a patch release.

## Testing

n/a

## Docs

n/a