### PR TITLE
fix object styles not escaped

### DIFF
--- a/.changeset/swift-moles-crash.md
+++ b/.changeset/swift-moles-crash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix object styles not escaped

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -72,7 +72,7 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 
 	// support "class" from an expression passed into an element (#782)
 	if (key === 'class:list') {
-		const listValue = toAttributeString(serializeListValue(value));
+		const listValue = toAttributeString(serializeListValue(value), shouldEscape);
 		if (listValue === '') {
 			return '';
 		}

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -81,7 +81,7 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 
 	// support object styles for better JSX compat
 	if (key === 'style' && !(value instanceof HTMLString) && typeof value === 'object') {
-		return markHTMLString(` ${key}="${toStyleString(value)}"`);
+		return markHTMLString(` ${key}="${toAttributeString(toStyleString(value), shouldEscape)}"`);
 	}
 
 	// support `className` for better JSX compat

--- a/packages/astro/test/astro-object-style.test.js
+++ b/packages/astro/test/astro-object-style.test.js
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Object style', async () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/astro-object-style/' });
+		await fixture.build();
+	});
+
+	it('Passes style attributes as expected to elements', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerio.load(html);
+
+		expect($('[style="background-color:green"]')).to.have.lengthOf(1);
+		expect($('[style="background-color:red"]')).to.have.lengthOf(1);
+		expect($('[style="background-color:blue"]')).to.have.lengthOf(1);
+		expect($(`[style='background-image:url("a")']`)).to.have.lengthOf(1);
+	});
+
+	it('Passes style attributes as expected to components', async () => {
+		const html = await fixture.readFile('/component/index.html');
+		const $ = cheerio.load(html);
+
+		expect($('[style="background-color:green"]')).to.have.lengthOf(1);
+		expect($('[style="background-color:red"]')).to.have.lengthOf(1);
+		expect($('[style="background-color:blue"]')).to.have.lengthOf(1);
+		expect($(`[style='background-image:url("a")']`)).to.have.lengthOf(1);
+	});
+});

--- a/packages/astro/test/fixtures/astro-object-style/package.json
+++ b/packages/astro/test/fixtures/astro-object-style/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/astro-class-list",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/astro-object-style/package.json
+++ b/packages/astro/test/fixtures/astro-object-style/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/astro-class-list",
+  "name": "@test/astro-object-style",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/astro-object-style/src/components/Span.astro
+++ b/packages/astro/test/fixtures/astro-object-style/src/components/Span.astro
@@ -1,0 +1,1 @@
+<span {...Astro.props} />

--- a/packages/astro/test/fixtures/astro-object-style/src/pages/component.astro
+++ b/packages/astro/test/fixtures/astro-object-style/src/pages/component.astro
@@ -1,0 +1,10 @@
+---
+import Component from '../components/Span.astro'
+---
+<Component style="background-color:green" />
+
+<Component style={"background-color:red"} />
+
+<Component style={{backgroundColor:"blue"}} />
+
+<Component style={{backgroundImage:'url("a")'}} />

--- a/packages/astro/test/fixtures/astro-object-style/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-object-style/src/pages/index.astro
@@ -1,0 +1,7 @@
+<span style="background-color:green" />
+
+<span style={"background-color:red"} />
+
+<span style={{backgroundColor:"blue"}} />
+
+<span style={{backgroundImage:'url("a")'}} />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1341,6 +1341,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/astro-object-style:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/astro-page-directory-url:
     specifiers:
       astro: workspace:*


### PR DESCRIPTION
## Changes

Before this PR:

```
<div
  style={{
    backgroundImage: `url("test.png")`,
  }}
>
</div>
```

would be rendered as

```
<div
  style="background-image: url("test.png")"
>
</div>
```

which is invalid HTML, since the quotes in url are not escaped.

After the fix in this PR, the output is:

```
<div
  style="background-image: url(&#34;test.png&#34;)"
>
</div>
```

Also found a bug where `shouldEscape` isn't passed down to `toAttributeString` and I fixed it.

## Testing

Added `astro-object-style` test

## Docs

Minor fix
