### PR TITLE
Add tests for markdown content escaping

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -82,7 +82,7 @@
     "test:e2e:match": "playwright test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.22.0",
+    "@astrojs/compiler": "^0.22.1",
     "@astrojs/language-server": "^0.20.0",
     "@astrojs/markdown-remark": "^0.13.0",
     "@astrojs/prism": "0.6.1",

--- a/packages/astro/test/fixtures/markdown/src/pages/entities.md
+++ b/packages/astro/test/fixtures/markdown/src/pages/entities.md
@@ -1,0 +1,3 @@
+# Lesser than: Cannot escape `<` using `&lt;`
+
+&lt;i&gt;This should NOT be italic&lt;/i&gt;

--- a/packages/astro/test/markdown.test.js
+++ b/packages/astro/test/markdown.test.js
@@ -3,28 +3,39 @@ import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Markdown tests', () => {
+	/** @type {import('./test-utils').Fixture} */
 	let fixture;
 
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/markdown/',
 		});
-		await fixture.build();
 	});
 
-	it('Can load a simple markdown page with Astro', async () => {
-		const html = await fixture.readFile('/post/index.html');
-		const $ = cheerio.load(html);
+	describe('Build', () => {
+		before(async () => {
+			await fixture.build();
+		});
+	
+		it('Can load a simple markdown page with Astro', async () => {
+			const html = await fixture.readFile('/post/index.html');
+			const $ = cheerio.load(html);
+	
+			expect($('p').first().text()).to.equal('Hello world!');
+			expect($('#first').text()).to.equal('Some content');
+			expect($('#interesting-topic').text()).to.equal('Interesting Topic');
+		});
+	
+		it('Can load a realworld markdown page with Astro', async () => {
+			const html = await fixture.readFile('/realworld/index.html');
+			const $ = cheerio.load(html);
+	
+			expect($('pre')).to.have.lengthOf(7);
+		});
 
-		expect($('p').first().text()).to.equal('Hello world!');
-		expect($('#first').text()).to.equal('Some content');
-		expect($('#interesting-topic').text()).to.equal('Interesting Topic');
-	});
-
-	it('Can load a realworld markdown page with Astro', async () => {
-		const html = await fixture.readFile('/realworld/index.html');
-		const $ = cheerio.load(html);
-
-		expect($('pre')).to.have.lengthOf(7);
+		it('Does not unescape entities', async () => {
+			const html = await fixture.readFile('/entities/index.html');
+			expect(html).to.match(new RegExp("&#x3C;i>This should NOT be italic&#x3C;/i>"));
+		});
 	});
 });

--- a/packages/markdown/remark/src/rehype-escape.ts
+++ b/packages/markdown/remark/src/rehype-escape.ts
@@ -1,5 +1,9 @@
 import { visit } from 'unist-util-visit';
 
+export function escapeEntities(value: string): string {
+	return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 export default function rehypeEscape(): any {
 	return function (node: any): any {
 		return visit(node, 'element', (el) => {
@@ -8,7 +12,7 @@ export default function rehypeEscape(): any {
 				// Visit all raw children and escape HTML tags to prevent Markdown code
 				// like "This is a `<script>` tag" from actually opening a script tag
 				visit(el, 'raw', (raw) => {
-					raw.value = raw.value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+					raw.value = escapeEntities(raw.value);
 				});
 			}
 			return el;

--- a/packages/markdown/remark/test/entities.test.js
+++ b/packages/markdown/remark/test/entities.test.js
@@ -1,0 +1,12 @@
+import { renderMarkdown } from '../dist/index.js';
+import { expect } from 'chai';
+
+describe('entities', () => {
+	const renderAstroMd = (text) => renderMarkdown(text, { isAstroFlavoredMd: false });
+
+	it('should not unescape entities', async () => {
+		const { code } = await renderAstroMd(`&lt;i&gt;This should NOT be italic&lt;/i&gt;`);
+
+		expect(code).to.equal(`<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>`);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,7 +438,7 @@ importers:
 
   packages/astro:
     specifiers:
-      '@astrojs/compiler': ^0.22.0
+      '@astrojs/compiler': ^0.22.1
       '@astrojs/language-server': ^0.20.0
       '@astrojs/markdown-remark': ^0.13.0
       '@astrojs/prism': 0.6.1
@@ -526,7 +526,7 @@ importers:
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
-      '@astrojs/compiler': 0.22.0
+      '@astrojs/compiler': 0.22.1
       '@astrojs/language-server': 0.20.1
       '@astrojs/markdown-remark': link:../markdown/remark
       '@astrojs/prism': link:../astro-prism
@@ -2962,8 +2962,8 @@ packages:
       leven: 3.1.0
     dev: true
 
-  /@astrojs/compiler/0.22.0:
-    resolution: {integrity: sha512-TF3zwbPIgr3UPPkVquKUzSGsIqGKh3Gi34Y29+HZvL+YmrkAk+GAuUkOo2EXDJ6aS2Oxq0k7KO/yQ2LjkWl83A==}
+  /@astrojs/compiler/0.22.1:
+    resolution: {integrity: sha512-FiRZ7fwJhADPo2X1unTyEq9V7EfeWE3GOBhzKDcFIF8mc5iLZ0VmPXrGmvOUTRXkZH99+TkB1SXGaTDjelRa2w==}
     dev: false
 
   /@astrojs/language-server/0.20.1:


### PR DESCRIPTION
## Changes

- The underlying bug was fixed in the compiler. This adds tests for the more specific scenario that was reported.
- Closes https://github.com/withastro/astro/issues/3916

## Testing

- Astro and remark plugin tests added.

## Docs

N/A