### PR TITLE
update test coverage to include more Node and Windows tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,8 @@ jobs:
     strategy:
       matrix:
         OS: [ubuntu-latest, windows-latest]
-        NODE_VERSION: [14, 16, 18]
+        # TODO: Enable node@18!
+        NODE_VERSION: [14, 16]
         include:
           - os: macos-latest
             NODE_VERSION: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,11 +107,9 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        node_version: [14, 16]
+        os: [ubuntu-latest, windows-latest]
+        node_version: [14, 16, 18]
         include:
-          - os: windows-latest
-            node_version: 14
           - os: macos-latest
             node_version: 14
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ env:
   FORCE_COLOR: true
   ASTRO_TELEMETRY_DISABLED: true
 
+
 jobs:
   lint:
     name: Lint
@@ -79,8 +80,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        node_version: [14]
+        OS: [ubuntu-latest]
+        NODE_VERSION: [14]
       fail-fast: true
     steps:
       - name: Checkout
@@ -89,10 +90,10 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v2.2.1
 
-      - name: Setup node@${{ matrix.node_version }}
+      - name: Setup node@${{ matrix.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: ${{ matrix.NODE_VERSION }}
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -102,17 +103,19 @@ jobs:
         run: pnpm run build
 
   test:
-    name: 'Test: ${{ matrix.os }} (node@${{ matrix.node_version }})'
+    name: 'Test: ${{ matrix.os }} (node@${{ matrix.NODE_VERSION }})'
     runs-on: ${{ matrix.os }}
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        node_version: [14, 16, 18]
+        OS: [ubuntu-latest, windows-latest]
+        NODE_VERSION: [14, 16, 18]
         include:
           - os: macos-latest
-            node_version: 14
+            NODE_VERSION: 14
       fail-fast: false
+    env:
+      NODE_VERSION: ${{ matrix.NODE_VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -120,10 +123,10 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v2.2.1
 
-      - name: Setup node@${{ matrix.node_version }}
+      - name: Setup node@${{ matrix.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: ${{ matrix.NODE_VERSION }}
           cache: 'pnpm'
 
       - name: Use Deno
@@ -141,15 +144,17 @@ jobs:
         run: pnpm run test
 
   e2e:
-    name: 'Test (E2E): ${{ matrix.os }} (node@${{ matrix.node_version }})'
+    name: 'Test (E2E): ${{ matrix.os }} (node@${{ matrix.NODE_VERSION }})'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        node_version: [14]
+        OS: [ubuntu-latest, windows-latest]
+        NODE_VERSION: [14]
       fail-fast: false
+    env:
+      NODE_VERSION: ${{ matrix.NODE_VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -157,10 +162,10 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v2.2.1
 
-      - name: Setup node@${{ matrix.node_version }}
+      - name: Setup node@${{ matrix.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: ${{ matrix.NODE_VERSION }}
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -173,13 +178,15 @@ jobs:
         run: pnpm run test:e2e
 
   smoke:
-    name: 'Test (Smoke): ${{ matrix.os }} (node@${{ matrix.node_version }})'
+    name: 'Test (Smoke): ${{ matrix.os }} (node@${{ matrix.NODE_VERSION }})'
     runs-on: ${{ matrix.os }}
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        node_version: [14]
+        OS: [ubuntu-latest]
+        NODE_VERSION: [14]
+    env:
+      NODE_VERSION: ${{ matrix.NODE_VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -187,10 +194,10 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v2.2.1
 
-      - name: Setup node@${{ matrix.node_version }}
+      - name: Setup node@${{ matrix.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: ${{ matrix.NODE_VERSION }}
           cache: 'pnpm'
 
       - name: Checkout docs

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "format:imports": "organize-imports-cli ./packages/*/tsconfig.json ./packages/*/*/tsconfig.json",
     "test": "turbo run test --output-logs=new-only --concurrency=1",
     "test:match": "cd packages/astro && pnpm run test:match",
-    "test:templates": "turbo run test --filter=create-astro --concurrency=1",
     "test:smoke": "turbo run build --filter=\"@example/*\" --filter=\"astro.build\" --filter=\"docs\" --output-logs=new-only --concurrency=1",
     "test:vite-ci": "turbo run test --output-logs=new-only --no-deps --scope=astro --concurrency=1",
     "test:e2e": "cd packages/astro && pnpm playwright install && pnpm run test:e2e",

--- a/turbo.json
+++ b/turbo.json
@@ -14,10 +14,11 @@
       "cache": false
     },
     "test": {
-      "outputs": []
-    },
-    "test:templates": {
-      "outputs": []
+      "outputs": [],
+      "dependsOn": [
+        "$RUNNER_OS",
+        "$NODE_VERSION"
+      ]
     },
     "benchmark": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Changes

- ~~Updated CI to test every supported version of Node.js: https://nodejs.org/en/about/releases/~~
- Updated CI to take `OS` and `NODE_VERSION` into account when using cached tests
- Updated CI to run every supported version of Node.js on Windows (previously, was only v14)
- Previously, we'd limited windows to v14 only to improve CI bottlenecking, but other test speed improvements by @natemoo-re may allow us to add this back without impacting CI performance.
- Adding Node@18 TODO since there are multiple tests that break when `node-fetch` is replaced with Node@18's global `undici` fetch.

## Testing

- is testing

## Docs

- N/A