### PR TITLE
Omit closing tags for void HTML elements

### DIFF
--- a/examples/basics/src/layouts/Layout.astro
+++ b/examples/basics/src/layouts/Layout.astro
@@ -9,9 +9,9 @@ const { title } = Astro.props as Props;
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<title>{title}</title>
 	</head>
 	<body>

--- a/examples/basics/src/layouts/Layout.astro
+++ b/examples/basics/src/layouts/Layout.astro
@@ -9,7 +9,7 @@ const { title } = Astro.props as Props;
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<title>{title}</title>

--- a/examples/blog-multiple-authors/src/components/MainHead.astro
+++ b/examples/blog-multiple-authors/src/components/MainHead.astro
@@ -17,33 +17,33 @@ const { title, description, image, type, next, prev, canonicalURL } = Astro.prop
 <!-- Common -->
 <meta charset="utf-8">
 <title>{title}</title>
-<meta name="description" content={description} />
-<link rel="preconnect" href="https://fonts.gstatic.com" />
+<meta name="description" content={description}>
+<link rel="preconnect" href="https://fonts.gstatic.com">
 <link
 	href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,400;0,700;1,400;1,700&display=swap"
 	rel="stylesheet"
-/>
+>
 <!-- Sitemap -->
-<link rel="sitemap" href="/sitemap.xml" />
+<link rel="sitemap" href="/sitemap.xml">
 <!-- RSS -->
-<link rel="alternate" type="application/rss+xml" href="/feed/posts.xml" />
+<link rel="alternate" type="application/rss+xml" href="/feed/posts.xml">
 
 <!-- Favicon -->
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
 
 <!-- SEO -->
-<link rel="canonical" href={canonicalURL} />
-{next && <link rel="next" aria-label="Previous Page" href={new URL(next, canonicalURL).href} />}
-{prev && <link rel="prev" aria-label="Next Page" href={new URL(prev, canonicalURL).href} />}
+<link rel="canonical" href={canonicalURL}>
+{next && <link rel="next" aria-label="Previous Page" href={new URL(next, canonicalURL).href}>}
+{prev && <link rel="prev" aria-label="Next Page" href={new URL(prev, canonicalURL).href}>}
 
 <!-- OpenGraph -->
-<meta property="og:title" content={title} />
-<meta property="og:description" content={description} />
-{image && <meta property="og:image" content={new URL(image, canonicalURL)} />}
+<meta property="og:title" content={title}>
+<meta property="og:description" content={description}>
+{image && <meta property="og:image" content={new URL(image, canonicalURL)}>}
 
 <!-- Twitter -->
-<meta name="twitter:card" content={image ? "summary_large_image" : "summary"} />
-<meta name="twitter:site" content="@astro" />
-<meta name="twitter:title" content={title} />
-<meta name="twitter:description" content={description} />
-{image && <meta name="twitter:image" content={image} />}
+<meta name="twitter:card" content={image ? "summary_large_image" : "summary"}>
+<meta name="twitter:site" content="@astro">
+<meta name="twitter:title" content={title}>
+<meta name="twitter:description" content={description}>
+{image && <meta name="twitter:image" content={image}>}

--- a/examples/blog-multiple-authors/src/components/MainHead.astro
+++ b/examples/blog-multiple-authors/src/components/MainHead.astro
@@ -15,7 +15,7 @@ const { title, description, image, type, next, prev, canonicalURL } = Astro.prop
 ---
 
 <!-- Common -->
-<meta charset="UTF-8">
+<meta charset="utf-8">
 <title>{title}</title>
 <meta name="description" content={description} />
 <link rel="preconnect" href="https://fonts.gstatic.com" />

--- a/examples/blog-multiple-authors/src/components/MainHead.astro
+++ b/examples/blog-multiple-authors/src/components/MainHead.astro
@@ -15,7 +15,7 @@ const { title, description, image, type, next, prev, canonicalURL } = Astro.prop
 ---
 
 <!-- Common -->
-<meta charset="UTF-8" />
+<meta charset="UTF-8">
 <title>{title}</title>
 <meta name="description" content={description} />
 <link rel="preconnect" href="https://fonts.gstatic.com" />
@@ -29,7 +29,7 @@ const { title, description, image, type, next, prev, canonicalURL } = Astro.prop
 <link rel="alternate" type="application/rss+xml" href="/feed/posts.xml" />
 
 <!-- Favicon -->
-<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+<link rel="icon" type="image/x-icon" href="/favicon.ico">
 
 <!-- SEO -->
 <link rel="canonical" href={canonicalURL} />

--- a/examples/blog/src/components/BaseHead.astro
+++ b/examples/blog/src/components/BaseHead.astro
@@ -11,9 +11,9 @@ const { title, description } = Astro.props;
 ---
 
 <!-- Global Metadata -->
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width" />
-<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width">
+<link rel="icon" type="image/x-icon" href="/favicon.ico">
 
 <!-- Primary Meta Tags -->
 <title>{title}</title>

--- a/examples/blog/src/components/BaseHead.astro
+++ b/examples/blog/src/components/BaseHead.astro
@@ -11,7 +11,7 @@ const { title, description } = Astro.props;
 ---
 
 <!-- Global Metadata -->
