### PR TITLE
docs: specify lang for a codeblock

### DIFF
--- a/packages/integrations/preact/README.md
+++ b/packages/integrations/preact/README.md
@@ -43,7 +43,7 @@ Because this command is new, it might not properly set things up. If that happen
 
 First, install the `@astrojs/preact` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
 
-```
+```sh
 npm install @astrojs/preact
 ```
 

--- a/packages/integrations/turbolinks/README.md
+++ b/packages/integrations/turbolinks/README.md
@@ -39,7 +39,7 @@ If you run into any hiccups, [feel free to log an issue on our GitHub](https://g
 
 First, install the `@astrojs/turbolinks` integration like so:
 
-```
+```sh
 npm install @astrojs/turbolinks
 ```
 

--- a/packages/webapi/README.md
+++ b/packages/webapi/README.md
@@ -2,7 +2,7 @@
 
 **WebAPI** lets you use Web APIs in Node v12, v14, and v16.
 
-```shell
+```sh
 npm install @astrojs/webapi
 ```
 


### PR DESCRIPTION
## Changes

- What does this change?
Documentation: 
Adds langauge to the codeblock haiving: 
```sh
npm install @astrojs/preact
```

- Be short and concise. Bullet points can help!
The command looks out of place, as someone who generally skips reading the text while quickly reading the guide, it's easy to miss the command.

- Before/after screenshots can help as well.
<img width="783" alt="Screenshot 2022-08-14 at 8 00 52 AM" src="https://user-images.githubusercontent.com/36479718/184520029-53fcaaa6-df6f-4f1a-99da-6286b60e1513.png">

- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
This is a change in docs

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
This is a change in docs
<!-- https://github.com/withastro/docs -->