### PR TITLE
Updating the <Picture /> component to default to async image decoding

### DIFF
--- a/.changeset/quiet-bananas-obey.md
+++ b/.changeset/quiet-bananas-obey.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Bug: Updating the <Picture /> component to default to async image decoding

--- a/packages/integrations/image/components/Picture.astro
+++ b/packages/integrations/image/components/Picture.astro
@@ -21,7 +21,7 @@ export interface RemoteImageProps extends Omit<PictureAttributes, 'src' | 'width
 
 export type Props = LocalImageProps | RemoteImageProps;
 
-const { src, sizes, widths, aspectRatio, formats = ['avif', 'webp'], loading = 'lazy', decoding = 'eager', ...attrs } = Astro.props as Props;
+const { src, sizes, widths, aspectRatio, formats = ['avif', 'webp'], loading = 'lazy', decoding = 'async', ...attrs } = Astro.props as Props;
 
 const { image, sources } = await getPicture({ loader, src, widths, formats, aspectRatio });
 ---


### PR DESCRIPTION
## Changes

Fixing a copy/paste error in the new `<Picture />` component - it should default the img to `decoding="async"` instead of `eager`

## Testing

Existing tests should pass

## Docs

Bug fix only