### PR TITLE
fix: correctly add `react-dom` alias to Vercel edge

### DIFF
--- a/.changeset/heavy-pants-change.md
+++ b/.changeset/heavy-pants-change.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Fix react-dom on Vercel edge

--- a/packages/integrations/vercel/src/edge/adapter.ts
+++ b/packages/integrations/vercel/src/edge/adapter.ts
@@ -32,8 +32,17 @@ export default function vercelEdge(): AstroIntegration {
 				if (target === 'server') {
 					vite.resolve ||= {};
 					vite.resolve.alias ||= {};
-					const alias = vite.resolve.alias as Record<string, string>;
-					alias['react-dom/server'] = 'react-dom/server.browser';
+
+					const aliases = [{ find: 'react-dom/server', replacement: 'react-dom/server.browser' }];
+
+					if (Array.isArray(vite.resolve.alias)) {
+						vite.resolve.alias = [...vite.resolve.alias, ...aliases];
+					} else {
+						for (const alias of aliases) {
+							(vite.resolve.alias as Record<string, string>)[alias.find] = alias.replacement;
+						}
+					}
+
 					vite.ssr = {
 						noExternal: true,
 					};


### PR DESCRIPTION
## Changes

Resolves #4391 

Handle array and object signature in Vite aliases. This check was missing on the Vercel edge adapter, so `react-dom` was never aliased to something deno-ready!

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->