### PR TITLE
Fix astro preview not working on Windows

### DIFF
--- a/.changeset/swift-papayas-kiss.md
+++ b/.changeset/swift-papayas-kiss.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix astro preview not working on Windows

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -1,5 +1,6 @@
 import type { AstroTelemetry } from '@astrojs/telemetry';
 import { createRequire } from 'module';
+import { pathToFileURL } from 'url';
 import type { AstroSettings, PreviewModule, PreviewServer } from '../../@types/astro';
 import { runHookConfigDone, runHookConfigSetup } from '../../integrations/index.js';
 import type { LogOptions } from '../logger/core';
@@ -41,9 +42,11 @@ export default async function preview(
 	// don't treat this as a dependency of Astro itself. This correctly resolves the
 	// preview entrypoint of the integration package, relative to the user's project root.
 	const require = createRequire(settings.config.root);
-	const previewEntrypoint = require.resolve(settings.adapter.previewEntrypoint);
+	const previewEntrypointUrl = pathToFileURL(
+		require.resolve(settings.adapter.previewEntrypoint)
+	).href;
 
-	const previewModule = (await import(previewEntrypoint)) as Partial<PreviewModule>;
+	const previewModule = (await import(previewEntrypointUrl)) as Partial<PreviewModule>;
 	if (typeof previewModule.default !== 'function') {
 		throw new Error(`[preview] ${settings.adapter.name} cannot preview your app.`);
 	}

--- a/packages/astro/test/fixtures/ssr-preview/package.json
+++ b/packages/astro/test/fixtures/ssr-preview/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/ssr-preview",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/ssr-preview/preview.mjs
+++ b/packages/astro/test/fixtures/ssr-preview/preview.mjs
@@ -1,0 +1,8 @@
+export default () => {
+	// noop
+	return {
+		port: 3000,
+		closed() {},
+		stop() {}
+	}
+}

--- a/packages/astro/test/fixtures/ssr-preview/src/pages/index.astro
+++ b/packages/astro/test/fixtures/ssr-preview/src/pages/index.astro
@@ -1,0 +1,8 @@
+<html lang="en">
+	<head>
+		<title>Astro</title>
+	</head>
+	<body>
+		Hello
+	</body>
+</html>

--- a/packages/astro/test/ssr-preview.test.js
+++ b/packages/astro/test/ssr-preview.test.js
@@ -1,0 +1,22 @@
+import { loadFixture } from './test-utils.js';
+import testAdapter from './test-adapter.js';
+
+describe('SSR Preview', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/ssr-preview/',
+			output: 'server',
+			adapter: testAdapter({ extendAdapter: { previewEntrypoint: './preview.mjs' } }),
+		});
+		await fixture.build();
+	});
+
+	it('preview server works', async () => {
+		/** @type {import('./test-utils').PreviewServer} */
+		const previewServer = await fixture.preview();
+		await previewServer.stop();
+	});
+});

--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -4,7 +4,7 @@ import { viteID } from '../dist/core/util.js';
  *
  * @returns {import('../src/@types/astro').AstroIntegration}
  */
-export default function ({ provideAddress } = { provideAddress: true }) {
+export default function ({ provideAddress = true, extendAdapter } = { provideAddress: true }) {
 	return {
 		name: 'my-ssr-adapter',
 		hooks: {
@@ -66,6 +66,7 @@ export default function ({ provideAddress } = { provideAddress: true }) {
 					name: 'my-ssr-adapter',
 					serverEntrypoint: '@my-ssr',
 					exports: ['manifest', 'createApp'],
+					...extendAdapter,
 				});
 			},
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2276,6 +2276,12 @@ importers:
       '@astrojs/partytown': link:../../../../integrations/partytown
       astro: link:../../..
 
+  packages/astro/test/fixtures/ssr-preview:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/ssr-redirect:
     specifiers:
       astro: workspace:*
@@ -3831,7 +3837,7 @@ packages:
       '@astro-community/astro-embed-twitter': 0.1.3_astro@packages+astro
       '@astro-community/astro-embed-vimeo': 0.1.1_astro@packages+astro
       '@astro-community/astro-embed-youtube': 0.2.1_astro@packages+astro
-      astro: link:packages/astro
+      astro: link:packages\astro
       unist-util-select: 4.0.1
     dev: false
 
@@ -3841,7 +3847,7 @@ packages:
       astro: ^1.0.0-beta.10
     dependencies:
       '@astro-community/astro-embed-utils': 0.0.3
-      astro: link:packages/astro
+      astro: link:packages\astro
     dev: false
 
   /@astro-community/astro-embed-utils/0.0.3:
@@ -3853,7 +3859,7 @@ packages:
     peerDependencies:
       astro: ^1.0.0-beta.10
     dependencies:
-      astro: link:packages/astro
+      astro: link:packages\astro
       lite-vimeo-embed: 0.1.0
     dev: false
 
@@ -3862,7 +3868,7 @@ packages:
     peerDependencies:
       astro: ^1.0.0-beta.10
     dependencies:
-      astro: link:packages/astro
+      astro: link:packages\astro
       lite-youtube-embed: 0.2.0
     dev: false
 
@@ -10594,7 +10600,7 @@ packages:
       '@astro-community/astro-embed-twitter': 0.1.3_astro@packages+astro
       '@astro-community/astro-embed-vimeo': 0.1.1_astro@packages+astro
       '@astro-community/astro-embed-youtube': 0.2.1_astro@packages+astro
-      astro: link:packages/astro
+      astro: link:packages\astro
     dev: false
 
   /async-sema/3.1.1:


### PR DESCRIPTION
## Changes

When running `astro preview` on Windows, it didn't work with the following error.

> Only URLs with a scheme in: file, data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'

This PR fixes this error.

## Testing

I added a test. Also I tested with adapter-node manually.

## Docs

Docs isn't needed as it's a bug fix.
