### PR TITLE
feat: add screenshots to official theme readme files

### DIFF
--- a/examples/basics/README.md
+++ b/examples/basics/README.md
@@ -4,6 +4,9 @@
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 
+![basics](https://user-images.githubusercontent.com/4677417/186188965-73453154-fdec-4d6b-9c34-cb35c248ae5b.png)
+
+
 ## 🚀 Project Structure
 
 Inside of your Astro project, you'll see the following folders and files:

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -8,6 +8,9 @@ npm init astro -- --template blog
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 
+
+![blog](https://user-images.githubusercontent.com/4677417/186189140-4ef17aac-c3c9-4918-a8c2-ce86ba1bb394.png)
+
 Features:
 
 - ✅ Minimal styling (make it your own!)

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -6,6 +6,9 @@ npm init astro -- --template docs
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/docs)
 
+![docs](https://user-images.githubusercontent.com/4677417/186189283-0831b9ab-d6b9-485d-8955-3057e532ab31.png)
+
+
 ## Features
 
 - ✅ **Full Markdown support**

--- a/examples/portfolio/README.md
+++ b/examples/portfolio/README.md
@@ -8,6 +8,9 @@ npm init astro -- --template portfolio
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 
+![portfolio](https://user-images.githubusercontent.com/4677417/186189473-03dda103-65d3-4220-8b60-180ccaee5939.png)
+
+
 ## 🧞 Commands
 
 All commands are run from the root of the project, from a terminal:


### PR DESCRIPTION
## Changes

- The screenshots on https://astro.build/themes/official/ are really small -> Users might click on the GitHub link to see the theme in more detail
- Firing up Stackblitz for a visual inspection is a very high bar, many people will bail before this
- I've added screenshots to all "official" examples
