### PR TITLE
Fix double injecting of head content in md pages

### DIFF
--- a/.changeset/hip-bobcats-divide.md
+++ b/.changeset/hip-bobcats-divide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix double injecting of head content in md pages

--- a/packages/astro/src/runtime/server/render/astro.ts
+++ b/packages/astro/src/runtime/server/render/astro.ts
@@ -56,6 +56,10 @@ export function isAstroComponent(obj: any): obj is AstroComponent {
 	);
 }
 
+export function isAstroComponentFactory(obj: any): obj is AstroComponentFactory {
+	return obj == null ? false : !!obj.isComponentFactory;
+}
+
 export async function* renderAstroComponent(
 	component: InstanceType<typeof AstroComponent>
 ): AsyncIterable<string | RenderInstruction> {

--- a/packages/astro/src/runtime/server/render/astro.ts
+++ b/packages/astro/src/runtime/server/render/astro.ts
@@ -57,7 +57,7 @@ export function isAstroComponent(obj: any): obj is AstroComponent {
 }
 
 export function isAstroComponentFactory(obj: any): obj is AstroComponentFactory {
-	return obj == null ? false : !!obj.isComponentFactory;
+	return obj == null ? false : !!obj.isAstroComponentFactory;
 }
 
 export async function* renderAstroComponent(

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -6,7 +6,7 @@ import { extractDirectives, generateHydrateScript } from '../hydration.js';
 import { serializeProps } from '../serialize.js';
 import { shorthash } from '../shorthash.js';
 import { renderSlot } from './any.js';
-import { renderAstroComponent, renderTemplate, renderToIterable } from './astro.js';
+import { isAstroComponentFactory, renderAstroComponent, renderTemplate, renderToIterable } from './astro.js';
 import { Fragment, Renderer } from './common.js';
 import { componentIsHTMLElement, renderHTMLElement } from './dom.js';
 import { formatList, internalSpreadAttributes, renderElement, voidElementNames } from './util.js';
@@ -37,7 +37,7 @@ function getComponentType(Component: unknown): ComponentType {
 	if (Component && typeof Component === 'object' && (Component as any)['astro:html']) {
 		return 'html';
 	}
-	if (Component && (Component as any).isAstroComponentFactory) {
+	if (isAstroComponentFactory(Component)) {
 		return 'astro-factory';
 	}
 	return 'unknown';

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -2,21 +2,27 @@ import type { SSRResult } from '../../../@types/astro';
 import type { AstroComponentFactory } from './index';
 
 import { createResponse } from '../response.js';
-import { isAstroComponent, renderAstroComponent } from './astro.js';
+import { isAstroComponent, isAstroComponentFactory, renderAstroComponent } from './astro.js';
 import { stringifyChunk } from './common.js';
 import { renderComponent } from './component.js';
 import { maybeRenderHead } from './head.js';
 
 const encoder = new TextEncoder();
+const needsHeadRenderingSymbol =  Symbol.for('astro.needsHeadRendering');
+
+type NonAstroPageComponent = {
+	name: string;
+	[needsHeadRenderingSymbol]: boolean;
+};
 
 export async function renderPage(
 	result: SSRResult,
-	componentFactory: AstroComponentFactory,
+	componentFactory: AstroComponentFactory | NonAstroPageComponent,
 	props: any,
 	children: any,
 	streaming: boolean
 ): Promise<Response> {
-	if (!componentFactory.isAstroComponentFactory) {
+	if (!isAstroComponentFactory(componentFactory)) {
 		const pageProps: Record<string, any> = { ...(props ?? {}), 'server:root': true };
 		const output = await renderComponent(
 			result,
@@ -29,8 +35,13 @@ export async function renderPage(
 		if (!/<!doctype html/i.test(html)) {
 			let rest = html;
 			html = `<!DOCTYPE html>`;
-			for await (let chunk of maybeRenderHead(result)) {
-				//html += chunk;
+			// This symbol currently exists for md components, but is something that could
+			// be added for any page-level component that's not an Astro component.
+			// to signal that head rendering is needed.
+			if((needsHeadRenderingSymbol in componentFactory) && componentFactory[needsHeadRenderingSymbol]) {
+				for await (let chunk of maybeRenderHead(result)) {
+					html += chunk;
+				}
 			}
 			html += rest;
 		}

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -30,7 +30,7 @@ export async function renderPage(
 			let rest = html;
 			html = `<!DOCTYPE html>`;
 			for await (let chunk of maybeRenderHead(result)) {
-				html += chunk;
+				//html += chunk;
 			}
 			html += rest;
 		}

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -15,6 +15,13 @@ type NonAstroPageComponent = {
 	[needsHeadRenderingSymbol]: boolean;
 };
 
+function nonAstroPageNeedsHeadInjection(pageComponent: NonAstroPageComponent): boolean {
+	return (
+		(needsHeadRenderingSymbol in pageComponent) &&
+		!!pageComponent[needsHeadRenderingSymbol]
+	);
+}
+
 export async function renderPage(
 	result: SSRResult,
 	componentFactory: AstroComponentFactory | NonAstroPageComponent,
@@ -38,7 +45,7 @@ export async function renderPage(
 			// This symbol currently exists for md components, but is something that could
 			// be added for any page-level component that's not an Astro component.
 			// to signal that head rendering is needed.
-			if((needsHeadRenderingSymbol in componentFactory) && componentFactory[needsHeadRenderingSymbol]) {
+			if(nonAstroPageNeedsHeadInjection(componentFactory)) {
 				for await (let chunk of maybeRenderHead(result)) {
 					html += chunk;
 				}

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -118,7 +118,6 @@ export default function markdown({ config, logging }: AstroPluginOptions): Plugi
 					};
 				}
 				Content[Symbol.for('astro.needsHeadRendering')] = ${layout ? 'false' : 'true'};
-				Content.hasLayout = false;
 				export default Content;
 				`);
 

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -117,6 +117,8 @@ export default function markdown({ config, logging }: AstroPluginOptions): Plugi
 							: `contentFragment`
 					};
 				}
+				Content[Symbol.for('astro.needsHeadRendering')] = ${layout ? 'false' : 'true'};
+				Content.hasLayout = false;
 				export default Content;
 				`);
 

--- a/packages/astro/test/fixtures/head-injection-md/package.json
+++ b/packages/astro/test/fixtures/head-injection-md/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/head-injection-md",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/head-injection-md/src/components/Layout.astro
+++ b/packages/astro/test/fixtures/head-injection-md/src/components/Layout.astro
@@ -1,0 +1,18 @@
+---
+const title = 'My Title';
+---
+<!DOCTYPE html>
+<html lang="en" class="dark">
+  <head>
+    <title set:html={title}></title>
+    <meta name="theme-color" content="#ffffff" />
+    <style>
+      body {
+        font-family: Arial;
+      }
+    </style>
+  </head>
+  <body class="flex flex-col min-h-screen font-sans bg-indigo-50 dark:bg-slate-900">
+    <slot />
+  </body>
+  </html>

--- a/packages/astro/test/fixtures/head-injection-md/src/pages/index.md
+++ b/packages/astro/test/fixtures/head-injection-md/src/pages/index.md
@@ -1,0 +1,7 @@
+---
+layout: ../components/Layout.astro
+---
+
+# Heading
+
+And content here.

--- a/packages/astro/test/head-injection-md.test.js
+++ b/packages/astro/test/head-injection-md.test.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Head injection with markdown', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/head-injection-md/',
+		});
+	});
+
+	describe('build', () => {
+		before(async () => {
+			await fixture.build();
+		});
+
+		it('only injects head content once', async () => {
+			const html = await fixture.readFile(`/index.html`);
+			const $ = cheerio.load(html);
+
+			expect($('link[rel=stylesheet]')).to.have.a.lengthOf(1);
+		});
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1531,6 +1531,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/head-injection-md:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/hmr-css:
     specifiers:
       astro: workspace:*


### PR DESCRIPTION
## Changes

- For markdown components, we were eagerly rendering the head when appending the doctype. 
- However if any layout is used the head is going to be injected there anyways.
- The change is to only make head injection occur for a markdown page that has no layout (and therefore has no real head).

## Testing

- Test added for the regression that was found.

## Docs

N/A, bug fix