### PR TITLE
Patch static build regression

### DIFF
--- a/.changeset/small-camels-mix.md
+++ b/.changeset/small-camels-mix.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix static build regression where chunks would not be generated

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -362,7 +362,9 @@ async function cleanServerOutput(opts: StaticBuildOptions) {
 		await Promise.all(
 			Array.from(directories).map(async (filename) => {
 				const url = new URL(filename, out);
-				const dir = await glob(fileURLToPath(url), { absolute: true });
+				const dir = await glob(fileURLToPath(url));
+				// Do not delete chunks/ directory!
+				if (filename === 'chunks') return;
 				if (!dir.length) {
 					await fs.promises.rm(url, { recursive: true, force: true });
 				}


### PR DESCRIPTION
## Changes

- Can't say I fully understand what changed this behavior, but it looks like due to some timing changes in the build, the `chunks` directory is empty before it's populated by the client build.
- If we remove the `chunks` directory because it is empty, the client assets also disappear.
- Closes https://github.com/withastro/astro/issues/5643, closes https://github.com/withastro/astro/issues/5632, closes https://github.com/withastro/astro/issues/5621

## Testing

Tested manually, need to figure out how to test this

## Docs

Bug fix only