### PR TITLE
Fix theme.css location in docs starter project

### DIFF
--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -47,7 +47,7 @@ Welcome! Check out [our documentation](https://docs.astro.build) or jump into ou
 
 ### CSS styling
 
-The theme's look and feel is controlled by a few key variables that you can customize yourself. You'll find them in the `public/theme.css` CSS file.
+The theme's look and feel is controlled by a few key variables that you can customize yourself. You'll find them in the `src/styles/theme.css` CSS file.
 
 If you've never worked with CSS variables before, give [MDN's guide on CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) a quick read.
 

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -54,7 +54,7 @@ If you've never worked with CSS variables before, give [MDN's guide on CSS varia
 This theme uses a "cool blue" accent color by default. To customize this for your project, change the `--theme-accent` variable to whatever color you'd like:
 
 ```diff
-/* public/theme.css */
+/* src/styles/theme.css */
 :root {
   color-scheme: light;
 -  --theme-accent: hsla(var(--color-blue), 1);


### PR DESCRIPTION
## Changes

Fixes the incorrect location of `theme.css` file in the docs starter example.

## Testing

N/A - wording change in a readme only

## Docs

N/A - basically a docs fix itself

