### PR TITLE
add back missing ssr-utils.ts file

### DIFF
--- a/.changeset/many-terms-do.md
+++ b/.changeset/many-terms-do.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Add back missing ssr-utils.js file

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -13,7 +13,8 @@
   "homepage": "https://astro.build",
   "main": "./dist/index.js",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./ssr-utils": "./dist/ssr-utils.js"
   },
   "scripts": {
     "prepublish": "pnpm build",

--- a/packages/markdown/remark/src/ssr-utils.ts
+++ b/packages/markdown/remark/src/ssr-utils.ts
@@ -1,0 +1,8 @@
+/** Utilities used in deployment-ready SSR bundles */
+import Slugger from 'github-slugger';
+
+const slugger = new Slugger();
+/** @see {@link "/packages/astro/vite-plugin-markdown"} */
+export function slug(value: string): string {
+	return slugger.slug(value);
+}


### PR DESCRIPTION
## Changes

- Adds back a missing file that was removed as a patch, causing upstream to break
- Plan: release this as a patch, and then release a new minor with the file removed again (reverting this PR commit)

## Testing

- N/A (existing tests)

## Docs

- N/A