### PR TITLE
MD/MDX collect headings refactor

### DIFF
--- a/.changeset/fast-baboons-prove.md
+++ b/.changeset/fast-baboons-prove.md
@@ -8,18 +8,18 @@ Run heading ID injection after user plugins
 
 If you are using a rehype plugin that depends on heading IDs injected by Astro, the IDs will no longer be available when your plugin runs by default.
 
-To inject IDs before your plugins run, import and add the `rehypeHeadingSlugs` plugin to your `rehypePlugins` config:
+To inject IDs before your plugins run, import and add the `rehypeHeadingIds` plugin to your `rehypePlugins` config:
 
 ```diff
 // astro.config.mjs
-+ import { rehypeHeadingSlugs } from '@astrojs/markdown-remark';
++ import { rehypeHeadingIds } from '@astrojs/markdown-remark';
 import mdx from '@astrojs/mdx';
 
 export default {
   integrations: [mdx()],
   markdown: {
     rehypePlugins: [
-+     rehypeHeadingSlugs,
++     rehypeHeadingIds,
       otherPluginThatReliesOnHeadingIDs,
     ],
   },

--- a/.changeset/fast-baboons-prove.md
+++ b/.changeset/fast-baboons-prove.md
@@ -1,0 +1,27 @@
+---
+'@astrojs/mdx': minor
+---
+
+Run heading ID injection after user plugins
+
+⚠️ BREAKING CHANGE ⚠️
+
+If you are using a rehype plugin that depends on heading IDs injected by Astro, the IDs will no longer be available when your plugin runs by default.
+
+To inject IDs before your plugins run, import and add the `rehypeHeadingSlugs` plugin to your `rehypePlugins` config:
+
+```diff
+// astro.config.mjs
++ import { rehypeHeadingSlugs } from '@astrojs/markdown-remark';
+import mdx from '@astrojs/mdx';
+
+export default {
+  integrations: [mdx()],
+  markdown: {
+    rehypePlugins: [
++     rehypeHeadingSlugs,
+      otherPluginThatReliesOnHeadingIDs,
+    ],
+  },
+}
+```

--- a/.changeset/violet-mice-push.md
+++ b/.changeset/violet-mice-push.md
@@ -2,6 +2,6 @@
 '@astrojs/markdown-remark': minor
 ---
 
-Refactor and export `rehypeHeadingSlugs` plugin
+Refactor and export `rehypeHeadingIds` plugin
 
-The `rehypeHeadingSlugs` plugin injects IDs for all headings in a Markdown document and can now also handle MDX inputs if needed. You can import and use this plugin if you need heading IDs to be injected _before_ other rehype plugins run.
+The `rehypeHeadingIds` plugin injects IDs for all headings in a Markdown document and can now also handle MDX inputs if needed. You can import and use this plugin if you need heading IDs to be injected _before_ other rehype plugins run.

--- a/.changeset/violet-mice-push.md
+++ b/.changeset/violet-mice-push.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/markdown-remark': minor
+---
+
+Refactor and export `rehypeHeadingSlugs` plugin
+
+The `rehypeHeadingSlugs` plugin injects IDs for all headings in a Markdown document and can now also handle MDX inputs if needed. You can import and use this plugin if you need heading IDs to be injected _before_ other rehype plugins run.

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -30,6 +30,7 @@
     "test:match": "mocha --timeout 20000 -g"
   },
   "dependencies": {
+    "@astrojs/markdown-remark": "^1.1.3",
     "@astrojs/prism": "^1.0.2",
     "@mdx-js/mdx": "^2.1.2",
     "@mdx-js/rollup": "^2.1.1",

--- a/packages/integrations/mdx/src/plugins.ts
+++ b/packages/integrations/mdx/src/plugins.ts
@@ -1,4 +1,4 @@
-import { rehypeHeadingSlugs } from '@astrojs/markdown-remark';
+import { rehypeHeadingIds } from '@astrojs/markdown-remark';
 import { nodeTypes } from '@mdx-js/mdx';
 import type { PluggableList } from '@mdx-js/mdx/lib/core.js';
 import type { Options as MdxRollupPluginOptions } from '@mdx-js/rollup';
@@ -178,8 +178,8 @@ export function getRehypePlugins(
 		...rehypePlugins,
 		...(mdxOptions.rehypePlugins ?? []),
 		// getHeadings() is guaranteed by TS, so this must be included.
-		// We run `rehypeHeadingSlugs` _last_ to respect any custom IDs set by user plugins.
-		rehypeHeadingSlugs,
+		// We run `rehypeHeadingIds` _last_ to respect any custom IDs set by user plugins.
+		rehypeHeadingIds,
 		rehypeInjectHeadingsExport,
 	];
 	return rehypePlugins;

--- a/packages/integrations/mdx/src/rehype-collect-headings.ts
+++ b/packages/integrations/mdx/src/rehype-collect-headings.ts
@@ -1,48 +1,9 @@
-import Slugger from 'github-slugger';
-import { visit } from 'unist-util-visit';
+import { MarkdownVFile, MarkdownHeading } from '@astrojs/markdown-remark';
 import { jsToTreeNode } from './utils.js';
 
-export interface MarkdownHeading {
-	depth: number;
-	slug: string;
-	text: string;
-}
-
-export default function rehypeCollectHeadings() {
-	const slugger = new Slugger();
-	return function (tree: any) {
-		const headings: MarkdownHeading[] = [];
-		visit(tree, (node) => {
-			if (node.type !== 'element') return;
-			const { tagName } = node;
-			if (tagName[0] !== 'h') return;
-			const [_, level] = tagName.match(/h([0-6])/) ?? [];
-			if (!level) return;
-			const depth = Number.parseInt(level);
-
-			let text = '';
-			visit(node, (child, __, parent) => {
-				if (child.type === 'element' || parent == null) {
-					return;
-				}
-				if (child.type === 'raw' && child.value.match(/^\n?<.*>\n?$/)) {
-					return;
-				}
-				if (new Set(['text', 'raw', 'mdxTextExpression']).has(child.type)) {
-					text += child.value;
-				}
-			});
-
-			node.properties = node.properties || {};
-			if (typeof node.properties.id !== 'string') {
-				let slug = slugger.slug(text);
-				if (slug.endsWith('-')) {
-					slug = slug.slice(0, -1);
-				}
-				node.properties.id = slug;
-			}
-			headings.push({ depth, slug: node.properties.id, text });
-		});
+export function rehypeInjectHeadingsExport() {
+	return function (tree: any, file: MarkdownVFile) {
+		const headings: MarkdownHeading[] = file.data.__astroHeadings || [];
 		tree.children.unshift(
 			jsToTreeNode(`export function getHeadings() { return ${JSON.stringify(headings)} }`)
 		);

--- a/packages/integrations/mdx/test/mdx-get-headings.test.js
+++ b/packages/integrations/mdx/test/mdx-get-headings.test.js
@@ -1,4 +1,6 @@
+import { rehypeHeadingSlugs } from '@astrojs/markdown-remark';
 import mdx from '@astrojs/mdx';
+import { visit } from 'unist-util-visit';
 
 import { expect } from 'chai';
 import { parseHTML } from 'linkedom';
@@ -56,5 +58,94 @@ describe('MDX getHeadings', () => {
 				{ depth: 3, slug: 'h3title', text: 'h3Title' },
 			])
 		);
+	});
+});
+
+describe('MDX heading IDs can be customized by user plugins', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/mdx-get-headings/', import.meta.url),
+			integrations: [mdx()],
+			markdown: {
+				rehypePlugins: [
+					() => (tree) => {
+						let count = 0;
+						visit(tree, 'element', (node, index, parent) => {
+							if (!/^h\d$/.test(node.tagName)) return;
+							if (!node.properties?.id) {
+								node.properties = { ...node.properties, id: String(count++) };
+							}
+						});
+					},
+				],
+			},
+		});
+
+		await fixture.build();
+	});
+
+	it('adds user-specified IDs to HTML output', async () => {
+		const html = await fixture.readFile('/test/index.html');
+		const { document } = parseHTML(html);
+
+		const h1 = document.querySelector('h1');
+		expect(h1?.textContent).to.equal('Heading test');
+		expect(h1?.getAttribute('id')).to.equal('0');
+
+		const headingIDs = document.querySelectorAll('h1,h2,h3').map((el) => el.id);
+		expect(JSON.stringify(headingIDs)).to.equal(
+			JSON.stringify(Array.from({ length: headingIDs.length }, (_, idx) => String(idx)))
+		);
+	});
+
+	it('generates correct getHeadings() export', async () => {
+		const { headingsByPage } = JSON.parse(await fixture.readFile('/pages.json'));
+		expect(JSON.stringify(headingsByPage['./test.mdx'])).to.equal(
+			JSON.stringify([
+				{ depth: 1, slug: '0', text: 'Heading test' },
+				{ depth: 2, slug: '1', text: 'Section 1' },
+				{ depth: 3, slug: '2', text: 'Subsection 1' },
+				{ depth: 3, slug: '3', text: 'Subsection 2' },
+				{ depth: 2, slug: '4', text: 'Section 2' },
+			])
+		);
+	});
+});
+
+describe('MDX heading IDs can be injected before user plugins', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/mdx-get-headings/', import.meta.url),
+			integrations: [
+				mdx({
+					rehypePlugins: [
+						rehypeHeadingSlugs,
+						() => (tree) => {
+							visit(tree, 'element', (node, index, parent) => {
+								if (!/^h\d$/.test(node.tagName)) return;
+								if (node.properties?.id) {
+									node.children.push({ type: 'text', value: ' ' + node.properties.id });
+								}
+							});
+						},
+					],
+				}),
+			],
+		});
+
+		await fixture.build();
+	});
+
+	it('adds user-specified IDs to HTML output', async () => {
+		const html = await fixture.readFile('/test/index.html');
+		const { document } = parseHTML(html);
+
+		const h1 = document.querySelector('h1');
+		expect(h1?.textContent).to.equal('Heading test heading-test');
+		expect(h1?.id).to.equal('heading-test');
 	});
 });

--- a/packages/integrations/mdx/test/mdx-get-headings.test.js
+++ b/packages/integrations/mdx/test/mdx-get-headings.test.js
@@ -1,4 +1,4 @@
-import { rehypeHeadingSlugs } from '@astrojs/markdown-remark';
+import { rehypeHeadingIds } from '@astrojs/markdown-remark';
 import mdx from '@astrojs/mdx';
 import { visit } from 'unist-util-visit';
 
@@ -123,7 +123,7 @@ describe('MDX heading IDs can be injected before user plugins', () => {
 			integrations: [
 				mdx({
 					rehypePlugins: [
-						rehypeHeadingSlugs,
+						rehypeHeadingIds,
 						() => (tree) => {
 							visit(tree, 'element', (node, index, parent) => {
 								if (!/^h\d$/.test(node.tagName)) return;

--- a/packages/markdown/remark/src/index.ts
+++ b/packages/markdown/remark/src/index.ts
@@ -1,7 +1,7 @@
-import type { MarkdownRenderingOptions, MarkdownRenderingResult } from './types';
+import type { MarkdownRenderingOptions, MarkdownRenderingResult, MarkdownVFile } from './types';
 
 import { loadPlugins } from './load-plugins.js';
-import createCollectHeadings from './rehype-collect-headings.js';
+import { rehypeHeadingSlugs } from './rehype-collect-headings.js';
 import rehypeEscape from './rehype-escape.js';
 import rehypeExpressions from './rehype-expressions.js';
 import rehypeIslands from './rehype-islands.js';
@@ -22,6 +22,7 @@ import markdownToHtml from 'remark-rehype';
 import { unified } from 'unified';
 import { VFile } from 'vfile';
 
+export { rehypeHeadingSlugs } from './rehype-collect-headings.js';
 export * from './types.js';
 
 export const DEFAULT_REMARK_PLUGINS = ['remark-gfm', 'remark-smartypants'];
@@ -44,7 +45,6 @@ export async function renderMarkdown(
 	} = opts;
 	const input = new VFile({ value: content, path: fileURL });
 	const scopedClassName = opts.$?.scopedClassName;
-	const { headings, rehypeCollectHeadings } = createCollectHeadings();
 
 	let parser = unified()
 		.use(markdown)
@@ -99,12 +99,12 @@ export async function renderMarkdown(
 	parser
 		.use(
 			isAstroFlavoredMd
-				? [rehypeJsx, rehypeExpressions, rehypeEscape, rehypeIslands, rehypeCollectHeadings]
-				: [rehypeCollectHeadings, rehypeRaw]
+				? [rehypeJsx, rehypeExpressions, rehypeEscape, rehypeIslands, rehypeHeadingSlugs]
+				: [rehypeHeadingSlugs, rehypeRaw]
 		)
 		.use(rehypeStringify, { allowDangerousHtml: true });
 
-	let vfile: VFile;
+	let vfile: MarkdownVFile;
 	try {
 		vfile = await parser.process(input);
 	} catch (err) {
@@ -116,6 +116,7 @@ export async function renderMarkdown(
 		throw err;
 	}
 
+	const headings = vfile?.data.__astroHeadings || [];
 	return {
 		metadata: { headings, source: content, html: String(vfile.value) },
 		code: String(vfile.value),

--- a/packages/markdown/remark/src/index.ts
+++ b/packages/markdown/remark/src/index.ts
@@ -1,7 +1,7 @@
 import type { MarkdownRenderingOptions, MarkdownRenderingResult, MarkdownVFile } from './types';
 
 import { loadPlugins } from './load-plugins.js';
-import { rehypeHeadingSlugs } from './rehype-collect-headings.js';
+import { rehypeHeadingIds } from './rehype-collect-headings.js';
 import rehypeEscape from './rehype-escape.js';
 import rehypeExpressions from './rehype-expressions.js';
 import rehypeIslands from './rehype-islands.js';
@@ -22,7 +22,7 @@ import markdownToHtml from 'remark-rehype';
 import { unified } from 'unified';
 import { VFile } from 'vfile';
 
-export { rehypeHeadingSlugs } from './rehype-collect-headings.js';
+export { rehypeHeadingIds } from './rehype-collect-headings.js';
 export * from './types.js';
 
 export const DEFAULT_REMARK_PLUGINS = ['remark-gfm', 'remark-smartypants'];
@@ -99,8 +99,8 @@ export async function renderMarkdown(
 	parser
 		.use(
 			isAstroFlavoredMd
-				? [rehypeJsx, rehypeExpressions, rehypeEscape, rehypeIslands, rehypeHeadingSlugs]
-				: [rehypeHeadingSlugs, rehypeRaw]
+				? [rehypeJsx, rehypeExpressions, rehypeEscape, rehypeIslands, rehypeHeadingIds]
+				: [rehypeHeadingIds, rehypeRaw]
 		)
 		.use(rehypeStringify, { allowDangerousHtml: true });
 

--- a/packages/markdown/remark/src/rehype-collect-headings.ts
+++ b/packages/markdown/remark/src/rehype-collect-headings.ts
@@ -71,5 +71,5 @@ export function rehypeHeadingSlugs(): ReturnType<RehypePlugin> {
 }
 
 function isMDXFile(file: MarkdownVFile) {
-	return file.history[0].endsWith('.mdx');
+	return Boolean(file.history[0]?.endsWith('.mdx'));
 }

--- a/packages/markdown/remark/src/rehype-collect-headings.ts
+++ b/packages/markdown/remark/src/rehype-collect-headings.ts
@@ -2,72 +2,66 @@ import Slugger from 'github-slugger';
 import { toHtml } from 'hast-util-to-html';
 import { visit } from 'unist-util-visit';
 
-import type { MarkdownHeading, RehypePlugin } from './types.js';
+import type { MarkdownHeading, MarkdownVFile, RehypePlugin } from './types.js';
 
-export default function createCollectHeadings() {
-	const headings: MarkdownHeading[] = [];
-	const slugger = new Slugger();
+export function rehypeHeadingSlugs(): ReturnType<RehypePlugin> {
+	return function (tree, file: MarkdownVFile) {
+		const headings: MarkdownHeading[] = [];
+		const slugger = new Slugger();
+		visit(tree, (node) => {
+			if (node.type !== 'element') return;
+			const { tagName } = node;
+			if (tagName[0] !== 'h') return;
+			const [_, level] = tagName.match(/h([0-6])/) ?? [];
+			if (!level) return;
+			const depth = Number.parseInt(level);
 
-	function rehypeCollectHeadings(): ReturnType<RehypePlugin> {
-		return function (tree) {
-			visit(tree, (node) => {
-				if (node.type !== 'element') return;
-				const { tagName } = node;
-				if (tagName[0] !== 'h') return;
-				const [_, level] = tagName.match(/h([0-6])/) ?? [];
-				if (!level) return;
-				const depth = Number.parseInt(level);
-
-				let text = '';
-				let isJSX = false;
-				visit(node, (child, __, parent) => {
-					if (child.type === 'element' || parent == null) {
+			let text = '';
+			let isJSX = false;
+			visit(node, (child, __, parent) => {
+				if (child.type === 'element' || parent == null) {
+					return;
+				}
+				if (child.type === 'raw') {
+					if (child.value.match(/^\n?<.*>\n?$/)) {
 						return;
 					}
-					if (child.type === 'raw') {
-						if (child.value.match(/^\n?<.*>\n?$/)) {
-							return;
-						}
-					}
-					if (child.type === 'text' || child.type === 'raw') {
-						if (new Set(['code', 'pre']).has(parent.tagName)) {
-							text += child.value;
-						} else {
-							text += child.value.replace(/\{/g, '${');
-							isJSX = isJSX || child.value.includes('{');
-						}
-					}
-				});
-
-				node.properties = node.properties || {};
-				if (typeof node.properties.id !== 'string') {
-					if (isJSX) {
-						// HACK: serialized JSX from internal plugins, ignore these for slug
-						const raw = toHtml(node.children, { allowDangerousHtml: true })
-							.replace(/\n(<)/g, '<')
-							.replace(/(>)\n/g, '>');
-						// HACK: for ids that have JSX content, use $$slug helper to generate slug at runtime
-						node.properties.id = `$$slug(\`${text}\`)`;
-						(node as any).type = 'raw';
-						(
-							node as any
-						).value = `<${node.tagName} id={${node.properties.id}}>${raw}</${node.tagName}>`;
+				}
+				if (child.type === 'text' || child.type === 'raw') {
+					if (new Set(['code', 'pre']).has(parent.tagName)) {
+						text += child.value;
 					} else {
-						let slug = slugger.slug(text);
-
-						if (slug.endsWith('-')) slug = slug.slice(0, -1);
-
-						node.properties.id = slug;
+						text += child.value.replace(/\{/g, '${');
+						isJSX = isJSX || child.value.includes('{');
 					}
 				}
-
-				headings.push({ depth, slug: node.properties.id, text });
 			});
