### PR TITLE
Fixed broken link in Cloudflare SSR adapter README

### DIFF
--- a/packages/integrations/cloudflare/README.md
+++ b/packages/integrations/cloudflare/README.md
@@ -25,7 +25,7 @@ It's then possible to update the preview script in your `package.json` to `"prev
 
 ## Streams
 
-Some integrations such as (react)[https://github.com/withastro/astro/tree/main/packages/integrations/react] rely on web streams. Currently Cloudflare Pages functions are in beta and don't support the `streams_enable_constructors` feature flag.
+Some integrations such as [React](https://github.com/withastro/astro/tree/main/packages/integrations/react) rely on web streams. Currently Cloudflare Pages functions are in beta and don't support the `streams_enable_constructors` feature flag.
 
 In order to work around this:
 - install the `"web-streams-polyfill"` package


### PR DESCRIPTION
## Changes

- There was a broken Markdown link in the Cloudflare SSR adapter README.md
- It was mistakenly typed as (link)[URL] instead of the proper \[link\]\(URL\)
- This PR fixes that.

## Testing

- Docs change only, no tests needed

## Docs

- Updated README.md for Astro's Cloudflare SSR adapter