### PR TITLE
Fix memleak caused by directory names containing '.md' or '.mdx'

### DIFF
--- a/.changeset/clever-files-wash.md
+++ b/.changeset/clever-files-wash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed memleak caused by project dir names containing '.md' or '.mdx'

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -19,19 +19,10 @@ export function isURL(value: unknown): value is URL {
 	return Object.prototype.toString.call(value) === '[object URL]';
 }
 /** Check if a file is a markdown file based on its extension */
-export function isMarkdownFile(
-	fileId: string,
-	option: { criteria: 'endsWith' | 'includes'; suffix?: string }
-): boolean {
-	const _suffix = option.suffix ?? '';
-	if (option.criteria === 'endsWith') {
-		for (let markdownFileExtension of SUPPORTED_MARKDOWN_FILE_EXTENSIONS) {
-			if (fileId.endsWith(`${markdownFileExtension}${_suffix}`)) return true;
-		}
-		return false;
-	}
+export function isMarkdownFile(fileId: string, option?: { suffix?: string }): boolean {
+	const _suffix = option?.suffix ?? '';
 	for (let markdownFileExtension of SUPPORTED_MARKDOWN_FILE_EXTENSIONS) {
-		if (fileId.includes(`${markdownFileExtension}${_suffix}`)) return true;
+		if (fileId.endsWith(`${markdownFileExtension}${_suffix}`)) return true;
 	}
 	return false;
 }

--- a/packages/astro/src/vite-plugin-astro-postprocess/index.ts
+++ b/packages/astro/src/vite-plugin-astro-postprocess/index.ts
@@ -18,7 +18,7 @@ export default function astro(_opts: AstroPluginOptions): Plugin {
 		name: 'astro:postprocess',
 		async transform(code, id) {
 			// Currently only supported in ".astro" and ".md" (or any alternative markdown file extension like `.markdown`) files
-			if (!id.endsWith('.astro') && !isMarkdownFile(id, { criteria: 'endsWith' })) {
+			if (!id.endsWith('.astro') && !isMarkdownFile(id)) {
 				return null;
 			}
 

--- a/packages/astro/src/vite-plugin-jsx/index.ts
+++ b/packages/astro/src/vite-plugin-jsx/index.ts
@@ -193,7 +193,7 @@ export default function jsx({ settings, logging }: AstroPluginJSXOptions): Plugi
 
 			const { mode } = viteConfig;
 			// Shortcut: only use Astro renderer for MD and MDX files
-			if (id.includes('.mdx') || isMarkdownFile(id, { criteria: 'includes' })) {
+			if (id.endsWith('.mdx')) {
 				const { code: jsxCode } = await esbuild.transform(code, {
 					loader: getEsbuildLoader(path.extname(id)) as esbuild.Loader,
 					jsx: 'preserve',

--- a/packages/astro/src/vite-plugin-markdown-legacy/index.ts
+++ b/packages/astro/src/vite-plugin-markdown-legacy/index.ts
@@ -90,7 +90,7 @@ export default function markdown({ settings }: AstroPluginOptions): Plugin {
 			// Resolve any .md (or alternative extensions of markdown files like .markdown) files with the `?content` cache buster. This should only come from
 			// an already-resolved JS module wrapper. Needed to prevent infinite loops in Vite.
 			// Unclear if this is expected or if cache busting is just working around a Vite bug.
-			if (isMarkdownFile(id, { criteria: 'endsWith', suffix: MARKDOWN_CONTENT_FLAG })) {
+			if (isMarkdownFile(id, { suffix: MARKDOWN_CONTENT_FLAG })) {
 				const resolvedId = await this.resolve(id, importer, { skipSelf: true, ...options });
 				return resolvedId?.id.replace(MARKDOWN_CONTENT_FLAG, '');
 			}
@@ -98,7 +98,7 @@ export default function markdown({ settings }: AstroPluginOptions): Plugin {
 			// that defers the markdown -> HTML rendering until it is needed. This is especially useful
 			// when fetching and then filtering many markdown files, like with import.meta.glob() or Astro.glob().
 			// Otherwise, resolve directly to the actual component.
-			if (isMarkdownFile(id, { criteria: 'endsWith' }) && !isRootImport(importer)) {
+			if (isMarkdownFile(id) && !isRootImport(importer)) {
 				const resolvedId = await this.resolve(id, importer, { skipSelf: true, ...options });
 				if (resolvedId) {
 					return resolvedId.id + MARKDOWN_IMPORT_FLAG;
@@ -111,7 +111,7 @@ export default function markdown({ settings }: AstroPluginOptions): Plugin {
 			// A markdown file has been imported via ESM!
 			// Return the file's JS representation, including all Markdown
 			// frontmatter and a deferred `import() of the compiled markdown content.
-			if (isMarkdownFile(id, { criteria: 'endsWith', suffix: MARKDOWN_IMPORT_FLAG })) {
+			if (isMarkdownFile(id, { suffix: MARKDOWN_IMPORT_FLAG })) {
 				const { fileId, fileUrl } = getFileInfo(id, config);
 
 				const source = await fs.promises.readFile(fileId, 'utf8');
@@ -151,7 +151,7 @@ export default function markdown({ settings }: AstroPluginOptions): Plugin {
 			// A markdown file is being rendered! This markdown file was either imported
 			// directly as a page in Vite, or it was a deferred render from a JS module.
 			// This returns the compiled markdown -> astro component that renders to HTML.
-			if (isMarkdownFile(id, { criteria: 'endsWith' })) {
+			if (isMarkdownFile(id)) {
 				const filename = normalizeFilename(id);
 				const source = await fs.promises.readFile(filename, 'utf8');
 				const renderOpts = config.markdown;

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -59,7 +59,7 @@ export default function markdown({ settings, logging }: AstroPluginOptions): Plu
 		// passing to the transform hook. This lets us get the truly raw value
 		// to escape "import.meta.env" ourselves.
 		async load(id) {
-			if (isMarkdownFile(id, { criteria: 'endsWith' })) {
+			if (isMarkdownFile(id)) {
 				const { fileId, fileUrl } = getFileInfo(id, settings.config);
 				const rawFile = await fs.promises.readFile(fileId, 'utf-8');
 				const raw = safeMatter(rawFile, id);

--- a/packages/astro/test/fixtures/impostor-mdx-file/astro.config.mjs
+++ b/packages/astro/test/fixtures/impostor-mdx-file/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [react()],
+});

--- a/packages/astro/test/fixtures/impostor-mdx-file/package.json
+++ b/packages/astro/test/fixtures/impostor-mdx-file/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@test/impostor-md-file",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/react": "workspace:*",
+    "astro": "workspace:*",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0"
+  }
+}

--- a/packages/astro/test/fixtures/impostor-mdx-file/src/components/Foo.mdx.jsx
+++ b/packages/astro/test/fixtures/impostor-mdx-file/src/components/Foo.mdx.jsx
@@ -1,0 +1,6 @@
+import {useState} from "react";
+
+export default function Foo() {
+  const [bar, setBar] = useState("Baz");
+  return <div className="main-component">{bar}</div>
+}

--- a/packages/astro/test/fixtures/impostor-mdx-file/src/pages/index.astro
+++ b/packages/astro/test/fixtures/impostor-mdx-file/src/pages/index.astro
@@ -1,0 +1,12 @@
+---
+import Foo from '../components/Foo.mdx.jsx';
+---
+
+<html>
+  <head>
+    <!-- Head Stuff -->
+  </head>
+  <body>
+    <Foo client:load />
+  </body>
+</html>

--- a/packages/astro/test/impostor-mdx-file.js
+++ b/packages/astro/test/impostor-mdx-file.js
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import { isWindows, loadFixture } from './test-utils.js';
+
+let fixture;
+
+describe('Impostor MDX File', () => {
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/impostor-mdx-file/',
+		});
+	});
+	if (isWindows) return;
+
+	describe('dev', () => {
+		/** @type {import('./test-utils').Fixture} */
+		let devServer;
+
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('does not crash when loading react component with .md or .mdx in name', async () => {
+			const result = await fixture.fetch('/').then((response) => response.text());
+			expect(result).to.contain('Baz');
+		});
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1810,6 +1810,18 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/impostor-mdx-file:
+    specifiers:
+      '@astrojs/react': workspace:*
+      astro: workspace:*
+      react: ^18.1.0
+      react-dom: ^18.1.0
+    dependencies:
+      '@astrojs/react': link:../../../../integrations/react
+      astro: link:../../..
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+
   packages/astro/test/fixtures/integration-add-page-extension:
     specifiers:
       astro: workspace:*


### PR DESCRIPTION
## Changes

I must mention, I'm _very_ excited to contribute in some way to this awesome project.
Now, the matter at hand:

This fixes a bug caused by wrongly treating files as markdown. If the project's path contains '.md' (or any markdown extension) serving any page containing javascript results in the server crashing due to the heap running out of memory.

I noticed this behaviour when developing my personal website, 'vladinski.md' :)

## Testing

Ran entire test suite.
Writing a test seemed overkill, considering such a peculiar type of bug.
If a test is required, please tell me so and I'll find a way to implement it.

## Docs

No docs added since this is a fix that doesn't modify a user's usage.
