### PR TITLE
Add 404 routing logic to Netlify redirects file

### DIFF
--- a/.changeset/orange-pens-live.md
+++ b/.changeset/orange-pens-live.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Adds 404 routing logic to Netlify redirects file

--- a/packages/integrations/netlify/src/shared.ts
+++ b/packages/integrations/netlify/src/shared.ts
@@ -16,6 +16,11 @@ export async function createRedirects(
 		if (route.pathname) {
 			_redirects += `
   ${route.pathname}    /.netlify/${kind}/${entryFile}    200`;
+
+			if(route.route === '/404') {
+				_redirects += `
+  /*    /.netlify/${kind}/${entryFile}    404`;
+			}
 		} else {
 			const pattern =
 				'/' + route.segments.map(([part]) => (part.dynamic ? '*' : part.content)).join('/');

--- a/packages/integrations/netlify/test/functions/404.test.js
+++ b/packages/integrations/netlify/test/functions/404.test.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import netlifyAdapter from '../../dist/index.js';
+import { loadFixture, testIntegration } from './test-utils.js';
+
+describe('404 page', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/404/', import.meta.url).toString(),
+			output: 'server',
+			adapter: netlifyAdapter({
+				dist: new URL('./fixtures/404/dist/', import.meta.url),
+			}),
+			site: `http://example.com`,
+			integrations: [testIntegration()],
+		});
+		await fixture.build();
+	});
+
+	it('404 route is included in the redirect file', async () => {
+		const redir = await fixture.readFile('/_redirects');
+		const expr = new RegExp("/*    /.netlify/functions/entry    404");
+		expect(redir).to.match(expr);
+	});
+});

--- a/packages/integrations/netlify/test/functions/fixtures/404/src/pages/404.astro
+++ b/packages/integrations/netlify/test/functions/fixtures/404/src/pages/404.astro
@@ -1,0 +1,11 @@
+---
+
+---
+<html>
+<head>
+	<title>Not found</title>
+</head>
+<body>
+	<h1>Not found</h1>
+</body>
+</html>

--- a/packages/integrations/netlify/test/functions/fixtures/404/src/pages/index.astro
+++ b/packages/integrations/netlify/test/functions/fixtures/404/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+
+---
+<html>
+<head>
+	<title>Testing</title>
+</head>
+<body>
+	<h1>Testing</h1>
+</body>
+</html>


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/4269

Produces this example `_redirects`:

```
  /    /.netlify/functions/entry    200
  /404    /.netlify/functions/entry    200
  /*    /.netlify/functions/entry    404
```

## Testing

- Test added to check the redirects file.

## Docs

N/A