### PR TITLE
TEMPORARY Chore: remove astro build from smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,12 +201,6 @@ jobs:
           repository: withastro/docs
           path: smoke/docs
 
-      - name: Checkout astro.build
-        uses: actions/checkout@v3
-        with:
-          repository: withastro/astro.build
-          path: smoke/astro-build
-
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 


### PR DESCRIPTION
## Changes

Temporarily remove astro.build from Smoke pipeline. Vite 3 was merged before smoke tests were re-run, and we need time to properly debug!

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->