### PR TITLE
Properly support trailingSlash: never with a base

### DIFF
--- a/.changeset/kind-icons-destroy.md
+++ b/.changeset/kind-icons-destroy.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Properly support trailingSlash: never with a base

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -325,10 +325,11 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: URL) {
 		) {
 			config.build.client = new URL('./dist/client/', config.outDir);
 		}
-		if(trimSlashes(config.base).length && config.trailingSlash === 'never') {
-      config.base = prependForwardSlash(trimSlashes(config.base));
+		const trimmedBase = trimSlashes(config.base);
+		if(trimmedBase.length && config.trailingSlash === 'never') {
+      config.base = prependForwardSlash(trimmedBase);
     } else {
-      config.base = prependForwardSlash(appendForwardSlash(trimSlashes(config.base)));
+      config.base = prependForwardSlash(appendForwardSlash(trimmedBase));
     }
 		return config;
 	});

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -77,8 +77,7 @@ export const AstroConfigSchema = z.object({
 	base: z
 		.string()
 		.optional()
-		.default(ASTRO_CONFIG_DEFAULTS.base)
-		.transform((val) => prependForwardSlash(appendForwardSlash(trimSlashes(val)))),
+		.default(ASTRO_CONFIG_DEFAULTS.base),
 	trailingSlash: z
 		.union([z.literal('always'), z.literal('never'), z.literal('ignore')])
 		.optional()
@@ -326,6 +325,11 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: URL) {
 		) {
 			config.build.client = new URL('./dist/client/', config.outDir);
 		}
+		if(trimSlashes(config.base).length && config.trailingSlash === 'never') {
+      config.base = prependForwardSlash(trimSlashes(config.base));
+    } else {
+      config.base = prependForwardSlash(appendForwardSlash(trimSlashes(config.base)));
+    }
 		return config;
 	});
 

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -93,7 +93,10 @@ function getPattern(segments: RoutePart[][], base: string, addTrailingSlash: Ast
 
 	const trailing =
 		addTrailingSlash && segments.length ? getTrailingSlashPattern(addTrailingSlash) : '$';
-	const initial = base === '/' ? '\\/' : '';
+	let initial = '\\/';
+	if(addTrailingSlash === 'never' && base !== '/') {
+		initial = '';
+	}
 	return new RegExp(`^${pathname || initial}${trailing}`);
 }
 

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -307,7 +307,7 @@ export function createRouteManifest(
 				components.push(item.file);
 				const component = item.file;
 				const trailingSlash = item.isPage ? settings.config.trailingSlash : 'never';
-				const pattern = getPattern(segments, trailingSlash);
+				const pattern = getPattern(segments, settings.config.base, trailingSlash);
 				const generate = getRouteGenerator(segments, trailingSlash);
 				const pathname = segments.every((segment) => segment.length === 1 && !segment[0].dynamic)
 					? `/${segments.map((segment) => segment[0].content).join('/')}`
@@ -368,7 +368,7 @@ export function createRouteManifest(
 			const isPage = type === 'page';
 			const trailingSlash = isPage ? config.trailingSlash : 'never';
 
-			const pattern = getPattern(segments, trailingSlash);
+			const pattern = getPattern(segments, settings.config.base, trailingSlash);
 			const generate = getRouteGenerator(segments, trailingSlash);
 			const pathname = segments.every((segment) => segment.length === 1 && !segment[0].dynamic)
 				? `/${segments.map((segment) => segment[0].content).join('/')}`

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -61,7 +61,7 @@ function getParts(part: string, file: string) {
 	return result;
 }
 
-function getPattern(segments: RoutePart[][], addTrailingSlash: AstroConfig['trailingSlash']) {
+function getPattern(segments: RoutePart[][], base: string, addTrailingSlash: AstroConfig['trailingSlash']) {
 	const pathname = segments
 		.map((segment) => {
 			if (segment.length === 1 && segment[0].spread) {
@@ -93,7 +93,8 @@ function getPattern(segments: RoutePart[][], addTrailingSlash: AstroConfig['trai
 
 	const trailing =
 		addTrailingSlash && segments.length ? getTrailingSlashPattern(addTrailingSlash) : '$';
-	return new RegExp(`^${pathname || '\\/'}${trailing}`);
+	const initial = base === '/' ? '\\/' : '';
+	return new RegExp(`^${pathname || initial}${trailing}`);
 }
 
 function getTrailingSlashPattern(addTrailingSlash: AstroConfig['trailingSlash']): string {

--- a/packages/astro/src/vite-plugin-astro-server/base.ts
+++ b/packages/astro/src/vite-plugin-astro-server/base.ts
@@ -15,6 +15,7 @@ export function baseMiddleware(
 	const site = config.site ? new URL(config.base, config.site) : undefined;
 	const devRootURL = new URL(config.base, 'http://localhost');
 	const devRoot = site ? site.pathname : devRootURL.pathname;
+	const devRootReplacement = devRoot.endsWith('/') ? '/' : '';
 
 	return function devBaseMiddleware(req, res, next) {
 		const url = req.url!;
@@ -22,7 +23,7 @@ export function baseMiddleware(
 		const pathname = decodeURI(new URL(url, 'http://localhost').pathname);
 
 		if (pathname.startsWith(devRoot)) {
-			req.url = url.replace(devRoot, '/');
+			req.url = url.replace(devRoot, devRootReplacement);
 			return next();
 		}
 

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -50,8 +50,10 @@ export default function createVitePluginAstroServer({
 					});
 				}
 				viteServer.middlewares.use(async (req, res) => {
-					if (!req.url || !req.method) {
-						throw new Error('Incomplete request');
+					if (req.url === undefined || !req.method) {
+						res.writeHead(500, 'Incomplete request');
+						res.end();
+						return;
 					}
 					handleRequest(env, manifest, serverController, req, res);
 				});

--- a/packages/astro/src/vite-plugin-astro-server/request.ts
+++ b/packages/astro/src/vite-plugin-astro-server/request.ts
@@ -28,7 +28,10 @@ export async function handleRequest(
 	// routing behavior matches production builds. This supports both file and directory
 	// build formats, and is necessary based on how the manifest tracks build targets.
 	const url = new URL(origin + req.url?.replace(/(index)?\.html$/, ''));
-	const pathname = req.url ?? decodeURI(url.pathname);
+	let pathname = decodeURI(url.pathname);
+	if(config.trailingSlash === 'never' && !req.url) {
+		pathname = '';
+	}
 
 	// Add config.base back to url before passing it to SSR
 	url.pathname = removeTrailingForwardSlash(config.base) + url.pathname;

--- a/packages/astro/src/vite-plugin-astro-server/request.ts
+++ b/packages/astro/src/vite-plugin-astro-server/request.ts
@@ -28,9 +28,11 @@ export async function handleRequest(
 	// routing behavior matches production builds. This supports both file and directory
 	// build formats, and is necessary based on how the manifest tracks build targets.
 	const url = new URL(origin + req.url?.replace(/(index)?\.html$/, ''));
-	let pathname = decodeURI(url.pathname);
+	let pathname: string;
 	if(config.trailingSlash === 'never' && !req.url) {
 		pathname = '';
+	} else {
+		pathname = decodeURI(url.pathname);
 	}
 
 	// Add config.base back to url before passing it to SSR

--- a/packages/astro/src/vite-plugin-astro-server/request.ts
+++ b/packages/astro/src/vite-plugin-astro-server/request.ts
@@ -7,6 +7,7 @@ import { collectErrorMetadata } from '../core/errors/dev/index.js';
 import { createSafeError } from '../core/errors/index.js';
 import { error } from '../core/logger/core.js';
 import * as msg from '../core/messages.js';
+import { removeTrailingForwardSlash } from '../core/path.js';
 import { runWithErrorHandling } from './controller.js';
 import { handle500Response } from './response.js';
 import { handleRoute, matchRoute } from './route.js';
@@ -27,10 +28,10 @@ export async function handleRequest(
 	// routing behavior matches production builds. This supports both file and directory
 	// build formats, and is necessary based on how the manifest tracks build targets.
 	const url = new URL(origin + req.url?.replace(/(index)?\.html$/, ''));
-	const pathname = decodeURI(url.pathname);
+	const pathname = req.url ?? decodeURI(url.pathname);
 
 	// Add config.base back to url before passing it to SSR
-	url.pathname = config.base.substring(0, config.base.length - 1) + url.pathname;
+	url.pathname = removeTrailingForwardSlash(config.base) + url.pathname;
 
 	// HACK! @astrojs/image uses query params for the injected route in `dev`
 	if (!buildingToSSR && pathname !== '/_image') {

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -25,7 +25,10 @@ describe('Astro Global', () => {
 		});
 
 		it('Astro.request.url', async () => {
-			const html = await fixture.fetch('/blog/?foo=42').then((res) => res.text());
+			const res = await await fixture.fetch('/blog/?foo=42');
+			expect(res.status).to.equal(200);
+
+			const html = await res.text();
 			const $ = cheerio.load(html);
 			expect($('#pathname').text()).to.equal('/blog/');
 			expect($('#searchparams').text()).to.equal('{}');

--- a/packages/astro/test/units/dev/base.test.js
+++ b/packages/astro/test/units/dev/base.test.js
@@ -1,0 +1,106 @@
+import { expect } from 'chai';
+
+import { runInContainer } from '../../../dist/core/dev/index.js';
+import { createFs, createRequestAndResponse } from '../test-utils.js';
+
+const root = new URL('../../fixtures/alias/', import.meta.url);
+
+describe('base configuration', () => {
+	describe('with trailingSlash: "never"', () => {
+		describe('index route', () => {
+			it('Requests that include a trailing slash 404', async () => {
+				const fs = createFs({
+					'/src/pages/index.astro': `<h1>testing</h1>`,
+				}, root);
+		
+				await runInContainer({
+					fs,
+					root,
+					userConfig: {
+						base: '/docs',
+						trailingSlash: 'never',
+					},
+				}, async (container) => {
+					const { req, res, done } = createRequestAndResponse({
+						method: 'GET',
+						url: '/docs/',
+					});
+					container.handle(req, res);
+					await done;
+					expect(res.statusCode).to.equal(404);
+				});
+			});
+	
+			it('Requests that exclude a trailing slash 200', async () => {
+				const fs = createFs({
+					'/src/pages/index.astro': `<h1>testing</h1>`,
+				}, root);
+		
+				await runInContainer({
+					fs,
+					root,
+					userConfig: {
+						base: '/docs',
+						trailingSlash: 'never',
+					},
+				}, async (container) => {
+					const { req, res, done } = createRequestAndResponse({
+						method: 'GET',
+						url: '/docs',
+					});
+					container.handle(req, res);
+					await done;
+					expect(res.statusCode).to.equal(200);
+				});
+			});
+		});
+
+		describe('sub route', () => {
+			it('Requests that include a trailing slash 404', async () => {
+				const fs = createFs({
+					'/src/pages/sub/index.astro': `<h1>testing</h1>`,
+				}, root);
+		
+				await runInContainer({
+					fs,
+					root,
+					userConfig: {
+						base: '/docs',
+						trailingSlash: 'never',
+					},
+				}, async (container) => {
+					const { req, res, done } = createRequestAndResponse({
+						method: 'GET',
+						url: '/docs/sub/',
+					});
+					container.handle(req, res);
+					await done;
+					expect(res.statusCode).to.equal(404);
+				});
+			});
+	
+			it('Requests that exclude a trailing slash 200', async () => {
+				const fs = createFs({
+					'/src/pages/sub/index.astro': `<h1>testing</h1>`,
+				}, root);
+		
+				await runInContainer({
+					fs,
+					root,
+					userConfig: {
+						base: '/docs',
+						trailingSlash: 'never',
+					},
+				}, async (container) => {
+					const { req, res, done } = createRequestAndResponse({
+						method: 'GET',
+						url: '/docs/sub',
+					});
+					container.handle(req, res);
+					await done;
+					expect(res.statusCode).to.equal(200);
+				});
+			});
+		});
+	});
+});

--- a/packages/astro/test/units/routing/manifest.test.js
+++ b/packages/astro/test/units/routing/manifest.test.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+
+import { createFs } from '../test-utils.js';
+import { createRouteManifest } from '../../../dist/core/routing/manifest/create.js';
+import { createDefaultDevSettings } from '../../../dist/core/config/index.js';
+import { fileURLToPath } from 'url';
+
+const root = new URL('../../fixtures/alias/', import.meta.url);
+
+describe('routing - createRouteManifest', () => {
+	it('using trailingSlash: "never" does not match the index route when it contains a trailing slash', async () => {
+		const fs = createFs({
+			'/src/pages/index.astro': `<h1>test</h1>`,
+		}, root);
+		const settings = await createDefaultDevSettings({
+			base: '/search',
+			trailingSlash: 'never'
+		}, root);
+		const manifest = createRouteManifest({
+			cwd: fileURLToPath(root),
+			settings,
+			fsMod: fs
+		});
+		const [{ pattern }] = manifest.routes;
+		expect(pattern.test('')).to.equal(true);
+		expect(pattern.test('/')).to.equal(false);
+	});
+});

--- a/packages/astro/test/units/vite-plugin-astro-server/request.test.js
+++ b/packages/astro/test/units/vite-plugin-astro-server/request.test.js
@@ -26,7 +26,7 @@ describe('vite-plugin-astro-server', () => {
 		it('renders a request', async () => {
 			const env = await createDevEnvironment({
 				loader: createLoader({
-					import(id) {
+					import() {
 						const Page = createComponent(() => {
 							return render`<div id="test">testing</div>`;
 						});
@@ -53,11 +53,13 @@ describe('vite-plugin-astro-server', () => {
 
 			try {
 				await handleRequest(env, manifest, controller, req, res);
-				const html = await text();
-				expect(html).to.include('<div id="test">');
 			} catch (err) {
-				expect(err).to.be.undefined();
+				expect(err.message).to.be.undefined();
 			}
+
+			const html = await text();
+			expect(res.statusCode).to.equal(200);
+			expect(html).to.include('<div id="test">');
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- When using `trailingSlash: 'never'` and a base such as `/docs` it should allow requests to `/docs` but not to `/docs/`.
- This was a bit tricky to fix given how we remove the base in the dev server and then later put it back. That's why this touches a few different files.
- It might be worth in the future creating a class / module or something that sort of encapsulates all of the base, trailingSlash, etc. behavior. And then have everything use that.

## Testing

- Unit tests added for the dev server to ensure this works as expected.
- Unit test added for routing.

## Docs

N/A, bug fix