### PR TITLE
Improve prefetch conditions

### DIFF
--- a/.changeset/lemon-spies-approve.md
+++ b/.changeset/lemon-spies-approve.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/prefetch': patch
+---
+
+Do not prefetch if browser is offline or uses 3G

--- a/packages/integrations/prefetch/src/index.ts
+++ b/packages/integrations/prefetch/src/index.ts
@@ -5,7 +5,7 @@ export default function (options: PrefetchOptions = {}): AstroIntegration {
 	return {
 		name: '@astrojs/prefetch',
 		hooks: {
-			'astro:config:setup': ({ updateConfig, addRenderer, injectScript }) => {
+			'astro:config:setup': ({ injectScript }) => {
 				// Inject the necessary polyfills on every page (inlined for speed).
 				injectScript(
 					'page',


### PR DESCRIPTION
I took a general look at the prefetch package and found that prefetching doesn't make sense in some cases.
For example, when the browser is offline.
Also, 3G is a relatively slow connection over which, in my opinion, no prefetching should be done.

## Changes

* Only prefetch when browser is online
* Only prefetch when browser is not 2G/3G
* Minor style changes / partly happen automatically by the linter

## Testing

Tests passing

## Docs

No docs required