### PR TITLE
Mark @astrojs/node to be noExternal

### DIFF
--- a/.changeset/afraid-baboons-return.md
+++ b/.changeset/afraid-baboons-return.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Fixes finding the client folder for serving assets

--- a/packages/integrations/node/src/index.ts
+++ b/packages/integrations/node/src/index.ts
@@ -21,6 +21,15 @@ export default function createIntegration(userOptions: UserOptions): AstroIntegr
 	return {
 		name: '@astrojs/node',
 		hooks: {
+			'astro:config:setup': ({ updateConfig }) => {
+        updateConfig({
+          vite: {
+            ssr: {
+              noExternal: ['@astrojs/node']
+            }
+          }
+        });
+      },
 			'astro:config:done': ({ setAdapter, config }) => {
 				needsBuildConfig = !config.build?.server;
 				_options = {


### PR DESCRIPTION
## Changes

- We want the server.js to be bundled, so that we can find the relative path to the `client/` directory.
- Fixes https://github.com/withastro/astro/issues/5093

## Testing

- Tests already worked within the monorepo, because the monorepo does not allow actual node_modules/ folders which is where the bug occured.
- Tested with the example in the issue.

## Docs

N/A, bug fix