### PR TITLE
Load configs with Vite when loading with Proload fails

### DIFF
--- a/.changeset/dull-radios-sparkle.md
+++ b/.changeset/dull-radios-sparkle.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/mdx': patch
+---
+
+Fix MDX working with a ts config file

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -490,7 +490,6 @@ async function tryLoadConfig(configOptions: LoadConfigOptions, flags: CLIFlags, 
 
 		return config as TryLoadConfigResult;
 	} catch(e) {
-		//console.log("THE REAL ERROR", e);
 		if (e instanceof ProloadError && flags.config) {
 			throw new Error(`Unable to resolve --config "${flags.config}"! Does the file exist?`);
 		}
@@ -500,6 +499,7 @@ async function tryLoadConfig(configOptions: LoadConfigOptions, flags: CLIFlags, 
 			throw e;
 		}
 
+		// Fallback to use Vite DevServer
 		const viteServer = await vite.createServer({});
 		try {
 			const mod = await viteServer.ssrLoadModule(fileURLToPath(configURL));

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -500,7 +500,10 @@ async function tryLoadConfig(configOptions: LoadConfigOptions, flags: CLIFlags, 
 		}
 
 		// Fallback to use Vite DevServer
-		const viteServer = await vite.createServer({});
+		const viteServer = await vite.createServer({
+			server: { middlewareMode: true, hmr: false },
+			appType: 'custom'
+		});
 		try {
 			const mod = await viteServer.ssrLoadModule(fileURLToPath(configURL));
 

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -457,7 +457,7 @@ export async function openConfig(configOptions: LoadConfigOptions): Promise<Open
 	try {
 		const configURL = await resolveConfigURL(configOptions);
 		if(configURL) {
-			const mod = await loadWithVite(configURL);
+			const mod = await loadFileThatMightNeedTransformation(configURL);
 			if(mod?.default) {
 				config = {
 					filePath: fileURLToPath(configURL),
@@ -492,7 +492,10 @@ export async function openConfig(configOptions: LoadConfigOptions): Promise<Open
 	};
 }
 
-async function loadWithVite(url: URL) {
+async function loadFileThatMightNeedTransformation(url: URL) {
+	if(/\.m?js/.test(url.pathname)) {
+		return import(url.toString());
+	}
 	const viteServer = await vite.createServer({});
 	const mod = await viteServer.ssrLoadModule(fileURLToPath(url));
 	await viteServer.close();
@@ -522,7 +525,7 @@ export async function loadConfig(configOptions: LoadConfigOptions): Promise<Astr
 	try {
 		const configURL = await resolveConfigURL(configOptions);
 		if(configURL) {
-			const mod = await loadWithVite(configURL);
+			const mod = await loadFileThatMightNeedTransformation(configURL);
 			if(mod?.default) {
 				config = { value: mod.default };
 			}

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -490,9 +490,6 @@ async function tryLoadConfig(configOptions: LoadConfigOptions, flags: CLIFlags, 
 
 		return config as TryLoadConfigResult;
 	} catch(e) {
-		console.error = function(ee) {
-			console.log("I SHOULD NOT HAVE DONE THIS!");
-		}
 		//console.log("THE REAL ERROR", e);
 		if (e instanceof ProloadError && flags.config) {
 			throw new Error(`Unable to resolve --config "${flags.config}"! Does the file exist?`);

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -49,7 +49,7 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 						// Workarounds tried:
 						// - "import * as remarkShikiTwoslash"
 						// - "import { default as remarkShikiTwoslash }"
-						(remarkShikiTwoslash as any).default,
+						(remarkShikiTwoslash as any).default ?? remarkShikiTwoslash,
 						config.markdown.shikiConfig,
 					]);
 					rehypePlugins.push([rehypeRaw, { passThrough: nodeTypes }]);

--- a/packages/integrations/mdx/test/fixtures/mdx-page/astro.config.ts
+++ b/packages/integrations/mdx/test/fixtures/mdx-page/astro.config.ts
@@ -1,0 +1,5 @@
+import mdx from '@astrojs/mdx';
+
+export default {
+	integrations: [mdx()]
+}

--- a/packages/integrations/mdx/test/fixtures/mdx-page/package.json
+++ b/packages/integrations/mdx/test/fixtures/mdx-page/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/mdx-page",
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/mdx": "workspace:*"
+  }
+}

--- a/packages/integrations/mdx/test/mdx-page.test.js
+++ b/packages/integrations/mdx/test/mdx-page.test.js
@@ -9,8 +9,7 @@ describe('MDX Page', () => {
 
 	before(async () => {
 		fixture = await loadFixture({
-			root: new URL('./fixtures/mdx-page/', import.meta.url),
-			integrations: [mdx()],
+			root: new URL('./fixtures/mdx-page/', import.meta.url)
 		});
 	});
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2221,6 +2221,14 @@ importers:
       mocha: 9.2.2
       remark-toc: 8.0.1
 
+  packages/integrations/mdx/test/fixtures/mdx-page:
+    specifiers:
+      '@astrojs/mdx': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/mdx': link:../../..
+      astro: link:../../../../../astro
+
   packages/integrations/netlify:
     specifiers:
       '@astrojs/webapi': ^0.12.0


### PR DESCRIPTION
## Changes

- Use `vite.createServer().ssrLoadModule` to load the config, rather than using preloads plugins.
- Only do this when Proload fails, as Vite transforms modules in ways that can break them.
- Fixes https://github.com/withastro/astro/issues/4078

## Testing

- Test added

## Docs

N/A