### PR TITLE
Fix MDX + Tailwind, add support for injected page-ssr scripts to MDX extension

### DIFF
--- a/.changeset/great-insects-beam.md
+++ b/.changeset/great-insects-beam.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Add support for injected "page-ssr" scripts

--- a/packages/astro/test/fixtures/tailwindcss/astro.config.mjs
+++ b/packages/astro/test/fixtures/tailwindcss/astro.config.mjs
@@ -1,12 +1,13 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
+import mdx from '@astrojs/mdx';
 
 // https://astro.build/config
 export default defineConfig({
 	legacy: {
 		astroFlavoredMarkdown: true,
 	},
-	integrations: [tailwind()],
+	integrations: [tailwind(), mdx()],
 	vite: {
 		build: {
 			assetsInlineLimit: 0,

--- a/packages/astro/test/fixtures/tailwindcss/package.json
+++ b/packages/astro/test/fixtures/tailwindcss/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@astrojs/tailwind": "workspace:*",
+    "@astrojs/mdx": "workspace:*",
     "astro": "workspace:*",
     "autoprefixer": "^10.4.7",
     "postcss": "^8.4.14",

--- a/packages/astro/test/fixtures/tailwindcss/src/pages/mdx-page.mdx
+++ b/packages/astro/test/fixtures/tailwindcss/src/pages/mdx-page.mdx
@@ -1,0 +1,7 @@
+import Button from '../components/Button.astro';
+import Complex from '../components/Complex.astro';
+
+<div class="grid place-items-center h-screen content-center">
+    <Button>Tailwind Button in Markdown!</Button>
+    <Complex />
+</div>

--- a/packages/astro/test/tailwindcss.test.js
+++ b/packages/astro/test/tailwindcss.test.js
@@ -65,5 +65,13 @@ describe('Tailwind', () => {
 			const mdBundledCSS = await fixture.readFile(bundledCSSHREF.replace(/^\/?/, '/'));
 			expect(mdBundledCSS, 'includes used component classes').to.match(/\.bg-purple-600{/);
 		});
+
+		it('handles MDX pages (with integration)', async () => {
+			const html = await fixture.readFile('/mdx-page/index.html');
+			const $md = cheerio.load(html);
+			const bundledCSSHREF = $md('link[rel=stylesheet][href^=/assets/]').attr('href');
+			const mdBundledCSS = await fixture.readFile(bundledCSSHREF.replace(/^\/?/, '/'));
+			expect(mdBundledCSS, 'includes used component classes').to.match(/\.bg-purple-600{/);
+		});
 	});
 });

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -89,6 +89,13 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 									if (!id.endsWith('.mdx')) return;
 									const [, moduleExports] = parseESM(code);
 
+									// This adds support for injected "page-ssr" scripts in MDX files.
+									// TODO: This should only be happening on page entrypoints, not all imported MDX.
+									// TODO: This code is copy-pasted across all Astro/Vite plugins that deal with page
+									// entrypoints (.astro, .md, .mdx). This should be handled in some centralized place,
+									// or otherwise refactored to not require copy-paste handling logic.
+									code += `\nimport "${'astro:scripts/page-ssr.js'}";`;
+
 									if (!moduleExports.includes('url')) {
 										const { fileUrl } = getFileInfo(id, config);
 										code += `\nexport const url = ${JSON.stringify(fileUrl)};`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1929,12 +1929,14 @@ importers:
 
   packages/astro/test/fixtures/tailwindcss:
     specifiers:
+      '@astrojs/mdx': workspace:*
       '@astrojs/tailwind': workspace:*
       astro: workspace:*
       autoprefixer: ^10.4.7
       postcss: ^8.4.14
       tailwindcss: ^3.0.24
     dependencies:
+      '@astrojs/mdx': link:../../../../integrations/mdx
       '@astrojs/tailwind': link:../../../../integrations/tailwind
       astro: link:../../..
       autoprefixer: 10.4.7_postcss@8.4.14


### PR DESCRIPTION
## Changes

- This is a short-term fix to add basic script injection handling to the MDX integration, to unblock MDX + Tailwind.
- I call it short term because this is code that we've identified as a copy-paste risk that I've now pasted into a third place. On top of that, it is missing some logic to only inject the page script on MDX pages, and not non-page MDX files. That is considered a larger regression that will probably need a larger refactoring to solve for. In the meantime, this unblocks a v1.0 RC release.
- With this I now see tailwind working with `.mdx`, `.md (legacy)`, and `.md (current)`

## Testing

- Added a test.

## Docs

- N/A