### PR TITLE
fix(vercel): Include all files inside `dist/` instead of only `entry.mjs`

### DIFF
--- a/.changeset/nine-roses-explain.md
+++ b/.changeset/nine-roses-explain.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Edge adapter includes all the generated files (all files inside `dist/`) instead of only `entry.mjs`

--- a/packages/integrations/vercel/src/edge/adapter.ts
+++ b/packages/integrations/vercel/src/edge/adapter.ts
@@ -2,7 +2,13 @@ import type { AstroAdapter, AstroConfig, AstroIntegration } from 'astro';
 import { relative as relativePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { copyFilesToFunction, getVercelOutput, removeDir, writeJson } from '../lib/fs.js';
+import {
+	copyFilesToFunction,
+	getFilesFromFolder,
+	getVercelOutput,
+	removeDir,
+	writeJson,
+} from '../lib/fs.js';
 import { getRedirects } from '../lib/redirects.js';
 
 const PACKAGE_NAME = '@astrojs/vercel/edge';
@@ -88,13 +94,11 @@ export default function vercelEdge({ includeFiles = [] }: VercelEdgeConfig = {})
 			},
 			'astro:build:done': async ({ routes }) => {
 				const entry = new URL(serverEntry, buildTempFolder);
+				const generatedFiles = await getFilesFromFolder(buildTempFolder);
 
 				// Copy entry and other server files
 				const commonAncestor = await copyFilesToFunction(
-					[
-						new URL(serverEntry, buildTempFolder),
-						...includeFiles.map((file) => new URL(file, _config.root)),
-					],
+					[...generatedFiles, ...includeFiles.map((file) => new URL(file, _config.root))],
 					functionFolder
 				);
 

--- a/packages/integrations/vercel/src/lib/fs.ts
+++ b/packages/integrations/vercel/src/lib/fs.ts
@@ -16,6 +16,20 @@ export async function emptyDir(dir: PathLike): Promise<void> {
 	await fs.mkdir(dir, { recursive: true });
 }
 
+export async function getFilesFromFolder(dir: URL) {
+	const data = await fs.readdir(dir, { withFileTypes: true });
+	let files: URL[] = [];
+	for (const item of data) {
+		if (item.isDirectory()) {
+			const moreFiles = await getFilesFromFolder(new URL(`./${item.name}/`, dir));
+			files = files.concat(moreFiles);
+		} else {
+			files.push(new URL(`./${item.name}`, dir));
+		}
+	}
+	return files;
+}
+
 export const getVercelOutput = (root: URL) => new URL('./.vercel/output/', root);
 
 /**


### PR DESCRIPTION
## Changes

Fixes #5138

The edge adapter now copies all files inside dist/ (entry.mjs and all chunks)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
