### PR TITLE
Add “Open with CodeSandbox” buttons to example project READMEs

### DIFF
--- a/examples/basics/README.md
+++ b/examples/basics/README.md
@@ -1,6 +1,7 @@
 # Welcome to [Astro](https://astro.build)
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/basics)
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/basics)
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -6,6 +6,8 @@ npm create astro@latest -- --template blog
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/blog)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/blog)
+
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 
 

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template blog
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/blog)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/blog)
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!

--- a/examples/component/README.md
+++ b/examples/component/README.md
@@ -7,7 +7,6 @@ npm create astro@latest -- --template component
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/non-html-pages)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/non-html-pages)
 
 

--- a/examples/component/README.md
+++ b/examples/component/README.md
@@ -8,6 +8,8 @@ npm create astro@latest -- --template component
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/non-html-pages)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/non-html-pages)
+
 
 ## 🚀 Project Structure
 

--- a/examples/deno/README.md
+++ b/examples/deno/README.md
@@ -1,8 +1,7 @@
 # Welcome to [Astro](https://astro.build)
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/basics)
-
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/basics)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/deno)
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/deno)
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 

--- a/examples/deno/README.md
+++ b/examples/deno/README.md
@@ -2,6 +2,8 @@
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/basics)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/basics)
+
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 
 ![basics](https://user-images.githubusercontent.com/4677417/186188965-73453154-fdec-4d6b-9c34-cb35c248ae5b.png)

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template docs
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/docs)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/docs)
 
 ![docs](https://user-images.githubusercontent.com/4677417/186189283-0831b9ab-d6b9-485d-8955-3057e532ab31.png)

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -6,6 +6,8 @@ npm create astro@latest -- --template docs
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/docs)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/docs)
+
 ![docs](https://user-images.githubusercontent.com/4677417/186189283-0831b9ab-d6b9-485d-8955-3057e532ab31.png)
 
 

--- a/examples/framework-alpine/README.md
+++ b/examples/framework-alpine/README.md
@@ -6,5 +6,7 @@ npm create astro@latest -- --template framework-alpine
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-alpine)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-alpine)
+
 This example showcases Astro working with [AlpineJS](https://alpinejs.dev/).
 

--- a/examples/framework-alpine/README.md
+++ b/examples/framework-alpine/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template framework-alpine
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-alpine)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-alpine)
 
 This example showcases Astro working with [AlpineJS](https://alpinejs.dev/).

--- a/examples/framework-lit/README.md
+++ b/examples/framework-lit/README.md
@@ -6,4 +6,6 @@ npm create astro@latest -- --template framework-lit
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-lit)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-lit)
+
 This example showcases Astro working with [Lit](https://lit.dev/).

--- a/examples/framework-lit/README.md
+++ b/examples/framework-lit/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template framework-lit
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-lit)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-lit)
 
 This example showcases Astro working with [Lit](https://lit.dev/).

--- a/examples/framework-multiple/README.md
+++ b/examples/framework-multiple/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template framework-multiple
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-multiple)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-multiple)
 
 This example showcases Astro's built-in support for multiple frameworks ([React](https://reactjs.org), [Preact](https://preactjs.com), [Svelte](https://svelte.dev), and [Vue (`v3.x`)](https://v3.vuejs.org/)).

--- a/examples/framework-multiple/README.md
+++ b/examples/framework-multiple/README.md
@@ -6,6 +6,8 @@ npm create astro@latest -- --template framework-multiple
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-multiple)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-multiple)
+
 This example showcases Astro's built-in support for multiple frameworks ([React](https://reactjs.org), [Preact](https://preactjs.com), [Svelte](https://svelte.dev), and [Vue (`v3.x`)](https://v3.vuejs.org/)).
 
 No configuration is needed to enable these frameworks—just start writing components in `src/components`.

