### PR TITLE
fix: Lookbehind regex crashing on Safari

### DIFF
--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -15,7 +15,7 @@ const STATIC_DIRECTIVES = new Set(['set:html', 'set:text']);
 
 // converts (most) arbitrary strings to valid JS identifiers
 const toIdent = (k: string) =>
-	k.trim().replace(/(?:(?<!^)\b\w|\s+|[^\w]+)/g, (match, index) => {
+	k.trim().replace(/(?:(?!^)\b\w|\s+|[^\w]+)/g, (match, index) => {
 		if (/[^\w]|\s/.test(match)) return '';
 		return index === 0 ? match : match.toUpperCase();
 	});


### PR DESCRIPTION
Attempts to fix #4865 

I'm not a regex master, but given that here negative lookahead, shall behave same as lookbehind (as for matching spaces (or anything)). To me these two regexs seem same as checked on regex101.com's explanation.

This happens as the component is loaded with client:idle that requires that chunk of JS to be inserted as an island so it runs in the browser eventually.