### PR TITLE
Do not crawl non-style deps imported by styles

### DIFF
--- a/.changeset/weak-crabs-pump.md
+++ b/.changeset/weak-crabs-pump.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix edge case with hoisted scripts and Tailwind during dev

--- a/packages/astro/src/core/render/dev/vite.ts
+++ b/packages/astro/src/core/render/dev/vite.ts
@@ -1,5 +1,6 @@
 import npath from 'path';
 import vite from 'vite';
+import { STYLE_EXTENSIONS } from '../util.js';
 import { unwrapId } from '../../util.js';
 
 /**
@@ -36,6 +37,7 @@ export async function* crawlGraph(
 		}
 		if (id === entry.id) {
 			scanned.add(id);
+			const entryIsStyle = STYLE_EXTENSIONS.has(npath.extname(id))
 			for (const importedModule of entry.importedModules) {
 				// some dynamically imported modules are *not* server rendered in time
 				// to only SSR modules that we can safely transform, we check against
@@ -43,6 +45,14 @@ export async function* crawlGraph(
 				if (importedModule.id) {
 					// use URL to strip special query params like "?content"
 					const { pathname } = new URL(`file://${importedModule.id}`);
+					// If the entry is a style, skip any modules that are not also styles.
+					// Tools like Tailwind might add HMR dependencies as `importedModules`
+					// but we should skip them--they aren't really imported. Without this,
+					// every hoisted script in the project is added to every page!
+					if (entryIsStyle && !STYLE_EXTENSIONS.has(npath.extname(pathname))) {
+						importedModules.add(importedModule);
+						continue;
+					}
 					if (fileExtensionsToSSR.has(npath.extname(pathname))) {
 						const mod = viteServer.moduleGraph.getModuleById(importedModule.id);
 						if (!mod?.ssrModule) {

--- a/packages/astro/src/core/render/dev/vite.ts
+++ b/packages/astro/src/core/render/dev/vite.ts
@@ -50,7 +50,6 @@ export async function* crawlGraph(
 					// but we should skip them--they aren't really imported. Without this,
 					// every hoisted script in the project is added to every page!
 					if (entryIsStyle && !STYLE_EXTENSIONS.has(npath.extname(pathname))) {
-						importedModules.add(importedModule);
 						continue;
 					}
 					if (fileExtensionsToSSR.has(npath.extname(pathname))) {


### PR DESCRIPTION
## Changes

- I hit a very strange bug during `dev`... every page included every hoisted script in the project, even though the component was not imported.
- Turns out this was because of the way our `crawlGraph` utility interacted with Tailwind.
- Tailwind treats every component in the project as an `importedModule` of the `@tailwind base;` entrypoint. We were crawling these because they seem like valid imports.
- The fix is to check if the entrypoint is a style, and then only crawl the `importedModules` that are also styles. This sidesteps the over-eager hoisting.

## Testing

Tested manually, there's not a great way to test this edge case.

## Docs

N/A, bug fix