### PR TITLE
Automatically include `vuetify` in `ssr.noExternal`

### DIFF
--- a/.changeset/silly-windows-sin.md
+++ b/.changeset/silly-windows-sin.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vue': patch
+---
+
+Automatically add `vuetify` to `vite.ssr.noExternal`

--- a/packages/integrations/vue/src/index.ts
+++ b/packages/integrations/vue/src/index.ts
@@ -62,7 +62,7 @@ async function getViteConfiguration(options?: Options): Promise<UserConfig> {
 		plugins: [vue(options), virtualAppEntrypoint(options)],
 		ssr: {
 			external: ['@vue/server-renderer'],
-			noExternal: ['vueperslides'],
+			noExternal: ['vuetify', 'vueperslides'],
 		},
 	};
 


### PR DESCRIPTION
## Changes

- Since `vuetify` is a common library, we should include the necessary configuration out of the box
- This PR includes the proper configuration for `vuetify` in the `@astrojs/vue` integration

## Testing

N/A, config change only

## Docs

N/A, config change only
