### PR TITLE
fix: partytown base path

### DIFF
--- a/.changeset/popular-melons-pretend.md
+++ b/.changeset/popular-melons-pretend.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/partytown': patch
+---
+
+fix partytown when base path specified

--- a/packages/integrations/partytown/src/index.ts
+++ b/packages/integrations/partytown/src/index.ts
@@ -36,7 +36,7 @@ export default function createPlugin(options: PartytownOptions): AstroIntegratio
 				config = _config;
 			},
 			'astro:server:setup': ({ server }) => {
-				const lib = `${config.base}~partytown/`;
+				const lib = `/~partytown/`;
 				server.middlewares.use(
 					sirv(partytownLibDirectory, {
 						mount: lib,


### PR DESCRIPTION
Closes issue https://github.com/withastro/astro/issues/5424

## Changes

When serving up the partytown-sandbox-sw.js it is already scoped to the base path. The code that matches the request url is at the following.

https://github.com/withastro/astro/blob/main/packages/integrations/partytown/src/sirv.ts#L209

## Testing

I was able to reproduce the problem locally and then tinkered around a bit until I figured out the problem. Might need some more tesing since I am still very new.

## Docs

Shouldn't have any effect on the docs. It is just a fix with the expected behavior.
