### PR TITLE
feat(vercel): remove requirement of `ENABLE_VC_BUILD=1`

### DIFF
--- a/.changeset/rotten-candles-count.md
+++ b/.changeset/rotten-candles-count.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': minor
+---
+
+Removed requirement for `ENABLE_VC_BUILD=1`, since Build Output v3 is now stable. [Learn more](https://vercel.com/blog/build-output-api).

--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -63,24 +63,9 @@ import vercel from '@astrojs/vercel/static';
 You can deploy by CLI (`vercel deploy`) or by connecting your new repo in the [Vercel Dashboard](https://vercel.com/). Alternatively, you can create a production build locally:
 
 ```sh
-ENABLE_VC_BUILD=1 astro build
+astro build
 vercel deploy --prebuilt
 ```
-
-**Vercel's [Build Output API](https://vercel.com/docs/build-output-api/v3) must be enabled.** You must enable it yourself by setting the environment variable: `ENABLE_VC_BUILD=1`. 
-
-```js
-// vercel.json
-{
-  "build": {
-    "env": {
-      "ENABLE_VC_BUILD": "1"
-    }
-  }
-}
-```
-
-[Learn more about setting enviroment variables in Vercel](https://vercel.com/docs/concepts/projects/environment-variables).
 
 ## Configuration
 

--- a/packages/integrations/vercel/src/edge/adapter.ts
+++ b/packages/integrations/vercel/src/edge/adapter.ts
@@ -40,12 +40,6 @@ export default function vercelEdge(): AstroIntegration {
 				}
 			},
 			'astro:build:start': async ({ buildConfig }) => {
-				if (String(process.env.ENABLE_VC_BUILD) !== '1') {
-					throw new Error(
-						`The enviroment variable "ENABLE_VC_BUILD" was not found. Make sure you have it set to "1" in your Vercel project.\nLearn how to set enviroment variables here: https://vercel.com/docs/concepts/projects/environment-variables`
-					);
-				}
-
 				buildConfig.serverEntry = serverEntry = 'entry.mjs';
 				buildConfig.client = new URL('./static/', _config.outDir);
 				buildConfig.server = functionFolder = new URL('./functions/render.func/', _config.outDir);

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -30,12 +30,6 @@ export default function vercelEdge(): AstroIntegration {
 				_config = config;
 			},
 			'astro:build:start': async ({ buildConfig }) => {
-				if (String(process.env.ENABLE_VC_BUILD) !== '1') {
-					throw new Error(
-						`The enviroment variable "ENABLE_VC_BUILD" was not found. Make sure you have it set to "1" in your Vercel project.\nLearn how to set enviroment variables here: https://vercel.com/docs/concepts/projects/environment-variables`
-					);
-				}
-
 				buildConfig.serverEntry = serverEntry = 'entry.js';
 				buildConfig.client = new URL('./static/', _config.outDir);
 				buildConfig.server = functionFolder = new URL('./functions/render.func/', _config.outDir);

--- a/packages/integrations/vercel/src/static/adapter.ts
+++ b/packages/integrations/vercel/src/static/adapter.ts
@@ -24,12 +24,6 @@ export default function vercelStatic(): AstroIntegration {
 				_config = config;
 			},
 			'astro:build:start': async ({ buildConfig }) => {
-				if (String(process.env.ENABLE_VC_BUILD) !== '1') {
-					throw new Error(
-						`The enviroment variable "ENABLE_VC_BUILD" was not found. Make sure you have it set to "1" in your Vercel project.\nLearn how to set enviroment variables here: https://vercel.com/docs/concepts/projects/environment-variables`
-					);
-				}
-
 				buildConfig.staticMode = true;
 
 				// Ensure to have `.vercel/output` empty.


### PR DESCRIPTION
## Changes

Removed requirement for `ENABLE_VC_BUILD=1`, since Build Output v3 is now stable. [More info here](https://vercel.com/blog/build-output-api).

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->