### PR TITLE
[Image] Make `alt` paramater optional

### DIFF
--- a/packages/integrations/image/src/lib/get-image.ts
+++ b/packages/integrations/image/src/lib/get-image.ts
@@ -11,7 +11,7 @@ import type { ImageMetadata } from '../vite-plugin-astro-image.js';
 
 export interface GetImageTransform extends Omit<TransformOptions, 'src'> {
 	src: string | ImageMetadata | Promise<{ default: ImageMetadata }>;
-	alt: string;
+	alt?: string;
 }
 
 function resolveSize(transform: TransformOptions): TransformOptions {

--- a/packages/integrations/image/src/lib/get-picture.ts
+++ b/packages/integrations/image/src/lib/get-picture.ts
@@ -7,7 +7,7 @@ import { getImage } from './get-image.js';
 
 export interface GetPictureParams {
 	src: string | ImageMetadata | Promise<{ default: ImageMetadata }>;
-	alt: string;
+	alt?: string;
 	widths: number[];
 	formats: OutputFormat[];
 	aspectRatio?: TransformOptions['aspectRatio'];


### PR DESCRIPTION
## Changes

- This fixes the `alt` parameter being required. 
- 
The actual code works fine without an `alt` attribute. This is solely an issue with the types.

Originally (pre `v0.12.x`) `alt` wasn't required. Introducing it as a required type is a breaking change and shouldn't have been done in a minor patch (although `@astrojs/image` is still pre `1.0.0`, so I don't think it's technically a semver violation). 

Aside from the semver issue, there are many cases where images might be used without requiring an alt text (e.g. a background image).

## Testing

I don't think any tests need to be updated.

## Docs

No docs are needed.
