### PR TITLE
[vercel] Use Edge Functions instead of Edge Middlewares

### DIFF
--- a/.changeset/polite-beds-happen.md
+++ b/.changeset/polite-beds-happen.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/vercel': minor
+'@astrojs/vercel': major
 ---
 
 Use Edge Functions instead of Edge Middlewares

--- a/.changeset/polite-beds-happen.md
+++ b/.changeset/polite-beds-happen.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': minor
+---
+
+Use Edge Functions instead of Edge Middlewares

--- a/packages/integrations/vercel/src/edge/adapter.ts
+++ b/packages/integrations/vercel/src/edge/adapter.ts
@@ -68,7 +68,7 @@ export default function vercelEdge(): AstroIntegration {
 					routes: [
 						...getRedirects(routes, _config),
 						{ handle: 'filesystem' },
-						{ src: '/.*', middlewarePath: 'render' },
+						{ src: '/.*', dest: 'render' },
 					],
 				});
 			},


### PR DESCRIPTION
## Changes

Use Edge Functions instead of Edge Middlewares
https://discord.com/channels/830184174198718474/845451724738265138/1018069733603545122

We used to use middlewares because that was the way to access the Edge way back in April. Now, we should use normal functions.

This could be a breaking change for some people, should we bump to `1.1.0` or to `2.0.0`?

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
