### PR TITLE
fix: Script with innerHTML not working on Safari

### DIFF
--- a/.changeset/cool-camels-tease.md
+++ b/.changeset/cool-camels-tease.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+use const instead of let for define:vars

--- a/.changeset/cool-camels-tease.md
+++ b/.changeset/cool-camels-tease.md
@@ -1,5 +1,5 @@
 ---
-'astro': major
+'astro': patch
 ---
 
 use const instead of let for define:vars

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -34,7 +34,9 @@ const toStyleString = (obj: Record<string, any>) =>
 export function defineScriptVars(vars: Record<any, any>) {
 	let output = '';
 	for (const [key, value] of Object.entries(vars)) {
-		output += `let ${toIdent(key)} = ${JSON.stringify(value)};\n`;
+		// Use const instead of let as let global unsupported with Safari
+		// https://stackoverflow.com/questions/29194024/cant-use-let-keyword-in-safari-javascript
+		output += `const ${toIdent(key)} = ${JSON.stringify(value)};\n`;
 	}
 	return markHTMLString(output);
 }

--- a/packages/astro/test/astro-directives.test.js
+++ b/packages/astro/test/astro-directives.test.js
@@ -23,10 +23,10 @@ describe('Directives', async () => {
 			expect($(script).text().at(-1)).to.equal('}');
 			if (i < 2) {
 				// Inline defined variables
-				expect($(script).toString()).to.include('let foo = "bar"');
+				expect($(script).toString()).to.include('const foo = "bar"');
 			} else {
 				// Convert invalid keys to valid identifiers
-				expect($(script).toString()).to.include('let dashCase = "bar"');
+				expect($(script).toString()).to.include('const dashCase = "bar"');
 			}
 			i++;
 		}


### PR DESCRIPTION
fixes #4859, specifically: https://github.com/withastro/astro/issues/4859#issuecomment-1256944568

Have another approach in mind using (https://stackoverflow.com/questions/7944460/detect-safari-browser/31732310#31732310), but since define:vars is supposed to be used as passing prop on SSR (whether static build or SSR build), changing to a const shall not affect client-side operations. We might need to put alert on docs tho.