### PR TITLE
fix: getFileInfo does not add .html extension in url when build.format is file

### DIFF
--- a/.changeset/light-shrimps-draw.md
+++ b/.changeset/light-shrimps-draw.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+append .html to the file URL in case build.format says file

--- a/packages/astro/src/core/path.ts
+++ b/packages/astro/src/core/path.ts
@@ -1,3 +1,7 @@
+export function appendExtension(path: string, extension: string) {
+	return path + '.' + extension;
+}
+
 export function appendForwardSlash(path: string) {
 	return path.endsWith('/') ? path : path + '/';
 }

--- a/packages/astro/src/vite-plugin-utils/index.ts
+++ b/packages/astro/src/vite-plugin-utils/index.ts
@@ -1,6 +1,6 @@
 import { Data } from 'vfile';
 import type { AstroConfig, MarkdownAstroData } from '../@types/astro';
-import { appendForwardSlash } from '../core/path.js';
+import { appendForwardSlash, appendExtension } from '../core/path.js';
 
 export function getFileInfo(id: string, config: AstroConfig) {
 	const sitePathname = appendForwardSlash(
@@ -13,6 +13,9 @@ export function getFileInfo(id: string, config: AstroConfig) {
 		: undefined;
 	if (fileUrl && config.trailingSlash === 'always') {
 		fileUrl = appendForwardSlash(fileUrl);
+	}
+	if (fileUrl && config.build.format === 'file') {
+		fileUrl = appendExtension(fileUrl, 'html');
 	}
 	return { fileId, fileUrl };
 }


### PR DESCRIPTION
fixes #4661

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
