### PR TITLE
Add missing language to code block

### DIFF
--- a/packages/integrations/cloudflare/README.md
+++ b/packages/integrations/cloudflare/README.md
@@ -72,7 +72,7 @@ It's then possible to update the preview script in your `package.json` to `"prev
 
 You can access all the Cloudflare bindings and environment variables from Astro components and API routes through the adapter API.
 
-```
+```js
 import { getRuntime } from "@astrojs/cloudflare/runtime";
 
 getRuntime(Astro.request);


### PR DESCRIPTION
## Changes

- Updates a code block in the Cloudflare README to include a `js` language tag (nice for syntax highlighting but also fixes a build issue in our docs integration pages: https://github.com/withastro/docs/pull/1926)

## Testing

Docs only.

## Docs

Docs only! /cc @withastro/maintainers-docs
