### PR TITLE
Include trailingSlash in astro:build:done hook

### DIFF
--- a/.changeset/moody-cars-return.md
+++ b/.changeset/moody-cars-return.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Include trailingSlash in astro:build:done hook
+
+This change ensures that the `pages` provided in the `astro:build:done` hook conform to the `trailingSlash` and `build.format` configs.

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -240,8 +240,26 @@ interface GeneratePathOptions {
 	renderers: SSRLoadedRenderer[];
 }
 
+function shouldAppendForwardSlash(trailingSlash: AstroConfig['trailingSlash'], buildFormat: AstroConfig['build']['format']): boolean {
+	switch(trailingSlash) {
+		case 'always': return true;
+		case 'never': return false;
+		case 'ignore': {
+			switch(buildFormat) {
+				case 'directory': return true;
+				case 'file': return false;
+			}
+		}
+	}
+}
+
 function addPageName(pathname: string, opts: StaticBuildOptions): void {
-	opts.pageNames.push(pathname.replace(/^\//, ''));
+	const trailingSlash = opts.astroConfig.trailingSlash;
+	const buildFormat = opts.astroConfig.build.format;
+	const pageName = shouldAppendForwardSlash(trailingSlash, buildFormat) ?
+		pathname.replace(/\/?$/, '/').replace(/^\//, '') :
+		pathname.replace(/^\//, '')
+	opts.pageNames.push(pageName);
 }
 
 function getUrlForPath(

--- a/packages/integrations/sitemap/package.json
+++ b/packages/integrations/sitemap/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "astro": "workspace:*",
-    "astro-scripts": "workspace:*"
+    "astro-scripts": "workspace:*",
+    "xml2js": "0.4.23"
   }
 }

--- a/packages/integrations/sitemap/test/fixtures/trailing-slash/astro.config.mjs
+++ b/packages/integrations/sitemap/test/fixtures/trailing-slash/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
+
+export default defineConfig({
+  integrations: [sitemap()],
+	site: 'http://example.com'
+})

--- a/packages/integrations/sitemap/test/fixtures/trailing-slash/package.json
+++ b/packages/integrations/sitemap/test/fixtures/trailing-slash/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/sitemap-trailing-slash",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/sitemap": "workspace:*"
+  }
+}

--- a/packages/integrations/sitemap/test/fixtures/trailing-slash/src/pages/one.astro
+++ b/packages/integrations/sitemap/test/fixtures/trailing-slash/src/pages/one.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>One</title>
+	</head>
+	<body>
+		<h1>One</h1>
+	</body>
+</html>

--- a/packages/integrations/sitemap/test/fixtures/trailing-slash/src/pages/two.astro
+++ b/packages/integrations/sitemap/test/fixtures/trailing-slash/src/pages/two.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>Two</title>
+	</head>
+	<body>
+		<h1>Two</h1>
+	</body>
+</html>

--- a/packages/integrations/sitemap/test/test-utils.js
+++ b/packages/integrations/sitemap/test/test-utils.js
@@ -1,0 +1,30 @@
+import { loadFixture as baseLoadFixture } from '../../../astro/test/test-utils.js';
+import * as xml2js from 'xml2js';
+
+/**
+ * @typedef {import('../../../astro/test/test-utils').Fixture} Fixture
+ */
+
+export function loadFixture(inlineConfig) {
+	if (!inlineConfig || !inlineConfig.root)
+		throw new Error("Must provide { root: './fixtures/...' }");
+
+	// resolve the relative root (i.e. "./fixtures/tailwindcss") to a full filepath
+	// without this, the main `loadFixture` helper will resolve relative to `packages/astro/test`
+	return baseLoadFixture({
+		...inlineConfig,
+		root: new URL(inlineConfig.root, import.meta.url).toString(),
+	});
+}
+
+export function readXML(fileOrPromise) {
+	const parseString = xml2js.parseString;
+	return Promise.resolve(fileOrPromise).then(xml => {
+		return new Promise((resolve, reject) => {
+			parseString(xml, function (err, result) {
+				if(err) return reject(err);
+				resolve(result);
+		});
+		})
+	});
+}

--- a/packages/integrations/sitemap/test/trailing-slash.test.js
+++ b/packages/integrations/sitemap/test/trailing-slash.test.js
@@ -1,0 +1,79 @@
+import { loadFixture, readXML } from './test-utils.js';
+import { expect } from 'chai';
+
+describe('Trailing slash', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	describe('trailingSlash: ignore', () => {
+		describe('build.format: directory', () => {
+			before(async () => {
+				fixture = await loadFixture({
+					root: './fixtures/trailing-slash/',
+					trailingSlash: 'ignore',
+					build: {
+						format: 'directory'
+					}
+				});
+				await fixture.build();
+			});
+		
+			it('URLs end with trailing slash', async () => {
+				const data = await readXML(fixture.readFile('/sitemap-0.xml'));
+				const urls = data.urlset.url;
+				expect(urls[0].loc[0]).to.equal('http://example.com/one/');
+			});
+		});
+
+		describe('build.format: file', () => {
+			before(async () => {
+				fixture = await loadFixture({
+					root: './fixtures/trailing-slash/',
+					trailingSlash: 'ignore',
+					build: {
+						format: 'file'
+					}
+				});
+				await fixture.build();
+			});
+		
+			it('URLs do not end with trailing slash', async () => {
+				const data = await readXML(fixture.readFile('/sitemap-0.xml'));
+				const urls = data.urlset.url;	
+				expect(urls[0].loc[0]).to.equal('http://example.com/one');
+			});
+		});
+	});
+
+	describe('trailingSlash: never', () => {
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/trailing-slash/',
+				trailingSlash: 'never',
+			});
+			await fixture.build();
+		});
+	
+		it('URLs do no end with trailing slash', async () => {
+			const data = await readXML(fixture.readFile('/sitemap-0.xml'));
+			const urls = data.urlset.url;
+			expect(urls[0].loc[0]).to.equal('http://example.com/one');
+		});
+	});
+
+	describe('trailingSlash: always', () => {
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/trailing-slash/',
+				trailingSlash: 'always',
+			});
+			await fixture.build();
+		});
+	
+		it('URLs end with trailing slash', async () => {
+			const data = await readXML(fixture.readFile('/sitemap-0.xml'));
+			const urls = data.urlset.url;
+			expect(urls[0].loc[0]).to.equal('http://example.com/one/');
+		});
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2552,6 +2552,7 @@ importers:
       astro: workspace:*
       astro-scripts: workspace:*
       sitemap: ^7.1.1
