### PR TITLE
Do not send body with HEAD and GET on node integration

### DIFF
--- a/.changeset/seven-suits-sit.md
+++ b/.changeset/seven-suits-sit.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Do not send `body` with `HEAD` or `GET` requests when using `server` output.

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -11,10 +11,11 @@ function createRequestFromNodeRequest(req: IncomingMessage, body?: Uint8Array): 
 	let url = `http://${req.headers.host}${req.url}`;
 	let rawHeaders = req.headers as Record<string, any>;
 	const entries = Object.entries(rawHeaders);
+	const method = req.method || 'GET';
 	let request = new Request(url, {
-		method: req.method || 'GET',
+		method,
 		headers: new Headers(entries),
-		body,
+		body: ['HEAD', 'GET'].includes(method) ? null : body,
 	});
 	if (req.socket?.remoteAddress) {
 		Reflect.set(request, clientAddressSymbol, req.socket.remoteAddress);


### PR DESCRIPTION
## Changes

- With latest change astro always set body on node integration Request

## Testing

With the default SSR it does not works and get error, after it works.

Error reported:

```
TypeError: Request with GET/HEAD method cannot have body.
    at new Request (node:internal/deps/undici/undici:5599:17)
    at createRequestFromNodeRequest (file:///Users/e01/Workspace/astro-ssr-demo/node_modules/astro/dist/core/app/node.js:11:16)
    at file:///Users/e01/Workspace/astro-ssr-demo/node_modules/astro/dist/core/app/node.js:40:60
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async handler (file:///Users/e01/Workspace/astro-ssr-demo/node_modules/@astrojs/node/dist/server.js:14:30)
```

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->