### PR TITLE
Exclude astro from Vite optimization

### DIFF
--- a/.changeset/chilled-papayas-build.md
+++ b/.changeset/chilled-papayas-build.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Exclude astro from Vite optimization

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -93,7 +93,7 @@ export async function createVite(
 		appType: 'custom',
 		optimizeDeps: {
 			entries: ['src/**/*'],
-			exclude: ['node-fetch'],
+			exclude: ['astro', 'node-fetch'],
 		},
 		plugins: [
 			configAliasVitePlugin({ settings }),


### PR DESCRIPTION
## Changes

The Astro package and subpaths shouldn't be prebundled as they are node-only, Astro components, types, or internal files.

Fixes https://github.com/withastro/astro/issues/5517 but short-term only. The better approach which I can do soon is to have Vite's scanner recognize `---` as searches imports there. That way we can set the `optimizeDeps.entries` as `src/pages/**/*` and it should work properly.

The issue with #5517 is that they put config subfiles in `src` and that makes Vite prebundle the scanned dependencies (which are almost always not used)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested locally with the repro in #5517. Realistically someone shouldn't import `astro` in their codebase but it could happen indirectly like in the issue.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a bug fix