### PR TITLE
Add `renderer` keyword to alpinejs integration

### DIFF
--- a/.changeset/tough-buses-hang.md
+++ b/.changeset/tough-buses-hang.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/alpinejs': patch
+---
+
+add renderer category to alpinejs package keywords

--- a/packages/integrations/alpinejs/package.json
+++ b/packages/integrations/alpinejs/package.json
@@ -14,6 +14,8 @@
   "keywords": [
     "astro-integration",
     "astro-component",
+    "renderer",
+    "alpinejs",
     "performance"
   ],
   "bugs": "https://github.com/withastro/astro/issues",


### PR DESCRIPTION
## Changes

- Added `renderer` keyword to `AlpineJS` integration, Which should by result allow `scripts/generate-integration-pages.ts` to put AlpineJS in the right category inside https://docs.astro.build/en/guides/integrations-guide

Results on the docs: https://deploy-preview-1417--astro-docs-2.netlify.app/en/guides/integrations-guide/

Before: 
![image](https://user-images.githubusercontent.com/9967336/186946825-c8775e91-f832-4fc0-accc-4af46028803e.png)

After:
![image](https://user-images.githubusercontent.com/9967336/186947295-f7273947-fd18-4e98-947e-75ef956f9908.png)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

This will auto update the docs. 