### PR TITLE
Fix `getStaticPaths` regressions with nested arrays

### DIFF
--- a/.changeset/angry-dragons-drive.md
+++ b/.changeset/angry-dragons-drive.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix regression causing nested arrays in `getStaticPaths`'s return value to throw an error

--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -49,11 +49,15 @@ export async function callGetStaticPaths({
 		},
 	});
 
+	// Flatten the array before validating the content, otherwise users using `.map` will run into errors
+	if (Array.isArray(staticPaths)) {
+		staticPaths = staticPaths.flat();
+	}
+
 	if (isValidate) {
 		validateGetStaticPathsResult(staticPaths, logging, route);
 	}
 
-	staticPaths = staticPaths.flat();
 	const keyedStaticPaths = staticPaths as GetStaticPathsResultKeyed;
 	keyedStaticPaths.keyed = new Map<string, GetStaticPathsItem>();
 

--- a/packages/astro/test/astro-get-static-paths.test.js
+++ b/packages/astro/test/astro-get-static-paths.test.js
@@ -101,6 +101,11 @@ describe('getStaticPaths - route params type validation', () => {
 		await devServer.stop();
 	});
 
+	it('resolves 200 on nested array parameters', async () => {
+		const res = await fixture.fetch('/nested-arrays/slug1');
+		expect(res.status).to.equal(200);
+	});
+
 	it('resolves 200 on matching static path - string params', async () => {
 		// route provided with { params: { year: "2022", slug: "post-2" }}
 		const res = await fixture.fetch('/blog/2022/post-1');

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/nested-arrays/[slug].astro
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/nested-arrays/[slug].astro
@@ -1,0 +1,8 @@
+---
+  export function getStaticPaths() {
+    return [
+      [ { params: {slug: "slug1"} } ],
+      [ { params: {slug: "slug2"} } ],
+    ]
+  }
+---


### PR DESCRIPTION
## Changes

After my recent PR that made the validation of `getStaticPaths` a bit more strict, the flatten call wasn't running at the right time, this caused the validation to fail since they expect the return value to be objects

## Testing

Added a test for nested arrays

## Docs

N/A. Nested array support is already documented
