### PR TITLE
Prevent inlining SCSS partials in dev

### DIFF
--- a/.changeset/twelve-kings-rest.md
+++ b/.changeset/twelve-kings-rest.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent inlining SCSS partials in dev

--- a/packages/astro/test/fixtures/0-css/src/pages/index.astro
+++ b/packages/astro/test/fixtures/0-css/src/pages/index.astro
@@ -49,6 +49,9 @@ import raw from '../styles/raw.css?raw'
 		<style lang="sass">
 			@import '../styles/linked.sass'
 		</style>
+    <style lang="scss">
+			@import '../styles/partial-main.scss';
+		</style>
   </head>
   <body>
     <div class="wrapper">

--- a/packages/astro/test/fixtures/0-css/src/styles/_partial-1.scss
+++ b/packages/astro/test/fixtures/0-css/src/styles/_partial-1.scss
@@ -1,0 +1,3 @@
+@mixin make-red {
+  color: red;
+}

--- a/packages/astro/test/fixtures/0-css/src/styles/_partial-2.scss
+++ b/packages/astro/test/fixtures/0-css/src/styles/_partial-2.scss
@@ -1,0 +1,5 @@
+// relies on partial-1. make sure astro don't inline this style.
+
+.partial-test {
+  @include make-red;
+}

--- a/packages/astro/test/fixtures/0-css/src/styles/partial-main.scss
+++ b/packages/astro/test/fixtures/0-css/src/styles/partial-main.scss
@@ -1,0 +1,2 @@
+@import './partial-1';
+@import './partial-2';


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/5441

Actually fixing https://github.com/withastro/astro/issues/5441 also relies on https://github.com/vitejs/vite/pull/11079 too, but we could close it as the work has been done for the issue.

SCSS partials may refer to mixins in other files, so it can't be loaded individually by itself. It's safe to skip as they are likely already inlined in other SCSS files.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added SCSS partials to css test

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a, bug fix