### PR TITLE
fix: 🐛 BUG: class:list directive adding class attribute when undefined

### DIFF
--- a/.changeset/lucky-comics-bow.md
+++ b/.changeset/lucky-comics-bow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+check if class:list's value is defined before converting

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -92,8 +92,10 @@ export function extractDirectives(inputProps: Record<string | number, any>): Ext
 				}
 			}
 		} else if (key === 'class:list') {
-			// support "class" from an expression passed into a component (#782)
-			extracted.props[key.slice(0, -5)] = serializeListValue(value);
+			if (value) {
+				// support "class" from an expression passed into a component (#782)
+				extracted.props[key.slice(0, -5)] = serializeListValue(value);
+			}
 		} else {
 			extracted.props[key] = value;
 		}


### PR DESCRIPTION
fixes #4001 

With the specific reproduction, it seemed as if class:list in component with mapped attributes would always created even if value is undefined. Fixed it by checking if value exists beforehand, else it gets to the point `push(value)` and hence the empty class attribute.