### PR TITLE
Fix "failed to load for SSR" error when removing Astro `<style>` blocks

### DIFF
--- a/packages/astro/src/core/render/dev/vite.ts
+++ b/packages/astro/src/core/render/dev/vite.ts
@@ -3,12 +3,6 @@ import vite from 'vite';
 import { unwrapId } from '../../util.js';
 import { STYLE_EXTENSIONS } from '../util.js';
 
-/**
- * List of file extensions signalling we can (and should) SSR ahead-of-time
- * See usage below
- */
-const fileExtensionsToSSR = new Set(['.astro', '.md']);
-
 const STRIP_QUERY_PARAMS_REGEX = /\?.*$/;
 
 /** recursively crawl the module graph to get all style files imported by parent id */
@@ -55,12 +49,6 @@ export async function* crawlGraph(
 					// every hoisted script in the project is added to every page!
 					if (entryIsStyle && !STYLE_EXTENSIONS.has(npath.extname(importedModulePathname))) {
 						continue;
-					}
-					if (fileExtensionsToSSR.has(npath.extname(importedModulePathname))) {
-						const mod = viteServer.moduleGraph.getModuleById(importedModule.id);
-						if (!mod?.ssrModule) {
-							await viteServer.ssrLoadModule(importedModule.id);
-						}
 					}
 				}
 				importedModules.add(importedModule);


### PR DESCRIPTION
## Changes

- Working towards #4541 - "deleting a style tag killed the server!"
- Reproducible when using Tailwind and removing a `style` tag that was present when the dev server started
- Culprit: the `ssrLoadModule` attempt on `.astro` files. When using larger dependencies like Tailwind, the imported style module graph may be out-of-date. It _seems_ this is no longer needed to load styles with HMR in Vite 3. Waiting for e2e tests to confirm!

## Testing

Existing e2e tests should cover style reloading

## Docs

N/A