### PR TITLE
Add type argument to AstroGlobal to type Props

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -93,7 +93,7 @@ export interface BuildConfig {
  *
  * [Astro reference](https://docs.astro.build/reference/api-reference/#astro-global)
  */
-export interface AstroGlobal extends AstroGlobalPartial {
+export interface AstroGlobal<T = Record<string, number | string | any>> extends AstroGlobalPartial {
 	/**
 	 * Canonical URL of the current page.
 	 * @deprecated Use `Astro.url` instead.
@@ -149,7 +149,7 @@ export interface AstroGlobal extends AstroGlobalPartial {
 	 *
 	 * [Astro reference](https://docs.astro.build/en/core-concepts/astro-components/#component-props)
 	 */
-	props: Record<string, number | string | any>;
+	props: T;
 	/** Information about the current request. This is a standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object
 	 *
 	 * For example, to get a URL object of the current URL, you can use:


### PR DESCRIPTION
## Changes

Small change to allow the language-tools to type the Props object strictly without needing to copy paste the JSDoc comment for props. Not a breaking change for core, which is nice

## Testing

N/A

## Docs

N/A