### PR TITLE
[ci] Skip OG images in docs smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,4 +219,5 @@ jobs:
       - name: Test
         run: pnpm run test:smoke
         env:
+          SKIP_OG: 1
           NODE_OPTIONS: "--max-old-space-size=4096"


### PR DESCRIPTION
## Changes

- Adds `SKIP_OG` env flag for `docs` smoke test.
- This should speed up our smoke tests by avoiding Open Graph image generation in the docs!

## Testing

N/A, tooling change only

## Docs

N/A, tooling change only