### PR TITLE
closes #4633

### DIFF
--- a/.changeset/lemon-pets-sneeze.md
+++ b/.changeset/lemon-pets-sneeze.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that logged route cache warnings in `astro dev`

--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -5,6 +5,7 @@ import type {
 	GetStaticPathsResultKeyed,
 	Params,
 	RouteData,
+	RuntimeMode,
 } from '../../@types/astro';
 import { debug, LogOptions, warn } from '../logger/core.js';
 
@@ -77,9 +78,11 @@ export interface RouteCacheEntry {
 export class RouteCache {
 	private logging: LogOptions;
 	private cache: Record<string, RouteCacheEntry> = {};
+	private mode: RuntimeMode;
 
-	constructor(logging: LogOptions) {
+	constructor(logging: LogOptions, mode: RuntimeMode = 'production') {
 		this.logging = logging;
+		this.mode = mode;
 	}
 
 	/** Clear the cache. */
@@ -91,7 +94,7 @@ export class RouteCache {
 		// NOTE: This shouldn't be called on an already-cached component.
 		// Warn here so that an unexpected double-call of getStaticPaths()
 		// isn't invisible and developer can track down the issue.
-		if (this.cache[route.component]) {
+		if (this.mode === 'production' && this.cache[route.component]) {
 			warn(
 				this.logging,
 				'routeCache',

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -436,7 +436,7 @@ export default function createPlugin({ settings, logging }: AstroPluginOptions):
 	return {
 		name: 'astro:server',
 		configureServer(viteServer) {
-			let routeCache = new RouteCache(logging);
+			let routeCache = new RouteCache(logging, 'development');
 			let manifest: ManifestData = createRouteManifest({ settings }, logging);
 			/** rebuild the route cache + manifest, as needed. */
 			function rebuildManifest(needsManifestRebuild: boolean, file: string) {


### PR DESCRIPTION
## Changes

Closes #4633

The cache used for `getStaticPaths()` will warn if it's called a second time for the same route.  This PR updates the warning to only be logged in production builds since HMR will trigger a cache invalidation in `dev`

## Testing

All existing tests should pass - no new tests since it's just a logger fix

## Docs

None, logging bug fix only