### PR TITLE
Fix extra slash when adding integrations that ends with `/astro`

### DIFF
--- a/.changeset/lovely-seals-compare.md
+++ b/.changeset/lovely-seals-compare.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix parsing integration names with astro add command

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -304,11 +304,12 @@ async function parseAstroConfig(configURL: URL): Promise<t.File> {
 //  - 123numeric => numeric
 //  - @npm/thingy => npmThingy
 //  - @jane/foo.js => janeFoo
+//  - @tokencss/astro => tokencss
 const toIdent = (name: string) => {
 	const ident = name
 		.trim()
 		// Remove astro or (astrojs) prefix and suffix
-		.replace(/[-_\.]?astro(?:js)?[-_\.]?/g, '')
+		.replace(/[-_\.\/]?astro(?:js)?[-_\.]?/g, '')
 		// drop .js suffix
 		.replace(/\.js/, '')
 		// convert to camel case


### PR DESCRIPTION
## Changes

This  PR fixes a bug in `toIdent` funtion used by `astro add` to convert an arbitrary NPM package name into a JS identifier.
see #4808

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
