### PR TITLE
Node: better serverEntrypoint error

### DIFF
--- a/.changeset/nice-pens-lie.md
+++ b/.changeset/nice-pens-lie.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Improve error message when serverEntrypoint does not exist

--- a/packages/integrations/node/src/preview.ts
+++ b/packages/integrations/node/src/preview.ts
@@ -26,7 +26,7 @@ const preview: CreatePreviewServer = async function ({
 		}
 	} catch (_err) {
 		throw new Error(
-			`The server entrypoint ${fileURLToPath} does not exist. Have you ran a build yet?`
+			`The server entrypoint ${fileURLToPath(serverEntrypoint)} does not exist. Have you ran a build yet?`
 		);
 	}
 

--- a/packages/integrations/node/src/preview.ts
+++ b/packages/integrations/node/src/preview.ts
@@ -24,10 +24,14 @@ const preview: CreatePreviewServer = async function ({
 				`The server entrypoint doesn't have a handler. Are you sure this is the right file?`
 			);
 		}
-	} catch (_err) {
-		throw new Error(
-			`The server entrypoint ${fileURLToPath(serverEntrypoint)} does not exist. Have you ran a build yet?`
-		);
+	} catch (err) {
+		if ((err as any).code === 'ERR_MODULE_NOT_FOUND') {
+			throw new Error(
+				`The server entrypoint ${fileURLToPath(serverEntrypoint)} does not exist. Have you ran a build yet?`
+			);
+		} else {
+			throw err;
+		}
 	}
 
 	const handler: http.RequestListener = (req, res) => {


### PR DESCRIPTION
## Changes

- We were accidentally logging `${fileURLToPath}` instead of `${fileURLToPath(serverEntrypoint)}`

## Testing

Tested manually

## Docs

N/A, bug fix only