### PR TITLE
Fix Lit `astro-slot` bug

### DIFF
--- a/.changeset/rich-mayflies-trade.md
+++ b/.changeset/rich-mayflies-trade.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/lit': patch
+---
+
+Fix Lit astro-slot bug

--- a/packages/integrations/lit/server.js
+++ b/packages/integrations/lit/server.js
@@ -67,7 +67,7 @@ function* render(Component, attrs, slots) {
 			} else {
 				// Add the slot attribute to all the nested HTML elements,
 				// so that it can be rendered inside the appropriate Lit Component slot.
-				yield htmlString.replace(/<(?<tag>\w+)/gm, `<$<tag> slot="${slot}"`);
+				yield htmlString.replace(/<(?<tag>(?:\w+-?)+)/gm, `<$<tag> slot="${slot}"`);
 			}
 		}
 	}

--- a/packages/integrations/lit/server.js
+++ b/packages/integrations/lit/server.js
@@ -59,10 +59,15 @@ function* render(Component, attrs, slots) {
 	}
 	if (slots) {
 		for (const [slot, value] of Object.entries(slots)) {
+			const htmlString = value || '';
+
 			if (slot === 'default') {
-				yield `<astro-slot>${value || ''}</astro-slot>`;
+				// This will render inside the Lit Component default slot.
+				yield htmlString;
 			} else {
-				yield `<astro-slot slot="${slot}">${value || ''}</astro-slot>`;
+				// Add the slot attribute to all the nested HTML elements,
+				// so that it can be rendered inside the appropriate Lit Component slot.
+				yield htmlString.replace(/<(?<tag>\w+)/gm, `<$<tag> slot="${slot}"`);
 			}
 		}
 	}


### PR DESCRIPTION
## Changes

- This removes the extraneous  `<astro-slot>` element which surrounds native slotted content.
- See issue #5475

## Testing

- There was already a test for `Lit` slotted content and that test still succeeds.
- I used my own test project.
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

While this is a bug fix, it can cause rendering issues for users upgrading their project.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->

 It is a bug fix and restoring standard functionality.
