### PR TITLE
Fix links in content used by docs

### DIFF
--- a/examples/with-content/README.md
+++ b/examples/with-content/README.md
@@ -1,6 +1,6 @@
 # Astro Content Collections (Experimental)
 
-This demos our Blog Starter using **[the experimental Content Collections API.](https://docs.astro.build/en/guides/content-collections)**
+This demos our Blog Starter using **[the experimental Content Collections API.](https://docs.astro.build/en/guides/content-collections/)**
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-content)
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/with-content)

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -814,7 +814,7 @@ export interface AstroUserConfig {
 	 *
 	 * Extend Astro with custom integrations. Integrations are your one-stop-shop for adding framework support (like Solid.js), new features (like sitemaps), and new libraries (like Partytown and Turbolinks).
 	 *
-	 * Read our [Integrations Guide](/en/guides/integrations-guide/) for help getting started with Astro Integrations.
+	 * Read our [Integrations Guide](https://docs.astro.build/en/guides/integrations-guide/) for help getting started with Astro Integrations.
 	 *
 	 * ```js
 	 * import react from '@astrojs/react';
@@ -881,9 +881,9 @@ export interface AstroUserConfig {
 		 * @version 1.0.0-rc.1
 		 * @description
 		 * Enable Astro's pre-v1.0 support for components and JSX expressions in `.md` (and alternative extensions for markdown files like ".markdown") Markdown files.
-		 * In Astro `1.0.0-rc`, this original behavior was removed as the default, in favor of our new [MDX integration](/en/guides/integrations-guide/mdx/).
+		 * In Astro `1.0.0-rc`, this original behavior was removed as the default, in favor of our new [MDX integration](https://docs.astro.build/en/guides/integrations-guide/mdx/).
 		 *
-		 * To enable this behavior, set `legacy.astroFlavoredMarkdown` to `true` in your [`astro.config.mjs` configuration file](/en/guides/configuring-astro/#the-astro-config-file).
+		 * To enable this behavior, set `legacy.astroFlavoredMarkdown` to `true` in your [`astro.config.mjs` configuration file](https://docs.astro.build/en/guides/configuring-astro/#the-astro-config-file).
 		 *
 		 * ```js
 		 * {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -938,7 +938,7 @@ export interface AstroUserConfig {
 		 * @default `false`
 		 * @version 1.7.0
 		 * @description
-		 * Enable experimental support for [Content Collections](/en/guides/content-collections). This makes the `src/content/` directory a reserved directory for Astro to manage, and introduces the `astro:content` module for querying this content.
+		 * Enable experimental support for [Content Collections](https://docs.astro.build/en/guides/content-collections/). This makes the `src/content/` directory a reserved directory for Astro to manage, and introduces the `astro:content` module for querying this content.
 		 *
 		 * To enable this feature, set `experimental.contentCollections` to `true` in your Astro config:
 		 *

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -507,7 +507,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	 * A Markdown document's frontmatter in `src/content/` does not match its collection schema.
 	 * Make sure that all required fields are present, and that all fields are of the correct type.
 	 * You can check against the collection schema in your `src/content/config.*` file.
-	 * See the [Content collections documentation](https://docs.astro.build/en/guides/content-collections) for more information.
+	 * See the [Content collections documentation](https://docs.astro.build/en/guides/content-collections/) for more information.
 	 */
 	MarkdownContentSchemaValidationError: {
 		title: 'Content collection frontmatter invalid.',
@@ -518,7 +518,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 				...error.errors.map((zodError) => zodError.message),
 			].join('\n');
 		},
-		hint: 'See https://docs.astro.build/en/guides/content-collections for more information on content schemas.',
+		hint: 'See https://docs.astro.build/en/guides/content-collections/ for more information on content schemas.',
 	},
 	// Config Errors - 7xxx
 	UnknownConfigError: {


### PR DESCRIPTION
## Changes

- Use trailing slashes on docs links as required by docs link checker
- Fix up a couple of relative links so they work when shown in editor tooltips
- Unblocks https://github.com/withastro/docs/pull/2191/ & https://github.com/withastro/docs/pull/2192/

## Testing

No testing, docs only.

## Docs

Docs links changes — /cc @withastro/maintainers-docs for feedback!