### PR TITLE
Fix types.d.ts not being included in the npm package

### DIFF
--- a/.changeset/olive-tomatoes-jog.md
+++ b/.changeset/olive-tomatoes-jog.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix missing types.d.ts in npm package

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -82,6 +82,7 @@
     "client-base.d.ts",
     "import-meta.d.ts",
     "astro-jsx.d.ts",
+    "types.d.ts",
     "README.md",
     "vendor"
   ],


### PR DESCRIPTION
## Changes

We forgot to add a file to the `files` field in `package.json`, a third time 🤫

## Testing

N/A

## Docs

N/A

