### PR TITLE
Fix missing language tag on README code block

### DIFF
--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -461,7 +461,7 @@ Local images will be cached for 1 year and invalidated when the original image f
 
 By default, transformed images will be cached to `./node_modules/.astro/image`. This can be configured in the integration's config options.
 
-```
+```js
 export default defineConfig({
 	integrations: [image({
     // may be useful if your hosting provider allows caching between CI builds


### PR DESCRIPTION
## Changes

Adds a language tag to a recently added code block in the image integration README.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
No testing, docs change only.

## Docs

Fix for docs CI issue https://github.com/withastro/docs/pull/1649

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
