### PR TITLE
Adds astro cli dynamic imports

### DIFF
--- a/.changeset/friendly-beds-explode.md
+++ b/.changeset/friendly-beds-explode.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Changes slow astro cli imports to dynamic


### PR DESCRIPTION
fixes https://github.com/withastro/astro/issues/5255

## Changes

Changes slow astro cli imports of add, build, preview, devServer and telemetryHandler to dynamic. 
These changes make the cli ~50% faster.

## Testing

Tested with ```pnpm run test:match "cli"```

## Docs

No docs need to be updated, only internal behaviour has been changed.
