### PR TITLE
Update the Astro.cookies.set types to receive boolean and numbers

### DIFF
--- a/.changeset/witty-sheep-wave.md
+++ b/.changeset/witty-sheep-wave.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Update Astro.cookies.set types to allow booleans and numbers
+
+Note that booleans and numbers were already allowed, they just were not allowed by the type definitions.

--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -25,7 +25,7 @@ interface AstroCookieInterface {
 interface AstroCookiesInterface {
 	get(key: string): AstroCookieInterface;
 	has(key: string): boolean;
-	set(key: string, value: string | Record<string, any>, options?: AstroCookieSetOptions): void;
+	set(key: string, value: string | number | boolean | Record<string, any>, options?: AstroCookieSetOptions): void;
 	delete(key: string, options?: AstroCookieDeleteOptions): void;
 }
 

--- a/packages/astro/test/units/cookies/set.test.js
+++ b/packages/astro/test/units/cookies/set.test.js
@@ -45,6 +45,16 @@ describe('astro/src/core/cookies', () => {
 			expect(headers[0]).to.equal('one=2');
 		});
 
+		it('Can pass a boolean', () => {
+			let req = new Request('http://example.com/');
+			let cookies = new AstroCookies(req);
+			cookies.set('admin', true);
+			expect(cookies.get('admin').boolean()).to.equal(true);
+			let headers = Array.from(cookies.headers());
+			expect(headers).to.have.a.lengthOf(1);
+			expect(headers[0]).to.equal('admin=true');
+		});
+
 		it('Can get the value after setting', () => {
 			let req = new Request('http://example.com/');
 			let cookies = new AstroCookies(req);

--- a/packages/integrations/deno/test/basics.test.ts
+++ b/packages/integrations/deno/test/basics.test.ts
@@ -126,3 +126,20 @@ Deno.test({
 	sanitizeResources: false,
 	sanitizeOps: false,
 });
+
+Deno.test({
+	name: 'Astro.cookies',
+	permissions: defaultTestPermissions,
+	async fn() {
+		await startApp(async (baseUrl: URL) => {
+			const url = new URL('/admin', baseUrl);
+			const resp = await fetch(url, { redirect: 'manual' });
+			assertEquals(resp.status, 302);
+
+			const headers = resp.headers;
+			assertEquals(headers.get('set-cookie'), 'logged-in=false; Max-Age=77760000; Path=/');
+		});
+	},
+	sanitizeResources: false,
+	sanitizeOps: false,
+});

--- a/packages/integrations/deno/test/fixtures/basics/src/pages/admin.astro
+++ b/packages/integrations/deno/test/fixtures/basics/src/pages/admin.astro
@@ -1,0 +1,8 @@
+---
+Astro.cookies.set('logged-in', false, {
+	maxAge: 60 * 60 * 24 * 900,
+	path: '/'
+});
+
+return Astro.redirect('/login');
+---

--- a/packages/integrations/deno/test/fixtures/basics/src/pages/login.astro
+++ b/packages/integrations/deno/test/fixtures/basics/src/pages/login.astro
@@ -1,0 +1,10 @@
+---
+---
+<html>
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<h1>Testing</h1>
+	</body>
+</html>


### PR DESCRIPTION
## Changes

- We were already allowing number and boolean but types did not reflect.
- Closes https://github.com/withastro/astro/issues/5031

## Testing

Test added for booleans since there wasn't one.

## Docs

N/A