### PR TITLE
Add template tsconfigs for users to extend from

### DIFF
--- a/.changeset/healthy-kangaroos-smoke.md
+++ b/.changeset/healthy-kangaroos-smoke.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'create-astro': patch
+---
+
+Add tsconfig templates for users to extend from

--- a/examples/basics/tsconfig.json
+++ b/examples/basics/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/blog/tsconfig.json
+++ b/examples/blog/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/docs/tsconfig.json
+++ b/examples/docs/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/env-vars/tsconfig.json
+++ b/examples/env-vars/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/framework-alpine/tsconfig.json
+++ b/examples/framework-alpine/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/framework-lit/tsconfig.json
+++ b/examples/framework-lit/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/framework-multiple/tsconfig.json
+++ b/examples/framework-multiple/tsconfig.json
@@ -1,17 +1,7 @@
 {
+  "extends": "astro/tsconfigs/base",
   "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
     // Needed for TypeScript intellisense in the template inside Vue files
-    "jsx": "preserve",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
+    "jsx": "preserve"
   }
 }

--- a/examples/framework-preact/tsconfig.json
+++ b/examples/framework-preact/tsconfig.json
@@ -1,18 +1,8 @@
 {
+  "extends": "astro/tsconfigs/base",
   "compilerOptions": {
     // Preact specific settings
     "jsx": "react-jsx",
-    "jsxImportSource": "preact",
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
+    "jsxImportSource": "preact"
   }
 }

--- a/examples/framework-react/tsconfig.json
+++ b/examples/framework-react/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/framework-solid/tsconfig.json
+++ b/examples/framework-solid/tsconfig.json
@@ -1,18 +1,8 @@
 {
+  "extends": "astro/tsconfigs/base",
   "compilerOptions": {
     // Solid specific settings
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
   }
 }

--- a/examples/framework-svelte/tsconfig.json
+++ b/examples/framework-svelte/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/framework-vue/tsconfig.json
+++ b/examples/framework-vue/tsconfig.json
@@ -1,17 +1,7 @@
 {
+  "extends": "astro/tsconfigs/base",
   "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
     // Needed for TypeScript intellisense in the template inside Vue files
-    "jsx": "preserve",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
+    "jsx": "preserve"
   }
 }

--- a/examples/minimal/tsconfig.json
+++ b/examples/minimal/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/non-html-pages/tsconfig.json
+++ b/examples/non-html-pages/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/portfolio/tsconfig.json
+++ b/examples/portfolio/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/ssr/tsconfig.json
+++ b/examples/ssr/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/subpath/tsconfig.json
+++ b/examples/subpath/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/with-markdown-plugins/tsconfig.json
+++ b/examples/with-markdown-plugins/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/with-markdown-shiki/tsconfig.json
+++ b/examples/with-markdown-shiki/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/with-mdx/tsconfig.json
+++ b/examples/with-mdx/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/with-nanostores/tsconfig.json
+++ b/examples/with-nanostores/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/with-tailwindcss/tsconfig.json
+++ b/examples/with-tailwindcss/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/with-vite-plugin-pwa/tsconfig.json
+++ b/examples/with-vite-plugin-pwa/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/examples/with-vitest/astro.config.ts
+++ b/examples/with-vitest/astro.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
-export default defineConfig();
+export default defineConfig({});

--- a/examples/with-vitest/tsconfig.json
+++ b/examples/with-vitest/tsconfig.json
@@ -1,18 +1,3 @@
 {
-  "compilerOptions": {
-    // Preact specific settings
-    "jsx": "react-jsx",
-    "jsxImportSource": "preact",
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Add type definitions for our Astro runtime.
-    "types": ["astro/client"]
-  }
+  "extends": "astro/tsconfigs/base"
 }

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -29,6 +29,8 @@
     "./client": "./client.d.ts",
     "./client-base": "./client-base.d.ts",
     "./astro-jsx": "./astro-jsx.d.ts",
+    "./tsconfigs/*.json": "./tsconfigs/*",
+    "./tsconfigs/*": "./tsconfigs/*.json",
     "./jsx/*": "./dist/jsx/*",
     "./jsx-runtime": "./dist/jsx-runtime/index.js",
     "./config": "./config.mjs",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -62,6 +62,7 @@
   },
   "files": [
     "components",
+    "tsconfigs",
     "dist",
     "astro.js",
     "config.d.ts",

--- a/packages/astro/tsconfigs/base.json
+++ b/packages/astro/tsconfigs/base.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     // Enable top-level await, and other modern ESM features.
     "target": "ESNext",
@@ -9,11 +10,11 @@
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
+    // Astro directly run TypeScript code, no transpilation needed.
     "noEmit": true,
-    // Enable strict type checking.
-    "strict": true,
-    // Error when a value import is only used as a type.
-    "importsNotUsedAsValues": "error"
+    // Report an error when importing a file using a casing different from the casing on disk.
+    "forceConsistentCasingInFileNames": true,
+    // Properly support importing CJS modules in ESM
+    "esModuleInterop": true
   }
 }

