### PR TITLE
Removes default content-visibility styles from image components

### DIFF
--- a/.changeset/chilly-experts-add.md
+++ b/.changeset/chilly-experts-add.md
@@ -1,0 +1,9 @@
+---
+'@astrojs/image': minor
+---
+
+Removes the `content-visibility: auto` styling added by the `<Picture />` and `<Image />` components.
+
+**Why:** The [content-visibility](https://developer.mozilla.org/en-US/docs/Web/CSS/content-visibility) style is rarely needed for an `<img>` and can actually break certain layouts.
+
+**Migration:** Do images in your layout actually depend on `content-visibility`?  No problem!  You can add these styles where needed in your own component styles.

--- a/packages/integrations/image/components/Image.astro
+++ b/packages/integrations/image/components/Image.astro
@@ -34,9 +34,3 @@ const attrs = await getImage(props);
 ---
 
 <img {...attrs} {loading} {decoding} />
-
-<style>
-	img {
-		content-visibility: auto;
-	}
-</style>

--- a/packages/integrations/image/components/Picture.astro
+++ b/packages/integrations/image/components/Picture.astro
@@ -69,9 +69,3 @@ delete image.height;
 	{sources.map((attrs) => <source {...attrs} {sizes} />)}
 	<img {...image} {loading} {decoding} {alt} {...attrs} />
 </picture>
-
-<style>
-	img {
-		content-visibility: auto;
-	}
-</style>


### PR DESCRIPTION
## Changes

This removes the `content-visibility: auto` style added to `<Image />` and `<Picture />` components by default.

**Why?** This came up in a [docs issue](https://github.com/withastro/docs/issues/1517) where the style actually broke a user's layout.  This style really doesn't impact most layouts and is rarely needed, removing this from our components leaves all image styling up to a user's project-specific styling

## Testing

None, styling fix only

## Docs

Fixes a bug that raised docs questions, no new docs needed 🎉 

/cc @withastro/maintainers-docs 