### PR TITLE
add missing word in image integration-guide

### DIFF
--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -244,7 +244,7 @@ This is the helper function used by the `<Image />` component to build `<img />`
 
 This helper takes in an object with the same properties as the `<Image />` component and returns an object with attributes that should be included on the final `<img />` element.
 
-This can helpful if you need to add preload links to a page's `<head>`.
+This can be helpful if you need to add preload links to a page's `<head>`.
 
 ```astro
 ---


### PR DESCRIPTION
## Changes

This is a documentation change and does not impact any functionality.

## Testing

None

## Docs

This change adds a missing word in the integration-guide for the image integration.