### PR TITLE
Support rendering `<Fragment>` in MDX `<Content />` component

### DIFF
--- a/.changeset/sweet-chairs-buy.md
+++ b/.changeset/sweet-chairs-buy.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Support use of `<Fragment>` in MDX files rendered with `<Content />` component

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -113,6 +113,7 @@ export async function renderPage(mod: ComponentInstance, ctx: RenderContext, env
 	}
 
 	// HACK: expose `Fragment` for all MDX components
+	// TODO: Remove in Astro v2 — redundant as of @astrojs/mdx@>0.12.0
 	if (typeof mod.default === 'function' && mod.default.name.startsWith('MDX')) {
 		Object.assign(pageProps, {
 			components: Object.assign((pageProps?.components as any) ?? {}, { Fragment }),

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -3,7 +3,7 @@ import type { LogOptions } from '../logger/core.js';
 import type { RenderContext } from './context.js';
 import type { Environment } from './environment.js';
 
-import { renderPage as runtimeRenderPage } from '../../runtime/server/index.js';
+import { Fragment, renderPage as runtimeRenderPage } from '../../runtime/server/index.js';
 import { attachToResponse } from '../cookies/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 import { getParams } from '../routing/params.js';
@@ -110,6 +110,13 @@ export async function renderPage(mod: ComponentInstance, ctx: RenderContext, env
 	// Support `export const components` for `MDX` pages
 	if (typeof (mod as any).components === 'object') {
 		Object.assign(pageProps, { components: (mod as any).components });
+	}
+
+	// HACK: expose `Fragment` for all MDX components
+	if (typeof mod.default === 'function' && mod.default.name.startsWith('MDX')) {
+		Object.assign(pageProps, {
+			components: Object.assign((pageProps?.components as any) ?? {}, { Fragment }),
+		});
 	}
 
 	const response = await runtimeRenderPage(

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -3,7 +3,7 @@ import type { LogOptions } from '../logger/core.js';
 import type { RenderContext } from './context.js';
 import type { Environment } from './environment.js';
 
-import { Fragment, renderPage as runtimeRenderPage } from '../../runtime/server/index.js';
+import { renderPage as runtimeRenderPage } from '../../runtime/server/index.js';
 import { attachToResponse } from '../cookies/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 import { getParams } from '../routing/params.js';
@@ -110,13 +110,6 @@ export async function renderPage(mod: ComponentInstance, ctx: RenderContext, env
 	// Support `export const components` for `MDX` pages
 	if (typeof (mod as any).components === 'object') {
 		Object.assign(pageProps, { components: (mod as any).components });
-	}
-
-	// HACK: expose `Fragment` for all MDX components
-	if (typeof mod.default === 'function' && mod.default.name.startsWith('MDX')) {
-		Object.assign(pageProps, {
-			components: Object.assign((pageProps?.components as any) ?? {}, { Fragment }),
-		});
 	}
 
 	const response = await runtimeRenderPage(

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -156,7 +156,13 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 										)}) };`;
 									}
 									if (!moduleExports.includes('Content')) {
-										code += `\nexport const Content = MDXContent;`;
+										// Make `Content` the default export so we can wrap `MDXContent` and pass in `Fragment`
+										code = code.replace('export default MDXContent;', '');
+										code += `\nexport const Content = (props = {}) => MDXContent({
+											...props,
+											components: { Fragment, ...props.components },
+										});
+										export default Content;`;
 									}
 
 									if (command === 'dev') {

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -132,10 +132,6 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 								transform(code, id) {
 									if (!id.endsWith('.mdx')) return;
 
-									// Ensures styles and scripts are injected into a `<head>`
-									// When a layout is not applied
-									code += `\nMDXContent[Symbol.for('astro.needsHeadRendering')] = !Boolean(frontmatter.layout);`;
-
 									const [, moduleExports] = parseESM(code);
 
 									const { fileUrl, fileId } = getFileInfo(id, config);
@@ -164,6 +160,10 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 										});
 										export default Content;`;
 									}
+
+									// Ensures styles and scripts are injected into a `<head>`
+									// When a layout is not applied
+									code += `\nContent[Symbol.for('astro.needsHeadRendering')] = !Boolean(frontmatter.layout);`;
 
 									if (command === 'dev') {
 										// TODO: decline HMR updates until we have a stable approach

--- a/packages/integrations/mdx/test/fixtures/mdx-component/src/components/WithFragment.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-component/src/components/WithFragment.mdx
@@ -1,3 +1,3 @@
 # MDX containing `<Fragment />`
 
-<Fragment>bar</Fragment>
+<p><Fragment>bar</Fragment></p>

--- a/packages/integrations/mdx/test/fixtures/mdx-component/src/components/WithFragment.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-component/src/components/WithFragment.mdx
@@ -1,0 +1,3 @@
+# MDX containing `<Fragment />`
+
+<Fragment>bar</Fragment>

--- a/packages/integrations/mdx/test/fixtures/mdx-component/src/pages/glob.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-component/src/pages/glob.astro
@@ -1,11 +1,20 @@
 ---
+import { parse } from 'node:path';
 const components = await Astro.glob('../components/*.mdx');
 ---
 
 <div data-default-export>
-	{components.map(Component => <Component.default />)}
+	{components.map(Component => (
+		<div data-file={parse(Component.file).base}>
+			<Component.default />
+		</div>
+	))}
 </div>
 
 <div data-content-export>
-	{components.map(({ Content }) => <Content />)}
+	{components.map(({ Content, file }) => (
+		<div data-file={parse(file).base}>
+			<Content />
+		</div>
+	))}
 </div>

--- a/packages/integrations/mdx/test/fixtures/mdx-component/src/pages/w-fragment.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-component/src/pages/w-fragment.astro
@@ -1,0 +1,5 @@
+---
+import WithFragment from '../components/WithFragment.mdx';
+---
+
+<WithFragment />

--- a/packages/integrations/mdx/test/fixtures/mdx-slots/src/components/Slotted.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-slots/src/components/Slotted.astro
@@ -1,0 +1,4 @@
+<div class="slotted">
+	<div data-default-slot><slot /></div>
+	<div data-named-slot><slot name="named" /></div>
+</div>

--- a/packages/integrations/mdx/test/fixtures/mdx-slots/src/components/Test.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-slots/src/components/Test.mdx
@@ -1,0 +1,15 @@
+import Slotted from './Slotted.astro'
+
+# Hello slotted component!
+
+<Slotted>
+
+Default content.
+
+<Fragment slot="named">
+
+Content for named slot.
+
+</Fragment>
+
+</Slotted>

--- a/packages/integrations/mdx/test/fixtures/mdx-slots/src/pages/glob.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-slots/src/pages/glob.astro
@@ -1,0 +1,11 @@
+---
+const components = await Astro.glob('../components/*.mdx');
+---
+
+<div data-default-export>
+	{components.map(Component => <Component.default />)}
+</div>
+
+<div data-content-export>
+	{components.map(({ Content }) => <Content />)}
+</div>

--- a/packages/integrations/mdx/test/fixtures/mdx-slots/src/pages/index.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-slots/src/pages/index.astro
@@ -1,0 +1,5 @@
+---
+import Test from '../components/Test.mdx';
+---
+
+<Test />

--- a/packages/integrations/mdx/test/mdx-component.test.js
+++ b/packages/integrations/mdx/test/mdx-component.test.js
@@ -51,6 +51,41 @@ describe('MDX Component', () => {
 			expect(h1.textContent).to.equal('Hello component!');
 			expect(foo.textContent).to.equal('bar');
 		});
+
+		describe('with <Fragment>', () => {
+			it('supports top-level imports', async () => {
+				const html = await fixture.readFile('/w-fragment/index.html');
+				const { document } = parseHTML(html);
+
+				const h1 = document.querySelector('h1');
+				const p = document.querySelector('p');
+
+				expect(h1.textContent).to.equal('MDX containing <Fragment />');
+				expect(p.textContent).to.equal('bar');
+			});
+
+			it('supports glob imports - <Component.default />', async () => {
+				const html = await fixture.readFile('/glob/index.html');
+				const { document } = parseHTML(html);
+
+				const h = document.querySelector('[data-default-export] [data-file="WithFragment.mdx"] h1');
+				const p = document.querySelector('[data-default-export] [data-file="WithFragment.mdx"] p');
+
+				expect(h.textContent).to.equal('MDX containing <Fragment />');
+				expect(p.textContent).to.equal('bar');
+			});
+
+			it('supports glob imports - <Content />', async () => {
+				const html = await fixture.readFile('/glob/index.html');
+				const { document } = parseHTML(html);
+
+				const h = document.querySelector('[data-content-export] [data-file="WithFragment.mdx"] h1');
+				const p = document.querySelector('[data-content-export] [data-file="WithFragment.mdx"] p');
+
+				expect(h.textContent).to.equal('MDX containing <Fragment />');
+				expect(p.textContent).to.equal('bar');
+			});
+		});
 	});
 
 	describe('dev', () => {
@@ -107,6 +142,50 @@ describe('MDX Component', () => {
 
 			expect(h1.textContent).to.equal('Hello component!');
 			expect(foo.textContent).to.equal('bar');
+		});
+
+		describe('with <Fragment>', () => {
+			it('supports top-level imports', async () => {
+				const res = await fixture.fetch('/w-fragment');
+				expect(res.status).to.equal(200);
+
+				const html = await res.text();
+				const { document } = parseHTML(html);
+
+				const h1 = document.querySelector('h1');
+				const p = document.querySelector('p');
+
+				expect(h1.textContent).to.equal('MDX containing <Fragment />');
+				expect(p.textContent).to.equal('bar');
+			});
+
+			it('supports glob imports - <Component.default />', async () => {
+				const res = await fixture.fetch('/glob');
+				expect(res.status).to.equal(200);
+
+				const html = await res.text();
+				const { document } = parseHTML(html);
+
+				const h = document.querySelector('[data-default-export] [data-file="WithFragment.mdx"] h1');
+				const p = document.querySelector('[data-default-export] [data-file="WithFragment.mdx"] p');
+
+				expect(h.textContent).to.equal('MDX containing <Fragment />');
+				expect(p.textContent).to.equal('bar');
+			});
+
+			it('supports glob imports - <Content />', async () => {
+				const res = await fixture.fetch('/glob');
+				expect(res.status).to.equal(200);
+
+				const html = await res.text();
+				const { document } = parseHTML(html);
+
+				const h = document.querySelector('[data-content-export] [data-file="WithFragment.mdx"] h1');
+				const p = document.querySelector('[data-content-export] [data-file="WithFragment.mdx"] p');
+
+				expect(h.textContent).to.equal('MDX containing <Fragment />');
+				expect(p.textContent).to.equal('bar');
+			});
 		});
 	});
 });

