### PR TITLE
Remove hardcoded Vite middleware handling

### DIFF
--- a/.changeset/fuzzy-frogs-try.md
+++ b/.changeset/fuzzy-frogs-try.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Remove hardcoded Vite middleware handling

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -72,7 +72,6 @@ class AstroBuilder {
 					hmr: false,
 					middlewareMode: true,
 				},
-				appType: 'custom',
 			},
 			{ astroConfig: this.config, logging, mode: 'build' }
 		);

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -65,6 +65,7 @@ export async function createVite(
 		cacheDir: fileURLToPath(new URL('./node_modules/.vite/', astroConfig.root)), // using local caches allows Astro to be used in monorepos, etc.
 		clearScreen: false, // we want to control the output, not Vite
 		logLevel: 'warn', // log warnings and errors only
+		appType: 'custom',
 		optimizeDeps: {
 			entries: ['src/**/*'],
 			exclude: ['node-fetch'],

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -28,20 +28,6 @@ interface AstroPluginOptions {
 	logging: LogOptions;
 }
 
-const BAD_VITE_MIDDLEWARE = [
-	'viteIndexHtmlMiddleware',
-	'vite404Middleware',
-	'viteSpaFallbackMiddleware',
-];
-function removeViteHttpMiddleware(server: vite.Connect.Server) {
-	for (let i = server.stack.length - 1; i > 0; i--) {
-		// @ts-expect-error using internals until https://github.com/vitejs/vite/pull/4640 is merged
-		if (BAD_VITE_MIDDLEWARE.includes(server.stack[i].handle.name)) {
-			server.stack.splice(i, 1);
-		}
-	}
-}
-
 function truncateString(str: string, n: number) {
 	if (str.length > n) {
 		return str.substring(0, n) + '&#8230;';
@@ -386,8 +372,6 @@ export default function createPlugin({ config, logging }: AstroPluginOptions): v
 			viteServer.watcher.on('unlink', rebuildManifest.bind(null, true));
 			viteServer.watcher.on('change', rebuildManifest.bind(null, false));
 			return () => {
-				removeViteHttpMiddleware(viteServer.middlewares);
-
 				// Push this middleware to the front of the stack so that it can intercept responses.
 				if (config.base !== '/') {
 					viteServer.middlewares.stack.unshift({


### PR DESCRIPTION
## Changes

From https://github.com/vitejs/vite/pull/9865, we can remove the hardcoded Vite middleware removal code as we use `appType: 'custom'` that does the same thing.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing test should pass.

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A