### PR TITLE
Remove renderer tag to fix a docs issue

### DIFF
--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -14,7 +14,6 @@
   "keywords": [
     "astro-integration",
     "astro-component",
-    "renderer",
     "mdx"
   ],
   "bugs": "https://github.com/withastro/astro/issues",


### PR DESCRIPTION
[This page](https://docs.astro.build/en/guides/integrations-guide/) is autogenerated based on the packages in this repo and said packages' tags. Removing the renderer tag here should stop it from appearing in the UI Framework category.

## Changes

- Removes `renderer` tag from `@astrojs/mdx` package

## Testing

Only changes some npm package metadata; no test updates are needed.

## Docs

This will fix an issue with the docs that was discussed [here](https://discord.com/channels/830184174198718474/853350631389265940/1003857322885517362) (discord). This fix should be visible as soon as the docs site is deployed again.