### PR TITLE
SSR doesn't need to block multiple routes that match the same URL

### DIFF
--- a/.changeset/orange-llamas-glow.md
+++ b/.changeset/orange-llamas-glow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates routing logic to allow multiple routes to match the same URL in SSR

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -251,13 +251,6 @@ async function handleRequest(
 	async function matchRoute() {
 		const matches = matchAllRoutes(pathname, manifest);
 
-		if (config.output === 'server' && matches.length > 1) {
-			throw new Error(`Found multiple matching routes for "${pathname}"! When using \`output: 'server'\`, only one route in \`src/pages\` can match a given URL. Found:
-
-${matches.map(({ component }) => `- ${component}`).join('\n')}
-`);
-		}
-
 		for await (const maybeRoute of matches) {
 			const filePath = new URL(`./${maybeRoute.component}`, config.root);
 			const preloadedComponent = await preload({ astroConfig: config, filePath, viteServer });


### PR DESCRIPTION
## Changes

Closes #4310

Updates route matching logic to allow SSR builds to allow multiple routes that match the same URL.  This error was originally added in #4087 but is too aggressive, the SSR build can actually handle this to prioritize the correct route match in production deployments

## Testing

All existing tests should pass

#4087 included new tests to ensure that `injectRoute` routes are prioritized before `src/pages` routes

## Docs

Bug fix only