### PR TITLE
No 👏 more 👏 server 👏 restarts 👏 on 👏 config 👏 changes

### DIFF
--- a/.changeset/tricky-cows-travel.md
+++ b/.changeset/tricky-cows-travel.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Restart dev server when config file is added, updated, or removed

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -105,7 +105,7 @@
     "@babel/plugin-transform-react-jsx": "^7.17.12",
     "@babel/traverse": "^7.18.2",
     "@babel/types": "^7.18.4",
-    "@proload/core": "^0.3.2",
+    "@proload/core": "^0.3.3",
     "@proload/plugin-tsm": "^0.2.1",
     "boxen": "^6.2.1",
     "ci-info": "^3.3.1",

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -174,7 +174,7 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 								flags,
 								cmd,
 								logging,
-								invalidateWithCache: true,
+								isConfigReload: true,
 							});
 							info(logging, 'astro', logMsg + '\n');
 							astroConfig = newConfig.astroConfig;

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -152,7 +152,7 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 				let restartInFlight = false;
 				const configFlag = resolveFlags(flags).config;
 				const configFlagPath = configFlag
-					? (await resolveConfigURL({ cwd: root, flags }))?.pathname
+					? (await resolveConfigURL({ cwd: root, flags }, false))?.pathname
 					: undefined;
 				const resolvedRoot = appendForwardSlash(resolveRoot(root));
 

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { normalizePath } from 'vite';
 import add from '../core/add/index.js';
 import build from '../core/build/index.js';
-import { openConfig, resolveConfigURL, resolveFlags, resolveRoot } from '../core/config.js';
+import { openConfig, resolveConfigPath, resolveFlags, resolveRoot } from '../core/config.js';
 import devServer from '../core/dev/index.js';
 import { collectErrorMetadata } from '../core/errors.js';
 import { debug, info, LogOptions, warn } from '../core/logger/core.js';
@@ -152,7 +152,7 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 				let restartInFlight = false;
 				const configFlag = resolveFlags(flags).config;
 				const configFlagPath = configFlag
-					? (await resolveConfigURL({ cwd: root, flags }, false))?.pathname
+					? await resolveConfigPath({ cwd: root, flags }, false)
 					: undefined;
 				const resolvedRoot = appendForwardSlash(resolveRoot(root));
 

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -152,7 +152,7 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 				let restartInFlight = false;
 				const configFlag = resolveFlags(flags).config;
 				const configFlagPath = configFlag
-					? await resolveConfigPath({ cwd: root, flags }, false)
+					? await resolveConfigPath({ cwd: root, flags })
 					: undefined;
 				const resolvedRoot = appendForwardSlash(resolveRoot(root));
 

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -10,7 +10,7 @@ import preferredPM from 'preferred-pm';
 import prompts from 'prompts';
 import { fileURLToPath, pathToFileURL } from 'url';
 import type yargs from 'yargs-parser';
-import { resolveConfigURL } from '../config.js';
+import { resolveConfigPath } from '../config.js';
 import { debug, info, LogOptions } from '../logger/core.js';
 import * as msg from '../messages.js';
 import { printHelp } from '../messages.js';
@@ -97,7 +97,8 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 	}
 	let configURL: URL | undefined;
 	const root = pathToFileURL(cwd ? path.resolve(cwd) : process.cwd());
