### PR TITLE
[astro add] Set `output: 'server'` when adding adapter

### DIFF
--- a/.changeset/witty-bears-joke.md
+++ b/.changeset/witty-bears-joke.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+[astro add] Set `output: 'server'` when adding adapter

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -396,6 +396,23 @@ async function setAdapter(ast: t.File, adapter: IntegrationInfo, exportName: str
 			const configObject = path.node.declaration.arguments[0];
 			if (!t.isObjectExpression(configObject)) return;
 
+			let outputProp = configObject.properties.find((prop) => {
+				if (prop.type !== 'ObjectProperty') return false;
+				if (prop.key.type === 'Identifier') {
+					if (prop.key.name === 'output') return true;
+				}
+				if (prop.key.type === 'StringLiteral') {
+					if (prop.key.value === 'output') return true;
+				}
+				return false;
+			}) as t.ObjectProperty | undefined;
+
+			if (!outputProp) {
+				configObject.properties.push(
+					t.objectProperty(t.identifier('output'), t.stringLiteral('server'))
+				);
+			}
+
 			let adapterProp = configObject.properties.find((prop) => {
 				if (prop.type !== 'ObjectProperty') return false;
 				if (prop.key.type === 'Identifier') {


### PR DESCRIPTION
## Changes

- Resolves #4285
- Set `output: 'server'` when adding an adapter, if not present.

## Testing

N/A

## Docs

N/A