### PR TITLE
Remove `pages` param from `astro:build:done`

### DIFF
--- a/.changeset/green-mangos-fix.md
+++ b/.changeset/green-mangos-fix.md
@@ -1,0 +1,12 @@
+---
+'astro': major
+'@astrojs/sitemap': patch
+---
+
+Remove the `pages` parameter from the `astro:build:done` integration hook.
+
+#### Migration
+
+The `pages` parameter was an undocumented parameter used by the `@astrojs/sitemap` integration. If your integration relied on `pages`, use the `routes` parameter and associated `pathname` property instead.
+
+Note: The `pathname` property on `routes` does _not_ respect [the `trailingSlash` property](https://docs.astro.build/en/reference/configuration-reference/#trailingslash) in your Astro config. If needed, ensure you append this slash after reading the user's Astro config.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1440,11 +1440,7 @@ export interface AstroIntegration {
 			updateConfig: (newConfig: vite.InlineConfig) => void;
 		}) => void | Promise<void>;
 		'astro:build:generated'?: (options: { dir: URL }) => void | Promise<void>;
-		'astro:build:done'?: (options: {
-			pages: { pathname: string }[];
-			dir: URL;
-			routes: RouteData[];
-		}) => void | Promise<void>;
+		'astro:build:done'?: (options: { dir: URL; routes: RouteData[] }) => void | Promise<void>;
 	};
 }
 

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -239,35 +239,6 @@ interface GeneratePathOptions {
 	renderers: SSRLoadedRenderer[];
 }
 
-function shouldAppendForwardSlash(
-	trailingSlash: AstroConfig['trailingSlash'],
-	buildFormat: AstroConfig['build']['format']
-): boolean {
-	switch (trailingSlash) {
-		case 'always':
-			return true;
-		case 'never':
-			return false;
-		case 'ignore': {
-			switch (buildFormat) {
-				case 'directory':
-					return true;
-				case 'file':
-					return false;
-			}
-		}
-	}
-}
-
-function addPageName(pathname: string, opts: StaticBuildOptions): void {
-	const trailingSlash = opts.settings.config.trailingSlash;
-	const buildFormat = opts.settings.config.build.format;
-	const pageName = shouldAppendForwardSlash(trailingSlash, buildFormat)
-		? pathname.replace(/\/?$/, '/').replace(/^\//, '')
-		: pathname.replace(/^\//, '');
-	opts.pageNames.push(pageName);
-}
-
 function getUrlForPath(
 	pathname: string,
 	base: string,
@@ -303,11 +274,6 @@ async function generatePath(
 ) {
 	const { settings, logging, origin, routeCache } = opts;
 	const { mod, internals, linkIds, scripts: hoistedScripts, pageData, renderers } = gopts;
-
-	// This adds the page name to the array so it can be shown as part of stats.
-	if (pageData.route.type === 'page') {
-		addPageName(pathname, opts);
-	}
 
 	debug('build', `Generating: ${pathname}`);
 

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -107,9 +107,6 @@ class AstroBuilder {
 
 		debug('build', timerMessage('All pages loaded', this.timer.loadStart));
 
-		// The names of each pages
-		const pageNames: string[] = [];
-
 		// Bundle the assets in your final build: This currently takes the HTML output
 		// of every page (stored in memory) and bundles the assets pointed to on those pages.
 		this.timer.buildStart = performance.now();
@@ -126,7 +123,6 @@ class AstroBuilder {
 			manifest: this.manifest,
 			mode: this.mode,
 			origin: this.origin,
-			pageNames,
 			routeCache: this.routeCache,
 			viteConfig,
 			buildConfig,
@@ -143,12 +139,13 @@ class AstroBuilder {
 		});
 		debug('build', timerMessage('Additional assets copied', this.timer.assetsStart));
 
+		const routes = Object.values(allPages).map((pd) => pd.route);
+
 		// You're done! Time to clean up.
 		await runHookBuildDone({
 			config: this.settings.config,
 			buildConfig,
-			pages: pageNames,
-			routes: Object.values(allPages).map((pd) => pd.route),
+			routes,
 			logging: this.logging,
 		});
 
@@ -156,7 +153,7 @@ class AstroBuilder {
 			await this.printStats({
 				logging: this.logging,
 				timeStart: this.timer.init,
-				pageCount: pageNames.length,
+				pageCount: routes.filter((r) => r.type === 'page').length,
 				buildMode: this.settings.config.output,
 			});
 		}

--- a/packages/astro/src/core/build/types.ts
+++ b/packages/astro/src/core/build/types.ts
@@ -35,7 +35,6 @@ export interface StaticBuildOptions {
 	manifest: ManifestData;
 	mode: RuntimeMode;
 	origin: string;
-	pageNames: string[];
 	routeCache: RouteCache;
 	viteConfig: InlineConfig;
 }

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -335,13 +335,11 @@ export async function runHookBuildGenerated({
 export async function runHookBuildDone({
 	config,
 	buildConfig,
-	pages,
 	routes,
 	logging,
 }: {
 	config: AstroConfig;
 	buildConfig: BuildConfig;
-	pages: string[];
 	routes: RouteData[];
 	logging: LogOptions;
 }) {
@@ -353,7 +351,6 @@ export async function runHookBuildDone({
 			await withTakingALongTimeMsg({
 				name: integration.name,
 				hookResult: integration.hooks['astro:build:done']({
-					pages: pages.map((p) => ({ pathname: p })),
 					dir,
 					routes,
 				}),

--- a/packages/integrations/sitemap/src/utils/format-pathname.ts
+++ b/packages/integrations/sitemap/src/utils/format-pathname.ts
@@ -1,0 +1,30 @@
+import type { AstroConfig } from 'astro';
+
+export function formatPathname({
+	pathname,
+	config,
+}: {
+	pathname: string;
+	config: AstroConfig;
+}): string {
+	return shouldAppendForwardSlash(config)
+		? pathname.replace(/\/?$/, '/').replace(/^\//, '')
+		: pathname.replace(/^\//, '');
+}
+
+function shouldAppendForwardSlash(config: AstroConfig): boolean {
+	switch (config.trailingSlash) {
+		case 'always':
+			return true;
+		case 'never':
+			return false;
+		case 'ignore': {
+			switch (config.build.format) {
+				case 'directory':
+					return true;
+				case 'file':
+					return false;
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Changes

This PR removes the `pages` parameter from the `astro:build:done` hook and associated core logic. `pages` is an undocumented parameter that only the `@astrojs/sitemap` integration depends on. Its behavior has been replaced by `routes` across our other integrations and adapters, and requires a `pageNames` calculation that's unused by core.

## Testing

Ensure existing sitemap integration tests still pass

## Docs

- Remove `pages` from API quick reference (didn't match `astro:build:done` full length docs!) https://github.com/withastro/docs/pull/2277
