### PR TITLE
Simulate Vite resolve id to url

### DIFF
--- a/.changeset/nervous-socks-sin.md
+++ b/.changeset/nervous-socks-sin.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix Astro client scripts sourcemap 404

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath } from 'url';
+import path from 'path';
 import type { ViteDevServer } from 'vite';
 import type {
 	AstroConfig,
@@ -12,7 +13,7 @@ import type {
 import { prependForwardSlash } from '../../../core/path.js';
 import { PAGE_SCRIPT_ID } from '../../../vite-plugin-scripts/index.js';
 import { LogOptions } from '../../logger/core.js';
-import { isPage } from '../../util.js';
+import { isPage, resolveIdToUrl } from '../../util.js';
 import { render as coreRender } from '../core.js';
 import { RouteCache } from '../route-cache.js';
 import { collectMdMetadata } from '../util.js';
@@ -116,7 +117,7 @@ export async function render(
 		scripts.add({
 			props: {
 				type: 'module',
-				src: '/@id/astro/runtime/client/hmr.js',
+				src: await resolveIdToUrl(viteServer, 'astro/runtime/client/hmr.js'),
 			},
 			children: '',
 		});
@@ -186,7 +187,7 @@ export async function render(
 			if (s.startsWith('/@fs')) {
 				return resolveClientDevPath(s);
 			}
-			return '/@id' + prependForwardSlash(s);
+			return await resolveIdToUrl(viteServer, s);
 		},
 		renderers,
 		request,

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -4,9 +4,9 @@ import path from 'path';
 import resolve from 'resolve';
 import slash from 'slash';
 import { fileURLToPath, pathToFileURL } from 'url';
-import type { ErrorPayload } from 'vite';
+import type { ErrorPayload, ViteDevServer } from 'vite';
 import type { AstroConfig } from '../@types/astro';
-import { removeTrailingForwardSlash } from './path.js';
+import { prependForwardSlash, removeTrailingForwardSlash } from './path.js';
 
 // process.env.PACKAGE_VERSION is injected when we build and publish the astro package.
 export const ASTRO_VERSION = process.env.PACKAGE_VERSION ?? 'development';
@@ -206,4 +206,20 @@ export function getLocalAddress(serverAddress: string, host: string | boolean): 
 	} else {
 		return serverAddress;
 	}
+}
+
+/**
+ * Simulate Vite's resolve and import analysis so we can import the id as an URL
+ * through a script tag or a dynamic import as-is.
+ */
+// NOTE: `/@id/` should only be used when the id is fully resolved
+export async function resolveIdToUrl(viteServer: ViteDevServer, id: string) {
+	const result = await viteServer.pluginContainer.resolveId(id);
+	if (!result) {
+		return VALID_ID_PREFIX + id;
+	}
+	if (path.isAbsolute(result.id)) {
+		return '/@fs' + prependForwardSlash(result.id);
+	}
+	return VALID_ID_PREFIX + result.id;
 }


### PR DESCRIPTION
## Changes

Fix #4219

- Create a util to simulate Vite resolve for `/@id` and `/@fs`
- Correctly resolves modules to be loaded directly via url

Notes:

- Ideally this should be kept within Vite internally but I haven't found a way for us to do so without a big refactor.
- I could take a look in Vite to see if it's something we can expose.

## Testing

Tested with an example app locally that shows no more sourcemap 404. The refactor should be covered by the existing tests too.

## Docs

N/A