### PR TITLE
[@astrojs/prefetch]: Prevent prefetching current page

### DIFF
--- a/.changeset/cold-colts-laugh.md
+++ b/.changeset/cold-colts-laugh.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/prefetch': patch
+---
+
+Prevents prefetching the current page

--- a/packages/integrations/prefetch/src/client.ts
+++ b/packages/integrations/prefetch/src/client.ts
@@ -11,7 +11,7 @@ function shouldPreload({ href }: { href: string }) {
 		const url = new URL(href);
 		return (
 			window.location.origin === url.origin &&
-			//window.location.pathname !== url.hash &&
+			window.location.pathname !== url.pathname &&
 			!preloaded.has(href)
 		);
 	} catch {}

--- a/packages/integrations/prefetch/src/client.ts
+++ b/packages/integrations/prefetch/src/client.ts
@@ -11,7 +11,7 @@ function shouldPreload({ href }: { href: string }) {
 		const url = new URL(href);
 		return (
 			window.location.origin === url.origin &&
-			window.location.pathname !== url.hash &&
+			//window.location.pathname !== url.hash &&
 			!preloaded.has(href)
 		);
 	} catch {}

--- a/packages/integrations/prefetch/test/basic-prefetch.test.js
+++ b/packages/integrations/prefetch/test/basic-prefetch.test.js
@@ -34,6 +34,7 @@ test.describe('Basic prefetch', () => {
 					'/contact was prefetched'
 				).toBeTruthy();
 				await expect(requests.has(astro.resolveUrl('/admin')), '/admin was skipped').toBeFalsy();
+				await expect(requests.has(astro.resolveUrl('/')), '/ was skipped').toBeTruthy();
 			});
 		});
 	});
@@ -70,6 +71,7 @@ test.describe('Basic prefetch', () => {
 					'/contact was prefetched'
 				).toBeTruthy();
 				await expect(requests.has(astro.resolveUrl('/admin')), '/admin was skipped').toBeFalsy();
+				await expect(requests.has(astro.resolveUrl('/')), '/ was skipped').toBeTruthy();
 			});
 		});
 	});

