### PR TITLE
Refactor tailwind integration setup

### DIFF
--- a/.changeset/thick-walls-smell.md
+++ b/.changeset/thick-walls-smell.md
@@ -1,0 +1,6 @@
+---
+'astro': major
+'@astrojs/tailwind': major
+---
+
+Remove `style.postcss` Astro config. Refactor tailwind integration to configure through `vite` instead. Also disables `autoprefixer` in dev.

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -29,7 +29,6 @@ const ASTRO_CONFIG_DEFAULTS: AstroUserConfig & any = {
 		port: 3000,
 		streaming: true,
 	},
-	style: { postcss: { options: {}, plugins: [] } },
 	integrations: [],
 	markdown: {
 		drafts: false,
@@ -136,18 +135,6 @@ export const AstroConfigSchema = z.object({
 			.optional()
 			.default({})
 	),
-	style: z
-		.object({
-			postcss: z
-				.object({
-					options: z.any(),
-					plugins: z.array(z.any()),
-				})
-				.optional()
-				.default(ASTRO_CONFIG_DEFAULTS.style.postcss),
-		})
-		.optional()
-		.default({}),
 	markdown: z
 		.object({
 			drafts: z.boolean().default(false),
@@ -311,21 +298,6 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: URL) {
 				.optional()
 				.default({})
 		),
-		style: z
-			.object({
-				postcss: z.preprocess(
-					(val) => resolvePostcssConfig(val, fileProtocolRoot),
-					z
-						.object({
-							options: z.any(),
-							plugins: z.array(z.any()),
-						})
-						.optional()
-						.default(ASTRO_CONFIG_DEFAULTS.style.postcss)
-				),
-			})
-			.optional()
-			.default({}),
 	}).transform((config) => {
 		// If the user changed outDir but not build.server, build.config, adjust so those
 		// are relative to the outDir, as is the expected default.

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -151,9 +151,6 @@ export async function createVite(
 				ignored: mode === 'build' ? ['**'] : undefined,
 			},
 		},
-		css: {
-			postcss: settings.config.style.postcss || {},
-		},
 		resolve: {
 			alias: [
 				{

--- a/packages/integrations/svelte/src/index.ts
+++ b/packages/integrations/svelte/src/index.ts
@@ -1,6 +1,6 @@
 import type { Options } from '@sveltejs/vite-plugin-svelte';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
-import type { AstroConfig, AstroIntegration, AstroRenderer } from 'astro';
+import type { AstroIntegration, AstroRenderer } from 'astro';
 import preprocess from 'svelte-preprocess';
 import type { UserConfig } from 'vite';
 
@@ -15,21 +15,16 @@ function getRenderer(): AstroRenderer {
 type ViteConfigurationArgs = {
 	isDev: boolean;
 	options?: Options | OptionsCallback;
-	postcssConfig: AstroConfig['style']['postcss'];
 };
 
-function getViteConfiguration({
-	options,
-	postcssConfig,
-	isDev,
-}: ViteConfigurationArgs): UserConfig {
+function getViteConfiguration({ options, isDev }: ViteConfigurationArgs): UserConfig {
 	const defaultOptions: Partial<Options> = {
 		emitCss: true,
 		compilerOptions: { dev: isDev, hydratable: true },
 		preprocess: [
 			preprocess({
 				less: true,
-				postcss: postcssConfig,
+				postcss: true,
 				sass: { renderSync: true },
 				scss: { renderSync: true },
 				stylus: true,
@@ -78,13 +73,12 @@ export default function (options?: Options | OptionsCallback): AstroIntegration 
 		name: '@astrojs/svelte',
 		hooks: {
 			// Anything that gets returned here is merged into Astro Config
-			'astro:config:setup': ({ command, updateConfig, addRenderer, config }) => {
+			'astro:config:setup': ({ command, updateConfig, addRenderer }) => {
 				addRenderer(getRenderer());
 				updateConfig({
 					vite: getViteConfiguration({
 						options,
 						isDev: command === 'dev',
-						postcssConfig: config.style.postcss,
 					}),
 				});
 			},


### PR DESCRIPTION
## Changes

As discussed in the [maintainers chat](https://discord.com/channels/830184174198718474/857704189723541514/1057581910051794994), the `style.postcss` Astro config can be removed in favour of `vite.css.postcss`. They do the same thing internally, and is only a property used by the tailwind integration.

I also disabled autoprefixer in dev. I'm not sure if this was intentional, but enabling it slows down dev a lot so I changed that in the PR too.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
It doesn't seem like there's existing tests for tailwind, but I've tested manually with the `with-tailwindcss` example and it works.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. internal refactor.