### PR TITLE
Shiki config allow themes

### DIFF
--- a/.changeset/orange-boxes-compete.md
+++ b/.changeset/orange-boxes-compete.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/markdown-remark': patch
+---
+
+allow `themes` in ShikiConfig (syntax highlighter for MDX)

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -193,6 +193,11 @@ export const AstroConfigSchema = z.object({
 						.enum(BUNDLED_THEMES as [Theme, ...Theme[]])
 						.or(z.custom<IThemeRegistration>())
 						.default(ASTRO_CONFIG_DEFAULTS.markdown.shikiConfig.theme),
+					themes: z
+						.enum(BUNDLED_THEMES as [Theme, ...Theme[]])
+						.or(z.custom<IThemeRegistration>())
+						.array()
+						.optional(),
 					wrap: z.boolean().or(z.null()).default(ASTRO_CONFIG_DEFAULTS.markdown.shikiConfig.wrap),
 				})
 				.default({}),

--- a/packages/markdown/remark/src/types.ts
+++ b/packages/markdown/remark/src/types.ts
@@ -23,6 +23,7 @@ export type RehypePlugins = (string | [string, any] | RehypePlugin | [RehypePlug
 export interface ShikiConfig {
 	langs?: ILanguageRegistration[];
 	theme?: Theme | IThemeRegistration;
+	themes?: Array<Theme | IThemeRegistration>;
 	wrap?: boolean | null;
 }
 


### PR DESCRIPTION
## Changes

- What does this change?

Allows `themes` in ShikiConfig (syntax highlighter for MDX) #4245

- adds type in interface declaration
- adds validation type

## Testing

Tested against new & existing Astro projects

## Docs

This is a shiki twoslash feature, it's documented there. All this patch does is stop breaking it.
