### PR TITLE
Allow string as a valid value for the target attribute

### DIFF
--- a/.changeset/nice-mice-teach.md
+++ b/.changeset/nice-mice-teach.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow arbitrary strings on the target attribute

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -548,7 +548,7 @@ declare namespace astroHTML.JSX {
 		| 'strict-origin-when-cross-origin'
 		| 'unsafe-url';
 
-	type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top';
+	type HTMLAttributeAnchorTarget = '_self' | '_blank' | '_parent' | '_top' | (string & {});
 
 	interface AnchorHTMLAttributes extends HTMLAttributes {
 		download?: string | boolean | undefined | null;
@@ -756,7 +756,7 @@ declare namespace astroHTML.JSX {
 		size?: number | string | undefined | null;
 		src?: string | undefined | null;
 		step?: number | string | undefined | null;
-		type?: HTMLInputTypeAttribute | string | undefined | null;
+		type?: HTMLInputTypeAttribute | undefined | null;
 		value?: string | string[] | number | undefined | null;
 		width?: number | string | undefined | null;
 	}


### PR DESCRIPTION
## Changes

Small fix to our JSX definition to allow strings on the target attribute. Also disallow strings on the `type` attribute on input as it's an enumerable attribute

## Testing

Tested manually

## Docs

N/A