### PR TITLE
Handle EXIF orientation flag

### DIFF
--- a/.changeset/gentle-mails-mate.md
+++ b/.changeset/gentle-mails-mate.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/image": patch
+---
+
+Handle EXIF orientation flag

--- a/packages/integrations/image/src/metadata.ts
+++ b/packages/integrations/image/src/metadata.ts
@@ -5,7 +5,8 @@ import { ImageMetadata, InputFormat } from './types';
 export async function metadata(src: string): Promise<ImageMetadata | undefined> {
 	const file = await fs.readFile(src);
 
-	const { width, height, type } = await sizeOf(file);
+	const { width, height, type, orientation } = await sizeOf(file);
+	const isPortrait = (orientation || 0) >= 5;
 
 	if (!width || !height || !type) {
 		return undefined;
@@ -13,8 +14,8 @@ export async function metadata(src: string): Promise<ImageMetadata | undefined> 
 
 	return {
 		src,
-		width,
-		height,
+		width: isPortrait ? height : width,
+		height: isPortrait ? width : height,
 		format: type as InputFormat,
 	};
 }


### PR DESCRIPTION
## Changes

Update the metadata retrieval method used by the image integration to take the EXIF orientation flag into account.

An example of this technique is shown in the Sharp docs (3rd example): <https://sharp.pixelplumbing.com/api-input#examples>

The `image-size` module being used here similarly returns `orientation` if found.

## Testing

Not tested yet — would need an image with the flag to do that.

## Docs

No docs needed as this is effectively a bug fix.