### PR TITLE
Prevent tailwind config errors from crashing dev server

### DIFF
--- a/.changeset/long-turtles-run.md
+++ b/.changeset/long-turtles-run.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/tailwind': patch
+---
+
+Prevent errors during HMR from crashing dev server

--- a/packages/integrations/tailwind/src/index.ts
+++ b/packages/integrations/tailwind/src/index.ts
@@ -40,7 +40,7 @@ async function getUserConfig(root: URL, configPath?: string, isRestart = false) 
 		const tempConfigPath = path.join(dir, `.temp.${Date.now()}.${base}`);
 		await fs.copyFile(resolvedConfigPath, tempConfigPath);
 
-		let result: Record<any, any> | undefined;
+		let result: load.Config<Record<any, any>> | undefined;
 		try {
 			result = await load('tailwind', {
 				mustExist: false,

--- a/packages/integrations/tailwind/src/index.ts
+++ b/packages/integrations/tailwind/src/index.ts
@@ -40,13 +40,14 @@ async function getUserConfig(root: URL, configPath?: string, isRestart = false) 
 		const tempConfigPath = path.join(dir, `.temp.${Date.now()}.${base}`);
 		await fs.copyFile(resolvedConfigPath, tempConfigPath);
 
-		const result = await load('tailwind', {
-			mustExist: false,
-			cwd: resolvedRoot,
-			filePath: tempConfigPath,
-		});
-
+		let result: Record<any, any> | undefined;
 		try {
+			result = await load('tailwind', {
+				mustExist: false,
+				cwd: resolvedRoot,
+				filePath: tempConfigPath,
+			});
+
 			await fs.unlink(tempConfigPath);
 		} catch {
 			/** file already removed */


### PR DESCRIPTION
## Changes

- If the tailwind config contains an error it should not crash the dev server on restart.
- Note that it *does* crash on initial start which is wanted.
- Closes https://github.com/withastro/astro/issues/5142

## Testing

Tested in demo project.

## Docs

N/A