### PR TITLE
Consistent MD frontmatter typing

### DIFF
--- a/.changeset/thin-trains-complain.md
+++ b/.changeset/thin-trains-complain.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Consistent Markdown frontmatter typing (`MarkdownAstroData["frontmatter"]` in particular was `object` before)

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1005,6 +1005,8 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 	default: AstroComponentFactory;
 }
 
+type MD = MarkdownInstance<Record<string, any>>;
+
 export interface MDXInstance<T extends Record<string, any>>
 	extends Omit<MarkdownInstance<T>, 'rawContent' | 'compiledContent'> {
 	/** MDX does not support rawContent! If you need to read the Markdown contents to calculate values (ex. reading time), we suggest injecting frontmatter via remark plugins. Learn more on our docs: https://docs.astro.build/en/guides/integrations-guide/mdx/#inject-frontmatter-via-remark-or-rehype-plugins */
@@ -1083,9 +1085,7 @@ export interface ManifestData {
 }
 
 export interface MarkdownParserResponse extends MarkdownRenderingResult {
-	frontmatter: {
-		[key: string]: any;
-	};
+	frontmatter: MD['frontmatter'];
 }
 
 /**
@@ -1410,7 +1410,9 @@ export interface SSRResult {
 	_metadata: SSRMetadata;
 }
 
-export type MarkdownAstroData = { frontmatter: object };
+export type MarkdownAstroData = {
+	frontmatter: MD['frontmatter'];
+};
 
 /* Preview server stuff */
 export interface PreviewServer {


### PR DESCRIPTION
## Changes

- `MarkdownAstroData["frontmatter"]` was too vague (`object`), now using `MarkdownInstance`
- `MarkdownParserResponse` uses `MarkdownInstance` (minor)
- I was going to go with something more like:
    ```ts
    export type MarkdownAstroData<T extends Record<string, any>> = {
        frontmatter: MarkdownInstance<T>['frontmatter'];
    };
    ```
    ... but I didn't want to make those generic (breaking change).

## Testing

n/a, type changes only

## Docs

n/a, type changes only