### PR TITLE
Docs: Fix `prerender` error message

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -397,7 +397,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	 * @docs
 	 * @message
 	 * **Example error messages:**<br/>
-	 * InvalidPrerenderExport: A \`prerender\` export has been detected, but its value cannot be statically analyzed.
+	 * InvalidPrerenderExport: A `prerender` export has been detected, but its value cannot be statically analyzed.
 	 * @description
 	 * The `prerender` feature only supports a subset of valid JavaScript—be sure to use exactly `export const prerender = true` so that our compiler can detect this directive at build time. Variables, `let`, and `var` declarations are not supported.
 	 */

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -399,7 +399,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	 * **Example error messages:**<br/>
 	 * InvalidPrerenderExport: A `prerender` export has been detected, but its value cannot be statically analyzed.
 	 * @description
-	 * The `prerender` feature only supports a subset of valid JavaScript—be sure to use exactly `export const prerender = true` so that our compiler can detect this directive at build time. Variables, `let`, and `var` declarations are not supported.
+	 * The `prerender` feature only supports a subset of valid JavaScript — be sure to use exactly `export const prerender = true` so that our compiler can detect this directive at build time. Variables, `let`, and `var` declarations are not supported.
 	 */
 	InvalidPrerenderExport: {
 		title: 'Invalid prerender export.',

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -399,7 +399,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	 * **Example error messages:**<br/>
 	 * InvalidPrerenderExport: A \`prerender\` export has been detected, but its value cannot be statically analyzed.
 	 * @description
-	 * A `prerender` export was detected, but the value was not statically analyzable. Values computed at runtime are not supported, so `export const prerender` can only be set to `true` or `false`. Variables are not supported.
+	 * The `prerender` feature only supports a subset of valid JavaScript—be sure to use exactly `export const prerender = true` so that our compiler can detect this directive at build time. Variables, `let`, and `var` declarations are not supported.
 	 */
 	InvalidPrerenderExport: {
 		title: 'Invalid prerender export.',

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -395,6 +395,9 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	},
 	/**
 	 * @docs
+	 * @message
+	 * **Example error messages:**<br/>
+	 * InvalidPrerenderExport: A \`prerender\` export has been detected, but its value cannot be statically analyzed.
 	 * @description
 	 * A `prerender` export was detected, but the value was not statically analyzable. Values computed at runtime are not supported, so `export const prerender` can only be set to `true` or `false`. Variables are not supported.
 	 */


### PR DESCRIPTION
## Changes

- Updates `message` to avoid stringifying the function.
- Updates `description` for clarity.

## Testing

N/A

## Docs

This is only a docs change