### PR TITLE
Fixes charset issue on development mode

### DIFF
--- a/.changeset/spicy-pumas-compare.md
+++ b/.changeset/spicy-pumas-compare.md
@@ -1,0 +1,6 @@
+---
+'astro': minor
+---
+
+Add charset=utf-8 to html streaming
+Add html-charset e2e test 

--- a/packages/astro/e2e/fixtures/html-page/package.json
+++ b/packages/astro/e2e/fixtures/html-page/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@e2e/html-page",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/e2e/fixtures/html-page/src/pages/index.html
+++ b/packages/astro/e2e/fixtures/html-page/src/pages/index.html
@@ -1,0 +1,1 @@
+<p id="text">Astro🚀</p>

--- a/packages/astro/e2e/fixtures/html-page/src/pages/streaming.astro
+++ b/packages/astro/e2e/fixtures/html-page/src/pages/streaming.astro
@@ -1,0 +1,18 @@
+---
+function wait(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function * iterable() {
+	const chars = ['A', 's', 't', 'r', 'o' , '🚀'];
+	for(const char of chars) {
+		await wait(15);
+		yield char;
+	}
+}
+---
+<p id="text">{(async function * () {
+  for await(const value of iterable()) {
+    yield <Fragment set:html={value} />;
+  }
+})()}</p>

--- a/packages/astro/e2e/html-charset.test.js
+++ b/packages/astro/e2e/html-charset.test.js
@@ -1,0 +1,32 @@
+import { expect } from '@playwright/test';
+import { testFactory } from './test-utils.js';
+
+const test = testFactory({ root: './fixtures/html-page/', output: 'server' });
+
+let devServer;
+
+test.beforeAll(async ({ astro }) => {
+  devServer = await astro.startDevServer();
+});
+
+test.afterAll(async () => {
+  await devServer.stop();
+});
+
+test.describe('static content', () => {
+  test('Parse static content', async ({ astro, page }) => {
+    await page.goto('/');
+
+    const text = await page.locator('#text');
+    await expect(text, 'parse the charset correctly').toHaveText('Astro🚀');
+  });
+})
+
+test.describe('streaming content', () => {
+  test('Parse streaming content', async ({ astro, page }) => {
+    await page.goto('/streaming');
+
+    const text = await page.locator('#text');
+    await expect(text, 'parse the charset correctly').toHaveText('Astro🚀');
+  });
+})

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -133,7 +133,7 @@ export function createResult(args: CreateResultArgs): SSRResult {
 
 	const url = new URL(request.url);
 	const headers = new Headers();
-	headers.set('Content-Type', 'text/html');
+	headers.set('Content-Type', 'text/html; charset=utf-8');
 	const response: ResponseInit = {
 		status: args.status,
 		statusText: 'OK',

--- a/packages/astro/test/config-mode.test.js
+++ b/packages/astro/test/config-mode.test.js
@@ -24,7 +24,7 @@ describe('AstroConfig - config.output', () => {
 				const request = new Request('http://example.com/');
 				const response = await app.render(request);
 				expect(response.status).to.equal(200);
-				expect(response.headers.get('content-type')).to.equal('text/html');
+				expect(response.headers.get('content-type')).to.equal('text/html; charset=utf-8');
 				const html = await response.text();
 				expect(html.length).to.be.greaterThan(0);
 			});

--- a/packages/astro/test/streaming.test.js
+++ b/packages/astro/test/streaming.test.js
@@ -124,7 +124,7 @@ describe('Streaming disabled', () => {
 			const response = await app.render(request);
 
 			expect(response.status).to.equal(200);
-			expect(response.headers.get('content-type')).to.equal('text/html');
+			expect(response.headers.get('content-type')).to.equal('text/html; charset=utf-8');
 			expect(response.headers.has('content-length')).to.equal(true);
 			expect(parseInt(response.headers.get('content-length'))).to.be.greaterThan(0);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,6 +706,12 @@ importers:
       svelte: 3.52.0
       vue: 3.2.41
 
+  packages/astro/e2e/fixtures/html-page:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/e2e/fixtures/hydration-race:
     specifiers:
       '@astrojs/preact': workspace:*


### PR DESCRIPTION
## Changes

- add charset=utf8 to render result header
- add e2e test case

## Testing

- added new e2e test case: html-charset

## Docs

The patch fixes the charset issue that may occur on SSR mode or dev app. 