### PR TITLE
Update deno integration dependencies

### DIFF
--- a/packages/integrations/deno/README.md
+++ b/packages/integrations/deno/README.md
@@ -130,7 +130,7 @@ export default defineConfig({
 If you disable this, you need to write your own Deno web server. Import and call `handle` from the generated entry script to render requests:
 
 ```ts
-import { serve } from "https://deno.land/std@0.132.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.167.0/http/server.ts";
 import { handle } from './dist/entry.mjs';
 
 serve((req: Request) => {

--- a/packages/integrations/deno/src/server.ts
+++ b/packages/integrations/deno/src/server.ts
@@ -2,7 +2,7 @@
 import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
 // @ts-ignore
-import { Server } from 'https://deno.land/std@0.132.0/http/server.ts';
+import { Server } from 'https://deno.land/std@0.167.0/http/server.ts';
 // @ts-ignore
 import { fetch } from 'https://deno.land/x/file_fetch/mod.ts';
 


### PR DESCRIPTION
## Changes
- Bumps the `deno_std` dependency to be up to date

## Testing
- No new tests are required since we are just changing the dependency version

## Docs
- I have also updated the dependency in the docs
