### PR TITLE
Fix relaxed and default TypeScript settings not working

### DIFF
--- a/.changeset/itchy-hats-exist.md
+++ b/.changeset/itchy-hats-exist.md
@@ -1,0 +1,5 @@
+---
+"create-astro": patch
+---
+
+Fix relaxed and default TypeScript settings not working

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -343,14 +343,16 @@ export async function main() {
 	if (args.dryRun) {
 		ora().info(dim(`--dry-run enabled, skipping.`));
 	} else if (tsResponse.typescript) {
-		fs.copyFileSync(
-			path.join(
-				url.fileURLToPath(new URL('..', import.meta.url)),
-				'tsconfigs',
-				`tsconfig.${tsResponse.typescript}.json`
-			),
-			path.join(cwd, 'tsconfig.json')
-		);
+		if (tsResponse.typescript !== 'default') {
+			fs.copyFileSync(
+				path.join(
+					url.fileURLToPath(new URL('..', import.meta.url)),
+					'tsconfigs',
+					`tsconfig.${tsResponse.typescript}.json`
+				),
+				path.join(cwd, 'tsconfig.json')
+			);
+		}
 		ora().succeed('TypeScript settings applied!');
 	}
 


### PR DESCRIPTION
## Changes

Fix the default and relaxed settings not working in create-astro, we should only copy when the user selected either strict or stricter, as the default template is already in the template 

## Testing

I did this PR on my phone at 5am, so cannot test right now

## Docs

N/A