### PR TITLE
Fix load `base` option in build

### DIFF
--- a/.changeset/gold-suns-repair.md
+++ b/.changeset/gold-suns-repair.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix load `base` option in build

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -160,6 +160,7 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 		],
 		publicDir: ssr ? false : viteConfig.publicDir,
 		envPrefix: 'PUBLIC_',
+		base: astroConfig.base,
 	};
 
 	await runHookBuildSetup({
@@ -230,6 +231,7 @@ async function clientBuild(
 			...(viteConfig.plugins || []),
 		],
 		envPrefix: 'PUBLIC_',
+		base: astroConfig.base,
 	} as ViteConfigWithSSR;
 
 	await runHookBuildSetup({


### PR DESCRIPTION
## Changes

Fix #4468

in #4344 , `base: astroConfig.base,` was deleted, but it was needed because it was NOT from `viteConfig`

## Testing

tested only locally
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

None
<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->