### PR TITLE
Refactor static build config merge

### DIFF
--- a/.changeset/giant-ants-smoke.md
+++ b/.changeset/giant-ants-smoke.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Refactor static build config merge

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -116,19 +116,16 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 	const out = ssr ? opts.buildConfig.server : astroConfig.outDir;
 
 	const viteBuildConfig: ViteConfigWithSSR = {
+		...viteConfig,
 		logLevel: opts.viteConfig.logLevel ?? 'error',
 		mode: 'production',
-		css: viteConfig.css,
-		optimizeDeps: {
-			include: [...(viteConfig.optimizeDeps?.include ?? [])],
-			exclude: [...(viteConfig.optimizeDeps?.exclude ?? [])],
-		},
 		build: {
 			...viteConfig.build,
 			emptyOutDir: false,
 			manifest: false,
 			outDir: fileURLToPath(out),
 			rollupOptions: {
+				...viteConfig.build?.rollupOptions,
 				input: [],
 				output: {
 					format: 'esm',
@@ -138,7 +135,6 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 					entryFileNames: opts.buildConfig.serverEntry,
 				},
 			},
-
 			ssr: true,
 			// must match an esbuild target
 			target: 'esnext',
@@ -163,12 +159,7 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 			vitePluginAnalyzer(internals),
 		],
 		publicDir: ssr ? false : viteConfig.publicDir,
-		root: viteConfig.root,
 		envPrefix: 'PUBLIC_',
-		server: viteConfig.server,
-		base: astroConfig.base,
-		ssr: viteConfig.ssr,
-		resolve: viteConfig.resolve,
 	};
 
 	await runHookBuildSetup({
@@ -178,7 +169,6 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 		target: 'server',
 	});
 
-	// TODO: use vite.mergeConfig() here?
 	return await vite.build(viteBuildConfig);
 }
 
@@ -206,19 +196,16 @@ async function clientBuild(
 	info(opts.logging, null, `\n${bgGreen(black(' building client '))}`);
 
 	const viteBuildConfig = {
+		...viteConfig,
 		logLevel: 'info',
 		mode: 'production',
-		css: viteConfig.css,
-		optimizeDeps: {
-			include: [...(viteConfig.optimizeDeps?.include ?? [])],
-			exclude: [...(viteConfig.optimizeDeps?.exclude ?? [])],
-		},
 		build: {
 			...viteConfig.build,
 			emptyOutDir: false,
 			minify: 'esbuild',
 			outDir: fileURLToPath(out),
 			rollupOptions: {
+				...viteConfig.build?.rollupOptions,
 				input: Array.from(input),
 				output: {
 					format: 'esm',
@@ -242,11 +229,7 @@ async function clientBuild(
 			}),
 			...(viteConfig.plugins || []),
 		],
-		publicDir: viteConfig.publicDir,
-		root: viteConfig.root,
 		envPrefix: 'PUBLIC_',
-		server: viteConfig.server,
-		base: astroConfig.base,
 	} as ViteConfigWithSSR;
 
 	await runHookBuildSetup({

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -192,7 +192,6 @@ async function clientBuild(
 		return null;
 	}
 
-	// TODO: use vite.mergeConfig() here?
 	info(opts.logging, null, `\n${bgGreen(black(' building client '))}`);
 
 	const viteBuildConfig = {


### PR DESCRIPTION
## Changes

Refactor Vite config merging for static build and remove TODO.

`vite.mergeConfig` is not used as we want control ordering in some fields, e.g. `plugins` and `rollupOptions`


## Testing

Should work with `pnpm test`

## Docs

N/A