### PR TITLE
Add @babel/core dependencies to react/preact integrations

### DIFF
--- a/packages/integrations/preact/package.json
+++ b/packages/integrations/preact/package.json
@@ -31,6 +31,7 @@
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {
+    "@babel/core": ">=7.0.0-0 <8.0.0",
     "@babel/plugin-transform-react-jsx": "^7.17.12",
     "babel-plugin-module-resolver": "^4.1.0",
     "preact-render-to-string": "^5.2.0"

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -34,6 +34,7 @@
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {
+    "@babel/core": ">=7.0.0-0 <8.0.0",
     "@babel/plugin-transform-react-jsx": "^7.17.12"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2079,6 +2079,7 @@ importers:
 
   packages/integrations/preact:
     specifiers:
+      '@babel/core': '>=7.0.0-0 <8.0.0'
       '@babel/plugin-transform-react-jsx': ^7.17.12
       astro: workspace:*
       astro-scripts: workspace:*
@@ -2086,7 +2087,8 @@ importers:
       preact: ^10.7.3
       preact-render-to-string: ^5.2.0
     dependencies:
-      '@babel/plugin-transform-react-jsx': 7.18.6
+      '@babel/core': 7.18.6
+      '@babel/plugin-transform-react-jsx': 7.18.6_@babel+core@7.18.6
       babel-plugin-module-resolver: 4.1.0
       preact-render-to-string: 5.2.0_preact@10.9.0
     devDependencies:
@@ -2123,6 +2125,7 @@ importers:
 
   packages/integrations/react:
     specifiers:
+      '@babel/core': '>=7.0.0-0 <8.0.0'
       '@babel/plugin-transform-react-jsx': ^7.17.12
       '@types/react': ^17.0.45
       '@types/react-dom': ^17.0.17
@@ -2131,7 +2134,8 @@ importers:
       react: ^18.1.0
       react-dom: ^18.1.0
     dependencies:
-      '@babel/plugin-transform-react-jsx': 7.18.6
+      '@babel/core': 7.18.6
+      '@babel/plugin-transform-react-jsx': 7.18.6_@babel+core@7.18.6
     devDependencies:
       '@types/react': 17.0.47
       '@types/react-dom': 17.0.17
@@ -3778,22 +3782,6 @@ packages:
       '@babel/core': 7.18.6
       '@babel/helper-plugin-utils': 7.18.6
     dev: true
-
-  /@babel/plugin-transform-react-jsx/7.18.6:
-    resolution: {integrity: sha512-Mz7xMPxoy9kPS/JScj6fJs03TZ/fZ1dJPlMjRAgTaxaS0fUBk8FV/A2rRgfPsVCZqALNwMexD+0Uaf5zlcKPpw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.18.6
-      '@babel/types': 7.18.8
-    dev: false
 
   /@babel/plugin-transform-react-jsx/7.18.6_@babel+core@7.18.6:
     resolution: {integrity: sha512-Mz7xMPxoy9kPS/JScj6fJs03TZ/fZ1dJPlMjRAgTaxaS0fUBk8FV/A2rRgfPsVCZqALNwMexD+0Uaf5zlcKPpw==}


### PR DESCRIPTION
## Changes

- `@astrojs/react` and `@astrojs/preact` depend on `@babel/plugin-transform-react-jsx` which as `@babel/core` as a peerDependencies.
- When you install either integration you get what *looks* like an error message (it's actually a warning).

<img width="380" alt="Screen Shot 2022-07-14 at 2 15 51 PM" src="https://user-images.githubusercontent.com/361671/179053829-a25309c7-7227-4cb6-be9b-11b491eaf19a.png">

- This adds `@babel/core` as a dependency, fixing the issue.

## Testing

N/A

## Docs

N/A