### PR TITLE
Fix typo in the docs example

### DIFF
--- a/examples/docs/src/components/LeftSidebar/LeftSidebar.astro
+++ b/examples/docs/src/components/LeftSidebar/LeftSidebar.astro
@@ -9,8 +9,8 @@ const sidebarSections = SIDEBAR[langCode].reduce((col, item, i) => {
 	// If the first item is not a section header, create a new container section.
 	if (i === 0) {
 		if (!item.header) {
-			const pesudoSection = { text: '' };
-			col.push({ ...pesudoSection, children: [] });
+			const pseudoSection = { text: '' };
+			col.push({ ...pseudoSection, children: [] });
 		}
 	}
 	if (item.header) {


### PR DESCRIPTION
## Changes
Corrected spelling in `examples/docs/src/components/LeftSideBar/LeftSideBar.astro`, changing pesudoSection to pseudoSection in order to fix #4367 .

## Testing
No tests necessary as the variable doesn't show up anywhere else (verified with a recursive grep) and both names were substituted at the same time.

## Docs
As far as I can see, no changes are required for the docs.