### PR TITLE
Use Vite to load non JS astro configs

### DIFF
--- a/.changeset/swift-bees-hope.md
+++ b/.changeset/swift-bees-hope.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Uses vite to load astro.config.ts files

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -114,6 +114,8 @@
     "@types/babel__core": "^7.1.19",
     "@types/html-escaper": "^3.0.0",
     "@types/yargs-parser": "^21.0.0",
+    "@proload/core": "^0.3.3",
+    "@proload/plugin-tsm": "^0.2.1",
     "boxen": "^6.2.1",
     "ci-info": "^3.3.1",
     "common-ancestor-path": "^1.0.1",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -111,8 +111,6 @@
     "@babel/plugin-transform-react-jsx": "^7.17.12",
     "@babel/traverse": "^7.18.2",
     "@babel/types": "^7.18.4",
-    "@proload/core": "^0.3.3",
-    "@proload/plugin-tsm": "^0.2.1",
     "@types/babel__core": "^7.1.19",
     "@types/html-escaper": "^3.0.0",
     "@types/yargs-parser": "^21.0.0",

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -3,6 +3,7 @@ import * as colors from 'kleur/colors';
 import type { Arguments as Flags } from 'yargs-parser';
 import yargs from 'yargs-parser';
 import { z } from 'zod';
