### PR TITLE
Fix `astro add` with third-party integrations

### DIFF
--- a/.changeset/wise-cups-greet.md
+++ b/.changeset/wise-cups-greet.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Make third-party integration names slightly nicer when using `astro add`
+Make third-party integration names nicer when using `astro add`

--- a/.changeset/wise-cups-greet.md
+++ b/.changeset/wise-cups-greet.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Make third-party integration names slightly nicer when using `astro add`

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -289,11 +289,30 @@ async function parseAstroConfig(configURL: URL): Promise<t.File> {
 	return result;
 }
 
+// Convert an arbitrary NPM package name into a JS identifier
+// Some examples:
+//  - @astrojs/image => image
+//  - @astrojs/markdown-component => markdownComponent
+//  - astro-cast => cast
+//  - markdown-astro => markdown
+//  - some-package => somePackage
+//  - example.com => exampleCom
+//  - under_score => underScore
+//  - 123numeric => numeric
+//  - @npm/thingy => npmThingy
+//  - @jane/foo.js => janeFoo
 const toIdent = (name: string) => {
-	if (name.includes('-')) {
-		return name.replace(/^astro-/, '').split('-')[0];
-	}
-	return name;
+  const ident = name
+    .trim()
+		// Remove astro or (astrojs) prefix and suffix
+    .replace(/[-_\.]?astro(?:js)?[-_\.]?/g, '')
+		// drop .js suffix
+    .replace(/\.js/, '')
+		// convert to camel case
+    .replace(/(?:[\.\-\_\/]+)([a-zA-Z])/g, (_, w) => w.toUpperCase())
+		// drop invalid first characters
+    .replace(/^[^a-zA-Z$_]+/, '');
+  return `${ident[0].toLowerCase()}${ident.slice(1)}`;
 };
 
 function createPrettyError(err: Error) {

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -291,7 +291,7 @@ async function parseAstroConfig(configURL: URL): Promise<t.File> {
 
 const toIdent = (name: string) => {
 	if (name.includes('-')) {
-		return name.split('-')[0];
+		return name.replace(/^astro-/, '').split('-')[0];
 	}
 	return name;
 };


### PR DESCRIPTION
## Changes

Previously, running `astro add astro-pkg`, would generate weird code:
```js
import { defineConfig } from 'astro/config';
import astro from 'astro-pkg';

export const defineConfig({
  integrations: [
    astro()
  ]
})
```

With this PR, the generated code will now be:
```js
import { defineConfig } from 'astro/config';
import pkg from 'astro-pkg';

export const defineConfig({
  integrations: [
    pkg()
  ]
})
```


## Testing

Nah, we don't test `astro add`

## Docs

N/A