### PR TITLE
Respect Vite user config for third-party packages

### DIFF
--- a/.changeset/metal-suns-tell.md
+++ b/.changeset/metal-suns-tell.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/solid-js': patch
+---
+
+Respect Vite user config for third-party packages config handling

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -158,7 +158,7 @@
     "unist-util-visit": "^4.1.0",
     "vfile": "^5.3.2",
     "vite": "~3.2.1",
-    "vitefu": "^0.1.0",
+    "vitefu": "^0.2.0",
     "yargs-parser": "^21.0.1",
     "zod": "^3.17.3"
   },

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -62,6 +62,7 @@ export async function createVite(
 	const astroPkgsConfig = await crawlFrameworkPkgs({
 		root: fileURLToPath(settings.config.root),
 		isBuild: mode === 'build',
+		viteUserConfig: settings.config.vite,
 		isFrameworkPkgByJson(pkgJson) {
 			return (
 				// Attempt: package relies on `astro`. ✅ Definitely an Astro package

--- a/packages/integrations/solid/package.json
+++ b/packages/integrations/solid/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "babel-preset-solid": "^1.4.2",
-    "vitefu": "^0.1.0"
+    "vitefu": "^0.2.0"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/packages/integrations/solid/src/dependencies.ts
+++ b/packages/integrations/solid/src/dependencies.ts
@@ -1,10 +1,12 @@
+import type { AstroConfig } from 'astro';
 import { fileURLToPath } from 'url';
 import { crawlFrameworkPkgs } from 'vitefu';
 
-export async function getSolidPkgsConfig(root: URL, isBuild: boolean) {
+export async function getSolidPkgsConfig(isBuild: boolean, astroConfig: AstroConfig) {
 	return await crawlFrameworkPkgs({
-		root: fileURLToPath(root),
+		root: fileURLToPath(astroConfig.root),
 		isBuild,
+		viteUserConfig: astroConfig.vite,
 		isFrameworkPkgByJson(pkgJson) {
 			return containsSolidField(pkgJson.exports || {});
 		},

--- a/packages/integrations/solid/src/index.ts
+++ b/packages/integrations/solid/src/index.ts
@@ -1,4 +1,4 @@
-import type { AstroIntegration, AstroRenderer } from 'astro';
+import type { AstroConfig, AstroIntegration, AstroRenderer } from 'astro';
 import { getSolidPkgsConfig } from './dependencies.js';
 
 function getRenderer(): AstroRenderer {
@@ -24,11 +24,11 @@ function getRenderer(): AstroRenderer {
 	};
 }
 
-async function getViteConfiguration(isDev: boolean, root: URL) {
+async function getViteConfiguration(isDev: boolean, astroConfig: AstroConfig) {
 	// https://github.com/solidjs/vite-plugin-solid
 	// We inject the dev mode only if the user explicitely wants it or if we are in dev (serve) mode
 	const nestedDeps = ['solid-js', 'solid-js/web', 'solid-js/store', 'solid-js/html', 'solid-js/h'];
-	const solidPkgsConfig = await getSolidPkgsConfig(root, !isDev);
+	const solidPkgsConfig = await getSolidPkgsConfig(!isDev, astroConfig);
 	return {
 		/**
 		 * We only need esbuild on .ts or .js files.
@@ -58,7 +58,7 @@ export default function (): AstroIntegration {
 		hooks: {
 			'astro:config:setup': async ({ command, addRenderer, updateConfig, config }) => {
 				addRenderer(getRenderer());
-				updateConfig({ vite: await getViteConfiguration(command === 'dev', config.root) });
+				updateConfig({ vite: await getViteConfiguration(command === 'dev', config) });
 			},
 		},
 	};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,7 +465,7 @@ importers:
       unist-util-visit: ^4.1.0
       vfile: ^5.3.2
       vite: ~3.2.1
-      vitefu: ^0.1.0
+      vitefu: ^0.2.0
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
@@ -527,7 +527,7 @@ importers:
       unist-util-visit: 4.1.1
       vfile: 5.3.5
       vite: 3.2.3_sass@1.56.0
-      vitefu: 0.1.1_vite@3.2.3
+      vitefu: 0.2.0_vite@3.2.3
       yargs-parser: 21.1.1
       zod: 3.19.1
     devDependencies:
@@ -3115,10 +3115,10 @@ importers:
       astro-scripts: workspace:*
       babel-preset-solid: ^1.4.2
       solid-js: ^1.5.1
-      vitefu: ^0.1.0
+      vitefu: ^0.2.0
     dependencies:
       babel-preset-solid: 1.6.1
-      vitefu: 0.1.1
+      vitefu: 0.2.0
     devDependencies:
       astro: link:../../astro
       astro-scripts: link:../../../scripts
@@ -18132,8 +18132,8 @@ packages:
       fsevents: 2.3.2
     dev: false
 
-  /vitefu/0.1.1:
-    resolution: {integrity: sha512-HClD14fjMJ+NQgXBqT3dC3RdO/+Chayil+cCPYZKY3kT+KcJomKzrdgzfCHJkIL2L0OAY+VPvrSW615iPtc7ag==}
+  /vitefu/0.2.0:
+    resolution: {integrity: sha512-58946QxFCr0OnNbF73JPA3nyzfI65G82bWwKV8zxAcQfTeAyGU99ejSFIG7RBUDBUr1RonXI/VEMzIrNl/euXA==}
     peerDependencies:
       vite: ^3.0.0
     peerDependenciesMeta:
@@ -18141,8 +18141,8 @@ packages:
         optional: true
     dev: false
 
-  /vitefu/0.1.1_vite@3.2.3:
-    resolution: {integrity: sha512-HClD14fjMJ+NQgXBqT3dC3RdO/+Chayil+cCPYZKY3kT+KcJomKzrdgzfCHJkIL2L0OAY+VPvrSW615iPtc7ag==}
+  /vitefu/0.2.0_vite@3.2.3:
+    resolution: {integrity: sha512-58946QxFCr0OnNbF73JPA3nyzfI65G82bWwKV8zxAcQfTeAyGU99ejSFIG7RBUDBUr1RonXI/VEMzIrNl/euXA==}
     peerDependencies:
       vite: ^3.0.0
     peerDependenciesMeta:


### PR DESCRIPTION
## Changes

- Upgrade `vitefu` from 0.1.0 to [0.2.0](https://github.com/svitejs/vitefu/releases/tag/v0.2.0) - It's a breaking bump but for an API we're not using so we're safe.
- Pass Vite user config to `vitefu` `crawlFrameworkPackages` so that the generated Vite config respects the user config. This helps the user to make a workaround if there's any issues with it.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A. In most case this should be transparent to the users.