### PR TITLE
<Picture> component should pass all unknown attributes to the <img> element

### DIFF
--- a/.changeset/chatty-bikes-sin.md
+++ b/.changeset/chatty-bikes-sin.md
@@ -2,4 +2,4 @@
 '@astrojs/image': patch
 ---
 
-Updates the <Picture /> component to pass all unrecognized attributes down to the <img> element
+Updates the <Picture /> component to pass the `alt` attribute down to the <img> element

--- a/.changeset/chatty-bikes-sin.md
+++ b/.changeset/chatty-bikes-sin.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Updates the <Picture /> component to pass all unrecognized attributes down to the <img> element

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -179,8 +179,6 @@ description: Just a Hello World Post!
 
   For remote images, an `aspectRatio` is required to ensure the correct `height` can be calculated at build time.
 
-  Do you need to add attributes to the picture's `<img>` element? Just add them to the `<Picture />`! Any unrecognized props will be added directly to the `<img>` element.
-
 ```html
 ---
 import { Picture } from '@astrojs/image';
@@ -190,16 +188,13 @@ const imageUrl = 'https://www.google.com/images/branding/googlelogo/2x/googlelog
 ---
 
 // Local image with multiple sizes
-<Picture src={hero} widths={[200, 400, 800]} sizes="(max-width: 800px) 100vw, 800px" />
+<Picture src={hero} widths={[200, 400, 800]} sizes="(max-width: 800px) 100vw, 800px" alt="My hero image" />
 
 // Remote image (aspect ratio is required)
-<Picture src={imageUrl} widths={[200, 400, 800]} aspectRatio="4:3" sizes="(max-width: 800px) 100vw, 800px" />
+<Picture src={imageUrl} widths={[200, 400, 800]} aspectRatio="4:3" sizes="(max-width: 800px) 100vw, 800px" alt="My hero image" />
 
 // Inlined imports are supported
-<Picture src={import("../assets/hero.png")} widths={[200, 400, 800]} sizes="(max-width: 800px) 100vw, 800px" />
-
-// Add alt and class attributes to the <img>
-<Picture src={hero} widths={[200, 400, 800]} sizes="(max-width: 800px) 100vw, 800px" alt="My awesome image" class="my-hero" />
+<Picture src={import("../assets/hero.png")} widths={[200, 400, 800]} sizes="(max-width: 800px) 100vw, 800px" alt="My hero image" />
 ```
 
 </details>

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -179,6 +179,8 @@ description: Just a Hello World Post!
 
   For remote images, an `aspectRatio` is required to ensure the correct `height` can be calculated at build time.
 
+  Do you need to add attributes to the picture's `<img>` element? Just add them to the `<Picture />`! Any unrecognized props will be added directly to the `<img>` element.
+
 ```html
 ---
 import { Picture } from '@astrojs/image';
@@ -195,6 +197,9 @@ const imageUrl = 'https://www.google.com/images/branding/googlelogo/2x/googlelog
 
 // Inlined imports are supported
 <Picture src={import("../assets/hero.png")} widths={[200, 400, 800]} sizes="(max-width: 800px) 100vw, 800px" />
+
+// Add alt and class attributes to the <img>
+<Picture src={hero} widths={[200, 400, 800]} sizes="(max-width: 800px) 100vw, 800px" alt="My awesome image" class="my-hero" />
 ```
 
 </details>

--- a/packages/integrations/image/components/Picture.astro
+++ b/packages/integrations/image/components/Picture.astro
@@ -4,15 +4,17 @@ import loader from 'virtual:image-loader';
 import { getPicture } from '../src/get-picture.js';
 import type { ImageAttributes, ImageMetadata, OutputFormat, PictureAttributes, TransformOptions } from '../src/types.js';
 
