### PR TITLE
[MDX] Support remark-rehype options from Astro Markdown config

### DIFF
--- a/.changeset/nice-jokes-smile.md
+++ b/.changeset/nice-jokes-smile.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': minor
+---
+
+Uses remark-rehype options from astro.config.mjs

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -534,6 +534,9 @@ export default {
     },
   })],
 };
+```
+
+This inherits the configuration of `markdown.remarkRehype`. This behavior can be changed by configuring `extendPlugins`.
 
 ## Examples
 

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -520,9 +520,20 @@ We suggest [using AST Explorer](https://astexplorer.net/) to play with estree ou
 
 ### remarkRehype
 
-Options for `remarkRehype`. See [markdown.remarkRehype](https://docs.astro.build/en/reference/configuration-reference/#markdownremarkrehype).
+Markdown content is transformed into HTML through remark-rehype which has [a number of options](https://github.com/remarkjs/remark-rehype#options).
 
-When `extendPlugins` is set to `'markdown'` (default), this config is extended with `remarkRehype` from Astro's default markdown config.
+You can use remark-rehype options in your MDX integration config file like so:
+
+```js
+// astro.config.mjs
+export default {
+  integrations: [mdx({
+    remarkRehype: {
+      footnoteLabel: 'Catatan kaki',
+      footnoteBackLabel: 'Kembali ke konten',
+    },
+  })],
+};
 
 ## Examples
 

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -518,6 +518,12 @@ These are plugins that modify the output [estree](https://github.com/estree/estr
 
 We suggest [using AST Explorer](https://astexplorer.net/) to play with estree outputs, and trying [`estree-util-visit`](https://unifiedjs.com/explore/package/estree-util-visit/) for searching across JavaScript nodes.
 
+### remarkRehype
+
+Options for `remarkRehype`. See [markdown.remarkRehype](https://docs.astro.build/en/reference/configuration-reference/#markdownremarkrehype).
+
+When `extendPlugins` is set to `'markdown'` (default), this config is extended with `remarkRehype` from Astro's default markdown config.
+
 ## Examples
 
 - The [Astro MDX example](https://github.com/withastro/astro/tree/latest/examples/with-mdx) shows how to use MDX files in your Astro project.

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -63,6 +63,7 @@
     "mocha": "^9.2.2",
     "reading-time": "^1.5.0",
     "rehype-pretty-code": "^0.4.0",
+    "remark-rehype": "^10.1.0",
     "remark-shiki-twoslash": "^3.1.0",
     "remark-toc": "^8.0.1",
     "vite": "^3.0.0"

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -68,8 +68,8 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 
 				if (mdxOptions.extendPlugins === 'markdown') {
 					remarkRehypeOptions = {
-						...remarkRehypeOptions,
 						...config.markdown.remarkRehype,
+						...remarkRehypeOptions,
 					};
 				}
 

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -71,6 +71,7 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 					// Note: disable `.md` (and other alternative extensions for markdown files like `.markdown`) support
 					format: 'mdx',
 					mdExtensions: [],
+					remarkRehypeOptions: config.markdown.remarkRehype,
 				};
 
 				let importMetaEnv: Record<string, any> = {

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -1,3 +1,4 @@
+import type { Options as RemarkRehypeOptions } from 'remark-rehype';
 import { compile as mdxCompile } from '@mdx-js/mdx';
 import { PluggableList } from '@mdx-js/mdx/lib/core.js';
 import mdxPlugin, { Options as MdxRollupPluginOptions } from '@mdx-js/rollup';
@@ -33,6 +34,7 @@ export type MdxOptions = {
 	 * - false - do not inherit any plugins
 	 */
 	extendPlugins?: 'markdown' | 'astroDefaults' | false;
+	remarkRehype?: RemarkRehypeOptions;
 };
 
 export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
@@ -62,6 +64,15 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 					console.info(`See "extendPlugins" option to configure this behavior.`);
 				}
 
+				let remarkRehypeOptions = mdxOptions.remarkRehype;
+
+				if (mdxOptions.extendPlugins === 'markdown') {
+					remarkRehypeOptions = {
+						...remarkRehypeOptions,
+						...config.markdown.remarkRehype,
+					};
+				}
+
 				const mdxPluginOpts: MdxRollupPluginOptions = {
 					remarkPlugins: await getRemarkPlugins(mdxOptions, config),
 					rehypePlugins: getRehypePlugins(mdxOptions, config),
@@ -71,7 +82,7 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 					// Note: disable `.md` (and other alternative extensions for markdown files like `.markdown`) support
 					format: 'mdx',
 					mdExtensions: [],
-					remarkRehypeOptions: config.markdown.remarkRehype,
+					remarkRehypeOptions,
 				};
 
 				let importMetaEnv: Record<string, any> = {

--- a/packages/integrations/mdx/test/fixtures/mdx-astro-markdown-remarkRehype/src/pages/index.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-astro-markdown-remarkRehype/src/pages/index.mdx
@@ -1,0 +1,5 @@
+# Hello world
+
+This[^1] should be visible.
+
+[^1]: And there would be a footnote.

--- a/packages/integrations/mdx/test/mdx-astro-markdown-remarkRehype.test.js
+++ b/packages/integrations/mdx/test/mdx-astro-markdown-remarkRehype.test.js
@@ -1,0 +1,34 @@
+import mdx from '@astrojs/mdx';
+
+import { expect } from 'chai';
+import { parseHTML } from 'linkedom';
+import { loadFixture } from '../../../astro/test/test-utils.js';
+
+describe('MDX with Astro Markdown remark-rehype config', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/mdx-astro-markdown-remarkRehype/', import.meta.url),
+			integrations: [mdx()],
+			markdown: {
+				remarkRehype: {
+					footnoteLabel: 'Catatan kaki',
+					footnoteBackLabel: 'Kembali ke konten',
+				},
+			},
+		});
+
+		await fixture.build();
+	});
+
+	it('Renders footnotes with values from the configuration', async () => {
+		const html = await fixture.readFile('/index.html');
+		const { document } = parseHTML(html);
+
+		expect(document.querySelector('#footnote-label').textContent).to.equal('Catatan kaki');
+		expect(document.querySelector('.data-footnote-backref').getAttribute('aria-label')).to.equal(
+			'Kembali ke konten'
+		);
+	});
+});

