### PR TITLE
[Content Collections] Allow Zod unions, objects, and transforms as schemas

### DIFF
--- a/examples/with-content/src/content/config.ts
+++ b/examples/with-content/src/content/config.ts
@@ -2,7 +2,7 @@ import { defineCollection, z } from 'astro:content';
 
 const blog = defineCollection({
 	// Type-check frontmatter using a schema
-	schema: {
+	schema: z.object({
 		title: z.string(),
 		description: z.string(),
 		// Transform string to Date object
@@ -12,7 +12,7 @@ const blog = defineCollection({
 			.optional()
 			.transform((str) => (str ? new Date(str) : undefined)),
 		heroImage: z.string().optional(),
-	},
+	}),
 });
 
 export const collections = { blog };

--- a/examples/with-content/src/content/types.generated.d.ts
+++ b/examples/with-content/src/content/types.generated.d.ts
@@ -3,7 +3,20 @@ declare module 'astro:content' {
 	export type CollectionEntry<C extends keyof typeof entryMap> =
 		typeof entryMap[C][keyof typeof entryMap[C]] & Render;
 
-	type BaseCollectionConfig<S extends import('astro/zod').ZodType> = {
+	type BaseSchemaWithoutEffects =
+		| import('astro/zod').AnyZodObject
+		| import('astro/zod').ZodUnion<import('astro/zod').AnyZodObject[]>
+		| import('astro/zod').ZodDiscriminatedUnion<string, import('astro/zod').AnyZodObject[]>
+		| import('astro/zod').ZodIntersection<
+				import('astro/zod').AnyZodObject,
+				import('astro/zod').AnyZodObject
+		  >;
+
+	type BaseSchema =
+		| BaseSchemaWithoutEffects
+		| import('astro/zod').ZodEffects<BaseSchemaWithoutEffects>;
+
+	type BaseCollectionConfig<S extends BaseSchema> = {
 		schema?: S;
 		slug?: (entry: {
 			id: CollectionEntry<keyof typeof entryMap>['id'];
@@ -13,7 +26,7 @@ declare module 'astro:content' {
 			data: import('astro/zod').infer<S>;
 		}) => string | Promise<string>;
 	};
-	export function defineCollection<S extends import('astro/zod').ZodType>(
+	export function defineCollection<S extends BaseSchema>(
 		input: BaseCollectionConfig<S>
 	): BaseCollectionConfig<S>;
 

--- a/examples/with-content/src/content/types.generated.d.ts
+++ b/examples/with-content/src/content/types.generated.d.ts
@@ -3,7 +3,7 @@ declare module 'astro:content' {
 	export type CollectionEntry<C extends keyof typeof entryMap> =
 		typeof entryMap[C][keyof typeof entryMap[C]] & Render;
 
-	type BaseCollectionConfig<S extends import('astro/zod').ZodRawShape> = {
+	type BaseCollectionConfig<S extends import('astro/zod').ZodType> = {
 		schema?: S;
 		slug?: (entry: {
 			id: CollectionEntry<keyof typeof entryMap>['id'];
@@ -13,7 +13,7 @@ declare module 'astro:content' {
 			data: import('astro/zod').infer<S>;
 		}) => string | Promise<string>;
 	};
-	export function defineCollection<S extends import('astro/zod').ZodRawShape>(
+	export function defineCollection<S extends import('astro/zod').ZodType>(
 		input: BaseCollectionConfig<S>
 	): BaseCollectionConfig<S>;
 

--- a/examples/with-content/src/content/types.generated.d.ts
+++ b/examples/with-content/src/content/types.generated.d.ts
@@ -10,7 +10,7 @@ declare module 'astro:content' {
 			defaultSlug: string;
 			collection: string;
 			body: string;
-			data: import('astro/zod').infer<import('astro/zod').ZodObject<S>>;
+			data: import('astro/zod').infer<S>;
 		}) => string | Promise<string>;
 	};
 	export function defineCollection<S extends import('astro/zod').ZodRawShape>(
@@ -30,7 +30,7 @@ declare module 'astro:content' {
 	): Promise<(typeof entryMap[C][E] & Render)[]>;
 
 	type InferEntrySchema<C extends keyof typeof entryMap> = import('astro/zod').infer<
-		import('astro/zod').ZodObject<Required<ContentConfig['collections'][C]>['schema']>
+		Required<ContentConfig['collections'][C]>['schema']
 	>;
 
 	type Render = {
@@ -42,44 +42,45 @@ declare module 'astro:content' {
 	};
 
 	const entryMap: {
-		blog: {
-			'first-post.md': {
-				id: 'first-post.md';
-				slug: 'first-post';
-				body: string;
-				collection: 'blog';
-				data: InferEntrySchema<'blog'>;
-			};
-			'markdown-style-guide.md': {
-				id: 'markdown-style-guide.md';
-				slug: 'markdown-style-guide';
-				body: string;
-				collection: 'blog';
-				data: InferEntrySchema<'blog'>;
-			};
-			'second-post.md': {
-				id: 'second-post.md';
-				slug: 'second-post';
-				body: string;
-				collection: 'blog';
-				data: InferEntrySchema<'blog'>;
-			};
-			'third-post.md': {
-				id: 'third-post.md';
-				slug: 'third-post';
-				body: string;
-				collection: 'blog';
-				data: InferEntrySchema<'blog'>;
-			};
-			'using-mdx.mdx': {
-				id: 'using-mdx.mdx';
-				slug: 'using-mdx';
-				body: string;
-				collection: 'blog';
-				data: InferEntrySchema<'blog'>;
-			};
-		};
+		"blog": {
+"first-post.md": {
+  id: "first-post.md",
+  slug: "first-post",
+  body: string,
+  collection: "blog",
+  data: InferEntrySchema<"blog">
+},
+"markdown-style-guide.md": {
+  id: "markdown-style-guide.md",
+  slug: "markdown-style-guide",
+  body: string,
+  collection: "blog",
+  data: InferEntrySchema<"blog">
+},
+"second-post.md": {
+  id: "second-post.md",
+  slug: "second-post",
+  body: string,
+  collection: "blog",
+  data: InferEntrySchema<"blog">
+},
+"third-post.md": {
+  id: "third-post.md",
+  slug: "third-post",
+  body: string,
+  collection: "blog",
+  data: InferEntrySchema<"blog">
+},
+"using-mdx.mdx": {
+  id: "using-mdx.mdx",
+  slug: "using-mdx",
+  body: string,
+  collection: "blog",
+  data: InferEntrySchema<"blog">
+},
+},
+
 	};
 
-	type ContentConfig = typeof import('./config');
+	type ContentConfig = typeof import("./config");
 }

--- a/packages/astro/src/content/template/types.generated.d.ts
+++ b/packages/astro/src/content/template/types.generated.d.ts
@@ -10,7 +10,7 @@ declare module 'astro:content' {
 			defaultSlug: string;
 			collection: string;
 			body: string;
-			data: import('astro/zod').infer<import('astro/zod').ZodObject<S>>;
+			data: import('astro/zod').infer<S>;
 		}) => string | Promise<string>;
 	};
 	export function defineCollection<S extends import('astro/zod').ZodRawShape>(
@@ -30,7 +30,7 @@ declare module 'astro:content' {
 	): Promise<(typeof entryMap[C][E] & Render)[]>;
 
 	type InferEntrySchema<C extends keyof typeof entryMap> = import('astro/zod').infer<
-		import('astro/zod').ZodObject<Required<ContentConfig['collections'][C]>['schema']>
+		Required<ContentConfig['collections'][C]>['schema']
 	>;
 
 	type Render = {

--- a/packages/astro/src/content/template/types.generated.d.ts
+++ b/packages/astro/src/content/template/types.generated.d.ts
@@ -3,7 +3,20 @@ declare module 'astro:content' {
 	export type CollectionEntry<C extends keyof typeof entryMap> =
 		typeof entryMap[C][keyof typeof entryMap[C]] & Render;
 
-	type BaseCollectionConfig<S extends import('astro/zod').ZodType> = {
+	type BaseSchemaWithoutEffects =
+		| import('astro/zod').AnyZodObject
+		| import('astro/zod').ZodUnion<import('astro/zod').AnyZodObject[]>
+		| import('astro/zod').ZodDiscriminatedUnion<string, import('astro/zod').AnyZodObject[]>
+		| import('astro/zod').ZodIntersection<
+				import('astro/zod').AnyZodObject,
+				import('astro/zod').AnyZodObject
+		  >;
+
+	type BaseSchema =
+		| BaseSchemaWithoutEffects
+		| import('astro/zod').ZodEffects<BaseSchemaWithoutEffects>;
+
+	type BaseCollectionConfig<S extends BaseSchema> = {
 		schema?: S;
 		slug?: (entry: {
 			id: CollectionEntry<keyof typeof entryMap>['id'];
@@ -13,7 +26,7 @@ declare module 'astro:content' {
 			data: import('astro/zod').infer<S>;
 		}) => string | Promise<string>;
 	};
-	export function defineCollection<S extends import('astro/zod').ZodType>(
+	export function defineCollection<S extends BaseSchema>(
 		input: BaseCollectionConfig<S>
 	): BaseCollectionConfig<S>;
 

--- a/packages/astro/src/content/template/types.generated.d.ts
+++ b/packages/astro/src/content/template/types.generated.d.ts
@@ -3,7 +3,7 @@ declare module 'astro:content' {
 	export type CollectionEntry<C extends keyof typeof entryMap> =
 		typeof entryMap[C][keyof typeof entryMap[C]] & Render;
 
-	type BaseCollectionConfig<S extends import('astro/zod').ZodRawShape> = {
+	type BaseCollectionConfig<S extends import('astro/zod').ZodType> = {
 		schema?: S;
 		slug?: (entry: {
 			id: CollectionEntry<keyof typeof entryMap>['id'];
@@ -13,7 +13,7 @@ declare module 'astro:content' {
 			data: import('astro/zod').infer<S>;
 		}) => string | Promise<string>;
 	};
-	export function defineCollection<S extends import('astro/zod').ZodRawShape>(
+	export function defineCollection<S extends import('astro/zod').ZodType>(
 		input: BaseCollectionConfig<S>
 	): BaseCollectionConfig<S>;
 

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -4,7 +4,7 @@ import type fsMod from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createServer, ErrorPayload as ViteErrorPayload, normalizePath, ViteDevServer } from 'vite';
-import { z, ZodType } from 'zod';
+import { z } from 'zod';
 import { AstroSettings } from '../@types/astro.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { astroContentVirtualModPlugin } from './vite-plugin-content-virtual-mod.js';
@@ -69,7 +69,10 @@ export async function getEntryData(entry: Entry, collectionConfig: CollectionCon
 	let data = entry.data;
 	if (collectionConfig.schema) {
 		// TODO: remove for 2.0 stable release
-		if (!(collectionConfig.schema instanceof ZodType)) {
+		if (
+			typeof collectionConfig.schema === 'object' &&
+			!('safeParseAsync' in collectionConfig.schema)
+		) {
 			throw new AstroError({
 				title: 'Invalid content collection config',
 				message: `New: Content collection schemas must be Zod objects. Update your collection config to use \`schema: z.object({...})\` instead of \`schema: {...}\`.`,

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -103,6 +103,25 @@ describe('Content Collections', () => {
 				const slugs = json.withSlugConfig.map((item) => item.slug);
 				expect(slugs).to.deep.equal(['fancy-one.md', 'excellent-three.md', 'interesting-two.md']);
 			});
+
+			it('Returns `with union schema` collection', async () => {
+				expect(json).to.haveOwnProperty('withUnionSchema');
+				expect(Array.isArray(json.withUnionSchema)).to.equal(true);
+
+				const post = json.withUnionSchema.find((item) => item.id === 'post.md');
+				expect(post).to.not.be.undefined;
+				expect(post.data).to.deep.equal({
+					type: 'post',
+					title: 'My Post',
+					description: 'This is my post',
+				});
+				const newsletter = json.withUnionSchema.find((item) => item.id === 'newsletter.md');
+				expect(newsletter).to.not.be.undefined;
+				expect(newsletter.data).to.deep.equal({
+					type: 'newsletter',
+					subject: 'My Newsletter',
+				});
+			});
 		});
 
 		describe('Entry', () => {
@@ -129,6 +148,16 @@ describe('Content Collections', () => {
 			it('Returns `with custom slugs` collection entry', async () => {
 				expect(json).to.haveOwnProperty('twoWithSlugConfig');
 				expect(json.twoWithSlugConfig.slug).to.equal('interesting-two.md');
+			});
+
+			it('Returns `with union schema` collection entry', async () => {
+				expect(json).to.haveOwnProperty('postWithUnionSchema');
+				expect(json.postWithUnionSchema.id).to.equal('post.md');
+				expect(json.postWithUnionSchema.data).to.deep.equal({
+					type: 'post',
+					title: 'My Post',
+					description: 'This is my post',
+				});
 			});
 		});
 	});

--- a/packages/astro/test/fixtures/content-collections/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections/src/content/config.ts
@@ -4,18 +4,18 @@ const withSlugConfig = defineCollection({
 	slug({ id, data }) {
 		return `${data.prefix}-${id}`;
 	},
-	schema: {
+	schema: z.object({
 		prefix: z.string(),
-	}
+	})
 });
 
 const withSchemaConfig = defineCollection({
-	schema: {
+	schema: z.object({
 		title: z.string(),
 		isDraft: z.boolean().default(false),
 		lang: z.enum(['en', 'fr', 'es']).default('en'),
 		publishedAt: z.date().transform((val) => new Date(val)),
-	}
+	})
 });
 
 export const collections = {

--- a/packages/astro/test/fixtures/content-collections/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections/src/content/config.ts
@@ -2,11 +2,12 @@ import { z, defineCollection } from 'astro:content';
 
 const withSlugConfig = defineCollection({
 	slug({ id, data }) {
+		console.log({id, data})
 		return `${data.prefix}-${id}`;
 	},
 	schema: z.object({
 		prefix: z.string(),
-	})
+	}),
 });
 
 const withSchemaConfig = defineCollection({
@@ -18,7 +19,22 @@ const withSchemaConfig = defineCollection({
 	})
 });
 
+const withUnionSchema = defineCollection({
+	schema: z.discriminatedUnion('type', [
+		z.object({
+			type: z.literal('post'),
+			title: z.string(),
+			description: z.string(),
+		}),
+		z.object({
+			type: z.literal('newsletter'),
+			subject: z.string(),
+		}),
+	]),
+});
+
 export const collections = {
 	'with-slug-config': withSlugConfig,
 	'with-schema-config': withSchemaConfig,
+	'with-union-schema': withUnionSchema,
 }

--- a/packages/astro/test/fixtures/content-collections/src/content/with-union-schema/newsletter.md
+++ b/packages/astro/test/fixtures/content-collections/src/content/with-union-schema/newsletter.md
@@ -1,0 +1,6 @@
+---
+type: newsletter
+subject: My Newsletter
+---
+
+# It's a newsletter!

--- a/packages/astro/test/fixtures/content-collections/src/content/with-union-schema/post.md
+++ b/packages/astro/test/fixtures/content-collections/src/content/with-union-schema/post.md
@@ -1,0 +1,7 @@
+---
+type: post
+title: My Post
+description: This is my post
+---
+
+# It's a post!

--- a/packages/astro/test/fixtures/content-collections/src/pages/collections.json.js
+++ b/packages/astro/test/fixtures/content-collections/src/pages/collections.json.js
@@ -6,7 +6,9 @@ export async function get() {
 	const withoutConfig = stripAllRenderFn(await getCollection('without-config'));
 	const withSchemaConfig = stripAllRenderFn(await getCollection('with-schema-config'));
 	const withSlugConfig = stripAllRenderFn(await getCollection('with-slug-config'));
+	const withUnionSchema = stripAllRenderFn(await getCollection('with-union-schema'));
+
 	return {
-		body: devalue.stringify({withoutConfig, withSchemaConfig, withSlugConfig}),
+		body: devalue.stringify({withoutConfig, withSchemaConfig, withSlugConfig, withUnionSchema}),
 	}
 }

--- a/packages/astro/test/fixtures/content-collections/src/pages/entries.json.js
+++ b/packages/astro/test/fixtures/content-collections/src/pages/entries.json.js
@@ -6,7 +6,9 @@ export async function get() {
 	const columbiaWithoutConfig = stripRenderFn(await getEntry('without-config', 'columbia.md'));
 	const oneWithSchemaConfig = stripRenderFn(await getEntry('with-schema-config', 'one.md'));
 	const twoWithSlugConfig = stripRenderFn(await getEntry('with-slug-config', 'two.md'));
+	const postWithUnionSchema = stripRenderFn(await getEntry('with-union-schema', 'post.md'));
+
 	return {
-		body: devalue.stringify({columbiaWithoutConfig, oneWithSchemaConfig, twoWithSlugConfig}),
+		body: devalue.stringify({columbiaWithoutConfig, oneWithSchemaConfig, twoWithSlugConfig, postWithUnionSchema}),
 	}
 }

--- a/packages/astro/test/fixtures/content-ssr-integration/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-ssr-integration/src/content/config.ts
@@ -1,7 +1,7 @@
 import { defineCollection, z } from 'astro:content';
 
 const blog = defineCollection({
-	schema: {
+	schema: z.object({
 		title: z.string(),
 		description: z.string(),
 		pubDate: z.string().transform((str) => new Date(str)),
@@ -10,7 +10,7 @@ const blog = defineCollection({
 			.optional()
 			.transform((str) => (str ? new Date(str) : undefined)),
 		heroImage: z.string().optional(),
-	},
+	}),
 });
 
 export const collections = { blog };

--- a/packages/astro/test/fixtures/content-static-paths-integration/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-static-paths-integration/src/content/config.ts
@@ -1,7 +1,7 @@
 import { defineCollection, z } from 'astro:content';
 
 const blog = defineCollection({
-	schema: {
+	schema: z.object({
 		title: z.string(),
 		description: z.string(),
 		pubDate: z.string().transform((str) => new Date(str)),
@@ -10,7 +10,7 @@ const blog = defineCollection({
 			.optional()
 			.transform((str) => (str ? new Date(str) : undefined)),
 		heroImage: z.string().optional(),
-	},
+	}),
 });
 
 export const collections = { blog };

--- a/packages/astro/test/fixtures/content/src/content/config.ts
+++ b/packages/astro/test/fixtures/content/src/content/config.ts
@@ -1,10 +1,10 @@
 import { z, defineCollection } from 'astro:content';
 
 const blog = defineCollection({
-	schema: {
+	schema: z.object({
 		title: z.string(),
 		description: z.string().max(60, 'For SEO purposes, keep descriptions short!'),
-	},
+	}),
 });
 
 export const collections = { blog };


### PR DESCRIPTION
## Changes

- Allow Zod objects, unions, discriminated unions, intersections, and `transform` results as schemas
- Add helpful warning when `z.object(...)` wrapper is missing

### Why?

By enforcing the `z.object(...)` wrapper, we open the door for:
- using a `transform` to add and modify frontmatter properties

```ts
const blog = defineCollection({
  schema: z.object({
    youtube: z.string().url(),
  }).transform(data => ({
    embedUrl: toEmbedUrl(data.youtube),
    thumbnailUrl: toThumbnailUrl(data.youtube),
  })
});
```

- using unions and discriminated unions for supporting multiple schemas on the same collection. This is common when splitting multiple options based on a `type` property:

```ts
const posts = defineCollection({
	schema: z.discriminatedUnion('type', [
		z.object({
			type: z.literal('post'),
			title: z.string(),
			description: z.string(),
		}),
		z.object({
			type: z.literal('newsletter'),
			subject: z.string(),
		}),
	]),
});
```

## Testing

Add a test for Zod unions

## Docs

https://github.com/withastro/docs/pull/2335
