### PR TITLE
Fix expected types for Element in our JSX definitions

### DIFF
--- a/.changeset/nice-toes-cough.md
+++ b/.changeset/nice-toes-cough.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix JSX definitions being too strict as to what an element is, which lead to type issues in certain cases (Markdown imports, JSX components etc)

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -10,7 +10,6 @@
  * @see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts
  */
 declare namespace astroHTML.JSX {
-	/* html jsx */
 	export type Child = Node | Node[] | string | number | boolean | null | undefined | unknown;
 	export type Children = Child | Child[];
 
@@ -24,17 +23,18 @@ declare namespace astroHTML.JSX {
 		children?: Children;
 	}
 
-	type AstroBuiltinProps = import('astro').AstroBuiltinProps;
-	type AstroBuiltinAttributes = import('astro').AstroBuiltinAttributes;
-	type AstroDefineVarsAttribute = import('astro').AstroDefineVarsAttribute;
-	type AstroScriptAttributes = import('astro').AstroScriptAttributes & AstroDefineVarsAttribute;
-	type AstroStyleAttributes = import('astro').AstroStyleAttributes & AstroDefineVarsAttribute;
+	type AstroBuiltinProps = import('./dist/types/@types/astro').AstroBuiltinProps;
+	type AstroBuiltinAttributes = import('./dist/types/@types/astro').AstroBuiltinAttributes;
+	type AstroDefineVarsAttribute = import('./dist/types/@types/astro').AstroDefineVarsAttribute;
+	type AstroScriptAttributes = import('./dist/types/@types/astro').AstroScriptAttributes &
+		AstroDefineVarsAttribute;
+	type AstroStyleAttributes = import('./dist/types/@types/astro').AstroStyleAttributes &
+		AstroDefineVarsAttribute;
 
-	// Certain Astro methods returns AstroComponent using AstroComponentFactory
-	// The language-server does not really like this because it expects Elements to
-	// all be compatible with HTMLElement so we'll add AstroComponentFactory as a valid element type
-	type AstroComponent = import('astro').AstroComponentFactory;
-	type Element = HTMLElement | AstroComponent;
+	// This is an unfortunate use of `any`, but unfortunately we can't make a type that works for every framework
+	// without importing every single framework's types (which comes with its own set of problems).
+	// Using any isn't that bad here however as in Astro files the return type of a component isn't relevant in most cases
+	type Element = HTMLElement | any;
 
 	interface DOMAttributes {
 		children?: Children;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -16,7 +16,6 @@ import type { AstroConfigSchema } from '../core/config';
 import type { ViteConfigWithSSR } from '../core/create-vite';
 import type { AstroComponentFactory, Metadata } from '../runtime/server';
 export type { SSRManifest } from '../core/app/types';
-export type { AstroComponentFactory } from '../runtime/server';
 
 export interface AstroBuiltinProps {
 	'client:load'?: boolean;


### PR DESCRIPTION
## Changes

In a recent PR we fixed an import to `AstroComponentFactory`, this had the side effect of making our expected type for `Element` too strict (due to TypeScript weirdness), which lead to users encountering errors when using JSX frameworks

Also, this PR fixes the JSX definitions not working properly in the monorepo (finally!)

Fix https://github.com/withastro/astro/issues/3945


## Testing

 Tested manually, also ran the language-server test suite with this changes and everything passed

## Docs

N/A