### PR TITLE
Fixes index page with build.format=file

### DIFF
--- a/.changeset/many-lions-relate.md
+++ b/.changeset/many-lions-relate.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes index page with build.format=file

--- a/packages/astro/src/core/build/common.ts
+++ b/packages/astro/src/core/build/common.ts
@@ -30,7 +30,8 @@ export function getOutFolder(
 					return new URL('.' + appendForwardSlash(pathname), outRoot);
 				}
 				case 'file': {
-					return new URL('.' + appendForwardSlash(npath.dirname(pathname)), outRoot);
+					const d = pathname === '' ? pathname : npath.dirname(pathname);
+					return new URL('.' + appendForwardSlash(d), outRoot);
 				}
 			}
 	}

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -34,35 +34,6 @@ import { eachPageData, getPageDataByComponent, sortedCSS } from './internal.js';
 import type { PageBuildData, SingleFileBuiltModule, StaticBuildOptions } from './types';
 import { getTimeStat } from './util.js';
 
-// Render is usually compute, which Node.js can't parallelize well.
-// In real world testing, dropping from 10->1 showed a notiable perf
-// improvement. In the future, we can revisit a smarter parallel
-// system, possibly one that parallelizes if async IO is detected.
-const MAX_CONCURRENT_RENDERS = 1;
-
-// Throttle the rendering a paths to prevents creating too many Promises on the microtask queue.
-function* throttle(max: number, inPaths: string[]) {
-	let tmp = [];
-	let i = 0;
-	for (let path of inPaths) {
-		tmp.push(path);
-		if (i === max) {
-			yield tmp;
-			// Empties the array, to avoid allocating a new one.
-			tmp.length = 0;
-			i = 0;
-		} else {
-			i++;
-		}
-	}
-
-	// If tmp has items in it, that means there were less than {max} paths remaining
-	// at the end, so we need to yield these too.
-	if (tmp.length) {
-		yield tmp;
-	}
-}
-
 function shouldSkipDraft(pageModule: ComponentInstance, settings: AstroSettings): boolean {
 	return (
 		// Drafts are disabled

--- a/packages/astro/test/dynamic-route-build-file.test.js
+++ b/packages/astro/test/dynamic-route-build-file.test.js
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('build.format=file with dynamic routes', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/dynamic-route-build-file',
+			build: {
+				format: 'file'
+			}
+		});
+		await fixture.build();
+	});
+
+	it('Outputs a slug of undefined as the index.html', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerio.load(html);
+		expect($('h1').text()).to.equal('Astro Store');
+	});
+});

--- a/packages/astro/test/fixtures/dynamic-route-build-file/index.html
+++ b/packages/astro/test/fixtures/dynamic-route-build-file/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Astro Store</title>
+  </head>
+  <body>
+    <h1>Astro Store</h1>
+    <p>Welcome to the Astro store!</p>
+  </body>
+</html>

--- a/packages/astro/test/fixtures/dynamic-route-build-file/package.json
+++ b/packages/astro/test/fixtures/dynamic-route-build-file/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/dynamic-route-build-file",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/dynamic-route-build-file/src/pages/[...slug].astro
+++ b/packages/astro/test/fixtures/dynamic-route-build-file/src/pages/[...slug].astro
@@ -1,0 +1,38 @@
+---
+export async function getStaticPaths() {
+  const pages = [
+    {
+      slug: undefined,
+      title: "Astro Store",
+      text: "Welcome to the Astro store!",
+    },
+    {
+      slug: "products",
+      title: "Astro products",
+      text: "We have lots of products for you",
+    },
+    {
+      slug: "products/astro-handbook",
+      title: "The ultimative Astro handbook",
+      text: "If you want to learn Astro, you must read this book.",
+    },
+  ];
+  return pages.map(({ slug, title, text }) => {
+    return {
+      params: { slug },
+      props: { title, text },
+    };
+  });
+}
+
+const { title, text } = Astro.props;
+---
+<html>
+  <head>
+    <title>{title}</title>
+  </head>
+  <body>
+    <h1>{title}</h1>
+    <p>{text}</p>
+  </body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1676,6 +1676,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/dynamic-route-build-file:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/entry-file-names:
     specifiers:
       '@astrojs/preact': 'workspace:'


### PR DESCRIPTION
## Changes

- When using `build.format=file` and a dynamic route of `undefined`, do not use `path.dirname(pathname)` because that will result in `.` and thus build the file to the parent folder.
- Fixes https://github.com/withastro/astro/issues/5121

## Testing

- Fixture test case added

## Docs

N/A,  bug fix