### PR TITLE
Refactor hydration path handling

### DIFF
--- a/.changeset/honest-cats-invent.md
+++ b/.changeset/honest-cats-invent.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Refactor hydration path handling

--- a/packages/astro/src/core/path.ts
+++ b/packages/astro/src/core/path.ts
@@ -18,6 +18,10 @@ export function removeLeadingForwardSlash(path: string) {
 	return path.startsWith('/') ? path.substring(1) : path;
 }
 
+export function removeLeadingForwardSlashWindows(path: string) {
+	return path.startsWith('/') && path[2] === ':' ? path.substring(1) : path;
+}
+
 export function trimSlashes(path: string) {
 	return path.replace(/^\/|\/$/g, '');
 }

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -180,12 +180,20 @@ export async function render(
 		origin,
 		pathname,
 		scripts,
-		// Resolves specifiers in the inline hydrated scripts, such as "@astrojs/preact/client.js"
+		// Resolves specifiers in the inline hydrated scripts, such as:
+		// - @astrojs/preact/client.js
+		// - @/components/Foo.vue
+		// - /Users/macos/project/src/Foo.vue
+		// - C:/Windows/project/src/Foo.vue (normalized slash)
 		async resolve(s: string) {
-			if (s.startsWith('/@fs')) {
-				return resolveClientDevPath(s);
+			const url = await resolveIdToUrl(viteServer, s);
+			// Vite does not resolve .jsx -> .tsx when coming from hydration script import,
+			// clip it so Vite is able to resolve implicitly.
+			if (url.startsWith('/@fs') && url.endsWith('.jsx')) {
+				return url.slice(0, -4);
+			} else {
+				return url;
 			}
-			return await resolveIdToUrl(viteServer, s);
 		},
 		renderers,
 		request,

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -137,6 +137,11 @@ export function unwrapId(id: string): string {
 	return id.startsWith(VALID_ID_PREFIX) ? id.slice(VALID_ID_PREFIX.length) : id;
 }
 
+export function normalizePath(id: string): string {
+	return id
+	// return path.posix.normalize(slash(id));
+}
+
 /** An fs utility, similar to `rimraf` or `rm -rf` */
 export function removeDir(_dir: URL): void {
 	const dir = fileURLToPath(_dir);

--- a/packages/astro/src/jsx/babel.ts
+++ b/packages/astro/src/jsx/babel.ts
@@ -1,7 +1,7 @@
 import type { PluginObj } from '@babel/core';
 import * as t from '@babel/types';
-import { pathToFileURL } from 'node:url';
-import { resolveClientDevPath } from '../core/render/dev/resolve.js';
+import npath from 'path';
+import { normalizePath } from 'vite';
 import { HydrationDirectiveProps } from '../runtime/server/hydration.js';
 import type { PluginMetadata } from '../vite-plugin-astro/types';
 
@@ -218,8 +218,7 @@ export default function astroJSX(): PluginObj {
 				if (meta) {
 					let resolvedPath: string;
 					if (meta.path.startsWith('.')) {
-						const fileURL = pathToFileURL(state.filename!);
-						resolvedPath = resolveClientDevPath(`/@fs${new URL(meta.path, fileURL).pathname}`);
+						resolvedPath = normalizePath(npath.resolve(state.filename!, meta.path));
 					} else {
 						resolvedPath = meta.path;
 					}
@@ -298,8 +297,7 @@ export default function astroJSX(): PluginObj {
 					}
 					let resolvedPath: string;
 					if (meta.path.startsWith('.')) {
-						const fileURL = pathToFileURL(state.filename!);
-						resolvedPath = resolveClientDevPath(`/@fs${new URL(meta.path, fileURL).pathname}`);
+						resolvedPath = normalizePath(npath.resolve(state.filename!, meta.path));
 					} else {
 						resolvedPath = meta.path;
 					}


### PR DESCRIPTION
## Changes

Avoid usage of `/@fs` when compiling. We still have to embrace a leading slash for Windows as the compiler is resolving paths as URLs. (If this PR works, I'll make a fix in the compiler to gradually move over)

This time, we strip the leading slash issue as early as possible so other parts of the code won't have to worry about it.

WIP. Needs a bit more testing.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
All existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A. internal refactor.
