### PR TITLE
Unwrap templates that only include a single function expression

### DIFF
--- a/.changeset/itchy-items-shave.md
+++ b/.changeset/itchy-items-shave.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix a regression in 1.7.x that changed the signature of the internal slots API

--- a/packages/astro/src/runtime/server/render/astro/render-template.ts
+++ b/packages/astro/src/runtime/server/render/astro/render-template.ts
@@ -77,5 +77,9 @@ export async function* renderAstroTemplateResult(
 }
 
 export function renderTemplate(htmlParts: TemplateStringsArray, ...expressions: any[]) {
+	// Optimization: unwrap templates that only include a single function expression
+	if (htmlParts.length === 2 &&  expressions.length === 1 && typeof expressions[0] === 'function' && htmlParts.every(part => part.trim() === '')) {
+		return expressions[0];
+	}
 	return new RenderTemplateResult(htmlParts, expressions);
 }


### PR DESCRIPTION
## Changes

- There was a change to how we handle slots in 1.7.x https://github.com/withastro/astro/pull/5291/files#diff-b28cb24c3ad433b2aad5f08fff9eea8039cb4d6f517d427f401890e09d4acec9R35-R38
- This had the effect of _wrapping_ function slots with a template instance, which means any tools **unsafely** relying on our function signature might break.
- Changing this behavior is totally valid and not covered by semver because these are internal APIs, but in this case the fix is straightforward and helps make our function signature easier to reason about. It's also a very tiny performance optimization.

## Testing

Added a unit test to catch regressions

## Docs

N/A, this is an entirely private API