### PR TITLE
Fix typo in create-astro

### DIFF
--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -14,7 +14,7 @@ export const welcome = [
 	`Let's make the web weird!`,
 	`Let's make the web a better place!`,
 	`Let's create a new project!`,
-	`Let's create something unqiue!`,
+	`Let's create something unique!`,
 	`Time to build a new website.`,
 	`Time to build a faster website.`,
 	`Time to build a sweet new website.`,


### PR DESCRIPTION
## Changes

- Corrects a word that could show up when running `npm create astro`: `unqiue` -> `unique`

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
