### PR TITLE
fix traced warnings from unexpected token

### DIFF
--- a/.changeset/lazy-tomatoes-call.md
+++ b/.changeset/lazy-tomatoes-call.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': minor
+---
+
+Ignore warnings when traced file fails to parse

--- a/packages/integrations/vercel/src/lib/nft.ts
+++ b/packages/integrations/vercel/src/lib/nft.ts
@@ -1,8 +1,7 @@
+import { copyFilesToFunction } from './fs.js';
+import { fileURLToPath } from 'node:url';
 import { nodeFileTrace } from '@vercel/nft';
 import { relative as relativePath } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-import { copyFilesToFunction } from './fs.js';
 
 export async function copyDependenciesToFunction({
 	entry,
@@ -43,6 +42,12 @@ export async function copyDependenciesToFunction({
 					`[@astrojs/vercel] The module "${module}" inside the file "${file}" couldn't be resolved. This may not be a problem, but it's worth checking.`
 				);
 			}
+		}
+		// parse errors are likely not js and can safely be ignored,
+		// such as this html file in "main" meant for nw instead of node:
+		// https://github.com/vercel/nft/issues/311
+		else if (error.message.startsWith('Failed to parse')) {
+			continue;
 		} else {
 			throw error;
 		}

--- a/packages/integrations/vercel/src/lib/nft.ts
+++ b/packages/integrations/vercel/src/lib/nft.ts
@@ -1,7 +1,8 @@
-import { copyFilesToFunction } from './fs.js';
-import { fileURLToPath } from 'node:url';
 import { nodeFileTrace } from '@vercel/nft';
 import { relative as relativePath } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { copyFilesToFunction } from './fs.js';
 
 export async function copyDependenciesToFunction({
 	entry,


### PR DESCRIPTION
This PR fixes building a website when using @astrojs/vercel/serverless . It's a temporary fix until https://github.com/vercel/nft/issues/311 gets fixed

## Changes

- Added an if check to ignore "Failed to parse" errors from @vercel/nft

## Testing
I don't think tests are needed for this small change, if they are let me know.

## Docs
It shouldn't affect user behavior