-		};
-	}
 
-	return {
-		headings,
-		rehypeCollectHeadings,
+			node.properties = node.properties || {};
+			if (typeof node.properties.id !== 'string') {
+				if (isJSX) {
+					// HACK: serialized JSX from internal plugins, ignore these for slug
+					const raw = toHtml(node.children, { allowDangerousHtml: true })
+						.replace(/\n(<)/g, '<')
+						.replace(/(>)\n/g, '>');
+					// HACK: for ids that have JSX content, use $$slug helper to generate slug at runtime
+					node.properties.id = `$$slug(\`${text}\`)`;
+					(node as any).type = 'raw';
+					(
+						node as any
+					).value = `<${node.tagName} id={${node.properties.id}}>${raw}</${node.tagName}>`;
+				} else {
+					let slug = slugger.slug(text);
+
+					if (slug.endsWith('-')) slug = slug.slice(0, -1);
+
+					node.properties.id = slug;
+				}
+			}
+
+			headings.push({ depth, slug: node.properties.id, text });
+		});
+
+		file.data.__astroHeadings = headings;
 	};
 }

--- a/packages/markdown/remark/src/rehype-collect-headings.ts
+++ b/packages/markdown/remark/src/rehype-collect-headings.ts
@@ -7,7 +7,7 @@ import type { MarkdownHeading, MarkdownVFile, RehypePlugin } from './types.js';
 const rawNodeTypes = new Set(['text', 'raw', 'mdxTextExpression']);
 const codeTagNames = new Set(['code', 'pre']);
 
