### PR TITLE
fix a typo in Code component's wrap prop

### DIFF
--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -24,7 +24,7 @@ export interface Props {
 	/**
 	 * Enable word wrapping.
 	 *  - true: enabled.
-	 *  - false: enabled.
+	 *  - false: disabled.
 	 *  - null: All overflow styling removed. Code will overflow the element by default.
 	 *
 	 * @default false


### PR DESCRIPTION
in enable word wrapping, options are: true: enabled , false: enabled 
but it should be: true: enabled , false: disabled.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
