### PR TITLE
Allow 200 response for endpoints in build

### DIFF
--- a/.changeset/cool-ducks-mix.md
+++ b/.changeset/cool-ducks-mix.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow 200 response for endpoints in build

--- a/packages/astro/src/core/endpoint/index.ts
+++ b/packages/astro/src/core/endpoint/index.ts
@@ -1,4 +1,4 @@
-import type { APIContext, EndpointHandler, Params } from '../../@types/astro';
+import type { APIContext, AstroConfig, EndpointHandler, Params } from '../../@types/astro';
 import type { Environment, RenderContext } from '../render/index';
 
 import { renderEndpoint } from '../../runtime/server/index.js';
@@ -112,4 +112,16 @@ export async function call(
 		encoding: response.encoding,
 		cookies: context.cookies,
 	};
+}
+
+function isRedirect(statusCode: number) {
+	return statusCode >= 300 && statusCode < 400;
+}
+
+export function throwIfRedirectNotAllowed(response: Response, config: AstroConfig) {
+	if (config.output !== 'server' && isRedirect(response.status)) {
+		throw new Error(
+			`Redirects are only available when using output: 'server'. Update your Astro config if you need SSR features.`
+		);
+	}
 }

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -19,6 +19,7 @@ import { createRequest } from '../core/request.js';
 import { createRouteManifest, matchAllRoutes } from '../core/routing/index.js';
 import { resolvePages } from '../core/util.js';
 import notFoundTemplate, { subpathNotUsedTemplate } from '../template/4xx.js';
+import { throwIfRedirectNotAllowed } from '../core/endpoint/index.js';
 
 interface AstroPluginOptions {
 	settings: AstroSettings;
@@ -290,18 +291,6 @@ async function handleRequest(
 
 		error(env.logging, null, msg.formatErrorMessage(errorWithMetadata));
 		handle500Response(viteServer, origin, req, res, errorWithMetadata);
-	}
-}
-
-function isRedirect(statusCode: number) {
-	return statusCode >= 300 && statusCode < 400;
-}
-
-function throwIfRedirectNotAllowed(response: Response, config: AstroConfig) {
-	if (config.output !== 'server' && isRedirect(response.status)) {
-		throw new Error(
-			`Redirects are only available when using output: 'server'. Update your Astro config if you need SSR features.`
-		);
 	}
 }
 

--- a/packages/astro/test/fixtures/with-endpoint-routes/src/pages/invalid-redirect.json.ts
+++ b/packages/astro/test/fixtures/with-endpoint-routes/src/pages/invalid-redirect.json.ts
@@ -1,0 +1,11 @@
+export const get = () => {
+  return new Response(
+    undefined,
+    {
+      status: 301,
+      headers: {
+        Location: 'https://example.com',
+      }
+    }
+  );
+};


### PR DESCRIPTION
## Changes

Fix #4930

- Allow returning response with 200 status code from static endpoints.
- Throw on 300 status code for static endpoints like in dev mode.
- Also throw on 300 status code for page endpoints on build, previously would silently skip.

These changes should make build similar to dev.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
I'm not sure how to test errors that would cause build to fail, but I did test with #4930 to make sure it works.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Currently the docs doesn't document that they can return a response for static endpoints. I'll document this separately but I don't think it blocks this PR.

https://github.com/withastro/docs/pull/1961