### PR TITLE
Ensure JSX does not reference server entrypoint

### DIFF
--- a/.changeset/slimy-parrots-exist.md
+++ b/.changeset/slimy-parrots-exist.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Ensure JSX does not reference server entrypoint

--- a/packages/astro/src/jsx/babel.ts
+++ b/packages/astro/src/jsx/babel.ts
@@ -1,8 +1,9 @@
 import type { PluginObj } from '@babel/core';
 import * as t from '@babel/types';
 import { pathToFileURL } from 'node:url';
-import { ClientOnlyPlaceholder } from '../runtime/server/index.js';
 import type { PluginMetadata } from '../vite-plugin-astro/types';
+
+const ClientOnlyPlaceholder = 'astro-client-only';
 
 function isComponent(tagName: string) {
 	return (

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -34,8 +34,6 @@ import { Renderer } from './render/index.js';
 
 import { addAttribute } from './render/index.js';
 
-export const ClientOnlyPlaceholder = 'astro-client-only';
-
 // Used in creating the component. aka the main export.
 export function createComponent(cb: AstroComponentFactory) {
 	// Add a flag to this callback to mark it as an Astro component

--- a/packages/astro/src/runtime/server/jsx.ts
+++ b/packages/astro/src/runtime/server/jsx.ts
@@ -2,7 +2,6 @@
 import { SSRResult } from '../../@types/astro.js';
 import { AstroJSX, isVNode } from '../../jsx-runtime/index.js';
 import {
-	ClientOnlyPlaceholder,
 	escapeHTML,
 	HTMLString,
 	markHTMLString,
@@ -13,6 +12,8 @@ import {
 	stringifyChunk,
 	voidElementNames,
 } from './index.js';
+
+const ClientOnlyPlaceholder = 'astro-client-only';
 
 const skipAstroJSXCheck = new WeakSet();
 let originalConsoleError: any;


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/4194
- Previously, JSX was referencing an export from our server entrypoint and wasn't tree-shaken out.
- This PR inlines the references where it is needed.

## Testing

Manually

## Docs

N/A