### PR TITLE
Better TypeScript Prompts

### DIFF
--- a/.changeset/old-trains-hide.md
+++ b/.changeset/old-trains-hide.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Update TypeScript prompts to be more clear about the resulting action

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -290,7 +290,7 @@ export async function main() {
 				{ value: 'strict', title: 'Strict', description: '(recommended)' },
 				{ value: 'strictest', title: 'Strictest' },
 				{ value: 'base', title: 'Relaxed' },
-				{ value: 'unsure', title: 'Help me choose' },
+				{ value: 'unsure', title: `I'm Unsure` },
 			],
 		},
 		{

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -85,10 +85,7 @@ export async function error(prefix: string, text: string) {
 }
 
 export async function typescriptByDefault() {
-	await info(`Cool!`, 'Astro comes with TypeScript support enabled by default.');
-	console.log(
-		`${' '.repeat(3)}${color.dim(`We'll default to the most relaxed settings for you.`)}`
-	);
+	await info('No worries!', `We'll default to the most relaxed settings for you.`);
 	await sleep(300);
 }
 


### PR DESCRIPTION
### Changes

Renamed "Help Me Choose" option when selecting a TypeScript setup to "I'm Unsure" as "Help Me Choose" was misleading (See #5352).

### Testing

I just manually ran the CLI and saw if everything looked good (which I think it did)!

### Docs

This is such a minor change no docs changes should be needed!

### Comments

In #5352, we discussed about naming it "Use Default", but I think that having it as "I'm Unsure" fits the resulting action even better! Let me know your thoughts on this though.