### PR TITLE
Remove MDX Fragment hack

### DIFF
--- a/.changeset/lovely-terms-drive.md
+++ b/.changeset/lovely-terms-drive.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+Remove MDX Fragment hack. This was used by `@astrojs/mdx` to access the `Fragment` component, but isn't require anymore since `@astrojs/mdx` v0.12.0.

--- a/.changeset/lovely-terms-drive.md
+++ b/.changeset/lovely-terms-drive.md
@@ -2,4 +2,4 @@
 'astro': major
 ---
 
-Remove MDX Fragment hack. This was used by `@astrojs/mdx` to access the `Fragment` component, but isn't require anymore since `@astrojs/mdx` v0.12.0.
+Remove MDX Fragment hack. This was used by `@astrojs/mdx` to access the `Fragment` component, but isn't require anymore since `@astrojs/mdx` v0.12.1.

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -3,7 +3,7 @@ import type { LogOptions } from '../logger/core.js';
 import type { RenderContext } from './context.js';
 import type { Environment } from './environment.js';
 
-import { Fragment, renderPage as runtimeRenderPage } from '../../runtime/server/index.js';
+import { renderPage as runtimeRenderPage } from '../../runtime/server/index.js';
 import { attachToResponse } from '../cookies/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 import { getParams } from '../routing/params.js';
@@ -111,14 +111,6 @@ export async function renderPage(mod: ComponentInstance, ctx: RenderContext, env
 	// Support `export const components` for `MDX` pages
 	if (typeof (mod as any).components === 'object') {
 		Object.assign(pageProps, { components: (mod as any).components });
-	}
-
-	// HACK: expose `Fragment` for all MDX components
-	// TODO: Remove in Astro v2 — redundant as of @astrojs/mdx@>0.12.0
-	if (typeof mod.default === 'function' && mod.default.name.startsWith('MDX')) {
-		Object.assign(pageProps, {
-			components: Object.assign((pageProps?.components as any) ?? {}, { Fragment }),
-		});
 	}
 
 	const response = await runtimeRenderPage(


### PR DESCRIPTION
## Changes

Removed the hack used by `@astrojs/mdx` pre v0.12.0. Breaking change for Astro 2.0.

See https://github.com/withastro/astro/pull/5522 for more details.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing test should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. internal change.