### PR TITLE
Note private env var handling with cloudflare builds

### DIFF
--- a/packages/integrations/cloudflare/README.md
+++ b/packages/integrations/cloudflare/README.md
@@ -55,3 +55,17 @@ In order to work around this:
 - install the `"web-streams-polyfill"` package
 - add `import "web-streams-polyfill/es2018";` to the top of the front matter of every page which requires streams, such as server rendering a React component.
 
+## Environment Variables
+
+As Cloudflare Pages Functions [provides environment variables differently](https://developers.cloudflare.com/pages/platform/functions/#adding-environment-variables-locally), private environment variables needs to be set through [`vite.define`](https://vitejs.dev/config/shared-options.html#define) to work in builds.
+
+```js
+// astro.config.mjs
+export default {
+  vite: {
+    define: {
+      'process.env.MY_SECRET': JSON.stringify(process.env.MY_SECRET),
+    },
+  },
+}
+```


### PR DESCRIPTION
## Changes

Close #4416

The context of this is at https://github.com/withastro/astro/issues/4416#issuecomment-1228234136, but the gist is that since env in Cloudflare can only be accessed like:

```js
export async function onRequest({ env }) {
  return new Response(env.ENV_NAME);
}
```

private env vars which are transformed as runtime code like `process.env.ENV_NAME` won't work. Perhaps we can take a look at [SvelteKit's env var handling](https://kit.svelte.dev/docs/modules#$env-static-private) for this in the future.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
N/A

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
The docs script should auto pick this up.