### PR TITLE
Integrations: Fix NPM instructions to use `npx astro add` again

### DIFF
--- a/packages/integrations/alpinejs/README.md
+++ b/packages/integrations/alpinejs/README.md
@@ -27,7 +27,7 @@ pnpm astro add alpinejs
 
 Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
 

--- a/packages/integrations/alpinejs/README.md
+++ b/packages/integrations/alpinejs/README.md
@@ -18,14 +18,16 @@ The `astro add` command-line tool automates the installation for you. Run one of
 
 ```sh
 # Using NPM
-npm run astro add alpinejs
+npx astro add alpinejs
 # Using Yarn
 yarn astro add alpinejs
 # Using PNPM
 pnpm astro add alpinejs
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then type `npm run astro dev` to restart the dev server. 
+Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
+
+If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
 

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -38,7 +38,7 @@ pnpm astro add image
   
 Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
  ### Manual Install
   

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -29,16 +29,16 @@ The `astro add` command-line tool automates the installation for you. Run one of
    
 ```sh
 # Using NPM
-npm run astro add image
+npx astro add image
 # Using Yarn
 yarn astro add image
 # Using PNPM
 pnpm astro add image
 ```
   
-Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.
-  
-Because this command is new, it might not properly set things up. If that happens, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
+
+If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
  ### Manual Install
   

--- a/packages/integrations/lit/README.md
+++ b/packages/integrations/lit/README.md
@@ -16,12 +16,14 @@ To install `@astrojs/lit`, run the following from your project directory and fol
 
 ```sh
 # Using NPM
-npm run astro add lit
+npx astro add lit
 # Using Yarn
 yarn astro add lit
 # Using PNPM
 pnpm astro add lit
 ```
+
+Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/packages/integrations/lit/README.md
+++ b/packages/integrations/lit/README.md
@@ -25,7 +25,7 @@ pnpm astro add lit
 
 Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually
 

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -35,7 +35,7 @@ pnpm astro add mdx
 
 Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
 

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -26,16 +26,16 @@ The `astro add` command-line tool automates the installation for you. Run one of
 
 ```sh
 # Using NPM
-npm run astro add mdx
+npx astro add mdx
 # Using Yarn
 yarn astro add mdx
 # Using PNPM
 pnpm astro add mdx
 ```
 
-Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.
+Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-Because this command is new, it might not properly set things up. If that happens, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
 

--- a/packages/integrations/partytown/README.md
+++ b/packages/integrations/partytown/README.md
@@ -28,16 +28,16 @@ The `astro add` command-line tool automates the installation for you. Run one of
   
 ```sh
 # Using NPM
-npm run astro add partytown
+npx astro add partytown
 # Using Yarn
 yarn astro add partytown
 # Using PNPM
 pnpm astro add partytown
 ```
   
-Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.
-  
-Because this command is new, it might not properly set things up. If that happens, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
+
+If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
   

--- a/packages/integrations/partytown/README.md
+++ b/packages/integrations/partytown/README.md
@@ -37,7 +37,7 @@ pnpm astro add partytown
   
 Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
   

--- a/packages/integrations/preact/README.md
+++ b/packages/integrations/preact/README.md
@@ -37,7 +37,7 @@ pnpm astro add preact
 
 Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
 

--- a/packages/integrations/preact/README.md
+++ b/packages/integrations/preact/README.md
@@ -28,16 +28,16 @@ The `astro add` command-line tool automates the installation for you. Run one of
 
 ```sh
 # Using NPM
-npm run astro add preact
+npx astro add preact
 # Using Yarn
 yarn astro add preact
 # Using PNPM
 pnpm astro add preact
 ```
 
-Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.
+Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-Because this command is new, it might not properly set things up. If that happens, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
 

--- a/packages/integrations/prefetch/README.md
+++ b/packages/integrations/prefetch/README.md
@@ -22,16 +22,16 @@ The `astro add` command-line tool automates the installation for you. Run one of
   
 ```sh
 # Using NPM
-npm run astro add prefetch
+npx astro add prefetch
 # Using Yarn
 yarn astro add prefetch
 # Using PNPM
 pnpm astro add prefetch
 ```
   
-Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.
-  
-Because this command is new, it might not properly set things up. If that happens, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
+
+If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
   

--- a/packages/integrations/prefetch/README.md
+++ b/packages/integrations/prefetch/README.md
@@ -31,7 +31,7 @@ pnpm astro add prefetch
   
 Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
   

--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -16,12 +16,14 @@ To install `@astrojs/react`, run the following from your project directory and f
 
 ```sh
 # Using NPM
