### PR TITLE
[MDX] Fix remaining inconsistencies with Markdown

### DIFF
--- a/.changeset/empty-parents-lie.md
+++ b/.changeset/empty-parents-lie.md
@@ -1,6 +1,9 @@
 ---
 'astro': patch
-'@astrojs/mdx': patch
+'@astrojs/mdx': minor
 ---
 
-Align MD with MDX on layout props and "glob" import results. Also includes type updates
+Align MD with MDX on layout props and "glob" import results:
+- Add `Content` to MDX
+- Add `file` and `url` to MDX frontmatter (layout import only)
+- Update glob types to reflect differences (lack of `rawContent` and `compiledContent`)

--- a/.changeset/empty-parents-lie.md
+++ b/.changeset/empty-parents-lie.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/mdx': patch
+---
+
+Align MD with MDX on layout props and "glob" import results. Also includes type updates

--- a/packages/astro/env.d.ts
+++ b/packages/astro/env.d.ts
@@ -29,6 +29,23 @@ declare module '*.md' {
 	export default load;
 }
 
+declare module '*.mdx' {
+	type MDX = import('astro').MDXInstance<Record<string, any>>;
+
+	export const frontmatter: MDX['frontmatter'];
+	export const file: MDX['file'];
+	export const url: MDX['url'];
+	export const getHeadings: MDX['getHeadings'];
+	/** @deprecated Renamed to `getHeadings()` */
+	export const getHeaders: () => void;
+	export const Content: MDX['Content'];
+	export const rawContent: MDX['rawContent'];
+	export const compiledContent: MDX['compiledContent'];
+
+	const load: MDX['default'];
+	export default load;
+}
+
 declare module '*.html' {
 	const Component: { render(opts: { slots: Record<string, string> }): string };
 	export default Component;

--- a/packages/astro/env.d.ts
+++ b/packages/astro/env.d.ts
@@ -36,8 +36,6 @@ declare module '*.mdx' {
 	export const file: MDX['file'];
 	export const url: MDX['url'];
 	export const getHeadings: MDX['getHeadings'];
-	/** @deprecated Renamed to `getHeadings()` */
-	export const getHeaders: () => void;
 	export const Content: MDX['Content'];
 	export const rawContent: MDX['rawContent'];
 	export const compiledContent: MDX['compiledContent'];

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -871,12 +871,8 @@ export interface MarkdownLayoutProps<T extends Record<string, any>> {
 	compiledContent: MarkdownInstance<T>['compiledContent'];
 }
 
-export interface MDXLayoutProps<T extends Record<string, any>> {
-	frontmatter: { file: string; url: string | undefined } & T;
-	file: MDXInstance<T>['file'];
-	url: MDXInstance<T>['url'];
-	headings: MarkdownHeading[];
-}
+export interface MDXLayoutProps<T>
+	extends Omit<MarkdownLayoutProps<T>, 'rawContent' | 'compiledContent'> {}
 
 export type GetHydrateCallback = () => Promise<() => void | Promise<void>>;
 

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -862,6 +862,22 @@ export interface MDXInstance<T> extends MarkdownInstance<T> {
 	compiledContent: never;
 }
 
+export interface MarkdownLayoutProps<T extends Record<string, any>> {
+	frontmatter: { file: string; url: string | undefined } & T;
+	file: MarkdownInstance<T>['file'];
+	url: MarkdownInstance<T>['url'];
+	headings: MarkdownHeading[];
+	rawContent: MarkdownInstance<T>['rawContent'];
+	compiledContent: MarkdownInstance<T>['compiledContent'];
+}
+
+export interface MDXLayoutProps<T extends Record<string, any>> {
+	frontmatter: { file: string; url: string | undefined } & T;
+	file: MDXInstance<T>['file'];
+	url: MDXInstance<T>['url'];
+	headings: MarkdownHeading[];
+}
+
 export type GetHydrateCallback = () => Promise<() => void | Promise<void>>;
 
 /**

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -241,7 +241,7 @@ export interface AstroGlobalPartial {
 	 */
 	glob(globStr: `${any}.astro`): Promise<AstroInstance[]>;
 	glob<T extends Record<string, any>>(globStr: `${any}.md`): Promise<MarkdownInstance<T>[]>;
-	glob<T extends Record<string, any>>(globStr: `${any}.mdx`): Promise<MarkdownInstance<T>[]>;
+	glob<T extends Record<string, any>>(globStr: `${any}.mdx`): Promise<MDXInstance<T>[]>;
 	glob<T extends Record<string, any>>(globStr: string): Promise<T[]>;
 	/**
 	 * Returns a [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) object built from the [site](https://docs.astro.build/en/reference/configuration-reference/#site) config option
@@ -848,16 +848,18 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 	/** raw Markdown file content, excluding frontmatter */
 	rawContent(): string;
 	/** Markdown file compiled to valid Astro syntax. Queryable with most HTML parsing libraries */
-	compiledContent(): Promise<string>;
-	getHeadings(): Promise<MarkdownHeading[]>;
+	compiledContent(): string;
+	getHeadings(): MarkdownHeading[];
 	/** @deprecated Renamed to `getHeadings()` */
 	getHeaders(): void;
-	default: () => Promise<{
-		metadata: MarkdownMetadata;
-		frontmatter: MarkdownContent<T>;
-		$$metadata: Metadata;
-		default: AstroComponentFactory;
-	}>;
+	default: AstroComponentFactory;
+}
+
+export interface MDXInstance<T> extends MarkdownInstance<T> {
+	/** MDX does not support rawContent! If you need to read the Markdown contents to calculate values (ex. reading time), we suggest injecting frontmatter via remark plugins. Learn more on our docs: https://docs.astro.build/en/guides/integrations-guide/mdx/#inject-frontmatter-via-remark-or-rehype-plugins */
+	rawContent: never;
+	/** MDX does not support compiledContent! If you need to read the HTML contents to calculate values (ex. reading time), we suggest injecting frontmatter via rehype plugins. Learn more on our docs: https://docs.astro.build/en/guides/integrations-guide/mdx/#inject-frontmatter-via-remark-or-rehype-plugins */
+	compiledContent: never;
 }
 
 export type GetHydrateCallback = () => Promise<() => void | Promise<void>>;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -863,9 +863,10 @@ export interface MDXInstance<T> extends MarkdownInstance<T> {
 }
 
 export interface MarkdownLayoutProps<T extends Record<string, any>> {
-	frontmatter: { file: string; url: string | undefined } & T;
-	file: MarkdownInstance<T>['file'];
-	url: MarkdownInstance<T>['url'];
+	frontmatter: {
+		file: MarkdownInstance<T>['file'];
+		url: MarkdownInstance<T>['url'];
+	} & T;
 	headings: MarkdownHeading[];
 	rawContent: MarkdownInstance<T>['rawContent'];
 	compiledContent: MarkdownInstance<T>['compiledContent'];

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -860,11 +860,14 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 	}>;
 }
 
