### PR TITLE
Fix client build sourcemap generation

### DIFF
--- a/.changeset/strong-plants-tell.md
+++ b/.changeset/strong-plants-tell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix client build sourcemap generation

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -214,6 +214,7 @@ async function clientBuild(
 			exclude: [...(viteConfig.optimizeDeps?.exclude ?? [])],
 		},
 		build: {
+			...viteConfig.build,
 			emptyOutDir: false,
 			minify: 'esbuild',
 			outDir: fileURLToPath(out),

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -210,11 +210,11 @@ export default function astro({ config, logging }: AstroPluginOptions): vite.Plu
 			const parsedId = parseAstroRequest(id);
 			const query = parsedId.query;
 			if (!id.endsWith('.astro') || query.astro) {
-				return
+				return;
 			}
 			// if we still get a relative path here, vite couldn't resolve the import
 			if (isRelativePath(parsedId.filename)) {
-				return
+				return;
 			}
 
 			const filename = normalizeFilename(parsedId.filename);

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -210,11 +210,11 @@ export default function astro({ config, logging }: AstroPluginOptions): vite.Plu
 			const parsedId = parseAstroRequest(id);
 			const query = parsedId.query;
 			if (!id.endsWith('.astro') || query.astro) {
-				return source;
+				return
 			}
 			// if we still get a relative path here, vite couldn't resolve the import
 			if (isRelativePath(parsedId.filename)) {
-				return source;
+				return
 			}
 
 			const filename = normalizeFilename(parsedId.filename);

--- a/packages/astro/src/vite-plugin-env/index.ts
+++ b/packages/astro/src/vite-plugin-env/index.ts
@@ -67,11 +67,11 @@ export default function envVitePlugin({
 			const ssr = options?.ssr === true;
 
 			if (!ssr) {
-				return source;
+				return;
 			}
 
 			if (!source.includes('import.meta') || !/\benv\b/.test(source)) {
-				return source;
+				return;
 			}
 
 			if (typeof privateEnv === 'undefined') {
@@ -110,9 +110,9 @@ export default function envVitePlugin({
 				}
 			}
 
-			if (!privateEnv || !pattern) return source;
+			if (!privateEnv || !pattern) return;
 			const references = getReferencedPrivateKeys(source, privateEnv);
-			if (references.size === 0) return source;
+			if (references.size === 0) return;
 
 			// Find matches for *private* env and do our own replacement.
 			const s = new MagicString(source);
@@ -133,7 +133,10 @@ export default function envVitePlugin({
 				s.overwrite(start, end, replacement);
 			}
 
-			return s.toString();
+			return {
+				code: s.toString(),
+				map: s.generateMap(),
+			};
 		},
 	};
 }

--- a/packages/astro/test/fixtures/sourcemap/astro.config.mjs
+++ b/packages/astro/test/fixtures/sourcemap/astro.config.mjs
@@ -1,0 +1,11 @@
+import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
+
+export default defineConfig({
+	integrations: [react()],
+	vite: {
+		build: {
+			sourcemap: true,
+		}
+	}
+})

--- a/packages/astro/test/fixtures/sourcemap/package.json
+++ b/packages/astro/test/fixtures/sourcemap/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@test/sourcemap",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/react": "workspace:*",
+    "astro": "workspace:*",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0"
+  }
+}

--- a/packages/astro/test/fixtures/sourcemap/src/components/Counter.jsx
+++ b/packages/astro/test/fixtures/sourcemap/src/components/Counter.jsx
@@ -1,0 +1,11 @@
+import React, { useState } from 'react';
+
+export default function () {
+  const [count, setCount] = useState(0);
+  return (
+    <div>
+      <div>Count: {count}</div>
+      <button type="button" onClick={() => setCount(count+1)}>Increment</button>
+    </div>
+  );
+}

--- a/packages/astro/test/fixtures/sourcemap/src/components/Counter.jsx
+++ b/packages/astro/test/fixtures/sourcemap/src/components/Counter.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-export default function () {
+export default function Counter() {
   const [count, setCount] = useState(0);
   return (
     <div>

--- a/packages/astro/test/fixtures/sourcemap/src/pages/index.astro
+++ b/packages/astro/test/fixtures/sourcemap/src/pages/index.astro
@@ -1,0 +1,17 @@
+
+---
+import Counter from '../components/Counter';
+---
+
+<html>
+
+<head>
+	<title>Testing</title>
+</head>
+
+<body>
+	<h1>Testing</h1>
+	<Counter client:load />
+</body>
+
+</html>

--- a/packages/astro/test/sourcemap.test.js
+++ b/packages/astro/test/sourcemap.test.js
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+import { loadFixture } from './test-utils.js';
+
+describe('Sourcemap', async () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/sourcemap/' });
+		await fixture.build();
+	});
+
+	it('Builds sourcemap', async () => {
+		const dir = await fixture.readdir('.');
+		const counterMap = dir.find((file) => file.match(/^Counter\.\w+\.js\.map$/));
+		expect(counterMap).to.be.ok;
+	});
+
+	it('Builds non-empty sourcemap', async () => {
+		const map = await fixture.readFile('entry.mjs.map');
+		expect(map).to.not.include('"sources":[]');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1783,6 +1783,18 @@ importers:
       '@astrojs/solid-js': link:../../../../integrations/solid
       astro: link:../../..
 
+  packages/astro/test/fixtures/sourcemap:
+    specifiers:
+      '@astrojs/react': workspace:*
+      astro: workspace:*
+      react: ^18.1.0
+      react-dom: ^18.1.0
+    dependencies:
+      '@astrojs/react': link:../../../../integrations/react
+      astro: link:../../..
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+
   packages/astro/test/fixtures/ssr-api-route:
     specifiers:
       astro: workspace:*


### PR DESCRIPTION
## Changes

Fixes #3970

- Pass `viteConfig.build` config to client build Vite config
- Fix sourcemap generation in `astro:build` and `astro:vite-plugin-env` plugins

## Testing

Added new `sourcemap` fixture to `astro/test`. Might be useful in the future for more sourcemaps test.

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This should work by default without docs.