### PR TITLE
fix: portfolio example JSX error

### DIFF
--- a/.changeset/nervous-points-confess.md
+++ b/.changeset/nervous-points-confess.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fix portfolio example JSX error

--- a/examples/portfolio/src/pages/projects.astro
+++ b/examples/portfolio/src/pages/projects.astro
@@ -16,7 +16,7 @@ const projects = (await Astro.glob("./project/**/*.md"))
 	<head>
 		<MainHead
 			title="All Projects | Jeanine White"
-			description="Learn about Jenine White"
+			description="Learn about Jeanine White's most recent projects"
 			s
 			most
 			recent

--- a/examples/portfolio/src/pages/projects.astro
+++ b/examples/portfolio/src/pages/projects.astro
@@ -20,7 +20,7 @@ const projects = (await Astro.glob("./project/**/*.md"))
 			s
 			most
 			recent
-			projects'
+			projects
 		/>
 		<style lang="scss">
 			.grid {


### PR DESCRIPTION
## Changes

I created a new Astro project with the `portfolio` template and noticed a JSX error in `src/pages/projects.astro` (an extra `'` after the `projects` prop), so this PR remove it.

I've also noticed that the dev server starts and render the page without any error/bug with this extra `'`, so this is not really a bug, more of a typo.

## Testing

No test was added since this concern the portfolio example.

## Docs

No doc was changed since this concern the portfolio example.