### PR TITLE
Update contributing guide test-running examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,9 +61,12 @@ DEBUG=vite:[name] astro dev   # debug specific process, e.g. "vite:deps" or "vit
 ```shell
 # run this in the top-level project root to run all tests
 pnpm run test
-# run only a few tests, great for working on a single feature
-# (example - `pnpm run test:match "RSS"` runs `astro-rss.test.js`)
+# run only a few tests in the `astro` package, great for working on a single feature
+# (example - `pnpm run test:match "cli"` runs `cli.test.js`)
 pnpm run test:match "$STRING_MATCH"
+# run tests on another package
+# (example - `pnpm --filter @astrojs/rss run test` runs `packages/astro-rss/test/rss.test.js`)
+pnpm --filter $STRING_MATCH run test
 ```
 
 #### E2E tests


### PR DESCRIPTION
Existing example doesn’t work because RSS is handled in a separate package. (See [Discord](https://discord.com/channels/830184174198718474/845430950191038464/1051964090853117993).)

## Changes

This is a simple Markdown edit that changes `pnpm run test:match` example to one that works, adds an example of package filtering using that previous RSS case.

## Testing

Example commands were tested locally, but there’s too much irony in the fact that I can’t test the docs related to testing.

## Docs

This _is_ a documentation update. 😎 