### PR TITLE
Fix: TS lint on `MDXLayoutProps`

### DIFF
--- a/.changeset/thick-spiders-try.md
+++ b/.changeset/thick-spiders-try.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix MDXLayoutProps type signature for linting

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -880,8 +880,7 @@ export interface MarkdownLayoutProps<T extends Record<string, any>> {
 	compiledContent: MarkdownInstance<T>['compiledContent'];
 }
 
-export interface MDXLayoutProps<T>
-	extends Omit<MarkdownLayoutProps<T>, 'rawContent' | 'compiledContent'> {}
+export type MDXLayoutProps<T> = Omit<MarkdownLayoutProps<T>, 'rawContent' | 'compiledContent'>;
 
 export type GetHydrateCallback = () => Promise<() => void | Promise<void>>;
 


### PR DESCRIPTION
## Changes

Change `interface extends` to `type`. Avoids an empty `{}` that our linter (mysteriously) complains about.

## Testing

N/A

## Docs

N/A