### PR TITLE
.md only: npm init astro --> npm create astro

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,19 +3,19 @@
 The easiest way to check out one of these examples on your machine is by running this command in an empty directory:
 
 ```
-npm init astro -- --template [EXAMPLE_NAME]
+npm create astro -- --template [EXAMPLE_NAME]
 ```
 
 ## Community Examples
 
-Visit [awesome-astro](https://github.com/one-aalam/awesome-astro) for a full list of community examples. You can use `npm init astro` to check out any community examples:
+Visit [awesome-astro](https://github.com/one-aalam/awesome-astro) for a full list of community examples. You can use `npm create astro` to check out any community examples:
 
 ```
-npm init astro -- --template [GITHUB_USER]/[REPO_NAME]
+npm create astro -- --template [GITHUB_USER]/[REPO_NAME]
 ```
 
 Paths to examples nested inside of a repo are also supported:
 
 ```
-npm init astro -- --template [GITHUB_USER]/[REPO_NAME]/path/to/example
+npm create astro -- --template [GITHUB_USER]/[REPO_NAME]/path/to/example
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,19 +3,19 @@
 The easiest way to check out one of these examples on your machine is by running this command in an empty directory:
 
 ```
-npm create astro -- --template [EXAMPLE_NAME]
+npm create astro@latest -- --template [EXAMPLE_NAME]
 ```
 
 ## Community Examples
 
-Visit [awesome-astro](https://github.com/one-aalam/awesome-astro) for a full list of community examples. You can use `npm create astro` to check out any community examples:
+Visit [awesome-astro](https://github.com/one-aalam/awesome-astro) for a full list of community examples. You can use `npm create astro@latest` to check out any community examples:
 
 ```
-npm create astro -- --template [GITHUB_USER]/[REPO_NAME]
+npm create astro@latest -- --template [GITHUB_USER]/[REPO_NAME]
 ```
 
 Paths to examples nested inside of a repo are also supported:
 
 ```
-npm create astro -- --template [GITHUB_USER]/[REPO_NAME]/path/to/example
+npm create astro@latest -- --template [GITHUB_USER]/[REPO_NAME]/path/to/example
 ```

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -1,7 +1,7 @@
 # Astro Starter Kit: Blog
 
 ```
-npm create astro -- --template blog
+npm create astro@latest -- --template blog
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/blog)

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -1,7 +1,7 @@
 # Astro Starter Kit: Blog
 
 ```
-npm init astro -- --template blog
+npm create astro -- --template blog
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/blog)

--- a/examples/component/README.md
+++ b/examples/component/README.md
@@ -3,7 +3,7 @@
 This is a template for an Astro component library. Use this template for writing components to use in multiple projects or publish to NPM.
 
 ```
-npm create astro -- --template component
+npm create astro@latest -- --template component
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/non-html-pages)

--- a/examples/component/README.md
+++ b/examples/component/README.md
@@ -3,7 +3,7 @@
 This is a template for an Astro component library. Use this template for writing components to use in multiple projects or publish to NPM.
 
 ```
-npm init astro -- --template component
+npm create astro -- --template component
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/non-html-pages)

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -1,7 +1,7 @@
 # Astro Starter Kit: Docs Site
 
 ```bash
-npm init astro -- --template docs
+npm create astro -- --template docs
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/docs)

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -1,7 +1,7 @@
 # Astro Starter Kit: Docs Site
 
 ```bash
-npm create astro -- --template docs
+npm create astro@latest -- --template docs
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/docs)

--- a/examples/framework-alpine/README.md
+++ b/examples/framework-alpine/README.md
@@ -1,7 +1,7 @@
 # Astro + AlpineJS Example
 
 ```
-npm create astro -- --template framework-alpine
+npm create astro@latest -- --template framework-alpine
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-alpine)

--- a/examples/framework-alpine/README.md
+++ b/examples/framework-alpine/README.md
@@ -1,7 +1,7 @@
 # Astro + AlpineJS Example
 
 ```
-npm init astro -- --template framework-alpine
+npm create astro -- --template framework-alpine
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-alpine)

--- a/examples/framework-lit/README.md
+++ b/examples/framework-lit/README.md
@@ -1,7 +1,7 @@
 # Astro + Lit Example
 
 ```
-npm init astro -- --template framework-lit
+npm create astro -- --template framework-lit
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-lit)

