### PR TITLE
Fix aliases from jsconfig.json not being picked up anymore

### DIFF
--- a/.changeset/honest-crabs-scream.md
+++ b/.changeset/honest-crabs-scream.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix jsconfig.json aliases not working anymore after 1.5.0

--- a/packages/astro/src/core/config/tsconfig.ts
+++ b/packages/astro/src/core/config/tsconfig.ts
@@ -62,8 +62,6 @@ export function loadTSConfig(cwd: string | undefined, resolve = true): tsr.TsCon
 	// the file does not exists. We'll manually handle this so we can provide better errors to users
 	if (!resolve && config.reason === 'invalid-config' && !existsSync(join(cwd, 'tsconfig.json'))) {
 		config = { reason: 'not-found', path: undefined, exists: false };
-	} else {
-		return config;
 	}
 
 	// If we couldn't find a tsconfig.json, try to load a jsconfig.json instead
@@ -80,9 +78,9 @@ export function loadTSConfig(cwd: string | undefined, resolve = true): tsr.TsCon
 			!existsSync(join(cwd, 'jsconfig.json'))
 		) {
 			return { reason: 'not-found', path: undefined, exists: false };
-		} else {
-			return jsconfig;
 		}
+
+		return jsconfig;
 	}
 
 	return config;


### PR DESCRIPTION
## Changes

Starting from 1.5.0, aliases inside `jsconfig.json` were not being properly picked up anymore, this fix that. The issue was that we were returning the original `tsconfig.json` error before checking for a `jsconfig.json`

## Testing

We can't test this! Since we first try for a `tsconfig.json` before falling back to `jsconfig.json`, in the monorepo we always end up finding another `tsconfig.json` up the filesystem (notably, the new one at root added by Nate after his `tsconfig.json` adventures). 

`jsconfig.json` are.. kinda rare. All of our templates includes `tsconfig.json`, `astro add` adds `tsconfig.json` etc. So I think it's not that bad for it to not be tested. Loading a `jsconfig.json` directly however is tested

## Docs

N/A