### PR TITLE
fix: vercel static export path

### DIFF
--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -20,7 +20,7 @@
     "./edge/entrypoint": "./dist/edge/entrypoint.js",
     "./serverless": "./dist/serverless/adapter.js",
     "./serverless/entrypoint": "./dist/serverless/entrypoint.js",
-    "./static": "./dist/serverless/adapter.js",
+    "./static": "./dist/static/adapter.js",
     "./package.json": "./package.json"
   },
   "typesVersions": {


### PR DESCRIPTION
## Changes
  This enables the use of `{ output: static, adapter: vercelStaticAdapter}`.  

Previously, both paths, `@astro/vercel/static` and `@astro/vercel/serverless`, would resolve to the serverless adapter.

## Testing

Manually tested, observed build output changed from 
`[build] deploy adapter: @astrojs/vercel/serverless` to 
`[build] deploy adapter: @astrojs/vercel/static`

## Docs

nothing new to document
