### PR TITLE
Move getStaticPaths call to happen during generation

### DIFF
--- a/.changeset/old-stingrays-smoke.md
+++ b/.changeset/old-stingrays-smoke.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Perf: move getStaticPaths call during the build to during page generation

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -9,8 +9,9 @@ import type {
 	EndpointHandler,
 	SSRLoadedRenderer,
 } from '../../@types/astro';
+import * as colors from 'kleur/colors';
 import type { BuildInternals } from '../../core/build/internal.js';
-import { joinPaths, prependForwardSlash, removeLeadingForwardSlash } from '../../core/path.js';
+import { joinPaths, prependForwardSlash, removeLeadingForwardSlash, removeTrailingForwardSlash } from '../../core/path.js';
 import type { RenderOptions } from '../../core/render/core';
 import { BEFORE_HYDRATION_SCRIPT_ID } from '../../vite-plugin-scripts/index.js';
 import { call as callEndpoint } from '../endpoint/index.js';
@@ -23,6 +24,8 @@ import { getOutFile, getOutFolder } from './common.js';
 import { eachPageData, getPageDataByComponent } from './internal.js';
 import type { PageBuildData, SingleFileBuiltModule, StaticBuildOptions } from './types';
 import { getTimeStat } from './util.js';
+import { callGetStaticPaths, RouteCache, RouteCacheEntry } from '../render/route-cache.js';
+import { matchRoute } from '../routing/match.js';
 
 // Render is usually compute, which Node.js can't parallelize well.
 // In real world testing, dropping from 10->1 showed a notiable perf
