### PR TITLE
Update compiler

### DIFF
--- a/.changeset/fresh-kids-serve.md
+++ b/.changeset/fresh-kids-serve.md
@@ -1,5 +1,0 @@
----
-'astro': patch
----
-
-Update `@astrojs/compiler` to latest

--- a/.changeset/fresh-kids-serve.md
+++ b/.changeset/fresh-kids-serve.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Update `@astrojs/compiler` with improved sourcemaps
+Update `@astrojs/compiler` to latest

--- a/.changeset/fresh-kids-serve.md
+++ b/.changeset/fresh-kids-serve.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Update `@astrojs/compiler` with improved sourcemaps

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -109,7 +109,7 @@
     "test:e2e:match": "playwright test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "0.31.4",
+    "@astrojs/compiler": "^0.31.4",
     "@astrojs/language-server": "^0.28.3",
     "@astrojs/markdown-remark": "^2.0.0-beta.0",
     "@astrojs/telemetry": "^1.0.1",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -109,7 +109,7 @@
     "test:e2e:match": "playwright test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.31.2",
+    "@astrojs/compiler": "0.31.1",
     "@astrojs/language-server": "^0.28.3",
     "@astrojs/markdown-remark": "^2.0.0-beta.0",
     "@astrojs/telemetry": "^1.0.1",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -109,7 +109,7 @@
     "test:e2e:match": "playwright test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "0.31.3",
+    "@astrojs/compiler": "0.0.0-sourcemap-20230103195910",
     "@astrojs/language-server": "^0.28.3",
     "@astrojs/markdown-remark": "^2.0.0-beta.0",
     "@astrojs/telemetry": "^1.0.1",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -109,7 +109,7 @@
     "test:e2e:match": "playwright test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "^0.31.0",
+    "@astrojs/compiler": "^0.31.2",
     "@astrojs/language-server": "^0.28.3",
     "@astrojs/markdown-remark": "^2.0.0-beta.0",
     "@astrojs/telemetry": "^1.0.1",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -109,7 +109,7 @@
     "test:e2e:match": "playwright test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "0.31.1",
+    "@astrojs/compiler": "0.31.3",
     "@astrojs/language-server": "^0.28.3",
     "@astrojs/markdown-remark": "^2.0.0-beta.0",
     "@astrojs/telemetry": "^1.0.1",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -109,7 +109,7 @@
     "test:e2e:match": "playwright test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "0.0.0-sourcemap-20230103195910",
+    "@astrojs/compiler": "0.31.4",
     "@astrojs/language-server": "^0.28.3",
     "@astrojs/markdown-remark": "^2.0.0-beta.0",
     "@astrojs/telemetry": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,7 +385,7 @@ importers:
 
   packages/astro:
     specifiers:
-      '@astrojs/compiler': 0.31.4
+      '@astrojs/compiler': ^0.31.4
       '@astrojs/language-server': ^0.28.3
       '@astrojs/markdown-remark': ^2.0.0-beta.0
       '@astrojs/telemetry': ^1.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,7 +385,7 @@ importers:
 
   packages/astro:
     specifiers:
-      '@astrojs/compiler': ^0.31.0
+      '@astrojs/compiler': 0.31.4
       '@astrojs/language-server': ^0.28.3
       '@astrojs/markdown-remark': ^2.0.0-beta.0
       '@astrojs/telemetry': ^1.0.1
@@ -485,7 +485,7 @@ importers:
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
-      '@astrojs/compiler': 0.31.3
+      '@astrojs/compiler': 0.31.4
       '@astrojs/language-server': 0.28.3
       '@astrojs/markdown-remark': link:../markdown/remark
       '@astrojs/telemetry': link:../telemetry
@@ -3874,8 +3874,8 @@ packages:
       sisteransi: 1.0.5
     dev: false
 
-  /@astrojs/compiler/0.31.3:
-    resolution: {integrity: sha512-WbA05QH5xkdaJ3XtzDuYOjtqsip2InW5rk156sSdaHs5qN2NroUHbzWZthHJwmNAAjQSGXVIj+O6jQj81zzX/Q==}
+  /@astrojs/compiler/0.31.4:
+    resolution: {integrity: sha512-6bBFeDTtPOn4jZaiD3p0f05MEGQL9pw2Zbfj546oFETNmjJFWO3nzHz6/m+P53calknCvyVzZ5YhoBLIvzn5iw==}
 
   /@astrojs/language-server/0.28.3:
     resolution: {integrity: sha512-fPovAX/X46eE2w03jNRMpQ7W9m2mAvNt4Ay65lD9wl1Z5vIQYxlg7Enp9qP225muTr4jSVB5QiLumFJmZMAaVA==}
@@ -7954,7 +7954,7 @@ packages:
     engines: {node: ^14.18.0 || >=16.12.0, npm: '>=6.14.0'}
     hasBin: true
     dependencies:
-      '@astrojs/compiler': 0.31.3
+      '@astrojs/compiler': 0.31.4
       '@astrojs/language-server': 0.28.3
       '@astrojs/markdown-remark': 1.2.0
       '@astrojs/telemetry': 1.0.1
@@ -13255,7 +13255,7 @@ packages:
     engines: {node: ^14.15.0 || >=16.0.0, pnpm: '>=7.14.0'}
     requiresBuild: true
     dependencies:
-      '@astrojs/compiler': 0.31.3
+      '@astrojs/compiler': 0.31.4
       prettier: 2.8.1
       sass-formatter: 0.7.5
       synckit: 0.8.4


### PR DESCRIPTION
## Changes

- Blocked by https://github.com/withastro/compiler/pull/680
- Updates `@astrojs/compiler` to latest
- Improves JS sourcemap fidelity

## Testing

CI

## Docs

N/A