### PR TITLE
Fix `astro.config.mjs` in minimal example

### DIFF
--- a/examples/minimal/astro.config.mjs
+++ b/examples/minimal/astro.config.mjs
@@ -1,7 +1,4 @@
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
-export default defineConfig({
-	srcDir: '.',
-	root: '.',
-});
+export default defineConfig({});


### PR DESCRIPTION
## Changes

#5298 introduced a change in the config file of the minimal example, presumably for testing purposes, but that makes `index.astro` 404 on StackBlitz. (Only detected just now when we fixed auto-push to `latest` which is what astro.new pulls from.)

This PR reverts the change from #5298.

## Testing

Opening this branch on StackBlitz works as expected: https://stackblitz.com/github/withastro/astro/tree/chris/fix-minimal-example/examples/minimal

## Docs

Examples fix only, no docs changes needed.