--- a/examples/framework-lit/README.md
+++ b/examples/framework-lit/README.md
@@ -1,7 +1,7 @@
 # Astro + Lit Example
 
 ```
-npm create astro -- --template framework-lit
+npm create astro@latest -- --template framework-lit
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-lit)

--- a/examples/framework-multiple/README.md
+++ b/examples/framework-multiple/README.md
@@ -1,7 +1,7 @@
 # Kitchen Sink: Microfrontends with Astro
 
 ```
-npm init astro -- --template framework-multiple
+npm create astro -- --template framework-multiple
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-multiple)

--- a/examples/framework-multiple/README.md
+++ b/examples/framework-multiple/README.md
@@ -1,7 +1,7 @@
 # Kitchen Sink: Microfrontends with Astro
 
 ```
-npm create astro -- --template framework-multiple
+npm create astro@latest -- --template framework-multiple
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-multiple)

--- a/examples/framework-preact/README.md
+++ b/examples/framework-preact/README.md
@@ -1,7 +1,7 @@
 # Astro + Preact Example
 
 ```
-npm init astro -- --template framework-preact
+npm create astro -- --template framework-preact
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-preact)

--- a/examples/framework-preact/README.md
+++ b/examples/framework-preact/README.md
@@ -1,7 +1,7 @@
 # Astro + Preact Example
 
 ```
-npm create astro -- --template framework-preact
+npm create astro@latest -- --template framework-preact
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-preact)

--- a/examples/framework-react/README.md
+++ b/examples/framework-react/README.md
@@ -1,7 +1,7 @@
 # Astro + React Example
 
 ```
-npm create astro -- --template framework-react
+npm create astro@latest -- --template framework-react
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-react)

--- a/examples/framework-react/README.md
+++ b/examples/framework-react/README.md
@@ -1,7 +1,7 @@
 # Astro + React Example
 
 ```
-npm init astro -- --template framework-react
+npm create astro -- --template framework-react
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-react)

--- a/examples/framework-solid/README.md
+++ b/examples/framework-solid/README.md
@@ -1,7 +1,7 @@
 # Astro + Solid.js Example
 
 ```
-npm init astro -- --template framework-solid
+npm create astro -- --template framework-solid
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-solid)

--- a/examples/framework-solid/README.md
+++ b/examples/framework-solid/README.md
@@ -1,7 +1,7 @@
 # Astro + Solid.js Example
 
 ```
-npm create astro -- --template framework-solid
+npm create astro@latest -- --template framework-solid
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-solid)

--- a/examples/framework-svelte/README.md
+++ b/examples/framework-svelte/README.md
@@ -1,7 +1,7 @@
 # Astro + Svelte Example
 
 ```
-npm init astro -- --template framework-svelte
+npm create astro -- --template framework-svelte
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-svelte)

--- a/examples/framework-svelte/README.md
+++ b/examples/framework-svelte/README.md
@@ -1,7 +1,7 @@
 # Astro + Svelte Example
 
 ```
-npm create astro -- --template framework-svelte
+npm create astro@latest -- --template framework-svelte
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-svelte)

--- a/examples/framework-vue/README.md
+++ b/examples/framework-vue/README.md
@@ -1,7 +1,7 @@
 # Astro + Vue Example
 
 ```
-npm init astro -- --template framework-vue
+npm create astro -- --template framework-vue
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-vue)

--- a/examples/framework-vue/README.md
+++ b/examples/framework-vue/README.md
@@ -1,7 +1,7 @@
 # Astro + Vue Example
 
 ```
-npm create astro -- --template framework-vue
+npm create astro@latest -- --template framework-vue
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-vue)

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -1,7 +1,7 @@
 # Astro Starter Kit: Minimal
 
 ```
-npm init astro -- --template minimal
+npm create astro -- --template minimal
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -1,7 +1,7 @@
 # Astro Starter Kit: Minimal
 
 ```
-npm create astro -- --template minimal
+npm create astro@latest -- --template minimal
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)

--- a/examples/non-html-pages/README.md
+++ b/examples/non-html-pages/README.md
@@ -5,7 +5,7 @@ Documentation for "Non-HTML Pages":
 https://docs.astro.build/en/core-concepts/astro-pages/#non-html-pages
 
 ```
-npm init astro -- --template non-html-pages
+npm create astro -- --template non-html-pages
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/non-html-pages)

