### PR TITLE
Surface configuration errors to the client

### DIFF
--- a/.changeset/brown-clocks-press.md
+++ b/.changeset/brown-clocks-press.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Surface astro.config errors to the user

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -177,67 +177,21 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 	// by the end of this switch statement.
 	switch (cmd) {
 		case 'dev': {
-			async function startDevServer({ isRestart = false }: { isRestart?: boolean } = {}) {
-				const { watcher, stop } = await devServer(settings, { logging, telemetry, isRestart });
-				let restartInFlight = false;
-				const configFlag = resolveFlags(flags).config;
-				const configFlagPath = configFlag
-					? await resolveConfigPath({ cwd: root, flags })
-					: undefined;
-				const resolvedRoot = appendForwardSlash(resolveRoot(root));
+			const configFlag = resolveFlags(flags).config;
+			const configFlagPath = configFlag
+				? await resolveConfigPath({ cwd: root, flags })
+				: undefined;
 
-				const handleServerRestart = (logMsg: string) =>
-					async function (changedFile: string) {
-						if (restartInFlight) return;
-
-						let shouldRestart = false;
-
-						// If the config file changed, reload the config and restart the server.
-						shouldRestart = configFlag
-							? // If --config is specified, only watch changes for this file
-							  !!configFlagPath && normalizePath(configFlagPath) === normalizePath(changedFile)
-							: // Otherwise, watch for any astro.config.* file changes in project root
-							  new RegExp(
-									`${normalizePath(resolvedRoot)}.*astro\.config\.((mjs)|(cjs)|(js)|(ts))$`
-							  ).test(normalizePath(changedFile));
-
-						if (!shouldRestart && settings.watchFiles.length > 0) {
-							// If the config file didn't change, check if any of the watched files changed.
-							shouldRestart = settings.watchFiles.some(
-								(path) => normalizePath(path) === normalizePath(changedFile)
-							);
-						}
-
-						if (!shouldRestart) return;
-
-						restartInFlight = true;
-						console.clear();
-						try {
-							const newConfig = await openConfig({
-								cwd: root,
-								flags,
-								cmd,
-								logging,
-								isRestart: true,
-							});
-							info(logging, 'astro', logMsg + '\n');
-							let astroConfig = newConfig.astroConfig;
-							settings = createSettings(astroConfig, root);
-							await stop();
-							await startDevServer({ isRestart: true });
-						} catch (e) {
-							await handleConfigError(e, { cwd: root, flags, logging });
-							await stop();
-							info(logging, 'astro', 'Continuing with previous valid configuration\n');
-							await startDevServer({ isRestart: true });
-						}
-					};
-
-				watcher.on('change', handleServerRestart('Configuration updated. Restarting...'));
-				watcher.on('unlink', handleServerRestart('Configuration removed. Restarting...'));
-				watcher.on('add', handleServerRestart('Configuration added. Restarting...'));
-			}
-			await startDevServer({ isRestart: false });
+			await devServer(settings, {
+				configFlag,
+				configFlagPath,
+				logging,
+				telemetry,
+				handleConfigError(e) {
+					handleConfigError(e, { cwd: root, flags, logging });
+					info(logging, 'astro', 'Continuing with previous valid configuration\n');
+				}
+			});
 			return await new Promise(() => {}); // lives forever
 		}
 

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -105,7 +105,10 @@ export function resolveFlags(flags: Partial<Flags>): CLIFlags {
 	};
 }
 
