### PR TITLE
fixed broken emoji for in "Getting started" section of integration docs

### DIFF
--- a/packages/integrations/lit/README.md
+++ b/packages/integrations/lit/README.md
@@ -57,7 +57,7 @@ export default {
 To use your first Lit component in Astro, head to our [UI framework documentation][astro-ui-frameworks]. This explains:
 - 📦 how framework components are loaded,
 - 💧 client-side hydration options, and
-- 🤝opportunities to mix and nest frameworks together
+- 🤝 opportunities to mix and nest frameworks together
 
 However, there's a key difference with Lit _custom elements_ over conventional _components_: you can use the element tag name directly.
 

--- a/packages/integrations/lit/README.md
+++ b/packages/integrations/lit/README.md
@@ -57,7 +57,7 @@ export default {
 To use your first Lit component in Astro, head to our [UI framework documentation][astro-ui-frameworks]. This explains:
 - 📦 how framework components are loaded,
 - 💧 client-side hydration options, and
-- 🪆 opportunities to mix and nest frameworks together
+- 🤝opportunities to mix and nest frameworks together
 
 However, there's a key difference with Lit _custom elements_ over conventional _components_: you can use the element tag name directly.
 

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -78,7 +78,7 @@ You can [add MDX pages to your project](https://docs.astro.build/en/guides/markd
 To use components in your MDX pages in Astro, head to our [UI framework documentation][astro-ui-frameworks]. You'll explore:
 - 📦 how framework components are loaded,
 - 💧 client-side hydration options, and
-- 🪆 opportunities to mix and nest frameworks together
+- 🤝opportunities to mix and nest frameworks together
 
 [**Client Directives**](https://docs.astro.build/en/reference/directives-reference/#client-directives) are still required in `.mdx` files.
 

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -78,7 +78,7 @@ You can [add MDX pages to your project](https://docs.astro.build/en/guides/markd
 To use components in your MDX pages in Astro, head to our [UI framework documentation][astro-ui-frameworks]. You'll explore:
 - 📦 how framework components are loaded,
 - 💧 client-side hydration options, and
-- 🤝opportunities to mix and nest frameworks together
+- 🤝 opportunities to mix and nest frameworks together
 
 [**Client Directives**](https://docs.astro.build/en/reference/directives-reference/#client-directives) are still required in `.mdx` files.
 

--- a/packages/integrations/preact/README.md
+++ b/packages/integrations/preact/README.md
@@ -70,7 +70,7 @@ export default defineConfig({
 To use your first Preact component in Astro, head to our [UI framework documentation][astro-ui-frameworks]. You'll explore:
 - 📦 how framework components are loaded,
 - 💧 client-side hydration options, and
-- 🪆 opportunities to mix and nest frameworks together
+- 🤝opportunities to mix and nest frameworks together
 
 Also check our [Astro Integration Documentation][astro-integration] for more on integrations.
 

--- a/packages/integrations/preact/README.md
+++ b/packages/integrations/preact/README.md
@@ -70,7 +70,7 @@ export default defineConfig({
 To use your first Preact component in Astro, head to our [UI framework documentation][astro-ui-frameworks]. You'll explore:
 - 📦 how framework components are loaded,
 - 💧 client-side hydration options, and
-- 🤝opportunities to mix and nest frameworks together
+- 🤝 opportunities to mix and nest frameworks together
 
 Also check our [Astro Integration Documentation][astro-integration] for more on integrations.
 

--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -57,7 +57,7 @@ export default {
 To use your first React component in Astro, head to our [UI framework documentation][astro-ui-frameworks]. You'll explore:
 - 📦 how framework components are loaded,
 - 💧 client-side hydration options, and
-- 🪆 opportunities to mix and nest frameworks together
+- 🤝opportunities to mix and nest frameworks together
 
 Also check our [Astro Integration Documentation][astro-integration] for more on integrations.
 

--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -57,7 +57,7 @@ export default {
 To use your first React component in Astro, head to our [UI framework documentation][astro-ui-frameworks]. You'll explore:
 - 📦 how framework components are loaded,
 - 💧 client-side hydration options, and
-- 🤝opportunities to mix and nest frameworks together
+- 🤝 opportunities to mix and nest frameworks together
 
 Also check our [Astro Integration Documentation][astro-integration] for more on integrations.
 

--- a/packages/integrations/solid/README.md
+++ b/packages/integrations/solid/README.md
@@ -57,7 +57,7 @@ export default {
 To use your first SolidJS component in Astro, head to our [UI framework documentation][astro-ui-frameworks]. You'll explore:
 - 📦 how framework components are loaded,
 - 💧 client-side hydration options, and
-- 🪆 opportunities to mix and nest frameworks together
+- 🤝opportunities to mix and nest frameworks together
 
 Also check our [Astro Integration Documentation][astro-integration] for more on integrations.
 

--- a/packages/integrations/solid/README.md
+++ b/packages/integrations/solid/README.md
@@ -57,7 +57,7 @@ export default {
 To use your first SolidJS component in Astro, head to our [UI framework documentation][astro-ui-frameworks]. You'll explore:
 - 📦 how framework components are loaded,
 - 💧 client-side hydration options, and
-- 🤝opportunities to mix and nest frameworks together
+- 🤝 opportunities to mix and nest frameworks together
 
 Also check our [Astro Integration Documentation][astro-integration] for more on integrations.
 

--- a/packages/integrations/svelte/README.md
+++ b/packages/integrations/svelte/README.md
@@ -57,7 +57,7 @@ export default {
 To use your first Svelte component in Astro, head to our [UI framework documentation][astro-ui-frameworks]. You'll explore:
 - 📦 how framework components are loaded,
 - 💧 client-side hydration options, and
-- 🤝opportunities to mix and nest frameworks together
+- 🤝 opportunities to mix and nest frameworks together
 
 Also check our [Astro Integration Documentation][astro-integration] for more on integrations.
 

--- a/packages/integrations/svelte/README.md
+++ b/packages/integrations/svelte/README.md
@@ -57,7 +57,7 @@ export default {
 To use your first Svelte component in Astro, head to our [UI framework documentation][astro-ui-frameworks]. You'll explore:
 - 📦 how framework components are loaded,
 - 💧 client-side hydration options, and
-- 🪆 opportunities to mix and nest frameworks together
+- 🤝opportunities to mix and nest frameworks together
 
 Also check our [Astro Integration Documentation][astro-integration] for more on integrations.
 

--- a/packages/integrations/vue/README.md
+++ b/packages/integrations/vue/README.md
@@ -57,7 +57,7 @@ export default {
 To use your first Vue component in Astro, head to our [UI framework documentation][astro-ui-frameworks]. You'll explore:
 - 📦 how framework components are loaded,
 - 💧 client-side hydration options, and
-- 🪆 opportunities to mix and nest frameworks together
+- 🤝opportunities to mix and nest frameworks together
 
 Also check our [Astro Integration Documentation][astro-integration] for more on integrations.
 

--- a/packages/integrations/vue/README.md
+++ b/packages/integrations/vue/README.md
@@ -57,7 +57,7 @@ export default {
 To use your first Vue component in Astro, head to our [UI framework documentation][astro-ui-frameworks]. You'll explore:
 - 📦 how framework components are loaded,
 - 💧 client-side hydration options, and
-- 🤝opportunities to mix and nest frameworks together
+- 🤝 opportunities to mix and nest frameworks together
 
 Also check our [Astro Integration Documentation][astro-integration] for more on integrations.
 


### PR DESCRIPTION
## Changes

- What does this change?
- This PR fixes the issue in integration docs which I reported here https://github.com/withastro/docs/issues/1577
- The emoji is broken in 3rd point of `Getting started` inside integration docs

![broken emoji fix](https://iili.io/iI0Ddv.png)

## Testing

All tests are passing


<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

Fixes https://github.com/withastro/docs/issues/1577