### PR TITLE
Add JSDoc comments for error overlay to match other experimental flags

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -907,8 +907,23 @@ export interface AstroUserConfig {
 	 */
 	experimental?: {
 		/**
-		 * @hidden
+		 * @docs
+		 * @name experimental.errorOverlay
+		 * @type {boolean}
+		 * @default `false`
+		 * @version 1.7.0
+		 * @description
 		 * Turn on experimental support for the new error overlay component.
+		 *
+		 * To enable this feature, set `experimental.errorOverlay` to `true` in your Astro config:
+		 *
+		 * ```js
+		 * {
+		 * 	experimental: {
+		 * 		errorOverlay: true,
+		 * 	},
+		 * }
+		 * ```
 		 */
 		errorOverlay?: boolean;
 		/**


### PR DESCRIPTION
## Changes

Add configuration docs for the `experimental.errorOverlay` flag to match those for `prerender` and `contentCollections`.

Currently in docs we render out those other flags but not the `errorOverlay` flag: https://docs.astro.build/en/reference/configuration-reference/#experimental-flags

## Testing

n/a docs change only

## Docs

Yes. Is there a reason we wouldn’t want to document this like we do other experimental features?