### PR TITLE
fix windows package export

### DIFF
--- a/.changeset/neat-badgers-bow.md
+++ b/.changeset/neat-badgers-bow.md
@@ -1,0 +1,6 @@
+---
+"astro": patch
+"@astrojs/image": patch
+---
+
+fix windows "bad package export" error

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -50,7 +50,8 @@
     "./vite-plugin-jsx/*": "./dist/vite-plugin-jsx/*",
     "./vite-plugin-jsx": "./dist/vite-plugin-jsx/index.js",
     "./vite-plugin-markdown": "./dist/vite-plugin-markdown/index.js",
-    "./vite-plugin-markdown/*": "./dist/vite-plugin-markdown/*"
+    "./vite-plugin-markdown/*": "./dist/vite-plugin-markdown/*",
+    "./dist/jsx/*": "./dist/jsx/*"
   },
   "imports": {
     "#astro/*": "./dist/*.js"

--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -26,7 +26,8 @@
     "./endpoints/prod": "./dist/endpoints/prod.js",
     "./components": "./components/index.js",
     "./package.json": "./package.json",
-    "./client": "./client.d.ts"
+    "./client": "./client.d.ts",
+    "./dist/endpoints/*": "./dist/endpoints/*"
   },
   "files": [
     "components",


### PR DESCRIPTION
## Background

> Update on the `astro/dist` import problem: This may be bigger than we realized, it seems to be impacting all Windows users in two different use-cases:
> - `injectRoute` + `entryPoint: @astrojs/image/endpoints/dev`
> - renderers + `serverEntrypoint: astro/jsx/server.js` 
> 
> From some digging, I think this is a Vite 3 issue. The one thing that both of these have in common is that they are both eventually passed *already-resolved* to `viteServer.ssrLoadModule(id)` in our codebase. I think this is what causes the error on Windows, where Vite tries to resolve `id` itself via `ensureEntryFromUrl ` and fails because its resolved form is not a valid package export. 
> 
> None of the other framework renderers hit this because their export maps are 1:1 with the file location. ex: `"./server.js": "./server.js",` 

## Changes

- Short-term fix to the issue is to just add those resolved `dist/*` paths to the export map so that they become valid imports even in their resolved form.
- Long-term fix is to investigate why this is happening on Windows only, and how to fix. If we want to pass the unresolved id to `ssrLoadModule()` some refactoring will be needed on our end.

@matthewp and @bluwy -- this could be an interesting one to dig into together to at least figure out what Vite is expecting in this case, and maybe why Vite is only erroring on Windows.

## Testing

- Tests are covering this so I'm not sure why they are passing on Windows.
- I'm going to try to break tests in a different PR, maybe this is only happening on Node v16+

## Docs

- N/A