-export function rehypeHeadingSlugs(): ReturnType<RehypePlugin> {
+export function rehypeHeadingIds(): ReturnType<RehypePlugin> {
 	return function (tree, file: MarkdownVFile) {
 		const headings: MarkdownHeading[] = [];
 		const slugger = new Slugger();

--- a/packages/markdown/remark/src/types.ts
+++ b/packages/markdown/remark/src/types.ts
@@ -68,6 +68,12 @@ export interface MarkdownMetadata {
 	html: string;
 }
 
+export interface MarkdownVFile extends VFile {
+	data: {
+		__astroHeadings?: MarkdownHeading[];
+	};
+}
+
 export interface MarkdownRenderingResult {
 	metadata: MarkdownMetadata;
 	vfile: VFile;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2880,6 +2880,7 @@ importers:
 
   packages/integrations/mdx:
     specifiers:
+      '@astrojs/markdown-remark': ^1.1.3
       '@astrojs/prism': ^1.0.2
       '@mdx-js/mdx': ^2.1.2
       '@mdx-js/rollup': ^2.1.1
@@ -2916,6 +2917,7 @@ importers:
       vfile: ^5.3.2
       vite: ^3.0.0
     dependencies:
+      '@astrojs/markdown-remark': link:../../markdown/remark
       '@astrojs/prism': link:../../astro-prism
       '@mdx-js/mdx': 2.1.5
       '@mdx-js/rollup': 2.1.5


### PR DESCRIPTION
## Changes

- [x] Consolidate MD/MDX collect headings logic
- [x] Expose `rehypeHeadingSlugs` to Astro users via `@astrojs/markdown-remark`
- [x] Flip order of execution for MDX: inject heading IDs _after_ user plugins to match Markdown behaviour
- [x] Reuse `rehypeHeadingSlugs` in MDX integration instead of copy/paste duplication
- [x] Minor releases for both `@astrojs/markdown-remark` and `@astrojs/mdx` (minor == breaking pre v1)

Supersedes #5646 

## Testing

Added tests for:

- being able to override ID generation with the default config
- being able to inject IDs early by using `rehypeHeadingSlugs` directly

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Todo: will probably require an update to the Markdown guide
/cc @withastro/maintainers-docs for feedback!
