### PR TITLE
Allow all redirection status codes in redirect()

### DIFF
--- a/.changeset/chilly-pumpkins-fetch.md
+++ b/.changeset/chilly-pumpkins-fetch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix redirect() typing to allow all redirection status codes.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1187,7 +1187,7 @@ interface AstroSharedContext<Props extends Record<string, any> = Record<string, 
 	/**
 	 * Redirect to another page (**SSR Only**).
 	 */
-	redirect(path: string, status?: 301 | 302 | 308): Response;
+	redirect(path: string, status?: 301 | 302 | 303 | 307 | 308): Response;
 }
 
 export interface APIContext<Props extends Record<string, any> = Record<string, any>>


### PR DESCRIPTION

## Changes

This only changes the types file, not the implementation. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages for the list of redirection status codes.

## Testing

Tested manually.

## Docs

No docs; the restriction wasn't documented before.