### PR TITLE
Remove dev server during build

### DIFF
--- a/.changeset/silly-chairs-pretend.md
+++ b/.changeset/silly-chairs-pretend.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Remove dev server during build

--- a/packages/astro/src/core/build/page-data.ts
+++ b/packages/astro/src/core/build/page-data.ts
@@ -1,4 +1,3 @@
-import type { ViteDevServer } from 'vite';
 import type { AstroConfig, ManifestData } from '../../@types/astro';
 import type { LogOptions } from '../logger/core';
 import { info } from '../logger/core.js';
@@ -6,16 +5,11 @@ import type { AllPagesData } from './types';
 
 import * as colors from 'kleur/colors';
 import { debug } from '../logger/core.js';
-import { RouteCache } from '../render/route-cache.js';
 
 export interface CollectPagesDataOptions {
 	astroConfig: AstroConfig;
 	logging: LogOptions;
 	manifest: ManifestData;
-	origin: string;
-	routeCache: RouteCache;
-	viteServer: ViteDevServer;
-	ssr: boolean;
 }
 
 export interface CollectPagesDataResult {

--- a/packages/astro/src/core/errors.ts
+++ b/packages/astro/src/core/errors.ts
@@ -42,11 +42,14 @@ export function cleanErrorStack(stack: string) {
 		.join('\n');
 }
 
-/** Update the error message to correct any vite-isms that we don't want to expose to the user. */
-export function fixViteErrorMessage(_err: unknown, server: ViteDevServer, filePath?: URL) {
+/**
+ * Update the error message to correct any vite-isms that we don't want to expose to the user.
+ * The `server` is required if the error may come from `server.ssrLoadModule()`.
+ */
+export function fixViteErrorMessage(_err: unknown, server?: ViteDevServer, filePath?: URL) {
 	const err = createSafeError(_err);
 	// Vite will give you better stacktraces, using sourcemaps.
-	server.ssrFixStacktrace(err);
+	server?.ssrFixStacktrace(err);
 	// Fix: Astro.glob() compiles to import.meta.glob() by the time Vite sees it,
 	// so we need to update this error message in case it originally came from Astro.glob().
 	if (err.message === 'import.meta.glob() can only accept string literals.') {


### PR DESCRIPTION
## Changes

- Remove starting the dev server during the build process since it's not used anymore
- Small refactor to remove unused options when passing to `collectPagesData`

## Testing

No new tests added, but should be safe if all current tests pass.

## Docs

N/A