### PR TITLE
Deno custom 404 pages

### DIFF
--- a/.changeset/sharp-brooms-drum.md
+++ b/.changeset/sharp-brooms-drum.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/deno': patch
+---
+
+Make Deno SSR Backend Render Custom 404 Pages

--- a/packages/integrations/deno/src/server.ts
+++ b/packages/integrations/deno/src/server.ts
@@ -28,10 +28,22 @@ export function start(manifest: SSRManifest, options: Options) {
 			Reflect.set(request, Symbol.for('astro.clientAddress'), ip);
 			return await app.render(request);
 		}
-
+		
+		// If the request path wasn't found in astro,
+		// try to fetch a static file instead
 		const url = new URL(request.url);
 		const localPath = new URL('.' + url.pathname, clientRoot);
-		return fetch(localPath.toString());
+		const fileResp = await fetch(localPath.toString());
+		
+		// If the static file can't be found
+		if (fileResp.status == 404) {
+		    // Render the astro custom 404 page
+		    return await app.render(request);
+		
+		// If the static file is found
+		} else {
+		    return fileResp;
+		}
 	};
 
 	const port = options.port ?? 8085;

--- a/packages/integrations/deno/test/basics.test.js
+++ b/packages/integrations/deno/test/basics.test.js
@@ -27,6 +27,21 @@ Deno.test({
 });
 
 Deno.test({
+	name: 'Custom 404',
+	async fn() {
+		await startApp(async () => {
+			const resp = await fetch('http://127.0.0.1:8085/this-does-not-exist');
+			assertEquals(resp.status, 404);
+			const html = await resp.text();
+			assert(html);
+			const doc = new DOMParser().parseFromString(html, `text/html`);
+			const header = doc.querySelector('#custom-404');
+			assert(header, 'displays custom 404');
+		});
+	},
+});
+
+Deno.test({
 	name: 'Loads style assets',
 	async fn() {
 		await startApp(async () => {

--- a/packages/integrations/deno/test/fixtures/basics/src/pages/404.astro
+++ b/packages/integrations/deno/test/fixtures/basics/src/pages/404.astro
@@ -1,0 +1,1 @@
+<h1 id="custom-404">Custom 404 Page</h1>


### PR DESCRIPTION
## Changes

- Makes Deno SSR render custom 404 pages.
- It does this by detecting when it could not find a static file at a certain location, and then calling `app.render()` to make sure any custom 404 page is rendered instead of the browser's default.
- Resolves #4560 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Added a Deno test that makes sure the custom 404 page is displayed for non-existent routes.

## Docs

This is a visible change, but it updates the behavior to what I believe is the _expected_ behavior, according to the current documentation, so I don't think there are any doc changes required.

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->