### PR TITLE
chore: update to solid 1.5

### DIFF
--- a/.changeset/blue-peas-laugh.md
+++ b/.changeset/blue-peas-laugh.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/solid-js': minor
+---
+
+Update solid to 1.5

--- a/packages/integrations/solid/package.json
+++ b/packages/integrations/solid/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
-    "solid-js": "^1.4.3"
+    "solid-js": "^1.5.1"
   },
   "peerDependencies": {
     "solid-js": "^1.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2561,13 +2561,13 @@ importers:
       astro: workspace:*
       astro-scripts: workspace:*
       babel-preset-solid: ^1.4.2
-      solid-js: ^1.4.3
+      solid-js: ^1.5.1
     dependencies:
       babel-preset-solid: 1.4.8
     devDependencies:
       astro: link:../../astro
       astro-scripts: link:../../../scripts
-      solid-js: 1.4.8
+      solid-js: 1.5.1
 
   packages/integrations/svelte:
     specifiers:
@@ -2602,7 +2602,7 @@ importers:
       '@proload/core': 0.3.2
       autoprefixer: 10.4.8_postcss@8.4.16
       postcss: 8.4.16
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.16
     devDependencies:
       astro: link:../../astro
       astro-scripts: link:../../../scripts
@@ -15620,6 +15620,12 @@ packages:
   /solid-js/1.4.8:
     resolution: {integrity: sha512-XErZdnnYYXF7OwGSUAPcua2y5/ELB/c53zFCpWiEGqxTNoH1iQghzI8EsHJXk06sNn+Z/TGhb8bPDNNGSgimag==}
 
+  /solid-js/1.5.1:
+    resolution: {integrity: sha512-Y6aKystIxnrB0quV5nhqNuJV+l2Fk3/PQy1mMya/bzxlGiMHAym7v1NaqEgqDIvctbkxOi5dBj0ER/ewrH060g==}
+    dependencies:
+      csstype: 3.1.0
+    dev: true
+
   /sorcery/0.10.0:
     resolution: {integrity: sha512-R5ocFmKZQFfSTstfOtHjJuAwbpGyf9qjQa1egyhvXSbM7emjrtLXtGdZsDJDABC85YBfVvrOiGWKSYXPKdvP1g==}
     hasBin: true
@@ -16002,10 +16008,12 @@ packages:
       tslib: 2.4.0
     dev: true
 
-  /tailwindcss/3.1.8:
+  /tailwindcss/3.1.8_postcss@8.4.16:
     resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3


### PR DESCRIPTION
## Changes

- Updated `@astro/solid-js` integration to use `Solid` 1.5 see the [release notes](https://github.com/solidjs/solid/releases/tag/v1.5.0)

## Testing

<!-- How was this change tested? -->
N/A
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->


## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
N/A
<!-- https://github.com/withastro/docs -->