### PR TITLE
[Content Collections] Fix `import.meta.env.DEV` always set to `true`

### DIFF
--- a/.changeset/yellow-gifts-complain.md
+++ b/.changeset/yellow-gifts-complain.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `import.meta.env.DEV` always being set to `true` when using Content Collections

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -153,13 +153,20 @@ export async function loadContentConfig({
 		logLevel: 'silent',
 		plugins: [astroContentVirtualModPlugin({ settings })],
 	});
+
+	const nodeEnv = process.env.NODE_ENV;
 	let unparsedConfig;
 	try {
 		unparsedConfig = await tempConfigServer.ssrLoadModule(contentPaths.config.pathname);
 	} catch {
-		return new NotFoundError('Failed to resolve content config.');
 	} finally {
 		await tempConfigServer.close();
+		// Reset NODE_ENV to initial value
+		// Vite's `createServer()` sets NODE_ENV to 'development'!
+		process.env.NODE_ENV = nodeEnv;
+	}
+	if (!unparsedConfig) {
+		return new NotFoundError('Failed to resolve content config.');
 	}
 	const config = contentConfigParser.safeParse(unparsedConfig);
 	if (config.success) {


### PR DESCRIPTION
## Changes

- Resolves #5625 
- Reset `process.env.NODE_ENV` to initial value after reading content config file

## Testing

Manual testing

## Docs

N/A