### PR TITLE
improvement: add optional status parameter to Astro.redirect

### DIFF
--- a/.changeset/fair-students-kiss.md
+++ b/.changeset/fair-students-kiss.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+Add optional status parameter to Astro.redirect

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -182,9 +182,9 @@ export function createResult(args: CreateResultArgs): SSRResult {
 				request,
 				url,
 				redirect: args.ssr
-					? (path: string) => {
+					? (path: string, status: 301 | 302 | 307 = 302) => {
 							return new Response(null, {
-								status: 302,
+								status,
 								headers: {
 									Location: path,
 								},

--- a/packages/astro/test/fixtures/ssr-redirect/src/pages/permanent.astro
+++ b/packages/astro/test/fixtures/ssr-redirect/src/pages/permanent.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/login', 301);
+---

--- a/packages/astro/test/ssr-redirect.test.js
+++ b/packages/astro/test/ssr-redirect.test.js
@@ -22,4 +22,12 @@ describe('Astro.redirect', () => {
 		expect(response.status).to.equal(302);
 		expect(response.headers.get('location')).to.equal('/login');
 	});
+
+	it('Returns a 301 status', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		const request = new Request('http://example.com/permanent');
+		const response = await app.render(request);
+		expect(response.status).to.equal(301);
+		expect(response.headers.get('location')).to.equal('/login');
+	});
 });


### PR DESCRIPTION
## Changes

Currently Astro only provides 302 redirects. This change will provide an optional status parameter for permanent redirects.

## Testing

Added one test for 301 redirects.

## Docs

Has not been added yet.
<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->