### PR TITLE
fix KNOWN_LANGUAGES option child element for multi-language support

### DIFF
--- a/examples/docs/src/components/Header/LanguageSelect.tsx
+++ b/examples/docs/src/components/Header/LanguageSelect.tsx
@@ -37,7 +37,7 @@ const LanguageSelect: FunctionComponent<{ lang: string }> = ({ lang }) => {
 				{Object.entries(KNOWN_LANGUAGES).map(([key, value]) => {
 					return (
 						<option value={value} key={value}>
-							<span>{key}</span>
+							{key}
 						</option>
 					);
 				})}


### PR DESCRIPTION
adding a 2nd (or more) language(s) to the docs example template breaks the map at the end of LanguageSelect.tsx. This causes hydration errors and ReactDOM warnings (see screenshot) complaining about child tags of \<option\> tags in the map. Although the selector and pages function despite the errors, one of the errors is: "the entire root will switch to client rendering".

## Changes

- Removing \<span /\> tags appears to resolve warnings and errors and functionality is as expected (language selector works).


## Testing
Followed the Multiple Languages support section from README.md and added the required translated content pages for Spanish. After removing the \<span /\> tags, both spanish and english worked as expected in the selector.

## Docs
This change may not require changes to users behavior, nor may docs require updating...assuming my fix is acceptable, as it is a code-only fix for when users add 2 or more languages.
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
2 or more languages before the change with child tags of \<option /\>:
![Screenshot from 2022-10-18 22-19-55](https://user-images.githubusercontent.com/3238636/196583028-2748309b-15c0-412b-a3b2-8d6085384e6a.png)

After removing child tags of \<option /\>:
![Screenshot from 2022-10-18 22-38-05](https://user-images.githubusercontent.com/3238636/196584326-bed51698-dee6-427e-a428-d7d1b2e1976a.png)

