### PR TITLE
Allow defining Astro components in Vite plugins

### DIFF
--- a/.changeset/hungry-cougars-yell.md
+++ b/.changeset/hungry-cougars-yell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow defining Astro components in Vite plugins

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -11,7 +11,10 @@ import { viteID } from '../core/util.js';
 import { transformWithVite } from './styles.js';
 
 type CompilationCache = Map<string, CompileResult>;
-type CompileResult = TransformResult & { rawCSSDeps: Set<string> };
+type CompileResult = TransformResult & {
+	rawCSSDeps: Set<string>;
+	source: string;
+};
 
 /**
  * Note: this is currently needed because Astro is directly using a Vite internal CSS transform. This gives us
@@ -44,6 +47,19 @@ export interface CompileProps {
 	pluginContext: PluginContext;
 }
 
+function getNormalizedID(filename: string): string {
+	try {
+		const filenameURL = new URL(`file://${filename}`);
+		return fileURLToPath(filenameURL);
+	} catch(err) {
+		if((err as any).code === 'ERR_INVALID_FILE_URL_HOST') {
+			// Not a real file, so just use the provided filename as the normalized id
+			return filename;
+		}
+		throw err;
+	}
+}
+
 async function compile({
 	config,
 	filename,
@@ -53,9 +69,7 @@ async function compile({
 	viteTransform,
 	pluginContext,
 }: CompileProps): Promise<CompileResult> {
-	const filenameURL = new URL(`file://${filename}`);
-	const normalizedID = fileURLToPath(filenameURL);
-
+	const normalizedID = getNormalizedID(filename);
 	let rawCSSDeps = new Set<string>();
 	let cssTransformError: Error | undefined;
 
@@ -141,6 +155,9 @@ async function compile({
 		rawCSSDeps: {
 			value: rawCSSDeps,
 		},
+		source: {
+			value: source,
+		},
 	});
 
 	return compileResult;
@@ -148,6 +165,13 @@ async function compile({
 
 export function isCached(config: AstroConfig, filename: string) {
 	return configCache.has(config) && configCache.get(config)!.has(filename);
+}
+
+export function getCachedSource(config: AstroConfig, filename: string): string | null {
+	if(!isCached(config, filename)) return null;
+	let src = configCache.get(config)!.get(filename);
+	if(!src) return null;
+	return src.source;
 }
 
 export function invalidateCompilation(config: AstroConfig, filename: string) {

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -52,11 +52,8 @@ function getNormalizedID(filename: string): string {
 		const filenameURL = new URL(`file://${filename}`);
 		return fileURLToPath(filenameURL);
 	} catch(err) {
-		if((err as any).code === 'ERR_INVALID_FILE_URL_HOST') {
-			// Not a real file, so just use the provided filename as the normalized id
-			return filename;
-		}
-		throw err;
+		// Not a real file, so just use the provided filename as the normalized id
+		return filename;
 	}
 }
 

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -203,8 +203,11 @@ export default function astro({ config, logging }: AstroPluginOptions): vite.Plu
 			}
 
 			const filename = normalizeFilename(parsedId.filename);
-			const fileUrl = new URL(`file://${filename}`);
-			const isPage = fileUrl.pathname.startsWith(resolvePages(config).pathname);
+			let isPage = false;
+			try {
+				const fileUrl = new URL(`file://${filename}`);
+				isPage = fileUrl.pathname.startsWith(resolvePages(config).pathname);
+			} catch {}
 			if (isPage && config._ctx.scripts.some((s) => s.stage === 'page')) {
 				source += `\n<script src="${PAGE_SCRIPT_ID}" />`;
 			}

--- a/packages/astro/test/fixtures/virtual-astro-file/astro.config.mjs
+++ b/packages/astro/test/fixtures/virtual-astro-file/astro.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from 'astro/config';
+import myPlugin from './src/plugin/my-plugin.mjs';
+
+// https://astro.build/config
+export default defineConfig({
+	vite: {
+		plugins: [myPlugin()]
+	}
+});

--- a/packages/astro/test/fixtures/virtual-astro-file/package.json
+++ b/packages/astro/test/fixtures/virtual-astro-file/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/virtual-astro-file",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/virtual-astro-file/src/pages/index.astro
+++ b/packages/astro/test/fixtures/virtual-astro-file/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import Something from 'virtual.astro';
+import Something from '@my-plugin/virtual.astro';
 ---
 <html>
 	<head><title>Testing</title></head>

--- a/packages/astro/test/fixtures/virtual-astro-file/src/pages/index.astro
+++ b/packages/astro/test/fixtures/virtual-astro-file/src/pages/index.astro
@@ -1,0 +1,10 @@
+---
+import Something from 'virtual.astro';
+---
+<html>
+	<head><title>Testing</title></head>
+	<body>
+		<Something />
+	</body>
+</html>
+

--- a/packages/astro/test/fixtures/virtual-astro-file/src/plugin/my-plugin.mjs
+++ b/packages/astro/test/fixtures/virtual-astro-file/src/plugin/my-plugin.mjs
@@ -14,6 +14,11 @@ const works = true;
 ---
 <h1 id="something">This is a virtual module id</h1>
 <h2 id="works">{works}</h2>
+<style>
+  h1 {
+		color: green;
+	}
+</style>
 `;
       }
     },

--- a/packages/astro/test/fixtures/virtual-astro-file/src/plugin/my-plugin.mjs
+++ b/packages/astro/test/fixtures/virtual-astro-file/src/plugin/my-plugin.mjs
@@ -1,0 +1,21 @@
+
+
+export default function myPlugin() {
+  return {
+    enforce: 'pre',
+    name: 'virtual-astro-plugin',
+    resolveId(id) {
+      if (id === 'virtual.astro') return id;
+    },
+    load(id) {
+      if (id === 'virtual.astro') {
+        return `---
+const works = true;
+---
+<h1 id="something">This is a virtual module id</h1>
+<h2 id="works">{works}</h2>
+`;
+      }
+    },
+  };
+}

--- a/packages/astro/test/fixtures/virtual-astro-file/src/plugin/my-plugin.mjs
+++ b/packages/astro/test/fixtures/virtual-astro-file/src/plugin/my-plugin.mjs
@@ -1,14 +1,15 @@
 
 
 export default function myPlugin() {
+	const pluginId = `@my-plugin/virtual.astro`;
   return {
     enforce: 'pre',
     name: 'virtual-astro-plugin',
     resolveId(id) {
-      if (id === 'virtual.astro') return id;
+      if (id === pluginId) return id;
     },
     load(id) {
-      if (id === 'virtual.astro') {
+      if (id === pluginId) {
         return `---
 const works = true;
 ---

--- a/packages/astro/test/hmr-css.test.js
+++ b/packages/astro/test/hmr-css.test.js
@@ -22,6 +22,9 @@ describe('HMR - CSS', () => {
 	});
 
 	it('Timestamp URL used by Vite gets the right mime type', async () => {
+		// Index page is always loaded first by the browser
+		await fixture.fetch('/');
+		// Now we can simulate what happens in the browser
 		let res = await fixture.fetch(
 			'/src/pages/index.astro?astro=&type=style&index=0&lang.css=&t=1653657441095'
 		);

--- a/packages/astro/test/virtual-astro-file.js
+++ b/packages/astro/test/virtual-astro-file.js
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Loading virtual Astro files', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/virtual-astro-file/' });
+		await fixture.build();
+	});
+
+	it('works', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerio.load(html);
+		expect($('#something')).to.have.a.lengthOf(1);
+		expect($('#works').text()).to.equal('true');
+	});
+});

--- a/packages/astro/test/virtual-astro-file.js
+++ b/packages/astro/test/virtual-astro-file.js
@@ -10,10 +10,18 @@ describe('Loading virtual Astro files', () => {
 		await fixture.build();
 	});
 
-	it('works', async () => {
+	it('renders the component', async () => {
 		const html = await fixture.readFile('/index.html');
 		const $ = cheerio.load(html);
 		expect($('#something')).to.have.a.lengthOf(1);
 		expect($('#works').text()).to.equal('true');
+	});
+
+	it('builds component CSS', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerio.load(html);
+		const href = $('link').attr('href');
+		const css = await fixture.readFile(href);
+		expect(css).to.match(/green/, 'css bundled from virtual astro module');
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1822,6 +1822,12 @@ importers:
       postcss: 8.4.14
       tailwindcss: 3.1.5
 
+  packages/astro/test/fixtures/virtual-astro-file:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/vue-component:
     specifiers:
       '@astrojs/vue': workspace:*


### PR DESCRIPTION
## Changes

- Moves compilation to the `transform` hook.
- This allows defining Astro components as virtual modules in Vite plugins.
- Closes #3814

## Testing

- Test added

## Docs

N/A, bug fix