### PR TITLE
Handle builds with outDir outside of cwd

### DIFF
--- a/.changeset/kind-rats-lay.md
+++ b/.changeset/kind-rats-lay.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Handle builds with outDir outside of current working directory

--- a/packages/astro/src/core/build/common.ts
+++ b/packages/astro/src/core/build/common.ts
@@ -4,7 +4,7 @@ import type { AstroConfig, RouteType } from '../../@types/astro';
 import { appendForwardSlash } from '../../core/path.js';
 
 const STATUS_CODE_PAGES = new Set(['/404', '/500']);
-const FALLBACK_OUT_DIR_NAME = './.astro-temp/';
+const FALLBACK_OUT_DIR_NAME = './.astro/';
 
 function getOutRoot(astroConfig: AstroConfig): URL {
 	return new URL('./', astroConfig.outDir);
@@ -63,7 +63,7 @@ export function getOutFile(
 }
 
 /**
- * Ensures the `outDir` is within `process.cwd()`. If not it will fallback to `<cwd>/.astro-temp`.
+ * Ensures the `outDir` is within `process.cwd()`. If not it will fallback to `<cwd>/.astro`.
  * This is used for static `ssrBuild` so the output can access node_modules when we import
  * the output files. A hardcoded fallback dir is fine as it would be cleaned up after build.
  */

--- a/packages/astro/src/core/build/common.ts
+++ b/packages/astro/src/core/build/common.ts
@@ -1,8 +1,10 @@
 import npath from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
 import type { AstroConfig, RouteType } from '../../@types/astro';
 import { appendForwardSlash } from '../../core/path.js';
 
 const STATUS_CODE_PAGES = new Set(['/404', '/500']);
+const FALLBACK_OUT_DIR_NAME = './.astro-temp/';
 
 function getOutRoot(astroConfig: AstroConfig): URL {
 	return new URL('./', astroConfig.outDir);
@@ -57,5 +59,18 @@ export function getOutFile(
 					return new URL('./' + (baseName || 'index') + '.html', outFolder);
 				}
 			}
+	}
+}
+
+/**
+ * Ensures the `outDir` is within `process.cwd()`. If not it will fallback to `<root>/.astro-temp`.
+ * This is used for static `ssrBuild` so the output can access node_modules when we import
+ * the output files. A hardcoded fallback dir is fine as it would be cleaned up after build.
+ */
+export function getOutDirWithinCwd(outDir: URL): URL {
+	if (fileURLToPath(outDir).startsWith(process.cwd())) {
+		return outDir;
+	} else {
+		return new URL(FALLBACK_OUT_DIR_NAME, pathToFileURL(process.cwd() + npath.sep));
 	}
 }

--- a/packages/astro/src/core/build/common.ts
+++ b/packages/astro/src/core/build/common.ts
@@ -63,7 +63,7 @@ export function getOutFile(
 }
 
 /**
- * Ensures the `outDir` is within `process.cwd()`. If not it will fallback to `<root>/.astro-temp`.
+ * Ensures the `outDir` is within `process.cwd()`. If not it will fallback to `<cwd>/.astro-temp`.
  * This is used for static `ssrBuild` so the output can access node_modules when we import
  * the output files. A hardcoded fallback dir is fine as it would be cleaned up after build.
  */

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -28,7 +28,7 @@ import { createLinkStylesheetElementSet, createModuleScriptsSet } from '../rende
 import { createRequest } from '../request.js';
 import { matchRoute } from '../routing/match.js';
 import { getOutputFilename } from '../util.js';
-import { getOutFile, getOutFolder } from './common.js';
+import { getOutDirWithinCwd, getOutFile, getOutFolder } from './common.js';
 import { eachPageData, getPageDataByComponent, sortedCSS } from './internal.js';
 import type { PageBuildData, SingleFileBuiltModule, StaticBuildOptions } from './types';
 import { getTimeStat } from './util.js';
@@ -103,7 +103,7 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 
 	const ssr = opts.astroConfig.output === 'server';
 	const serverEntry = opts.buildConfig.serverEntry;
-	const outFolder = ssr ? opts.buildConfig.server : opts.astroConfig.outDir;
+	const outFolder = ssr ? opts.buildConfig.server : getOutDirWithinCwd(opts.astroConfig.outDir);
 	const ssrEntryURL = new URL('./' + serverEntry + `?time=${Date.now()}`, outFolder);
 	const ssrEntry = await import(ssrEntryURL.toString());
 	const builtPaths = new Set<string>();


### PR DESCRIPTION
## Changes

Fix #4006

If `outDir` is out of `process.cwd()`, build the ssr output to `<cwd>/.astro` instead. This directory will be removed after the build, unless an error occurs during the build, which it's preserved for debuggability.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
No test added as the monorepo structure makes it tricky to test this edge case (brings false positive). I did test with a separate project though and it works.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->

~~This PR handles static output only (`output: 'static'`). For server output, the `outDir` MUST be inside the current working directory as most integrations requires this for the deployment output to work. (e.g. netlify, vercel, cloudflare)~~

~~Should we document this? On the other hand, setting `outDir` outside of cwd feels like a special case.~~

~~/cc @withastro/maintainers-docs for feedback!~~

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
