### PR TITLE
Testing perf improvements for e2e tests

### DIFF
--- a/packages/astro/e2e/astro-component.test.js
+++ b/packages/astro/e2e/astro-component.test.js
@@ -6,11 +6,11 @@ const test = testFactory({ root: './fixtures/astro-component/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/client-only.test.js
+++ b/packages/astro/e2e/client-only.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/client-only/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/error-react-spectrum.test.js
+++ b/packages/astro/e2e/error-react-spectrum.test.js
@@ -5,13 +5,12 @@ const test = testFactory({ root: './fixtures/error-react-spectrum/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async ({ astro }) => {
+test.afterAll(async ({ astro }) => {
 	await devServer.stop();
-	astro.resetAllFiles();
 });
 
 test.describe('Error: React Spectrum', () => {

--- a/packages/astro/e2e/error-sass.test.js
+++ b/packages/astro/e2e/error-sass.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/error-sass/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async ({ astro }) => {
+test.afterAll(async ({ astro }) => {
 	await devServer.stop();
 	astro.resetAllFiles();
 });

--- a/packages/astro/e2e/errors.test.js
+++ b/packages/astro/e2e/errors.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/errors/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async ({ astro }) => {
+test.afterAll(async ({ astro }) => {
 	await devServer.stop();
 	astro.resetAllFiles();
 });

--- a/packages/astro/e2e/invalidate-script-deps.test.js
+++ b/packages/astro/e2e/invalidate-script-deps.test.js
@@ -7,11 +7,11 @@ const test = testFactory({
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/lit-component.test.js
+++ b/packages/astro/e2e/lit-component.test.js
@@ -8,7 +8,7 @@ const test = testFactory({
 // TODO: configure playwright to handle web component APIs
 // https://github.com/microsoft/playwright/issues/14241
 test.describe('Lit components', () => {
-	test.beforeEach(() => {
+	test.beforeAll(() => {
 		delete globalThis.window;
 	});
 
@@ -16,11 +16,11 @@ test.describe('Lit components', () => {
 		let devServer;
 		const t = test.extend({});
 
-		t.beforeEach(async ({ astro }) => {
+		t.beforeAll(async ({ astro }) => {
 			devServer = await astro.startDevServer();
 		});
 
-		t.afterEach(async () => {
+		t.afterAll(async () => {
 			await devServer.stop();
 		});
 
@@ -120,11 +120,11 @@ test.describe('Lit components', () => {
 			await astro.build();
 		});
 
-		t.beforeEach(async ({ astro }) => {
+		t.beforeAll(async ({ astro }) => {
 			previewServer = await astro.preview();
 		});
 
-		t.afterEach(async () => {
+		t.afterAll(async () => {
 			await previewServer.stop();
 		});
 

--- a/packages/astro/e2e/multiple-frameworks.test.js
+++ b/packages/astro/e2e/multiple-frameworks.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/multiple-frameworks/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/namespaced-component.test.js
+++ b/packages/astro/e2e/namespaced-component.test.js
@@ -7,11 +7,11 @@ const test = testFactory({
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/nested-in-preact.test.js
+++ b/packages/astro/e2e/nested-in-preact.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/nested-in-preact/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/nested-in-react.test.js
+++ b/packages/astro/e2e/nested-in-react.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/nested-in-react/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/nested-in-solid.test.js
+++ b/packages/astro/e2e/nested-in-solid.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/nested-in-solid/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/nested-in-svelte.test.js
+++ b/packages/astro/e2e/nested-in-svelte.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/nested-in-svelte/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/nested-in-vue.test.js
+++ b/packages/astro/e2e/nested-in-vue.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/nested-in-vue/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/nested-recursive.test.js
+++ b/packages/astro/e2e/nested-recursive.test.js
@@ -10,11 +10,11 @@ const test = base.extend({
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/nested-styles.test.js
+++ b/packages/astro/e2e/nested-styles.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/nested-styles/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/pass-js.test.js
+++ b/packages/astro/e2e/pass-js.test.js
@@ -7,11 +7,11 @@ const test = testFactory({
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/shared-component-tests.js
+++ b/packages/astro/e2e/shared-component-tests.js
@@ -6,11 +6,11 @@ export function prepareTestFactory(opts) {
 
 	let devServer;
 
-	test.beforeEach(async ({ astro }) => {
+	test.beforeAll(async ({ astro }) => {
 		devServer = await astro.startDevServer();
 	});
 
-	test.afterEach(async () => {
+	test.afterAll(async () => {
 		await devServer.stop();
 	});
 

--- a/packages/astro/e2e/solid-recurse.test.js
+++ b/packages/astro/e2e/solid-recurse.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/solid-recurse/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/tailwindcss.test.js
+++ b/packages/astro/e2e/tailwindcss.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/tailwindcss/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async ({ astro }) => {
+test.afterAll(async ({ astro }) => {
 	await devServer.stop();
 	astro.resetAllFiles();
 });

--- a/packages/astro/e2e/test-utils.js
+++ b/packages/astro/e2e/test-utils.js
@@ -18,7 +18,7 @@ export function testFactory(inlineConfig) {
 
 	const test = testBase.extend({
 		astro: async ({}, use) => {
-			fixture = await loadFixture(inlineConfig);
+			fixture = fixture || await loadFixture(inlineConfig);
 			await use(fixture);
 		},
 	});

--- a/packages/astro/e2e/ts-resolution.test.js
+++ b/packages/astro/e2e/ts-resolution.test.js
@@ -26,11 +26,11 @@ test.describe('TypeScript resolution -', () => {
 
 		let devServer;
 
-		t.beforeEach(async ({ astro }) => {
+		t.beforeAll(async ({ astro }) => {
 			devServer = await astro.startDevServer();
 		});
 
-		t.afterEach(async () => {
+		t.afterAll(async () => {
 			await devServer.stop();
 		});
 
@@ -44,13 +44,10 @@ test.describe('TypeScript resolution -', () => {
 
 		t.beforeAll(async ({ astro }) => {
 			await astro.build();
-		});
-
-		t.beforeEach(async ({ astro }) => {
 			previewServer = await astro.preview();
 		});
 
-		t.afterEach(async () => {
+		t.afterAll(async () => {
 			await previewServer.stop();
 		});
 

--- a/packages/astro/playwright.config.js
+++ b/packages/astro/playwright.config.js
@@ -15,6 +15,8 @@ const config = {
 	forbidOnly: !!process.env.CI,
 	/* Retry on CI only */
 	retries: process.env.CI ? 3 : 0,
+	/* Opt out of parallel tests on CI. */
+	workers: 1,
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/packages/astro/playwright.config.js
+++ b/packages/astro/playwright.config.js
@@ -15,8 +15,6 @@ const config = {
 	forbidOnly: !!process.env.CI,
 	/* Retry on CI only */
 	retries: process.env.CI ? 3 : 0,
-	/* Opt out of parallel tests on CI. */
-	workers: 1,
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */


### PR DESCRIPTION
## Changes

Fixes a bug that was causing E2E tests to restart the dev server for every single test case

Future improvements - synchronization on HMR tests seem to be flaky on Windows, need to investigate what could be breaking the `editFile` synchronization only for Windows tests

## Testing

All existing tests should pass...faster

## Docs

Test updates only