### PR TITLE
Skip JSX tagging for export statements with source

### DIFF
--- a/.changeset/serious-icons-dream.md
+++ b/.changeset/serious-icons-dream.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Skip JSX tagging for export statements with source

--- a/packages/astro/src/vite-plugin-jsx/tag.ts
+++ b/packages/astro/src/vite-plugin-jsx/tag.ts
@@ -104,7 +104,7 @@ export default function tagExportsWithRenderer({
 									addTag(property.key.name);
 								}
 							});
-						} else if (t.isExportNamedDeclaration(node)) {
+						} else if (t.isExportNamedDeclaration(node) && !node.source) {
 							node.specifiers.forEach((specifier) => {
 								if (t.isExportSpecifier(specifier) && t.isIdentifier(specifier.exported)) {
 									addTag(specifier.local.name);

--- a/packages/astro/test/fixtures/react-jsx-export/src/components/ListExportTest.jsx
+++ b/packages/astro/test/fixtures/react-jsx-export/src/components/ListExportTest.jsx
@@ -1,5 +1,7 @@
 import { useState } from "react"
 
+export { ListExportTestComponent } from './ListExportTestComponent'
+
 const ListExport = () => {
     const [example] = useState('Example')
     return <h2 id="default_list_export">{example}</h2>

--- a/packages/astro/test/fixtures/react-jsx-export/src/components/ListExportTestComponent.jsx
+++ b/packages/astro/test/fixtures/react-jsx-export/src/components/ListExportTestComponent.jsx
@@ -1,0 +1,6 @@
+import { useState } from "react"
+
+export const ListExportTestComponent = () => {
+  const [example] = useState('Example')
+  return <h2 id="list_export_test_component">{example}</h2>
+}

--- a/packages/astro/test/fixtures/react-jsx-export/src/pages/index.astro
+++ b/packages/astro/test/fixtures/react-jsx-export/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import ListAsDefaultExport, {ListExport, RenamedListExport} from '../components/ListExportTest'
+import ListAsDefaultExport, {ListExport, RenamedListExport, ListExportTestComponent} from '../components/ListExportTest'
 import {ConstDeclarationExport, LetDeclarationExport, FunctionDeclarationExport} from '../components/DeclarationExportTest'
 import AnonymousArrowDefaultExport from '../components/defaultExport/AnonymousArrowDefaultExport'
 import AnonymousFunctionDefaultExport from '../components/defaultExport/AnonymousFunctionDefaultExport'
@@ -12,6 +12,7 @@ import NamedFunctionDefaultExport from '../components/defaultExport/NamedFunctio
 <ListAsDefaultExport />
 <ListExport />
 <RenamedListExport />
+<ListExportTestComponent />
 
 <ConstDeclarationExport />
 <LetDeclarationExport />

--- a/packages/astro/test/react-jsx-export.test.js
+++ b/packages/astro/test/react-jsx-export.test.js
@@ -17,6 +17,7 @@ describe('react-jsx-export', () => {
 		'default_list_export',
 		'renamed_list_export',
 		'list_as_default_export',
+		'list_export_test_component',
 	];
 
 	const reactInvalidHookWarning =


### PR DESCRIPTION
## Changes

Skip tagging `__astro_tag_component__` for `export { foo } from './somewhere'` as `foo` can't be referenced.

Partial fix for #4871

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added a test

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A. a bug.