### PR TITLE
improve an error message for getstaticpaths

### DIFF
--- a/.changeset/pretty-bananas-refuse.md
+++ b/.changeset/pretty-bananas-refuse.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve an error message for getStaticPaths

--- a/packages/astro/src/core/routing/index.ts
+++ b/packages/astro/src/core/routing/index.ts
@@ -2,4 +2,4 @@ export { createRouteManifest } from './manifest/create.js';
 export { deserializeRouteData, serializeRouteData } from './manifest/serialization.js';
 export { matchAllRoutes, matchRoute } from './match.js';
 export { getParams } from './params.js';
-export { validateGetStaticPathsModule, validateGetStaticPathsResult } from './validation.js';
+export { validateDynamicRouteModule, validateGetStaticPathsResult } from './validation.js';


### PR DESCRIPTION
## Changes

- As reported here: https://discord.com/channels/830184174198718474/845451724738265138/1004770640877862912
- This error made it unclear that `output: server` mode allows you to skip `getStaticPaths` in your dynamic routes.
- Cleaned some code up while I was there, but no other behavioral changes made.

## Testing

- Covered by existing tests.

## Docs

- N/A