### PR TITLE
Ensure index pages are generated on paginated results

### DIFF
--- a/.changeset/odd-elephants-remember.md
+++ b/.changeset/odd-elephants-remember.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Ensure index pages are generated on paginated results

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -207,11 +207,6 @@ async function getPathsForRoute(
 		paths = result.staticPaths
 			.map((staticPath) => staticPath.params && route.generate(staticPath.params))
 			.filter((staticPath) => {
-				// Remove empty or undefined paths
-				if (!staticPath) {
-					return false;
-				}
-
 				// The path hasn't been built yet, include it
 				if (!builtPaths.has(removeTrailingForwardSlash(staticPath))) {
 					return true;

--- a/packages/astro/test/fixtures/get-static-paths-pages/package.json
+++ b/packages/astro/test/fixtures/get-static-paths-pages/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/get-static-paths-pages",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/get-static-paths-pages/src/pages/[...page].astro
+++ b/packages/astro/test/fixtures/get-static-paths-pages/src/pages/[...page].astro
@@ -1,0 +1,37 @@
+---
+export async function getStaticPaths({ paginate }) {
+	const astronautPages = [{
+		astronaut: 'Neil Armstrong',
+	}, {
+		astronaut: 'Buzz Aldrin',
+	}, {
+		astronaut: 'Sally Ride',
+	}, {
+		astronaut: 'John Glenn',
+	}];
+	// Generate pages from our array of astronauts, with 2 to a page
+	return paginate(astronautPages, { pageSize: 2 });
+}
+
+// All paginated data is passed on the "page" prop
+const { page } = Astro.props;
+---
+
+<html lang="en">
+
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width" />
+	<meta name="generator" content={Astro.generator} />
+	<title>Astro</title>
+</head>
+
+<body>
+	<h1>Page {page.currentPage}</h1>
+	<ul>
+		<!--List the array of astronaut info-->
+		{page.data.map(({ astronaut }: { astronaut: string }) => <li>{astronaut}</li>)}
+	</ul>
+</body>
+
+</html>

--- a/packages/astro/test/get-static-paths-pages.test.js
+++ b/packages/astro/test/get-static-paths-pages.test.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('getStaticPaths with trailingSlash: ignore', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/get-static-paths-pages/',
+			site: 'https://mysite.dev/',
+		});
+		await fixture.build();
+	});
+
+	it('includes index page', async () => {
+		let html = await fixture.readFile('/index.html');
+		let $ = cheerio.load(html);
+		expect($('h1').text()).to.equal('Page 1');
+	});
+
+	it('includes paginated page', async () => {
+		let html = await fixture.readFile('/2/index.html');
+		let $ = cheerio.load(html);
+		expect($('h1').text()).to.equal('Page 2');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,7 +360,7 @@ importers:
       autoprefixer: 10.4.8_postcss@8.4.16
       canvas-confetti: 1.5.1
       postcss: 8.4.16
-      tailwindcss: 3.1.8_postcss@8.4.16
+      tailwindcss: 3.1.8
 
   examples/with-vite-plugin-pwa:
     specifiers:
@@ -369,7 +369,7 @@ importers:
       workbox-window: ^6.5.3
     devDependencies:
       astro: link:../../packages/astro
-      vite-plugin-pwa: 0.11.11_workbox-window@6.5.4
+      vite-plugin-pwa: 0.11.11
       workbox-window: 6.5.4
 
   examples/with-vitest:
@@ -1533,6 +1533,12 @@ importers:
       '@fontsource/montserrat': 4.5.11
       astro: link:../../..
 
+  packages/astro/test/fixtures/get-static-paths-pages:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/glob-pages-css:
     specifiers:
       astro: workspace:*
@@ -2024,7 +2030,7 @@ importers:
       astro: link:../../..
       autoprefixer: 10.4.8_postcss@8.4.16
       postcss: 8.4.16
-      tailwindcss: 3.1.8_postcss@8.4.16
+      tailwindcss: 3.1.8
 
   packages/astro/test/fixtures/type-imports:
     specifiers:
@@ -2553,7 +2559,7 @@ importers:
       '@proload/core': 0.3.2
       autoprefixer: 10.4.8_postcss@8.4.16
       postcss: 8.4.16
-      tailwindcss: 3.1.8_postcss@8.4.16
+      tailwindcss: 3.1.8
     devDependencies:
       astro: link:../../astro
       astro-scripts: link:../../../scripts
@@ -15880,12 +15886,10 @@ packages:
       tslib: 2.4.0
     dev: true
 
-  /tailwindcss/3.1.8_postcss@8.4.16:
+  /tailwindcss/3.1.8:
     resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
     engines: {node: '>=12.13.0'}
     hasBin: true
-    peerDependencies:
-      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -16635,11 +16639,10 @@ packages:
       magic-string: 0.26.2
     dev: true
 
-  /vite-plugin-pwa/0.11.11_workbox-window@6.5.4:
+  /vite-plugin-pwa/0.11.11:
     resolution: {integrity: sha512-/nSLS7VfGN5UrL4a1ALGEQAyga/H0hYZjEkwPehiEFW1PM1DTi1A8GkPCsmevKwR6vt10P+5wS1wrvSgwQemzw==}
     peerDependencies:
       vite: ^2.0.0
-      workbox-window: ^6.4.0
     peerDependenciesMeta:
       vite:
         optional: true


### PR DESCRIPTION
## Changes

- In 1.0 there isn't an automatic trailingSlash added for pages. A check expecting there to never ben an empty string for a generated route is now wrong. This removes it.
- Closes https://github.com/withastro/astro/issues/4306

## Testing

- New test case added

## Docs

N/A, bug fix.