### PR TITLE
Make the Lit integration be compat with Vite 3.0.1

### DIFF
--- a/.changeset/mighty-poets-prove.md
+++ b/.changeset/mighty-poets-prove.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/lit': patch
+---
+
+Fixes Lit compat with Vite 3.0.1

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -136,7 +136,7 @@
     "strip-ansi": "^7.0.1",
     "supports-esm": "^1.0.0",
     "tsconfig-resolver": "^3.0.1",
-    "vite": "^3.0.2",
+    "vite": "3.0.2",
     "yargs-parser": "^21.0.1",
     "zod": "^3.17.3"
   },

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -136,7 +136,7 @@
     "strip-ansi": "^7.0.1",
     "supports-esm": "^1.0.0",
     "tsconfig-resolver": "^3.0.1",
-    "vite": "^3.0.0",
+    "vite": "^3.0.2",
     "yargs-parser": "^21.0.1",
     "zod": "^3.17.3"
   },

--- a/packages/integrations/lit/src/index.ts
+++ b/packages/integrations/lit/src/index.ts
@@ -14,11 +14,9 @@ function getViteConfiguration() {
 		},
 		ssr: {
 			external: [
-				'lit-element/lit-element.js',
-				'@lit-labs/ssr/lib/install-global-dom-shim.js',
-				'@lit-labs/ssr/lib/render-lit-html.js',
-				'@lit-labs/ssr/lib/lit-element-renderer.js',
-				'@astrojs/lit/server.js',
+				'lit-element',
+				'@lit-labs/ssr',
+				'@astrojs/lit',
 			],
 		},
 	};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,7 +519,7 @@ importers:
       strip-ansi: ^7.0.1
       supports-esm: ^1.0.0
       tsconfig-resolver: ^3.0.1
-      vite: ^3.0.2
+      vite: 3.0.2
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,7 +519,7 @@ importers:
       strip-ansi: ^7.0.1
       supports-esm: ^1.0.0
       tsconfig-resolver: ^3.0.1
-      vite: ^3.0.0
+      vite: ^3.0.2
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
@@ -577,7 +577,7 @@ importers:
       strip-ansi: 7.0.1
       supports-esm: 1.0.0
       tsconfig-resolver: 3.0.1
-      vite: 3.0.0_sass@1.53.0
+      vite: 3.0.2_sass@1.53.0
       yargs-parser: 21.0.1
       zod: 3.17.3
     devDependencies:
@@ -15785,9 +15785,9 @@ packages:
       fsevents: 2.3.2
     dev: false
 
-  /vite/3.0.0_sass@1.53.0:
-    resolution: {integrity: sha512-M7phQhY3+fRZa0H+1WzI6N+/onruwPTBTMvaj7TzgZ0v2TE+N2sdLKxJOfOv9CckDWt5C4HmyQP81xB4dwRKzA==}
-    engines: {node: '>=14.18.0'}
+  /vite/3.0.2_sass@1.53.0:
+    resolution: {integrity: sha512-TAqydxW/w0U5AoL5AsD9DApTvGb2iNbGs3sN4u2VdT1GFkQVUfgUldt+t08TZgi23uIauh1TUOQJALduo9GXqw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
       less: '*'


### PR DESCRIPTION
## Changes

- Vite 3.0.1 made it so you can't use `external` for non-main entrypoints in packages.
- In our case we can externalize the entire package.
- Related to https://github.com/vitejs/vite/issues/9275

## Testing

- lit-element test failed in 3.0.1 but passes not.

## Docs

N/A, bug fix.