### PR TITLE
Docs process tweaks: update PR template & CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 README.md @withastro/maintainers-docs
+packages/astro/src/@types/astro.ts @withastro/maintainers-docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snowpackjs/maintainers
+README.md @withastro/maintainers-docs

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,9 @@
 
 ## Docs
 
-<!-- Is this a visible change? You probably need to update docs! -->
+<!-- Could this affect a user’s behavior? We probably need to update docs! -->
+<!-- If adding docs or unsure, uncomment the next line: -->
+<!-- /cc @withastro/maintainers-docs for feedback! -->
+
 <!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
-<!-- Ping @withastro/maintainers-docs for feedback! -->
 <!-- https://github.com/withastro/docs -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,5 @@
 
 <!-- Is this a visible change? You probably need to update docs! -->
 <!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
+<!-- Ping @withastro/maintainers-docs for feedback! -->
 <!-- https://github.com/withastro/docs -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@
 ## Docs
 
 <!-- Could this affect a user’s behavior? We probably need to update docs! -->
-<!-- If adding docs or unsure, uncomment the next line: -->
+<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
 <!-- /cc @withastro/maintainers-docs for feedback! -->
 
 <!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->


### PR DESCRIPTION
## Changes

- Add a line to the PR template, prompting to ping @withastro/maintainers-docs for docs feedback

- Update `CODEOWNERS` to make @withastro/maintainers-docs “owners” of _all_ `README.md` files.

  What does this mean? File “owners” automatically receive a review request when a PR that touches their files come in. [GitHub code owners docs →](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners)

  Could be a bit too coarse-grained — could pick up `README.md` files in tests or whatever if we have them, so happy to refine that if it turns out to be annoying.

### Question

Do we want other files to auto-request a review from team docs? ~~The types file we use to generate our config reference springs to mind.~~ <-- Added types file in 2af6766

## Testing

GitHub tooling tweaks only.

## Docs

We’re here to help 🙌 