### PR TITLE
Remove "as Props" from the astro examples

### DIFF
--- a/examples/basics/src/components/Card.astro
+++ b/examples/basics/src/components/Card.astro
@@ -5,7 +5,7 @@ export interface Props {
 	href: string;
 }
 
-const { href, title, body } = Astro.props as Props;
+const { href, title, body } = Astro.props;
 ---
 
 <li class="link-card">

--- a/examples/basics/src/layouts/Layout.astro
+++ b/examples/basics/src/layouts/Layout.astro
@@ -3,7 +3,7 @@ export interface Props {
 	title: string;
 }
 
-const { title } = Astro.props as Props;
+const { title } = Astro.props;
 ---
 
 <!DOCTYPE html>

--- a/examples/blog/src/components/HeaderLink.astro
+++ b/examples/blog/src/components/HeaderLink.astro
@@ -1,7 +1,7 @@
 ---
 export interface Props extends astroHTML.JSX.AnchorHTMLAttributes {}
 
-const { href, class: className, ...props } = Astro.props as Props;
+const { href, class: className, ...props } = Astro.props;
 const isActive = href === Astro.url.pathname;
 ---
 

--- a/examples/blog/src/layouts/BlogPost.astro
+++ b/examples/blog/src/layouts/BlogPost.astro
@@ -15,7 +15,7 @@ export interface Props {
 
 const {
 	content: { title, description, pubDate, updatedDate, heroImage },
-} = Astro.props as Props;
+} = Astro.props;
 ---
 
 <html>

--- a/examples/component/packages/my-component/Button.astro
+++ b/examples/component/packages/my-component/Button.astro
@@ -5,7 +5,7 @@ export interface Props extends Record<any, any> {
 
 const { type, ...props } = {
 	...Astro.props,
-} as Props;
+};
 
 props.type = type || 'button';
 ---

--- a/examples/component/packages/my-component/Heading.astro
+++ b/examples/component/packages/my-component/Heading.astro
@@ -6,7 +6,7 @@ export interface Props extends Record<any, any> {
 
 const { level, role, ...props } = {
 	...Astro.props,
-} as Props;
+};
 
 props.role = role || 'heading';
 props['aria-level'] = level || '1';

--- a/examples/framework-alpine/src/components/Counter.astro
+++ b/examples/framework-alpine/src/components/Counter.astro
@@ -6,7 +6,7 @@ export interface Props {
 	initialCount?: number;
 }
 
-const { initialCount = 0 } = Astro.props as Props;
+const { initialCount = 0 } = Astro.props;
 ---
 
 <div class="counter" x-data={`{ count: ${initialCount} }`}>

--- a/examples/with-nanostores/src/layouts/Layout.astro
+++ b/examples/with-nanostores/src/layouts/Layout.astro
@@ -6,7 +6,7 @@ export interface Props {
 	title: string;
 }
 
-const { title } = Astro.props as Props;
+const { title } = Astro.props;
 ---
 
 <!DOCTYPE html>


### PR DESCRIPTION
## Changes

- This changes the astro examples to remove `as Props` casting. since it's not  needed any more with the new version of the asto language tools.

## Testing

No tests were added, since  the change only touches the examples.

## Docs