### PR TITLE
More integration README fixes

### DIFF
--- a/.changeset/calm-balloons-kneel.md
+++ b/.changeset/calm-balloons-kneel.md
@@ -1,4 +1,5 @@
 ---
+'@astrojs/cloudflare': patch
 '@astrojs/deno': patch
 '@astrojs/image': patch
 '@astrojs/mdx': patch
@@ -7,9 +8,13 @@
 '@astrojs/partytown': patch
 '@astrojs/preact': patch
 '@astrojs/prefetch': patch
+'@astrojs/react': patch
 '@astrojs/sitemap': patch
+'@astrojs/solid-js': patch
+'@astrojs/svelte': patch
 '@astrojs/tailwind': patch
 '@astrojs/vercel': patch
+'@astrojs/vue': patch
 ---
 
 Integration README fixes

--- a/.changeset/spotty-mirrors-chew.md
+++ b/.changeset/spotty-mirrors-chew.md
@@ -1,0 +1,15 @@
+---
+'@astrojs/deno': patch
+'@astrojs/image': patch
+'@astrojs/mdx': patch
+'@astrojs/netlify': patch
+'@astrojs/node': patch
+'@astrojs/partytown': patch
+'@astrojs/preact': patch
+'@astrojs/prefetch': patch
+'@astrojs/sitemap': patch
+'@astrojs/tailwind': patch
+'@astrojs/vercel': patch
+---
+
+Integration README fixes

--- a/packages/integrations/cloudflare/README.md
+++ b/packages/integrations/cloudflare/README.md
@@ -2,7 +2,7 @@
 
 An SSR adapter for use with Cloudflare Pages Functions targets. Write your code in Astro/Node and deploy to Cloudflare Pages.
 
-In your astro.config.mjs use:
+In your `astro.config.mjs` use:
 
 ```js
 import { defineConfig } from 'astro/config';

--- a/packages/integrations/deno/README.md
+++ b/packages/integrations/deno/README.md
@@ -22,13 +22,14 @@ If you wish to [use server-side rendering (SSR)](https://docs.astro.build/en/gui
 ## Installation
 
 First, install the `@astrojs/deno` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
-```sh
+
+```shell
 npm install @astrojs/deno
 ```
 
 Then, install this adapter in your `astro.config.*` file using the `adapter` property:
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import { defineConfig } from 'astro/config';
@@ -51,7 +52,8 @@ import './dist/entry.mjs';
 See the `start` option below for how you can have more control over starting the Astro server.
 
 You can also run the script directly using deno:
-```
+
+```shell
 deno run --allow-net --allow-read --allow-env ./dist/server/entry.mjs
 ```
 
@@ -60,7 +62,8 @@ deno run --allow-net --allow-read --allow-env ./dist/server/entry.mjs
 
 To configure this adapter, pass an object to the `deno()` function call in `astro.config.mjs`.
 
-__astro.config.mjs__
+__`astro.config.mjs`__
+
 ```js
 import { defineConfig } from 'astro/config';
 import deno from '@astrojs/deno';

