### PR TITLE
Documented how to access the base config in the app

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -432,6 +432,8 @@ export interface AstroUserConfig {
 	 * @description
 	 * The base path to deploy to. Astro will build your pages and assets using this path as the root. Currently, this has no effect during development.
 	 *
+	 * You can access this value in your app via `import.meta.env.BASE_URL`.
+	 *
 	 * ```js
 	 * {
 	 *   base: '/docs'


### PR DESCRIPTION
## Changes

While the `site` property in the Astro config can be accessed in the app via `Astro.site`, the `base` property is only accessible via `import.meta.env.BASE_URL`. It wasn't documented, so this PRs fixes this.

## Testing

No tests since it's just a docs change.

## Docs

This updates the types that are used to generate the reference pages (https://docs.astro.build/en/reference/).
