### PR TITLE
Fix `astro add @example-org/integration`

### DIFF
--- a/.changeset/loud-eagles-do.md
+++ b/.changeset/loud-eagles-do.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+astro add - Fix third-party npm orgs, i.e. `@example/integration`


### PR DESCRIPTION
## Changes

- Resolves #4420
- Correctly set integration to "third party" for unofficial integrations
- Remove duplicate `@` prepended to third part org scope

## Testing

N/A

## Docs

N/A