### PR TITLE
Implicit element types

### DIFF
--- a/.changeset/little-dodos-beam.md
+++ b/.changeset/little-dodos-beam.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Separate type definitions for built-in HTML elements and custom elements. Helpful when implementing an "as" prop similar to [styled-components](https://styled-components.com/docs/api#as-polymorphic-prop).

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -1288,7 +1288,7 @@ declare namespace astroHTML.JSX {
 		zoomAndPan?: string | undefined | null;
 	}
 
-	interface IntrinsicElements {
+	interface DefinedIntrinsicElements {
 		// HTML
 		a: AnchorHTMLAttributes;
 		abbr: HTMLAttributes;
@@ -1461,8 +1461,10 @@ declare namespace astroHTML.JSX {
 		tspan: SVGAttributes;
 		use: SVGAttributes;
 		view: SVGAttributes;
+	}
 
-		// Allow for arbitrary elements
-		[name: string]: { [name: string]: any };
+	interface IntrinsicElements extends DefinedIntrinsicElements {
+	  // Allow for arbitrary elements
+	  [name: string]: { [name: string]: any };
 	}
 }


### PR DESCRIPTION
## Changes

- Separates built-in elements and custom elements from the `IntrinsicElements` type definition
- This lets you use `keyof DefinedIntrinsicElements` to get a list of all supported HTML elements, for implementing an `as` prop similar to [styled-components](https://styled-components.com/docs/api#as-polymorphic-prop)
- Fixes #4915

## Testing

I did not test this Typescript-only change. I didn't see any references to the changed type in the codebase, but I'm happy to add tests if necessary. Please provide guidance on what those might look like.

## Docs

The `IntrinsicElements` type interface is not documented anywhere at the moment, so this change shouldn't require any documentation updates.
