### PR TITLE
Fix build output for endpoints route

### DIFF
--- a/.changeset/rude-birds-ring.md
+++ b/.changeset/rude-birds-ring.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix build output adding `/index.html` at the end of endpoints route

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -161,7 +161,7 @@ async function generatePage(
 		const timeEnd = performance.now();
 		const timeChange = getTimeStat(timeStart, timeEnd);
 		const timeIncrease = `(+${timeChange})`;
-		const filePath = getOutputFilename(opts.astroConfig, path);
+		const filePath = getOutputFilename(opts.astroConfig, path, pageData.route.type);
 		const lineIcon = i === paths.length - 1 ? '└─' : '├─';
 		info(opts.logging, null, `  ${cyan(lineIcon)} ${dim(filePath)} ${dim(timeIncrease)}`);
 	}

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -5,7 +5,7 @@ import resolve from 'resolve';
 import slash from 'slash';
 import { fileURLToPath, pathToFileURL } from 'url';
 import type { ErrorPayload, ViteDevServer } from 'vite';
-import type { AstroConfig } from '../@types/astro';
+import type { AstroConfig, RouteType } from '../@types/astro';
 import { prependForwardSlash, removeTrailingForwardSlash } from './path.js';
 
 // process.env.PACKAGE_VERSION is injected when we build and publish the astro package.
@@ -33,7 +33,11 @@ const STATUS_CODE_REGEXP = /^\/?[0-9]{3}$/;
  * Handles both "/foo" and "foo" `name` formats.
  * Handles `/404` and `/` correctly.
  */
-export function getOutputFilename(astroConfig: AstroConfig, name: string) {
+export function getOutputFilename(astroConfig: AstroConfig, name: string, type: RouteType) {
+	if (type === 'endpoint') {
+		return name;
+	}
+
 	if (name === '/' || name === '') {
 		return path.posix.join(name, 'index.html');
 	}


### PR DESCRIPTION
## Changes

Fix build output mistakenly adding `/index.html` to endpoints routes instead of the proper extension

Fix https://github.com/withastro/astro/issues/3954

## Testing

N/A

## Docs

N/A