### PR TITLE
Mdx/plugin unshift

### DIFF
--- a/.changeset/fuzzy-emus-develop.md
+++ b/.changeset/fuzzy-emus-develop.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Load builtin rehype plugins before user plugins instead of after

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -65,7 +65,7 @@ function getRehypePlugins(
 		rehypePlugins.push([rehypeRaw, { passThrough: nodeTypes }]);
 	}
 	// getHeadings() is guaranteed by TS, so we can't allow user to override
-	rehypePlugins.push(rehypeCollectHeadings);
+	rehypePlugins.unshift(rehypeCollectHeadings);
 
 	return rehypePlugins;
 }

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -62,7 +62,7 @@ function getRehypePlugins(
 	let rehypePlugins = handleExtends(mdxOptions.rehypePlugins, DEFAULT_REHYPE_PLUGINS);
 
 	if (config.markdown.syntaxHighlight === 'shiki' || config.markdown.syntaxHighlight === 'prism') {
-		rehypePlugins.push([rehypeRaw, { passThrough: nodeTypes }]);
+		rehypePlugins.unshift([rehypeRaw, { passThrough: nodeTypes }]);
 	}
 	// getHeadings() is guaranteed by TS, so we can't allow user to override
 	rehypePlugins.unshift(rehypeCollectHeadings);


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

Put built in rehype plugins before user added.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

No thorough testing was done due to the complexity of testing every major rehype plugin. Changing the load order should have minimal to no effect on usage.

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No visible change. No documentation mentioned builtin plugins being loaded last.

## Why

Specifically the `rehypeCollectHeadings` impacted one of my rehype plugins.

`rehypeAutolinkHeadings` requires ids to be added to headings for it to work, with pre this pr configuration, these ids were added after my plugin being ran.

[Context in discord thread](https://discord.com/channels/830184174198718474/1006916058709495859/1007011695056662548)

@bholmesdev 