### PR TITLE
Prevents automatic trailingSlash behavior with getStaticPaths

### DIFF
--- a/.changeset/fluffy-otters-guess.md
+++ b/.changeset/fluffy-otters-guess.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevents automatic trailingSlash appending on getStaticPaths produced pages

--- a/packages/astro/e2e/solid-recurse.test.js
+++ b/packages/astro/e2e/solid-recurse.test.js
@@ -15,7 +15,7 @@ test.afterEach(async () => {
 
 test.describe('Recursive elements with Solid', () => {
 	test('Counter', async ({ astro, page }) => {
-		await page.goto(astro.resolveUrl('/'));
+		await page.goto('/');
 
 		const wrapper = page.locator('#case1');
 		await expect(wrapper, 'component is visible').toBeVisible();

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -245,7 +245,7 @@ interface GeneratePathOptions {
 }
 
 function addPageName(pathname: string, opts: StaticBuildOptions): void {
-	opts.pageNames.push(pathname.replace(/\/?$/, '/').replace(/^\//, ''));
+	opts.pageNames.push(pathname.replace(/^\//, ''));
 }
 
 async function generatePath(

--- a/packages/astro/src/core/routing/manifest/generator.ts
+++ b/packages/astro/src/core/routing/manifest/generator.ts
@@ -28,7 +28,11 @@ export function getRouteGenerator(
 		})
 		.join('');
 
-	const trailing = addTrailingSlash !== 'never' && segments.length ? '/' : '';
+	// Unless trailingSlash config is set to 'always', don't automatically append it.
+	let trailing: '/' | '' = '';
+	if(addTrailingSlash === 'always' && segments.length) {
+		trailing = '/';
+	}
 	const toPath = compile(template + trailing);
 	return toPath;
 }

--- a/packages/astro/src/core/routing/manifest/generator.ts
+++ b/packages/astro/src/core/routing/manifest/generator.ts
@@ -33,7 +33,6 @@ export function getRouteGenerator(
 	if(addTrailingSlash === 'always' && segments.length) {
 		trailing = '/';
 	}
-	trailing = addTrailingSlash !== 'never' && segments.length ? '/' : '';
 	const toPath = compile(template + trailing);
 	return toPath;
 }

--- a/packages/astro/src/core/routing/manifest/generator.ts
+++ b/packages/astro/src/core/routing/manifest/generator.ts
@@ -33,6 +33,7 @@ export function getRouteGenerator(
 	if(addTrailingSlash === 'always' && segments.length) {
 		trailing = '/';
 	}
+	trailing = addTrailingSlash !== 'never' && segments.length ? '/' : '';
 	const toPath = compile(template + trailing);
 	return toPath;
 }

--- a/packages/astro/test/astro-get-static-paths.test.js
+++ b/packages/astro/test/astro-get-static-paths.test.js
@@ -150,3 +150,25 @@ describe('getStaticPaths - numeric route params', () => {
 		}
 	});
 });
+
+describe('getStaticPaths - Astro.url', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	before(async () => {
+		// reset the flag used by [...calledTwiceTest].astro between each test
+		globalThis.isCalledOnce = false;
+
+		fixture = await loadFixture({
+			root: './fixtures/astro-get-static-paths/',
+			site: 'https://mysite.dev/',
+		});
+		await fixture.build();
+	});
+
+	it('Sets the current pathname', async () => {
+		const html = await fixture.readFile('/food/tacos/index.html');
+		const $ = cheerio.load(html);
+
+		expect($('#url').text()).to.equal('/food/tacos');
+	});
+});

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/food/[name].astro
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/food/[name].astro
@@ -1,0 +1,26 @@
+---
+export async function getStaticPaths() {
+	return [
+		{
+			params: { name: 'tacos' },
+		},
+		{
+			params: { name: 'potatoes' },
+		},
+		{
+			params: { name: 'spaghetti' }
+		}
+	]
+}
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>Food</title>
+	</head>
+	<body>
+		<p id="url">{ Astro.url.pathname }</p>
+	</body>
+</html>


### PR DESCRIPTION
## Changes

- Previously we were assuming a trailing slash until `trailingSlash: 'never'` was set in the config.
- This produced a dev/prod difference, because dev was not requiring it.
- This change aligns with what is documented, which is that a trailing slash is not shown, see https://docs.astro.build/en/reference/api-reference/#data-passing-with-props as an example.
- #4252

## Testing

- Test added to confirm dev / build is same.

## Docs

N/A