### PR TITLE
Fix: set default charset for Astro pages in dev

### DIFF
--- a/.changeset/loud-feet-beg.md
+++ b/.changeset/loud-feet-beg.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix: set default charset for Astro pages in dev

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -326,6 +326,9 @@ async function handleRequest(
 			}
 		} else {
 			const result = await ssr(preloadedComponent, options);
+			if (!result.headers.has('Content-Type')) {
+				result.headers.set('Content-Type', 'text/html;charset=utf-8');
+			}
 			return await writeSSRResult(result, res);
 		}
 	} catch (_err) {

--- a/packages/astro/test/astro-pages.test.js
+++ b/packages/astro/test/astro-pages.test.js
@@ -42,5 +42,11 @@ describe('Pages', () => {
 
 			expect($('#testing').length).to.be.greaterThan(0);
 		});
+
+		it('Has default Content-Type with charset=utf-8', async () => {
+			const html = await fixture.fetch('/');
+
+			expect(html.headers.get('Content-Type')).to.equal('text/html;charset=utf-8');
+		});
 	});
 });


### PR DESCRIPTION
## Changes

Follow-up to #3573. Turns out `charset` was missing for Astro files in development as well!

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->