### PR TITLE
fix(astro): add `class:list` to `HTMLAttributes`

### DIFF
--- a/.changeset/dull-days-grin.md
+++ b/.changeset/dull-days-grin.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Include missing `class:list` within `HTMLAttributes` type

--- a/packages/astro/types.d.ts
+++ b/packages/astro/types.d.ts
@@ -6,7 +6,7 @@ export type HTMLTag = keyof astroHTML.JSX.DefinedIntrinsicElements;
 /** The built-in attributes for any known HTML or SVG element name */
 export type HTMLAttributes<Tag extends HTMLTag> = Omit<
 	astroHTML.JSX.IntrinsicElements[Tag],
-	keyof AstroBuiltinAttributes
+	keyof Omit<AstroBuiltinAttributes, 'class:list'>
 >;
 
 // TODO: Enable generic/polymorphic types once compiler output stabilizes in the Language Server


### PR DESCRIPTION
## Changes

- This adds the missing `class:list` to the `HTMLAttributes` type as explained in #5279

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested manually within `examples/basic/src/components/Card.astro` by extending the `Props` with `HTMLAttributes<"div">` and destructuring `'class:list': classList` from `Astro.props as Props`.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
The docs don't explicitly mention any props of HTMLAttributes.