### PR TITLE
Improve DX when astrojs/image isn't properly configured

### DIFF
--- a/.changeset/real-feet-rule.md
+++ b/.changeset/real-feet-rule.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Handle "not found" imports without throwing an "Invalid URL" error

--- a/.changeset/strange-meals-march.md
+++ b/.changeset/strange-meals-march.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Add better warnings if the integration was not properly configured.

--- a/packages/integrations/image/src/lib/get-image.ts
+++ b/packages/integrations/image/src/lib/get-image.ts
@@ -107,7 +107,9 @@ export async function getImage(
 
 	if (!loader) {
 		// @ts-ignore
-		const { default: mod } = await import('virtual:image-loader');
+		const { default: mod } = await import('virtual:image-loader').catch(() => {
+			throw new Error('[@astrojs/image] Builtin image loader not found. (Did you remember to add the integration to your Astro config?)');
+		});
 		loader = mod as ImageService;
 		globalThis.astroImage = globalThis.astroImage || {};
 		globalThis.astroImage.loader = loader;


### PR DESCRIPTION
## Changes

- Removes a user-unfriendly error from inside of our css/js crawl logic. 
- Adds a more user-friendly error when a user tries to import `@astrojs/image/components` without having added the integration to their Astro config file.
- Fixes #4257 
- Fixes #4161 ([nicolasverlhiac](https://github.com/nicolasverlhiac) to confirm!)

## Testing

- Tested this manually using https://github.com/withastro/astro/issues/4257
- I don't _think_ this error warrants its own test fixture?

## Docs

- N/A