### PR TITLE
Remove explicit `Transfer-Encoding: chunked` header

### DIFF
--- a/.changeset/sweet-ligers-push.md
+++ b/.changeset/sweet-ligers-push.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Remove explicit `Transfer-Encoding: chunked` header from streaming responses

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -149,7 +149,6 @@ export async function render(opts: RenderOptions): Promise<Response> {
 		site,
 		scripts,
 		ssr,
-		streaming,
 		status,
 	});
 

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -27,7 +27,6 @@ function onlyAvailableInSSR(name: string) {
 export interface CreateResultArgs {
 	adapterName: string | undefined;
 	ssr: boolean;
-	streaming: boolean;
 	logging: LogOptions;
 	origin: string;
 	markdown: MarkdownRenderingOptions;
@@ -126,12 +125,7 @@ export function createResult(args: CreateResultArgs): SSRResult {
 
 	const url = new URL(request.url);
 	const headers = new Headers();
-	if (args.streaming) {
-		headers.set('Transfer-Encoding', 'chunked');
-		headers.set('Content-Type', 'text/html');
-	} else {
-		headers.set('Content-Type', 'text/html');
-	}
+	headers.set('Content-Type', 'text/html');
 	const response: ResponseInit = {
 		status: args.status,
 		statusText: 'OK',


### PR DESCRIPTION
This header is not necessary and is ignored by essentially all HTTP servers when provided explicitly by the user. This is because the HTTP transport layer handles adding this header automatically as needed.

Some variations of HTTP transport (like HTTP/2, which is enabled by default in Deno, Netlify, and CFW) have no notion of
`Transfer-Encoding: chunked`, because all responses are streamed.

## Changes

- This removes the `Transfer-Encoding: chunked` header.

## Testing

If all existing streaming related tests pass, this should be considered working as I am arguing that the header is superfluous to the function of Astro.

## Docs

This does not affect users in any way.