### PR TITLE
[MDX] Fix: GFM and Smartypants missing by default

### DIFF
--- a/.changeset/weak-emus-confess.md
+++ b/.changeset/weak-emus-confess.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Fix: Add GFM and Smartypants to MDX by default

--- a/packages/integrations/mdx/src/utils.ts
+++ b/packages/integrations/mdx/src/utils.ts
@@ -127,7 +127,7 @@ export async function getRemarkPlugins(
 		default:
 			remarkPlugins = [
 				...remarkPlugins,
-				...(config.markdown.extendDefaultPlugins ? DEFAULT_REMARK_PLUGINS : []),
+				...(markdownShouldExtendDefaultPlugins(config) ? DEFAULT_REMARK_PLUGINS : []),
 				...ignoreStringPlugins(config.markdown.remarkPlugins ?? []),
 			];
 			break;
@@ -162,7 +162,7 @@ export function getRehypePlugins(
 		default:
 			rehypePlugins = [
 				...rehypePlugins,
-				...(config.markdown.extendDefaultPlugins ? DEFAULT_REHYPE_PLUGINS : []),
+				...(markdownShouldExtendDefaultPlugins(config) ? DEFAULT_REHYPE_PLUGINS : []),
 				...ignoreStringPlugins(config.markdown.rehypePlugins ?? []),
 			];
 			break;
@@ -170,6 +170,13 @@ export function getRehypePlugins(
 
 	rehypePlugins = [...rehypePlugins, ...(mdxOptions.rehypePlugins ?? [])];
 	return rehypePlugins;
+}
+
+function markdownShouldExtendDefaultPlugins(config: AstroConfig): boolean {
+	return (
+		config.markdown.extendDefaultPlugins ||
+		(config.markdown.remarkPlugins.length === 0 && config.markdown.rehypePlugins.length === 0)
+	);
 }
 
 function ignoreStringPlugins(plugins: any[]) {

--- a/packages/integrations/mdx/test/mdx-plugins.test.js
+++ b/packages/integrations/mdx/test/mdx-plugins.test.js
@@ -24,6 +24,17 @@ describe('MDX plugins', () => {
 		expect(selectTocLink(document)).to.not.be.null;
 	});
 
+	it('Applies GFM by default', async () => {
+		const fixture = await buildFixture({
+			integrations: [mdx()],
+		});
+
+		const html = await fixture.readFile(FILE);
+		const { document } = parseHTML(html);
+
+		expect(selectGfmLink(document)).to.not.be.null;
+	});
+
 	it('supports custom rehype plugins', async () => {
 		const fixture = await buildFixture({
 			integrations: [


### PR DESCRIPTION
## Changes

Make sure GFM and Smartypants are applied to MDX by default.

## Testing

Add test for GFM by default

## Docs

N/A