### PR TITLE
Fix tests with node 18

### DIFF
--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -73,9 +73,9 @@ export async function loadFixture(inlineConfig) {
 	// Compatible with different Node versions (https://vitejs.dev/guide/migration.html#dev-server-changes)
 	// TODO: Remove this to test in Node >= 17 where the dns resolver is verbatim
 	if (!inlineConfig?.server) {
-		inlineConfig.server = {
-			host: '127.0.0.1',
-		};
+		inlineConfig.server = { host: '127.0.0.1' };
+	} else {
+		inlineConfig.server.host = '127.0.0.1';
 	}
 
 	// load config


### PR DESCRIPTION
## Changes

Handle fetching URLs in Node 18. Node >= 17 sets the [DNS resolution](https://nodejs.org/api/dns.html#dnssetdefaultresultorderorder) to verbatim by default which changes how `localhost` resolves to `127.0.0.1` or `[::1]`.

Extra context: https://github.com/withastro/astro/pull/5266#discussion_r1013166899

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
All tests should pass. This should also make vite-ecosystem-ci pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A