### PR TITLE
integrations: update recommended method for running astro add

### DIFF
--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -28,11 +28,11 @@ The `astro add` command-line tool automates the installation for you. Run one of
    
 ```sh
 # Using NPM
-npx astro add image
+npm run astro add image
 # Using Yarn
 yarn astro add image
 # Using PNPM
-pnpx astro add image
+pnpm run astro add image
 ```
   
 Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -32,7 +32,7 @@ npm run astro add image
 # Using Yarn
 yarn astro add image
 # Using PNPM
-pnpm run astro add image
+pnpm astro add image
 ```
   
 Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.

--- a/packages/integrations/lit/README.md
+++ b/packages/integrations/lit/README.md
@@ -16,11 +16,11 @@ To install `@astrojs/lit`, run the following from your project directory and fol
 
 ```sh
 # Using NPM
-npx astro add lit
+npm run astro add lit
 # Using Yarn
 yarn astro add lit
 # Using PNPM
-pnpx astro add lit
+pnpm run astro add lit
 ```
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/packages/integrations/lit/README.md
+++ b/packages/integrations/lit/README.md
@@ -20,7 +20,7 @@ npm run astro add lit
 # Using Yarn
 yarn astro add lit
 # Using PNPM
-pnpm run astro add lit
+pnpm astro add lit
 ```
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -26,11 +26,11 @@ The `astro add` command-line tool automates the installation for you. Run one of
 
 ```sh
 # Using NPM
-npx astro add mdx
+npm run astro add mdx
 # Using Yarn
 yarn astro add mdx
 # Using PNPM
-pnpx astro add mdx
+pnpm run astro add mdx
 ```
 
 Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -30,7 +30,7 @@ npm run astro add mdx
 # Using Yarn
 yarn astro add mdx
 # Using PNPM
-pnpm run astro add mdx
+pnpm astro add mdx
 ```
 
 Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.

--- a/packages/integrations/partytown/README.md
+++ b/packages/integrations/partytown/README.md
@@ -32,7 +32,7 @@ npm run astro add partytown
 # Using Yarn
 yarn astro add partytown
 # Using PNPM
-pnpm run astro add partytown
+pnpm astro add partytown
 ```
   
 Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.

--- a/packages/integrations/partytown/README.md
+++ b/packages/integrations/partytown/README.md
@@ -28,11 +28,11 @@ The `astro add` command-line tool automates the installation for you. Run one of
   
 ```sh
 # Using NPM
-npx astro add partytown
+npm run astro add partytown
 # Using Yarn
 yarn astro add partytown
 # Using PNPM
-pnpx astro add partytown
+pnpm run astro add partytown
 ```
   
 Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.

--- a/packages/integrations/preact/README.md
+++ b/packages/integrations/preact/README.md
@@ -28,11 +28,11 @@ The `astro add` command-line tool automates the installation for you. Run one of
 
 ```sh
 # Using NPM
-npx astro add preact
+npm run astro add preact
 # Using Yarn
 yarn astro add preact
 # Using PNPM
-pnpx astro add preact
+pnpm run astro add preact
 ```
 
 Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.

--- a/packages/integrations/preact/README.md
+++ b/packages/integrations/preact/README.md
@@ -32,7 +32,7 @@ npm run astro add preact
 # Using Yarn
 yarn astro add preact
 # Using PNPM
-pnpm run astro add preact
+pnpm astro add preact
 ```
 
 Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.

--- a/packages/integrations/prefetch/README.md
+++ b/packages/integrations/prefetch/README.md
@@ -22,11 +22,11 @@ The `astro add` command-line tool automates the installation for you. Run one of
   
 ```sh
 # Using NPM
-npx astro add prefetch
+npm run astro add prefetch
 # Using Yarn
 yarn astro add prefetch
 # Using PNPM
-pnpx astro add prefetch
+pnpm run astro add prefetch
 ```
   
 Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.

--- a/packages/integrations/prefetch/README.md
+++ b/packages/integrations/prefetch/README.md
@@ -26,7 +26,7 @@ npm run astro add prefetch
 # Using Yarn
 yarn astro add prefetch
 # Using PNPM
-pnpm run astro add prefetch
+pnpm astro add prefetch
 ```
   
 Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.

--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -16,11 +16,11 @@ To install `@astrojs/react`, run the following from your project directory and f
 
 ```sh
 # Using NPM
-npx astro add react
+npm run astro add react
 # Using Yarn
 yarn astro add react
 # Using PNPM
-pnpx astro add react
+pnpm run astro add react
 ```
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -20,7 +20,7 @@ npm run astro add react
 # Using Yarn
 yarn astro add react
 # Using PNPM
