### PR TITLE
Include astro components for HMR invalidation

### DIFF
--- a/.changeset/nasty-gifts-push.md
+++ b/.changeset/nasty-gifts-push.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Properly invalidate Astro modules when a child script updates in HMR

--- a/packages/astro/e2e/fixtures/invalidate-script-deps/package.json
+++ b/packages/astro/e2e/fixtures/invalidate-script-deps/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@e2e/invalidate-script-deps",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/e2e/fixtures/invalidate-script-deps/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/invalidate-script-deps/src/pages/index.astro
@@ -1,0 +1,11 @@
+<html>
+	<head>
+		<title>Test</title>
+	</head>
+	<body>
+		<h1></h1>
+		<script>
+			import '../scripts/heading.js';
+		</script>
+	</body>
+</html>

--- a/packages/astro/e2e/fixtures/invalidate-script-deps/src/scripts/heading.js
+++ b/packages/astro/e2e/fixtures/invalidate-script-deps/src/scripts/heading.js
@@ -1,0 +1,2 @@
+
+document.querySelector('h1').textContent = 'before';

--- a/packages/astro/e2e/invalidate-script-deps.test.js
+++ b/packages/astro/e2e/invalidate-script-deps.test.js
@@ -1,0 +1,31 @@
+import { expect } from '@playwright/test';
+import { testFactory } from './test-utils.js';
+
+const test = testFactory({
+	root: './fixtures/invalidate-script-deps/',
+});
+
+let devServer;
+
+test.beforeEach(async ({ astro }) => {
+	devServer = await astro.startDevServer();
+});
+
+test.afterEach(async () => {
+	await devServer.stop();
+});
+
+test.describe('Scripts with dependencies', () => {
+	test('refresh with HMR', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/'));
+
+		const h = page.locator('h1');
+		await expect(h, 'original text set').toHaveText('before');
+
+		await astro.editFile('./src/scripts/heading.js', (original) =>
+			original.replace('before', 'after')
+		);
+
+		await expect(h, 'text changed').toHaveText('after');
+	});
+});

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -60,12 +60,11 @@ export interface HandleHotUpdateOptions {
 	config: AstroConfig;
 	logging: LogOptions;
 	compile: () => ReturnType<typeof cachedCompilation>;
-	viteServer: ViteDevServer;
 }
 
 export async function handleHotUpdate(
 	ctx: HmrContext,
-	{ config, logging, compile, viteServer }: HandleHotUpdateOptions
+	{ config, logging, compile }: HandleHotUpdateOptions
 ) {
 	let isStyleOnlyChange = false;
 	if (ctx.file.endsWith('.astro')) {
@@ -153,7 +152,7 @@ export async function handleHotUpdate(
 	// component so that it is cached by the time the script gets transformed.
 	for(const mod of filtered) {
     if(mod.id && isAstroScript(mod.id) && mod.file) {
-      const astroMod = viteServer.moduleGraph.getModuleById(mod.file);
+      const astroMod = ctx.server.moduleGraph.getModuleById(mod.file);
       if(astroMod) {
         mods.unshift(astroMod);
       }

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -359,7 +359,12 @@ ${source}
 				pluginContext: this,
 			};
 			const compile = () => cachedCompilation(compileProps);
-			return handleHotUpdate.call(this, context, { config, logging, compile });
+			return handleHotUpdate.call(this, context, {
+				config,
+				logging,
+				compile,
+				viteServer: context.server
+			});
 		},
 	};
 }

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -362,8 +362,7 @@ ${source}
 			return handleHotUpdate.call(this, context, {
 				config,
 				logging,
-				compile,
-				viteServer: context.server
+				compile
 			});
 		},
 	};

--- a/packages/astro/src/vite-plugin-astro/query.ts
+++ b/packages/astro/src/vite-plugin-astro/query.ts
@@ -35,3 +35,8 @@ export function parseAstroRequest(id: string): ParsedRequestResult {
 		query,
 	};
 }
+
+export function isAstroScript(id: string): boolean {
+	const parsed = parseAstroRequest(id);
+	return parsed.query.type === 'script';
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -659,6 +659,12 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
 
+  packages/astro/e2e/fixtures/invalidate-script-deps:
+    specifiers:
+      astro: workspace:*
+    devDependencies:
+      astro: link:../../..
+
   packages/astro/e2e/fixtures/lit-component:
     specifiers:
       '@astrojs/lit': workspace:*


### PR DESCRIPTION
## Changes

- If a module has a script importer, add the actual .astro component module to be reloaded, so that it is cached by the time the astro script reloads.
- Fixes https://github.com/withastro/astro/issues/4211

## Testing

- e2e test added

## Docs

bug fix only