### PR TITLE
fix(#4194): remove Astro runtime from browser

### DIFF
--- a/.changeset/heavy-nails-juggle.md
+++ b/.changeset/heavy-nails-juggle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix bug where Astro's server runtime would end up in the browser

--- a/packages/astro/src/vite-plugin-jsx/index.ts
+++ b/packages/astro/src/vite-plugin-jsx/index.ts
@@ -56,7 +56,10 @@ async function transformJSX({
 }: TransformJSXOptions): Promise<TransformResult> {
 	const { jsxTransformOptions } = renderer;
 	const options = await jsxTransformOptions!({ mode, ssr });
-	const plugins = [...(options.plugins || []), tagExportsPlugin({ rendererName: renderer.name })];
+	const plugins = [...(options.plugins || [])];
+	if (ssr) {
+		plugins.push(tagExportsPlugin({ rendererName: renderer.name }))
+	}
 	const result = await babel.transformAsync(code, {
 		presets: options.presets,
 		plugins,


### PR DESCRIPTION
## Changes

- There were some cases where the Astro server runtime ended up in the browser.
- By being a bit more careful about our transforms, we can avoid this!

## Testing

Tested manually

## Docs

Bug fix only