### PR TITLE
Add custom components to mdx integration guide

### DIFF
--- a/.changeset/kind-lobsters-leave.md
+++ b/.changeset/kind-lobsters-leave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Add custom components to README

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -265,7 +265,7 @@ will be converted into this HTML:
 </blockquote>
 ```
 
-But what if you want to specify your own markup for these blockquotes? In the above example, you could create a custom `<Blockquote />` component (in any language) that has either a `<slot />`  component or accepts a `children` prop. MDX provides a way to tap into this rendering and use your own custom components. In the above example, you could create a custom Blockquote component (in any language) that has either a `<slot />`  component or accepts a `children` prop. 
+But what if you want to specify your own markup for these blockquotes? In the above example, you could create a custom `<Blockquote />` component (in any language) that either has a `<slot />` component or accepts a `children` prop.
 
 ```astro title="src/components/Blockquote.astro"
 <blockquote class="bg-blue-50 p-4">

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -272,7 +272,7 @@ import Blockquote from '../components/Blockquote.astro';
 export const components = { blockquote: Blockquote };
 ```
 
-The advantage of this is it allows for the simplicity of writing in markdown without having to write the custom component or writing a remark/rehype plugin. A full list of components that can have custom components is on the [MDX website](https://mdxjs.com/table-of-components/).
+The advantage of this is it allows for the simplicity of writing in markdown without having to write the custom component or writing a remark/rehype plugin. Visit the [MDX website](https://mdxjs.com/table-of-components/) for a full list of HTML elements that support custom components.
 
 #### Custom components with imported `mdx`
 

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -251,7 +251,7 @@ const { title, fancyJsHelper } = Astro.props;
 
 ### Custom components
 
-Under the hood, MDX will convert markdown into html components. For example, this blockquote:
+Under the hood, MDX will convert Markdown into HTML components. For example, this blockquote:
 
 ```md
 > A blockquote with *some* emphasis.
@@ -265,20 +265,30 @@ will be converted into this HTML:
 </blockquote>
 ```
 
-MDX provides a way to tap into this rendering and use your own custom components. In the above example, you could create a custom Blockquote component (in any language) that has either a `<slot />`  component or accepts a `children` prop. Then in the MDX file you import the component and export it to the `components` export. 
+But what if you want to specify your own markup for these blockquotes? In the above example, you could create a custom `<Blockquote />` component (in any language) that has either a `<slot />`  component or accepts a `children` prop. MDX provides a way to tap into this rendering and use your own custom components. In the above example, you could create a custom Blockquote component (in any language) that has either a `<slot />`  component or accepts a `children` prop. 
 
-```mdx
+```astro title="src/components/Blockquote.astro"
+<blockquote class="bg-blue-400 p-4">
+  <span class="text-4xl text-blue-600 mb-2">“</span>
+  <slot />
+</blockquote>
+```
+
+Then in the MDX file you import the component and export it to the `components` export. 
+
+```mdx title="src/pages/posts/post-1.mdx" {2}
 import Blockquote from '../components/Blockquote.astro';
 export const components = { blockquote: Blockquote };
 ```
 
-The advantage of this is it allows for the simplicity of writing in markdown without having to write the custom component or writing a remark/rehype plugin. Visit the [MDX website](https://mdxjs.com/table-of-components/) for a full list of HTML elements that support custom components.
+Now, writing the standard Markdown blockquote syntax (`>`) will use your custom `<Blockquote />` component instead. No need to use a component in Markdown, or write a remark/rehype plugin! Visit the [MDX website](https://mdxjs.com/table-of-components/) for a full list of HTML elements that can be overwritten as custom components.
+
 
 #### Custom components with imported `mdx`
 
 When rendering imported MDX content, custom components can also be passed via the `components` prop:
 
-```astro
+```astro title="src/pages/page.astro" "components={{ h1: Heading }}"
 ---
 import Content from '../content.mdx';
 import Heading from '../Heading.astro';

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -251,7 +251,7 @@ const { title, fancyJsHelper } = Astro.props;
 
 ### Custom components
 
-Under the hood, MDX will convert markdown into html components. For example, 
+Under the hood, MDX will convert markdown into html components. For example, this blockquote:
 
 ```md
 > A blockquote with *some* emphasis.

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -257,7 +257,7 @@ Under the hood, MDX will convert markdown into html components. For example, thi
 > A blockquote with *some* emphasis.
 ```
 
-will be converted into
+will be converted into this HTML:
 
 ```html
 <blockquote>

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -268,7 +268,7 @@ will be converted into this HTML:
 But what if you want to specify your own markup for these blockquotes? In the above example, you could create a custom `<Blockquote />` component (in any language) that has either a `<slot />`  component or accepts a `children` prop. MDX provides a way to tap into this rendering and use your own custom components. In the above example, you could create a custom Blockquote component (in any language) that has either a `<slot />`  component or accepts a `children` prop. 
 
 ```astro title="src/components/Blockquote.astro"
-<blockquote class="bg-blue-400 p-4">
+<blockquote class="bg-blue-50 p-4">
   <span class="text-4xl text-blue-600 mb-2">“</span>
   <slot />
 </blockquote>

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -249,6 +249,44 @@ const { title, fancyJsHelper } = Astro.props;
 <!-- -->
 ```
 
+### Custom components
+
+Under the hood, MDX will convert markdown into html components. For example, 
+
+```md
+> A blockquote with *some* emphasis.
+```
+
+will be converted into
+
+```html
+<blockquote>
+  <p>A blockquote with <em>some</em> emphasis.</p>
+</blockquote>
+```
+
+MDX provides a way to tap into this rendering and use your own custom components. In the above example, you could create a custom Blockquote component (in any language) that has either a `<slot />`  component or accepts a `children` prop. Then in the MDX file you import the component and export it to the `components` export. 
+
+```mdx
+import Blockquote from '../components/Blockquote.astro';
+export const components = { blockquote: Blockquote };
+```
+
+The advantage of this is it allows for the simplicity of writing in markdown without having to write the custom component or writing a remark/rehype plugin. A full list of components that can have custom components is on the [MDX website](https://mdxjs.com/table-of-components/).
+
+#### Custom components with imported `mdx`
+
+Custom components can also be passed to the components prop when rending imported MDX content.
+
+```astro
+---
+import Content from '../content.mdx';
+import Heading from '../Heading.astro';
+---
+
+<Content components={{ h1: Heading }} />
+```
+
 ### Syntax highlighting
 
 The MDX integration respects [your project's `markdown.syntaxHighlight` configuration](https://docs.astro.build/en/guides/markdown-content/#syntax-highlighting).

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -276,7 +276,7 @@ The advantage of this is it allows for the simplicity of writing in markdown wit
 
 #### Custom components with imported `mdx`
 
-Custom components can also be passed to the components prop when rending imported MDX content.
+When rendering imported MDX content, custom components can also be passed via the `components` prop:
 
 ```astro
 ---


### PR DESCRIPTION
## Changes

Following https://github.com/withastro/docs/issues/1234, I've added a section to the integration guide on custom components in MDX


## Docs

This should be automatically pulled into the docs according to: https://github.com/withastro/docs/pull/1426