### PR TITLE
Move astro/config into src and typecheck

### DIFF
--- a/.changeset/smooth-horses-repeat.md
+++ b/.changeset/smooth-horses-repeat.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes getViteConfig from astro/config

--- a/packages/astro/config.mjs
+++ b/packages/astro/config.mjs
@@ -1,43 +1,4 @@
-export function defineConfig(config) {
-	return config;
-}
-
-export function getViteConfig(inlineConfig) {
-	// Return an async Vite config getter which exposes a resolved `mode` and `command`
-	return async ({ mode, command }) => {
-		// Vite `command` is `serve | build`, but Astro uses `dev | build`
-		const cmd = command === 'serve' ? 'dev' : command;
-
-		// Use dynamic import to avoid pulling in deps unless used
-		const [
-			{ mergeConfig },
-			{ nodeLogDestination },
-			{ openConfig },
-			{ createVite },
-			{ runHookConfigSetup, runHookConfigDone },
-		] = await Promise.all([
-			import('vite'),
-			import('./dist/core/logger/node.js'),
-			import('./dist/core/config.js'),
-			import('./dist/core/create-vite.js'),
-			import('./dist/integrations/index.js'),
-		]);
-		const logging = {
-			dest: nodeLogDestination,
-			level: 'info',
-		};
-		const { astroConfig: config } = await openConfig({
-			cmd,
-			logging,
-		});
-		await runHookConfigSetup({ config, command: cmd });
-		const viteConfig = await createVite(
-			{
-				mode,
-			},
-			{ astroConfig: config, logging: logging, mode }
-		);
-		await runHookConfigDone({ config });
-		return mergeConfig(viteConfig, inlineConfig);
-	};
-}
+export {
+	defineConfig,
+	getViteConfig
+} from './dist/config/index.js';

--- a/packages/astro/src/config/index.ts
+++ b/packages/astro/src/config/index.ts
@@ -1,0 +1,53 @@
+import type { AstroUserConfig } from '../@types/astro';
+import type { UserConfig } from 'vite';
+import type { LogOptions } from '../core/logger/core';
+
+export function defineConfig(config: AstroUserConfig) {
+	return config;
+}
+
+export function getViteConfig(inlineConfig: UserConfig) {
+	// Return an async Vite config getter which exposes a resolved `mode` and `command`
+	return async ({ mode, command }: { mode: string; command: 'serve' | 'build' }) => {
+		// Vite `command` is `serve | build`, but Astro uses `dev | build`
+		const cmd = command === 'serve' ? 'dev' : command;
+
+		// Use dynamic import to avoid pulling in deps unless used
+		const [
+			{ mergeConfig },
+			{ nodeLogDestination },
+			{ openConfig, createSettings, loadTSConfig },
+			{ createVite },
+			{ runHookConfigSetup, runHookConfigDone },
+		] = await Promise.all([
+			import('vite'),
+			import('../core/logger/node.js'),
+			import('../core/config/index.js'),
+			import('../core/create-vite.js'),
+			import('../integrations/index.js'),
+		]);
+		const logging: LogOptions = {
+			dest: nodeLogDestination,
+			level: 'info',
+		};
+		const { astroConfig: config } = await openConfig({
+			cmd,
+			logging,
+		});
+		const initialTsConfig = loadTSConfig(inlineConfig.root)
+		const settings = createSettings({
+			config,
+			tsConfig: initialTsConfig?.config,
+			tsConfigPath: initialTsConfig?.path,
+		});
+		await runHookConfigSetup({ settings, command: cmd, logging });
+		const viteConfig = await createVite(
+			{
+				mode,
+			},
+			{ settings, logging: logging, mode }
+		);
+		await runHookConfigDone({ settings, logging });
+		return mergeConfig(viteConfig, inlineConfig);
+	};
+}


### PR DESCRIPTION
## Changes

- Moves astro/config into `src/` so we get typechecking.
- Regression occurred due to some files being moved around. We didn't know it broke astro/config because it was a plain .mjs file.
- Closes https://github.com/withastro/astro/issues/4910

## Testing

- Typechecks now, that's a test!

## Docs

N/A, bug fix