### PR TITLE
Updates `astro add` to ignore optional peer dependencies

### DIFF
--- a/.changeset/smart-chicken-develop.md
+++ b/.changeset/smart-chicken-develop.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+`astro add` no longer automatically installs optional peer dependencies

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -705,8 +705,12 @@ export async function validateIntegrations(integrations: string[]): Promise<Inte
 				];
 
 				if (pkgJson['peerDependencies']) {
+					const meta = pkgJson['peerDependenciesMeta'] || {}
 					for (const peer in pkgJson['peerDependencies']) {
-						dependencies.push([peer, pkgJson['peerDependencies'][peer]]);
+						const optional = meta[peer]?.optional || false
+						if (!optional) {
+							dependencies.push([peer, pkgJson['peerDependencies'][peer]]);
+						}
 					}
 				}
 


### PR DESCRIPTION
## Changes

Closes #5191 

`astro add` will automatically install peer dependencies for the integration being installed.  This updates that check to ignore peer dependencies marked as optional, ex: `sharp` is optional for `@astrojs/image`

## Testing

Tested manually with `astro add image`

**Before**
<img width="467" alt="Screen Shot 2022-10-25 at 2 27 20 PM" src="https://user-images.githubusercontent.com/15836226/197865650-902ebc90-550f-46aa-884e-1c5bc7328212.png">

**After**
<img width="467" alt="Screen Shot 2022-10-25 at 2 27 52 PM" src="https://user-images.githubusercontent.com/15836226/197865572-558e6213-e637-4a1a-9181-53fa695a7725.png">

## Docs

Bug fix only, no docs update
