### PR TITLE
Prevent dev from crashing when there are errors in template

### DIFF
--- a/.changeset/wild-falcons-sparkle.md
+++ b/.changeset/wild-falcons-sparkle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent dev from crashing when there are errors in template

--- a/packages/astro/test/units/dev/hydration.test.js
+++ b/packages/astro/test/units/dev/hydration.test.js
@@ -1,0 +1,53 @@
+
+import { expect } from 'chai';
+
+import { runInContainer } from '../../../dist/core/dev/index.js';
+import { createFs, createRequestAndResponse } from '../test-utils.js';
+import svelte from '../../../../integrations/svelte/dist/index.js';
+import { defaultLogging } from '../../test-utils.js';
+
+const root = new URL('../../fixtures/alias/', import.meta.url);
+
+describe('dev container', () => {
+	it('should not crash when reassigning a hydrated component', async () => {
+		const fs = createFs(
+			{
+				'/src/pages/index.astro': `
+				---
+				import Svelte from '../components/Client.svelte';
+				const Foo = Svelte;
+				const Bar = Svelte;
+				---
+				<html>
+					<head><title>testing</title></head>
+					<body>
+						<Foo client:load />
+						<Bar client:load />
+					</body>
+				</html>
+			`
+			},
+			root
+		);
+
+		await runInContainer({
+			fs, root,
+			logging: {
+				...defaultLogging,
+				// Error is expected in this test
+				level: 'silent'
+			},
+			userConfig: {
+				integrations: [svelte()]
+			}
+		}, async (container) => {
+			const { req, res, done } = createRequestAndResponse({
+				method: 'GET',
+				url: '/',
+			});
+			container.handle(req, res);
+			const html = await done;
+			expect(res.statusCode).to.equal(200, 'We get a 200 because the error occurs in the template, but we didn\'t crash!');
+		});
+	});
+});


### PR DESCRIPTION
## Changes

- When an error occurs in a template only throw the first error that occurs. This is because latter errors can't be caught by the dev server. The user will see the first error in the error overlap (see below)
- Fixes https://github.com/withastro/astro/issues/5415

<img width="1207" alt="Screen Shot 2022-11-16 at 11 48 07 AM" src="https://user-images.githubusercontent.com/361671/202242287-9c31fee7-dff6-4260-b28d-b1473d022c95.png">


## Testing

- unit test added

## Docs

N/A, bug fix