### PR TITLE
Fix invalid hook usage for exports

### DIFF
--- a/.changeset/flat-ads-lay.md
+++ b/.changeset/flat-ads-lay.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix warning when using hooks inside the react components not exported as a function declaration

--- a/packages/astro/src/vite-plugin-jsx/tag.ts
+++ b/packages/astro/src/vite-plugin-jsx/tag.ts
@@ -55,21 +55,35 @@ export default function tagExportsWithRenderer({
 				if (node.exportKind === 'type') return;
 				if (node.type === 'ExportAllDeclaration') return;
 
-				if (node.type === 'ExportNamedDeclaration') {
-					if (t.isFunctionDeclaration(node.declaration)) {
-						if (node.declaration.id?.name) {
-							const id = node.declaration.id.name;
-							const tags = state.get('astro:tags') ?? [];
-							state.set('astro:tags', [...tags, id]);
-						}
+				const addTag = (id: string) => {
+					const tags = state.get('astro:tags') ?? [];
+					state.set('astro:tags', [...tags, id]);
+				}
+
+				if (node.type === 'ExportNamedDeclaration' || node.type === 'ExportDefaultDeclaration') {
+					if (t.isFunctionDeclaration(node.declaration) && node.declaration.id?.name) {
+						addTag(node.declaration.id.name);
 					}
-				} else if (node.type === 'ExportDefaultDeclaration') {
-					if (t.isFunctionDeclaration(node.declaration)) {
-						if (node.declaration.id?.name) {
-							const id = node.declaration.id.name;
-							const tags = state.get('astro:tags') ?? [];
-							state.set('astro:tags', [...tags, id]);
-						}
+					else if (t.isVariableDeclaration(node.declaration)) {
+						node.declaration.declarations?.forEach(declaration => {
+							if (t.isArrowFunctionExpression(declaration.init) && t.isIdentifier(declaration.id)) {
+								addTag(declaration.id.name);
+							}
+						});
+					}
+					else if (t.isObjectExpression(node.declaration)) {
+						node.declaration.properties?.forEach(property => {
+							if (t.isProperty(property) && t.isIdentifier(property.key)) {
+								addTag(property.key.name);
+							}
+						});
+					}
+					else if (t.isExportNamedDeclaration(node)) {
+						node.specifiers.forEach(specifier => {
+							if (t.isExportSpecifier(specifier) && t.isIdentifier(specifier.exported)) {
+								addTag(specifier.local.name);
+							}
+						});
 					}
 				}
 			},

--- a/packages/astro/src/vite-plugin-jsx/tag.ts
+++ b/packages/astro/src/vite-plugin-jsx/tag.ts
@@ -61,7 +61,10 @@ export default function tagExportsWithRenderer({
 				}
 
 				if (node.type === 'ExportNamedDeclaration' || node.type === 'ExportDefaultDeclaration') {
-					if (t.isFunctionDeclaration(node.declaration) && node.declaration.id?.name) {
+					if (t.isIdentifier(node.declaration)) {
+						addTag(node.declaration.name);
+					}
+					else if (t.isFunctionDeclaration(node.declaration) && node.declaration.id?.name) {
 						addTag(node.declaration.id.name);
 					}
 					else if (t.isVariableDeclaration(node.declaration)) {


### PR DESCRIPTION
## Changes

Closes #4220

Fixes warning when using hooks inside the react components not exported as a function declaration

Adds proper support for react components exported as
 ```ts
 // named arrow expression
 export const X = () => {...}; 

function Y1 () {...}
const Y2 = () => {...};

// Export default
export default Y2;

// Export specifiers
export { Y1 as Comp, Y2 }

// Export default object
export default { Y1, Y2 }
 ```

## Testing

Tested manually.
I would like to add tests if needed, just unsure of how to test for warnings in the build output

## Docs

No changes in docs needed