### PR TITLE
Support spread parameters for server endpoints

### DIFF
--- a/.changeset/gold-roses-argue.md
+++ b/.changeset/gold-roses-argue.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Support spread parameters for server endpoints

--- a/packages/astro/src/core/routing/manifest/generator.ts
+++ b/packages/astro/src/core/routing/manifest/generator.ts
@@ -8,23 +8,26 @@ export function getRouteGenerator(
 ) {
 	const template = segments
 		.map((segment) => {
-			return segment[0].spread
-				? `/:${segment[0].content.slice(3)}(.*)?`
-				: '/' +
-						segment
-							.map((part) => {
-								if (part)
-									return part.dynamic
-										? `:${part.content}`
-										: part.content
-												.normalize()
-												.replace(/\?/g, '%3F')
-												.replace(/#/g, '%23')
-												.replace(/%5B/g, '[')
-												.replace(/%5D/g, ']')
-												.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-							})
-							.join('');
+			return (
+				'/' +
+				segment
+					.map((part) => {
+						if (part.spread) {
+							return `:${part.content.slice(3)}(.*)?`;
+						} else if (part.dynamic) {
+							return `:${part.content}`;
+						} else {
+							return part.content
+								.normalize()
+								.replace(/\?/g, '%3F')
+								.replace(/#/g, '%23')
+								.replace(/%5B/g, '[')
+								.replace(/%5D/g, ']')
+								.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+						}
+					})
+					.join('')
+			);
 		})
 		.join('');
 

--- a/packages/astro/test/fixtures/routing-priority/src/pages/api/catch/[...slug].json.ts
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/api/catch/[...slug].json.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from 'astro';
+
+export const get: APIRoute = async ({ params }) => {
+  return {
+    body: JSON.stringify({
+      path: params.slug,
+    }),
+  };
+};
+
+export function getStaticPaths() {
+  return [{ params: { slug: 'a' } }, { params: { slug: 'b/c' } }];
+}

--- a/packages/astro/test/fixtures/routing-priority/src/pages/api/catch/[foo]-[bar].json.ts
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/api/catch/[foo]-[bar].json.ts
@@ -1,0 +1,14 @@
+import type { APIRoute } from 'astro';
+
+export const get: APIRoute = async ({ params }) => {
+  return {
+    body: JSON.stringify({
+      foo: params.foo,
+			bar: params.bar,
+    }),
+  };
+};
+
+export function getStaticPaths() {
+  return [{ params: { foo: 'a', bar: 'b' } }];
+}

--- a/packages/astro/test/routing-priority.test.js
+++ b/packages/astro/test/routing-priority.test.js
@@ -106,6 +106,21 @@ const routes = [
 		url: '/empty-slug/undefined',
 		fourOhFour: true,
 	},
+	{
+		description: 'matches /api/catch/a.json to api/catch/[...slug].json.ts',
+		url: '/api/catch/a.json',
+		htmlMatch: JSON.stringify({ path: 'a' }),
+	},
+	{
+		description: 'matches /api/catch/b/c.json to api/catch/[...slug].json.ts',
+		url: '/api/catch/b/c.json',
+		htmlMatch: JSON.stringify({ path: 'b/c' }),
+	},
+	{
+		description: 'matches /api/catch/a-b.json to api/catch/[foo]-[bar].json.ts',
+		url: '/api/catch/a-b.json',
+		htmlMatch: JSON.stringify({ foo: 'a', bar: 'b' }),
+	},
 ];
 
 function appendForwardSlash(path) {
@@ -123,9 +138,11 @@ describe('Routing priority', () => {
 			await fixture.build();
 		});
 
-		routes.forEach(({ description, url, fourOhFour, h1, p }) => {
+		routes.forEach(({ description, url, fourOhFour, h1, p, htmlMatch }) => {
+			const isEndpoint = htmlMatch && !h1 && !p;
+
 			it(description, async () => {
-				const htmlFile = `${appendForwardSlash(url)}index.html`;
+				const htmlFile = isEndpoint ? url : `${appendForwardSlash(url)}index.html`;
 
 				if (fourOhFour) {
 					expect(fixture.pathExists(htmlFile)).to.be.false;
@@ -135,10 +152,16 @@ describe('Routing priority', () => {
 				const html = await fixture.readFile(htmlFile);
 				const $ = cheerioLoad(html);
 
-				expect($('h1').text()).to.equal(h1);
+				if (h1) {
+					expect($('h1').text()).to.equal(h1);
+				}
 
 				if (p) {
 					expect($('p').text()).to.equal(p);
+				}
+
+				if (htmlMatch) {
+					expect(html).to.equal(htmlMatch);
 				}
 			});
 		});
@@ -160,7 +183,9 @@ describe('Routing priority', () => {
 			await devServer.stop();
 		});
 
-		routes.forEach(({ description, url, fourOhFour, h1, p }) => {
+		routes.forEach(({ description, url, fourOhFour, h1, p, htmlMatch }) => {
+			const isEndpoint = htmlMatch && !h1 && !p;
+
 			// checks URLs as written above
 			it(description, async () => {
 				const html = await fixture.fetch(url).then((res) => res.text());
@@ -171,12 +196,21 @@ describe('Routing priority', () => {
 					return;
 				}
 
-				expect($('h1').text()).to.equal(h1);
+				if (h1) {
+					expect($('h1').text()).to.equal(h1);
+				}
 
 				if (p) {
 					expect($('p').text()).to.equal(p);
 				}
+
+				if (htmlMatch) {
+					expect(html).to.equal(htmlMatch);
+				}
 			});
+
+			// skip for endpoint page test
+			if (isEndpoint) return;
 
 			// checks with trailing slashes, ex: '/de/' instead of '/de'
 			it(`${description} (trailing slash)`, async () => {
@@ -188,10 +222,16 @@ describe('Routing priority', () => {
 					return;
 				}
 
-				expect($('h1').text()).to.equal(h1);
+				if (h1) {
+					expect($('h1').text()).to.equal(h1);
+				}
 
 				if (p) {
 					expect($('p').text()).to.equal(p);
+				}
+
+				if (htmlMatch) {
+					expect(html).to.equal(htmlMatch);
 				}
 			});
 
@@ -207,10 +247,16 @@ describe('Routing priority', () => {
 					return;
 				}
 
-				expect($('h1').text()).to.equal(h1);
+				if (h1) {
+					expect($('h1').text()).to.equal(h1);
+				}
 
 				if (p) {
 					expect($('p').text()).to.equal(p);
+				}
+
+				if (htmlMatch) {
+					expect(html).to.equal(htmlMatch);
 				}
 			});
 		});


### PR DESCRIPTION
## Changes

Fix #3671 

Support `[...slug].json.ts`. `[...slug].ts` already works, but the `.json` was tripping the path matcher. 

I've marked this as a patch as this was supposed to work, but it could also be a minor.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added `routing-priority` tests

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A. Routing logic has been explained in https://docs.astro.build/en/core-concepts/routing/ so they should apply here too.
