### PR TITLE
Be able to configure the quality with Picture

### DIFF
--- a/.changeset/two-maps-greet.md
+++ b/.changeset/two-maps-greet.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': minor
+---
+
+Be able to configure the quality when using Picture

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -359,6 +359,16 @@ The output formats to be used in the optimized image. If not provided, `webp` an
 
 For remote images, the original image format is unknown. If not provided, only `webp` and `avif` will be used.
 
+#### quality
+
+<p>
+
+**Type:** `number`<br>
+**Default:** `undefined`
+</p>
+
+The compression quality used during optimization. The image service will use its own default quality depending on the image format if not provided.
+
 #### background
 
 <p>

--- a/packages/integrations/image/components/Picture.astro
+++ b/packages/integrations/image/components/Picture.astro
@@ -44,6 +44,7 @@ const {
 	formats = ['avif', 'webp'],
 	loading = 'lazy',
 	decoding = 'async',
+	quality,
 	...attrs
 } = Astro.props as Props;
 
@@ -59,6 +60,7 @@ const { image, sources } = await getPicture({
 	fit,
 	background,
 	position,
+	quality,
 });
 
 delete image.width;

--- a/packages/integrations/image/src/lib/get-picture.ts
+++ b/packages/integrations/image/src/lib/get-picture.ts
@@ -13,6 +13,7 @@ export interface GetPictureParams {
 	fit?: TransformOptions['fit'];
 	background?: TransformOptions['background'];
 	position?: TransformOptions['position'];
+	quality?: TransformOptions['quality'];
 }
 
 export interface GetPictureResult {
@@ -43,7 +44,7 @@ async function resolveFormats({ src, formats }: GetPictureParams) {
 }
 
 export async function getPicture(params: GetPictureParams): Promise<GetPictureResult> {
-	const { src, widths, fit, position, background } = params;
+	const { src, widths, fit, position, background, quality } = params;
 
 	if (!src) {
 		throw new Error('[@astrojs/image] `src` is required');
@@ -70,6 +71,7 @@ export async function getPicture(params: GetPictureParams): Promise<GetPictureRe
 					position,
 					background,
 					height: Math.round(width / aspectRatio!),
+					quality,
 				});
 				return `${img.src} ${width}w`;
 			})
@@ -92,6 +94,7 @@ export async function getPicture(params: GetPictureParams): Promise<GetPictureRe
 		position,
 		background,
 		format: allFormats[allFormats.length - 1],
+		quality,
 	});
 
 	const sources = await Promise.all(allFormats.map((format) => getSource(format)));


### PR DESCRIPTION
Hello everyone :)

## Changes

I have noticed that the `Picture` component of `@astrojs/image` cannot have `quality` prop as the `Image` component.
I would find it useful and will use it for sure :)

## Testing

I have tested my changes locally, by publishing my package on a local verdaccio. 
I didn't find test for this part of the code, if I am wrong do not hesitate to tell me where the tests are and will add one :)

I tried to make a snapshot, following the [contributing guide](https://github.com/withastro/astro/blob/main/CONTRIBUTING.md#releasing-pr-preview-snapshots) but did not get it. I have some 404 when releasing it. Actually, I do not understand where the snapshot should be deployed (astro npm registry ? one I need to create ?)

## Docs

For now, I did not uncomment this. If this PR is good for you I will uncomment the comments below and will make a PR in the documentation repository to add the `quality` prop for the `Picture` component.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

Thank you for reading me.
