### PR TITLE
Use `fs.promises.rm` to remove node deprecation warning

### DIFF
--- a/.changeset/eight-swans-divide.md
+++ b/.changeset/eight-swans-divide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Use `fs.promises.rm` to remove node deprecation warning

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -270,7 +270,7 @@ async function cleanSsrOutput(opts: StaticBuildOptions) {
 				const url = new URL(filename, out);
 				const folder = await fs.promises.readdir(url);
 				if (!folder.length) {
-					await fs.promises.rmdir(url, { recursive: true });
+					await fs.promises.rm(url, { recursive: true, force: true });
 				}
 			})
 		);


### PR DESCRIPTION
## Changes

`fs.promises.rmdir` is deprecated. I got this warning when building:

```
(node:45043) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
```

https://nodejs.org/api/deprecations.html#DEP0147

Use `fs.promises.rm(path, { recursive: true, force: true })` instead.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing test should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A