### PR TITLE
Fix Astro.params not having values when using base in SSR

### DIFF
--- a/.changeset/fast-carpets-float.md
+++ b/.changeset/fast-carpets-float.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix Astro.params not having values when using base in SSR

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -168,7 +168,7 @@ export class App {
 		status = 200
 	): Promise<Response> {
 		const url = new URL(request.url);
-		const manifest = this.#manifest;
+		const pathname = '/' + this.removeBase(url.pathname);
 		const info = this.#routeDataToRouteInfo.get(routeData!)!;
 		const links = createLinkStylesheetElementSet(info.links);
 
@@ -190,7 +190,7 @@ export class App {
 			const ctx = createRenderContext({
 				request,
 				origin: url.origin,
-				pathname: url.pathname,
+				pathname,
 				scripts,
 				links,
 				route: routeData,
@@ -215,12 +215,13 @@ export class App {
 		status = 200
 	): Promise<Response> {
 		const url = new URL(request.url);
+		const pathname = '/' + this.removeBase(url.pathname);
 		const handler = mod as unknown as EndpointHandler;
 
 		const ctx = createRenderContext({
 			request,
 			origin: url.origin,
-			pathname: url.pathname,
+			pathname,
 			route: routeData,
 			status,
 		});

--- a/packages/astro/test/fixtures/ssr-params/package.json
+++ b/packages/astro/test/fixtures/ssr-params/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/ssr-params",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/ssr-params/src/pages/[category].astro
+++ b/packages/astro/test/fixtures/ssr-params/src/pages/[category].astro
@@ -1,0 +1,12 @@
+---
+const { category } = Astro.params
+---
+<html>
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<h1>Testing</h1>
+		<h2 class="category">{ category }</h2>
+	</body>
+</html>

--- a/packages/astro/test/ssr-params.test.js
+++ b/packages/astro/test/ssr-params.test.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+import testAdapter from './test-adapter.js';
+
+describe('Astro.params in SSR', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/ssr-params/',
+			adapter: testAdapter(),
+			output: 'server',
+			base: '/users/houston/',
+		});
+		await fixture.build();
+	});
+
+	it('Params are passed to component', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		const request = new Request('http://example.com/users/houston/food');
+		const response = await app.render(request);
+		expect(response.status).to.equal(200);
+		const html = await response.text();
+		const $ = cheerio.load(html);
+		expect($('.category').text()).to.equal('food');
+	});
+
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2280,6 +2280,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/ssr-params:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/ssr-partytown:
     specifiers:
       '@astrojs/partytown': workspace:*
@@ -18434,7 +18440,7 @@ packages:
         optional: true
     dependencies:
       '@types/node': 18.11.9
-      esbuild: 0.15.18
+      esbuild: 0.15.14
       postcss: 8.4.19
       resolve: 1.22.1
       rollup: 2.79.1


### PR DESCRIPTION
## Changes

- Internal rendering expects `pathname` to be trimmed of the base because routing is not aware of base.
- Fix is to provide the pathname without base to rendering.
- `url.pathname` is still the real pathname. The other `pathname` is just used for internal route/param matching and not provided to the user.
- Fixes https://github.com/withastro/astro/issues/5537

## Testing

- New test case added

## Docs

N/A, bug fix