### PR TITLE
Revert "Prevent astro-scripts from being released (#5257)"

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@example/*", "@test/*", "astro-scripts"]
+  "ignore": ["@example/*", "@test/*"]
 }


### PR DESCRIPTION
This reverts commit 4f9391b33f9ec276536039daad65b2c9a2db53ca.

## Changes

- Hoped that this would prevent `astro-scripts` from showing up to be released but it actually breaks packages that depend on it.

## Testing

N/A

## Docs

N/A