### PR TITLE
ci: fix `prettier` arg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       # Checks that the formatter runs successfully on all files
       # In the future, we may have this fail PRs on unformatted code
       - name: Format Check
-        run: pnpm run format --list
+        run: pnpm run format --check
 
   # Build primes out build caches for Turbo
   build:


### PR DESCRIPTION
## Changes

- `pnpm run format --list`
    - ↳ `pnpm run format:code --list`
        - ↳ `prettier -w . --cache --plugin-search-dir=. --list`
- `[warn] Ignored unknown option --list.` <-- spotted in CI output
- [--list-different](https://prettier.io/docs/en/cli.html#--list-different) would work
- [--check](https://prettier.io/docs/en/cli.html#--check) outputs "a human-friendly message and a list of unformatted files, if any."
- In this case, since we're not trying to do anything in particular with the output, might as well go for "human-friendly"
- Originally added in https://github.com/withastro/astro/pull/2696

## Testing, Docs

n/a