### PR TITLE
Update `astro add` integrations list

### DIFF
--- a/.changeset/nice-cups-mix.md
+++ b/.changeset/nice-cups-mix.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Remove duplicate hosting output in `astro add`
+Update `astro add` to list official integrations & adapters with same organisation we use in docs

--- a/.changeset/nice-cups-mix.md
+++ b/.changeset/nice-cups-mix.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Remove duplicate hosting output in `astro add`

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -74,12 +74,6 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 					['solid-js', 'astro add solid-js'],
 					['lit', 'astro add lit'],
 				],
-				'Recommended: Hosting': [
-					['netlify', 'astro add netlify'],
-					['vercel', 'astro add vercel'],
-					['cloudflare', 'astro add cloudflare'],
-					['deno', 'astro add deno'],
-				],
 				'Recommended: Integrations': [
 					['tailwind', 'astro add tailwind'],
 					['partytown', 'astro add partytown'],
@@ -89,6 +83,7 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 					['netlify', 'astro add netlify'],
 					['vercel', 'astro add vercel'],
 					['deno', 'astro add deno'],
+					['cloudflare', 'astro add cloudflare'],
 				],
 			},
 			description: `For more integrations, check out: ${cyan('https://astro.build/integrations')}`,

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -66,24 +66,29 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 					['--yes', 'Accept all prompts.'],
 					['--help', 'Show this help message.'],
 				],
-				'Recommended: UI Frameworks': [
+				'UI Frameworks': [
 					['react', 'astro add react'],
 					['preact', 'astro add preact'],
 					['vue', 'astro add vue'],
 					['svelte', 'astro add svelte'],
 					['solid-js', 'astro add solid-js'],
 					['lit', 'astro add lit'],
+					['alpine', 'astro add alpine'],
 				],
-				'Recommended: Integrations': [
-					['tailwind', 'astro add tailwind'],
-					['partytown', 'astro add partytown'],
-					['sitemap', 'astro add sitemap'],
-				],
-				'Example: Add an SSR Adapter': [
+				'SSR Adapters': [
 					['netlify', 'astro add netlify'],
 					['vercel', 'astro add vercel'],
 					['deno', 'astro add deno'],
 					['cloudflare', 'astro add cloudflare'],
+					['node', 'astro add node'],
+				],
+				Others: [
+					['tailwind', 'astro add tailwind'],
+					['image', 'astro add image'],
+					['mdx', 'astro add mdx'],
+					['partytown', 'astro add partytown'],
+					['sitemap', 'astro add sitemap'],
+					['prefetch', 'astro add prefetch'],
 				],
 			},
 			description: `For more integrations, check out: ${cyan('https://astro.build/integrations')}`,


### PR DESCRIPTION
## Changes

Contributes towards #4541

- Remove duplicate content in the log shown when running `astro add` without arguments.
- Add missing integrations (image, mdx, node adapter, prefetch and alpine)
- Simplify section headings to match [docs navigation](https://docs.astro.build/en/guides/integrations-guide/#official-integrations): `UI Frameworks`, `SSR Adapters` & `Others`

## Testing

Not tested — just changing the logging output.

## Docs

No changes required.