--- a/packages/astro/tsconfigs/strict.json
+++ b/packages/astro/tsconfigs/strict.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "strict": true,
+    // Error when a value import is only used as a type.
+    "importsNotUsedAsValues": "error"
+  }
+}

--- a/packages/astro/tsconfigs/strictest.json
+++ b/packages/astro/tsconfigs/strictest.json
@@ -1,20 +1,7 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./strict.json",
   "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
-    "target": "ESNext",
-    "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
-    // Enable JSON imports.
-    "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
-    // Astro will directly run your TypeScript code, no transpilation needed.
-    "noEmit": true,
-    // Enable strict type checking.
-    "strict": true,
-    // Error when a value import is only used as a type.
-    "importsNotUsedAsValues": "error",
     // Report errors for fallthrough cases in switch statements
     "noFallthroughCasesInSwitch": true,
     // Force functions designed to override their parent class to be specified as `override`.
@@ -28,6 +15,10 @@
     // Force the usage of the indexed syntax to access fields declared using an index signature.
     "noUncheckedIndexedAccess": true,
     // Report an error when the value `undefined` is given to an optional property that doesn't specify `undefined` as a valid value.
-    "exactOptionalPropertyTypes": true
+    "exactOptionalPropertyTypes": true,
+    // Report an error for unreachable code instead of just a warning.
+    "allowUnreachableCode": false,
+    // Report an error for unused labels instead of just a warning.
+    "allowUnusedLabels": false
   }
 }

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -30,6 +30,7 @@
   ],
   "dependencies": {
     "chalk": "^5.0.1",
+    "comment-json": "^4.2.3",
     "degit": "^2.8.4",
     "execa": "^6.1.0",
     "kleur": "^4.1.4",

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -1,4 +1,5 @@
 /* eslint no-console: 'off' */
+import { assign, parse, stringify } from 'comment-json';
 import degit from 'degit';
 import { execa, execaCommand } from 'execa';
 import fs from 'fs';
@@ -7,7 +8,6 @@ import ora from 'ora';
 import os from 'os';
 import path from 'path';
 import prompts from 'prompts';
-import url from 'url';
 import detectPackageManager from 'which-pm-runs';
 import yargs from 'yargs-parser';
 import { loadWithRocketGradient, rocketAscii } from './gradient.js';
@@ -117,6 +117,7 @@ export async function main() {
 	const hash = args.commit ? `#${args.commit}` : '';
 
 	// Don't touch the template name if a GitHub repo was provided, ex: `--template cassidoo/shopify-react-astro`
+	const isThirdParty = options.template.includes('/');
 	const templateTarget = options.template.includes('/')
 		? options.template
 		: `withastro/astro/examples/${options.template}#latest`;
@@ -308,7 +309,7 @@ export async function main() {
 				{
 					title: 'Strictest',
 					description: 'Enable all typechecking rules',
-					value: 'stricter',
+					value: 'strictest',
 				},
 				{
 					title: 'I prefer not to use TypeScript',
@@ -335,7 +336,7 @@ export async function main() {
 		console.log(`  Astro supports TypeScript inside of ".astro" component scripts, so`);
 		console.log(`  we still need to create some TypeScript-related files in your project.`);
 		console.log(`  You can safely ignore these files, but don't delete them!`);
-		console.log(dim('  (ex: tsconfig.json, src/types.d.ts)'));
+		console.log(dim('  (ex: tsconfig.json, src/env.d.ts)'));
 		console.log(``);
 		tsResponse.typescript = 'default';
 		await wait(300);
@@ -344,14 +345,35 @@ export async function main() {
 		ora().info(dim(`--dry-run enabled, skipping.`));
 	} else if (tsResponse.typescript) {
 		if (tsResponse.typescript !== 'default') {
-			fs.copyFileSync(
-				path.join(
-					url.fileURLToPath(new URL('..', import.meta.url)),
-					'tsconfigs',
-					`tsconfig.${tsResponse.typescript}.json`
-				),
-				path.join(cwd, 'tsconfig.json')
-			);
+			const templateTSConfigPath = path.join(cwd, 'tsconfig.json');
+			fs.readFile(templateTSConfigPath, (err, data) => {
+				if (err && err.code === 'ENOENT') {
+					// If the template doesn't have a tsconfig.json, let's add one instead
+					fs.writeFileSync(
+						templateTSConfigPath,
+						stringify({ extends: `astro/tsconfigs/${tsResponse.typescript}` }, null, 2)
+					);
+
+					return;
+				}
+
+				const templateTSConfig = parse(data.toString());
+
+				if (templateTSConfig && typeof templateTSConfig === 'object') {
+					const result = assign(
+						{ extends: `astro/tsconfigs/${tsResponse.typescript}` },
+						templateTSConfig
+					);
+
+					fs.writeFileSync(templateTSConfigPath, stringify(result, null, 2));
+				} else {
+					console.log(
+						yellow(
+							"There was an error applying the requested TypeScript settings. This could be because the template's tsconfig.json is malformed"
+						)
+					);
+				}
+			});
 		}
 		ora().succeed('TypeScript settings applied!');
 	}

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -360,10 +360,9 @@ export async function main() {
 				const templateTSConfig = parse(data.toString());
 
 				if (templateTSConfig && typeof templateTSConfig === 'object') {
-					const result = assign(
-						{ extends: `astro/tsconfigs/${tsResponse.typescript}` },
-						templateTSConfig
-					);
+					const result = assign(templateTSConfig, {
+						extends: `astro/tsconfigs/${tsResponse.typescript}`,
+					});
 
 					fs.writeFileSync(templateTSConfigPath, stringify(result, null, 2));
 				} else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2082,6 +2082,7 @@ importers:
       astro-scripts: workspace:*
       chai: ^4.3.6
       chalk: ^5.0.1
+      comment-json: ^4.2.3
       degit: ^2.8.4
       execa: ^6.1.0
       kleur: ^4.1.4
@@ -2093,6 +2094,7 @@ importers:
       yargs-parser: ^21.0.1
     dependencies:
       chalk: 5.0.1
+      comment-json: 4.2.3
       degit: 2.8.4
       execa: 6.1.0
       kleur: 4.1.5
@@ -9423,6 +9425,10 @@ packages:
     resolution: {integrity: sha512-sNRaPGh9nnmdC8Zf+pT3UqP8rnWj5Hf9wiFGsX3wUQ2yVSIhO2ShFwCoceIPpB41QF6i2OEmrHmCo36xronCVA==}
     dev: false
 
+  /array-timsort/1.0.3:
+    resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
+    dev: false
+
   /array-union/2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
@@ -9993,6 +9999,17 @@ packages:
   /commander/2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
+
+  /comment-json/4.2.3:
+    resolution: {integrity: sha512-SsxdiOf064DWoZLH799Ata6u7iV658A11PlWtZATDlXPpKGJnbJZ5Z24ybixAi+LUUqJ/GKowAejtC5GFUG7Tw==}
+    engines: {node: '>= 6'}
+    dependencies:
+      array-timsort: 1.0.3
+      core-util-is: 1.0.3
+      esprima: 4.0.1
+      has-own-prop: 2.0.0
+      repeat-string: 1.6.1
+    dev: false
 
   /common-ancestor-path/1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
@@ -11719,6 +11736,11 @@ packages:
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  /has-own-prop/2.0.0:
+    resolution: {integrity: sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==}
+    engines: {node: '>=8'}
+    dev: false
 
   /has-package-exports/1.3.0:
     resolution: {integrity: sha512-e9OeXPQnmPhYoJ63lXC4wWe34TxEGZDZ3OQX9XRqp2VwsfLl3bQBy7VehLnd34g3ef8CmYlBLGqEMKXuz8YazQ==}
@@ -15074,6 +15096,11 @@ packages:
       mdast-util-toc: 6.1.0
       unified: 10.1.2
     dev: true
+
+  /repeat-string/1.6.1:
+    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
+    engines: {node: '>=0.10'}
+    dev: false
 
   /require-directory/2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}


### PR DESCRIPTION
## Changes

This adds tsconfig templates that users can extend from and update our templates and create-astro to use them. The benefits of having those templates is that it's neater, convenient for users to build from and that we can update them between versions of Astro without needing any users interaction (ex: adding new TypeScript settings, setting up aliases etc)

This also severely reduce the maintenance cost of our templates since we don't have to update all the tsconfig.json manually anymore

Fix https://github.com/withastro/astro/issues/4297 at the same time

## Testing

Tested manually

## Docs

N/A