### PR TITLE
Updates @astrojs/prefetch package keywords

### DIFF
--- a/.changeset/lucky-bees-impress.md
+++ b/.changeset/lucky-bees-impress.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/prefetch': patch
+---
+
+Adds additional package.json keywords used for discoverability in the Integrations catalog

--- a/packages/integrations/prefetch/package.json
+++ b/packages/integrations/prefetch/package.json
@@ -12,7 +12,9 @@
     "directory": "packages/astro-prefetch"
   },
   "keywords": [
-    "astro-integration"
+    "astro-integration",
+    "performance",
+    "withastro"
   ],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://docs.astro.build/en/guides/integrations-guide/prefetch/",


### PR DESCRIPTION
## Changes

Noticed the `@astrojs/prefetch` integration isn't showing up in our [Integrations catalog](https://astro.build/integrations)

This updates the package keywords so it will show up in the integration on the "Official" and "performance + seo" tabs

## Testing

Tested manually

## Docs

/cc @withastro/maintainers-docs in case the `package.json` update impacts any scripts that may be generating docs code
