### PR TITLE
404 when not using subpath for items in public in dev

### DIFF
--- a/.changeset/plenty-eyes-develop.md
+++ b/.changeset/plenty-eyes-develop.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+404 when not using subpath for items in public in dev
+
+Previously if using a base like `base: '/subpath/` you could load things from the root, which would break in prod. Now you must include the subpath.

--- a/packages/astro/test/fixtures/alias/public/test.txt
+++ b/packages/astro/test/fixtures/alias/public/test.txt
@@ -1,0 +1,1 @@
+this is a test

--- a/packages/astro/test/units/dev/dev.test.js
+++ b/packages/astro/test/units/dev/dev.test.js
@@ -157,4 +157,50 @@ describe('dev container', () => {
 			}
 		);
 	});
+
+	it('items in public/ are not available from root when using a base', async () => {
+		await runInContainer({
+			root,
+			userConfig: {
+				base: '/sub/'
+			}
+		}, async (container) => {
+			// First try the subpath
+			let r = createRequestAndResponse({
+				method: 'GET',
+				url: '/sub/test.txt',
+			});
+
+			container.handle(r.req, r.res);
+			await r.done;
+
+			expect(r.res.statusCode).to.equal(200);
+
+			// Next try the root path
+			r = createRequestAndResponse({
+				method: 'GET',
+				url: '/test.txt',
+			});
+
+			container.handle(r.req, r.res);
+			await r.done;
+
+			expect(r.res.statusCode).to.equal(404);
+		});
+	});
+
+	it('items in public/ are available from root when not using a base', async () => {
+		await runInContainer({ root }, async (container) => {
+			// Try the root path
+			let r = createRequestAndResponse({
+				method: 'GET',
+				url: '/test.txt',
+			});
+
+			container.handle(r.req, r.res);
+			await r.done;
+
+			expect(r.res.statusCode).to.equal(200);
+		});
+	});
 });


### PR DESCRIPTION
## Changes

- If you are referencing an item in `public/` and using base config, you must include the base in your URL.
- Previously you had to *not* include it. This was an obvious bug.
- Fixes https://github.com/withastro/astro/issues/5107
- Fixes https://github.com/withastro/astro/issues/4988

## Testing

Tests added for both base and non-base scenarios.

## Docs

N/A, bug fix