### PR TITLE
refactor(@astrojs/deno): take adventage of deno's `node shims layer` for supporting `node builtins` and `npm packages` in `ssr-deno`

### DIFF
--- a/examples/ssr-with-deno/.gitignore
+++ b/examples/ssr-with-deno/.gitignore
@@ -1,0 +1,2 @@
+public
+dist

--- a/examples/ssr-with-deno/.vscode/extensions.json
+++ b/examples/ssr-with-deno/.vscode/extensions.json
@@ -1,0 +1,4 @@
+{
+  "recommendations": ["astro-build.astro-vscode"],
+  "unwantedRecommendations": []
+}

--- a/examples/ssr-with-deno/.vscode/launch.json
+++ b/examples/ssr-with-deno/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "command": "./node_modules/.bin/astro dev",
+      "name": "Development server",
+      "request": "launch",
+      "type": "node-terminal"
+    }
+  ]
+}

--- a/examples/ssr-with-deno/astro.config.mjs
+++ b/examples/ssr-with-deno/astro.config.mjs
@@ -1,0 +1,15 @@
+import { defineConfig } from 'astro/config';
+import svelte from '@astrojs/svelte';
+import deno from "@astrojs/deno";
+import node from "@astrojs/node"
+import image from "@astrojs/image"
+
+// https://astro.build/config
+export default defineConfig({
+	output: 'server',
+	// adapter: node({
+	// 	mode: 'standalone',
+	// }),
+	adapter: deno(),
+	integrations: [svelte(), image()],
+});

--- a/examples/ssr-with-deno/astro.config.mjs
+++ b/examples/ssr-with-deno/astro.config.mjs
@@ -11,5 +11,8 @@ export default defineConfig({
 	// 	mode: 'standalone',
 	// }),
 	adapter: deno(),
-	integrations: [svelte(), image()],
+	integrations: [
+		svelte(),
+		image()
+	],
 });

--- a/examples/ssr-with-deno/package.json
+++ b/examples/ssr-with-deno/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@example/ssr",
+  "type": "module",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro build",
+    "preview": "deno run --allow-all dist/server/entry.mjs",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "@astrojs/deno": "^2.0.0",
+    "@astrojs/node": "^3.1.0",
+    "@astrojs/svelte": "^1.0.2",
+    "astro": "^1.6.11",
+    "concurrently": "^7.2.1",
+    "svelte": "^3.48.0",
+    "unocss": "^0.15.6",
+    "vite-imagetools": "^4.0.4"
+  }
+}

--- a/examples/ssr-with-deno/src/api.ts
+++ b/examples/ssr-with-deno/src/api.ts
@@ -1,0 +1,82 @@
+export interface Product {
+	id: number;
+	name: string;
+	price: number;
+	image: string;
+}
+
+interface User {
+	id: number;
+}
+
+interface Cart {
+	items: Array<{
+		id: number;
+		name: string;
+		count: number;
+	}>;
+}
+
+function getOrigin(request: Request): string {
+	return new URL(request.url).origin.replace('localhost', '127.0.0.1');
+}
+
+async function get<T>(
+	incomingReq: Request,
+	endpoint: string,
+	cb: (response: Response) => Promise<T>
+): Promise<T> {
+	const response = await fetch(`${getOrigin(incomingReq)}${endpoint}`, {
+		credentials: 'same-origin',
+		headers: incomingReq.headers,
+	});
+	if (!response.ok) {
+		// TODO make this better...
+		return null;
+	}
+	return cb(response);
+}
+
+export async function getProducts(incomingReq: Request): Promise<Product[]> {
+	return get<Product[]>(incomingReq, '/api/products', async (response) => {
+		const products: Product[] = await response.json();
+		return products;
+	});
+}
+
+export async function getProduct(incomingReq: Request, id: number): Promise<Product> {
+	return get<Product>(incomingReq, `/api/products/${id}`, async (response) => {
+		const product: Product = await response.json();
+		return product;
+	});
+}
+
+export async function getUser(incomingReq: Request): Promise<User> {
+	return get<User>(incomingReq, `/api/user`, async (response) => {
+		const user: User = await response.json();
+		return user;
+	});
+}
+
+export async function getCart(incomingReq: Request): Promise<Cart> {
+	return get<Cart>(incomingReq, `/api/cart`, async (response) => {
+		const cart: Cart = await response.json();
+		return cart;
+	});
+}
+
+export async function addToUserCart(id: number | string, name: string): Promise<void> {
+	await fetch(`${location.origin}/api/cart`, {
+		credentials: 'same-origin',
+		method: 'POST',
+		mode: 'no-cors',
+		headers: {
+			'Content-Type': 'application/json',
+			Cache: 'no-cache',
+		},
+		body: JSON.stringify({
+			id,
+			name,
+		}),
+	});
+}

