### PR TITLE
Parallelize @astrojs/image transforms

### DIFF
--- a/.changeset/rich-dolphins-teach.md
+++ b/.changeset/rich-dolphins-teach.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Parallelize image transforms

--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -40,6 +40,7 @@
     "test": "mocha --exit --timeout 20000 test"
   },
   "dependencies": {
+    "@altano/tiny-async-pool": "^1.0.2",
     "image-size": "^1.0.2",
     "magic-string": "^0.25.9",
     "mime": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2214,6 +2214,7 @@ importers:
 
   packages/integrations/image:
     specifiers:
+      '@altano/tiny-async-pool': ^1.0.2
       '@types/sharp': ^0.30.5
       astro: workspace:*
       astro-scripts: workspace:*
@@ -2223,6 +2224,7 @@ importers:
       mime: ^3.0.0
       sharp: ^0.30.6
     dependencies:
+      '@altano/tiny-async-pool': 1.0.2
       image-size: 1.0.2
       magic-string: 0.25.9
       mime: 3.0.0
@@ -3153,6 +3155,10 @@ packages:
       '@algolia/cache-common': 4.14.2
       '@algolia/logger-common': 4.14.2
       '@algolia/requester-common': 4.14.2
+    dev: false
+
+  /@altano/tiny-async-pool/1.0.2:
+    resolution: {integrity: sha512-qQzaI0TBUPdpjZ3qo5b2ziQY9MSNpbziH2ZrE5lvtUZL+kn9GwVuVJwoOubaoNkeDB+rqEefnpu1k+oMpOCYiw==}
     dev: false
 
   /@ampproject/remapping/2.2.0:


### PR DESCRIPTION
## Changes

This change parallelizes `@astrojs/image`  transforms to get a big performance boost.

`@astrojs/image` currently processes images serially, one after the other. If it processes 10 images and takes 1 second to process each, the total time will be 10 seconds.

This change makes it process images in batches. The batch size is the # of CPUs on the machine, e.g. 8 on my dev machine.

## Testing

I manually put the newly built code in dist/build/ssg.js into my current project (I can't figure out how to get `pnpm` and `npm` to let me link across projects). I then did a before and after build.

I then edited `astro.config.mts` and enabled `debug` logging:
```js
integrations: [
    image({
      logLevel: "debug",
    }),
...
```

### BEFORE - 92 second build 
![image](https://user-images.githubusercontent.com/1009/188425441-c4b06fcf-ae13-4778-9d92-fdb41f8bedad.png)

### AFTER - 39 second build 
![image](https://user-images.githubusercontent.com/1009/188425474-683684d6-6aa6-4ccc-bbcc-d47aa4dec4c4.png)

NOTE: Yes I know a 92s->39s build time is still abysmal. `@astrojs/image` is very slow at processing animated gifs. I will investigate that separately.

## Docs

No docs needed as this is a performance improvement
