### PR TITLE
Fix incorrect css test

### DIFF
--- a/.changeset/odd-oranges-laugh.md
+++ b/.changeset/odd-oranges-laugh.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Bump @astrojs/compiler dependency

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -86,7 +86,7 @@
     "test:e2e:match": "playwright test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.23.3",
+    "@astrojs/compiler": "^0.23.4",
     "@astrojs/language-server": "^0.20.0",
     "@astrojs/markdown-remark": "^1.0.0",
     "@astrojs/telemetry": "^1.0.0",

--- a/packages/astro/test/0-css.test.js
+++ b/packages/astro/test/0-css.test.js
@@ -46,7 +46,7 @@ describe('CSS', function () {
 				expect(el2.attr('class')).to.equal(`visible ${scopedClass}`);
 
 				// 2. check CSS
-				const expected = `.blue:where(.${scopedClass}){color:#b0e0e6}.color\\\\:blue:where(.${scopedClass}){color:#b0e0e6}.visible:where(.${scopedClass}){display:block}`;
+				const expected = `.blue:where(.${scopedClass}){color:#b0e0e6}.color\\:blue:where(.${scopedClass}){color:#b0e0e6}.visible:where(.${scopedClass}){display:block}`;
 				expect(bundledCSS).to.include(expected);
 			});
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,7 +383,7 @@ importers:
 
   packages/astro:
     specifiers:
-      '@astrojs/compiler': ^0.23.3
+      '@astrojs/compiler': ^0.23.4
       '@astrojs/language-server': ^0.20.0
       '@astrojs/markdown-remark': ^1.0.0
       '@astrojs/telemetry': ^1.0.0
@@ -466,7 +466,7 @@ importers:
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
-      '@astrojs/compiler': 0.23.3
+      '@astrojs/compiler': 0.23.4
       '@astrojs/language-server': 0.20.3
       '@astrojs/markdown-remark': link:../markdown/remark
       '@astrojs/telemetry': link:../telemetry
@@ -3148,8 +3148,8 @@ packages:
     resolution: {integrity: sha512-8nvyxZTfCXLyRmYfTttpJT6EPhfBRg0/q4J/Jj3/pNPLzp+vs05ZdktsY6QxAREaOMAnNEtSqcrB4S5DsXOfRg==}
     dev: true
 
-  /@astrojs/compiler/0.23.3:
-    resolution: {integrity: sha512-eBWo0d3DoRDeg2Di1/5YJtOXh5eGFSjJMp1wVoVfoITHR4egdUGgsrDHZTzj0a25M/S9W5S6SpXCyNWcqi8jOA==}
+  /@astrojs/compiler/0.23.4:
+    resolution: {integrity: sha512-vNZIa5Tf5nOqBEGJvM6xyYBnGcz4MAp+bBPnyVI0UYRjsIWlP7RgMdCpRV0OOh5kgh00BoAypGv27kcoJCMVfA==}
     dev: false
 
   /@astrojs/language-server/0.20.3:


### PR DESCRIPTION
## Changes

Fix an incorrect test for `\` escaping. Context: https://github.com/withastro/compiler/pull/503#issuecomment-1219201138

Also bump `@astrojs/compiler`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A