### PR TITLE
Use base rather than site to create subpath for links/scripts

### DIFF
--- a/.changeset/thirty-cheetahs-repeat.md
+++ b/.changeset/thirty-cheetahs-repeat.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prefer the `base` config rather than site config for creating URLs for links and scripts.

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -170,7 +170,7 @@ export class App {
 		const url = new URL(request.url);
 		const manifest = this.#manifest;
 		const info = this.#routeDataToRouteInfo.get(routeData!)!;
-		const links = createLinkStylesheetElementSet(info.links, manifest.site);
+		const links = createLinkStylesheetElementSet(info.links, manifest.base);
 
 		let scripts = new Set<SSRElement>();
 		for (const script of info.scripts) {
@@ -182,7 +182,7 @@ export class App {
 					});
 				}
 			} else {
-				scripts.add(createModuleScriptElement(script, manifest.site));
+				scripts.add(createModuleScriptElement(script, manifest.base));
 			}
 		}
 

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -291,14 +291,8 @@ async function generatePath(
 
 	debug('build', `Generating: ${pathname}`);
 
-	// If a base path was provided, append it to the site URL. This ensures that
-	// all injected scripts and links are referenced relative to the site and subpath.
-	const site =
-		settings.config.base !== '/'
-			? joinPaths(settings.config.site?.toString() || 'http://localhost/', settings.config.base)
-			: settings.config.site;
-	const links = createLinkStylesheetElementSet(linkIds, site);
-	const scripts = createModuleScriptsSet(hoistedScripts ? [hoistedScripts] : [], site);
+	const links = createLinkStylesheetElementSet(linkIds, settings.config.base);
+	const scripts = createModuleScriptsSet(hoistedScripts ? [hoistedScripts] : [], settings.config.base);
 
 	if (settings.scripts.some((script) => script.stage === 'page')) {
 		const hashedFilePath = internals.entrySpecifierToBundleMap.get(PAGE_SCRIPT_ID);

--- a/packages/astro/src/core/render/ssr-element.ts
+++ b/packages/astro/src/core/render/ssr-element.ts
@@ -3,34 +3,34 @@ import type { SSRElement } from '../../@types/astro';
 import npath from 'path-browserify';
 import { appendForwardSlash } from '../../core/path.js';
 
-function getRootPath(site?: string): string {
-	return appendForwardSlash(new URL(site || 'http://localhost/').pathname);
+function getRootPath(base?: string): string {
+	return appendForwardSlash(new URL(base || '/', 'http://localhost/').pathname);
 }
 
-function joinToRoot(href: string, site?: string): string {
-	return npath.posix.join(getRootPath(site), href);
+function joinToRoot(href: string, base?: string): string {
+	return npath.posix.join(getRootPath(base), href);
 }
 
-export function createLinkStylesheetElement(href: string, site?: string): SSRElement {
+export function createLinkStylesheetElement(href: string, base?: string): SSRElement {
 	return {
 		props: {
 			rel: 'stylesheet',
-			href: joinToRoot(href, site),
+			href: joinToRoot(href, base),
 		},
 		children: '',
 	};
 }
 
-export function createLinkStylesheetElementSet(hrefs: string[], site?: string) {
-	return new Set<SSRElement>(hrefs.map((href) => createLinkStylesheetElement(href, site)));
+export function createLinkStylesheetElementSet(hrefs: string[], base?: string) {
+	return new Set<SSRElement>(hrefs.map((href) => createLinkStylesheetElement(href, base)));
 }
 
 export function createModuleScriptElement(
 	script: { type: 'inline' | 'external'; value: string },
-	site?: string
+	base?: string
 ): SSRElement {
 	if (script.type === 'external') {
-		return createModuleScriptElementWithSrc(script.value, site);
+		return createModuleScriptElementWithSrc(script.value, base);
 	} else {
 		return {
 			props: {
@@ -60,7 +60,7 @@ export function createModuleScriptElementWithSrcSet(
 
 export function createModuleScriptsSet(
 	scripts: { type: 'inline' | 'external'; value: string }[],
-	site?: string
+	base?: string
 ): Set<SSRElement> {
-	return new Set<SSRElement>(scripts.map((script) => createModuleScriptElement(script, site)));
+	return new Set<SSRElement>(scripts.map((script) => createModuleScriptElement(script, base)));
 }

--- a/packages/astro/test/asset-url-base.test.js
+++ b/packages/astro/test/asset-url-base.test.js
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Asset URL resolution in build', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	describe('With site and base', async () => {
+		describe('with site', () => {
+			before(async () => {
+				fixture = await loadFixture({
+					root: './fixtures/asset-url-base/',
+					site: 'http://example.com/sub/path/'
+				});
+				await fixture.build();
+			});
+			
+			it('does not include the site\'s subpath', async () => {
+				const html = await fixture.readFile('/index.html');
+				const $ = cheerio.load(html);
+				const href = $('link[rel=stylesheet]').attr('href');
+				expect(href.startsWith('/sub/path/')).to.equal(false);
+			});
+		});
+
+		describe('with site and base', () => {
+			before(async () => {
+				fixture = await loadFixture({
+					root: './fixtures/asset-url-base/',
+					site: 'http://example.com/sub/path/',
+					base: '/another/base/'
+				});
+				await fixture.build();
+			});
+			
+			it('does not include the site\'s subpath', async () => {
+				const html = await fixture.readFile('/index.html');
+				const $ = cheerio.load(html);
+				const href = $('link[rel=stylesheet]').attr('href');
+				expect(href.startsWith('/sub/path/')).to.equal(false);
+			});
+
+			it('does include the base subpath', async () => {
+				const html = await fixture.readFile('/index.html');
+				const $ = cheerio.load(html);
+				const href = $('link[rel=stylesheet]').attr('href');
+				expect(href.startsWith('/another/base/')).to.equal(true);
+			});
+		});
+	});
+});

--- a/packages/astro/test/fixtures/asset-url-base/package.json
+++ b/packages/astro/test/fixtures/asset-url-base/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@test/asset-url-base",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  },
+  "scripts": {
+    "dev": "astro dev"
+  }
+}

--- a/packages/astro/test/fixtures/asset-url-base/src/pages/index.astro
+++ b/packages/astro/test/fixtures/asset-url-base/src/pages/index.astro
@@ -1,0 +1,13 @@
+<html>
+<head>
+	<title>Testing</title>
+	<style>
+		body {
+			background: blue;
+		}
+	</style>
+</head>
+<body>
+	<h1>Testing</h1>
+</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1150,6 +1150,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/asset-url-base:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/astro pages:
     specifiers:
       astro: workspace:*


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/astro/issues/5351
- Using `site` is leftover from before we had `base`

## Testing

- Added tests

## Docs

N/A, bug fix