### PR TITLE
Fix types not working properly when using `moduleResolution: 'node16'`

### DIFF
--- a/.changeset/olive-jeans-shout.md
+++ b/.changeset/olive-jeans-shout.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix types not working properly when using `moduleResolution: 'node16'`

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -23,12 +23,12 @@ declare namespace astroHTML.JSX {
 		children?: Children;
 	}
 
-	type AstroBuiltinProps = import('./dist/@types/astro').AstroBuiltinProps;
-	type AstroBuiltinAttributes = import('./dist/@types/astro').AstroBuiltinAttributes;
-	type AstroDefineVarsAttribute = import('./dist/@types/astro').AstroDefineVarsAttribute;
-	type AstroScriptAttributes = import('./dist/@types/astro').AstroScriptAttributes &
+	type AstroBuiltinProps = import('./dist/@types/astro.js').AstroBuiltinProps;
+	type AstroBuiltinAttributes = import('./dist/@types/astro.js').AstroBuiltinAttributes;
+	type AstroDefineVarsAttribute = import('./dist/@types/astro.js').AstroDefineVarsAttribute;
+	type AstroScriptAttributes = import('./dist/@types/astro.js').AstroScriptAttributes &
 		AstroDefineVarsAttribute;
-	type AstroStyleAttributes = import('./dist/@types/astro').AstroStyleAttributes &
+	type AstroStyleAttributes = import('./dist/@types/astro.js').AstroStyleAttributes &
 		AstroDefineVarsAttribute;
 
 	// This is an unfortunate use of `any`, but unfortunately we can't make a type that works for every framework

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -1,5 +1,5 @@
 type ViteUserConfig = import('vite').UserConfig;
-type AstroUserConfig = import('./dist/@types/astro').AstroUserConfig;
+type AstroUserConfig = import('./dist/@types/astro.js').AstroUserConfig;
 
 /**
  * See the full Astro Configuration API Documentation

--- a/packages/astro/env.d.ts
+++ b/packages/astro/env.d.ts
@@ -4,7 +4,7 @@
 // As such, if the typings you're trying to add should be available inside ex: React components, they should instead
 // be inside `client-base.d.ts`
 
-type Astro = import('./dist/@types/astro').AstroGlobal;
+type Astro = import('./dist/@types/astro.js').AstroGlobal;
 
 // We have to duplicate the description here because editors won't show the JSDoc comment from the imported type
 // However, they will for its properties, ex: Astro.request will show the AstroGlobal.request description

--- a/packages/astro/import-meta.d.ts
+++ b/packages/astro/import-meta.d.ts
@@ -1,4 +1,4 @@
-// File vendored from Vite itself, as a workaround to https://github.com/vitejs/vite/pull/9827 until Vite 3.2 comes out
+// File vendored from Vite itself, as a workaround to https://github.com/vitejs/vite/pull/9827 until Vite 4 comes out
 
 // This file is an augmentation to the built-in ImportMeta interface
 // Thus cannot contain any top-level imports

--- a/packages/astro/import-meta.d.ts
+++ b/packages/astro/import-meta.d.ts
@@ -1,4 +1,4 @@
-// File vendored from Vite itself, as a workaround to https://github.com/vitejs/vite/pull/9827 until Vite 4 comes out
+// File vendored from Vite itself, as a workaround to https://github.com/vitejs/vite/pull/9827 until Vite 3.2 comes out
 
 // This file is an augmentation to the built-in ImportMeta interface
 // Thus cannot contain any top-level imports

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -37,7 +37,10 @@
     "./tsconfigs/*": "./tsconfigs/*.json",
     "./jsx/*": "./dist/jsx/*",
     "./jsx-runtime": "./dist/jsx-runtime/index.js",
-    "./config": "./config.mjs",
+    "./config": {
+      "types": "./config.d.ts",
+      "default": "./config.mjs"
+    },
     "./app": "./dist/core/app/index.js",
     "./app/node": "./dist/core/app/node.js",
     "./client/*": "./dist/runtime/client/*",


### PR DESCRIPTION
## Changes

`moduleResolution: 'node16'` absolutely requires file extensions to be added to import paths, we were missing those in a few places which caused `astro check` (and in the editor too) to not being able to properly get certain types. This fix that

Fix https://github.com/withastro/astro/issues/5100

## Testing

Tested manually

## Docs

N/A
