### PR TITLE
Fallback to undefined rather than false when resolving CLI flags

### DIFF
--- a/.changeset/few-mayflies-invent.md
+++ b/.changeset/few-mayflies-invent.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Allow user config to set `markdown.drafts` option

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -363,7 +363,7 @@ function resolveFlags(flags: Partial<Flags>): CLIFlags {
 		config: typeof flags.config === 'string' ? flags.config : undefined,
 		host:
 			typeof flags.host === 'string' || typeof flags.host === 'boolean' ? flags.host : undefined,
-		drafts: typeof flags.drafts === 'boolean' ? flags.drafts : false,
+		drafts: typeof flags.drafts === 'boolean' ? flags.drafts : undefined,
 	};
 }
 


### PR DESCRIPTION
## Changes

- If a user did not set their CLI to --draft, then `typeof flags.drafts === 'boolean'` will not be true, which would cause the drafts config to be set to `false`, overriding user configuration.

## Testing

<!-- How was this change tested? -->
I was unable to run `pnpm install` on my machine. Any additional commits to add tests (or even pointing me the right direction to add them myself) would be very much appreciated.

I tested that this fix solves the issue by fiddling with dist/core/config.js on my own project.

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
This actually makes the behavior of `astro build` conform to the current documentation: https://docs.astro.build/en/guides/markdown-content/#markdown-drafts