### PR TITLE
examples/basics/ Layout: add missing comma to css code font-family

### DIFF
--- a/examples/basics/src/layouts/Layout.astro
+++ b/examples/basics/src/layouts/Layout.astro
@@ -55,6 +55,6 @@ const { title } = Astro.props;
 
 	code {
 		font-family: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono,
-			Bitstream Vera Sans Mono, Courier New, monospace;
+			Bitstream, Vera Sans Mono, Courier New, monospace;
 	}
 </style>


### PR DESCRIPTION
## Changes

- What does this change?
css font-family of code elements in the examples/basics/src/layout/Layout.astro now has a missing comma added

- Don't forget a changeset! `pnpm exec changeset`
`pnpm exec changeset` does not detect changes.

## Testing

no tests added because the change only impacts css and i could not find any integrity tests for css.
`npm run build` -> builds success, no changes
`npm run build:examples` -> build success, no changes
`npm run test` -> error for unrelated reasons, see #4628

## Docs

No docs needed, since this will be a css fix, not a user facing change.
