### PR TITLE
Narrow the type of Params

### DIFF
--- a/.changeset/nervous-laws-knock.md
+++ b/.changeset/nervous-laws-knock.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Narrow type of `Params`, as its values cannot be numbers

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1047,7 +1047,7 @@ export type GetHydrateCallback = () => Promise<() => void | Promise<void>>;
 	rss(): never;
 }
 
-export type GetStaticPathsItem = { params: Params; props?: Props };
+export type GetStaticPathsItem = { params: { [K in keyof Params]: Params[K] | number }; props?: Props };
 export type GetStaticPathsResult = GetStaticPathsItem[];
 export type GetStaticPathsResultKeyed = GetStaticPathsResult & {
 	keyed: Map<string, GetStaticPathsItem>;
@@ -1146,7 +1146,7 @@ export interface Page<T = any> {
 
 export type PaginateFunction = (data: any[], args?: PaginateOptions) => GetStaticPathsResult;
 
-export type Params = Record<string, string | number | undefined>;
+export type Params = Record<string, string | undefined>;
 
 export interface AstroAdapter {
 	name: string;

--- a/packages/astro/src/core/routing/params.ts
+++ b/packages/astro/src/core/routing/params.ts
@@ -1,4 +1,4 @@
-import type { Params } from '../../@types/astro';
+import type { GetStaticPathsItem, Params } from '../../@types/astro';
 import { validateGetStaticPathsParameter } from './validation.js';
 
 /**
@@ -27,12 +27,12 @@ export function getParams(array: string[]) {
  * values and create a stringified key for the route
  * that can be used to match request routes
  */
-export function stringifyParams(params: Params, routeComponent: string) {
+export function stringifyParams(params: GetStaticPathsItem['params'], routeComponent: string) {
 	// validate parameter values then stringify each value
 	const validatedParams = Object.entries(params).reduce((acc, next) => {
 		validateGetStaticPathsParameter(next, routeComponent);
 		const [key, value] = next;
-		acc[key] = typeof value === 'undefined' ? undefined : `${value}`;
+		acc[key] = value?.toString();
 		return acc;
 	}, {} as Params);
 


### PR DESCRIPTION
Fixes #5442.

/cc @tony-sull & @bholmesdev

## Changes

[#3087 changed the type of `Params`](//github.com/withastro/astro/pull/3087) from `Record<string, string | undefined>` to `Record<string, string | number | undefined>` to formerly allow `getStaticPaths` to return numbers.

However, as the change was made to `Params` and not `GetStaticPathsResult` or `GetStaticPathsItem`, it also affects `Astro.params`.

This PR essentially moves the change made in #3087 from `Params` to `GetStaticPathsItem`, reverting the type of `Astro.params` while keeping the type of `getStaticPaths`.

**Note** that while looking into this, I [found this comment](https://github.com/withastro/astro/issues/4309#issuecomment-1239779706) by @bholmesdev:

> * if you pass a number to `params.year` in your `getStaticPaths`, it should _still_ be a number when destructuring `Astro.params`. If not, that's a bug.
> * if you created an **SSR dynamic route** like `[year].astro`, `year` will _always_ be a `string` (even if it could be parsed to a number). This is where string -> number conversion would be manual.

In my experience, `Astro.params` never contains numbers, not even in static mode. While reviewing, please consider that this PR changes the types to match the behaviour, although judging by this comment, we might want to change the behaviour to match the types instead.

## Testing

This is testable like so:
```typescript
const artist: string | undefined = Astro.params.artist;
```
I haven't found any type definition tests to which this one could be added.

## Docs

From what I understand, this change is [in line with the current docs](https://docs.astro.build/en/reference/api-reference/#params):

> `params` are encoded into the URL, so only strings are supported as values.