### PR TITLE
fix not omitted extension in `url` metadata for newly added markdown files in development

### DIFF
--- a/.changeset/mighty-chairs-reply.md
+++ b/.changeset/mighty-chairs-reply.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix not included file extension in `url` metadata for newly added markdown files

--- a/packages/astro/src/vite-plugin-utils/index.ts
+++ b/packages/astro/src/vite-plugin-utils/index.ts
@@ -9,7 +9,9 @@ export function getFileInfo(id: string, config: AstroConfig) {
 
 	const fileId = id.split('?')[0];
 	let fileUrl = fileId.includes('/pages/')
-		? fileId.replace(/^.*?\/pages\//, sitePathname).replace(/(\/index)?\.(md|astro)$/, '')
+		? fileId
+				.replace(/^.*?\/pages\//, sitePathname)
+				.replace(/(\/index)?\.(md|markdown|mdown|mkdn|mkd|mdwn|md|astro)$/, '')
 		: undefined;
 	if (fileUrl && config.trailingSlash === 'always') {
 		fileUrl = appendForwardSlash(fileUrl);

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -72,8 +72,8 @@ describe('Astro Global', () => {
 		it('Astro.glob() correctly returns meta info for MD and Astro files', async () => {
 			const html = await fixture.readFile('/glob/index.html');
 			const $ = cheerio.load(html);
-			expect($('[data-file]').length).to.equal(3);
-			expect($('.post-url[href]').length).to.equal(3);
+			expect($('[data-file]').length).to.equal(8);
+			expect($('.post-url[href]').length).to.equal(8);
 		});
 	});
 });

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -15,12 +15,9 @@ describe('Astro Global', () => {
 
 	describe('dev', () => {
 		let devServer;
-		let $;
 
 		before(async () => {
 			devServer = await fixture.startDevServer();
-			const html = await fixture.fetch('/blog/?foo=42').then((res) => res.text());
-			$ = cheerio.load(html);
 		});
 
 		after(async () => {
@@ -28,10 +25,20 @@ describe('Astro Global', () => {
 		});
 
 		it('Astro.request.url', async () => {
+			const html = await fixture.fetch('/blog/?foo=42').then((res) => res.text());
+			const $ = cheerio.load(html);
 			expect($('#pathname').text()).to.equal('/blog/');
 			expect($('#searchparams').text()).to.equal('{}');
 			expect($('#child-pathname').text()).to.equal('/blog/');
 			expect($('#nested-child-pathname').text()).to.equal('/blog/');
+		});
+
+		it('Astro.glob() returned `url` metadata of each markdown file extensions DOES NOT include the extension', async () => {
+			const html = await fixture.fetch('/blog/omit-markdown-extensions/').then((res) => res.text());
+			const $ = cheerio.load(html);
+			expect($('[data-any-url-contains-extension]').data('any-url-contains-extension')).to.equal(
+				false
+			);
 		});
 	});
 

--- a/packages/astro/test/fixtures/astro-global/src/pages/omit-markdown-extensions.astro
+++ b/packages/astro/test/fixtures/astro-global/src/pages/omit-markdown-extensions.astro
@@ -1,0 +1,17 @@
+---
+const data = await Astro.glob('./post/**/*.{markdown,mdown,mkdn,mkd,mdwn,md}');
+console.log(data);
+const markdownExtensions = /(\.(markdown|mdown|mkdn|mkd|mdwn|md))$/g
+const aUrlContainsExtension = data.some((page:any)=> {
+	console.log(page.url);return markdownExtensions.test(page.url)
+	})
+---
+
+<html>
+  <head>
+    <title>Extensions omitted</title>
+  </head>
+  <body>
+    <p data-any-url-contains-extension={JSON.stringify(aUrlContainsExtension)}>Placeholder</p>
+  </body>
+</html>

--- a/packages/astro/test/fixtures/astro-global/src/pages/omit-markdown-extensions.astro
+++ b/packages/astro/test/fixtures/astro-global/src/pages/omit-markdown-extensions.astro
@@ -1,9 +1,8 @@
 ---
-const data = await Astro.glob('./post/**/*.{markdown,mdown,mkdn,mkd,mdwn,md}');
-console.log(data);
+const markdownPosts = await Astro.glob('./post/**/*.{markdown,mdown,mkdn,mkd,mdwn,md}');
 const markdownExtensions = /(\.(markdown|mdown|mkdn|mkd|mdwn|md))$/g
-const aUrlContainsExtension = data.some((page:any)=> {
-	console.log(page.url);return markdownExtensions.test(page.url)
+const aUrlContainsExtension = markdownPosts.some((page:any)=> {
+	return markdownExtensions.test(page.url)
 	})
 ---
 

--- a/packages/astro/test/fixtures/astro-global/src/pages/post/post-4.markdown
+++ b/packages/astro/test/fixtures/astro-global/src/pages/post/post-4.markdown
@@ -1,0 +1,6 @@
+---
+title: 'Another post'
+layout: '../../layouts/post.astro'
+---
+
+# Another post

--- a/packages/astro/test/fixtures/astro-global/src/pages/post/post-5.mdown
+++ b/packages/astro/test/fixtures/astro-global/src/pages/post/post-5.mdown
@@ -1,0 +1,6 @@
+---
+title: 'Another post'
+layout: '../../layouts/post.astro'
+---
+
+# Another post

--- a/packages/astro/test/fixtures/astro-global/src/pages/post/post-6.mkdn
+++ b/packages/astro/test/fixtures/astro-global/src/pages/post/post-6.mkdn
@@ -1,0 +1,6 @@
+---
+title: 'Another post'
+layout: '../../layouts/post.astro'
+---
+
+# Another post

--- a/packages/astro/test/fixtures/astro-global/src/pages/post/post-7.mkd
+++ b/packages/astro/test/fixtures/astro-global/src/pages/post/post-7.mkd
@@ -1,0 +1,6 @@
+---
+title: 'Another post'
+layout: '../../layouts/post.astro'
+---
+
+# Another post


### PR DESCRIPTION
## Changes

Closes #5228

## Testing

- After get the result of a glob import of all the markdown files using `Astro.glob` we check if any of the markdown modules `url` metadata ends with one of the markdown extensions.
- The result of that operation is passed to a data attribute that should be `false` if none of urls ends with a markdown.

## Docs

Nothing changes, it's a bug fix