### PR TITLE
Fix image integration's types not including Vite's types

### DIFF
--- a/.changeset/blue-knives-collect.md
+++ b/.changeset/blue-knives-collect.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Fix import.meta.env not being available when using the image integration's types

--- a/packages/integrations/image/client.d.ts
+++ b/packages/integrations/image/client.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="astro/client-base" />
+
 type InputFormat = 'avif' | 'gif' | 'heic' | 'heif' | 'jpeg' | 'jpg' | 'png' | 'tiff' | 'webp';
 
 interface ImageMetadata {


### PR DESCRIPTION
## Changes

The Image integration's types didn't refer to `client-base.d.ts`, as such numerous types were lost when using them. Notably `import.meta.env`

## Testing

Tested manually

## Docs

N/A