### PR TITLE
fix: add TypeScript type and documentation for markdown "mode" config

### DIFF
--- a/.changeset/beige-lizards-scream.md
+++ b/.changeset/beige-lizards-scream.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Added "mode" to Astro config file TypeScript definitions

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -515,6 +515,27 @@ export interface AstroUserConfig {
 
 		/**
 		 * @docs
+		 * @name markdown.mode
+		 * @type {'md' | 'mdx'}
+		 * @default `mdx`
+		 * @description
+		 * Control if markdown processing is done using MDX or not.
+		 *
+		 * MDX processing enables you to use JSX inside your Markdown files. However, there may be instances where you don't want this behavior, and would rather use a "vanilla" markdown processor. This field allows you to control that behavior.
+		 *
+		 * ```js
+		 * {
+		 *   markdown: {
+		 *     // Example: Use non-MDX processor for Markdown files
+		 *     mode: 'md',
+		 *   }
+		 * }
+		 * ```
+		 */
+		mode?: 'md' | 'mdx';
+
+		/**
+		 * @docs
 		 * @name markdown.shikiConfig
 		 * @typeraw {Partial<ShikiConfig>}
 		 * @description


### PR DESCRIPTION
## Changes

- What does this change?

This adds a `mode` field to the TypeScript definitions for `mode` in the configuration file.

Closes #3882 

- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

This was tested locally

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

I've added a draft of what I think the docs could look like for this field. I've also opened [a GH issue to track this issue from a documentation perspective as well.](https://github.com/withastro/docs/issues/960)