### PR TITLE
Error message: clarify "adapter does not have previewEntrypoint"

### DIFF
--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -33,7 +33,7 @@ export default async function preview(
 		throw new Error(`[preview] No adapter found.`);
 	}
 	if (!settings.adapter.previewEntrypoint) {
-		throw new Error(`[preview] adapter does not have previewEntrypoint.`);
+		throw new Error(`[preview] This adapter does not support the preview command.`);
 	}
 	// We need to use require.resolve() here so that advanced package managers like pnpm
 	// don't treat this as a dependency of Astro itself. This correctly resolves the

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -33,7 +33,7 @@ export default async function preview(
 		throw new Error(`[preview] No adapter found.`);
 	}
 	if (!settings.adapter.previewEntrypoint) {
-		throw new Error(`[preview] This adapter does not support the preview command.`);
+		throw new Error(`[preview] The ${settings.adapter.name} adapter does not support the preview command.`);
 	}
 	// We need to use require.resolve() here so that advanced package managers like pnpm
 	// don't treat this as a dependency of Astro itself. This correctly resolves the


### PR DESCRIPTION
## Changes

- Clarify the error message that is shown when your adapter doesn't support `astro preview`
- Closes #5181

## Testing

Just an error message

## Docs

cc @withastro/maintainers-docs for feedback! 

I'll also make a PR to update our description of `astro preview` in the docs, which hasn't been updated since the Node adapter started supporting `astro preview`.