### PR TITLE
[@astrojs/lit] Fix slotted content

### DIFF
--- a/.changeset/kind-beers-give.md
+++ b/.changeset/kind-beers-give.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/lit': patch
+---
+
+Fix Lit slotted content

--- a/packages/astro/test/fixtures/lit-element/src/pages/slots.astro
+++ b/packages/astro/test/fixtures/lit-element/src/pages/slots.astro
@@ -7,9 +7,33 @@ import {MyElement} from '../components/my-element.js';
   <title>LitElement | Slot</title>
 </head>
 <body>
-  <MyElement>
-		<div>default</div>
-		<div slot="named">named</div>
+  <MyElement id="root">
+		<div class="default">my-element default 1</div>
+		<div class="default">my-element default 2</div>
+
+		<h1 slot="named">my-element named 1</h1>
+		<h2 slot="named">my-element named 2</h2>
+
+		<ul slot="named" id="list">
+			<li>Custom elements</li>
+			<li>Shadow DOM</li>
+			<li>HTML templates</li>
+		</ul>
+
+		<my-element id="slotted" slot="named">
+			<h3 class="default">slotted my-element default</h3>
+
+			<div slot="named">slotted my-element named 1</div>
+			<div slot="named">slotted my-element named 2</div>
+
+			<MyElement id="slotted-slotted" slot="named">
+				<h4 class="default">slotted slotted my-element default 1</h4>
+				<h5 class="default">slotted slotted my-element default 2</h5>
+
+				<div slot="named">slotted slotted my-element named 1</div>
+				<div slot="named">slotted slotted my-element named 2</div>
+			</MyElement>
+		</my-element>
 	</MyElement>
 </body>
 </html>

--- a/packages/astro/test/fixtures/lit-element/tsconfig.json
+++ b/packages/astro/test/fixtures/lit-element/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "experimentalDecorators": true
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
 }

--- a/packages/astro/test/lit-element.test.js
+++ b/packages/astro/test/lit-element.test.js
@@ -70,15 +70,35 @@ describe('LitElement test', function () {
 		const html = await fixture.readFile('/slots/index.html');
 		const $ = cheerio.load(html);
 
-		expect($('my-element').length).to.equal(1);
+		const $rootMyElement = $('#root');
+		const $slottedMyElement = $('#slotted');
+		const $slottedSlottedMyElement = $('#slotted-slotted');
 
-		const [defaultSlot, namedSlot] = $('template').siblings().toArray();
+		expect($('my-element').length).to.equal(3);
 
-		// has default slot content in lightdom
-		expect($(defaultSlot).text()).to.equal('default');
+		// Root my-element
+		expect($rootMyElement.children('.default').length).to.equal(2);
+		expect($rootMyElement.children('.default').eq(1).text()).to.equal('my-element default 2');
 
-		// has named slot content in lightdom
-		expect($(namedSlot).text()).to.equal('named');
+		expect($rootMyElement.children('[slot="named"]').length).to.equal(4);
+		expect($rootMyElement.children('[slot="named"]').eq(1).text()).to.equal('my-element named 2');
+		expect($rootMyElement.children('[slot="named"]').eq(2).attr('id')).to.equal('list');
+		expect($rootMyElement.children('[slot="named"]').eq(3).attr('id')).to.equal('slotted');
+
+		// Slotted my-element first level
+		expect($slottedMyElement.children('.default').length).to.equal(1);
+		expect($slottedMyElement.children('.default').eq(0).text()).to.equal('slotted my-element default');
+
+		expect($slottedMyElement.children('[slot="named"]').length).to.equal(3);
+		expect($slottedMyElement.children('[slot="named"]').eq(1).text()).to.equal('slotted my-element named 2');
+		expect($slottedMyElement.children('[slot="named"]').eq(2).attr('id')).to.equal('slotted-slotted');
+
+		// Slotted my-element second level
+		expect($slottedSlottedMyElement.children('.default').length).to.equal(2);
+		expect($slottedSlottedMyElement.children('.default').eq(1).text()).to.equal('slotted slotted my-element default 2');
+
+		expect($slottedSlottedMyElement.children('[slot="named"]').length).to.equal(2);
+		expect($slottedSlottedMyElement.children('[slot="named"]').eq(1).text()).to.equal('slotted slotted my-element named 2');
 	});
 
 	it('Is able to build when behind getStaticPaths', async () => {

--- a/packages/astro/test/ssr-lit.test.js
+++ b/packages/astro/test/ssr-lit.test.js
@@ -25,7 +25,7 @@ describe('Lit integration in SSR', () => {
 	}
 
 	it('Is able to load', async () => {
-		delete globalThis.window;
+		delete globalThis.window; // On Windows this results in `ReferenceError: window is not defined`
 		const html = await fetchHTML('/');
 		const $ = cheerioLoad(html);
 		expect($('#win').text()).to.equal('function');

--- a/packages/integrations/lit/package.json
+++ b/packages/integrations/lit/package.json
@@ -33,7 +33,8 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@lit-labs/ssr": "^2.2.0"
+    "@lit-labs/ssr": "^2.2.0",
+    "parse5": "^7.1.2"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2874,9 +2874,11 @@ importers:
       cheerio: ^1.0.0-rc.11
       lit: ^2.2.5
       mocha: ^9.2.2
+      parse5: ^7.1.2
       sass: ^1.52.2
     dependencies:
       '@lit-labs/ssr': 2.2.3
+      parse5: 7.1.2
     devDependencies:
       astro: link:../../astro
       astro-scripts: link:../../../scripts
@@ -11158,7 +11160,7 @@ packages:
       domhandler: 5.0.3
       domutils: 3.0.1
       htmlparser2: 8.0.1
-      parse5: 7.1.1
+      parse5: 7.1.2
       parse5-htmlparser2-tree-adapter: 7.0.0
     dev: true
 
@@ -11869,7 +11871,6 @@ packages:
   /entities/4.4.0:
     resolution: {integrity: sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==}
     engines: {node: '>=0.12'}
-    dev: true
 
   /eol/0.9.1:
     resolution: {integrity: sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==}
@@ -15788,18 +15789,17 @@ packages:
     resolution: {integrity: sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==}
     dependencies:
       domhandler: 5.0.3
-      parse5: 7.1.1
+      parse5: 7.1.2
     dev: true
 
   /parse5/6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
     dev: false
 
-  /parse5/7.1.1:
-    resolution: {integrity: sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==}
+  /parse5/7.1.2:
+    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
     dependencies:
       entities: 4.4.0
-    dev: true
 
   /parseurl/1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}


### PR DESCRIPTION
## Changes

- This fixes #5475.
- It reverts the injected `<astro-slot>` components.
- And restores the `slot="name"` attributes.

I use [`parse5`](https://parse5.js.org/) to parse the HTML string into a _Fragment_ and then add the missing named slots. This is safer than using regex, but if there's a better parser, don't hesitate to change it.

```html
// Before
<my-element>
    <astro-slot slot="header">
        <h1>Header</h1>
    </astro-slot>

    <astro-slot>
        <p>Content</p>
        <p>Some more content</p>
    </astro-slot>

    <astro-slot slot="footer">
        <small>Legal stuff</small>
        <small>© 2023</small>
    </astro-slot>
</my-element>

// After
<my-element>
    <h1 slot="header">Header</h1>

    <p>Content</p>
    <p>Some more content</p>

    <small slot="footer">Legal stuff</small>
    <small slot="footer">© 2023</small>
</my-element>
```

## Testing

- Tests have been added for nested slotted HTML and Web Components.
- The code has been tested in my own projects.

## Docs

The docs do not need updating.
