### PR TITLE
Fix preview --host in Node.js 18

### DIFF
--- a/.changeset/sixty-chicken-obey.md
+++ b/.changeset/sixty-chicken-obey.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix preview --host in Node.js 18

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -126,13 +126,15 @@ export function resolveServerUrls({
 	let network: string | null = null;
 
 	if (networkLogging === 'visible') {
-		const nodeVersion = Number(process.version.substring(1, process.version.indexOf('.', 5)));
 		const ipv4Networks = Object.values(os.networkInterfaces())
 			.flatMap((networkInterface) => networkInterface ?? [])
 			.filter(
 				(networkInterface) =>
 					networkInterface?.address &&
-					networkInterface?.family === (nodeVersion < 18 || nodeVersion >= 18.4 ? 'IPv4' : 4)
+					// Node < v18
+					((typeof networkInterface.family === 'string' && networkInterface.family === 'IPv4') ||
+						// Node >= v18
+						(typeof networkInterface.family === 'number' && networkInterface.family === 4))
 			);
 		for (let { address: ipv4Address } of ipv4Networks) {
 			if (ipv4Address.includes('127.0.0.1')) {


### PR DESCRIPTION
## Changes

Fix #5303

Properly check host address ipv4 in Node.js 18

https://github.com/withastro/astro/pull/3599 and https://github.com/withastro/astro/pull/4032 were incorrectly supporting the ipv4 check in node 18. It's a 18.0.0 breaking change, not from a specific minor version.

The code is copied from [Vite](https://github.com/vitejs/vite/blob/d9779c7fae3f06e2d15b15f21f9a74f47679dce8/packages/vite/src/node/utils.ts#L884-L887)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
N/A. I manually tested with node 18.0.0 and it works with this PR.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A. bug fix.
