### PR TITLE
Prevent errors in React components from crashing the dev server

### DIFF
--- a/.changeset/tricky-walls-walk.md
+++ b/.changeset/tricky-walls-walk.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': patch
+---
+
+Prevent errors in React components from crashing the dev server

--- a/packages/astro/test/fixtures/react-component/src/components/ImportsThrowsAnError.jsx
+++ b/packages/astro/test/fixtures/react-component/src/components/ImportsThrowsAnError.jsx
@@ -1,0 +1,7 @@
+import ThrowsAnError from "./ThrowsAnError";
+
+export default function() {
+	return <>
+		<ThrowsAnError />
+	</>
+}

--- a/packages/astro/test/fixtures/react-component/src/components/ThrowsAnError.jsx
+++ b/packages/astro/test/fixtures/react-component/src/components/ThrowsAnError.jsx
@@ -2,6 +2,11 @@ import { useState } from 'react';
 
 export default function() {
 	let player = undefined;
+	// This is tested in dev mode, so make it work during the build to prevent
+	// breaking other tests.
+	if(import.meta.env.MODE === 'production') {
+		player = {};
+	}
 	const [] = useState(player.currentTime || null);
 
 	return (

--- a/packages/astro/test/fixtures/react-component/src/components/ThrowsAnError.jsx
+++ b/packages/astro/test/fixtures/react-component/src/components/ThrowsAnError.jsx
@@ -1,0 +1,10 @@
+import { useState } from 'react';
+
+export default function() {
+	let player = undefined;
+	const [] = useState(player.currentTime || null);
+
+	return (
+		<div>Should have thrown</div>
+	)
+}

--- a/packages/astro/test/fixtures/react-component/src/pages/error-rendering.astro
+++ b/packages/astro/test/fixtures/react-component/src/pages/error-rendering.astro
@@ -1,0 +1,11 @@
+---
+import ImportsThrowsAnError from '../components/ImportsThrowsAnError';
+---
+<html>
+<head>
+	<title>Testing</title>
+</head>
+<body>
+	<ImportsThrowsAnError />
+</body>
+</html>

--- a/packages/astro/test/react-component.test.js
+++ b/packages/astro/test/react-component.test.js
@@ -94,6 +94,7 @@ describe('React Components', () => {
 	if (isWindows) return;
 
 	describe('dev', () => {
+		/** @type {import('./test-utils').Fixture} */
 		let devServer;
 
 		before(async () => {
@@ -144,6 +145,11 @@ describe('React Components', () => {
 
 			// test 1: react/jsx-runtime is used for the component
 			expect(jsxRuntime).to.be.ok;
+		});
+
+		it('When a nested component throws it does not crash the server', async () => {
+			const res = await fixture.fetch('/error-rendering');
+			await res.arrayBuffer();
 		});
 	});
 });

--- a/packages/integrations/react/server.js
+++ b/packages/integrations/react/server.js
@@ -121,8 +121,11 @@ async function renderToPipeableStreamAsync(vnode) {
 async function renderToStaticNodeStreamAsync(vnode) {
 	const Writable = await getNodeWritable();
 	let html = '';
-	return new Promise((resolve) => {
+	return new Promise((resolve, reject) => {
 		let stream = ReactDOM.renderToStaticNodeStream(vnode);
+		stream.on('error', err => {
+			reject(err);
+		});
 		stream.pipe(
 			new Writable({
 				write(chunk, _encoding, callback) {


### PR DESCRIPTION
## Changes

- We were not listening for the `error` event in the stream, causing an unhandled exception that crashes the server.
- Fixes https://discord.com/channels/830184174198718474/1021564982430797895

## Testing

- Test added that recreates the scenario. The lack of crashing shows a passing test.

## Docs

N/A, bug fix