### PR TITLE
Fix race condition with directive definitions

### DIFF
--- a/.changeset/smooth-nails-remain.md
+++ b/.changeset/smooth-nails-remain.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes race condition between directives being defined

--- a/packages/astro/e2e/fixtures/hydration-race/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/hydration-race/astro.config.mjs
@@ -1,0 +1,5 @@
+import preact from '@astrojs/preact';
+
+export default {
+	integrations: [preact()]
+};

--- a/packages/astro/e2e/fixtures/hydration-race/package.json
+++ b/packages/astro/e2e/fixtures/hydration-race/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@e2e/hydration-race",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build"
+  },
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/preact": "workspace:*"
+  }
+}

--- a/packages/astro/e2e/fixtures/hydration-race/src/components/Deeper.astro
+++ b/packages/astro/e2e/fixtures/hydration-race/src/components/Deeper.astro
@@ -1,0 +1,9 @@
+---
+import One from './One.jsx';
+---
+
+<div>
+	<span>Before one</span>
+	<One name="One" client:idle />
+</div>
+

--- a/packages/astro/e2e/fixtures/hydration-race/src/components/Layout.astro
+++ b/packages/astro/e2e/fixtures/hydration-race/src/components/Layout.astro
@@ -1,0 +1,6 @@
+---
+import Wrapper from './Wrapper.astro';
+---
+
+<Wrapper />
+<slot />

--- a/packages/astro/e2e/fixtures/hydration-race/src/components/One.jsx
+++ b/packages/astro/e2e/fixtures/hydration-race/src/components/One.jsx
@@ -1,0 +1,8 @@
+import { h } from 'preact';
+
+export default function({ name }) {
+	const inTheClient = import.meta.env.SSR ? '' : ' in the client'
+	return (
+		<div id={name.toLowerCase()}>Hello {name}{inTheClient}</div>
+	);
+}

--- a/packages/astro/e2e/fixtures/hydration-race/src/components/Wrapper.astro
+++ b/packages/astro/e2e/fixtures/hydration-race/src/components/Wrapper.astro
@@ -1,0 +1,8 @@
+---
+import One from './One.jsx';
+import Deeper from './Deeper.astro';
+---
+
+
+<One name="Two" client:visible />
+<Deeper />

--- a/packages/astro/e2e/fixtures/hydration-race/src/pages/slot.astro
+++ b/packages/astro/e2e/fixtures/hydration-race/src/pages/slot.astro
@@ -1,0 +1,15 @@
+---
+import Layout from '../components/Layout.astro';
+import One from '../components/One.jsx';
+---
+<html>
+<head>
+	<title>Testing</title>
+</head>
+<body>
+	<One name="Four" client:idle />
+	<Layout>
+		<One name="Three" client:visible />
+	</Layout>
+</body>
+</html>

--- a/packages/astro/e2e/hydration-race.test.js
+++ b/packages/astro/e2e/hydration-race.test.js
@@ -1,0 +1,36 @@
+import { expect } from '@playwright/test';
+import { testFactory } from './test-utils.js';
+
+const test = testFactory({
+	root: './fixtures/hydration-race/',
+});
+
+let devServer;
+
+test.beforeEach(async ({ astro }) => {
+	devServer = await astro.startDevServer();
+});
+
+test.afterEach(async () => {
+	await devServer.stop();
+});
+
+test.describe('Hydration race', () => {
+	test('Islands inside of slots hydrate', async ({ page, astro }) => {
+		await page.goto('/slot');
+
+		const html = await page.content();
+
+		const one = page.locator('#one');
+		await expect(one, 'updated text').toHaveText('Hello One in the client');
+
+		const two = page.locator('#two');
+		await expect(two, 'updated text').toHaveText('Hello Two in the client');
+
+		const three = page.locator('#three');
+		await expect(three, 'updated text').toHaveText('Hello Three in the client');
+
+		const four = page.locator('#four');
+		await expect(four, 'updated text').toHaveText('Hello Four in the client');
+	});
+});

--- a/packages/astro/src/runtime/client/idle.ts
+++ b/packages/astro/src/runtime/client/idle.ts
@@ -10,3 +10,4 @@
 		setTimeout(cb, 200);
 	}
 };
+window.dispatchEvent(new Event('astro:idle'));

--- a/packages/astro/src/runtime/client/load.ts
+++ b/packages/astro/src/runtime/client/load.ts
@@ -4,3 +4,4 @@
 		await hydrate();
 	})();
 };
+window.dispatchEvent(new Event('astro:load'));

--- a/packages/astro/src/runtime/client/media.ts
+++ b/packages/astro/src/runtime/client/media.ts
@@ -16,3 +16,4 @@
 		}
 	}
 };
+window.dispatchEvent(new Event('astro:media'));

--- a/packages/astro/src/runtime/client/only.ts
+++ b/packages/astro/src/runtime/client/only.ts
@@ -7,3 +7,4 @@
 		await hydrate();
 	})();
 };
+window.dispatchEvent(new Event('astro:only'));

--- a/packages/astro/src/runtime/client/visible.ts
+++ b/packages/astro/src/runtime/client/visible.ts
@@ -24,3 +24,4 @@
 		io.observe(child);
 	}
 };
+window.dispatchEvent(new Event('astro:visible'));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -660,6 +660,14 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
 
+  packages/astro/e2e/fixtures/hydration-race:
+    specifiers:
+      '@astrojs/preact': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/preact': link:../../../../integrations/preact
+      astro: link:../../..
+
   packages/astro/e2e/fixtures/invalidate-script-deps:
     specifiers:
       astro: workspace:*


### PR DESCRIPTION
## Changes

- This replaces a reverted PR: https://github.com/withastro/astro/pull/4288
- That PR attempted to ensure that directive scripts always came before the first island that needed them.
  - This idea was based on the flawed idea that would move those scripts up the rendering chain through state, but this resulted in scripts some times being placed in the middle of where attribute expressions go.
- This is a new approach that accepts that some times an island will exist before the directive script is ready. When this happens listen to an event that fires when the directive script gets defined.
- Closes https://github.com/withastro/astro/issues/4286

## Testing

E2E test added that recreates the problem.

## Docs

Bug fix