### PR TITLE
Allow override `vite.build.target`

### DIFF
--- a/.changeset/green-baboons-clean.md
+++ b/.changeset/green-baboons-clean.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow override `vite.build.target`

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -118,6 +118,7 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 		logLevel: opts.viteConfig.logLevel ?? 'error',
 		mode: 'production',
 		build: {
+			target: 'esnext',
 			...viteConfig.build,
 			emptyOutDir: false,
 			manifest: false,
@@ -134,8 +135,6 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 				},
 			},
 			ssr: true,
-			// must match an esbuild target
-			target: 'esnext',
 			// improve build performance
 			minify: false,
 			polyfillModulePreload: false,
@@ -197,6 +196,7 @@ async function clientBuild(
 		logLevel: 'info',
 		mode: 'production',
 		build: {
+			target: 'esnext',
 			...viteConfig.build,
 			emptyOutDir: false,
 			minify: 'esbuild',
@@ -213,7 +213,6 @@ async function clientBuild(
 				},
 				preserveEntrySignatures: 'exports-only',
 			},
-			target: 'esnext', // must match an esbuild target
 		},
 		plugins: [
 			vitePluginInternals(input, internals),


### PR DESCRIPTION
## Changes

Allow changing `vite.build.target`. The default is `esnext`, which the user may want to use `es2020` instead.

I noticed it used to be `es2020` but bumped in https://github.com/withastro/astro/pull/2487. I think we should keep this value as baseline `es2020` so that user can opt-in to advanced feature instead, but it would be a breaking change.

This may help similar issues to #4812 (but not completely as we don't have full legacy support)

## Testing

N/A

## Docs

N/A. I think this is a transparent change.


