### PR TITLE
fix: pnpm install command on astro add

### DIFF
--- a/.changeset/tender-lemons-remain.md
+++ b/.changeset/tender-lemons-remain.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `astro add` pnpm command

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -573,7 +573,7 @@ async function getInstallIntegrationsCommand({
 		case 'yarn':
 			return { pm: 'yarn', command: 'add', flags: [], dependencies };
 		case 'pnpm':
-			return { pm: 'pnpm', command: 'install', flags: [], dependencies };
+			return { pm: 'pnpm', command: 'add', flags: [], dependencies };
 		default:
 			return null;
 	}


### PR DESCRIPTION
## Changes

`pnpm install <pkg>` is deprecated, `pnpm add <pkg>` should be used instead

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
