### PR TITLE
add double check on astro file Response return type with more readable error

### DIFF
--- a/examples/ssr/src/pages/index.astro
+++ b/examples/ssr/src/pages/index.astro
@@ -6,6 +6,8 @@ import { getProducts } from '../api';
 import '../styles/common.css';
 
 const products = await getProducts(Astro.request);
+
+return;
 ---
 
 <html lang="en">

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -112,7 +112,12 @@ export async function renderPage(
 
 		let response = createResponse(body, { ...init, headers });
 		return response;
-	} else {
-		return factoryReturnValue;
 	}
+
+	// We double check if the file return a Response
+	if (!(factoryReturnValue instanceof Response)) {
+		throw new Error('Only instance of Response can be returned from an Astro file');
+	}
+
+	return factoryReturnValue;
 }

--- a/packages/astro/test/astro-not-response.test.js
+++ b/packages/astro/test/astro-not-response.test.js
@@ -1,0 +1,35 @@
+import { expect, assert } from 'chai';
+import { loadFixture } from './test-utils.js';
+
+// Asset bundling
+describe('Not returning responses', () => {
+	let fixture;
+	/** @type {import('./test-utils').DevServer} */
+	let devServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/astro-not-response/',
+		});
+
+		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer.stop();
+	});
+
+	it('Does not work from a page', async () => {
+		try {
+			await fixture.build();
+		} catch (e) {
+			expect(e).to.be.instanceOf(
+				Error,
+				'Only instance of Response can be returned from an Astro file'
+			);
+			return null;
+		}
+
+		assert.fail('Should have thrown an error');
+	});
+});

--- a/packages/astro/test/fixtures/astro-not-response/package.json
+++ b/packages/astro/test/fixtures/astro-not-response/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/astro-not-response",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/astro-not-response/src/pages/not-response.astro
+++ b/packages/astro/test/fixtures/astro-not-response/src/pages/not-response.astro
@@ -1,0 +1,3 @@
+---
+return null;
+---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1335,6 +1335,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/astro-not-response:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/astro-page-directory-url:
     specifiers:
       astro: workspace:*


### PR DESCRIPTION
## Changes

- Add a more detailed error message on Astro file not returning an instance of `Response`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Not sure how to test this, I would love any pointer on this.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Behavior is already documented

Related issue: https://github.com/withastro/astro/issues/4631