--- a/packages/integrations/mdx/test/mdx-slots.js
+++ b/packages/integrations/mdx/test/mdx-slots.js
@@ -1,0 +1,124 @@
+import mdx from '@astrojs/mdx';
+
+import { expect } from 'chai';
+import { parseHTML } from 'linkedom';
+import { loadFixture } from '../../../astro/test/test-utils.js';
+
+describe('MDX slots', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/mdx-slots/', import.meta.url),
+			integrations: [mdx()],
+		});
+	});
+
+	describe('build', () => {
+		before(async () => {
+			await fixture.build();
+		});
+
+		it('supports top-level imports', async () => {
+			const html = await fixture.readFile('/index.html');
+			const { document } = parseHTML(html);
+
+			const h1 = document.querySelector('h1');
+			const defaultSlot = document.querySelector('[data-default-slot]');
+			const namedSlot = document.querySelector('[data-named-slot]');
+
+			expect(h1.textContent).to.equal('Hello slotted component!');
+			expect(defaultSlot.textContent).to.equal('Default content.');
+			expect(namedSlot.textContent).to.equal('Content for named slot.');
+		});
+
+		it('supports glob imports - <Component.default />', async () => {
+			const html = await fixture.readFile('/glob/index.html');
+			const { document } = parseHTML(html);
+
+			const h1 = document.querySelector('[data-default-export] h1');
+			const defaultSlot = document.querySelector('[data-default-export] [data-default-slot]');
+			const namedSlot = document.querySelector('[data-default-export] [data-named-slot]');
+
+			expect(h1.textContent).to.equal('Hello slotted component!');
+			expect(defaultSlot.textContent).to.equal('Default content.');
+			expect(namedSlot.textContent).to.equal('Content for named slot.');
+		});
+
+		it('supports glob imports - <Content />', async () => {
+			const html = await fixture.readFile('/glob/index.html');
+			const { document } = parseHTML(html);
+
+			const h1 = document.querySelector('[data-content-export] h1');
+			const defaultSlot = document.querySelector('[data-content-export] [data-default-slot]');
+			const namedSlot = document.querySelector('[data-content-export] [data-named-slot]');
+
+			expect(h1.textContent).to.equal('Hello slotted component!');
+			expect(defaultSlot.textContent).to.equal('Default content.');
+			expect(namedSlot.textContent).to.equal('Content for named slot.');
+		});
+	});
+
+	describe('dev', () => {
+		let devServer;
+
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('supports top-level imports', async () => {
+			const res = await fixture.fetch('/');
+
+			expect(res.status).to.equal(200);
+
+			const html = await res.text();
+			const { document } = parseHTML(html);
+
+			const h1 = document.querySelector('h1');
+			const defaultSlot = document.querySelector('[data-default-slot]');
+			const namedSlot = document.querySelector('[data-named-slot]');
+
+			expect(h1.textContent).to.equal('Hello slotted component!');
+			expect(defaultSlot.textContent).to.equal('Default content.');
+			expect(namedSlot.textContent).to.equal('Content for named slot.');
+		});
+
+		it('supports glob imports - <Component.default />', async () => {
+			const res = await fixture.fetch('/glob');
+
+			expect(res.status).to.equal(200);
+
+			const html = await res.text();
+			const { document } = parseHTML(html);
+
+			const h1 = document.querySelector('[data-default-export] h1');
+			const defaultSlot = document.querySelector('[data-default-export] [data-default-slot]');
+			const namedSlot = document.querySelector('[data-default-export] [data-named-slot]');
+
+			expect(h1.textContent).to.equal('Hello slotted component!');
+			expect(defaultSlot.textContent).to.equal('Default content.');
+			expect(namedSlot.textContent).to.equal('Content for named slot.');
+		});
+
+		it('supports glob imports - <Content />', async () => {
+			const res = await fixture.fetch('/glob');
+
+			expect(res.status).to.equal(200);
+
+			const html = await res.text();
+			const { document } = parseHTML(html);
+
+			const h1 = document.querySelector('[data-content-export] h1');
+			const defaultSlot = document.querySelector('[data-content-export] [data-default-slot]');
+			const namedSlot = document.querySelector('[data-content-export] [data-named-slot]');
+
+			expect(h1.textContent).to.equal('Hello slotted component!');
+			expect(defaultSlot.textContent).to.equal('Default content.');
+			expect(namedSlot.textContent).to.equal('Content for named slot.');
+		});
+	});
+});


### PR DESCRIPTION
## Changes

- Fixes #5519 
- Wraps MDX’s default `MDXContent` render function so we can pass in our definition of `Fragment` — otherwise `Fragment` is unsupported when rendering MDX using `<Content />`
- Reverts astro core workaround from #4136 which is no longer needed because this PR fixes the general case of fragments in MDX

## Testing

Expanded the `mdx-component` fixture/test suite to include an example `WithFragment.mdx` file which we test renders as expected.

## Docs

Bug fix only, should match existing docs expectations.
