### PR TITLE
fix: typo in snapshot ref checkout

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -49,7 +49,7 @@ jobs:
           
       - uses: actions/checkout@v3
         with:
-          ref: ${{ steps.refs.outputs.base_ref }}
+          ref: ${{ steps.refs.outputs.head_ref }}
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v2.2.1


### PR DESCRIPTION
## Changes

Fixes a typo in #4744, the action needs to checkout the head ref not the base ref

## Testing

N/A

## Docs

N/A
