### PR TITLE
Properly await on children before hydrating in Safari

### DIFF
--- a/.changeset/forty-colts-ring.md
+++ b/.changeset/forty-colts-ring.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix Safari client:visible refresh bug

--- a/packages/astro/src/runtime/server/astro-island.ts
+++ b/packages/astro/src/runtime/server/astro-island.ts
@@ -42,7 +42,7 @@ declare const Astro: {
 				public hydrator: any;
 				static observedAttributes = ['props'];
 				connectedCallback() {
-					if (!this.getAttribute('await-children') || this.firstChild) {
+					if (!this.hasAttribute('await-children') || this.firstChild) {
 						this.childrenConnectedCallback();
 					} else {
 						// connectedCallback may run *before* children are rendered (ex. HTML streaming)


### PR DESCRIPTION
## Changes

- In Safari `connectedCallback` is called before an element has children, so we need to wait for the children to occur before beginning the hydration process.
- A `await-children` attribute is added when we need to do this, but is a boolean attribute. Since we are using `!this.getAttribute('await-children')` this is always going to be a falsey condition. Using `hasAttribute` instead since that is the intended logic.
- Fixes #3878

## Testing

- No test added, Safari only condition and we don't have E2E tests for Safari at the moment.

## Docs

N/A, bug fix