### PR TITLE
[MDX] Remove verbose migration logs

### DIFF
--- a/.changeset/fluffy-cougars-care.md
+++ b/.changeset/fluffy-cougars-care.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Chore: remove verbose "Now interiting Markdown plugins..." logs

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -14,7 +14,7 @@ import {
 	recmaInjectImportMetaEnvPlugin,
 	rehypeApplyFrontmatterExport,
 } from './plugins.js';
-import { getFileInfo, handleExtendsNotSupported, parseFrontmatter } from './utils.js';
+import { getFileInfo, parseFrontmatter } from './utils.js';
 
 const RAW_CONTENT_ERROR =
 	'MDX does not support rawContent()! If you need to read the Markdown contents to calculate values (ex. reading time), we suggest injecting frontmatter via remark plugins. Learn more on our docs: https://docs.astro.build/en/guides/integrations-guide/mdx/#inject-frontmatter-via-remark-or-rehype-plugins';
@@ -45,33 +45,10 @@ export default function mdx(mdxOptions: MdxOptions = {}): AstroIntegration {
 				addPageExtension('.mdx');
 				mdxOptions.extendPlugins ??= 'markdown';
 
-				handleExtendsNotSupported(mdxOptions.remarkPlugins);
-				handleExtendsNotSupported(mdxOptions.rehypePlugins);
-
-				// TODO: remove for 1.0. Shipping to ease migration to new minor
-				if (
-					mdxOptions.extendPlugins === 'markdown' &&
-					(config.markdown.rehypePlugins?.length || config.markdown.remarkPlugins?.length)
-				) {
-					console.info(
-						blue(`[MDX] Now inheriting remark and rehype plugins from "markdown" config.`)
-					);
-					console.info(
-						`If you applied a plugin to both your Markdown and MDX configs, we suggest ${bold(
-							'removing the duplicate MDX entry.'
-						)}`
-					);
-					console.info(`See "extendPlugins" option to configure this behavior.`);
-				}
-
-				let remarkRehypeOptions = mdxOptions.remarkRehype;
-
-				if (mdxOptions.extendPlugins === 'markdown') {
-					remarkRehypeOptions = {
-						...config.markdown.remarkRehype,
-						...remarkRehypeOptions,
-					};
-				}
+				const remarkRehypeOptions = {
+					...(mdxOptions.extendPlugins === 'markdown' ? config.markdown.remarkRehype : {}),
+					...mdxOptions.remarkRehype,
+				};
 
 				const mdxPluginOpts: MdxRollupPluginOptions = {
 					remarkPlugins: await getRemarkPlugins(mdxOptions, config),

--- a/packages/integrations/mdx/src/utils.ts
+++ b/packages/integrations/mdx/src/utils.ts
@@ -83,21 +83,7 @@ export function jsToTreeNode(
 	};
 }
 
-// TODO: remove for 1.0
-export function handleExtendsNotSupported(pluginConfig: any) {
-	if (
-		typeof pluginConfig === 'object' &&
-		pluginConfig !== null &&
-		(pluginConfig as any).hasOwnProperty('extends')
-	) {
-		throw new Error(
-			`[MDX] The "extends" plugin option is no longer supported! Astro now extends your project's \`markdown\` plugin configuration by default. To customize this behavior, see the \`extendPlugins\` option instead: https://docs.astro.build/en/guides/integrations-guide/mdx/#extendplugins`
-		);
-	}
-}
-
 // Following utils taken from `packages/astro/src/core/path.ts`:
-
 export function isRelativePath(path: string) {
 	return startsWithDotDotSlash(path) || startsWithDotSlash(path);
 }


### PR DESCRIPTION
## Changes

- Remove "now inheriting Markdown plugins..." logs
- Remove check for legacy `extends` config option

## Testing

N/A

## Docs

N/A