### PR TITLE
Fix shape of Markdown component to work with the language-server

### DIFF
--- a/.changeset/rich-months-develop.md
+++ b/.changeset/rich-months-develop.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-component': patch
+---
+
+Fix TypeScript error when importing the component

--- a/packages/markdown/component/Markdown.astro
+++ b/packages/markdown/component/Markdown.astro
@@ -50,4 +50,6 @@ if (content) {
 html = htmlContent;
 ---
 
+<>
 {html ? <Fragment set:html={html} /> : <slot />}
+</>


### PR DESCRIPTION
## Changes

The language-server doesn't support an Astro component just being a JSX expression. This is fixed in the new TSX output, however until then, importing the Markdown component leads to an error for users, so might as well do this temporary fix by wrapping it in a Fragment

## Testing

Tested manually

## Docs

N/A