### PR TITLE
Update Vite 3.1.3

### DIFF
--- a/.changeset/ten-tips-argue.md
+++ b/.changeset/ten-tips-argue.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Update Vite 3.1.3

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -149,7 +149,7 @@
     "tsconfig-resolver": "^3.0.1",
     "unist-util-visit": "^4.1.0",
     "vfile": "^5.3.2",
-    "vite": "3.1.0",
+    "vite": "~3.1.3",
     "yargs-parser": "^21.0.1",
     "zod": "^3.17.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,7 +417,7 @@ importers:
       tsconfig-resolver: ^3.0.1
       unist-util-visit: ^4.1.0
       vfile: ^5.3.2
-      vite: 3.1.0
+      vite: ~3.1.3
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
@@ -475,7 +475,7 @@ importers:
       tsconfig-resolver: 3.0.1
       unist-util-visit: 4.1.1
       vfile: 5.3.5
-      vite: 3.1.0_sass@1.54.9
+      vite: 3.1.3_sass@1.54.9
       yargs-parser: 21.1.1
       zod: 3.19.1
     devDependencies:
@@ -17338,34 +17338,6 @@ packages:
       - supports-color
     dev: false
 
-  /vite/3.1.0_sass@1.54.9:
-    resolution: {integrity: sha512-YBg3dUicDpDWFCGttmvMbVyS9ydjntwEjwXRj2KBFwSB8SxmGcudo1yb8FW5+M/G86aS8x828ujnzUVdsLjs9g==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.15.7
-      postcss: 8.4.16
-      resolve: 1.22.1
-      rollup: 2.78.1
-      sass: 1.54.9
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: false
-
   /vite/3.1.1:
     resolution: {integrity: sha512-hgxQWev/AL7nWYrqByYo8nfcH9n97v6oFsta9+JX8h6cEkni7nHKP2kJleNYV2kcGhE8jsbaY1aStwPZXzPbgA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -17389,6 +17361,61 @@ packages:
       postcss: 8.4.16
       resolve: 1.22.1
       rollup: 2.78.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: false
+
+  /vite/3.1.3:
+    resolution: {integrity: sha512-/3XWiktaopByM5bd8dqvHxRt5EEgRikevnnrpND0gRfNkrMrPaGGexhtLCzv15RcCMtV2CLw+BPas8YFeSG0KA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.15.7
+      postcss: 8.4.16
+      resolve: 1.22.1
+      rollup: 2.78.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: false
+
+  /vite/3.1.3_sass@1.54.9:
+    resolution: {integrity: sha512-/3XWiktaopByM5bd8dqvHxRt5EEgRikevnnrpND0gRfNkrMrPaGGexhtLCzv15RcCMtV2CLw+BPas8YFeSG0KA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.15.7
+      postcss: 8.4.16
+      resolve: 1.22.1
+      rollup: 2.78.1
+      sass: 1.54.9
     optionalDependencies:
       fsevents: 2.3.2
     dev: false
@@ -17426,7 +17453,7 @@ packages:
       local-pkg: 0.4.2
       tinypool: 0.2.4
       tinyspy: 1.0.2
-      vite: 3.1.1
+      vite: 3.1.3
     transitivePeerDependencies:
       - less
       - sass


### PR DESCRIPTION
## Changes

Fix #4727

Brings in the fix from https://github.com/vitejs/vite/pull/10144

I also bumped as `~3.1.3` as discussed by @matthewp before, or we could stick to a pinned version.

## Testing

Tested the original repro in the issue and Vite 3.1.3 fixes it.

## Docs

N/A
