### PR TITLE
Earlier import snippet for `@astrojs/image`

### DIFF
--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -82,9 +82,7 @@ Or, alternatively if your project is using the types through a `tsconfig.json`
 
 ## Usage
 
-__`index.astro`__
-
-```astro
+```astro title="src/pages/index.astro"
 ---
 import { Image, Picture } from '@astrojs/image/components';
 ---

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -82,6 +82,14 @@ Or, alternatively if your project is using the types through a `tsconfig.json`
 
 ## Usage
 
+__`index.astro`__
+
+```astro
+---
+import { Image, Picture } from '@astrojs/image/components';
+---
+```
+
 The included `sharp` transformer supports resizing images and encoding them to different image formats. Third-party image services will be able to add support for custom transformations as well (ex: `blur`, `filter`, `rotate`, etc).
 
 ### `<Image />`


### PR DESCRIPTION
It is a bit unclear how to import the Image/Picture components for a first-time reader, this PR hopefully clears that up.

## Changes

Currently, how to import the `@astrojs/image` component is only mentioned in [`#Examples`](https://docs.astro.build/en/guides/integrations-guide/image/#examples), 3/4ths down the page.
This adds a small snippet in [`#Usage`](https://docs.astro.build/en/guides/integrations-guide/image/#usage) straight after install, so that a reader can immediately copy/paste it and start tinkering.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Only docs changed

## Docs

https://docs.astro.build/en/guides/integrations-guide/image
<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->