### PR TITLE
Help the user pick TypeScript setup rules

### DIFF
--- a/.changeset/old-trains-hide.md
+++ b/.changeset/old-trains-hide.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Update TypeScript prompts to be more clear about the resulting action

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -290,7 +290,7 @@ export async function main() {
 				{ value: 'strict', title: 'Strict', description: '(recommended)' },
 				{ value: 'strictest', title: 'Strictest' },
 				{ value: 'base', title: 'Relaxed' },
-				{ value: 'unsure', title: 'Help me choose' },
+				{ value: 'unsure', title: `I'm Unsure` },
 			],
 		},
 		{

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -285,7 +285,8 @@ export async function main() {
 	const choices = [
 				{ value: 'strict', title: 'Strict', description: '(recommended)' },
 				{ value: 'strictest', title: 'Strictest' },
-				{ value: 'base', title: 'Relaxed' },					{ value: 'unsure', title: `I'm unsure` },
+				{ value: 'base', title: 'Relaxed' },
+				{ value: 'unsure', title: `I'm unsure` },
 			];
 	do {
 		tsResponse = await prompts(
@@ -310,7 +311,9 @@ export async function main() {
 			// Prompt the user to look up the documentation
 			ora().info('No worries! Take a look at the documentation then come back to setup!\nhttps://docs.astro.build/en/guides/typescript/');
 			// Remove the unsure option because now the user knows what to expect
-			choices.splice(choices.findIndex((choice) => choice.value === 'unsure'), 1);
+			const index = choices.findIndex((choice) => choice.value === 'unsure');
+			if(index != -1)
+				choices.splice(index, 1);
 		}
 	} while (tsResponse == null || tsResponse === 'unsure');
 

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -85,10 +85,7 @@ export async function error(prefix: string, text: string) {
 }
 
 export async function typescriptByDefault() {
-	await info(`Cool!`, 'Astro comes with TypeScript support enabled by default.');
-	console.log(
-		`${' '.repeat(3)}${color.dim(`We'll default to the most relaxed settings for you.`)}`
-	);
+	await info('No worries!', `We'll default to the most relaxed settings for you.`);
 	await sleep(300);
 }
 


### PR DESCRIPTION
I'm not a fan of defaulting to Relaxed so I implemented a fast do/while that shows docs to the user and then requests the choice again.

## Changes

Changed `packages/create-astro/src/index.ts` so that it doesn't use a default for TypeScript and if the user is "unsure" the program shows a link for the user to browse and then asks again to pick (without the "unsure" option).

## Testing

Tested on [TypeScript official website](https://www.typescriptlang.org/play?#code/DYUwLgBGDOBKLQA4HsB20QQLwVQV2GAG4IB6UiAFQAsBLaCe1AckgEMIBjNaSAIxCc2eDIzDMGANzbA8mehABOINtGi0A5qhAATRqi6rMYaphEhFjBnnR5lAKG7pInaslqcE2CAG17EAMCggIBvCGlZEAAuCAkwRQ9xABooWjBQGOYAZXjE5hSdBE4ExDBaNEyACmVuAFtakFRCnQBKZggAXyT-YN6wiLlM3gTOMARk1PTo2JyRsd52rp7eoP6ZQdi+I3zJjNj4YDYAD11F7pXgtcjMm2g7EB2yqZiAAwBJZlqIW-uXzvOVgBdIj2HTICAhZZkUgmBTDKy4EC6XQQABmyEs80giDsKAwDFUUDoDG4hSsLEgaFwiC+AE9wFCnLwIPCYsNaKgND5Ad5XO5PNAAHS1NiISp8jyYLAAPi4bklgoGIBaIKCMHgSB4UogiEUyFqpUqLPigrAyFmHI0lRaEBVUNoqIglXVCBQ6EwAEIcPhCBAAGR+qBwV1a7BYHDMH7KZg2yEXcgQAAKeoNkBMZgwmPBwGQyAA1t9EETMGDOHgGqgwGwymgoUEmchQIKc1bmAA5cEAdwxCQQHqobDzmA4OfzEGrxYgpfLjSrNYM6YMdUwW04BbNLPAeEQHoAOqhqGAwIhoFFyKWhap4shBXw8LRgDpSI1SBp74VoDDaYgiiUwKQY1VFYE3gWpkEkYxTG+WxlAgZBSnKAwBCEcxcGQTtJ3MSw81QdCGE7agJw3EAjh-UY60CJlIA5Qojl5eUBUFVEaLeJoSMqcUGOVbBZQlTxFXWKVw1iKMHjtC4HUqGiSIgL0IAAWgARhaCjej4hBBSQYBJSktijhSZSgICDp7A6CACIfTBnWDTV3TDXACGACAAB9nKDDU3VEcMI1EwDHB4RsQGbZArRdWyMBVIA)

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->
No need to update docs which won't affect the user's behavior (except for the fact that the user will make a thought choice!)

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

## Comments
Discussed in #5352 and edited from #5362 