### PR TITLE
Prevent /undefined catch-all routes in dev

### DIFF
--- a/.changeset/mighty-garlics-exercise.md
+++ b/.changeset/mighty-garlics-exercise.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent /undefined catch-all routes in dev

--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -108,13 +108,9 @@ export class RouteCache {
 
 export function findPathItemByKey(staticPaths: GetStaticPathsResultKeyed, params: Params) {
 	const paramsKey = stringifyParams(params);
-	let matchedStaticPath = staticPaths.keyed.get(paramsKey);
+	const matchedStaticPath = staticPaths.keyed.get(paramsKey);
 	if (matchedStaticPath) {
 		return matchedStaticPath;
 	}
-
 	debug('findPathItemByKey', `Unexpected cache miss looking for ${paramsKey}`);
-	matchedStaticPath = staticPaths.find(
-		({ params: _params }) => JSON.stringify(_params) === paramsKey
-	);
 }

--- a/packages/astro/src/core/routing/params.ts
+++ b/packages/astro/src/core/routing/params.ts
@@ -32,7 +32,7 @@ export function stringifyParams(params: Params) {
 	const validatedParams = Object.entries(params).reduce((acc, next) => {
 		validateGetStaticPathsParameter(next);
 		const [key, value] = next;
-		acc[key] = `${value}`;
+		acc[key] = typeof value === 'undefined' ? undefined : `${value}`;
 		return acc;
 	}, {} as Params);
 

--- a/packages/astro/test/fixtures/routing-priority/src/pages/empty-slug/[...slug].astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/empty-slug/[...slug].astro
@@ -1,0 +1,22 @@
+---
+export function getStaticPaths() {
+	return [{
+		params: { slug: undefined },
+	}, {
+		params: { slug: 'potato' },
+  }]
+}
+const { slug } = Astro.params
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>{slug}</title>
+	</head>
+	<body>
+		<h1>empty-slug/[...slug].astro</h1>
+		<p>slug: {slug}</p>
+	</body>
+</html>

--- a/packages/astro/test/routing-priority.test.js
+++ b/packages/astro/test/routing-priority.test.js
@@ -95,6 +95,17 @@ const routes = [
 		h1: '[id].astro',
 		p: 'injected-2',
 	},
+	{
+		description: 'matches /empty-slug to empty-slug/[...slug].astro',
+		url: '/empty-slug',
+		h1: 'empty-slug/[...slug].astro',
+		p: 'slug: ',
+	},
+	{
+		description: 'do not match /empty-slug/undefined to empty-slug/[...slug].astro',
+		url: '/empty-slug/undefined',
+		fourOhFour: true,
+	},
 ];
 
 function appendForwardSlash(path) {
@@ -112,9 +123,16 @@ describe('Routing priority', () => {
 			await fixture.build();
 		});
 
-		routes.forEach(({ description, url, h1, p }) => {
+		routes.forEach(({ description, url, fourOhFour, h1, p }) => {
 			it(description, async () => {
-				const html = await fixture.readFile(`${appendForwardSlash(url)}index.html`);
+				const htmlFile = `${appendForwardSlash(url)}index.html`;
+
+				if (fourOhFour) {
+					expect(fixture.pathExists(htmlFile)).to.be.false;
+					return;
+				}
+
+				const html = await fixture.readFile(htmlFile);
 				const $ = cheerioLoad(html);
 
 				expect($('h1').text()).to.equal(h1);
@@ -142,11 +160,16 @@ describe('Routing priority', () => {
 			await devServer.stop();
 		});
 
-		routes.forEach(({ description, url, h1, p }) => {
+		routes.forEach(({ description, url, fourOhFour, h1, p }) => {
 			// checks URLs as written above
 			it(description, async () => {
 				const html = await fixture.fetch(url).then((res) => res.text());
 				const $ = cheerioLoad(html);
+
+				if (fourOhFour) {
+					expect($('title').text()).to.equal('404: Not Found');
+					return;
+				}
 
 				expect($('h1').text()).to.equal(h1);
 
@@ -159,6 +182,11 @@ describe('Routing priority', () => {
 			it(`${description} (trailing slash)`, async () => {
 				const html = await fixture.fetch(appendForwardSlash(url)).then((res) => res.text());
 				const $ = cheerioLoad(html);
+
+				if (fourOhFour) {
+					expect($('title').text()).to.equal('404: Not Found');
+					return;
+				}
 
 				expect($('h1').text()).to.equal(h1);
 
@@ -173,6 +201,11 @@ describe('Routing priority', () => {
 					.fetch(`${appendForwardSlash(url)}index.html`)
 					.then((res) => res.text());
 				const $ = cheerioLoad(html);
+
+				if (fourOhFour) {
+					expect($('title').text()).to.equal('404: Not Found');
+					return;
+				}
 
 				expect($('h1').text()).to.equal(h1);
 

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -156,6 +156,7 @@ export async function loadFixture(inlineConfig) {
 			const previewServer = await preview(settings, { logging, telemetry, ...opts });
 			return previewServer;
 		},
+		pathExists: (p) => fs.existsSync(new URL(p.replace(/^\//, ''), config.outDir)),
 		readFile: (filePath, encoding) =>
 			fs.promises.readFile(new URL(filePath.replace(/^\//, ''), config.outDir), encoding ?? 'utf8'),
 		readdir: (fp) => fs.promises.readdir(new URL(fp.replace(/^\//, ''), config.outDir)),


### PR DESCRIPTION
## Changes

Fix #4796 

In dev, for pages declared like `pages/[...slug].astro`, if `slug` is `undefined`, only serve at `http://localhost:3000` and `http://localhost:3000/`. Don't serve `http://localhost:3000/undefined`

This PR makes `undefined` and `"undefined"` as 2 distinct static paths to differentiate them, by not stringifying `undefined`.

Note: In build, `http://localhost:3000/undefined` is never built. So this PR makes dev consistent with build.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added a test under `routing-priority`

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->
N/A.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
