### PR TITLE
Fix usage of the Image component with the Vercel adapter

### DIFF
--- a/.changeset/tidy-shoes-yawn.md
+++ b/.changeset/tidy-shoes-yawn.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/image': patch
+'@astrojs/vercel': patch
+---
+
+Make vercel and image work well together

--- a/.changeset/tidy-shoes-yawn.md
+++ b/.changeset/tidy-shoes-yawn.md
@@ -3,4 +3,4 @@
 '@astrojs/vercel': patch
 ---
 
-Make vercel and image work well together
+Allows @astrojs/image to be used in Vercel SSR

--- a/packages/integrations/image/src/index.ts
+++ b/packages/integrations/image/src/index.ts
@@ -171,7 +171,7 @@ export default function integration(options: IntegrationOptions = {}): AstroInte
 			},
 			'astro:build:ssr': async () => {
 				if (resolvedOptions.serviceEntryPoint === '@astrojs/image/squoosh') {
-					await copyWasmFiles(_buildConfig.server);
+					await copyWasmFiles(new URL('./chunks/', _buildConfig.server));
 				}
 			},
 		},

--- a/packages/integrations/image/src/index.ts
+++ b/packages/integrations/image/src/index.ts
@@ -11,6 +11,12 @@ export { getPicture } from './lib/get-picture.js';
 
 const PKG_NAME = '@astrojs/image';
 const ROUTE_PATTERN = '/_image';
+const UNSUPPORTED_ADAPTERS = new Set([
+	'@astrojs/cloudflare',
+	'@astrojs/deno',
+	'@astrojs/netlify/edge-functions',
+	'@astrojs/vercel/edge',
+]);
 
 interface BuildConfig {
 	client: URL;
@@ -100,6 +106,13 @@ export default function integration(options: IntegrationOptions = {}): AstroInte
 				_buildConfig = config.build;
 			},
 			'astro:build:start': ({ buildConfig }) => {
+				const adapterName = _config.adapter?.name;
+				if (adapterName && UNSUPPORTED_ADAPTERS.has(adapterName)) {
+					throw new Error(
+						`@astrojs/image is not supported with the ${adapterName} adapter. Please choose a Node.js compatible adapter.`
+					);
+				}
+
 				// Backwards compat
 				if (needsBuildConfig) {
 					_buildConfig = buildConfig;

--- a/packages/integrations/image/src/loaders/squoosh.ts
+++ b/packages/integrations/image/src/loaders/squoosh.ts
@@ -3,10 +3,11 @@ import { red } from 'kleur/colors';
 import { error } from '../utils/logger.js';
 import { metadata } from '../utils/metadata.js';
 import { isRemoteImage } from '../utils/paths.js';
-import { processBuffer } from '../vendor/squoosh/image-pool.js';
 import type { Operation } from '../vendor/squoosh/image.js';
 import type { OutputFormat, TransformOptions } from './index.js';
 import { BaseSSRService } from './index.js';
+
+const imagePoolModulePromise = import('../vendor/squoosh/image-pool.js');
 
 class SquooshService extends BaseSSRService {
 	async processAvif(image: any, transform: TransformOptions) {
@@ -112,7 +113,7 @@ class SquooshService extends BaseSSRService {
 			});
 			throw new Error(`Unknown image output: "${transform.format}" used for ${transform.src}`);
 		}
-
+		const { processBuffer } = await imagePoolModulePromise;
 		const data = await processBuffer(inputBuffer, operations, transform.format, transform.quality);
 
 		return {

--- a/packages/integrations/image/src/vendor/squoosh/image-pool.ts
+++ b/packages/integrations/image/src/vendor/squoosh/image-pool.ts
@@ -1,5 +1,6 @@
 import { isMainThread } from 'node:worker_threads';
 import { cpus } from 'os';
+import { fileURLToPath } from 'url';
 import type { OutputFormat } from '../../loaders/index.js';
 import execOnce from '../../utils/execOnce.js';
 import WorkerPool from '../../utils/workerPool.js';
@@ -12,7 +13,7 @@ const getWorker = execOnce(
 			// There will be at most 7 workers needed since each worker will take
       // at least 1 operation type.
       Math.max(1, Math.min(cpus().length - 1, 7)),
-			'./node_modules/@astrojs/image/dist/vendor/squoosh/image-pool.js'
+			fileURLToPath(import.meta.url)
 		);
 	}
 )

--- a/packages/integrations/image/src/vite-plugin-astro-image.ts
+++ b/packages/integrations/image/src/vite-plugin-astro-image.ts
@@ -113,27 +113,6 @@ export function createPlugin(config: AstroConfig, options: Required<IntegrationO
 				return next();
 			});
 		},
