### PR TITLE
Add an option in the astro config build object to set concurrency

### DIFF
--- a/.changeset/healthy-cougars-relax.md
+++ b/.changeset/healthy-cougars-relax.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Add build concurrency config option

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -85,6 +85,7 @@ export interface BuildConfig {
 	client: URL;
 	server: URL;
 	serverEntry: string;
+	concurrency?: number;
 }
 
 /**

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -174,22 +174,14 @@ async function generatePage(
 	const concurrency = opts.buildConfig.concurrency || MAX_CONCURRENT_RENDERS;
 	if (concurrency > 1) {
 		info(opts.logging, null, `${magenta('⚠️')}  Building with ${concurrency} concurrent renders`);
-		// Throttle the paths to avoid overloading the CPU with too many tasks.
-		for await (let _ of generatePathsConcurrently(concurrency, opts, generationOptions, timeStart, paths.values(), pageData.route.type)) {
-			// Do nothing.
-		}
-	} else {
-		for (let i = 0; i < paths.length; i++) {
-			const path = paths[i];
-			await generatePath(path, opts, generationOptions);
-			const timeEnd = performance.now();
-			const timeChange = getTimeStat(timeStart, timeEnd);
-			const timeIncrease = `(+${timeChange})`;
-			const filePath = getOutputFilename(opts.astroConfig, path, pageData.route.type);
-			const lineIcon = i === paths.length - 1 ? '└─' : '├─';
-			info(opts.logging, null, `  ${cyan(lineIcon)} ${dim(filePath)} ${dim(timeIncrease)}`);
-		}
 	}
+	// Throttle the paths to avoid overloading the CPU with too many tasks.
+	for await (let _ of generatePathsConcurrently(concurrency, opts, generationOptions, timeStart, paths.values(), pageData.route.type)) {
+		// Do nothing.
+	}
+	const timeEnd = performance.now();
+	const timeChange = getTimeStat(timeStart, timeEnd);
+	info(opts.logging, null, `  ${cyan('└─')} ${dim(`Completed ${pageData.route.component} in ${timeChange}`)}`);
 }
 
 async function getPathsForRoute(

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -85,6 +85,7 @@ class AstroBuilder {
 			client: new URL('./client/', this.config.outDir),
 			server: new URL('./server/', this.config.outDir),
 			serverEntry: 'entry.mjs',
+			concurrency: this.config.build.concurrency,
 		};
 		await runHookBuildStart({ config: this.config, buildConfig, logging: this.logging });
 

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -149,6 +149,7 @@ export const AstroConfigSchema = z.object({
 				.union([z.literal('file'), z.literal('directory')])
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.build.format),
+			concurrency: z.number().optional().default(1),
 		})
 		.optional()
 		.default({}),


### PR DESCRIPTION
## Changes

This makes concurrency optional using the implementation that was removed before.
By default still use a concurrency of 1 and does not change anything in the build.

(reopen #4052)

One can set it in their `astro.config.mjs`:
```
export default defineConfig({
	// integrations: [...],
	build: {
		concurrency: 8,
	},
	// adapter: ...
});
```

Signed-off-by: Jeremy Wickersheimer <jwickers@gmail.com>

## Testing

Tested with a very large build that has >300k pages (mostly all in one URL pattern).
Manages to reduce the total build from 6000s to 3000s with a concurrency of 8.

## Docs

May need a Doc update to mention the new setting.