### PR TITLE
Fix console.error filtering

### DIFF
--- a/.changeset/nice-peaches-swim.md
+++ b/.changeset/nice-peaches-swim.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix console.error filtering

--- a/packages/astro/src/runtime/server/jsx.ts
+++ b/packages/astro/src/runtime/server/jsx.ts
@@ -222,4 +222,5 @@ function filteredConsoleError(msg: any, ...rest: any[]) {
 			msg.includes('https://reactjs.org/link/invalid-hook-call');
 		if (isKnownReactHookError) return;
 	}
+	originalConsoleError(msg, ...rest);
 }


### PR DESCRIPTION
## Changes

Fix #4459

The `filteredConsoleError` hook that patches `console.error` forgots to call the original `console.error` if is not filtered out.


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
N/A. I think this is a simple fix 😬 

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A
