### PR TITLE
Fix regression with loading .ts in .mjs config

### DIFF
--- a/.changeset/purple-tips-flash.md
+++ b/.changeset/purple-tips-flash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix regression with loading .ts in .mjs config

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -97,7 +97,7 @@ export async function createVite(
 		},
 		plugins: [
 			configAliasVitePlugin({ settings }),
-			astroLoadFallbackPlugin({ fs, settings }),
+			astroLoadFallbackPlugin({ fs, root: settings.config.root }),
 			astroVitePlugin({ settings, logging }),
 			astroScriptsPlugin({ settings }),
 			// The server plugin is for dev only and having it run during the build causes

--- a/packages/astro/src/vite-plugin-load-fallback/index.ts
+++ b/packages/astro/src/vite-plugin-load-fallback/index.ts
@@ -46,9 +46,13 @@ export default function loadFallbackPlugin({
 				// See if this can be loaded from our fs
 				if (parent) {
 					const candidateId = npath.posix.join(npath.posix.dirname(parent), id);
-					if(fs.existsSync(candidateId)) {
-						return candidateId;
-					}
+					try {
+						// Check to see if this file exists and is not a directory.
+						const stats = await fs.promises.stat(candidateId);
+						if(!stats.isDirectory()) {
+							return candidateId;
+						}
+					} catch {}
 				} 
 
 				let resolved = await this.resolve(id, parent, { skipSelf: true });

--- a/packages/astro/test/units/config/format.test.js
+++ b/packages/astro/test/units/config/format.test.js
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { fileURLToPath } from 'url';
+
+import {
+	runInContainer,
+} from '../../../dist/core/dev/index.js';
+import { openConfig, createSettings } from '../../../dist/core/config/index.js';
+import { createFs } from '../test-utils.js';
+import { defaultLogging } from '../../test-utils.js';
+
+const root = new URL('../../fixtures/tailwindcss-ts/', import.meta.url);
+
+describe('Astro config formats', () => {
+	it('An mjs config can import TypeScript modules', async () => {
+		const fs = createFs(
+			{
+				'/src/pages/index.astro': ``,
+				'/src/stuff.ts': `export default 'works';`,
+				'/astro.config.mjs': `
+					import stuff from './src/stuff.ts';
+					export default {}
+				`,
+			},
+			root
+		);
+
+		const { astroConfig } = await openConfig({
+			cwd: root,
+			flags: {},
+			cmd: 'dev',
+			logging: defaultLogging,
+			fsMod: fs
+		});
+		const settings = createSettings(astroConfig);
+
+		await runInContainer({ fs, root, settings }, () => {
+			expect(true).to.equal(true, 'We were able to get into the container which means the config loaded.');
+		});
+	});
+});


### PR DESCRIPTION
## Changes

- Previously if importing a `astro.config.mjs` via dynamic import failed, we just failed completely.
- Didn't realize that people were relying on being able to import non-JS in these types of configs.
- Change is to fallback to the Vite flow.
- Closes https://github.com/withastro/astro/issues/5428

## Testing

- Test added
- Had to clean up the mock fs fallback plugin a bit.

## Docs

N/A, bug fix