### PR TITLE
Make timeout higher for astro check tests as TS is slow on Windows in CI

### DIFF
--- a/packages/astro/test/cli.test.js
+++ b/packages/astro/test/cli.test.js
@@ -39,7 +39,7 @@ describe('astro cli', () => {
 		} catch (err) {}
 
 		expect(proc?.stdout).to.include('0 errors');
-	});
+	}).timeout(35000);
 
 	it('astro check has errors', async () => {
 		let stdout = undefined;
@@ -54,7 +54,7 @@ describe('astro cli', () => {
 		}
 
 		expect(stdout).to.include('1 error');
-	});
+	}).timeout(35000);
 
 	it('astro dev welcome', async () => {
 		const pkgURL = new URL('../package.json', import.meta.url);


### PR DESCRIPTION
## Changes

Unfortunately, TypeScript, on Windows, in CI, in a big monorepo is a recipe for TypeScript (so `astro check`) to take a very long time. This was causing CI to fail randomly so this PR augment the timeout so this shouldn't happen

## Testing

N/A

## Docs

N/A