### PR TITLE
Update blog post date text color to meet contrast-ratio guidelines

### DIFF
--- a/examples/blog/src/pages/blog.astro
+++ b/examples/blog/src/pages/blog.astro
@@ -25,7 +25,7 @@ const posts = (await Astro.glob('./blog/*.{md,mdx}')).sort(
 			ul li time {
 				flex: 0 0 130px;
 				font-style: italic;
-				color: #888;
+				color: #595959;
 			}
 			ul li a:visited {
 				color: #8e32dc;


### PR DESCRIPTION
## Changes

This changes the blog post data text color in the examples repo to meet WCAG constrat-ratio guidelines

## Testing

The new color, `#595959` was tested on a white background with https://webaim.org/resources/contrastchecker/
The contrast ratio is now 7:1 where the previous contrast ratio was 3.54:1

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No doc updates are needed for updating the blog post date text color in the examples folder