-<meta charset="UTF-8">
+<meta charset="utf-8">
 <meta name="viewport" content="width=device-width">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
 

--- a/examples/blog/src/components/BaseHead.astro
+++ b/examples/blog/src/components/BaseHead.astro
@@ -17,26 +17,26 @@ const { title, description } = Astro.props;
 
 <!-- Primary Meta Tags -->
 <title>{title}</title>
-<meta name="title" content={title} />
-<meta name="description" content={description} />
+<meta name="title" content={title}>
+<meta name="description" content={description}>
 
 <!-- Open Graph / Facebook -->
-<meta property="og:type" content="website" />
-<meta property="og:url" content={canonicalURL} />
-<meta property="og:title" content={title} />
-<meta property="og:description" content={description} />
-<meta property="og:image" content="https://astro.build/social.png" />
+<meta property="og:type" content="website">
+<meta property="og:url" content={canonicalURL}>
+<meta property="og:title" content={title}>
+<meta property="og:description" content={description}>
+<meta property="og:image" content="https://astro.build/social.png">
 
 <!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:url" content={canonicalURL} />
-<meta property="twitter:title" content={title} />
-<meta property="twitter:description" content={description} />
-<meta property="twitter:image" content="https://astro.build/social.png" />
+<meta property="twitter:card" content="summary_large_image">
+<meta property="twitter:url" content={canonicalURL}>
+<meta property="twitter:title" content={title}>
+<meta property="twitter:description" content={description}>
+<meta property="twitter:image" content="https://astro.build/social.png">
 
 <!-- Fonts -->
-<link rel="preconnect" href="https://fonts.gstatic.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com">
 <link
 	rel="stylesheet"
 	href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=IBM+Plex+Sans:wght@400;700&display=swap"
-/>
+>

--- a/examples/component/demo/src/pages/index.astro
+++ b/examples/component/demo/src/pages/index.astro
@@ -4,7 +4,7 @@ import * as Component from "@example/my-component";
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>Welcome to Astro</title>
 		<style is:global>

