### PR TITLE
Update Picture.astro

### DIFF
--- a/packages/integrations/image/components/Picture.astro
+++ b/packages/integrations/image/components/Picture.astro
@@ -60,6 +60,9 @@ const { image, sources } = await getPicture({
 	background,
 	position,
 });
+
+delete image.width;
+delete image.height;
 ---
 
 <picture {...attrs}>


### PR DESCRIPTION
## Changes

The image variable of getPicture contains a width and height property, which we usually require. In this case, the image is wrapped in a picture tag, and the img tag itself should not have a width and height property as this will break the responsiveness of the image provided by the picture tag.

## Testing

The picture component now renders the img tag without the width and height attributes.
I'm not sure how you would like to adjust the test files and if this is the correct way you would like to solve this issue.

## Docs

This has no impact on the docs as everything stated about the element is correct.