### PR TITLE
Add an error message for improperly configured renderers

### DIFF
--- a/.changeset/fuzzy-rats-remain.md
+++ b/.changeset/fuzzy-rats-remain.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Properly show an error message when a renderer is not properly configured

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -66,6 +66,14 @@ export async function runHookConfigSetup({
 				config: updatedConfig,
 				command,
 				addRenderer(renderer: AstroRenderer) {
+					if (!renderer.name) {
+						throw new Error(`Integration ${bold(integration.name)} has an unnamed renderer.`);
+					}
+
+					if (!renderer.serverEntrypoint) {
+						throw new Error(`Renderer ${bold(renderer.name)} does not provide a serverEntrypoint.`);
+					}
+
 					updatedConfig._ctx.renderers.push(renderer);
 				},
 				injectScript: (stage, content) => {


### PR DESCRIPTION
## Changes

Before, it wasn't super clear why your renderer wouldn't load if it was improperly configured (it'd show something like "can't read undefined of something"). After this PR, it'll instead show a nice error message telling you your renderer is missing things. Small fix, but nice

Fix https://github.com/withastro/astro/issues/3015 (most of the issue was already fixed, so it's really just this that was blocking it now)

## Testing

Tested manually

## Docs

N/A
