### PR TITLE
Skip clean SSR output if page generation fails

### DIFF
--- a/.changeset/nine-beans-divide.md
+++ b/.changeset/nine-beans-divide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Skip clean SSR output if page generation fails

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -96,11 +96,8 @@ Example:
 
 	timer.generate = performance.now();
 	if (astroConfig.output === 'static') {
-		try {
-			await generatePages(opts, internals);
-		} finally {
-			await cleanSsrOutput(opts);
-		}
+		await generatePages(opts, internals);
+		await cleanSsrOutput(opts);
 	} else {
 		// Inject the manifest
 		await injectManifest(opts, internals);


### PR DESCRIPTION
## Changes

If page generation fails, don't delete the SSR output, including `entry.mjs`, which is sometimes helpful in debugging the build errors as the stack trace references it.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested with #3639. I've done a similar patch in the past to debug build errors too.

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A