### PR TITLE
Allow dynamic segments in injected routes

### DIFF
--- a/.changeset/good-ghosts-attack.md
+++ b/.changeset/good-ghosts-attack.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow dynamic segments in injected routes

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -360,15 +360,12 @@ export function createRouteManifest(
 			}
 			const component = slash(path.relative(cwd || fileURLToPath(config.root), resolved));
 
-			const isDynamic = (str: string) => str?.[0] === '[';
-			const normalize = (str: string) => str?.substring(1, str?.length - 1);
-
 			const segments = removeLeadingForwardSlash(name)
-				.split(path.sep)
+				.split(path.posix.sep)
 				.filter(Boolean)
 				.map((s: string) => {
 					validateSegment(s);
-					return getParts(s, resolved);
+					return getParts(s, component);
 				});
 
 			const type = resolved.endsWith('.astro') ? 'page' : 'endpoint';

--- a/packages/astro/src/vite-plugin-load-fallback/index.ts
+++ b/packages/astro/src/vite-plugin-load-fallback/index.ts
@@ -1,5 +1,6 @@
 import nodeFs from 'fs';
 import npath from 'path';
+import slashify from 'slash';
 import type * as vite from 'vite';
 import type { AstroSettings } from '../@types/astro';
 
@@ -41,9 +42,15 @@ export default function loadFallbackPlugin({
 		{
 			name: 'astro:load-fallback',
 			enforce: 'post',
-			resolveId(id, parent) {
+			async resolveId(id, parent) {
 				if (id.startsWith('.') && parent && fs.existsSync(parent)) {
 					return npath.posix.join(npath.posix.dirname(parent), id);
+				} else {
+					let resolved = await this.resolve(id, parent, { skipSelf: true });
+					if(resolved) {
+						return resolved.id;
+					}
+					return slashify(id);
 				}
 			},
 			async load(id) {

--- a/packages/astro/test/units/test-utils.js
+++ b/packages/astro/test/units/test-utils.js
@@ -15,6 +15,8 @@ class MyVolume extends Volume {
 	#forcePath(p) {
 		if (p instanceof URL) {
 			p = unixify(fileURLToPath(p));
+		} else {
+			p = unixify(p);
 		}
 		return p;
 	}


### PR DESCRIPTION
## Changes

- Use `getParts` to parse a segment (part of a file path) in injected routes the same as in real routes.
- This fixes the ability to do `test-[slug].astro` in injected routes.
- Fixes https://github.com/withastro/astro/issues/5247

## Testing

- Test added

## Docs

N/A, bug fix