### PR TITLE
Markdown component: fix package name in readme.md

### DIFF
--- a/.changeset/dry-deers-vanish.md
+++ b/.changeset/dry-deers-vanish.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/markdown-component": patch
+---
+
+Fix package name in readme.md

--- a/.changeset/dry-deers-vanish.md
+++ b/.changeset/dry-deers-vanish.md
@@ -2,4 +2,4 @@
 "@astrojs/markdown-component": patch
 ---
 
-Fix package name in readme.md
+README update

--- a/packages/markdown/component/readme.md
+++ b/packages/markdown/component/readme.md
@@ -1,4 +1,4 @@
-# @astrojs/markdown
+# @astrojs/markdown-component
 
 This package brings legacy support for the `<Markdown />` component to all Astro projects.
 


### PR DESCRIPTION
## Changes

- updates the title in `packages/markdown/component/readme.md`
- previously it was `@astrojs/markdown` and was different from actual package name

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->