### PR TITLE
Bump pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
   ],
   "engines": {
     "node": "^14.18.0 || >=16.12.0",
-    "pnpm": ">=7.5.0"
+    "pnpm": ">=7.9.5"
   },
-  "packageManager": "pnpm@7.5.0",
+  "packageManager": "pnpm@7.9.5",
   "pnpm": {
     "packageExtensions": {
       "svelte2tsx": {


### PR DESCRIPTION
## Changes

Bump pnpm min version from 7.5.0 to 7.9.5 (latest)

The lockfile Github action uses 7.5.0 which generates a different lockfile than 7.9.5 (for some reason). Enforcing the latest one should prevent the back-and-forth changes. 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
N/A

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A