### PR TITLE
fix: don't throw when Shiki doesn't recognize a language

### DIFF
--- a/.changeset/healthy-donuts-dream.md
+++ b/.changeset/healthy-donuts-dream.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Don't throw when Shiki doesn't recognize a language

--- a/packages/astro/test/astro-markdown-shiki.test.js
+++ b/packages/astro/test/astro-markdown-shiki.test.js
@@ -119,6 +119,9 @@ describe('Astro Markdown Shiki', () => {
 			expect(segments[0].attribs.style).to.be.equal('color: #C9D1D9');
 			expect(segments[1].attribs.style).to.be.equal('color: #79C0FF');
 			expect(segments[2].attribs.style).to.be.equal('color: #C9D1D9');
+			
+			const unknownLang = $('.line').last().html();
+			expect(unknownLang).to.be.equal('<span style="color: #c9d1d9">This language does not exist</span>')
 		});
 
 		it('<Markdown /> component', async () => {
@@ -129,6 +132,9 @@ describe('Astro Markdown Shiki', () => {
 			expect(segments).to.have.lengthOf(3);
 			expect(segments[0].attribs.style).to.be.equal('color: #C9D1D9');
 			expect(segments[1].attribs.style).to.be.equal('color: #79C0FF');
+
+			const unknownLang = $('.line').last().html();
+			expect(unknownLang).to.be.equal('<span style="color: #c9d1d9">This language does not exist</span>')
 		});
 	});
 

--- a/packages/astro/test/fixtures/astro-markdown-shiki/langs/src/pages/astro.astro
+++ b/packages/astro/test/fixtures/astro-markdown-shiki/langs/src/pages/astro.astro
@@ -23,5 +23,9 @@ import Layout from '../layouts/content.astro';
 			Iniciar(Rinfo, 1, 1)
 		fin
 		```
+
+		```unknown
+		This language does not exist
+		```
 	</Markdown>
 </Layout>

--- a/packages/astro/test/fixtures/astro-markdown-shiki/langs/src/pages/index.md
+++ b/packages/astro/test/fixtures/astro-markdown-shiki/langs/src/pages/index.md
@@ -20,3 +20,7 @@ comenzar
   Iniciar(Rinfo, 1, 1)
 fin
 ```
+
+```unknown
+This language does not exist
+```

--- a/packages/markdown/remark/src/remark-shiki.ts
+++ b/packages/markdown/remark/src/remark-shiki.ts
@@ -30,7 +30,21 @@ const remarkShiki = async (
 
 	return () => (tree: any) => {
 		visit(tree, 'code', (node) => {
-			let html = highlighter!.codeToHtml(node.value, { lang: node.lang ?? 'plaintext' });
+			let lang: string;
+
+			if (typeof node.lang === 'string') {
+				const langExists = highlighter.getLoadedLanguages().includes(node.lang);
+				if (langExists) {
+					lang = node.lang;
+				} else {
+					console.warn(`The language "${node.lang}" doesn't exist, falling back to plaintext.`);
+					lang = 'plaintext';
+				}
+			} else {
+				lang = 'plaintext';
+			}
+
+			let html = highlighter!.codeToHtml(node.value, { lang });
 
 			// Q: Couldn't these regexes match on a user's inputted code blocks?
 			// A: Nope! All rendered HTML is properly escaped.


### PR DESCRIPTION
Fixes #3881

## Changes

When a language that isn't registered by Shiki is used, show a warning instead of an error.

## Testing

Added tests with a unknown language (it would be nice to analyze the logs, but I don't know how)

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->