### PR TITLE
feat: Support `-y` in `astro add`

### DIFF
--- a/.changeset/two-ducks-end.md
+++ b/.changeset/two-ducks-end.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+`astro add` now supports `-y`

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -701,7 +701,7 @@ function parseIntegrationName(spec: string) {
 }
 
 async function askToContinue({ flags }: { flags: yargs.Arguments }): Promise<boolean> {
-	if (flags.yes) return true;
+	if (flags.yes || flags.y) return true;
 
 	const response = await prompts({
 		type: 'confirm',


### PR DESCRIPTION
## Changes

Just checks `flags.y` in addition to `flags.yes`.

## Testing

I didn't see any tests.

## Docs

QoL change. Not sure if it needs to be documented.