### PR TITLE
Adds a new "astro:build:generated" hook for SSG builds

### DIFF
--- a/.changeset/four-eggs-compare.md
+++ b/.changeset/four-eggs-compare.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Adds a new "astro:build:generated" hook that runs after SSG builds finish but **before** build artifacts are cleaned up. This is a very specific use case, "astro:build:done" is probably what you're looking for.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1159,6 +1159,7 @@ export interface AstroIntegration {
 			target: 'client' | 'server';
 			updateConfig: (newConfig: ViteConfigWithSSR) => void;
 		}) => void | Promise<void>;
+		'astro:build:generated'?: (options: { dir: URL }) => void | Promise<void>;
 		'astro:build:done'?: (options: {
 			pages: { pathname: string }[];
 			dir: URL;

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -19,6 +19,7 @@ import {
 	removeTrailingForwardSlash,
 } from '../../core/path.js';
 import type { RenderOptions } from '../../core/render/core';
+import { runHookBuildGenerated } from '../../integrations/index.js';
 import { BEFORE_HYDRATION_SCRIPT_ID, PAGE_SCRIPT_ID } from '../../vite-plugin-scripts/index.js';
 import { call as callEndpoint } from '../endpoint/index.js';
 import { debug, info } from '../logger/core.js';
@@ -111,6 +112,9 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 	for (const pageData of eachPageData(internals)) {
 		await generatePage(opts, internals, pageData, ssrEntry, builtPaths);
 	}
+
+	await runHookBuildGenerated({ config: opts.astroConfig, buildConfig: opts.buildConfig, logging: opts.logging });
+	
 	info(opts.logging, null, dim(`Completed in ${getTimeStat(timer, performance.now())}.\n`));
 }
 

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -263,6 +263,28 @@ export async function runHookBuildSsr({
 	}
 }
 
+export async function runHookBuildGenerated({
+	config,
+	buildConfig,
+	logging,
+}: {
+	config: AstroConfig;
+	buildConfig: BuildConfig;
+	logging: LogOptions;
+}) {
+	const dir = config.output === 'server' ? buildConfig.client : config.outDir;
+
+	for (const integration of config.integrations) {
+		if (integration?.hooks?.['astro:build:generated']) {
+			await withTakingALongTimeMsg({
+				name: integration.name,
+				hookResult: integration.hooks['astro:build:generated']({ dir }),
+				logging,
+			});
+		}
+	}
+}
+
 export async function runHookBuildDone({
 	config,
 	buildConfig,

--- a/packages/astro/test/static-build-dir.test.js
+++ b/packages/astro/test/static-build-dir.test.js
@@ -4,6 +4,8 @@ import { loadFixture } from './test-utils.js';
 describe('Static build: dir takes the URL path to the output directory', () => {
 	/** @type {URL} */
 	let checkDir;
+	/** @type {URL} */
+	let checkGeneratedDir;
 	before(async () => {
 		const fixture = await loadFixture({
 			root: './fixtures/static-build-dir/',
@@ -11,6 +13,9 @@ describe('Static build: dir takes the URL path to the output directory', () => {
 				{
 					name: '@astrojs/dir',
 					hooks: {
+						'astro:build:generated': ({ dir }) => {
+							checkGeneratedDir = dir;
+						},
 						'astro:build:done': ({ dir }) => {
 							checkDir = dir;
 						},
@@ -25,5 +30,6 @@ describe('Static build: dir takes the URL path to the output directory', () => {
 		expect(removeTrailingSlash(checkDir.toString())).to.be.equal(
 			removeTrailingSlash(new URL('./fixtures/static-build-dir/dist', import.meta.url).toString())
 		);
+		expect(checkDir.toString()).to.be.equal(checkGeneratedDir.toString());
 	});
 });


### PR DESCRIPTION
## Changes

This adds a new `astro:build:generated` hook that runs after all SSG pages are generated but **before** build artifacts are cleaned up.

**Why?**

This handles a very specific use case for `@astrojs/image`.  The new wasm-based image service uses a worker pool to build multiple images in parallel.  The workers need to reference the build's main entrypoint bundle before it's removed by the cleanup process

**Alternatives considered**

- fire `astro:build:done` before the cleanup process

This would technically be a breaking change, and feels a little gross in general since the build really isn't done until it's finished cleanup and is exiting

- refactor the SSG image service to build images during the page generation rather than building all images at the end.

This is a huge performance hit, doing all images at once allows the process to read a local image file once and build all needed versions at once without hitting `fs.readFile` again

## Testing

Test added to make sure the event fires with the correct output directory

## Docs

Docs [PR #1572](https://github.com/withastro/docs/pull/1572)

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
