### PR TITLE
Add license from rimraf code usage

### DIFF
--- a/packages/astro/src/core/fs/index.ts
+++ b/packages/astro/src/core/fs/index.ts
@@ -27,8 +27,6 @@ export function emptyDir(_dir: URL, skip?: Set<string>): void {
 			if (er.code === 'ENOENT') {
 				return;
 			}
-			// Windows can EPERM on stat.  Life is suffering.
-			// From https://github.com/isaacs/rimraf/blob/8c10fb8d685d5cc35708e0ffc4dac9ec5dd5b444/rimraf.js#L294
 			if (er.code === 'EPERM' && isWindows) {
 				fixWinEPERMSync(p, rmOptions, er);
 			}
@@ -36,7 +34,25 @@ export function emptyDir(_dir: URL, skip?: Set<string>): void {
 	}
 }
 
-// Taken from https://github.com/isaacs/rimraf/blob/8c10fb8d685d5cc35708e0ffc4dac9ec5dd5b444/rimraf.js#L183
+/**
+ * https://github.com/isaacs/rimraf/blob/8c10fb8d685d5cc35708e0ffc4dac9ec5dd5b444/rimraf.js#L183
+ * @license ISC
+ * The ISC License
+ *
+ * Copyright (c) Isaac Z. Schlueter and Contributors
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
 const fixWinEPERMSync = (p: string, options: fs.RmDirOptions, er: any) => {
 	try {
 		fs.chmodSync(p, 0o666);


### PR DESCRIPTION
Just adding a license that was missing from the e2e PR.