### PR TITLE
Vite ignore unknown import

### DIFF
--- a/.changeset/thin-taxis-laugh.md
+++ b/.changeset/thin-taxis-laugh.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/react": patch
+---
+
+Add vite-ignore comment to suppress unknown import warnings

--- a/packages/integrations/react/server.js
+++ b/packages/integrations/react/server.js
@@ -53,7 +53,7 @@ async function check(Component, props, children) {
 
 async function getNodeWritable() {
 	let nodeStreamBuiltinModuleName = 'stream';
-	let { Writable } = await import(nodeStreamBuiltinModuleName);
+	let { Writable } = await import(/* @vite-ignore */ nodeStreamBuiltinModuleName);
 	return Writable;
 }
 


### PR DESCRIPTION
## Changes

Small change to `/* vite-ignore */` an unknown import as Vite warns about it since 3.0.9. This doesn't happen for the users, but only when they link Astro locally, which makes Astro `ssr.noExternal` by default.

Didn't add a changeset as it affects internal only.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
N/A

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A