### PR TITLE
[Docs READMEs] remove errant tags from details sweep

### DIFF
--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -338,7 +338,7 @@ const imageUrl = 'https://www.google.com/images/branding/googlelogo/2x/googlelog
 <Image src={imageUrl} height={200} aspectRatio="16:9" format="avif" />
 ```
 
-### Responsive pictures</strong></summary>
+### Responsive pictures
 
 The `<Picture />` component can be used to automatically build a `<picture>` with multiple sizes and formats. Check out [MDN](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images#art_direction) for a deep dive into responsive images and art direction.
 

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -323,7 +323,7 @@ export default {
 }
 ```
 
-### rehypePlugins</strong>
+### rehypePlugins
 
 [Rehype plugins](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md) allow you to transform the HTML that your Markdown generates. We recommend checking the [Remark plugin](https://github.com/remarkjs/remark/blob/main/doc/plugins.md) catalog first _before_ considering rehype plugins, since most users want to transform their Markdown syntax instead. If HTML transforms are what you need, we encourage you to browse [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for a full curated list of plugins!
 


### PR DESCRIPTION
## Changes

Removes some closing HTML tags from integration package READMEs that got missed in the Great Undetailing of 2022

## Testing

No tests.

## Docs

Content to mirror to Docs.