### PR TITLE
Clarify README on Cloudflare adapter

### DIFF
--- a/packages/integrations/cloudflare/README.md
+++ b/packages/integrations/cloudflare/README.md
@@ -1,6 +1,6 @@
 # @astrojs/cloudflare
 
-An SSR adapter for use with Cloudflare Pages Functions targets. Write your code in Astro/Node and deploy to Cloudflare Pages.
+An SSR adapter for use with Cloudflare Pages Functions targets. Write your code in Astro/Javascript and deploy to Cloudflare Pages.
 
 In your `astro.config.mjs` use:
 


### PR DESCRIPTION
## Changes

- This changes the wording "Write your code in Astro/Node" to "Write your code in Astro/Javascript"
- In my opinion, this change is good for a number of reasons.
  - Cloudflare Pages is not Node and never will be: Node modules such as `fs`, `path` and `http` are missing and while Astro might be able to polyfill some of them there's really no way to polyfill a filesystem or a couple of other Node-specific things.
  - With Astro you use `fetch` and similar APIs to make HTTP requests rather than 
  - "Javascript" is more generic than "Node" and better represents the way you code in Astro. You don't use a router like Node's `http` server or Express and similar (like people ask us often on the Cloudflare Developers Discord), you use the framework's built-in routing and primitives.
- I'm totally open to discussing this further, it just tripped me up for a second because I don't think of Cloudflare Pages Functions as Node (it's not).

## Testing

- No tests, docs change only.

## Docs

- This is a pure docs change, as summarized above.