### PR TITLE
Allow passing fetch() Response to set:html

### DIFF
--- a/.changeset/silent-comics-hang.md
+++ b/.changeset/silent-comics-hang.md
@@ -1,0 +1,49 @@
+---
+'astro': minor
+---
+
+Allows Responses to be passed to set:html
+
+This expands the abilities of `set:html` to ultimate service this use-case:
+
+```astro
+<div set:html={fetch('/legacy-post.html')}></div>
+```
+
+This means you can take a legacy app that has been statically generated to HTML and directly consume that HTML within your templates. As is always the case with `set:html`, this should only be used on trusted content.
+
+To make this possible, you can also pass several other types into `set:html` now:
+
+* `Response` objects, since that is what fetch() returns:
+    ```astro
+    <div set:html={new Response('<span>Hello world</span>', {
+      headers: {
+        'content-type': 'text/html'
+      }
+    })}></div>
+    ```
+* `ReadableStream`s:
+    ```astro
+    <div set:html={new ReadableStream({
+      start(controller) {
+        controller.enqueue(`<span>read me</span>`);
+        controller.close();
+      }
+    })}></div>
+    ```
+* `AsyncIterable`s:
+    ```astro
+    <div set:html={(async function * () {
+      for await (const num of [1, 2, 3, 4, 5]) {
+        yield `<li>${num}</li>`;
+      }
+    })()}>
+    ```
+* `Iterable`s (non-async):
+    ```astro
+    <div set:html={(function * () {
+      for (const num of [1, 2, 3, 4, 5]) {
+        yield `<li>${num}</li>`;
+      }
+    })()}>
+    ```

