### PR TITLE
Preserve all error stack lines

### DIFF
--- a/.changeset/rare-comics-roll.md
+++ b/.changeset/rare-comics-roll.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Preserve all error stack lines

--- a/packages/astro/src/core/errors.ts
+++ b/packages/astro/src/core/errors.ts
@@ -37,7 +37,6 @@ export interface ErrorWithMetadata {
 export function cleanErrorStack(stack: string) {
 	return stack
 		.split(/\n/g)
-		.filter((l) => /^\s*at/.test(l))
 		.map((l) => l.replace(/\/@fs\//g, '/'))
 		.join('\n');
 }

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -18,7 +18,7 @@ import type { AddressInfo } from 'net';
 import os from 'os';
 import { ZodError } from 'zod';
 import type { AstroConfig } from '../@types/astro';
-import { cleanErrorStack, ErrorWithMetadata } from './errors.js';
+import { ErrorWithMetadata } from './errors.js';
 import { emoji, getLocalAddress, padMultilineString } from './util.js';
 
 const PREFIX_PADDING = 6;
@@ -235,10 +235,10 @@ export function formatErrorMessage(err: ErrorWithMetadata, args: string[] = []):
 		args.push(red(padMultilineString(err.frame, 4)));
 	}
 	if (args.length === 1 && err.stack) {
-		args.push(dim(cleanErrorStack(err.stack)));
+		args.push(dim(err.stack));
 	} else if (err.stack) {
 		args.push(`  ${bold('Stacktrace:')}`);
-		args.push(dim(cleanErrorStack(err.stack)));
+		args.push(dim(err.stack));
 		args.push(``);
 	}
 	return args.join('\n');


### PR DESCRIPTION
## Changes

Fix #4357

Preserve all error stack lines to avoid hiding important information. I'm not sure if this may expose more dirty messages, but we could monitor along as we go.

Before:
<img width="949" alt="Screenshot 2022-08-17 at 5 06 47 PM" src="https://user-images.githubusercontent.com/34116392/185091021-833d68ab-38d0-450c-839e-231780df7106.png">

After:
<img width="935" alt="Screenshot 2022-08-17 at 5 07 34 PM" src="https://user-images.githubusercontent.com/34116392/185091056-91877c3c-4acc-473b-8428-5984f80c248a.png">

Note: I also tried parsing the stack to split out the stack and frame, but it doesn't work with Vite's overlay as it expects frames to start with a `|` pipe.

## Testing

Tested manually with the repro at #4357

## Docs

N/A