@@ -89,10 +92,8 @@ export function chunkIsPage(
 }
 
 export async function generatePages(
-	result: RollupOutput,
 	opts: StaticBuildOptions,
 	internals: BuildInternals,
-	facadeIdToPageDataMap: Map<string, PageBuildData>
 ) {
 	const timer = performance.now();
 	info(opts.logging, null, `\n${bgGreen(black(' generating static routes '))}`);
@@ -110,11 +111,10 @@ export async function generatePages(
 }
 
 async function generatePage(
-	//output: OutputChunk,
 	opts: StaticBuildOptions,
 	internals: BuildInternals,
 	pageData: PageBuildData,
-	ssrEntry: SingleFileBuiltModule
+	ssrEntry: SingleFileBuiltModule,
 ) {
 	let timeStart = performance.now();
 	const renderers = ssrEntry.renderers;
@@ -148,16 +148,81 @@ async function generatePage(
 	const icon = pageData.route.type === 'page' ? green('▶') : magenta('λ');
 	info(opts.logging, null, `${icon} ${pageData.route.component}`);
 
-	for (let i = 0; i < pageData.paths.length; i++) {
-		const path = pageData.paths[i];
+	// Get paths for the route, calling getStaticPaths if needed.
+	const paths = await getPathsForRoute(pageData, pageModule, opts);
+
+	for (let i = 0; i < paths.length; i++) {
+		const path = paths[i];
 		await generatePath(path, opts, generationOptions);
 		const timeEnd = performance.now();
 		const timeChange = getTimeStat(timeStart, timeEnd);
 		const timeIncrease = `(+${timeChange})`;
 		const filePath = getOutputFilename(opts.astroConfig, path);
-		const lineIcon = i === pageData.paths.length - 1 ? '└─' : '├─';
+		const lineIcon = i === paths.length - 1 ? '└─' : '├─';
 		info(opts.logging, null, `  ${cyan(lineIcon)} ${dim(filePath)} ${dim(timeIncrease)}`);
 	}
+}
+
+async function getPathsForRoute(
+	pageData: PageBuildData,
+	mod: ComponentInstance,
+	opts: StaticBuildOptions,
+): Promise<Array<string>> {
+	let paths: Array<string> = [];
+	if(pageData.route.pathname) {
+		paths.push(pageData.route.pathname);
+	} else {
+		const builtPaths = new Set<string>();
+		const route = pageData.route;
+		const result = await callGetStaticPaths({
+			mod,
+			route: pageData.route,
+			isValidate: false,
+			logging: opts.logging,
+			ssr: opts.astroConfig.output === 'server'
+		})
+		.then((_result) => {
+			const label = _result.staticPaths.length === 1 ? 'page' : 'pages';
+			debug(
+				'build',
+				`├── ${colors.bold(colors.green('✔'))} ${route.component} → ${colors.magenta(
+					`[${_result.staticPaths.length} ${label}]`
+				)}`
+			);
+			return _result;
+		})
+		.catch((err) => {
+			debug('build', `├── ${colors.bold(colors.red('✗'))} ${route.component}`);
+			throw err;
+		});
+
+		// Save the route cache so it doesn't get called again
+		opts.routeCache.set(route, result);
+
+		paths = result.staticPaths
+			.map((staticPath) => staticPath.params && route.generate(staticPath.params))
+			.filter((staticPath) => {
+				// Remove empty or undefined paths
+				if (!staticPath) {
+					return false;
+				}
+
+				// The path hasn't been built yet, include it
+				if (!builtPaths.has(removeTrailingForwardSlash(staticPath))) {
+					return true;
+				}
+
+				// The path was already built once. Check the manifest to see if
+				// this route takes priority for the final URL.
+				// NOTE: The same URL may match multiple routes in the manifest.
+				// Routing priority needs to be verified here for any duplicate
+				// paths to ensure routing priority rules are enforced in the final build.
+				const matchedRoute = matchRoute(staticPath, opts.manifest);
+				return matchedRoute === route;
+			});
+	}
+
+	return paths;
 }
 
 interface GeneratePathOptions {

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -1,7 +1,6 @@
 import glob from 'fast-glob';
 import fs from 'fs';
 import { bgGreen, bgMagenta, black, dim } from 'kleur/colors';
-import type { RollupOutput } from 'rollup';
 import { fileURLToPath } from 'url';
 import * as vite from 'vite';
 import { BuildInternals, createBuildInternals } from '../../core/build/internal.js';
@@ -72,7 +71,7 @@ Example:
 	// Build your project (SSR application code, assets, client JS, etc.)
 	timer.ssr = performance.now();
 	info(opts.logging, 'build', `Building ${astroConfig.output} entrypoints...`);
-	const ssrResult = (await ssrBuild(opts, internals, pageInput)) as RollupOutput;
+	await ssrBuild(opts, internals, pageInput);
 	info(opts.logging, 'build', dim(`Completed in ${getTimeStat(timer.ssr, performance.now())}.`));
 
 	const rendererClientEntrypoints = opts.astroConfig._ctx.renderers
@@ -93,7 +92,7 @@ Example:
 	timer.generate = performance.now();
 	if (astroConfig.output === 'static') {
 		try {
-			await generatePages(ssrResult, opts, internals, facadeIdToPageDataMap);
+			await generatePages(opts, internals);
 		} finally {
 			await cleanSsrOutput(opts);
 		}

--- a/packages/astro/src/core/build/types.ts
+++ b/packages/astro/src/core/build/types.ts
@@ -16,7 +16,6 @@ export type ViteID = string;
 
 export interface PageBuildData {
 	component: ComponentPath;
-	paths: string[];
 	route: RouteData;
 	moduleSpecifier: string;
 	css: Set<string>;

--- a/packages/astro/test/astro-get-static-paths.test.js
+++ b/packages/astro/test/astro-get-static-paths.test.js
@@ -52,12 +52,15 @@ describe('getStaticPaths - 404 behavior', () => {
 });
 
 describe('getStaticPaths - route params type validation', () => {
-	let fixture;
-	let devServer;
+	let fixture, devServer;
 
 	before(async () => {
 		fixture = await loadFixture({ root: './fixtures/astro-get-static-paths/' });
 		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer.stop();
 	});
 
 	it('resolves 200 on matching static path - string params', async () => {

--- a/packages/astro/test/fixtures/lit-element/src/pages/[page].astro
+++ b/packages/astro/test/fixtures/lit-element/src/pages/[page].astro
@@ -1,0 +1,30 @@
+---
+import {MyElement} from '../components/my-element.js';
+export async function getStaticPaths() {
+	return [
+		{
+			params: { page: 1 },
+		},
+		{
+			params: { page: 2 },
+		},
+		{
+			params: { page: 3 }
+		}
+	]
+};
+
+const { page } = Astro.params
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>Posts Page {page}</title>
+	</head>
+	<body>
+		<h1>Welcome to page {page}</h1>
+		<MyElement />
+	</body>
+</html>

--- a/packages/astro/test/fixtures/routing-priority/src/pages/de/index.astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/de/index.astro
@@ -1,4 +1,5 @@
 ---
+// This route should take priority over src/pages/[lang]/index.astro
 ---
 <html lang="en">
 	<head>
@@ -7,6 +8,7 @@
 		<title>Routing</title>
 	</head>
 	<body>
-		<h1>de/index.astro</h1>
-	</body>
+		<h1>de/index.astro (priority)</h1>
+		<p>de</p>
+</body>
 </html>

--- a/packages/astro/test/lit-element.test.js
+++ b/packages/astro/test/lit-element.test.js
@@ -80,4 +80,9 @@ describe('LitElement test', function () {
 		// has named slot content in lightdom
 		expect($(namedSlot).text()).to.equal('named');
 	});
+
+	it('Is able to build when behind getStaticPaths', async () => {
+		const dynamicPage = await fixture.readFile('/1/index.html');
+		expect(dynamicPage.length).to.be.greaterThan(0);
+	});
 });

--- a/packages/astro/test/routing-priority.test.js
+++ b/packages/astro/test/routing-priority.test.js
@@ -103,7 +103,7 @@ describe('Routing priority', () => {
 			const html = await fixture.readFile('/de/index.html');
 			const $ = cheerioLoad(html);
 
-			expect($('h1').text()).to.equal('de/index.astro');
+			expect($('h1').text()).to.equal('de/index.astro (priority)');
 		});
 
 		it('matches /en to [lang]/index.astro', async () => {
@@ -169,7 +169,7 @@ describe('Routing priority', () => {
 			const html = await fixture.fetch('/de').then((res) => res.text());
 			const $ = cheerioLoad(html);
 
-			expect($('h1').text()).to.equal('[lang]/index.astro');
+			expect($('h1').text()).to.equal('de/index.astro (priority)');
 			expect($('p').text()).to.equal('de');
 		});
 
@@ -177,7 +177,7 @@ describe('Routing priority', () => {
 			const html = await fixture.fetch('/de/').then((res) => res.text());
 			const $ = cheerioLoad(html);
 
-			expect($('h1').text()).to.equal('[lang]/index.astro');
+			expect($('h1').text()).to.equal('de/index.astro (priority)');
 			expect($('p').text()).to.equal('de');
 		});
 
@@ -185,10 +185,10 @@ describe('Routing priority', () => {
 			const html = await fixture.fetch('/de/index.html').then((res) => res.text());
 			const $ = cheerioLoad(html);
 
-			expect($('h1').text()).to.equal('[lang]/index.astro');
+			expect($('h1').text()).to.equal('de/index.astro (priority)');
 			expect($('p').text()).to.equal('de');
 		});
-		
+
 		it('matches /en to [lang]/index.astro', async () => {
 			const html = await fixture.fetch('/en').then((res) => res.text());
 			const $ = cheerioLoad(html);

--- a/packages/astro/test/routing-priority.test.js
+++ b/packages/astro/test/routing-priority.test.js
@@ -169,30 +169,26 @@ describe('Routing priority', () => {
 			const html = await fixture.fetch('/de').then((res) => res.text());
 			const $ = cheerioLoad(html);
 
-			expect($('h1').text()).to.equal('de/index.astro');
-		});
-
-		it('matches /de to de/index.astro', async () => {
-			const html = await fixture.fetch('/de').then((res) => res.text());
-			const $ = cheerioLoad(html);
-
-			expect($('h1').text()).to.equal('de/index.astro');
+			expect($('h1').text()).to.equal('[lang]/index.astro');
+			expect($('p').text()).to.equal('de');
 		});
 
 		it('matches /de/ to de/index.astro', async () => {
 			const html = await fixture.fetch('/de/').then((res) => res.text());
 			const $ = cheerioLoad(html);
 
-			expect($('h1').text()).to.equal('de/index.astro');
+			expect($('h1').text()).to.equal('[lang]/index.astro');
+			expect($('p').text()).to.equal('de');
 		});
 
 		it('matches /de/index.html to de/index.astro', async () => {
 			const html = await fixture.fetch('/de/index.html').then((res) => res.text());
 			const $ = cheerioLoad(html);
 
-			expect($('h1').text()).to.equal('de/index.astro');
+			expect($('h1').text()).to.equal('[lang]/index.astro');
+			expect($('p').text()).to.equal('de');
 		});
-
+		
 		it('matches /en to [lang]/index.astro', async () => {
 			const html = await fixture.fetch('/en').then((res) => res.text());
 			const $ = cheerioLoad(html);


### PR DESCRIPTION
## Changes

- The call to `getStaticPaths` during the build is moved to the end of the process, during page generation.
- This prevents us from ever needing to call `vite.ssrLoadModule` anywhere in the build now. We are 100% completely static.
- This should improve performance as we are no longer double-building this code.
- This also fixes a bug with Lit and `getStaticPaths`. Before this change if you use a Lit element in a page behind getStaticPaths you would get a `window is undefined` error. This was because getStaticPaths was being called upfront, when the renderer had not yet run, and therefore the shim was not applied. Now it happens as it should.
- Closes https://github.com/withastro/astro/issues/3951

## Testing

- Tests added

## Docs

N/A, bug fix.