### PR TITLE
Inject vfile.data into markdown metadata

### DIFF
--- a/.changeset/witty-worms-reply.md
+++ b/.changeset/witty-worms-reply.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/markdown-remark': minor
+---
+
+Inject vfile.data into metadata
+
+`VFile` supports a `data` field that Remark / Rehype plugins can use to pass arbitrary metadata for other plugins to use. After content has been processed, this data is merged with `MarkdownMetadata`.

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astrojs/markdown-remark",
-  "version": "0.11.7",
+  "version": "0.12.0",
   "type": "module",
   "author": "withastro",
   "license": "MIT",

--- a/packages/markdown/remark/src/rehype-collect-headers.ts
+++ b/packages/markdown/remark/src/rehype-collect-headers.ts
@@ -4,70 +4,65 @@ import { visit } from 'unist-util-visit';
 
 import type { MarkdownHeader, RehypePlugin } from './types.js';
 
-export default function createCollectHeaders() {
+const slugger = new Slugger();
+
+export default function rehypeCollectHeaders(): ReturnType<RehypePlugin> {
 	const headers: MarkdownHeader[] = [];
-	const slugger = new Slugger();
+	return function (tree, vfile) {
+		visit(tree, (node) => {
+			if (node.type !== 'element') return;
+			const { tagName } = node;
+			if (tagName[0] !== 'h') return;
+			const [_, level] = tagName.match(/h([0-6])/) ?? [];
+			if (!level) return;
+			const depth = Number.parseInt(level);
 
-	function rehypeCollectHeaders(): ReturnType<RehypePlugin> {
-		return function (tree) {
-			visit(tree, (node) => {
-				if (node.type !== 'element') return;
-				const { tagName } = node;
-				if (tagName[0] !== 'h') return;
-				const [_, level] = tagName.match(/h([0-6])/) ?? [];
-				if (!level) return;
-				const depth = Number.parseInt(level);
-
-				let text = '';
-				let isJSX = false;
-				visit(node, (child, __, parent) => {
-					if (child.type === 'element' || parent == null) {
+			let text = '';
+			let isJSX = false;
+			visit(node, (child, __, parent) => {
+				if (child.type === 'element' || parent == null) {
+					return;
+				}
+				if (child.type === 'raw') {
+					if (child.value.match(/^\n?<.*>\n?$/)) {
 						return;
 					}
-					if (child.type === 'raw') {
-						if (child.value.match(/^\n?<.*>\n?$/)) {
-							return;
-						}
-					}
-					if (child.type === 'text' || child.type === 'raw') {
-						if (new Set(['code', 'pre']).has(parent.tagName)) {
-							text += child.value;
-						} else {
-							text += child.value.replace(/\{/g, '${');
-							isJSX = isJSX || child.value.includes('{');
-						}
-					}
-				});
-
-				node.properties = node.properties || {};
-				if (typeof node.properties.id !== 'string') {
-					if (isJSX) {
-						// HACK: serialized JSX from internal plugins, ignore these for slug
-						const raw = toHtml(node.children, { allowDangerousHtml: true })
-							.replace(/\n(<)/g, '<')
-							.replace(/(>)\n/g, '>');
-						// HACK: for ids that have JSX content, use $$slug helper to generate slug at runtime
-						node.properties.id = `$$slug(\`${text}\`)`;
-						(node as any).type = 'raw';
-						(
-							node as any
-						).value = `<${node.tagName} id={${node.properties.id}}>${raw}</${node.tagName}>`;
+				}
+				if (child.type === 'text' || child.type === 'raw') {
+					if (new Set(['code', 'pre']).has(parent.tagName)) {
+						text += child.value;
 					} else {
-						let slug = slugger.slug(text);
-
-						if (slug.endsWith('-')) slug = slug.slice(0, -1);
-
-						node.properties.id = slug;
+						text += child.value.replace(/\{/g, '${');
+						isJSX = isJSX || child.value.includes('{');
 					}
 				}
-
-				headers.push({ depth, slug: node.properties.id, text });
 			});
-		};
-	}
 
-	return {
-		headers,
-		rehypeCollectHeaders,
+			node.properties = node.properties || {};
+			if (typeof node.properties.id !== 'string') {
+				if (isJSX) {
+					// HACK: serialized JSX from internal plugins, ignore these for slug
+					const raw = toHtml(node.children, { allowDangerousHtml: true })
+						.replace(/\n(<)/g, '<')
+						.replace(/(>)\n/g, '>');
+					// HACK: for ids that have JSX content, use $$slug helper to generate slug at runtime
+					node.properties.id = `$$slug(\`${text}\`)`;
+					(node as any).type = 'raw';
+					(
+						node as any
+					).value = `<${node.tagName} id={${node.properties.id}}>${raw}</${node.tagName}>`;
+				} else {
+					let slug = slugger.slug(text);
+
+					if (slug.endsWith('-')) slug = slug.slice(0, -1);
+
+					node.properties.id = slug;
+				}
+			}
+
+			headers.push({ depth, slug: node.properties.id, text });
+		});
+
+		vfile.data.headers = headers;
 	};
 }

--- a/packages/markdown/remark/test/metadata.test.js
+++ b/packages/markdown/remark/test/metadata.test.js
@@ -1,0 +1,28 @@
+import { renderMarkdown } from '../dist/index.js';
+import chai, { expect } from 'chai';
+
+describe('metadata', () => {
+	it('should be able to extract all headings', async () => {
+		const { metadata } = await renderMarkdown(
+			`# Alpha
+			## Bravo
+			### Charlie
+			## Delta`, 
+			{}
+		);
+
+		const expectedHeaders = [
+			{ depth: 1, slug: 'alpha', text: 'Alpha' },
+			{ depth: 2, slug: 'bravo', text: 'Bravo' },
+			{ depth: 3, slug: 'charlie', text: 'Charlie' },
+			{ depth: 2, slug: 'delta', text: 'Delta' }
+		];
+
+		chai.expect(metadata.headers).to.deep.equal(expectedHeaders);
+	});
+
+	it('should have empty headers when content has no headings', async () => {
+		const { metadata } = await renderMarkdown(`*emphasized*`, {});
+		chai.expect(metadata.headers).to.be.empty;
+	});
+});


### PR DESCRIPTION
## Changes

- `VFile` supports a `data` field that Remark / Rehype plugins can use to pass arbitrary metadata for other plugins to use. After content has been processed, this data is merged with `MarkdownMetadata`.
- This should allow metadata enrichment by plugins like [rehype-infer-reading-time-meta](https://github.com/rehypejs/rehype-infer-reading-time-meta)

## Testing

- Unit tests added in `metadata.test.js` to verify the positive and negative cases.

## Docs

https://github.com/withastro/docs/pull/1023