### PR TITLE
chore: Upgrade Astro compiler to 0.27.1

### DIFF
--- a/.changeset/sixty-ladybugs-return.md
+++ b/.changeset/sixty-ladybugs-return.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Upgrade Astro compiler to 0.27.1

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -95,7 +95,7 @@
     "test:e2e:match": "playwright test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.26.0",
+    "@astrojs/compiler": "^0.27.1",
     "@astrojs/language-server": "^0.26.2",
     "@astrojs/markdown-remark": "^1.1.3",
     "@astrojs/telemetry": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,7 +357,7 @@ importers:
 
   packages/astro:
     specifiers:
-      '@astrojs/compiler': ^0.26.0
+      '@astrojs/compiler': ^0.27.1
       '@astrojs/language-server': ^0.26.2
       '@astrojs/markdown-remark': ^1.1.3
       '@astrojs/telemetry': ^1.0.1
@@ -451,7 +451,7 @@ importers:
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
-      '@astrojs/compiler': 0.26.0
+      '@astrojs/compiler': 0.27.1
       '@astrojs/language-server': 0.26.2
       '@astrojs/markdown-remark': link:../markdown/remark
       '@astrojs/telemetry': link:../telemetry
@@ -3733,8 +3733,8 @@ packages:
     resolution: {integrity: sha512-vBMPy9ok4iLapSyCCT1qsZ9dK7LkVFl9mObtLEmWiec9myGHS9h2kQY2xzPeFNJiWXUf9O6tSyQpQTy5As/p3g==}
     dev: false
 
-  /@astrojs/compiler/0.26.0:
-    resolution: {integrity: sha512-we6XcJp4BnG2+1HhKYwIqfM6xt/T0nrhBkNSZNcrY/g449t2TyA6H/j0dRadiV8CGIE27T6q3sEq7Nm2Qfi6oQ==}
+  /@astrojs/compiler/0.27.1:
+    resolution: {integrity: sha512-jdbnULQkafKuSBa9yL7amQ5Ee7WIiQSAkCCGSgWhpt7t1HvtlbviNYuNIw5ob9Ax+rA08jNQ896rHqaPB31XjA==}
     dev: false
 
   /@astrojs/language-server/0.26.2:


### PR DESCRIPTION
## Changes

Upgrade Astro compiler to 0.27.1 (fixes regression withastro/compier#556)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
