### PR TITLE
do not resolve renderer.serverEntrypoint url before loading it

### DIFF
--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -51,13 +51,7 @@ async function loadRenderer(
 	viteServer: ViteDevServer,
 	renderer: AstroRenderer
 ): Promise<SSRLoadedRenderer> {
-	// Vite modules can be out-of-date when using an un-resolved url
-	// We also encountered inconsistencies when using the resolveUrl and resolveId helpers
-	// We've found that pulling the ID directly from the urlToModuleMap is the most stable!
-	const id =
-		viteServer.moduleGraph.urlToModuleMap.get(renderer.serverEntrypoint)?.id ??
-		renderer.serverEntrypoint;
-	const mod = (await viteServer.ssrLoadModule(id)) as { default: SSRLoadedRenderer['ssr'] };
+	const mod = (await viteServer.ssrLoadModule(renderer.serverEntrypoint)) as { default: SSRLoadedRenderer['ssr'] };
 	return { ...renderer, ssr: mod.default };
 }
 


### PR DESCRIPTION
## Changes

- Followup to https://github.com/withastro/astro/pull/4141 to attempt a fix for one of the two Windows issues: `renderer. serverEntrypoint`
- Vite 3 appears to not like having resolved package exports passed to `ssrLoadModule` (but only on Windows?) and instead expects the unresolved package entrypoint.
- This is only safe to remove if we can confirm that the bug that this comment is referencing is out of date. I've confirmed that this change runs fine in the examples, but unclear which exact issue it was addressing since this is only ever used for loading renderers. @bholmesdev maybe you remember?

## Testing

- Unclear if this is covered by existing tests or not. @bholmesdev to confirm?

## Docs

- N/A