### PR TITLE
Suppress warnings for solidjs dependency crawling

### DIFF
--- a/.changeset/silver-hotels-jam.md
+++ b/.changeset/silver-hotels-jam.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/solid-js': patch
+---
+
+Suppress warnings for dependency crawling

--- a/packages/integrations/solid/src/dependencies.ts
+++ b/packages/integrations/solid/src/dependencies.ts
@@ -45,9 +45,7 @@ export function getSolidDeps(root: URL) {
 					}
 					dir = parent;
 				}
-			} catch (e) {
-				console.warn("Couldn't find package.json for", dep, e);
-			}
+			} catch {}
 		}
 	});
 	return deps.reduce<string[]>((acc, dep, i) => {


### PR DESCRIPTION
## Changes

The latest solidjs integration crawls for solidjs libraries, but this generates a warning for pure ESM libraries that do not have a CJS entrypoint (since it relies on `require.resolve`).

Since the crawling is best-effort, we can suppress the warning here.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested with a local project.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A