### PR TITLE
Hoist hydration script out of slot templates

### DIFF
--- a/.changeset/smart-elephants-check.md
+++ b/.changeset/smart-elephants-check.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Hoist hydration scripts out of slot templates

--- a/packages/astro/src/runtime/server/render/any.ts
+++ b/packages/astro/src/runtime/server/render/any.ts
@@ -1,10 +1,15 @@
 import { escapeHTML, HTMLString, markHTMLString } from '../escape.js';
 import { AstroComponent, renderAstroComponent } from './astro.js';
-import { stringifyChunk } from './common.js';
+import { SlotString } from './slot.js';
 
 export async function* renderChild(child: any): AsyncIterable<any> {
 	child = await child;
-	if (child instanceof HTMLString) {
+	if(child instanceof SlotString) {
+		if(child.instructions) {
+			yield * child.instructions;
+		}
+		yield child;
+	} else if (child instanceof HTMLString) {
 		yield child;
 	} else if (Array.isArray(child)) {
 		for (const value of child) {
@@ -37,20 +42,4 @@ export async function* renderChild(child: any): AsyncIterable<any> {
 	} else {
 		yield child;
 	}
-}
-
-export async function renderSlot(result: any, slotted: string, fallback?: any): Promise<string> {
-	if (slotted) {
-		let iterator = renderChild(slotted);
-		let content = '';
-		for await (const chunk of iterator) {
-			if ((chunk as any).type === 'directive') {
-				content += stringifyChunk(result, chunk);
-			} else {
-				content += chunk;
-			}
-		}
-		return markHTMLString(content);
-	}
-	return fallback;
 }

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -71,7 +71,7 @@ export async function renderComponent(
 			const { slotInstructions, children } = await renderSlots(result, slots);
 			const html = (Component as any).render({ slots: children });
 			const hydrationHtml = slotInstructions ? slotInstructions.map(instr => stringifyChunk(result, instr)).join('') : '';
-			return hydrationHtml + html;
+			return markHTMLString(hydrationHtml + html);
 		}
 
 		case 'astro-factory': {

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -12,7 +12,7 @@ import {
 	renderTemplate,
 	renderToIterable,
 } from './astro.js';
-import { Fragment, Renderer } from './common.js';
+import { Fragment, Renderer, stringifyChunk } from './common.js';
 import { componentIsHTMLElement, renderHTMLElement } from './dom.js';
 import { formatList, internalSpreadAttributes, renderElement, voidElementNames } from './util.js';
 
@@ -70,13 +70,8 @@ export async function renderComponent(
 		case 'html': {
 			const { slotInstructions, children } = await renderSlots(result, slots);
 			const html = (Component as any).render({ slots: children });
-
-			return (async function*() {
-				if(slotInstructions) {
-					yield * slotInstructions;
-				}
-				yield markHTMLString(html);
-			})();
+			const hydrationHtml = slotInstructions ? slotInstructions.map(instr => stringifyChunk(result, instr)).join('') : '';
+			return hydrationHtml + html;
 		}
 
 		case 'astro-factory': {

--- a/packages/astro/src/runtime/server/render/dom.ts
+++ b/packages/astro/src/runtime/server/render/dom.ts
@@ -1,7 +1,7 @@
 import type { SSRResult } from '../../../@types/astro';
 
 import { markHTMLString } from '../escape.js';
-import { renderSlot } from './any.js';
+import { renderSlot } from './slot.js';
 import { toAttributeString } from './util.js';
 
 export function componentIsHTMLElement(Component: unknown) {

--- a/packages/astro/src/runtime/server/render/index.ts
+++ b/packages/astro/src/runtime/server/render/index.ts
@@ -1,6 +1,6 @@
 import { renderTemplate } from './astro.js';
 
-export { renderSlot } from './any.js';
+export { renderSlot } from './slot.js';
 export { renderAstroComponent, renderTemplate, renderToString } from './astro.js';
 export { Fragment, Renderer, stringifyChunk } from './common.js';
 export { renderComponent } from './component.js';

--- a/packages/astro/src/runtime/server/render/slot.ts
+++ b/packages/astro/src/runtime/server/render/slot.ts
@@ -37,7 +37,7 @@ interface RenderSlotsResult {
 	children: Record<string, string>;
 }
 
-export async function renderSlots(result: any, slots: any = {}): Promise<RenderSlotsResult> {
+export async function renderSlots(result: SSRResult, slots: any = {}): Promise<RenderSlotsResult> {
 	let slotInstructions: RenderSlotsResult['slotInstructions'] = null;
 	let children: RenderSlotsResult['children'] = {};
 	if (slots) {

--- a/packages/astro/src/runtime/server/render/slot.ts
+++ b/packages/astro/src/runtime/server/render/slot.ts
@@ -1,0 +1,59 @@
+import type { RenderInstruction } from './types.js';
+import type { SSRResult } from '../../../@types/astro.js';
+
+import { renderChild } from './any.js';
+import { HTMLString, markHTMLString } from '../escape.js';
+
+export class SlotString extends HTMLString {
+	public instructions: null | RenderInstruction[];
+	constructor(content: string, instructions: null | RenderInstruction[]) {
+		super(content);
+		this.instructions = instructions;
+	}
+}
+
+export async function renderSlot(_result: any, slotted: string, fallback?: any): Promise<string> {
+	if (slotted) {
+		let iterator = renderChild(slotted);
+		let content = '';
+		let instructions: null | RenderInstruction[] = null;
+		for await (const chunk of iterator) {
+			if ((chunk as any).type === 'directive') {
+				if(instructions === null) {
+					instructions = [];
+				}
+				instructions.push(chunk);
+			} else {
+				content += chunk;
+			}
+		}
+		return markHTMLString(new SlotString(content, instructions));
+	}
+	return fallback;
+}
+
+interface RenderSlotsResult {
+	slotInstructions: null | RenderInstruction[],
+	children: Record<string, string>;
+}
+
+export async function renderSlots(result: any, slots: any = {}): Promise<RenderSlotsResult> {
+	let slotInstructions: RenderSlotsResult['slotInstructions'] = null;
+	let children: RenderSlotsResult['children'] = {};
+	if (slots) {
+		await Promise.all(
+			Object.entries(slots).map(([key, value]) =>
+				renderSlot(result, value as string).then((output: any) => {
+					if(output.instructions) {
+						if(slotInstructions === null) {
+							slotInstructions = [];
+						}
+						slotInstructions.push(...output.instructions);
+					}
+					children[key] = output;
+				})
+			)
+		);
+	}
+	return { slotInstructions, children };
+}

--- a/packages/astro/test/astro-slots-nested.test.js
+++ b/packages/astro/test/astro-slots-nested.test.js
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Nested Slots', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/astro-slots-nested/' });
+		await fixture.build();
+	});
+
+	it('Hidden nested slots see their hydration scripts hoisted', async () => {
+		const html = await fixture.readFile('/hidden-nested/index.html');
+		const $ = cheerio.load(html);
+		expect($('script')).to.have.a.lengthOf(1, 'script rendered');
+		const scriptInTemplate = $($('template')[0].children[0]).find('script');
+		expect(scriptInTemplate).to.have.a.lengthOf(0, 'script defined outside of the inner template');
+	});
+});

--- a/packages/astro/test/fixtures/astro-slots-nested/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-slots-nested/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
+
+export default defineConfig({
+	integrations: [react()]
+});

--- a/packages/astro/test/fixtures/astro-slots-nested/package.json
+++ b/packages/astro/test/fixtures/astro-slots-nested/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/astro-slots-nested",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/react": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/astro-slots-nested/src/components/Inner.tsx
+++ b/packages/astro/test/fixtures/astro-slots-nested/src/components/Inner.tsx
@@ -1,0 +1,3 @@
+export default function Inner() {
+  return <span>Inner</span>;
+}

--- a/packages/astro/test/fixtures/astro-slots-nested/src/components/Parent.jsx
+++ b/packages/astro/test/fixtures/astro-slots-nested/src/components/Parent.jsx
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+export default function Parent({ children }) {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    console.log('mount');
+  }, []);
+
+  return (
+    <>
+      <p>
+        <input type="checkbox" value={show} onChange={() => setShow(!show)} />
+        Toggle show (true should show "Inner")
+      </p>
+      {show ? children : 'Nothing'}
+    </>
+  );
+}

--- a/packages/astro/test/fixtures/astro-slots-nested/src/pages/hidden-nested.astro
+++ b/packages/astro/test/fixtures/astro-slots-nested/src/pages/hidden-nested.astro
@@ -1,0 +1,18 @@
+---
+import Parent from '../components/Parent'
+import Inner from '../components/Inner'
+---
+
+<html lang="en">
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<main>
+			<!-- Try to remove client:load to see it work -->
+			<Parent client:load>
+				<Inner client:load />
+			</Parent>
+		</main>
+	</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1397,6 +1397,14 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/astro-slots-nested:
+    specifiers:
+      '@astrojs/react': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/react': link:../../../../integrations/react
+      astro: link:../../..
+
   packages/astro/test/fixtures/before-hydration:
     specifiers:
       '@astrojs/preact': workspace:*


### PR DESCRIPTION
## Changes

- When we encounter a slot that contains hydration scripts, hoist those hydration scripts out of the template. This ensures that they are rendered within the body.
- Closes https://github.com/withastro/astro/issues/4343

## Testing

- Test added, ensures that the hydration script is not created within the template.

## Docs
N/A, bug fix