### PR TITLE
[MD] `extendDefaultPlugins` to preserve default remark plugins

### DIFF
--- a/.changeset/cool-turtles-lay.md
+++ b/.changeset/cool-turtles-lay.md
@@ -1,0 +1,6 @@
+---
+'astro': minor
+'@astrojs/markdown-remark': minor
+---
+
+Add "extends" to markdown plugin config to preserve Astro defaults

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -650,18 +650,7 @@ export interface AstroUserConfig {
 		 * @description
 		 * Pass [remark plugins](https://github.com/remarkjs/remark) to customize how your Markdown is built. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 		 *
-		 * We apply the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins by default. Use a nested "extends" object to preserve these defaults:
-		 *
-		 * ```js
-		 * import remarkToc from 'remark-toc';
-		 * {
-		 *   markdown: {
-		 *     remarkPlugins: { extends: [remarkToc] }
-		 *   }
-		 * }
-		 * ```
-		 *
-		 * Or pass a top-level array to **remove** these defaults:
+		 * Note: Providing a list of plugins will **remove** our default plugins. To preserve these defaults, see the `extendDefaultPlugins` flag.
 		 *
 		 * ```js
 		 * import remarkToc from 'remark-toc';
@@ -680,18 +669,7 @@ export interface AstroUserConfig {
 		 * @description
 		 * Pass [rehype plugins](https://github.com/remarkjs/remark-rehype) to customize how your Markdown's output HTML is processed. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 		 *
-		 * We apply the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins by default. Use a nested "extends" object to preserve these defaults:
-		 *
-		 * ```js
-		 * import rehypeMinifyHtml from 'rehype-minify';
-		 * {
-		 *   markdown: {
-		 *     rehypePlugins: { extends: [rehypeMinifyHtml] }
-		 *   }
-		 * }
-		 * ```
-		 *
-		 * Or pass a top-level array to **remove** these defaults:
+		 * Note: Providing a list of plugins will **remove** our default plugins. To preserve these defaults, see the `extendDefaultPlugins` flag.
 		 *
 		 * ```js
 		 * import rehypeMinifyHtml from 'rehype-minify';
@@ -703,6 +681,25 @@ export interface AstroUserConfig {
 		 * ```
 		 */
 		rehypePlugins?: RehypePlugins;
+		/**
+		 * @docs
+		 * @name markdown.extendDefaultPlugins
+		 * @type {boolean}
+		 * @default false
+		 * @description
+		 * We apply the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins by default. When adding your own remark or rehype plugins, you can preserve these defaults by setting the `extendDefaultPlugins` flag to `true`:
+		 *
+		 * ```js
+		 * {
+		 *   markdown: {
+		 *     extendDefaultPlugins: true,
+		 * 		 remarkPlugins: [exampleRemarkPlugin],
+		 *     rehypePlugins: [exampleRehypePlugin],
+		 *   }
+		 * }
+		 * ```
+		 */
+		extendDefaultPlugins?: boolean;
 		/**
 		 * @docs
 		 * @name markdown.remarkRehype

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -648,17 +648,28 @@ export interface AstroUserConfig {
 		 * @name markdown.remarkPlugins
 		 * @type {RemarkPlugins}
 		 * @description
-		 * Pass a custom [Remark](https://github.com/remarkjs/remark) plugin to customize how your Markdown is built.
+		 * Pass [remark plugins](https://github.com/remarkjs/remark) to customize how your Markdown is built. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 		 *
-		 * **Note:** Enabling custom `remarkPlugins` or `rehypePlugins` removes Astro's built-in support for [GitHub-flavored Markdown](https://github.github.com/gfm/) support and [Smartypants](https://github.com/silvenon/remark-smartypants). You must explicitly add these plugins to your `astro.config.mjs` file, if desired.
+		 * We apply the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins by default. Use a nested "extends" object to preserve these defaults:
 		 *
 		 * ```js
+		 * import remarkToc from 'remark-toc';
 		 * {
 		 *   markdown: {
-		 *     // Example: The default set of remark plugins used by Astro
-		 *     remarkPlugins: ['remark-gfm', 'remark-smartypants'],
-		 *   },
-		 * };
+		 *     remarkPlugins: { extends: [remarkToc] }
+		 *   }
+		 * }
+		 * ```
+		 *
+		 * Or pass a top-level array to **remove** these defaults:
+		 *
+		 * ```js
+		 * import remarkToc from 'remark-toc';
+		 * {
+		 *   markdown: {
+		 *     remarkPlugins: [remarkToc]
+		 *   }
+		 * }
 		 * ```
 		 */
 		remarkPlugins?: RemarkPlugins;
@@ -667,17 +678,28 @@ export interface AstroUserConfig {
 		 * @name markdown.rehypePlugins
 		 * @type {RehypePlugins}
 		 * @description
-		 * Pass a custom [Rehype](https://github.com/remarkjs/remark-rehype) plugin to customize how your Markdown is built.
+		 * Pass [rehype plugins](https://github.com/remarkjs/remark-rehype) to customize how your Markdown's output HTML is processed. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 		 *
-		 * **Note:** Enabling custom `remarkPlugins` or `rehypePlugins` removes Astro's built-in support for [GitHub-flavored Markdown](https://github.github.com/gfm/) support and [Smartypants](https://github.com/silvenon/remark-smartypants). You must explicitly add these plugins to your `astro.config.mjs` file, if desired.
+		 * We apply the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins by default. Use a nested "extends" object to preserve these defaults:
 		 *
 		 * ```js
+		 * import rehypeMinifyHtml from 'rehype-minify';
 		 * {
 		 *   markdown: {
-		 *     // Example: The default set of rehype plugins used by Astro
-		 *     rehypePlugins: [],
-		 *   },
-		 * };
+		 *     rehypePlugins: { extends: [rehypeMinifyHtml] }
+		 *   }
+		 * }
+		 * ```
+		 *
+		 * Or pass a top-level array to **remove** these defaults:
+		 *
+		 * ```js
+		 * import rehypeMinifyHtml from 'rehype-minify';
+		 * {
+		 *   markdown: {
+		 *     rehypePlugins: [rehypeMinifyHtml]
+		 *   }
+		 * }
 		 * ```
 		 */
 		rehypePlugins?: RehypePlugins;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -650,7 +650,9 @@ export interface AstroUserConfig {
 		 * @description
 		 * Pass [remark plugins](https://github.com/remarkjs/remark) to customize how your Markdown is built. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 		 *
-		 * Note: Providing a list of plugins will **remove** our default plugins. To preserve these defaults, see the `extendDefaultPlugins` flag.
+		 * :::caution 
+		 * Providing a list of plugins will **remove** our default plugins. To preserve these defaults, see the `extendDefaultPlugins` flag.
+		 * :::
 		 *
 		 * ```js
 		 * import remarkToc from 'remark-toc';