--- a/examples/ssr-with-deno/src/components/AddToCart.svelte
+++ b/examples/ssr-with-deno/src/components/AddToCart.svelte
@@ -1,0 +1,54 @@
+<script>
+	import { addToUserCart } from '../api';
+	export let id = 0;
+	export let name = '';
+
+	function notifyCartItem(id) {
+		window.dispatchEvent(new CustomEvent('add-to-cart', {
+			detail: id
+		}));
+	}
+
+	async function addToCart() {
+		await addToUserCart(id, name);
+		notifyCartItem(id);
+	}
+</script>
+<style>
+	button {
+  display:block;
+  padding:0.5em 1em 0.5em 1em;
+  border-radius:100px;
+  border:none;
+  font-size: 1.4em;
+  position:relative;
+  background:#0652DD;
+  cursor:pointer;
+  height:2em;
+  width:10em;
+  overflow:hidden;
+  transition:transform 0.1s;
+  z-index:1;
+}
+button:hover {
+  transform:scale(1.1);
+}
+
+.pretext {
+  color:#fff;
+  background:#0652DD;
+  position:absolute;
+  top:0;
+  left:0;
+  height:100%;
+  width:100%;
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  font-family: 'Quicksand', sans-serif;
+	text-transform: uppercase;
+}
+</style>
+<button on:click={addToCart}>
+	<span class="pretext">Add to cart</span>
+</button>

--- a/examples/ssr-with-deno/src/components/Cart.svelte
+++ b/examples/ssr-with-deno/src/components/Cart.svelte
@@ -1,0 +1,34 @@
+<script>
+	export let count = 0;
+	let items = new Set();
+
+	function onAddToCart(ev) {
+		const id = ev.detail;
+		items.add(id);
+		count++;
+	}
+</script>
+<style>
+	.cart {
+		display: flex;
+		align-items: center;
+		text-decoration: none;
+		color: inherit;
+	}
+	.cart :first-child {
+		margin-right: 5px;
+	}
+
+	.cart-icon {
+		font-size: 36px;
+	}
+
+	.count {
+		font-size: 24px;
+	}
+</style>
+<svelte:window on:add-to-cart={onAddToCart}/>
+<a href="/cart" class="cart">
+	<span class="material-icons cart-icon">shopping_cart</span>
+	<span class="count">{count}</span>
+</a>

--- a/examples/ssr-with-deno/src/components/Container.astro
+++ b/examples/ssr-with-deno/src/components/Container.astro
@@ -1,0 +1,13 @@
+---
+const { tag = 'div' } = Astro.props;
+const Tag = tag;
+---
+
+<style>
+	.container {
+		width: 1248px; /** TODO: responsive */
+		margin-left: auto;
+		margin-right: auto;
+	}
+</style>
+<Tag class="container"><slot /></Tag>

