### PR TITLE
Add missing slot attribute to possible attributes on SVG elements

### DIFF
--- a/.changeset/stale-paws-rhyme.md
+++ b/.changeset/stale-paws-rhyme.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add missing `slot` attributes to SVG definitions

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -1007,7 +1007,7 @@ declare namespace astroHTML.JSX {
 	//   - "string"
 	//   - union of string literals
 	interface SVGAttributes extends AriaAttributes, DOMAttributes, AstroBuiltinAttributes {
-		// Attributes which also defined in HTMLAttributes
+		// Attributes which are also defined in HTMLAttributes
 		class?: string | undefined | null;
 		color?: string | undefined | null;
 		height?: number | string | undefined | null;
@@ -1018,6 +1018,7 @@ declare namespace astroHTML.JSX {
 		method?: string | undefined | null;
 		min?: number | string | undefined | null;
 		name?: string | undefined | null;
+		slot?: string | undefined | null;
 		style?: string | Record<string, any> | undefined | null;
 		target?: string | undefined | null;
 		type?: string | undefined | null;


### PR DESCRIPTION
## Changes

`slot` was missing from the list of possible attributes on SVG elements

## Testing

Tested manually

## Docs

N/A