### PR TITLE
[ci] Add docs and astro.build to smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,11 +187,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: withastro/docs
+          path: examples/.generated/astro-docs
 
       - name: Checkout astro.build
         uses: actions/checkout@v3
         with:
           repository: withastro/astro.build
+          path: examples/.generated/astro-build
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -206,7 +208,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
 
       - name: Build Packages
         run: pnpm run build

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "turbo run test --output-logs=new-only --concurrency=1",
     "test:match": "cd packages/astro && pnpm run test:match",
     "test:templates": "turbo run test --filter=create-astro --concurrency=1",
-    "test:smoke": "turbo run build --filter=\"@example/*\" --output-logs=new-only",
+    "test:smoke": "turbo run build --filter=\"@example/*\" --filter=\"astro.build\" --filter=\"docs\" --output-logs=new-only",
     "test:vite-ci": "turbo run test --output-logs=new-only --no-deps --scope=astro --concurrency=1",
     "test:e2e": "cd packages/astro && pnpm playwright install && pnpm run test:e2e",
     "test:e2e:match": "cd packages/astro && pnpm playwright install && pnpm run test:e2e:match",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
 packages:
   - 'packages/**/*'
   - 'examples/**/*'
-  - 'smoke/**/*'
   - 'scripts'


### PR DESCRIPTION
## Changes

- Add docs and astro.build to `examples/.generated` directory
- Add both repos to `test:smoke` filter
- Add back `--no-frozen-lockfile` flag 😢 

## Testing

New `test:smoke` filters

## Docs

N/A