### PR TITLE
Add `astro/types` for common prop patterns

### DIFF
--- a/.changeset/dirty-cycles-lick.md
+++ b/.changeset/dirty-cycles-lick.md
@@ -9,7 +9,7 @@ Add `astro/types` entrypoint. These utilities can be used for common prop type p
 If you would like to extend valid HTML attributes for a given HTML element, you may use the provided `HTMLAttributes` type—it accepts an element name and returns the valid HTML attributes for that element name.
 
 ```ts
-import { HTMLAttributes } from 'astro/type-utils';
+import { HTMLAttributes } from 'astro/types';
 interface Props extends HTMLAttributes<'a'> {
   myProp?: string;
 };

--- a/.changeset/dirty-cycles-lick.md
+++ b/.changeset/dirty-cycles-lick.md
@@ -2,7 +2,7 @@
 'astro': minor
 ---
 
-Add `astro/type-utils` entrypoint. These utilities can be used for common prop type patterns.
+Add `astro/types` entrypoint. These utilities can be used for common prop type patterns.
 
 ## `HTMLAttributes`
 
@@ -11,26 +11,6 @@ If you would like to extend valid HTML attributes for a given HTML element, you 
 ```ts
 import { HTMLAttributes } from 'astro/type-utils';
 interface Props extends HTMLAttributes<'a'> {
-  myProp?: string;
-};
-```
-
-## `NoProps`
-
-If your component takes no props or slotted content, you can use the provided `NoProps` type.
-
-```ts
-import { NoProps } from 'astro/type-utils';
-type Props = NoProps;
-```
-
-## `WithChildren`
-
-If your component requires children passed to the default slot, you can extend the provided `WithChildren` type.
-
-```ts
-import { WithChildren } from 'astro/type-utils';
-interface Props extends WithChildren {
   myProp?: string;
 };
 ```

--- a/.changeset/dirty-cycles-lick.md
+++ b/.changeset/dirty-cycles-lick.md
@@ -1,0 +1,36 @@
+---
+'astro': minor
+---
+
+Add `astro/type-utils` entrypoint. These utilities can be used for common prop type patterns.
+
+## `HTMLAttributes`
+
+If you would like to extend valid HTML attributes for a given HTML element, you may use the provided `HTMLAttributes` type—it accepts an element name and returns the valid HTML attributes for that element name.
+
+```ts
+import { HTMLAttributes } from 'astro/type-utils';
+interface Props extends HTMLAttributes<'a'> {
+  myProp?: string;
+};
+```
+
+## `NoProps`
+
+If your component takes no props or slotted content, you can use the provided `NoProps` type.
+
+```ts
+import { NoProps } from 'astro/type-utils';
+type Props = NoProps;
+```
+
+## `WithChildren`
+
+If your component requires children passed to the default slot, you can extend the provided `WithChildren` type.
+
+```ts
+import { WithChildren } from 'astro/type-utils';
+interface Props extends WithChildren {
+  myProp?: string;
+};
+```

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -29,6 +29,7 @@
       "default": "./astro.js"
     },
     "./env": "./env.d.ts",
+    "./type-utils": "./type-utils.d.ts",
     "./client": "./client.d.ts",
     "./client-base": "./client-base.d.ts",
     "./import-meta": "./import-meta.d.ts",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -29,7 +29,7 @@
       "default": "./astro.js"
     },
     "./env": "./env.d.ts",
-    "./type-utils": "./type-utils.d.ts",
+    "./types": "./types.d.ts",
     "./client": "./client.d.ts",
     "./client-base": "./client-base.d.ts",
     "./import-meta": "./import-meta.d.ts",

--- a/packages/astro/type-utils.d.ts
+++ b/packages/astro/type-utils.d.ts
@@ -1,0 +1,8 @@
+import './astro-jsx';
+import { AstroBuiltinAttributes } from './dist/@types/astro';
+
+export type HTMLTag = keyof astroHTML.JSX.IntrinsicElements;
+export type HTMLAttributes<Tag extends HTMLTag> = Omit<astroHTML.JSX.IntrinsicElements[Tag], keyof AstroBuiltinAttributes>;
+
+type PolymorphicAttributes<P extends { as: HTMLTag }> = Omit<(P & HTMLAttributes<P['as']>), 'as'> & { as?: P['as'] };
+export type Polymorphic<P extends { as: HTMLTag }> = PolymorphicAttributes<Omit<P, 'as'> & { as: NonNullable<P['as']>}>;

--- a/packages/astro/type-utils.d.ts
+++ b/packages/astro/type-utils.d.ts
@@ -1,8 +1,16 @@
 import './astro-jsx';
 import { AstroBuiltinAttributes } from './dist/@types/astro';
 
-export type HTMLTag = keyof astroHTML.JSX.IntrinsicElements;
+/** Enforce that a component accepts no props or slots */
+export type NoProps = Record<string, never>;
+/** Enforce that a component requires a default slot */
+export type RequireDefaultSlot = { children: any; };
+
+/** Any supported HTML or SVG element name, as defined by the HTML specification */
+export type HTMLTag = keyof astroHTML.JSX.DefinedIntrinsicElements;
+/** The built-in attributes for any known HTML or SVG element name */
 export type HTMLAttributes<Tag extends HTMLTag> = Omit<astroHTML.JSX.IntrinsicElements[Tag], keyof AstroBuiltinAttributes>;
 
-type PolymorphicAttributes<P extends { as: HTMLTag }> = Omit<(P & HTMLAttributes<P['as']>), 'as'> & { as?: P['as'] };
-export type Polymorphic<P extends { as: HTMLTag }> = PolymorphicAttributes<Omit<P, 'as'> & { as: NonNullable<P['as']>}>;
+// TODO: Enable generic/polymorphic types once compiler output stabilizes in the Language Server
+// type PolymorphicAttributes<P extends { as: HTMLTag }> = Omit<(P & HTMLAttributes<P['as']>), 'as'> & { as?: P['as'] };
+// export type Polymorphic<P extends { as: HTMLTag }> = PolymorphicAttributes<Omit<P, 'as'> & { as: NonNullable<P['as']>}>;

--- a/packages/astro/type-utils.d.ts
+++ b/packages/astro/type-utils.d.ts
@@ -4,7 +4,7 @@ import { AstroBuiltinAttributes } from './dist/@types/astro';
 /** Enforce that a component accepts no props or slots */
 export type NoProps = Record<string, never>;
 /** Enforce that a component requires a default slot */
-export type RequireDefaultSlot = { children: any; };
+export type WithChildren = { children: any; };
 
 /** Any supported HTML or SVG element name, as defined by the HTML specification */
 export type HTMLTag = keyof astroHTML.JSX.DefinedIntrinsicElements;

--- a/packages/astro/types.d.ts
+++ b/packages/astro/types.d.ts
@@ -1,11 +1,6 @@
 import './astro-jsx';
 import { AstroBuiltinAttributes } from './dist/@types/astro';
 
-/** Enforce that a component accepts no props or slots */
-export type NoProps = Record<string, never>;
-/** Enforce that a component requires a default slot */
-export type WithChildren = { children: any; };
-
 /** Any supported HTML or SVG element name, as defined by the HTML specification */
 export type HTMLTag = keyof astroHTML.JSX.DefinedIntrinsicElements;
 /** The built-in attributes for any known HTML or SVG element name */


### PR DESCRIPTION
## Changes

- We have some common patterns that folks ask about, so this adds an `astro/types` entrypoint with some helpful utility types.
- This keeps folks from needing to access the `astroHTML.JSX.AnchorHTMLAttributes` stuff directly
- Based on docs section [TypeScript: Common Prop Type Patterns](https://docs.astro.build/en/guides/typescript/#common-prop-type-patterns)
## `HTMLAttributes`

If you would like to extend valid HTML attributes for a given HTML element, you may use the provided `HTMLAttributes` type—it accepts an element name and returns the valid HTML attributes for that element name.

```ts
import { HTMLAttributes } from 'astro/types';
interface Props extends HTMLAttributes<'a'> {
  myProp?: string;
};
```

## Testing

Tested manually

## Docs

https://github.com/withastro/docs/pull/1857