### PR TITLE
fix: astro preview does not serve custom 404 (4113)

### DIFF
--- a/.changeset/thick-ducks-sparkle.md
+++ b/.changeset/thick-ducks-sparkle.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix custom 404 pages when using `astro preview` (#4113)

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -3,8 +3,8 @@ import type { AddressInfo } from 'net';
 import type { AstroConfig } from '../../@types/astro';
 import type { LogOptions } from '../logger/core';
 
-import http from 'http';
 import fs from 'fs';
+import http from 'http';
 import { performance } from 'perf_hooks';
 import sirv from 'sirv';
 import { fileURLToPath } from 'url';
@@ -80,7 +80,7 @@ export default async function preview(
 				req.url = '/' + req.url?.replace(baseURL.pathname, '');
 				staticFileServer(req, res, () => {
 					const errorPagePath = fileURLToPath(config.outDir + '/404.html');
-					if (fs.statSync(errorPagePath)) {
+					if (fs.existsSync(errorPagePath)) {
 						res.statusCode = 404;
 						res.setHeader('Content-Type', 'text/html;charset=utf-8');
 						res.end(fs.readFileSync(errorPagePath));


### PR DESCRIPTION
## Changes

Fixes problem that preview server doesn't serve a custom 404 page.
https://github.com/withastro/astro/issues/4113

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->