### PR TITLE
Type declarations for vite-plugin-pwa example

### DIFF
--- a/examples/with-vite-plugin-pwa/tsconfig.json
+++ b/examples/with-vite-plugin-pwa/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "astro/tsconfigs/base"
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "types": [
+      "vite-plugin-pwa/client"
+    ]
+  }
 }


### PR DESCRIPTION
Add types declaration for IDE integration

## Changes

- Add types declaration to vite-plugin-pwa example, defined in tsconfig.json


