### PR TITLE
Upgrade compiler

### DIFF
--- a/.changeset/poor-eagles-melt.md
+++ b/.changeset/poor-eagles-melt.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Upgrade `@astrojs/compiler` to latest

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -100,7 +100,7 @@
     "test:e2e:match": "playwright test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.29.5",
+    "@astrojs/compiler": "^0.29.11",
     "@astrojs/language-server": "^0.28.3",
     "@astrojs/markdown-remark": "^1.1.3",
     "@astrojs/telemetry": "^1.0.1",
@@ -188,6 +188,7 @@
     "astro-scripts": "workspace:*",
     "chai": "^4.3.6",
     "cheerio": "^1.0.0-rc.11",
+    "eol": "^0.9.1",
     "memfs": "^3.4.7",
     "mocha": "^9.2.2",
     "node-fetch": "^3.2.5",
@@ -198,8 +199,7 @@
     "remark-code-titles": "^0.1.2",
     "sass": "^1.52.2",
     "srcset-parse": "^1.1.0",
-    "unified": "^10.1.2",
-    "eol": "^0.9.1"
+    "unified": "^10.1.2"
   },
   "engines": {
     "node": "^14.18.0 || >=16.12.0",

--- a/packages/astro/test/astro-directives.test.js
+++ b/packages/astro/test/astro-directives.test.js
@@ -36,6 +36,9 @@ describe('Directives', async () => {
 		const html = await fixture.readFile('/define-vars/index.html');
 		const $ = cheerio.load(html);
 
+		// All styles should be bundled
+		expect($('style')).to.have.lengthOf(0);
+
 		// Inject style attribute on top-level element in page
 		expect($('html').attr('style').toString()).to.include('--bg: white;');
 		expect($('html').attr('style').toString()).to.include('--fg: black;');

--- a/packages/astro/test/astro-directives.test.js
+++ b/packages/astro/test/astro-directives.test.js
@@ -36,8 +36,6 @@ describe('Directives', async () => {
 		const html = await fixture.readFile('/define-vars/index.html');
 		const $ = cheerio.load(html);
 
-		expect($('style')).to.have.lengthOf(2);
-
 		// Inject style attribute on top-level element in page
 		expect($('html').attr('style').toString()).to.include('--bg: white;');
 		expect($('html').attr('style').toString()).to.include('--fg: black;');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,7 +370,7 @@ importers:
 
   packages/astro:
     specifiers:
-      '@astrojs/compiler': ^0.29.5
+      '@astrojs/compiler': ^0.29.11
       '@astrojs/language-server': ^0.28.3
       '@astrojs/markdown-remark': ^1.1.3
       '@astrojs/telemetry': ^1.0.1
@@ -469,7 +469,7 @@ importers:
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
-      '@astrojs/compiler': 0.29.9
+      '@astrojs/compiler': 0.29.11
       '@astrojs/language-server': 0.28.3
       '@astrojs/markdown-remark': link:../markdown/remark
       '@astrojs/telemetry': link:../telemetry
@@ -3837,8 +3837,8 @@ packages:
       sisteransi: 1.0.5
     dev: false
 
-  /@astrojs/compiler/0.29.9:
-    resolution: {integrity: sha512-/oMQ0z3CJzGg6sv51tQTiHf/ETVsEu8ObN9OA7zs937dQx9Uo4SToYfdw3C4hf6olrLiADuDUsbkKSRe6fLSgA==}
+  /@astrojs/compiler/0.29.11:
+    resolution: {integrity: sha512-iNJMknLhALllV69eSsdDK9o+xEPOiOaCKN9Sv5VK33cbOmcRI8ICFaUN8lMIQnVSXWyKFvX1o9w08PivJ24NfQ==}
 
   /@astrojs/language-server/0.28.3:
     resolution: {integrity: sha512-fPovAX/X46eE2w03jNRMpQ7W9m2mAvNt4Ay65lD9wl1Z5vIQYxlg7Enp9qP225muTr4jSVB5QiLumFJmZMAaVA==}
@@ -15882,7 +15882,7 @@ packages:
     resolution: {integrity: sha512-ehCUx7MqHWvkHwUmxxAWLsL35pFaCTM5YXQ8xjG/1W6dY2yBhvEks+2aCfjeI5zmMrZNCXkiMQtpznSlLSLrxw==}
     engines: {node: ^14.15.0 || >=16.0.0, npm: '>=6.14.0'}
     dependencies:
-      '@astrojs/compiler': 0.29.9
+      '@astrojs/compiler': 0.29.11
       prettier: 2.7.1
       sass-formatter: 0.7.5
       synckit: 0.8.4


### PR DESCRIPTION
## Changes

- Compiler has a `define:vars` fix, but test was out of date with the new implementation
- This upgrades the compiler and updates the test

## Testing

Existing test updated

## Docs

N/A