### PR TITLE
Updated Express code to serve assets

### DIFF
--- a/packages/integrations/node/README.md
+++ b/packages/integrations/node/README.md
@@ -57,6 +57,7 @@ import express from 'express';
 import { handler as ssrHandler } from './dist/server/entry.mjs';
 
 const app = express();
+app.use(express.static('dist/client/'))
 app.use(ssrHandler);
 
 app.listen(8080);


### PR DESCRIPTION
Assets where not served so the style was not applied, fixed this by adding the line app.use(express.static('dist/client/'))

## Changes

-Just makes that express serves the assets as well, if it doesn't, styles and favicon will return a 404 error.

## Testing

<!-- How was this change tested? -->
I tested it with a blank project and it fixed the issue properly.
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

There must be a change in the docs to show the small fix.

