### PR TITLE
fix: consider trailing slashes when calculating current path in blog example

### DIFF
--- a/examples/blog/src/components/HeaderLink.astro
+++ b/examples/blog/src/components/HeaderLink.astro
@@ -2,7 +2,9 @@
 export interface Props extends astroHTML.JSX.AnchorHTMLAttributes {}
 
 const { href, class: className, ...props } = Astro.props;
-const isActive = href === Astro.url.pathname.replace(/\/$/, '');
+
+const { pathname } = Astro.url;
+const isActive = href === pathname || href === pathname.replace(/\/$/, '');
 ---
 
 <a href={href} class:list={[className, { active: isActive }]} {...props}>


### PR DESCRIPTION
Closes #5248 

## Changes

In the blog example

- calculate `isActive` correctly
- take into consideration both cases: trailing slash and no trailing slash

## Testing

This was tested in a dev server as well as a production environment on vercel.

## Docs

It could be a bit confusing to people why we're calculating the active path like this. I think a comment above explaining it should be enough. Do need some help coming up with a brief way to explain this.
