### PR TITLE
Adds back `create-astro` support for GitHub repos

### DIFF
--- a/.changeset/lemon-tools-rescue.md
+++ b/.changeset/lemon-tools-rescue.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fixes support for using templates from any GitHub repository

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -108,6 +108,7 @@ export async function main() {
 
 	const hash = args.commit ? `#${args.commit}` : '';
 
+	// Don't touch the template name if a GitHub repo was provided, ex: `--template cassidoo/shopify-react-astro`
 	const templateTarget = options.template.includes('/')
 		? options.template
 		: `withastro/astro/examples/${options.template}#latest`;

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -108,7 +108,9 @@ export async function main() {
 
 	const hash = args.commit ? `#${args.commit}` : '';
 
-	const templateTarget = `withastro/astro/examples/${options.template}#latest`;
+	const templateTarget = options.template.includes('/')
+		? options.template
+		: `withastro/astro/examples/${options.template}#latest`;
 
 	const emitter = degit(`${templateTarget}${hash}`, {
 		cache: false,


### PR DESCRIPTION
## Changes

Brings back support for using remote GitHub repos with `create-astro`

## Testing

Tested locally by cloning the `cassidoo/shopify-react-astro` repo.  I think the automated test was disabled to avoid reliability and network delay issues in CI runs, leaving it disabled for now

## Docs

None (feature is already documented as supported)