### PR TITLE
Fix client only import with importsNotUsedAsValues error

### DIFF
--- a/.changeset/two-pants-enjoy.md
+++ b/.changeset/two-pants-enjoy.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `client:only` imports with `"importsNotUsedAsValues": "error"` tsconfig

--- a/packages/astro/e2e/fixtures/client-only/src/components/ReactCounter.jsx
+++ b/packages/astro/e2e/fixtures/client-only/src/components/ReactCounter.jsx
@@ -1,5 +1,8 @@
 import { useState } from 'react';
 
+// accessing browser globals as side effects is allowed if the component is client:only
+console.log(document.title)
+
 /** a counter written in React */
 export function Counter({ children, id }) {
 	const [count, setCount] = useState(0);

--- a/packages/astro/e2e/fixtures/client-only/tsconfig.json
+++ b/packages/astro/e2e/fixtures/client-only/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "importsNotUsedAsValues": "error"
+  }
+}

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -41,6 +41,12 @@ export async function cachedFullCompilation({
 			loader: 'ts',
 			target: 'esnext',
 			sourcemap: 'external',
+			tsconfigRaw: {
+				compilerOptions: {
+					// Ensure client:only imports are treeshaken
+					importsNotUsedAsValues: 'remove',
+				},
+			},
 		});
 	} catch (err: any) {
 		await enhanceCompileError({

--- a/packages/astro/src/vite-plugin-jsx/index.ts
+++ b/packages/astro/src/vite-plugin-jsx/index.ts
@@ -140,6 +140,12 @@ export default function jsx({ settings, logging }: AstroPluginJSXOptions): Plugi
 					loader: getEsbuildLoader(id),
 					jsx: 'preserve',
 					sourcemap: 'inline',
+					tsconfigRaw: {
+						compilerOptions: {
+							// Ensure client:only imports are treeshaken
+							importsNotUsedAsValues: 'remove',
+						},
+					},
 				});
 				return transformJSX({
 					code: jsxCode,


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/5541
fix https://github.com/withastro/astro/issues/5624

If a framework component as side effects that access browser globals, and is used as `client:only`, Astro should treeshake the import of that component import to prevent the side effect from running in SSR.

#5553 accidentally break this as `"importsNotUsedAsValues": "error"` is respected when specified in the tsconfig, causing the import to be preserved and not treeshaken.

This PR forces `"importsNotUsedAsValues": "error"`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
updated client-only test

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a bug fix