### PR TITLE
Share picture fallback image with source

### DIFF
--- a/.changeset/fifty-olives-end.md
+++ b/.changeset/fifty-olives-end.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Share fallback img src with source of Picture component

--- a/packages/integrations/image/test/picture-ssg.test.js
+++ b/packages/integrations/image/test/picture-ssg.test.js
@@ -381,3 +381,27 @@ describe('SSG pictures with subpath - build', function () {
 		});
 	});
 });
+
+describe('SSG pictures others - build', function () {
+	let fixture;
+	let $;
+	let html;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/basic-picture/' });
+		await fixture.build();
+
+		html = await fixture.readFile('/index.html');
+		$ = cheerio.load(html);
+	});
+
+	it('fallback image should share last source', async () => {
+		const hero = $('#hero');
+		const picture = hero.closest('picture');
+
+		const source = picture.children('source').last();
+		const image = picture.children('img').last();
+
+		expect(source.attr('srcset')).to.include(image.attr('src'));
+	});
+});


### PR DESCRIPTION
## Changes

Fix #5185

`picture` has a fallback `img` tag (for legacy browsers). It can reuse the images generated for `source` tags to prevent duplicate images. This is safe as the format/width permutations overlaps for images and pictures.


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added an SSG picture test.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A. Internal optimization.
