### PR TITLE
astro-rss: Generate feed with proper XML escaping

### DIFF
--- a/.changeset/hungry-snakes-live.md
+++ b/.changeset/hungry-snakes-live.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': patch
+---
+
+Generate RSS feed with proper XML escaping

--- a/packages/astro-rss/package.json
+++ b/packages/astro-rss/package.json
@@ -31,6 +31,7 @@
     "astro-scripts": "workspace:*",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
+    "chai-xml": "^0.4.0",
     "mocha": "^9.2.2"
   },
   "dependencies": {

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -1,4 +1,4 @@
-import { XMLValidator } from 'fast-xml-parser';
+import { XMLBuilder, XMLParser } from 'fast-xml-parser';
 import { createCanonicalURL, isValidURL } from './util.js';
 
 type GlobResult = Record<string, () => Promise<{ [key: string]: any }>>;
@@ -100,15 +100,17 @@ export default async function getRSS(rssOptions: RSSOptions) {
 /** Generate RSS 2.0 feed */
 export async function generateRSS({ rssOptions, items }: GenerateRSSArgs): Promise<string> {
 	const { site } = rssOptions;
-	let xml = `<?xml version="1.0" encoding="UTF-8"?>`;
+	const xmlOptions = { ignoreAttributes: false };
+	const parser = new XMLParser(xmlOptions);
+	const root: any = { '?xml': { '@_version': '1.0', '@_encoding': 'UTF-8' } };
 	if (typeof rssOptions.stylesheet === 'string') {
-		xml += `<?xml-stylesheet href="${rssOptions.stylesheet}" type="text/xsl"?>`;
+		root['?xml-stylesheet'] = { '@_href': rssOptions.stylesheet, '@_encoding': 'UTF-8' };
 	}
-	xml += `<rss version="2.0"`;
+	root.rss = { '@_version': '2.0' };
 	if (items.find((result) => result.content)) {
 		// the namespace to be added to the xmlns:content attribute to enable the <content> RSS feature
 		const XMLContentNamespace = 'http://purl.org/rss/1.0/modules/content/';
-		xml += ` xmlns:content="${XMLContentNamespace}"`;
+		root.rss['@_xmlns:content'] = XMLContentNamespace;
 		// Ensure that the user hasn't tried to manually include the necessary namespace themselves
 		if (rssOptions.xmlns?.content && rssOptions.xmlns.content === XMLContentNamespace) {
 			delete rssOptions.xmlns.content;
@@ -118,29 +120,36 @@ export async function generateRSS({ rssOptions, items }: GenerateRSSArgs): Promi
 	// xmlns
 	if (rssOptions.xmlns) {
 		for (const [k, v] of Object.entries(rssOptions.xmlns)) {
-			xml += ` xmlns:${k}="${v}"`;
+			root.rss[`@_xmlns:${k}`] = v;
 		}
 	}
-	xml += `>`;
-	xml += `<channel>`;
 
 	// title, description, customData
-	xml += `<title><![CDATA[${rssOptions.title}]]></title>`;
-	xml += `<description><![CDATA[${rssOptions.description}]]></description>`;
-	xml += `<link>${createCanonicalURL(site).href}</link>`;
-	if (typeof rssOptions.customData === 'string') xml += rssOptions.customData;
+	root.rss.channel = {
+		title: rssOptions.title,
+		description: rssOptions.description,
+		link: createCanonicalURL(site).href,
+	};
+	if (typeof rssOptions.customData === 'string')
+		Object.assign(
+			root.rss.channel,
+			parser.parse(`<channel>${rssOptions.customData}</channel>`).channel
+		);
 	// items
-	for (const result of items) {
+	root.rss.channel.item = items.map((result) => {
 		validate(result);
-		xml += `<item>`;
-		xml += `<title><![CDATA[${result.title}]]></title>`;
 		// If the item's link is already a valid URL, don't mess with it.
 		const itemLink = isValidURL(result.link)
 			? result.link
 			: createCanonicalURL(result.link, site).href;
-		xml += `<link>${itemLink}</link>`;
-		xml += `<guid>${itemLink}</guid>`;
-		if (result.description) xml += `<description><![CDATA[${result.description}]]></description>`;
+		const item: any = {
+			title: result.title,
+			link: itemLink,
+			guid: itemLink,
+		};
+		if (result.description) {
+			item.description = result.description;
+		}
 		if (result.pubDate) {
 			// note: this should be a Date, but if user provided a string or number, we can work with that, too.
 			if (typeof result.pubDate === 'number' || typeof result.pubDate === 'string') {
@@ -148,26 +157,18 @@ export async function generateRSS({ rssOptions, items }: GenerateRSSArgs): Promi
 			} else if (result.pubDate instanceof Date === false) {
 				throw new Error('[${filename}] rss.item().pubDate must be a Date');
 			}
-			xml += `<pubDate>${result.pubDate.toUTCString()}</pubDate>`;
+			item.pubDate = result.pubDate.toUTCString();
 		}
 		// include the full content of the post if the user supplies it
 		if (typeof result.content === 'string') {
-			xml += `<content:encoded><![CDATA[${result.content}]]></content:encoded>`;
+			item['content:encoded'] = result.content;
 		}
-		if (typeof result.customData === 'string') xml += result.customData;
-		xml += `</item>`;
-	}
+		if (typeof rssOptions.customData === 'string')
+			Object.assign(item, parser.parse(`<item>${rssOptions.customData}</item>`).item);
+		return item;
+	});
 
-	xml += `</channel></rss>`;
-
-	// validate user’s inputs to see if it’s valid XML
-	const isValid = XMLValidator.validate(xml);
-	if (isValid !== true) {
-		// If valid XML, isValid will be `true`. Otherwise, this will be an error object. Throw.
-		throw new Error(isValid as any);
-	}
-
-	return xml;
+	return new XMLBuilder(xmlOptions).build(root);
 }
 
 const requiredFields = Object.freeze(['link', 'title']);

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -1,8 +1,10 @@
 import rss from '../dist/index.js';
 import chai from 'chai';
 import chaiPromises from 'chai-as-promised';
+import chaiXml from 'chai-xml';
 
 chai.use(chaiPromises);
+chai.use(chaiXml);
 
 const title = 'My RSS feed';
 const description = 'This sure is a nice RSS feed';
@@ -49,7 +51,7 @@ describe('rss', () => {
 			site,
 		});
 
-		chai.expect(body).to.equal(validXmlResult);
+		chai.expect(body).xml.to.equal(validXmlResult);
 	});
 
 	it('should generate on valid RSSFeedItem array with HTML content included', async () => {
@@ -60,7 +62,7 @@ describe('rss', () => {
 			site,
 		});
 
-		chai.expect(body).to.equal(validXmlWithContentResult);
+		chai.expect(body).xml.to.equal(validXmlWithContentResult);
 	});
 
 	describe('glob result', () => {
@@ -97,7 +99,7 @@ describe('rss', () => {
 				site,
 			});
 
-			chai.expect(body).to.equal(validXmlResult);
+			chai.expect(body).xml.to.equal(validXmlResult);
 		});
 
 		it('should fail on missing "title" key', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -590,6 +590,7 @@ importers:
       astro-scripts: workspace:*
       chai: ^4.3.6
       chai-as-promised: ^7.1.1
+      chai-xml: ^0.4.0
       fast-xml-parser: ^4.0.8
       mocha: ^9.2.2
     dependencies:
@@ -602,6 +603,7 @@ importers:
       astro-scripts: link:../../scripts
       chai: 4.3.7
       chai-as-promised: 7.1.1_chai@4.3.7
+      chai-xml: 0.4.0_chai@4.3.7
       mocha: 9.2.2
 
   packages/astro/e2e/fixtures/_deps/astro-linked-lib:
@@ -10969,6 +10971,16 @@ packages:
     dependencies:
       chai: 4.3.7
       check-error: 1.0.2
+    dev: true
+
+  /chai-xml/0.4.0_chai@4.3.7:
+    resolution: {integrity: sha512-VjFPW64Hcp9CuuZbAC26cBWi+DPhyWOW8yxNpfQX3W+jQLPJxN/sm5FAaW+FOKTzsNeIFQpt5yhGbZA5s/pEyg==}
+    engines: {node: '>= 0.8.0'}
+    peerDependencies:
+      chai: '>=1.10.0 '
+    dependencies:
+      chai: 4.3.7
+      xml2js: 0.4.23
     dev: true
 
   /chai/4.3.7:


### PR DESCRIPTION
## Changes

Generating XML using string concatenation is dangerous and can lead to underescaping.

Just to preemptively dismiss some excuses for this unsafety 😛:

- _“But most of the content was surrounded with with `<![CDATA[…]]>`, so it was fine!”_ Wrong. The content might contain `]]>` itself and break out of the `<![CDATA[` early.
- _“But URLs don’t need to be escaped, so it was fine!”_ Wrong. `&` commonly appears in URLs and needs to be escaped for XML or HTML serialization.
- _“But we were validating the output XML, so it was fine!”_ Wrong. A bug that’s caught at generation time is still a bug; also, some cases of underescaping could lead to incorrect output that isn’t invalid.
- _“But there’s no user-generated content for an attacker to control, so it was fine!”_ Wrong. Underescaping is still a bug even when it’s not a security vulnerability.

So let’s take the `fast-xml-parser` library that we were using to validate our hand-rolled XML, and use it to properly generate XML instead.

## Testing

I updated the existing tests to compare the XML using `chai-xml`, so that the snapshotted XML strings didn’t need to change. This verifies that the new output is semantically equivalent.

## Docs

This doesn’t need any documentation changes. I even preserve support for the existing `customData` option by parsing and re-serializing the XML string.