### PR TITLE
P5: fix MDX memory leak

### DIFF
--- a/.changeset/tall-files-smash.md
+++ b/.changeset/tall-files-smash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix MDX error handling, preventing a memory leak

--- a/packages/astro/src/jsx-runtime/index.ts
+++ b/packages/astro/src/jsx-runtime/index.ts
@@ -1,9 +1,10 @@
-import { Fragment, markHTMLString } from '../runtime/server/index.js';
+import { Renderer, Fragment, markHTMLString } from '../runtime/server/index.js';
 
 const AstroJSX = 'astro:jsx';
 const Empty = Symbol('empty');
 
 export interface AstroVNode {
+	[Renderer]: string;
 	[AstroJSX]: boolean;
 	type: string | ((...args: any) => any);
 	props: Record<string, any>;
@@ -74,6 +75,7 @@ function transformSetDirectives(vnode: AstroVNode) {
 
 function createVNode(type: any, props: Record<string, any>) {
 	const vnode: AstroVNode = {
+		[Renderer]: 'astro:jsx',
 		[AstroJSX]: true,
 		type,
 		props: props ?? {},

--- a/packages/astro/src/runtime/server/jsx.ts
+++ b/packages/astro/src/runtime/server/jsx.ts
@@ -38,6 +38,10 @@ export async function renderJSX(result: SSRResult, vnode: any): Promise<any> {
 	}
 	if (isVNode(vnode)) {
 		switch (true) {
+			case !vnode.type: {
+				throw new Error(`Unable to render ${result._metadata.pathname} because it contains an undefined Component!
+Did you forget to import the component or is it possible there is a typo?`)
+			}
 			case (vnode.type as any) === Symbol.for('astro:fragment'):
 				return renderJSX(result, vnode.props.children);
 			case (vnode.type as any).isAstroComponentFactory: {

--- a/packages/integrations/mdx/test/fixtures/mdx-infinite-loop/astro.config.ts
+++ b/packages/integrations/mdx/test/fixtures/mdx-infinite-loop/astro.config.ts
@@ -1,0 +1,6 @@
+import mdx from '@astrojs/mdx';
+import preact from '@astrojs/preact';
+
+export default {
+	integrations: [mdx(), preact()]
+}

--- a/packages/integrations/mdx/test/fixtures/mdx-infinite-loop/package.json
+++ b/packages/integrations/mdx/test/fixtures/mdx-infinite-loop/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@test/mdx-infinite-loop",
+  "type": "module",
+  "dependencies": {
+    "@astrojs/mdx": "workspace:*",
+    "@astrojs/preact": "workspace:*",
+    "preact": "^10.7.3",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/mdx/test/fixtures/mdx-infinite-loop/src/components/Test.js
+++ b/packages/integrations/mdx/test/fixtures/mdx-infinite-loop/src/components/Test.js
@@ -1,0 +1,3 @@
+export default function () {
+	return 'Hello world'
+}

--- a/packages/integrations/mdx/test/fixtures/mdx-infinite-loop/src/components/Test.jsx
+++ b/packages/integrations/mdx/test/fixtures/mdx-infinite-loop/src/components/Test.jsx
@@ -1,0 +1,5 @@
+import { h } from 'preact';
+
+export default function () {
+	return <div>Hello world</div>
+}

--- a/packages/integrations/mdx/test/fixtures/mdx-infinite-loop/src/components/Test.jsx
+++ b/packages/integrations/mdx/test/fixtures/mdx-infinite-loop/src/components/Test.jsx
@@ -1,5 +1,0 @@
-import { h } from 'preact';
-
-export default function () {
-	return <div>Hello world</div>
-}

--- a/packages/integrations/mdx/test/fixtures/mdx-infinite-loop/src/pages/doc.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-infinite-loop/src/pages/doc.mdx
@@ -1,0 +1,6 @@
+import Test, { Missing } from '../components/Test';
+
+# Hello page!
+
+<Test />
+<Missing />

--- a/packages/integrations/mdx/test/fixtures/mdx-infinite-loop/src/pages/index.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-infinite-loop/src/pages/index.astro
@@ -1,0 +1,5 @@
+---
+const files = await Astro.glob('./**/*.mdx')
+---
+
+{files.map((file: any) => <file.Content />)}

--- a/packages/integrations/mdx/test/mdx-infinite-loop.test.js
+++ b/packages/integrations/mdx/test/mdx-infinite-loop.test.js
@@ -1,0 +1,31 @@
+import mdx from '@astrojs/mdx';
+import preact from '@astrojs/preact';
+
+import { expect } from 'chai';
+import { loadFixture } from '../../../astro/test/test-utils.js';
+
+describe('MDX Infinite Loop', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/mdx-infinite-loop/', import.meta.url),
+			integrations: [mdx(), preact()],
+		});
+	});
+
+	describe('build', () => {
+		let err;
+		before(async () => {
+			try {
+				await fixture.build();
+			} catch (e) {
+				err = e;
+			}
+		});
+
+		it('does not hang forever if an error is thrown', async () => {
+			expect(!!err).to.be.true;
+		});
+	});
+});

--- a/packages/integrations/mdx/test/mdx-infinite-loop.test.js
+++ b/packages/integrations/mdx/test/mdx-infinite-loop.test.js
@@ -1,5 +1,4 @@
 import mdx from '@astrojs/mdx';
-import preact from '@astrojs/preact';
 
 import { expect } from 'chai';
 import { loadFixture } from '../../../astro/test/test-utils.js';
@@ -10,7 +9,7 @@ describe('MDX Infinite Loop', () => {
 	before(async () => {
 		fixture = await loadFixture({
 			root: new URL('./fixtures/mdx-infinite-loop/', import.meta.url),
-			integrations: [mdx(), preact()],
+			integrations: [mdx()],
 		});
 	});
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2729,6 +2729,18 @@ importers:
       reading-time: 1.5.0
       unist-util-visit: 4.1.1
 
+  packages/integrations/mdx/test/fixtures/mdx-infinite-loop:
+    specifiers:
+      '@astrojs/mdx': workspace:*
+      '@astrojs/preact': workspace:*
+      astro: workspace:*
+      preact: ^10.7.3
+    dependencies:
+      '@astrojs/mdx': link:../../..
+      '@astrojs/preact': link:../../../../preact
+      astro: link:../../../../../astro
+      preact: 10.11.0
+
   packages/integrations/mdx/test/fixtures/mdx-namespace:
     specifiers:
       '@astrojs/mdx': workspace:*


### PR DESCRIPTION
## Changes

- Got reports of a possible memory leak
- Was able to narrow it down to MDX (our internal `jsx-runtime`) when an error was being thrown.
- These errors were ignored and users would be dropped into an infinite loop
- This PR fixes this by adding the `[Renderer]: 'astro:jsx'` to JSX vnodes, so we know immediately that they should be rendered with the JSX renderer. If this throws, we'll be able to surface the error.

## Testing

Adds a regression test in `@astrojs/mdx` and tested manually

## Docs

Bug fix only
