### PR TITLE
[docs] remove confusing note added in wrong place

### DIFF
--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -12,15 +12,7 @@ This adapter allows Astro to deploy your SSR site to [Vercel](https://www.vercel
 
 ## Why Astro Vercel
 
-If you're using Astro as a static site builder — its behavior out of the box — you don't need an adapter. In order to return the correct status code for non existing pages, you must add the following config file at the root of your project:
-
- __`vercel.json`__
-```json
-{
-  "cleanUrls": true,
-  "trailingSlash": false
-}
-```
+If you're using Astro as a static site builder — its behavior out of the box — you don't need an adapter. 
 
 If you wish to [use server-side rendering (SSR)](https://docs.astro.build/en/guides/server-side-rendering/), Astro requires an adapter that matches your deployment runtime.
 


### PR DESCRIPTION
## Changes

A note related only to SSG deployment on Vercel was added to this Vercel adapter README that was confusing to readers and in the wrong place.

I'm deleting this here and making note on the Vercel deploy page instead, where we describe deploying a static site to Vercel.

Note: I'm assuming this only affects SSG (not SSR deployment) because 
a) that was the description in the original PR that put the note here (https://github.com/withastro/astro/pull/4299) and 
b) the person added this at the top of the page, with the introductory sentence about not needing an adaptor for SSG (i.e. placed this content where the mention of SSG was instead of further down the page in Usage or something like that.) 

If this `vercel.json` file is in fact needed for SSR, too, then instead of just deleting, I would move this down to Usage. There is no need for this to be at the very top of the page like this, as it in no way contradicts or adds to the warning statement that you don't need this adapter for SSG, the purpose of which is just to tell people when NOT to install this integration. They should go to the regular Vercel deploy page for that kind of information re: SSG deployment.

## Testing

Not tested. Docs change

## Docs

Will update Docs site.