### PR TITLE
fix: exportName metadata for JSXMemberExpressions that use named imports

### DIFF
--- a/.changeset/soft-icons-travel.md
+++ b/.changeset/soft-icons-travel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix for components, declared with JSXMemberExpression nodes, that failed to hydrate due to incomplete 'component-export' metadata

--- a/packages/astro/e2e/fixtures/namespaced-component/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/namespaced-component/astro.config.mjs
@@ -1,7 +1,8 @@
 import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
+import mdx from "@astrojs/mdx";
 
 // https://astro.build/config
 export default defineConfig({
-	integrations: [preact()],
+  integrations: [preact(), mdx()]
 });

--- a/packages/astro/e2e/fixtures/namespaced-component/package.json
+++ b/packages/astro/e2e/fixtures/namespaced-component/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
+    "@astrojs/mdx": "workspace:*",
     "@astrojs/preact": "workspace:*",
     "astro": "workspace:*"
   },

--- a/packages/astro/e2e/fixtures/namespaced-component/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/namespaced-component/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import * as ns from '../components/PreactCounter.tsx';
+import { components } from '../components/PreactCounter.tsx';
 ---
 
 <html lang="en">
@@ -10,9 +11,13 @@ import * as ns from '../components/PreactCounter.tsx';
 	</head>
 	<body>
 		<main>
-			<ns.components.PreactCounter id="preact-counter" client:load>
-				<h1>preact</h1>
+			<ns.components.PreactCounter id="preact-counter-namespace" client:load>
+				<h1>preact (namespace import)</h1>
 			</ns.components.PreactCounter>
+
+      <components.PreactCounter id="preact-counter-named" client:load>
+				<h1>preact (named import)</h1>
+			</components.PreactCounter>
 		</main>
 	</body>
 </html>

--- a/packages/astro/e2e/fixtures/namespaced-component/src/pages/mdx.mdx
+++ b/packages/astro/e2e/fixtures/namespaced-component/src/pages/mdx.mdx
@@ -1,0 +1,10 @@
+import * as ns from '../components/PreactCounter.tsx';
+import { components } from '../components/PreactCounter.tsx';
+
+<ns.components.PreactCounter id="preact-counter-namespace" client:load>
+  preact (namespace import)
+</ns.components.PreactCounter>
+
+<components.PreactCounter id="preact-counter-named" client:load>
+  preact (named import)
+</components.PreactCounter>

--- a/packages/astro/e2e/namespaced-component.test.js
+++ b/packages/astro/e2e/namespaced-component.test.js
@@ -19,18 +19,36 @@ test.describe('Hydrating namespaced components', () => {
 	test('Preact Component', async ({ page }) => {
 		await page.goto('/');
 
-		const counter = await page.locator('#preact-counter');
-		await expect(counter, 'component is visible').toBeVisible();
+		// Counter declared with: <ns.components.PreactCounter id="preact-counter-namespace" client:load>
 
-		const count = await counter.locator('pre');
-		await expect(count, 'initial count is 0').toHaveText('0');
+		const namespacedCounter = await page.locator('#preact-counter-namespace');
+		await expect(namespacedCounter, 'component is visible').toBeVisible();
 
-		const children = await counter.locator('.children');
-		await expect(children, 'children exist').toHaveText('preact');
+		const namespacedCount = await namespacedCounter.locator('pre');
+		await expect(namespacedCount, 'initial count is 0').toHaveText('0');
 
-		const increment = await counter.locator('.increment');
-		await increment.click();
+		const namespacedChildren = await namespacedCounter.locator('.children');
+		await expect(namespacedChildren, 'children exist').toHaveText('preact (namespace import)');
 
-		await expect(count, 'count incremented by 1').toHaveText('1');
+		const namespacedIncrement = await namespacedCounter.locator('.increment');
+		await namespacedIncrement.click();
+
+		await expect(namespacedCount, 'count incremented by 1').toHaveText('1');
+
+		// Counter declared with: <components.PreactCounter id="preact-counter-named" client:load>
+
+		const namedCounter = await page.locator('#preact-counter-named');
+		await expect(namedCounter, 'component is visible').toBeVisible();
+
+		const namedCount = await namedCounter.locator('pre');
+		await expect(namedCount, 'initial count is 0').toHaveText('0');
+
+		const namedChildren = await namedCounter.locator('.children');
+		await expect(namedChildren, 'children exist').toHaveText('preact (named import)');
+
+		const namedIncrement = await namedCounter.locator('.increment');
+		await namedIncrement.click();
+
+		await expect(namedCount, 'count incremented by 1').toHaveText('1');
 	});
 });

