### PR TITLE
Fix the alignment of errors when the source code used tab for indent

### DIFF
--- a/.changeset/warm-frogs-vanish.md
+++ b/.changeset/warm-frogs-vanish.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Fix the alignment of errors when the source code used tab for indentation

--- a/packages/astro/src/cli/check.ts
+++ b/packages/astro/src/cli/check.ts
@@ -93,7 +93,7 @@ export async function check(astroConfig: AstroConfig) {
 					let str = diag.text.substring(startOffset, endOffset - 1);
 					const lineNumStr = d.range.start.line.toString();
 					const lineNumLen = lineNumStr.length;
-					console.error(`${bgWhite(black(lineNumStr))}  ${str}`);
+					console.error(`${bgWhite(black(lineNumStr))}  ${str.replaceAll('\t', ' ')}`);
 					let tildes = generateString('~', d.range.end.character - d.range.start.character);
 					let spaces = generateString(' ', d.range.start.character + lineNumLen - 1);
 					console.error(`   ${spaces}${bold(red(tildes))}\n`);


### PR DESCRIPTION

Signed-off-by: Jeremy Wickersheimer <jwickers@gmail.com>

## Changes

Fix the alignment of errors when the source code used tab for indentation. See screenshots below.

- before
<img width="1311" alt="Screen Shot 2022-07-17 at 18 07 57" src="https://user-images.githubusercontent.com/199478/179393472-84c95265-3ad3-4bd3-b9c3-c7218349b04e.png">

- after
<img width="1366" alt="Screen Shot 2022-07-17 at 18 07 28" src="https://user-images.githubusercontent.com/199478/179393483-8fd2b2eb-ba8d-4b9f-9493-ff323c622ae8.png">

## Testing

Tested on my code base where the bug was noticed.

## Docs

Bugfix, no doc changes.