### PR TITLE
Use passive listeners in prefetch

### DIFF
--- a/packages/integrations/prefetch/src/client.ts
+++ b/packages/integrations/prefetch/src/client.ts
@@ -25,7 +25,7 @@ let observer: IntersectionObserver;
 function observe(link: HTMLAnchorElement) {
 	preloaded.add(link.href);
 	observer.observe(link);
-	events.map((event) => link.addEventListener(event, onLinkEvent, { once: true }));
+	events.map((event) => link.addEventListener(event, onLinkEvent, { passive:true, once: true }));
 }
 
 function unobserve(link: HTMLAnchorElement) {


### PR DESCRIPTION
Without passive=true, Lighthouse complains about not using passive listeners to improve scrolling performance.
