### PR TITLE
Show warning about hydrating Astro components in build

### DIFF
--- a/.changeset/yellow-lizards-shout.md
+++ b/.changeset/yellow-lizards-shout.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Added a warning in build when trying to hydrate an Astro component

--- a/packages/astro/src/runtime/server/render/astro.ts
+++ b/packages/astro/src/runtime/server/render/astro.ts
@@ -8,9 +8,9 @@ import { isPromise } from '../util.js';
 import { renderChild } from './any.js';
 import { HTMLParts } from './common.js';
 
-// In dev mode, check props and make sure they are valid for an Astro component
+// Issue warnings for invalid props for Astro components
 function validateComponentProps(props: any, displayName: string) {
-	if (import.meta.env?.DEV && props != null) {
+	if (props != null) {
 		for (const prop of Object.keys(props)) {
 			if (HydrationDirectiveProps.has(prop)) {
 				// eslint-disable-next-line


### PR DESCRIPTION
## Changes

Bit of a lazy fix. I was hoping to be able to provide more information in the warning, but much like what I faced in https://github.com/withastro/astro/pull/5316, we don't have access to much there. In the future, I'd like to investigate a larger endeavour there to see if we can drill down info for error / warnings reporting (or bubble up warnings and errors, maybe?)

For now this is still an improvement. It's not that big of an issue that the location isn't in the message as the warning will show up when you visit the page / build it so you'll know either way in which file it is. In the future we'll also add an editor warning for this, which should also help users avoid this situation!

Fix https://github.com/withastro/astro/issues/4090

## Testing

Tested manually

## Docs

N/A
