### PR TITLE
Support `vite.build.cssCodeSplit: false` option

### DIFF
--- a/.changeset/sour-avocados-exercise.md
+++ b/.changeset/sour-avocados-exercise.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Support `vite.build.cssCodeSplit: false` option

--- a/packages/astro/test/css-no-code-split.test.js
+++ b/packages/astro/test/css-no-code-split.test.js
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('vite.build.cssCodeSplit: false', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/css-no-code-split/' });
+		await fixture.build();
+	});
+
+	it('loads styles correctly', async () => {
+		let html = await fixture.readFile('/index.html');
+		let $ = cheerio.load(html);
+		const cssHref = $('link[rel=stylesheet][href^=/assets/]').attr('href');
+		expect(cssHref).to.match(/\/assets\/style\..*?\.css/);
+	});
+});

--- a/packages/astro/test/fixtures/css-no-code-split/astro.config.mjs
+++ b/packages/astro/test/fixtures/css-no-code-split/astro.config.mjs
@@ -1,0 +1,11 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+    vite: {
+        build: {
+            cssCodeSplit: false,
+        },
+    },
+});
+

--- a/packages/astro/test/fixtures/css-no-code-split/package.json
+++ b/packages/astro/test/fixtures/css-no-code-split/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/css-no-code-split",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/css-no-code-split/src/pages/index.astro
+++ b/packages/astro/test/fixtures/css-no-code-split/src/pages/index.astro
@@ -1,0 +1,13 @@
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <h1>css no code split</h1>
+    <style>
+      h1 {
+        color: red;
+      }
+    </style>
+  </body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,7 +361,7 @@ importers:
       autoprefixer: 10.4.8_postcss@8.4.16
       canvas-confetti: 1.5.1
       postcss: 8.4.16
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.16
 
   examples/with-vite-plugin-pwa:
     specifiers:
@@ -370,7 +370,7 @@ importers:
       workbox-window: ^6.5.3
     devDependencies:
       astro: link:../../packages/astro
-      vite-plugin-pwa: 0.11.11
+      vite-plugin-pwa: 0.11.11_workbox-window@6.5.4
       workbox-window: 6.5.4
 
   examples/with-vitest:
@@ -1469,6 +1469,12 @@ importers:
   packages/astro/test/fixtures/css-assets/packages/font-awesome:
     specifiers: {}
 
+  packages/astro/test/fixtures/css-no-code-split:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/css-order:
     specifiers:
       astro: workspace:*
@@ -2045,7 +2051,7 @@ importers:
       astro: link:../../..
       autoprefixer: 10.4.8_postcss@8.4.16
       postcss: 8.4.16
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.16
 
   packages/astro/test/fixtures/type-imports:
     specifiers:
@@ -2584,7 +2590,7 @@ importers:
       '@proload/core': 0.3.2
       autoprefixer: 10.4.8_postcss@8.4.16
       postcss: 8.4.16
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.16
     devDependencies:
       astro: link:../../astro
       astro-scripts: link:../../../scripts
@@ -15959,10 +15965,12 @@ packages:
       tslib: 2.4.0
     dev: true
 
-  /tailwindcss/3.1.8:
+  /tailwindcss/3.1.8_postcss@8.4.16:
     resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -16712,10 +16720,11 @@ packages:
       magic-string: 0.26.2
     dev: true
 
-  /vite-plugin-pwa/0.11.11:
+  /vite-plugin-pwa/0.11.11_workbox-window@6.5.4:
     resolution: {integrity: sha512-/nSLS7VfGN5UrL4a1ALGEQAyga/H0hYZjEkwPehiEFW1PM1DTi1A8GkPCsmevKwR6vt10P+5wS1wrvSgwQemzw==}
     peerDependencies:
       vite: ^2.0.0
+      workbox-window: ^6.4.0
     peerDependenciesMeta:
       vite:
         optional: true


### PR DESCRIPTION
## Changes

Fix #4413 

When `vite.build.cssCodeSplit: false`, the reference to the single `style.css` file generated by Vite doesn't exist in `chunk.viteMetadata.importedCss`, but only in the `bundle`. We simulate how Vite does it [here](https://github.com/vitejs/vite/blob/b2c0ee04d4db4a0ef5a084c50f49782c5f88587c/packages/vite/src/node/plugins/html.ts#L690-L705)
 
## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added css-no-code-split test

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A