### PR TITLE
add an alpine integration and update example

### DIFF
--- a/.changeset/purple-guests-fetch.md
+++ b/.changeset/purple-guests-fetch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/alpinejs': minor
+---
+
+Add new official Alpine.js integration

--- a/examples/framework-alpine/astro.config.mjs
+++ b/examples/framework-alpine/astro.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from 'astro/config';
+import alpine from '@astrojs/alpinejs';
 
 // https://astro.build/config
 export default defineConfig({
-	// No integrations are needed for AlpineJS support, just use Astro components!
-	integrations: [],
+	integrations: [alpine()],
 });

--- a/examples/framework-alpine/package.json
+++ b/examples/framework-alpine/package.json
@@ -10,10 +10,10 @@
     "astro": "astro"
   },
   "devDependencies": {
+    "@astrojs/alpinejs": "^0.0.1",
     "@types/alpinejs": "^3.7.0",
+    "alpinejs": "^3.10.2",
     "astro": "^1.0.6"
   },
-  "dependencies": {
-    "alpinejs": "^3.10.2"
-  }
+  "dependencies": {}
 }

--- a/examples/framework-alpine/src/pages/index.astro
+++ b/examples/framework-alpine/src/pages/index.astro
@@ -22,12 +22,6 @@ import Counter from '../components/Counter.astro';
 				padding: 2rem;
 			}
 		</style>
-
-		<!-- Load AlpineJS on the page -->
-		<script>
-			import Alpine from 'alpinejs';
-			Alpine.start();
-		</script>
 	</head>
 	<body>
 		<main>

