### PR TITLE
Remove devDependency flag from `astro add` 

### DIFF
--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -579,7 +579,7 @@ async function tryToInstallIntegrations({
 	} else {
 		const coloredOutput = `${bold(installCommand.pm)} ${
 			installCommand.command
-		} ${installCommand.flags.join(' ')} ${cyan(installCommand.dependencies.join(' '))}`;
+		}${['', ...installCommand.flags].join(' ')} ${cyan(installCommand.dependencies.join(' '))}`;
 		const message = `\n${boxen(coloredOutput, {
 			margin: 0.5,
 			padding: 0.5,

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -551,11 +551,11 @@ async function getInstallIntegrationsCommand({
 
 	switch (pm.name) {
 		case 'npm':
-			return { pm: 'npm', command: 'install', flags: ['--save-dev'], dependencies };
+			return { pm: 'npm', command: 'install', flags: [], dependencies };
 		case 'yarn':
-			return { pm: 'yarn', command: 'add', flags: ['--dev'], dependencies };
+			return { pm: 'yarn', command: 'add', flags: [], dependencies };
 		case 'pnpm':
-			return { pm: 'pnpm', command: 'install', flags: ['--save-dev'], dependencies };
+			return { pm: 'pnpm', command: 'install', flags: [], dependencies };
 		default:
 			return null;
 	}


### PR DESCRIPTION
## Changes

In line with our template changes in #4544, this changes `astro add` to install to `dependencies` instead of `devDependencies`.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
I couldn't find a test that this affects, and I don't think it's a new feature that needs to be tested.

## Docs

We've already changed the docs to recommend `dependencies` over `devDependencies`, this just catches up `astro add`.
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
