### PR TITLE
fix: add export keyword to file stub

### DIFF
--- a/.changeset/cold-eyes-run.md
+++ b/.changeset/cold-eyes-run.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add export keyword to astro config file stub created by add cli command

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -38,7 +38,7 @@ const ALIASES = new Map([
 	['solid', 'solid-js'],
 	['tailwindcss', 'tailwind'],
 ]);
-const ASTRO_CONFIG_STUB = `import { defineConfig } from 'astro/config';\n\ndefault defineConfig({});`;
+const ASTRO_CONFIG_STUB = `import { defineConfig } from 'astro/config';\n\nexport default defineConfig({});`;
 const TAILWIND_CONFIG_STUB = `/** @type {import('tailwindcss').Config} */
 module.exports = {
 	content: ['./src/**/*.{astro,html,js,jsx,md,svelte,ts,tsx,vue}'],


### PR DESCRIPTION
## Changes

Adds missing export keyword to astro config file stub created by the add CLI command.

## Testing

Did not test explicitly, I think this is pretty self-explanatory. The add command seems to be experimental and not covered by tests.

## Docs

No docs change, bugfix.