### PR TITLE
Docs: add yarn workaround to node integration docs

### DIFF
--- a/packages/integrations/node/README.md
+++ b/packages/integrations/node/README.md
@@ -112,7 +112,7 @@ This adapter does not expose any configuration options.
 
 ### SyntaxError: Named export 'compile' not found
 
-This error occurs when running the entry script if it was built with Yarn. This is a [known issue](https://github.com/withastro/astro/issues/4974) that will be fixed in a future release. As a workaround, add `"path-to-regexp"` to the `noExternal` array:
+You may see this when running the entry script if it was built with npm or Yarn. This is a [known issue](https://github.com/withastro/astro/issues/4974) that will be fixed in a future release. As a workaround, add `"path-to-regexp"` to the `noExternal` array:
 
 ```js title="astro.config.mjs" ins={8-12}
 import { defineConfig } from 'astro/config';

--- a/packages/integrations/node/README.md
+++ b/packages/integrations/node/README.md
@@ -110,7 +110,27 @@ This adapter does not expose any configuration options.
 
 ## Troubleshooting
 
-For help, check out the `#support` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+### SyntaxError: Named export 'compile' not found
+
+This error occurs when running the entry script if it was built with Yarn. This is a [known issue](https://github.com/withastro/astro/issues/4974) that will be fixed in a future release. As a workaround, add `"path-to-regexp"` to the `noExternal` array:
+
+```js title="astro.config.mjs" ins={8-12}
+import { defineConfig } from 'astro/config';
+
+import node from "@astrojs/node";
+
+export default defineConfig({
+  output: "server",
+  adapter: node(),
+  vite: {
+    ssr: {
+      noExternal: ["path-to-regexp"]
+    }
+  }
+});
+```
+
+For more help, check out the `#support` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
 
 You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
 


### PR DESCRIPTION
## Changes

This documents a workaround for the node integration [issue](https://github.com/withastro/astro/issues/4974) that people are asking about in [support threads](https://discord.com/channels/830184174198718474/1025507121481134131).

## Testing

Docs only

## Docs
cc @withastro/maintainers-docs for feedback!