--- a/packages/integrations/prefetch/test/basic-prefetch.test.js
+++ b/packages/integrations/prefetch/test/basic-prefetch.test.js
@@ -17,24 +17,24 @@ test.describe('Basic prefetch', () => {
 
 		test.describe('prefetches rel="prefetch" links', () => {
 			test('skips /admin', async ({ page, astro }) => {
-				const requests = new Set();
+				const requests = [];
 
-				page.on('request', async (request) => requests.add(request.url()));
+				page.on('request', async (request) => requests.push(request.url()));
 
 				await page.goto(astro.resolveUrl('/'));
 
 				await page.waitForLoadState('networkidle');
 
-				await expect(
-					requests.has(astro.resolveUrl('/about')),
-					'/about was prefetched'
-				).toBeTruthy();
-				await expect(
-					requests.has(astro.resolveUrl('/contact')),
+				expect(requests.includes(astro.resolveUrl('/about')), '/about was prefetched').toBeTruthy();
+				expect(
+					requests.includes(astro.resolveUrl('/contact')),
 					'/contact was prefetched'
 				).toBeTruthy();
-				await expect(requests.has(astro.resolveUrl('/admin')), '/admin was skipped').toBeFalsy();
-				await expect(requests.has(astro.resolveUrl('/')), '/ was skipped').toBeTruthy();
+				expect(requests.includes(astro.resolveUrl('/admin')), '/admin was skipped').toBeFalsy();
+				expect(
+					requests.filter((r) => r === astro.resolveUrl('/')).length === 1,
+					'/ was skipped by prefetch and only queried once'
+				).toBeTruthy();
 			});
 		});
 	});
@@ -54,24 +54,24 @@ test.describe('Basic prefetch', () => {
 
 		test.describe('prefetches rel="prefetch" links', () => {
 			test('skips /admin', async ({ page, astro }) => {
-				const requests = new Set();
+				const requests = [];
 
-				page.on('request', async (request) => requests.add(request.url()));
+				page.on('request', async (request) => requests.push(request.url()));
 
 				await page.goto(astro.resolveUrl('/'));
 
 				await page.waitForLoadState('networkidle');
 
-				await expect(
-					requests.has(astro.resolveUrl('/about')),
-					'/about was prefetched'
-				).toBeTruthy();
-				await expect(
-					requests.has(astro.resolveUrl('/contact')),
+				expect(requests.includes(astro.resolveUrl('/about')), '/about was prefetched').toBeTruthy();
+				expect(
+					requests.includes(astro.resolveUrl('/contact')),
 					'/contact was prefetched'
 				).toBeTruthy();
-				await expect(requests.has(astro.resolveUrl('/admin')), '/admin was skipped').toBeFalsy();
-				await expect(requests.has(astro.resolveUrl('/')), '/ was skipped').toBeTruthy();
+				expect(requests.includes(astro.resolveUrl('/admin')), '/admin was skipped').toBeFalsy();
+				expect(
+					requests.filter((r) => r === astro.resolveUrl('/')).length === 1,
+					'/ was skipped by prefetch and only queried once'
+				).toBeTruthy();
 			});
 		});
 	});

--- a/packages/integrations/prefetch/test/custom-selectors.test.js
+++ b/packages/integrations/prefetch/test/custom-selectors.test.js
@@ -25,20 +25,24 @@ test.describe('Custom prefetch selectors', () => {
 
 		test.describe('prefetches links by custom selector', () => {
 			test('only prefetches /contact', async ({ page, astro }) => {
-				const requests = new Set();
+				const requests = [];
 
-				page.on('request', async (request) => requests.add(request.url()));
+				page.on('request', async (request) => requests.push(request.url()));
 
 				await page.goto(astro.resolveUrl('/'));
 
 				await page.waitForLoadState('networkidle');
 
-				await expect(requests.has(astro.resolveUrl('/about')), '/about was skipped').toBeFalsy();
-				await expect(
-					requests.has(astro.resolveUrl('/contact')),
+				expect(requests.includes(astro.resolveUrl('/about')), '/about was skipped').toBeFalsy();
+				expect(
+					requests.includes(astro.resolveUrl('/contact')),
 					'/contact was prefetched'
 				).toBeTruthy();
-				await expect(requests.has(astro.resolveUrl('/admin')), '/admin was skipped').toBeFalsy();
+				expect(requests.includes(astro.resolveUrl('/admin')), '/admin was skipped').toBeFalsy();
+				expect(
+					requests.filter((r) => r === astro.resolveUrl('/')).length === 1,
+					'/ was skipped by prefetch and only queried once'
+				).toBeTruthy();
 			});
 		});
 	});
@@ -58,20 +62,24 @@ test.describe('Custom prefetch selectors', () => {
 
 		test.describe('prefetches links by custom selector', () => {
 			test('only prefetches /contact', async ({ page, astro }) => {
-				const requests = new Set();
+				const requests = [];
 
-				page.on('request', async (request) => requests.add(request.url()));
+				page.on('request', async (request) => requests.push(request.url()));
 
 				await page.goto(astro.resolveUrl('/'));
 
 				await page.waitForLoadState('networkidle');
 
-				await expect(requests.has(astro.resolveUrl('/about')), '/about was skipped').toBeFalsy();
-				await expect(
-					requests.has(astro.resolveUrl('/contact')),
+				expect(requests.includes(astro.resolveUrl('/about')), '/about was skipped').toBeFalsy();
+				expect(
+					requests.includes(astro.resolveUrl('/contact')),
 					'/contact was prefetched'
 				).toBeTruthy();
-				await expect(requests.has(astro.resolveUrl('/admin')), '/admin was skipped').toBeFalsy();
+				expect(requests.includes(astro.resolveUrl('/admin')), '/admin was skipped').toBeFalsy();
+				expect(
+					requests.filter((r) => r === astro.resolveUrl('/')).length === 1,
+					'/ was skipped by prefetch and only queried once'
+				).toBeTruthy();
 			});
 		});
 	});

--- a/packages/integrations/prefetch/test/fixtures/basic-prefetch/src/pages/index.astro
+++ b/packages/integrations/prefetch/test/fixtures/basic-prefetch/src/pages/index.astro
@@ -11,6 +11,9 @@
 	<nav>
 		<ul>
 			<li>
+				<a href="/" rel="prefetch">Home</a>
+			</li>
+			<li>
 				<a href="/about" rel="prefetch">About</a>
 			</li>
 			<li>


### PR DESCRIPTION
## Changes

- As described in #4963 a check is added to ensure that the current page is not requested if present as a prefetch link
- Removed useless hash check that most probably was a typo IMHO

## Testing

- Added prefetch link to `"/"` to the test page
- Added tests to check that the path `"/"` is only requested once
- Refactored the unnecessary use of `await` keyword

## Docs

As this is a bugfix, no docs change is needed.

Fixes #4963