### PR TITLE
Remove: references to Lit

### DIFF
--- a/examples/framework-multiple/astro.config.mjs
+++ b/examples/framework-multiple/astro.config.mjs
@@ -4,10 +4,10 @@ import react from '@astrojs/react';
 import svelte from '@astrojs/svelte';
 import vue from '@astrojs/vue';
 import solid from '@astrojs/solid-js';
-import lit from '@astrojs/lit';
+
 
 // https://astro.build/config
 export default defineConfig({
 	// Enable many frameworks to support all different kinds of components.
-	integrations: [preact(), react(), svelte(), vue(), solid(), lit()],
+	integrations: [preact(), react(), svelte(), vue(), solid()],
 });


### PR DESCRIPTION
## Changes
Removed all referenced to Lit within the `astro.config.mjs` file 

There is no `lit` component example within the `framework-multiple` example, this maybe something we could consider on adding at some point in the future. 

No registered `lit` dependencies either.

PR Does not need a `changeset`

## Testing

User Testing: now starts perfectly without any errors being reported

## Docs
No Docs needed. 