### PR TITLE
Prevent Svelte HMR warning during the build

### DIFF
--- a/.changeset/lucky-phones-mix.md
+++ b/.changeset/lucky-phones-mix.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/svelte': patch
+---
+
+Remove Svelte HMR warning during the build

--- a/packages/integrations/svelte/src/index.ts
+++ b/packages/integrations/svelte/src/index.ts
@@ -38,6 +38,11 @@ function getViteConfiguration({
 		],
 	};
 
+	// Disable hot mode during the build
+	if(!isDev) {
+		defaultOptions.hot = false;
+	}
+
 	let resolvedOptions: Partial<Options>;
 
 	if (!options) {


### PR DESCRIPTION
## Changes

- This warning is shown in svelte: `[vite-plugin-svelte] hmr is enabled but compilerOptions.dev is false, forcing it to true`
- This sets hot to false when not in dev, getting rid of the warning.

## Testing

Just manually since it's a warning that can't be easily unit-tested.

## Docs

N/A