--- a/examples/ssr-with-deno/src/components/Header.astro
+++ b/examples/ssr-with-deno/src/components/Header.astro
@@ -1,0 +1,49 @@
+---
+import TextDecorationSkip from './TextDecorationSkip.astro';
+import Cart from './Cart.svelte';
+import { getCart } from '../api';
+
+const cart = await getCart(Astro.request);
+const cartCount = cart.items.reduce((sum, item) => sum + item.count, 0);
+---
+
+<style>
+	@import url('https://fonts.googleapis.com/css2?family=Lobster&display=swap');
+
+	header {
+		margin: 1rem 2rem;
+		display: flex;
+		justify-content: space-between;
+	}
+
+	h1 {
+		margin: 0;
+		font-family: 'Lobster', cursive;
+		color: black;
+	}
+
+	a,
+	a:visited {
+		color: inherit;
+		text-decoration: none;
+	}
+
+	.right-pane {
+		display: flex;
+	}
+
+	.material-icons {
+		font-size: 36px;
+		margin-right: 1rem;
+	}
+</style>
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+<header>
+	<h1><a href="/"><TextDecorationSkip text="Online Store" /></a></h1>
+	<div class="right-pane">
+		<a href="/login">
+			<span class="material-icons"> login</span>
+		</a>
+		<Cart client:idle count={cartCount} />
+	</div>
+</header>

