### PR TITLE
Handle metadata for MDX files during build

### DIFF
--- a/.changeset/purple-flowers-arrive.md
+++ b/.changeset/purple-flowers-arrive.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix metadata handling for building MDX files

--- a/examples/with-mdx/src/pages/index.mdx
+++ b/examples/with-mdx/src/pages/index.mdx
@@ -14,4 +14,4 @@ Written by: {new Intl.ListFormat('en').format(authors.map(d => d.name))}.
 
 Published on: {new Intl.DateTimeFormat('en', {dateStyle: 'long'}).format(published)}.
 
-<Counter>## This is a counter!</Counter>
+<Counter client:idle>This is a **counter**!</Counter>

--- a/packages/astro/src/jsx-runtime/index.ts
+++ b/packages/astro/src/jsx-runtime/index.ts
@@ -3,9 +3,9 @@ import { Fragment, markHTMLString } from '../runtime/server/index.js';
 const AstroJSX = 'astro:jsx';
 const Empty = Symbol('empty');
 
-interface AstroVNode {
+export interface AstroVNode {
 	[AstroJSX]: boolean;
-	type: string | ((...args: any) => any) | typeof Fragment;
+	type: string | ((...args: any) => any);
 	props: Record<string, any>;
 }
 

--- a/packages/astro/src/jsx/server.ts
+++ b/packages/astro/src/jsx/server.ts
@@ -34,10 +34,8 @@ export async function renderToStaticMarkup(
 	}
 
 	const { result } = this;
-	try {
-		const html = await renderJSX(result, jsx(Component, { ...props, ...slots, children }));
-		return { html };
-	} catch (e) {}
+	const html = await renderJSX(result, jsx(Component, { ...props, ...slots, children }));
+	return { html };
 }
 
 export default {

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -58,6 +58,9 @@ export function extractDirectives(inputProps: Record<string | number, any>): Ext
 				case 'client:component-hydration': {
 					break;
 				}
+				case 'client:display-name': {
+					break;
+				}
 				default: {
 					extracted.hydration.directive = key.split(':')[1];
 					extracted.hydration.value = value;

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -155,7 +155,7 @@ export function mergeSlots(...slotted: unknown[]) {
 	return slots;
 }
 
-export const Fragment = Symbol('Astro.Fragment');
+export const Fragment = Symbol.for('astro:fragment');
 export const ClientOnlyPlaceholder = 'astro-client-only';
 
 function guessRenderers(componentUrl?: string): string[] {

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -156,6 +156,7 @@ export function mergeSlots(...slotted: unknown[]) {
 }
 
 export const Fragment = Symbol('Astro.Fragment');
+export const ClientOnlyPlaceholder = 'astro-client-only';
 
 function guessRenderers(componentUrl?: string): string[] {
 	const extname = componentUrl?.split('.').pop();

--- a/packages/astro/src/runtime/server/jsx.ts
+++ b/packages/astro/src/runtime/server/jsx.ts
@@ -46,15 +46,11 @@ export async function renderJSX(result: any, vnode: any): Promise<any> {
 			return await renderElement(result, vnode.type, vnode.props ?? {});
 		}
 		if (!!vnode.type) {
-			try {
-				// TODO: silence Invalid hook call warning from React
+			// Only handle pages which will have the `server:root` property
+			if (vnode.props['server:root']) {
 				const output = await vnode.type(vnode.props ?? {});
-				if (output && output[AstroJSX]) {
-					return await renderJSX(result, output);
-				} else if (!output) {
-					return await renderJSX(result, output);
-				}
-			} catch (e) {}
+				return await renderJSX(result, output);
+			}
 
 			const { children = null, ...props } = vnode.props ?? {};
 			const slots: Record<string, any> = {

--- a/packages/astro/src/runtime/server/jsx.ts
+++ b/packages/astro/src/runtime/server/jsx.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import { SSRResult } from '../../@types/astro.js';
-import type { AstroVNode } from '../../jsx-runtime';
 import { AstroJSX, isVNode } from '../../jsx-runtime/index.js';
 import {
 	escapeHTML,

--- a/packages/astro/src/runtime/server/jsx.ts
+++ b/packages/astro/src/runtime/server/jsx.ts
@@ -54,8 +54,8 @@ export async function renderJSX(result: SSRResult, vnode: any): Promise<any> {
 				return await renderElement(result, vnode.type as string, vnode.props ?? {});
 		}
 
-		if (!!vnode.type) {
-			if (vnode.props['server:root']) {
+		if (vnode.type) {
+			if (typeof vnode.type === 'function' && vnode.props['server:root']) {
 				const output = await vnode.type(vnode.props ?? {});
 				return await renderJSX(result, output);
 			}
@@ -108,7 +108,7 @@ export async function renderJSX(result: SSRResult, vnode: any): Promise<any> {
 					slots
 				);
 			} else {
-				output = await renderComponent(result, vnode.type.name, vnode.type, props, slots);
+				output = await renderComponent(result, typeof vnode.type === 'function' ? vnode.type.name : vnode.type, vnode.type, props, slots);
 			}
 			return markHTMLString(output);
 		}

--- a/packages/astro/src/vite-plugin-jsx/index.ts
+++ b/packages/astro/src/vite-plugin-jsx/index.ts
@@ -2,6 +2,7 @@ import type { TransformResult } from 'rollup';
 import type { Plugin, ResolvedConfig } from 'vite';
 import type { AstroConfig, AstroRenderer } from '../@types/astro';
 import type { LogOptions } from '../core/logger/core.js';
+import type { PluginMetadata } from '../vite-plugin-astro/types';
 
 import babel from '@babel/core';
 import * as eslexer from 'es-module-lexer';
@@ -70,6 +71,23 @@ async function transformJSX({
 	// TODO: Be more strict about bad return values here.
 	// Should we throw an error instead? Should we never return `{code: ""}`?
 	if (!result) return null;
+
+	if (renderer.name === 'astro:jsx') {
+		const { astro } = result.metadata as unknown as PluginMetadata;
+		return {
+			code: result.code || '',
+			map: result.map,
+			meta: {
+				astro,
+				vite: {
+					// Setting this vite metadata to `ts` causes Vite to resolve .js
+					// extensions to .ts files.
+					lang: 'ts',
+				},
+			},
+		};
+	}
+	
 	return {
 		code: result.code || '',
 		map: result.map,


### PR DESCRIPTION
## Changes

- Our `with-mdx` example was hanging on build, and occasionally on dev!
- This was caused by a few things...
- We were swallowing errors from the built-in JSX renderer, causing an infinite recursive loop
- We weren't passing along `metadata` from our Babel plugin, so the build was never going to find hydrated components.
- As a bonus, `client:only` wasn't really supported in `.mdx` files. Now it is!

## Testing

Tested manually, but this should fix our fixtures

## Docs

Bug fix only