### PR TITLE
Compat with Astro < 1.5

### DIFF
--- a/.changeset/tender-cars-wait.md
+++ b/.changeset/tender-cars-wait.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/tailwind': patch
+---
+
+Make Tailwind integration compatible with Astro < 1.5

--- a/packages/integrations/tailwind/src/index.ts
+++ b/packages/integrations/tailwind/src/index.ts
@@ -103,7 +103,7 @@ export default function tailwindIntegration(options?: TailwindOptions): AstroInt
 					);
 				}
 
-				if (userConfig?.filePath) {
+				if (addWatchFile && userConfig?.filePath) {
 					addWatchFile(userConfig.filePath);
 				}
 


### PR DESCRIPTION
## Changes

- Tailwind is depending on an Astro 1.5 API. This fixes that

## Testing

no, quick fix

## Docs

N/A, bug fix