### PR TITLE
Prefer loading renderers with native ESM over Vite

### DIFF
--- a/.changeset/quiet-games-cross.md
+++ b/.changeset/quiet-games-cross.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/preact': patch
+---
+
+Fixes double loading of preact deps

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -58,16 +58,16 @@ async function loadRenderer(
 	// it is explicitly marked as noExternal.
 	const noExternal = viteServer.config.ssr.noExternal;
 	if(noExternal === true || Array.isArray(noExternal) && noExternal.includes(renderer.serverEntrypoint)) {
-		const id = renderer.serverEntrypoint;
-		mod = (await import(id)) as SSRLoadedRendererServerModule;
-	} else {
-			// Vite modules can be out-of-date when using an un-resolved url
-	// We also encountered inconsistencies when using the resolveUrl and resolveId helpers
-	// We've found that pulling the ID directly from the urlToModuleMap is the most stable!
+		// Vite modules can be out-of-date when using an un-resolved url
+		// We also encountered inconsistencies when using the resolveUrl and resolveId helpers
+		// We've found that pulling the ID directly from the urlToModuleMap is the most stable!
 		const id =
 		viteServer.moduleGraph.urlToModuleMap.get(renderer.serverEntrypoint)?.id ??
 		renderer.serverEntrypoint;
 		mod = (await viteServer.ssrLoadModule(id)) as SSRLoadedRendererServerModule;
+	}	else {
+		const id = renderer.serverEntrypoint;
+		mod = (await import(id)) as SSRLoadedRendererServerModule;
 	}
 
 	return Object.create(renderer, {

--- a/packages/integrations/preact/src/index.ts
+++ b/packages/integrations/preact/src/index.ts
@@ -56,12 +56,7 @@ function getViteConfiguration(compat?: boolean): ViteUserConfig {
 				'@astrojs/preact/client.js',
 				'preact',
 				'preact/jsx-runtime',
-				'preact-render-to-string',
 			],
-			exclude: ['@astrojs/preact/server.js'],
-		},
-		ssr: {
-			external: ['preact-render-to-string'],
 		},
 	};
 


### PR DESCRIPTION
## Changes

- With Vite 3 most dependencies are loaded as `external` by default. However, when you explicitly call `viteServer.loadSsrModule` it will be vite-processed regardless of whether it is a dependency or not.
- This changes it so that we use `import()` by default for renderers.
- This fixes a bug specifically with preact, but very possible with others, where Vite processed files prefer to load direct deps as CJS and Node prefers to load them as ESM, which causes the possibility of double-loading. Using `import()` avoids that.
- Fixes https://github.com/withastro/astro/issues/3449

## Testing

- I tried adding a test to our fixtures, but because of the monorepo setup the test fails even before the change.
- Tested against https://stackblitz.com/edit/github-exuehl?file=astro.config.mjs

## Docs

N/A, bug fix