### PR TITLE
Improve MDX glob perf - move Layout to async import

### DIFF
--- a/.changeset/kind-onions-reply.md
+++ b/.changeset/kind-onions-reply.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Fix dev server reload performance when globbing from an MDX layout

--- a/packages/integrations/mdx/src/astro-data-utils.ts
+++ b/packages/integrations/mdx/src/astro-data-utils.ts
@@ -20,6 +20,10 @@ export function rehypeApplyFrontmatterExport(pageFrontmatter: Record<string, any
 			jsToTreeNode(`export const ${EXPORT_NAME} = ${JSON.stringify(frontmatter)};`),
 		];
 		if (frontmatter.layout) {
+			// NOTE(bholmesdev) 08-22-2022
+			// Using an async layout import (i.e. `const Layout = (await import...)`)
+			// Preserves the dev server import cache when globbing a large set of MDX files
+			// Full explanation: 'https://github.com/withastro/astro/pull/4428'
 			exportNodes.unshift(
 				jsToTreeNode(
 					/** @see 'vite-plugin-markdown' for layout props reference */

--- a/packages/integrations/mdx/src/astro-data-utils.ts
+++ b/packages/integrations/mdx/src/astro-data-utils.ts
@@ -24,9 +24,9 @@ export function rehypeApplyFrontmatterExport(pageFrontmatter: Record<string, any
 				jsToTreeNode(
 					/** @see 'vite-plugin-markdown' for layout props reference */
 					`import { jsx as layoutJsx } from 'astro/jsx-runtime';
-				import Layout from ${JSON.stringify(frontmatter.layout)};
 				
-				export default function ({ children }) {
+				export default async function ({ children }) {
+					const Layout = (await import(${JSON.stringify(frontmatter.layout)})).default;
 					const { layout, ...content } = frontmatter;
 					content.file = file;
 					content.url = url;


### PR DESCRIPTION
## Changes

- Resolves #4307 
- Moves frontmatter layout import to an `async` import

### Wait, why an `async` import?

We found some interesting `import.meta.glob` behavior in the dev server after #4255 was introduced.

**Scenario:** a directory of MDX files use the same `layout` in their frontmatter. This layout **includes an `Astro.glob` call for that same directory of MDX files.** This is common when generating a "what to read next" section, navigation, etc.
- **Before:** When editing a single MDX file imported by the layout glob, **only that file is re-transformed by Vite.** All other globbed files will come from cache. This means near-instant dev server feedback (ignoring initial startup time).
- **After:** When editing a single MDX file imported by the layout glob, **all globbed files are re-transformed by Vite.** This could mean a 5-10 sec delay for every change in a project with 200ish MDX files.

I discovered that moving the frontmatter layout from an asynchronous import to a synchronous one introduced this issue. Recursion is to blame here: layout -> glob -> posts, which import -> layout -> glob -> posts, which import -> layout -> glob...

## Testing

N/A

## Docs

N/A