### PR TITLE
Revise vite-plugin-svelte dep on Svelte Integration

### DIFF
--- a/.changeset/tender-eagles-rule.md
+++ b/.changeset/tender-eagles-rule.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/svelte': patch
+---
+
+Revised @sveltejs/vite-plugin-svelte in @astro/svelte

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -33,7 +33,7 @@
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {
-    "@sveltejs/vite-plugin-svelte": "^1.0.0-next.48",
+    "@sveltejs/vite-plugin-svelte": ">=1.0.0-next.49 <1.0.1",
     "postcss-load-config": "^3.1.4",
     "svelte-preprocess": "^4.10.7",
     "svelte2tsx": "^0.5.11",


### PR DESCRIPTION
This commit revises the dependency `@sveltejs/vite-plugin-svelte` in `@astro/svelte` because the `latest` is already using `^vite-3.0.0`.