### PR TITLE
[docs] fix typo in image integration README

### DIFF
--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -74,7 +74,7 @@ export default {
 
 ### Installing `sharp` (optional)
 
-First, install the `sharp` package using your package manger. If you're using npm or aren't sure, run this in the terminal:
+First, install the `sharp` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
 ```sh
 npm install sharp
 ```


### PR DESCRIPTION
## Changes
fix typo

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
no test needed, just fixed a typo

## Docs
![image](https://user-images.githubusercontent.com/84649871/202231452-853ce3c2-0590-4a07-962b-c4e1542c110d.png)
![image](https://user-images.githubusercontent.com/84649871/202231488-60ada2e9-673a-4ea2-84b3-f522a3fee081.png)

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
