### PR TITLE
Fix typo in portfolio example

### DIFF
--- a/examples/portfolio/src/pages/index.astro
+++ b/examples/portfolio/src/pages/index.astro
@@ -230,7 +230,7 @@ const featuredProject = projects[0];
 					<h3 class="sectionTitle">Selected Work</h3>
 					<PortfolioPreview project={featuredProject} />
 					<div class="buttonContainer">
-						<a href="/products/" class="button">View All</a>
+						<a href="/projects/" class="button">View All</a>
 					</div>
 				</div>
 				<div class="section">


### PR DESCRIPTION
Found a very small typo. `/products/` doesn't exist in the example site. Likely means`/projects/`. It was changed from `/projects/` to `/products/` in [this commit](https://github.com/withastro/astro/pull/4556/files#diff-1b82a0a1dff5a1ed618445a8f95e787ae5166d7703ada35b9a4392f738301f13L220).