### PR TITLE
fix: always get latest pnpm

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,11 @@ image:
   file: .Dockerfile
 # Commands to start on workspace startup
 tasks:
-  - init: |
+  - before: |
+      # Get latest pnpm version, in case the custom docker image was not updated
+      # Until this issue gets resolved - https://github.com/gitpod-io/gitpod/issues/12551
+      curl -fsSL https://get.pnpm.io/install.sh | SHELL=`which bash` bash -
+    init: |
       pnpm install
       pnpm run build
     command: |


### PR DESCRIPTION
## Changes

Until https://github.com/gitpod-io/gitpod/issues/12551 gets resolved, this PR make sure Gitpod workspaces would always use latest pnpm.

## Testing

* Open this PR in Gitpod
* Run `pnpm -v`.
* Confirm it is using latest pnpm version (7.9.5)

## Docs

(this PR only affect Gitpod)

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->