### PR TITLE
Warn hydration directive for Astro components in JSX

### DIFF
--- a/.changeset/eight-adults-guess.md
+++ b/.changeset/eight-adults-guess.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Warn hydration directive for Astro components in JSX

--- a/packages/astro/src/jsx/babel.ts
+++ b/packages/astro/src/jsx/babel.ts
@@ -281,7 +281,8 @@ export default function astroJSX(): PluginObj {
 
 				const meta = path.getData('import');
 				if (meta) {
-					// check props and make sure they are valid for an Astro component
+					// If JSX is importing an Astro component, e.g. using MDX for templating,
+					// check Astro node's props and make sure they are valid for an Astro component
 					if (meta.path.endsWith('.astro')) {
 						const displayName = getTagName(parentNode);
 						for (const attr of parentNode.openingElement.attributes) {
@@ -296,7 +297,6 @@ export default function astroJSX(): PluginObj {
 							}
 						}
 					}
-
 					let resolvedPath: string;
 					if (meta.path.startsWith('.')) {
 						const fileURL = pathToFileURL(state.filename!);

--- a/packages/astro/src/jsx/babel.ts
+++ b/packages/astro/src/jsx/babel.ts
@@ -1,6 +1,7 @@
 import type { PluginObj } from '@babel/core';
 import * as t from '@babel/types';
 import { pathToFileURL } from 'node:url';
+import { HydrationDirectiveProps } from '../runtime/server/hydration.js';
 import type { PluginMetadata } from '../vite-plugin-astro/types';
 
 const ClientOnlyPlaceholder = 'astro-client-only';
@@ -280,6 +281,22 @@ export default function astroJSX(): PluginObj {
 
 				const meta = path.getData('import');
 				if (meta) {
+					// check props and make sure they are valid for an Astro component
+					if (meta.path.endsWith('.astro')) {
+						const displayName = getTagName(parentNode);
+						for (const attr of parentNode.openingElement.attributes) {
+							if (t.isJSXAttribute(attr)) {
+								const name = jsxAttributeToString(attr);
+								if (HydrationDirectiveProps.has(name)) {
+									// eslint-disable-next-line
+									console.warn(
+										`You are attempting to render <${displayName} ${name} />, but ${displayName} is an Astro component. Astro components do not render in the client and should not have a hydration directive. Please use a framework component for client rendering.`
+									);
+								}
+							}
+						}
+					}
+
 					let resolvedPath: string;
 					if (meta.path.startsWith('.')) {
 						const fileURL = pathToFileURL(state.filename!);


### PR DESCRIPTION
## Changes

Fix #4101

When a JSX file imports an Astro component, e.g. using MDX for templating, we don't warn about setting `client:*` directive. This PR warns about it during compile time, and in both dev/build, for cases like this.

## Testing

Tested manually with the repro at #4101

## Docs

N/A