### PR TITLE
Ignore bundle size check for irrelevant PRs

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - 'main'
+    paths:
+      - 'packages/astro/src/runtime/client/**/*'
 
 # Automatically cancel in-progress actions on the same branch
 concurrency:


### PR DESCRIPTION
## Changes

- GitHub Actions change only
- Small fix to avoid running `scripts.yml` on irrelevant PRs

## Testing

N/A

## Docs

N/A