### PR TITLE
Setup changesets to backport to 1.0 legacy branch

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "1-legacy",
   "updateInternalDependencies": "patch",
   "ignore": ["@example/*", "@test/*"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "1-legacy",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": ["@example/*", "@test/*"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - 1-legacy
 
 defaults:
   run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches:
+      - main
       - 1-legacy
 
 defaults:


### PR DESCRIPTION
This is so that we can run a patch release for 1.0 without doing so manually. Once the legacy branch has been created we will revert this change.