### PR TITLE
Fix astro-embed peerDep issue

### DIFF
--- a/packages/astro/test/fixtures/third-party-astro/package.json
+++ b/packages/astro/test/fixtures/third-party-astro/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "astro": "workspace:*",
+    "astro": "^1.0.0",
     "astro-embed": "^0.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2493,7 +2493,7 @@ importers:
 
   packages/astro/test/fixtures/third-party-astro:
     specifiers:
-      astro: workspace:*
+      astro: ^1.0.0
       astro-embed: ^0.1.1
     dependencies:
       astro: link:../../..


### PR DESCRIPTION
This is needed to get the beta release out. astro-embed depends on Astro 1, so bumping to 2 breaks its peerDep.