### PR TITLE
[@astrojs/image] Handle query params in remote image URLs during SSG builds

### DIFF
--- a/.changeset/chatty-ants-shop.md
+++ b/.changeset/chatty-ants-shop.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+When using remote images in SSG builds, query parameters from the original image source should be stripped from final build output

--- a/packages/integrations/image/src/utils/paths.ts
+++ b/packages/integrations/image/src/utils/paths.ts
@@ -5,13 +5,19 @@ import type { TransformOptions } from '../loaders/index.js';
 import { isRemoteImage } from './images.js';
 import { shorthash } from './shorthash.js';
 
+function removeQueryString(src: string) {
+	const index = src.lastIndexOf('?');
+	return index > 0 ? src.substring(0, index) : src;
+}
+
 export function ensureDir(dir: string) {
 	fs.mkdirSync(dir, { recursive: true });
 }
 
 export function propsToFilename({ src, width, height, format }: TransformOptions) {
-	const ext = path.extname(src);
-	let filename = src.replace(ext, '');
+	let filename = removeQueryString(src);
+	const ext = path.extname(filename);
+	filename = filename.replace(ext, '');
 
 	// for remote images, add a hash of the full URL to dedupe images with the same filename
 	if (isRemoteImage(src)) {

--- a/packages/integrations/image/src/utils/paths.ts
+++ b/packages/integrations/image/src/utils/paths.ts
@@ -10,14 +10,26 @@ function removeQueryString(src: string) {
 	return index > 0 ? src.substring(0, index) : src;
 }
 
+function removeExtname(src: string) {
+	const ext = path.extname(src);
+
+	if (!ext) {
+		return src;
+	}
+
+	const index = src.lastIndexOf(ext);
+	return src.substring(0, index);
+}
+
 export function ensureDir(dir: string) {
 	fs.mkdirSync(dir, { recursive: true });
 }
 
 export function propsToFilename({ src, width, height, format }: TransformOptions) {
+	// strip off the querystring first, then remove the file extension
 	let filename = removeQueryString(src);
 	const ext = path.extname(filename);
-	filename = filename.replace(ext, '');
+	filename = removeExtname(filename);
 
 	// for remote images, add a hash of the full URL to dedupe images with the same filename
 	if (isRemoteImage(src)) {

--- a/packages/integrations/image/test/fixtures/basic-image/src/pages/index.astro
+++ b/packages/integrations/image/test/fixtures/basic-image/src/pages/index.astro
@@ -12,6 +12,8 @@ import { Image } from '@astrojs/image/components';
 		<br />
 		<Image id="google" src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png" width={544} height={184} format="webp" />
 		<br />
-		<Image id='inline' src={import('../assets/social.jpg')} width={506} />
+		<Image id="inline" src={import('../assets/social.jpg')} width={506} />
+		<br />
+		<Image id="query" src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png?token=abc" width={544} height={184} format="webp" />
   </body>
 </html>

--- a/packages/integrations/image/test/image-ssg.test.js
+++ b/packages/integrations/image/test/image-ssg.test.js
@@ -58,9 +58,10 @@ describe('SSG images', function () {
 		});
 
 		describe('Remote images', () => {
-			// Hard-coding in the test! This should never change since the hash is based
+			// Hard-coding in the test! These should never change since the hash is based
 			// on the static `src` string
 			const HASH = 'Z1iI4xW';
+			const HASH_WITH_QUERY = '18Aq0m';
 
 			it('includes <img> attributes', () => {
 				const image = $('#google');
@@ -77,6 +78,14 @@ describe('SSG images', function () {
 					width: 544,
 					height: 184,
 					type: 'webp',
+				});
+			});
+
+			it('removes query strings', () => {
+				verifyImage(`_image/googlelogo_color_272x92dp-${HASH_WITH_QUERY}_544x184.webp`, {
+					width: 544,
+					height: 184,
+					type: 'webp'
 				});
 			});
 		});
@@ -172,6 +181,24 @@ describe('SSG images', function () {
 				expect(searchParams.get('h')).to.equal('184');
 				expect(searchParams.get('href')).to.equal(
 					'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png'
+				);
+			});
+
+			it('keeps remote image query params', () => {
+				const image = $('#query');
+
+				const src = image.attr('src');
+				const [route, params] = src.split('?');
+
+				expect(route).to.equal('/_image');
+
+				const searchParams = new URLSearchParams(params);
+
+				expect(searchParams.get('f')).to.equal('webp');
+				expect(searchParams.get('w')).to.equal('544');
+				expect(searchParams.get('h')).to.equal('184');
+				expect(searchParams.get('href')).to.equal(
+					'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png?token=abc'
 				);
 			});
 		});

--- a/packages/integrations/image/test/image-ssr.test.js
+++ b/packages/integrations/image/test/image-ssr.test.js
@@ -122,8 +122,30 @@ describe('SSR images - build', function () {
 			expect(searchParams.get('f')).to.equal('webp');
 			expect(searchParams.get('w')).to.equal('544');
 			expect(searchParams.get('h')).to.equal('184');
-			// TODO: possible to avoid encoding the full image path?
 			expect(searchParams.get('href').endsWith('googlelogo_color_272x92dp.png')).to.equal(true);
+		});
+
+		it('keeps remote image query params', async () => {
+			const app = await fixture.loadTestAdapterApp();
+
+			const request = new Request('http://example.com/');
+			const response = await app.render(request);
+			const html = await response.text();
+			const $ = cheerio.load(html);
+
+			const image = $('#query');
+
+			const src = image.attr('src');
+			const [route, params] = src.split('?');
+
+			expect(route).to.equal('/_image');
+
+			const searchParams = new URLSearchParams(params);
+
+			expect(searchParams.get('f')).to.equal('webp');
+			expect(searchParams.get('w')).to.equal('544');
+			expect(searchParams.get('h')).to.equal('184');
+			expect(searchParams.get('href').endsWith('googlelogo_color_272x92dp.png?token=abc')).to.equal(true);
 		});
 	});
 });
@@ -214,6 +236,24 @@ describe('SSR images - dev', function () {
 			expect(searchParams.get('h')).to.equal('184');
 			expect(searchParams.get('href')).to.equal(
 				'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png'
+			);
+		});
+
+		it('keeps remote image query params', () => {
+			const image = $('#query');
+
+			const src = image.attr('src');
+			const [route, params] = src.split('?');
+
+			expect(route).to.equal('/_image');
+
+			const searchParams = new URLSearchParams(params);
+
+			expect(searchParams.get('f')).to.equal('webp');
+			expect(searchParams.get('w')).to.equal('544');
+			expect(searchParams.get('h')).to.equal('184');
+			expect(searchParams.get('href')).to.equal(
+				'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png?token=abc'
 			);
 		});
 	});


### PR DESCRIPTION
## Changes

Closes #4317 

When building optimized images for SSG builds, any query params used for remote images should be stripped out from the final built HTML

Note that during `astro dev` and for SSR builds the query params are still needed to make sure the remote image can be fetched properly

## Testing

Added `dev` and `build` test coverage for remote image query params in SSG and SSR

## Docs

Bug fix only