### PR TITLE
Ensure CLI flags override function-style server config

### DIFF
--- a/.changeset/eighty-planes-kneel.md
+++ b/.changeset/eighty-planes-kneel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Ensure CLI flags override function-style server config

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -271,8 +271,18 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: URL) {
 			.default({}),
 		server: z.preprocess(
 			// preprocess
-			(val) =>
-				typeof val === 'function' ? val({ command: cmd === 'dev' ? 'dev' : 'preview' }) : val,
+			(val) => {
+				if (typeof val === 'function') {
+					const result = val({ command: cmd === 'dev' ? 'dev' : 'preview' });
+					// @ts-expect-error revive attached prop added from CLI flags
+					if (val.port) result.port = val.port;
+					// @ts-expect-error revive attached prop added from CLI flags
+					if (val.host) result.host = val.host;
+					return result;
+				} else {
+					return val;
+				}
+			},
 			// validate
 			z
 				.object({

--- a/packages/astro/test/fixtures/astro-basic/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-basic/astro.config.mjs
@@ -4,4 +4,6 @@ import preact from '@astrojs/preact';
 // https://astro.build/config
 export default defineConfig({
 	integrations: [preact()],
+	// make sure CLI flags have precedence
+  server: () => ({ port: 3000 })
 });


### PR DESCRIPTION
## Changes

Fix #5102 

Revive the attached CLI flags props from https://github.com/withastro/astro/blob/c0db5818e995ea531af86c1f539129d59a260241/packages/astro/src/core/config/config.ts#L118-L127

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Updated the `astro-basic` config that would cause `cli.test.js` to fail without this PR

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a