-	configURL = await resolveConfigURL({ cwd, flags });
+	const rawConfigPath = await resolveConfigPath({ cwd, flags });
+	configURL = rawConfigPath ? pathToFileURL(rawConfigPath) : undefined;
 	applyPolyfill();
 
 	if (configURL) {

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -426,12 +426,19 @@ export async function resolveConfigPath(
 
 	// Resolve config file path using Proload
 	// If `userConfigPath` is `undefined`, Proload will search for `astro.config.[cm]?[jt]s`
-	const configPath = await resolve('astro', {
-		mustExist: !!userConfigPath,
-		cwd: root,
-		filePath: userConfigPath,
-	});
-	return configPath;
+	try {
+		const configPath = await resolve('astro', {
+			mustExist: !!userConfigPath,
+			cwd: root,
+			filePath: userConfigPath,
+		});
+		return configPath;
+	} catch (e) {
+		if (e instanceof ProloadError && flags.config) {
+			throw new Error(`Unable to resolve --config "${flags.config}"! Does the file exist?`);
+		}
+		throw e
+	}
 }
 
 interface OpenConfigResult {

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -488,8 +488,9 @@ async function tryLoadConfig(
 		if (configOptions.invalidateWithCache) {
 			// Hack: Write config to temporary file at project root
 			// This invalidates and reloads file contents when using ESM imports or "resolve"
-			const tempConfigPath = vite.normalizePath(
-				path.join(root, `.temp.${Date.now()}.config${path.extname(configPath)}`)
+			const tempConfigPath = path.join(
+				root,
+				`.temp.${Date.now()}.config${path.extname(configPath)}`
 			);
 			await fs.promises.writeFile(tempConfigPath, await fs.promises.readFile(configPath));
 			finallyCleanup = async () => {

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -510,7 +510,6 @@ async function tryLoadConfig(
 
 		return config as TryLoadConfigResult;
 	} catch (e) {
-		console.log({ e });
 		if (e instanceof ProloadError && flags.config) {
 			throw new Error(`Unable to resolve --config "${flags.config}"! Does the file exist?`);
 		}

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -509,6 +509,7 @@ async function tryLoadConfig(
 			cwd: root,
 			filePath: configPath,
 		});
+		console.log('worked', config?.filePath);
 
 		return config as TryLoadConfigResult;
 	} catch (e) {

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -486,7 +486,7 @@ async function tryLoadConfig(
 		let configPath = (
 			await resolveConfigURL({ cwd: configOptions.cwd, flags: configOptions.flags })
 		)?.pathname;
-		console.log('resolved config path');
+		console.log('resolved config path', configPath);
 		if (!configPath) return undefined;
 		if (configOptions.isConfigReload) {
 			console.log('why here?');
@@ -509,7 +509,7 @@ async function tryLoadConfig(
 
 		console.log('loading config');
 		const config = await load('astro', {
-			mustExist: true,
+			mustExist: !!configPath,
 			cwd: root,
 			filePath: configPath,
 		});
@@ -517,6 +517,7 @@ async function tryLoadConfig(
 
 		return config as TryLoadConfigResult;
 	} catch (e) {
+		console.log({ e });
 		if (e instanceof ProloadError && flags.config) {
 			throw new Error(`Unable to resolve --config "${flags.config}"! Does the file exist?`);
 		}

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -374,6 +374,10 @@ export function resolveFlags(flags: Partial<Flags>): CLIFlags {
 	};
 }
 
+export function resolveRoot(cwd?: string): string {
+	return cwd ? path.resolve(cwd) : process.cwd();
+}
+
 /** Merge CLI flags & user config object (CLI flags take priority) */
 function mergeCLIFlags(astroConfig: AstroUserConfig, flags: CLIFlags, cmd: string) {
 	astroConfig.server = astroConfig.server || {};
@@ -411,7 +415,7 @@ interface LoadConfigOptions {
 export async function resolveConfigURL(
 	configOptions: Pick<LoadConfigOptions, 'cwd' | 'flags'>
 ): Promise<URL | undefined> {
-	const root = configOptions.cwd ? path.resolve(configOptions.cwd) : process.cwd();
+	const root = resolveRoot(configOptions.cwd);
 	const flags = resolveFlags(configOptions.flags || {});
 	let userConfigPath: string | undefined;
 
@@ -441,7 +445,7 @@ interface OpenConfigResult {
 
 /** Load a configuration file, returning both the userConfig and astroConfig */
 export async function openConfig(configOptions: LoadConfigOptions): Promise<OpenConfigResult> {
-	const root = configOptions.cwd ? path.resolve(configOptions.cwd) : process.cwd();
+	const root = resolveRoot(configOptions.cwd);
 	const flags = resolveFlags(configOptions.flags || {});
 	let userConfig: AstroUserConfig = {};
 
@@ -544,7 +548,7 @@ async function tryLoadConfig(
  * @deprecated
  */
 export async function loadConfig(configOptions: LoadConfigOptions): Promise<AstroConfig> {
-	const root = configOptions.cwd ? path.resolve(configOptions.cwd) : process.cwd();
+	const root = resolveRoot(configOptions.cwd);
 	const flags = resolveFlags(configOptions.flags || {});
 	let userConfig: AstroUserConfig = {};
 

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -404,7 +404,7 @@ interface LoadConfigOptions {
 	validate?: boolean;
 	logging: LogOptions;
 	/** Invalidate when reloading a previously loaded config */
-	invalidateWithCache?: boolean;
+	isConfigReload?: boolean;
 }
 
 /**
@@ -485,7 +485,7 @@ async function tryLoadConfig(
 			await resolveConfigURL({ cwd: configOptions.cwd, flags: configOptions.flags })
 		)?.pathname;
 		if (!configPath) return undefined;
-		if (configOptions.invalidateWithCache) {
+		if (configOptions.isConfigReload) {
 			// Hack: Write config to temporary file at project root
 			// This invalidates and reloads file contents when using ESM imports or "resolve"
 			const tempConfigPath = path.join(

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -482,11 +482,14 @@ async function tryLoadConfig(
 ): Promise<TryLoadConfigResult | undefined> {
 	let finallyCleanup = async () => {};
 	try {
+		console.log('resolving config path');
 		let configPath = (
 			await resolveConfigURL({ cwd: configOptions.cwd, flags: configOptions.flags })
 		)?.pathname;
+		console.log('resolved config path');
 		if (!configPath) return undefined;
 		if (configOptions.isConfigReload) {
+			console.log('why here?');
 			// Hack: Write config to temporary file at project root
 			// This invalidates and reloads file contents when using ESM imports or "resolve"
 			const tempConfigPath = path.join(
@@ -504,12 +507,13 @@ async function tryLoadConfig(
 			configPath = tempConfigPath;
 		}
 
+		console.log('loading config');
 		const config = await load('astro', {
 			mustExist: true,
 			cwd: root,
 			filePath: configPath,
 		});
-		console.log('worked', config?.filePath);
+		console.log('loaded config', config?.filePath);
 
 		return config as TryLoadConfigResult;
 	} catch (e) {

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -483,9 +483,10 @@ async function tryLoadConfig(
 	let finallyCleanup = async () => {};
 	try {
 		console.log('resolving config path');
-		let configPath = (
-			await resolveConfigURL({ cwd: configOptions.cwd, flags: configOptions.flags })
-		)?.pathname;
+		let configPath = vite.normalizePath(
+			(await resolveConfigURL({ cwd: configOptions.cwd, flags: configOptions.flags }))?.pathname ??
+				''
+		);
 		console.log('resolved config path', configPath);
 		if (!configPath) return undefined;
 		if (configOptions.isConfigReload) {

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -413,7 +413,8 @@ interface LoadConfigOptions {
  * instead of the resolved config
  */
 export async function resolveConfigURL(
-	configOptions: Pick<LoadConfigOptions, 'cwd' | 'flags'>
+	configOptions: Pick<LoadConfigOptions, 'cwd' | 'flags'>,
+	mustExist?: boolean
 ): Promise<URL | undefined> {
 	const root = resolveRoot(configOptions.cwd);
 	const flags = resolveFlags(configOptions.flags || {});
@@ -427,7 +428,7 @@ export async function resolveConfigURL(
 	// Resolve config file path using Proload
 	// If `userConfigPath` is `undefined`, Proload will search for `astro.config.[cm]?[jt]s`
 	const configPath = await resolve('astro', {
-		mustExist: !!userConfigPath,
+		mustExist: mustExist ?? !!userConfigPath,
 		cwd: root,
 		filePath: userConfigPath,
 	});

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -432,6 +432,7 @@ export async function resolveConfigURL(
 		cwd: root,
 		filePath: userConfigPath,
 	});
+	console.log('real', configPath);
 	if (configPath) {
 		return pathToFileURL(configPath);
 	}

--- a/packages/astro/src/core/config.ts
+++ b/packages/astro/src/core/config.ts
@@ -413,8 +413,7 @@ interface LoadConfigOptions {
  * instead of the resolved config
  */
 export async function resolveConfigPath(
-	configOptions: Pick<LoadConfigOptions, 'cwd' | 'flags'>,
-	mustExist?: boolean
+	configOptions: Pick<LoadConfigOptions, 'cwd' | 'flags'>
 ): Promise<string | undefined> {
 	const root = resolveRoot(configOptions.cwd);
 	const flags = resolveFlags(configOptions.flags || {});
@@ -428,7 +427,7 @@ export async function resolveConfigPath(
 	// Resolve config file path using Proload
 	// If `userConfigPath` is `undefined`, Proload will search for `astro.config.[cm]?[jt]s`
 	const configPath = await resolve('astro', {
-		mustExist: mustExist ?? !!userConfigPath,
+		mustExist: !!userConfigPath,
 		cwd: root,
 		filePath: userConfigPath,
 	});

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -18,6 +18,7 @@ import { apply as applyPolyfill } from '../polyfill.js';
 export interface DevOptions {
 	logging: LogOptions;
 	telemetry: AstroTelemetry;
+	isRestart?: boolean;
 }
 
 export interface DevServer {
@@ -33,6 +34,7 @@ export default async function dev(config: AstroConfig, options: DevOptions): Pro
 	await options.telemetry.record([]);
 	config = await runHookConfigSetup({ config, command: 'dev', logging: options.logging });
 	const { host, port } = config.server;
+	const { isRestart = false } = options;
 
 	// The client entrypoint for renderers. Since these are imported dynamically
 	// we need to tell Vite to preoptimize them.
@@ -66,6 +68,7 @@ export default async function dev(config: AstroConfig, options: DevOptions): Pro
 			devServerAddressInfo,
 			site,
 			https: !!viteConfig.server?.https,
+			isRestart
 		})
 	);
 

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -58,14 +58,14 @@ export function devStart({
 	config,
 	https,
 	site,
-	isRestart
+	isRestart = false
 }: {
 	startupTime: number;
 	devServerAddressInfo: AddressInfo;
 	config: AstroConfig;
 	https: boolean;
 	site: URL | undefined;
-	isRestart: boolean
+	isRestart?: boolean
 }): string {
 	// PACKAGE_VERSION is injected at build-time
 	const version = process.env.PACKAGE_VERSION ?? '0.0.0';

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -58,12 +58,14 @@ export function devStart({
 	config,
 	https,
 	site,
+	isRestart
 }: {
 	startupTime: number;
 	devServerAddressInfo: AddressInfo;
 	config: AstroConfig;
 	https: boolean;
 	site: URL | undefined;
+	isRestart: boolean
 }): string {
 	// PACKAGE_VERSION is injected at build-time
 	const version = process.env.PACKAGE_VERSION ?? '0.0.0';
@@ -106,7 +108,7 @@ export function devStart({
 
 	const messages = [
 		`${emoji('🚀 ', '')}${bgGreen(black(` astro `))} ${green(`v${version}`)} ${dim(
-			`started in ${Math.round(startupTime)}ms`
+			`${isRestart ? 're' : ''}started in ${Math.round(startupTime)}ms`
 		)}`,
 		'',
 		local,

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -125,6 +125,7 @@ export async function handleHotUpdate(
 	// TODO: Svelte files should be marked as `isSelfAccepting` but they don't appear to be
 	const isSelfAccepting = mods.every((m) => m.isSelfAccepting || m.url.endsWith('.svelte'));
 	if (isSelfAccepting) {
+		if (/astro\.config\.[cm][jt]s$/.test(file)) return mods;
 		info(logging, 'astro', msg.hmr({ file }));
 	} else {
 		info(logging, 'astro', msg.reload({ file }));

--- a/packages/integrations/alpinejs/README.md
+++ b/packages/integrations/alpinejs/README.md
@@ -25,8 +25,6 @@ yarn astro add alpinejs
 pnpm astro add alpinejs
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
@@ -55,8 +53,6 @@ export default defineConfig({
   integrations: [alpine()],
 });
 ```
-
-Finally, restart the dev server.
 
 ## Usage
 

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -466,7 +466,7 @@ const imageUrl = 'https://www.google.com/images/branding/googlelogo/2x/googlelog
 ```
 
 ## Troubleshooting
-- If your installation doesn't seem to be working, make sure to restart the dev server.
+- If your installation doesn't seem to be working, try restarting the dev server.
 - If you edit and save a file and don't see your site update accordingly, try refreshing the page.
 - If refreshing the page doesn't update your preview, or if a new installation doesn't seem to be working, then restart the dev server.
 

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -36,8 +36,6 @@ yarn astro add image
 pnpm astro add image
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
  ### Manual Install
@@ -58,7 +56,6 @@ export default {
   integrations: [image()],
 }
 ```
-Then, restart the dev server.
 
 ### Update `env.d.ts`
 

--- a/packages/integrations/lit/README.md
+++ b/packages/integrations/lit/README.md
@@ -23,8 +23,6 @@ yarn astro add lit
 pnpm astro add lit
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -33,8 +33,6 @@ yarn astro add mdx
 pnpm astro add mdx
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
@@ -58,8 +56,6 @@ export default defineConfig({
   integrations: [mdx()],
 });
 ```
-
-Finally, restart the dev server.
 
 ## Usage
 

--- a/packages/integrations/partytown/README.md
+++ b/packages/integrations/partytown/README.md
@@ -35,8 +35,6 @@ yarn astro add partytown
 pnpm astro add partytown
 ```
   
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
@@ -59,7 +57,6 @@ export default defineConfig({
 })
 ```
   
-Then, restart the dev server.
 
 ## Usage
 

--- a/packages/integrations/preact/README.md
+++ b/packages/integrations/preact/README.md
@@ -35,8 +35,6 @@ yarn astro add preact
 pnpm astro add preact
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
@@ -66,8 +64,6 @@ export default defineConfig({
   integrations: [preact()],
 });
 ```
-
-Finally, restart the dev server.
 
 ## Usage
 

--- a/packages/integrations/prefetch/README.md
+++ b/packages/integrations/prefetch/README.md
@@ -91,7 +91,7 @@ export default {
 ```
 
 ## Troubleshooting
-- If your installation doesn't seem to be working, make sure to restart the dev server.
+- If your installation doesn't seem to be working, try restarting the dev server.
 - If a link doesn't seem to be prefetching, make sure that the link is pointing to a page on the same domain and matches the integration's `selector` option.
 
 For help, check out the `#support-threads` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!

--- a/packages/integrations/prefetch/README.md
+++ b/packages/integrations/prefetch/README.md
@@ -29,8 +29,6 @@ yarn astro add prefetch
 pnpm astro add prefetch
 ```
   
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
@@ -52,7 +50,6 @@ export default {
 }
 ```
   
-Then, restart the dev server.
 
 ## Usage
 

--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -23,8 +23,6 @@ yarn astro add react
 pnpm astro add react
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually

--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -35,8 +35,6 @@ yarn astro add sitemap
 pnpm astro add sitemap
 ```
   
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
@@ -59,7 +57,6 @@ export default defineConfig({
 })
 ```
   
-Then, restart the dev server.
 
 ## Usage
 

--- a/packages/integrations/solid/README.md
+++ b/packages/integrations/solid/README.md
@@ -23,8 +23,6 @@ yarn astro add solid
 pnpm astro add solid
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually

--- a/packages/integrations/svelte/README.md
+++ b/packages/integrations/svelte/README.md
@@ -23,8 +23,6 @@ yarn astro add svelte
 pnpm astro add svelte
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually

--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -151,7 +151,7 @@ module.exports = {
 - [Browse Astro Tailwind projects on GitHub](https://github.com/search?q=%22%40astrojs%2Ftailwind%22+filename%3Apackage.json&type=Code) for more examples!
 
 ## Troubleshooting
-- If your installation doesn't seem to be working, make sure to restart the dev server.
+- If your installation doesn't seem to be working, try restarting the dev server.
 - If you edit and save a file and don't see your site update accordingly, try refreshing the page.
 - If refreshing the page doesn't update your preview, or if a new installation doesn't seem to be working, then restart the dev server.
 

--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -38,8 +38,6 @@ yarn astro add tailwind
 pnpm astro add tailwind
 ```
   
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
@@ -61,7 +59,6 @@ export default {
 }
 ```
   
-Then, restart the dev server.
 
 
 ## Usage

--- a/packages/integrations/turbolinks/README.md
+++ b/packages/integrations/turbolinks/README.md
@@ -33,8 +33,6 @@ yarn astro add turbolinks
 pnpm astro add turbolinks
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually

--- a/packages/integrations/vue/README.md
+++ b/packages/integrations/vue/README.md
@@ -23,8 +23,6 @@ yarn astro add vue
 pnpm astro add vue
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,7 +350,7 @@ importers:
       '@babel/traverse': ^7.18.2
       '@babel/types': ^7.18.4
       '@playwright/test': ^1.22.2
-      '@proload/core': ^0.3.2
+      '@proload/core': ^0.3.3
       '@proload/plugin-tsm': ^0.2.1
       '@types/babel__core': ^7.1.19
       '@types/babel__generator': ^7.6.4


### PR DESCRIPTION
## Changes

- You heard right. Restart the dev server whenever configs are added, updated, or removed 🥳
- Add `restartInFlight` flag to avoid clobbering when saving multiple times in a row
- When a `--config` is specified, only watch changes on that file. Otherwise, watch for any new `astro.config.*` files in the project root. Yes, this means your server reloads when you swap file extensions!

### About that `writeFile` call...

All good PRs have some spice: When a config file changes, **[write the config contents to temporary file at the project root](https://github.com/withastro/astro/pull/4578/files#diff-376630862e295fd5d974f4fff5419d9cb97c8f88f1a180092917500fb62b28ffR487-R504)** with a unique timestamp, and quickly delete once the config is resolved.

Proload uses a native ESM import to resolve `mjs` and `js` configs, which is great... until the file contents change. Re-importing a file in Node will _not_ get the file's up-to-date contents; once a file is imported in an application, the contents are cached as long as the process is running. This approach writes to a new file path so Node will _think_ it's a new import every time. This is informed by [Vite's ESM loader](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/config.ts#L1047-L1070), which does a similar write-read-then-delete strategy.

I also considered writing to an internal `node_modules/.astro` directory instead of the project root. However, managing the "if this directory exists..." logic _and_ relying on `node_modules` being present felt like unneeded overhead. This temporary file only appears briefly during development (not production), and will be removed whenever an error in thrown during config resolution (see `finally` block). Vite's comparable PR also writes to the project root for reference.

## Testing

TODO? Is it worth an E2E test?

## Docs

TODO: check if "restart the server" recs are mentioned in the docs