### PR TITLE
Automatically set up Preact DevTools in dev mode

### DIFF
--- a/.changeset/brown-berries-eat.md
+++ b/.changeset/brown-berries-eat.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/preact': minor
+---
+
+Automatically set up Preact DevTools bridge when running `astro dev`.

--- a/packages/integrations/preact/client-dev.js
+++ b/packages/integrations/preact/client-dev.js
@@ -1,0 +1,4 @@
+import "preact/debug"
+import clientFn from "./client.js";
+
+export default clientFn;

--- a/packages/integrations/preact/package.json
+++ b/packages/integrations/preact/package.json
@@ -22,6 +22,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./client.js": "./client.js",
+    "./client-dev.js": "./client-dev.js",
     "./server.js": "./server.js",
     "./package.json": "./package.json"
   },

--- a/packages/integrations/preact/src/index.ts
+++ b/packages/integrations/preact/src/index.ts
@@ -1,9 +1,9 @@
 import { AstroIntegration, AstroRenderer, ViteUserConfig } from 'astro';
 
-function getRenderer(): AstroRenderer {
+function getRenderer(development: boolean): AstroRenderer {
 	return {
 		name: '@astrojs/preact',
-		clientEntrypoint: '@astrojs/preact/client.js',
+		clientEntrypoint: development ? '@astrojs/preact/client-dev.js' : '@astrojs/preact/client.js',
 		serverEntrypoint: '@astrojs/preact/server.js',
 		jsxImportSource: 'preact',
 		jsxTransformOptions: async () => {
@@ -18,10 +18,10 @@ function getRenderer(): AstroRenderer {
 	};
 }
 
-function getCompatRenderer(): AstroRenderer {
+function getCompatRenderer(development: boolean): AstroRenderer {
 	return {
 		name: '@astrojs/preact',
-		clientEntrypoint: '@astrojs/preact/client.js',
+		clientEntrypoint: development ? '@astrojs/preact/client-dev.js' : '@astrojs/preact/client.js',
 		serverEntrypoint: '@astrojs/preact/server.js',
 		jsxImportSource: 'react',
 		jsxTransformOptions: async () => {
@@ -96,9 +96,10 @@ export default function ({ compat }: { compat?: boolean } = {}): AstroIntegratio
 	return {
 		name: '@astrojs/preact',
 		hooks: {
-			'astro:config:setup': ({ addRenderer, updateConfig }) => {
-				if (compat) addRenderer(getCompatRenderer());
-				addRenderer(getRenderer());
+			'astro:config:setup': ({ addRenderer, updateConfig, command }) => {
+				const development = command === 'dev';
+				if (compat) addRenderer(getCompatRenderer(development));
+				addRenderer(getRenderer(development));
 				updateConfig({
 					vite: getViteConfiguration(compat),
 				});


### PR DESCRIPTION
## Changes

This PR automatically sets up the bridge to Preact DevTools in the Preact integration when `astro dev` is run.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Browser extensions are very tricky to test automatically. So I mainly tested it locally in an astro starter project.

Screenshot:

<img width="947" alt="Screenshot 2022-08-27 at 16 01 42" src="https://user-images.githubusercontent.com/1062408/187033585-185bfd10-1e59-47c0-8e4d-2c34c649077f.png">


## Docs

I don't think there is a need to add docs as it's kinda expected that DevTools works out of the box.
<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->