### PR TITLE
[docs] update image integration README

### DIFF
--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -22,7 +22,7 @@ This integration provides `<Image />` and `<Picture>` components as well as a ba
 
 ## Installation
 
-Along with our integration, we recommending installing [sharp](https://sharp.pixelplumbing.com/) when appropriate. 
+Along with our integration, we recommend installing [sharp](https://sharp.pixelplumbing.com/) when appropriate. 
 
 The `@astrojs/image` default image transformer is based on [Squoosh](https://github.com/GoogleChromeLabs/squoosh) and uses WebAssembly libraries to support most deployment environments, including those that do not support sharp, such as StackBlitz and Netlify Edge.
 

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -22,7 +22,7 @@ This integration provides `<Image />` and `<Picture>` components as well as a ba
 
 ## Installation
 
-Along with our integration, we recommending installing [sharp](https://sharp.pixelplumbing.com/) where appropriate. 
+Along with our integration, we recommending installing [sharp](https://sharp.pixelplumbing.com/) when appropriate. 
 
 The `@astrojs/image` default image transformer is based on [Squoosh](https://github.com/GoogleChromeLabs/squoosh) and uses WebAssembly libraries to support most deployment environments, including those that do not support sharp, such as StackBlitz and Netlify Edge.
 

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -22,7 +22,7 @@ This integration provides `<Image />` and `<Picture>` components as well as a ba
 
 ## Installation
 
-The default image transformer is based on [Squoosh](https://github.com/GoogleChromeLabs/squoosh) and uses web assembly libraries to support most deployment environments, including those that do not support sharp, such as StackBlitz and Netlify Edge.
+The default image transformer is based on [Squoosh](https://github.com/GoogleChromeLabs/squoosh) and uses WebAssembly libraries to support most deployment environments, including those that do not support sharp, such as StackBlitz and Netlify Edge.
 
 For faster builds and more fine-grained control of image transformations, we recommend also installing [sharp](https://sharp.pixelplumbing.com/) if
 - You are building a static site with Astro.

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -33,8 +33,9 @@ For faster builds and more fine-grained control of image transformations, instal
 
 Note that `@astrojs/image` is not currently supported on
 - Cloudflare SSR
-- @astrojs/deno
-- @astrojs/vercel/edge
+- `@astrojs/deno`
+- `@astrojs/netlify/edge-functions`
+- `@astrojs/vercel/edge`
 
 
 ### Quick Install

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -22,7 +22,9 @@ This integration provides `<Image />` and `<Picture>` components as well as a ba
 
 ## Installation
 
-The default image transformer is based on [Squoosh](https://github.com/GoogleChromeLabs/squoosh) and uses WebAssembly libraries to support most deployment environments, including those that do not support sharp, such as StackBlitz and Netlify Edge.
+Along with our integration, we recommending installing [sharp](https://sharp.pixelplumbing.com/) where appropriate. 
+
+The `@astrojs/image` default image transformer is based on [Squoosh](https://github.com/GoogleChromeLabs/squoosh) and uses WebAssembly libraries to support most deployment environments, including those that do not support sharp, such as StackBlitz and Netlify Edge.
 
 For faster builds and more fine-grained control of image transformations, we recommend also installing [sharp](https://sharp.pixelplumbing.com/) if
 - You are building a static site with Astro.

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -26,7 +26,7 @@ Along with our integration, we recommending installing [sharp](https://sharp.pix
 
 The `@astrojs/image` default image transformer is based on [Squoosh](https://github.com/GoogleChromeLabs/squoosh) and uses WebAssembly libraries to support most deployment environments, including those that do not support sharp, such as StackBlitz and Netlify Edge.
 
-For faster builds and more fine-grained control of image transformations, install sharp if
+For faster builds and more fine-grained control of image transformations, install sharp in addition to `@astrojs/image` if
 - You are building a static site with Astro.
 - You are using an SSR deployment host that supports NodeJS using `@astrojs/netlify/functions`, `@astrojs/vercel/serverless` or `@astrojs/node`.
 

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -26,7 +26,7 @@ Along with our integration, we recommending installing [sharp](https://sharp.pix
 
 The `@astrojs/image` default image transformer is based on [Squoosh](https://github.com/GoogleChromeLabs/squoosh) and uses WebAssembly libraries to support most deployment environments, including those that do not support sharp, such as StackBlitz and Netlify Edge.
 
-For faster builds and more fine-grained control of image transformations, we recommend also installing [sharp](https://sharp.pixelplumbing.com/) if
+For faster builds and more fine-grained control of image transformations, install sharp if
 - You are building a static site with Astro.
 - You are using an SSR deployment host that supports NodeJS using `@astrojs/netlify/functions`, `@astrojs/vercel/serverless` or `@astrojs/node`.
 

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -24,7 +24,7 @@ This integration provides `<Image />` and `<Picture>` components as well as a ba
 
 Along with our integration, we recommend installing [sharp](https://sharp.pixelplumbing.com/) when appropriate. 
 
-The `@astrojs/image` default image transformer is based on [Squoosh](https://github.com/GoogleChromeLabs/squoosh) and uses WebAssembly libraries to support most deployment environments, including those that do not support sharp, such as StackBlitz and Netlify Edge.
+The `@astrojs/image` default image transformer is based on [Squoosh](https://github.com/GoogleChromeLabs/squoosh) and uses WebAssembly libraries to support most deployment environments, including those that do not support sharp, such as StackBlitz.
 
 For faster builds and more fine-grained control of image transformations, install sharp in addition to `@astrojs/image` if
 - You are building a static site with Astro.


### PR DESCRIPTION
## Changes

Some suggested updates and clarifications based on Image Interrogation with @tony-sull 
- more thorough treatment of when Squoosh/sharp do/don't work
- updating some properties for remote image guidance, where defaults don't hold
- includes mention of `alt` being required
- more clearly describes what happens re: building/optimizing to images in public folder

## Testing

No tests

## Docs

only docs
