### PR TITLE
Only rethrow renderer error when no renderer found

### DIFF
--- a/.changeset/lazy-cameras-float.md
+++ b/.changeset/lazy-cameras-float.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes use of multiple renderers when one throws

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -310,7 +310,9 @@ Did you mean to add ${formatList(probableRendererNames.map((r) => '`' + r + '`')
 				}
 			}
 
-			if (error) {
+			// If no renderer is found and there is an error, throw that error because
+			// it is likely a problem with the component code.
+			if (!renderer && error) {
 				throw error;
 			}
 		}

--- a/packages/astro/test/fixtures/multiple-renderers/astro.config.mjs
+++ b/packages/astro/test/fixtures/multiple-renderers/astro.config.mjs
@@ -1,0 +1,6 @@
+import one from '@astrojs/renderer-one';
+import two from '@astrojs/renderer-two';
+
+export default {
+	integrations: [one(), two()]
+};

--- a/packages/astro/test/fixtures/multiple-renderers/package.json
+++ b/packages/astro/test/fixtures/multiple-renderers/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/multiple-renderers",
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/renderer-one": "file:./renderers/one",
+    "@astrojs/renderer-two": "file:./renderers/two"
+  }
+}

--- a/packages/astro/test/fixtures/multiple-renderers/renderers/one/index.mjs
+++ b/packages/astro/test/fixtures/multiple-renderers/renderers/one/index.mjs
@@ -1,0 +1,15 @@
+
+export default function() {
+	return {
+		name: 'renderer-one',
+		hooks: {
+			'astro:config:setup': ({ addRenderer }) => {
+				addRenderer({
+					name: 'renderer-one',
+					clientEntrypoint: null,
+					serverEntrypoint: '@astrojs/renderer-one/server.mjs',
+				});
+			}
+		}
+	};
+}

--- a/packages/astro/test/fixtures/multiple-renderers/renderers/one/package.json
+++ b/packages/astro/test/fixtures/multiple-renderers/renderers/one/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@astrojs/renderer-one",
+  "version": "1.0.0",
+  "main": "index.mjs"
+}

--- a/packages/astro/test/fixtures/multiple-renderers/renderers/one/server.mjs
+++ b/packages/astro/test/fixtures/multiple-renderers/renderers/one/server.mjs
@@ -1,0 +1,11 @@
+
+export default {
+	check() {
+		throw new Error(`Oops this did not work`);
+	},
+	renderToStaticMarkup(Component) {
+		return {
+			html: Component()
+		};
+	},
+};

--- a/packages/astro/test/fixtures/multiple-renderers/renderers/two/index.mjs
+++ b/packages/astro/test/fixtures/multiple-renderers/renderers/two/index.mjs
@@ -1,0 +1,15 @@
+
+export default function() {
+	return {
+		name: 'renderer-two',
+		hooks: {
+			'astro:config:setup': ({ addRenderer }) => {
+				addRenderer({
+					name: 'renderer-two',
+					clientEntrypoint: null,
+					serverEntrypoint: '@astrojs/renderer-two/server.mjs',
+				});
+			}
+		}
+	};
+}

--- a/packages/astro/test/fixtures/multiple-renderers/renderers/two/package.json
+++ b/packages/astro/test/fixtures/multiple-renderers/renderers/two/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@astrojs/renderer-two",
+  "version": "1.0.0",
+  "main": "index.mjs"
+}

--- a/packages/astro/test/fixtures/multiple-renderers/renderers/two/server.mjs
+++ b/packages/astro/test/fixtures/multiple-renderers/renderers/two/server.mjs
@@ -1,0 +1,11 @@
+
+export default {
+	check() {
+		return true;
+	},
+	renderToStaticMarkup(Component) {
+		return {
+			html: Component()
+		};
+	},
+};

--- a/packages/astro/test/fixtures/multiple-renderers/src/pages/index.astro
+++ b/packages/astro/test/fixtures/multiple-renderers/src/pages/index.astro
@@ -1,0 +1,14 @@
+---
+	function Component() {
+		return `<div id="component">works</div>`;
+	}
+---
+<html>
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<h1>Testing</h1>
+		<Component />
+	</body>
+</html>

--- a/packages/astro/test/multiple-renderers.test.js
+++ b/packages/astro/test/multiple-renderers.test.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Multiple renderers', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/multiple-renderers/',
+		});
+		await fixture.build();
+	});
+
+	it('when the first throws but the second does not, use the second renderer', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerio.load(html);
+		expect($('#component')).to.have.a.lengthOf(1);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1634,6 +1634,22 @@ importers:
       '@astrojs/preact': link:../../../../integrations/preact
       astro: link:../../..
 
+  packages/astro/test/fixtures/multiple-renderers:
+    specifiers:
+      '@astrojs/renderer-one': file:./renderers/one
+      '@astrojs/renderer-two': file:./renderers/two
+      astro: workspace:*
+    dependencies:
+      '@astrojs/renderer-one': file:packages/astro/test/fixtures/multiple-renderers/renderers/one
+      '@astrojs/renderer-two': file:packages/astro/test/fixtures/multiple-renderers/renderers/two
+      astro: link:../../..
+
+  packages/astro/test/fixtures/multiple-renderers/renderers/one:
+    specifiers: {}
+
+  packages/astro/test/fixtures/multiple-renderers/renderers/two:
+    specifiers: {}
+
   packages/astro/test/fixtures/page-level-styles:
     specifiers:
       astro: workspace:*
@@ -17056,4 +17072,16 @@ packages:
     resolution: {directory: packages/astro/test/fixtures/css-assets/packages/font-awesome, type: directory}
     name: '@astrojs/test-font-awesome-package'
     version: 0.0.1
+    dev: false
+
+  file:packages/astro/test/fixtures/multiple-renderers/renderers/one:
+    resolution: {directory: packages/astro/test/fixtures/multiple-renderers/renderers/one, type: directory}
+    name: '@astrojs/renderer-one'
+    version: 1.0.0
+    dev: false
+
+  file:packages/astro/test/fixtures/multiple-renderers/renderers/two:
+    resolution: {directory: packages/astro/test/fixtures/multiple-renderers/renderers/two, type: directory}
+    name: '@astrojs/renderer-two'
+    version: 1.0.0
     dev: false


### PR DESCRIPTION
## Changes

- When there are multiple renderers, like React and Solid, and the first throws, we continue to check for other renderers.
- However, previously we would always rethrow if any error was found. We should only do that if no renderer is found. This fixes that.
- Fixes bug reported in Discord https://discord.com/channels/830184174198718474/1001948001599770724

## Testing

- Test case added

## Docs

N/A, bug fix