### PR TITLE
Add Windows back to smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        OS: [ubuntu-latest]
+        OS: [ubuntu-latest, windows-latest]
         NODE_VERSION: [14]
     env:
       NODE_VERSION: ${{ matrix.NODE_VERSION }}


### PR DESCRIPTION
## Changes

- Test only, see below

## Testing

- Adds back `windows-latest` to our smoke tests.
- All passing!

## Docs

N/A