### PR TITLE
Updated @astrojs/image README.md missing formats prop as subtitle

### DIFF
--- a/.changeset/fast-drinks-visit.md
+++ b/.changeset/fast-drinks-visit.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/image": patch
+---
+
+README update

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -228,6 +228,8 @@ A `string` can be provided in the form of `{width}:{height}`, ex: `16:9` or `3:4
 
 A `number` can also be provided, useful when the aspect ratio is calculated at build time. This can be an inline number such as `1.777` or inlined as a JSX expression like `aspectRatio={16/9}`.
 
+#### formats
+
 <p>
 
 **Type:** `Array<'avif' | 'jpeg' | 'png' | 'webp'>`<br>


### PR DESCRIPTION
Added missing subtitle for the `formats` prop of the `<Picture>` component in the @astrojs/image README.md.

## Changes

Added missing subtitle for the `formats` prop of the `<Picture>` component in the @astrojs/image README.md.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Added missing subtitle for the `formats` prop of the `<Picture>` component in the @astrojs/image README.md.

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->