### PR TITLE
Shorter CSS naming algorithm

### DIFF
--- a/.changeset/six-oranges-shop.md
+++ b/.changeset/six-oranges-shop.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+New algorithm for shorter CSS bundle names

--- a/packages/astro/src/core/build/vite-plugin-css.ts
+++ b/packages/astro/src/core/build/vite-plugin-css.ts
@@ -30,9 +30,8 @@ export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] 
 
 	function createNameForParentPages(id: string, ctx: { getModuleInfo: GetModuleInfo }): string {
 		const parents = Array.from(getTopLevelPages(id, ctx));
-		const firstParentId = parents[0]?.[0].id || 'index';
-		const firstParentExt = npath.extname(firstParentId);
-		const firstParentName = firstParentId.slice(firstParentId.lastIndexOf('/') + 1, firstParentId.indexOf(firstParentExt));
+		const firstParentId = parents[0]?.[0].id
+		const firstParentName = firstParentId ? npath.parse(firstParentId).name : 'index'
 
 		const hash = crypto.createHash('sha256');
 		for (const [page] of parents) {

--- a/packages/astro/src/core/build/vite-plugin-css.ts
+++ b/packages/astro/src/core/build/vite-plugin-css.ts
@@ -7,7 +7,6 @@ import esbuild from 'esbuild';
 import npath from 'path';
 import { Plugin as VitePlugin, ResolvedConfig } from 'vite';
 import { isCSSRequest } from '../render/util.js';
-import { relativeToSrcDir } from '../util.js';
 import { getTopLevelPages, moduleIsTopLevelPage, walkParentInfos } from './graph.js';
 import {
 	eachPageData,
@@ -23,47 +22,25 @@ interface PluginOptions {
 	target: 'client' | 'server';
 }
 
-// Arbitrary magic number, can change.
-const MAX_NAME_LENGTH = 70;
-
 export function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 	const { internals, buildOptions } = options;
 	const { settings } = buildOptions;
 
 	let resolvedConfig: ResolvedConfig;
 
-	// Turn a page location into a name to be used for the CSS file.
-	function nameifyPage(id: string) {
-		let rel = relativeToSrcDir(settings.config, id);
-		// Remove pages, ex. blog/posts/something.astro
-		if (rel.startsWith('pages/')) {
-			rel = rel.slice(6);
-		}
-		// Remove extension, ex. blog/posts/something
-		const ext = npath.extname(rel);
-		const noext = rel.slice(0, rel.length - ext.length);
-		// Replace slashes with dashes, ex. blog-posts-something
-		const named = noext.replace(/\//g, '-');
-		return named;
-	}
-
 	function createNameForParentPages(id: string, ctx: { getModuleInfo: GetModuleInfo }): string {
 		const parents = Array.from(getTopLevelPages(id, ctx));
-		const proposedName = parents
-			.map(([page]) => nameifyPage(page.id))
-			.sort()
-			.join('-');
-
-		// We don't want absurdedly long chunk names, so if this is too long create a hashed version instead.
-		if (proposedName.length <= MAX_NAME_LENGTH) {
-			return proposedName;
-		}
+		const firstParentId = parents[0]?.[0].id || 'index';
+		const firstParentExt = npath.extname(firstParentId);
+		const firstParentName = firstParentId.slice(firstParentId.lastIndexOf('/') + 1, firstParentId.indexOf(firstParentExt));
 
 		const hash = crypto.createHash('sha256');
 		for (const [page] of parents) {
 			hash.update(page.id, 'utf-8');
 		}
-		return hash.digest('hex').slice(0, 8);
+		const h = hash.digest('hex').slice(0, 8);
+		const proposedName = firstParentName + '.' + h;
+		return proposedName;
 	}
 
 	function* getParentClientOnlys(


### PR DESCRIPTION
## Changes

- This shortens the naming algorithm for CSS bundles. Previously we were concatenating each page in the bundle's from-src path which created some long names.
- Now this takes just the last segment from the first page, for example `src/pages/about.astro` it takes just `about` and then also hashes all of the page ids, which gives us our unique hash.
- With this change names will be shortened to something like: `about.f6e31204.css` in all cases.
- Closes https://github.com/withastro/astro/issues/4672

## Testing

- Tested with the examples to ensure short names
- Tests should pass

## Docs

N/A, bug fix