### PR TITLE
[RSS] Fix failure when globbing index route

### DIFF
--- a/.changeset/blue-seals-warn.md
+++ b/.changeset/blue-seals-warn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': patch
+---
+
+Fix globs for homepage route

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -56,7 +56,7 @@ function mapGlobResult(items: GlobResult): Promise<RSSFeedItem[]> {
 	return Promise.all(
 		Object.values(items).map(async (getInfo) => {
 			const { url, frontmatter } = await getInfo();
-			if (!Boolean(url)) {
+			if (url === undefined || url === null) {
 				throw new Error(
 					`[RSS] When passing an import.meta.glob result directly, you can only glob ".md" files within /pages! Consider mapping the result to an array of RSSFeedItems. See the RSS docs for usage examples: https://docs.astro.build/en/guides/rss/#2-list-of-rss-feed-objects`
 				);

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -17,7 +17,8 @@ const phpFeedItem = {
 };
 
 const web1FeedItem = {
-	link: '/web1',
+	// Should support empty string as a URL (possible for homepage route)
+	link: '',
 	title: 'Web 1.0',
 	pubDate: '1997-05-03',
 	description:
@@ -26,7 +27,7 @@ const web1FeedItem = {
 
 // note: I spent 30 minutes looking for a nice node-based snapshot tool
 // ...and I gave up. Enjoy big strings!
-const validXmlResult = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title><![CDATA[My RSS feed]]></title><description><![CDATA[This sure is a nice RSS feed]]></description><link>https://example.com/</link><item><title><![CDATA[Remember PHP?]]></title><link>https://example.com/php/</link><guid>https://example.com/php/</guid><description><![CDATA[PHP is a general-purpose scripting language geared toward web development. It was originally created by Danish-Canadian programmer Rasmus Lerdorf in 1994.]]></description><pubDate>Tue, 03 May 1994 00:00:00 GMT</pubDate></item><item><title><![CDATA[Web 1.0]]></title><link>https://example.com/web1/</link><guid>https://example.com/web1/</guid><description><![CDATA[Web 1.0 is the term used for the earliest version of the Internet as it emerged from its origins with Defense Advanced Research Projects Agency (DARPA) and became, for the first time, a global network representing the future of digital communications.]]></description><pubDate>Sat, 03 May 1997 00:00:00 GMT</pubDate></item></channel></rss>`;
+const validXmlResult = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title><![CDATA[My RSS feed]]></title><description><![CDATA[This sure is a nice RSS feed]]></description><link>https://example.com/</link><item><title><![CDATA[Remember PHP?]]></title><link>https://example.com/php/</link><guid>https://example.com/php/</guid><description><![CDATA[PHP is a general-purpose scripting language geared toward web development. It was originally created by Danish-Canadian programmer Rasmus Lerdorf in 1994.]]></description><pubDate>Tue, 03 May 1994 00:00:00 GMT</pubDate></item><item><title><![CDATA[Web 1.0]]></title><link>https://example.com/</link><guid>https://example.com/</guid><description><![CDATA[Web 1.0 is the term used for the earliest version of the Internet as it emerged from its origins with Defense Advanced Research Projects Agency (DARPA) and became, for the first time, a global network representing the future of digital communications.]]></description><pubDate>Sat, 03 May 1997 00:00:00 GMT</pubDate></item></channel></rss>`;
 
 describe('rss', () => {
 	it('should generate on valid RSSFeedItem array', async () => {
@@ -158,6 +159,46 @@ describe('rss', () => {
 				chai.expect(false).to.equal(true, 'Should have errored');
 			} catch (err) {
 				chai.expect(err.message).to.contain('Required field [link] is missing');
+			}
+		});
+
+		it('should provide a good error message when passing glob result form outside pages/', async () => {
+			const globResult = {
+				'./posts/php.md': () =>
+					new Promise((resolve) =>
+						resolve({
+							// "undefined" when outside pages/
+							url: undefined,
+							frontmatter: {
+								title: phpFeedItem.title,
+								pubDate: phpFeedItem.pubDate,
+								description: phpFeedItem.description,
+							},
+						})
+					),
+				'./posts/nested/web1.md': () =>
+					new Promise((resolve) =>
+						resolve({
+							url: undefined,
+							frontmatter: {
+								title: web1FeedItem.title,
+								pubDate: web1FeedItem.pubDate,
+								description: web1FeedItem.description,
+							},
+						})
+					),
+			};
+
+			try {
+				await rss({
+					title: 'Your Website Title',
+					description: 'Your Website Description',
+					site: 'https://astro-demo',
+					items: globResult,
+				});
+				chai.expect(false).to.equal(true, 'Should have errored');
+			} catch (err) {
+				chai.expect(err.message).to.contain('you can only glob ".md" files within /pages');
 			}
 		});
 	});


### PR DESCRIPTION
## Changes

- Only throw when `url` is `undefined`. Empty string URLs _should_ be supported for globbing homepage routes (i.e. `src/pages/index.md`)
- Resolves #4598

## Testing

Add test for globs outside `pages/` and a route with `url: ''`

## Docs

N/A