### PR TITLE
docs: fixed typo in the tailwind integration docs

### DIFF
--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -76,7 +76,7 @@ https://user-images.githubusercontent.com/4033662/169918388-8ed153b2-0ba0-4b24-b
 
 If you used the Quick Install instructions and said yes to each prompt, you'll see a `tailwind.config.cjs` file in your project's root directory. Use this file for your Tailwind configuration changes. You can learn how to customize Tailwind using this file [in the Tailwind docs](https://tailwindcss.com/docs/configuration).
 
-If it isn't there, you add your own `tailwind.config.(js|cjs|mjs)` file to the root directory and the integration will use its configurations. This can be great if you already have Tailwind configured in aother project and want to bring those settings over to this one.
+If it isn't there, you add your own `tailwind.config.(js|cjs|mjs)` file to the root directory and the integration will use its configurations. This can be great if you already have Tailwind configured in another project and want to bring those settings over to this one.
 
 ### Configuring the Integration
 


### PR DESCRIPTION
## Changes

Corrected "aother" with "another" in [the tailwind integration docs](https://docs.astro.build/en/guides/integrations-guide/tailwind/).

## Testing

No tests because this pr is just fixing a typo in the docs

## Docs

Well this PR fixes a typo in the docs
<!-- https://github.com/withastro/docs -->