+import fs from 'fs';
 import {
 	createSettings,
 	openConfig,
@@ -88,7 +89,7 @@ async function handleConfigError(
 	e: any,
 	{ cwd, flags, logging }: { cwd?: string; flags?: Flags; logging: LogOptions }
 ) {
-	const path = await resolveConfigPath({ cwd, flags });
+	const path = await resolveConfigPath({ cwd, flags, fs });
 	if (e instanceof Error) {
 		if (path) {
 			error(logging, 'astro', `Unable to load ${colors.bold(path)}\n`);
@@ -173,7 +174,7 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 			const { default: devServer } = await import('../core/dev/index.js');
 
 			const configFlag = resolveFlags(flags).config;
-			const configFlagPath = configFlag ? await resolveConfigPath({ cwd: root, flags }) : undefined;
+			const configFlagPath = configFlag ? await resolveConfigPath({ cwd: root, flags, fs }) : undefined;
 
 			await devServer(settings, {
 				configFlag,

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -2,7 +2,7 @@ import type { AstroTelemetry } from '@astrojs/telemetry';
 import boxen from 'boxen';
 import { diffWords } from 'diff';
 import { execa } from 'execa';
-import { existsSync, promises as fs } from 'fs';
+import fsMod, { existsSync, promises as fs } from 'fs';
 import { bold, cyan, dim, green, magenta, red, yellow } from 'kleur/colors';
 import ora from 'ora';
 import path from 'path';
@@ -164,7 +164,7 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 		}
 	}
 
-	const rawConfigPath = await resolveConfigPath({ cwd, flags });
+	const rawConfigPath = await resolveConfigPath({ cwd, flags, fs: fsMod });
 	let configURL = rawConfigPath ? pathToFileURL(rawConfigPath) : undefined;
 
 	if (configURL) {

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -162,7 +162,7 @@ export async function resolveConfigPath(
 	// If `userConfigPath` is `undefined`, Proload will search for `astro.config.[cm]?[jt]s`
 	try {
 		const config = await loadConfigWithVite(root, {
-			mustExist: !!userConfigPath
+			configPath: userConfigPath
 		});
 		return config.filePath;
 	} catch (e) {
@@ -243,7 +243,7 @@ async function tryLoadConfig(
 		
 		// Create a vite server to load the config
 		const config = await loadConfigWithVite(root, {
-			mustExist: !!configPath
+			configPath
 		});
 		return config as TryLoadConfigResult;
 	} finally {

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -161,7 +161,9 @@ export async function resolveConfigPath(
 	// Resolve config file path using Proload
 	// If `userConfigPath` is `undefined`, Proload will search for `astro.config.[cm]?[jt]s`
 	try {
-		const config = await loadConfigWithVite(root);
+		const config = await loadConfigWithVite(root, {
+			mustExist: !!userConfigPath
+		});
 		return config.filePath;
 	} catch (e) {
 		if (flags.config) {
@@ -240,7 +242,9 @@ async function tryLoadConfig(
 		}
 		
 		// Create a vite server to load the config
-		const config = await loadConfigWithVite(root);
+		const config = await loadConfigWithVite(root, {
+			mustExist: !!configPath
+		});
 		return config as TryLoadConfigResult;
 	} finally {
 		await finallyCleanup();

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -1,0 +1,74 @@
+import * as vite from 'vite';
+import npath from 'path';
+
+export interface ViteLoader {
+	root: string;
+	viteServer: vite.ViteDevServer;
+}
+
+async function createViteLoader(root: string): Promise<ViteLoader> {
+	const viteServer = await vite.createServer({
+		server: { middlewareMode: true, hmr: false },
+		optimizeDeps: { entries: [] },
+		clearScreen: false,
+		appType: 'custom',
+		ssr: {
+			// NOTE: Vite doesn't externalize linked packages by default. During testing locally,
+			// these dependencies trip up Vite's dev SSR transform. In the future, we should
+			// avoid `vite.createServer` and use `loadConfigFromFile` instead.
+			external: ['@astrojs/tailwind', '@astrojs/mdx', '@astrojs/react']
+		}
+	});
+
+	return {
+		root,
+		viteServer,
+	};
+}
+
+interface TryLoadResult {
+	value: Record<string, any>;
+	filePath?: string;
+}
+
+async function tryLoadWith(root: string, paths: string[], cb: (path: string) => Promise<Record<string, any>>): Promise<TryLoadResult | null> {
+	for(const path of paths) {
+		const file = npath.join(root, path);
+		try {
+			const config = await cb(file);
+			return {
+				value: config.default ?? {},
+				filePath: file
+			};
+		} catch {}
+	}
+	return null;
+}
+
+export async function loadConfigWithVite(root: string): Promise<{
+	value: Record<string, any>;
+	filePath?: string;
+}> {
+	let config = await tryLoadWith(root, ['astro.config.mjs', 'astro.config.js'], path => import(path));
+	if(config) {
+		return config;
+	}
+
+	const loader = await createViteLoader(root);
+	config = await tryLoadWith(root, [
+		'astro.config.ts',
+		'astro.config.mts',
+		'astro.config.cts'
+	], async path => {
+		const mod = await loader.viteServer.ssrLoadModule(path);
+		await loader.viteServer.close();
+		return mod;
+	});
+
+	if(config) {
+		return config;
+	}
+
+	await loader.viteServer.close();
+	throw new Error(`Unable to find a config in ${root}`);
+}

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -45,7 +45,11 @@ async function tryLoadWith(root: string, paths: string[], cb: (path: string) => 
 	return null;
 }
 
-export async function loadConfigWithVite(root: string): Promise<{
+interface LoadConfigWithViteOptions {
+	mustExist: boolean;
+}
+
+export async function loadConfigWithVite(root: string, { mustExist }: LoadConfigWithViteOptions): Promise<{
 	value: Record<string, any>;
 	filePath?: string;
 }> {
@@ -70,5 +74,13 @@ export async function loadConfigWithVite(root: string): Promise<{
 	}
 
 	await loader.viteServer.close();
-	throw new Error(`Unable to find a config in ${root}`);
+
+	if(mustExist) {
+		throw new Error(`Unable to find a config in ${root}`);
+	}
+
+	return {
+		value: {},
+		filePath: undefined
+	};
 }

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -64,6 +64,7 @@ export async function loadConfigWithVite({ configPath, fs, root }: LoadConfigWit
 			'astro.config.js',
 			'astro.config.ts',
 			'astro.config.mts',
+			'astro.config.cjs',
 			'astro.config.cjs'
 		].map(path => npath.join(root, path));
 	}

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -82,7 +82,7 @@ export async function loadConfigWithVite({ configPath, fs, root }: LoadConfigWit
 			}
 
 			// Try loading with Node import()
-			if(/\.(m?)js$/.test(file)) {
+			if(/\.[cm]?js$/.test(file)) {
 				try {
 					const config = await import(pathToFileURL(file).toString());
 					return {

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -1,5 +1,6 @@
 import * as vite from 'vite';
 import npath from 'path';
+import { pathToFileURL } from 'url';
 
 export interface ViteLoader {
 	root: string;
@@ -53,7 +54,7 @@ export async function loadConfigWithVite(root: string, { mustExist }: LoadConfig
 	value: Record<string, any>;
 	filePath?: string;
 }> {
-	let config = await tryLoadWith(root, ['astro.config.mjs', 'astro.config.js'], path => import(path));
+	let config = await tryLoadWith(root, ['astro.config.mjs', 'astro.config.js'], path => import(pathToFileURL(path).toString()));
 	if(config) {
 		return config;
 	}

--- a/packages/astro/test/fixtures/tailwindcss-ts/astro.config.ts
+++ b/packages/astro/test/fixtures/tailwindcss-ts/astro.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import tailwind from "@astrojs/tailwind";
+
+// https://astro.build/config
+export default defineConfig({
+  integrations: [tailwind()]
+});

--- a/packages/astro/test/fixtures/tailwindcss-ts/package.json
+++ b/packages/astro/test/fixtures/tailwindcss-ts/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@astrojs/tailwind": "workspace:*",
     "astro": "workspace:*",
-    "tailwindcss": "^3.2.4"
+    "tailwindcss": "^3.2.4",
+    "postcss": ">=8.3.3 <9.0.0"
   }
 }

--- a/packages/astro/test/fixtures/tailwindcss-ts/package.json
+++ b/packages/astro/test/fixtures/tailwindcss-ts/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@test/tailwindcss-ts",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/tailwind": "workspace:*",
+    "astro": "workspace:*",
+    "tailwindcss": "^3.2.4"
+  }
+}

--- a/packages/astro/test/fixtures/tailwindcss-ts/tailwind.config.cjs
+++ b/packages/astro/test/fixtures/tailwindcss-ts/tailwind.config.cjs
@@ -1,0 +1,4 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+	content: ['src/**/*.{astro,tsx}']
+};

--- a/packages/astro/test/units/dev/restart.test.js
+++ b/packages/astro/test/units/dev/restart.test.js
@@ -112,18 +112,18 @@ describe('dev container restarts', () => {
 		}
 	});
 
-	it.only('Is able to restart project using Tailwind + astro.config.ts', async () => {
-		const root = new URL('../../fixtures/tailwindcss-ts/', import.meta.url);
+	it('Is able to restart project using Tailwind + astro.config.ts', async () => {
+		const troot = new URL('../../fixtures/tailwindcss-ts/', import.meta.url);
 		const fs = createFs(
 			{
 				'/src/pages/index.astro': ``,
 				'/astro.config.ts': ``,
 			},
-			root
+			troot
 		);
 
 		const { astroConfig } = await openConfig({
-			cwd: root,
+			cwd: troot,
 			flags: {},
 			cmd: 'dev',
 			logging: defaultLogging,

--- a/packages/integrations/image/src/index.ts
+++ b/packages/integrations/image/src/index.ts
@@ -76,7 +76,9 @@ export default function integration(options: IntegrationOptions = {}): AstroInte
 			'astro:config:setup': async ({ command, config, updateConfig, injectRoute }) => {
 				needsBuildConfig = !config.build?.server;
 				_config = config;
-				updateConfig({ vite: getViteConfiguration(command === 'dev') });
+				updateConfig({
+					vite: getViteConfiguration(command === 'dev'),
+				});
 
 				if (command === 'dev' || config.output === 'server') {
 					injectRoute({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2394,11 +2394,13 @@ importers:
     specifiers:
       '@astrojs/tailwind': workspace:*
       astro: workspace:*
+      postcss: '>=8.3.3 <9.0.0'
       tailwindcss: ^3.2.4
     dependencies:
       '@astrojs/tailwind': link:../../../../integrations/tailwind
       astro: link:../../..
-      tailwindcss: 3.2.4
+      postcss: 8.4.19
+      tailwindcss: 3.2.4_postcss@8.4.19
 
   packages/astro/test/fixtures/third-party-astro:
     specifiers:
@@ -17263,38 +17265,6 @@ packages:
       resolve: 1.22.1
     transitivePeerDependencies:
       - ts-node
-
-  /tailwindcss/3.2.4:
-    resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
-    engines: {node: '>=12.13.0'}
-    hasBin: true
-    dependencies:
-      arg: 5.0.2
-      chokidar: 3.5.3
-      color-name: 1.1.4
-      detective: 5.2.1
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.2.12
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      lilconfig: 2.0.6
-      micromatch: 4.0.5
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.0.0
-      postcss: 8.4.19
-      postcss-import: 14.1.0_postcss@8.4.19
-      postcss-js: 4.0.0_postcss@8.4.19
-      postcss-load-config: 3.1.4_postcss@8.4.19
-      postcss-nested: 6.0.0_postcss@8.4.19
-      postcss-selector-parser: 6.0.10
-      postcss-value-parser: 4.2.0
-      quick-lru: 5.1.1
-      resolve: 1.22.1
-    transitivePeerDependencies:
-      - ts-node
-    dev: false
 
   /tar-fs/2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,8 +382,6 @@ importers:
       '@babel/traverse': ^7.18.2
       '@babel/types': ^7.18.4
       '@playwright/test': ^1.22.2
-      '@proload/core': ^0.3.3
-      '@proload/plugin-tsm': ^0.2.1
       '@types/babel__core': ^7.1.19
       '@types/babel__generator': ^7.6.4
       '@types/babel__traverse': ^7.17.1
@@ -480,8 +478,6 @@ importers:
       '@babel/plugin-transform-react-jsx': 7.19.0_@babel+core@7.20.2
       '@babel/traverse': 7.20.1
       '@babel/types': 7.20.2
-      '@proload/core': 0.3.3
-      '@proload/plugin-tsm': 0.2.1_@proload+core@0.3.3
       '@types/babel__core': 7.1.20
       '@types/html-escaper': 3.0.0
       '@types/yargs-parser': 21.0.0
@@ -2389,6 +2385,16 @@ importers:
       autoprefixer: 10.4.13_postcss@8.4.19
       postcss: 8.4.19
       tailwindcss: 3.2.4_postcss@8.4.19
+
+  packages/astro/test/fixtures/tailwindcss-ts:
+    specifiers:
+      '@astrojs/tailwind': workspace:*
+      astro: workspace:*
+      tailwindcss: ^3.2.4
+    dependencies:
+      '@astrojs/tailwind': link:../../../../integrations/tailwind
+      astro: link:../../..
+      tailwindcss: 3.2.4
 
   packages/astro/test/fixtures/third-party-astro:
     specifiers:
@@ -6435,15 +6441,6 @@ packages:
     dependencies:
       deepmerge: 4.2.2
       escalade: 3.1.1
-    dev: false
-
-  /@proload/plugin-tsm/0.2.1_@proload+core@0.3.3:
-    resolution: {integrity: sha512-Ex1sL2BxU+g8MHdAdq9SZKz+pU34o8Zcl9PHWo2WaG9hrnlZme607PU6gnpoAYsDBpHX327+eu60wWUk+d/b+A==}
-    peerDependencies:
-      '@proload/core': ^0.3.2
-    dependencies:
-      '@proload/core': 0.3.3
-      tsm: 2.2.2
     dev: false
 
   /@react-aria/actiongroup/3.4.2_react@18.2.0:
@@ -17254,6 +17251,38 @@ packages:
     transitivePeerDependencies:
       - ts-node
 
+  /tailwindcss/3.2.4:
+    resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+    dependencies:
+      arg: 5.0.2
+      chokidar: 3.5.3
+      color-name: 1.1.4
+      detective: 5.2.1
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.12
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      lilconfig: 2.0.6
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.19
+      postcss-import: 14.1.0_postcss@8.4.19
+      postcss-js: 4.0.0_postcss@8.4.19
+      postcss-load-config: 3.1.4_postcss@8.4.19
+      postcss-nested: 6.0.0_postcss@8.4.19
+      postcss-selector-parser: 6.0.10
+      postcss-value-parser: 4.2.0
+      quick-lru: 5.1.1
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - ts-node
+    dev: false
+
   /tar-fs/2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
     dependencies:
@@ -17436,14 +17465,6 @@ packages:
 
   /tslib/2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
-
-  /tsm/2.2.2:
-    resolution: {integrity: sha512-bXkt675NbbqfwRHSSn8kSNEEHvoIUFDM9G6tUENkjEKpAEbrEzieO3PxUiRJylMw8fEGpcf5lSjadzzz12pc2A==}
-    engines: {node: '>=12'}
-    hasBin: true
-    dependencies:
-      esbuild: 0.14.54
-    dev: false
 
   /tsutils/3.21.0_typescript@4.7.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,6 +382,8 @@ importers:
       '@babel/traverse': ^7.18.2
       '@babel/types': ^7.18.4
       '@playwright/test': ^1.22.2
+      '@proload/core': ^0.3.3
+      '@proload/plugin-tsm': ^0.2.1
       '@types/babel__core': ^7.1.19
       '@types/babel__generator': ^7.6.4
       '@types/babel__traverse': ^7.17.1
@@ -478,6 +480,8 @@ importers:
       '@babel/plugin-transform-react-jsx': 7.19.0_@babel+core@7.20.2
       '@babel/traverse': 7.20.1
       '@babel/types': 7.20.2
+      '@proload/core': 0.3.3
+      '@proload/plugin-tsm': 0.2.1_@proload+core@0.3.3
       '@types/babel__core': 7.1.20
       '@types/html-escaper': 3.0.0
       '@types/yargs-parser': 21.0.0
@@ -6441,6 +6445,15 @@ packages:
     dependencies:
       deepmerge: 4.2.2
       escalade: 3.1.1
+    dev: false
+
+  /@proload/plugin-tsm/0.2.1_@proload+core@0.3.3:
+    resolution: {integrity: sha512-Ex1sL2BxU+g8MHdAdq9SZKz+pU34o8Zcl9PHWo2WaG9hrnlZme607PU6gnpoAYsDBpHX327+eu60wWUk+d/b+A==}
+    peerDependencies:
+      '@proload/core': ^0.3.2
+    dependencies:
+      '@proload/core': 0.3.3
+      tsm: 2.2.2
     dev: false
 
   /@react-aria/actiongroup/3.4.2_react@18.2.0:
@@ -17465,6 +17478,14 @@ packages:
 
   /tslib/2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
+
+  /tsm/2.2.2:
+    resolution: {integrity: sha512-bXkt675NbbqfwRHSSn8kSNEEHvoIUFDM9G6tUENkjEKpAEbrEzieO3PxUiRJylMw8fEGpcf5lSjadzzz12pc2A==}
+    engines: {node: '>=12'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.14.54
+    dev: false
 
   /tsutils/3.21.0_typescript@4.7.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/5373
- When using a `astro.config.ts` proload was not able to load `@astrojs/tailwind` on a reload correctly (not sure why).
- Switches to using Vite for all non (m)js configs. 

## Testing

- Restart test added

## Docs

N/A, bug fix