### PR TITLE
docs: `extendDefaultPlugins` cross-linking (minor)

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -729,7 +729,7 @@ export interface AstroUserConfig {
 		 * Pass [remark plugins](https://github.com/remarkjs/remark) to customize how your Markdown is built. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 		 *
 		 * :::caution
-		 * Providing a list of plugins will **remove** our default plugins. To preserve these defaults, see the `extendDefaultPlugins` flag.
+		 * Providing a list of plugins will **remove** our default plugins. To preserve these defaults, see the [`extendDefaultPlugins`](#markdownextenddefaultplugins) flag.
 		 * :::
 		 *
 		 * ```js
@@ -750,7 +750,7 @@ export interface AstroUserConfig {
 		 * Pass [rehype plugins](https://github.com/remarkjs/remark-rehype) to customize how your Markdown's output HTML is processed. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 		 *
 		 * :::caution
-		 * Providing a list of plugins will **remove** our default plugins. To preserve these defaults, see the `extendDefaultPlugins` flag.
+		 * Providing a list of plugins will **remove** our default plugins. To preserve these defaults, see the [`extendDefaultPlugins`](#markdownextenddefaultplugins) flag.
 		 * :::
 		 *
 		 * ```js


### PR DESCRIPTION
## Changes

- Docs-only change, link mentions of `extendDefaultPlugins` to relevant section.
- This change was inadvertently made (by me) and merged [in the docs repo](https://github.com/withastro/docs/pull/1777/files#diff-18c1e75709f34e49949440b223bdd17d76b3c870813a66f5d29e10875b50bd73) (in a page that is sourced from here via GitHub Action), just now getting around to open a PR here.

## Testing

n/a

## Docs

n/a
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
