### PR TITLE
Enabling the publish step for snapshot releases

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -73,17 +73,17 @@ jobs:
           # Needs access to run the script
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-#      - name: Publish Release
-#        id: publish
-#        run: echo "::set-output name=result::$(pnpm run release --tag next--${{ steps.getSnapshotName.outputs.result }})"
-#        env:
-#          # Needs access to publish to npm
-#          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish Release
+        id: publish
+        run: echo "::set-output name=result::$(pnpm run release --tag next--${{ steps.getSnapshotName.outputs.result }})"
+        env:
+          # Needs access to publish to npm
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Pull Request Notification
         uses: actions/github-script@v6
         env:
-          MESSAGE: ${{ steps.changesets.outputs.result }}
+          MESSAGE: ${{ steps.publish.outputs.result }}
         with:
           script: |
             console.log(process.env.MESSAGE);


### PR DESCRIPTION
## Changes

This enables the publish step of the new `Create a Snapshot Release` GitHub Action

Example output can be found [here](https://github.com/withastro/astro/pull/4738#issuecomment-1245947938) (the publish step is currently disabled, its through building the changesets for a `next-wasm.0` release then exits)

## Testing

Manually tested the action with all but the publish step, will be using #4738 for a live test in production

## Docs

None, dev tooling updates only
