### PR TITLE
Add warnings on markdown deprecations

### DIFF
--- a/.changeset/large-seas-drum.md
+++ b/.changeset/large-seas-drum.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds warnings for legacy markdown behavior

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -73,7 +73,7 @@ export async function createVite(
 			// the build to run very slow as the filewatcher is triggered often.
 			mode === 'dev' && astroViteServerPlugin({ config: astroConfig, logging }),
 			envVitePlugin({ config: astroConfig }),
-			markdownVitePlugin({ config: astroConfig }),
+			markdownVitePlugin({ config: astroConfig, logging }),
 			htmlVitePlugin(),
 			jsxVitePlugin({ config: astroConfig, logging }),
 			astroPostprocessVitePlugin({ config: astroConfig }),

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -6,6 +6,7 @@ import matter from 'gray-matter';
 import { fileURLToPath } from 'url';
 import type { Plugin } from 'vite';
 import type { AstroConfig } from '../@types/astro';
+import type { LogOptions } from '../core/logger/core.js';
 import { pagesVirtualModuleId } from '../core/app/index.js';
 import { collectErrorMetadata } from '../core/errors.js';
 import { resolvePages } from '../core/util.js';
@@ -14,9 +15,11 @@ import { getViteTransform, TransformHook } from '../vite-plugin-astro/styles.js'
 import type { PluginMetadata as AstroPluginMetadata } from '../vite-plugin-astro/types';
 import { PAGE_SSR_SCRIPT_ID } from '../vite-plugin-scripts/index.js';
 import { getFileInfo } from '../vite-plugin-utils/index.js';
+import { warn } from '../core/logger/core.js';
 
 interface AstroPluginOptions {
 	config: AstroConfig;
+	logging: LogOptions;
 }
 
 const MARKDOWN_IMPORT_FLAG = '?mdImport';
@@ -34,7 +37,7 @@ function safeMatter(source: string, id: string) {
 // TODO: Clean up some of the shared logic between this Markdown plugin and the Astro plugin.
 // Both end up connecting a `load()` hook to the Astro compiler, and share some copy-paste
 // logic in how that is done.
-export default function markdown({ config }: AstroPluginOptions): Plugin {
+export default function markdown({ config, logging }: AstroPluginOptions): Plugin {
 	function normalizeFilename(filename: string) {
 		if (filename.startsWith('/@fs')) {
 			filename = filename.slice('/@fs'.length);
@@ -170,6 +173,12 @@ export default function markdown({ config }: AstroPluginOptions): Plugin {
 				content.astro = metadata;
 				content.url = getFileInfo(id, config).fileUrl;
 				content.file = filename;
+
+				// Warn when attempting to use setup without the legacy flag
+				if(setup && !isAstroFlavoredMd) {
+					warn(logging, 'markdown', `The setup: property in frontmatter only works with the legacy.astroFlavoredMarkdown flag enabled.`);
+				}
+
 				const prelude = `---
 import Slugger from 'github-slugger';
 ${layout ? `import Layout from '${layout}';` : ''}

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -188,8 +188,16 @@ const $$content = ${JSON.stringify(
 						: // Avoid stripping "setup" and "components"
 						  // in plain MD mode
 						  { ...content, setup, components }
-				)}
+				)};
+
+Object.defineProperty($$content.astro, 'headers', {
+	get() {
+		console.warn('content.astro.headers has been removed and replaced with content.astro.headings.');
+		return undefined;
+	}
+});
 ---`;
+
 				const imports = `${layout ? `import Layout from '${layout}';` : ''}
 ${isAstroFlavoredMd ? setup : ''}`.trim();
 


### PR DESCRIPTION
## Changes

- Adds warning when attempting to read from `content.astro.headers`.
- Adds warning when using `setup:` in frontmatter without the astroFlavoredMarkdown legacy flag enabled.

## Testing

Just manually

## Docs

N/A