### PR TITLE
Adds the "withastro" keyword to adapter packages

### DIFF
--- a/.changeset/chatty-foxes-bow.md
+++ b/.changeset/chatty-foxes-bow.md
@@ -1,0 +1,9 @@
+---
+'@astrojs/cloudflare': patch
+'@astrojs/deno': patch
+'@astrojs/netlify': patch
+'@astrojs/node': patch
+'@astrojs/vercel': patch
+---
+
+Adding the `withastro` keyword to include the adapters on the [Integrations Catalog](https://astro.build/integrations)

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/cloudflare"
   },
   "keywords": [
+    "withastro",
     "astro-adapter"
   ],
   "bugs": "https://github.com/withastro/astro/issues",

--- a/packages/integrations/deno/package.json
+++ b/packages/integrations/deno/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/deno"
   },
   "keywords": [
+    "withastro",
     "astro-adapter"
   ],
   "bugs": "https://github.com/withastro/astro/issues",

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/netlify"
   },
   "keywords": [
+    "withastro",
     "astro-adapter"
   ],
   "bugs": "https://github.com/withastro/astro/issues",

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -12,6 +12,7 @@
     "directory": "packages/integrations/node"
   },
   "keywords": [
+    "withastro",
     "astro-adapter"
   ],
   "bugs": "https://github.com/withastro/astro/issues",

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -11,6 +11,7 @@
     "directory": "packages/integrations/vercel"
   },
   "keywords": [
+    "withastro",
     "astro-adapter"
   ],
   "bugs": "https://github.com/withastro/astro/issues",


### PR DESCRIPTION
## Changes

Adds the `withastro` keyword to all host adapters.  This will make sure they're included in a new `adapters` tab in the [Integrations Catalog](https://astro.build/integrations)

## Testing

N/A

## Docs

[Related docs PR](https://github.com/withastro/docs/pull/1441) updating the list of keywords that our integration catalog searches for