### PR TITLE
Refactor ViteConfigWithSSR type

### DIFF
--- a/.changeset/moody-gifts-press.md
+++ b/.changeset/moody-gifts-press.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Refactor ViteConfigWithSSR type

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -16,7 +16,6 @@ import type { SerializedSSRManifest } from '../core/app/types';
 import type { PageBuildData } from '../core/build/types';
 import type { AstroConfigSchema } from '../core/config';
 import type { AstroCookies } from '../core/cookies';
-import type { ViteConfigWithSSR } from '../core/create-vite';
 import type { AstroComponentFactory, Metadata } from '../runtime/server';
 export type {
 	MarkdownHeading,
@@ -1161,10 +1160,10 @@ export interface AstroIntegration {
 		'astro:build:ssr'?: (options: { manifest: SerializedSSRManifest }) => void | Promise<void>;
 		'astro:build:start'?: (options: { buildConfig: BuildConfig }) => void | Promise<void>;
 		'astro:build:setup'?: (options: {
-			vite: ViteConfigWithSSR;
+			vite: vite.InlineConfig;
 			pages: Map<string, PageBuildData>;
 			target: 'client' | 'server';
-			updateConfig: (newConfig: ViteConfigWithSSR) => void;
+			updateConfig: (newConfig: vite.InlineConfig) => void;
 		}) => void | Promise<void>;
 		'astro:build:generated'?: (options: { dir: URL }) => void | Promise<void>;
 		'astro:build:done'?: (options: {

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -5,13 +5,14 @@ import type { LogOptions } from '../logger/core';
 import fs from 'fs';
 import * as colors from 'kleur/colors';
 import { performance } from 'perf_hooks';
+import * as vite from 'vite';
 import {
 	runHookBuildDone,
 	runHookBuildStart,
 	runHookConfigDone,
 	runHookConfigSetup,
 } from '../../integrations/index.js';
-import { createVite, ViteConfigWithSSR } from '../create-vite.js';
+import { createVite } from '../create-vite.js';
 import { fixViteErrorMessage } from '../errors.js';
 import { debug, info, levels, timerMessage } from '../logger/core.js';
 import { apply as applyPolyfill } from '../polyfill.js';
@@ -84,7 +85,7 @@ class AstroBuilder {
 	}
 
 	/** Run the build logic. build() is marked private because usage should go through ".run()" */
-	private async build({ viteConfig }: { viteConfig: ViteConfigWithSSR }) {
+	private async build({ viteConfig }: { viteConfig: vite.InlineConfig }) {
 		const buildConfig: BuildConfig = {
 			client: new URL('./client/', this.settings.config.outDir),
 			server: new URL('./server/', this.settings.config.outDir),

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -9,7 +9,6 @@ import { prependForwardSlash } from '../../core/path.js';
 import { emptyDir, isModeServerWithNoAdapter, removeDir } from '../../core/util.js';
 import { runHookBuildSetup } from '../../integrations/index.js';
 import { PAGE_SCRIPT_ID } from '../../vite-plugin-scripts/index.js';
-import type { ViteConfigWithSSR } from '../create-vite';
 import { info } from '../logger/core.js';
 import { getOutDirWithinCwd } from './common.js';
 import { generatePages } from './generate.js';
@@ -114,7 +113,7 @@ async function ssrBuild(opts: StaticBuildOptions, internals: BuildInternals, inp
 	const ssr = settings.config.output === 'server';
 	const out = ssr ? opts.buildConfig.server : getOutDirWithinCwd(settings.config.outDir);
 
-	const viteBuildConfig: ViteConfigWithSSR = {
+	const viteBuildConfig: vite.InlineConfig = {
 		...viteConfig,
 		mode: viteConfig.mode || 'production',
 		logLevel: opts.viteConfig.logLevel ?? 'error',
@@ -192,7 +191,7 @@ async function clientBuild(
 
 	info(opts.logging, null, `\n${bgGreen(black(' building client '))}`);
 
-	const viteBuildConfig = {
+	const viteBuildConfig: vite.InlineConfig = {
 		...viteConfig,
 		mode: viteConfig.mode || 'production',
 		logLevel: 'info',
@@ -226,7 +225,7 @@ async function clientBuild(
 		],
 		envPrefix: 'PUBLIC_',
 		base: settings.config.base,
-	} as ViteConfigWithSSR;
+	} ;
 
 	await runHookBuildSetup({
 		config: settings.config,

--- a/packages/astro/src/core/build/types.ts
+++ b/packages/astro/src/core/build/types.ts
@@ -1,3 +1,4 @@
+import type { InlineConfig } from 'vite';
 import type {
 	AstroSettings,
 	BuildConfig,
@@ -7,7 +8,6 @@ import type {
 	RuntimeMode,
 	SSRLoadedRenderer,
 } from '../../@types/astro';
-import type { ViteConfigWithSSR } from '../create-vite';
 import type { LogOptions } from '../logger/core';
 import type { RouteCache } from '../render/route-cache';
 
@@ -34,7 +34,7 @@ export interface StaticBuildOptions {
 	origin: string;
 	pageNames: string[];
 	routeCache: RouteCache;
-	viteConfig: ViteConfigWithSSR;
+	viteConfig: InlineConfig;
 }
 
 export interface SingleFileBuiltModule {

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -21,9 +21,6 @@ import astroScriptsPageSSRPlugin from '../vite-plugin-scripts/page-ssr.js';
 import { createCustomViteLogger } from './errors.js';
 import { resolveDependency } from './util.js';
 
-// note: ssr is still an experimental API hence the type omission from `vite`
-export type ViteConfigWithSSR = vite.InlineConfig & { ssr?: vite.SSROptions };
-
 interface CreateViteOptions {
 	settings: AstroSettings;
 	logging: LogOptions;
@@ -58,12 +55,12 @@ function getSsrNoExternalDeps(projectRoot: URL): string[] {
 
 /** Return a common starting point for all Vite actions */
 export async function createVite(
-	commandConfig: ViteConfigWithSSR,
+	commandConfig: vite.InlineConfig,
 	{ settings, logging, mode }: CreateViteOptions
-): Promise<ViteConfigWithSSR> {
+): Promise<vite.InlineConfig> {
 	const thirdPartyAstroPackages = await getAstroPackages(settings);
 	// Start with the Vite configuration that Astro core needs
-	const commonConfig: ViteConfigWithSSR = {
+	const commonConfig: vite.InlineConfig = {
 		cacheDir: fileURLToPath(new URL('./node_modules/.vite/', settings.config.root)), // using local caches allows Astro to be used in monorepos, etc.
 		clearScreen: false, // we want to control the output, not Vite
 		logLevel: 'warn', // log warnings and errors only

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -1,6 +1,6 @@
 import { bold } from 'kleur/colors';
 import type { AddressInfo } from 'net';
-import type { ViteDevServer } from 'vite';
+import type { InlineConfig, ViteDevServer } from 'vite';
 import {
 	AstroConfig,
 	AstroRenderer,
@@ -12,7 +12,6 @@ import {
 import type { SerializedSSRManifest } from '../core/app/types';
 import type { PageBuildData } from '../core/build/types';
 import { mergeConfig } from '../core/config/config.js';
-import type { ViteConfigWithSSR } from '../core/create-vite.js';
 import { info, LogOptions } from '../core/logger/core.js';
 
 async function withTakingALongTimeMsg<T>({
@@ -224,7 +223,7 @@ export async function runHookBuildSetup({
 	logging,
 }: {
 	config: AstroConfig;
-	vite: ViteConfigWithSSR;
+	vite: InlineConfig;
 	pages: Map<string, PageBuildData>;
 	target: 'server' | 'client';
 	logging: LogOptions;


### PR DESCRIPTION
## Changes

Vite 3 stabilizes the `.ssr` property and is exposed from the types, so this type isn't needed anymore

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A
