### PR TITLE
fix (astro): handle quotes in path names

### DIFF
--- a/packages/astro/src/core/build/vite-plugin-pages.ts
+++ b/packages/astro/src/core/build/vite-plugin-pages.ts
@@ -27,8 +27,10 @@ export function vitePluginPages(opts: StaticBuildOptions, internals: BuildIntern
 				let i = 0;
 				for (const pageData of eachPageData(internals)) {
 					const variable = `_page${i}`;
-					imports.push(`import * as ${variable} from '${pageData.moduleSpecifier}';`);
-					importMap += `['${pageData.component}', ${variable}],`;
+					const escapedSpecifier = pageData.moduleSpecifier.replace("'", "\\'");
+					const escapedComponent = pageData.component.replace("'", "\\'");
+					imports.push(`import * as ${variable} from '${escapedSpecifier}';`);
+					importMap += `['${escapedComponent}', ${variable}],`;
 					i++;
 				}
 

--- a/packages/astro/test/astro-pages.test.js
+++ b/packages/astro/test/astro-pages.test.js
@@ -21,6 +21,13 @@ describe('Pages', () => {
 
 			expect($('h1').text()).to.equal('Name with index');
 		});
+
+		it('can find pages with quotes in the name', async () => {
+			const html = await fixture.readFile("/posts/name-with-'-quotes/index.html");
+			const $ = cheerio.load(html);
+
+			expect($('h1').text()).to.equal('Name with quotes');
+		});
 	});
 
 	if (isWindows) return;
@@ -41,6 +48,13 @@ describe('Pages', () => {
 			const $ = cheerio.load(html);
 
 			expect($('#testing').length).to.be.greaterThan(0);
+		});
+
+		it('can load pages with quotes in the name', async () => {
+			const html = await fixture.fetch("/posts/name-with-'-quotes").then((res) => res.text());
+			const $ = cheerio.load(html);
+
+			expect($('h1').text()).to.equal('Name with quotes');
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- Fixes #5670 
- Handles module names with quotes in by escaping them

## Testing

- Added tests to the pages test quite

## Docs

- No docs changes

---

similar to withastro/compiler#683 im just trying to account for paths with quotes in.

let me know if it should be done any differently
