### PR TITLE
Improved benchmark output

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Run benchmark
         id: benchmark-pr
         run: |
-          pnpm run --silent benchmark > ./bench-result.md
-          result=$(awk '/requests in/' ./bench-result.md)
+          pnpm run --silent benchmark &> ./bench-result.md
+          result=$(awk -v RS="" '/┌/' ./bench-result.md)
           echo "::set-output name=BENCH_RESULT${{matrix.node-version}}::$result"
 
       # main benchmark
@@ -68,8 +68,8 @@ jobs:
       - name: Run benchmark
         id: benchmark-main
         run: |
-          pnpm run --silent benchmark > ./bench-result.md
-          result=$(awk '/requests in/' ./bench-result.md)
+          pnpm run --silent benchmark &> ./bench-result.md
+          result=$(awk -v RS="" '/┌/' ./bench-result.md)
           echo "::set-output name=BENCH_RESULT${{matrix.node-version}}::$result"
 
   output-benchmark:
@@ -86,11 +86,15 @@ jobs:
           pr_number: ${{ github.event.issue.number }}
           message: |
             **Node**: 14
-            **PR**: ${{ needs.benchmark.outputs.PR-BENCH-14 }}
-            **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-14 }}
+            **PR**:
+            ${{ needs.benchmark.outputs.PR-BENCH-14 }}
+            **MAIN**:
+            ${{ needs.benchmark.outputs.MAIN-BENCH-14 }}
             
             ---
             
             **Node**: 16
-            **PR**: ${{ needs.benchmark.outputs.PR-BENCH-16 }}
-            **MAIN**: ${{ needs.benchmark.outputs.MAIN-BENCH-16 }}
+            **PR**:
+            ${{ needs.benchmark.outputs.PR-BENCH-16 }}
+            **MAIN**:
+            ${{ needs.benchmark.outputs.MAIN-BENCH-16 }}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:vite-ci": "turbo run test --filter=astro --output-logs=new-only --no-deps --concurrency=1",
     "test:e2e": "cd packages/astro && pnpm playwright install && pnpm run test:e2e",
     "test:e2e:match": "cd packages/astro && pnpm playwright install && pnpm run test:e2e:match",
-    "benchmark": "pnpm --filter @benchmark/simple run build && pnpm dlx concurrently -k -s first \"node packages/astro/test/benchmark/simple/server.mjs\" \"pnpm dlx autocannon -c 100 -d 30 -p 10 localhost:3002/\"",
+    "benchmark": "pnpm --filter @benchmark/simple run build && pnpm dlx concurrently -k -s first --raw \"node packages/astro/test/benchmark/simple/server.mjs\" \"pnpm dlx autocannon -c 100 -d 30 -p 10 localhost:3002/\"",
     "lint": "eslint .",
     "version": "changeset version && pnpm install --no-frozen-lockfile && pnpm run format"
   },


### PR DESCRIPTION
Currently it is output like this:

```
**Node**: 14
**PR**: [0m[1][0m 23k requests in 30.11s, 1.57 GB read
**MAIN**: [0m[1][0m 22k requests in 30.08s, 1.53 GB read
```

With this PR it should instead become:

```
**Node**: 14
**PR**: 23k requests in 30.11s, 1.57 GB read
**MAIN**: 22k requests in 30.08s, 1.53 GB read
```