### PR TITLE
fix(astro/core): Do not add base to hoisted script body

### DIFF
--- a/.changeset/good-carpets-confess.md
+++ b/.changeset/good-carpets-confess.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Do not add base path to a hoisted script body

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -167,7 +167,7 @@ function buildManifest(
 		if (pageData.hoistedScript) {
 			scripts.unshift(
 				Object.assign({}, pageData.hoistedScript, {
-					value: joinBase(pageData.hoistedScript.value),
+					value: pageData.hoistedScript.value,
 				})
 			);
 		}

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -44,24 +44,23 @@ const _manifest = Object.assign(_deserializeManifest('${manifestReplace}'), {
 	renderers: _main.renderers
 });
 const _args = ${adapter.args ? JSON.stringify(adapter.args) : 'undefined'};
-
 export * from '${pagesVirtualModuleId}';
-
+${
+	adapter.exports
+		? `const _exports = adapter.createExports(_manifest, _args);
 ${adapter.exports
-						? `const _exports = adapter.createExports(_manifest, _args);
-${adapter.exports
-							.map((name) => {
-								if (name === 'default') {
-									return `const _default = _exports['default'];
+	.map((name) => {
+		if (name === 'default') {
+			return `const _default = _exports['default'];
 export { _default as default };`;
-								} else {
-									return `export const ${name} = _exports['${name}'];`;
-								}
-							})
-							.join('\n')}
+		} else {
+			return `export const ${name} = _exports['${name}'];`;
+		}
+	})
+	.join('\n')}
 `
-						: ''
-					}
+		: ''
+}
 const _start = 'start';
 if(_start in adapter) {
 	adapter[_start](_manifest, _args);

--- a/packages/astro/src/core/build/vite-plugin-ssr.ts
+++ b/packages/astro/src/core/build/vite-plugin-ssr.ts
@@ -47,22 +47,21 @@ const _args = ${adapter.args ? JSON.stringify(adapter.args) : 'undefined'};
 
 export * from '${pagesVirtualModuleId}';
 
-${
-	adapter.exports
-		? `const _exports = adapter.createExports(_manifest, _args);
 ${adapter.exports
-	.map((name) => {
-		if (name === 'default') {
-			return `const _default = _exports['default'];
+						? `const _exports = adapter.createExports(_manifest, _args);
+${adapter.exports
+							.map((name) => {
+								if (name === 'default') {
+									return `const _default = _exports['default'];
 export { _default as default };`;
-		} else {
-			return `export const ${name} = _exports['${name}'];`;
-		}
-	})
-	.join('\n')}
+								} else {
+									return `export const ${name} = _exports['${name}'];`;
+								}
+							})
+							.join('\n')}
 `
-		: ''
-}
+						: ''
+					}
 const _start = 'start';
 if(_start in adapter) {
 	adapter[_start](_manifest, _args);
@@ -165,9 +164,11 @@ function buildManifest(
 	for (const pageData of eachServerPageData(internals)) {
 		const scripts: SerializedRouteInfo['scripts'] = [];
 		if (pageData.hoistedScript) {
+			const hoistedValue = pageData.hoistedScript.value
+			const value = hoistedValue.endsWith('.js') ? joinBase(hoistedValue) : hoistedValue
 			scripts.unshift(
 				Object.assign({}, pageData.hoistedScript, {
-					value: pageData.hoistedScript.value,
+					value,
 				})
 			);
 		}

--- a/packages/astro/test/ssr-hoisted-script.test.js
+++ b/packages/astro/test/ssr-hoisted-script.test.js
@@ -29,4 +29,24 @@ describe('Hoisted scripts in SSR', () => {
 		const $ = cheerioLoad(html);
 		expect($('script').length).to.equal(1);
 	});
+
+	describe('base path', () => {
+		const base = '/hello';
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/ssr-hoisted-script/',
+				output: 'server',
+				adapter: testAdapter(),
+				base,
+			});
+			await fixture.build();
+		});
+
+		it('Inlined scripts get included without base path in the script', async () => {
+			const html = await fetchHTML('/hello/');
+			const $ = cheerioLoad(html);
+			expect($('script').html()).to.equal('console.log("hello world");\n');
+		});
+	});
 });


### PR DESCRIPTION
## Changes

Remove inclusion of the base path from config into a hoisted script body. 

Before the hoisted script would be like this if the config has this base value: `base: 'astro-base-bug'`

```js
astro-base-bug/console.log("hello");
```

This would break when the page loads.

After my changes, things are as expected:

```js
console.log("hello");
```

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Added a test to confirm the fix. While writing the tests, I had the previous version in `dist` and it fail and include the base path value in the script as well.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No changes to docs necessary