--- a/packages/integrations/deno/README.md
+++ b/packages/integrations/deno/README.md
@@ -74,8 +74,6 @@ export default defineConfig({
 
 <details>
   <summary><strong>start</strong></summary>
-  
-  <br/>
 
   This adapter automatically starts a server when it is imported. You can turn this off with the `start` option:
 
@@ -106,8 +104,6 @@ export default defineConfig({
 
 <details>
   <summary><strong>port</strong> and <strong>hostname</strong></summary>
-  
-  <br/>
 
   You can set the port (default: `8085`) and hostname (default: `0.0.0.0`) for the deno server to use. If `start` is false, this has no effect; your own server must configure the port and hostname.
 
@@ -130,10 +126,16 @@ The [Astro Deno](https://github.com/withastro/astro/tree/main/examples/deno) exa
 
 ## Troubleshooting
 
+For help, check out the `#support-threads` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+
+You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
 ## Contributing
 
 This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
 
 ## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a history of changes to this integration.
 
 [astro-integration]: https://docs.astro.build/en/guides/integrations-guide/

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -49,7 +49,7 @@ npm install @astrojs/image
 ```
 Then, apply this integration to your `astro.config.*` file using the `integrations` property:
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import image from '@astrojs/image';

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -23,7 +23,6 @@ This integration provides `<Image />` and `<Picture>` components as well as a ba
 
 <details>
   <summary>Quick Install</summary>
-  <br/>
   
 The experimental `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
   
@@ -43,8 +42,6 @@ Because this command is new, it might not properly set things up. If that happen
 
 <details>
   <summary>Manual Install</summary>
-  
-<br/>
   
 First, install the `@astrojs/image` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
 ```sh
@@ -81,8 +78,6 @@ There are currently no other configuration options for the `@astrojs/image` inte
 <details>
   <summary><strong>config.serviceEntryPoint</strong></summary>
   
-  <br/>
-  
   The `serviceEntryPoint` should resolve to the image service installed from NPM. The default entry point is `@astrojs/image/sharp`, which resolves to the entry point exported from this integration's `package.json`.
 
 ```js
@@ -102,8 +97,6 @@ export default {
 
 <details>
   <summary><strong>Local images</strong></summary>
-  
-  <br/>
   
   Image files in your project's `src` directory can be imported in frontmatter and passed directly to the `<Image />` component. All other properties are optional and will default to the original image file's properties if not provided.
 
@@ -133,8 +126,6 @@ import heroImage from '../assets/hero.png';
 <details>
   <summary><strong>Remote images</strong></summary>
   
-  <br/>
-  
   Remote images can be transformed with the `<Image />` component. The `<Image />` component needs to know the final dimensions for the `<img />` element to avoid content layout shifts. For remote images, this means you must either provide `width` and `height`, or one of the dimensions plus the required `aspectRatio`.
 
 ```html
@@ -158,8 +149,6 @@ const imageUrl = 'https://www.google.com/images/branding/googlelogo/2x/googlelog
 <details>
 <summary><strong>Images in markdown</strong></summary>
   
-  <br/>
-  
   The `<Image />` component can also be used to optimize images in markdown pages. For local images imported from your project's `src` directory, use Astro's the `setup` frontmatter to import the image file.
 
 ```html
@@ -181,8 +170,6 @@ description: Just a Hello World Post!
 
 <details>
 <summary><strong>Responsive pictures</strong></summary>
-
-  <br />
 
   The `<Picture />` component can be used to automatically build a `<picture>` with multiple sizes and formats. Check out [MDN](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images#art_direction) for a deep dive into responsive images and art direction.
 
@@ -227,3 +214,5 @@ You can also check our [Astro Integration Documentation][astro-integration] for 
 This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
 
 ## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a history of changes to this integration.

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -50,7 +50,7 @@ First, install the `@astrojs/mdx` package using your package manager. If you're 
 
 Then, apply this integration to your `astro.config.*` file using the `integrations` property:
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import { defineConfig } from 'astro/config';

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -22,7 +22,6 @@ Check out [“What is MDX?”](https://mdxjs.com/docs/what-is-mdx/), a deep-dive
 
 <details>
   <summary>Quick Install</summary>
-  <br/>
 
 The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
 
@@ -42,7 +41,6 @@ Because this command is new, it might not properly set things up. If that happen
 
 <details>
   <summary>Manual Install</summary>
-  <br/>
 
 First, install the `@astrojs/mdx` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
 

--- a/packages/integrations/netlify/README.md
+++ b/packages/integrations/netlify/README.md
@@ -30,7 +30,7 @@ npm install @astrojs/netlify
 
 Then, install this adapter in your `astro.config.*` file using the `adapter` property. Note: there are two different adapters, one for Netlify Functions and one for Edge Functions. See [Edge Functions](#edge-functions) below on importing the latter.
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import { defineConfig } from 'astro/config';
@@ -113,14 +113,14 @@ We check for common mime types for audio, image, and video files. To include spe
 import fs from 'node:fs';
 
 export function get() {
-	const buffer = fs.readFileSync('../image.jpg');
+  const buffer = fs.readFileSync('../image.jpg');
 
   // Return the buffer directly, @astrojs/netlify will base64 encode the body
   return new Response(buffer, {
     status: 200,
-		headers: {
-			'content-type': 'image/jpeg'
-		}
+    headers: {
+      'content-type': 'image/jpeg'
+    }
   });
 }
 ```

--- a/packages/integrations/netlify/README.md
+++ b/packages/integrations/netlify/README.md
@@ -75,8 +75,6 @@ To configure this adapter, pass an object to the `netlify()` function call in `a
 
 <details>
   <summary><strong>dist</strong></summary>
-  
-  <br/>
 
 We build to the `dist` directory at the base of your project. To change this, use the `dist` option:
 
@@ -136,11 +134,17 @@ export function get() {
 
 ## Troubleshooting
 
+For help, check out the `#support-threads` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+
+You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
 ## Contributing
 
 This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
 
 ## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a history of changes to this integration.
 
 [astro-integration]: https://docs.astro.build/en/guides/integrations-guide/
 

--- a/packages/integrations/node/README.md
+++ b/packages/integrations/node/README.md
@@ -6,7 +6,6 @@ This adapter allows Astro to deploy your SSR site to Node targets.
 - <strong>[Installation](#installation)</strong>
 - <strong>[Usage](#usage)</strong>
 - <strong>[Configuration](#configuration)</strong>
-- <strong>[Examples](#examples)</strong>
 - <strong>[Troubleshooting](#troubleshooting)</strong>
 - <strong>[Contributing](#contributing)</strong>
 - <strong>[Changelog](#changelog)</strong> 
@@ -96,14 +95,18 @@ http.createServer(function(req, res) {
 
 This adapter does not expose any configuration options.
 
-## Examples
-
 ## Troubleshooting
+
+For help, check out the `#support-threads` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+
+You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
 
 ## Contributing
 
 This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
 
 ## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a history of changes to this integration.
 
 [astro-integration]: https://docs.astro.build/en/guides/integrations-guide/

--- a/packages/integrations/node/README.md
+++ b/packages/integrations/node/README.md
@@ -22,13 +22,14 @@ If you wish to [use server-side rendering (SSR)](https://docs.astro.build/en/gui
 ## Installation
 
 First, install the `@astrojs/node` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
-```sh
+
+```shell
 npm install @astrojs/node
 ```
 
 Then, install this adapter in your `astro.config.*` file using the `adapter` property:
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import { defineConfig } from 'astro/config';

--- a/packages/integrations/partytown/README.md
+++ b/packages/integrations/partytown/README.md
@@ -50,7 +50,7 @@ npm install @astrojs/partytown
 ```
 Then, apply this integration to your `astro.config.*` file using the `integrations` property:
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import { defineConfig } from 'astro/config';
@@ -80,7 +80,7 @@ If you open the "Network" tab from [your browser's dev tools](https://developer.
 
 To configure this integration, pass a 'config' object to the `partytown()` function call in `astro.config.mjs`.
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 ```js
 ...
 export default defineConfig({
@@ -101,7 +101,7 @@ This mirrors the [Partytown config object](https://partytown.builder.io/configur
 
   If this option isn't set, `debug` mode will be on by default in [dev](https://docs.astro.build/en/reference/cli-reference/#astro-dev) or [preview](https://docs.astro.build/en/reference/cli-reference/#astro-preview) mode. 
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 export default defineConfig({
@@ -123,7 +123,7 @@ export default defineConfig({
   You can specify which variables to forward with the `config.forward` option. [Read more in Partytown's documentation.](https://partytown.builder.io/forwarding-events)
 
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 export default defineConfig ({

--- a/packages/integrations/partytown/README.md
+++ b/packages/integrations/partytown/README.md
@@ -24,7 +24,6 @@ The Astro Partytown integration installs Partytown for you and makes sure it's e
 
 <details>
   <summary>Quick Install</summary>
-  <br/>
   
 The experimental `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
   
@@ -44,8 +43,6 @@ Because this command is new, it might not properly set things up. If that happen
 
 <details>
   <summary>Manual Install</summary>
-
-<br/>
   
 First, install the `@astrojs/partytown` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
 ```sh
@@ -99,8 +96,6 @@ This mirrors the [Partytown config object](https://partytown.builder.io/configur
 
 <details>
   <summary><strong>config.debug</strong></summary>
-  
-  <br/>
 
   Partytown ships with a `debug` mode; enable or disable it by passing `true` or `false` to `config.debug`. If [`debug` mode](https://partytown.builder.io/debugging) is enabled, it will output detailed logs to the browser console. 
 
@@ -120,8 +115,6 @@ export default defineConfig({
 
 <details>
   <summary><strong>config.forward</strong></summary>
-  
-  <br/>
   
   Third-party scripts typically add variables to the `window` object so that you can communicate with them throughout your site. But when a script is loaded in a web-worker, it doesn't have access to that global `window` object.
 
@@ -152,10 +145,16 @@ export default defineConfig ({
 
 ## Troubleshooting
 
+For help, check out the `#support-threads` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+
+You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
 ## Contributing
 
 This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
 
 ## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a history of changes to this integration.
 
 [astro-integration]: https://docs.astro.build/en/guides/integrations-guide/

--- a/packages/integrations/preact/README.md
+++ b/packages/integrations/preact/README.md
@@ -24,7 +24,6 @@ Check out [“Learn Preact in 10 minutes”](https://preactjs.com/tutorial), an 
 
 <details>
   <summary>Quick Install</summary>
-  <br/>
 
 The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
 
@@ -44,7 +43,6 @@ Because this command is new, it might not properly set things up. If that happen
 
 <details>
   <summary>Manual Install</summary>
-  <br/>
 
 First, install the `@astrojs/preact` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
 

--- a/packages/integrations/preact/README.md
+++ b/packages/integrations/preact/README.md
@@ -58,7 +58,7 @@ Most package managers will install associated peer dependencies as well. Still, 
 
 Then, apply this integration to your `astro.config.*` file using the `integrations` property:
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import { defineConfig } from 'astro/config';

--- a/packages/integrations/prefetch/README.md
+++ b/packages/integrations/prefetch/README.md
@@ -44,7 +44,7 @@ npm install @astrojs/prefetch
 ```
 Then, apply this integration to your `astro.config.*` file using the `integrations` property:
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import prefetch from '@astrojs/prefetch';

--- a/packages/integrations/prefetch/README.md
+++ b/packages/integrations/prefetch/README.md
@@ -4,9 +4,9 @@
 - <strong>[Installation](#installation)</strong>
 - <strong>[Usage](#usage)</strong>
 - <strong>[Configuration](#configuration)</strong>
-- <strong>[Examples](#examples)</strong>
 - <strong>[Troubleshooting](#troubleshooting)</strong>
 - <strong>[Contributing](#contributing)</strong>
+- <strong>[Changelog](#changelog)</strong>
 
 ## Why Prefetch?
 
@@ -18,7 +18,6 @@ To further improve the experience, especially on similar pages, stylesheets are 
 
 <details>
   <summary>Quick Install</summary>
-  <br/>
   
 The experimental `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
   
@@ -38,8 +37,6 @@ Because this command is new, it might not properly set things up. If that happen
 
 <details>
   <summary>Manual Install</summary>
-  
-<br/>
   
 First, install the `@astrojs/prefetch` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
 ```sh
@@ -72,11 +69,7 @@ The Astro Prefetch integration handles which links on the site are prefetched an
 <details>
   <summary><strong>config.selector</strong></summary>
   
-  <br/>
-  
 By default the prefetch script searches the page for any links that include a `rel="prefetch"` attribute, ex: `<a rel="prefetch" />` or `<a rel="nofollow prefetch" />`. This behavior can be changed in your `astro.config.*` file to use a custom query selector when finding prefetch links. 
-  
-  <br/>
 
 ```js
 import prefetch from '@astrojs/prefetch';
@@ -94,11 +87,7 @@ export default {
 <details>
   <summary><strong>config.throttle</strong></summary>
   
-  <br/>
-  
 By default the prefetch script will only prefetch one link at a time. This behavior can be changed in your `astro.config.*` file to increase the limit for concurrent downloads.
-  
-  <br/>
 
 ```js
 import prefetch from '@astrojs/prefetch';
@@ -113,14 +102,20 @@ export default {
 ```
 </details>
 
-## Examples
-
-> Coming soon!
-
 ## Troubleshooting
 - If your installation doesn't seem to be working, make sure to restart the dev server.
 - If a link doesn't seem to be prefetching, make sure that the link is pointing to a page on the same domain and matches the integration's `selector` option.
 
+For help, check out the `#support-threads` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+
+You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
 ## Contributing
 
 This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a history of changes to this integration.
+
+[astro-integration]: https://docs.astro.build/en/guides/integrations-guide/

--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -41,7 +41,7 @@ npm install react react-dom
 
 Now, apply this integration to your `astro.config.*` file using the `integrations` property:
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import react from '@astrojs/react';

--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -24,7 +24,6 @@ With Astro Sitemap, you don't have to worry about creating this file: build your
 
 <details>
   <summary>Quick Install</summary>
-  <br/>
   
 The experimental `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
   
@@ -44,8 +43,6 @@ Because this command is new, it might not properly set things up. If that happen
 
 <details>
   <summary>Manual Install</summary>
-
-<br/>
   
 First, install the `@astrojs/sitemap` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
 ```sh
@@ -53,7 +50,7 @@ npm install @astrojs/sitemap
 ```
 Then, apply this integration to your `astro.config.*` file using the `integrations` property:
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import { defineConfig } from 'astro/config';
@@ -72,7 +69,7 @@ Then, restart the dev server.
 
 `@astrojs/sitemap` requires a deployment / site URL for generation. Add your site's URL under your `astro.config.*` using the `site` property. This must begin with `http:` or `https:`.
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import { defineConfig } from 'astro/config';
@@ -93,11 +90,9 @@ Now, [build your site for production](https://docs.astro.build/en/reference/cli-
 > If you forget to add a `site`, you'll get a friendly warning when you build, and the `sitemap.xml` file won't be generated.
 
 <details>
-<summary>
-Example of generated sitemap content for a two-page website:
-</summary>
+<summary>Example of generated files for a two-page website</summary>
 
-**sitemap-index.xml**
+**`sitemap-index.xml`**
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -108,7 +103,7 @@ Example of generated sitemap content for a two-page website:
 </sitemapindex>
 ```
 
-**sitemap-0.xml**
+**`sitemap-0.xml`**
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -130,7 +125,7 @@ Example of generated sitemap content for a two-page website:
 
 To configure this integration, pass an object to the `sitemap()` function call in `astro.config.mjs`.
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 ```js
 ...
 export default defineConfig({
@@ -143,11 +138,9 @@ export default defineConfig({
 <details>
   <summary><strong>filter</strong></summary>
   
-  <br/>
-  
   All pages are included in your sitemap by default. By adding a custom `filter` function, you can filter  included pages by URL.
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 ...
@@ -163,12 +156,10 @@ The function will be called for every page on your site. The `page` function par
 <details>
   <summary><strong>customPages</strong></summary>
   
-  <br/>
-  
   In some cases, a page might be part of your deployed site but not part of your Astro project.
   If you'd like to include a page in your sitemap that _isn't_ created by Astro, you can use this option.
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 ...
@@ -179,13 +170,11 @@ __astro.config.mjs__
 </details>
 
 <details>
-  <summary>
-    entryLimit
-  </summary>
+  <summary><strong>entryLimit</strong></summary>
 
 The maximum number entries per sitemap file. The default value is 45000. A sitemap index and multiple sitemaps are created if you have more entries. See this [explanation of splitting up a large sitemap](https://developers.google.com/search/docs/advanced/sitemaps/large-sitemaps).
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import sitemap from '@astrojs/sitemap';
@@ -203,9 +192,7 @@ export default {
 
 
 <details>
-  <summary>
-    <strong>changefreq</strong>, <strong>lastmod</strong>, and <strong>priority</strong>
-  </summary>
+  <summary><strong>changefreq</strong>, <strong>lastmod</strong>, and <strong>priority</strong></summary>
 
 These options correspond to the `<changefreq>`, `<lastmod>`, and `<priortity>` tags in the [Sitemap XML specification.](https://www.sitemaps.org/protocol.html)
 
@@ -214,7 +201,7 @@ Note that `changefreq` and `priority` are ignored by Google.
 > **Note**
 > Due to limitations of Astro's [Integration API](https://docs.astro.build/en/reference/integrations-reference/), this integration can't analyze a given page's source code. This configuration option can set `changefreq`, `lastmod` and `priority` on a _site-wide_ basis; see the next option **serialize** for how you can set these values on a per-page basis.
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import sitemap from '@astrojs/sitemap';
@@ -255,7 +242,7 @@ The `serialize` function should return `SitemapItem`, touched or not.
 
 The example below shows the ability to add sitemap specific properties individually.
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import sitemap from '@astrojs/sitemap';
@@ -299,7 +286,7 @@ This object has two required properties:
 
 [Read more about localization](https://developers.google.com/search/docs/advanced/crawling/localized-versions#all-method-guidelines).
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import sitemap from '@astrojs/sitemap';
@@ -363,11 +350,16 @@ export default {
 
 ## Troubleshooting
 
+For help, check out the `#support-threads` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+
+You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
 ## Contributing
 
 This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
 
 ## Changelog
 
+See [CHANGELOG.md](CHANGELOG.md) for a history of changes to this integration.
 
 [astro-integration]: https://docs.astro.build/en/guides/integrations-guide/

--- a/packages/integrations/solid/README.md
+++ b/packages/integrations/solid/README.md
@@ -41,7 +41,7 @@ npm install solid-js
 
 Now, apply this integration to your `astro.config.*` file using the `integrations` property:
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import solid from '@astrojs/solid-js';

--- a/packages/integrations/svelte/README.md
+++ b/packages/integrations/svelte/README.md
@@ -41,7 +41,7 @@ npm install svelte
 
 Now, apply this integration to your `astro.config.*` file using the `integrations` property:
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import svelte from '@astrojs/svelte';

--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -53,7 +53,7 @@ npm install @astrojs/tailwind
 ```
 Then, apply this integration to your `astro.config.*` file using the `integrations` property:
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import tailwind from '@astrojs/tailwind';

--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -27,7 +27,6 @@ https://user-images.githubusercontent.com/4033662/169920154-4b42fc52-e2b5-4ca4-b
 
 <details>
   <summary>Quick Install</summary>
-  <br/>
   
 The experimental `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
   
@@ -47,8 +46,6 @@ Because this command is new, it might not properly set things up. If that happen
 
 <details>
   <summary>Manual Install</summary>
-  
-<br/>
   
 First, install the `@astrojs/tailwind` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
 ```sh
@@ -91,12 +88,8 @@ The Astro Tailwind integration handles the communication between Astro and Tailw
 <details>
   <summary><strong>config.path</strong></summary>
   
-  <br/>
-  
-  If you want to use a different Tailwind configuration file instead of the default `tailwind.config.(js|cjs|mjs)`, specify that file's location using this integration's `config.path` option. If `config.path` is relative, it will be resolved relative to the root. 
-  
-  <br/>
-  
+If you want to use a different Tailwind configuration file instead of the default `tailwind.config.(js|cjs|mjs)`, specify that file's location using this integration's `config.path` option. If `config.path` is relative, it will be resolved relative to the root.
+
 > **Warning**
 > Changing this isn't recommended since it can cause problems with other tools that integrate with Tailwind, like the official Tailwind VSCode extension.
 
@@ -167,4 +160,4 @@ This package is maintained by Astro's Core team. You're welcome to submit an iss
 
 ## Changelog
 
-
+See [CHANGELOG.md](CHANGELOG.md) for a history of changes to this integration.

--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -6,7 +6,6 @@ This adapter allows Astro to deploy your SSR site to [Vercel](https://www.vercel
 - <strong>[Installation](#installation)</strong>
 - <strong>[Usage](#usage)</strong>
 - <strong>[Configuration](#configuration)</strong>
-- <strong>[Examples](#examples)</strong>
 - <strong>[Troubleshooting](#troubleshooting)</strong>
 - <strong>[Contributing](#contributing)</strong>
 - <strong>[Changelog](#changelog)</strong>
@@ -87,16 +86,18 @@ vercel deploy --prebuilt
 
 This adapter does not expose any configuration options.
 
-## Examples
-
 ## Troubleshooting
 
 **A few known complex packages (example: [puppeteer](https://github.com/puppeteer/puppeteer)) do not support bundling and therefore will not work properly with this adapter.** By default, Vercel doesn't include npm installed files & packages from your project's `./node_modules` folder. To address this, the `@astrojs/vercel` adapter automatically bundles your final build output using `esbuild`.
+
+For help, check out the `#support-threads` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
 
 ## Contributing
 
 This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
 
 ## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a history of changes to this integration.
 
 [astro-integration]: https://docs.astro.build/en/guides/integrations-guide/

--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -27,7 +27,7 @@ npm install @astrojs/vercel
 
 Then, install this adapter in your `astro.config.*` file using the `adapter` property (note the import from `@astrojs/vercel/serverless` - see [targets](#targets)).
 
- __astro.config.mjs__ 
+ __`astro.config.mjs`__ 
 
 ```js
 import { defineConfig } from 'astro/config';
@@ -40,7 +40,7 @@ export default defineConfig({
 
 ### Targets
 
-You can deploy to different targes:
+You can deploy to different targets:
 
 - `edge`: SSR inside an [Edge function](https://vercel.com/docs/concepts/functions/edge-functions).
 - `serverless`: SSR inside a [Node.js function](https://vercel.com/docs/concepts/functions/serverless-functions).

--- a/packages/integrations/vue/README.md
+++ b/packages/integrations/vue/README.md
@@ -41,7 +41,7 @@ npm install vue
 
 Now, apply this integration to your `astro.config.*` file using the `integrations` property:
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import vue from '@astrojs/vue';
@@ -68,7 +68,7 @@ Also check our [Astro Integration Documentation][astro-integration] for more on 
 
 This integration is powered by `@vitejs/plugin-vue`. To customize the Vue compiler, options can be provided to the integration. See the `@vitejs/plugin-vue` [docs](https://github.com/vitejs/vite/tree/main/packages/plugin-vue) for more details.
 
-__astro.config.mjs__
+__`astro.config.mjs`__
 
 ```js
 import vue from '@astrojs/vue';


### PR DESCRIPTION
## Changes

More tweaks to README formatting to accompany https://github.com/withastro/docs/pull/954

Key things:

- Add standard content for troubleshooting & changelog sections of READMEs
- Remove empty Examples sections from READMEs
- Don’t use `<br>` as they look out of place in the styled context of the docs
- Use code backticks for filenames

## Testing

n/a

## Docs

All docs, all the time ✨ 