### PR TITLE
Add `vite.build.cssTarget` support for CSS build

### DIFF
--- a/.changeset/empty-eagles-reply.md
+++ b/.changeset/empty-eagles-reply.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Add `vite.build.cssTaregt` support for CSS build

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -153,6 +153,7 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 			rollupPluginAstroBuildCSS({
 				internals,
 				target: 'server',
+				astroConfig,
 			}),
 			...(viteConfig.plugins || []),
 			// SSR needs to be last
@@ -234,6 +235,7 @@ async function clientBuild(
 			rollupPluginAstroBuildCSS({
 				internals,
 				target: 'client',
+				astroConfig,
 			}),
 			...(viteConfig.plugins || []),
 		],

--- a/packages/astro/src/vite-plugin-build-css/index.ts
+++ b/packages/astro/src/vite-plugin-build-css/index.ts
@@ -8,10 +8,12 @@ import { Plugin as VitePlugin } from 'vite';
 import { getTopLevelPages, walkParentInfos } from '../core/build/graph.js';
 import { getPageDataByViteID, getPageDatasByClientOnlyID } from '../core/build/internal.js';
 import { isCSSRequest } from '../core/render/util.js';
+import { AstroConfig } from '../@types/astro';
 
 interface PluginOptions {
 	internals: BuildInternals;
 	target: 'client' | 'server';
+	astroConfig: AstroConfig;
 }
 
 export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
@@ -118,9 +120,11 @@ export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] 
 					for (const [, output] of Object.entries(bundle)) {
 						if (output.type === 'asset') {
 							if (output.name?.endsWith('.css') && typeof output.source === 'string') {
+								const cssTarget = options.astroConfig.vite.build?.cssTarget;
 								const { code: minifiedCSS } = await esbuild.transform(output.source, {
 									loader: 'css',
 									minify: true,
+									...(cssTarget ? { target: cssTarget } : {}),
 								});
 								output.source = minifiedCSS;
 							}

--- a/packages/astro/test/config-vite-css-target.test.js
+++ b/packages/astro/test/config-vite-css-target.test.js
@@ -1,0 +1,39 @@
+/**
+ * css-target
+ */
+
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+let fixture;
+
+describe('CSS', function () {
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/config-vite-css-target/' });
+	});
+
+	describe('build', () => {
+		let $;
+		let html;
+		let bundledCSS;
+
+		before(async () => {
+			await fixture.build();
+
+			// get bundled CSS (will be hashed, hence DOM query)
+			html = await fixture.readFile('/index.html');
+			$ = cheerio.load(html);
+			const bundledCSSHREF = $('link[rel=stylesheet][href^=/assets/]').attr('href');
+			bundledCSS = (await fixture.readFile(bundledCSSHREF.replace(/^\/?/, '/')))
+				.replace(/\s/g, '')
+				.replace('/n', '');
+		});
+
+		it('vite.build.cssTarget is respected', async () => {
+			expect(bundledCSS).to.match(
+				new RegExp('.class\\:where\\(.astro-[^{]*{top:0;right:0;bottom:0;left:0}')
+			);
+		});
+	});
+});

--- a/packages/astro/test/fixtures/config-vite-css-target/astro.config.mjs
+++ b/packages/astro/test/fixtures/config-vite-css-target/astro.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	vite: {
+		build: {
+			cssTarget: "safari14",
+		}
+	}
+})

--- a/packages/astro/test/fixtures/config-vite-css-target/package.json
+++ b/packages/astro/test/fixtures/config-vite-css-target/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/config-vite-css-target",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/config-vite-css-target/src/pages/index.astro
+++ b/packages/astro/test/fixtures/config-vite-css-target/src/pages/index.astro
@@ -1,0 +1,18 @@
+<html>
+	<head>
+		<title>css-target</title>
+	</head>
+	<body>
+		<h1>css-target</h1>
+		<div class="class"></div>
+	</body>
+</html>
+
+<style>
+	.class {
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+	}
+</style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1389,6 +1389,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/config-vite-css-target:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/css-assets:
     specifiers:
       '@astrojs/test-font-awesome-package': file:packages/font-awesome


### PR DESCRIPTION
## Changes

To solve #4092 
Support `vite.build.cssTarget` option in CSS minification

## Testing

Add a test file
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

None
<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->