### PR TITLE
Fix client:only CSS missing from child packages

### DIFF
--- a/.changeset/orange-clocks-exist.md
+++ b/.changeset/orange-clocks-exist.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix missing CSS in client:only in child packages

--- a/packages/astro/src/core/build/vite-plugin-analyzer.ts
+++ b/packages/astro/src/core/build/vite-plugin-analyzer.ts
@@ -70,7 +70,7 @@ export function vitePluginAnalyzer(internals: BuildInternals): VitePlugin {
 
 	return {
 		name: '@astro/rollup-plugin-astro-analyzer',
-		generateBundle() {
+		async generateBundle() {
 			const hoistScanner = hoistedScriptScanner();
 
 			const ids = this.getModuleIds();
@@ -95,6 +95,15 @@ export function vitePluginAnalyzer(internals: BuildInternals): VitePlugin {
 						const cid = c.resolvedPath ? decodeURI(c.resolvedPath) : c.specifier;
 						internals.discoveredClientOnlyComponents.add(cid);
 						clientOnlys.push(cid);
+						// Bare module specifiers need to be resolved so that the CSS
+						// plugin can walk up the graph to find which page they belong to.
+						if(c.resolvedPath === c.specifier) {
+							const resolvedId = await this.resolve(c.specifier, id);
+							if(resolvedId) {
+								clientOnlys.push(resolvedId.id);
+							}
+						}
+						
 					}
 
 					for (const [pageInfo] of getTopLevelPages(id, this)) {

--- a/packages/astro/test/astro-client-only.test.js
+++ b/packages/astro/test/astro-client-only.test.js
@@ -3,6 +3,7 @@ import { load as cheerioLoad } from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Client only components', () => {
+	/** @type {import('./test-utils').Fixture} */
 	let fixture;
 
 	before(async () => {
@@ -36,6 +37,12 @@ describe('Client only components', () => {
 
 	it('Includes CSS from components that use CSS modules', async () => {
 		const html = await fixture.readFile('/css-modules/index.html');
+		const $ = cheerioLoad(html);
+		expect($('link[rel=stylesheet]')).to.have.a.lengthOf(1);
+	});
+
+	it('Includes CSS from package components', async () => {
+		const html = await fixture.readFile('/pkg/index.html');
 		const $ = cheerioLoad(html);
 		expect($('link[rel=stylesheet]')).to.have.a.lengthOf(1);
 	});

--- a/packages/astro/test/fixtures/astro-client-only/package.json
+++ b/packages/astro/test/fixtures/astro-client-only/package.json
@@ -7,6 +7,7 @@
     "@astrojs/react": "workspace:*",
     "astro": "workspace:*",
     "react": "^18.1.0",
-    "react-dom": "^18.1.0"
+    "react-dom": "^18.1.0",
+    "@test/astro-client-only-pkg": "file:./pkg"
   }
 }

--- a/packages/astro/test/fixtures/astro-client-only/pkg/index.svelte
+++ b/packages/astro/test/fixtures/astro-client-only/pkg/index.svelte
@@ -1,0 +1,6 @@
+<h1>Testing</h1>
+<style>
+	h1 {
+		background: green;
+	}
+</style>

--- a/packages/astro/test/fixtures/astro-client-only/pkg/package.json
+++ b/packages/astro/test/fixtures/astro-client-only/pkg/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/astro-client-only-pkg",
+  "main": "index.svelte"
+}

--- a/packages/astro/test/fixtures/astro-client-only/src/pages/pkg.astro
+++ b/packages/astro/test/fixtures/astro-client-only/src/pages/pkg.astro
@@ -1,0 +1,12 @@
+---
+import IndexSvelte from '@test/astro-client-only-pkg';
+---
+<html>
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<h1>Testing</h1>
+		<IndexSvelte client:only="svelte" />
+	</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1097,15 +1097,20 @@ importers:
     specifiers:
       '@astrojs/react': workspace:*
       '@astrojs/svelte': workspace:*
+      '@test/astro-client-only-pkg': file:./pkg
       astro: workspace:*
       react: ^18.1.0
       react-dom: ^18.1.0
     dependencies:
       '@astrojs/react': link:../../../../integrations/react
       '@astrojs/svelte': link:../../../../integrations/svelte
+      '@test/astro-client-only-pkg': file:packages/astro/test/fixtures/astro-client-only/pkg
       astro: link:../../..
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+
+  packages/astro/test/fixtures/astro-client-only/pkg:
+    specifiers: {}
 
   packages/astro/test/fixtures/astro-component-code:
     specifiers:
@@ -17932,6 +17937,11 @@ packages:
 
   /zwitch/2.0.2:
     resolution: {integrity: sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA==}
+    dev: false
+
+  file:packages/astro/test/fixtures/astro-client-only/pkg:
+    resolution: {directory: packages/astro/test/fixtures/astro-client-only/pkg, type: directory}
+    name: '@test/astro-client-only-pkg'
     dev: false
 
   file:packages/astro/test/fixtures/css-assets/packages/font-awesome:


### PR DESCRIPTION
## Changes

- The build analyzer tracks client:only usage. When it's from a child package we need to fully resolve the id so that the CSS plugin can find it later.
- Fixes https://github.com/withastro/astro/issues/4671

## Testing

Test added

## Docs

N/A, bug fix