--- a/examples/component/demo/src/pages/index.astro
+++ b/examples/component/demo/src/pages/index.astro
@@ -4,8 +4,8 @@ import * as Component from "@example/my-component";
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>Welcome to Astro</title>
 		<style is:global>
 			h {

--- a/examples/docs/src/components/HeadCommon.astro
+++ b/examples/docs/src/components/HeadCommon.astro
@@ -4,8 +4,8 @@ import "../styles/index.css";
 ---
 
 <!-- Global Metadata -->
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width" />
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width">
 
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <link rel="alternate icon" type="image/x-icon" href="/favicon.ico" />

--- a/examples/docs/src/components/HeadCommon.astro
+++ b/examples/docs/src/components/HeadCommon.astro
@@ -7,18 +7,18 @@ import "../styles/index.css";
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width">
 
-<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-<link rel="alternate icon" type="image/x-icon" href="/favicon.ico" />
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="alternate icon" type="image/x-icon" href="/favicon.ico">
 
-<link rel="sitemap" href="/sitemap.xml" />
+<link rel="sitemap" href="/sitemap.xml">
 
 <!-- Preload Fonts -->
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link
 	href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital@0;1&display=swap"
 	rel="stylesheet"
-/>
+>
 
 <!-- Scrollable a11y code helper -->
 <script src="/make-scrollable-code-focusable.js" is:inline>

--- a/examples/docs/src/components/HeadCommon.astro
+++ b/examples/docs/src/components/HeadCommon.astro
@@ -4,7 +4,7 @@ import "../styles/index.css";
 ---
 
 <!-- Global Metadata -->
-<meta charset="UTF-8">
+<meta charset="utf-8">
 <meta name="viewport" content="width=device-width">
 
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/examples/docs/src/components/HeadSEO.astro
+++ b/examples/docs/src/components/HeadSEO.astro
@@ -15,32 +15,32 @@ const imageAlt = content?.image?.alt ?? OPEN_GRAPH.image.alt;
 ---
 
 <!-- Page Metadata -->
-<link rel="canonical" href={canonicalURL} />
+<link rel="canonical" href={canonicalURL}>
 
 <!-- OpenGraph Tags -->
-<meta property="og:title" content={formattedContentTitle} />
-<meta property="og:type" content="article" />
-<meta property="og:url" content={canonicalURL} />
-<meta property="og:locale" content={content.ogLocale ?? SITE.defaultLanguage} />
-<meta property="og:image" content={canonicalImageSrc} />
-<meta property="og:image:alt" content={imageAlt} />
+<meta property="og:title" content={formattedContentTitle}>
+<meta property="og:type" content="article">
+<meta property="og:url" content={canonicalURL}>
+<meta property="og:locale" content={content.ogLocale ?? SITE.defaultLanguage}>
+<meta property="og:image" content={canonicalImageSrc}>
+<meta property="og:image:alt" content={imageAlt}>
 <meta
 	name="description"
 	property="og:description"
 	content={content.description ? content.description : SITE.description}
-/>
-<meta property="og:site_name" content={SITE.title} />
+>
+<meta property="og:site_name" content={SITE.title}>
 
 <!-- Twitter Tags -->
-<meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:site" content={OPEN_GRAPH.twitter} />
-<meta name="twitter:title" content={formattedContentTitle} />
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content={OPEN_GRAPH.twitter}>
+<meta name="twitter:title" content={formattedContentTitle}>
 <meta
 	name="twitter:description"
 	content={content.description ? content.description : SITE.description}
-/>
-<meta name="twitter:image" content={canonicalImageSrc} />
-<meta name="twitter:image:alt" content={imageAlt} />
+>
+<meta name="twitter:image" content={canonicalImageSrc}>
+<meta name="twitter:image:alt" content={imageAlt}>
 
 <!--
   TODO: Add json+ld data, maybe https://schema.org/APIReference makes sense?

--- a/examples/env-vars/src/pages/index.astro
+++ b/examples/env-vars/src/pages/index.astro
@@ -10,8 +10,8 @@ console.log({ SSR, PUBLIC_SOME_KEY });
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>
 	<body>

--- a/examples/env-vars/src/pages/index.astro
+++ b/examples/env-vars/src/pages/index.astro
@@ -10,7 +10,7 @@ console.log({ SSR, PUBLIC_SOME_KEY });
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>

--- a/examples/framework-alpine/src/pages/index.astro
+++ b/examples/framework-alpine/src/pages/index.astro
@@ -8,9 +8,9 @@ import Counter from "../components/Counter.astro";
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>
 			html,
 			body {

--- a/examples/framework-alpine/src/pages/index.astro
+++ b/examples/framework-alpine/src/pages/index.astro
@@ -8,7 +8,7 @@ import Counter from "../components/Counter.astro";
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>

--- a/examples/framework-lit/src/pages/index.astro
+++ b/examples/framework-lit/src/pages/index.astro
@@ -7,7 +7,7 @@ import { MyCounter } from "../components/my-counter.js";
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<title>Demo</title>
 	</head>
 	<body>

--- a/examples/framework-multiple/src/pages/index.astro
+++ b/examples/framework-multiple/src/pages/index.astro
@@ -16,9 +16,9 @@ import SvelteCounter from "../components/SvelteCounter.svelte";
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>
 	<body>
 		<main>

--- a/examples/framework-multiple/src/pages/index.astro
+++ b/examples/framework-multiple/src/pages/index.astro
@@ -16,7 +16,7 @@ import SvelteCounter from "../components/SvelteCounter.svelte";
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>

--- a/examples/framework-preact/src/pages/index.astro
+++ b/examples/framework-preact/src/pages/index.astro
@@ -8,9 +8,9 @@ import Counter from "../components/Counter.tsx";
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>
 			html,
 			body {

--- a/examples/framework-preact/src/pages/index.astro
+++ b/examples/framework-preact/src/pages/index.astro
@@ -8,7 +8,7 @@ import Counter from "../components/Counter.tsx";
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>

--- a/examples/framework-react/src/pages/index.astro
+++ b/examples/framework-react/src/pages/index.astro
@@ -11,9 +11,9 @@ const someProps = {
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>
 			html,
 			body {

--- a/examples/framework-react/src/pages/index.astro
+++ b/examples/framework-react/src/pages/index.astro
@@ -11,7 +11,7 @@ const someProps = {
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>

--- a/examples/framework-solid/src/pages/index.astro
+++ b/examples/framework-solid/src/pages/index.astro
@@ -4,9 +4,9 @@ import Counter from "../components/Counter.jsx";
 
 <html>
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>
 			html,
 			body {

--- a/examples/framework-solid/src/pages/index.astro
+++ b/examples/framework-solid/src/pages/index.astro
@@ -4,7 +4,7 @@ import Counter from "../components/Counter.jsx";
 
 <html>
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>

--- a/examples/framework-svelte/src/pages/index.astro
+++ b/examples/framework-svelte/src/pages/index.astro
@@ -8,7 +8,7 @@ import Counter from "../components/Counter.svelte";
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>

--- a/examples/framework-svelte/src/pages/index.astro
+++ b/examples/framework-svelte/src/pages/index.astro
@@ -8,9 +8,9 @@ import Counter from "../components/Counter.svelte";
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>
 			html,
 			body {

--- a/examples/framework-vue/src/pages/index.astro
+++ b/examples/framework-vue/src/pages/index.astro
@@ -8,9 +8,9 @@ import Counter from "../components/Counter.vue";
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>
 			html,
 			body {

--- a/examples/framework-vue/src/pages/index.astro
+++ b/examples/framework-vue/src/pages/index.astro
@@ -8,7 +8,7 @@ import Counter from "../components/Counter.vue";
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>

--- a/examples/integrations-playground/src/pages/foo.astro
+++ b/examples/integrations-playground/src/pages/foo.astro
@@ -6,7 +6,7 @@ import Link from "../components/Link.jsx";
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<title>Demo: Page 2</title>
 	</head>
 	<body>

--- a/examples/integrations-playground/src/pages/index.astro
+++ b/examples/integrations-playground/src/pages/index.astro
@@ -9,7 +9,7 @@ import { MyCounter } from "../components/my-counter.js";
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<title>Demo</title>
 	</head>
 	<body>

--- a/examples/minimal/src/pages/index.astro
+++ b/examples/minimal/src/pages/index.astro
@@ -3,7 +3,7 @@
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>

--- a/examples/minimal/src/pages/index.astro
+++ b/examples/minimal/src/pages/index.astro
@@ -3,8 +3,8 @@
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>
 	<body>

--- a/examples/non-html-pages/src/pages/index.astro
+++ b/examples/non-html-pages/src/pages/index.astro
@@ -1,7 +1,7 @@
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>
 	<body>

--- a/examples/non-html-pages/src/pages/index.astro
+++ b/examples/non-html-pages/src/pages/index.astro
@@ -1,6 +1,6 @@
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>

--- a/examples/portfolio/src/components/MainHead.astro
+++ b/examples/portfolio/src/components/MainHead.astro
@@ -7,13 +7,13 @@ const {
 ---
 
 <meta charset="utf-8">
-<meta name="description" property="og:description" content={description} />
+<meta name="description" property="og:description" content={description}>
 <meta name="viewport" content="width=device-width">
 <title>{title}</title>
 
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link
 	href="https://fonts.googleapis.com/css2?family=Inter:wght@200;400;700;900&display=swap"
 	rel="stylesheet"

--- a/examples/portfolio/src/components/MainHead.astro
+++ b/examples/portfolio/src/components/MainHead.astro
@@ -6,12 +6,12 @@ const {
 } = Astro.props;
 ---
 
-<meta charset="UTF-8" />
+<meta charset="UTF-8">
 <meta name="description" property="og:description" content={description} />
-<meta name="viewport" content="width=device-width" />
+<meta name="viewport" content="width=device-width">
 <title>{title}</title>
 
-<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+<link rel="icon" type="image/x-icon" href="/favicon.ico">
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link

--- a/examples/portfolio/src/components/MainHead.astro
+++ b/examples/portfolio/src/components/MainHead.astro
@@ -6,7 +6,7 @@ const {
 } = Astro.props;
 ---
 
-<meta charset="UTF-8">
+<meta charset="utf-8">
 <meta name="description" property="og:description" content={description} />
 <meta name="viewport" content="width=device-width">
 <title>{title}</title>

--- a/examples/ssr/src/components/Header.astro
+++ b/examples/ssr/src/components/Header.astro
@@ -37,7 +37,7 @@ const cartCount = cart.items.reduce((sum, item) => sum + item.count, 0);
 		margin-right: 1rem;
 	}
 </style>
-<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 <header>
 	<h1><a href="/"><TextDecorationSkip text="Online Store" /></a></h1>
 	<div class="right-pane">

--- a/examples/starter/src/pages/index.astro
+++ b/examples/starter/src/pages/index.astro
@@ -17,7 +17,7 @@ let title = "My Astro Site";
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>{title}</title>
 

--- a/examples/starter/src/pages/index.astro
+++ b/examples/starter/src/pages/index.astro
@@ -17,11 +17,11 @@ let title = "My Astro Site";
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>{title}</title>
 
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 
 		<style>
 			header {

--- a/examples/subpath/src/pages/index.astro
+++ b/examples/subpath/src/pages/index.astro
@@ -5,7 +5,7 @@ import Time from "../components/Time.jsx";
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<meta name="viewport" content="width=device-width">
 		<title>Welcome to Astro</title>

--- a/examples/subpath/src/pages/index.astro
+++ b/examples/subpath/src/pages/index.astro
@@ -5,9 +5,9 @@ import Time from "../components/Time.jsx";
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
+		<meta name="viewport" content="width=device-width">
 		<title>Welcome to Astro</title>
 	</head>
 

--- a/examples/with-markdown-plugins/src/layouts/main.astro
+++ b/examples/with-markdown-plugins/src/layouts/main.astro
@@ -6,7 +6,7 @@ const { content } = Astro.props;
 
 <html lang={content.lang || "en"}>
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 

--- a/examples/with-markdown-plugins/src/layouts/main.astro
+++ b/examples/with-markdown-plugins/src/layouts/main.astro
@@ -6,9 +6,9 @@ const { content } = Astro.props;
 
 <html lang={content.lang || "en"}>
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="UTF-8">
 
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 
 		<title>{content.title}</title>
 		<style>

--- a/examples/with-markdown-shiki/src/layouts/main.astro
+++ b/examples/with-markdown-shiki/src/layouts/main.astro
@@ -6,7 +6,7 @@ const { content } = Astro.props;
 
 <html lang={content.lang || "en"}>
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 

--- a/examples/with-markdown-shiki/src/layouts/main.astro
+++ b/examples/with-markdown-shiki/src/layouts/main.astro
@@ -6,9 +6,9 @@ const { content } = Astro.props;
 
 <html lang={content.lang || "en"}>
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="UTF-8">
 
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 
 		<title>{content.title}</title>
 	</head>

--- a/examples/with-nanostores/src/layouts/Layout.astro
+++ b/examples/with-nanostores/src/layouts/Layout.astro
@@ -14,7 +14,7 @@ const { title } = Astro.props as Props;
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width">
-	<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+	<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	<title>{title}</title>
 </head>
 <body>

--- a/examples/with-nanostores/src/layouts/Layout.astro
+++ b/examples/with-nanostores/src/layouts/Layout.astro
@@ -12,7 +12,7 @@ const { title } = Astro.props as Props;
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
 	<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	<title>{title}</title>

--- a/examples/with-tailwindcss/src/pages/index.astro
+++ b/examples/with-tailwindcss/src/pages/index.astro
@@ -8,8 +8,8 @@ import Button from "../components/Button.astro";
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<title>Astro + TailwindCSS</title>
 	</head>
 

--- a/examples/with-tailwindcss/src/pages/index.astro
+++ b/examples/with-tailwindcss/src/pages/index.astro
@@ -8,7 +8,7 @@ import Button from "../components/Button.astro";
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<title>Astro + TailwindCSS</title>
 	</head>

--- a/examples/with-vite-plugin-pwa/src/pages/index.astro
+++ b/examples/with-vite-plugin-pwa/src/pages/index.astro
@@ -3,7 +3,7 @@
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<meta name="viewport" content="width=device-width">
 		<title>Welcome to Astro</title>

--- a/examples/with-vite-plugin-pwa/src/pages/index.astro
+++ b/examples/with-vite-plugin-pwa/src/pages/index.astro
@@ -3,9 +3,9 @@
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
+		<meta name="viewport" content="width=device-width">
 		<title>Welcome to Astro</title>
 	</head>
 

--- a/packages/astro/e2e/fixtures/client-only/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/client-only/src/pages/index.astro
@@ -11,7 +11,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>

--- a/packages/astro/e2e/fixtures/client-only/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/client-only/src/pages/index.astro
@@ -11,9 +11,9 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>
 	<body>
 		<main>

--- a/packages/astro/e2e/fixtures/error-react-spectrum/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/error-react-spectrum/src/pages/index.astro
@@ -5,9 +5,9 @@ import '@adobe/react-spectrum';
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>
 		</style>
 	</head>

--- a/packages/astro/e2e/fixtures/error-react-spectrum/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/error-react-spectrum/src/pages/index.astro
@@ -5,7 +5,7 @@ import '@adobe/react-spectrum';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>

--- a/packages/astro/e2e/fixtures/multiple-frameworks/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/multiple-frameworks/src/pages/index.astro
@@ -15,7 +15,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>

--- a/packages/astro/e2e/fixtures/multiple-frameworks/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/multiple-frameworks/src/pages/index.astro
@@ -15,9 +15,9 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>
 	<body>
 		<main>

--- a/packages/astro/e2e/fixtures/nested-in-preact/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-preact/src/pages/index.astro
@@ -11,7 +11,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>

--- a/packages/astro/e2e/fixtures/nested-in-preact/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-preact/src/pages/index.astro
@@ -11,9 +11,9 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>
 	<body>
 		<main>

--- a/packages/astro/e2e/fixtures/nested-in-react/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-react/src/pages/index.astro
@@ -11,7 +11,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>

--- a/packages/astro/e2e/fixtures/nested-in-react/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-react/src/pages/index.astro
@@ -11,9 +11,9 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>
 	<body>
 		<main>

--- a/packages/astro/e2e/fixtures/nested-in-solid/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-solid/src/pages/index.astro
@@ -11,7 +11,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>

--- a/packages/astro/e2e/fixtures/nested-in-solid/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-solid/src/pages/index.astro
@@ -11,9 +11,9 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>
 	<body>
 		<main>

--- a/packages/astro/e2e/fixtures/nested-in-svelte/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-svelte/src/pages/index.astro
@@ -11,7 +11,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>

--- a/packages/astro/e2e/fixtures/nested-in-svelte/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-svelte/src/pages/index.astro
@@ -11,9 +11,9 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>
 	<body>
 		<main>

--- a/packages/astro/e2e/fixtures/nested-in-vue/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-vue/src/pages/index.astro
@@ -11,7 +11,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>

--- a/packages/astro/e2e/fixtures/nested-in-vue/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-vue/src/pages/index.astro
@@ -11,9 +11,9 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>
 	<body>
 		<main>

--- a/packages/astro/e2e/fixtures/nested-recursive/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-recursive/src/pages/index.astro
@@ -8,7 +8,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>

--- a/packages/astro/e2e/fixtures/nested-recursive/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-recursive/src/pages/index.astro
@@ -8,9 +8,9 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>
 	<body>
 		<main>

--- a/packages/astro/e2e/fixtures/nested-styles/src/components/partials/Layout/index.astro
+++ b/packages/astro/e2e/fixtures/nested-styles/src/components/partials/Layout/index.astro
@@ -5,7 +5,7 @@ import '../../../styles/global.css'
 ---
 <html>
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta http-equiv="x-ua-compatible" content="ie=edge" />
 		<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no" />
 	</head>

--- a/packages/astro/e2e/fixtures/nested-styles/src/components/partials/Layout/index.astro
+++ b/packages/astro/e2e/fixtures/nested-styles/src/components/partials/Layout/index.astro
@@ -5,7 +5,7 @@ import '../../../styles/global.css'
 ---
 <html>
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="UTF-8">
 		<meta http-equiv="x-ua-compatible" content="ie=edge" />
 		<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no" />
 	</head>

--- a/packages/astro/e2e/fixtures/pass-js/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/pass-js/src/pages/index.astro
@@ -24,7 +24,7 @@ set.add('test2');
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>

--- a/packages/astro/e2e/fixtures/pass-js/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/pass-js/src/pages/index.astro
@@ -24,9 +24,9 @@ set.add('test2');
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 	</head>
 	<body>
 		<main>

--- a/packages/astro/e2e/fixtures/tailwindcss/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/tailwindcss/src/pages/index.astro
@@ -6,7 +6,7 @@ import Complex from '../components/Complex.astro';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<title>Astro + TailwindCSS</title>
 	</head>

--- a/packages/astro/e2e/fixtures/tailwindcss/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/tailwindcss/src/pages/index.astro
@@ -6,8 +6,8 @@ import Complex from '../components/Complex.astro';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<title>Astro + TailwindCSS</title>
 	</head>
 

--- a/packages/astro/src/template/4xx.ts
+++ b/packages/astro/src/template/4xx.ts
@@ -25,7 +25,7 @@ export default function template({
 	return `<!doctype html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<title>${tabTitle}</title>
 		<style>
 			${baseCSS}

--- a/packages/astro/test/fixtures/0-css/src/pages/index.astro
+++ b/packages/astro/test/fixtures/0-css/src/pages/index.astro
@@ -26,7 +26,7 @@ import '../styles/imported.scss';
 
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <style lang="scss">
       .wrapper {
         margin-left: auto;

--- a/packages/astro/test/fixtures/0-css/src/pages/index.astro
+++ b/packages/astro/test/fixtures/0-css/src/pages/index.astro
@@ -26,7 +26,7 @@ import '../styles/imported.scss';
 
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
     <style lang="scss">
       .wrapper {
         margin-left: auto;

--- a/packages/astro/test/fixtures/alias-tsconfig/src/pages/index.astro
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/pages/index.astro
@@ -3,8 +3,8 @@ import Client from '@components/Client.svelte'
 ---
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width">
     <title>Aliases using tsconfig</title>
   </head>
   <body>

--- a/packages/astro/test/fixtures/alias-tsconfig/src/pages/index.astro
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/pages/index.astro
@@ -3,7 +3,7 @@ import Client from '@components/Client.svelte'
 ---
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <title>Aliases using tsconfig</title>
   </head>

--- a/packages/astro/test/fixtures/alias/src/pages/index.astro
+++ b/packages/astro/test/fixtures/alias/src/pages/index.astro
@@ -3,7 +3,7 @@ import Client from 'component:Client.svelte'
 ---
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <title>Svelte Client</title>
     <style>

--- a/packages/astro/test/fixtures/alias/src/pages/index.astro
+++ b/packages/astro/test/fixtures/alias/src/pages/index.astro
@@ -3,8 +3,8 @@ import Client from 'component:Client.svelte'
 ---
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width">
     <title>Svelte Client</title>
     <style>
       html,

--- a/packages/astro/test/fixtures/astro-check-errors/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-check-errors/src/pages/index.astro
@@ -4,7 +4,7 @@
 
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Document</title>

--- a/packages/astro/test/fixtures/astro-check-no-errors/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-check-no-errors/src/pages/index.astro
@@ -1,6 +1,6 @@
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Document</title>

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/pizza/[...pizza].astro
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/pizza/[...pizza].astro
@@ -12,7 +12,7 @@ const { pizza } = Astro.params
 ---
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>{pizza ?? 'The landing page'}</title>
 	</head>

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/pizza/[...pizza].astro
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/pizza/[...pizza].astro
@@ -12,8 +12,8 @@ const { pizza } = Astro.params
 ---
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>{pizza ?? 'The landing page'}</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/pizza/[cheese]-[topping].astro
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/pizza/[cheese]-[topping].astro
@@ -10,7 +10,7 @@ const { cheese, topping } = Astro.params
 ---
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>{cheese}</title>
 	</head>

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/pizza/[cheese]-[topping].astro
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/pizza/[cheese]-[topping].astro
@@ -10,8 +10,8 @@ const { cheese, topping } = Astro.params
 ---
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>{cheese}</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/posts/[page].astro
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/posts/[page].astro
@@ -19,8 +19,8 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>Posts Page {page}</title>
 		<link rel="canonical" href={canonicalURL.href}>
 	</head>

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/posts/[page].astro
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/posts/[page].astro
@@ -19,7 +19,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>Posts Page {page}</title>
 		<link rel="canonical" href={canonicalURL.href}>

--- a/packages/astro/test/fixtures/astro-head/src/components/Head.astro
+++ b/packages/astro/test/fixtures/astro-head/src/components/Head.astro
@@ -4,7 +4,7 @@ const { title } = Astro.props;
 ---
 
 <head>
-  <meta charset="UTF-8">
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <title>{title}</title>

--- a/packages/astro/test/fixtures/astro-head/src/components/Head.astro
+++ b/packages/astro/test/fixtures/astro-head/src/components/Head.astro
@@ -6,6 +6,6 @@ const { title } = Astro.props;
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <title>{title}</title>
 </head>

--- a/packages/astro/test/fixtures/astro-markdown-css/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-markdown-css/src/pages/index.astro
@@ -4,8 +4,8 @@ const article2 = await import('../markdown/article2.md')
 ---
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/astro-markdown-css/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-markdown-css/src/pages/index.astro
@@ -4,7 +4,7 @@ const article2 = await import('../markdown/article2.md')
 ---
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>

--- a/packages/astro/test/fixtures/astro-scripts/src/pages/glob.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/pages/glob.astro
@@ -5,8 +5,8 @@ const MyComponent = components[0].default;
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/astro-scripts/src/pages/glob.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/pages/glob.astro
@@ -5,7 +5,7 @@ const MyComponent = components[0].default;
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>

--- a/packages/astro/test/fixtures/fontsource-package/src/pages/index.astro
+++ b/packages/astro/test/fixtures/fontsource-package/src/pages/index.astro
@@ -4,8 +4,8 @@ import "@fontsource/monofett";
 ---
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/fontsource-package/src/pages/index.astro
+++ b/packages/astro/test/fixtures/fontsource-package/src/pages/index.astro
@@ -4,7 +4,7 @@ import "@fontsource/monofett";
 ---
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>

--- a/packages/astro/test/fixtures/large-array/src/pages/index.astro
+++ b/packages/astro/test/fixtures/large-array/src/pages/index.astro
@@ -8,9 +8,9 @@ for (let i = 0; i < 600; i++) {
 
 <html>
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>
 			html,
 			body {

--- a/packages/astro/test/fixtures/large-array/src/pages/index.astro
+++ b/packages/astro/test/fixtures/large-array/src/pages/index.astro
@@ -8,7 +8,7 @@ for (let i = 0; i < 600; i++) {
 
 <html>
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<style>

--- a/packages/astro/test/fixtures/page-level-styles/src/layouts/Base.astro
+++ b/packages/astro/test/fixtures/page-level-styles/src/layouts/Base.astro
@@ -3,8 +3,8 @@
 ---
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/page-level-styles/src/layouts/Base.astro
+++ b/packages/astro/test/fixtures/page-level-styles/src/layouts/Base.astro
@@ -3,7 +3,7 @@
 ---
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>

--- a/packages/astro/test/fixtures/page-level-styles/src/layouts/Styled.astro
+++ b/packages/astro/test/fixtures/page-level-styles/src/layouts/Styled.astro
@@ -3,7 +3,7 @@ import "../styles/main.css";
 ---
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>

--- a/packages/astro/test/fixtures/page-level-styles/src/layouts/Styled.astro
+++ b/packages/astro/test/fixtures/page-level-styles/src/layouts/Styled.astro
@@ -3,8 +3,8 @@ import "../styles/main.css";
 ---
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/routing-priority/src/pages/[lang]/[...catchall].astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/[lang]/[...catchall].astro
@@ -10,8 +10,8 @@
 <html lang="en">
 
 <head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width" />
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Routing</title>
 </head>
 

--- a/packages/astro/test/fixtures/routing-priority/src/pages/[lang]/[...catchall].astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/[lang]/[...catchall].astro
@@ -10,7 +10,7 @@
 <html lang="en">
 
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
 	<title>Routing</title>
 </head>

--- a/packages/astro/test/fixtures/routing-priority/src/pages/[lang]/index.astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/[lang]/index.astro
@@ -10,8 +10,8 @@
 <html lang="en">
 
 <head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width" />
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Routing</title>
 </head>
 

--- a/packages/astro/test/fixtures/routing-priority/src/pages/[lang]/index.astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/[lang]/index.astro
@@ -10,7 +10,7 @@
 <html lang="en">
 
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
 	<title>Routing</title>
 </head>

--- a/packages/astro/test/fixtures/routing-priority/src/pages/de/index.astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/de/index.astro
@@ -2,8 +2,8 @@
 ---
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>Routing</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/routing-priority/src/pages/de/index.astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/de/index.astro
@@ -2,7 +2,7 @@
 ---
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>Routing</title>
 	</head>

--- a/packages/astro/test/fixtures/routing-priority/src/pages/index.astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/index.astro
@@ -2,8 +2,8 @@
 ---
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>Routing</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/routing-priority/src/pages/index.astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/index.astro
@@ -2,7 +2,7 @@
 ---
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>Routing</title>
 	</head>

--- a/packages/astro/test/fixtures/routing-priority/src/pages/posts/[...slug].astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/posts/[...slug].astro
@@ -11,8 +11,8 @@
 <html lang="en">
 
 <head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width" />
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Routing</title>
 </head>
 

--- a/packages/astro/test/fixtures/routing-priority/src/pages/posts/[...slug].astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/posts/[...slug].astro
@@ -11,7 +11,7 @@
 <html lang="en">
 
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
 	<title>Routing</title>
 </head>

--- a/packages/astro/test/fixtures/routing-priority/src/pages/posts/[pid].astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/posts/[pid].astro
@@ -10,8 +10,8 @@
 <html lang="en">
 
 <head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width" />
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Routing</title>
 </head>
 

--- a/packages/astro/test/fixtures/routing-priority/src/pages/posts/[pid].astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/posts/[pid].astro
@@ -10,7 +10,7 @@
 <html lang="en">
 
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
 	<title>Routing</title>
 </head>

--- a/packages/astro/test/fixtures/ssr-assets/src/pages/index.astro
+++ b/packages/astro/test/fixtures/ssr-assets/src/pages/index.astro
@@ -3,7 +3,7 @@
 ---
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 		<style is:global>

--- a/packages/astro/test/fixtures/ssr-assets/src/pages/index.astro
+++ b/packages/astro/test/fixtures/ssr-assets/src/pages/index.astro
@@ -3,8 +3,8 @@
 ---
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 		<style is:global>
 			h1 {

--- a/packages/astro/test/fixtures/static-build/src/components/MainHead.astro
+++ b/packages/astro/test/fixtures/static-build/src/components/MainHead.astro
@@ -3,7 +3,7 @@ import '../styles/main.scss';
 const { title = 'Static Build', description = 'This is a demo of the static build' } = Astro.props;
 ---
 
-<meta charset="UTF-8">
+<meta charset="utf-8">
 <meta name="description" property="og:description" content={description} />
 <meta name="viewport" content="width=device-width">
 <title>{title}</title>

--- a/packages/astro/test/fixtures/static-build/src/components/MainHead.astro
+++ b/packages/astro/test/fixtures/static-build/src/components/MainHead.astro
@@ -3,9 +3,9 @@ import '../styles/main.scss';
 const { title = 'Static Build', description = 'This is a demo of the static build' } = Astro.props;
 ---
 
-<meta charset="UTF-8" />
+<meta charset="UTF-8">
 <meta name="description" property="og:description" content={description} />
-<meta name="viewport" content="width=device-width" />
+<meta name="viewport" content="width=device-width">
 <title>{title}</title>
 
-<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+<link rel="icon" type="image/x-icon" href="/favicon.ico">

--- a/packages/astro/test/fixtures/svelte-component/src/pages/typescript.astro
+++ b/packages/astro/test/fixtures/svelte-component/src/pages/typescript.astro
@@ -7,8 +7,8 @@ import Custom from '../components/Custom.sve'
 ---
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width">
     <title>Svelte TypeScript</title>
     <style>
       html,

--- a/packages/astro/test/fixtures/svelte-component/src/pages/typescript.astro
+++ b/packages/astro/test/fixtures/svelte-component/src/pages/typescript.astro
@@ -7,7 +7,7 @@ import Custom from '../components/Custom.sve'
 ---
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <title>Svelte TypeScript</title>
     <style>

--- a/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
+++ b/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
@@ -6,7 +6,7 @@ import Complex from '../components/Complex.astro';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<title>Astro + TailwindCSS</title>
 	</head>

--- a/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
+++ b/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
@@ -6,8 +6,8 @@ import Complex from '../components/Complex.astro';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta charset="UTF-8">
+		<link rel="icon" type="image/x-icon" href="/favicon.ico">
 		<title>Astro + TailwindCSS</title>
 	</head>
 

--- a/packages/astro/test/fixtures/type-imports/src/pages/index.astro
+++ b/packages/astro/test/fixtures/type-imports/src/pages/index.astro
@@ -3,8 +3,8 @@ import type { MarkdownInstance } from 'astro'
 ---
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 		<style is:global>
 			h1 {

--- a/packages/astro/test/fixtures/type-imports/src/pages/index.astro
+++ b/packages/astro/test/fixtures/type-imports/src/pages/index.astro
@@ -3,7 +3,7 @@ import type { MarkdownInstance } from 'astro'
 ---
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>Astro</title>
 		<style is:global>

--- a/packages/astro/test/fixtures/vue-component/src/pages/index.astro
+++ b/packages/astro/test/fixtures/vue-component/src/pages/index.astro
@@ -3,7 +3,7 @@ import Counter from '../components/Counter.vue'
 ---
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="UTF-8">
     <meta
       name="viewport"
       content="width=device-width"

--- a/packages/astro/test/fixtures/vue-component/src/pages/index.astro
+++ b/packages/astro/test/fixtures/vue-component/src/pages/index.astro
@@ -3,7 +3,7 @@ import Counter from '../components/Counter.vue'
 ---
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
     <meta
       name="viewport"
       content="width=device-width"

--- a/packages/markdown/component/test/fixtures/astro-markdown/src/pages/nested-list.astro
+++ b/packages/markdown/component/test/fixtures/astro-markdown/src/pages/nested-list.astro
@@ -12,7 +12,7 @@ const content = `
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
 		<title>Welcome to Astro</title>
 	</head>

--- a/packages/markdown/component/test/fixtures/astro-markdown/src/pages/nested-list.astro
+++ b/packages/markdown/component/test/fixtures/astro-markdown/src/pages/nested-list.astro
@@ -12,8 +12,8 @@ const content = `
 
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width">
 		<title>Welcome to Astro</title>
 	</head>
 


### PR DESCRIPTION
## Changes
Omit closing tags for void HTML elements.

[meta element](https://html.spec.whatwg.org/multipage/semantics.html#the-meta-element)
> Tag omission in text/html: No end tag.

[link element](https://html.spec.whatwg.org/multipage/semantics.html#the-link-element)
> Tag omission in text/html: No end tag.

## Testing
Not tested; semantic change, no changes in functionality.

## Docs
Semantic change, no changes in visibility.