### PR TITLE
Prevent "preview" from running if output mode is set to server

### DIFF
--- a/.changeset/yellow-insects-add.md
+++ b/.changeset/yellow-insects-add.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent preview if 'output: server' is configured

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -37,7 +37,7 @@ function printAstroHelp() {
 	printHelp({
 		commandName: 'astro',
 		usage: '[command] [...flags]',
-		headline: 'Futuristic web development tool.',
+		headline: 'Build faster websites.',
 		tables: {
 			Commands: [
 				['add', 'Add an integration.'],

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -33,6 +33,9 @@ export default async function preview(
 	config: AstroConfig,
 	{ logging }: PreviewOptions
 ): Promise<PreviewServer> {
+	if (config.output === 'server') {
+		throw new Error(`[preview] 'output: server' not supported. Use your deploy platform's preview command directly instead, if one exists. (ex: 'netlify dev', 'vercel dev', 'wrangler', etc.)`);
+	}
 	const startServerTime = performance.now();
 	const defaultOrigin = 'http://localhost';
 	const trailingSlash = config.trailingSlash;

--- a/packages/astro/test/cli.test.js
+++ b/packages/astro/test/cli.test.js
@@ -12,8 +12,7 @@ describe('astro cli', () => {
 
 	it('astro', async () => {
 		const proc = await cli();
-
-		expect(proc.stdout).to.include('Futuristic web development tool');
+		expect(proc.exitCode).to.equal(0);
 	});
 
 	it('astro --version', async () => {


### PR DESCRIPTION
## Changes

- Right now, "astro preview" only supports static output 
- We have some interesting ideas for how to support deploy-specific preview commands like `netlify dev`, `vercel dev`, etc. 
- But for now, this small fix will prevent the unfriendly error that users see today.

## Testing

- N/A

## Docs

- N/A