### PR TITLE
fix(markdown-remark): declare `hast-util-to-html` as a dependency

### DIFF
--- a/.changeset/tidy-glasses-unite.md
+++ b/.changeset/tidy-glasses-unite.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+declare `hast-util-to-html` as a dependency

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -29,6 +29,7 @@
     "acorn": "^8.7.1",
     "acorn-jsx": "^5.3.2",
     "github-slugger": "^1.4.0",
+    "hast-util-to-html": "^8.0.3",
     "mdast-util-mdx-expression": "^1.2.1",
     "mdast-util-mdx-jsx": "^1.2.0",
     "micromark-extension-mdx-expression": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2841,6 +2841,7 @@ importers:
       astro-scripts: workspace:*
       chai: ^4.3.6
       github-slugger: ^1.4.0
+      hast-util-to-html: ^8.0.3
       mdast-util-mdx-expression: ^1.2.1
       mdast-util-mdx-jsx: ^1.2.0
       micromark-extension-mdx-expression: ^1.0.3
@@ -2865,6 +2866,7 @@ importers:
       acorn: 8.8.0
       acorn-jsx: 5.3.2_acorn@8.8.0
       github-slugger: 1.4.0
+      hast-util-to-html: 8.0.3
       mdast-util-mdx-expression: 1.3.0
       mdast-util-mdx-jsx: 1.2.0
       micromark-extension-mdx-expression: 1.0.3
@@ -3243,7 +3245,7 @@ packages:
     dependencies:
       '@astro-community/astro-embed-twitter': 0.1.3_astro@packages+astro
       '@astro-community/astro-embed-youtube': 0.1.1_astro@packages+astro
-      astro: link:packages/astro
+      astro: link:packages\astro
       unist-util-select: 4.0.1
     dev: false
 
@@ -3253,7 +3255,7 @@ packages:
       astro: ^1.0.0-beta.10
     dependencies:
       '@astro-community/astro-embed-utils': 0.0.3
-      astro: link:packages/astro
+      astro: link:packages\astro
     dev: false
 
   /@astro-community/astro-embed-utils/0.0.3:
@@ -3265,7 +3267,7 @@ packages:
     peerDependencies:
       astro: ^1.0.0-beta.10
     dependencies:
-      astro: link:packages/astro
+      astro: link:packages\astro
       lite-youtube-embed: 0.2.0
     dev: false
 
@@ -9839,7 +9841,7 @@ packages:
       '@astro-community/astro-embed-integration': 0.1.0_astro@packages+astro
       '@astro-community/astro-embed-twitter': 0.1.3_astro@packages+astro
       '@astro-community/astro-embed-youtube': 0.1.1_astro@packages+astro
-      astro: link:packages/astro
+      astro: link:packages\astro
     dev: false
 
   /async/3.2.4:


### PR DESCRIPTION
## Changes

This PR declares `hast-util-to-html` as a dependency of `@astrojs/markdown-remark` since it uses it here:
https://github.com/withastro/astro/blob/6e27a5fdc21276cad26cd50e16a2709a40a7cbac/packages/markdown/remark/src/rehype-collect-headings.ts#L2

## Testing

Ran Astro in a strict dependency environment to verify that all dependencies were declared, after declaring `hast-util-to-html` it passed.

## Docs

No docs should be needed for this bugfix.