### PR TITLE
fix(rss): add missing type-attribute for xsl stylesheets

### DIFF
--- a/.changeset/five-moose-push.md
+++ b/.changeset/five-moose-push.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': patch
+---
+
+Fix missing type-attribute in xml-stylesheet

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -104,7 +104,8 @@ export async function generateRSS({ rssOptions, items }: GenerateRSSArgs): Promi
 	const parser = new XMLParser(xmlOptions);
 	const root: any = { '?xml': { '@_version': '1.0', '@_encoding': 'UTF-8' } };
 	if (typeof rssOptions.stylesheet === 'string') {
-		root['?xml-stylesheet'] = { '@_href': rssOptions.stylesheet, '@_encoding': 'UTF-8' };
+		const isXSL = /\.xsl$/i.test(rssOptions.stylesheet);
+		root['?xml-stylesheet'] = { '@_href': rssOptions.stylesheet, ...(isXSL && { '@_type': 'text/xsl' }) };
 	}
 	root.rss = { '@_version': '2.0' };
 	if (items.find((result) => result.content)) {

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -47,6 +47,10 @@ const validXmlResult = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
 const validXmlWithContentResult = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/"><channel><title><![CDATA[${title}]]></title><description><![CDATA[${description}]]></description><link>${site}/</link><item><title><![CDATA[${phpFeedItemWithContent.title}]]></title><link>${site}${phpFeedItemWithContent.link}/</link><guid>${site}${phpFeedItemWithContent.link}/</guid><description><![CDATA[${phpFeedItemWithContent.description}]]></description><pubDate>${new Date(phpFeedItemWithContent.pubDate).toUTCString()}</pubDate><content:encoded><![CDATA[${phpFeedItemWithContent.content}]]></content:encoded></item><item><title><![CDATA[${web1FeedItemWithContent.title}]]></title><link>${site}${web1FeedItemWithContent.link}/</link><guid>${site}${web1FeedItemWithContent.link}/</guid><description><![CDATA[${web1FeedItemWithContent.description}]]></description><pubDate>${new Date(web1FeedItemWithContent.pubDate).toUTCString()}</pubDate><content:encoded><![CDATA[${web1FeedItemWithContent.content}]]></content:encoded></item></channel></rss>`;
 // prettier-ignore
 const validXmlWithCustomDataResult = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/"><channel><title><![CDATA[${title}]]></title><description><![CDATA[${description}]]></description><link>${site}/</link><item><title><![CDATA[${phpFeedItemWithCustomData.title}]]></title><link>${site}${phpFeedItemWithCustomData.link}/</link><guid>${site}${phpFeedItemWithCustomData.link}/</guid><description><![CDATA[${phpFeedItemWithCustomData.description}]]></description><pubDate>${new Date(phpFeedItemWithCustomData.pubDate).toUTCString()}</pubDate>${phpFeedItemWithCustomData.customData}</item><item><title><![CDATA[${web1FeedItemWithContent.title}]]></title><link>${site}${web1FeedItemWithContent.link}/</link><guid>${site}${web1FeedItemWithContent.link}/</guid><description><![CDATA[${web1FeedItemWithContent.description}]]></description><pubDate>${new Date(web1FeedItemWithContent.pubDate).toUTCString()}</pubDate><content:encoded><![CDATA[${web1FeedItemWithContent.content}]]></content:encoded></item></channel></rss>`;
+// prettier-ignore
+const validXmlWithStylesheet = `<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet href="/feedstylesheet.css"?><rss version="2.0"><channel><title><![CDATA[${title}]]></title><description><![CDATA[${description}]]></description><link>${site}/</link></channel></rss>`;
+// prettier-ignore
+const validXmlWithXSLStylesheet = `<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet href="/feedstylesheet.xsl" type="text/xsl"?><rss version="2.0"><channel><title><![CDATA[${title}]]></title><description><![CDATA[${description}]]></description><link>${site}/</link></channel></rss>`;
 
 describe('rss', () => {
 	it('should generate on valid RSSFeedItem array', async () => {
@@ -83,6 +87,30 @@ describe('rss', () => {
 		});
 
 		chai.expect(body).xml.to.equal(validXmlWithCustomDataResult);
+	});
+
+	it('should include xml-stylesheet instruction when stylesheet is defined', async () => {
+		const { body } = await rss({
+			title,
+			description,
+			items: [],
+			site,
+			stylesheet: '/feedstylesheet.css',
+		});
+
+		chai.expect(body).xml.to.equal(validXmlWithStylesheet);
+	});
+
+	it('should include xml-stylesheet instruction with xsl type when stylesheet is set to xsl file', async () => {
+		const { body } = await rss({
+			title,
+			description,
+			items: [],
+			site,
+			stylesheet: '/feedstylesheet.xsl',
+		});
+
+		chai.expect(body).xml.to.equal(validXmlWithXSLStylesheet);
 	});
 
 	describe('glob result', () => {


### PR DESCRIPTION
## Changes

Adds the `type="text/xsl"` attribute to xml-stylesheet processing instruction in rss. It was removed by mistake in #5550.

The type attribute will only be added when the stylesheet ends with `.xsl` to enable support for css-stylesheet as well.

Fix #5581

## Testing

Updated the tests using `chai-xml` to verify both using a xsl stylesheet (include attribute) and a css stylesheet (no type-attribute).

## Docs

Not sure if necessary. This is a bugfix for xsl-stylesheets, but technically allows use of css-stylesheets. Not sure if it should be recommended by including in docs.

/cc @withastro/maintainers-docs for feedback!
