### PR TITLE
Improve third-party Astro package support

### DIFF
--- a/.changeset/fifty-avocados-lay.md
+++ b/.changeset/fifty-avocados-lay.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Improve third-party Astro package support

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -188,13 +188,11 @@ async function getAstroPackages({ root }: AstroConfig): Promise<string[]> {
  * themselves also Astro packages.
  */
 class DependencyWalker {
-	private root: URL;
-	private require: NodeRequire;
-	private astroDeps = new Set<string>();
-	private nonAstroDeps = new Set<string>();
+	private readonly require: NodeRequire;
+	private readonly astroDeps = new Set<string>();
+	private readonly nonAstroDeps = new Set<string>();
 
 	constructor(root: URL) {
-		this.root = root;
 		const pkgUrl = new URL('./package.json', root);
 		this.require = createRequire(pkgUrl);
 		const pkgPath = fileURLToPath(pkgUrl);

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -185,8 +185,8 @@ async function getAstroPackages({ root }: AstroConfig): Promise<string[]> {
 	return deps.filter((dep) => {
 		// Attempt: package is common and not Astro. ❌ Skip these for perf
 		if (isCommonNotAstro(dep)) return false;
-		// Attempt: package is named `astro-something`. ✅ Likely a community package
-		if (/^astro\-/.test(dep)) return true;
+		// Attempt: package is named `astro-something` or `@scope/astro-something`. ✅ Likely a community package
+		if (/^(@[^\/]+\/)?astro\-/.test(dep)) return true;
 		const depPkgUrl = new URL(`./node_modules/${dep}/package.json`, root);
 		const depPkgPath = fileURLToPath(depPkgUrl);
 		if (!fs.existsSync(depPkgPath)) return false;

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -205,11 +205,11 @@ class DependencyWalker {
 		this.walkDependencies(deps);
 	}
 
-	public get astroPackages() {
+	public get astroPackages(): string[] {
 		return Array.from(this.astroDeps);
 	}
 
-	private seen(dep: string) {
+	private seen(dep: string): boolean {
 		return this.astroDeps.has(dep) || this.nonAstroDeps.has(dep);
 	}
 

--- a/packages/astro/test/fixtures/third-party-astro/astro.config.mjs
+++ b/packages/astro/test/fixtures/third-party-astro/astro.config.mjs
@@ -1,0 +1,4 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({});

--- a/packages/astro/test/fixtures/third-party-astro/package.json
+++ b/packages/astro/test/fixtures/third-party-astro/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@e2e/third-party-astro",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "astro-embed": "^0.1.1"
+  }
+}

--- a/packages/astro/test/fixtures/third-party-astro/src/pages/astro-embed.astro
+++ b/packages/astro/test/fixtures/third-party-astro/src/pages/astro-embed.astro
@@ -1,0 +1,16 @@
+---
+import { YouTube } from 'astro-embed'
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Third-Party Package Test</title>
+  </head>
+  <body>
+    <main>
+      <h1>Third-Party .astro test</h1>
+      <YouTube id="https://youtu.be/xtTy5nKay_Y" />
+    </main>
+  </body>
+</html>

--- a/packages/astro/test/third-party-astro.test.js
+++ b/packages/astro/test/third-party-astro.test.js
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { isWindows, loadFixture } from './test-utils.js';
+
+describe('third-party .astro component', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/third-party-astro/',
+		});
+	});
+
+	describe('build', () => {
+		before(async () => {
+			await fixture.build();
+		});
+
+		it('renders a page using a third-party .astro component', async () => {
+			const html = await fixture.readFile('/astro-embed/index.html');
+			const $ = cheerio.load(html);
+			expect($('h1').text()).to.equal('Third-Party .astro test');
+		});
+	});
+
+	// if (isWindows) return;
+
+	describe('dev', () => {
+		let devServer;
+
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('renders a page using a third-party .astro component', async () => {
+			const html = await fixture.fetch('/astro-embed/').then((res) => res.text());
+			const $ = cheerio.load(html);
+			expect($('h1').text()).to.equal('Third-Party .astro test');
+		});
+	});
+});

--- a/packages/astro/test/third-party-astro.test.js
+++ b/packages/astro/test/third-party-astro.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
-import { isWindows, loadFixture } from './test-utils.js';
+import { loadFixture } from './test-utils.js';
 
 describe('third-party .astro component', () => {
 	let fixture;
@@ -22,8 +22,6 @@ describe('third-party .astro component', () => {
 			expect($('h1').text()).to.equal('Third-Party .astro test');
 		});
 	});
-
-	// if (isWindows) return;
 
 	describe('dev', () => {
 		let devServer;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -996,6 +996,14 @@ importers:
       '@astrojs/tailwind': link:../../../../integrations/tailwind
       astro: link:../../..
 
+  packages/astro/e2e/fixtures/third-party-astro:
+    specifiers:
+      astro: workspace:*
+      astro-embed: ^0.1.1
+    dependencies:
+      astro: link:../../..
+      astro-embed: 0.1.1_astro@packages+astro
+
   packages/astro/e2e/fixtures/ts-resolution:
     specifiers:
       '@astrojs/react': workspace:*
@@ -2052,6 +2060,14 @@ importers:
       autoprefixer: 10.4.8_postcss@8.4.16
       postcss: 8.4.16
       tailwindcss: 3.1.8_postcss@8.4.16
+
+  packages/astro/test/fixtures/third-party-astro:
+    specifiers:
+      astro: workspace:*
+      astro-embed: ^0.1.1
+    dependencies:
+      astro: link:../../..
+      astro-embed: 0.1.1_astro@packages+astro
 
   packages/astro/test/fixtures/type-imports:
     specifiers:
@@ -3190,6 +3206,39 @@ packages:
       json-schema: 0.4.0
       jsonpointer: 5.0.1
       leven: 3.1.0
+    dev: false
+
+  /@astro-community/astro-embed-integration/0.1.0_astro@packages+astro:
+    resolution: {integrity: sha512-qR4us0hAqIYo6MduvpXLrjeakX04afDILa7WkQbmWj3c4sbOqIcFCirLrmFs+dPjcPkv2Zpl2l3PxN3G6+ONSA==}
+    peerDependencies:
+      astro: ^1.0.0-beta.10
+    dependencies:
+      '@astro-community/astro-embed-twitter': 0.1.3_astro@packages+astro
+      '@astro-community/astro-embed-youtube': 0.1.1_astro@packages+astro
+      astro: link:packages/astro
+      unist-util-select: 4.0.1
+    dev: false
+
+  /@astro-community/astro-embed-twitter/0.1.3_astro@packages+astro:
+    resolution: {integrity: sha512-lcOBnzhczNrngkafzD+8BGKiK8oJvahg3/QUuWgueNwHRU8C+18brdxKc1i4ttZWgAt1A5u+jx21Tc4bquMUzg==}
+    peerDependencies:
+      astro: ^1.0.0-beta.10
+    dependencies:
+      '@astro-community/astro-embed-utils': 0.0.3
+      astro: link:packages/astro
+    dev: false
+
+  /@astro-community/astro-embed-utils/0.0.3:
+    resolution: {integrity: sha512-hXwSMtSAL3V9fnFHps+/CoDIJst26U/qSdI7srIQ8GPmFqdbcqJd/qOqYzGezAR/qTM8gmTjDCGOuVI0Z+xT3Q==}
+    dev: false
+
+  /@astro-community/astro-embed-youtube/0.1.1_astro@packages+astro:
+    resolution: {integrity: sha512-qIf5nr3BMB/pWJWf7x/t86CIjpPA69eVKQql7TNJW7lTYL2SVPFA9WowsfvvrhNN9aWV/kTaSpW9e/m4FtXdkQ==}
+    peerDependencies:
+      astro: ^1.0.0-beta.10
+    dependencies:
+      astro: link:packages/astro
+      lite-youtube-embed: 0.2.0
     dev: false
 
   /@astrojs/compiler/0.19.0:
@@ -9735,6 +9784,17 @@ packages:
     hasBin: true
     dev: false
 
+  /astro-embed/0.1.1_astro@packages+astro:
+    resolution: {integrity: sha512-NBnLDB0PygbahCBFeGDPzmW4/PJSrieWgjN7mN8vmStUACM+cdTz1vhLDSWt4LlbWxozq0x9G1dTnoVbHyYKLA==}
+    peerDependencies:
+      astro: ^1.0.0-beta.10
+    dependencies:
+      '@astro-community/astro-embed-integration': 0.1.0_astro@packages+astro
+      '@astro-community/astro-embed-twitter': 0.1.3_astro@packages+astro
+      '@astro-community/astro-embed-youtube': 0.1.1_astro@packages+astro
+      astro: link:packages/astro
+    dev: false
+
   /async/3.2.4:
     resolution: {integrity: sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==}
     dev: false
@@ -12848,6 +12908,10 @@ packages:
       '@lit/reactive-element': 1.4.1
       lit-element: 3.2.2
       lit-html: 2.3.1
+    dev: false
+
+  /lite-youtube-embed/0.2.0:
+    resolution: {integrity: sha512-XXXAk5sbvtjjwbie3XG+6HppgTm1HTGL/Uk9z9NkJH53o7puZLur434heHzAjkS60hZB3vT4ls25zl5rMiX4EA==}
     dev: false
 
   /load-yaml-file/0.2.0:
@@ -16793,6 +16857,16 @@ packages:
     dependencies:
       '@types/unist': 2.0.6
       unist-util-visit: 4.1.1
+    dev: false
+
+  /unist-util-select/4.0.1:
+    resolution: {integrity: sha512-zPozyEo5vr1csbHf1TqlQrnuLVJ0tNMo63og3HrnINh2+OIDAgQpqHVr+0BMw1DIVHJV8ft/e6BZqtvD1Y5enw==}
+    dependencies:
+      '@types/unist': 2.0.6
+      css-selector-parser: 1.4.1
+      nth-check: 2.1.1
+      unist-util-is: 5.1.1
+      zwitch: 2.0.2
     dev: false
 
   /unist-util-stringify-position/3.0.2:


### PR DESCRIPTION
## Changes

Fix #4071 

Search for Astro package dependencies beyond a project’s direct dependencies.

See [this comment](https://github.com/withastro/astro/issues/4071#issuecomment-1236431134) for more background — it lays out some alternative approaches, I’d be curious what people think!

**TL;DR** Current logic only adds _direct_ dependencies to `vite.ssr.noExternal`. The changes in this PR walk the dependency tree, checking child dependencies of any Astro packages it finds recursively. It bails out of a branch when it encounters a non-Astro package. This should still be reasonably performant, while being much more robust.

## Testing

Help would be appreciated. @natemoo-re’s original PR for this code (https://github.com/withastro/astro/pull/2665) mentions:

> Not sure there's a great way to test this.

What I did manually:

1. `pnpm build` in this repo
2. `cd packages/astro && npm pack` to get a tarball for the new version
3. Create a new minimal Astro project locally
4. Install `astro-embed` and use its `YouTube` component:
    ```astro
    ---
    import { YouTube } from "astro-embed";
    ---
    <YouTube id="https://youtu.be/xtTy5nKay_Y" />
    ```
5. `npm start` — encounters errors as reported in #4071
6. `npm i ../astro/packages/astro/astro-1.1.5.tgz` to install Astro from the tarball
7. `npm start` — errors go away! ✨ 

## Docs

Bug fix for an issue that we’re not documenting in detail yet, although this is related to https://github.com/withastro/docs/issues/1455.