### PR TITLE
refactor the JSX plugin, improve performance

### DIFF
--- a/.changeset/silver-dragons-run.md
+++ b/.changeset/silver-dragons-run.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Refactor JSX build plugin, improve performance


### PR DESCRIPTION
## Changes

- Refactor the JSX plugin to move expensive work out of the hot code path
- This actually was a nice chance to clean up the file a bit, move some code into helper functions, and remove some redundant code that was no longer needed due to Astro's internal JSX renderer.
- **NOTE:** This changes one thing about current behavior, which is that it now prioritizes the explicit `@jsxImportSource` pragma over import scanning. I had assumed that the explicit pragma always beat out the implicit import scanning, and would make the case here that ignoring an explicit pragma is a bug. This change would only impact a user who had a `@jsxImportSource` to one framework and then ESM imports to another. I don't think that's realistic, but I thought I'd call it out here in case anyone feels differently.

## Testing

- Covered by existing tests
- On a flight so can't perf test, but this should be worth merging regardless

## Docs

- N/A