### PR TITLE
docs: Standardize troubleshooting and contributing sections for integrations

### DIFF
--- a/packages/integrations/cloudflare/README.md
+++ b/packages/integrations/cloudflare/README.md
@@ -90,3 +90,15 @@ export default {
   },
 }
 ```
+
+## Troubleshooting
+
+For help, check out the `#support` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+
+You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
+## Contributing
+
+This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
+
+[astro-integration]: https://docs.astro.build/en/guides/integrations-guide/

--- a/packages/integrations/lit/README.md
+++ b/packages/integrations/lit/README.md
@@ -111,9 +111,15 @@ import {MyElement} from '../components/my-element.js';
 
 The above will only load the element's JavaScript when the user has scrolled it into view. Since it is server rendered they will not see any jank; it will load and hydrate transparently.
 
-### More documentation
+## Troubleshooting
 
-Check our [Astro Integration Documentation][astro-integration] for more on integrations.
+For help, check out the `#support` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+
+You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
+## Contributing
+
+This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
 
 [astro-integration]: https://docs.astro.build/en/guides/integrations-guide/
 [astro-ui-frameworks]: https://docs.astro.build/en/core-concepts/framework-components/#using-framework-components

--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -59,7 +59,15 @@ To use your first React component in Astro, head to our [UI framework documentat
 - 💧 client-side hydration options, and
 - 🤝 opportunities to mix and nest frameworks together
 
-Also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+## Troubleshooting
+
+For help, check out the `#support` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+
+You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
+## Contributing
+
+This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
 
 [astro-integration]: https://docs.astro.build/en/guides/integrations-guide/
 [astro-ui-frameworks]: https://docs.astro.build/en/core-concepts/framework-components/#using-framework-components

--- a/packages/integrations/solid/README.md
+++ b/packages/integrations/solid/README.md
@@ -59,7 +59,15 @@ To use your first SolidJS component in Astro, head to our [UI framework document
 - 💧 client-side hydration options, and
 - 🤝 opportunities to mix and nest frameworks together
 
-Also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+## Troubleshooting
+
+For help, check out the `#support` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+
+You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
+## Contributing
+
+This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
 
 [astro-integration]: https://docs.astro.build/en/guides/integrations-guide/
 [astro-ui-frameworks]: https://docs.astro.build/en/core-concepts/framework-components/#using-framework-components

--- a/packages/integrations/svelte/README.md
+++ b/packages/integrations/svelte/README.md
@@ -59,7 +59,15 @@ To use your first Svelte component in Astro, head to our [UI framework documenta
 - 💧 client-side hydration options, and
 - 🤝 opportunities to mix and nest frameworks together
 
-Also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+## Troubleshooting
+
+For help, check out the `#support` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+
+You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
+## Contributing
+
+This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
 
 [astro-integration]: https://docs.astro.build/en/guides/integrations-guide/
 [astro-ui-frameworks]: https://docs.astro.build/en/core-concepts/framework-components/#using-framework-components

--- a/packages/integrations/turbolinks/README.md
+++ b/packages/integrations/turbolinks/README.md
@@ -62,5 +62,15 @@ Turbo links, frames, and more should be ready-to-use with zero config. For insta
 
 Head to [the Turbo handbook](https://turbo.hotwired.dev/handbook/introduction) for all options and features available. You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
 
+## Troubleshooting
+
+For help, check out the `#support` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+
+You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
+## Contributing
+
+This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
+
 [astro-integration]: https://docs.astro.build/en/guides/integrations-guide/
 [astro-ui-frameworks]: https://docs.astro.build/en/core-concepts/framework-components/#using-framework-components

--- a/packages/integrations/vue/README.md
+++ b/packages/integrations/vue/README.md
@@ -59,7 +59,15 @@ To use your first Vue component in Astro, head to our [UI framework documentatio
 - 💧 client-side hydration options, and
 - 🤝 opportunities to mix and nest frameworks together
 
-Also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+## Troubleshooting
+
+For help, check out the `#support` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+
+You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
+## Contributing
+
+This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
 
 [astro-integration]: https://docs.astro.build/en/guides/integrations-guide/
 [astro-ui-frameworks]: https://docs.astro.build/en/core-concepts/framework-components/#using-framework-components


### PR DESCRIPTION
## Changes

- Adds the `Troubleshooting` and `Contributing` sections to the following `README.md` files in `packages/integrations` as discussed at in #4872.
  - `cloudflare`
  - `lit`
  - `react`
  - `solid`
  - `svelte`
  - `turbolinks`
  - `vue`  

This brings those documents inline with the other Astro supported packages.
I found lots of instances where my markdown linting in VSCode was complaining about other items, but I avoided my desire to "clean up" additional items. 

There were places where it was unclear where these headings should live, such as in the `@astro/vue` and `@astro/svelte` packages where there was previously a line mentioning checking out the Astro Integration Documentation, but appeared not at the end of the files as many others, but instead prior to `Options` and other integration related items.

## Testing

Visual.

## Docs

The Changes section describes the changes as they are all minor documentation edits. 