### PR TITLE
fixing multiple doctype injections in single file

### DIFF
--- a/.changeset/chilly-carrots-think.md
+++ b/.changeset/chilly-carrots-think.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+preventing multiple doctype injection into html documents

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -30,6 +30,7 @@ async function iterableToHTMLBytes(
 	for await (const chunk of iterable) {
 		if (isHTMLString(chunk)) {
 			if (i === 0) {
+				i++;
 				if (!/<!doctype html/i.test(String(chunk))) {
 					parts.append('<!DOCTYPE html>\n', result);
 					if (onDocTypeInjection) {


### PR DESCRIPTION
## Changes

- limiting doctype injection to the first occurrence of html string

## Testing

with the example from the solid framework (by adding the cloudflare adapter)

## Docs

just a simple fix, so no doc update required.