+      xml2js: 0.4.23
       zod: ^3.17.3
     dependencies:
       sitemap: 7.1.1
@@ -2559,6 +2560,15 @@ importers:
     devDependencies:
       astro: link:../../astro
       astro-scripts: link:../../../scripts
+      xml2js: 0.4.23
+
+  packages/integrations/sitemap/test/fixtures/trailing-slash:
+    specifiers:
+      '@astrojs/sitemap': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/sitemap': link:../../..
+      astro: link:../../../../../astro
 
   packages/integrations/solid:
     specifiers:
@@ -15540,7 +15550,6 @@ packages:
 
   /sax/1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
-    dev: false
 
   /scheduler/0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
@@ -17441,6 +17450,19 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: true
+
+  /xml2js/0.4.23:
+    resolution: {integrity: sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      sax: 1.2.4
+      xmlbuilder: 11.0.1
+    dev: true
+
+  /xmlbuilder/11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
     dev: true
 
   /xregexp/2.0.0:


### PR DESCRIPTION
## Changes

- When calculating the pages for the `pages` prop in `astro:build:done` account for the trailingSlash and build.format configs.
- This fixes integrations like sitemaps which need the correct production URLs.
- Closes https://github.com/withastro/astro/issues/4539

## Testing

- Test added in the sitemap integration to cover every scenario

## Docs

N/A, bug fix