--- a/packages/integrations/mdx/test/mdx-astro-markdown-remarkRehype.test.js
+++ b/packages/integrations/mdx/test/mdx-astro-markdown-remarkRehype.test.js
@@ -5,10 +5,8 @@ import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
 describe('MDX with Astro Markdown remark-rehype config', () => {
-	let fixture;
-
-	before(async () => {
-		fixture = await loadFixture({
+	it('Renders footnotes with values from the default configuration', async () => {
+		const fixture = await loadFixture({
 			root: new URL('./fixtures/mdx-astro-markdown-remarkRehype/', import.meta.url),
 			integrations: [mdx()],
 			markdown: {
@@ -20,15 +18,64 @@ describe('MDX with Astro Markdown remark-rehype config', () => {
 		});
 
 		await fixture.build();
-	});
-
-	it('Renders footnotes with values from the configuration', async () => {
 		const html = await fixture.readFile('/index.html');
 		const { document } = parseHTML(html);
 
 		expect(document.querySelector('#footnote-label').textContent).to.equal('Catatan kaki');
 		expect(document.querySelector('.data-footnote-backref').getAttribute('aria-label')).to.equal(
 			'Kembali ke konten'
+		);
+	});
+
+	it('Renders footnotes with values from custom configuration extending the default', async () => {
+		const fixture = await loadFixture({
+			root: new URL('./fixtures/mdx-astro-markdown-remarkRehype/', import.meta.url),
+			integrations: [mdx({
+				remarkRehype: {
+					footnoteLabel: 'Catatan kaki',
+					footnoteBackLabel: 'Kembali ke konten',
+				},
+			})],
+			markdown: {
+				remarkRehype: {
+					footnoteBackLabel: 'Replace me',
+				},
+			},
+		});
+
+		await fixture.build();
+		const html = await fixture.readFile('/index.html');
+		const { document } = parseHTML(html);
+
+		expect(document.querySelector('#footnote-label').textContent).to.equal('Catatan kaki');
+		expect(document.querySelector('.data-footnote-backref').getAttribute('aria-label')).to.equal(
+			'Kembali ke konten'
+		);
+	});
+
+	it('Renders footnotes with values from custom configuration without extending the default', async () => {
+		const fixture = await loadFixture({
+			root: new URL('./fixtures/mdx-astro-markdown-remarkRehype/', import.meta.url),
+			integrations: [mdx({
+				extendPlugins: 'astroDefaults',
+				remarkRehype: {
+					footnoteLabel: 'Catatan kaki',
+				},
+			})],
+			markdown: {
+				remarkRehype: {
+					footnoteBackLabel: 'Kembali ke konten',
+				},
+			},
+		});
+
+		await fixture.build();
+		const html = await fixture.readFile('/index.html');
+		const { document } = parseHTML(html);
+
+		expect(document.querySelector('#footnote-label').textContent).to.equal('Catatan kaki');
+		expect(document.querySelector('.data-footnote-backref').getAttribute('aria-label')).to.equal(
+			'Back to content'
 		);
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2804,6 +2804,7 @@ importers:
       rehype-raw: ^6.1.1
       remark-frontmatter: ^4.0.1
       remark-gfm: ^3.0.1
+      remark-rehype: ^10.1.0
       remark-shiki-twoslash: ^3.1.0
       remark-smartypants: ^2.0.0
       remark-toc: ^8.0.1
@@ -2844,6 +2845,7 @@ importers:
       mocha: 9.2.2
       reading-time: 1.5.0
       rehype-pretty-code: 0.4.0_shiki@0.11.1
+      remark-rehype: 10.1.0
       remark-shiki-twoslash: 3.1.0
       remark-toc: 8.0.1
       vite: 3.2.3
@@ -14160,7 +14162,6 @@ packages:
       '@types/mdast': 3.0.10
       '@types/unist': 2.0.6
       unist-util-visit: 4.1.1
-    dev: false
 
   /mdast-util-find-and-replace/2.2.1:
     resolution: {integrity: sha512-SobxkQXFAdd4b5WmEakmkVoh18icjQRxGy5OWTCzgsLRm1Fu/KCtwD1HIQSsmq5ZRjVH0Ehwg6/Fn3xIUk+nKw==}
@@ -14320,7 +14321,6 @@ packages:
       unist-util-generated: 2.0.0
       unist-util-position: 4.0.3
       unist-util-visit: 4.1.1
-    dev: false
 
   /mdast-util-to-markdown/1.3.0:
     resolution: {integrity: sha512-6tUSs4r+KK4JGTTiQ7FfHmVOaDrLQJPmpjD6wPMlHGUVXoG9Vjc3jIeP+uyBWRf8clwB2blM+W7+KrlMYQnftA==}
@@ -16371,7 +16371,6 @@ packages:
       '@types/mdast': 3.0.10
       mdast-util-to-hast: 12.2.4
       unified: 10.1.2
-    dev: false
 
   /remark-shiki-twoslash/3.1.0:
     resolution: {integrity: sha512-6LqSqVtHQR4S0DKfdQ2/ePn9loTKUtpyopYvwk8johjDTeUW5MkaLQuZHlWNkkST/4aMbz6aTkstIcwfwcHpXg==}
@@ -17436,7 +17435,6 @@ packages:
 
   /trim-lines/3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
-    dev: false
 
   /trim-newlines/3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
@@ -17792,11 +17790,9 @@ packages:
     resolution: {integrity: sha512-GFxmfEAa0vi9i5sd0R2kcrI9ks0r82NasRq5QHh2ysGngrc6GiqD5CDf1FjPenY4vApmFASBIIlk/jj5J5YbmQ==}
     dependencies:
       '@types/unist': 2.0.6
-    dev: false
 
   /unist-util-generated/2.0.0:
     resolution: {integrity: sha512-TiWE6DVtVe7Ye2QxOVW9kqybs6cZexNwTwSMVgkfjEReqy/xwGpAXb99OxktoWwmL+Z+Epb0Dn8/GNDYP1wnUw==}
-    dev: false
 
   /unist-util-is/3.0.0:
     resolution: {integrity: sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==}
@@ -17831,7 +17827,6 @@ packages:
     resolution: {integrity: sha512-p/5EMGIa1qwbXjA+QgcBXaPWjSnZfQ2Sc3yBEEfgPwsEmJd8Qh+DSk3LGnmOM4S1bY2C0AjmMnB8RuEYxpPwXQ==}
     dependencies:
       '@types/unist': 2.0.6
-    dev: false
 
   /unist-util-remove-position/4.0.1:
     resolution: {integrity: sha512-0yDkppiIhDlPrfHELgB+NLQD5mfjup3a8UYclHruTJWmY74je8g+CIFr79x5f6AkmzSwlvKLbs63hC0meOMowQ==}


### PR DESCRIPTION
## Changes

- Uses remark-rehype options from astro.config.mjs
- Based on https://github.com/withastro/astro/pull/4138

## Testing

See https://github.com/withastro/astro/pull/4138 and `test/fixtures/mdx-astro-markdown-remarkRehype/src/pages/index.mdx`

## Docs

/cc @withastro/maintainers-docs for feedback! 