--- a/examples/framework-preact/README.md
+++ b/examples/framework-preact/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template framework-preact
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-preact)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-preact)
 
 This example showcases Astro working with [Preact](https://preactjs.com).

--- a/examples/framework-preact/README.md
+++ b/examples/framework-preact/README.md
@@ -6,6 +6,8 @@ npm create astro@latest -- --template framework-preact
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-preact)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-preact)
+
 This example showcases Astro working with [Preact](https://preactjs.com).
 
 Write your Preact components as `.jsx` or `.tsx` files in your project.

--- a/examples/framework-react/README.md
+++ b/examples/framework-react/README.md
@@ -6,6 +6,8 @@ npm create astro@latest -- --template framework-react
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-react)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-react)
+
 This example showcases Astro working with [React](https://reactjs.org/).
 
 Write your React components as `.jsx` or `.tsx` files in your project.

--- a/examples/framework-react/README.md
+++ b/examples/framework-react/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template framework-react
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-react)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-react)
 
 This example showcases Astro working with [React](https://reactjs.org/).

--- a/examples/framework-solid/README.md
+++ b/examples/framework-solid/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template framework-solid
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-solid)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-solid)
 
 This example showcases Astro working with [Solid](https://www.solidjs.com/).

--- a/examples/framework-solid/README.md
+++ b/examples/framework-solid/README.md
@@ -6,6 +6,8 @@ npm create astro@latest -- --template framework-solid
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-solid)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-solid)
+
 This example showcases Astro working with [Solid](https://www.solidjs.com/).
 
 Write your Solid components as `.jsx` or `.tsx` files in your project.

--- a/examples/framework-svelte/README.md
+++ b/examples/framework-svelte/README.md
@@ -6,4 +6,6 @@ npm create astro@latest -- --template framework-svelte
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-svelte)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-svelte)
+
 This example showcases Astro working with [Svelte](https://svelte.dev/).

--- a/examples/framework-svelte/README.md
+++ b/examples/framework-svelte/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template framework-svelte
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-svelte)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-svelte)
 
 This example showcases Astro working with [Svelte](https://svelte.dev/).

--- a/examples/framework-vue/README.md
+++ b/examples/framework-vue/README.md
@@ -6,5 +6,7 @@ npm create astro@latest -- --template framework-vue
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-vue)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-vue)
+
 This example showcases Astro working with [Vue](https://v3.vuejs.org/).
 

--- a/examples/framework-vue/README.md
+++ b/examples/framework-vue/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template framework-vue
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-vue)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/framework-vue)
 
 This example showcases Astro working with [Vue](https://v3.vuejs.org/).

--- a/examples/hackernews/README.md
+++ b/examples/hackernews/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template hackernews
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/hackernews)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/hackernews)
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!

--- a/examples/hackernews/README.md
+++ b/examples/hackernews/README.md
@@ -6,6 +6,8 @@ npm create astro@latest -- --template hackernews
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/hackernews)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/hackernews)
+
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 
 ## 🚀 Project Structure

--- a/examples/integration/README.md
+++ b/examples/integration/README.md
@@ -8,6 +8,8 @@ npm create astro@latest -- --template integration
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/integration)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/integration)
+
 
 ## 🚀 Project Structure
 

--- a/examples/integration/README.md
+++ b/examples/integration/README.md
@@ -7,7 +7,6 @@ npm create astro@latest -- --template integration
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/integration)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/integration)
 
 

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -6,6 +6,8 @@ npm create astro@latest -- --template minimal
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/minimal)
+
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 
 ## 🚀 Project Structure

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template minimal
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/minimal)
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!

--- a/examples/non-html-pages/README.md
+++ b/examples/non-html-pages/README.md
@@ -10,6 +10,8 @@ npm create astro@latest -- --template non-html-pages
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/non-html-pages)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/non-html-pages)
+
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 
 ## 🚀 Project Structure

--- a/examples/non-html-pages/README.md
+++ b/examples/non-html-pages/README.md
@@ -9,7 +9,6 @@ npm create astro@latest -- --template non-html-pages
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/non-html-pages)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/non-html-pages)
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!

--- a/examples/portfolio/README.md
+++ b/examples/portfolio/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template portfolio
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/portfolio)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/portfolio)
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!

--- a/examples/portfolio/README.md
+++ b/examples/portfolio/README.md
@@ -6,6 +6,8 @@ npm create astro@latest -- --template portfolio
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/portfolio)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/portfolio)
+
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 
 ![portfolio](https://user-images.githubusercontent.com/4677417/186189473-03dda103-65d3-4220-8b60-180ccaee5939.png)

--- a/examples/with-markdown-plugins/README.md
+++ b/examples/with-markdown-plugins/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template with-markdown-plugins
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-markdown-plugins)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/with-markdown-plugins)
 
 This example showcases Astro's [built-in Markdown support](https://docs.astro.build/en/guides/markdown-content/) with additional, user-provided plugins.

--- a/examples/with-markdown-plugins/README.md
+++ b/examples/with-markdown-plugins/README.md
@@ -6,4 +6,6 @@ npm create astro@latest -- --template with-markdown-plugins
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-markdown-plugins)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/with-markdown-plugins)
+
 This example showcases Astro's [built-in Markdown support](https://docs.astro.build/en/guides/markdown-content/) with additional, user-provided plugins.

--- a/examples/with-markdown-shiki/README.md
+++ b/examples/with-markdown-shiki/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template with-markdown-shiki
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-markdown-shiki)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/with-markdown-shiki)
 
 This example showcases Astro's [built-in Markdown support](https://docs.astro.build/en/guides/markdown-content/).

