### PR TITLE
Remove `component/packages` from pnpm workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "packages/*",
     "examples/*",
     "examples/component/demo",
-    "examples/component/packages/*",
     "scripts",
     "packages/astro/test/fixtures/component-library-shared",
     "packages/astro/test/fixtures/custom-elements/my-component-lib",


### PR DESCRIPTION
## Changes

Remove nonexistent `examples/component/packages` from pnpm workspace

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
