### PR TITLE
Hide error overlay tip

### DIFF
--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -120,7 +120,7 @@ export async function render(
 		scripts.add({
 			props: {
 				type: 'module',
-				src: new URL('../../../runtime/client/hmr.js', import.meta.url).pathname,
+				src: '/@id/astro/runtime/client/hmr.js',
 			},
 			children: '',
 		});

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -406,5 +406,13 @@ export default function createPlugin({ config, logging }: AstroPluginOptions): v
 				});
 			};
 		},
+		// HACK: hide `.tip` in Vite's ErrorOverlay and replace [vite] messages with [astro]
+		transform(code, id, opts = {}) {
+			if (opts.ssr) return;
+			if (!id.includes('vite/dist/client/client.mjs')) return;
+			return code
+					.replace(/\.tip \{[^}]*\}/gm, '.tip {\n  display: none;\n}')
+					.replace(/\[vite\]/g, '[astro]')
+		}
 	};
 }


### PR DESCRIPTION
## Changes

- Hides confusing `.tip` content in Vite's error overlay
- Updates client logs to use `[astro]` instead of `[vite]`

## Testing

Tested manually, not relevant for tests IMO

## Docs

N/A