### PR TITLE
fix homepage url for integrations

### DIFF
--- a/.changeset/curvy-countries-kiss.md
+++ b/.changeset/curvy-countries-kiss.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/prism': patch
+'@astrojs/markdown-component': patch
+---
+
+Update URLs in package.json

--- a/packages/astro-prism/package.json
+++ b/packages/astro-prism/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/withastro/astro.git",
     "directory": "packages/astro-prism"
   },
-  "homepage": "https://astro.build",
+  "homepage": "https://docs.astro.build/en/reference/api-reference/#prism-",
   "main": "dist/index.js",
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",

--- a/packages/markdown/component/package.json
+++ b/packages/markdown/component/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/markdown/component"
   },
   "bugs": "https://github.com/withastro/astro/issues",
-  "homepage": "https://astro.build",
+  "homepage": "https://docs.astro.build/en/migrate/#markdown--component-removed",
   "main": "./Markdown.astro",
   "exports": {
     ".": {


### PR DESCRIPTION
## Changes

This fixes the links for `@astrojs/prism` and `@astrojs/markdown-component` on [https://astro.build/integrations](https://astro.build/integrations/) that were previously pointing back to the homepage (astro.build).

The first PR was https://github.com/withastro/astro.build/pull/386 on the actual website but I was told that the links are generated from `package.json` for each integration/package. That is what is edited here, though I haven't found where the link for `agnosticui-astro` is coming from.

## Testing

No tests, it is a simple change related to astro.build website.

## Docs

No docs changes are needed as it doesn't affect the user’s behavior.