### PR TITLE
init git repo with `main` as default branch

### DIFF
--- a/.changeset/smooth-wombats-scream.md
+++ b/.changeset/smooth-wombats-scream.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Default branch for the git repo of created project is changed from `master` to `main`

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -284,7 +284,7 @@ export async function main() {
 	if (args.dryRun) {
 		ora().info(dim(`--dry-run enabled, skipping.`));
 	} else if (gitResponse.git) {
-		await execaCommand('git init', { cwd });
+		await execaCommand('git init -b main', { cwd });
 		ora().succeed('Git repository created!');
 	} else {
 		ora().info(dim(`Sounds good! You can come back and run ${cyan(`git init`)} later.`));


### PR DESCRIPTION
## Changes
- Changes in packages/create-astro
- Initially default git branch for generated projects was `master`, which is now changed to `main` as per latest convention. 

| ![Screenshot 2022-09-16 at 15 06 46](https://user-images.githubusercontent.com/7466924/190607361-d7785a0b-8655-44b9-8bf7-c4e1e53299af.png) | ![Screenshot 2022-09-16 at 15 04 57](https://user-images.githubusercontent.com/7466924/190607003-b5431b2c-2b96-4774-9311-76f9bf6201cb.png) | 
|:---:|:---:|
| Before | After |

## Testing
Can be tested manually by running `npx /workspace/astro/packages/create-astro`

## Docs
No docs are required for this as this is not changing any user-related behavior or any astro related functionality.  

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