--- a/packages/astro/e2e/namespaced-component.test.js
+++ b/packages/astro/e2e/namespaced-component.test.js
@@ -20,7 +20,6 @@ test.describe('Hydrating namespaced components', () => {
 		await page.goto('/');
 
 		// Counter declared with: <ns.components.PreactCounter id="preact-counter-namespace" client:load>
-
 		const namespacedCounter = await page.locator('#preact-counter-namespace');
 		await expect(namespacedCounter, 'component is visible').toBeVisible();
 
@@ -35,8 +34,41 @@ test.describe('Hydrating namespaced components', () => {
 
 		await expect(namespacedCount, 'count incremented by 1').toHaveText('1');
 
-		// Counter declared with: <components.PreactCounter id="preact-counter-named" client:load>
+		// Counter declared with: <components.PreactCounterTwo id="preact-counter-named" client:load>
+		const namedCounter = await page.locator('#preact-counter-named');
+		await expect(namedCounter, 'component is visible').toBeVisible();
 
+		const namedCount = await namedCounter.locator('pre');
+		await expect(namedCount, 'initial count is 0').toHaveText('0');
+
+		const namedChildren = await namedCounter.locator('.children');
+		await expect(namedChildren, 'children exist').toHaveText('preact (named import)');
+
+		const namedIncrement = await namedCounter.locator('.increment');
+		await namedIncrement.click();
+
+		await expect(namedCount, 'count incremented by 1').toHaveText('1');
+	});
+
+	test('MDX', async ({ page }) => {
+		await page.goto('/mdx');
+
+		// Counter declared with: <ns.components.PreactCounter id="preact-counter-namespace" client:load>
+		const namespacedCounter = await page.locator('#preact-counter-namespace');
+		await expect(namespacedCounter, 'component is visible').toBeVisible();
+
+		const namespacedCount = await namespacedCounter.locator('pre');
+		await expect(namespacedCount, 'initial count is 0').toHaveText('0');
+
+		const namespacedChildren = await namespacedCounter.locator('.children');
+		await expect(namespacedChildren, 'children exist').toHaveText('preact (namespace import)');
+
+		const namespacedIncrement = await namespacedCounter.locator('.increment');
+		await namespacedIncrement.click();
+
+		await expect(namespacedCount, 'count incremented by 1').toHaveText('1');
+
+		// Counter declared with: <components.PreactCounterTwo id="preact-counter-named" client:load>
 		const namedCounter = await page.locator('#preact-counter-named');
 		await expect(namedCounter, 'component is visible').toBeVisible();
 

--- a/packages/astro/src/jsx/babel.ts
+++ b/packages/astro/src/jsx/babel.ts
@@ -205,7 +205,8 @@ export default function astroJSX(): PluginObj {
 							break;
 						}
 						if (namespace.at(0) === local) {
-							path.setData('import', { name: imported, path: source });
+							const name = imported === '*' ? imported : tagName;
+							path.setData('import', { name, path: source });
 							break;
 						}
 					}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -715,12 +715,14 @@ importers:
 
   packages/astro/e2e/fixtures/namespaced-component:
     specifiers:
+      '@astrojs/mdx': workspace:*
       '@astrojs/preact': workspace:*
       astro: workspace:*
       preact: ^10.7.3
     dependencies:
       preact: 10.10.2
     devDependencies:
+      '@astrojs/mdx': link:../../../../integrations/mdx
       '@astrojs/preact': link:../../../../integrations/preact
       astro: link:../../..
 


### PR DESCRIPTION
## Changes

Fix for issue described in: https://github.com/withastro/astro/issues/4389

Components declared using `JSXMemberExpression` nodes were not hydrating properly, due to how the `component-export` attribute was being determined in the `astroJSX` Babel plugin.

Example:
```jsx
const SampleComponent = () => { ... }

export const Namespace = { SampleComponent };
```

The `component-export` attribute for this component (`<Namespace.SampleComponent client:load />`) was `'SampleComponent'`, but will now be `'Namespace.SampleComponent'`, which can be resolved properly via the hydration logic here: https://github.com/withastro/astro/blob/dfa3519d4c1aba888dceec50f285677d659d1540/packages/astro/src/runtime/server/astro-island.ts#L72-L75

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Tested locally. I also added to the existing `e2e/namespaced-component.test.js`.

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No documentation updates needed. This is a minor bug fix.