### PR TITLE
Update Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/---01-bug-report.yml
@@ -1,6 +1,5 @@
 name: "\U0001F41B Bug Report"
 description: Report an issue or possible bug
-title: "\U0001F41B BUG:"
 labels: []
 assignees: []
 body:


### PR DESCRIPTION
## Changes

- We're still getting bug reports with no title (just `🐛 BUG:`)
- Every issue is prefixed with `🐛 BUG:`
- The only issues people can open are bugs, so the prefix doesn't really add anything.

## Testing

N/A

## Docs

N/A