### PR TITLE
Fix page not loading scripts when using tailwind

### DIFF
--- a/.changeset/dull-waves-vanish.md
+++ b/.changeset/dull-waves-vanish.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix page not loading scripts on `astro dev` when using tailwindcss

--- a/packages/astro/e2e/fixtures/tailwindcss/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/tailwindcss/src/pages/index.astro
@@ -14,5 +14,9 @@ import Complex from '../components/Complex.astro';
 	<body class="bg-dawn text-midnight">
 		<Button>I’m a Tailwind Button!</Button>
 		<Complex />
+		<div id="script-target"></div>
+		<script>
+			import '../scripts/insert-text.js';
+		</script>
 	</body>
 </html>

--- a/packages/astro/e2e/fixtures/tailwindcss/src/scripts/insert-text.js
+++ b/packages/astro/e2e/fixtures/tailwindcss/src/scripts/insert-text.js
@@ -1,0 +1,1 @@
+document.getElementById('script-target').textContent = 'text';

--- a/packages/astro/e2e/tailwindcss.test.js
+++ b/packages/astro/e2e/tailwindcss.test.js
@@ -47,6 +47,13 @@ test.describe('Tailwind CSS', () => {
 		await expect(button, 'should have font weight').toHaveCSS('font-weight', '900');
 	});
 
+	test('Load script', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/'));
+
+		const target = page.locator('#script-target');
+		await expect(target, 'text set').toHaveText('text');
+	});
+
 	test('HMR', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/'));
 

--- a/packages/astro/src/core/render/dev/scripts.ts
+++ b/packages/astro/src/core/render/dev/scripts.ts
@@ -16,6 +16,7 @@ export async function getScriptsForURL(
 	const elements = new Set<SSRElement>();
 	const rootID = viteID(filePath);
 	let rootProjectFolder = slash(fileURLToPath(astroConfig.root));
+	await viteServer.ssrLoadModule(rootID);
 	const modInfo = viteServer.pluginContainer.getModuleInfo(rootID);
 	addHoistedScripts(elements, modInfo, rootProjectFolder);
 	for await (const moduleNode of crawlGraph(viteServer, rootID, true)) {


### PR DESCRIPTION
## Changes

Fix #4217 .

When using tailwindcss, Vite adds files specified by `content` option in tailwind.config.js to the deps after compiling CSS.
Then, moduleInfo (`meta`) of these files are cleared.
We need to re-transform the file before getting moduleInfo.

Please tell me if my understanding is not correct!

## Testing

Add a test in tailwindcss.test.js

## Docs

None. 