### PR TITLE
Removes `fileURLToPath` dependency from `@astrojs/image` SSR production endpoint

### DIFF
--- a/.changeset/khaki-tables-design.md
+++ b/.changeset/khaki-tables-design.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Removes Node's `fileURLToPath` dependency in the production SSR endpoint

--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -48,13 +48,13 @@
     "image-type": "^4.1.0",
     "mrmime": "^1.0.0",
     "sharp": "^0.30.6",
-    "slash": "^4.0.0"
+    "slash": "^4.0.0",
+    "tiny-glob": "^0.2.9"
   },
   "devDependencies": {
     "@types/etag": "^1.8.1",
     "@types/sharp": "^0.30.4",
     "astro": "workspace:*",
-    "astro-scripts": "workspace:*",
-    "tiny-glob": "^0.2.9"
+    "astro-scripts": "workspace:*"
   }
 }

--- a/packages/integrations/image/src/build/ssg.ts
+++ b/packages/integrations/image/src/build/ssg.ts
@@ -1,6 +1,6 @@
-import fs from 'fs/promises';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { OUTPUT_DIR } from '../constants.js';
 import type { SSRImageService, TransformOptions } from '../types.js';
 import { isRemoteImage, loadLocalImage, loadRemoteImage } from '../utils/images.js';

--- a/packages/integrations/image/src/build/ssr.ts
+++ b/packages/integrations/image/src/build/ssr.ts
@@ -1,7 +1,7 @@
-import fs from 'fs/promises';
-import path from 'path';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import glob from 'tiny-glob';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { ensureDir } from '../utils/paths.js';
 
 async function globImages(dir: URL) {

--- a/packages/integrations/image/src/endpoints/prod.ts
+++ b/packages/integrations/image/src/endpoints/prod.ts
@@ -1,7 +1,6 @@
 import type { APIRoute } from 'astro';
 import etag from 'etag';
 import { lookup } from 'mrmime';
-import { fileURLToPath } from 'url';
 // @ts-ignore
 import loader from 'virtual:image-loader';
 import { isRemoteImage, loadLocalImage, loadRemoteImage } from '../utils/images.js';
@@ -20,8 +19,9 @@ export const get: APIRoute = async ({ request }) => {
 		if (isRemoteImage(transform.src)) {
 			inputBuffer = await loadRemoteImage(transform.src);
 		} else {
-			const pathname = fileURLToPath(new URL(`../client${transform.src}`, import.meta.url));
-			inputBuffer = await loadLocalImage(pathname);
+			const clientRoot = new URL('../client/', import.meta.url);
+			const localPath = new URL('.' + transform.src, clientRoot);
+			inputBuffer = await loadLocalImage(localPath.pathname);
 		}
 
 		if (!inputBuffer) {

--- a/packages/integrations/image/src/lib/get-picture.ts
+++ b/packages/integrations/image/src/lib/get-picture.ts
@@ -1,5 +1,5 @@
 import { lookup } from 'mrmime';
-import { extname } from 'path';
+import { extname } from 'node:path';
 import { ImageAttributes, ImageMetadata, OutputFormat, TransformOptions } from '../types.js';
 import { parseAspectRatio } from '../utils/images.js';
 import { getImage } from './get-image.js';

--- a/packages/integrations/image/src/utils/images.ts
+++ b/packages/integrations/image/src/utils/images.ts
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 import type { OutputFormat, TransformOptions } from '../types.js';
 
 export function isOutputFormat(value: string): value is OutputFormat {

--- a/packages/integrations/image/src/utils/metadata.ts
+++ b/packages/integrations/image/src/utils/metadata.ts
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 import sizeOf from 'image-size';
 import { ImageMetadata, InputFormat } from '../types.js';
 

--- a/packages/integrations/image/src/utils/paths.ts
+++ b/packages/integrations/image/src/utils/paths.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { OUTPUT_DIR } from '../constants.js';
 import type { TransformOptions } from '../types.js';
 import { isRemoteImage } from './images.js';

--- a/packages/integrations/image/src/vite-plugin-astro-image.ts
+++ b/packages/integrations/image/src/vite-plugin-astro-image.ts
@@ -1,7 +1,7 @@
 import type { AstroConfig } from 'astro';
 import type { PluginContext } from 'rollup';
 import slash from 'slash';
-import { pathToFileURL } from 'url';
+import { pathToFileURL } from 'node:url';
 import type { Plugin, ResolvedConfig } from 'vite';
 import type { IntegrationOptions } from './types.js';
 import { metadata } from './utils/metadata.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2090,12 +2090,12 @@ importers:
       mrmime: 1.0.1
       sharp: 0.30.7
       slash: 4.0.0
+      tiny-glob: 0.2.9
     devDependencies:
       '@types/etag': 1.8.1
       '@types/sharp': 0.30.4
       astro: link:../../astro
       astro-scripts: link:../../../scripts
-      tiny-glob: 0.2.9
 
   packages/integrations/image/test/fixtures/basic-image:
     specifiers:
@@ -11046,7 +11046,6 @@ packages:
 
   /globalyzer/0.1.0:
     resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
-    dev: true
 
   /globby/11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -11074,7 +11073,6 @@ packages:
 
   /globrex/0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-    dev: true
 
   /graceful-fs/4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
@@ -15340,7 +15338,6 @@ packages:
     dependencies:
       globalyzer: 0.1.0
       globrex: 0.1.2
-    dev: true
 
   /tmp/0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}


### PR DESCRIPTION
## Changes

Closes #4041 
This removes the `fileURLToPath` dependency from the SSR production endpoint used by `@astrojs/image`

## Testing

All existing SSR tests should pass

## Docs

None, bug fix only