### PR TITLE
Added missing "loading" attribute for "IFrameHTMLAttributes" 

### DIFF
--- a/.changeset/rude-stingrays-fry.md
+++ b/.changeset/rude-stingrays-fry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Added missing "loading" attribute to IFrameHTMLAttributes

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -679,6 +679,7 @@ declare namespace astroHTML.JSX {
 		src?: string | undefined | null;
 		srcdoc?: string | undefined | null;
 		width?: number | string | undefined | null;
+		loading?: 'eager' | 'lazy' | undefined | null;
 	}
 
 	interface ImgHTMLAttributes extends HTMLAttributes {


### PR DESCRIPTION
## Changes

As discussed with @Princesseuh, added missing "loading" attribute to IFrameHTMLAttributes. This eliminates the extension error where `Property 'loading' does not exist on type 'IFrameHTMLAttributes'`.

## Testing

Added loading attribute the same way it's implemented on the `ImgHTMLAttributes`.

## Docs

No extra documentation needed, it's the expected behavior.