### PR TITLE
feat(create-astro): add --fancy flag

### DIFF
--- a/.changeset/empty-feet-brush.md
+++ b/.changeset/empty-feet-brush.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Allow Windows users to pass `--fancy` to enable full unicode support

--- a/packages/create-astro/README.md
+++ b/packages/create-astro/README.md
@@ -42,6 +42,7 @@ May be provided in place of prompts
 |:-------------|:----------------------------------------------------|
 | `--template` | Specify the template name ([list][examples])        |
 | `--commit`   | Specify a specific Git commit or branch to use from this repo (by default, `main` branch of this repo will be used) |
+| `--fancy`    | For Windows users, `--fancy` will enable full unicode support |
 
 ### Debugging
 

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -29,7 +29,7 @@
     "tsconfigs"
   ],
   "dependencies": {
-    "@astrojs/cli-kit": "^0.1.0",
+    "@astrojs/cli-kit": "^0.1.3",
     "chalk": "^5.0.1",
     "comment-json": "^4.2.3",
     "execa": "^6.1.0",

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -1,5 +1,6 @@
 /* eslint no-console: 'off' */
 import { color, generateProjectName, label, say } from '@astrojs/cli-kit';
+import { forceUnicode } from '@astrojs/cli-kit/utils';
 import { random } from '@astrojs/cli-kit/utils';
 import { assign, parse, stringify } from 'comment-json';
 import { execa, execaCommand } from 'execa';
@@ -29,8 +30,13 @@ import { TEMPLATES } from './templates.js';
 // broke our arg parser, since `--` is a special kind of flag. Filtering for `--` here
 // fixes the issue so that create-astro now works on all npm version.
 const cleanArgv = process.argv.filter((arg) => arg !== '--');
-const args = yargs(cleanArgv);
+const args = yargs(cleanArgv, { boolean: ['fancy']});
 prompts.override(args);
+
+// Enable full unicode support if the `--fancy` flag is passed
+if (args.fancy) {
+	forceUnicode();
+}
 
 export function mkdirp(dir: string) {
 	try {
@@ -99,7 +105,7 @@ export async function main() {
 				`${username}!`,
 			],
 			random(welcome),
-		]);
+		], { hat: args.fancy ? '🎩' : undefined });
 		await banner(version);
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2434,7 +2434,7 @@ importers:
 
   packages/create-astro:
     specifiers:
-      '@astrojs/cli-kit': ^0.1.0
+      '@astrojs/cli-kit': ^0.1.3
       '@types/chai': ^4.3.1
       '@types/degit': ^2.8.3
       '@types/mocha': ^9.1.1
@@ -2456,7 +2456,7 @@ importers:
       which-pm-runs: ^1.1.0
       yargs-parser: ^21.0.1
     dependencies:
-      '@astrojs/cli-kit': 0.1.0
+      '@astrojs/cli-kit': 0.1.3
       chalk: 5.1.2
       comment-json: 4.2.3
       execa: 6.1.0
@@ -3795,8 +3795,8 @@ packages:
       lite-youtube-embed: 0.2.0
     dev: false
 
-  /@astrojs/cli-kit/0.1.0:
-    resolution: {integrity: sha512-H/J6C1dHKoBlQD/+YVzgy723UMJ5AZEB5NJl4LiOyGdOT4tWFSyUaqEppgaUm/qQ8OnZ9Q5pA5Ce2fjvPww4Eg==}
+  /@astrojs/cli-kit/0.1.3:
+    resolution: {integrity: sha512-thLIdCggboKsOyYF5prn46tIpUH55Y+Y0fRN2NGD09WyxqqO5eA5aon0i4cELKTuzQrmSuu0Wl4d4xFin5OPvg==}
     dependencies:
       chalk: 5.1.2
       log-update: 5.0.1


### PR DESCRIPTION
## Changes

- Adds a `--fancy` flag for Windows users that want full Unicode support
- Also gives Houston a top-hat

## Testing

Tested manually

## Docs

Updated the README. Houston is mostly undocumented right now!
