### PR TITLE
Update example blog post markdown-style-guide.md to use correct image extension

### DIFF
--- a/examples/blog/src/pages/blog/markdown-style-guide.md
+++ b/examples/blog/src/pages/blog/markdown-style-guide.md
@@ -27,7 +27,7 @@ Itatur? Quiatae cullecum rem ent aut odis in re eossequodi nonsequ idebis ne sap
 
 ## Images
 
-![This is a placeholder image description](/placeholder-social.png)
+![This is a placeholder image description](/placeholder-social.jpg)
 
 ## Blockquotes
 


### PR DESCRIPTION
Image linked in markdown had .png instead of .jpg
This is the only image affected in all the example blog posts.

## Changes

- Image will properly load now

## Testing

N/A

## Docs

N/A