### PR TITLE
Fix regression in rendering strings

### DIFF
--- a/.changeset/breezy-teachers-clean.md
+++ b/.changeset/breezy-teachers-clean.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Final perf fix from 1.3.0 regression
+
+A regression in rendering perf happened in 1.3.0. This is the final fix for the underlying issue.

--- a/packages/astro/src/runtime/server/render/any.ts
+++ b/packages/astro/src/runtime/server/render/any.ts
@@ -1,4 +1,4 @@
-import { escapeHTML, HTMLString, markHTMLString } from '../escape.js';
+import { escapeHTML, isHTMLString, markHTMLString } from '../escape.js';
 import { AstroComponent, renderAstroComponent } from './astro.js';
 import { SlotString } from './slot.js';
 
@@ -9,7 +9,7 @@ export async function* renderChild(child: any): AsyncIterable<any> {
 			yield* child.instructions;
 		}
 		yield child;
-	} else if (child instanceof HTMLString) {
+	} else if (isHTMLString(child)) {
 		yield child;
 	} else if (Array.isArray(child)) {
 		for (const value of child) {


### PR DESCRIPTION
## Changes

- This should ultimately fix the issues that came with 1.3.0
- Was using `instanceof` to check if a string is an escaped string, but there is 2 instances of this module so instanceof is returning false negative.
  - This was likely happening for a long time but still working on accident.
- In 1.3.0 I added the ability for the template to handle iterators. Since a string *is* an iterator it would iterate on each character in the string.
- The result was that we were rendering 1 character at a time. Very slow!
- Fixes #4958
- Fixes #4900

## Testing

Benchmarks should show

## Docs

N/A, bug fix.