### PR TITLE
Ensure head content rendered once with lazy layouts

### DIFF
--- a/.changeset/popular-horses-lie.md
+++ b/.changeset/popular-horses-lie.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent multiple rendering of head content

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1212,6 +1212,7 @@ export interface SSRMetadata {
 	pathname: string;
 	hasHydrationScript: boolean;
 	hasDirectives: Set<string>;
+	hasRenderedHead: boolean;
 }
 
 export interface SSRResult {

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -270,6 +270,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 			renderers,
 			pathname,
 			hasHydrationScript: false,
+			hasRenderedHead: false,
 			hasDirectives: new Set(),
 		},
 		response,

--- a/packages/astro/src/runtime/server/render/head.ts
+++ b/packages/astro/src/runtime/server/render/head.ts
@@ -12,9 +12,8 @@ const uniqueElements = (item: any, index: number, all: any[]) => {
 	);
 };
 
-const alreadyHeadRenderedResults = new WeakSet<SSRResult>();
 export function renderHead(result: SSRResult): Promise<string> {
-	alreadyHeadRenderedResults.add(result);
+	result._metadata.hasRenderedHead = true;
 	const styles = Array.from(result.styles)
 		.filter(uniqueElements)
 		.map((style) => renderElement('style', style));
@@ -36,7 +35,7 @@ export function renderHead(result: SSRResult): Promise<string> {
 // is called before a component's first non-head HTML element. If the head was
 // already injected it is a noop.
 export async function* maybeRenderHead(result: SSRResult): AsyncIterable<string> {
-	if (alreadyHeadRenderedResults.has(result)) {
+	if (result._metadata.hasRenderedHead) {
 		return;
 	}
 	yield renderHead(result);

--- a/packages/astro/test/fixtures/lazy-layout/package.json
+++ b/packages/astro/test/fixtures/lazy-layout/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@test/lazy-layout",
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/lazy-layout/src/layouts/Main.astro
+++ b/packages/astro/test/fixtures/lazy-layout/src/layouts/Main.astro
@@ -1,0 +1,13 @@
+<html>
+	<head>
+		<title>Testing</title>
+		<style>
+			body {
+				background: green;
+			}
+		</style>
+	</head>
+	<body>
+		<slot />
+	</body>
+</html>

--- a/packages/astro/test/fixtures/lazy-layout/src/pages/index.astro
+++ b/packages/astro/test/fixtures/lazy-layout/src/pages/index.astro
@@ -1,0 +1,6 @@
+---
+const Layout = (await import('../layouts/Main.astro')).default;
+---
+<Layout>
+	<div>Stuff here</div>
+</Layout>

--- a/packages/astro/test/lazy-layout.test.js
+++ b/packages/astro/test/lazy-layout.test.js
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Lazily imported layouts', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/lazy-layout/' });
+		await fixture.build();
+	});
+
+	it('Renders styles only once', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerio.load(html);
+		expect($('link')).to.have.a.lengthOf(1);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1664,6 +1664,12 @@ importers:
       '@astrojs/solid-js': link:../../../../integrations/solid
       astro: link:../../..
 
+  packages/astro/test/fixtures/lazy-layout:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/legacy-astro-flavored-markdown:
     specifiers:
       '@astrojs/preact': workspace:*


### PR DESCRIPTION
## Changes

- When there is a lazy layout it creates a split point and a new chunk. The chunk imports from the main entrypoint to render the head.
- This resulted in 2 instances of the weakmap :D, which meant that we falsely would render the head contents twice.
- The fix is to remove the global weakmap and instead store this state on result._metadata, which is the same instance throughout.
- Closes https://github.com/withastro/astro/issues/4757

## Testing

- Test added

## Docs

N/A, bug fix