-		outputOptions(outputOptions) {
-			if (resolvedConfig.build.ssr) {
-				// Build the image-pool chunk to the top-level and not inside of a chunks/
-				// folder. This is because the wasm is built at the top-level and this makes
-				// it accessible from the pool worker.
-				const chunkFileNames = outputOptions.chunkFileNames;
-				outputOptions.chunkFileNames = (chunk) => {
-					for (const name of Object.keys(chunk.modules)) {
-						if (name.endsWith('vendor/squoosh/image-pool.js')) {
-							return '[name].[hash].mjs';
-						}
-					}
-
-					if (typeof chunkFileNames === 'function') {
-						return chunkFileNames.call(this, chunk);
-					}
-
-					return chunkFileNames!;
-				};
-			}
-		},
 		async renderChunk(code) {
 			const assetUrlRE = /__ASTRO_IMAGE_ASSET__([a-z\d]{8})__(?:_(.*?)__)?/g;
 

--- a/packages/integrations/image/src/vite-plugin-astro-image.ts
+++ b/packages/integrations/image/src/vite-plugin-astro-image.ts
@@ -113,6 +113,27 @@ export function createPlugin(config: AstroConfig, options: Required<IntegrationO
 				return next();
 			});
 		},
+		outputOptions(outputOptions) {
+			if (resolvedConfig.build.ssr) {
+				// Build the image-pool chunk to the top-level and not inside of a chunks/
+				// folder. This is because the wasm is built at the top-level and this makes
+				// it accessible from the pool worker.
+				const chunkFileNames = outputOptions.chunkFileNames;
+				outputOptions.chunkFileNames = (chunk) => {
+					for (const name of Object.keys(chunk.modules)) {
+						if (name.endsWith('vendor/squoosh/image-pool.js')) {
+							return '[name].[hash].mjs';
+						}
+					}
+
+					if (typeof chunkFileNames === 'function') {
+						return chunkFileNames.call(this, chunk);
+					}
+
+					return chunkFileNames!;
+				};
+			}
+		},
 		async renderChunk(code) {
 			const assetUrlRE = /__ASTRO_IMAGE_ASSET__([a-z\d]{8})__(?:_(.*?)__)?/g;
 

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -45,7 +45,8 @@
   },
   "dependencies": {
     "@astrojs/webapi": "^1.1.1",
-    "@vercel/nft": "^0.22.1"
+    "@vercel/nft": "^0.22.1",
+    "fast-glob": "^3.2.11"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3180,10 +3180,12 @@ importers:
       astro: workspace:*
       astro-scripts: workspace:*
       chai: ^4.3.6
+      fast-glob: ^3.2.11
       mocha: ^9.2.2
     dependencies:
       '@astrojs/webapi': link:../../webapi
       '@vercel/nft': 0.22.1
+      fast-glob: 3.2.12
     devDependencies:
       astro: link:../../astro
       astro-scripts: link:../../../scripts


### PR DESCRIPTION
…" (#5360)"

This reverts commit 20e60c6e0857f7b6938494df6027e8c1ad74cdc1.

## Changes

- Allows the image component to be used within Vercel.
- Bundles the squoosh worker along with the other SSR code.
- Moves the wasm files into the chunks folder, like in SSG.

## Testing

- Test app https://astro-test-image-ssr-matthew6.vercel.app/

## Docs

N/A