### PR TITLE
doc: tailwind: link to import doc for applyBaseStyles

### DIFF
--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -130,6 +130,8 @@ export default {
   })],
 }
 ```
+
+You can now [import your own `base.css` as a local stylesheet](https://docs.astro.build/en/guides/styling/#import-a-local-stylesheet).
 </details>
 
 ## Examples


### PR DESCRIPTION
## Changes

- Add some doc to prevent mistakes like #4192
- Don't forget a changeset! `pnpm exec changeset` => is it needed for documentation changes?

## Testing

Testing is probably irrelevant for documentation.

## Docs

I don't know why this documentation lives here, and not at https://github.com/withastro/docs