### PR TITLE
Fix typo on astro image integration quick install guide with NPM

### DIFF
--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -28,7 +28,7 @@ The `astro add` command-line tool automates the installation for you. Run one of
    
 ```sh
 # Using NPM
-npm run astro add image
+npx astro add image
 # Using Yarn
 yarn astro add image
 # Using PNPM


### PR DESCRIPTION
## Changes
Replace `npm run astro add image` with `npx astro add image`

## Testing
I have try to run `npm run astro add image`
result :
```bash
npm ERR! Missing script: "astro"
npm ERR! 
npm ERR! To see a list of scripts, run:
npm ERR!   npm run

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/codespace/.npm/_logs/2022-08-19T06_51_44_826Z-debug-0.log
```
Expected :
New package installed `@astrojs/image`

Solution :
Use `npx astro add image`
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
I notice that quick install guide is using 

`npm run astro add image`

and I believe this is doens't work and not available by default on `package.json` file

In my view, we can just using

`npx astro add image`

then it should be fine and will installing `@astrojs/image` in node_modules folder

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->