### PR TITLE
Add dark mode support for blog template

### DIFF
--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -20,6 +20,7 @@ Features:
 - ✅ Sitemap support
 - ✅ RSS Feed support
 - ✅ Markdown & MDX support
+- ✅ Dark and Light Mode
 
 ## 🚀 Project Structure
 

--- a/examples/blog/src/pages/blog.astro
+++ b/examples/blog/src/pages/blog.astro
@@ -25,7 +25,6 @@ const posts = (await Astro.glob('./blog/*.{md,mdx}')).sort(
 			ul li time {
 				flex: 0 0 130px;
 				font-style: italic;
-				color: #595959;
 			}
 			ul li a:visited {
 				color: #8e32dc;

--- a/examples/blog/src/styles/global.css
+++ b/examples/blog/src/styles/global.css
@@ -3,17 +3,37 @@
   https://github.com/HermanMartinus/bearblog/blob/297026a877bc2ab2b3bdfbd6b9f7961c350917dd/templates/styles/blog/default.css
   License MIT: https://github.com/HermanMartinus/bearblog/blob/master/LICENSE.md
  */
+:root {
+	--background-color: #fff;
+	--heading-color: #222;
+	--text-color: #444;
+	--link-color: #3273dc;
+	--code-background-color: #f2f2f2;
+	--blockquote-color: #222;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--background-color: #01242e;
+		--heading-color: #eee;
+		--text-color: #ddd;
+		--link-color: #8cc2dd;
+		--code-background-color: #000;
+		--blockquote-color: #ccc;
+	}
+}
+
 body {
 	font-family: Verdana, sans-serif;
 	margin: auto;
 	padding: 20px;
 	max-width: 65ch;
 	text-align: left;
-	background-color: #fff;
+	background-color: var(--background-color);
 	word-wrap: break-word;
 	overflow-wrap: break-word;
 	line-height: 1.5;
-	color: #444;
+	color: var(--text-color);
 }
 h1,
 h2,
@@ -23,10 +43,10 @@ h5,
 h6,
 strong,
 b {
-	color: #222;
+	color: var(--heading-color);
 }
 a {
-	color: #3273dc;
+	color: var(--link-color);
 }
 nav a {
 	margin-right: 10px;
@@ -50,7 +70,7 @@ img {
 }
 code {
 	padding: 2px 5px;
-	background-color: #f2f2f2;
+	background-color: var(--code-background-color);
 }
 pre {
 	padding: 1rem;
@@ -60,7 +80,7 @@ pre > code {
 }
 blockquote {
 	border: 1px solid #999;
-	color: #222;
+	color: var(--blockquote-color);
 	padding: 2px 0px 2px 20px;
 	margin: 0px;
 	font-style: italic;


### PR DESCRIPTION
## Changes

- I've updated styles to support dark mode. I took colors from https://bearblog.dev

https://user-images.githubusercontent.com/17102399/202660193-3383d912-d34d-4e58-b919-b4a2ee21f37a.mp4

## Testing

<!-- How was this change tested? -->
I just reviewed all pages and updated colors, you can check them as well in a video I attached above

## Docs

- It'll affect users who use Dark Mode system preferences, now they'll have dark mode version of website. Do we need to update any docs for that? 🤔 
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
