### PR TITLE
Add action to check if PR can be merged

### DIFF
--- a/.github/workflows/check-merge.yml
+++ b/.github/workflows/check-merge.yml
@@ -32,6 +32,16 @@ jobs:
             fi
           done
 
+      - name: Add label
+        if: steps.find-blockers.outputs.found == 'true'
+        run: |
+          curl --request POST \
+            --url https://api.github.com/repos/${{github.repository}}/issues/${{github.event.number}}/labels \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            --header 'content-type: application/json' \
+            -d '["semver minor"]'
+
+
       - name: Send PR review
         if: steps.find-blockers.outputs.found == 'true'
         run: | # approve the pull request

--- a/.github/workflows/check-merge.yml
+++ b/.github/workflows/check-merge.yml
@@ -1,0 +1,42 @@
+name: Check mergeability
+
+on: pull_request # run on pull request events
+
+permissions:
+  # grant write permission on the pull-requests endpoint
+  pull-requests: write
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files in the .changeset folder
+        id: changed-files
+        uses: tj-actions/changed-files@v29
+        with:
+          files: |
+            .changeset/**/*.md
+
+      - name: Check if any changesets contain minor changes
+        id: find-blockers
+        run: |
+          echo "Checking for changesets marked as minor"
+          echo '::set-output name=found::false'
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            if grep -q "'astro': minor" "$file"; then
+              echo '::set-output name=found::true'
+              echo "$file has a minor release tag"
+            fi
+          done
+
+      - name: Send PR review
+        if: steps.find-blockers.outputs.found == 'true'
+        run: | # approve the pull request
+          curl --request POST \
+          --url https://api.github.com/repos/${{github.repository}}/pulls/${{github.event.number}}/reviews \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'content-type: application/json' \
+          -d '{"event":"REQUEST_CHANGES","body":"This PR is blocked because it contains a `minor` changeset. A reviewer will merge this at the next release if approved."}'

--- a/.github/workflows/check-merge.yml
+++ b/.github/workflows/check-merge.yml
@@ -9,19 +9,36 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      - name: Retrieve existing PR reviews
+        id: set-reviews
+        run: |
+          echo ::set-output name=reviews::$(curl --request GET \
+            --url https://api.github.com/repos/${{github.repository}}/pulls/${{github.event.number}}/reviews \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}')
+
+      - name: Check if there is already a block on this PR
+        id: set-blocks
+        run: |
+          echo ::set-output name=blocks::$(echo '${{ steps.set-reviews.outputs.reviews }}' \
+            | jq '.[] | select(.user.id == 41898282 and .state == "CHANGES_REQUESTED") | length' \
+            | uniq)
+
       - uses: actions/checkout@v3
+        if: steps.set-blocks.outputs.blocks == ''
         with:
           fetch-depth: 0
 
       - name: Get changed files in the .changeset folder
         id: changed-files
         uses: tj-actions/changed-files@v29
+        if: steps.set-blocks.outputs.blocks == ''
         with:
           files: |
             .changeset/**/*.md
 
       - name: Check if any changesets contain minor changes
         id: find-blockers
+        if: steps.set-blocks.outputs.blocks == ''
         run: |
           echo "Checking for changesets marked as minor"
           echo '::set-output name=found::false'


### PR DESCRIPTION
## Changes

- This adds a new action that checks PRs to see if they can be merged, based on whether they have a changeset marked as minor.
- If there is a minor changeset it will add a blocking review that needs to be overridden.
- If there is already a blocking review from this bot, do not apply it a second time.
- Adds the `semver minor` label automatically.

## Testing

- Tested in this PR - https://github.com/withastro/astro/pull/4853

## Docs

N/A