### PR TITLE
Update MarkdownContent type

### DIFF
--- a/.changeset/quick-onions-itch.md
+++ b/.changeset/quick-onions-itch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add `url` and `file` properties to `MarkdownContent` type

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -857,6 +857,8 @@ export interface MarkdownParserResponse extends MarkdownRenderingResult {
  */
 export type MarkdownContent<T extends Record<string, any> = Record<string, any>> = T & {
 	astro: MarkdownMetadata;
+	url: string | undefined;
+	file: string;
 };
 
 /**


### PR DESCRIPTION
## Changes
- Add `url` and `file` properties to `MarkdownContent` type

## Testing
N/A

## Docs
[Current docs](https://docs.astro.build/en/guides/markdown-content/#markdown-layouts) indicates that `MarkdownContent` type should have properties `url` and `file`.

![astro Docs - Markdown Layout (astro@1.0.0-beta.73)](https://gcdnb.pbrd.co/images/Ay8wls2XiwJA.png)