### PR TITLE
Support Astro.slots.render for mdx

### DIFF
--- a/.changeset/friendly-wolves-juggle.md
+++ b/.changeset/friendly-wolves-juggle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Support Astro.slots.render for mdx

--- a/packages/astro/src/runtime/server/jsx.ts
+++ b/packages/astro/src/runtime/server/jsx.ts
@@ -29,6 +29,8 @@ export async function renderJSX(result: SSRResult, vnode: any): Promise<any> {
 			return vnode;
 		case typeof vnode === 'string':
 			return markHTMLString(escapeHTML(vnode));
+		case typeof vnode === 'function':
+			return vnode;
 		case !vnode && vnode !== 0:
 			return '';
 		case Array.isArray(vnode):

--- a/packages/astro/test/fixtures/slots-react/src/components/Render.astro
+++ b/packages/astro/test/fixtures/slots-react/src/components/Render.astro
@@ -1,0 +1,6 @@
+---
+const { id } = Astro.props;
+const content = await Astro.slots.render('default');
+---
+
+<div id={id} set:html={content} />

--- a/packages/astro/test/fixtures/slots-react/src/components/RenderArgs.astro
+++ b/packages/astro/test/fixtures/slots-react/src/components/RenderArgs.astro
@@ -1,0 +1,5 @@
+---
+const { id, text } = Astro.props;
+---
+
+<div id={id} set:html={Astro.slots.render('default', [text])} />

--- a/packages/astro/test/fixtures/slots-react/src/components/RenderFn.astro
+++ b/packages/astro/test/fixtures/slots-react/src/components/RenderFn.astro
@@ -1,0 +1,6 @@
+---
+const { id } = Astro.props;
+const content = await Astro.slots.render('default');
+---
+
+<div id={id} set:html={content} />

--- a/packages/astro/test/fixtures/slots-react/src/pages/slottedapi-render.mdx
+++ b/packages/astro/test/fixtures/slots-react/src/pages/slottedapi-render.mdx
@@ -1,0 +1,9 @@
+import Render from '../components/Render.astro';
+import RenderFn from '../components/RenderFn.astro';
+import RenderArgs from '../components/RenderArgs.astro';
+
+# Slots: MDX
+
+<Render id="render">render</Render>
+<RenderFn id="render-fn">{() => "render-fn"}</RenderFn>
+<RenderArgs id="render-args" text="render-args">{(text) => <span>{text}</span>}</RenderArgs>

--- a/packages/astro/test/slots-react.test.js
+++ b/packages/astro/test/slots-react.test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
+import { describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('Slots: React', () => {
@@ -71,6 +72,33 @@ describe('Slots: React', () => {
 			const html = await fixture.readFile('/mdx/index.html');
 			const $ = cheerio.load(html);
 			expect($('#dash-case').text().trim()).to.equal('Fallback / Dash Case');
+		});
+	});
+
+	describe('Slots.render() API', async () => {
+		it('Simple imperative slot render', async () => {
+			const html = await fixture.readFile('/slottedapi-render/index.html');
+			const $ = cheerio.load(html);
+
+			expect($('#render')).to.have.lengthOf(1);
+			expect($('#render').text()).to.equal('render');
+		});
+
+		it('Child function render without args', async () => {
+			const html = await fixture.readFile('/slottedapi-render/index.html');
+			const $ = cheerio.load(html);
+
+			expect($('#render-fn')).to.have.lengthOf(1);
+			expect($('#render-fn').text()).to.equal('render-fn');
+		});
+
+		it('Child function render with args', async () => {
+			const html = await fixture.readFile('/slottedapi-render/index.html');
+			const $ = cheerio.load(html);
+
+			expect($('#render-args')).to.have.lengthOf(1);
+			expect($('#render-args span')).to.have.lengthOf(1);
+			expect($('#render-args').text()).to.equal('render-args');
 		});
 	});
 });

--- a/packages/astro/test/slots-react.test.js
+++ b/packages/astro/test/slots-react.test.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
-import { describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('Slots: React', () => {


### PR DESCRIPTION
## Changes

Fix #4826

The `Astro.slots.render` API only renders Astro slots, but not JSX slots. This PR updates the API to support rendering JSX slots.



## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Copied astro-slots tests for `Astro.slots.render` for mdx.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A. this should be working in the first place.
