### PR TITLE
docs: add MDXLayoutProps to README

### DIFF
--- a/.changeset/metal-bees-pretend.md
+++ b/.changeset/metal-bees-pretend.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Document MDXLayoutProps utility type

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -259,7 +259,7 @@ const { frontmatter, url } = Astro.props;
 
 #### Layout props
 
-All [exported properties](#exported-properties) are available from `Astro.props` in your layout, **with a couple key differences:**
+All [exported properties](#exported-properties) are available from `Astro.props` in your layout, **with two key differences:**
 - Heading information (i.e. `h1 -> h6` elements) is available via the `headings` array, rather than a `getHeadings()` function.
 - `file` and `url` are _also_ available as nested `frontmatter` properties (i.e. `frontmatter.url` and `frontmatter.file`). This is consistent with Astro's Markdown layout properties.
 

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -223,7 +223,7 @@ const { frontmatter, url } = Astro.props;
 </html>
 ```
 
-You can also add type safety using [the `Props` type](/en/guides/typescript/#component-props) with the `MDXLayoutProps` helper.
+You can set a layout’s [`Props` type](/en/guides/typescript/#component-props) with the `MDXLayoutProps` helper.
 
 :::note
 `MDXLayoutProps` is the same as the `MarkdownLayoutProps` utility type with `rawContent()` and `compiledContent()` removed (since these are not available for `.mdx` files). Feel free to **use `MarkdownLayoutProps` instead** when sharing a layout across `.md` and `.mdx` files.

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -203,15 +203,16 @@ title: 'My Blog Post'
 ---
 ```
 
-Then, you can retrieve all other frontmatter properties from your layout via the `frontmatter` property, and render your MDX using the default [`<slot />`](https://docs.astro.build/en/core-concepts/astro-components/#slots):
+Then, you can retrieve all other frontmatter properties from your layout via the `frontmatter` property, and render your MDX using the default [`<slot />`](https://docs.astro.build/en/core-concepts/astro-components/#slots). See [layout props](#layout-props) for a complete list of props available.
 
 ```astro
 ---
 // src/layouts/BaseLayout.astro
-const { frontmatter } = Astro.props;
+const { frontmatter, url } = Astro.props;
 ---
 <html>
   <head>
+    <meta rel="canonical" href={new URL(url, Astro.site).pathname}>
     <title>{frontmatter.title}</title>
   </head>
   <body>
@@ -221,6 +222,46 @@ const { frontmatter } = Astro.props;
   </body>
 </html>
 ```
+
+You can also add type safety using [the `Props` type](/en/guides/typescript/#component-props) with the `MDXLayoutProps` helper.
+
+_**Note:** `MDXLayoutProps` is the same as the `MarkdownLayoutProps` utility type, with `rawContent()` and `compiledContent()` removed (since these are not available for `.mdx` files). If you understand this difference, feel free to use `MarkdownLayoutProps` instead when sharing a layout across `.md` and `.mdx` files._
+
+```astro ins={2,4-9}
+---
+// src/layouts/BaseLayout.astro
+import type { MDXLayoutProps } from 'astro';
+
+type Props = MDXLayoutProps<{
+  // Define frontmatter props here
+  title: string;
+  author: string;
+  date: string;
+}>;
+
+// Now, `frontmatter`, `url`, and other MDX layout properties
+// are accessible with type safety
+const { frontmatter, url } = Astro.props;
+---
+<html>
+  <head>
+    <meta rel="canonical" href={new URL(url, Astro.site).pathname}>
+    <title>{frontmatter.title}</title>
+  </head>
+  <body>
+    <h1>{frontmatter.title}</h1>
+    <slot />
+  </body>
+</html>
+```
+
+#### Layout props
+
+All [exported properties](#exported-properties) are available from `Astro.props` in your layout, **with a couple key differences:**
+- Heading information (i.e. `h1 -> h6` elements) is available via the `headings` array, rather than a `getHeadings()` function.
+- `file` and `url` are _also_ available as nested `frontmatter` properties (i.e. `frontmatter.url` and `frontmatter.file`). This is consistent with Astro's Markdown layout properties.
+
+Astro recommends using the `MDXLayoutProps` type (see previous section) to explore all available properties.
 
 #### Importing layouts manually
 

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -225,7 +225,9 @@ const { frontmatter, url } = Astro.props;
 
 You can also add type safety using [the `Props` type](/en/guides/typescript/#component-props) with the `MDXLayoutProps` helper.
 
-_**Note:** `MDXLayoutProps` is the same as the `MarkdownLayoutProps` utility type, with `rawContent()` and `compiledContent()` removed (since these are not available for `.mdx` files). If you understand this difference, feel free to use `MarkdownLayoutProps` instead when sharing a layout across `.md` and `.mdx` files._
+:::note
+`MDXLayoutProps` is the same as the `MarkdownLayoutProps` utility type with `rawContent()` and `compiledContent()` removed (since these are not available for `.mdx` files). Feel free to **use `MarkdownLayoutProps` instead** when sharing a layout across `.md` and `.mdx` files.
+:::
 
 ```astro ins={2,4-9}
 ---


### PR DESCRIPTION
## Changes

- Add `MDXLayoutProps` utility to MDX README. Includes difference with `MarkdownLayoutProps`, and advises using `MarkdownLayoutProps` instead when sharing a layout across `.md` and `.mdx`.
- Add "layout props" section to explain props available.

## Testing

N/A

## Docs

Uh yeah
