### PR TITLE
Suppress eslint warnings

### DIFF
--- a/.changeset/tough-turkeys-teach.md
+++ b/.changeset/tough-turkeys-teach.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Log markdown hints with console.info

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,5 +32,11 @@ module.exports = {
         'no-console': 'off',
       },
     },
+    {
+      files: ['packages/integrations/**/*.ts'],
+      rules: {
+        'no-console': 'off',
+      },
+    },
   ],
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -35,7 +35,7 @@ module.exports = {
     {
       files: ['packages/integrations/**/*.ts'],
       rules: {
-        'no-console': 'off',
+        'no-console': ['error', { allow: ['warn', 'error', 'info', 'debug'] }],
       },
     },
   ],

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -50,18 +50,15 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 					mdxOptions.extendPlugins === 'markdown' &&
 					(config.markdown.rehypePlugins?.length || config.markdown.remarkPlugins?.length)
 				) {
-					// eslint-disable-next-line no-console
-					console.log(
+					console.info(
 						blue(`[MDX] Now inheriting remark and rehype plugins from "markdown" config.`)
 					);
-					// eslint-disable-next-line no-console
-					console.log(
+					console.info(
 						`If you applied a plugin to both your Markdown and MDX configs, we suggest ${bold(
 							'removing the duplicate MDX entry.'
 						)}`
 					);
-					// eslint-disable-next-line no-console
-					console.log(`See "extendPlugins" option to configure this behavior.`);
+					console.info(`See "extendPlugins" option to configure this behavior.`);
 				}
 
 				const mdxPluginOpts: MdxRollupPluginOptions = {

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -50,14 +50,17 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 					mdxOptions.extendPlugins === 'markdown' &&
 					(config.markdown.rehypePlugins?.length || config.markdown.remarkPlugins?.length)
 				) {
+					// eslint-disable-next-line no-console
 					console.log(
 						blue(`[MDX] Now inheriting remark and rehype plugins from "markdown" config.`)
 					);
+					// eslint-disable-next-line no-console
 					console.log(
 						`If you applied a plugin to both your Markdown and MDX configs, we suggest ${bold(
 							'removing the duplicate MDX entry.'
 						)}`
 					);
+					// eslint-disable-next-line no-console
 					console.log(`See "extendPlugins" option to configure this behavior.`);
 				}
 


### PR DESCRIPTION
## Changes

Suppress `console.log` usage warnings from eslint in integration packages

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
N/A. GitHub shouldn't annotate them in the UI anymore.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A