### PR TITLE
Fix missing RSS item `customData`

### DIFF
--- a/.changeset/ninety-socks-chew.md
+++ b/.changeset/ninety-socks-chew.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': minor
+---
+
+Fixes a bug that prevented an item’s `customData` from being included.

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -163,8 +163,9 @@ export async function generateRSS({ rssOptions, items }: GenerateRSSArgs): Promi
 		if (typeof result.content === 'string') {
 			item['content:encoded'] = result.content;
 		}
-		if (typeof rssOptions.customData === 'string')
-			Object.assign(item, parser.parse(`<item>${rssOptions.customData}</item>`).item);
+		if (typeof result.customData === 'string') {
+			Object.assign(item, parser.parse(`<item>${result.customData}</item>`).item);
+		}
 		return item;
 	});
 

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -21,6 +21,10 @@ const phpFeedItemWithContent = {
 	...phpFeedItem,
 	content: `<h1>${phpFeedItem.title}</h1><p>${phpFeedItem.description}</p>`,
 };
+const phpFeedItemWithCustomData = {
+	...phpFeedItem,
+	customData: '<dc:creator><![CDATA[Buster Bluth]]></dc:creator>'
+};
 
 const web1FeedItem = {
 	// Should support empty string as a URL (possible for homepage route)
@@ -41,6 +45,8 @@ const web1FeedItemWithContent = {
 const validXmlResult = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title><![CDATA[${title}]]></title><description><![CDATA[${description}]]></description><link>${site}/</link><item><title><![CDATA[${phpFeedItem.title}]]></title><link>${site}${phpFeedItem.link}/</link><guid>${site}${phpFeedItem.link}/</guid><description><![CDATA[${phpFeedItem.description}]]></description><pubDate>${new Date(phpFeedItem.pubDate).toUTCString()}</pubDate></item><item><title><![CDATA[${web1FeedItem.title}]]></title><link>${site}${web1FeedItem.link}/</link><guid>${site}${web1FeedItem.link}/</guid><description><![CDATA[${web1FeedItem.description}]]></description><pubDate>${new Date(web1FeedItem.pubDate).toUTCString()}</pubDate></item></channel></rss>`;
 // prettier-ignore
 const validXmlWithContentResult = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/"><channel><title><![CDATA[${title}]]></title><description><![CDATA[${description}]]></description><link>${site}/</link><item><title><![CDATA[${phpFeedItemWithContent.title}]]></title><link>${site}${phpFeedItemWithContent.link}/</link><guid>${site}${phpFeedItemWithContent.link}/</guid><description><![CDATA[${phpFeedItemWithContent.description}]]></description><pubDate>${new Date(phpFeedItemWithContent.pubDate).toUTCString()}</pubDate><content:encoded><![CDATA[${phpFeedItemWithContent.content}]]></content:encoded></item><item><title><![CDATA[${web1FeedItemWithContent.title}]]></title><link>${site}${web1FeedItemWithContent.link}/</link><guid>${site}${web1FeedItemWithContent.link}/</guid><description><![CDATA[${web1FeedItemWithContent.description}]]></description><pubDate>${new Date(web1FeedItemWithContent.pubDate).toUTCString()}</pubDate><content:encoded><![CDATA[${web1FeedItemWithContent.content}]]></content:encoded></item></channel></rss>`;
+// prettier-ignore
+const validXmlWithCustomDataResult = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/"><channel><title><![CDATA[${title}]]></title><description><![CDATA[${description}]]></description><link>${site}/</link><item><title><![CDATA[${phpFeedItemWithCustomData.title}]]></title><link>${site}${phpFeedItemWithCustomData.link}/</link><guid>${site}${phpFeedItemWithCustomData.link}/</guid><description><![CDATA[${phpFeedItemWithCustomData.description}]]></description><pubDate>${new Date(phpFeedItemWithCustomData.pubDate).toUTCString()}</pubDate>${phpFeedItemWithCustomData.customData}</item><item><title><![CDATA[${web1FeedItemWithContent.title}]]></title><link>${site}${web1FeedItemWithContent.link}/</link><guid>${site}${web1FeedItemWithContent.link}/</guid><description><![CDATA[${web1FeedItemWithContent.description}]]></description><pubDate>${new Date(web1FeedItemWithContent.pubDate).toUTCString()}</pubDate><content:encoded><![CDATA[${web1FeedItemWithContent.content}]]></content:encoded></item></channel></rss>`;
 
 describe('rss', () => {
 	it('should generate on valid RSSFeedItem array', async () => {
@@ -63,6 +69,20 @@ describe('rss', () => {
 		});
 
 		chai.expect(body).xml.to.equal(validXmlWithContentResult);
+	});
+
+	it('should generate on valid RSSFeedItem array with custom data included', async () => {
+		const { body } = await rss({
+			xmlns: {
+				dc: 'http://purl.org/dc/elements/1.1/',
+			},
+			title,
+			description,
+			items: [phpFeedItemWithCustomData, web1FeedItemWithContent],
+			site,
+		});
+
+		chai.expect(body).xml.to.equal(validXmlWithCustomDataResult);
 	});
 
 	describe('glob result', () => {


### PR DESCRIPTION
## Changes

This fixes #5582 by basically correcting a typo, but it also adds a test so RSS item `customData` is slightly harder to break in the future.

## Testing

I added another variation of hardcoded RSS output that follows my use-case of appending a `<dc:creator>` node for the item. Adds a top-level namespace to support the node, uses `RSSFeedItem`’s `customData` property to append it, and makes sure the resulting output includes both.

## Docs

Nope! Just fixes a regression. When merged, the feature will work as currently described.