### PR TITLE
Support strict dependency install for image integration

### DIFF
--- a/.changeset/small-laws-dream.md
+++ b/.changeset/small-laws-dream.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Support strict dependency install

--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -45,6 +45,7 @@
     "@altano/tiny-async-pool": "^1.0.2",
     "http-cache-semantics": "^4.1.0",
     "image-size": "^1.0.2",
+    "kleur": "^4.1.5",
     "magic-string": "^0.25.9",
     "mime": "^3.0.0",
     "slash": "^4.0.0"
@@ -57,7 +58,6 @@
     "astro-scripts": "workspace:*",
     "chai": "^4.3.6",
     "cheerio": "^1.0.0-rc.11",
-    "kleur": "^4.1.4",
     "mocha": "^9.2.2",
     "rollup-plugin-copy": "^3.4.0",
     "sharp": "^0.31.0",

--- a/packages/integrations/image/src/index.ts
+++ b/packages/integrations/image/src/index.ts
@@ -49,9 +49,6 @@ export default function integration(options: IntegrationOptions = {}): AstroInte
 	function getViteConfiguration() {
 		return {
 			plugins: [createPlugin(_config, resolvedOptions)],
-			optimizeDeps: {
-				include: ['image-size'].filter(Boolean),
-			},
 			build: {
 				rollupOptions: {
 					external: ['sharp'],
@@ -59,6 +56,8 @@ export default function integration(options: IntegrationOptions = {}): AstroInte
 			},
 			ssr: {
 				noExternal: ['@astrojs/image', resolvedOptions.serviceEntryPoint],
+				// CJS dependencies used by `serviceEntryPoint`
+				external: ['http-cache-semantics', 'image-size', 'mime'],
 			},
 			assetsInclude: ['**/*.wasm'],
 		};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2536,7 +2536,7 @@ importers:
       cheerio: ^1.0.0-rc.11
       http-cache-semantics: ^4.1.0
       image-size: ^1.0.2
-      kleur: ^4.1.4
+      kleur: ^4.1.5
       magic-string: ^0.25.9
       mime: ^3.0.0
       mocha: ^9.2.2
@@ -2549,6 +2549,7 @@ importers:
       '@altano/tiny-async-pool': 1.0.2
       http-cache-semantics: 4.1.0
       image-size: 1.0.2
+      kleur: 4.1.5
       magic-string: 0.25.9
       mime: 3.0.0
       slash: 4.0.0
@@ -2560,7 +2561,6 @@ importers:
       astro-scripts: link:../../../scripts
       chai: 4.3.6
       cheerio: 1.0.0-rc.12
-      kleur: 4.1.5
       mocha: 9.2.2
       rollup-plugin-copy: 3.4.0
       sharp: 0.31.1


### PR DESCRIPTION
## Changes

Fix #4995

- Add deps to `ssr.external` so they are not transformed by Vite when calling `ssrLoadModule` to load the renderer.
- Move `kleur` as dependency as it's used in `ssg.ts`

Note: Vite's SSR externalization doesn't take into account of loading modules from `node_modules` hence we got this issue and have to use `ssr.external` manually. This could be fixed in Vite, but I feel like we should use normal `import()` to load renderers instead (that would be a breaking change)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
This one's hard to test due to our monorepo structure, however I tested the repro in #4995 which works with this PR.

Existing tests should ideally pass too.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A. should work by default.