--- a/examples/non-html-pages/README.md
+++ b/examples/non-html-pages/README.md
@@ -5,7 +5,7 @@ Documentation for "Non-HTML Pages":
 https://docs.astro.build/en/core-concepts/astro-pages/#non-html-pages
 
 ```
-npm create astro -- --template non-html-pages
+npm create astro@latest -- --template non-html-pages
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/non-html-pages)

--- a/examples/portfolio/README.md
+++ b/examples/portfolio/README.md
@@ -1,7 +1,7 @@
 # Astro Starter Kit: Portfolio
 
 ```
-npm init astro -- --template portfolio
+npm create astro -- --template portfolio
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/portfolio)

--- a/examples/portfolio/README.md
+++ b/examples/portfolio/README.md
@@ -1,7 +1,7 @@
 # Astro Starter Kit: Portfolio
 
 ```
-npm create astro -- --template portfolio
+npm create astro@latest -- --template portfolio
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/portfolio)

--- a/examples/with-markdown-plugins/README.md
+++ b/examples/with-markdown-plugins/README.md
@@ -1,7 +1,7 @@
 # Astro Example: Markdown with Plugins
 
 ```
-npm create astro -- --template with-markdown-plugins
+npm create astro@latest -- --template with-markdown-plugins
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-markdown-plugins)

--- a/examples/with-markdown-plugins/README.md
+++ b/examples/with-markdown-plugins/README.md
@@ -1,7 +1,7 @@
 # Astro Example: Markdown with Plugins
 
 ```
-npm init astro -- --template with-markdown-plugins
+npm create astro -- --template with-markdown-plugins
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-markdown-plugins)

--- a/examples/with-markdown-shiki/README.md
+++ b/examples/with-markdown-shiki/README.md
@@ -1,7 +1,7 @@
 # Astro Example: Markdown with Shiki
 
 ```
-npm init astro -- --template with-markdown-shiki
+npm create astro -- --template with-markdown-shiki
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-markdown-shiki)

--- a/examples/with-markdown-shiki/README.md
+++ b/examples/with-markdown-shiki/README.md
@@ -1,7 +1,7 @@
 # Astro Example: Markdown with Shiki
 
 ```
-npm create astro -- --template with-markdown-shiki
+npm create astro@latest -- --template with-markdown-shiki
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-markdown-shiki)

--- a/examples/with-mdx/README.md
+++ b/examples/with-mdx/README.md
@@ -1,7 +1,7 @@
 # Astro Example: MDX
 
 ```
-npm init astro -- --template with-mdx
+npm create astro -- --template with-mdx
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-mdx)

--- a/examples/with-mdx/README.md
+++ b/examples/with-mdx/README.md
@@ -1,7 +1,7 @@
 # Astro Example: MDX
 
 ```
-npm create astro -- --template with-mdx
+npm create astro@latest -- --template with-mdx
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-mdx)

--- a/examples/with-nanostores/README.md
+++ b/examples/with-nanostores/README.md
@@ -1,7 +1,7 @@
 # Astro Example: Nanostores
 
 ```
-npm init astro -- --template with-nanostores
+npm create astro -- --template with-nanostores
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-nanostores)

--- a/examples/with-nanostores/README.md
+++ b/examples/with-nanostores/README.md
@@ -1,7 +1,7 @@
 # Astro Example: Nanostores
 
 ```
-npm create astro -- --template with-nanostores
+npm create astro@latest -- --template with-nanostores
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-nanostores)

--- a/examples/with-tailwindcss/README.md
+++ b/examples/with-tailwindcss/README.md
@@ -1,7 +1,7 @@
 # Astro with Tailwind
 
 ```
-npm init astro -- --template with-tailwindcss
+npm create astro -- --template with-tailwindcss
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-tailwindcss)

--- a/examples/with-tailwindcss/README.md
+++ b/examples/with-tailwindcss/README.md
@@ -1,7 +1,7 @@
 # Astro with Tailwind
 
 ```
-npm create astro -- --template with-tailwindcss
+npm create astro@latest -- --template with-tailwindcss
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-tailwindcss)

--- a/examples/with-vite-plugin-pwa/README.md
+++ b/examples/with-vite-plugin-pwa/README.md
@@ -1,7 +1,7 @@
 # Astro Starter Kit: Vite PWA
 
 ```
-npm init astro -- --template with-vite-plugin-pwa
+npm create astro -- --template with-vite-plugin-pwa
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-vite-plugin-pwa)

