### PR TITLE
fix (core): allow falsy values in astro config integrations arrays

### DIFF
--- a/.changeset/eleven-shoes-lie.md
+++ b/.changeset/eleven-shoes-lie.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix config types to allow falsy values in integrations list, to match docs

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -679,7 +679,9 @@ export interface AstroUserConfig {
 	 * }
 	 * ```
 	 */
-	integrations?: Array<AstroIntegration | AstroIntegration[]>;
+	integrations?: Array<
+		AstroIntegration | (AstroIntegration | false | undefined | null)[] | false | undefined | null
+	>;
 
 	/**
 	 * @docs


### PR DESCRIPTION
## Changes

TL;DR: this updates the astro config type to allow falsy values in the `integrations` array, which the docs indicate should be possible. Related: https://github.com/withastro/docs/issues/1334

---

The [docs state](https://docs.astro.build/en/guides/integrations-guide/#toggle-an-integration):

> Falsy integrations are ignored, so you can toggle integrations on & off without worrying about left-behind undefined and boolean values.
> ```
> integrations: [
>   // Example: Skip building a sitemap on Windows
>   process.platform !== 'win32' && sitemap()
> ]
> ```

However, Typescript will generate the following error if you try to do this:

```
Type 'false | AstroIntegration' is not assignable to type 'AstroIntegration | AstroIntegration[]'.
```

In this particular change, I've chosen a nullish interpretation of "falsy" allowing `false`, `null`, and `undefined`. I'm happy to update to a more conservative `false` only solution, which might read more cleanly.

Based on the schema in https://github.com/withastro/astro/blob/main/packages/astro/src/core/config.ts#L139, I believe this is a safe change, as the looser type will still conform to the validation format due to the `filter(Boolean)` preprocessing.

I'm in a bit over my head with the contribution formula here, so holler at me if I've done something wrong or there's a better way to handle this.

## Testing

Tests are not included because I couldn't get them to fully run locally with a fresh install prior to making this change. I'm hoping the PR checks will run the appropriate checks, at which point I'll update.

## Docs

There are no changes to the docs, as this change brings the codebase inline with what the docs already state.