### PR TITLE
Prevent the root from being deleted during the build

### DIFF
--- a/.changeset/hot-lamps-search.md
+++ b/.changeset/hot-lamps-search.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent the root folder from being deleted during the build

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -91,6 +91,7 @@ class AstroBuilder {
 			serverEntry: 'entry.mjs',
 		};
 		await runHookBuildStart({ config: this.settings.config, buildConfig, logging: this.logging });
+		this.validateConfig();
 
 		info(this.logging, 'build', `output target: ${colors.green(this.settings.config.output)}`);
 		if (this.settings.adapter) {
@@ -168,6 +169,15 @@ class AstroBuilder {
 			await this.build(setupData);
 		} catch (_err) {
 			throw fixViteErrorMessage(_err);
+		}
+	}
+
+	private validateConfig() {
+		const { config } = this.settings;
+		
+		// outDir gets blown away so it can't be the root.
+		if(config.outDir.toString() === config.root.toString()) {
+			throw new Error(`the outDir cannot be the root folder. Please build to a folder such as dist.`);
 		}
 	}
 

--- a/packages/astro/test/dont-delete-root.test.js
+++ b/packages/astro/test/dont-delete-root.test.js
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import { loadFixture } from './test-utils.js';
+import * as fs from 'fs';
+
+describe('outDir set to project root', async () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	/** @type {Error | undefined} */
+	let error;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/dont-delete-me/' });
+		try {
+			await fixture.build();
+		} catch(err) {
+			error = err;
+		}
+	});
+
+	it('Throws an error when you attempt to build', async () => {
+		expect(error).to.be.an.instanceOf(Error);
+		expect(error.message).to.match(/outDir cannot be the root folder/);
+	});
+
+	it('Files have not been deleted', async () => {
+		const expectedFiles = [
+			'package.json',
+			'astro.config.mjs',
+			'src/pages/index.astro'
+		];
+
+		for(const rel of expectedFiles) {
+			const root = new URL('./fixtures/dont-delete-me/', import.meta.url);
+			const url = new URL('./' + rel, root);
+			const stats = await fs.promises.stat(url);
+			expect(stats).to.not.be.undefined;
+		}
+	});
+});

--- a/packages/astro/test/fixtures/dont-delete-me/astro.config.mjs
+++ b/packages/astro/test/fixtures/dont-delete-me/astro.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	outDir: './'
+});

--- a/packages/astro/test/fixtures/dont-delete-me/package.json
+++ b/packages/astro/test/fixtures/dont-delete-me/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@test/dont-delete-me",
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/dont-delete-me/src/pages/index.astro
+++ b/packages/astro/test/fixtures/dont-delete-me/src/pages/index.astro
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Testing</title>
+</head>
+<body>
+	
+</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1505,6 +1505,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/dont-delete-me:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/entry-file-names:
     specifiers:
       '@astrojs/preact': 'workspace:'


### PR DESCRIPTION
## Changes

- If `outDir === root` throw a helpful error message. Not doing so blows away the root folder.
- Fixes https://github.com/withastro/astro/issues/4844

## Testing

- Test added

## Docs

N/A, bug fix