### PR TITLE
Fix type import in config.d.ts

### DIFF
--- a/.changeset/thirty-taxis-lick.md
+++ b/.changeset/thirty-taxis-lick.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix import in the config type declarations

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -1,5 +1,5 @@
 type ViteUserConfig = import('vite').UserConfig;
-type AstroUserConfig = import('./dist/types/@types/astro').AstroUserConfig;
+type AstroUserConfig = import('./dist/@types/astro').AstroUserConfig;
 
 /**
  * See the full Astro Configuration API Documentation


### PR DESCRIPTION
## Problem
When using `defineConfig` in an Astro config file, the type `AstroUserConfig` is not resolved correctly. No editor autocompletion is provided because the TypeScript language server is unable to resolve an import in the declaration file and defaults to `any`.

![image](https://user-images.githubusercontent.com/55333787/187105254-7a65cf75-47b4-45e5-ad5d-fbf31c1a0494.png)

## Changes
I have updated the import path to the correct location.

## Testing / Docs
A testing/docs update should not be needed since this change simply fixes the code such that it has the expected behaviour.