### PR TITLE
fix(types): add `server.headers` typing

### DIFF
--- a/.changeset/slow-nails-retire.md
+++ b/.changeset/slow-nails-retire.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+- Add `server.headers` typing

--- a/.changeset/slow-nails-retire.md
+++ b/.changeset/slow-nails-retire.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-- Add `server.headers` typing
+Add `server.headers` typing

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -8,6 +8,7 @@ import type {
 	ShikiConfig,
 } from '@astrojs/markdown-remark';
 import type * as babel from '@babel/core';
+import type { OutgoingHttpHeaders } from 'http';
 import type { AddressInfo } from 'net';
 import type { TsConfigJson } from 'tsconfig-resolver';
 import type * as vite from 'vite';
@@ -319,6 +320,16 @@ type ServerConfig = {
 	 * If the given port is already in use, Astro will automatically try the next available port.
 	 */
 	port?: number;
+
+	/**
+	 * @name server.headers
+	 * @typeraw {OutgoingHttpHeaders}
+	 * @default `{}`
+	 * @version 1.70.0
+	 * @description
+	 * Set custom HTTP response headers to be sent in `astro dev` and `astro preview`.
+	 */
+	headers?: OutgoingHttpHeaders;
 };
 
 export interface ViteUserConfig extends vite.UserConfig {
@@ -664,6 +675,16 @@ export interface AstroUserConfig {
 	 *   server: { port: 8080 }
 	 * }
 	 * ```
+	 */
+
+	/**
+	 * @docs
+	 * @name server.headers
+	 * @typeraw {OutgoingHttpHeaders}
+	 * @default `{}`
+	 * @version 1.70.0
+	 * @description
+	 * Set custom HTTP response headers to be sent in `astro dev` and `astro preview`.
 	 */
 
 	server?: ServerConfig | ((options: { command: 'dev' | 'preview' }) => ServerConfig);

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -325,7 +325,7 @@ type ServerConfig = {
 	 * @name server.headers
 	 * @typeraw {OutgoingHttpHeaders}
 	 * @default `{}`
-	 * @version 1.70.0
+	 * @version 1.7.0
 	 * @description
 	 * Set custom HTTP response headers to be sent in `astro dev` and `astro preview`.
 	 */
@@ -682,7 +682,7 @@ export interface AstroUserConfig {
 	 * @name server.headers
 	 * @typeraw {OutgoingHttpHeaders}
 	 * @default `{}`
-	 * @version 1.70.0
+	 * @version 1.7.0
 	 * @description
 	 * Set custom HTTP response headers to be sent in `astro dev` and `astro preview`.
 	 */


### PR DESCRIPTION
## Changes

Added `server.headers` typing.
This is needed to use `server.headers` along with `defineConfig`.

## Testing

I'm sorry but I couldn't figure out how to add TS test so no tests were added.

## Docs

I'm not sure about docs generation.

/cc @withastro/maintainers-docs for feedback!