-pnpm run astro add react
+pnpm astro add react
 ```
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -32,7 +32,7 @@ npm run astro add sitemap
 # Using Yarn
 yarn astro add sitemap
 # Using PNPM
-pnpm run astro add sitemap
+pnpm astro add sitemap
 ```
   
 Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.

--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -28,11 +28,11 @@ The `astro add` command-line tool automates the installation for you. Run one of
   
 ```sh
 # Using NPM
-npx astro add sitemap
+npm run astro add sitemap
 # Using Yarn
 yarn astro add sitemap
 # Using PNPM
-pnpx astro add sitemap
+pnpm run astro add sitemap
 ```
   
 Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.

--- a/packages/integrations/solid/README.md
+++ b/packages/integrations/solid/README.md
@@ -20,7 +20,7 @@ npm run astro add solid
 # Using Yarn
 yarn astro add solid
 # Using PNPM
-pnpm run astro add solid
+pnpm astro add solid
 ```
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/packages/integrations/solid/README.md
+++ b/packages/integrations/solid/README.md
@@ -16,11 +16,11 @@ To install `@astrojs/solid-js`, run the following from your project directory an
 
 ```sh
 # Using NPM
-npx astro add solid
+npm run astro add solid
 # Using Yarn
 yarn astro add solid
 # Using PNPM
-pnpx astro add solid
+pnpm run astro add solid
 ```
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/packages/integrations/svelte/README.md
+++ b/packages/integrations/svelte/README.md
@@ -20,7 +20,7 @@ npm run astro add svelte
 # Using Yarn
 yarn astro add svelte
 # Using PNPM
-pnpm run astro add svelte
+pnpm astro add svelte
 ```
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/packages/integrations/svelte/README.md
+++ b/packages/integrations/svelte/README.md
@@ -16,11 +16,11 @@ To install `@astrojs/svelte`, run the following from your project directory and 
 
 ```sh
 # Using NPM
-npx astro add svelte
+npm run astro add svelte
 # Using Yarn
 yarn astro add svelte
 # Using PNPM
-pnpx astro add svelte
+pnpm run astro add svelte
 ```
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -35,7 +35,7 @@ npm run astro add tailwind
 # Using Yarn
 yarn astro add tailwind
 # Using PNPM
-pnpm run astro add tailwind
+pnpm astro add tailwind
 ```
   
 Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.

--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -31,11 +31,11 @@ The `astro add` command-line tool automates the installation for you. Run one of
   
 ```sh
 # Using NPM
-npx astro add tailwind
+npm run astro add tailwind
 # Using Yarn
 yarn astro add tailwind
 # Using PNPM
-pnpx astro add tailwind
+pnpm run astro add tailwind
 ```
   
 Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.

--- a/packages/integrations/turbolinks/README.md
+++ b/packages/integrations/turbolinks/README.md
@@ -30,7 +30,7 @@ npm run astro add turbolinks
 # Using Yarn
 yarn astro add turbolinks
 # Using PNPM
-pnpm run astro add turbolinks
+pnpm astro add turbolinks
 ```
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/packages/integrations/turbolinks/README.md
+++ b/packages/integrations/turbolinks/README.md
@@ -26,11 +26,11 @@ To install `@astrojs/turbolinks`, run the following from your project directory 
 
 ```sh
 # Using NPM
-npx astro add turbolinks
+npm run astro add turbolinks
 # Using Yarn
 yarn astro add turbolinks
 # Using PNPM
-pnpx astro add turbolinks
+pnpm run astro add turbolinks
 ```
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/packages/integrations/vue/README.md
+++ b/packages/integrations/vue/README.md
@@ -16,11 +16,11 @@ To install `@astrojs/vue`, run the following from your project directory and fol
 
 ```sh
 # Using NPM
-npx astro add vue
+npm run astro add vue
 # Using Yarn
 yarn astro add vue
 # Using PNPM
-pnpx astro add vue
+pnpm run astro add vue
 ```
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/packages/integrations/vue/README.md
+++ b/packages/integrations/vue/README.md
@@ -20,7 +20,7 @@ npm run astro add vue
 # Using Yarn
 yarn astro add vue
 # Using PNPM
-pnpm run astro add vue
+pnpm astro add vue
 ```
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.


### PR DESCRIPTION
## Changes

- Updates `astro add` instructions in integrations READMES to use `npm run astro add ...` or `pnpm run astro add ...` instead of `npx`/`pnpx`

- I assume no changes are needed for `yarn` as it already runs a named script when found so `yarn astro add ...` was and will be correct.

- My perennial dilemma: should this include a patch changeset? Seems kind of drastic for a docs change this small.

## Testing

N/A

## Docs

YUP