### PR TITLE
Add errors to cloudflare/vercel adapters when no output config

### DIFF
--- a/.changeset/giant-dolls-reply.md
+++ b/.changeset/giant-dolls-reply.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/cloudflare': minor
+'@astrojs/vercel': minor
+---
+
+Add explicit errors when omitting output config

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
-    "dev": "astro-scripts dev \"src/**/*.ts\""
+    "dev": "astro-scripts dev \"src/**/*.ts\"",
+    "test": "mocha --exit --timeout 20000 test/"
   },
   "dependencies": {
     "esbuild": "^0.14.42"

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -23,12 +23,10 @@ export default function createIntegration(): AstroIntegration {
 				_config = config;
 
 				if (config.output === 'static') {
-					console.warn(
-						`[@astrojs/cloudflare] \`output: "server"\` is required to use this adapter.`
-					);
-					console.warn(
-						`[@astrojs/cloudflare] Otherwise, this adapter is not required to deploy a static site to Cloudflare.`
-					);
+					throw new Error(`
+  [@astrojs/cloudflare] \`output: "server"\` is required to use this adapter. Otherwise, this adapter is not necessary to deploy a static site to Cloudflare.
+
+`);
 				}
 			},
 			'astro:build:start': ({ buildConfig }) => {

--- a/packages/integrations/cloudflare/test/fixtures/no-output/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/no-output/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+import cloudflare from '@astrojs/cloudflare';
+
+export default defineConfig({
+	adapter: cloudflare()
+});

--- a/packages/integrations/cloudflare/test/fixtures/no-output/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/no-output/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/astro-cloudflare-no-output",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/cloudflare": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/cloudflare/test/no-output.test.js
+++ b/packages/integrations/cloudflare/test/no-output.test.js
@@ -1,0 +1,25 @@
+import { loadFixture } from './test-utils.js';
+import { expect } from 'chai';
+
+describe('Missing output config', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/no-output/',
+		});
+	});
+
+	it('throws during the build', async () => {
+		let error = undefined;
+		try {
+			await fixture.build();
+		} catch(err) {
+			error = err;
+		}
+		expect(error).to.not.be.equal(undefined);
+		expect(error.message).to.include(`output: "server"`);
+	});
+});
+

--- a/packages/integrations/cloudflare/test/test-utils.js
+++ b/packages/integrations/cloudflare/test/test-utils.js
@@ -1,0 +1,10 @@
+import { loadFixture as baseLoadFixture } from '../../../astro/test/test-utils.js';
+
+export { fixLineEndings } from '../../../astro/test/test-utils.js';
+
+export function loadFixture(config) {
+	if (config?.root) {
+		config.root = new URL(config.root, import.meta.url);
+	}
+	return baseLoadFixture(config);
+}

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -39,7 +39,8 @@
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
-    "dev": "astro-scripts dev \"src/**/*.ts\""
+    "dev": "astro-scripts dev \"src/**/*.ts\"",
+    "test": "mocha --exit --timeout 20000 test/"
   },
   "dependencies": {
     "@astrojs/webapi": "^0.12.0",

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -28,6 +28,13 @@ export default function vercelEdge(): AstroIntegration {
 			'astro:config:done': ({ setAdapter, config }) => {
 				setAdapter(getAdapter());
 				_config = config;
+
+				if(config.output === 'static') {
+						throw new Error(`
+		[@astrojs/vercel] \`output: "server"\` is required to use the serverless adapter.
+	
+	`);
+				}
 			},
 			'astro:build:start': async ({ buildConfig }) => {
 				buildConfig.serverEntry = serverEntry = 'entry.js';

--- a/packages/integrations/vercel/test/fixtures/no-output/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/no-output/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+import vercel from '@astrojs/vercel/serverless';
+
+export default defineConfig({
+	adapter: vercel()
+});

--- a/packages/integrations/vercel/test/fixtures/no-output/package.json
+++ b/packages/integrations/vercel/test/fixtures/no-output/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/astro-vercel-no-output",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/vercel": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/vercel/test/fixtures/no-output/src/pages/index.astro
+++ b/packages/integrations/vercel/test/fixtures/no-output/src/pages/index.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>testing</title>
+	</head>
+	<body>
+		<h1>testing</h1>
+	</body>
+</html>

--- a/packages/integrations/vercel/test/no-output.test.js
+++ b/packages/integrations/vercel/test/no-output.test.js
@@ -1,0 +1,25 @@
+import { loadFixture } from './test-utils.js';
+import { expect } from 'chai';
+
+describe('Missing output config', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/no-output/',
+		});
+	});
+
+	it('throws during the build', async () => {
+		let error = undefined;
+		try {
+			await fixture.build();
+		} catch(err) {
+			error = err;
+		}
+		expect(error).to.not.be.equal(undefined);
+		expect(error.message).to.include(`output: "server"`);
+	});
+});
+

--- a/packages/integrations/vercel/test/test-utils.js
+++ b/packages/integrations/vercel/test/test-utils.js
@@ -1,0 +1,10 @@
+import { loadFixture as baseLoadFixture } from '../../../astro/test/test-utils.js';
+
+export { fixLineEndings } from '../../../astro/test/test-utils.js';
+
+export function loadFixture(config) {
+	if (config?.root) {
+		config.root = new URL(config.root, import.meta.url);
+	}
+	return baseLoadFixture(config);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2039,6 +2039,14 @@ importers:
       astro: link:../../astro
       astro-scripts: link:../../../scripts
 
+  packages/integrations/cloudflare/test/fixtures/no-output:
+    specifiers:
+      '@astrojs/cloudflare': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/cloudflare': link:../../..
+      astro: link:../../../../../astro
+
   packages/integrations/deno:
     specifiers:
       astro: workspace:*
@@ -2430,6 +2438,14 @@ importers:
     devDependencies:
       astro: link:../../astro
       astro-scripts: link:../../../scripts
+
+  packages/integrations/vercel/test/fixtures/no-output:
+    specifiers:
+      '@astrojs/vercel': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/vercel': link:../../..
+      astro: link:../../../../../astro
 
   packages/integrations/vue:
     specifiers:


### PR DESCRIPTION
## Changes

- Throw an error in these adapters when `output` config is set to static.
- This problem was reported by multiple people in Discord that did not realize you needed the config.
- Closes https://github.com/withastro/astro/issues/4066

## Testing

- Tests added for both.

## Docs

None