@@ -669,7 +671,7 @@ export interface AstroUserConfig {
 		 * @description
 		 * Pass [rehype plugins](https://github.com/remarkjs/remark-rehype) to customize how your Markdown's output HTML is processed. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 		 *
-		 * :::note 
+		 * :::caution 
 		 * Providing a list of plugins will **remove** our default plugins. To preserve these defaults, see the `extendDefaultPlugins` flag.
 		 * :::
 		 *
@@ -707,7 +709,7 @@ export interface AstroUserConfig {
 		 * @name markdown.remarkRehype
 		 * @type {RemarkRehype}
 		 * @description
-		 * Pass options to [remark-rehype](https://github.com/remarkjs/remark-rehype#api) .
+		 * Pass options to [remark-rehype](https://github.com/remarkjs/remark-rehype#api).
 		 *
 		 * ```js
 		 * {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -669,7 +669,9 @@ export interface AstroUserConfig {
 		 * @description
 		 * Pass [rehype plugins](https://github.com/remarkjs/remark-rehype) to customize how your Markdown's output HTML is processed. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 		 *
-		 * Note: Providing a list of plugins will **remove** our default plugins. To preserve these defaults, see the `extendDefaultPlugins` flag.
+		 * :::note 
+		 * Providing a list of plugins will **remove** our default plugins. To preserve these defaults, see the `extendDefaultPlugins` flag.
+		 * :::
 		 *
 		 * ```js
 		 * import rehypeMinifyHtml from 'rehype-minify';

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -687,7 +687,7 @@ export interface AstroUserConfig {
 		 * @type {boolean}
 		 * @default false
 		 * @description
-		 * We apply the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins by default. When adding your own remark or rehype plugins, you can preserve these defaults by setting the `extendDefaultPlugins` flag to `true`:
+		 * Astro applies the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins by default. When adding your own remark or rehype plugins, you can preserve these defaults by setting the `extendDefaultPlugins` flag to `true`:
 		 *
 		 * ```js
 		 * {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -685,7 +685,7 @@ export interface AstroUserConfig {
 		 * @docs
 		 * @name markdown.extendDefaultPlugins
 		 * @type {boolean}
-		 * @default false
+		 * @default `false`
 		 * @description
 		 * Astro applies the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins by default. When adding your own remark or rehype plugins, you can preserve these defaults by setting the `extendDefaultPlugins` flag to `true`:
 		 *

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -219,6 +219,7 @@ export const AstroConfigSchema = z.object({
 				.custom<RemarkRehype>((data) => data instanceof Object && !Array.isArray(data))
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.markdown.remarkRehype),
+			extendDefaultPlugins: z.boolean().default(false),
 		})
 		.default({}),
 	vite: z

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -59,6 +59,24 @@ const ASTRO_CONFIG_DEFAULTS: AstroUserConfig & any = {
 	},
 };
 
+const remarkPluginSchema = z
+	.union([
+		z.string(),
+		z.tuple([z.string(), z.any()]),
+		z.custom<RemarkPlugin>((data) => typeof data === 'function'),
+		z.tuple([z.custom<RemarkPlugin>((data) => typeof data === 'function'), z.any()]),
+	])
+	.array();
+
+const rehypePluginSchema = z
+	.union([
+		z.string(),
+		z.tuple([z.string(), z.any()]),
+		z.custom<RehypePlugin>((data) => typeof data === 'function'),
+		z.tuple([z.custom<RehypePlugin>((data) => typeof data === 'function'), z.any()]),
+	])
+	.array();
+
 async function resolvePostcssConfig(inlineOptions: any, root: URL): Promise<PostCSSConfigResult> {
 	if (isObject(inlineOptions)) {
 		const options = { ...inlineOptions };
@@ -198,22 +216,10 @@ export const AstroConfigSchema = z.object({
 				})
 				.default({}),
 			remarkPlugins: z
-				.union([
-					z.string(),
-					z.tuple([z.string(), z.any()]),
-					z.custom<RemarkPlugin>((data) => typeof data === 'function'),
-					z.tuple([z.custom<RemarkPlugin>((data) => typeof data === 'function'), z.any()]),
-				])
-				.array()
+				.union([remarkPluginSchema, z.object({ extends: remarkPluginSchema })])
 				.default(ASTRO_CONFIG_DEFAULTS.markdown.remarkPlugins),
 			rehypePlugins: z
-				.union([
-					z.string(),
-					z.tuple([z.string(), z.any()]),
-					z.custom<RehypePlugin>((data) => typeof data === 'function'),
-					z.tuple([z.custom<RehypePlugin>((data) => typeof data === 'function'), z.any()]),
-				])
-				.array()
+				.union([rehypePluginSchema, z.object({ extends: rehypePluginSchema })])
 				.default(ASTRO_CONFIG_DEFAULTS.markdown.rehypePlugins),
 			remarkRehype: z
 				.custom<RemarkRehype>((data) => data instanceof Object && !Array.isArray(data))

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -59,24 +59,6 @@ const ASTRO_CONFIG_DEFAULTS: AstroUserConfig & any = {
 	},
 };
 
-const remarkPluginSchema = z
-	.union([
-		z.string(),
-		z.tuple([z.string(), z.any()]),
-		z.custom<RemarkPlugin>((data) => typeof data === 'function'),
-		z.tuple([z.custom<RemarkPlugin>((data) => typeof data === 'function'), z.any()]),
-	])
-	.array();
-
-const rehypePluginSchema = z
-	.union([
-		z.string(),
-		z.tuple([z.string(), z.any()]),
-		z.custom<RehypePlugin>((data) => typeof data === 'function'),
-		z.tuple([z.custom<RehypePlugin>((data) => typeof data === 'function'), z.any()]),
-	])
-	.array();
-
 async function resolvePostcssConfig(inlineOptions: any, root: URL): Promise<PostCSSConfigResult> {
 	if (isObject(inlineOptions)) {
 		const options = { ...inlineOptions };
@@ -216,10 +198,22 @@ export const AstroConfigSchema = z.object({
 				})
 				.default({}),
 			remarkPlugins: z
-				.union([remarkPluginSchema, z.object({ extends: remarkPluginSchema })])
+				.union([
+					z.string(),
+					z.tuple([z.string(), z.any()]),
+					z.custom<RemarkPlugin>((data) => typeof data === 'function'),
+					z.tuple([z.custom<RemarkPlugin>((data) => typeof data === 'function'), z.any()]),
+				])
+				.array()
 				.default(ASTRO_CONFIG_DEFAULTS.markdown.remarkPlugins),
 			rehypePlugins: z
-				.union([rehypePluginSchema, z.object({ extends: rehypePluginSchema })])
+				.union([
+					z.string(),
+					z.tuple([z.string(), z.any()]),
+					z.custom<RehypePlugin>((data) => typeof data === 'function'),
+					z.tuple([z.custom<RehypePlugin>((data) => typeof data === 'function'), z.any()]),
+				])
+				.array()
 				.default(ASTRO_CONFIG_DEFAULTS.markdown.rehypePlugins),
 			remarkRehype: z
 				.custom<RemarkRehype>((data) => data instanceof Object && !Array.isArray(data))

--- a/packages/astro/test/astro-markdown-plugins.test.js
+++ b/packages/astro/test/astro-markdown-plugins.test.js
@@ -43,47 +43,33 @@ describe('Astro Markdown plugins', () => {
 		expect($('#hello-world').hasClass('title')).to.equal(true);
 	});
 
-	it('Preserves default plugins with "extends"', async () => {
-		const fixture = await buildFixture({
-			markdown: {
-				remarkPlugins: {
-					extends: [remarkExamplePlugin],
+	for (const extendDefaultPlugins of [true, false]) {
+		it(`Handles default plugins when extendDefaultPlugins = ${extendDefaultPlugins}`, async () => {
+			const fixture = await buildFixture({
+				markdown: {
+					remarkPlugins: [remarkExamplePlugin],
+					rehypePlugins: [
+						[addClasses, { 'h1,h2,h3': 'title' }],
+					],
+					extendDefaultPlugins,
 				},
-				rehypePlugins: [
-					[addClasses, { 'h1,h2,h3': 'title' }],
-				],
-			},
-		});
-		const html = await fixture.readFile('/with-gfm/index.html');
-		const $ = cheerio.load(html);
-
-		// test 1: GFM autolink applied
-		expect($('a[href="https://example.com"]')).to.have.lengthOf(1);
-
-		// test 2: Code title applied
-		expect(html).to.include('Remark plugin applied!');
-
-		// test 3: (sanity check) rehype plugins still applied
-		expect($('#github-flavored-markdown-test')).to.have.lengthOf(1);
-		expect($('#github-flavored-markdown-test').hasClass('title')).to.equal(true);
-	})
-
-	it('Removes default plugins without "extends"', async () => {
-		const fixture = await buildFixture({
-			markdown: {
-				remarkPlugins: [remarkExamplePlugin],
-				rehypePlugins: [
-					[addClasses, { 'h1,h2,h3': 'title' }],
-				],
-			},
-		});
-		const html = await fixture.readFile('/with-gfm/index.html');
-		const $ = cheerio.load(html);
-
-		// test 1: GFM autolink no longer applied
-		expect($('a[href="https://example.com"]')).to.have.lengthOf(0);
-
-		// test 2: Code title still applied
-		expect(html).to.include('Remark plugin applied!');
-	})
+			});
+			const html = await fixture.readFile('/with-gfm/index.html');
+			const $ = cheerio.load(html);
+	
+			// test 1: GFM autolink applied correctly
+			if (extendDefaultPlugins === true) {
+				expect($('a[href="https://example.com"]')).to.have.lengthOf(1);
+			} else {
+				expect($('a[href="https://example.com"]')).to.have.lengthOf(0);
+			}
+	
+			// test 2: (sanity check) remark plugins still applied
+			expect(html).to.include('Remark plugin applied!');
+	
+			// test 3: (sanity check) rehype plugins still applied
+			expect($('#github-flavored-markdown-test')).to.have.lengthOf(1);
+			expect($('#github-flavored-markdown-test').hasClass('title')).to.equal(true);
+		})
+	}
 });

--- a/packages/astro/test/astro-markdown-plugins.test.js
+++ b/packages/astro/test/astro-markdown-plugins.test.js
@@ -3,12 +3,24 @@ import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 import addClasses from './fixtures/astro-markdown-plugins/add-classes.mjs';
 
-describe('Astro Markdown plugins', () => {
-	let fixture;
+async function buildFixture(config) {
+	const fixture = await loadFixture({
+		root: './fixtures/astro-markdown-plugins/',
+		...config,
+	});
+	await fixture.build();
+	return fixture;
+}
 
-	before(async () => {
-		fixture = await loadFixture({
-			root: './fixtures/astro-markdown-plugins/',
+function remarkExamplePlugin() {
+	return (tree) => {
+		tree.children.push({ type: 'paragraph', children: [{ type: 'text', value: 'Remark plugin applied!' }] })
+	}
+}
+
+describe('Astro Markdown plugins', () => {
+	it('Can render markdown with plugins', async () => {
+		const fixture = await buildFixture({
 			markdown: {
 				remarkPlugins: [
 					'remark-code-titles',
@@ -21,17 +33,57 @@ describe('Astro Markdown plugins', () => {
 				],
 			},
 		});
-		await fixture.build();
-	});
-
-	it('Can render markdown with plugins', async () => {
 		const html = await fixture.readFile('/index.html');
 		const $ = cheerio.load(html);
 
 		// test 1: Added a TOC
 		expect($('.toc')).to.have.lengthOf(1);
 
-		// teste 2: Added .title to h1
+		// test 2: Added .title to h1
 		expect($('#hello-world').hasClass('title')).to.equal(true);
 	});
+
+	it('Preserves default plugins with "extends"', async () => {
+		const fixture = await buildFixture({
+			markdown: {
+				remarkPlugins: {
+					extends: [remarkExamplePlugin],
+				},
+				rehypePlugins: [
+					[addClasses, { 'h1,h2,h3': 'title' }],
+				],
+			},
+		});
+		const html = await fixture.readFile('/with-gfm/index.html');
+		const $ = cheerio.load(html);
+
+		// test 1: GFM autolink applied
+		expect($('a[href="https://example.com"]')).to.have.lengthOf(1);
+
+		// test 2: Code title applied
+		expect(html).to.include('Remark plugin applied!');
+
+		// test 3: (sanity check) rehype plugins still applied
+		expect($('#github-flavored-markdown-test')).to.have.lengthOf(1);
+		expect($('#github-flavored-markdown-test').hasClass('title')).to.equal(true);
+	})
+
+	it('Removes default plugins without "extends"', async () => {
+		const fixture = await buildFixture({
+			markdown: {
+				remarkPlugins: [remarkExamplePlugin],
+				rehypePlugins: [
+					[addClasses, { 'h1,h2,h3': 'title' }],
+				],
+			},
+		});
+		const html = await fixture.readFile('/with-gfm/index.html');
+		const $ = cheerio.load(html);
+
+		// test 1: GFM autolink no longer applied
+		expect($('a[href="https://example.com"]')).to.have.lengthOf(0);
+
+		// test 2: Code title still applied
+		expect(html).to.include('Remark plugin applied!');
+	})
 });

--- a/packages/astro/test/fixtures/astro-markdown-plugins/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-markdown-plugins/astro.config.mjs
@@ -1,7 +1,6 @@
 import { defineConfig } from 'astro/config';
-import preact from '@astrojs/preact';
 
 // https://astro.build/config
 export default defineConfig({
-	integrations: [preact()],
+	integrations: [],
 });

--- a/packages/astro/test/fixtures/astro-markdown-plugins/package.json
+++ b/packages/astro/test/fixtures/astro-markdown-plugins/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@astrojs/preact": "workspace:*",
     "astro": "workspace:*",
     "hast-util-select": "^5.0.2",
     "rehype-slug": "^5.0.1"

--- a/packages/astro/test/fixtures/astro-markdown-plugins/src/pages/with-gfm.md
+++ b/packages/astro/test/fixtures/astro-markdown-plugins/src/pages/with-gfm.md
@@ -1,0 +1,3 @@
+# GitHub-flavored Markdown test
+
+This should auto-gen a link: https://example.com

--- a/packages/markdown/remark/src/index.ts
+++ b/packages/markdown/remark/src/index.ts
@@ -39,6 +39,7 @@ export async function renderMarkdown(
 		remarkPlugins = [],
 		rehypePlugins = [],
 		remarkRehype = {},
+		extendDefaultPlugins = false,
 		isAstroFlavoredMd = false,
 	} = opts;
 	const input = new VFile({ value: content, path: fileURL });
@@ -50,9 +51,9 @@ export async function renderMarkdown(
 		.use(remarkInitializeAstroData)
 		.use(isAstroFlavoredMd ? [remarkMdxish, remarkMarkAndUnravel, remarkUnwrap, remarkEscape] : []);
 
-	if (remarkPlugins.length === 0 && rehypePlugins.length === 0) {
-		remarkPlugins = [...DEFAULT_REMARK_PLUGINS];
-		rehypePlugins = [...DEFAULT_REHYPE_PLUGINS];
+	if (extendDefaultPlugins || (remarkPlugins.length === 0 && rehypePlugins.length === 0)) {
+		remarkPlugins = [...DEFAULT_REMARK_PLUGINS, ...remarkPlugins];
+		rehypePlugins = [...DEFAULT_REHYPE_PLUGINS, ...rehypePlugins];
 	}
 
 	const loadedRemarkPlugins = await Promise.all(loadPlugins(remarkPlugins));

--- a/packages/markdown/remark/src/index.ts
+++ b/packages/markdown/remark/src/index.ts
@@ -21,11 +21,18 @@ import markdown from 'remark-parse';
 import markdownToHtml from 'remark-rehype';
 import { unified } from 'unified';
 import { VFile } from 'vfile';
+import type { WithExtends } from './types.js';
 
 export * from './types.js';
 
 export const DEFAULT_REMARK_PLUGINS = ['remark-gfm', 'remark-smartypants'];
 export const DEFAULT_REHYPE_PLUGINS = [];
+
+function handleExtends<T>(config: WithExtends<T[] | undefined>, defaults: T[] = []): T[] {
+	if (Array.isArray(config)) return config;
+
+	return [...defaults, ...(config?.extends ?? [])];
+}
 
 /** Shared utility for rendering markdown */
 export async function renderMarkdown(
@@ -50,13 +57,19 @@ export async function renderMarkdown(
 		.use(remarkInitializeAstroData)
 		.use(isAstroFlavoredMd ? [remarkMdxish, remarkMarkAndUnravel, remarkUnwrap, remarkEscape] : []);
 
-	if (remarkPlugins.length === 0 && rehypePlugins.length === 0) {
+	if (Array.isArray(remarkPlugins) && remarkPlugins.length === 0) {
 		remarkPlugins = [...DEFAULT_REMARK_PLUGINS];
-		rehypePlugins = [...DEFAULT_REHYPE_PLUGINS];
+	}
+	if (Array.isArray(rehypePlugins) && rehypePlugins.length === 0) {
+		remarkPlugins = [...DEFAULT_REHYPE_PLUGINS];
 	}
 
-	const loadedRemarkPlugins = await Promise.all(loadPlugins(remarkPlugins));
-	const loadedRehypePlugins = await Promise.all(loadPlugins(rehypePlugins));
+	const loadedRemarkPlugins = await Promise.all(
+		loadPlugins(handleExtends(remarkPlugins, DEFAULT_REMARK_PLUGINS))
+	);
+	const loadedRehypePlugins = await Promise.all(
+		loadPlugins(handleExtends(rehypePlugins, DEFAULT_REHYPE_PLUGINS))
+	);
 
 	loadedRemarkPlugins.forEach(([plugin, pluginOpts]) => {
 		parser.use([[plugin, pluginOpts]]);

--- a/packages/markdown/remark/src/index.ts
+++ b/packages/markdown/remark/src/index.ts
@@ -21,18 +21,11 @@ import markdown from 'remark-parse';
 import markdownToHtml from 'remark-rehype';
 import { unified } from 'unified';
 import { VFile } from 'vfile';
-import type { WithExtends } from './types.js';
 
 export * from './types.js';
 
 export const DEFAULT_REMARK_PLUGINS = ['remark-gfm', 'remark-smartypants'];
 export const DEFAULT_REHYPE_PLUGINS = [];
-
-function handleExtends<T>(config: WithExtends<T[] | undefined>, defaults: T[] = []): T[] {
-	if (Array.isArray(config)) return config;
-
-	return [...defaults, ...(config?.extends ?? [])];
-}
 
 /** Shared utility for rendering markdown */
 export async function renderMarkdown(
@@ -57,19 +50,13 @@ export async function renderMarkdown(
 		.use(remarkInitializeAstroData)
 		.use(isAstroFlavoredMd ? [remarkMdxish, remarkMarkAndUnravel, remarkUnwrap, remarkEscape] : []);
 
-	if (Array.isArray(remarkPlugins) && remarkPlugins.length === 0) {
+	if (remarkPlugins.length === 0 && rehypePlugins.length === 0) {
 		remarkPlugins = [...DEFAULT_REMARK_PLUGINS];
-	}
-	if (Array.isArray(rehypePlugins) && rehypePlugins.length === 0) {
 		rehypePlugins = [...DEFAULT_REHYPE_PLUGINS];
 	}
 
-	const loadedRemarkPlugins = await Promise.all(
-		loadPlugins(handleExtends(remarkPlugins, DEFAULT_REMARK_PLUGINS))
-	);
-	const loadedRehypePlugins = await Promise.all(
-		loadPlugins(handleExtends(rehypePlugins, DEFAULT_REHYPE_PLUGINS))
-	);
+	const loadedRemarkPlugins = await Promise.all(loadPlugins(remarkPlugins));
+	const loadedRehypePlugins = await Promise.all(loadPlugins(rehypePlugins));
 
 	loadedRemarkPlugins.forEach(([plugin, pluginOpts]) => {
 		parser.use([[plugin, pluginOpts]]);

--- a/packages/markdown/remark/src/index.ts
+++ b/packages/markdown/remark/src/index.ts
@@ -61,7 +61,7 @@ export async function renderMarkdown(
 		remarkPlugins = [...DEFAULT_REMARK_PLUGINS];
 	}
 	if (Array.isArray(rehypePlugins) && rehypePlugins.length === 0) {
-		remarkPlugins = [...DEFAULT_REHYPE_PLUGINS];
+		rehypePlugins = [...DEFAULT_REHYPE_PLUGINS];
 	}
 
 	const loadedRemarkPlugins = await Promise.all(

--- a/packages/markdown/remark/src/types.ts
+++ b/packages/markdown/remark/src/types.ts
@@ -43,6 +43,7 @@ export interface AstroMarkdownOptions {
 	remarkPlugins?: RemarkPlugins;
 	rehypePlugins?: RehypePlugins;
 	remarkRehype?: RemarkRehype;
+	extendDefaultPlugins?: boolean;
 }
 
 export interface MarkdownRenderingOptions extends AstroMarkdownOptions {

--- a/packages/markdown/remark/src/types.ts
+++ b/packages/markdown/remark/src/types.ts
@@ -35,8 +35,6 @@ export interface ShikiConfig {
 	wrap?: boolean | null;
 }
 
-export type WithExtends<T> = T | { extends: T };
-
 export interface AstroMarkdownOptions {
 	mode?: 'md' | 'mdx';
 	drafts?: boolean;

--- a/packages/markdown/remark/src/types.ts
+++ b/packages/markdown/remark/src/types.ts
@@ -35,6 +35,8 @@ export interface ShikiConfig {
 	wrap?: boolean | null;
 }
 
+export type WithExtends<T> = T | { extends: T };
+
 export interface AstroMarkdownOptions {
 	mode?: 'md' | 'mdx';
 	drafts?: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1286,12 +1286,10 @@ importers:
 
   packages/astro/test/fixtures/astro-markdown-plugins:
     specifiers:
-      '@astrojs/preact': workspace:*
       astro: workspace:*
       hast-util-select: ^5.0.2
       rehype-slug: ^5.0.1
     dependencies:
-      '@astrojs/preact': link:../../../../integrations/preact
       astro: link:../../..
       hast-util-select: 5.0.2
       rehype-slug: 5.0.1


### PR DESCRIPTION
## Changes

Add `extendDefaultPlugins` to preserve default markdown plugins:
```js
// astro.config.mjs
export default {
  markdown: {
    remarkPlugins: [myCoolPlugin],
    // preserves GitHub-flavored markdown and smartypants
    extendDefaultPlugins: true,
  }
}
```

## Testing

Add remark plugin tests with and without `extends`

## Docs

https://github.com/withastro/docs/pull/1409