### PR TITLE
enable access to cloudflare runtime

### DIFF
--- a/.changeset/poor-frogs-clean.md
+++ b/.changeset/poor-frogs-clean.md
@@ -3,3 +3,4 @@
 ---
 
 enable access to cloudflare runtime [KV, R2, Durable Objects]
+- access native cloudflare runtime through `import { getRuntime } from "@astrojs/cloudflare/runtime"` now you can call `getRuntime(Astro.request)` and get access to the runtime environment

--- a/.changeset/poor-frogs-clean.md
+++ b/.changeset/poor-frogs-clean.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+enable access to cloudflare runtime [KV, R2, Durable Objects]

--- a/packages/integrations/cloudflare/README.md
+++ b/packages/integrations/cloudflare/README.md
@@ -68,6 +68,18 @@ $ pnpm install wrangler --save-dev
 
 It's then possible to update the preview script in your `package.json` to `"preview": "wrangler pages dev ./dist"`.This will allow you run your entire application locally with [Wrangler](https://github.com/cloudflare/wrangler2), which supports secrets, environment variables, KV namespaces, Durable Objects and [all other supported Cloudflare bindings](https://developers.cloudflare.com/pages/platform/functions/#adding-bindings).
 
+## Access to the cloudflare runtime
+
+You have the posibility to access all the cloudflare bindings and environment variables from your astro pages and api routes through the adapter API
+
+```
+import { getRuntime } from "@astrojs/cloudflare/runtime";
+
+getRuntime(Astro.request);
+```
+
+Depending your adapter mode (advanced = worker, directory = pages) the runtime object will look a little different due to the difference in the cloudflare API.
+
 ## Streams
 
 Some integrations such as [React](https://github.com/withastro/astro/tree/main/packages/integrations/react) rely on web streams. Currently Cloudflare Pages Functions require enabling a flag to support Streams.

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astrojs/cloudflare",
-  "description": "Deploy your site to cloudflare pages functions",
+  "description": "Deploy your site to cloudflare workers or cloudflare pages",
   "version": "3.1.0",
   "type": "module",
   "types": "./dist/index.d.ts",
@@ -19,6 +19,7 @@
   "homepage": "https://docs.astro.build/en/guides/integrations-guide/cloudflare/",
   "exports": {
     ".": "./dist/index.js",
+    "./runtime": "./dist/runtime.js",
     "./server.advanced.js": "./dist/server.advanced.js",
     "./server.directory.js": "./dist/server.directory.js",
     "./package.json": "./package.json"

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -19,7 +19,10 @@
   "homepage": "https://docs.astro.build/en/guides/integrations-guide/cloudflare/",
   "exports": {
     ".": "./dist/index.js",
-    "./runtime": "./dist/runtime.js",
+    "./runtime": {
+      "import": "./dist/runtime.js",
+      "types": "./dist/runtime.d.ts"
+    },
     "./server.advanced.js": "./dist/server.advanced.js",
     "./server.directory.js": "./dist/server.directory.js",
     "./package.json": "./package.json"

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -19,10 +19,7 @@
   "homepage": "https://docs.astro.build/en/guides/integrations-guide/cloudflare/",
   "exports": {
     ".": "./dist/index.js",
-    "./runtime": {
-      "import": "./dist/runtime.js",
-      "types": "./dist/runtime.d.ts"
-    },
+    "./runtime": "./dist/runtime.js",
     "./server.advanced.js": "./dist/server.advanced.js",
     "./server.directory.js": "./dist/server.directory.js",
     "./package.json": "./package.json"

--- a/packages/integrations/cloudflare/src/runtime.ts
+++ b/packages/integrations/cloudflare/src/runtime.ts
@@ -1,7 +1,20 @@
+export type WorkerRuntime<T> = {
+	name: 'cloudflare';
+	env: T;
+	waitUntil(promise: Promise<any>): void;
+	passThroughOnException(): void;
+};
 
-export function getRuntime(request: Request): any {
-  return Reflect.get(
-    request,
-    Symbol.for('runtime')
-  );
+export type PagesRuntime<T, U> = {
+	name: 'cloudflare';
+	env: T;
+	functionPath: string;
+	params: Record<string, string>;
+	data: U;
+	waitUntil(promise: Promise<any>): void;
+	next(request: Request): void;
+};
+
+export function getRuntime<T, U>(request: Request): WorkerRuntime<T> | PagesRuntime<T, U> {
+	return Reflect.get(request, Symbol.for('runtime'));
 }

--- a/packages/integrations/cloudflare/src/runtime.ts
+++ b/packages/integrations/cloudflare/src/runtime.ts
@@ -1,0 +1,7 @@
+
+export function getRuntime(request: Request): any {
+  return Reflect.get(
+    request,
+    Symbol.for('runtime')
+  );
+}

--- a/packages/integrations/cloudflare/src/runtime.ts
+++ b/packages/integrations/cloudflare/src/runtime.ts
@@ -15,6 +15,14 @@ export type PagesRuntime<T = unknown, U = unknown> = {
 	next(request: Request): void;
 };
 
-export function getRuntime<T = unknown, U = unknown>(request: Request): WorkerRuntime<T> | PagesRuntime<T, U> {
-	return Reflect.get(request, Symbol.for('runtime'));
+export function getRuntime<T = unknown, U = unknown>(
+	request: Request
+): WorkerRuntime<T> | PagesRuntime<T, U> {
+	if (!!request) {
+		return Reflect.get(request, Symbol.for('runtime'));
+	} else {
+		throw new Error(
+			'To retrieve the current cloudflare runtime you need to pass in the Astro request object'
+		);
+	}
 }

--- a/packages/integrations/cloudflare/src/runtime.ts
+++ b/packages/integrations/cloudflare/src/runtime.ts
@@ -1,11 +1,11 @@
-export type WorkerRuntime<T> = {
+export type WorkerRuntime<T = unknown> = {
 	name: 'cloudflare';
 	env: T;
 	waitUntil(promise: Promise<any>): void;
 	passThroughOnException(): void;
 };
 
-export type PagesRuntime<T, U> = {
+export type PagesRuntime<T = unknown, U = unknown> = {
 	name: 'cloudflare';
 	env: T;
 	functionPath: string;
@@ -15,6 +15,6 @@ export type PagesRuntime<T, U> = {
 	next(request: Request): void;
 };
 
-export function getRuntime<T, U>(request: Request): WorkerRuntime<T> | PagesRuntime<T, U> {
+export function getRuntime<T = unknown, U = unknown>(request: Request): WorkerRuntime<T> | PagesRuntime<T, U> {
 	return Reflect.get(request, Symbol.for('runtime'));
 }

--- a/packages/integrations/cloudflare/src/server.advanced.ts
+++ b/packages/integrations/cloudflare/src/server.advanced.ts
@@ -5,16 +5,14 @@ import { App } from 'astro/app';
 
 type Env = {
 	ASSETS: { fetch: (req: Request) => Promise<Response> };
-  name: string;
+	name: string;
 };
 
 export function createExports(manifest: SSRManifest) {
 	const app = new App(manifest, false);
 
 	const fetch = async (request: Request, env: Env, context: any) => {
-    
 		const { origin, pathname } = new URL(request.url);
-    env.name = "cloudflare";
 
 		// static assets
 		if (manifest.assets.has(pathname)) {
@@ -29,11 +27,7 @@ export function createExports(manifest: SSRManifest) {
 				Symbol.for('astro.clientAddress'),
 				request.headers.get('cf-connecting-ip')
 			);
-      Reflect.set(
-        request,
-        Symbol.for('runtime'),
-        { env, ...context }
-      );
+			Reflect.set(request, Symbol.for('runtime'), { env, name: 'cloudflare', ...context });
 			let response = await app.render(request, routeData);
 
 			if (app.setCookieHeaders) {

--- a/packages/integrations/cloudflare/src/server.advanced.ts
+++ b/packages/integrations/cloudflare/src/server.advanced.ts
@@ -5,6 +5,7 @@ import { App } from 'astro/app';
 
 type Env = {
 	ASSETS: { fetch: (req: Request) => Promise<Response> };
+  name: string;
 };
 
 export function createExports(manifest: SSRManifest) {
@@ -12,6 +13,7 @@ export function createExports(manifest: SSRManifest) {
 
 	const fetch = async (request: Request, env: Env) => {
 		const { origin, pathname } = new URL(request.url);
+    env.name = "cloudflare";
 
 		// static assets
 		if (manifest.assets.has(pathname)) {
@@ -26,6 +28,11 @@ export function createExports(manifest: SSRManifest) {
 				Symbol.for('astro.clientAddress'),
 				request.headers.get('cf-connecting-ip')
 			);
+      Reflect.set(
+        request,
+        Symbol.for('runtime'),
+        env
+      );
 			let response = await app.render(request, routeData);
 
 			if (app.setCookieHeaders) {

--- a/packages/integrations/cloudflare/src/server.advanced.ts
+++ b/packages/integrations/cloudflare/src/server.advanced.ts
@@ -11,7 +11,8 @@ type Env = {
 export function createExports(manifest: SSRManifest) {
 	const app = new App(manifest, false);
 
-	const fetch = async (request: Request, env: Env) => {
+	const fetch = async (request: Request, env: Env, context: any) => {
+    
 		const { origin, pathname } = new URL(request.url);
     env.name = "cloudflare";
 
@@ -31,7 +32,7 @@ export function createExports(manifest: SSRManifest) {
       Reflect.set(
         request,
         Symbol.for('runtime'),
-        env
+        { env, ...context }
       );
 			let response = await app.render(request, routeData);
 

--- a/packages/integrations/cloudflare/src/server.directory.ts
+++ b/packages/integrations/cloudflare/src/server.directory.ts
@@ -9,14 +9,12 @@ export function createExports(manifest: SSRManifest) {
 	const onRequest = async ({
 		request,
 		next,
-    ...runtimeEnv
+		...runtimeEnv
 	}: {
 		request: Request;
 		next: (request: Request) => void;
 	} & Record<string, unknown>) => {
 		const { origin, pathname } = new URL(request.url);
-    runtimeEnv.name = "cloudflare";
-
 		// static assets
 		if (manifest.assets.has(pathname)) {
 			const assetRequest = new Request(`${origin}/static${pathname}`, request);
@@ -30,11 +28,11 @@ export function createExports(manifest: SSRManifest) {
 				Symbol.for('astro.clientAddress'),
 				request.headers.get('cf-connecting-ip')
 			);
-      Reflect.set(
-        request,
-        Symbol.for('runtime'),
-        runtimeEnv
-      );
+			Reflect.set(request, Symbol.for('runtime'), {
+				...runtimeEnv,
+				name: 'cloudflare',
+				next,
+			});
 			let response = await app.render(request, routeData);
 
 			if (app.setCookieHeaders) {

--- a/packages/integrations/cloudflare/src/server.directory.ts
+++ b/packages/integrations/cloudflare/src/server.directory.ts
@@ -9,11 +9,13 @@ export function createExports(manifest: SSRManifest) {
 	const onRequest = async ({
 		request,
 		next,
+    ...runtimeEnv
 	}: {
 		request: Request;
 		next: (request: Request) => void;
-	}) => {
+	} & Record<string, unknown>) => {
 		const { origin, pathname } = new URL(request.url);
+    runtimeEnv.name = "cloudflare";
 
 		// static assets
 		if (manifest.assets.has(pathname)) {
@@ -28,6 +30,11 @@ export function createExports(manifest: SSRManifest) {
 				Symbol.for('astro.clientAddress'),
 				request.headers.get('cf-connecting-ip')
 			);
+      Reflect.set(
+        request,
+        Symbol.for('runtime'),
+        runtimeEnv
+      );
 			let response = await app.render(request, routeData);
 
 			if (app.setCookieHeaders) {


### PR DESCRIPTION
## Changes

- adding a runtime symbol onto the request object to enable access to the `cloudflare` runtime, therefore enables to `KV`,  `Durable Objects`, `R2` services

## Testing

Take any example from the repo and add `cloudflare` to astro. Add the following lines into the index:
```
// get runtime
const runtime = Reflect.get(Astro.request, Symbol.for("runtime"));

if (runtime && runtime.name === "cloudflare") {
  console.log("Running on Cloudflare Workers");
}
```

## Docs
This would add a piece of documentation to the `cloudflare` worker how it is possible to access services like `KV`, `R2` and `Durable Objects`.
/cc @withastro/maintainers-docs for feedback!