### PR TITLE
Fix: ignore common dev-tool configs while initializing astro

### DIFF
--- a/.changeset/old-birds-float.md
+++ b/.changeset/old-birds-float.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+allow common dev-tools configs and directories while initializing astro in an empty folder

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -39,8 +39,37 @@ export function mkdirp(dir: string) {
 	}
 }
 
+//credits: https://github.com/vercel/next.js/blob/canary/packages/create-next-app/helpers/is-folder-empty.ts
 function isEmpty(dirPath: string) {
-	return !fs.existsSync(dirPath) || fs.readdirSync(dirPath).length === 0;
+	const validFiles = [
+		'.DS_Store',
+		'.git',
+		'.gitattributes',
+		'.gitignore',
+		'.gitlab-ci.yml',
+		'.hg',
+		'.hgcheck',
+		'.hgignore',
+		'.idea',
+		'.npmignore',
+		'.travis.yml',
+		'LICENSE',
+		'Thumbs.db',
+		'docs',
+		'mkdocs.yml',
+		'npm-debug.log',
+		'yarn-debug.log',
+		'yarn-error.log',
+		'yarnrc.yml',
+		'.yarn',
+	];
+	const conflicts = fs
+		.readdirSync(dirPath)
+		.filter((file) => !validFiles.includes(file))
+		// Support IntelliJ IDEA-based editors
+		.filter((file) => !/\.iml$/.test(file));
+
+	return !fs.existsSync(dirPath) || conflicts.length === 0;
 }
 
 const { version } = JSON.parse(


### PR DESCRIPTION
## Changes

fixes #3538 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->