--- a/examples/with-vite-plugin-pwa/README.md
+++ b/examples/with-vite-plugin-pwa/README.md
@@ -1,7 +1,7 @@
 # Astro Starter Kit: Vite PWA
 
 ```
-npm create astro -- --template with-vite-plugin-pwa
+npm create astro@latest -- --template with-vite-plugin-pwa
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-vite-plugin-pwa)

--- a/examples/with-vitest/README.md
+++ b/examples/with-vitest/README.md
@@ -1,7 +1,7 @@
 # Astro + [Vitest](https://vitest.dev/) Example
 
 ```
-npm init astro -- --template with-vitest
+npm create astro -- --template with-vitest
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-vitest)

--- a/examples/with-vitest/README.md
+++ b/examples/with-vitest/README.md
@@ -1,7 +1,7 @@
 # Astro + [Vitest](https://vitest.dev/) Example
 
 ```
-npm create astro -- --template with-vitest
+npm create astro@latest -- --template with-vitest
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-vitest)

--- a/packages/create-astro/README.md
+++ b/packages/create-astro/README.md
@@ -5,7 +5,7 @@
 **With NPM:**
 
 ```bash
-npm init astro
+npm create astro
 ```
 
 **With Yarn:**
@@ -18,10 +18,10 @@ yarn create astro
 
 ```bash
 # npm 6.x
-npm init astro my-astro-project --template starter
+npm create astro my-astro-project --template starter
 
 # npm 7+, extra double-dash is needed:
-npm init astro my-astro-project -- --template starter
+npm create astro my-astro-project -- --template starter
 
 # yarn
 yarn create astro my-astro-project --template starter
@@ -31,7 +31,7 @@ yarn create astro my-astro-project --template starter
 You can also use any GitHub repo as a template:
 
 ```bash
-npm init astro my-astro-project -- --template cassidoo/shopify-react-astro
+npm create astro my-astro-project -- --template cassidoo/shopify-react-astro
 ```
 
 ### CLI Flags
@@ -49,10 +49,10 @@ To debug `create-astro`, you can use the `--verbose` flag which will log the out
 
 ```bash
 # npm 6.x
-npm init astro my-astro-project --verbose
+npm create astro my-astro-project --verbose
 
 # npm 7+, extra double-dash is needed:
-npm init astro my-astro-project -- --verbose
+npm create astro my-astro-project -- --verbose
 
 # yarn
 yarn create astro my-astro-project --verbose

--- a/packages/create-astro/README.md
+++ b/packages/create-astro/README.md
@@ -5,7 +5,7 @@
 **With NPM:**
 
 ```bash
-npm create astro
+npm create astro@latest
 ```
 
 **With Yarn:**
@@ -18,10 +18,10 @@ yarn create astro
 
 ```bash
 # npm 6.x
-npm create astro my-astro-project --template starter
+npm create astro@latest my-astro-project --template starter
 
 # npm 7+, extra double-dash is needed:
-npm create astro my-astro-project -- --template starter
+npm create astro@latest my-astro-project -- --template starter
 
 # yarn
 yarn create astro my-astro-project --template starter
@@ -31,7 +31,7 @@ yarn create astro my-astro-project --template starter
 You can also use any GitHub repo as a template:
 
 ```bash
-npm create astro my-astro-project -- --template cassidoo/shopify-react-astro
+npm create astro@latest my-astro-project -- --template cassidoo/shopify-react-astro
 ```
 
 ### CLI Flags
@@ -49,10 +49,10 @@ To debug `create-astro`, you can use the `--verbose` flag which will log the out
 
 ```bash
 # npm 6.x
-npm create astro my-astro-project --verbose
+npm create astro@latest my-astro-project --verbose
 
 # npm 7+, extra double-dash is needed:
-npm create astro my-astro-project -- --verbose
+npm create astro@latest my-astro-project -- --verbose
 
 # yarn
 yarn create astro my-astro-project --verbose


### PR DESCRIPTION
## Changes

For consistency with https://github.com/withastro/docs/pull/360. Docs always use `npm create astro` (never `npm init astro`), README.md files in this repo should do the same.

Search:
`\b(npm|yarn|pnpm) init astro\b`
Replace:
`$1 create astro`

Except for two instances:

1. `packages/create-astro/CHANGELOG.md` -- skipped because changelog.

2. `packages/create-astro/test/create-astro.test.js.skipped` -- skipped, old test file disabled in https://github.com/withastro/astro/pull/3168.

_Q: should I run `pnpm exec changeset` for minor changes only touching *.md files? I would guess no._

## Testing

n/a, no code changes.

## Docs

n/a, changes make README.md files consistent with docs, see above.