### PR TITLE
remove unused util polyfill dependency

### DIFF
--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -539,7 +539,6 @@ async function tryToInstallIntegrations({
 	const installCommand = await getInstallIntegrationsCommand({ integrations, cwd });
 
 	if (installCommand === null) {
-		info(logging, null);
 		return UpdateResult.none;
 	} else {
 		const coloredOutput = `${bold(installCommand.pm)} ${

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -168,8 +168,8 @@ export class App {
 			});
 
 			return response;
-		} catch (err) {
-			error(this.#logging, 'ssr', err);
+		} catch (err: any) {
+			error(this.#logging, 'ssr', err.stack || err.message || String(err));
 			return new Response(null, {
 				status: 500,
 				statusText: 'Internal server error',

--- a/packages/astro/src/core/logger/console.ts
+++ b/packages/astro/src/core/logger/console.ts
@@ -1,5 +1,4 @@
 import { bold, cyan, dim, red, reset, yellow } from 'kleur/colors';
-import { format as utilFormat } from 'util';
 import type { LogMessage } from './core.js';
 import { dateTimeFormat, levels } from './core.js';
 
@@ -33,7 +32,7 @@ export const consoleLogDestination = {
 			return reset(prefix);
 		}
 
-		let message = utilFormat(...event.args);
+		let message = event.message;
 		// For repeat messages, only update the message counter
 		if (message === lastMessage) {
 			lastMessageCount++;

--- a/packages/astro/src/core/logger/core.ts
+++ b/packages/astro/src/core/logger/core.ts
@@ -32,7 +32,6 @@ export interface LogMessage {
 	type: string | null;
 	level: LoggerLevel;
 	message: string;
-	args: Array<any>;
 }
 
 export const levels: Record<LoggerLevel, number> = {
@@ -48,15 +47,14 @@ export function log(
 	opts: LogOptions,
 	level: LoggerLevel,
 	type: string | null,
-	...args: Array<any>
+	message: string,
 ) {
 	const logLevel = opts.level;
 	const dest = opts.dest;
 	const event: LogMessage = {
 		type,
 		level,
-		args,
-		message: '',
+		message
 	};
 
 	// test if this level is enabled or not
@@ -68,26 +66,26 @@ export function log(
 }
 
 /** Emit a user-facing message. Useful for UI and other console messages. */
-export function info(opts: LogOptions, type: string | null, ...messages: Array<any>) {
-	return log(opts, 'info', type, ...messages);
+export function info(opts: LogOptions, type: string | null, message: string) {
+	return log(opts, 'info', type, message);
 }
 
 /** Emit a warning message. Useful for high-priority messages that aren't necessarily errors. */
-export function warn(opts: LogOptions, type: string | null, ...messages: Array<any>) {
-	return log(opts, 'warn', type, ...messages);
+export function warn(opts: LogOptions, type: string | null, message: string) {
+	return log(opts, 'warn', type, message);
 }
 
 /** Emit a error message, Useful when Astro can't recover from some error. */
-export function error(opts: LogOptions, type: string | null, ...messages: Array<any>) {
-	return log(opts, 'error', type, ...messages);
+export function error(opts: LogOptions, type: string | null, message: string) {
+	return log(opts, 'error', type, message);
 }
 
 type LogFn = typeof info | typeof warn | typeof error;
 
 export function table(opts: LogOptions, columns: number[]) {
 	return function logTable(logFn: LogFn, ...input: Array<any>) {
-		const messages = columns.map((len, i) => padStr(input[i].toString(), len));
-		logFn(opts, null, ...messages);
+		const message = columns.map((len, i) => padStr(input[i].toString(), len)).join(' ');
+		logFn(opts, null, message);
 	};
 }
 

--- a/packages/astro/src/core/logger/node.ts
+++ b/packages/astro/src/core/logger/node.ts
@@ -3,7 +3,6 @@ import { bold, cyan, dim, red, reset, yellow } from 'kleur/colors';
 import * as readline from 'readline';
 import { Writable } from 'stream';
 import stringWidth from 'string-width';
-import { format as utilFormat } from 'util';
 import { dateTimeFormat, error, info, warn } from './core.js';
 
 type ConsoleStream = Writable & {
@@ -39,7 +38,8 @@ export const nodeLogDestination = new Writable({
 			return reset(prefix);
 		}
 
-		let message = utilFormat(...event.args);
+		// console.log({msg: event.message, args: event.args});
+		let message = event.message;
 		// For repeat messages, only update the message counter
 		if (message === lastMessage) {
 			lastMessageCount++;
@@ -90,7 +90,6 @@ export interface LogMessage {
 	type: string | null;
 	level: LoggerLevel;
 	message: string;
-	args: Array<any>;
 }
 
 export const levels: Record<LoggerLevel, number> = {

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -124,7 +124,7 @@ export default async function preview(
 					port++;
 					return listen(); // retry
 				} else {
-					error(logging, 'astro', err.stack);
+					error(logging, 'astro', err.stack || err.message);
 					httpServer?.removeListener('error', onError);
 					reject(err); // reject
 				}

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -176,7 +176,7 @@ describe('Static build', () => {
 		for (const log of logs) {
 			if (
 				log.type === 'ssg' &&
-				/[hH]eaders are not exposed in static \(SSG\) output mode/.test(log.args[0])
+				/[hH]eaders are not exposed in static \(SSG\) output mode/.test(log.message)
 			) {
 				found = true;
 			}


### PR DESCRIPTION
## Changes

- This removes a previously undiscovered transitive dependency on the npm `util` package (polyfilling the node `util` package when deploying to SSR)
- Turns out we weren't actually using this feature anywhere, and creating a more strict type signature actually found a couple of small errors in the code.
- This will let us remove the `util` dependency entirely via https://github.com/withastro/astro/pull/4096, saving [~ 44 total deps](https://npm.anvaka.com/#/view/2d/util) from our dep tree. 
- cc @Princesseuh 

## Testing

- Covered by existing tests.

## Docs

- N/A