### PR TITLE
Feat: log warning on `astro.config` change, restart server on `astro.config` added

### DIFF
--- a/.changeset/wet-wombats-prove.md
+++ b/.changeset/wet-wombats-prove.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve warning logs on astro.config change

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -416,7 +416,7 @@ function mergeCLIFlags(astroConfig: AstroUserConfig, flags: CLIFlags, cmd: strin
 	return astroConfig;
 }
 
-interface LoadConfigOptions {
+export interface LoadConfigOptions {
 	cwd?: string;
 	flags?: Flags;
 	cmd: string;
@@ -453,6 +453,7 @@ export async function resolveConfigURL(
 
 interface OpenConfigResult {
 	userConfig: AstroUserConfig;
+	userConfigPath: string | undefined;
 	astroConfig: AstroConfig;
 	flags: CLIFlags;
 	root: string;
@@ -489,12 +490,14 @@ export async function openConfig(configOptions: LoadConfigOptions): Promise<Open
 	}
 	if (config) {
 		userConfig = config.value;
+		userConfigPath = config.filePath;
 	}
 	const astroConfig = await resolveConfig(userConfig, root, flags, configOptions.cmd);
 
 	return {
 		astroConfig,
 		userConfig,
+		userConfigPath,
 		flags,
 		root,
 	};

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -416,7 +416,7 @@ function mergeCLIFlags(astroConfig: AstroUserConfig, flags: CLIFlags, cmd: strin
 	return astroConfig;
 }
 
-export interface LoadConfigOptions {
+interface LoadConfigOptions {
 	cwd?: string;
 	flags?: Flags;
 	cmd: string;


### PR DESCRIPTION
## Changes

- Adds warning log to restart the server when 1. editing, 2. deleting, or 3. renaming a config file
- Restarts the dev server when a new config file is **added**. This should be nice for projects using `astro add` to programmatically add a config!
  - Edge case: if you delete a config and _add it back_ while the dev server is running, the dev server will not restart and a warning will not be logged. If we supported this, we could run into all sorts of issues with old config caches we haven't busted. Changing a config's file extension is correctly handled with a warning though!

https://user-images.githubusercontent.com/51384119/179629703-37a9ea90-757f-4daf-912c-21c7480b143c.mov


## Testing

N/A

## Docs

N/A