### PR TITLE
fix: add unique key to elements in map

### DIFF
--- a/examples/docs/src/components/Header/LanguageSelect.tsx
+++ b/examples/docs/src/components/Header/LanguageSelect.tsx
@@ -36,7 +36,7 @@ const LanguageSelect: FunctionComponent<{ lang: string }> = ({ lang }) => {
 			>
 				{Object.entries(KNOWN_LANGUAGES).map(([key, value]) => {
 					return (
-						<option value={value}>
+						<option value={value} key={value}>
 							<span>{key}</span>
 						</option>
 					);


### PR DESCRIPTION
When user adds another language to the `KNOWN_LANGUAGES`, there's a console error because `LanguageSelect.tsx` map doesn't have unique keys for the options.

## Changes

- Add key to LanguageSelect options

## Testing

No tests added because it was a minor update.

## Docs

No need to add docs, because it's for the initial template.