### PR TITLE
Add `server.headers` option

### DIFF
--- a/.changeset/light-moose-attend.md
+++ b/.changeset/light-moose-attend.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Add `server.headers` option

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'url';
 import { z } from 'zod';
 import { appendForwardSlash, prependForwardSlash, trimSlashes } from '../path.js';
 import { isObject } from '../util.js';
+import { OutgoingHttpHeaders } from 'http';
 
 const ASTRO_CONFIG_DEFAULTS: AstroUserConfig & any = {
 	root: '.',
@@ -125,6 +126,7 @@ export const AstroConfigSchema = z.object({
 					.optional()
 					.default(ASTRO_CONFIG_DEFAULTS.server.host),
 				port: z.number().optional().default(ASTRO_CONFIG_DEFAULTS.server.port),
+				headers: z.custom<OutgoingHttpHeaders>().optional(),
 			})
 			.optional()
 			.default({})
@@ -287,6 +289,7 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: URL) {
 						.optional()
 						.default(ASTRO_CONFIG_DEFAULTS.server.host),
 					port: z.number().optional().default(ASTRO_CONFIG_DEFAULTS.server.port),
+					headers: z.custom<OutgoingHttpHeaders>().optional(),
 					streaming: z.boolean().optional().default(true),
 				})
 				.optional()

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -65,7 +65,7 @@ export async function createContainer(params: CreateContainerParams = {}): Promi
 		logging,
 		isRestart,
 	});
-	const { host } = settings.config.server;
+	const { host, headers } = settings.config.server;
 
 	// The client entrypoint for renderers. Since these are imported dynamically
 	// we need to tell Vite to preoptimize them.
@@ -76,7 +76,7 @@ export async function createContainer(params: CreateContainerParams = {}): Promi
 	const viteConfig = await createVite(
 		{
 			mode: 'development',
-			server: { host },
+			server: { host, headers },
 			optimizeDeps: {
 				include: rendererClientEntries,
 			},

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -24,10 +24,10 @@ export default async function preview(
 	});
 	await runHookConfigDone({ settings: settings, logging: logging });
 	const host = getResolvedHostForHttpServer(settings.config.server.host);
-	const { port } = settings.config.server;
+	const { port, headers } = settings.config.server;
 
 	if (settings.config.output === 'static') {
-		const server = await createStaticPreviewServer(settings, { logging, host, port });
+		const server = await createStaticPreviewServer(settings, { logging, host, port, headers });
 		return server;
 	}
 	if (!settings.adapter) {

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -144,6 +144,11 @@ export async function handleRoute(
 		clientAddress: buildingToSSR ? req.socket.remoteAddress : undefined,
 	});
 
+	// Set user specified headers to response object.
+	for (const [name, value] of Object.entries(config.server.headers ?? {})) {
+		if (value) res.setHeader(name, value);
+	}
+
 	// attempt to get static paths
 	// if this fails, we have a bad URL match!
 	const paramsAndPropsRes = await getParamsAndProps({

--- a/packages/astro/test/astro-dev-headers.test.js
+++ b/packages/astro/test/astro-dev-headers.test.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import { loadFixture } from './test-utils.js';
+
+describe('Astro dev headers', () => {
+	let fixture;
+	let devServer;
+	const headers = {
+		'x-astro': 'test',
+	};
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/astro-dev-headers/',
+			server: {
+				headers,
+			},
+		});
+		await fixture.build();
+		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer.stop();
+	});
+
+	describe('dev', () => {
+		it('returns custom headers for valid URLs', async () => {
+			const result = await fixture.fetch('/');
+			expect(result.status).to.equal(200);
+			expect(Object.fromEntries(result.headers)).to.include(headers);
+		});
+
+		it('does not return custom headers for invalid URLs', async () => {
+			const result = await fixture.fetch('/bad-url');
+			expect(result.status).to.equal(404);
+			expect(Object.fromEntries(result.headers)).not.to.include(headers);
+		});
+	});
+});

--- a/packages/astro/test/astro-preview-headers.test.js
+++ b/packages/astro/test/astro-preview-headers.test.js
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import { loadFixture } from './test-utils.js';
+
+describe('Astro preview headers', () => {
+	let fixture;
+	let previewServer;
+	const headers = {
+		astro: 'test',
+	};
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/astro-preview-headers/',
+			server: {
+				headers,
+			},
+		});
+		await fixture.build();
+		previewServer = await fixture.preview();
+	});
+
+	// important: close preview server (free up port and connection)
+	after(async () => {
+		await previewServer.stop();
+	});
+
+	describe('preview', () => {
+		it('returns custom headers for valid URLs', async () => {
+			const result = await fixture.fetch('/');
+			expect(result.status).to.equal(200);
+			expect(Object.fromEntries(result.headers)).to.include(headers);
+		});
+
+		it('does not return custom headers for invalid URLs', async () => {
+			const result = await fixture.fetch('/bad-url');
+			expect(result.status).to.equal(404);
+			expect(Object.fromEntries(result.headers)).not.to.include(headers);
+		});
+	});
+});

--- a/packages/astro/test/fixtures/astro-dev-headers/package.json
+++ b/packages/astro/test/fixtures/astro-dev-headers/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/astro-dev-headers",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/astro-dev-headers/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-dev-headers/src/pages/index.astro
@@ -1,0 +1,8 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>Hello world!</h1>
+  </body>
+</html>
+

--- a/packages/astro/test/fixtures/astro-preview-headers/package.json
+++ b/packages/astro/test/fixtures/astro-preview-headers/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/astro-preview-headers",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/astro-preview-headers/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-preview-headers/src/pages/index.astro
@@ -1,0 +1,8 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>Hello world!</h1>
+  </body>
+</html>
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1288,6 +1288,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/astro-dev-headers:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/astro-directives:
     specifiers:
       astro: workspace:*
@@ -1513,6 +1519,12 @@ importers:
       astro: link:../../..
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+
+  packages/astro/test/fixtures/astro-preview-headers:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
 
   packages/astro/test/fixtures/astro-public:
     specifiers:


### PR DESCRIPTION
With this new `server.headers` option, the users can specify custom headers for `astro dev` and `astro preview` servers.

This is useful when they want to build a website requiring specific response headers such as `Cross-Origin-Opener-Policy`.

## Changes

Adding a new `server.headers` option to allow the users to specify HTTP response headers for both `astro dev` and `astro preview`.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Added new unit tests for both `astro dev` and `astro preview`.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This document should be updated: https://docs.astro.build/en/reference/configuration-reference/#server-options