--- a/packages/integrations/alpinejs/README.md
+++ b/packages/integrations/alpinejs/README.md
@@ -1,0 +1,108 @@
+# @astrojs/alpinejs ⚛️
+
+This **[Astro integration][astro-integration]** adds [Alpine.js](https://alpinejs.dev/) to your project so that you can use Alpine.js anywhere on your page.
+
+- <strong>[Installation](#installation)</strong>
+- <strong>[Usage](#usage)</strong>
+- <strong>[Configuration](#configuration)</strong>
+- <strong>[Examples](#examples)</strong>
+- <strong>[Troubleshooting](#troubleshooting)</strong>
+- <strong>[Contributing](#contributing)</strong>
+- <strong>[Changelog](#changelog)</strong>
+
+## Installation
+
+### Quick Install
+
+The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
+
+```sh
+# Using NPM
+npm run astro add alpinejs
+# Using Yarn
+yarn astro add alpinejs
+# Using PNPM
+pnpm astro add alpinejs
+```
+
+Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.
+
+### Manual Install
+
+First, install the `@astrojs/alpinejs` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
+
+```sh
+npm install @astrojs/alpinejs
+```
+
+Most package managers will install associated peer dependencies as well. Still, if you see a "Cannot find package 'alpinejs'" (or similar) warning when you start up Astro, you'll need to install Alpine.js yourself:
+
+```sh
+npm install alpinejs @types/alpinejs
+```
+
+Then, apply this integration to your `astro.config.*` file using the `integrations` property:
+
+__`astro.config.mjs`__
+
+```js
+import { defineConfig } from 'astro/config';
+import alpine from '@astrojs/alpinejs';
+
+export default defineConfig({
+  // ...
+  integrations: [alpine()],
+});
+```
+
+Finally, restart the dev server.
+
+## Usage
+
+Once the integration is installed, you can use [Alpine.js](https://alpinejs.dev/) directivers and syntax inside any Astro component. The Alpine.js script is automatically added and enabled on every page of your website.
+
+Check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
+## Limitations
+
+The Apline.js integration does not give you control over how the script is loaded or initialized. If you require this control, consider [installing and using Alpine.js manually](https://alpinejs.dev/essentials/installation). Astro supports all officially documented Alpine.js manual setup instructions, using `<script>` tags inside of an Astro component.
+
+**It is not currently possible to [extend Alpine.js](https://alpinejs.dev/advanced/extending) when using this component.** If you need this feature, consider following [the manual Alpine.js setup](https://alpinejs.dev/essentials/installation) instead using an Astro script tag:
+
+```astro
+<!-- Example: Load AlpineJS on a single page. -->
+<script>
+  import Alpine from 'alpinejs';
+
+  // Optional: Extend Alpine.js
+  // Alpine.directive('foo', ...)
+
+  window.Alpine = Alpine;
+  Alpine.start();
+</script>
+```
+
+## Configuration
+
+The Apline.js integration does not support any custom configuration at this time.
+
+## Examples
+
+- The [Astro Alpine.js example](https://github.com/withastro/astro/tree/latest/examples/framework-alpine) shows how to use Alpine.js in an Astro project.
+
+## Troubleshooting
+
+For help, check out the `#support-threads` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+
+You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
+## Contributing
+
+This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a history of changes to this integration.
+
+[astro-integration]: https://docs.astro.build/en/guides/integrations-guide/
+[astro-ui-frameworks]: https://docs.astro.build/en/core-concepts/framework-components/#using-framework-components

--- a/packages/integrations/alpinejs/package.json
+++ b/packages/integrations/alpinejs/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@astrojs/alpinejs",
+  "description": "The official Alpine.js integration for Astro.",
+  "version": "0.0.1",
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "author": "withastro",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/withastro/astro.git",
+    "directory": "packages/integrations/alpinejs"
+  },
+  "keywords": [
+    "astro-integration",
+    "astro-component",
+    "performance"
+  ],
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://astro.build",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
+    "dev": "astro-scripts dev \"src/**/*.ts\""
+  },
+  "peerDependencies": {
+    "@types/alpinejs": "^3.0.0",
+    "alpinejs": "^3.0.0"
+  },
+  "devDependencies": {
+    "astro": "workspace:*",
+    "astro-scripts": "workspace:*"
+  }
+}

--- a/packages/integrations/alpinejs/src/index.ts
+++ b/packages/integrations/alpinejs/src/index.ts
@@ -1,0 +1,17 @@
+import type { AstroIntegration } from 'astro';
+
+export default function createPlugin(): AstroIntegration {
+	return {
+		name: '@astrojs/alpinejs',
+		hooks: {
+			'astro:config:setup': ({ injectScript }) => {
+				// This gets injected into the user's page, so the import will pull
+				// from the project's version of Alpine.js in their package.json.
+				injectScript(
+					'page',
+					`import Alpine from 'alpinejs'; window.Alpine = Alpine; Alpine.start();`
+				);
+			},
+		},
+	};
+}

--- a/packages/integrations/alpinejs/tsconfig.json
+++ b/packages/integrations/alpinejs/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "allowJs": true,
+    "module": "ES2020",
+    "outDir": "./dist",
+    "target": "ES2020"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,13 +122,14 @@ importers:
 
   examples/framework-alpine:
     specifiers:
+      '@astrojs/alpinejs': ^0.0.1
       '@types/alpinejs': ^3.7.0
       alpinejs: ^3.10.2
       astro: ^1.0.6
-    dependencies:
-      alpinejs: 3.10.3
     devDependencies:
+      '@astrojs/alpinejs': link:../../packages/integrations/alpinejs
       '@types/alpinejs': 3.7.0
+      alpinejs: 3.10.3
       astro: link:../../packages/astro
 
   examples/framework-lit:
@@ -2102,6 +2103,14 @@ importers:
       chai: 4.3.6
       mocha: 9.2.2
       uvu: 0.5.6
+
+  packages/integrations/alpinejs:
+    specifiers:
+      astro: workspace:*
+      astro-scripts: workspace:*
+    devDependencies:
+      astro: link:../../astro
+      astro-scripts: link:../../../scripts
 
   packages/integrations/cloudflare:
     specifiers:
@@ -9155,7 +9164,7 @@ packages:
     resolution: {integrity: sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==}
     dependencies:
       '@vue/shared': 3.1.5
-    dev: false
+    dev: true
 
   /@vue/reactivity/3.2.37:
     resolution: {integrity: sha512-/7WRafBOshOc6m3F7plwzPeCu/RCVv9uMpOwa/5PiY1Zz+WLVRWiy0MYKwmg19KBdGtFWsmZ4cD+LOdVPcs52A==}
@@ -9186,7 +9195,7 @@ packages:
 
   /@vue/shared/3.1.5:
     resolution: {integrity: sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==}
-    dev: false
+    dev: true
 
   /@vue/shared/3.2.37:
     resolution: {integrity: sha512-4rSJemR2NQIo9Klm1vabqWjD8rs/ZaJSzMxkMNeJS6lHiUjjUeYFbooN19NgFjztubEKh3WlZUeOLVdbbUWHsw==}
@@ -9309,7 +9318,7 @@ packages:
     resolution: {integrity: sha512-nt/w4hLq9pPaexCsHmO5zV5Alvq4yu9n0Iclti6aV0HmiqLWH/axUb0pn8z3XVuVNcj8EOXOQw+WpwPzMzLBWg==}
     dependencies:
       '@vue/reactivity': 3.1.5
-    dev: false
+    dev: true
 
   /ansi-align/3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}


### PR DESCRIPTION
## Changes

- @Princesseuh and I had talked about this a while ago, but never got around to it. 
- This adds the new Alpine.js integration that should be good for most users.
- This updates the `framework-alpine` example to use the new integration.
- Helps to address feedback like this.

## Testing

- Tested manually.
- Covered by existing smoke tests.

## Docs

- [x] Integration README will be automatically pulled into docs site
- [ ] Is there anything that I need to do to get this integration added to the integrations page of docs?
- [ ] Is there anything that I need to do to get this integration added to the integrations catalog of www?