### PR TITLE
Mark image integration release as a patch

### DIFF
--- a/.changeset/eight-deers-repair.md
+++ b/.changeset/eight-deers-repair.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/image': minor
+'@astrojs/image': patch
 ---
 
 Allows passing alt to getPicture


### PR DESCRIPTION
## Changes

- Mark the next image integration release as a patch instead of a minor

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
