### PR TITLE
Fix: hydrate components that return `null`

### DIFF
--- a/.changeset/quiet-pugs-tie.md
+++ b/.changeset/quiet-pugs-tie.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix hydration for SSR components that return null

--- a/packages/astro/src/runtime/server/astro-island.ts
+++ b/packages/astro/src/runtime/server/astro-island.ts
@@ -42,7 +42,7 @@ declare const Astro: {
 				public hydrator: any;
 				static observedAttributes = ['props'];
 				connectedCallback() {
-					if (this.getAttribute('client') === 'only' || this.firstChild) {
+					if (!this.getAttribute('await-children') || this.firstChild) {
 						this.childrenConnectedCallback();
 					} else {
 						// connectedCallback may run *before* children are rendered (ex. HTML streaming)

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -452,6 +452,10 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 
 	island.children = `${html ?? ''}${template}`;
 
+	if (island.children) {
+		island.props['await-children'] = ''
+	}
+
 	// Scripts to prepend
 	let prescriptType: PrescriptType = needsHydrationScript
 		? 'both'


### PR DESCRIPTION
## Changes

This ensures we hydrate SSR components that return `null`. This is common for dropdowns and sidebars that reveal conditionally.

## Testing

N/A

## Docs

N/A