### PR TITLE
Correctly transform third-party JSX files

### DIFF
--- a/.changeset/dull-camels-accept.md
+++ b/.changeset/dull-camels-accept.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Correctly transform third-party JSX files

--- a/packages/astro/src/core/path.ts
+++ b/packages/astro/src/core/path.ts
@@ -59,3 +59,8 @@ export function removeFileExtension(path: string) {
 	let idx = path.lastIndexOf('.');
 	return idx === -1 ? path : path.slice(0, idx);
 }
+
+export function removeQueryString(path: string) {
+	const index = path.lastIndexOf('?');
+	return index > 0 ? path.substring(0, index) : path;
+}

--- a/packages/astro/src/vite-plugin-jsx/index.ts
+++ b/packages/astro/src/vite-plugin-jsx/index.ts
@@ -11,6 +11,7 @@ import esbuild from 'esbuild';
 import * as colors from 'kleur/colors';
 import path from 'path';
 import { error } from '../core/logger/core.js';
+import { removeQueryString } from '../core/path.js';
 import { parseNpmName } from '../core/util.js';
 import tagExportsPlugin from './tag.js';
 
@@ -187,6 +188,7 @@ export default function jsx({ settings, logging }: AstroPluginJSXOptions): Plugi
 		},
 		async transform(code, id, opts) {
 			const ssr = Boolean(opts?.ssr);
+			id = removeQueryString(id);
 			if (!JSX_EXTENSIONS.has(path.extname(id))) {
 				return null;
 			}

--- a/packages/astro/test/fixtures/solid-component/deps/solid-jsx-component/Counter.jsx
+++ b/packages/astro/test/fixtures/solid-component/deps/solid-jsx-component/Counter.jsx
@@ -1,0 +1,18 @@
+import { createSignal } from 'solid-js';
+
+export default function Counter(props) {
+	const [count, setCount] = createSignal(0);
+	const add = () => setCount(count() + 1);
+	const subtract = () => setCount(count() - 1);
+
+	return (
+		<>
+			<div class="counter">
+				<button onClick={subtract}>-</button>
+				<pre>{count()}</pre>
+				<button onClick={add}>+</button>
+			</div>
+			<div class="counter-message">{props.children}</div>
+		</>
+	);
+}

--- a/packages/astro/test/fixtures/solid-component/deps/solid-jsx-component/index.js
+++ b/packages/astro/test/fixtures/solid-component/deps/solid-jsx-component/index.js
@@ -1,0 +1,1 @@
+export { default as Counter } from './Counter'

--- a/packages/astro/test/fixtures/solid-component/deps/solid-jsx-component/package.json
+++ b/packages/astro/test/fixtures/solid-component/deps/solid-jsx-component/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@test/solid-jsx-component",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "solid": "./index.js",
+      "default": "./index.js"
+    }
+  },
+  "dependencies": {
+    "solid-js": "^1.5.6"
+  }
+}

--- a/packages/astro/test/fixtures/solid-component/package.json
+++ b/packages/astro/test/fixtures/solid-component/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@astrojs/solid-js": "workspace:*",
     "@solidjs/router": "^0.5.0",
+    "@test/solid-jsx-component": "file:./deps/solid-jsx-component",
     "astro": "workspace:*",
     "solid-js": "^1.5.6"
   }

--- a/packages/astro/test/fixtures/solid-component/src/pages/index.astro
+++ b/packages/astro/test/fixtures/solid-component/src/pages/index.astro
@@ -3,6 +3,7 @@ import Hello from '../components/Hello.jsx';
 import WithNewlines from '../components/WithNewlines.jsx';
 import { Router } from "@solidjs/router";
 import ProxyComponent from '../components/ProxyComponent.jsx';
+import { Counter as DepCounter } from '@test/solid-jsx-component';
 ---
 <html>
 <head><title>Solid</title></head>
@@ -12,6 +13,7 @@ import ProxyComponent from '../components/ProxyComponent.jsx';
 		<WithNewlines client:load />
     <Router />
     <ProxyComponent client:load />
+    <DepCounter client:load />
   </div>
 </body>
 </html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2178,12 +2178,20 @@ importers:
     specifiers:
       '@astrojs/solid-js': workspace:*
       '@solidjs/router': ^0.5.0
+      '@test/solid-jsx-component': file:./deps/solid-jsx-component
       astro: workspace:*
       solid-js: ^1.5.6
     dependencies:
       '@astrojs/solid-js': link:../../../../integrations/solid
       '@solidjs/router': 0.5.0_solid-js@1.6.2
+      '@test/solid-jsx-component': file:packages/astro/test/fixtures/solid-component/deps/solid-jsx-component
       astro: link:../../..
+      solid-js: 1.6.2
+
+  packages/astro/test/fixtures/solid-component/deps/solid-jsx-component:
+    specifiers:
+      solid-js: ^1.5.6
+    dependencies:
       solid-js: 1.6.2
 
   packages/astro/test/fixtures/sourcemap:
@@ -18820,4 +18828,12 @@ packages:
     resolution: {directory: packages/astro/test/fixtures/multiple-renderers/renderers/two, type: directory}
     name: '@astrojs/renderer-two'
     version: 1.0.0
+    dev: false
+
+  file:packages/astro/test/fixtures/solid-component/deps/solid-jsx-component:
+    resolution: {directory: packages/astro/test/fixtures/solid-component/deps/solid-jsx-component, type: directory}
+    name: '@test/solid-jsx-component'
+    version: 0.0.0
+    dependencies:
+      solid-js: 1.6.2
     dev: false


### PR DESCRIPTION
## Changes

Fix #5058

JSX files in node_modules are usually not appended with `?v=blabla` in Vite, but there are cases [where it does](https://github.com/vitejs/vite/blob/0d734732dac890cf0c6c784510059f66005a64b0/packages/vite/src/node/plugins/importAnalysis.ts#L354-L357) (not sure if it's a bug).

This PR updates `vite-plugin-jsx` to strip query strings before checking the extension.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added a test to simulate the edge case in Vite. The `index.js` file will have a version query, and that its transferred to `Counter.jsx` during import analysis.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A. bug fix