### PR TITLE
[chore] replaces hard-coded `minify` values with `vite.build.minify`

### DIFF
--- a/.changeset/tender-nails-sip.md
+++ b/.changeset/tender-nails-sip.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+replaces hard-coded `minify` values with `vite.build.minify`

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -179,6 +179,7 @@ async function clientBuild(
 	const timer = performance.now();
 	const ssr = settings.config.output === 'server';
 	const out = ssr ? opts.buildConfig.client : settings.config.outDir;
+	const minify = settings.config.vite.build?.minify ?? 'esbuild';
 
 	// Nothing to do if there is no client-side JS.
 	if (!input.size) {
@@ -199,7 +200,7 @@ async function clientBuild(
 		build: {
 			...viteConfig.build,
 			emptyOutDir: false,
-			minify: 'esbuild',
+			minify,
 			outDir: fileURLToPath(out),
 			rollupOptions: {
 				...viteConfig.build?.rollupOptions,

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -179,7 +179,6 @@ async function clientBuild(
 	const timer = performance.now();
 	const ssr = settings.config.output === 'server';
 	const out = ssr ? opts.buildConfig.client : settings.config.outDir;
-	const minify = settings.config.vite.build?.minify ?? 'esbuild';
 
 	// Nothing to do if there is no client-side JS.
 	if (!input.size) {
@@ -200,7 +199,6 @@ async function clientBuild(
 		build: {
 			...viteConfig.build,
 			emptyOutDir: false,
-			minify,
 			outDir: fileURLToPath(out),
 			rollupOptions: {
 				...viteConfig.build?.rollupOptions,

--- a/packages/astro/src/core/build/vite-plugin-css.ts
+++ b/packages/astro/src/core/build/vite-plugin-css.ts
@@ -239,7 +239,7 @@ export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] 
 						if (output.type === 'asset') {
 							if (output.name?.endsWith('.css') && typeof output.source === 'string') {
 								const cssTarget = settings.config.vite.build?.cssTarget;
-								const minify = settings.config.vite.build?.minify === false ? false : true;
+								const minify = settings.config.vite.build?.minify !== false
 								const { code: minifiedCSS } = await esbuild.transform(output.source, {
 									loader: 'css',
 									minify,

--- a/packages/astro/src/core/build/vite-plugin-css.ts
+++ b/packages/astro/src/core/build/vite-plugin-css.ts
@@ -239,9 +239,10 @@ export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] 
 						if (output.type === 'asset') {
 							if (output.name?.endsWith('.css') && typeof output.source === 'string') {
 								const cssTarget = settings.config.vite.build?.cssTarget;
+								const minify = settings.config.vite.build?.minify === false ? false : true;
 								const { code: minifiedCSS } = await esbuild.transform(output.source, {
 									loader: 'css',
-									minify: true,
+									minify,
 									...(cssTarget ? { target: cssTarget } : {}),
 								});
 								output.source = minifiedCSS;


### PR DESCRIPTION
## Changes

- replaces hard-coded `minify` values with `vite.build.minify`, so that users can override minification from `astro.config`.
