### PR TITLE
Fix Prism indentation and class

### DIFF
--- a/.changeset/old-pears-design.md
+++ b/.changeset/old-pears-design.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/prism': patch
+---
+
+Fix `<Prism />` component indentation
+
+Prefer `class="language-plaintext"` to `class="language-undefined"`

--- a/packages/astro-prism/Prism.astro
+++ b/packages/astro-prism/Prism.astro
@@ -11,8 +11,4 @@ const { class: className, lang, code } = Astro.props as Props;
 const { classLanguage, html } = runHighlighterWithAstro(lang, code);
 ---
 
-<pre
-	class={[className, classLanguage].join(
-		' '
-	)}>	<code class={classLanguage}><Fragment set:html={html} /></code>
-</pre>
+<pre class={[className, classLanguage].filter(Boolean).join(' ')}><code class={classLanguage} set:html={html} /></pre>

--- a/packages/astro-prism/src/highlighter.ts
+++ b/packages/astro-prism/src/highlighter.ts
@@ -5,12 +5,10 @@ import { addAstro } from './plugin.js';
 const languageMap = new Map([['ts', 'typescript']]);
 
 export function runHighlighterWithAstro(lang: string | undefined, code: string) {
-	let classLanguage = `language-${lang}`;
-
 	if (!lang) {
 		lang = 'plaintext';
 	}
-
+	let classLanguage = `language-${lang}`;
 	const ensureLoaded = (language: string) => {
 		if (language && !Prism.languages[language]) {
 			loadLanguages([language]);


### PR DESCRIPTION
## Changes

- Closes #4246
- `@astrojs/prism` should not change your code indentation
- `@astrojs/prism` should not use `class="language-undefined"`, it should use `class="language-plaintext"`

## Testing

Tried to add tests to `astro-prism`, but I couldn't get it working

## Docs

bug fix only