### PR TITLE
Add canonical URL to blog example

### DIFF
--- a/examples/blog/src/components/BaseHead.astro
+++ b/examples/blog/src/components/BaseHead.astro
@@ -9,6 +9,8 @@ export interface Props {
 	image?: string;
 }
 
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+
 const { title, description, image = '/placeholder-social.jpg' } = Astro.props;
 ---
 
@@ -18,6 +20,9 @@ const { title, description, image = '/placeholder-social.jpg' } = Astro.props;
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <meta name="generator" content={Astro.generator} />
 
+<!-- Canonical URL -->
+<link rel="canonical" href={canonicalURL} />
+	
 <!-- Primary Meta Tags -->
 <title>{title}</title>
 <meta name="title" content={title} />


### PR DESCRIPTION
## Changes
- Adds canonical URL which is important for SEO
- Helps with page duplicacy (eg. www -> non-www)

## Testing
It was tested on my landing page 
![image](https://user-images.githubusercontent.com/23727670/208600357-6144468f-c719-4dfb-8291-f71d56f19a6c.png)


<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

No docs needs to be updated

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
