### PR TITLE
fix(create-astro): fix error when don't have template input

### DIFF
--- a/.changeset/violet-apricots-smash.md
+++ b/.changeset/violet-apricots-smash.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+fix error when don't have template input

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -163,7 +163,7 @@ export async function main() {
 		{ onCancel: () => ora().info(dim('Operation cancelled. See you later, astronaut!')) }
 	);
 
-	if (!options.template) {
+  if (!options.template || options.template === true) {
 		ora().info(dim('No template provided. See you later, astronaut!'));
 		process.exit(1);
 	}


### PR DESCRIPTION
## Changes

- fix error when don't have template input


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

## Before
When input `npm create astro@latest -- --template`, `create-astro` will throw error:

<img width="1201" alt="image" src="https://user-images.githubusercontent.com/25167721/201842465-146993ca-a3d6-44c4-9019-cbe9bfdc9cdc.png">

## After
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/25167721/201842880-5da4fd53-d2fd-4614-8641-7dd80fb26550.png">

