### PR TITLE
Indentation fixes (spaces --> tabs mostly)

### DIFF
--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -23,9 +23,9 @@ export interface Props {
 	theme?: shiki.IThemeRegistration;
 	/**
 	 * Enable word wrapping.
-	 *  - true: enabled.
-	 *  - false: disabled.
-	 *  - null: All overflow styling removed. Code will overflow the element by default.
+	 * - true: enabled.
+	 * - false: disabled.
+	 * - null: All overflow styling removed. Code will overflow the element by default.
 	 *
 	 * @default false
 	 */

--- a/packages/astro/e2e/fixtures/errors/src/components/JSRuntimeError.js
+++ b/packages/astro/e2e/fixtures/errors/src/components/JSRuntimeError.js
@@ -1,3 +1,3 @@
 export default function Error() {
-  return undefinedvar;
+	return undefinedvar;
 }

--- a/packages/astro/e2e/fixtures/errors/src/components/JSSyntaxError.js
+++ b/packages/astro/e2e/fixtures/errors/src/components/JSSyntaxError.js
@@ -1,4 +1,4 @@
 export default function Error() {
-  const 1badvar = true;
-  return 1badvar;
+	const 1badvar = true;
+	return 1badvar;
 }

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -130,7 +130,7 @@ export interface AstroGlobal<Props extends Record<string, any> = Record<string, 
 	 * ```astro
 	 * ---
 	 * export async function getStaticPaths() {
-	 *    return [
+	 *   return [
 	 *     { params: { id: '1' } },
 	 *   ];
 	 * }
@@ -474,7 +474,7 @@ export interface AstroUserConfig {
 	 * import netlify from '@astrojs/netlify/functions';
 	 * {
 	 *   // Example: Build for Netlify serverless deployment
-	 * 	 adapter: netlify(),
+	 *   adapter: netlify(),
 	 * }
 	 * ```
 	 */
@@ -768,7 +768,7 @@ export interface AstroUserConfig {
 		 * {
 		 *   markdown: {
 		 *     extendDefaultPlugins: true,
-		 * 		 remarkPlugins: [exampleRemarkPlugin],
+		 *     remarkPlugins: [exampleRemarkPlugin],
 		 *     rehypePlugins: [exampleRehypePlugin],
 		 *   }
 		 * }
@@ -1208,9 +1208,9 @@ export interface APIContext<Props extends Record<string, any> = Record<string, a
 	 * }
 	 *
 	 * export async function get({ params }) {
-	 *  return {
-	 * 	  body: `Hello user ${params.id}!`,
-	 *  }
+	 *   return {
+	 *     body: `Hello user ${params.id}!`,
+	 *   }
 	 * }
 	 * ```
 	 *

--- a/packages/astro/src/cli/open.ts
+++ b/packages/astro/src/cli/open.ts
@@ -2,8 +2,8 @@ import type { ExecaChildProcess } from 'execa';
 import { execa } from 'execa';
 
 /**
- *  Credit: Azhar22
- *  @see https://github.com/azhar22k/ourl/blob/master/index.js
+ * Credit: Azhar22
+ * @see https://github.com/azhar22k/ourl/blob/master/index.js
  */
 const getPlatformSpecificCommand = (): [string] | [string, string[]] => {
 	const isGitPod = Boolean(process.env.GITPOD_REPO_ROOT);

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -136,8 +136,8 @@ export async function createVite(
 
 	// Merge configs: we merge vite configuration objects together in the following order,
 	// where future values will override previous values.
-	// 	 1. common vite config
-	// 	 2. user-provided vite config, via AstroConfig
+	//   1. common vite config
+	//   2. user-provided vite config, via AstroConfig
 	//   3. integration-provided vite config, via the `config:setup` hook
 	//   4. command vite config, passed as the argument to this function
 	let result = commonConfig;

--- a/packages/astro/src/template/css.ts
+++ b/packages/astro/src/template/css.ts
@@ -1,5 +1,5 @@
 /**
- *  CSS is exported as a string so the error pages:
+ * CSS is exported as a string so the error pages:
  * 1. don’t need to resolve a deep internal CSS import
  * 2. don’t need external dependencies to render (they may be shown because of a dep!)
  */

--- a/packages/astro/test/astro-external-files.test.js
+++ b/packages/astro/test/astro-external-files.test.js
@@ -6,16 +6,16 @@ import { loadFixture } from './test-utils.js';
 let fixture;
 
 before(async () => {
-  fixture = await loadFixture({ root: './fixtures/astro-external-files/' });
-  await fixture.build();
+	fixture = await loadFixture({ root: './fixtures/astro-external-files/' });
+	await fixture.build();
 });
 
 // TODO: Vite error: fix external files
 describe('Externeal file references', () => {
-  it('Build with externeal reference', async () => {
-    let rss = await fixture.readFile('/index.html');
-    expect(rss).to.be(''); // TODO: inline snapshot
-  });
+	it('Build with externeal reference', async () => {
+		let rss = await fixture.readFile('/index.html');
+		expect(rss).to.be(''); // TODO: inline snapshot
+	});
 });
 */
 

--- a/packages/astro/test/benchmark/build.bench.js
+++ b/packages/astro/test/benchmark/build.bench.js
@@ -63,14 +63,14 @@ const benchmarks = [
 		run: runBuild,
 	}),
 	/*new Benchmark({
-    name: 'Snowpack Example Dev Server Cached',
-    root: snowpackExampleRoot,
-    file: new URL('./dev-server-cached.json', import.meta.url),
-    async setup() {
-      // Execute once to make sure Snowpack is cached.
-      await this.execute();
-    }
-  })*/
+		name: 'Snowpack Example Dev Server Cached',
+		root: snowpackExampleRoot,
+		file: new URL('./dev-server-cached.json', import.meta.url),
+		async setup() {
+			// Execute once to make sure Snowpack is cached.
+			await this.execute();
+		}
+	})*/
 ];
 
 async function run() {

--- a/packages/astro/test/fixtures/astro-children/src/pages/no-render.astro
+++ b/packages/astro/test/fixtures/astro-children/src/pages/no-render.astro
@@ -4,19 +4,19 @@ import PreactComponent from '../components/NoRender.jsx';
 <html>
 <head><title>Children</title></head>
 <body>
-  <PreactComponent id="ssr-only">
-    <h1>Hello world</h1>
-    <h1>Goodbye world</h1>
-  </PreactComponent>
-  <PreactComponent id="client" client:load>
-    <h1>Hello world</h1>
-    <h1>Goodbye world</h1>
-  </PreactComponent>
-  <PreactComponent id="client-render" render={true} client:load>
-    <h1>Hello world</h1>
-    <h1>Goodbye world</h1>
-  </PreactComponent>
+	<PreactComponent id="ssr-only">
+		<h1>Hello world</h1>
+		<h1>Goodbye world</h1>
+	</PreactComponent>
+	<PreactComponent id="client" client:load>
+		<h1>Hello world</h1>
+		<h1>Goodbye world</h1>
+	</PreactComponent>
+	<PreactComponent id="client-render" render={true} client:load>
+		<h1>Hello world</h1>
+		<h1>Goodbye world</h1>
+	</PreactComponent>
 
-  <PreactComponent id="client-no-children" client:load></PreactComponent>
+	<PreactComponent id="client-no-children" client:load></PreactComponent>
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-children/src/pages/no-render.astro
+++ b/packages/astro/test/fixtures/astro-children/src/pages/no-render.astro
@@ -8,15 +8,15 @@ import PreactComponent from '../components/NoRender.jsx';
     <h1>Hello world</h1>
     <h1>Goodbye world</h1>
   </PreactComponent>
-	<PreactComponent id="client" client:load>
-	  <h1>Hello world</h1>
+  <PreactComponent id="client" client:load>
+    <h1>Hello world</h1>
     <h1>Goodbye world</h1>
-	</PreactComponent>
-	<PreactComponent id="client-render" render={true} client:load>
-	  <h1>Hello world</h1>
+  </PreactComponent>
+  <PreactComponent id="client-render" render={true} client:load>
+    <h1>Hello world</h1>
     <h1>Goodbye world</h1>
-	</PreactComponent>
+  </PreactComponent>
 
-	<PreactComponent id="client-no-children" client:load></PreactComponent>
+  <PreactComponent id="client-no-children" client:load></PreactComponent>
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-client-only/src/components/logResize.js
+++ b/packages/astro/test/fixtures/astro-client-only/src/components/logResize.js
@@ -1,3 +1,3 @@
 window.addEventListener("resize", function() {
-  console.log("window resized");
+	console.log("window resized");
 });

--- a/packages/astro/test/fixtures/astro-client-only/src/pages/persistent-counter-standalone.astro
+++ b/packages/astro/test/fixtures/astro-client-only/src/pages/persistent-counter-standalone.astro
@@ -3,12 +3,12 @@ import PersistentCounter from '../components/PersistentCounterStandalone.svelte'
 ---
 <html>
 <head>
-	<title>Client only pages - Only PersistentCounter, nothing else</title>
+  <title>Client only pages - Only PersistentCounter, nothing else</title>
 </head>
 <body>
-	<!--
-		Do not add another test-case to this file. This is meant to test if only a single component is used.
-	 -->
+  <!--
+    Do not add another test-case to this file. This is meant to test if only a single component is used.
+  -->
 
   <PersistentCounter client:only />
 </body>

--- a/packages/astro/test/fixtures/astro-client-only/src/pages/persistent-counter-standalone.astro
+++ b/packages/astro/test/fixtures/astro-client-only/src/pages/persistent-counter-standalone.astro
@@ -3,13 +3,13 @@ import PersistentCounter from '../components/PersistentCounterStandalone.svelte'
 ---
 <html>
 <head>
-  <title>Client only pages - Only PersistentCounter, nothing else</title>
+	<title>Client only pages - Only PersistentCounter, nothing else</title>
 </head>
 <body>
-  <!--
-    Do not add another test-case to this file. This is meant to test if only a single component is used.
-  -->
+	<!--
+		Do not add another test-case to this file. This is meant to test if only a single component is used.
+	-->
 
-  <PersistentCounter client:only />
+	<PersistentCounter client:only />
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-dynamic/src/components/logResize.js
+++ b/packages/astro/test/fixtures/astro-dynamic/src/components/logResize.js
@@ -1,3 +1,3 @@
 window.addEventListener("resize", function() {
-    console.log("window resized");
+	console.log("window resized");
 });

--- a/packages/astro/test/fixtures/custom-elements/my-component-lib/server.js
+++ b/packages/astro/test/fixtures/custom-elements/my-component-lib/server.js
@@ -1,30 +1,30 @@
 function getConstructor(Component) {
-  if (typeof Component === 'string') {
-    const tagName = Component;
-    Component = customElements.get(tagName);
-  }
-  return Component;
+	if (typeof Component === 'string') {
+		const tagName = Component;
+		Component = customElements.get(tagName);
+	}
+	return Component;
 }
 
 function check(component) {
-  const Component = getConstructor(component);
-  if (typeof Component === 'function' && globalThis.HTMLElement.isPrototypeOf(Component)) {
-    return true;
-  }
-  return false;
+	const Component = getConstructor(component);
+	if (typeof Component === 'function' && globalThis.HTMLElement.isPrototypeOf(Component)) {
+		return true;
+	}
+	return false;
 }
 
 function renderToStaticMarkup(component, props, innerHTML) {
-  const Component = getConstructor(component);
-  const el = new Component();
-  el.connectedCallback();
-  const html = `<${el.localName}><template shadowroot="open">${el.shadowRoot.innerHTML}</template>${el.innerHTML}</${el.localName}>`
-  return {
-    html
-  };
+	const Component = getConstructor(component);
+	const el = new Component();
+	el.connectedCallback();
+	const html = `<${el.localName}><template shadowroot="open">${el.shadowRoot.innerHTML}</template>${el.innerHTML}</${el.localName}>`
+	return {
+		html
+	};
 }
 
 export default {
-  check,
-  renderToStaticMarkup
+	check,
+	renderToStaticMarkup
 };

--- a/packages/astro/test/fixtures/custom-elements/my-component-lib/shim.js
+++ b/packages/astro/test/fixtures/custom-elements/my-component-lib/shim.js
@@ -1,28 +1,28 @@
 globalThis.customElements = {
-  _elements: new Map(),
-  define(name, ctr) {
-    ctr.tagName = name;
-    this._elements.set(name, ctr);
-  },
-  get(name) {
-    return this._elements.get(name);
-  }
+	_elements: new Map(),
+	define(name, ctr) {
+		ctr.tagName = name;
+		this._elements.set(name, ctr);
+	},
+	get(name) {
+		return this._elements.get(name);
+	}
 };
 
 globalThis.HTMLElement = class {
-  attachShadow() {
-    this.shadowRoot = new HTMLElement();
-  }
+	attachShadow() {
+		this.shadowRoot = new HTMLElement();
+	}
 
-  get localName() {
-    return this.constructor.tagName;
-  }
+	get localName() {
+		return this.constructor.tagName;
+	}
 
-  get innerHTML() {
-    return this._innerHTML;
-  }
+	get innerHTML() {
+		return this._innerHTML;
+	}
 
-  set innerHTML(val) {
-    this._innerHTML = val;
-  }
+	set innerHTML(val) {
+		this._innerHTML = val;
+	}
 };

--- a/packages/astro/test/fixtures/custom-elements/src/components/my-element.js
+++ b/packages/astro/test/fixtures/custom-elements/src/components/my-element.js
@@ -1,11 +1,11 @@
 export const tagName = 'my-element';
 
 class MyElement extends HTMLElement {
-  connectedCallback() {
-    this.attachShadow({ mode: 'open' });
-    this.shadowRoot.innerHTML = `<span id="custom">Hello from a custom element!</span>`;
-    this.innerHTML = `<div id="custom-light">Light dom!</div>`
-  }
+	connectedCallback() {
+		this.attachShadow({ mode: 'open' });
+		this.shadowRoot.innerHTML = `<span id="custom">Hello from a custom element!</span>`;
+		this.innerHTML = `<div id="custom-light">Light dom!</div>`
+	}
 }
 
 customElements.define(tagName, MyElement);

--- a/packages/astro/test/fixtures/debug-component/src/pages/posts/[slug].astro
+++ b/packages/astro/test/fixtures/debug-component/src/pages/posts/[slug].astro
@@ -3,19 +3,18 @@ import Debug from 'astro/debug';
 
 // all the content that should be generated
 export async function getStaticPaths() {
-    const data = await Astro.glob('../../data/posts/*.md')
+  const data = await Astro.glob('../../data/posts/*.md')
 
-    const allArticles = data.map((article) => {
-        return {
-      	    params: { slug: article.frontmatter.slug },
-      	    props: {
-	            article: article,
-	        }
-        }
-    })
-    
-    return allArticles
+  const allArticles = data.map((article) => {
+    return {
+      params: { slug: article.frontmatter.slug },
+      props: {
+        article: article,
+      }
+    }
+  })
 
+  return allArticles
 }
 
 const x = Astro.props

--- a/packages/astro/test/fixtures/debug-component/src/pages/posts/[slug].astro
+++ b/packages/astro/test/fixtures/debug-component/src/pages/posts/[slug].astro
@@ -3,18 +3,18 @@ import Debug from 'astro/debug';
 
 // all the content that should be generated
 export async function getStaticPaths() {
-  const data = await Astro.glob('../../data/posts/*.md')
+	const data = await Astro.glob('../../data/posts/*.md')
 
-  const allArticles = data.map((article) => {
-    return {
-      params: { slug: article.frontmatter.slug },
-      props: {
-        article: article,
-      }
-    }
-  })
+	const allArticles = data.map((article) => {
+		return {
+			params: { slug: article.frontmatter.slug },
+			props: {
+				article: article,
+			}
+		}
+	})
 
-  return allArticles
+	return allArticles
 }
 
 const x = Astro.props

--- a/packages/astro/test/fixtures/preact-compat-component/packages/react-lib/index.js
+++ b/packages/astro/test/fixtures/preact-compat-component/packages/react-lib/index.js
@@ -1,5 +1,5 @@
 import { useState } from "react";
 
 export function useSpecialState(initialState) {
-  return useState(initialState);
+	return useState(initialState);
 }

--- a/packages/astro/test/fixtures/ssr-api-route/src/pages/login.js
+++ b/packages/astro/test/fixtures/ssr-api-route/src/pages/login.js
@@ -1,11 +1,11 @@
 
 export function post() {
-  const headers = new Headers();
-  headers.append('Set-Cookie', `foo=foo; HttpOnly`);
-  headers.append('Set-Cookie', `bar=bar; HttpOnly`);
+	const headers = new Headers();
+	headers.append('Set-Cookie', `foo=foo; HttpOnly`);
+	headers.append('Set-Cookie', `bar=bar; HttpOnly`);
 
-  return new Response('', {
-    status: 201,
-    headers,
-  });
+	return new Response('', {
+		status: 201,
+		headers,
+	});
 }

--- a/packages/astro/test/fixtures/static-build/src/pages/posts.json.js
+++ b/packages/astro/test/fixtures/static-build/src/pages/posts.json.js
@@ -1,22 +1,22 @@
 async function fetchPosts() {
-    const files = import.meta.glob('./posts/**/*.md');
-    
-    const posts = await Promise.all(
-        Object.entries(files).map(([filename, load]) => load().then(({ frontmatter }) => {
-            return {
-                filename,
-                title: frontmatter.title,
-            };
-        })),
-    );
+	const files = import.meta.glob('./posts/**/*.md');
 
-    return posts.sort((a, b) => a.title.localeCompare(b.title));
+	const posts = await Promise.all(
+		Object.entries(files).map(([filename, load]) => load().then(({ frontmatter }) => {
+			return {
+				filename,
+				title: frontmatter.title,
+			};
+		})),
+	);
+
+	return posts.sort((a, b) => a.title.localeCompare(b.title));
 }
 
 export async function get() {
-    const posts = await fetchPosts();
+	const posts = await fetchPosts();
 
-    return {
-        body: JSON.stringify(posts, null, 4),
-    };
+	return {
+		body: JSON.stringify(posts, null, 4),
+	};
 }

--- a/packages/integrations/netlify/test/functions/fixtures/base64-response/src/pages/font.js
+++ b/packages/integrations/netlify/test/functions/fixtures/base64-response/src/pages/font.js
@@ -2,10 +2,10 @@
 export function get() {
 	const buffer = Buffer.from('base64 test font', 'utf-8')
 
-  return new Response(buffer, {
-    status: 200,
+	return new Response(buffer, {
+		status: 200,
 		headers: {
 			'Content-Type': 'font/otf'
 		}
-  });
+	});
 }

--- a/packages/integrations/netlify/test/functions/fixtures/base64-response/src/pages/image.js
+++ b/packages/integrations/netlify/test/functions/fixtures/base64-response/src/pages/image.js
@@ -2,10 +2,10 @@
 export function get() {
 	const buffer = Buffer.from('base64 test string', 'utf-8')
 
-  return new Response(buffer, {
-    status: 200,
+	return new Response(buffer, {
+		status: 200,
 		headers: {
 			'content-type': 'image/jpeg;foo=foo'
 		}
-  });
+	});
 }

--- a/packages/integrations/netlify/test/functions/fixtures/cookies/src/pages/login.js
+++ b/packages/integrations/netlify/test/functions/fixtures/cookies/src/pages/login.js
@@ -1,12 +1,12 @@
 
 export function post() {
 	const headers = new Headers();
-  headers.append('Set-Cookie', `foo=foo; HttpOnly`);
-  headers.append('Set-Cookie', `bar=bar; HttpOnly`);
+	headers.append('Set-Cookie', `foo=foo; HttpOnly`);
+	headers.append('Set-Cookie', `bar=bar; HttpOnly`);
 	headers.append('Location', '/');
 
-  return new Response('', {
-    status: 301,
-    headers,
-  });
+	return new Response('', {
+		status: 301,
+		headers,
+	});
 }

--- a/packages/markdown/component/test/astro-markdown.test.js
+++ b/packages/markdown/component/test/astro-markdown.test.js
@@ -244,13 +244,13 @@ describe('Astro Markdown', () => {
 		const $ = cheerio.load(html);
 		/**
 		 * - list
-		 *  - list
+		 *   - list
 		 */
 		expect($('#target > ul > li').children()).to.have.lengthOf(1);
 		expect($('#target > ul > li > ul > li').text()).to.equal('nested list');
 		/**
 		 * 1. Hello
-		 *  1. nested hello
+		 *   1. nested hello
 		 */
 		expect($('#target > ol > li').children()).to.have.lengthOf(1);
 		expect($('#target > ol > li > ol > li').text()).to.equal('nested hello');

--- a/packages/markdown/remark/test/expressions.test.js
+++ b/packages/markdown/remark/test/expressions.test.js
@@ -114,7 +114,7 @@ describe('expressions', () => {
 	it('should unwrap HTML comments in code fences', async () => {
 		const { code } = await renderAstroMd(
 			`
-			  \`\`\`
+				\`\`\`
 				<!-- HTML comment -->
 				\`\`\`
 			`


### PR DESCRIPTION
## Changes

- Replace ` {2}` with `\t` (spaces to tabs) where applicable.
- Found & fixed some other indentation issues
- Note that `prettier` is insisting on using a pair of spaces when indenting ternary operators, see [Google search: site:github.com/prettier/prettier/issues ternary spaces tabs](https://www.google.com/search?q=site%3Agithub.com%2Fprettier%2Fprettier%2Fissues+ternary+spaces+tabs), I left these alone, as they will just reappear next time `prettier` runs. They can be located with:
  ```
  ^\t+[:?].+\n\t+ {2}
  ```
- In several cases, I took `.astro` files with mixes tabs and spaces and converted them to spaces-only, but maybe I should back out those changes, and convert spaces-only `.astro` files to tabs-only, as that seems to be (slightly) more common?
- In general, my personal take is that this codebase should change to spaces only, or failing that, `.astro` files and `.md` files should only use spaces (`.md` files are already mostly spaces-only). The Astro Docs repo uses spaces, and having both repos synced would reduce the occurrence of mixed indentation due to copy-and-pasting without "show invisibles" / "show spaces" enabled in code editors.

## Testing

n/a, no actual code changes.

## Docs

n/a, no actual code changes.