### PR TITLE
fix: ensure SSR module is loaded before testing is CSS

### DIFF
--- a/.changeset/smooth-hats-smell.md
+++ b/.changeset/smooth-hats-smell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Ensure SSR module is loaded before testing if it's CSS in dev

--- a/packages/astro/src/core/render/dev/css.ts
+++ b/packages/astro/src/core/render/dev/css.ts
@@ -18,11 +18,14 @@ export async function getStylesForURL(
 	for await (const importedModule of crawlGraph(viteServer, viteID(filePath), true)) {
 		const ext = path.extname(importedModule.url).toLowerCase();
 		if (STYLE_EXTENSIONS.has(ext)) {
+			// The SSR module is possibly not loaded. Load it if it's null.
+			const ssrModule =
+				importedModule.ssrModule ?? (await viteServer.ssrLoadModule(importedModule.url));
 			if (
 				mode === 'development' && // only inline in development
-				typeof importedModule.ssrModule?.default === 'string' // ignore JS module styles
+				typeof ssrModule?.default === 'string' // ignore JS module styles
 			) {
-				importedStylesMap.set(importedModule.url, importedModule.ssrModule.default);
+				importedStylesMap.set(importedModule.url, ssrModule.default);
 			} else {
 				// NOTE: We use the `url` property here. `id` would break Windows.
 				importedCssUrls.add(importedModule.url);


### PR DESCRIPTION
## Changes

Ensure SSR module is loaded before testing is CSS in `getStylesForURL`.

### Why

There are some problems when trying to use UnoCSS with Astro in dev. Sometimes the CSS is not inlined in the HTML, making some styles not applied. For example:
- https://github.com/AllanChain/astro-uno/issues/3

I found that's because the `uno.css` SSR module is not loaded when trying to determine whether it is a JS module style. Ensuring loading the SSR module fixes the problem.

## Testing

Manually tested with https://stackblitz.com/edit/withastro-astro-pzexzk and my blog.

It's not a big change, so no tests were added.

## Docs

Just a fix. No docs were added.
