### PR TITLE
Provide correct MIME type for dynamic endpoint routes in dev

### DIFF
--- a/.changeset/six-jars-push.md
+++ b/.changeset/six-jars-push.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Provide correct MIME type for dynamic endpoint routes in dev

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -346,7 +346,9 @@ async function handleRequest(
 			} else {
 				let contentType = 'text/plain';
 				// Dynamic routes don’t include `route.pathname`, so synthesise a path for these (e.g. 'src/pages/[slug].svg')
-				const filepath = route.pathname || route.segments.map(segment => segment.map(p => p.content).join('')).join('/');
+				const filepath =
+					route.pathname ||
+					route.segments.map((segment) => segment.map((p) => p.content).join('')).join('/');
 				const computedMimeType = mime.getType(filepath);
 				if (computedMimeType) {
 					contentType = computedMimeType;

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -345,7 +345,9 @@ async function handleRequest(
 				await writeWebResponse(res, result.response);
 			} else {
 				let contentType = 'text/plain';
-				const computedMimeType = route.pathname ? mime.getType(route.pathname) : null;
+				// Dynamic routes don’t include `route.pathname`, so synthesise a path for these (e.g. 'src/pages/[slug].svg')
+				const filepath = route.pathname || route.segments.map(segment => segment.map(p => p.content).join('')).join('/');
+				const computedMimeType = mime.getType(filepath);
 				if (computedMimeType) {
 					contentType = computedMimeType;
 				}

--- a/packages/astro/test/dev-routing.test.js
+++ b/packages/astro/test/dev-routing.test.js
@@ -246,6 +246,26 @@ describe('Development Routing', () => {
 			expect(body.slug).to.equal('thing4');
 			expect(body.title).to.equal('data [slug]');
 		});
+
+		it('correct MIME type when loading /home.json (static route)', async () => {
+			const response = await fixture.fetch('/home.json');
+			expect(response.headers.get('content-type')).to.match(/application\/json/);
+		});
+
+		it('correct MIME type when loading /thing1.json (dynamic route)', async () => {
+			const response = await fixture.fetch('/thing1.json');
+			expect(response.headers.get('content-type')).to.match(/application\/json/);
+		});
+
+		it('correct MIME type when loading /images/static.svg (static image)', async () => {
+			const response = await fixture.fetch('/images/static.svg');
+			expect(response.headers.get('content-type')).to.match(/image\/svg\+xml/);
+		});
+
+		it('correct MIME type when loading /images/1.svg (dynamic image)', async () => {
+			const response = await fixture.fetch('/images/1.svg');
+			expect(response.headers.get('content-type')).to.match(/image\/svg\+xml/);
+		});
 	});
 
 	describe('file format routing', () => {

--- a/packages/astro/test/fixtures/with-endpoint-routes/src/pages/images/[image].svg.ts
+++ b/packages/astro/test/fixtures/with-endpoint-routes/src/pages/images/[image].svg.ts
@@ -1,0 +1,14 @@
+export async function getStaticPaths() {
+	return [
+			{ params: { image: 1 } },
+			{ params: { image: 2 } },
+	];
+}
+
+export async function get({ params }) {
+	return {
+			body: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200">
+	<title>${params.image}</title>
+</svg>`
+	};
+}

--- a/packages/astro/test/fixtures/with-endpoint-routes/src/pages/images/static.svg.ts
+++ b/packages/astro/test/fixtures/with-endpoint-routes/src/pages/images/static.svg.ts
@@ -1,0 +1,7 @@
+export async function get() {
+	return {
+			body: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200">
+	<title>Static SVG</title>
+</svg>`
+	};
+}


### PR DESCRIPTION
## Changes

Fix #3950

On the dev server, we were only setting MIME types if the route had a pathname, which meant only for static routes. Endpoints like `[filename].svg.ts` would be served as `text/html`. This PR fixes that by building a fake pathname based on the endpoint filename, so that the extension can be used to hint at MIME type.

Don’t know if there’s an argument that a production server might _not_ do this for you? I’d assume in all reasonable scenarios, a server will see an `image.svg` file and serve it with the correct MIME type for you.
 
## Testing

Added some new tests to the `dev-routing-test` to cover MIME types for JSON & SVG endpoints.

## Docs

Only a bug fix.