### PR TITLE
fix missing newline bug in mdx

### DIFF
--- a/.changeset/shaggy-beds-itch.md
+++ b/.changeset/shaggy-beds-itch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Fix a missing newline bug when `layout` was set.

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -99,7 +99,7 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 										const frontmatter = getFrontmatter(code, id);
 										if (frontmatter.layout) {
 											const { layout, ...content } = frontmatter;
-											code += `\nexport default async function({ children }) {\nconst Layout = (await import(${JSON.stringify(
+											code += `\n\nexport default async function({ children }) {\nconst Layout = (await import(${JSON.stringify(
 												frontmatter.layout
 											)})).default;\nconst frontmatter=${JSON.stringify(
 												content

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter/src/pages/index.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter/src/pages/index.mdx
@@ -5,3 +5,6 @@ illThrowIfIDontExist: "Oh no, that's scary!"
 ---
 
 {frontmatter.illThrowIfIDontExist}
+
+> Note: newline intentionally missing from the end of this file.
+> Useful since that can be the source of bugs in our compile step.


### PR DESCRIPTION
## Changes

- Users reported needing a newline at the end of their files.
- tracked it down to MDX needing two newlines between content and where we inject any exports.

## Testing

- Updated existing test to test for this.

## Docs

- N/A