### PR TITLE
Add Astro.joinBase

### DIFF
--- a/.changeset/good-balloons-add.md
+++ b/.changeset/good-balloons-add.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Adds Astro.joinBase

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -100,7 +100,7 @@
     "test:e2e:match": "playwright test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.30.0",
+    "@astrojs/compiler": "0.0.0-join-base-20221208164627",
     "@astrojs/language-server": "^0.28.3",
     "@astrojs/markdown-remark": "^1.1.3",
     "@astrojs/telemetry": "^1.0.1",

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -126,6 +126,31 @@ export interface AstroGlobal<Props extends Record<string, any> = Record<string, 
 	 * [Astro reference](https://docs.astro.build/en/reference/api-reference/#url)
 	 */
 	url: AstroSharedContext['url'];
+	/**
+	 * Create a URL path that is joined to your `base` configuration.
+	 * 
+	 * Example config:
+	 * 
+	 * ```js
+	 * export default {
+	 *   base: '/blog/'
+	 * }
+	 * ```
+	 * 
+	 * Example usage:
+	 * 
+	 * ```astro
+	 * <img src={Astro.joinBase('/images/penguin.png')} />
+	 * ```
+	 * 
+	 * Will produce this HTML:
+	 * 
+	 * ```html
+	 * <img src="/blog/images/penguin.png" />
+	 * ```
+	 * @param path 
+	 */
+	joinBase(path: `/${string}`): string,
 	/** Parameters passed to a dynamic page generated using [getStaticPaths](https://docs.astro.build/en/reference/api-reference/#getstaticpaths)
 	 *
 	 * Example usage:

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -56,6 +56,7 @@ export class App {
 		this.#routeDataToRouteInfo = new Map(manifest.routes.map((route) => [route.routeData, route]));
 		this.#env = createEnvironment({
 			adapterName: manifest.adapterName,
+			base: manifest.base ?? '/',
 			logging: this.#logging,
 			markdown: manifest.markdown,
 			mode: 'production',

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -328,6 +328,7 @@ async function generatePath(
 	);
 	const env = createEnvironment({
 		adapterName: undefined,
+		base: settings.config.base,
 		logging,
 		markdown: {
 			...settings.config.markdown,

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -89,6 +89,7 @@ export async function renderPage(mod: ComponentInstance, ctx: RenderContext, env
 
 	const result = createResult({
 		adapterName: env.adapterName,
+		base: env.base,
 		links: ctx.links,
 		styles: ctx.styles,
 		logging: env.logging,

--- a/packages/astro/src/core/render/dev/environment.ts
+++ b/packages/astro/src/core/render/dev/environment.ts
@@ -20,6 +20,7 @@ export function createDevelopmentEnvironment(
 	const mode: RuntimeMode = 'development';
 	let env = createEnvironment({
 		adapterName: settings.adapter?.name,
+		base: settings.config.base,
 		logging,
 		markdown: {
 			...settings.config.markdown,

--- a/packages/astro/src/core/render/environment.ts
+++ b/packages/astro/src/core/render/environment.ts
@@ -10,6 +10,7 @@ import { RouteCache } from './route-cache.js';
  */
 export interface Environment {
 	adapterName?: string;
+	base: string;
 	/** logging options */
 	logging: LogOptions;
 	markdown: MarkdownRenderingOptions;
@@ -37,6 +38,7 @@ export function createBasicEnvironment(options: CreateBasicEnvironmentArgs): Env
 	const mode = options.mode ?? 'development';
 	return createEnvironment({
 		...options,
+		base: '/',
 		markdown: options.markdown ?? {},
 		mode,
 		renderers: options.renderers ?? [],

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -17,6 +17,7 @@ import { AstroError, AstroErrorData } from '../errors/index.js';
 import { LogOptions, warn } from '../logger/core.js';
 import { isScriptRequest } from './script.js';
 import { isCSSRequest } from './util.js';
+import { prependForwardSlash, removeTrailingForwardSlash, removeLeadingForwardSlash } from '../path.js';
 
 const clientAddressSymbol = Symbol.for('astro.clientAddress');
 
@@ -31,6 +32,7 @@ function onlyAvailableInSSR(name: 'Astro.redirect') {
 
 export interface CreateResultArgs {
 	adapterName: string | undefined;
+	base: string;
 	ssr: boolean;
 	logging: LogOptions;
 	origin: string;
@@ -127,7 +129,7 @@ class Slots {
 let renderMarkdown: any = null;
 
 export function createResult(args: CreateResultArgs): SSRResult {
-	const { markdown, params, pathname, renderers, request, resolve } = args;
+	const { base, markdown, params, pathname, renderers, request, resolve } = args;
 
 	const url = new URL(request.url);
 	const headers = new Headers();
@@ -196,6 +198,13 @@ export function createResult(args: CreateResultArgs): SSRResult {
 				props,
 				request,
 				url,
+				joinBase(path) {
+					return prependForwardSlash(
+						removeLeadingForwardSlash(removeTrailingForwardSlash(base)) +
+						'/' +
+						removeLeadingForwardSlash(path)
+					);
+				},
 				redirect: args.ssr
 					? (path, status) => {
 							return new Response(null, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,7 +373,7 @@ importers:
 
   packages/astro:
     specifiers:
-      '@astrojs/compiler': ^0.30.0
+      '@astrojs/compiler': 0.0.0-join-base-20221208164627
       '@astrojs/language-server': ^0.28.3
       '@astrojs/markdown-remark': ^1.1.3
       '@astrojs/telemetry': ^1.0.1
@@ -471,7 +471,7 @@ importers:
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
-      '@astrojs/compiler': 0.30.0
+      '@astrojs/compiler': 0.0.0-join-base-20221208164627
       '@astrojs/language-server': 0.28.3
       '@astrojs/markdown-remark': link:../markdown/remark
       '@astrojs/telemetry': link:../telemetry
@@ -3904,12 +3904,12 @@ packages:
       sisteransi: 1.0.5
     dev: false
 
+  /@astrojs/compiler/0.0.0-join-base-20221208164627:
+    resolution: {integrity: sha512-ZARaC1LiKy5L1D+cq4lZk5Np6mn85WQmJiojM3IZw7bd4VN8Wu543vQNV3gD+SIuw1ENZ6J3yDiNZyML2x8w4w==}
+    dev: false
+
   /@astrojs/compiler/0.29.15:
     resolution: {integrity: sha512-vicPD8oOPNkcFZvz71Uz/nJcadovurUQ3L0yMZNPb6Nn6T1nHhlSHt5nAKaurB2pYU9DrxOFWZS2/RdV+JsWmQ==}
-
-  /@astrojs/compiler/0.30.0:
-    resolution: {integrity: sha512-av2HV5NuyzI5E12hpn4k7XNEHbfF81/JUISPu6CclC5yKCxTS7z64hRU68tA8k7dYLATcxvjQtvN2H/dnxHaMw==}
-    dev: false
 
   /@astrojs/language-server/0.28.3:
     resolution: {integrity: sha512-fPovAX/X46eE2w03jNRMpQ7W9m2mAvNt4Ay65lD9wl1Z5vIQYxlg7Enp9qP225muTr4jSVB5QiLumFJmZMAaVA==}


### PR DESCRIPTION
Note that this PR is **just an experiment**. If it is successful then this might become an RFC. 

## Motivation

This PR is intended to aid when using `base` configuration in Astro. A common issue is that because Astro does not mutate your templates when you set things like `<a href=` or `<img src=`, you have to remember to include the base yourself. This raises the problem of what do you do if your base changes? Or if it is dynamic per-environment?

### Astro.joinBase

With this PR there is a new utility method `Astro.joinBase`. With this method you simply pass it in a path (starting with a `/`) and it will join your base onto it. Here's an example usage:

```astro
---
const contactsLink = Astro.joinBase('/contacts');
---

<a href={contactsLink}>Contacts page</a>
```

When using the base of `/docs/` that will produce `/docs/contacts`.

### join-base: directive

However, since this is so commonly needed inside of the template this change also includes a directive `join-base:` which is used within your template to get the same effect, but without needing to create an expression and call the function.

Here's the same example but used with the directive:

```astro
<a join-base:href="/contacts">Contacts page</a>
```

## Example

This Stackblitz demonstrates usage: https://stackblitz.com/edit/github-lzehwm?file=astro.config.mjs,src%2Fpages%2Findex.astro,src%2Fpages%2Fabout.astro&on=stackblitz

## Installation

This change is in preview. You can install with a special prerelease tag:

```shell
npm install astro@next--join-base
```

## Changes

- Adds `Astro.joinBase` which is created in the Astro global.
  - Note that this problem can/should be created as the top-level global instead.
- Updates the compiler which includes `join-base:` directive.

## Testing

- None yet. Compiler has a test

## Docs

- Docs added in Astro types
- Need to update types for the directive
- Needs real docs on the site, obviously