### PR TITLE
Fix docs link in MDX integration README

### DIFF
--- a/.changeset/honest-chairs-confess.md
+++ b/.changeset/honest-chairs-confess.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Fix broken link in README

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -191,7 +191,7 @@ export default {
 };
 ```
 
-…every MDX file will have `customProperty` in its frontmatter! See [our Markdown documentation](https://docs.astro.build/en/guides/markdown-content/#injecting-frontmatter) for more usage instructions and a [reading time plugin example](https://docs.astro.build/en/guides/markdown-content/#example-calculate-reading-time).
+…every MDX file will have `customProperty` in its frontmatter! See [our Markdown documentation](https://docs.astro.build/en/guides/markdown-content/#example-injecting-frontmatter) for more usage instructions and a [reading time plugin example](https://docs.astro.build/en/guides/markdown-content/#example-calculate-reading-time).
 
 ### Layouts
 Layouts can be applied [in the same way as standard Astro Markdown](https://docs.astro.build/en/guides/markdown-content/#frontmatter-layout). You can add a `layout` to [your frontmatter](#frontmatter) like so:


### PR DESCRIPTION
## Changes

- Updates a link that changed on the docs site

## Testing

Clicked through from the Markdown file to ensure it went where I expected.

## Docs

Small docs fix only
/cc @withastro/maintainers-docs for feedback!
