### PR TITLE
chore: bump tailwind version to ^3.1

### DIFF
--- a/.changeset/thick-owls-brake.md
+++ b/.changeset/thick-owls-brake.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/tailwind': minor
+---
+
+bump tailwindcss to ^3.1

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -15,6 +15,6 @@
     "autoprefixer": "^10.4.7",
     "canvas-confetti": "^1.5.1",
     "postcss": "^8.4.14",
-    "tailwindcss": "^3.0.24"
+    "tailwindcss": "^3.1.8"
   }
 }

--- a/packages/astro/test/fixtures/tailwindcss/package.json
+++ b/packages/astro/test/fixtures/tailwindcss/package.json
@@ -8,6 +8,6 @@
     "astro": "workspace:*",
     "autoprefixer": "^10.4.7",
     "postcss": "^8.4.14",
-    "tailwindcss": "^3.0.24"
+    "tailwindcss": "^3.1.8"
   }
 }

--- a/packages/integrations/tailwind/package.json
+++ b/packages/integrations/tailwind/package.json
@@ -31,7 +31,7 @@
     "@proload/core": "^0.3.2",
     "autoprefixer": "^10.4.7",
     "postcss": "^8.4.14",
-    "tailwindcss": "^3.0.24"
+    "tailwindcss": "^3.1.8"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,7 +354,7 @@ importers:
       autoprefixer: ^10.4.7
       canvas-confetti: ^1.5.1
       postcss: ^8.4.14
-      tailwindcss: ^3.0.24
+      tailwindcss: ^3.1.8
     devDependencies:
       '@astrojs/tailwind': link:../../packages/integrations/tailwind
       astro: link:../../packages/astro
@@ -2054,7 +2054,7 @@ importers:
       astro: workspace:*
       autoprefixer: ^10.4.7
       postcss: ^8.4.14
-      tailwindcss: ^3.0.24
+      tailwindcss: ^3.1.8
     dependencies:
       '@astrojs/mdx': link:../../../../integrations/mdx
       '@astrojs/tailwind': link:../../../../integrations/tailwind
@@ -2597,7 +2597,7 @@ importers:
       astro-scripts: workspace:*
       autoprefixer: ^10.4.7
       postcss: ^8.4.14
-      tailwindcss: ^3.0.24
+      tailwindcss: ^3.1.8
     dependencies:
       '@proload/core': 0.3.2
       autoprefixer: 10.4.8_postcss@8.4.16


### PR DESCRIPTION
## Changes

- Updated `tailwindcss` to v ^3.1 in `@astrojs/tailwind` integration and in Astro fixture + example with tailwind [full release note](https://tailwindcss.com/blog/tailwindcss-v3-1)


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
N/A
## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A