-export interface LocalImageProps extends Omit<PictureAttributes, 'src' | 'width' | 'height'>, Omit<TransformOptions, 'src'>, Omit<ImageAttributes, 'src' | 'width' | 'height'> {
+export interface LocalImageProps extends Omit<PictureAttributes, 'src' | 'width' | 'height'>, Omit<TransformOptions, 'src'>, Pick<ImageAttributes, 'loading' | 'decoding'> {
 	src: ImageMetadata | Promise<{ default: ImageMetadata }>;
+	alt?: string;
 	sizes: HTMLImageElement['sizes'];
 	widths: number[];
 	formats?: OutputFormat[];
 }
 
-export interface RemoteImageProps extends Omit<PictureAttributes, 'src' | 'width' | 'height'>, TransformOptions, Omit<ImageAttributes, 'src' | 'width' | 'height'> {
+export interface RemoteImageProps extends Omit<PictureAttributes, 'src' | 'width' | 'height'>, TransformOptions, Pick<ImageAttributes, 'loading' | 'decoding'> {
 	src: string;
+	alt?: string;
 	sizes: HTMLImageElement['sizes'];
 	widths: number[];
 	aspectRatio: TransformOptions['aspectRatio'];
@@ -21,7 +23,7 @@ export interface RemoteImageProps extends Omit<PictureAttributes, 'src' | 'width
 
 export type Props = LocalImageProps | RemoteImageProps;
 
-const { src, sizes, widths, aspectRatio, formats = ['avif', 'webp'], loading = 'lazy', decoding = 'async', ...attrs } = Astro.props as Props;
+const { src, alt, sizes, widths, aspectRatio, formats = ['avif', 'webp'], loading = 'lazy', decoding = 'async', ...attrs } = Astro.props as Props;
 
 const { image, sources } = await getPicture({ loader, src, widths, formats, aspectRatio });
 ---
@@ -29,7 +31,7 @@ const { image, sources } = await getPicture({ loader, src, widths, formats, aspe
 <picture {...attrs}>
 	{sources.map(attrs => (
 	<source {...attrs} {sizes}>))}
-	<img {...image} {loading} {decoding} />
+	<img {...image} {loading} {decoding} {alt} />
 </picture>
 
 <style>

--- a/packages/integrations/image/components/Picture.astro
+++ b/packages/integrations/image/components/Picture.astro
@@ -4,14 +4,14 @@ import loader from 'virtual:image-loader';
 import { getPicture } from '../src/get-picture.js';
 import type { ImageAttributes, ImageMetadata, OutputFormat, PictureAttributes, TransformOptions } from '../src/types.js';
 
-export interface LocalImageProps extends Omit<PictureAttributes, 'src' | 'width' | 'height'>, Omit<TransformOptions, 'src'>, Omit<ImageAttributes, 'src' | 'width' | 'height'> {
+export interface LocalImageProps extends Omit<TransformOptions, 'src'>, Omit<ImageAttributes, 'src' | 'width' | 'height'> {
 	src: ImageMetadata | Promise<{ default: ImageMetadata }>;
 	sizes: HTMLImageElement['sizes'];
 	widths: number[];
 	formats?: OutputFormat[];
 }
 
-export interface RemoteImageProps extends Omit<PictureAttributes, 'src' | 'width' | 'height'>, TransformOptions, Omit<ImageAttributes, 'src' | 'width' | 'height'> {
+export interface RemoteImageProps extends TransformOptions, Omit<ImageAttributes, 'src' | 'width' | 'height'> {
 	src: string;
 	sizes: HTMLImageElement['sizes'];
 	widths: number[];
@@ -26,10 +26,10 @@ const { src, sizes, widths, aspectRatio, formats = ['avif', 'webp'], loading = '
 const { image, sources } = await getPicture({ loader, src, widths, formats, aspectRatio });
 ---
 
-<picture {...attrs}>
+<picture>
 	{sources.map(attrs => (
 	<source {...attrs} {sizes}>))}
-	<img {...image} {loading} {decoding} />
+	<img {...image} {...attrs} {loading} {decoding} />
 </picture>
 
 <style>

--- a/packages/integrations/image/components/Picture.astro
+++ b/packages/integrations/image/components/Picture.astro
@@ -4,14 +4,14 @@ import loader from 'virtual:image-loader';
 import { getPicture } from '../src/get-picture.js';
 import type { ImageAttributes, ImageMetadata, OutputFormat, PictureAttributes, TransformOptions } from '../src/types.js';
 
-export interface LocalImageProps extends Omit<TransformOptions, 'src'>, Omit<ImageAttributes, 'src' | 'width' | 'height'> {
+export interface LocalImageProps extends Omit<PictureAttributes, 'src' | 'width' | 'height'>, Omit<TransformOptions, 'src'>, Omit<ImageAttributes, 'src' | 'width' | 'height'> {
 	src: ImageMetadata | Promise<{ default: ImageMetadata }>;
 	sizes: HTMLImageElement['sizes'];
 	widths: number[];
 	formats?: OutputFormat[];
 }
 
-export interface RemoteImageProps extends TransformOptions, Omit<ImageAttributes, 'src' | 'width' | 'height'> {
+export interface RemoteImageProps extends Omit<PictureAttributes, 'src' | 'width' | 'height'>, TransformOptions, Omit<ImageAttributes, 'src' | 'width' | 'height'> {
 	src: string;
 	sizes: HTMLImageElement['sizes'];
 	widths: number[];
@@ -26,10 +26,10 @@ const { src, sizes, widths, aspectRatio, formats = ['avif', 'webp'], loading = '
 const { image, sources } = await getPicture({ loader, src, widths, formats, aspectRatio });
 ---
 
-<picture>
+<picture {...attrs}>
 	{sources.map(attrs => (
 	<source {...attrs} {sizes}>))}
-	<img {...image} {...attrs} {loading} {decoding} />
+	<img {...image} {loading} {decoding} />
 </picture>
 
 <style>

--- a/packages/integrations/image/test/fixtures/basic-picture/src/pages/index.astro
+++ b/packages/integrations/image/test/fixtures/basic-picture/src/pages/index.astro
@@ -8,10 +8,10 @@ import { Picture } from '@astrojs/image';
     <!-- Head Stuff -->
   </head>
   <body>
-		<Picture id="social-jpg" src={socialJpg} sizes="(min-width: 640px) 50vw, 100vw" widths={[253, 506]} />
+		<Picture id="social-jpg" src={socialJpg} sizes="(min-width: 640px) 50vw, 100vw" widths={[253, 506]} alt="Social image" />
 		<br />
-		<Picture id="google" src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png" sizes="(min-width: 640px) 50vw, 100vw" widths={[272, 544]} aspectRatio={544/184} />
+		<Picture id="google" src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png" sizes="(min-width: 640px) 50vw, 100vw" widths={[272, 544]} aspectRatio={544/184} alt="Google logo" />
 		<br />
-		<Picture id='inline' src={import('../assets/social.jpg')} sizes="(min-width: 640px) 50vw, 100vw" widths={[253, 506]} />
+		<Picture id='inline' src={import('../assets/social.jpg')} sizes="(min-width: 640px) 50vw, 100vw" widths={[253, 506]} alt="Inline social image" />
   </body>
 </html>

--- a/packages/integrations/image/test/picture-ssg.test.js
+++ b/packages/integrations/image/test/picture-ssg.test.js
@@ -38,7 +38,8 @@ describe('SSG pictures', function () {
 
 		describe('Local images', () => {
 			it('includes sources', () => {
-				const sources = $('#social-jpg source');
+				const picture = $('#social-jpg').parent('picture');
+				const sources = picture.children('source');
 
 				expect(sources.length).to.equal(3);
 
@@ -46,7 +47,7 @@ describe('SSG pictures', function () {
 			});
 
 			it('includes src, width, and height attributes', () => {
-				const image = $('#social-jpg img');
+				const image = $('#social-jpg');
 
 				expect(image.attr('src')).to.equal('/_image/assets/social_506x253.jpg');
 				expect(image.attr('width')).to.equal('506');
@@ -65,7 +66,8 @@ describe('SSG pictures', function () {
 
 		describe('Inline imports', () => {
 			it('includes sources', () => {
-				const sources = $('#inline source');
+				const picture = $('#inline').parent('picture');
+				const sources = picture.children('source');
 
 				expect(sources.length).to.equal(3);
 
@@ -73,7 +75,7 @@ describe('SSG pictures', function () {
 			});
 
 			it('includes src, width, and height attributes', () => {
-				const image = $('#inline img');
+				const image = $('#inline');
 
 				expect(image.attr('src')).to.equal('/_image/assets/social_506x253.jpg');
 				expect(image.attr('width')).to.equal('506');
@@ -96,7 +98,8 @@ describe('SSG pictures', function () {
 			const HASH = 'Z1iI4xW';
 
 			it('includes sources', () => {
-				const sources = $('#google source');
+				const picture = $('#google').parent('picture');
+				const sources = picture.children('source');
 
 				expect(sources.length).to.equal(3);
 
@@ -104,7 +107,7 @@ describe('SSG pictures', function () {
 			});
 
 			it('includes src, width, and height attributes', () => {
-				const image = $('#google img');
+				const image = $('#google');
 
 				expect(image.attr('src')).to.equal(`/_image/googlelogo_color_272x92dp-${HASH}_544x184.png`);
 				expect(image.attr('width')).to.equal('544');
@@ -162,7 +165,8 @@ describe('SSG pictures', function () {
 
 		describe('Local images', () => {
 			it('includes sources', () => {
-				const sources = $('#social-jpg source');
+				const picture = $('#social-jpg').parent('picture');
+				const sources = picture.children('source');
 
 				expect(sources.length).to.equal(3);
 
@@ -170,7 +174,7 @@ describe('SSG pictures', function () {
 			});
 
 			it('includes src, width, and height attributes', () => {
-				const image = $('#social-jpg img');
+				const image = $('#social-jpg');
 
 				const src = image.attr('src');
 				const [route, params] = src.split('?');
@@ -187,7 +191,7 @@ describe('SSG pictures', function () {
 			});
 
 			it('returns the optimized image', async () => {
-				const image = $('#social-jpg img');
+				const image = $('#social-jpg');
 
 				const res = await fixture.fetch(image.attr('src'));
 
@@ -200,7 +204,8 @@ describe('SSG pictures', function () {
 
 		describe('Local images with inline imports', () => {
 			it('includes sources', () => {
-				const sources = $('#inline source');
+				const picture = $('#inline').parent('picture');
+				const sources = picture.children('source');
 
 				expect(sources.length).to.equal(3);
 
@@ -208,7 +213,7 @@ describe('SSG pictures', function () {
 			});
 
 			it('includes src, width, and height attributes', () => {
-				const image = $('#inline img');
+				const image = $('#inline');
 
 				const src = image.attr('src');
 				const [route, params] = src.split('?');
@@ -225,7 +230,7 @@ describe('SSG pictures', function () {
 			});
 
 			it('returns the optimized image', async () => {
-				const image = $('#inline img');
+				const image = $('#inline');
 
 				const res = await fixture.fetch(image.attr('src'));
 
@@ -238,7 +243,8 @@ describe('SSG pictures', function () {
 
 		describe('Remote images', () => {
 			it('includes sources', () => {
-				const sources = $('#google source');
+				const picture = $('#google').parent('picture');
+				const sources = picture.children('source');
 
 				expect(sources.length).to.equal(3);
 
@@ -246,7 +252,7 @@ describe('SSG pictures', function () {
 			});
 
 			it('includes src, width, and height attributes', () => {
-				const image = $('#google img');
+				const image = $('#google');
 
 				const src = image.attr('src');
 				const [route, params] = src.split('?');

--- a/packages/integrations/image/test/picture-ssg.test.js
+++ b/packages/integrations/image/test/picture-ssg.test.js
@@ -46,12 +46,13 @@ describe('SSG pictures', function () {
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes src, width, and height attributes', () => {
+			it('includes <img> attributes', () => {
 				const image = $('#social-jpg');
 
 				expect(image.attr('src')).to.equal('/_image/assets/social_506x253.jpg');
 				expect(image.attr('width')).to.equal('506');
 				expect(image.attr('height')).to.equal('253');
+				expect(image.attr('alt')).to.equal('Social image');
 			});
 
 			it('built the optimized image', () => {
@@ -74,12 +75,13 @@ describe('SSG pictures', function () {
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes src, width, and height attributes', () => {
+			it('includes <img> attributes', () => {
 				const image = $('#inline');
 
 				expect(image.attr('src')).to.equal('/_image/assets/social_506x253.jpg');
 				expect(image.attr('width')).to.equal('506');
 				expect(image.attr('height')).to.equal('253');
+				expect(image.attr('alt')).to.equal('Inline social image');
 			});
 
 			it('built the optimized image', () => {
@@ -106,12 +108,13 @@ describe('SSG pictures', function () {
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes src, width, and height attributes', () => {
+			it('includes <img> attributes', () => {
 				const image = $('#google');
 
 				expect(image.attr('src')).to.equal(`/_image/googlelogo_color_272x92dp-${HASH}_544x184.png`);
 				expect(image.attr('width')).to.equal('544');
 				expect(image.attr('height')).to.equal('184');
+				expect(image.attr('alt')).to.equal('Google logo');
 			});
 
 			it('built the optimized image', () => {
@@ -173,7 +176,7 @@ describe('SSG pictures', function () {
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes src, width, and height attributes', () => {
+			it('includes <img> attributes', () => {
 				const image = $('#social-jpg');
 
 				const src = image.attr('src');
@@ -188,6 +191,7 @@ describe('SSG pictures', function () {
 				expect(searchParams.get('h')).to.equal('253');
 				// TODO: possible to avoid encoding the full image path?
 				expect(searchParams.get('href').endsWith('/assets/social.jpg')).to.equal(true);
+				expect(image.attr('alt')).to.equal('Social image');
 			});
 
 			it('returns the optimized image', async () => {
@@ -212,7 +216,7 @@ describe('SSG pictures', function () {
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes src, width, and height attributes', () => {
+			it('includes <img> attributes', () => {
 				const image = $('#inline');
 
 				const src = image.attr('src');
@@ -227,6 +231,7 @@ describe('SSG pictures', function () {
 				expect(searchParams.get('h')).to.equal('253');
 				// TODO: possible to avoid encoding the full image path?
 				expect(searchParams.get('href').endsWith('/assets/social.jpg')).to.equal(true);
+				expect(image.attr('alt')).to.equal('Inline social image');
 			});
 
 			it('returns the optimized image', async () => {
@@ -251,7 +256,7 @@ describe('SSG pictures', function () {
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes src, width, and height attributes', () => {
+			it('includes <img> attributes', () => {
 				const image = $('#google');
 
 				const src = image.attr('src');
@@ -267,6 +272,7 @@ describe('SSG pictures', function () {
 				expect(searchParams.get('href')).to.equal(
 					'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png'
 				);
+				expect(image.attr('alt')).to.equal('Google logo');
 			});
 		});
 	});

--- a/packages/integrations/image/test/picture-ssg.test.js
+++ b/packages/integrations/image/test/picture-ssg.test.js
@@ -45,7 +45,7 @@ describe('SSG pictures', function () {
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes src, width, and height attributes', () => {
+			it('includes <img> attributes', () => {
 				const image = $('#social-jpg img');
 
 				expect(image.attr('src')).to.equal('/_image/assets/social_506x253.jpg');
@@ -73,7 +73,7 @@ describe('SSG pictures', function () {
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes src, width, and height attributes', () => {
+			it('includes <img> attributes', () => {
 				const image = $('#inline img');
 
 				expect(image.attr('src')).to.equal('/_image/assets/social_506x253.jpg');
@@ -105,7 +105,7 @@ describe('SSG pictures', function () {
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes src, width, and height attributes', () => {
+			it('includes <img> attributes', () => {
 				const image = $('#google img');
 
 				expect(image.attr('src')).to.equal(`/_image/googlelogo_color_272x92dp-${HASH}_544x184.png`);
@@ -172,7 +172,7 @@ describe('SSG pictures', function () {
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes src, width, and height attributes', () => {
+			it('includes <img> attributes', () => {
 				const image = $('#social-jpg img');
 
 				const src = image.attr('src');
@@ -211,7 +211,7 @@ describe('SSG pictures', function () {
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes src, width, and height attributes', () => {
+			it('includes <img> attributes', () => {
 				const image = $('#inline img');
 
 				const src = image.attr('src');
@@ -250,7 +250,7 @@ describe('SSG pictures', function () {
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes src, width, and height attributes', () => {
+			it('includes <img> attributes', () => {
 				const image = $('#google img');
 
 				const src = image.attr('src');

--- a/packages/integrations/image/test/picture-ssg.test.js
+++ b/packages/integrations/image/test/picture-ssg.test.js
@@ -38,16 +38,15 @@ describe('SSG pictures', function () {
 
 		describe('Local images', () => {
 			it('includes sources', () => {
-				const picture = $('#social-jpg').parent('picture');
-				const sources = picture.children('source');
+				const sources = $('#social-jpg source');
 
 				expect(sources.length).to.equal(3);
 
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes <img> attributes', () => {
-				const image = $('#social-jpg');
+			it('includes src, width, and height attributes', () => {
+				const image = $('#social-jpg img');
 
 				expect(image.attr('src')).to.equal('/_image/assets/social_506x253.jpg');
 				expect(image.attr('width')).to.equal('506');
@@ -67,16 +66,15 @@ describe('SSG pictures', function () {
 
 		describe('Inline imports', () => {
 			it('includes sources', () => {
-				const picture = $('#inline').parent('picture');
-				const sources = picture.children('source');
+				const sources = $('#inline source');
 
 				expect(sources.length).to.equal(3);
 
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes <img> attributes', () => {
-				const image = $('#inline');
+			it('includes src, width, and height attributes', () => {
+				const image = $('#inline img');
 
 				expect(image.attr('src')).to.equal('/_image/assets/social_506x253.jpg');
 				expect(image.attr('width')).to.equal('506');
@@ -100,16 +98,15 @@ describe('SSG pictures', function () {
 			const HASH = 'Z1iI4xW';
 
 			it('includes sources', () => {
-				const picture = $('#google').parent('picture');
-				const sources = picture.children('source');
+				const sources = $('#google source');
 
 				expect(sources.length).to.equal(3);
 
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes <img> attributes', () => {
-				const image = $('#google');
+			it('includes src, width, and height attributes', () => {
+				const image = $('#google img');
 
 				expect(image.attr('src')).to.equal(`/_image/googlelogo_color_272x92dp-${HASH}_544x184.png`);
 				expect(image.attr('width')).to.equal('544');
@@ -168,16 +165,15 @@ describe('SSG pictures', function () {
 
 		describe('Local images', () => {
 			it('includes sources', () => {
-				const picture = $('#social-jpg').parent('picture');
-				const sources = picture.children('source');
+				const sources = $('#social-jpg source');
 
 				expect(sources.length).to.equal(3);
 
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes <img> attributes', () => {
-				const image = $('#social-jpg');
+			it('includes src, width, and height attributes', () => {
+				const image = $('#social-jpg img');
 
 				const src = image.attr('src');
 				const [route, params] = src.split('?');
@@ -195,7 +191,7 @@ describe('SSG pictures', function () {
 			});
 
 			it('returns the optimized image', async () => {
-				const image = $('#social-jpg');
+				const image = $('#social-jpg img');
 
 				const res = await fixture.fetch(image.attr('src'));
 
@@ -208,16 +204,15 @@ describe('SSG pictures', function () {
 
 		describe('Local images with inline imports', () => {
 			it('includes sources', () => {
-				const picture = $('#inline').parent('picture');
-				const sources = picture.children('source');
+				const sources = $('#inline source');
 
 				expect(sources.length).to.equal(3);
 
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes <img> attributes', () => {
-				const image = $('#inline');
+			it('includes src, width, and height attributes', () => {
+				const image = $('#inline img');
 
 				const src = image.attr('src');
 				const [route, params] = src.split('?');
@@ -235,7 +230,7 @@ describe('SSG pictures', function () {
 			});
 
 			it('returns the optimized image', async () => {
-				const image = $('#inline');
+				const image = $('#inline img');
 
 				const res = await fixture.fetch(image.attr('src'));
 
@@ -248,16 +243,15 @@ describe('SSG pictures', function () {
 
 		describe('Remote images', () => {
 			it('includes sources', () => {
-				const picture = $('#google').parent('picture');
-				const sources = picture.children('source');
+				const sources = $('#google source');
 
 				expect(sources.length).to.equal(3);
 
 				// TODO: better coverage to verify source props
 			});
 
-			it('includes <img> attributes', () => {
-				const image = $('#google');
+			it('includes src, width, and height attributes', () => {
+				const image = $('#google img');
 
 				const src = image.attr('src');
 				const [route, params] = src.split('?');

--- a/packages/integrations/image/test/picture-ssr.test.js
+++ b/packages/integrations/image/test/picture-ssr.test.js
@@ -26,7 +26,8 @@ describe('SSR pictures - build', function () {
 			const html = await response.text();
 			const $ = cheerio.load(html);
 
-			const sources = $('#social-jpg source');
+			const picture = $('#social-jpg').parent('picture');
+			const sources = picture.children('source');
 
 			expect(sources.length).to.equal(3);
 
@@ -41,7 +42,7 @@ describe('SSR pictures - build', function () {
 			const html = await response.text();
 			const $ = cheerio.load(html);
 
-			const image = $('#social-jpg img');
+			const image = $('#social-jpg');
 
 			const src = image.attr('src');
 			const [route, params] = src.split('?');
@@ -66,7 +67,7 @@ describe('SSR pictures - build', function () {
 			const html = await response.text();
 			const $ = cheerio.load(html);
 
-			const image = $('#social-jpg img');
+			const image = $('#social-jpg');
 
 			const res = await fixture.fetch(image.attr('src'));
 
@@ -86,7 +87,8 @@ describe('SSR pictures - build', function () {
 			const html = await response.text();
 			const $ = cheerio.load(html);
 
-			const sources = $('#inline source');
+			const picture = $('#inline').parent('picture');
+			const sources = picture.children('source');
 
 			expect(sources.length).to.equal(3);
 
@@ -101,7 +103,7 @@ describe('SSR pictures - build', function () {
 			const html = await response.text();
 			const $ = cheerio.load(html);
 
-			const image = $('#inline img');
+			const image = $('#inline');
 
 			const src = image.attr('src');
 			const [route, params] = src.split('?');
@@ -127,7 +129,8 @@ describe('SSR pictures - build', function () {
 			const html = await response.text();
 			const $ = cheerio.load(html);
 
-			const sources = $('#google source');
+			const picture = $('#google').parent('picture');
+			const sources = picture.children('source');
 
 			expect(sources.length).to.equal(3);
 
@@ -142,7 +145,7 @@ describe('SSR pictures - build', function () {
 			const html = await response.text();
 			const $ = cheerio.load(html);
 
-			const image = $('#google img');
+			const image = $('#google');
 
 			const src = image.attr('src');
 			const [route, params] = src.split('?');
@@ -185,7 +188,8 @@ describe('SSR images - dev', function () {
 
 	describe('Local images', () => {
 		it('includes sources', () => {
-			const sources = $('#social-jpg source');
+			const picture = $('#social-jpg').parent('picture');
+			const sources = picture.children('source');
 
 			expect(sources.length).to.equal(3);
 
@@ -193,7 +197,7 @@ describe('SSR images - dev', function () {
 		});
 
 		it('includes src, width, and height attributes', () => {
-			const image = $('#social-jpg img');
+			const image = $('#social-jpg');
 
 			const src = image.attr('src');
 			const [route, params] = src.split('?');
@@ -210,7 +214,7 @@ describe('SSR images - dev', function () {
 		});
 
 		it('returns the optimized image', async () => {
-			const image = $('#social-jpg img');
+			const image = $('#social-jpg');
 
 			const res = await fixture.fetch(image.attr('src'));
 
@@ -223,7 +227,8 @@ describe('SSR images - dev', function () {
 
 	describe('Inline imports', () => {
 		it('includes sources', () => {
-			const sources = $('#inline source');
+			const picture = $('#inline').parent('picture');
+			const sources = picture.children('source');
 
 			expect(sources.length).to.equal(3);
 
@@ -231,7 +236,7 @@ describe('SSR images - dev', function () {
 		});
 
 		it('includes src, width, and height attributes', () => {
-			const image = $('#inline img');
+			const image = $('#inline');
 
 			const src = image.attr('src');
 			const [route, params] = src.split('?');
@@ -250,7 +255,8 @@ describe('SSR images - dev', function () {
 
 	describe('Remote images', () => {
 		it('includes sources', () => {
-			const sources = $('#google source');
+			const picture = $('#google').parent('picture');
+			const sources = picture.children('source');
 
 			expect(sources.length).to.equal(3);
 
@@ -258,7 +264,7 @@ describe('SSR images - dev', function () {
 		});
 
 		it('includes src, width, and height attributes', () => {
-			const image = $('#google img');
+			const image = $('#google');
 
 			const src = image.attr('src');
 			const [route, params] = src.split('?');

--- a/packages/integrations/image/test/picture-ssr.test.js
+++ b/packages/integrations/image/test/picture-ssr.test.js
@@ -26,8 +26,7 @@ describe('SSR pictures - build', function () {
 			const html = await response.text();
 			const $ = cheerio.load(html);
 
-			const picture = $('#social-jpg').parent('picture');
-			const sources = picture.children('source');
+			const sources = $('#social-jpg source');
 
 			expect(sources.length).to.equal(3);
 
@@ -42,7 +41,7 @@ describe('SSR pictures - build', function () {
 			const html = await response.text();
 			const $ = cheerio.load(html);
 
-			const image = $('#social-jpg');
+			const image = $('#social-jpg img');
 
 			const src = image.attr('src');
 			const [route, params] = src.split('?');
@@ -68,7 +67,7 @@ describe('SSR pictures - build', function () {
 			const html = await response.text();
 			const $ = cheerio.load(html);
 
-			const image = $('#social-jpg');
+			const image = $('#social-jpg img');
 
 			const res = await fixture.fetch(image.attr('src'));
 
@@ -88,8 +87,7 @@ describe('SSR pictures - build', function () {
 			const html = await response.text();
 			const $ = cheerio.load(html);
 
-			const picture = $('#inline').parent('picture');
-			const sources = picture.children('source');
+			const sources = $('#inline source');
 
 			expect(sources.length).to.equal(3);
 
@@ -104,7 +102,7 @@ describe('SSR pictures - build', function () {
 			const html = await response.text();
 			const $ = cheerio.load(html);
 
-			const image = $('#inline');
+			const image = $('#inline img');
 
 			const src = image.attr('src');
 			const [route, params] = src.split('?');
@@ -131,8 +129,7 @@ describe('SSR pictures - build', function () {
 			const html = await response.text();
 			const $ = cheerio.load(html);
 
-			const picture = $('#google').parent('picture');
-			const sources = picture.children('source');
+			const sources = $('#google source');
 
 			expect(sources.length).to.equal(3);
 
@@ -147,7 +144,7 @@ describe('SSR pictures - build', function () {
 			const html = await response.text();
 			const $ = cheerio.load(html);
 
-			const image = $('#google');
+			const image = $('#google img');
 
 			const src = image.attr('src');
 			const [route, params] = src.split('?');
@@ -191,16 +188,15 @@ describe('SSR images - dev', function () {
 
 	describe('Local images', () => {
 		it('includes sources', () => {
-			const picture = $('#social-jpg').parent('picture');
-			const sources = picture.children('source');
+			const sources = $('#social-jpg source');
 
 			expect(sources.length).to.equal(3);
 
 			// TODO: better coverage to verify source props
 		});
 
-		it('includes <img> attributes', () => {
-			const image = $('#social-jpg');
+		it('includes src, width, and height attributes', () => {
+			const image = $('#social-jpg img');
 
 			const src = image.attr('src');
 			const [route, params] = src.split('?');
@@ -218,7 +214,7 @@ describe('SSR images - dev', function () {
 		});
 
 		it('returns the optimized image', async () => {
-			const image = $('#social-jpg');
+			const image = $('#social-jpg img');
 
 			const res = await fixture.fetch(image.attr('src'));
 
@@ -231,16 +227,15 @@ describe('SSR images - dev', function () {
 
 	describe('Inline imports', () => {
 		it('includes sources', () => {
-			const picture = $('#inline').parent('picture');
-			const sources = picture.children('source');
+			const sources = $('#inline source');
 
 			expect(sources.length).to.equal(3);
 
 			// TODO: better coverage to verify source props
 		});
 
-		it('includes <img> attributes', () => {
-			const image = $('#inline');
+		it('includes src, width, and height attributes', () => {
+			const image = $('#inline img');
 
 			const src = image.attr('src');
 			const [route, params] = src.split('?');
@@ -260,16 +255,15 @@ describe('SSR images - dev', function () {
 
 	describe('Remote images', () => {
 		it('includes sources', () => {
-			const picture = $('#google').parent('picture');
-			const sources = picture.children('source');
+			const sources = $('#google source');
 
 			expect(sources.length).to.equal(3);
 
 			// TODO: better coverage to verify source props
 		});
 
-		it('includes <img> attributes', () => {
-			const image = $('#google');
+		it('includes src, width, and height attributes', () => {
+			const image = $('#google img');
 
 			const src = image.attr('src');
 			const [route, params] = src.split('?');

--- a/packages/integrations/image/test/picture-ssr.test.js
+++ b/packages/integrations/image/test/picture-ssr.test.js
@@ -34,7 +34,7 @@ describe('SSR pictures - build', function () {
 			// TODO: better coverage to verify source props
 		});
 
-		it('includes src, width, and height attributes', async () => {
+		it('includes <img> attributes', async () => {
 			const app = await fixture.loadTestAdapterApp();
 
 			const request = new Request('http://example.com/');
@@ -56,6 +56,7 @@ describe('SSR pictures - build', function () {
 			expect(searchParams.get('h')).to.equal('253');
 			// TODO: possible to avoid encoding the full image path?
 			expect(searchParams.get('href').endsWith('/assets/social.jpg')).to.equal(true);
+			expect(image.attr('alt')).to.equal('Social image');
 		});
 
 		// TODO: Track down why the fixture.fetch is failing with the test adapter
@@ -95,7 +96,7 @@ describe('SSR pictures - build', function () {
 			// TODO: better coverage to verify source props
 		});
 
-		it('includes src, width, and height attributes', async () => {
+		it('includes <img> attributes', async () => {
 			const app = await fixture.loadTestAdapterApp();
 
 			const request = new Request('http://example.com/');
@@ -117,6 +118,7 @@ describe('SSR pictures - build', function () {
 			expect(searchParams.get('h')).to.equal('253');
 			// TODO: possible to avoid encoding the full image path?
 			expect(searchParams.get('href').endsWith('/assets/social.jpg')).to.equal(true);
+			expect(image.attr('alt')).to.equal('Inline social image');
 		});
 	});
 
@@ -137,7 +139,7 @@ describe('SSR pictures - build', function () {
 			// TODO: better coverage to verify source props
 		});
 
-		it('includes src, width, and height attributes', async () => {
+		it('includes <img> attributes', async () => {
 			const app = await fixture.loadTestAdapterApp();
 
 			const request = new Request('http://example.com/');
@@ -159,6 +161,7 @@ describe('SSR pictures - build', function () {
 			expect(searchParams.get('h')).to.equal('184');
 			// TODO: possible to avoid encoding the full image path?
 			expect(searchParams.get('href').endsWith('googlelogo_color_272x92dp.png')).to.equal(true);
+			expect(image.attr('alt')).to.equal('Google logo');
 		});
 	});
 });
@@ -196,7 +199,7 @@ describe('SSR images - dev', function () {
 			// TODO: better coverage to verify source props
 		});
 
-		it('includes src, width, and height attributes', () => {
+		it('includes <img> attributes', () => {
 			const image = $('#social-jpg');
 
 			const src = image.attr('src');
@@ -211,6 +214,7 @@ describe('SSR images - dev', function () {
 			expect(searchParams.get('h')).to.equal('253');
 			// TODO: possible to avoid encoding the full image path?
 			expect(searchParams.get('href').endsWith('/assets/social.jpg')).to.equal(true);
+			expect(image.attr('alt')).to.equal('Social image');
 		});
 
 		it('returns the optimized image', async () => {
@@ -235,7 +239,7 @@ describe('SSR images - dev', function () {
 			// TODO: better coverage to verify source props
 		});
 
-		it('includes src, width, and height attributes', () => {
+		it('includes <img> attributes', () => {
 			const image = $('#inline');
 
 			const src = image.attr('src');
@@ -250,6 +254,7 @@ describe('SSR images - dev', function () {
 			expect(searchParams.get('h')).to.equal('253');
 			// TODO: possible to avoid encoding the full image path?
 			expect(searchParams.get('href').endsWith('/assets/social.jpg')).to.equal(true);
+			expect(image.attr('alt')).to.equal('Inline social image');
 		});
 	});
 
@@ -263,7 +268,7 @@ describe('SSR images - dev', function () {
 			// TODO: better coverage to verify source props
 		});
 
-		it('includes src, width, and height attributes', () => {
+		it('includes <img> attributes', () => {
 			const image = $('#google');
 
 			const src = image.attr('src');
@@ -279,6 +284,7 @@ describe('SSR images - dev', function () {
 			expect(searchParams.get('href')).to.equal(
 				'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png'
 			);
+			expect(image.attr('alt')).to.equal('Google logo');
 		});
 	});
 });


### PR DESCRIPTION
Closes #3909

## Changes

This updates the `<Picture />` component to pass any unused attributes directly to the `<img />` element

Current behavior is that the attributes are added to the `<picture>` but this is a really uncommon use case **and** breaks accessibility since there is no way currently to add `alt` to the picture's `img`

## Testing

Tests updated to verify custom `<img />` attributes are included

## Docs

Integration's README updated with a note on how to add attributes to the picture's `<img>` element