### PR TITLE
Refactor Astro plugin and compile flow

### DIFF
--- a/.changeset/lazy-walls-sneeze.md
+++ b/.changeset/lazy-walls-sneeze.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Dedupe Astro package when resolving

--- a/.changeset/seven-seahorses-talk.md
+++ b/.changeset/seven-seahorses-talk.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Refactor Astro compile flow

--- a/packages/astro/src/core/compile/cache.ts
+++ b/packages/astro/src/core/compile/cache.ts
@@ -1,0 +1,42 @@
+import type { AstroConfig } from '../../@types/astro';
+import { compile, CompileProps, CompileResult } from './compile';
+
+type CompilationCache = Map<string, CompileResult>;
+
+const configCache = new WeakMap<AstroConfig, CompilationCache>();
+
+export function isCached(config: AstroConfig, filename: string) {
+	return configCache.has(config) && configCache.get(config)!.has(filename);
+}
+
+export function getCachedCompileResult(
+	config: AstroConfig,
+	filename: string
+): CompileResult | null {
+	if (!isCached(config, filename)) return null;
+	return configCache.get(config)!.get(filename)!;
+}
+
+export function invalidateCompilation(config: AstroConfig, filename: string) {
+	if (configCache.has(config)) {
+		const cache = configCache.get(config)!;
+		cache.delete(filename);
+	}
+}
+
+export async function cachedCompilation(props: CompileProps): Promise<CompileResult> {
+	const { astroConfig, filename } = props;
+	let cache: CompilationCache;
+	if (!configCache.has(astroConfig)) {
+		cache = new Map();
+		configCache.set(astroConfig, cache);
+	} else {
+		cache = configCache.get(astroConfig)!;
+	}
+	if (cache.has(filename)) {
+		return cache.get(filename)!;
+	}
+	const compileResult = await compile(props);
+	cache.set(filename, compileResult);
+	return compileResult;
+}

--- a/packages/astro/src/core/compile/cache.ts
+++ b/packages/astro/src/core/compile/cache.ts
@@ -1,5 +1,5 @@
 import type { AstroConfig } from '../../@types/astro';
-import { compile, CompileProps, CompileResult } from './compile';
+import { compile, CompileProps, CompileResult } from './compile.js';
 
 type CompilationCache = Map<string, CompileResult>;
 

--- a/packages/astro/src/core/compile/compile.ts
+++ b/packages/astro/src/core/compile/compile.ts
@@ -5,8 +5,7 @@ import type { AstroConfig } from '../../@types/astro';
 import { transform } from '@astrojs/compiler';
 import { AggregateError, AstroError, CompilerError } from '../errors/errors.js';
 import { AstroErrorData } from '../errors/index.js';
-import { prependForwardSlash } from '../path.js';
-import { resolvePath, viteID } from '../util.js';
+import { resolvePath } from '../util.js';
 import { createStylePreprocessor } from './style.js';
 
 type CompilationCache = Map<string, CompileResult>;