--- a/packages/astro/src/runtime/server/escape.ts
+++ b/packages/astro/src/runtime/server/escape.ts
@@ -16,7 +16,7 @@ export class HTMLBytes extends Uint8Array {
  */
 export class HTMLString extends String {
 	get [Symbol.toStringTag]() {
-		return 'HTMLSTring';
+		return 'HTMLString';
 	}
 }
 

--- a/packages/astro/src/runtime/server/escape.ts
+++ b/packages/astro/src/runtime/server/escape.ts
@@ -3,11 +3,24 @@ import { escape } from 'html-escaper';
 // Leverage the battle-tested `html-escaper` npm package.
 export const escapeHTML = escape;
 
+export class HTMLBytes extends Uint8Array {
+	// @ts-ignore
+	get [Symbol.toStringTag]() {
+		return 'HTMLBytes';
+	}
+}
+
 /**
  * A "blessed" extension of String that tells Astro that the string
  * has already been escaped. This helps prevent double-escaping of HTML.
  */
-export class HTMLString extends String {}
+export class HTMLString extends String {
+	get [Symbol.toStringTag]() {
+		return 'HTMLSTring';
+	}
+}
+
+type BlessedType = string | HTMLBytes;
 
 /**
  * markHTMLString marks a string as raw or "already escaped" by returning
@@ -30,12 +43,52 @@ export const markHTMLString = (value: any) => {
 	return value;
 };
 
-export function unescapeHTML(str: any) {
-	// If a promise, await the result and mark that.
-	if (!!str && typeof str === 'object' && typeof str.then === 'function') {
-		return Promise.resolve(str).then((value) => {
-			return markHTMLString(value);
-		});
+export function isHTMLString(value: any): value is HTMLString {
+	return Object.prototype.toString.call(value) === '[object HTMLString]';
+}
+
+function markHTMLBytes(bytes: Uint8Array) {
+	return new HTMLBytes(bytes);
+}
+
+export function isHTMLBytes(value: any): value is HTMLBytes {
+	return Object.prototype.toString.call(value) === '[object HTMLBytes]';
+}
+
+async function * unescapeChunksAsync(iterable: AsyncIterable<Uint8Array>): any {
+	for await (const chunk of iterable) {
+		yield unescapeHTML(chunk as BlessedType);
+	}
+}
+
+function * unescapeChunks(iterable: Iterable<any>): any {
+	for(const chunk of iterable) {
+		yield unescapeHTML(chunk);
+	}
+}
+
+export function unescapeHTML(str: any): BlessedType | Promise<BlessedType | AsyncGenerator<BlessedType, void, unknown>> | AsyncGenerator<BlessedType, void, unknown> {
+	if (!!str && typeof str === 'object') {
+		if(str instanceof Uint8Array) {
+			return markHTMLBytes(str);
+		}
+		// If a response, stream out the chunks
+		else if(str instanceof Response && str.body) {
+			const body = str.body as unknown as AsyncIterable<Uint8Array>;
+			return unescapeChunksAsync(body);
+		}
+		// If a promise, await the result and mark that.
+		else if(typeof str.then === 'function') {
+			return Promise.resolve(str).then((value) => {
+				return unescapeHTML(value);
+			});
+		}
+		else if(Symbol.iterator in str) {
+			return unescapeChunks(str);
+		}
+		else if(Symbol.asyncIterator in str) {
+			return unescapeChunksAsync(str);
+		}
 	}
 	return markHTMLString(str);
 }

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -1,6 +1,6 @@
 export { createAstro } from './astro-global.js';
 export { renderEndpoint } from './endpoint.js';
-export { escapeHTML, HTMLString, markHTMLString, unescapeHTML } from './escape.js';
+export { escapeHTML, HTMLString, HTMLBytes, markHTMLString, unescapeHTML } from './escape.js';
 export type { Metadata } from './metadata';
 export { createMetadata } from './metadata.js';
 export {

--- a/packages/astro/src/runtime/server/jsx.ts
+++ b/packages/astro/src/runtime/server/jsx.ts
@@ -12,7 +12,7 @@ import {
 	spreadAttributes,
 	voidElementNames,
 } from './index.js';
-import { chunkToByteArray, decoder, concatUint8Arrays } from './render/common.js';
+import { HTMLParts } from './render/common.js';
 
 const ClientOnlyPlaceholder = 'astro-client-only';
 
@@ -142,11 +142,12 @@ export async function renderJSX(result: SSRResult, vnode: any): Promise<any> {
 				);
 			}
 			if (typeof output !== 'string' && Symbol.asyncIterator in output) {
-				let parts: Uint8Array[] = [];
+				//let parts: Uint8Array[] = [];
+				let parts = new HTMLParts();
 				for await (const chunk of output) {
-					parts.push(chunkToByteArray(result, chunk));
+					parts.append(chunk, result);
 				}
-				return markHTMLString(decoder.decode(concatUint8Arrays(parts)));
+				return markHTMLString(parts.toString());
 			} else {
 				return markHTMLString(output);
 			}

--- a/packages/astro/src/runtime/server/jsx.ts
+++ b/packages/astro/src/runtime/server/jsx.ts
@@ -142,7 +142,6 @@ export async function renderJSX(result: SSRResult, vnode: any): Promise<any> {
 				);
 			}
 			if (typeof output !== 'string' && Symbol.asyncIterator in output) {
-				//let parts: Uint8Array[] = [];
 				let parts = new HTMLParts();
 				for await (const chunk of output) {
 					parts.append(chunk, result);

--- a/packages/astro/src/runtime/server/render/any.ts
+++ b/packages/astro/src/runtime/server/render/any.ts
@@ -29,9 +29,7 @@ export async function* renderChild(child: any): AsyncIterable<any> {
 		yield* renderAstroComponent(child);
 	} else if(ArrayBuffer.isView(child)) {
 		yield child;
-	} else if (typeof child === 'object' && Symbol.asyncIterator in child) {
-		yield* child;
-	} else if(Symbol.iterator in child) {
+	} else if (typeof child === 'object' && (Symbol.asyncIterator in child || Symbol.iterator in child)) {
 		yield* child;
 	} else {
 		yield child;

--- a/packages/astro/src/runtime/server/render/any.ts
+++ b/packages/astro/src/runtime/server/render/any.ts
@@ -27,7 +27,11 @@ export async function* renderChild(child: any): AsyncIterable<any> {
 		Object.prototype.toString.call(child) === '[object AstroComponent]'
 	) {
 		yield* renderAstroComponent(child);
+	} else if(ArrayBuffer.isView(child)) {
+		yield child;
 	} else if (typeof child === 'object' && Symbol.asyncIterator in child) {
+		yield* child;
+	} else if(Symbol.iterator in child) {
 		yield* child;
 	} else {
 		yield child;

--- a/packages/astro/src/runtime/server/render/astro.ts
+++ b/packages/astro/src/runtime/server/render/astro.ts
@@ -2,10 +2,10 @@ import type { SSRResult } from '../../../@types/astro';
 import type { AstroComponentFactory } from './index';
 import type { RenderInstruction } from './types';
 
-import { markHTMLString } from '../escape.js';
+import { markHTMLString, HTMLBytes } from '../escape.js';
 import { HydrationDirectiveProps } from '../hydration.js';
 import { renderChild } from './any.js';
-import { stringifyChunk } from './common.js';
+import { chunkToByteArray, concatUint8Arrays, decoder } from './common.js';
 
 // In dev mode, check props and make sure they are valid for an Astro component
 function validateComponentProps(props: any, displayName: string) {
@@ -62,7 +62,7 @@ export function isAstroComponentFactory(obj: any): obj is AstroComponentFactory 
 
 export async function* renderAstroComponent(
 	component: InstanceType<typeof AstroComponent>
-): AsyncIterable<string | RenderInstruction> {
+): AsyncIterable<string | HTMLBytes | RenderInstruction> {
 	for await (const value of component) {
 		if (value || value === 0) {
 			for await (const chunk of renderChild(value)) {
@@ -95,11 +95,11 @@ export async function renderToString(
 		throw response;
 	}
 
-	let html = '';
+	let bytes: Uint8Array[] = [];
 	for await (const chunk of renderAstroComponent(Component)) {
-		html += stringifyChunk(result, chunk);
+		bytes.push(chunkToByteArray(result, chunk));
 	}
-	return html;
+	return decoder.decode(concatUint8Arrays(bytes));
 }
 
 export async function renderToIterable(
@@ -108,7 +108,7 @@ export async function renderToIterable(
 	displayName: string,
 	props: any,
 	children: any
-): Promise<AsyncIterable<string | RenderInstruction>> {
+): Promise<AsyncIterable<string | HTMLBytes | RenderInstruction>> {
 	validateComponentProps(props, displayName);
 	const Component = await componentFactory(result, props, children);
 

--- a/packages/astro/src/runtime/server/render/astro.ts
+++ b/packages/astro/src/runtime/server/render/astro.ts
@@ -5,7 +5,7 @@ import type { RenderInstruction } from './types';
 import { markHTMLString, HTMLBytes } from '../escape.js';
 import { HydrationDirectiveProps } from '../hydration.js';
 import { renderChild } from './any.js';
-import { chunkToByteArray, concatUint8Arrays, decoder } from './common.js';
+import { HTMLParts } from './common.js';
 
 // In dev mode, check props and make sure they are valid for an Astro component
 function validateComponentProps(props: any, displayName: string) {
@@ -95,11 +95,11 @@ export async function renderToString(
 		throw response;
 	}
 
-	let bytes: Uint8Array[] = [];
+	let parts = new HTMLParts();
 	for await (const chunk of renderAstroComponent(Component)) {
-		bytes.push(chunkToByteArray(result, chunk));
+		parts.append(chunk, result);
 	}
-	return decoder.decode(concatUint8Arrays(bytes));
+	return parts.toString();
 }
 
 export async function renderToIterable(

--- a/packages/astro/src/runtime/server/render/common.ts
+++ b/packages/astro/src/runtime/server/render/common.ts
@@ -1,7 +1,7 @@
 import type { SSRResult } from '../../../@types/astro';
 import type { RenderInstruction } from './types.js';
 
-import { markHTMLString } from '../escape.js';
+import { markHTMLString, HTMLBytes } from '../escape.js';
 import {
 	determineIfNeedsHydrationScript,
 	determinesIfNeedsDirectiveScript,
@@ -11,6 +11,9 @@ import {
 
 export const Fragment = Symbol.for('astro:fragment');
 export const Renderer = Symbol.for('astro:renderer');
+
+export const encoder = new TextEncoder();
+export const decoder = new TextDecoder();
 
 // Rendering produces either marked strings of HTML or instructions for hydration.
 // These directive instructions bubble all the way up to renderPage so that we
@@ -39,4 +42,23 @@ export function stringifyChunk(result: SSRResult, chunk: string | RenderInstruct
 			return chunk.toString();
 		}
 	}
+}
+
+export function chunkToByteArray(result: SSRResult, chunk: string | HTMLBytes | RenderInstruction): Uint8Array {
+	if(chunk instanceof Uint8Array) {
+		return chunk as Uint8Array;
+	}
+	return encoder.encode(stringifyChunk(result, chunk));
+}
+
+export function concatUint8Arrays(arrays: Array<Uint8Array>) {
+	let len = 0;
+	arrays.forEach(arr => len += arr.length);
+	let merged = new Uint8Array(len);
+	let offset = 0;
+	arrays.forEach(arr => {
+		merged.set(arr, offset);
+		offset += arr.length;
+	});
+	return merged;
 }

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -1,7 +1,7 @@
 import type { AstroComponentMetadata, SSRLoadedRenderer, SSRResult } from '../../../@types/astro';
 import type { RenderInstruction } from './types.js';
 
-import { markHTMLString } from '../escape.js';
+import { markHTMLString, HTMLBytes } from '../escape.js';
 import { extractDirectives, generateHydrateScript } from '../hydration.js';
 import { serializeProps } from '../serialize.js';
 import { shorthash } from '../shorthash.js';
@@ -54,7 +54,7 @@ export async function renderComponent(
 	Component: unknown,
 	_props: Record<string | number, any>,
 	slots: any = {}
-): Promise<string | AsyncIterable<string | RenderInstruction>> {
+): Promise<string | AsyncIterable<string | HTMLBytes | RenderInstruction>> {
 	Component = await Component;
 
 	switch (getComponentType(Component)) {
@@ -84,7 +84,7 @@ export async function renderComponent(
 
 		case 'astro-factory': {
 			async function* renderAstroComponentInline(): AsyncGenerator<
-				string | RenderInstruction,
+				string | HTMLBytes | RenderInstruction,
 				void,
 				undefined
 			> {

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -3,11 +3,11 @@ import type { AstroComponentFactory } from './index';
 
 import { createResponse } from '../response.js';
 import { isAstroComponent, isAstroComponentFactory, renderAstroComponent } from './astro.js';
-import { stringifyChunk } from './common.js';
+import { encoder, chunkToByteArray, concatUint8Arrays } from './common.js';
 import { renderComponent } from './component.js';
+import { isHTMLString } from '../escape.js';
 import { maybeRenderHead } from './head.js';
 
-const encoder = new TextEncoder();
 const needsHeadRenderingSymbol = Symbol.for('astro.needsHeadRendering');
 
 type NonAstroPageComponent = {
@@ -72,17 +72,16 @@ export async function renderPage(
 						let i = 0;
 						try {
 							for await (const chunk of iterable) {
-								let html = stringifyChunk(result, chunk);
-
-								if (i === 0) {
-									if (!/<!doctype html/i.test(html)) {
-										controller.enqueue(encoder.encode('<!DOCTYPE html>\n'));
+								if(isHTMLString(chunk)) {
+									if (i === 0) {
+										if (!/<!doctype html/i.test(String(chunk))) {
+											controller.enqueue(encoder.encode('<!DOCTYPE html>\n'));
+										}
 									}
 								}
-								// Convert HTML object to string
-								// for environments that won't "toString" automatically
-								// (ex. Cloudflare and Vercel Edge)
-								controller.enqueue(encoder.encode(String(html)));
+								
+								let bytes = chunkToByteArray(result, chunk);
+								controller.enqueue(bytes);
 								i++;
 							}
 							controller.close();
@@ -94,20 +93,21 @@ export async function renderPage(
 				},
 			});
 		} else {
-			body = '';
+			let parts: Array<Uint8Array> = [];
 			let i = 0;
 			for await (const chunk of iterable) {
-				let html = stringifyChunk(result, chunk);
-				if (i === 0) {
-					if (!/<!doctype html/i.test(html)) {
-						body += '<!DOCTYPE html>\n';
+				if(isHTMLString(chunk)) {
+					if (i === 0) {
+						if (!/<!doctype html/i.test(String(chunk))) {
+							parts.push(encoder.encode('<!DOCTYPE html>\n'));
+						}
 					}
 				}
-				body += html;
+				parts.push(chunkToByteArray(result, chunk));
 				i++;
 			}
-			const bytes = encoder.encode(body);
-			headers.set('Content-Length', bytes.byteLength.toString());
+			body = concatUint8Arrays(parts);
+			headers.set('Content-Length', body.byteLength.toString());
 		}
 
 		let response = createResponse(body, { ...init, headers });

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -3,7 +3,7 @@ import type { AstroComponentFactory } from './index';
 
 import { createResponse } from '../response.js';
 import { isAstroComponent, isAstroComponentFactory, renderAstroComponent } from './astro.js';
-import { encoder, chunkToByteArray, concatUint8Arrays } from './common.js';
+import { encoder, chunkToByteArray, HTMLParts } from './common.js';
 import { renderComponent } from './component.js';
 import { isHTMLString } from '../escape.js';
 import { maybeRenderHead } from './head.js';
@@ -93,20 +93,20 @@ export async function renderPage(
 				},
 			});
 		} else {
-			let parts: Array<Uint8Array> = [];
+			let parts = new HTMLParts();
 			let i = 0;
 			for await (const chunk of iterable) {
 				if(isHTMLString(chunk)) {
 					if (i === 0) {
 						if (!/<!doctype html/i.test(String(chunk))) {
-							parts.push(encoder.encode('<!DOCTYPE html>\n'));
+							parts.append('<!DOCTYPE html>\n', result);
 						}
 					}
 				}
-				parts.push(chunkToByteArray(result, chunk));
+				parts.append(chunk, result);
 				i++;
 			}
-			body = concatUint8Arrays(parts);
+			body = parts.toArrayBuffer();
 			headers.set('Content-Length', body.byteLength.toString());
 		}
 

--- a/packages/astro/src/runtime/server/response.ts
+++ b/packages/astro/src/runtime/server/response.ts
@@ -59,7 +59,7 @@ type CreateResponseFn = (body?: BodyInit | null, init?: ResponseInit) => Respons
 
 export const createResponse: CreateResponseFn = isNodeJS
 	? (body, init) => {
-			if (typeof body === 'string') {
+			if (typeof body === 'string' || ArrayBuffer.isView(body)) {
 				return new Response(body, init);
 			}
 			if (typeof StreamingCompatibleResponse === 'undefined') {

--- a/packages/astro/src/runtime/server/util.ts
+++ b/packages/astro/src/runtime/server/util.ts
@@ -1,9 +1,3 @@
-function formatList(values: string[]): string {
-	if (values.length === 1) {
-		return values[0];
-	}
-	return `${values.slice(0, -1).join(', ')} or ${values[values.length - 1]}`;
-}
 
 export function serializeListValue(value: any) {
 	const hash: Record<string, any> = {};
@@ -33,4 +27,8 @@ export function serializeListValue(value: any) {
 			}
 		}
 	}
+}
+
+export function isPromise<T = any>(value: any): value is Promise<T> {
+	return !!value && typeof value === 'object' && typeof value.then === 'function';
 }

--- a/packages/astro/test/fixtures/set-html/package.json
+++ b/packages/astro/test/fixtures/set-html/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/set-html",
+  "version": "1.0.0",
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/set-html/public/test.html
+++ b/packages/astro/test/fixtures/set-html/public/test.html
@@ -1,0 +1,1 @@
+<div id="fetched-html">works</div>

--- a/packages/astro/test/fixtures/set-html/src/pages/fetch.astro
+++ b/packages/astro/test/fixtures/set-html/src/pages/fetch.astro
@@ -1,0 +1,18 @@
+---
+// This is a dev only test
+const mode = import.meta.env.MODE;
+---
+<html>
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<h1>Testing</h1>
+		<div id="fetch" set:html={
+			mode === 'development' ?
+				// @ts-ignore
+				TEST_FETCH(fetch, '/test.html') :
+				'build mode'
+		}></div>
+	</body>
+</html>

--- a/packages/astro/test/fixtures/set-html/src/pages/index.astro
+++ b/packages/astro/test/fixtures/set-html/src/pages/index.astro
@@ -1,0 +1,36 @@
+---
+function * iterator(id = 'iterator') {
+	for(const num of [1, 2, 3, 4, 5]) {
+		yield `<span id="${id}-num">${num}</span>`;
+	}
+}
+
+async function * asynciterator() {
+	for(const num of iterator('asynciterator')) {
+		yield Promise.resolve(num);
+	}
+}
+---
+<html>
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<h1>Testing</h1>
+		<div id="html" set:html={`<span id="html-inner">works</span>`}></div>
+		<div id="promise-html" set:html={Promise.resolve(`<span id="promise-html-inner">works</span>`)}></div>
+		<div id="response" set:html={new Response(`<span id="response-html-inner"></span>`, {
+			headers: {
+				'content-type': 'text/html'
+			}
+		})}></div>
+		<div id="iterator" set:html={iterator()}></div>
+		<div id="asynciterator" set:html={asynciterator()}></div>
+		<div id="readablestream" set:html={new ReadableStream({
+			start(controller) {
+				controller.enqueue(`<span id="readable-inner">read me</span>`);
+				controller.close();
+			},
+		})}></div>
+	</body>
+</html>

--- a/packages/astro/test/set-html.test.js
+++ b/packages/astro/test/set-html.test.js
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+
+describe('set:html', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/set-html/',
+		});
+	});
+
+	describe('Development', () => {
+		/** @type {import('./test-utils').DevServer} */
+		let devServer;
+
+		before(async () => {
+			devServer = await fixture.startDevServer();
+			globalThis.TEST_FETCH = (fetch, url, init) => {
+				return fetch(fixture.resolveUrl(url), init);
+			};
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('can take a fetch()', async () => {
+			let res = await fixture.fetch('/fetch');
+			expect(res.status).to.equal(200);
+			let html = await res.text();
+			const $ = cheerio.load(html);
+			expect($('#fetched-html')).to.have.a.lengthOf(1);
+			expect($('#fetched-html').text()).to.equal('works');
+		});
+	});
+
+	describe('Build', () => {
+		before(async () => {
+			await fixture.build();
+		});
+
+		it('can take a string of HTML', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			expect($('#html-inner')).to.have.a.lengthOf(1);
+		});
+
+		it('can take a Promise to a string of HTML', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			expect($('#promise-html-inner')).to.have.a.lengthOf(1);
+		});
+
+		it('can take a Response to a string of HTML', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			expect($('#response-html-inner')).to.have.a.lengthOf(1);
+		});
+
+		it('can take an Iterator', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			expect($('#iterator-num')).to.have.a.lengthOf(5);
+		});
+
+		it('Can take an AsyncIterator', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			expect($('#asynciterator-num')).to.have.a.lengthOf(5);
+		});
+
+		it('Can take a ReadableStream', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			expect($('#readable-inner')).to.have.a.lengthOf(1);
+		});
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1817,6 +1817,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/set-html:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/slots-preact:
     specifiers:
       '@astrojs/mdx': workspace:*


### PR DESCRIPTION
## Changes

- This allows doing `<Fragment set:html={fetch('/posts/legacy-post.html')} />` and more.
- See the changeset.
- Closes https://github.com/withastro/astro/issues/4828

## Testing

- New test cases added in `packages/astro/test/set-html.test.js` for all scenarios.

## Docs

- https://github.com/withastro/docs/pull/1599