### PR TITLE
feat: provide HOST env variable at runtime

### DIFF
--- a/.changeset/violet-buckets-repeat.md
+++ b/.changeset/violet-buckets-repeat.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': minor
+---
+
+Allow HOST env variable to be provided at runtime

--- a/packages/integrations/node/README.md
+++ b/packages/integrations/node/README.md
@@ -109,6 +109,16 @@ node ./dist/server/entry.mjs
 
 For standalone mode the server handles file servering in addition to the page and API routes.
 
+
+#### Runtime HOST and PORT
+
+It is possible to override built HOST and PORT values with [runtime environment variables](https://docs.astro.
+build/en/guides/environment-variables/#using-the-cli)
+
+```shell
+HOST=0.0.0.0 PORT=3000 node ./dist/server/entry.mjs
+```
+
 #### HTTPS
 
 By default the standalone server uses HTTP. This works well if you have a proxy server in front of it that does HTTPS. If you need the standalone server to run HTTPS itself you need to provide your SSL key and certificate.

--- a/packages/integrations/node/README.md
+++ b/packages/integrations/node/README.md
@@ -110,10 +110,9 @@ node ./dist/server/entry.mjs
 For standalone mode the server handles file servering in addition to the page and API routes.
 
 
-#### Runtime HOST and PORT
+#### Custom host and port
 
-It is possible to override built HOST and PORT values with [runtime environment variables](https://docs.astro.
-build/en/guides/environment-variables/#using-the-cli)
+You can override the host and port the standalone server runs on by passing them as environment variables at runtime:
 
 ```shell
 HOST=0.0.0.0 PORT=3000 node ./dist/server/entry.mjs

--- a/packages/integrations/node/src/standalone.ts
+++ b/packages/integrations/node/src/standalone.ts
@@ -40,7 +40,7 @@ export default function startServer(app: NodeApp, options: Options) {
 	const handler = middleware(app);
 
 	// Allow to provide host value at runtime
-	const host = getResolvedHostForHttpServer(process.env.HOST !== undefined ? process.env.HOST : options.host);
+	const host = getResolvedHostForHttpServer(process.env.HOST !== undefined && process.env.HOST !== '' ? process.env.HOST : options.host);
 	const server = createServer(
 		{
 			client,

--- a/packages/integrations/node/src/standalone.ts
+++ b/packages/integrations/node/src/standalone.ts
@@ -39,7 +39,8 @@ export default function startServer(app: NodeApp, options: Options) {
 	const { client } = resolvePaths(options);
 	const handler = middleware(app);
 
-	const host = getResolvedHostForHttpServer(options.host);
+	// Allow to provide host value at runtime
+	const host = getResolvedHostForHttpServer(process.env.HOST !== undefined ? process.env.HOST : options.host);
 	const server = createServer(
 		{
 			client,


### PR DESCRIPTION
## Changes

Provides a way to handle runtime HOST environment variable on Node Standalone builds

## Testing

I did not see any test for this section, should I write some ?

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

Hi! I think this could be documented next to the host definition mechanism, I can participate if needed!
