### PR TITLE
Fix component frameworks on Vercel Edge

### DIFF
--- a/.changeset/tasty-owls-watch.md
+++ b/.changeset/tasty-owls-watch.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/react': patch
+---
+
+Fix framework components on Vercel Edge

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -79,6 +79,9 @@ export async function renderPage(
 										controller.enqueue(encoder.encode('<!DOCTYPE html>\n'));
 									}
 								}
+								// Convert HTML object to string
+								// for environments that won't "toString" automatically
+								// (ex. Cloudflare and Vercel Edge)
 								controller.enqueue(encoder.encode(String(html)));
 								i++;
 							}

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -79,7 +79,7 @@ export async function renderPage(
 										controller.enqueue(encoder.encode('<!DOCTYPE html>\n'));
 									}
 								}
-								controller.enqueue(encoder.encode(html));
+								controller.enqueue(encoder.encode(String(html)));
 								i++;
 							}
 							controller.close();


### PR DESCRIPTION
## Changes

- Resolves #4391 
- Switch from `for await` to `while` loop on React stream renderer. Based on similar Cloudflare issue https://github.com/facebook/react/issues/24169
- Convert HTML object to string before encoding. Vercel Edge won't do this automatically, which broke other framework renderers

## Testing

Manually deployed to Vercel Edge. Could use deployment tests one day!

## Docs

N/A