### PR TITLE
Fix linked Astro library style HMR

### DIFF
--- a/.changeset/ten-emus-raise.md
+++ b/.changeset/ten-emus-raise.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix linked Astro library style HMR

--- a/packages/astro/e2e/fixtures/_deps/astro-linked-lib/Component.astro
+++ b/packages/astro/e2e/fixtures/_deps/astro-linked-lib/Component.astro
@@ -1,0 +1,9 @@
+<!-- NOTE: this dep is in `_deps` to test HMR with the `/@fs` id -->
+
+<h1 id="astro-linked-lib">astro-linked-lib</h1>
+   
+<style>
+    h1 {
+        color: red;
+    }
+</style>

--- a/packages/astro/e2e/fixtures/_deps/astro-linked-lib/package.json
+++ b/packages/astro/e2e/fixtures/_deps/astro-linked-lib/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@e2e/astro-linked-lib",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": {
+      "astro": "./Component.astro"
+    }
+  },
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/e2e/fixtures/astro-component/package.json
+++ b/packages/astro/e2e/fixtures/astro-component/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@astrojs/preact": "^1.1.0",
+    "@e2e/astro-linked-lib": "link:../_deps/astro-linked-lib",
     "astro": "workspace:*",
     "preact": "^10.11.0"
   }

--- a/packages/astro/e2e/fixtures/astro-component/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/astro-component/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Hero from '../components/Hero.astro';
+import LinkedLib from '@e2e/astro-linked-lib'
 ---
 
 <html>
@@ -11,6 +12,7 @@ import Hero from '../components/Hero.astro';
 			<Hero title="Astro Components">
 				Lorem ipsum, dolor sit amet consectetur adipisicing elit.
 			</Hero>
+			<LinkedLib />
 		</main>
   </body>
 </html>

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -9,7 +9,12 @@ import esbuild from 'esbuild';
 import slash from 'slash';
 import { fileURLToPath } from 'url';
 import { cachedCompilation, CompileProps, getCachedSource } from '../core/compile/index.js';
-import { isRelativePath, prependForwardSlash, startsWithForwardSlash } from '../core/path.js';
+import {
+	isRelativePath,
+	prependForwardSlash,
+	removeLeadingForwardSlashWindows,
+	startsWithForwardSlash,
+} from '../core/path.js';
 import { viteID } from '../core/util.js';
 import { getFileInfo } from '../vite-plugin-utils/index.js';
 import { handleHotUpdate } from './hmr.js';
@@ -92,7 +97,7 @@ export default function astro({ settings, logging }: AstroPluginOptions): vite.P
 				// part of the same "file" as the main Astro module in the module graph.
 				// "file" refers to `moduleGraph.fileToModulesMap`.
 				if (query.type === 'style' && id.startsWith('/@fs')) {
-					id = id.slice(4);
+					id = removeLeadingForwardSlashWindows(id.slice(4));
 				}
 				// Convert file paths to ViteID, meaning on Windows it omits the leading slash
 				if (isFullFilePath(id)) {

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -80,17 +80,18 @@ export default function astro({ settings, logging }: AstroPluginOptions): vite.P
 			// serve sub-part requests (*?astro) as virtual modules
 			const { query } = parseAstroRequest(id);
 			if (query.astro) {
+				// TODO: Try to remove these custom resolve so HMR is more predictable.
 				// Convert /src/pages/index.astro?astro&type=style to /Users/name/
 				// Because this needs to be the id for the Vite CSS plugin to property resolve
 				// relative @imports.
 				if (query.type === 'style' && isBrowserPath(id)) {
 					return relativeToRoot(id);
 				}
+				// Strip `/@fs` from linked dependencies outside of root so we can normalize
+				// it in the condition below. This ensures that the style module shared the same is
+				// part of the same "file" as the main Astro module in the module graph.
+				// "file" refers to `moduleGraph.fileToModulesMap`.
 				if (query.type === 'style' && id.startsWith('/@fs')) {
-					// Strip `/@fs` from linked dependencies outside of root so we can normalize
-					// it in the condition below. This ensures that the style module shared the same is
-					// part of the same "file" as the main Astro module in the module graph.
-					// "file" refers to `moduleGraph.fileToModulesMap`.
 					id = id.slice(4);
 				}
 				// Convert file paths to ViteID, meaning on Windows it omits the leading slash

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -86,6 +86,13 @@ export default function astro({ settings, logging }: AstroPluginOptions): vite.P
 				if (query.type === 'style' && isBrowserPath(id)) {
 					return relativeToRoot(id);
 				}
+				if (query.type === 'style' && id.startsWith('/@fs')) {
+					// Strip `/@fs` from linked dependencies outside of root so we can normalize
+					// it in the condition below. This ensures that the style module shared the same is
+					// part of the same "file" as the main Astro module in the module graph.
+					// "file" refers to `moduleGraph.fileToModulesMap`.
+					id = id.slice(4);
+				}
 				// Convert file paths to ViteID, meaning on Windows it omits the leading slash
 				if (isFullFilePath(id)) {
 					return viteID(new URL('file://' + id));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,13 +606,21 @@ importers:
       chai-as-promised: 7.1.1_chai@4.3.7
       mocha: 9.2.2
 
+  packages/astro/e2e/fixtures/_deps/astro-linked-lib:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../../..
+
   packages/astro/e2e/fixtures/astro-component:
     specifiers:
       '@astrojs/preact': ^1.1.0
+      '@e2e/astro-linked-lib': link:../_deps/astro-linked-lib
       astro: workspace:*
       preact: ^10.11.0
     dependencies:
       '@astrojs/preact': link:../../../../integrations/preact
+      '@e2e/astro-linked-lib': link:../_deps/astro-linked-lib
       astro: link:../../..
       preact: 10.11.3
 


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/5343

Remove `/@fs` when resolving third-party Astro component style virtual module. Ideally we can pass it through for Vite's resolver to resolve itself, but I found that still causes other HMR problems. So sticking with this simple fix for now.

We could revisit this again and fix as a whole, but this bug alone took quite a while to figure out ~~that I almost considerd retiring~~ so putting it aside for now.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added new test in `astro-component`

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A. bug fix