-npm run astro add react
+npx astro add react
 # Using Yarn
 yarn astro add react
 # Using PNPM
 pnpm astro add react
 ```
+
+Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -25,7 +25,7 @@ pnpm astro add react
 
 Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually
 

--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -37,7 +37,7 @@ pnpm astro add sitemap
   
 Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
   

--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -28,16 +28,16 @@ The `astro add` command-line tool automates the installation for you. Run one of
   
 ```sh
 # Using NPM
-npm run astro add sitemap
+npx astro add sitemap
 # Using Yarn
 yarn astro add sitemap
 # Using PNPM
 pnpm astro add sitemap
 ```
   
-Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.
-  
-Because this command is new, it might not properly set things up. If that happens, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
+
+If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
   

--- a/packages/integrations/solid/README.md
+++ b/packages/integrations/solid/README.md
@@ -25,7 +25,7 @@ pnpm astro add solid
 
 Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually
 

--- a/packages/integrations/solid/README.md
+++ b/packages/integrations/solid/README.md
@@ -16,12 +16,14 @@ To install `@astrojs/solid-js`, run the following from your project directory an
 
 ```sh
 # Using NPM
-npm run astro add solid
+npx astro add solid
 # Using Yarn
 yarn astro add solid
 # Using PNPM
 pnpm astro add solid
 ```
+
+Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/packages/integrations/svelte/README.md
+++ b/packages/integrations/svelte/README.md
@@ -25,7 +25,7 @@ pnpm astro add svelte
 
 Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually
 

--- a/packages/integrations/svelte/README.md
+++ b/packages/integrations/svelte/README.md
@@ -16,12 +16,14 @@ To install `@astrojs/svelte`, run the following from your project directory and 
 
 ```sh
 # Using NPM
-npm run astro add svelte
+npx astro add svelte
 # Using Yarn
 yarn astro add svelte
 # Using PNPM
 pnpm astro add svelte
 ```
+
+Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -40,7 +40,7 @@ pnpm astro add tailwind
   
 Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
   

--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -31,16 +31,16 @@ The `astro add` command-line tool automates the installation for you. Run one of
   
 ```sh
 # Using NPM
-npm run astro add tailwind
+npx astro add tailwind
 # Using Yarn
 yarn astro add tailwind
 # Using PNPM
 pnpm astro add tailwind
 ```
   
-Then, restart the dev server by typing `CTRL-C` and then `npm run astro dev` in the terminal window that was running Astro.
-  
-Because this command is new, it might not properly set things up. If that happens, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
+
+If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
   

--- a/packages/integrations/turbolinks/README.md
+++ b/packages/integrations/turbolinks/README.md
@@ -26,12 +26,14 @@ To install `@astrojs/turbolinks`, run the following from your project directory 
 
 ```sh
 # Using NPM
-npm run astro add turbolinks
+npx astro add turbolinks
 # Using Yarn
 yarn astro add turbolinks
 # Using PNPM
 pnpm astro add turbolinks
 ```
+
+Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/packages/integrations/turbolinks/README.md
+++ b/packages/integrations/turbolinks/README.md
@@ -35,7 +35,7 @@ pnpm astro add turbolinks
 
 Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually
 

--- a/packages/integrations/vue/README.md
+++ b/packages/integrations/vue/README.md
@@ -25,7 +25,7 @@ pnpm astro add vue
 
 Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
-If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually
 

--- a/packages/integrations/vue/README.md
+++ b/packages/integrations/vue/README.md
@@ -16,12 +16,14 @@ To install `@astrojs/vue`, run the following from your project directory and fol
 
 ```sh
 # Using NPM
-npm run astro add vue
+npx astro add vue
 # Using Yarn
 yarn astro add vue
 # Using PNPM
 pnpm astro add vue
 ```
+
+Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
 
 If you run into any hiccups, [feel free to log an issue on our GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 


### PR DESCRIPTION
## Changes

- Fixes [#1468](https://github.com/withastro/docs/issues/1468)
- We introduced the previous non-`npx` version in #4340, but got multiple issue reports about this syntax not working both on Discord and GitHub since then. Also, a poll we made on Discord between the two versions was overwhelmingly positive for using the `npx` version (13 people were preferring `npx astro add` while only 1 person was preferring `npm run astro add`).
- Therefore, this PR changes the recommended installation instructions for npm users to the community-preferred and apparently less issue-prone choice.
- I have also unified the CTA to report any `astro add` issues on GitHub to a version that no longer states that this command is new, as it no longer is. :)

## Testing

- Pure docs change, no tests required

## Docs

- It's all about docs! :)
