### PR TITLE
Add file location to errors in build

### DIFF
--- a/.changeset/shaggy-melons-tap.md
+++ b/.changeset/shaggy-melons-tap.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add error location during build for user-generated errors

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -403,7 +403,7 @@ async function generatePath(
 		try {
 			response = await renderPage(mod, ctx, env);
 		} catch (err) {
-			if (!AstroError.is(err) && !(err as SSRError).id) {
+			if (!AstroError.is(err) && !(err as SSRError).id && typeof err === 'object') {
 				(err as SSRError).id = pageData.component;
 			}
 			throw err;

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -10,6 +10,7 @@ import type {
 	ComponentInstance,
 	EndpointHandler,
 	RouteType,
+	SSRError,
 	SSRLoadedRenderer,
 } from '../../@types/astro';
 import { getContentPaths } from '../../content/index.js';
@@ -22,6 +23,7 @@ import {
 import { runHookBuildGenerated } from '../../integrations/index.js';
 import { BEFORE_HYDRATION_SCRIPT_ID, PAGE_SCRIPT_ID } from '../../vite-plugin-scripts/index.js';
 import { call as callEndpoint, throwIfRedirectNotAllowed } from '../endpoint/index.js';
+import { AstroError } from '../errors/index.js';
 import { debug, info } from '../logger/core.js';
 import { createEnvironment, createRenderContext, renderPage } from '../render/index.js';
 import { callGetStaticPaths } from '../render/route-cache.js';
@@ -397,7 +399,15 @@ async function generatePath(
 			encoding = result.encoding;
 		}
 	} else {
-		const response = await renderPage(mod, ctx, env);
+		let response: Response;
+		try {
+			response = await renderPage(mod, ctx, env);
+		} catch (err) {
+			if (!AstroError.is(err) && !(err as SSRError).id) {
+				(err as SSRError).id = pageData.component;
+			}
+			throw err;
+		}
 		throwIfRedirectNotAllowed(response, opts.settings.config);
 		// If there's no body, do nothing
 		if (!response.body) return;

--- a/packages/astro/src/core/errors/utils.ts
+++ b/packages/astro/src/core/errors/utils.ts
@@ -80,7 +80,7 @@ export function createSafeError(err: any): Error {
 
 		(
 			error as SSRError
-		).hint = `To get as much information as possible from your errors, make sure to throw Error objects instead of \`${typeof err}\`. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error for more information`;
+		).hint = `To get as much information as possible from your errors, make sure to throw Error objects instead of \`${typeof err}\`. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error for more information.`;
 
 		return error;
 	}

--- a/packages/astro/src/core/errors/utils.ts
+++ b/packages/astro/src/core/errors/utils.ts
@@ -1,4 +1,5 @@
 import { DiagnosticCode } from '@astrojs/compiler/shared/diagnostics.js';
+import type { SSRError } from '../../@types/astro.js';
 import { AstroErrorCodes, AstroErrorData } from './errors-data.js';
 
 /**
@@ -72,9 +73,17 @@ function getLineOffsets(text: string) {
 
 /** Coalesce any throw variable to an Error instance. */
 export function createSafeError(err: any): Error {
-	return err instanceof Error || (err && err.name && err.message)
-		? err
-		: new Error(JSON.stringify(err));
+	if (err instanceof Error || (err && err.name && err.message)) {
+		return err;
+	} else {
+		const error = new Error(JSON.stringify(err));
+
+		(
+			error as SSRError
+		).hint = `To get as much information as possible from your errors, make sure to throw Error objects instead of \`${typeof err}\`. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error for more information`;
+
+		return error;
+	}
 }
 
 export function normalizeLF(code: string) {

--- a/packages/astro/test/error-build-location.test.js
+++ b/packages/astro/test/error-build-location.test.js
@@ -5,7 +5,7 @@ describe('Errors information in build', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
 
-	it('Does not crash the dev server', async () => {
+	it('includes the file where the error happened', async () => {
 		fixture = await loadFixture({
 			root: './fixtures/error-build-location',
 		});

--- a/packages/astro/test/error-build-location.test.js
+++ b/packages/astro/test/error-build-location.test.js
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+import { loadFixture } from './test-utils.js';
+
+describe('Errors information in build', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	it('Does not crash the dev server', async () => {
+		fixture = await loadFixture({
+			root: './fixtures/error-build-location',
+		});
+
+		let errorContent;
+		try {
+			await fixture.build();
+		} catch (e) {
+			errorContent = e;
+		}
+
+		expect(errorContent.id).to.equal('src/pages/index.astro');
+	});
+});

--- a/packages/astro/test/fixtures/error-build-location/astro.config.mjs
+++ b/packages/astro/test/fixtures/error-build-location/astro.config.mjs
@@ -1,0 +1,3 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({});

--- a/packages/astro/test/fixtures/error-build-location/package.json
+++ b/packages/astro/test/fixtures/error-build-location/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@test/error-non-error",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/error-build-location/src/env.d.ts
+++ b/packages/astro/test/fixtures/error-build-location/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/packages/astro/test/fixtures/error-build-location/src/pages/index.astro
+++ b/packages/astro/test/fixtures/error-build-location/src/pages/index.astro
@@ -1,0 +1,3 @@
+---
+throw new Error("I'm happening in build!")
+---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1781,6 +1781,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/error-build-location:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/error-non-error:
     specifiers:
       astro: workspace:*


### PR DESCRIPTION
## Changes

Errors in build don't go through the same pipeline as in dev, as such some information was missing from errors thrown there. This doesn't add all of it, and presumably we should do this through the sourcemap eventually, but at least this now show in which file the error happened. This is only a problem for user-thrown errors, our errors already included the location as far as I could tell.

This PR additionally adds a hint to non-Error errors recommending users to instead throw Errors to get as much information as possible from their errors

Fix https://github.com/withastro/astro/issues/5733

## Testing

Added a test

## Docs

N/A