### PR TITLE
Make React integration work with Deno

### DIFF
--- a/.changeset/orange-llamas-play.md
+++ b/.changeset/orange-llamas-play.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': patch
+---
+
+Prevent decoder from leaking

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "packages/*",
     "examples/*",
     "examples/component/demo",
-    "examples/component/packages/*",
     "scripts",
     "packages/astro/test/fixtures/component-library-shared",
     "packages/astro/test/fixtures/custom-elements/my-component-lib",

--- a/packages/integrations/react/server.js
+++ b/packages/integrations/react/server.js
@@ -144,10 +144,17 @@ async function readResult(stream) {
   let result = '';
   const decoder = new TextDecoder('utf-8')
   while (true) {
-    const { done, value } = await reader.read();
-    if (done) {
-      return result;
-    }
+		const { done, value } = await reader.read();
+		if (done) {
+			if(value) {
+				result += decoder.decode(value);
+			} else {
+				// This closes the decoder
+				decoder.decode(new Uint8Array());
+			}
+			
+			return result;
+		}
     result += decoder.decode(value, { stream: true });
   }
 }


### PR DESCRIPTION
## Changes

- This broke the Deno tests: https://github.com/withastro/astro/pull/4667/files
- It's unclear why it passed in that branch.
- This fixes it, a streaming decode needs to be closed or there's a leak (which the Deno tests exposes).

## Testing

- Tests were failing but now pass

## Docs

N/A, bug fix