### PR TITLE
Fix AlpineJS homepage link

### DIFF
--- a/.changeset/three-owls-help.md
+++ b/.changeset/three-owls-help.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/alpinejs': patch
+---
+
+Update homepage link

--- a/packages/integrations/alpinejs/package.json
+++ b/packages/integrations/alpinejs/package.json
@@ -19,7 +19,7 @@
     "performance"
   ],
   "bugs": "https://github.com/withastro/astro/issues",
-  "homepage": "https://astro.build",
+  "homepage": "https://docs.astro.build/en/guides/integrations-guide/alpinejs",
   "exports": {
     ".": "./dist/index.js",
     "./package.json": "./package.json"


### PR DESCRIPTION
## Changes

- Update  broken alpinejs homepage

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
This change requires no tests.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs
This change will fix the broken link on the `alpinejs` integration: https://astro.build/integrations/frameworks

