### PR TITLE
[READMEs] removed "experimental" from astro add instructions

### DIFF
--- a/.changeset/moody-teachers-knock.md
+++ b/.changeset/moody-teachers-knock.md
@@ -1,0 +1,9 @@
+---
+"@astrojs/image": patch
+"@astrojs/partytown": patch
+"@astrojs/prefetch": patch
+"@astrojs/sitemap": patch
+"@astrojs/tailwind": patch
+---
+
+[READMEs] removed "experimental" from astro add instructions

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -24,7 +24,7 @@ This integration provides `<Image />` and `<Picture>` components as well as a ba
 <details>
   <summary>Quick Install</summary>
   
-The experimental `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
+The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
   
   ```sh
   # Using NPM

--- a/packages/integrations/partytown/README.md
+++ b/packages/integrations/partytown/README.md
@@ -25,7 +25,7 @@ The Astro Partytown integration installs Partytown for you and makes sure it's e
 <details>
   <summary>Quick Install</summary>
   
-The experimental `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
+The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
   
   ```sh
   # Using NPM

--- a/packages/integrations/prefetch/README.md
+++ b/packages/integrations/prefetch/README.md
@@ -19,7 +19,7 @@ To further improve the experience, especially on similar pages, stylesheets are 
 <details>
   <summary>Quick Install</summary>
   
-The experimental `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
+The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
   
   ```sh
   # Using NPM

--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -25,7 +25,7 @@ With Astro Sitemap, you don't have to worry about creating this file: build your
 <details>
   <summary>Quick Install</summary>
   
-The experimental `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
+The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
   
   ```sh
   # Using NPM

--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -28,7 +28,7 @@ https://user-images.githubusercontent.com/4033662/169920154-4b42fc52-e2b5-4ca4-b
 <details>
   <summary>Quick Install</summary>
   
-The experimental `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
+The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
   
   ```sh
   # Using NPM


### PR DESCRIPTION
## Changes
Removes references to astro add being "experimental" in integration package READMEs ("Other" category).
Closes [Docs 1029](https://github.com/withastro/docs/issues/1029)

## Testing
No tests; documentation only.

## Docs

Updates documentation 