### PR TITLE
[@astrojs/image] web-streams-polyfill should be included as a prod dependency

### DIFF
--- a/.changeset/tame-keys-kiss.md
+++ b/.changeset/tame-keys-kiss.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Fixes a bug where the `web-streams-polyfill` dependency would not be installed with the `--production` flag

--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -48,7 +48,8 @@
     "kleur": "^4.1.5",
     "magic-string": "^0.25.9",
     "mime": "^3.0.0",
-    "slash": "^4.0.0"
+    "slash": "^4.0.0",
+    "web-streams-polyfill": "^3.2.1"
   },
   "devDependencies": {
     "@types/http-cache-semantics": "^4.0.1",
@@ -61,8 +62,7 @@
     "mocha": "^9.2.2",
     "rollup-plugin-copy": "^3.4.0",
     "sharp": "^0.31.0",
-    "vite": "^3.0.0",
-    "web-streams-polyfill": "^3.2.1"
+    "vite": "^3.0.0"
   },
   "peerDependencies": {
     "sharp": ">=0.31.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2586,6 +2586,7 @@ importers:
       magic-string: 0.25.9
       mime: 3.0.0
       slash: 4.0.0
+      web-streams-polyfill: 3.2.1
     devDependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/mime': 2.0.3
@@ -2598,7 +2599,6 @@ importers:
       rollup-plugin-copy: 3.4.0
       sharp: 0.31.1
       vite: 3.2.0
-      web-streams-polyfill: 3.2.1
 
   packages/integrations/image/test/fixtures/background-color-image:
     specifiers:


### PR DESCRIPTION
## Changes

fixes #5252

Fixes a bug where the `web-streams-polyfill` dependency may not be installed in certain situations, like `npm install --production`

## Testing

All existing tests should pass

## Docs

None, bug fix only
