### PR TITLE
Fixes #4915 - Separate IntrinsicElements interface

### DIFF
--- a/.changeset/tidy-flies-whisper.md
+++ b/.changeset/tidy-flies-whisper.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Split IntrinsicElements interface in two and restrict unknown tags to custom elements

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -1288,7 +1288,7 @@ declare namespace astroHTML.JSX {
 		zoomAndPan?: string | undefined | null;
 	}
 
-	interface IntrinsicElements {
+	interface NativeIntrinsicElements {
 		// HTML
 		a: AnchorHTMLAttributes;
 		abbr: HTMLAttributes;
@@ -1461,8 +1461,10 @@ declare namespace astroHTML.JSX {
 		tspan: SVGAttributes;
 		use: SVGAttributes;
 		view: SVGAttributes;
-
-		// Allow for arbitrary elements
-		[name: string]: { [name: string]: any };
 	}
+
+	type IntrinsicElements = NativeIntrinsicElements & {
+		// Allow for arbitrary custom elements
+		[TagName in `${string}-${string}`]: { [attribute: string]: any };
+	};
 }


### PR DESCRIPTION
## Changes

Separates `IntrinsicElements` into `NativeIntrinsicElements` and an index type for custom elements. The index type requires the element names contain a hyphen.

## Testing

No tests added for type only change

## Docs

No docs for small change
