### PR TITLE
Updated magic-string to 0.27.0

### DIFF
--- a/.changeset/ten-books-burn.md
+++ b/.changeset/ten-books-burn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updated magic-string to 0.27.0

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -132,7 +132,7 @@
     "html-escaper": "^3.0.3",
     "import-meta-resolve": "^2.1.0",
     "kleur": "^4.1.4",
-    "magic-string": "^0.25.9",
+    "magic-string": "^0.27.0",
     "mime": "^3.0.0",
     "ora": "^6.1.0",
     "path-browserify": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,7 +431,7 @@ importers:
       html-escaper: ^3.0.3
       import-meta-resolve: ^2.1.0
       kleur: ^4.1.4
-      magic-string: ^0.25.9
+      magic-string: ^0.27.0
       memfs: ^3.4.7
       mime: ^3.0.0
       mocha: ^9.2.2
@@ -503,7 +503,7 @@ importers:
       html-escaper: 3.0.3
       import-meta-resolve: 2.1.0
       kleur: 4.1.5
-      magic-string: 0.25.9
+      magic-string: 0.27.0
       mime: 3.0.0
       ora: 6.1.2
       path-browserify: 1.0.1
@@ -14434,6 +14434,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       sourcemap-codec: 1.4.8
+    dev: false
+
+  /magic-string/0.27.0:
+    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.14
     dev: false
 
   /make-dir/3.1.0:


### PR DESCRIPTION
## Changes

- Updates magic-string to 0.27.0

## Testing

Magic-string is used in vite-plugin-env, vite-plugin-html and vite-plugin-scripts. Tests for it pass locally.

## Docs

Update, shouldn't change anything. 


Related to issue #5555 . Library used a version newer than astro so I had to explicitly install it, it was bad DX and took a little bit to figure out.