### PR TITLE
docs: Modify legacy flag description

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -710,7 +710,7 @@ export interface AstroUserConfig {
 	 * @kind heading
 	 * @name Legacy Flags
 	 * @description
-	 * To help some users migrate between versions of Astro, we will introduce `legacy` flags.
+	 * To help some users migrate between versions of Astro, we occasionally introduce `legacy` flags.
 	 * These flags allow you to opt in to deprecated or otherwise outdated behavior of Astro
 	 * in the latest version, so that you can continue to upgrade and take advantage of new Astro releases.
 	 */

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -722,7 +722,7 @@ export interface AstroUserConfig {
 		 * @default `false`
 		 * @version 1.0.0-rc.1
 		 * @description
-		 * Enable Astro's pre-v1.0 support for components and JSX expressions in `.md` Standard Markdown files.
+		 * Enable Astro's pre-v1.0 support for components and JSX expressions in `.md` Markdown files.
 		 * In Astro `1.0.0-rc`, this original behavior was removed as the default, in favor of our new [MDX integration](/en/guides/integrations-guide/mdx/).
 		 * 
 		 * To enable this behavior, set `legacy.astroFlavoredMarkdown` to `true` in your [astro.config.mjs]{/en/guides/configuring-astro/} configuration file.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -725,14 +725,16 @@ export interface AstroUserConfig {
 		 * Enable Astro's pre-v1.0 support for components and JSX expressions in `.md` Markdown files.
 		 * In Astro `1.0.0-rc`, this original behavior was removed as the default, in favor of our new [MDX integration](/en/guides/integrations-guide/mdx/).
 		 * 
-		 * To enable this behavior, set `legacy.astroFlavoredMarkdown` to `true` in your [astro.config.mjs]{/en/guides/configuring-astro/} configuration file.
+		 * To enable this behavior, set `legacy.astroFlavoredMarkdown` to `true` in your [`astro.config.mjs` configuration file](/en/guides/configuring-astro/#the-astro-config-file).
 		 * 
+		 * ```js
 		 * {
-		 *  legacy: {
-		 *    	//example: Add support for legacy .md files
-		 * 			astroFlavoredMarkdown: true,
-		 * 		},
-		 * 	}
+		 *   legacy: {
+		 *     // Example: Add support for legacy Markdown features
+		 *     astroFlavoredMarkdown: true,
+		 *   },
+		 * }
+		 * ```
 		 */
 		astroFlavoredMarkdown?: boolean;
 	};

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -711,7 +711,7 @@ export interface AstroUserConfig {
 	 * @name Legacy Flags
 	 * @description
 	 * To help some users migrate between versions of Astro, we occasionally introduce `legacy` flags.
-	 * These flags allow you to opt in to deprecated or otherwise outdated behavior of Astro
+	 * These flags allow you to opt in to some deprecated or otherwise outdated behavior of Astro
 	 * in the latest version, so that you can continue to upgrade and take advantage of new Astro releases.
 	 */
 	legacy?: {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -710,8 +710,8 @@ export interface AstroUserConfig {
 	 * @kind heading
 	 * @name Legacy Flags
 	 * @description
-	 * To help some users migrate between versions of Astro, we occasionally introduce `legacy` flags.
-	 * These flags allow you to opt in to some deprecated or otherwise outdated behavior of Astro
+	 * To help some users migrate between versions of Astro, we will introduce `legacy` flags.
+	 * These flags allow you to opt in to deprecated or otherwise outdated behavior of Astro
 	 * in the latest version, so that you can continue to upgrade and take advantage of new Astro releases.
 	 */
 	legacy?: {
@@ -722,8 +722,17 @@ export interface AstroUserConfig {
 		 * @default `false`
 		 * @version 1.0.0-rc.1
 		 * @description
-		 * Enable Astro's pre-v1.0 support for components and JSX expressions in `.md` Markdown files.
+		 * Enable Astro's pre-v1.0 support for components and JSX expressions in `.md` Standard Markdown files.
 		 * In Astro `1.0.0-rc`, this original behavior was removed as the default, in favor of our new [MDX integration](/en/guides/integrations-guide/mdx/).
+		 * 
+		 * To enable this behavior, set `legacy.astroFlavoredMarkdown` to `true` in your [astro.config.mjs]{/en/guides/configuring-astro/} configuration file.
+		 * 
+		 * {
+		 *  legacy: {
+		 *    	//example: Add support for legacy .md files
+		 * 			astroFlavoredMarkdown: true,
+		 * 		},
+		 * 	}
 		 */
 		astroFlavoredMarkdown?: boolean;
 	};


### PR DESCRIPTION
## Changes

- What does this change?
   - The description to Legacy Flag : `astroFlavoredMarkdown`
   - Resolves issue [#1191](https://github.com/withastro/docs/issues/1191)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
- No testing as this is comment section of an existing field of text. 

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
- This is a Autogenerated page to Docs as per @sarah11918 comment on issue 1191. See mentioned issue above.