### PR TITLE
examples rss: add mdx file ending

### DIFF
--- a/examples/blog/src/pages/rss.xml.js
+++ b/examples/blog/src/pages/rss.xml.js
@@ -6,5 +6,5 @@ export const get = () =>
 		title: SITE_TITLE,
 		description: SITE_DESCRIPTION,
 		site: import.meta.env.SITE,
-		items: import.meta.glob('./blog/**/*.md'),
+		items: import.meta.glob('./blog/**/*.{md,mdx}'),
 	});


### PR DESCRIPTION
This follows the same pattern used in https://github.com/withastro/astro/blob/main/examples/blog/src/pages/blog.astro#L8. Without adding `mdx` here, only some blog posts will be part of the rss.xml file.

## Changes

This makes sure that the rss.xml lists the same posts as the /blog/ index.

> Don't forget a changeset! `pnpm exec changeset`

Don't know what that means. This change is made via the Github Edit UI.

## Testing

I tested the issue in the page I am building ATM.