### PR TITLE
Move module declarations for Markdown and MDX so they're available everywhere

### DIFF
--- a/.changeset/thirty-crabs-shout.md
+++ b/.changeset/thirty-crabs-shout.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix module definition of Markdown and MDX files not being available outside Astro files

--- a/packages/astro/client-base.d.ts
+++ b/packages/astro/client-base.d.ts
@@ -1,5 +1,39 @@
 /// <reference path="./import-meta.d.ts" />
 
+declare module '*.md' {
+	type MD = import('./dist/@types/astro').MarkdownInstance<Record<string, any>>;
+
+	export const frontmatter: MD['frontmatter'];
+	export const file: MD['file'];
+	export const url: MD['url'];
+	export const getHeadings: MD['getHeadings'];
+	/** @deprecated Renamed to `getHeadings()` */
+	export const getHeaders: () => void;
+	export const Content: MD['Content'];
+	export const rawContent: MD['rawContent'];
+	export const compiledContent: MD['compiledContent'];
+
+	const load: MD['default'];
+	export default load;
+}
+
+declare module '*.mdx' {
+	type MDX = import('./dist/@types/astro').MDXInstance<Record<string, any>>;
+
+	export const frontmatter: MDX['frontmatter'];
+	export const file: MDX['file'];
+	export const url: MDX['url'];
+	export const getHeadings: MDX['getHeadings'];
+	export const Content: MDX['Content'];
+	export const rawContent: MDX['rawContent'];
+	export const compiledContent: MDX['compiledContent'];
+
+	const load: MDX['default'];
+	export default load;
+}
+
+// Everything below are Vite's types (apart from image types, which are in `client.d.ts`)
+
 // CSS modules
 type CSSModuleClasses = { readonly [key: string]: string };
 

--- a/packages/astro/env.d.ts
+++ b/packages/astro/env.d.ts
@@ -1,8 +1,13 @@
 /// <reference path="./client.d.ts" />
 
+// Caution! The types here are only available inside Astro files (injected automatically by our language server)
+// As such, if the typings you're trying to add should be available inside ex: React components, they should instead
+// be inside `client-base.d.ts`
+
 type Astro = import('./dist/@types/astro').AstroGlobal;
 
-// We duplicate the description here because editors won't show the JSDoc comment from the imported type (but will for its properties, ex: Astro.request will show the AstroGlobal.request description)
+// We have to duplicate the description here because editors won't show the JSDoc comment from the imported type
+// However, they will for its properties, ex: Astro.request will show the AstroGlobal.request description
 /**
  * Astro global available in all contexts in .astro files
  *
@@ -11,38 +16,6 @@ type Astro = import('./dist/@types/astro').AstroGlobal;
 declare const Astro: Readonly<Astro>;
 
 declare const Fragment: any;
-
-declare module '*.md' {
-	type MD = import('./dist/@types/astro').MarkdownInstance<Record<string, any>>;
-
-	export const frontmatter: MD['frontmatter'];
-	export const file: MD['file'];
-	export const url: MD['url'];
-	export const getHeadings: MD['getHeadings'];
-	/** @deprecated Renamed to `getHeadings()` */
-	export const getHeaders: () => void;
-	export const Content: MD['Content'];
-	export const rawContent: MD['rawContent'];
-	export const compiledContent: MD['compiledContent'];
-
-	const load: MD['default'];
-	export default load;
-}
-
-declare module '*.mdx' {
-	type MDX = import('./dist/@types/astro').MDXInstance<Record<string, any>>;
-
-	export const frontmatter: MDX['frontmatter'];
-	export const file: MDX['file'];
-	export const url: MDX['url'];
-	export const getHeadings: MDX['getHeadings'];
-	export const Content: MDX['Content'];
-	export const rawContent: MDX['rawContent'];
-	export const compiledContent: MDX['compiledContent'];
-
-	const load: MDX['default'];
-	export default load;
-}
 
 declare module '*.html' {
 	const Component: { render(opts: { slots: Record<string, string> }): string };

--- a/packages/astro/tsconfig.json
+++ b/packages/astro/tsconfig.json
@@ -6,7 +6,6 @@
     "declarationDir": "./dist",
     "module": "ES2020",
     "outDir": "./dist",
-    "target": "ES2020",
-    "types": ["./client"]
+    "target": "ES2020"
   }
 }


### PR DESCRIPTION
## Changes

It turns out that importing Markdown and MDX files works outside of Astro files, so the module declaration needs to be in `client-base.d.ts` and not `env.d.ts`. The latter being only things available in Astro files

## Testing

Tested manually. Stackblitz showing the behaviour working: https://stackblitz.com/edit/github-skrkkd?file=src%2Fscript.ts,src%2Fpages%2Findex.astro&on=stackblitz

## Docs

N/A
