### PR TITLE
fix(create-astro): improve error messages when create-astro fails

### DIFF
--- a/.changeset/chilly-mice-agree.md
+++ b/.changeset/chilly-mice-agree.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Improve error messages when `create-astro` fails

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -147,6 +147,7 @@ export async function main() {
 	}
 
 	if (!cwd) {
+		ora().info(dim('No directory provided. See you later, astronaut!'))
 		process.exit(1);
 	}
 
@@ -163,6 +164,7 @@ export async function main() {
 	);
 
 	if (!options.template) {
+		ora().info(dim('No template provided. See you later, astronaut!'))
 		process.exit(1);
 	}
 


### PR DESCRIPTION
## Changes

- There were two cases where `create-astro` would silently `process.exit(1)`.
- I think this might be making https://github.com/withastro/astro/issues/5227 worse than it seems.
- This PR makes these exits log something so it's easier to debug.

## Testing

Manually confirmed

## Docs

N/A