### PR TITLE
[Fix] Incorrect error message for MDX peer dependency

### DIFF
--- a/.changeset/red-nails-mix.md
+++ b/.changeset/red-nails-mix.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix error message when using Content Collections and an out-of-date `@astrojs/mdx` integration

--- a/packages/astro/src/content/internal.ts
+++ b/packages/astro/src/content/internal.ts
@@ -138,9 +138,7 @@ async function render({
 	});
 
 	if (!mod._internal && id.endsWith('.mdx')) {
-		throw new Error(
-			`[Content] Failed to render MDX entry. Try installing @astrojs/mdx@next--content-schemas`
-		);
+		throw new Error(`[Content] Failed to render MDX entry. Try installing @astrojs/mdx@latest`);
 	}
 	return {
 		Content,


### PR DESCRIPTION
## Changes

Content collections requires the latest MDX minor release. Remove reference to `next--content-schemas` in MDX error message.

## Testing

N/A

## Docs

N/A