### PR TITLE
Fix route validation for Netlify Edge

### DIFF
--- a/.changeset/dull-flowers-prove.md
+++ b/.changeset/dull-flowers-prove.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Fix route validation failures on Netlify Edge

--- a/packages/integrations/netlify/src/integration-edge-functions.ts
+++ b/packages/integrations/netlify/src/integration-edge-functions.ts
@@ -53,7 +53,10 @@ async function createEdgeManifest(routes: RouteData[], entryFile: string, dir: U
 		} else {
 			functions.push({
 				function: entryFile,
-				pattern: route.pattern.toString(),
+				// Make route pattern serializable to match expected
+				// Netlify Edge validation format. Mirrors Netlify's own edge bundler:
+				// https://github.com/netlify/edge-bundler/blob/main/src/manifest.ts#L34
+				pattern: route.pattern.source.replace(/\\\//g, '/').toString(),
 			});
 		}
 	}


### PR DESCRIPTION
## Changes

- Resolves #4376
- Co-authored-by: Jackie Macharia @jackiewmacharia (okay you did all the work 😅 )
- Serialize route pattern to match Netlify Edge's expected format. Mirrors the serialization done by [Netlify's own edge bundler](https://github.com/netlify/edge-bundler/blob/main/src/manifest.ts#L34).

## Testing

Manually ran `netlify build` on Netlify CLI v10.18.1

## Docs

N/A
