### PR TITLE
Prevent overcaching of astro components for HMR

### DIFF
--- a/.changeset/heavy-bananas-deny.md
+++ b/.changeset/heavy-bananas-deny.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent overcaching .astro HMR changes

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -96,6 +96,7 @@ export async function createVite(
 		},
 		plugins: [
 			configAliasVitePlugin({ settings }),
+			astroLoadFallbackPlugin({ fs, settings }),
 			astroVitePlugin({ settings, logging }),
 			astroScriptsPlugin({ settings }),
 			// The server plugin is for dev only and having it run during the build causes
@@ -110,7 +111,6 @@ export async function createVite(
 			astroPostprocessVitePlugin({ settings }),
 			astroIntegrationsContainerPlugin({ settings, logging }),
 			astroScriptsPageSSRPlugin({ settings }),
-			astroLoadFallbackPlugin({ fs }),
 		],
 		publicDir: fileURLToPath(settings.config.publicDir),
 		root: fileURLToPath(settings.config.root),

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -24,7 +24,7 @@ export async function handleHotUpdate(
 	{ config, logging, compile }: HandleHotUpdateOptions
 ) {
 	let isStyleOnlyChange = false;
-	if (ctx.file.endsWith('.astro')) {
+	if (ctx.file.endsWith('.astro') && isCached(config, ctx.file)) {
 		// Get the compiled result from the cache
 		const oldResult = await compile();
 		// But we also need a fresh, uncached result to compare it to

--- a/packages/astro/src/vite-plugin-load-fallback/index.ts
+++ b/packages/astro/src/vite-plugin-load-fallback/index.ts
@@ -1,34 +1,65 @@
-import nodeFs from 'fs';
+import type { AstroSettings } from '../@types/astro';
 import type * as vite from 'vite';
+import nodeFs from 'fs';
+import npath from 'path';
+
 
 type NodeFileSystemModule = typeof nodeFs;
 
 export interface LoadFallbackPluginParams {
 	fs?: NodeFileSystemModule;
+	settings: AstroSettings;
 }
 
-export default function loadFallbackPlugin({ fs }: LoadFallbackPluginParams): vite.Plugin | false {
+export default function loadFallbackPlugin({ fs, settings }: LoadFallbackPluginParams): vite.Plugin[] | false {
 	// Only add this plugin if a custom fs implementation is provided.
 	if (!fs || fs === nodeFs) {
 		return false;
 	}
 
-	return {
-		name: 'astro:load-fallback',
-		enforce: 'post',
-		async load(id) {
+	const tryLoadModule = async (id: string) => {
+		try {
+			// await is necessary for the catch
+			return await fs.promises.readFile(cleanUrl(id), 'utf-8');
+		} catch (e) {
 			try {
-				// await is necessary for the catch
-				return await fs.promises.readFile(cleanUrl(id), 'utf-8');
-			} catch (e) {
+				return await fs.promises.readFile(id, 'utf-8');
+			} catch (e2) {
 				try {
-					return await fs.promises.readFile(id, 'utf-8');
-				} catch (e2) {
+					const fullpath = new URL('.' + id, settings.config.root);
+					return await fs.promises.readFile(fullpath, 'utf-8');
+				} catch (e3) {
 					// Let fall through to the next
 				}
 			}
-		},
+		}
 	};
+
+	return [{
+		name: 'astro:load-fallback',
+		enforce: 'post',
+		resolveId(id, parent) {
+			if(id.startsWith('.') && parent && fs.existsSync(parent)) {
+				return npath.posix.join(npath.posix.dirname(parent), id);
+			}
+		},
+		async load(id) {
+			const source = await tryLoadModule(id);
+			return source;
+		}
+	}, {
+		name: 'astro:load-fallback-hmr',
+		enforce: 'pre',
+		handleHotUpdate(context) {
+			// Wrap context.read so it checks our filesystem first.
+			const read = context.read;
+			context.read = async () => {
+				const source = await tryLoadModule(context.file);
+				if(source) return source;
+				return read.call(context);
+			};
+		}
+	}];
 }
 
 const queryRE = /\?.*$/s;

--- a/packages/astro/test/units/dev/dev.test.js
+++ b/packages/astro/test/units/dev/dev.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as cheerio from 'cheerio';
 
 import { runInContainer } from '../../../dist/core/dev/index.js';
-import { createFs, createRequestAndResponse } from '../test-utils.js';
+import { createFs, createRequestAndResponse, triggerFSEvent } from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
@@ -73,11 +73,7 @@ describe('dev container', () => {
 			fs.writeFileFromRootSync('/src/components/Header.astro', `
 				<h1>{Astro.props.title}</h1>
 			`);
-
-			container.viteServer.watcher.emit(
-				'change',
-				fs.getFullyResolvedPath('/src/components/Header.astro')
-			);
+			triggerFSEvent(container, fs, '/src/components/Header.astro', 'change');
 			
 			fs.writeFileFromRootSync('/src/pages/index.astro', `
 				---
@@ -91,11 +87,7 @@ describe('dev container', () => {
 					</body>
 				</html>
 			`);
-
-			container.viteServer.watcher.emit(
-				'change',
-				fs.getFullyResolvedPath('/src/pages/index.astro')
-			);
+			triggerFSEvent(container, fs, '/src/pages/index.astro', 'change');
 
 			r = createRequestAndResponse({
 				method: 'GET',

--- a/packages/astro/test/units/test-utils.js
+++ b/packages/astro/test/units/test-utils.js
@@ -66,9 +66,10 @@ export function triggerFSEvent(container, fs, shortPath, eventType) {
 	);
 
 	if(!fileURLToPath(container.settings.config.root).startsWith('/')) {
+		const drive = fileURLToPath(container.settings.config.root).slice(0, 2);
 		container.viteServer.watcher.emit(
 			eventType,
-			'C:' + fs.getFullyResolvedPath(shortPath)
+			drive + fs.getFullyResolvedPath(shortPath)
 		);
 	}
 }

--- a/packages/astro/test/units/test-utils.js
+++ b/packages/astro/test/units/test-utils.js
@@ -12,15 +12,23 @@ class MyVolume extends Volume {
 		this.#root = root;
 	}
 
+	#forcePath(p) {
+		if (p instanceof URL) {
+			p = fileURLToPath(p);
+		}
+		return p;
+	}
+
 	getFullyResolvedPath(pth) {
 		return npath.posix.join(this.#root, pth);
 	}
 
 	existsSync(p) {
-		if (p instanceof URL) {
-			p = fileURLToPath(p);
-		}
-		return super.existsSync(p);
+		return super.existsSync(this.#forcePath(p));
+	}
+
+	readFile(p, ...args) {
+		return super.readFile(this.#forcePath(p), ...args);
 	}
 
 	writeFileFromRootSync(pth, ...rest) {

--- a/packages/astro/test/units/test-utils.js
+++ b/packages/astro/test/units/test-utils.js
@@ -14,7 +14,7 @@ class MyVolume extends Volume {
 
 	#forcePath(p) {
 		if (p instanceof URL) {
-			p = fileURLToPath(p);
+			p = unixify(fileURLToPath(p));
 		}
 		return p;
 	}
@@ -50,6 +50,27 @@ export function createFs(json, root) {
 	const fs = new MyVolume(root);
 	fs.fromJSON(structure);
 	return fs;
+}
+
+/**
+ *
+ * @param {import('../../src/core/dev/container').Container} container
+ * @param {typeof import('fs')} fs
+ * @param {string} shortPath
+ * @param {'change'} eventType
+ */
+export function triggerFSEvent(container, fs, shortPath, eventType) {
+	container.viteServer.watcher.emit(
+		eventType,
+		fs.getFullyResolvedPath(shortPath)
+	);
+
+	if(!fileURLToPath(container.settings.config.root).startsWith('/')) {
+		container.viteServer.watcher.emit(
+			eventType,
+			'C:' + fs.getFullyResolvedPath(shortPath)
+		);
+	}
 }
 
 export function createRequestAndResponse(reqOptions = {}) {


### PR DESCRIPTION
## Changes

- The Astro vite plugin compares previous compilation results to determine if an HMR update has resulted in anything more than a style change.
- When doing this, only compare if the module is already in the cache.
- Fixes https://github.com/withastro/astro/issues/4651

## Testing

- Test case added
- Update the mock file system fallback plugin to account for HMR. This plugin only runs in tests.

## Docs

N/A, bug fix