### PR TITLE
Order server CSS the same as static

### DIFF
--- a/.changeset/curvy-donuts-build.md
+++ b/.changeset/curvy-donuts-build.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes SSR CSS ordering to match static mode

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -139,7 +139,7 @@ function buildManifest(
 
 		routes.push({
 			file: '',
-			links: Array.from(pageData.css),
+			links: Array.from(pageData.css).reverse(),
 			scripts: [
 				...scripts,
 				...astroConfig._ctx.scripts

--- a/packages/astro/test/css-order.test.js
+++ b/packages/astro/test/css-order.test.js
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+import testAdapter from './test-adapter.js';
+
+describe('CSS production ordering', () => {
+	let staticHTML, serverHTML;
+	let staticCSS, serverCSS;
+
+	const commonConfig = Object.freeze({
+		root: './fixtures/css-order/',
+	});
+
+	function getLinks(html) {
+		let $ = cheerio.load(html);
+		let out = [];
+		$('link[rel=stylesheet]').each((i, el) => {
+			out.push($(el).attr('href'))
+		});
+		return out;
+	}
+
+	before(async () => {
+		let fixture = await loadFixture({ ...commonConfig });
+		await fixture.build();
+		staticHTML = await fixture.readFile('/one/index.html');
+		staticCSS = await Promise.all(getLinks(staticHTML).map(async (href) => {
+			const css = await fixture.readFile(href);
+			return { href, css };
+		}));
+	});
+
+	before(async () => {
+		let fixture = await loadFixture({
+			...commonConfig,
+			adapter: testAdapter(),
+			output: 'server',
+		});
+		await fixture.build();
+
+		const app = await fixture.loadTestAdapterApp();
+		const request = new Request('http://example.com/one');
+		const response = await app.render(request);
+		serverHTML = await response.text();
+		serverCSS = await Promise.all(getLinks(serverHTML).map(async (href) => {
+			const css = await fixture.readFile(`/client${href}`);
+			return { href, css };
+		}));
+	});
+
+	it('is in the same order for output: server and static', async () => {
+		const staticContent = staticCSS.map(o => o.css);
+		const serverContent = serverCSS.map(o => o.css);
+
+		expect(staticContent).to.deep.equal(serverContent);
+	});
+});

--- a/packages/astro/test/fixtures/css-order/package.json
+++ b/packages/astro/test/fixtures/css-order/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@test/css-order",
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/css-order/src/components/CommonHead.astro
+++ b/packages/astro/test/fixtures/css-order/src/components/CommonHead.astro
@@ -1,0 +1,5 @@
+<style is:global>
+	body {
+		color: red;
+	}
+</style>

--- a/packages/astro/test/fixtures/css-order/src/pages/one.astro
+++ b/packages/astro/test/fixtures/css-order/src/pages/one.astro
@@ -1,0 +1,17 @@
+---
+import CommonHead from '../components/CommonHead.astro';
+---
+<html>
+	<head>
+		<title>Testing</title>
+		<CommonHead />
+		<style>
+			body {
+				margin: 1px;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>Testing</h1>
+	</body>
+</html>

--- a/packages/astro/test/fixtures/css-order/src/pages/two.astro
+++ b/packages/astro/test/fixtures/css-order/src/pages/two.astro
@@ -1,0 +1,17 @@
+---
+import CommonHead from '../components/CommonHead.astro';
+---
+<html>
+	<head>
+		<title>Testing</title>
+		<CommonHead />
+		<style>
+			body {
+				margin: 2px;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>Testing</h1>
+	</body>
+</html>

--- a/packages/astro/test/ssr-response.test.js
+++ b/packages/astro/test/ssr-response.test.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { load as cheerioLoad } from 'cheerio';
 import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1462,6 +1462,12 @@ importers:
   packages/astro/test/fixtures/css-assets/packages/font-awesome:
     specifiers: {}
 
+  packages/astro/test/fixtures/css-order:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/custom-404:
     specifiers:
       astro: workspace:*


### PR DESCRIPTION
## Changes

- Fixes bug where `output: 'server'` CSS was in a different order than `output: 'static'`. 
- We order CSS so that your dependencies CSS comes before your own (for example a component CSS comes before a page). This makes dev.
- Closes #4110

## Testing

- Test added that does static and server rendering and then compares them.

## Docs

N/A