### PR TITLE
docs: correct mistake in `@astrojs/node` integration

### DIFF
--- a/packages/integrations/node/README.md
+++ b/packages/integrations/node/README.md
@@ -39,7 +39,7 @@ If you prefer to install the adapter manually instead, complete the following tw
 
     ```js title="astro.config.mjs" ins={2, 5-6}
     import { defineConfig } from 'astro/config';
-    import netlify from '@astrojs/node';
+    import node from '@astrojs/node';
 
     export default defineConfig({
       output: 'server',


### PR DESCRIPTION
## Changes

Replaces `netlify` with `node` in the `astrojs/node` integration guide

## Testing

<!-- How was this change tested? -->
This is a change in the docs content

## Docs

This is a change in the docs content