-export interface MDXInstance<T> extends MarkdownInstance<T> {
+export interface MDXInstance<T>
+	extends Omit<MarkdownInstance<T>, 'rawContent' | 'compiledContent' | 'Content' | 'default'> {
 	/** MDX does not support rawContent! If you need to read the Markdown contents to calculate values (ex. reading time), we suggest injecting frontmatter via remark plugins. Learn more on our docs: https://docs.astro.build/en/guides/integrations-guide/mdx/#inject-frontmatter-via-remark-or-rehype-plugins */
 	rawContent: never;
 	/** MDX does not support compiledContent! If you need to read the HTML contents to calculate values (ex. reading time), we suggest injecting frontmatter via rehype plugins. Learn more on our docs: https://docs.astro.build/en/guides/integrations-guide/mdx/#inject-frontmatter-via-remark-or-rehype-plugins */
 	compiledContent: never;
+	default: AstroComponentFactory;
+	Content: AstroComponentFactory;
 }
 
 export interface MarkdownLayoutProps<T extends Record<string, any>> {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -848,11 +848,16 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 	/** raw Markdown file content, excluding frontmatter */
 	rawContent(): string;
 	/** Markdown file compiled to valid Astro syntax. Queryable with most HTML parsing libraries */
-	compiledContent(): string;
-	getHeadings(): MarkdownHeading[];
+	compiledContent(): Promise<string>;
+	getHeadings(): Promise<MarkdownHeading[]>;
 	/** @deprecated Renamed to `getHeadings()` */
 	getHeaders(): void;
-	default: AstroComponentFactory;
+	default: () => Promise<{
+		metadata: MarkdownMetadata;
+		frontmatter: MarkdownContent<T>;
+		$$metadata: Metadata;
+		default: AstroComponentFactory;
+	}>;
 }
 
 export interface MDXInstance<T> extends MarkdownInstance<T> {

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -48,8 +48,6 @@ export default function markdown({ config, logging }: AstroPluginOptions): Plugi
 				const frontmatter = {
 					...injectedFrontmatter,
 					...raw.data,
-					url: fileUrl,
-					file: fileId,
 				} as any;
 
 				const { layout } = frontmatter;
@@ -86,6 +84,8 @@ export default function markdown({ config, logging }: AstroPluginOptions): Plugi
 				};
 				export async function Content() {
 					const { layout, ...content } = frontmatter;
+					content.file = file;
+					content.url = url;
 					content.astro = {};
 					Object.defineProperty(content.astro, 'headings', {
 						get() {
@@ -106,6 +106,8 @@ export default function markdown({ config, logging }: AstroPluginOptions): Plugi
 					return ${
 						layout
 							? `h(Layout, {
+									file,
+									url,
 									content,
 									frontmatter: content,
 									headings: getHeadings(),

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -106,8 +106,6 @@ export default function markdown({ config, logging }: AstroPluginOptions): Plugi
 					return ${
 						layout
 							? `h(Layout, {
-									file,
-									url,
 									content,
 									frontmatter: content,
 									headings: getHeadings(),

--- a/packages/integrations/mdx/src/astro-data-utils.ts
+++ b/packages/integrations/mdx/src/astro-data-utils.ts
@@ -28,6 +28,8 @@ export function rehypeApplyFrontmatterExport(pageFrontmatter: Record<string, any
 				
 				export default function ({ children }) {
 					const { layout, ...content } = frontmatter;
+					content.file = file;
+					content.url = url;
 					content.astro = {};
 					Object.defineProperty(content.astro, 'headings', {
 						get() {

--- a/packages/integrations/mdx/src/astro-data-utils.ts
+++ b/packages/integrations/mdx/src/astro-data-utils.ts
@@ -45,6 +45,8 @@ export function rehypeApplyFrontmatterExport(pageFrontmatter: Record<string, any
 						}
 					});
 					return layoutJsx(Layout, {
+						file,
+						url,
 						content,
 						frontmatter: content,
 						headings: getHeadings(),

--- a/packages/integrations/mdx/src/astro-data-utils.ts
+++ b/packages/integrations/mdx/src/astro-data-utils.ts
@@ -47,8 +47,6 @@ export function rehypeApplyFrontmatterExport(pageFrontmatter: Record<string, any
 						}
 					});
 					return layoutJsx(Layout, {
-						file,
-						url,
 						content,
 						frontmatter: content,
 						headings: getHeadings(),

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -26,6 +26,12 @@ const DEFAULT_REMARK_PLUGINS: MdxRollupPluginOptions['remarkPlugins'] = [
 ];
 const DEFAULT_REHYPE_PLUGINS: MdxRollupPluginOptions['rehypePlugins'] = [];
 
+const RAW_CONTENT_ERROR =
+	'MDX does not support rawContent()! If you need to read the Markdown contents to calculate values (ex. reading time), we suggest injecting frontmatter via remark plugins. Learn more on our docs: https://docs.astro.build/en/guides/integrations-guide/mdx/#inject-frontmatter-via-remark-or-rehype-plugins';
+
+const COMPILED_CONTENT_ERROR =
+	'MDX does not support compiledContent()! If you need to read the HTML contents to calculate values (ex. reading time), we suggest injecting frontmatter via rehype plugins. Learn more on our docs: https://docs.astro.build/en/guides/integrations-guide/mdx/#inject-frontmatter-via-remark-or-rehype-plugins';
+
 function handleExtends<T>(config: WithExtends<T[] | undefined>, defaults: T[] = []): T[] {
 	if (Array.isArray(config)) return config;
 
@@ -126,6 +132,16 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 									}
 									if (!moduleExports.includes('file')) {
 										code += `\nexport const file = ${JSON.stringify(fileId)};`;
+									}
+									if (!moduleExports.includes('rawContent')) {
+										code += `\nexport function rawContent() { throw new Error(${JSON.stringify(
+											RAW_CONTENT_ERROR
+										)}) };`;
+									}
+									if (!moduleExports.includes('compiledContent')) {
+										code += `\nexport function compiledContent() { throw new Error(${JSON.stringify(
+											COMPILED_CONTENT_ERROR
+										)}) };`;
 									}
 
 									if (command === 'dev') {

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -143,6 +143,9 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 											COMPILED_CONTENT_ERROR
 										)}) };`;
 									}
+									if (!moduleExports.includes('Content')) {
+										code += `\nexport const Content = MDXContent;`;
+									}
 
 									if (command === 'dev') {
 										// TODO: decline HMR updates until we have a stable approach

--- a/packages/integrations/mdx/test/fixtures/mdx-component/src/pages/glob.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-component/src/pages/glob.astro
@@ -1,0 +1,11 @@
+---
+const components = await Astro.glob('../components/*.mdx');
+---
+
+<div data-default-export>
+	{components.map(Component => <Component.default />)}
+</div>
+
+<div data-content-export>
+	{components.map(({ Content }) => <Content />)}
+</div>

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter/src/layouts/Base.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter/src/layouts/Base.astro
@@ -2,6 +2,8 @@
 const {
 	content = { title: "content didn't work" },
 	frontmatter = { title: "frontmatter didn't work" },
+	file = "file didn't work",
+	url = "url didn't work",
 	headings = [],
 } = Astro.props;
 ---
@@ -18,6 +20,10 @@ const {
 <body>
 	<p data-content-title>{content.title}</p>
 	<p data-frontmatter-title>{frontmatter.title}</p>
+	<p data-file>{file}</p>
+	<p data-frontmatter-file>{frontmatter.file}</p>
+	<p data-url>{url}</p>
+	<p data-frontmatter-url>{frontmatter.url}</p>
 	<p data-layout-rendered>Layout rendered!</p>
 	<ul data-headings>
 		{headings.map(heading => <li>{heading.slug}</li>)}

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter/src/layouts/Base.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter/src/layouts/Base.astro
@@ -1,9 +1,11 @@
 ---
 const {
 	content = { title: "content didn't work" },
-	frontmatter = { title: "frontmatter didn't work" },
-	file = "file didn't work",
-	url = "url didn't work",
+	frontmatter = {
+		title: "frontmatter didn't work",
+		file = "file didn't work",
+		url = "url didn't work",
+	},
 	headings = [],
 } = Astro.props;
 ---
@@ -20,9 +22,7 @@ const {
 <body>
 	<p data-content-title>{content.title}</p>
 	<p data-frontmatter-title>{frontmatter.title}</p>
-	<p data-file>{file}</p>
 	<p data-frontmatter-file>{frontmatter.file}</p>
-	<p data-url>{url}</p>
 	<p data-frontmatter-url>{frontmatter.url}</p>
 	<p data-layout-rendered>Layout rendered!</p>
 	<ul data-headings>

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter/src/layouts/Base.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter/src/layouts/Base.astro
@@ -3,8 +3,8 @@ const {
 	content = { title: "content didn't work" },
 	frontmatter = {
 		title: "frontmatter didn't work",
-		file = "file didn't work",
-		url = "url didn't work",
+		file: "file didn't work",
+		url: "url didn't work",
 	},
 	headings = [],
 } = Astro.props;

--- a/packages/integrations/mdx/test/mdx-component.test.js
+++ b/packages/integrations/mdx/test/mdx-component.test.js
@@ -19,12 +19,34 @@ describe('MDX Component', () => {
 			await fixture.build();
 		});
 
-		it('works', async () => {
+		it('supports top-level imports', async () => {
 			const html = await fixture.readFile('/index.html');
 			const { document } = parseHTML(html);
 
 			const h1 = document.querySelector('h1');
 			const foo = document.querySelector('#foo');
+
+			expect(h1.textContent).to.equal('Hello component!');
+			expect(foo.textContent).to.equal('bar');
+		});
+
+		it('supports glob imports - <Component.default />', async () => {
+			const html = await fixture.readFile('/glob/index.html');
+			const { document } = parseHTML(html);
+
+			const h1 = document.querySelector('[data-default-export] h1');
+			const foo = document.querySelector('[data-default-export] #foo');
+
+			expect(h1.textContent).to.equal('Hello component!');
+			expect(foo.textContent).to.equal('bar');
+		});
+
+		it('supports glob imports - <Content />', async () => {
+			const html = await fixture.readFile('/glob/index.html');
+			const { document } = parseHTML(html);
+
+			const h1 = document.querySelector('[data-content-export] h1');
+			const foo = document.querySelector('[data-content-export] #foo');
 
 			expect(h1.textContent).to.equal('Hello component!');
 			expect(foo.textContent).to.equal('bar');
@@ -42,7 +64,7 @@ describe('MDX Component', () => {
 			await devServer.stop();
 		});
 
-		it('works', async () => {
+		it('supports top-level imports', async () => {
 			const res = await fixture.fetch('/');
 
 			expect(res.status).to.equal(200);
@@ -52,6 +74,36 @@ describe('MDX Component', () => {
 
 			const h1 = document.querySelector('h1');
 			const foo = document.querySelector('#foo');
+
+			expect(h1.textContent).to.equal('Hello component!');
+			expect(foo.textContent).to.equal('bar');
+		});
+
+		it('supports glob imports - <Component.default />', async () => {
+			const res = await fixture.fetch('/glob');
+
+			expect(res.status).to.equal(200);
+
+			const html = await res.text();
+			const { document } = parseHTML(html);
+
+			const h1 = document.querySelector('[data-default-export] h1');
+			const foo = document.querySelector('[data-default-export] #foo');
+
+			expect(h1.textContent).to.equal('Hello component!');
+			expect(foo.textContent).to.equal('bar');
+		});
+
+		it('supports glob imports - <Content />', async () => {
+			const res = await fixture.fetch('/glob');
+
+			expect(res.status).to.equal(200);
+
+			const html = await res.text();
+			const { document } = parseHTML(html);
+
+			const h1 = document.querySelector('[data-content-export] h1');
+			const foo = document.querySelector('[data-content-export] #foo');
 
 			expect(h1.textContent).to.equal('Hello component!');
 			expect(foo.textContent).to.equal('bar');

--- a/packages/integrations/mdx/test/mdx-frontmatter.test.js
+++ b/packages/integrations/mdx/test/mdx-frontmatter.test.js
@@ -56,4 +56,19 @@ describe('MDX frontmatter', () => {
 		expect(headingSlugs).to.contain('section-1');
 		expect(headingSlugs).to.contain('section-2');
 	});
+
+	it('passes "file" and "url" to layout via top-level props and frontmatter', async () => {
+		const html = await fixture.readFile('/with-headings/index.html');
+		const { document } = parseHTML(html);
+
+		const file = document.querySelector('[data-file]')?.textContent;
+		const url = document.querySelector('[data-url]')?.textContent;
+		const frontmatterFile = document.querySelector('[data-frontmatter-file]')?.textContent;
+		const frontmatterUrl = document.querySelector('[data-frontmatter-url]')?.textContent;
+
+		expect(file?.endsWith('with-headings.mdx')).to.equal(true, '"file" prop does not end with correct path or is undefined');
+		expect(url).to.equal('/with-headings');
+		expect(frontmatterFile).to.equal(file);
+		expect(frontmatterUrl).to.equal(url);
+	});
 });

--- a/packages/integrations/mdx/test/mdx-frontmatter.test.js
+++ b/packages/integrations/mdx/test/mdx-frontmatter.test.js
@@ -57,18 +57,14 @@ describe('MDX frontmatter', () => {
 		expect(headingSlugs).to.contain('section-2');
 	});
 
-	it('passes "file" and "url" to layout via top-level props and frontmatter', async () => {
+	it('passes "file" and "url" to layout via frontmatter', async () => {
 		const html = await fixture.readFile('/with-headings/index.html');
 		const { document } = parseHTML(html);
 
-		const file = document.querySelector('[data-file]')?.textContent;
-		const url = document.querySelector('[data-url]')?.textContent;
 		const frontmatterFile = document.querySelector('[data-frontmatter-file]')?.textContent;
 		const frontmatterUrl = document.querySelector('[data-frontmatter-url]')?.textContent;
 
-		expect(file?.endsWith('with-headings.mdx')).to.equal(true, '"file" prop does not end with correct path or is undefined');
-		expect(url).to.equal('/with-headings');
-		expect(frontmatterFile).to.equal(file);
-		expect(frontmatterUrl).to.equal(url);
+		expect(frontmatterFile?.endsWith('with-headings.mdx')).to.equal(true, '"file" prop does not end with correct path or is undefined');
+		expect(frontmatterUrl).to.equal('/with-headings');
 	});
 });


### PR DESCRIPTION
## Changes

- **Layout props**
  - Add `file` and `url` to frontmatter props
- **`glob`**
  - Add `<Content />` component export
  - Add `rawContent` and `compiledContent` of type `never`. If called, this will log a helpful error message pointing to new frontmatter injection docs.
- Types
  - Add `*.mdx` to declared type module
  - Update `glob` to use `MDXInstance` instead. This overrides the `rawContent` and `compiledContent` props to be type `never`
  - Add new `MarkdownLayoutProps` and `MDXLayoutProps`. Can remove if out of scope, but should be useful!

## Testing

- test new `Content` component
- test `file` and `url` from layouts

## Docs

N/A