### PR TITLE
Preserve reactivity in Solid example component

### DIFF
--- a/examples/framework-solid/src/components/Counter.tsx
+++ b/examples/framework-solid/src/components/Counter.tsx
@@ -1,7 +1,7 @@
 import { createSignal } from 'solid-js';
 import './Counter.css';
 
-export default function Counter({ children }) {
+export default function Counter(props) {
 	const [count, setCount] = createSignal(0);
 	const add = () => setCount(count() + 1);
 	const subtract = () => setCount(count() - 1);
@@ -13,7 +13,7 @@ export default function Counter({ children }) {
 				<pre>{count()}</pre>
 				<button onClick={add}>+</button>
 			</div>
-			<div class="counter-message">{children}</div>
+			<div class="counter-message">{props.children}</div>
 		</>
 	);
 }


### PR DESCRIPTION
## Changes

In the `framework-solid` example, I updated the only Solid component not to destructure its props. Unlike in React, Solid uses property access for tracking reactivity, so those accesses need to be in the JSX in this example. I caught the problem with `eslint-plugin-solid`.

From what I can tell I don't need a changeset for this change, but please let me know if I do!

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
`eslint-plugin-solid` doesn't show a reactivity warning anymore.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
As a patch change this shouldn't affect a user's behavior.
