### PR TITLE
Add fontsource packages to always be noExternal

### DIFF
--- a/.changeset/clever-nails-pump.md
+++ b/.changeset/clever-nails-pump.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes use of @fontsource packages

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -34,6 +34,8 @@ const ALWAYS_NOEXTERNAL = new Set([
 	// Handle recommended nanostores. Only @nanostores/preact is required from our testing!
 	// Full explanation and related bug report: https://github.com/withastro/astro/pull/3667
 	'@nanostores/preact',
+	// fontsource packages are CSS that need to be processed
+	'@fontsource/*',
 ]);
 
 function getSsrNoExternalDeps(projectRoot: URL): string[] {


### PR DESCRIPTION
## Changes

- Adds `'@fontsource/*'` to always be part of `noExternal` config.
- Fixes https://github.com/withastro/astro/issues/4071

## Testing

- tested manually
- we have a fontsource mocha test, but because of the monorepo it doesn't get loaded the same way as in a real app :/

## Docs

N/A, bug fix