### PR TITLE
Fix MDX rendering of `Content` if JSX components are exported (#5027)

### DIFF
--- a/.changeset/shiny-cars-develop.md
+++ b/.changeset/shiny-cars-develop.md
@@ -1,0 +1,13 @@
+---
+'@astrojs/mdx': patch
+---
+
+[@astrojs/mdx] Added self-injected exported components when rendering `Content` component
+
+Rendering the `Content` component imported from an MDX file would render
+differently from rendering as MDX page, because the mapping from
+`export const components = { h1: Title, ...}` would not be respected.
+
+This fix will inject the `components` into the `Content`.
+
+Closes #5027

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -26,7 +26,8 @@
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "mocha --exit --timeout 20000"
+    "test": "mocha --exit --timeout 20000",
+    "test:match": "mocha --timeout 20000 -g"
   },
   "dependencies": {
     "@astrojs/prism": "^1.0.1",

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -144,7 +144,17 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 										)}) };`;
 									}
 									if (!moduleExports.includes('Content')) {
-										code += `\nexport const Content = MDXContent;`;
+										/*
+										 * Make the behavior of the `Content` component imported
+										 * from an MDX file similar to the behavior of an MDX page,
+										 * i.e. it uses the exported `components` to render HTML
+										 * tags.
+										 */
+										if (moduleExports.includes('components')) {
+											code += `\nexport const Content = ({components: moreComponents = {}, ...props}) => MDXContent({components: {...components, ...moreComponents}, ...props});`;
+										} else {
+											code += `\nexport const Content = MDXContent;`;
+										}
 									}
 
 									if (command === 'dev') {

--- a/packages/integrations/mdx/test/fixtures/mdx-component/src/exported-components/T1.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-component/src/exported-components/T1.astro
@@ -1,0 +1,5 @@
+---
+const props = Astro.props;
+---
+
+<h1 {...props}>T1: <slot /></h1>

--- a/packages/integrations/mdx/test/fixtures/mdx-component/src/exported-components/T1.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-component/src/exported-components/T1.mdx
@@ -1,0 +1,8 @@
+# Hello T1
+
+import { Content as T2 } from './T2.mdx';
+
+<T2 />
+
+import T1 from './T1.astro';
+export const components = { h1: T1 };

--- a/packages/integrations/mdx/test/fixtures/mdx-component/src/exported-components/T2.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-component/src/exported-components/T2.astro
@@ -1,0 +1,5 @@
+---
+const props = Astro.props;
+---
+
+<h2 {...props}>T2: <slot /></h2>

--- a/packages/integrations/mdx/test/fixtures/mdx-component/src/exported-components/T2.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-component/src/exported-components/T2.mdx
@@ -1,0 +1,4 @@
+# Hello T2
+
+import T2 from './T2.astro';
+export const components = { h1: T2 };

--- a/packages/integrations/mdx/test/fixtures/mdx-component/src/pages/exported-components.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-component/src/pages/exported-components.astro
@@ -1,0 +1,9 @@
+---
+/*
+ * Self-injected exported components work only with the `Content` component,
+ * not with the default export.
+ */
+import { Content as T1 } from '../exported-components/T1.mdx';
+---
+
+<T1 />

--- a/packages/integrations/mdx/test/mdx-component.test.js
+++ b/packages/integrations/mdx/test/mdx-component.test.js
@@ -51,6 +51,17 @@ describe('MDX Component', () => {
 			expect(h1.textContent).to.equal('Hello component!');
 			expect(foo.textContent).to.equal('bar');
 		});
+
+		it('supports exported components - <Content />', async () => {
+			const html = await fixture.readFile('/exported-components/index.html');
+			const { document } = parseHTML(html);
+
+			const h1 = document.querySelector('#hello-t1');
+			const h2 = document.querySelector('#hello-t2');
+
+			expect(h1.textContent).to.equal('T1: Hello T1');
+			expect(h2.textContent).to.equal('T2: Hello T2');
+		});
 	});
 
 	describe('dev', () => {
@@ -107,6 +118,17 @@ describe('MDX Component', () => {
 
 			expect(h1.textContent).to.equal('Hello component!');
 			expect(foo.textContent).to.equal('bar');
+		});
+
+		it('supports exported components - <Content />', async () => {
+			const html = await fixture.readFile('/exported-components/index.html');
+			const { document } = parseHTML(html);
+
+			const h1 = document.querySelector('#hello-t1');
+			const h2 = document.querySelector('#hello-t2');
+
+			expect(h1.textContent).to.equal('T1: Hello T1');
+			expect(h2.textContent).to.equal('T2: Hello T2');
 		});
 	});
 });


### PR DESCRIPTION
Rendering the `Content` component imported from an MDX file would render differently from rendering as MDX page, because the mapping from `export const components = { h1: Title, ...}` would not be respected.

## Changes

- only in the MDX integration
- This fix injects the `components` into the `Content`
- components from the file and from the props are merged
- components from the props take precedence

## Testing

- tests were added to the suite 'MDX Component'
- tests check, whether respective JSX components from the mapping are used

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
The docs already explain the behavior as it is fixed now (https://docs.astro.build/en/guides/integrations-guide/mdx/#custom-components-with-imported-mdx): It mentions, that 'components can **also** be passed via the `components` prop', implying that the mechanism from the above section would work for imported MDX, too.

Actually, we will need to adapt the docs, as the fix only works for the `Content` component, but not for the default export. How is this done?