### PR TITLE
update readme language sidebar

### DIFF
--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -132,18 +132,24 @@ Last step: you'll need to add a new entry to your sidebar, to create the table o
 ```diff
 // src/config.ts
 export const SIDEBAR = {
-  en: [
-    { text: 'Section Header', header: true, },
-    { text: 'Introduction', link: 'en/introduction' },
-    // ...
-  ],
-+  es: [
-+    { text: 'Encabezado de sección', header: true, },
-+    { text: 'Introducción', link: 'es/introduction' },
-+    // ...
-+  ],
-};
 
+en: {
+ 'Section Header': [
+  { text: 'Introduction', link: 'en/introduction' },
+	{ text: 'Page 2', link: 'en/page-2' },
+	{ text: 'Page 3', link: 'en/page-3' },
+ ],
+ 'Another Section': [{ text: 'Page 4', link: 'en/page-4' }],
+},
++ es: {
++  'Encabezado de sección': [
++  { text: 'Introducción', link: 'es/introduction' },
++  { text: 'Página 2', link: 'es/page-2' },
++  { text: 'Página 3', link: 'es/page-3' },
++  ],
++  'Otra Seccion': [{ text: 'Página 4', link: 'es/page-4' }],
++ },
+  
 // ...
 ```
 


### PR DESCRIPTION
config.ts show languages as json objects, where each language object contains an array of sections. However, README.md shows languages as arrays, each containing key: value objects. Assuming config.ts is more current than docs, I updated the readme to match config.ts

## Changes

- What does this change?
The Multiple Languages support section of README.md

No testing as it's a docs-only suggestion.

## Testing
None

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
This will affect a user's behavior.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
