### PR TITLE
fix bug: added a warning if the image was GIF

### DIFF
--- a/.changeset/dirty-scissors-fail.md
+++ b/.changeset/dirty-scissors-fail.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': minor
+---
+
+added a warning if the image was GIF

--- a/packages/integrations/image/src/vendor/squoosh/impl.ts
+++ b/packages/integrations/image/src/vendor/squoosh/impl.ts
@@ -31,6 +31,10 @@ export async function decodeBuffer(
   const firstChunkString = Array.from(firstChunk)
     .map((v) => String.fromCodePoint(v))
     .join('')
+	// TODO (future PR): support more formats
+	if (firstChunkString.includes('GIF')) {
+		throw Error(`GIF images are not supported, please install the @astrojs/image/sharp plugin`)
+	}
   const key = Object.entries(supportedFormats).find(([, { detectors }]) =>
     detectors.some((detector) => detector.exec(firstChunkString))
   )?.[0] as EncoderKey | undefined


### PR DESCRIPTION
## Changes

bug fix #5028

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
