### PR TITLE
Fix JSX tagging for anonymous higher-order components default export

### DIFF
--- a/.changeset/sixty-apricots-drum.md
+++ b/.changeset/sixty-apricots-drum.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix JSX tagging for anonymous higher-order components default export

--- a/packages/astro/src/vite-plugin-jsx/tag.ts
+++ b/packages/astro/src/vite-plugin-jsx/tag.ts
@@ -67,8 +67,14 @@ export default async function tagExportsWithRenderer({
 					const node = path.node;
 					if (node.type !== 'ExportDefaultDeclaration') return;
 
-					if (node.declaration?.type === 'ArrowFunctionExpression') {
-						const uidIdentifier = path.scope.generateUidIdentifier('_arrow_function');
+					if (
+						t.isArrowFunctionExpression(node.declaration) ||
+						t.isCallExpression(node.declaration)
+					) {
+						const varName = t.isArrowFunctionExpression(node.declaration)
+							? '_arrow_function'
+							: '_hoc_function';
+						const uidIdentifier = path.scope.generateUidIdentifier(varName);
 						path.insertBefore(
 							t.variableDeclaration('const', [
 								t.variableDeclarator(uidIdentifier, node.declaration),

--- a/packages/astro/src/vite-plugin-jsx/tag.ts
+++ b/packages/astro/src/vite-plugin-jsx/tag.ts
@@ -65,7 +65,7 @@ export default async function tagExportsWithRenderer({
 				 */
 				enter(path) {
 					const node = path.node;
-					if (node.type !== 'ExportDefaultDeclaration') return;
+					if (!t.isExportDefaultDeclaration(node)) return;
 
 					if (
 						t.isArrowFunctionExpression(node.declaration) ||
@@ -81,10 +81,7 @@ export default async function tagExportsWithRenderer({
 							])
 						);
 						node.declaration = uidIdentifier;
-					} else if (
-						node.declaration?.type === 'FunctionDeclaration' &&
-						!node.declaration.id?.name
-					) {
+					} else if (t.isFunctionDeclaration(node.declaration) && !node.declaration.id?.name) {
 						const uidIdentifier = path.scope.generateUidIdentifier('_function');
 						node.declaration.id = uidIdentifier;
 					}
@@ -92,12 +89,12 @@ export default async function tagExportsWithRenderer({
 				exit(path, state) {
 					const node = path.node;
 					if (node.exportKind === 'type') return;
-					if (node.type === 'ExportAllDeclaration') return;
+					if (t.isExportAllDeclaration(node)) return;
 					const addTag = (id: string) => {
 						const tags = state.get('astro:tags') ?? [];
 						state.set('astro:tags', [...tags, id]);
 					};
-					if (node.type === 'ExportNamedDeclaration' || node.type === 'ExportDefaultDeclaration') {
+					if (t.isExportNamedDeclaration(node) || t.isExportDefaultDeclaration(node)) {
 						if (t.isIdentifier(node.declaration)) {
 							addTag(node.declaration.name);
 						} else if (t.isFunctionDeclaration(node.declaration) && node.declaration.id?.name) {

--- a/packages/astro/test/fixtures/react-jsx-export/src/components/defaultExport/HocDefaultExport.jsx
+++ b/packages/astro/test/fixtures/react-jsx-export/src/components/defaultExport/HocDefaultExport.jsx
@@ -1,0 +1,14 @@
+import { useState } from "react"
+
+function withSomething(Component) {
+    return (props) => {
+        const [example] = useState('Example')
+        return <Component {...props} example={example} />;
+    };
+}
+
+function Child({ example }) {
+    return <h2 id="hoc_default_export">{example}</h2>
+}
+
+export default withSomething(Child)

--- a/packages/astro/test/fixtures/react-jsx-export/src/pages/index.astro
+++ b/packages/astro/test/fixtures/react-jsx-export/src/pages/index.astro
@@ -3,6 +3,7 @@ import ListAsDefaultExport, {ListExport, RenamedListExport, ListExportTestCompon
 import {ConstDeclarationExport, LetDeclarationExport, FunctionDeclarationExport} from '../components/DeclarationExportTest'
 import AnonymousArrowDefaultExport from '../components/defaultExport/AnonymousArrowDefaultExport'
 import AnonymousFunctionDefaultExport from '../components/defaultExport/AnonymousFunctionDefaultExport'
+import HocDefaultExport from '../components/defaultExport/HocDefaultExport'
 import NamedArrowDefaultExport from '../components/defaultExport/NamedArrowDefaultExport'
 import NamedFunctionDefaultExport from '../components/defaultExport/NamedFunctionDefaultExport'
 ---
@@ -20,5 +21,6 @@ import NamedFunctionDefaultExport from '../components/defaultExport/NamedFunctio
 
 <AnonymousArrowDefaultExport />
 <AnonymousFunctionDefaultExport /> 
+<HocDefaultExport />
 <NamedArrowDefaultExport />
 <NamedFunctionDefaultExport />

--- a/packages/astro/test/react-jsx-export.test.js
+++ b/packages/astro/test/react-jsx-export.test.js
@@ -18,6 +18,7 @@ describe('react-jsx-export', () => {
 		'renamed_list_export',
 		'list_as_default_export',
 		'list_export_test_component',
+		'hoc_default_export',
 	];
 
 	const reactInvalidHookWarning =


### PR DESCRIPTION
## Changes

Fix #5305 

Tag JSX (with `__astro_tag_component__`) for `export default withHoc(Something)`, which is a call expression.

It transforms into

```
const _hoc_function = withHoc(Something)
export default _hoc_function
__astro_tag_component__(_hoc_function)
```

to tag it. (Shares the same logic as arrow functions).

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added default export test.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A. bug fix