### PR TITLE
Set SSR target webworker for Vercel edge

### DIFF
--- a/.changeset/curvy-comics-smash.md
+++ b/.changeset/curvy-comics-smash.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Set SSR target webworker

--- a/packages/integrations/vercel/src/edge/adapter.ts
+++ b/packages/integrations/vercel/src/edge/adapter.ts
@@ -44,6 +44,7 @@ export default function vercelEdge(): AstroIntegration {
 					}
 
 					vite.ssr = {
+						target: 'webworker',
 						noExternal: true,
 					};
 				}


### PR DESCRIPTION
## Changes

Fix #4630

Vercel edge, like Cloudflare, doens't have access to nodejs modules. Set `ssr.target: 'webworker'` so that Vite resolves the `browser` field of packages instead.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Ran `npm run build` with [this repro](https://stackblitz.com/edit/github-vgszev?file=astro.config.mjs) locally.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A. This should work ootb without docs.
