### PR TITLE
Improve rendering perf

### DIFF
--- a/.changeset/fifty-icons-smash.md
+++ b/.changeset/fifty-icons-smash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix perf regression in SSR

--- a/packages/astro/src/runtime/server/render/common.ts
+++ b/packages/astro/src/runtime/server/render/common.ts
@@ -45,35 +45,22 @@ export function stringifyChunk(result: SSRResult, chunk: string | RenderInstruct
 }
 
 export class HTMLParts {
-	public parts: Array<HTMLBytes | string>;
+	public parts: string;
 	constructor() {
-		this.parts = [];
+		this.parts = ''
 	}
 	append(part: string | HTMLBytes | RenderInstruction, result: SSRResult) {
 		if (ArrayBuffer.isView(part)) {
-			this.parts.push(part);
+			this.parts += decoder.decode(part);
 		} else {
-			this.parts.push(stringifyChunk(result, part));
+			this.parts += stringifyChunk(result, part);
 		}
 	}
 	toString() {
-		let html = '';
-		for (const part of this.parts) {
-			if (ArrayBuffer.isView(part)) {
-				html += decoder.decode(part);
-			} else {
-				html += part;
-			}
-		}
-		return html;
+		return this.parts;
 	}
 	toArrayBuffer() {
-		this.parts.forEach((part, i) => {
-			if (!ArrayBuffer.isView(part)) {
-				this.parts[i] = encoder.encode(String(part));
-			}
-		});
-		return concatUint8Arrays(this.parts as Uint8Array[]);
+		return encoder.encode(this.parts);
 	}
 }
 
@@ -85,16 +72,4 @@ export function chunkToByteArray(
 		return chunk as Uint8Array;
 	}
 	return encoder.encode(stringifyChunk(result, chunk));
-}
-
-export function concatUint8Arrays(arrays: Array<Uint8Array>) {
-	let len = 0;
-	arrays.forEach((arr) => (len += arr.length));
-	let merged = new Uint8Array(len);
-	let offset = 0;
-	arrays.forEach((arr) => {
-		merged.set(arr, offset);
-		offset += arr.length;
-	});
-	return merged;
 }

--- a/packages/astro/test/benchmark/simple/astro.config.mjs
+++ b/packages/astro/test/benchmark/simple/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import nodejs from '@astrojs/node';
+
+export default defineConfig({
+	output: 'server',
+	adapter: nodejs()
+});

--- a/packages/astro/test/benchmark/simple/package.json
+++ b/packages/astro/test/benchmark/simple/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@benchmark/simple",
+  "scripts": {
+    "start": "node server.mjs",
+    "build": "astro build"
+  },
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/node": "workspace:*"
+  }
+}

--- a/packages/astro/test/benchmark/simple/server.mjs
+++ b/packages/astro/test/benchmark/simple/server.mjs
@@ -15,4 +15,5 @@ const listener = (req, res) => {
 
 const server = http.createServer(listener);
 server.listen(3002);
+// eslint-disable-next-line no-console
 console.log(`Listening at http://localhost:3002`);

--- a/packages/astro/test/benchmark/simple/server.mjs
+++ b/packages/astro/test/benchmark/simple/server.mjs
@@ -1,0 +1,18 @@
+import http from 'http';
+import { handler } from './dist/server/entry.mjs';
+
+const listener = (req, res) => {
+	handler(req, res, err => {
+		if(err) {
+			res.writeHead(500);
+			res.end(err.toString());
+		} else {
+			res.writeHead(404);
+			res.end('Not found');
+		}
+	});
+};
+
+const server = http.createServer(listener);
+server.listen(3002);
+console.log(`Listening at http://localhost:3002`);

--- a/packages/astro/test/benchmark/simple/src/components/Layout.astro
+++ b/packages/astro/test/benchmark/simple/src/components/Layout.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>{ Astro.props.title }</title>
+	</head>
+	<body>
+		<slot />
+	</body>
+</html>

--- a/packages/astro/test/benchmark/simple/src/pages/index.astro
+++ b/packages/astro/test/benchmark/simple/src/pages/index.astro
@@ -1,0 +1,9 @@
+---
+import Layout from '../components/Layout.astro';
+const name = 'world';
+---
+
+<Layout title={`Index page`}>
+	<h1>index page</h1>
+	<h2>Hello { name }</h2>
+</Layout>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1055,6 +1055,14 @@ importers:
       astro: link:../../..
       vue: 3.2.40
 
+  packages/astro/test/benchmark/simple:
+    specifiers:
+      '@astrojs/node': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/node': link:../../../../integrations/node
+      astro: link:../../..
+
   packages/astro/test/fixtures/0-css:
     specifiers:
       '@astrojs/react': workspace:*


### PR DESCRIPTION
## Changes

- Note that this is just a draft and might not be an improvement.
- In 1.3.0 in order to support typed arrays in the template (via set:html) I switched how we concat HTML to first convert to byte arrays. I'm not sure why this caused the slowdowns (still investigating). It does add an extra loop which could be part of it.

## Testing

- New benchmark test added
 - Note that this test isn't running in CI at the moment. The plan is to do a follow-up that makes it run as a nightly task.

## Docs

N/A, bug fix