### PR TITLE
Allow automatic JSX runtime alongside MDX

### DIFF
--- a/.changeset/slow-frogs-hope.md
+++ b/.changeset/slow-frogs-hope.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/mdx': patch
+---
+
+Allow automatic JSX runtime with MDX

--- a/packages/astro/src/jsx/babel.ts
+++ b/packages/astro/src/jsx/babel.ts
@@ -136,6 +136,7 @@ export default function astroJSX(): PluginObj {
 		visitor: {
 			Program: {
 				enter(path, state) {
+					const { file } = state;
 					if (!(state.file.metadata as PluginMetadata).astro) {
 						(state.file.metadata as PluginMetadata).astro = {
 							clientOnlyComponents: [],
@@ -143,6 +144,13 @@ export default function astroJSX(): PluginObj {
 							scripts: [],
 						};
 					}
+					if(!file.ast.comments) {
+						file.ast.comments = [];
+					}
+					file.ast.comments?.push({
+						type: 'CommentBlock',
+						value: '* @jsxImportSource astro '
+					});
 					path.node.body.splice(
 						0,
 						0,

--- a/packages/astro/src/jsx/renderer.ts
+++ b/packages/astro/src/jsx/renderer.ts
@@ -1,7 +1,6 @@
 const renderer = {
 	name: 'astro:jsx',
 	serverEntrypoint: 'astro/jsx/server.js',
-	jsxImportSource: 'astro',
 	jsxTransformOptions: async () => {
 		const {
 			default: { default: jsx },
@@ -11,7 +10,7 @@ const renderer = {
 		return {
 			plugins: [
 				astroJSX(),
-				jsx({}, { throwIfNamespace: false, runtime: 'automatic', importSource: 'astro' }),
+				jsx({}, { throwIfNamespace: false, runtime: 'automatic' }),
 			],
 		};
 	},

--- a/packages/astro/src/vite-plugin-jsx/index.ts
+++ b/packages/astro/src/vite-plugin-jsx/index.ts
@@ -69,6 +69,9 @@ async function transformJSX({
 		babelrc: false,
 		inputSourceMap: options.inputSourceMap,
 	});
+
+	console.log("AFTER", result?.code);
+
 	// TODO: Be more strict about bad return values here.
 	// Should we throw an error instead? Should we never return `{code: ""}`?
 	if (!result) return null;

--- a/packages/astro/src/vite-plugin-jsx/tag.ts
+++ b/packages/astro/src/vite-plugin-jsx/tag.ts
@@ -20,7 +20,7 @@ export default function tagExportsWithRenderer({
 				// Inject `import { __astro_tag_component__ } from 'astro/server/index.js'`
 				enter(path) {
 					path.node.body.splice(
-						0,
+						1,
 						0,
 						t.importDeclaration(
 							[

--- a/packages/integrations/mdx/test/fixtures/mdx-plus-react/astro.config.mjs
+++ b/packages/integrations/mdx/test/fixtures/mdx-plus-react/astro.config.mjs
@@ -1,0 +1,6 @@
+import mdx from '@astrojs/mdx';
+import react from '@astrojs/react';
+
+export default {
+	integrations: [react(), mdx()]
+}

--- a/packages/integrations/mdx/test/fixtures/mdx-plus-react/package.json
+++ b/packages/integrations/mdx/test/fixtures/mdx-plus-react/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/mdx-plus-react",
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/mdx": "workspace:*",
+    "@astrojs/react": "workspace:*"
+  }
+}

--- a/packages/integrations/mdx/test/fixtures/mdx-plus-react/src/components/Component.jsx
+++ b/packages/integrations/mdx/test/fixtures/mdx-plus-react/src/components/Component.jsx
@@ -1,0 +1,5 @@
+const Component = () => {
+  return <p>Hello world</p>;
+};
+
+export default Component;

--- a/packages/integrations/mdx/test/fixtures/mdx-plus-react/src/pages/index.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-plus-react/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+import Component from "../components/Component.jsx";
+---
+<html>
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<Component />
+	</body>
+</html>

--- a/packages/integrations/mdx/test/mdx-plus-react.test.js
+++ b/packages/integrations/mdx/test/mdx-plus-react.test.js
@@ -16,11 +16,10 @@ describe('MDX and React', () => {
 
 	it('can be used in the same project', async () => {
 		const html = await fixture.readFile('/index.html');
-		console.log(html);
-		/*const { document } = parseHTML(html);
+		const { document } = parseHTML(html);
 
-		const h1 = document.querySelector('h1');
+		const p = document.querySelector('p');
 
-		expect(h1.textContent).to.equal('Hello page!');*/
+		expect(p.textContent).to.equal('Hello world');
 	});
 });

--- a/packages/integrations/mdx/test/mdx-plus-react.test.js
+++ b/packages/integrations/mdx/test/mdx-plus-react.test.js
@@ -1,0 +1,26 @@
+import mdx from '@astrojs/mdx';
+
+import { expect } from 'chai';
+import { parseHTML } from 'linkedom';
+import { loadFixture } from '../../../astro/test/test-utils.js';
+
+describe('MDX and React', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/mdx-plus-react/', import.meta.url),
+		});
+		await fixture.build();
+	});
+
+	it('can be used in the same project', async () => {
+		const html = await fixture.readFile('/index.html');
+		console.log(html);
+		/*const { document } = parseHTML(html);
+
+		const h1 = document.querySelector('h1');
+
+		expect(h1.textContent).to.equal('Hello page!');*/
+	});
+});

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -14,7 +14,7 @@ function getRenderer() {
 		jsxTransformOptions: async () => {
 			// @ts-expect-error types not found
 			const babelPluginTransformReactJsxModule = await import('@babel/plugin-transform-react-jsx');
-			const jsx = babelPluginTransformReactJsxModule?.default ?? babelPluginTransformReactJsxModule?.default?.default;
+			const jsx = babelPluginTransformReactJsxModule?.default?.default ?? babelPluginTransformReactJsxModule?.default;
 			return {
 				plugins: [
 					jsx(

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -12,10 +12,9 @@ function getRenderer() {
 			: '@astrojs/react/server-v17.js',
 		jsxImportSource: 'react',
 		jsxTransformOptions: async () => {
-			const {
-				default: { default: jsx },
-				// @ts-expect-error types not found
-			} = await import('@babel/plugin-transform-react-jsx');
+			// @ts-expect-error types not found
+			const babelPluginTransformReactJsxModule = await import('@babel/plugin-transform-react-jsx');
+			const jsx = babelPluginTransformReactJsxModule?.default ?? babelPluginTransformReactJsxModule?.default?.default;
 			return {
 				plugins: [
 					jsx(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2188,6 +2188,16 @@ importers:
       '@astrojs/mdx': link:../../..
       astro: link:../../../../../astro
 
+  packages/integrations/mdx/test/fixtures/mdx-plus-react:
+    specifiers:
+      '@astrojs/mdx': workspace:*
+      '@astrojs/react': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/mdx': link:../../..
+      '@astrojs/react': link:../../../../react
+      astro: link:../../../../../astro
+
   packages/integrations/netlify:
     specifiers:
       '@astrojs/webapi': ^0.12.0


### PR DESCRIPTION
## Changes

- Instead of using the automatic runtime to append Astro JSX, this makes it so that we use the pragma comment `/** @jsxImportSource astro */` to make our Astro JSX (MDX) files get the right jsx runtime import.
- This means that you can rely on the automatic imports for other renderers, like React.
- Fixes https://github.com/withastro/astro/issues/4084

## Testing

- Test added
- Other tests still passing

## Docs

N/A, bug fix