### PR TITLE
Supports Uint8Array/Uint16Array/Uint32Array for serialize props

### DIFF
--- a/.changeset/healthy-ears-compete.md
+++ b/.changeset/healthy-ears-compete.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+astro-island now correctly passes Uint8Array/Uint16Array/Uint32Array

--- a/packages/astro/src/runtime/server/astro-island.ts
+++ b/packages/astro/src/runtime/server/astro-island.ts
@@ -26,6 +26,9 @@ declare const Astro: {
 		5: (value) => new Set(JSON.parse(value, reviver)),
 		6: (value) => BigInt(value),
 		7: (value) => new URL(value),
+		8: (value) => new Uint8Array(Object.values(JSON.parse(value, reviver))),
+		9: (value) => new Uint16Array(Object.values(JSON.parse(value, reviver))),
+		10: (value) => new Uint32Array(Object.values(JSON.parse(value, reviver)))
 	};
 
 	const reviver = (propKey: string, raw: string): any => {

--- a/packages/astro/src/runtime/server/serialize.ts
+++ b/packages/astro/src/runtime/server/serialize.ts
@@ -9,6 +9,9 @@ const PROP_TYPE = {
 	Set: 5,
 	BigInt: 6,
 	URL: 7,
+	Uint8Array: 8,
+	Uint16Array: 9,
+	Uint32Array: 10
 };
 
 function serializeArray(value: any[]): any[] {
@@ -46,6 +49,15 @@ function convertToSerializedForm(value: any): [ValueOf<typeof PROP_TYPE>, any] {
 		}
 		case '[object Array]': {
 			return [PROP_TYPE.JSON, JSON.stringify(serializeArray(value))];
+		}
+		case '[object Uint8Array]': {
+			return [PROP_TYPE.Uint8Array, JSON.stringify(serializeArray(value))];
+		}
+		case '[object Uint16Array]': {
+			return [PROP_TYPE.Uint16Array, JSON.stringify(serializeArray(value))];
+		}
+		case '[object Uint32Array]': {
+			return [PROP_TYPE.Uint32Array, JSON.stringify(serializeArray(value))];
 		}
 		default: {
 			if (value !== null && typeof value === 'object') {


### PR DESCRIPTION
## Changes

- Allow astro-island to handle Uint8Array/Uint16Array/Uint32Array correctly
- Currently, for example, `new Uint8Array([1,2,3])` is handled as `{0: 1, 1: 2, 2: 3}` and loses the type

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I couldn't find any hydration tests for `astro-island.props`. If there is, I will gladly update the test.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This changes doesn't affect the docs.