### PR TITLE
Add a TypeScript step to `create-astro`

### DIFF
--- a/.changeset/ninety-planets-work.md
+++ b/.changeset/ninety-planets-work.md
@@ -1,0 +1,5 @@
+---
+'create-astro': minor
+---
+
+Add a step to configure how strict TypeScript should be

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -25,7 +25,8 @@
   },
   "files": [
     "dist",
-    "create-astro.js"
+    "create-astro.js",
+    "tsconfigs"
   ],
   "dependencies": {
     "chalk": "^5.0.1",

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -294,23 +294,26 @@ export async function main() {
 		{
 			type: 'select',
 			name: 'typescript',
-			message:
-				'Astro is a TypeScript-first framework. How strict would you like the typechecking to be?',
+			message: 'How would you like to setup TypeScript?',
 			choices: [
 				{
 					title: 'Relaxed',
-					description: "Not a big fan of TypeScript? No issues, we'll keep this kind",
 					value: 'default',
 				},
 				{
 					title: 'Strict (recommended)',
-					description: 'Will enable `strict`',
+					description: 'Enable `strict` typechecking rules',
 					value: 'strict',
 				},
 				{
-					title: 'Stricter',
-					description: 'Will enable `strict` and some stricter settings',
+					title: 'Strictest',
+					description: 'Enable all typechecking rules',
 					value: 'stricter',
+				},
+				{
+					title: 'I prefer not to use TypeScript',
+					description: `That's cool too!`,
+					value: 'optout',
 				},
 			],
 		},
@@ -318,7 +321,7 @@ export async function main() {
 			onCancel: () => {
 				ora().info(
 					dim(
-						'Operation cancelled. No worries, your project folder has already been created and TypeScript settings have been set to "Relaxed"'
+						'Operation cancelled. Your project folder has been created but no TypeScript configuration file was created.'
 					)
 				);
 				process.exit(1);
@@ -326,6 +329,17 @@ export async function main() {
 		}
 	);
 
+	if (tsResponse.typescript === 'optout') {
+		console.log(``);
+		ora().warn(yellow(bold(`Astro ❤️ TypeScript!`)));
+		console.log(`  Astro supports TypeScript inside of ".astro" component scripts, so`);
+		console.log(`  we still need to create some TypeScript-related files in your project.`);
+		console.log(`  You can safely ignore these files, but don't delete them!`);
+		console.log(dim('  (ex: tsconfig.json, src/types.d.ts)'));
+		console.log(``);
+		tsResponse.typescript = 'default';
+		await wait(300);
+	}
 	if (args.dryRun) {
 		ora().info(dim(`--dry-run enabled, skipping.`));
 	} else if (tsResponse.typescript) {

--- a/packages/create-astro/tsconfigs/tsconfig.strict.json
+++ b/packages/create-astro/tsconfigs/tsconfig.strict.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    // Enable top-level await, and other modern ESM features.
+    "target": "ESNext",
+    "module": "ESNext",
+    // Enable node-style module resolution, for things like npm package imports.
+    "moduleResolution": "node",
+    // Enable JSON imports.
+    "resolveJsonModule": true,
+    // Enable stricter transpilation for better output.
+    "isolatedModules": true,
+    // Astro will directly run your TypeScript code, no transpilation needed.
+    "noEmit": true,
+    // Enable strict type checking.
+    "strict": true,
+    // Error when a value import is only used as a type.
+    "importsNotUsedAsValues": "error"
+  }
+}

--- a/packages/create-astro/tsconfigs/tsconfig.stricter.json
+++ b/packages/create-astro/tsconfigs/tsconfig.stricter.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    // Enable top-level await, and other modern ESM features.
+    "target": "ESNext",
+    "module": "ESNext",
+    // Enable node-style module resolution, for things like npm package imports.
+    "moduleResolution": "node",
+    // Enable JSON imports.
+    "resolveJsonModule": true,
+    // Enable stricter transpilation for better output.
+    "isolatedModules": true,
+    // Astro will directly run your TypeScript code, no transpilation needed.
+    "noEmit": true,
+    // Enable strict type checking.
+    "strict": true,
+    // Error when a value import is only used as a type.
+    "importsNotUsedAsValues": "error",
+    // Report errors for fallthrough cases in switch statements
+    "noFallthroughCasesInSwitch": true,
+    // Force functions designed to override their parent class to be specified as `override`.
+    "noImplicitOverride": true,
+    // Force functions to specify that they can return `undefined` if a possibe code path does not return a value.
+    "noImplicitReturns": true,
+    // Report an error when a variable is declared but never used.
+    "noUnusedLocals": true,
+    // Report an error when a parameter is declared but never used.
+    "noUnusedParameters": true,
+    // Force the usage of the indexed syntax to access fields declared using an index signature.
+    "noUncheckedIndexedAccess": true,
+    // Report an error when the value `undefined` is given to an optional property that doesn't specify `undefined` as a valid value.
+    "exactOptionalPropertyTypes": true
+  }
+}


### PR DESCRIPTION
## Changes

This PR adds a step to `create-astro` to allow users to configure how strict they want their TypeScript install to be

<img width="906" alt="image" src="https://user-images.githubusercontent.com/3019731/183214592-64305712-90b3-427c-982f-a631437240c7.png">

I've set the "Strict" preset as the recommended one ~~in hope of making everyone's code better~~ as it's the one TypeScript itself recommend for new projects (same goes for all our other recommended settings)

The "Stricter" settings were mostly sourced from `create-t3-app`, it has very cool settings for TypeScript

## Testing

Tested manually

## Docs

Will PR docs if needed