### PR TITLE
Switched etag dependency in @astrojs/image to etag-webcrypto for Vercel Edge support

### DIFF
--- a/.changeset/friendly-snakes-compete.md
+++ b/.changeset/friendly-snakes-compete.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Switched etag dependency to etag-webcrypto, this should allow the production endpoint to function on Vercel Edge Functions.

--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -43,7 +43,7 @@
     "test": "mocha --exit --timeout 20000 test"
   },
   "dependencies": {
-    "etag": "^1.8.1",
+    "etag-webcrypto": "^0.0.2",
     "image-size": "^1.0.1",
     "image-type": "^4.1.0",
     "mrmime": "^1.0.0",

--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -43,7 +43,7 @@
     "test": "mocha --exit --timeout 20000 test"
   },
   "dependencies": {
-    "etag-webcrypto": "^0.0.7",
+    "etag-webcrypto": "^0.0.8",
     "image-size": "^1.0.1",
     "image-type": "^4.1.0",
     "mrmime": "^1.0.0",

--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -43,7 +43,7 @@
     "test": "mocha --exit --timeout 20000 test"
   },
   "dependencies": {
-    "etag-webcrypto": "^0.0.3",
+    "etag-webcrypto": "^0.0.7",
     "image-size": "^1.0.1",
     "image-type": "^4.1.0",
     "mrmime": "^1.0.0",
@@ -51,7 +51,6 @@
     "slash": "^4.0.0"
   },
   "devDependencies": {
-    "@types/etag": "^1.8.1",
     "@types/sharp": "^0.30.4",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",

--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -43,7 +43,7 @@
     "test": "mocha --exit --timeout 20000 test"
   },
   "dependencies": {
-    "etag-webcrypto": "^0.0.2",
+    "etag-webcrypto": "^0.0.3",
     "image-size": "^1.0.1",
     "image-type": "^4.1.0",
     "mrmime": "^1.0.0",

--- a/packages/integrations/image/src/endpoints/prod.ts
+++ b/packages/integrations/image/src/endpoints/prod.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import etag from 'etag-webcrypto';
+import { etag } from 'etag-webcrypto';
 import { lookup } from 'mrmime';
 import { fileURLToPath } from 'url';
 // @ts-ignore
@@ -29,13 +29,12 @@ export const get: APIRoute = async ({ request }) => {
 		}
 
 		const { data, format } = await loader.transform(inputBuffer, transform);
-
 		return new Response(data, {
 			status: 200,
 			headers: {
 				'Content-Type': lookup(format) || '',
 				'Cache-Control': 'public, max-age=31536000',
-				ETag: etag(inputBuffer),
+				ETag: await etag(inputBuffer),
 				Date: new Date().toUTCString(),
 			},
 		});

--- a/packages/integrations/image/src/endpoints/prod.ts
+++ b/packages/integrations/image/src/endpoints/prod.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import etag from 'etag';
+import etag from 'etag-webcrypto';
 import { lookup } from 'mrmime';
 import { fileURLToPath } from 'url';
 // @ts-ignore

--- a/packages/integrations/image/test/image-ssr.test.js
+++ b/packages/integrations/image/test/image-ssr.test.js
@@ -5,7 +5,14 @@ import { fileURLToPath } from 'url';
 import { loadFixture } from './test-utils.js';
 import testAdapter from '../../../astro/test/test-adapter.js';
 
+/**
+ * @typedef {import('../../../astro/test/test-utils.js').Fixture} Fixture
+ */
+
 describe('SSR images - build', function () {
+	/**
+	 * @type {Fixture}
+	 */
 	let fixture;
 
 	function verifyImage(pathname) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2072,11 +2072,10 @@ importers:
 
   packages/integrations/image:
     specifiers:
-      '@types/etag': ^1.8.1
       '@types/sharp': ^0.30.4
       astro: workspace:*
       astro-scripts: workspace:*
-      etag-webcrypto: ^0.0.3
+      etag-webcrypto: ^0.0.7
       image-size: ^1.0.1
       image-type: ^4.1.0
       mrmime: ^1.0.0
@@ -2084,14 +2083,13 @@ importers:
       slash: ^4.0.0
       tiny-glob: ^0.2.9
     dependencies:
-      etag-webcrypto: 0.0.3
+      etag-webcrypto: 0.0.7
       image-size: 1.0.2
       image-type: 4.1.0
       mrmime: 1.0.1
       sharp: 0.30.7
       slash: 4.0.0
     devDependencies:
-      '@types/etag': 1.8.1
       '@types/sharp': 0.30.4
       astro: link:../../astro
       astro-scripts: link:../../../scripts
@@ -8222,12 +8220,6 @@ packages:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
     dev: false
 
-  /@types/etag/1.8.1:
-    resolution: {integrity: sha512-bsKkeSqN7HYyYntFRAmzcwx/dKW4Wa+KVMTInANlI72PWLQmOpZu96j0OqHZGArW4VQwCmJPteQlXaUDeOB0WQ==}
-    dependencies:
-      '@types/node': 18.0.6
-    dev: true
-
   /@types/extend/3.0.1:
     resolution: {integrity: sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw==}
     dev: true
@@ -10629,8 +10621,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /etag-webcrypto/0.0.3:
-    resolution: {integrity: sha512-WzTLf2Y+f+YW25CT+g0mKbTVPKy0v+vthKKoGabV0Pu4/1LTQzkfivkWu4MEmd62B86PA6/buUg6QWkRqgb42A==}
+  /etag-webcrypto/0.0.7:
+    resolution: {integrity: sha512-doEK0Y/yjsItb97aJ1j+MnSVwKefI+34wTtRfEwxflnBeNSlhLORyMdS+HdCUPKoXs/RXncMZ9omt3CXml+2YA==}
     engines: {node: '>= 0.6'}
     dependencies:
       '@peculiar/webcrypto': 1.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2076,7 +2076,7 @@ importers:
       '@types/sharp': ^0.30.4
       astro: workspace:*
       astro-scripts: workspace:*
-      etag: ^1.8.1
+      etag-webcrypto: ^0.0.2
       image-size: ^1.0.1
       image-type: ^4.1.0
       mrmime: ^1.0.0
@@ -2084,7 +2084,7 @@ importers:
       slash: ^4.0.0
       tiny-glob: ^0.2.9
     dependencies:
-      etag: 1.8.1
+      etag-webcrypto: 0.0.2
       image-size: 1.0.2
       image-type: 4.1.0
       mrmime: 1.0.1
@@ -5188,6 +5188,32 @@ packages:
     dependencies:
       '@octokit/openapi-types': 12.10.1
     dev: true
+
+  /@peculiar/asn1-schema/2.2.0:
+    resolution: {integrity: sha512-1ENEJNY7Lwlua/1wvzpYP194WtjQBfFxvde2FlzfBFh/ln6wvChrtxlORhbKEnYswzn6fOC4c7HdC5izLPMTJg==}
+    dependencies:
+      asn1js: 3.0.5
+      pvtsutils: 1.3.2
+      tslib: 2.4.0
+    dev: false
+
+  /@peculiar/json-schema/1.1.12:
+    resolution: {integrity: sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      tslib: 2.4.0
+    dev: false
+
+  /@peculiar/webcrypto/1.4.0:
+    resolution: {integrity: sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==}
+    engines: {node: '>=10.12.0'}
+    dependencies:
+      '@peculiar/asn1-schema': 2.2.0
+      '@peculiar/json-schema': 1.1.12
+      pvtsutils: 1.3.2
+      tslib: 2.4.0
+      webcrypto-core: 1.7.5
+    dev: false
 
   /@playwright/test/1.24.0:
     resolution: {integrity: sha512-sZLH2N6aWN9TtG+vMjNSomSfX0dSVHwWE+GhHQPV+ZeGcuZ/6CgMCGFuGjobgq/hNF9ZkuVOjeyoceZ0owKnHQ==}
@@ -9050,6 +9076,15 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /asn1js/3.0.5:
+    resolution: {integrity: sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      pvtsutils: 1.3.2
+      pvutils: 1.1.3
+      tslib: 2.4.0
+    dev: false
+
   /assert/2.0.0:
     resolution: {integrity: sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==}
     dependencies:
@@ -10594,9 +10629,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /etag/1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+  /etag-webcrypto/0.0.2:
+    resolution: {integrity: sha512-yHMmcYSHC3zFvL2EnzBRD2GFufsds/OmwzEQWSlHWMwsksUcP70zYozm6Y4ev7PK+GTHSWIaN3m42q/tOEMDzg==}
     engines: {node: '>= 0.6'}
+    dependencies:
+      '@peculiar/webcrypto': 1.4.0
     dev: false
 
   /event-target-shim/5.0.1:
@@ -14046,6 +14083,17 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /pvtsutils/1.3.2:
+    resolution: {integrity: sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==}
+    dependencies:
+      tslib: 2.4.0
+    dev: false
+
+  /pvutils/1.1.3:
+    resolution: {integrity: sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==}
+    engines: {node: '>=6.0.0'}
+    dev: false
+
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -16133,6 +16181,16 @@ packages:
   /web-streams-polyfill/3.2.1:
     resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
     engines: {node: '>= 8'}
+
+  /webcrypto-core/1.7.5:
+    resolution: {integrity: sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.2.0
+      '@peculiar/json-schema': 1.1.12
+      asn1js: 3.0.5
+      pvtsutils: 1.3.2
+      tslib: 2.4.0
+    dev: false
 
   /webidl-conversions/3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2075,7 +2075,7 @@ importers:
       '@types/sharp': ^0.30.4
       astro: workspace:*
       astro-scripts: workspace:*
-      etag-webcrypto: ^0.0.7
+      etag-webcrypto: ^0.0.8
       image-size: ^1.0.1
       image-type: ^4.1.0
       mrmime: ^1.0.0
@@ -2083,7 +2083,7 @@ importers:
       slash: ^4.0.0
       tiny-glob: ^0.2.9
     dependencies:
-      etag-webcrypto: 0.0.7
+      etag-webcrypto: 0.0.8
       image-size: 1.0.2
       image-type: 4.1.0
       mrmime: 1.0.1
@@ -10621,8 +10621,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /etag-webcrypto/0.0.7:
-    resolution: {integrity: sha512-doEK0Y/yjsItb97aJ1j+MnSVwKefI+34wTtRfEwxflnBeNSlhLORyMdS+HdCUPKoXs/RXncMZ9omt3CXml+2YA==}
+  /etag-webcrypto/0.0.8:
+    resolution: {integrity: sha512-5h4pU8Rkc2CK4lJenOWmjll+selgV6cL4yRuZ1m18RZHTQMzT0CuIMntRp2S6POk5E/aUk7WS6ekn86V73rYYg==}
     engines: {node: '>= 0.6'}
     dependencies:
       '@peculiar/webcrypto': 1.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2076,7 +2076,7 @@ importers:
       '@types/sharp': ^0.30.4
       astro: workspace:*
       astro-scripts: workspace:*
-      etag-webcrypto: ^0.0.2
+      etag-webcrypto: ^0.0.3
       image-size: ^1.0.1
       image-type: ^4.1.0
       mrmime: ^1.0.0
@@ -2084,7 +2084,7 @@ importers:
       slash: ^4.0.0
       tiny-glob: ^0.2.9
     dependencies:
-      etag-webcrypto: 0.0.2
+      etag-webcrypto: 0.0.3
       image-size: 1.0.2
       image-type: 4.1.0
       mrmime: 1.0.1
@@ -10629,8 +10629,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /etag-webcrypto/0.0.2:
-    resolution: {integrity: sha512-yHMmcYSHC3zFvL2EnzBRD2GFufsds/OmwzEQWSlHWMwsksUcP70zYozm6Y4ev7PK+GTHSWIaN3m42q/tOEMDzg==}
+  /etag-webcrypto/0.0.3:
+    resolution: {integrity: sha512-WzTLf2Y+f+YW25CT+g0mKbTVPKy0v+vthKKoGabV0Pu4/1LTQzkfivkWu4MEmd62B86PA6/buUg6QWkRqgb42A==}
     engines: {node: '>= 0.6'}
     dependencies:
       '@peculiar/webcrypto': 1.4.0


### PR DESCRIPTION
## Changes

This PR changes the `etag` dependency to [etag-webcrypto](https://www.npmjs.com/package/etag-webcrypto). WebCrypto is a [supported API on Vercel Edge](https://vercel.com/docs/concepts/functions/edge-functions/edge-functions-api) unlike the Node.js crypto module.

## Testing

This change has not yet been tested but the existing tests (if any) should catch any issues given the nature of the change.

## Docs

I believe the docs don't need to be changed as there may be other blocking changes before a full support for Edge Functions can be advertised.

Closes #4035 