### PR TITLE
Allow `class` to be passed into Svelte islands

### DIFF
--- a/.changeset/early-pillows-deliver.md
+++ b/.changeset/early-pillows-deliver.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/svelte': patch
+---
+
+Allow class to be passed into Svelte islands

--- a/packages/integrations/svelte/client.js
+++ b/packages/integrations/svelte/client.js
@@ -3,7 +3,6 @@ const noop = () => {};
 export default (target) => {
 	return (Component, props, slotted, { client }) => {
 		if (!target.hasAttribute('ssr')) return;
-		delete props['class'];
 		const slots = {};
 		for (const [key, value] of Object.entries(slotted)) {
 			slots[key] = createSlotDefinition(key, value);


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/astro/issues/5029
- This code was old, from when the old compiler would *always* pass a class (the Astro class name). It's no longer needed and causes the above bug.

## Testing

Tested in the examples

## Docs

N/A, bug fix