### PR TITLE
Astro image cache dependency fix scottaw66

### DIFF
--- a/.changeset/clever-lies-reflect.md
+++ b/.changeset/clever-lies-reflect.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Moves http-cache-semantics from dev dependency to dependency

--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@altano/tiny-async-pool": "^1.0.2",
+    "http-cache-semantics": "^4.1.0",
     "image-size": "^1.0.2",
     "magic-string": "^0.25.9",
     "mime": "^3.0.0",
@@ -56,7 +57,6 @@
     "astro-scripts": "workspace:*",
     "chai": "^4.3.6",
     "cheerio": "^1.0.0-rc.11",
-    "http-cache-semantics": "^4.1.0",
     "kleur": "^4.1.4",
     "mocha": "^9.2.2",
     "rollup-plugin-copy": "^3.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2507,6 +2507,7 @@ importers:
       web-streams-polyfill: ^3.2.1
     dependencies:
       '@altano/tiny-async-pool': 1.0.2
+      http-cache-semantics: 4.1.0
       image-size: 1.0.2
       magic-string: 0.25.9
       mime: 3.0.0
@@ -2519,7 +2520,6 @@ importers:
       astro-scripts: link:../../../scripts
       chai: 4.3.6
       cheerio: 1.0.0-rc.12
-      http-cache-semantics: 4.1.0
       kleur: 4.1.5
       mocha: 9.2.2
       rollup-plugin-copy: 3.4.0
@@ -13124,7 +13124,6 @@ packages:
 
   /http-cache-semantics/4.1.0:
     resolution: {integrity: sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==}
-    dev: true
 
   /http-errors/2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

Change in astro image (/packages/integrations/image). Moved 'http-cache-semantics' package from dev-dependency to dependency to resolve error "Cannot find package 'http-cache-semantics' imported from /Volumes/BFD/Sites/scottwillsey2.0/node_modules/@astrojs/image/dist/build/ssg.js"

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

ran "pnpm run test:match "image"

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

No doc changes needed

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No change in component functionality or use method. Fixing runtime error for component dependency.