-export function resolveRoot(cwd?: string): string {
+export function resolveRoot(cwd?: string | URL): string {
+	if(cwd instanceof URL) {
+		cwd = fileURLToPath(cwd);
+	}
 	return cwd ? path.resolve(cwd) : process.cwd();
 }
 
@@ -137,6 +140,7 @@ interface LoadConfigOptions {
 	logging: LogOptions;
 	/** Invalidate when reloading a previously loaded config */
 	isRestart?: boolean;
+	fsMod?: typeof fs;
 }
 
 /**
@@ -210,6 +214,7 @@ async function tryLoadConfig(
 	flags: CLIFlags,
 	root: string
 ): Promise<TryLoadConfigResult | undefined> {
+	const fsMod = configOptions.fsMod ?? fs;
 	let finallyCleanup = async () => {};
 	try {
 		let configPath = await resolveConfigPath({
@@ -224,7 +229,9 @@ async function tryLoadConfig(
 				root,
 				`.temp.${Date.now()}.config${path.extname(configPath)}`
 			);
-			await fs.promises.writeFile(tempConfigPath, await fs.promises.readFile(configPath));
+
+			const currentConfigContent = await fsMod.promises.readFile(configPath, 'utf-8');
+			await fs.promises.writeFile(tempConfigPath, currentConfigContent);
 			finallyCleanup = async () => {
 				try {
 					await fs.promises.unlink(tempConfigPath);

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -9,10 +9,12 @@ import {
 	runHookConfigSetup,
 	runHookServerSetup,
 	runHookServerStart,
+	runHookServerDone
 } from '../../integrations/index.js';
-import { createDefaultDevSettings } from '../config/index.js';
+import { createDefaultDevSettings, resolveRoot } from '../config/index.js';
 import { createVite } from '../create-vite.js';
 import { LogOptions } from '../logger/core.js';
+import { appendForwardSlash } from '../path.js';
 import { nodeLogDestination } from '../logger/node.js';
 import { apply as applyPolyfill } from '../polyfill.js';
 
@@ -27,6 +29,10 @@ export interface Container {
 	settings: AstroSettings;
 	viteConfig: vite.InlineConfig;
 	viteServer: vite.ViteDevServer;
+	resolvedRoot: string;
+	configFlag: string | undefined;
+	configFlagPath: string | undefined;
+	restartInFlight: boolean; // gross
 	handle: (req: http.IncomingMessage, res: http.ServerResponse) => void;
 	close: () => Promise<void>;
 }
@@ -38,6 +44,9 @@ export interface CreateContainerParams {
 	settings?: AstroSettings;
 	fs?: typeof nodeFs;
 	root?: string | URL;
+	// The string passed to --config and the resolved path
+	configFlag?: string;
+	configFlagPath?: string;
 }
 
 export async function createContainer(params: CreateContainerParams = {}): Promise<Container> {
@@ -83,9 +92,13 @@ export async function createContainer(params: CreateContainerParams = {}): Promi
 	const viteServer = await vite.createServer(viteConfig);
 	runHookServerSetup({ config: settings.config, server: viteServer, logging });
 
-	return {
+	const container: Container = {
+		configFlag: params.configFlag,
+		configFlagPath: params.configFlagPath,
 		fs,
 		logging,
+		resolvedRoot: appendForwardSlash(resolveRoot(params.root)),
+		restartInFlight: false,
 		settings,
 		viteConfig,
 		viteServer,
@@ -93,10 +106,25 @@ export async function createContainer(params: CreateContainerParams = {}): Promi
 		handle(req, res) {
 			viteServer.middlewares.handle(req, res, Function.prototype);
 		},
+		// TODO deprecate and remove
 		close() {
-			return viteServer.close();
-		},
+			return closeContainer(container);
+		}
 	};
+
+	return container;
+}
+
+async function closeContainer({
+	viteServer,
+	settings,
+	logging
+}: Container) {
+	await viteServer.close();
+	await runHookServerDone({
+		config: settings.config,
+		logging,
+	});
 }
 
 export async function startContainer({
@@ -115,6 +143,7 @@ export async function startContainer({
 
 	return devServerAddressInfo;
 }
+
 
 export async function runInContainer(
 	params: CreateContainerParams,

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -102,7 +102,6 @@ export async function createContainer(params: CreateContainerParams = {}): Promi
 		settings,
 		viteConfig,
 		viteServer,
-
 		handle(req, res) {
 			viteServer.middlewares.handle(req, res, Function.prototype);
 		},
@@ -144,6 +143,9 @@ export async function startContainer({
 	return devServerAddressInfo;
 }
 
+export function isStarted(container: Container): boolean {
+	return !!container.viteServer.httpServer?.listening;
+}
 
 export async function runInContainer(
 	params: CreateContainerParams,

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -1,2 +1,9 @@
-export { createContainer, runInContainer, startContainer } from './container.js';
+export {
+	createContainer,
+	runInContainer,
+	startContainer
+} from './container.js';
+export {
+	createContainerWithAutomaticRestart
+} from './restart.js';
 export { default } from './dev.js';

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -1,0 +1,166 @@
+import type { AstroSettings } from '../../@types/astro';
+import type { Container, CreateContainerParams } from './container';
+import * as vite from 'vite';
+import { createSettings, openConfig } from '../config/index.js';
+import { info } from '../logger/core.js';
+import { createContainer } from './container.js';
+import { createSafeError } from '../errors/index.js';
+
+function createRestartedContainer({
+	logging,
+	fs,
+	resolvedRoot,
+	configFlag,
+	configFlagPath
+}: Container, settings: AstroSettings): Promise<Container> {
+	return createContainer({
+		isRestart: true,
+		logging,
+		settings,
+		fs,
+		root: resolvedRoot,
+		configFlag,
+		configFlagPath,
+	})
+}
+
+export function shouldRestartContainer({
+	settings,
+	configFlag,
+	configFlagPath,
+	resolvedRoot,
+	restartInFlight
+}: Container, changedFile: string): boolean {
+	if(restartInFlight) return false;
+
+	let shouldRestart = false;
+
+	// If the config file changed, reload the config and restart the server.
+	shouldRestart = configFlag
+		? // If --config is specified, only watch changes for this file
+			!!configFlagPath && vite.normalizePath(configFlagPath) === vite.normalizePath(changedFile)
+		: // Otherwise, watch for any astro.config.* file changes in project root
+			new RegExp(
+				`${vite.normalizePath(resolvedRoot)}.*astro\.config\.((mjs)|(cjs)|(js)|(ts))$`
+			).test(vite.normalizePath(changedFile));
+
+	if (!shouldRestart && settings.watchFiles.length > 0) {
+		// If the config file didn't change, check if any of the watched files changed.
+		shouldRestart = settings.watchFiles.some(
+			(path) => vite.normalizePath(path) === vite.normalizePath(changedFile)
+		);
+	}
+
+	return shouldRestart;
+}
+
+interface RestartContainerParams {
+	container: Container;
+	flags: any;
+	logMsg: string;
+	handleConfigError: (err: unknown) => Promise<void> | void;
+}
+
+export async function restartContainer({
+	container,
+	flags,
+	logMsg,
+	handleConfigError
+}: RestartContainerParams): Promise<Container> {
+	const {
+		logging,
+		close,
+		resolvedRoot,
+		settings: existingSettings
+	} = container;
+	container.restartInFlight = true;
+
+	//console.clear(); // TODO move this
+	try {
+		const newConfig = await openConfig({
+			cwd: resolvedRoot,
+			flags,
+			cmd: 'dev',
+			logging,
+			isRestart: true,
+			fsMod: container.fs,
+		});
+		info(logging, 'astro', logMsg + '\n');
+		let astroConfig = newConfig.astroConfig;
+		const settings = createSettings(astroConfig, resolvedRoot);
+		await close();
+		return createRestartedContainer(container, settings);
+	} catch (e) {
+		await handleConfigError(e);
+		await close();
+		info(logging, 'astro', 'Continuing with previous valid configuration\n');
+		return createRestartedContainer(container, existingSettings);
+	}
+}
+
+export interface CreateContainerWithAutomaticRestart {
+	flags: any;
+	params: CreateContainerParams;
+	handleConfigError?: (error: Error) => void | Promise<void>;
+}
+
+interface Restart {
+	container: Container;
+	restarted: () => Promise<void>;
+}
+
+export async function createContainerWithAutomaticRestart({
+	flags,
+	handleConfigError = (_e: Error) => {},
+	params
+}: CreateContainerWithAutomaticRestart): Promise<Restart> {
+	let container = await createContainer(params);
+	let resolveRestart: (value: void) => void;
+	let restartComplete = new Promise<void>(resolve => {
+		resolveRestart = resolve;
+	});
+
+	let restart: Restart = {
+		container,
+		restarted() {
+			return restartComplete;
+		}
+	};
+
+	function handleServerRestart(logMsg: string) {
+		return async function(changedFile: string) {
+			if(shouldRestartContainer(container, changedFile)) {
+				restart.container = await restartContainer({
+					container,
+					flags,
+					logMsg,
+					async handleConfigError(_err) {
+						// Send an error message to the client if one is connected.
+						const error = createSafeError(_err);
+						await handleConfigError(error);
+						container.viteServer.ws.send({
+							type: 'error',
+							err: {
+								message: error.message,
+								stack: error.stack || ''
+							}
+						});
+					}
+				});
+
+				resolveRestart();
+				restartComplete = new Promise<void>(resolve => {
+					resolveRestart = resolve;
+				});
+			}
+		}
+	}
+
+	// Set up watches
+	const watcher = container.viteServer.watcher;
+	watcher.on('change', handleServerRestart('Configuration updated. Restarting...'));
+	watcher.on('unlink', handleServerRestart('Configuration removed. Restarting...'));
+	watcher.on('add', handleServerRestart('Configuration added. Restarting...'));
+
+	return restart;
+}

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -36,7 +36,6 @@ export function shouldRestartContainer({
 	settings,
 	configFlag,
 	configFlagPath,
-	resolvedRoot,
 	restartInFlight
 }: Container, changedFile: string): boolean {
 	if(restartInFlight) return false;
@@ -44,13 +43,17 @@ export function shouldRestartContainer({
 	let shouldRestart = false;
 
 	// If the config file changed, reload the config and restart the server.
-	shouldRestart = configFlag
-		? // If --config is specified, only watch changes for this file
-			!!configFlagPath && vite.normalizePath(configFlagPath) === vite.normalizePath(changedFile)
-		: // Otherwise, watch for any astro.config.* file changes in project root
-			new RegExp(
-				`${vite.normalizePath(resolvedRoot)}.*astro\.config\.((mjs)|(cjs)|(js)|(ts))$`
-			).test(vite.normalizePath(changedFile));
+	if(configFlag) {
+		if(!!configFlagPath) {
+			shouldRestart = vite.normalizePath(configFlagPath) === vite.normalizePath(changedFile);
+		}
+	}
+	// Otherwise, watch for any astro.config.* file changes in project root
+	else {
+		const exp = new RegExp(`.*astro\.config\.((mjs)|(cjs)|(js)|(ts))$`);
+		const normalizedChangedFile = vite.normalizePath(changedFile);
+		shouldRestart = exp.test(normalizedChangedFile);
+	}
 
 	if (!shouldRestart && settings.watchFiles.length > 0) {
 		// If the config file didn't change, check if any of the watched files changed.

--- a/packages/astro/test/units/dev/restart.test.js
+++ b/packages/astro/test/units/dev/restart.test.js
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+
+import { createContainerWithAutomaticRestart, runInContainer } from '../../../dist/core/dev/index.js';
+import { createFs, createRequestAndResponse } from '../test-utils.js';
+
+const root = new URL('../../fixtures/alias/', import.meta.url);
+
+describe('dev container restarts', () => {
+	it.only('Surfaces config errors on restarts', async () => {
+		const fs = createFs(
+			{
+				'/src/pages/index.astro': `
+				<html>
+					<head><title>Test</title></head>
+					<body>
+						<h1>Test</h1>
+					</body>
+				</html>
+			`,
+				'/astro.config.mjs': `
+				
+				`
+			},
+			root
+		);
+
+		let restart = await createContainerWithAutomaticRestart({
+			params: { fs, root }
+		});
+
+		let hmrError;
+		const oldSend = restart.container.viteServer.ws.send;
+		restart.container.viteServer.ws.send = function(ev) {
+			hmrError = ev;
+			return oldSend.apply(this, arguments);
+		};
+
+		try {
+			let r = createRequestAndResponse({
+				method: 'GET',
+				url: '/',
+			});
+			restart.container.handle(r.req, r.res);
+			let html = await r.text();
+			const $ = cheerio.load(html);
+			expect(r.res.statusCode).to.equal(200);
+			expect($('h1')).to.have.a.lengthOf(1);
+	
+			// Create an error
+			let restartComplete = restart.restarted();
+			fs.writeFileFromRootSync('/astro.config.mjs', 'const foo = bar');
+
+			// Vite watches the real filesystem, so we have to mock this part. It's not so bad.
+			restart.container.viteServer.watcher.emit('change', fs.getFullyResolvedPath('/astro.config.mjs'));
+
+			// Wait for the restart to finish
+			await restartComplete;
+
+			expect(hmrError).to.not.be.a('undefined');
+			expect(hmrError.type).to.equal('error');
+		} finally {
+			await restart.container.close();
+		}
+	});
+});

--- a/packages/astro/test/units/test-utils.js
+++ b/packages/astro/test/units/test-utils.js
@@ -6,11 +6,25 @@ import npath from 'path';
 import { unixify } from './correct-path.js';
 
 class MyVolume extends Volume {
+	#root = '';
+	constructor(root) {
+		super();
+		this.#root = root;
+	}
+
+	getFullyResolvedPath(pth) {
+		return npath.posix.join(this.#root, pth);
+	}
+
 	existsSync(p) {
 		if (p instanceof URL) {
 			p = fileURLToPath(p);
 		}
 		return super.existsSync(p);
+	}
+
+	writeFileFromRootSync(pth, ...rest) {
+		return super.writeFileSync(this.getFullyResolvedPath(pth), ...rest);
 	}
 }
 
@@ -25,7 +39,7 @@ export function createFs(json, root) {
 		structure[fullpath] = value;
 	}
 
-	const fs = new MyVolume();
+	const fs = new MyVolume(root);
 	fs.fromJSON(structure);
 	return fs;
 }


### PR DESCRIPTION
## Changes

- This is a bit of a refactor of how dev restarts take place. It moves the code out of the CLI and into `core/dev`. There it watches for changes to the astro config and restarts the vite server, etc. when that occurs.
- Closes https://github.com/withastro/astro/issues/5159

## Testing

- Tested the new functionality via unit tests. This is a slow test so we should be careful about adding too many.

## Docs

N/A