### PR TITLE
Gitpod  - fix pnpm version error

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,6 +1,8 @@
 FROM gitpod/workspace-node-lts
 
 # Install latest pnpm
+RUN export PNPM_HOME="/home/gitpod/.local/share/pnpm"
+RUN export PATH="$PNPM_HOME:$PATH"
 RUN pnpm i -g pnpm
 
 # Install deno in gitpod

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,9 +1,7 @@
-FROM gitpod/workspace-node-lts
+FROM gitpod/workspace-node
 
 # Install latest pnpm
-RUN export PNPM_HOME="/home/gitpod/.local/share/pnpm"
-RUN export PATH="$PNPM_HOME:$PATH"
-RUN pnpm i -g pnpm
+RUN curl -fsSL https://get.pnpm.io/install.sh | sh -
 
 # Install deno in gitpod
 RUN curl -fsSL https://deno.land/x/install/install.sh | sh

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,7 +1,7 @@
 FROM gitpod/workspace-node
 
 # Install latest pnpm
-RUN curl -fsSL https://get.pnpm.io/install.sh | sh -
+RUN curl -fsSL https://get.pnpm.io/install.sh | SHELL=`which bash` bash -
 
 # Install deno in gitpod
 RUN curl -fsSL https://deno.land/x/install/install.sh | sh

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-node
+FROM gitpod/workspace-node-lts
 
 # Install latest pnpm
 RUN pnpm i -g pnpm

--- a/.gitpod/gitpod-setup.sh
+++ b/.gitpod/gitpod-setup.sh
@@ -15,7 +15,7 @@ else
 fi
 
 # Wait for VSCode to be ready (port 23000)
-gp await-port 23000 > /dev/null 2>&1
+gp ports --await 23000 > /dev/null 2>&1
 
 echo "Loading example project:" $EXAMPLE_PROJECT
 

--- a/.gitpod/gitpod-setup.sh
+++ b/.gitpod/gitpod-setup.sh
@@ -15,7 +15,7 @@ else
 fi
 
 # Wait for VSCode to be ready (port 23000)
-gp ports --await 23000 > /dev/null 2>&1
+gp ports await 23000 > /dev/null 2>&1
 
 echo "Loading example project:" $EXAMPLE_PROJECT
 


### PR DESCRIPTION
## Changes

- After #3747 was merged,
- `Open in Gitpod` button in https://astro.new ended up in a Gitpod workspace with errors.
- This PR installs the latest version of pnpm.

## Testing

- Use the fork branch of this PR, with the name of example you would like to test, here's how to test `framework-vue` -
https://gitpod.io/#https://github.com/shaal/astro/tree/gitpod--fix-pnpm-version-error/examples/framework-vue
- After a few seconds, Gitpod workspace would open with the example you selected displayed in a preview

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Note

- After running `pnpm run build`, there are 2 minor changes in `packages/webapi/mod.d.ts`, I think these changes are not related to this PR, but probably should be committed to the repo.

## Docs

This PR does not change anything in Astro itself, so no documentation update is needed.
<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->