### PR TITLE
Markdown component import ts error

### DIFF
--- a/.changeset/four-eyes-kneel.md
+++ b/.changeset/four-eyes-kneel.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-component': patch
+---
+
+Fixed markdown component import TypeScript error

--- a/packages/markdown/component/package.json
+++ b/packages/markdown/component/package.json
@@ -11,11 +11,8 @@
   },
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
-  "main": "./Markdown.astro",
   "exports": {
-    ".": {
-      "astro": "./Markdown.astro"
-    }
+    ".": "./Markdown.astro"
   },
   "scripts": {
     "test": "mocha --exit --timeout 20000"


### PR DESCRIPTION
## Changes

- Fixed TS error when importing the `<Markdown />` component from `@astrojs/markdown-component`

## Testing

## Docs