### PR TITLE
Add missing media attribute on MetaHTMLAttributes

### DIFF
--- a/.changeset/old-walls-draw.md
+++ b/.changeset/old-walls-draw.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Added missing `media` attributes from the JSX definitions for the `meta` element

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -820,6 +820,7 @@ declare namespace astroHTML.JSX {
 		content?: string | URL | undefined | null;
 		'http-equiv'?: string | undefined | null;
 		name?: string | undefined | null;
+		media: string | undefined | null;
 	}
 
 	interface MeterHTMLAttributes extends HTMLAttributes {

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -820,7 +820,7 @@ declare namespace astroHTML.JSX {
 		content?: string | URL | undefined | null;
 		'http-equiv'?: string | undefined | null;
 		name?: string | undefined | null;
-		media: string | undefined | null;
+		media?: string | undefined | null;
 	}
 
 	interface MeterHTMLAttributes extends HTMLAttributes {


### PR DESCRIPTION
## Changes

Small fix. Running `astro check` on the docs made me realize that [the `media` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color) was missing from the Meta element definition

## Testing

Tested manually

## Docs

N/A