--- a/examples/ssr-with-deno/src/components/ProductListing.astro
+++ b/examples/ssr-with-deno/src/components/ProductListing.astro
@@ -1,0 +1,70 @@
+---
+import type { Product } from '../api';
+
+interface Props {
+	products: Product[];
+}
+
+const { products } = Astro.props;
+---
+
+<style>
+	ul {
+		list-style-type: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+	}
+
+	figure {
+		width: 200px;
+		padding: 7px;
+		border: 1px solid black;
+		display: flex;
+		flex-direction: column;
+	}
+
+	figure figcaption {
+		text-align: center;
+		line-height: 1.6;
+	}
+
+	figure img {
+		width: 100%;
+		height: 250px;
+		object-fit: cover;
+	}
+
+	.product a {
+		display: block;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.name {
+		font-weight: 500;
+	}
+
+	.price {
+		font-size: 90%;
+		color: #787878;
+	}
+</style>
+<slot name="title" />
+<ul>
+	{
+		products.map((product) => (
+			<li class="product">
+				<a href={`/products/${product.id}`}>
+					<figure>
+						<img src={product.image} />
+						<figcaption>
+							<div class="name">{product.name}</div>
+							<div class="price">${product.price}</div>
+						</figcaption>
+					</figure>
+				</a>
+			</li>
+		))
+	}
+</ul>

--- a/examples/ssr-with-deno/src/components/TextDecorationSkip.astro
+++ b/examples/ssr-with-deno/src/components/TextDecorationSkip.astro
@@ -1,0 +1,23 @@
+---
+interface Props {
+	text: string;
+}
+
+const { text } = Astro.props;
+const words = text.split(' ');
+const last = words.length - 1;
+---
+
+<style>
+	span {
+		text-decoration: underline;
+	}
+</style>
+{
+	words.map((word, i) => (
+		<Fragment>
+			<span>{word}</span>
+			{i !== last && <Fragment>&#32;</Fragment>}
+		</Fragment>
+	))
+}

--- a/examples/ssr-with-deno/src/env.d.ts
+++ b/examples/ssr-with-deno/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/examples/ssr-with-deno/src/models/db.json
+++ b/examples/ssr-with-deno/src/models/db.json
@@ -1,0 +1,28 @@
+{
+  "products": [
+    {
+      "id": 1,
+      "name": "Cereal",
+      "price": 3.99,
+      "image": "/images/products/cereal.jpg"
+    },
+    {
+      "id": 2,
+      "name": "Yogurt",
+      "price": 3.97,
+      "image": "/images/products/yogurt.jpg"
+    },
+    {
+      "id": 3,
+      "name": "Rolled Oats",
+      "price": 2.89,
+      "image": "/images/products/oats.jpg"
+    },
+    {
+      "id": 4,
+      "name": "Muffins",
+      "price": 4.39,
+      "image": "/images/products/muffins.jpg"
+    }
+  ]
+}

--- a/examples/ssr-with-deno/src/models/db.ts
+++ b/examples/ssr-with-deno/src/models/db.ts
@@ -1,0 +1,6 @@
+import db from './db.json';
+
+const products = db.products;
+const productMap = new Map(products.map((product) => [product.id, product]));
+
+export { products, productMap };

--- a/examples/ssr-with-deno/src/models/session.ts
+++ b/examples/ssr-with-deno/src/models/session.ts
@@ -1,0 +1,2 @@
+// Normally this would be in a database.
+export const userCartItems = new Map();

--- a/examples/ssr-with-deno/src/pages/api/cart.ts
+++ b/examples/ssr-with-deno/src/pages/api/cart.ts
@@ -1,0 +1,46 @@
+import { APIContext } from 'astro';
+import { userCartItems } from '../../models/session';
+
+export function get({ cookies }: APIContext) {
+	let userId = cookies.get('user-id').value;
+
+	if (!userId || !userCartItems.has(userId)) {
+		return {
+			body: JSON.stringify({ items: [] }),
+		};
+	}
+	let items = userCartItems.get(userId);
+	let array = Array.from(items.values());
+
+	return {
+		body: JSON.stringify({ items: array }),
+	};
+}
+
+interface AddToCartItem {
+	id: number;
+	name: string;
+}
+
+export async function post({ cookies, request }: APIContext) {
+	const item: AddToCartItem = await request.json();
+
+	let userId = cookies.get('user-id').value;
+
+	if (!userCartItems.has(userId)) {
+		userCartItems.set(userId, new Map());
+	}
+
+	let cart = userCartItems.get(userId);
+	if (cart.has(item.id)) {
+		cart.get(item.id).count++;
+	} else {
+		cart.set(item.id, { id: item.id, name: item.name, count: 1 });
+	}
+
+	return {
+		body: JSON.stringify({
+			ok: true,
+		}),
+	};
+}

--- a/examples/ssr-with-deno/src/pages/api/products.ts
+++ b/examples/ssr-with-deno/src/pages/api/products.ts
@@ -1,0 +1,7 @@
+import { products } from '../../models/db';
+
+export function get() {
+	return {
+		body: JSON.stringify(products),
+	};
+}

--- a/examples/ssr-with-deno/src/pages/api/products/[id].ts
+++ b/examples/ssr-with-deno/src/pages/api/products/[id].ts
@@ -1,0 +1,18 @@
+import { productMap } from '../../../models/db';
+import type { APIContext } from 'astro';
+
+export function get({ params }: APIContext) {
+	const id = Number(params.id);
+	if (productMap.has(id)) {
+		const product = productMap.get(id);
+
+		return {
+			body: JSON.stringify(product),
+		};
+	} else {
+		return new Response(null, {
+			status: 400,
+			statusText: 'Not found',
+		});
+	}
+}

--- a/examples/ssr-with-deno/src/pages/cart.astro
+++ b/examples/ssr-with-deno/src/pages/cart.astro
@@ -1,0 +1,51 @@
+---
+import Header from '../components/Header.astro';
+import Container from '../components/Container.astro';
+import { getCart } from '../api';
+
+if (!Astro.cookies.get('user-id').value) {
+	return Astro.redirect('/');
+}
+
+// They must be logged in.
+
+const user = { name: 'test' }; // getUser?
+const cart = await getCart(Astro.request);
+---
+
+<html lang="en">
+	<head>
+		<title>Cart | Online Store</title>
+		<style>
+			h1 {
+				font-size: 36px;
+			}
+		</style>
+	</head>
+	<body>
+		<Header />
+
+		<Container tag="main">
+			<h1>Cart</h1>
+			<p>Hi {user.name}! Here are your cart items:</p>
+			<table>
+				<thead>
+					<tr>
+						<th>Item</th>
+						<th>Count</th>
+					</tr>
+				</thead>
+				<tbody>
+					{
+						cart.items.map((item) => (
+							<tr>
+								<td>{item.name}</td>
+								<td>{item.count}</td>
+							</tr>
+						))
+					}
+				</tbody>
+			</table>
+		</Container>
+	</body>
+</html>

--- a/examples/ssr-with-deno/src/pages/index.astro
+++ b/examples/ssr-with-deno/src/pages/index.astro
@@ -1,0 +1,33 @@
+---
+import Header from '../components/Header.astro';
+import Container from '../components/Container.astro';
+import ProductListing from '../components/ProductListing.astro';
+import { getProducts } from '../api';
+import '../styles/common.css';
+
+const products = await getProducts(Astro.request);
+---
+
+<html lang="en">
+	<head>
+		<title>Online Store</title>
+		<style>
+			h1 {
+				font-size: 36px;
+			}
+
+			.product-listing-title {
+				text-align: center;
+			}
+		</style>
+	</head>
+	<body>
+		<Header />
+
+		<Container tag="main">
+			<ProductListing products={products}>
+				<h2 class="product-listing-title" slot="title">Product Listing</h2>
+			</ProductListing>
+		</Container>
+	</body>
+</html>

--- a/examples/ssr-with-deno/src/pages/login.astro
+++ b/examples/ssr-with-deno/src/pages/login.astro
@@ -1,0 +1,55 @@
+---
+import Header from '../components/Header.astro';
+import Container from '../components/Container.astro';
+---
+
+<html lang="en">
+	<head>
+		<title>Online Store</title>
+		<style>
+			h1 {
+				font-size: 36px;
+			}
+		</style>
+
+		<script type="module" is:inline>
+			document.addEventListener('DOMContentLoaded', () => {
+				console.log('loaded');
+				document.querySelector('form').addEventListener('submit', (e) => {
+					e.preventDefault();
+					const form = e.target;
+					const formData = new FormData(form);
+					const data = Object.fromEntries(formData);
+
+					fetch('/login.form.async', {
+						method: 'POST',
+						body: JSON.stringify(data),
+					})
+						.then((res) => res.json())
+						.then((data) => {
+							document.querySelector('#result').innerHTML =
+								'Progressive login was successful! you will be redirected to the store in 3 seconds';
+							setTimeout(() => (location.href = '/'), 3000);
+						});
+				});
+			});
+		</script>
+	</head>
+	<body>
+		<Header />
+
+		<Container tag="main">
+			<h1>Login</h1>
+			<form action="/login.form" method="POST">
+				<label for="name">Name</label>
+				<input type="text" name="name" />
+
+				<label for="password">Password</label>
+				<input type="password" name="password" />
+
+				<input type="submit" value="Submit" />
+			</form>
+			<div id="result"></div>
+		</Container>
+	</body>
+</html>

--- a/examples/ssr-with-deno/src/pages/login.form.async.ts
+++ b/examples/ssr-with-deno/src/pages/login.form.async.ts
@@ -1,0 +1,16 @@
+import { APIContext, APIRoute } from 'astro';
+
+export const post: APIRoute = ({ cookies, params, request }: APIContext) => {
+	// add a new cookie
+	cookies.set('user-id', '1', {
+		path: '/',
+		maxAge: 2592000,
+	});
+
+	return {
+		body: JSON.stringify({
+			ok: true,
+			user: 1,
+		}),
+	};
+};

--- a/examples/ssr-with-deno/src/pages/login.form.ts
+++ b/examples/ssr-with-deno/src/pages/login.form.ts
@@ -1,0 +1,16 @@
+import { APIContext } from 'astro';
+
+export function post({ cookies, params, request }: APIContext) {
+	// add a new cookie
+	cookies.set('user-id', '1', {
+		path: '/',
+		maxAge: 2592000,
+	});
+
+	return new Response(null, {
+		status: 301,
+		headers: {
+			Location: '/',
+		},
+	});
+}

--- a/examples/ssr-with-deno/src/pages/products/[id].astro
+++ b/examples/ssr-with-deno/src/pages/products/[id].astro
@@ -1,0 +1,45 @@
+---
+import Header from '../../components/Header.astro';
+import Container from '../../components/Container.astro';
+import AddToCart from '../../components/AddToCart.svelte';
+import { getProduct } from '../../api';
+import '../../styles/common.css';
+
+const id = Number(Astro.params.id);
+const product = await getProduct(Astro.request, id);
+---
+
+<html lang="en">
+	<head>
+		<title>{product.name} | Online Store</title>
+		<style>
+			h2 {
+				text-align: center;
+				font-size: 3.5rem;
+			}
+
+			figure {
+				display: grid;
+				grid-template-columns: 1fr 1fr;
+			}
+
+			img {
+				width: 400px;
+			}
+		</style>
+	</head>
+	<body>
+		<Header />
+
+		<Container tag="article">
+			<h2>{product.name}</h2>
+			<figure>
+				<img src={product.image} />
+				<figcaption>
+					<AddToCart client:idle id={id} name={product.name} />
+					<p>Description here...</p>
+				</figcaption>
+			</figure>
+		</Container>
+	</body>
+</html>

--- a/examples/ssr-with-deno/src/styles/common.css
+++ b/examples/ssr-with-deno/src/styles/common.css
@@ -1,0 +1,3 @@
+body {
+	font-family: 'GT America Standard', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}

--- a/examples/ssr-with-deno/tsconfig.json
+++ b/examples/ssr-with-deno/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/base"
+}

--- a/packages/astro/src/runtime/server/response.ts
+++ b/packages/astro/src/runtime/server/response.ts
@@ -1,6 +1,9 @@
 const isNodeJS =
 	typeof process === 'object' && Object.prototype.toString.call(process) === '[object process]';
 
+declare const Deno: any;
+const isDeno = typeof Deno !== 'undefined' && Deno?.build?.target != null;
+
 let StreamingCompatibleResponse: typeof Response | undefined;
 
 function createResponseClass() {

--- a/packages/integrations/deno/src/index.ts
+++ b/packages/integrations/deno/src/index.ts
@@ -97,13 +97,13 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					content
 						.replace(
 							/import(.*?)from.*?"node:(.*?)"/g,
-							'import$1from "https://deno.land/std/node/$2.ts"'
+							'/**#__REPLACE_BY_DENO__*/import$1from "https://deno.land/std/node/$2.ts"'
 						)
 						.replace(
 							// replace other node builtins but didn't start with node:
 							// also ignore deno modules start with http(s)://
 							/import(.*?)from.*?"((?!(http|https):\/\/)(.*?))"/g,
-							'import$1from "https://deno.land/std/node/$2.ts"'
+							'/**#__REPLACE_BY_DENO__*/import$1from "https://deno.land/std/node/$2.ts"'
 						),
 					'utf-8'
 				);

--- a/packages/integrations/image/src/index.ts
+++ b/packages/integrations/image/src/index.ts
@@ -109,11 +109,11 @@ export default function integration(options: IntegrationOptions = {}): AstroInte
 			},
 			'astro:build:start': ({ buildConfig }) => {
 				const adapterName = _config.adapter?.name;
-				if (adapterName && UNSUPPORTED_ADAPTERS.has(adapterName)) {
-					throw new Error(
-						`@astrojs/image is not supported with the ${adapterName} adapter. Please choose a Node.js compatible adapter.`
-					);
-				}
+				// if (adapterName && UNSUPPORTED_ADAPTERS.has(adapterName)) {
+				// 	throw new Error(
+				// 		`@astrojs/image is not supported with the ${adapterName} adapter. Please choose a Node.js compatible adapter.`
+				// 	);
+				// }
 
 				// Backwards compat
 				if (needsBuildConfig) {

--- a/packages/integrations/image/src/index.ts
+++ b/packages/integrations/image/src/index.ts
@@ -13,7 +13,7 @@ const PKG_NAME = '@astrojs/image';
 const ROUTE_PATTERN = '/_image';
 const UNSUPPORTED_ADAPTERS = new Set([
 	'@astrojs/cloudflare',
-	'@astrojs/deno',
+	// '@astrojs/deno',
 	'@astrojs/netlify/edge-functions',
 	'@astrojs/vercel/edge',
 ]);
@@ -109,11 +109,11 @@ export default function integration(options: IntegrationOptions = {}): AstroInte
 			},
 			'astro:build:start': ({ buildConfig }) => {
 				const adapterName = _config.adapter?.name;
-				// if (adapterName && UNSUPPORTED_ADAPTERS.has(adapterName)) {
-				// 	throw new Error(
-				// 		`@astrojs/image is not supported with the ${adapterName} adapter. Please choose a Node.js compatible adapter.`
-				// 	);
-				// }
+				if (adapterName && UNSUPPORTED_ADAPTERS.has(adapterName)) {
+					throw new Error(
+						`@astrojs/image is not supported with the ${adapterName} adapter. Please choose a Node.js compatible adapter.`
+					);
+				}
 
 				// Backwards compat
 				if (needsBuildConfig) {

--- a/packages/integrations/image/src/utils/workerPool.ts
+++ b/packages/integrations/image/src/utils/workerPool.ts
@@ -1,5 +1,5 @@
 /* tslint-disable ban-types */
-import { TransformStream } from 'web-streams-polyfill';
+import { TransformStream } from 'web-streams-polyfill/dist/ponyfill.js';
 import { parentPort, Worker } from 'worker_threads';
 
 function uuid() {

--- a/packages/webapi/mod.d.ts
+++ b/packages/webapi/mod.d.ts
@@ -10,4 +10,4 @@ interface PolyfillOptions {
     override?: Record<string, {
         (...args: any[]): any;
     }>;
-}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,26 @@ importers:
       unocss: 0.15.6
       vite-imagetools: 4.0.11
 
+  examples/ssr-with-deno:
+    specifiers:
+      '@astrojs/deno': ^2.0.0
+      '@astrojs/node': ^3.1.0
+      '@astrojs/svelte': ^1.0.2
+      astro: ^1.6.11
+      concurrently: ^7.2.1
+      svelte: ^3.48.0
+      unocss: ^0.15.6
+      vite-imagetools: ^4.0.4
+    dependencies:
+      '@astrojs/deno': link:../../packages/integrations/deno
+      '@astrojs/node': link:../../packages/integrations/node
+      '@astrojs/svelte': link:../../packages/integrations/svelte
+      astro: link:../../packages/astro
+      concurrently: 7.5.0
+      svelte: 3.53.1
+      unocss: 0.15.6
+      vite-imagetools: 4.0.11
+
   examples/with-markdown-plugins:
     specifiers:
       '@astrojs/markdown-remark': ^1.1.3
@@ -3831,7 +3851,7 @@ packages:
       '@astro-community/astro-embed-twitter': 0.1.3_astro@packages+astro
       '@astro-community/astro-embed-vimeo': 0.1.1_astro@packages+astro
       '@astro-community/astro-embed-youtube': 0.2.1_astro@packages+astro
-      astro: link:packages/astro
+      astro: link:packages\astro
       unist-util-select: 4.0.1
     dev: false
 
@@ -3841,7 +3861,7 @@ packages:
       astro: ^1.0.0-beta.10
     dependencies:
       '@astro-community/astro-embed-utils': 0.0.3
-      astro: link:packages/astro
+      astro: link:packages\astro
     dev: false
 
   /@astro-community/astro-embed-utils/0.0.3:
@@ -3853,7 +3873,7 @@ packages:
     peerDependencies:
       astro: ^1.0.0-beta.10
     dependencies:
-      astro: link:packages/astro
+      astro: link:packages\astro
       lite-vimeo-embed: 0.1.0
     dev: false
 
@@ -3862,7 +3882,7 @@ packages:
     peerDependencies:
       astro: ^1.0.0-beta.10
     dependencies:
-      astro: link:packages/astro
+      astro: link:packages\astro
       lite-youtube-embed: 0.2.0
     dev: false
 
@@ -10594,7 +10614,7 @@ packages:
       '@astro-community/astro-embed-twitter': 0.1.3_astro@packages+astro
       '@astro-community/astro-embed-vimeo': 0.1.1_astro@packages+astro
       '@astro-community/astro-embed-youtube': 0.2.1_astro@packages+astro
-      astro: link:packages/astro
+      astro: link:packages\astro
     dev: false
 
   /async-sema/3.1.1:


### PR DESCRIPTION
## Changes
- @astrojs/deno previous is trying to packaging use target `browser`, and I think we can just target `node` then use deno's `node shims layer`
- add an example in `example/ssr-with-deno`

## Motivation
- support node builtins and npm packages in deno ssr
- makes @astrojs/image works

core code is [here](https://github.com/withastro/astro/pull/5471/files#diff-37889ae53dbdf96554d2fc0abd42f56134033c983d4ac8ad3974eccf4987a2c0R94-R109)