### PR TITLE
Provide a better error message for when RSS is missing `link` field

### DIFF
--- a/.changeset/weak-mangos-double.md
+++ b/.changeset/weak-mangos-double.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': patch
+---
+
+Adds error messages for missing required fields

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -113,6 +113,7 @@ export async function generateRSS({ rssOptions, items }: GenerateRSSArgs): Promi
 	if (typeof rssOptions.customData === 'string') xml += rssOptions.customData;
 	// items
 	for (const result of items) {
+		validate(result);
 		xml += `<item>`;
 		xml += `<title><![CDATA[${result.title}]]></title>`;
 		// If the item's link is already a valid URL, don't mess with it.
@@ -145,4 +146,15 @@ export async function generateRSS({ rssOptions, items }: GenerateRSSArgs): Promi
 	}
 
 	return xml;
+}
+
+const requiredFields = Object.freeze(['link', 'title']);
+
+// Perform validation to make sure all required fields are passed.
+function validate(item: RSSFeedItem) {
+	for(const field of requiredFields) {
+		if(!(field in item)) {
+			throw new Error(`@astrojs/rss: Required field [${field}] is missing. RSS cannot be generated without it.`);
+		}
+	}
 }

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -123,4 +123,24 @@ describe('rss', () => {
 			).to.be.rejected;
 		});
 	});
+
+	describe('errors', () => {
+		it('should provide a good error message when a link is not provided', async () => {
+			try {
+				await rss({
+					title: 'Your Website Title',
+					description: 'Your Website Description',
+					site: 'https://astro-demo',
+					items: [{
+						pubDate: new Date(),
+						title: 'Some title',
+						slug: 'foo'
+					}]
+				});
+				chai.expect(false).to.equal(true, 'Should have errored');
+			} catch(err) {
+				chai.expect(err.message).to.contain('Required field [link] is missing');
+			}
+		});
+	})
 });


### PR DESCRIPTION
## Changes

- Adds an error message whenever the required fields of the RSS plugin are missing.
- Part of #3846

## Testing

- Test added

## Docs

N/A, bug fix