### PR TITLE
Fix `astro check` file paths not handling URL paths correctly

### DIFF
--- a/.changeset/breezy-llamas-behave.md
+++ b/.changeset/breezy-llamas-behave.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix certain characters showing incorrectly in `astro check`

--- a/packages/astro/src/cli/check/print.ts
+++ b/packages/astro/src/cli/check/print.ts
@@ -11,6 +11,7 @@ import {
 	white,
 	yellow,
 } from 'kleur/colors';
+import { fileURLToPath } from 'url';
 import stringWidth from 'string-width';
 
 export function printDiagnostic(filePath: string, text: string, diag: Diagnostic): string {
@@ -19,9 +20,10 @@ export function printDiagnostic(filePath: string, text: string, diag: Diagnostic
 	// Lines and characters are 0-indexed, so we need to add 1 to the offset to get the actual line and character
 	const realStartLine = diag.range.start.line + 1;
 	const realStartCharacter = diag.range.start.character + 1;
+	const normalizedFilePath = fileURLToPath(new URL(filePath, 'file://'));
 
 	// IDE friendly path that user can CTRL+Click to open the file at a specific line / character
-	const IDEFilePath = `${bold(cyan(filePath))}:${bold(yellow(realStartLine))}:${bold(
+	const IDEFilePath = `${bold(cyan(normalizedFilePath))}:${bold(yellow(realStartLine))}:${bold(
 		yellow(realStartCharacter)
 	)}`;
 	result.push(


### PR DESCRIPTION
## Changes

The language server returns partial URLs for files during `astro check`, as such they need to be properly decoded and transformed to paths before being shown or some characters won't show properly. Ultimately, this could be handled better in the language server itself (by, for instance, return full URLs instead of partials ones), but this is a fine fix too

Before
<img width="474" alt="image" src="https://user-images.githubusercontent.com/3019731/179999339-57ff5b17-00bd-416e-95a7-450ef7a9e19d.png">

After
<img width="452" alt="image" src="https://user-images.githubusercontent.com/3019731/179999398-b4c38b2b-000d-4e72-9eb4-464e679bb4cc.png">


## Testing

Tested manually

## Docs

N/A
