### PR TITLE
Fix missing image src in config for examples docs

### DIFF
--- a/examples/docs/src/config.ts
+++ b/examples/docs/src/config.ts
@@ -6,7 +6,7 @@ export const SITE = {
 
 export const OPEN_GRAPH = {
 	image: {
-		src: 'https://github.com/withastro/astro/blob/main/assets/social/banner.jpg?raw=true',
+		src: 'https://github.com/withastro/astro/blob/main/assets/social/banner-minimal.png?raw=true',
 		alt:
 			'astro logo on a starry expanse of space,' +
 			' with a purple saturn-like planet floating in the right foreground',


### PR DESCRIPTION
## Changes

replace missing `banner.jpg` resource with available `banner-minimal.png` in `config.ts` for docs example.

## Testing

tested new url. non astro related. no test required.
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

does not effect astro. no documentation changes required.
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
