### PR TITLE
Fix typo in image integration documentatation

### DIFF
--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -78,7 +78,7 @@ First, install the `sharp` package using your package manger. If you're using np
 ```sh
 npm install sharp
 ```
-Then, update the integration in you `astro.config.*` file to use the built-in `sharp` image transformer.
+Then, update the integration in your `astro.config.*` file to use the built-in `sharp` image transformer.
 ```astro title="astro.config.mjs"
 ---
 import image from '@astrojs/image';


### PR DESCRIPTION
## Changes

- Fixed typo in Image integration docs en-only
- you -> your

## Testing

- One letter change - no testing required.

## Docs

- Edit is to the docs.