--- a/examples/with-markdown-shiki/README.md
+++ b/examples/with-markdown-shiki/README.md
@@ -6,6 +6,8 @@ npm create astro@latest -- --template with-markdown-shiki
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-markdown-shiki)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/with-markdown-shiki)
+
 This example showcases Astro's [built-in Markdown support](https://docs.astro.build/en/guides/markdown-content/).
 
 - `src/pages/index.md` is a treated as a page entrypoint and uses a `layout`.

--- a/examples/with-mdx/README.md
+++ b/examples/with-mdx/README.md
@@ -6,4 +6,6 @@ npm create astro@latest -- --template with-mdx
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-mdx)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/with-mdx)
+
 This example showcases using [`@astrojs/mdx`](https://www.npmjs.com/package/@astrojs/mdx) to author content using [MDX](https://mdxjs.com/).

--- a/examples/with-mdx/README.md
+++ b/examples/with-mdx/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template with-mdx
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-mdx)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/with-mdx)
 
 This example showcases using [`@astrojs/mdx`](https://www.npmjs.com/package/@astrojs/mdx) to author content using [MDX](https://mdxjs.com/).

--- a/examples/with-nanostores/README.md
+++ b/examples/with-nanostores/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template with-nanostores
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-nanostores)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/with-nanostores)
 
 This example showcases using [`nanostores`](https://github.com/nanostores/nanostores) to provide shared state between components of any framework. [**Read our documentation on sharing state**](https://docs.astro.build/en/core-concepts/sharing-state/) for a complete breakdown of this project, along with guides to use React, Vue, Svelte, or Solid!

--- a/examples/with-nanostores/README.md
+++ b/examples/with-nanostores/README.md
@@ -6,4 +6,6 @@ npm create astro@latest -- --template with-nanostores
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-nanostores)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/with-nanostores)
+
 This example showcases using [`nanostores`](https://github.com/nanostores/nanostores) to provide shared state between components of any framework. [**Read our documentation on sharing state**](https://docs.astro.build/en/core-concepts/sharing-state/) for a complete breakdown of this project, along with guides to use React, Vue, Svelte, or Solid!

--- a/examples/with-tailwindcss/README.md
+++ b/examples/with-tailwindcss/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template with-tailwindcss
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-tailwindcss)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/with-tailwindcss)
 
 Astro comes with [Tailwind](https://tailwindcss.com) support out of the box. This example showcases how to style your Astro project with Tailwind.

--- a/examples/with-tailwindcss/README.md
+++ b/examples/with-tailwindcss/README.md
@@ -6,6 +6,8 @@ npm create astro@latest -- --template with-tailwindcss
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-tailwindcss)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/with-tailwindcss)
+
 Astro comes with [Tailwind](https://tailwindcss.com) support out of the box. This example showcases how to style your Astro project with Tailwind.
 
 For complete setup instructions, please see our [Styling Guide](https://docs.astro.build/guides/styling#-tailwind).

--- a/examples/with-vite-plugin-pwa/README.md
+++ b/examples/with-vite-plugin-pwa/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template with-vite-plugin-pwa
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-vite-plugin-pwa)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/with-vite-plugin-pwa)
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!

--- a/examples/with-vite-plugin-pwa/README.md
+++ b/examples/with-vite-plugin-pwa/README.md
@@ -6,6 +6,8 @@ npm create astro@latest -- --template with-vite-plugin-pwa
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-vite-plugin-pwa)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/with-vite-plugin-pwa)
+
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 
 ## 🚀 Project Structure

--- a/examples/with-vitest/README.md
+++ b/examples/with-vitest/README.md
@@ -5,7 +5,6 @@ npm create astro@latest -- --template with-vitest
 ```
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-vitest)
-
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/with-vitest)
 
 This example showcases Astro working with [Vitest](https://vitest.dev/).

--- a/examples/with-vitest/README.md
+++ b/examples/with-vitest/README.md
@@ -6,4 +6,6 @@ npm create astro@latest -- --template with-vitest
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-vitest)
 
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/with-vitest)
+
 This example showcases Astro working with [Vitest](https://vitest.dev/).


### PR DESCRIPTION
## Changes

- What does this change?
Just like in https://github.com/withastro/docs/pull/1982. I have been using codesandbox a lot for my open-source contributions, and I think it's really cool. Astro doc contributors can work seamlessly, and I wanted to add it here as an option.

I noticed that in astro.new you have the option to open in codesandbox, but in the repos that are cloned, only the stackBlitz option exists. 


- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
