### PR TITLE
Throw helpful errors when attempting to serialize cyclic references

### DIFF
--- a/.changeset/giant-beds-beam.md
+++ b/.changeset/giant-beds-beam.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add cyclic ref detection when serializing props

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -146,7 +146,7 @@ export async function generateHydrateScript(
 	if (renderer.clientEntrypoint) {
 		island.props['component-export'] = componentExport.value;
 		island.props['renderer-url'] = await result.resolve(renderer.clientEntrypoint);
-		island.props['props'] = escapeHTML(serializeProps(props));
+		island.props['props'] = escapeHTML(serializeProps(props, metadata));
 	}
 
 	island.props['ssr'] = '';

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -302,9 +302,7 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 
 	// Include componentExport name, componentUrl, and props in hash to dedupe identical islands
 	const astroId = shorthash(
-		`<!--${metadata.componentExport!.value}:${metadata.componentUrl}-->\n${html}\n${serializeProps(
-			props
-		)}`
+		`<!--${metadata.componentExport!.value}:${metadata.componentUrl}-->\n${html}\n${serializeProps(props, metadata)}`
 	);
 
 	const island = await generateHydrateScript(

--- a/packages/astro/src/runtime/server/serialize.ts
+++ b/packages/astro/src/runtime/server/serialize.ts
@@ -1,3 +1,7 @@
+import type {
+	AstroComponentMetadata,
+} from '../../@types/astro';
+
 type ValueOf<T> = T[keyof T];
 
 const PROP_TYPE = {
@@ -11,19 +15,25 @@ const PROP_TYPE = {
 	URL: 7,
 };
 
-function serializeArray(value: any[]): any[] {
-	return value.map((v) => convertToSerializedForm(v));
+function serializeArray(value: any[], metadata: AstroComponentMetadata): any[] {
+	return value.map((v) => convertToSerializedForm(v, metadata));
 }
 
-function serializeObject(value: Record<any, any>): Record<any, any> {
+function serializeObject(value: Record<any, any>, metadata: AstroComponentMetadata): Record<any, any> {
+	if (cyclicRefs.has(value)) {
+		throw new Error(`Cyclic reference detected while serializing props for <${metadata.displayName} client:${metadata.hydrate}>!
+
+Cyclic references cannot be safely serialized for client-side usage. Please remove the cyclic reference.`)
+	}
+	cyclicRefs.add(value);
 	return Object.fromEntries(
 		Object.entries(value).map(([k, v]) => {
-			return [k, convertToSerializedForm(v)];
+			return [k, convertToSerializedForm(v, metadata)];
 		})
 	);
 }
 
-function convertToSerializedForm(value: any): [ValueOf<typeof PROP_TYPE>, any] {
+function convertToSerializedForm(value: any, metadata: AstroComponentMetadata): [ValueOf<typeof PROP_TYPE>, any] {
 	const tag = Object.prototype.toString.call(value);
 	switch (tag) {
 		case '[object Date]': {
@@ -33,10 +43,10 @@ function convertToSerializedForm(value: any): [ValueOf<typeof PROP_TYPE>, any] {
 			return [PROP_TYPE.RegExp, (value as RegExp).source];
 		}
 		case '[object Map]': {
-			return [PROP_TYPE.Map, JSON.stringify(serializeArray(Array.from(value as Map<any, any>)))];
+			return [PROP_TYPE.Map, JSON.stringify(serializeArray(Array.from(value as Map<any, any>), metadata))];
 		}
 		case '[object Set]': {
-			return [PROP_TYPE.Set, JSON.stringify(serializeArray(Array.from(value as Set<any>)))];
+			return [PROP_TYPE.Set, JSON.stringify(serializeArray(Array.from(value as Set<any>), metadata))];
 		}
 		case '[object BigInt]': {
 			return [PROP_TYPE.BigInt, (value as bigint).toString()];
@@ -45,11 +55,11 @@ function convertToSerializedForm(value: any): [ValueOf<typeof PROP_TYPE>, any] {
 			return [PROP_TYPE.URL, (value as URL).toString()];
 		}
 		case '[object Array]': {
-			return [PROP_TYPE.JSON, JSON.stringify(serializeArray(value))];
+			return [PROP_TYPE.JSON, JSON.stringify(serializeArray(value, metadata))];
 		}
 		default: {
 			if (value !== null && typeof value === 'object') {
-				return [PROP_TYPE.Value, serializeObject(value)];
+				return [PROP_TYPE.Value, serializeObject(value, metadata)];
 			} else {
 				return [PROP_TYPE.Value, value];
 			}
@@ -57,6 +67,9 @@ function convertToSerializedForm(value: any): [ValueOf<typeof PROP_TYPE>, any] {
 	}
 }
 
-export function serializeProps(props: any) {
-	return JSON.stringify(serializeObject(props));
+let cyclicRefs = new WeakSet<any>();
+export function serializeProps(props: any, metadata: AstroComponentMetadata) {
+	const serialized = JSON.stringify(serializeObject(props, metadata));
+	cyclicRefs = new WeakSet<any>();
+	return serialized;
 }


### PR DESCRIPTION
## Changes

- Patch to improve experience reported in https://github.com/withastro/astro/issues/4332
- Throws a helpful when cyclic (circular) references are run through our serialization logic
- Non-breaking change, this already didn't work, this just gives a helpful error when it's broken

## Testing

Will add a test

## Docs

Hmm, need to add to error reference?