### PR TITLE
Revert "Adds a new "astro:build:generated" hook for SSG builds (#4772)"

### DIFF
--- a/.changeset/four-eggs-compare.md
+++ b/.changeset/four-eggs-compare.md
@@ -1,5 +1,0 @@
----
-'astro': minor
----
-
-Adds a new "astro:build:generated" hook that runs after SSG builds finish but **before** build artifacts are cleaned up. This is a very specific use case, "astro:build:done" is probably what you're looking for.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1159,7 +1159,6 @@ export interface AstroIntegration {
 			target: 'client' | 'server';
 			updateConfig: (newConfig: ViteConfigWithSSR) => void;
 		}) => void | Promise<void>;
-		'astro:build:generated'?: (options: { dir: URL }) => void | Promise<void>;
 		'astro:build:done'?: (options: {
 			pages: { pathname: string }[];
 			dir: URL;

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -19,7 +19,6 @@ import {
 	removeTrailingForwardSlash,
 } from '../../core/path.js';
 import type { RenderOptions } from '../../core/render/core';
-import { runHookBuildGenerated } from '../../integrations/index.js';
 import { BEFORE_HYDRATION_SCRIPT_ID, PAGE_SCRIPT_ID } from '../../vite-plugin-scripts/index.js';
 import { call as callEndpoint } from '../endpoint/index.js';
 import { debug, info } from '../logger/core.js';
@@ -112,9 +111,6 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 	for (const pageData of eachPageData(internals)) {
 		await generatePage(opts, internals, pageData, ssrEntry, builtPaths);
 	}
-
-	await runHookBuildGenerated({ config: opts.astroConfig, buildConfig: opts.buildConfig, logging: opts.logging });
-	
 	info(opts.logging, null, dim(`Completed in ${getTimeStat(timer, performance.now())}.\n`));
 }
 

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -263,28 +263,6 @@ export async function runHookBuildSsr({
 	}
 }
 
-export async function runHookBuildGenerated({
-	config,
-	buildConfig,
-	logging,
-}: {
-	config: AstroConfig;
-	buildConfig: BuildConfig;
-	logging: LogOptions;
-}) {
-	const dir = config.output === 'server' ? buildConfig.client : config.outDir;
-
-	for (const integration of config.integrations) {
-		if (integration?.hooks?.['astro:build:generated']) {
-			await withTakingALongTimeMsg({
-				name: integration.name,
-				hookResult: integration.hooks['astro:build:generated']({ dir }),
-				logging,
-			});
-		}
-	}
-}
-
 export async function runHookBuildDone({
 	config,
 	buildConfig,

--- a/packages/astro/test/static-build-dir.test.js
+++ b/packages/astro/test/static-build-dir.test.js
@@ -4,8 +4,6 @@ import { loadFixture } from './test-utils.js';
 describe('Static build: dir takes the URL path to the output directory', () => {
 	/** @type {URL} */
 	let checkDir;
-	/** @type {URL} */
-	let checkGeneratedDir;
 	before(async () => {
 		const fixture = await loadFixture({
 			root: './fixtures/static-build-dir/',
@@ -13,9 +11,6 @@ describe('Static build: dir takes the URL path to the output directory', () => {
 				{
 					name: '@astrojs/dir',
 					hooks: {
-						'astro:build:generated': ({ dir }) => {
-							checkGeneratedDir = dir;
-						},
 						'astro:build:done': ({ dir }) => {
 							checkDir = dir;
 						},
@@ -30,6 +25,5 @@ describe('Static build: dir takes the URL path to the output directory', () => {
 		expect(removeTrailingSlash(checkDir.toString())).to.be.equal(
 			removeTrailingSlash(new URL('./fixtures/static-build-dir/dist', import.meta.url).toString())
 		);
-		expect(checkDir.toString()).to.be.equal(checkGeneratedDir.toString());
 	});
 });


### PR DESCRIPTION
This reverts commit 03b18e8d1b9b88d7e9b22e15809a78cc222cb55b.

## Changes

Reverts [PR #4772](https://github.com/withastro/astro/pull/4772), clicked merge on a `minor` too early

## Testing

NA

## Docs

NA

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
