### PR TITLE
Use less memory in .astro compilation

### DIFF
--- a/.changeset/real-apples-mix.md
+++ b/.changeset/real-apples-mix.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Reduce memory usage in .astro compilation

--- a/packages/astro/src/core/compile/cache.ts
+++ b/packages/astro/src/core/compile/cache.ts
@@ -1,5 +1,6 @@
 import type { AstroConfig } from '../../@types/astro';
-import { compile, CompileProps, CompileResult } from './compile.js';
+import type { ResolvedConfig } from 'vite';
+import { compile, CompileResult } from './compile.js';
 
 type CompilationCache = Map<string, CompileResult>;
 
@@ -24,8 +25,13 @@ export function invalidateCompilation(config: AstroConfig, filename: string) {
 	}
 }
 
-export async function cachedCompilation(props: CompileProps): Promise<CompileResult> {
-	const { astroConfig, filename } = props;
+export async function cachedCompilation(
+	astroConfig: AstroConfig,
+	viteConfig: ResolvedConfig,
+	filename: string,
+	moduleId: string | undefined,
+	source: string
+): Promise<CompileResult> {
 	let cache: CompilationCache;
 	if (!configCache.has(astroConfig)) {
 		cache = new Map();
@@ -36,7 +42,7 @@ export async function cachedCompilation(props: CompileProps): Promise<CompileRes
 	if (cache.has(filename)) {
 		return cache.get(filename)!;
 	}
-	const compileResult = await compile(props);
+	const compileResult = await compile(astroConfig, viteConfig, filename, moduleId, source);
 	cache.set(filename, compileResult);
 	return compileResult;
 }

--- a/packages/astro/src/core/compile/index.ts
+++ b/packages/astro/src/core/compile/index.ts
@@ -4,5 +4,5 @@ export {
 	invalidateCompilation,
 	isCached,
 } from './cache.js';
-export type { CompileProps, CompileResult } from './compile';
+export type { CompileResult } from './compile';
 export type { TransformStyle } from './types';


### PR DESCRIPTION
## Changes

- Reduce memory usage in the .astro vite plugin in 2 ways:
  - Avoid creating extra closures in style preprocessing (this was the biggest reduction).
  - Avoid temporary objects and use function arguments instead.
  - Avoid object spread which creates larger objects just to add a couple of properties to an object.

## Testing

- Tests should all still pass
- Tested with an example app to reduce memory.

## Docs

N/A