### PR TITLE
[MDX] Pass injected frontmatter to layouts

### DIFF
--- a/.changeset/tasty-masks-draw.md
+++ b/.changeset/tasty-masks-draw.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Pass injected frontmatter from remark and rehype plugins to layouts

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -98,16 +98,7 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 								async transform(code, id) {
 									if (!id.endsWith('mdx')) return;
 
-									let { data: frontmatter, content: pageContent } = parseFrontmatter(code, id);
-									if (frontmatter.layout) {
-										const { layout, ...contentProp } = frontmatter;
-										pageContent += `\n\nexport default async function({ children }) {\nconst Layout = (await import(${JSON.stringify(
-											frontmatter.layout
-										)})).default;\nconst frontmatter=${JSON.stringify(
-											contentProp
-										)};\nreturn <Layout frontmatter={frontmatter} content={frontmatter} headings={getHeadings()}>{children}</Layout> }`;
-									}
-
+									const { data: frontmatter, content: pageContent } = parseFrontmatter(code, id);
 									const compiled = await mdxCompile(new VFile({ value: pageContent, path: id }), {
 										...mdxPluginOpts,
 										rehypePlugins: [

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/layouts/Base.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/layouts/Base.astro
@@ -9,7 +9,7 @@ const { frontmatter = defaults, content = defaults } = Astro.props;
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{frontmatter.title ?? content.title}</title>
+  <title>{frontmatter.title}</title>
 </head>
 <body>
   <slot />

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/layouts/Base.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/layouts/Base.astro
@@ -1,0 +1,17 @@
+---
+const defaults = { title: 'Frontmatter not passed to layout!' }
+const { frontmatter = defaults, content = defaults } = Astro.props;
+---
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{frontmatter.title ?? content.title}</title>
+</head>
+<body>
+  <slot />
+</body>
+</html>

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/pages/page-1.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/pages/page-1.mdx
@@ -1,3 +1,7 @@
+---
+layout: '../layouts/Base.astro'
+---
+
 # Page 1
 
 Look at that!

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/pages/page-2.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/pages/page-2.mdx
@@ -1,3 +1,7 @@
+---
+layout: '../layouts/Base.astro'
+---
+
 # Page 2
 
 ## Table of contents

--- a/packages/integrations/mdx/test/mdx-frontmatter-injection.test.js
+++ b/packages/integrations/mdx/test/mdx-frontmatter-injection.test.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
 const FIXTURE_ROOT = new URL('./fixtures/mdx-frontmatter-injection/', import.meta.url);
@@ -40,5 +41,16 @@ describe('MDX frontmatter injection', () => {
 		const titles = frontmatterByPage.map((frontmatter = {}) => frontmatter.title);
 		expect(titles).to.contain('Overridden title');
 		expect(readingTimes).to.contain('1000 min read');
+	});
+
+	it('passes injected frontmatter to layouts', async () => {
+		const html1 = await fixture.readFile('/page-1/index.html');
+		const html2 = await fixture.readFile('/page-2/index.html');
+
+		const title1 = parseHTML(html1).document.querySelector('title');
+		const title2 = parseHTML(html2).document.querySelector('title');
+
+		expect(title1.innerHTML).to.equal('Page 1');
+		expect(title2.innerHTML).to.equal('Page 2');
 	});
 });


### PR DESCRIPTION
## Changes

- Resolves #4216
- Moves layout generation to our frontmatter rehype plugin. This lets us parse injected frontmatter before passing as a layout prop, and aligns our MDX code with `vite-plugin-markdown`!

## Testing

Test injected frontmatter in layouts

## Docs

N/A