### PR TITLE
Fix typo in stricter tsconfig

### DIFF
--- a/packages/create-astro/tsconfigs/tsconfig.stricter.json
+++ b/packages/create-astro/tsconfigs/tsconfig.stricter.json
@@ -19,7 +19,7 @@
     "noFallthroughCasesInSwitch": true,
     // Force functions designed to override their parent class to be specified as `override`.
     "noImplicitOverride": true,
-    // Force functions to specify that they can return `undefined` if a possibe code path does not return a value.
+    // Force functions to specify that they can return `undefined` if a possible code path does not return a value.
     "noImplicitReturns": true,
     // Report an error when a variable is declared but never used.
     "noUnusedLocals": true,


### PR DESCRIPTION
## Changes
- Fixes a typo in the stricter tsconfig file in create-astro package. Changes "possibe" to "possible"

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

No test changes required

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No documentation changes required