### PR TITLE
Properly support and type optional props in Svelte components

### DIFF
--- a/.changeset/lovely-lions-attend.md
+++ b/.changeset/lovely-lions-attend.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/svelte': patch
+---
+
+Fix optional props not being recognized properly in the editor

--- a/packages/integrations/svelte/src/editor.cts
+++ b/packages/integrations/svelte/src/editor.cts
@@ -7,14 +7,14 @@ export function toTSX(code: string, className: string): string {
 	`;
 
 	try {
-		let tsx = svelte2tsx(code).code;
-		tsx = 'let Props = render().props;\n' + tsx;
+		let tsx = svelte2tsx(code, { mode: 'ts' }).code;
+		tsx = '/// <reference types="svelte2tsx/svelte-shims" />\n' + tsx;
 
-		// Replace Svelte's class export with a function export
 		result = tsx.replace(
-			/^export default[\S\s]*/gm,
-			`export default function ${className}__AstroComponent_(_props: typeof Props): any {}`
+			'export default class extends __sveltets_1_createSvelte2TsxComponent(',
+			'let Component = '
 		);
+		result += `\nexport default function ${className}__AstroComponent_(_props: typeof Component.props): any {}`;
 	} catch (e: any) {
 		return result;
 	}

--- a/packages/integrations/svelte/src/editor.cts
+++ b/packages/integrations/svelte/src/editor.cts
@@ -9,12 +9,10 @@ export function toTSX(code: string, className: string): string {
 	try {
 		let tsx = svelte2tsx(code, { mode: 'ts' }).code;
 		tsx = '/// <reference types="svelte2tsx/svelte-shims" />\n' + tsx;
-
 		result = tsx.replace(
 			'export default class extends __sveltets_1_createSvelte2TsxComponent(',
-			'let Component = '
+			`export default function ${className}__AstroComponent_(_props: typeof Component.props): any {}\nlet Component = `
 		);
-		result += `\nexport default function ${className}__AstroComponent_(_props: typeof Component.props): any {}`;
 	} catch (e: any) {
 		return result;
 	}


### PR DESCRIPTION
## Changes

This changes the shape of the generated TSX for Svelte components to be more in line with how Svelte's tooling actually work

Previously, what we did was skip over every `svelte2tsx` type and just make our own type from `render().props`, this works for getting a list of the props, but it doesn't work for optional props as those are still included in the list and we don't have the needed type info to know it's optional or not due to how optional props work in Svelte

Now we use `svelte2tsx`'s `__sveltets_1_partial` return type, which through TS trickery return the proper types and information for all kinds of situations

Fix https://github.com/withastro/language-tools/issues/314

## Testing

Tested manually against https://github.com/withastro/language-tools/pull/344

## Docs

N/A