### PR TITLE
Restart dev server on package.json changes

### DIFF
--- a/.changeset/olive-walls-hunt.md
+++ b/.changeset/olive-walls-hunt.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Restart dev server on package.json changes

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -157,7 +157,7 @@
     "typescript": "*",
     "unist-util-visit": "^4.1.0",
     "vfile": "^5.3.2",
-    "vite": "~3.2.1",
+    "vite": "~3.2.4",
     "vitefu": "^0.2.0",
     "yargs-parser": "^21.0.1",
     "zod": "^3.17.3"

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -158,7 +158,7 @@
     "unist-util-visit": "^4.1.0",
     "vfile": "^5.3.2",
     "vite": "~3.2.4",
-    "vitefu": "^0.2.0",
+    "vitefu": "^0.2.1",
     "yargs-parser": "^21.0.1",
     "zod": "^3.17.3"
   },

--- a/packages/astro/src/core/config/settings.ts
+++ b/packages/astro/src/core/config/settings.ts
@@ -1,7 +1,7 @@
 import type { AstroConfig, AstroSettings, AstroUserConfig } from '../../@types/astro';
 import { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from './../constants.js';
 
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import jsxRenderer from '../../jsx/renderer.js';
 import { createDefaultDevConfig } from './config.js';
 import { loadTSConfig } from './tsconfig.js';
@@ -24,9 +24,16 @@ export function createBaseSettings(config: AstroConfig): AstroSettings {
 export function createSettings(config: AstroConfig, cwd?: string): AstroSettings {
 	const tsconfig = loadTSConfig(cwd);
 	const settings = createBaseSettings(config);
+
+	const watchFiles = tsconfig?.exists ? [tsconfig.path, ...tsconfig.extendedPaths] : [];
+
+	if(cwd) {
+		watchFiles.push(fileURLToPath(new URL('./package.json', pathToFileURL(cwd))));
+	}
+
 	settings.tsConfig = tsconfig?.config;
 	settings.tsConfigPath = tsconfig?.path;
-	settings.watchFiles = tsconfig?.exists ? [tsconfig.path, ...tsconfig.extendedPaths] : [];
+	settings.watchFiles = watchFiles;
 	return settings;
 }
 

--- a/packages/integrations/solid/package.json
+++ b/packages/integrations/solid/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "babel-preset-solid": "^1.4.2",
-    "vitefu": "^0.2.0"
+    "vitefu": "^0.2.1"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18162,6 +18162,17 @@ packages:
         optional: true
     dev: false
 
+  /vitefu/0.2.1_vite@3.2.3:
+    resolution: {integrity: sha512-clkvXTAeUf+XQKm3bhWUhT4pye+3acm6YCTGaWhxxIvZZ/QjnA3JA8Zud+z/mO5y5XYvJJhevs5Sjkv/FI8nRw==}
+    peerDependencies:
+      vite: ^3.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      vite: 3.2.3
+    dev: false
+
   /vitefu/0.2.1_vite@3.2.4:
     resolution: {integrity: sha512-clkvXTAeUf+XQKm3bhWUhT4pye+3acm6YCTGaWhxxIvZZ/QjnA3JA8Zud+z/mO5y5XYvJJhevs5Sjkv/FI8nRw==}
     peerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,7 +465,7 @@ importers:
       unist-util-visit: ^4.1.0
       vfile: ^5.3.2
       vite: ~3.2.4
-      vitefu: ^0.2.0
+      vitefu: ^0.2.1
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
@@ -3133,7 +3133,7 @@ importers:
       astro-scripts: workspace:*
       babel-preset-solid: ^1.4.2
       solid-js: ^1.5.1
-      vitefu: ^0.2.0
+      vitefu: ^0.2.1
     dependencies:
       babel-preset-solid: 1.6.2
       vitefu: 0.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -464,7 +464,7 @@ importers:
       unified: ^10.1.2
       unist-util-visit: ^4.1.0
       vfile: ^5.3.2
-      vite: ~3.2.1
+      vite: ~3.2.4
       vitefu: ^0.2.0
       yargs-parser: ^21.0.1
       zod: ^3.17.3
@@ -526,8 +526,8 @@ importers:
       typescript: 4.8.4
       unist-util-visit: 4.1.1
       vfile: 5.3.5
-      vite: 3.2.3_sass@1.56.1
-      vitefu: 0.2.1_vite@3.2.3
+      vite: 3.2.4_sass@1.56.1
+      vitefu: 0.2.1_vite@3.2.4
       yargs-parser: 21.1.1
       zod: 3.19.1
     devDependencies:
@@ -18119,8 +18119,8 @@ packages:
       fsevents: 2.3.2
     dev: false
 
-  /vite/3.2.3_sass@1.56.1:
-    resolution: {integrity: sha512-h8jl1TZ76eGs3o2dIBSsvXDLb1m/Ec1iej8ZMdz+PsaFUsftZeWe2CZOI3qogEsMNaywc17gu0q6cQDzh/weCQ==}
+  /vite/3.2.4_sass@1.56.1:
+    resolution: {integrity: sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -18162,7 +18162,7 @@ packages:
         optional: true
     dev: false
 
-  /vitefu/0.2.1_vite@3.2.3:
+  /vitefu/0.2.1_vite@3.2.4:
     resolution: {integrity: sha512-clkvXTAeUf+XQKm3bhWUhT4pye+3acm6YCTGaWhxxIvZZ/QjnA3JA8Zud+z/mO5y5XYvJJhevs5Sjkv/FI8nRw==}
     peerDependencies:
       vite: ^3.0.0
@@ -18170,7 +18170,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 3.2.3_sass@1.56.1
+      vite: 3.2.4_sass@1.56.1
     dev: false
 
   /vitest/0.20.3:


### PR DESCRIPTION
## Changes

- Adds the package.json to the list of watch files. We restart the dev container any time one of these files changes.
- This is needed to get `sass` to work when installed after the dev server has already been started.
- This now works in Vite 3.2.4
- Closes https://github.com/withastro/astro/issues/5145

## Testing

- Unit test added which confirms the dev server is restarted when the package.json changes.

## Docs

N/A, bug fix