### PR TITLE
Blog template changes

### DIFF
--- a/examples/blog/src/layouts/BlogPost.astro
+++ b/examples/blog/src/layouts/BlogPost.astro
@@ -18,7 +18,6 @@ const {
 } = Astro.props;
 ---
 
-<!DOCTYPE html>
 <html lang="en-us">
 	<head>
 		<BaseHead title={title} description={description} />

--- a/examples/blog/src/layouts/BlogPost.astro
+++ b/examples/blog/src/layouts/BlogPost.astro
@@ -18,7 +18,8 @@ const {
 } = Astro.props;
 ---
 
-<html>
+<!DOCTYPE html>
+<html lang="en-us">
 	<head>
 		<BaseHead title={title} description={description} />
 		<style>

--- a/examples/blog/src/layouts/BlogPost.astro
+++ b/examples/blog/src/layouts/BlogPost.astro
@@ -18,7 +18,7 @@ const {
 } = Astro.props;
 ---
 
-<html lang="en-us">
+<html lang="en">
 	<head>
 		<BaseHead title={title} description={description} />
 		<style>

--- a/examples/blog/src/pages/blog.astro
+++ b/examples/blog/src/pages/blog.astro
@@ -11,7 +11,7 @@ const posts = (await Astro.glob('./blog/*.{md,mdx}')).sort(
 ---
 
 <!DOCTYPE html>
-<html lang="en-us">
+<html lang="en">
 	<head>
 		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
 		<style>

--- a/examples/blog/src/pages/blog.astro
+++ b/examples/blog/src/pages/blog.astro
@@ -51,7 +51,7 @@ const posts = (await Astro.glob('./blog/*.{md,mdx}')).sort(
 					))}
 				</ul>
 			</section>
-			<Footer />
 		</main>
+		<Footer />
 	</body>
 </html>

--- a/examples/blog/src/pages/index.astro
+++ b/examples/blog/src/pages/index.astro
@@ -6,7 +6,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../config';
 ---
 
 <!DOCTYPE html>
-<html lang="en-us">
+<html lang="en">
 	<head>
 		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
 	</head>

--- a/examples/ssr/src/pages/cart.astro
+++ b/examples/ssr/src/pages/cart.astro
@@ -14,7 +14,7 @@ const user = { name: 'test' }; // getUser?
 const cart = await getCart(Astro.request);
 ---
 
-<html>
+<html lang="en">
 	<head>
 		<title>Cart | Online Store</title>
 		<style>

--- a/examples/ssr/src/pages/index.astro
+++ b/examples/ssr/src/pages/index.astro
@@ -8,7 +8,7 @@ import '../styles/common.css';
 const products = await getProducts(Astro.request);
 ---
 
-<html>
+<html lang="en">
 	<head>
 		<title>Online Store</title>
 		<style>

--- a/examples/ssr/src/pages/login.astro
+++ b/examples/ssr/src/pages/login.astro
@@ -3,7 +3,7 @@ import Header from '../components/Header.astro';
 import Container from '../components/Container.astro';
 ---
 
-<html>
+<html lang="en">
 	<head>
 		<title>Online Store</title>
 		<style>


### PR DESCRIPTION
## Changes

This just makes a couple of trivial changes to `examples/blog` for consistency  with other layouts:

- Moves the `<Footer />` component outside of `<main>` in `blog.astro`
- Adds a `DOCTYPE` and `lang="en-us"` attribute to `BlogPost.astro`. 

I didn't change any of the other examples as there's no consistency between all the examples. Some have a `DOCTYPE`, some have `lang="en"` or more attributes. However these changes are within the Blog example, so I felt updating them for consistency made sense (and my accessibility checked complained about the lack of a `lang` attribute).

No changeset as contributing.md says they're not needed for examples. 

## Testing

This was tested by making the changes in my own Blog site and viewing the results in the browser. I don't believe there are specific tests related to the examples.

## Docs

This change isn't explicitly visible, it's an internal change to the example markup. 