@@ -42,9 +41,7 @@ async function compile({
 		site: astroConfig.site?.toString(),
 		sourcefile: filename,
 		sourcemap: 'both',
-		internalURL: `/@fs${prependForwardSlash(
-			viteID(new URL('../../runtime/server/index.js', import.meta.url))
-		)}`,
+		internalURL: 'astro/server/index.js',
 		// TODO: baseline flag
 		experimentalStaticExtraction: true,
 		preprocessStyle: createStylePreprocessor({

--- a/packages/astro/src/core/compile/compile.ts
+++ b/packages/astro/src/core/compile/compile.ts
@@ -68,16 +68,11 @@ export async function compile({
 
 	handleCompileResultErrors(transformResult, cssTransformErrors);
 
-	const compileResult: CompileResult = Object.create(transformResult, {
-		cssDeps: {
-			value: cssDeps,
-		},
-		source: {
-			value: source,
-		},
-	});
-
-	return compileResult;
+	return {
+		...transformResult,
+		cssDeps,
+		source,
+	};
 }
 
 function handleCompileResultErrors(result: TransformResult, cssTransformErrors: AstroError[]) {
@@ -97,6 +92,8 @@ function handleCompileResultErrors(result: TransformResult, cssTransformErrors: 
 	}
 
 	switch (cssTransformErrors.length) {
+		case 0:
+			break;
 		case 1: {
 			const error = cssTransformErrors[0];
 			if (!error.errorCode) {

--- a/packages/astro/src/core/compile/compile.ts
+++ b/packages/astro/src/core/compile/compile.ts
@@ -119,11 +119,12 @@ export function isCached(config: AstroConfig, filename: string) {
 	return configCache.has(config) && configCache.get(config)!.has(filename);
 }
 
-export function getCachedSource(config: AstroConfig, filename: string): string | null {
+export function getCachedCompileResult(
+	config: AstroConfig,
+	filename: string
+): CompileResult | null {
 	if (!isCached(config, filename)) return null;
-	let src = configCache.get(config)!.get(filename);
-	if (!src) return null;
-	return src.source;
+	return configCache.get(config)!.get(filename)!;
 }
 
 export function invalidateCompilation(config: AstroConfig, filename: string) {

--- a/packages/astro/src/core/compile/index.ts
+++ b/packages/astro/src/core/compile/index.ts
@@ -1,3 +1,8 @@
 export type { CompileProps } from './compile';
-export { cachedCompilation, getCachedSource, invalidateCompilation, isCached } from './compile.js';
+export {
+	cachedCompilation,
+	getCachedCompileResult,
+	invalidateCompilation,
+	isCached,
+} from './compile.js';
 export type { TransformStyle } from './types';

--- a/packages/astro/src/core/compile/index.ts
+++ b/packages/astro/src/core/compile/index.ts
@@ -1,8 +1,8 @@
-export type { CompileProps } from './compile';
 export {
 	cachedCompilation,
 	getCachedCompileResult,
 	invalidateCompilation,
 	isCached,
-} from './compile.js';
+} from './cache.js';
+export type { CompileProps } from './compile';
 export type { TransformStyle } from './types';

--- a/packages/astro/src/core/compile/index.ts
+++ b/packages/astro/src/core/compile/index.ts
@@ -4,5 +4,5 @@ export {
 	invalidateCompilation,
 	isCached,
 } from './cache.js';
-export type { CompileProps } from './compile';
+export type { CompileProps, CompileResult } from './compile';
 export type { TransformStyle } from './types';

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -151,6 +151,8 @@ export async function createVite(
 				},
 			],
 			conditions: ['astro'],
+			// Astro imports in third-party packages should use the same version as root
+			dedupe: ['astro'],
 		},
 		ssr: {
 			noExternal: [

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -1,10 +1,9 @@
 import { fileURLToPath } from 'url';
 import { ESBuildTransformResult, transformWithEsbuild } from 'vite';
 import { AstroConfig } from '../@types/astro';
-import { cachedCompilation, CompileProps } from '../core/compile';
-import { CompileResult } from '../core/compile/compile';
-import { LogOptions } from '../core/logger/core';
-import { getFileInfo } from '../vite-plugin-utils';
+import { cachedCompilation, CompileProps, CompileResult } from '../core/compile/index.js';
+import { LogOptions } from '../core/logger/core.js';
+import { getFileInfo } from '../vite-plugin-utils/index.js';
 
 interface CachedFullCompilation {
 	compileProps: CompileProps;
@@ -40,6 +39,7 @@ export async function cachedFullCompilation({
 		// Also, catches invalid JS/TS in the compiled output before returning.
 		esbuildResult = await transformWithEsbuild(transformResult.code, rawId, {
 			loader: 'ts',
+			target: 'esnext',
 			sourcemap: 'external',
 		});
 	} catch (err: any) {
@@ -76,7 +76,7 @@ export async function cachedFullCompilation({
 
 	return {
 		...transformResult,
-		code: esbuildResult.code,
+		code: esbuildResult.code + SUFFIX,
 		map: esbuildResult.map,
 	};
 }
@@ -101,6 +101,7 @@ async function enhanceCompileError({
 		try {
 			await transformWithEsbuild(scannedFrontmatter[1], id, {
 				loader: 'ts',
+				target: 'esnext',
 				sourcemap: false,
 			});
 		} catch (frontmatterErr: any) {

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -1,0 +1,44 @@
+import { ESBuildTransformResult, transformWithEsbuild } from 'vite';
+import { cachedCompilation, CompileProps } from '../core/compile';
+import { CompileResult } from '../core/compile/compile';
+import { getFileInfo } from '../vite-plugin-utils';
+
+interface FullCompileResult extends Omit<CompileResult, 'map'> {
+	map: ESBuildTransformResult['map'];
+}
+
+export async function cachedFullCompilation(
+	compileProps: CompileProps,
+	rawId: string
+): Promise<FullCompileResult> {
+	const transformResult = await cachedCompilation(compileProps);
+	const { fileId: file, fileUrl: url } = getFileInfo(rawId, compileProps.astroConfig);
+
+	// Compile all TypeScript to JavaScript.
+	// Also, catches invalid JS/TS in the compiled output before returning.
+	const { code, map } = await transformWithEsbuild(transformResult.code, rawId, {
+		loader: 'ts',
+		sourcemap: 'external',
+	});
+
+	let SUFFIX = '';
+	SUFFIX += `\nconst $$file = ${JSON.stringify(file)};\nconst $$url = ${JSON.stringify(
+		url
+	)};export { $$file as file, $$url as url };\n`;
+
+	// Add HMR handling in dev mode.
+	if (!compileProps.viteConfig.isProduction) {
+		let i = 0;
+		while (i < transformResult.scripts.length) {
+			SUFFIX += `import "${rawId}?astro&type=script&index=${i}&lang.ts";`;
+			i++;
+		}
+	}
+
+	// Prefer live reload to HMR in `.astro` files
+	if (!compileProps.viteConfig.isProduction) {
+		SUFFIX += `\nif (import.meta.hot) { import.meta.hot.decline() }`;
+	}
+
+	return { ...transformResult, code, map };
+}

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -1,25 +1,59 @@
+import { fileURLToPath } from 'url';
 import { ESBuildTransformResult, transformWithEsbuild } from 'vite';
+import { AstroConfig } from '../@types/astro';
 import { cachedCompilation, CompileProps } from '../core/compile';
 import { CompileResult } from '../core/compile/compile';
+import { LogOptions } from '../core/logger/core';
 import { getFileInfo } from '../vite-plugin-utils';
+
+interface CachedFullCompilation {
+	compileProps: CompileProps;
+	rawId: string;
+	logging: LogOptions;
+}
 
 interface FullCompileResult extends Omit<CompileResult, 'map'> {
 	map: ESBuildTransformResult['map'];
 }
 
-export async function cachedFullCompilation(
-	compileProps: CompileProps,
-	rawId: string
-): Promise<FullCompileResult> {
-	const transformResult = await cachedCompilation(compileProps);
-	const { fileId: file, fileUrl: url } = getFileInfo(rawId, compileProps.astroConfig);
+interface EnhanceCompilerErrorOptions {
+	err: Error;
+	id: string;
+	source: string;
+	config: AstroConfig;
+	logging: LogOptions;
+}
 
-	// Compile all TypeScript to JavaScript.
-	// Also, catches invalid JS/TS in the compiled output before returning.
-	const { code, map } = await transformWithEsbuild(transformResult.code, rawId, {
-		loader: 'ts',
-		sourcemap: 'external',
-	});
+const FRONTMATTER_PARSE_REGEXP = /^\-\-\-(.*)^\-\-\-/ms;
+
+export async function cachedFullCompilation({
+	compileProps,
+	rawId,
+	logging,
+}: CachedFullCompilation): Promise<FullCompileResult> {
+	let transformResult: CompileResult;
+	let esbuildResult: ESBuildTransformResult;
+
+	try {
+		transformResult = await cachedCompilation(compileProps);
+		// Compile all TypeScript to JavaScript.
+		// Also, catches invalid JS/TS in the compiled output before returning.
+		esbuildResult = await transformWithEsbuild(transformResult.code, rawId, {
+			loader: 'ts',
+			sourcemap: 'external',
+		});
+	} catch (err: any) {
+		await enhanceCompileError({
+			err,
+			id: rawId,
+			source: compileProps.source,
+			config: compileProps.astroConfig,
+			logging: logging,
+		});
+		throw err;
+	}
+
+	const { fileId: file, fileUrl: url } = getFileInfo(rawId, compileProps.astroConfig);
 
 	let SUFFIX = '';
 	SUFFIX += `\nconst $$file = ${JSON.stringify(file)};\nconst $$url = ${JSON.stringify(
@@ -40,5 +74,73 @@ export async function cachedFullCompilation(
 		SUFFIX += `\nif (import.meta.hot) { import.meta.hot.decline() }`;
 	}
 
-	return { ...transformResult, code, map };
+	return {
+		...transformResult,
+		code: esbuildResult.code,
+		map: esbuildResult.map,
+	};
+}
+
+async function enhanceCompileError({
+	err,
+	id,
+	source,
+	config,
+	logging,
+}: EnhanceCompilerErrorOptions): Promise<never> {
+	// Verify frontmatter: a common reason that this plugin fails is that
+	// the user provided invalid JS/TS in the component frontmatter.
+	// If the frontmatter is invalid, the `err` object may be a compiler
+	// panic or some other vague/confusing compiled error message.
+	//
+	// Before throwing, it is better to verify the frontmatter here, and
+	// let esbuild throw a more specific exception if the code is invalid.
+	// If frontmatter is valid or cannot be parsed, then continue.
+	const scannedFrontmatter = FRONTMATTER_PARSE_REGEXP.exec(source);
+	if (scannedFrontmatter) {
+		try {
+			await transformWithEsbuild(scannedFrontmatter[1], id, {
+				loader: 'ts',
+				sourcemap: false,
+			});
+		} catch (frontmatterErr: any) {
+			// Improve the error by replacing the phrase "unexpected end of file"
+			// with "unexpected end of frontmatter" in the esbuild error message.
+			if (frontmatterErr && frontmatterErr.message) {
+				frontmatterErr.message = frontmatterErr.message.replace(
+					'end of file',
+					'end of frontmatter'
+				);
+			}
+			throw frontmatterErr;
+		}
+	}
+
+	// improve compiler errors
+	if (err.stack && err.stack.includes('wasm-function')) {
+		const search = new URLSearchParams({
+			labels: 'compiler',
+			title: '🐛 BUG: `@astrojs/compiler` panic',
+			template: '---01-bug-report.yml',
+			'bug-description': `\`@astrojs/compiler\` encountered an unrecoverable error when compiling the following file.
+
+**${id.replace(fileURLToPath(config.root), '')}**
+\`\`\`astro
+${source}
+\`\`\``,
+		});
+		(err as any).url = `https://github.com/withastro/astro/issues/new?${search.toString()}`;
+		err.message = `Error: Uh oh, the Astro compiler encountered an unrecoverable error!
+
+    Please open
+    a GitHub issue using the link below:
+    ${(err as any).url}`;
+
+		if (logging.level !== 'debug') {
+			// TODO: remove stack replacement when compiler throws better errors
+			err.stack = `    at ${id}`;
+		}
+	}
+
+	throw err;
 }

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -103,7 +103,8 @@ export default function astro({ settings, logging }: AstroPluginOptions): vite.P
 				return null;
 			}
 
-			const raw = await this.resolve(parsedId.filename, undefined);
+			const filename = parsedId.filename;
+			const raw = await this.resolve(filename, undefined);
 			if (!raw) {
 				return null;
 			}

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -17,7 +17,7 @@ import { viteID } from '../core/util.js';
 import { normalizeFilename } from '../vite-plugin-utils/index.js';
 import { handleHotUpdate } from './hmr.js';
 import { parseAstroRequest, ParsedRequestResult } from './query.js';
-import { cachedFullCompilation } from './compile';
+import { cachedFullCompilation } from './compile.js';
 
 interface AstroPluginOptions {
 	settings: AstroSettings;

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -102,12 +102,18 @@ export default function astro({ settings, logging }: AstroPluginOptions): vite.P
 			if (!query.astro) {
 				return null;
 			}
+
+			const raw = await this.resolve(parsedId.filename, undefined);
+			if (!raw) {
+				return null;
+			}
+
 			// For CSS / hoisted scripts, the main Astro module should already be cached
-			const filename = normalizeFilename(parsedId.filename, config);
-			const compileResult = getCachedCompileResult(config, filename);
+			const compileResult = getCachedCompileResult(config, raw.id);
 			if (!compileResult) {
 				return null;
 			}
+
 			switch (query.type) {
 				case 'style': {
 					if (typeof query.index === 'undefined') {

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -102,19 +102,12 @@ export default function astro({ settings, logging }: AstroPluginOptions): vite.P
 			if (!query.astro) {
 				return null;
 			}
-
-			const filename = parsedId.filename;
-			const raw = await this.resolve(filename, undefined);
-			if (!raw) {
-				return null;
-			}
-
 			// For CSS / hoisted scripts, the main Astro module should already be cached
-			const compileResult = getCachedCompileResult(config, raw.id);
+			const filename = normalizeFilename(parsedId.filename, config);
+			const compileResult = getCachedCompileResult(config, filename);
 			if (!compileResult) {
 				return null;
 			}
-
 			switch (query.type) {
 				case 'style': {
 					if (typeof query.index === 'undefined') {

--- a/packages/astro/src/vite-plugin-utils/index.ts
+++ b/packages/astro/src/vite-plugin-utils/index.ts
@@ -1,7 +1,13 @@
 import ancestor from 'common-ancestor-path';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { Data } from 'vfile';
 import type { AstroConfig, MarkdownAstroData } from '../@types/astro';
-import { appendExtension, appendForwardSlash } from '../core/path.js';
+import {
+	appendExtension,
+	appendForwardSlash,
+	removeLeadingForwardSlashWindows,
+} from '../core/path.js';
 
 export function getFileInfo(id: string, config: AstroConfig) {
 	const sitePathname = appendForwardSlash(
@@ -60,9 +66,9 @@ export function safelyGetAstroData(vfileData: Data): MarkdownAstroData {
  */
 export function normalizeFilename(filename: string, config: AstroConfig) {
 	if (filename.startsWith('/@fs')) {
-		filename = filename.slice('/@fs'.length);
+		filename = removeLeadingForwardSlashWindows(filename.slice('/@fs'.length));
 	} else if (filename.startsWith('/') && !ancestor(filename, config.root.pathname)) {
-		filename = new URL('.' + filename, config.root).pathname;
+		filename = path.join(fileURLToPath(config.root), filename);
 	}
 	return filename;
 }

--- a/packages/astro/src/vite-plugin-utils/index.ts
+++ b/packages/astro/src/vite-plugin-utils/index.ts
@@ -62,13 +62,13 @@ export function safelyGetAstroData(vfileData: Data): MarkdownAstroData {
  * - /@fs/home/user/project/src/pages/index.astro
  * - /src/pages/index.astro
  *
- * as absolute file paths.
+ * as absolute file paths with forward slashes.
  */
 export function normalizeFilename(filename: string, config: AstroConfig) {
 	if (filename.startsWith('/@fs')) {
-		filename = removeLeadingForwardSlashWindows(filename.slice('/@fs'.length));
+		filename = filename.slice('/@fs'.length);
 	} else if (filename.startsWith('/') && !ancestor(filename, config.root.pathname)) {
-		filename = path.join(fileURLToPath(config.root), filename);
+		filename = new URL('.' + filename, config.root).pathname;
 	}
-	return filename;
+	return removeLeadingForwardSlashWindows(filename);
 }


### PR DESCRIPTION
## Changes

- Refactor `vite-plugin-astro` to split of core logic out of `index.ts` so they can be tested.
- Remove `/@fs` usage when compiling (uses `resolve.dedupe` to achieve this)

It's easier to review the changes by checking each commit individually.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
All existing tests should pass.


## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A. refactors.
