### PR TITLE
update frontmatter injection link to match docs changes

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -523,7 +523,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	/**
 	 * @docs
 	 * @see
-	 * - [Frontmatter injection](https://docs.astro.build/en/guides/markdown-content/#example-injecting-frontmatter)
+	 * - [Frontmatter injection](https://docs.astro.build/en/guides/markdown-content/#modifying-frontmatter-programmatically)
 	 * @description
 	 * A remark or rehype plugin attempted to inject invalid frontmatter. This occurs when "astro.frontmatter" is set to `null`, `undefined`, or an invalid JSON object.
 	 */
@@ -532,7 +532,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 		code: 6003,
 		message:
 			'A remark or rehype plugin attempted to inject invalid frontmatter. Ensure "astro.frontmatter" is set to a valid JSON object that is not `null` or `undefined`.',
-		hint: 'See the frontmatter injection docs https://docs.astro.build/en/guides/markdown-content/#example-injecting-frontmatter for more information.',
+		hint: 'See the frontmatter injection docs https://docs.astro.build/en/guides/markdown-content/#modifying-frontmatter-programmatically for more information.',
 	},
 	// Config Errors - 7xxx
 	UnknownConfigError: {

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -523,7 +523,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	/**
 	 * @docs
 	 * @see
-	 * - [Frontmatter injection](https://docs.astro.build/en/guides/markdown-content/#modifying-frontmatter-programmatically)
+	 * - [Modifying frontmatter programmatically](https://docs.astro.build/en/guides/markdown-content/#modifying-frontmatter-programmatically)
 	 * @description
 	 * A remark or rehype plugin attempted to inject invalid frontmatter. This occurs when "astro.frontmatter" is set to `null`, `undefined`, or an invalid JSON object.
 	 */


### PR DESCRIPTION
## Changes

Docs changed some headings, so this link needs to be updated:

frontmatter injection -> modifying frontmatter

I don't know whether we want to change the error message name or anything else in the description now that we decided to say "modifying frontmatter" vs "frontmatter injection", but at least this corrects the outdated link.

cc @bholmesdev @Princesseuh 

## Testing

No tests.

## Docs

Will reflect in docs.
