### PR TITLE
fix: export AstroComponentFactory for tsc validation to pass

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -15,6 +15,7 @@ import type { PageBuildData } from '../core/build/types';
 import type { AstroConfigSchema } from '../core/config';
 import type { ViteConfigWithSSR } from '../core/create-vite';
 import type { AstroComponentFactory, Metadata } from '../runtime/server';
+export type { AstroComponentFactory } from '../runtime/server';
 export type { SSRManifest } from '../core/app/types';
 
 export interface AstroBuiltinProps {


### PR DESCRIPTION
## Changes

- Exports `AstroComponentFactory` for `tsc` validation to pass

## Testing

Just CI should pass

## Docs

No change in docs is needed.
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->