### PR TITLE
Handle `base` in adapters

### DIFF
--- a/.changeset/blue-parrots-jam.md
+++ b/.changeset/blue-parrots-jam.md
@@ -1,0 +1,12 @@
+---
+'@astrojs/cloudflare': major
+'@astrojs/deno': major
+'@astrojs/node': major
+'astro': patch
+---
+
+Handle base configuration in adapters
+
+This allows adapters to correctly handle `base` configuration. Internally Astro now matches routes when the URL includes the `base`.
+
+Adapters now also have access to the `removeBase` method which will remove the `base` from a pathname. This is useful to look up files for static assets.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1426,6 +1426,7 @@ export interface PreviewServerParams {
 	serverEntrypoint: URL;
 	host: string | undefined;
 	port: number;
+	base: string;
 }
 
 export type CreatePreviewServer = (

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -169,7 +169,6 @@ export class App {
 	): Promise<Response> {
 		const url = new URL(request.url);
 		const manifest = this.#manifest;
-		const renderers = manifest.renderers;
 		const info = this.#routeDataToRouteInfo.get(routeData!)!;
 		const links = createLinkStylesheetElementSet(info.links, manifest.site);
 

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -13,7 +13,7 @@ import { attachToResponse, getSetCookiesFromResponse } from '../cookies/index.js
 import { call as callEndpoint } from '../endpoint/index.js';
 import { consoleLogDestination } from '../logger/console.js';
 import { error } from '../logger/core.js';
-import { joinPaths, prependForwardSlash } from '../path.js';
+import { joinPaths, prependForwardSlash, removeTrailingForwardSlash } from '../path.js';
 import {
 	createEnvironment,
 	createRenderContext,
@@ -45,6 +45,8 @@ export class App {
 		dest: consoleLogDestination,
 		level: 'info',
 	};
+	#base: string;
+	#baseWithoutTrailingSlash: string;
 
 	constructor(manifest: Manifest, streaming = true) {
 		this.#manifest = manifest;
@@ -78,6 +80,15 @@ export class App {
 			ssr: true,
 			streaming,
 		});
+
+		this.#base = this.#manifest.base || '/';
+		this.#baseWithoutTrailingSlash = removeTrailingForwardSlash(this.#base);
+	}
+	removeBase(pathname: string) {
+		if(pathname.startsWith(this.#base)) {
+			return pathname.slice(this.#baseWithoutTrailingSlash.length + 1);
+		}
+		return pathname;
 	}
 	match(request: Request, { matchNotFound = false }: MatchOptions = {}): RouteData | undefined {
 		const url = new URL(request.url);
@@ -85,7 +96,8 @@ export class App {
 		if (this.#manifest.assets.has(url.pathname)) {
 			return undefined;
 		}
-		let routeData = matchRoute(url.pathname, this.#manifestData);
+		let pathname = '/' + this.removeBase(url.pathname);
+		let routeData = matchRoute(pathname, this.#manifestData);
 
 		if (routeData) {
 			return routeData;

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -13,6 +13,7 @@ import { pagesVirtualModuleId } from '../app/index.js';
 import { serializeRouteData } from '../routing/index.js';
 import { addRollupInput } from './add-rollup-input.js';
 import { eachPageData, sortedCSS } from './internal.js';
+import { removeLeadingForwardSlash, removeTrailingForwardSlash } from '../path.js';
 
 export const virtualModuleId = '@astrojs-ssr-virtual-entry';
 const resolvedVirtualModuleId = '\0' + virtualModuleId;
@@ -141,9 +142,12 @@ function buildManifest(
 			scripts.push({ type: 'external', value: entryModules[PAGE_SCRIPT_ID] });
 		}
 
+		const bareBase = removeTrailingForwardSlash(removeLeadingForwardSlash(settings.config.base));
+		const links =  sortedCSS(pageData).map(pth => bareBase ? bareBase + '/' + pth : pth);
+
 		routes.push({
 			file: '',
-			links: sortedCSS(pageData),
+			links,
 			scripts: [
 				...scripts,
 				...settings.scripts

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -172,7 +172,7 @@ function buildManifest(
 		pageMap: null as any,
 		renderers: [],
 		entryModules,
-		assets: staticFiles.map((s) => '/' + s),
+		assets: staticFiles.map((s) => settings.config.base + s),
 	};
 
 	return ssrManifest;

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -54,6 +54,7 @@ export default async function preview(
 		serverEntrypoint: new URL(settings.config.build.serverEntry, settings.config.build.server),
 		host,
 		port,
+		base: settings.config.base,
 	});
 
 	return server;

--- a/packages/astro/test/fixtures/ssr-request/src/pages/request.astro
+++ b/packages/astro/test/fixtures/ssr-request/src/pages/request.astro
@@ -3,7 +3,14 @@ const origin = Astro.url.origin;
 ---
 
 <html>
-<head><title>Testing</title></head>
+<head>
+	<title>Testing</title>
+	<style>
+		body {
+			background: orangered;
+		}
+	</style>
+</head>
 <body>
 <h1 id="origin">{origin}</h1>
 </body>

--- a/packages/astro/test/ssr-request.test.js
+++ b/packages/astro/test/ssr-request.test.js
@@ -32,6 +32,25 @@ describe('Using Astro.request in SSR', () => {
 		expect(json).to.not.be.undefined;
 	});
 
+	it('CSS assets have their base prefix', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		let request = new Request('http://example.com/subpath/request');
+		let response = await app.render(request);
+		expect(response.status).to.equal(200);
+		const html = await response.text();
+		const $ = cheerioLoad(html);
+		
+		const linkHref = $('link').attr('href');
+		expect(linkHref.startsWith('/subpath/')).to.equal(true);
+
+		request = new Request('http://example.com' + linkHref);
+		response = await app.render(request);
+
+		expect(response.status).to.equal(200);
+		const css = await response.text();
+		expect(css).to.not.be.an('undefined');
+	});
+
 	it('assets can be fetched', async () => {
 		const app = await fixture.loadTestAdapterApp();
 		const request = new Request('http://example.com/subpath/cars.json');

--- a/packages/astro/test/ssr-request.test.js
+++ b/packages/astro/test/ssr-request.test.js
@@ -12,14 +12,16 @@ describe('Using Astro.request in SSR', () => {
 			root: './fixtures/ssr-request/',
 			adapter: testAdapter(),
 			output: 'server',
+			base: '/subpath/'
 		});
 		await fixture.build();
 	});
 
-	it('Gets the request pased in', async () => {
+	it('Gets the request passed in', async () => {
 		const app = await fixture.loadTestAdapterApp();
-		const request = new Request('http://example.com/request');
+		const request = new Request('http://example.com/subpath/request');
 		const response = await app.render(request);
+		expect(response.status).to.equal(200);
 		const html = await response.text();
 		const $ = cheerioLoad(html);
 		expect($('#origin').text()).to.equal('http://example.com');
@@ -28,5 +30,14 @@ describe('Using Astro.request in SSR', () => {
 	it('public file is copied over', async () => {
 		const json = await fixture.readFile('/client/cars.json');
 		expect(json).to.not.be.undefined;
+	});
+
+	it('assets can be fetched', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		const request = new Request('http://example.com/subpath/cars.json');
+		const response = await app.render(request);
+		expect(response.status).to.equal(200);
+		const data = await response.json();
+		expect(data).to.be.an('array');
 	});
 });

--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -27,10 +27,6 @@ export default function ({ provideAddress } = { provideAddress: true }) {
 											import { App } from 'astro/app';
 											import fs from 'fs';
 
-											function removeTrailingSlash(path) {
-												return path[path.length - 1] === '/' ? path.slice(0, path.length - 1) : path;
-											}
-
 											class MyApp extends App {
 												#manifest = null;
 												constructor(manifest, streaming) {
@@ -41,8 +37,7 @@ export default function ({ provideAddress } = { provideAddress: true }) {
 												async render(request, routeData) {
 													const url = new URL(request.url);
 													if(this.#manifest.assets.has(url.pathname)) {
-														const withoutBase = url.pathname.replace(removeTrailingSlash(this.#manifest.base), '');
-														const filePath = new URL('../client' + withoutBase, import.meta.url);
+														const filePath = new URL('../client/' + this.removeBase(url.pathname), import.meta.url);
 														const data = await fs.promises.readFile(filePath);
 														return new Response(data);
 													}

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -36,6 +36,9 @@
   "dependencies": {
     "esbuild": "^0.14.42"
   },
+  "peerDependencies": {
+    "astro": "^1.6.3"
+  },
   "devDependencies": {
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",

--- a/packages/integrations/cloudflare/src/server.advanced.ts
+++ b/packages/integrations/cloudflare/src/server.advanced.ts
@@ -11,12 +11,14 @@ type Env = {
 export function createExports(manifest: SSRManifest) {
 	const app = new App(manifest, false);
 
+	//manifest.base
+
 	const fetch = async (request: Request, env: Env, context: any) => {
 		const { origin, pathname } = new URL(request.url);
 
 		// static assets
 		if (manifest.assets.has(pathname)) {
-			const assetRequest = new Request(`${origin}/static${pathname}`, request);
+			const assetRequest = new Request(`${origin}/static/${app.removeBase(pathname)}`, request);
 			return env.ASSETS.fetch(assetRequest);
 		}
 

--- a/packages/integrations/cloudflare/src/server.advanced.ts
+++ b/packages/integrations/cloudflare/src/server.advanced.ts
@@ -11,8 +11,6 @@ type Env = {
 export function createExports(manifest: SSRManifest) {
 	const app = new App(manifest, false);
 
-	//manifest.base
-
 	const fetch = async (request: Request, env: Env, context: any) => {
 		const { origin, pathname } = new URL(request.url);
 

--- a/packages/integrations/cloudflare/src/server.directory.ts
+++ b/packages/integrations/cloudflare/src/server.directory.ts
@@ -17,7 +17,7 @@ export function createExports(manifest: SSRManifest) {
 		const { origin, pathname } = new URL(request.url);
 		// static assets
 		if (manifest.assets.has(pathname)) {
-			const assetRequest = new Request(`${origin}/static${pathname}`, request);
+			const assetRequest = new Request(`${origin}/static/${app.removeBase(pathname)}`, request);
 			return next(assetRequest);
 		}
 

--- a/packages/integrations/deno/package.json
+++ b/packages/integrations/deno/package.json
@@ -31,6 +31,9 @@
   "dependencies": {
     "esbuild": "^0.14.43"
   },
+  "peerDependencies": {
+    "astro": "^1.6.3"
+  },
   "devDependencies": {
     "astro": "workspace:*",
     "astro-scripts": "workspace:*"

--- a/packages/integrations/deno/src/server.ts
+++ b/packages/integrations/deno/src/server.ts
@@ -38,7 +38,7 @@ export function start(manifest: SSRManifest, options: Options) {
 		// If the request path wasn't found in astro,
 		// try to fetch a static file instead
 		const url = new URL(request.url);
-		const localPath = new URL('.' + url.pathname, clientRoot);
+		const localPath = new URL('./' + app.removeBase(url.pathname), clientRoot);
 		const fileResp = await fetch(localPath.toString());
 
 		// If the static file can't be found

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -33,6 +33,9 @@
     "@astrojs/webapi": "^1.1.1",
     "send": "^0.18.0"
   },
+  "peerDependencies": {
+    "astro": "^1.6.3"
+  },
   "devDependencies": {
     "@types/send": "^0.17.1",
     "astro": "workspace:*",

--- a/packages/integrations/node/src/http-server.ts
+++ b/packages/integrations/node/src/http-server.ts
@@ -8,15 +8,17 @@ interface CreateServerOptions {
 	client: URL;
 	port: number;
 	host: string | undefined;
+	removeBase: (pathname: string) => string;
 }
 
 export function createServer(
-	{ client, port, host }: CreateServerOptions,
+	{ client, port, host, removeBase }: CreateServerOptions,
 	handler: http.RequestListener
 ) {
 	const listener: http.RequestListener = (req, res) => {
 		if (req.url) {
-			const stream = send(req, encodeURI(req.url), {
+			const pathname = '/' + removeBase(req.url);
+			const stream = send(req, encodeURI(pathname), {
 				root: fileURLToPath(client),
 				dotfiles: 'deny',
 			});

--- a/packages/integrations/node/src/preview.ts
+++ b/packages/integrations/node/src/preview.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url';
 import { createServer } from './http-server.js';
 import type { createExports } from './server';
 
-const preview: CreatePreviewServer = async function ({ client, serverEntrypoint, host, port }) {
+const preview: CreatePreviewServer = async function ({ client, serverEntrypoint, host, port, base }) {
 	type ServerModule = ReturnType<typeof createExports>;
 	type MaybeServerModule = Partial<ServerModule>;
 	let ssrHandler: ServerModule['handler'];
@@ -36,11 +36,20 @@ const preview: CreatePreviewServer = async function ({ client, serverEntrypoint,
 		});
 	};
 
+	const baseWithoutTrailingSlash: string = base.endsWith('/') ? base.slice(0, base.length - 1) : base;
+	function removeBase(pathname: string): string {
+		if(pathname.startsWith(base)) {
+			return pathname.slice(0, baseWithoutTrailingSlash.length);
+		}
+		return pathname;
+	}
+
 	const server = createServer(
 		{
 			client,
 			port,
 			host,
+			removeBase
 		},
 		handler
 	);

--- a/packages/integrations/node/src/preview.ts
+++ b/packages/integrations/node/src/preview.ts
@@ -39,7 +39,7 @@ const preview: CreatePreviewServer = async function ({ client, serverEntrypoint,
 	const baseWithoutTrailingSlash: string = base.endsWith('/') ? base.slice(0, base.length - 1) : base;
 	function removeBase(pathname: string): string {
 		if(pathname.startsWith(base)) {
-			return pathname.slice(0, baseWithoutTrailingSlash.length);
+			return pathname.slice(baseWithoutTrailingSlash.length);
 		}
 		return pathname;
 	}

--- a/packages/integrations/node/src/standalone.ts
+++ b/packages/integrations/node/src/standalone.ts
@@ -45,6 +45,7 @@ export default function startServer(app: NodeApp, options: Options) {
 			client,
 			port,
 			host,
+			removeBase: app.removeBase.bind(app),
 		},
 		handler
 	);


### PR DESCRIPTION
## Changes

- `src/app` now trims the base when looking up routes, so it will match routes when the URL includes the base.
- `src/app` has a new `removeBase` method which trims the base from a pathname. This is useful for adapters that need to look up assets from the filesystem, such as the Node and Deno adapters.
- For the 3 adapters that use this functionality they all have a `major` bump as they now depend on it via the `peerDependency`.
- Fixes https://github.com/withastro/astro/issues/5288

## Testing

Test added in our test adapter which mimics the scenario.

## Docs

N/A, bug fix