### PR TITLE
Prevent astro-scripts from being released

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@example/*", "@test/*"]
+  "ignore": ["@example/*", "@test/*", "astro-scripts"]
 }


### PR DESCRIPTION
## Changes

- Ignores `astro-scripts` in changesets, as it's not a real package.
- Noticed in https://github.com/withastro/astro/pull/5239 that it's currently scheduled to be released. Hoping this change fixes that.

## Testing

N/A

## Docs

N/A