### PR TITLE
doc(node): fix wrong import

### DIFF
--- a/packages/integrations/node/README.md
+++ b/packages/integrations/node/README.md
@@ -65,7 +65,7 @@ Controls whether the adapter builds to `middleware` or `standalone` mode.
 - `middleware` mode allows the built output to be used as middleware for another Node.js server, like Express.js or Fastify.
     ```js
     import { defineConfig } from 'astro/config';
-    import nodejs from '@astrojs/node';
+    import node from '@astrojs/node';
 
     export default defineConfig({
       output: 'server',


### PR DESCRIPTION
## Changes

- Fix node adapter exemple in README to match the function used bellow 

## Testing

no need

## Docs

no need


(And thanks for building Astro, I use it daily at work, It's realy great :) )