### PR TITLE
When creating a new dev container, restart it if previously started

### DIFF
--- a/.changeset/selfish-mangos-drum.md
+++ b/.changeset/selfish-mangos-drum.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes regression with config file restarts

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -1,3 +1,3 @@
-export { createContainer, runInContainer, startContainer } from './container.js';
+export { createContainer, runInContainer, startContainer, isStarted } from './container.js';
 export { default } from './dev.js';
 export { createContainerWithAutomaticRestart } from './restart.js';

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -8,10 +8,10 @@ import { createContainer, isStarted, startContainer } from './container.js';
 
 async function createRestartedContainer(
 	container: Container,
-	settings: AstroSettings
+	settings: AstroSettings,
+	needsStart: boolean
 ): Promise<Container> {
 	const { logging, fs, resolvedRoot, configFlag, configFlagPath } = container;
-	const needsStart = isStarted(container);
 	const newContainer = await createContainer({
 		isRestart: true,
 		logging,
@@ -78,10 +78,10 @@ export async function restartContainer({
 	const { logging, close, resolvedRoot, settings: existingSettings } = container;
 	container.restartInFlight = true;
 
-	//console.clear(); // TODO move this
 	if (beforeRestart) {
 		beforeRestart();
 	}
+	const needsStart = isStarted(container);
 	try {
 		const newConfig = await openConfig({
 			cwd: resolvedRoot,
@@ -96,7 +96,7 @@ export async function restartContainer({
 		const settings = createSettings(astroConfig, resolvedRoot);
 		await close();
 		return {
-			container: await createRestartedContainer(container, settings),
+			container: await createRestartedContainer(container, settings, needsStart),
 			error: null,
 		};
 	} catch (_err) {
@@ -105,7 +105,7 @@ export async function restartContainer({
 		await close();
 		info(logging, 'astro', 'Continuing with previous valid configuration\n');
 		return {
-			container: await createRestartedContainer(container, existingSettings),
+			container: await createRestartedContainer(container, existingSettings, needsStart),
 			error,
 		};
 	}


### PR DESCRIPTION
## Changes

- We close the Vite server on config changes in order to restart it, but were determining if it was previously running *after* closing it, giving a false negative.
- Fix is to move the check to happen before we call close.
- Fixes https://github.com/withastro/astro/issues/5313

## Testing

- New test case added

## Docs

N/A, bug fix