### PR TITLE
Remove proload for config loading

### DIFF
--- a/.changeset/calm-peas-doubt.md
+++ b/.changeset/calm-peas-doubt.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+Remove proload to load the Astro config. It will now use NodeJS and Vite to load the config only.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -120,8 +120,6 @@
     "@babel/plugin-transform-react-jsx": "^7.17.12",
     "@babel/traverse": "^7.18.2",
     "@babel/types": "^7.18.4",
-    "@proload/core": "^0.3.3",
-    "@proload/plugin-tsm": "^0.2.1",
     "@types/babel__core": "^7.1.19",
     "@types/html-escaper": "^3.0.0",
     "@types/yargs-parser": "^21.0.0",

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -190,7 +190,6 @@ export async function loadContentConfig({
 	settings: AstroSettings;
 }): Promise<ContentConfig | Error> {
 	const contentPaths = getContentPaths({ srcDir: settings.config.srcDir });
-	const nodeEnv = process.env.NODE_ENV;
 	const tempConfigServer: ViteDevServer = await createServer({
 		root: fileURLToPath(settings.config.root),
 		server: { middlewareMode: true, hmr: false },
@@ -207,9 +206,6 @@ export async function loadContentConfig({
 		return new NotFoundError('Failed to resolve content config.');
 	} finally {
 		await tempConfigServer.close();
-		// Reset NODE_ENV to initial value
-		// Vite's `createServer()` sets NODE_ENV to 'development'!
-		process.env.NODE_ENV = nodeEnv;
 	}
 	const config = contentConfigParser.safeParse(unparsedConfig);
 	if (config.success) {

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -136,7 +136,7 @@ function mergeCLIFlags(astroConfig: AstroUserConfig, flags: CLIFlags, cmd: strin
 	return astroConfig;
 }
 
-async function search(fsObj: typeof fs, root: string) {
+async function search(fsMod: typeof fs, root: string) {
 	const paths = [
 		'astro.config.mjs',
 		'astro.config.js',
@@ -147,7 +147,7 @@ async function search(fsObj: typeof fs, root: string) {
 	].map((p) => path.join(root, p));
 
 	for (const file of paths) {
-		if (fsObj.existsSync(file)) {
+		if (fsMod.existsSync(file)) {
 			return file;
 		}
 	}

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -115,7 +115,7 @@ export function resolveRoot(cwd?: string | URL): string {
 }
 
 /** Merge CLI flags & user config object (CLI flags take priority) */
-function mergeCLIFlags(astroConfig: AstroUserConfig, flags: CLIFlags, cmd: string) {
+function mergeCLIFlags(astroConfig: AstroUserConfig, flags: CLIFlags) {
 	astroConfig.server = astroConfig.server || {};
 	astroConfig.markdown = astroConfig.markdown || {};
 	astroConfig.experimental = astroConfig.experimental || {};
@@ -280,7 +280,7 @@ export async function resolveConfig(
 	flags: CLIFlags = {},
 	cmd: string
 ): Promise<AstroConfig> {
-	const mergedConfig = mergeCLIFlags(userConfig, flags, cmd);
+	const mergedConfig = mergeCLIFlags(userConfig, flags);
 	const validatedConfig = await validateConfig(mergedConfig, root, cmd);
 
 	return validatedConfig;

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -16,8 +16,8 @@ async function createViteLoader(root: string, fs: typeof fsType): Promise<ViteLo
 		appType: 'custom',
 		ssr: {
 			// NOTE: Vite doesn't externalize linked packages by default. During testing locally,
-			// these dependencies trip up Vite's dev SSR transform. In the future, we should
-			// avoid `vite.createServer` and use `loadConfigFromFile` instead.
+			// these dependencies trip up Vite's dev SSR transform. Awaiting upstream feature:
+			// https://github.com/vitejs/vite/pull/10939
 			external: [
 				'@astrojs/tailwind',
 				'@astrojs/mdx',

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -1,15 +1,7 @@
 import type fsType from 'fs';
-import npath from 'path';
 import { pathToFileURL } from 'url';
 import * as vite from 'vite';
 import loadFallbackPlugin from '../../vite-plugin-load-fallback/index.js';
-import { AstroError, AstroErrorData } from '../errors/index.js';
-
-// Fallback for legacy
-import load from '@proload/core';
-import loadTypeScript from '@proload/plugin-tsm';
-
-load.use([loadTypeScript]);
 
 export interface ViteLoader {
 	root: string;
@@ -43,40 +35,6 @@ async function createViteLoader(root: string, fs: typeof fsType): Promise<ViteLo
 	};
 }
 
-async function stat(fs: typeof fsType, configPath: string, mustExist: boolean): Promise<boolean> {
-	try {
-		await fs.promises.stat(configPath);
-		return true;
-	} catch {
-		if (mustExist) {
-			throw new AstroError({
-				...AstroErrorData.ConfigNotFound,
-				message: AstroErrorData.ConfigNotFound.message(configPath),
-			});
-		}
-		return false;
-	}
-}
-
-async function search(fs: typeof fsType, root: string) {
-	const paths = [
-		'astro.config.mjs',
-		'astro.config.js',
-		'astro.config.ts',
-		'astro.config.mts',
-		'astro.config.cjs',
-		'astro.config.cjs',
-	].map((path) => npath.join(root, path));
-
-	for (const file of paths) {
-		// First verify the file event exists
-		const exists = await stat(fs, file, false);
-		if (exists) {
-			return file;
-		}
-	}
-}
-
 interface LoadConfigWithViteOptions {
 	root: string;
 	configPath: string | undefined;
@@ -91,35 +49,25 @@ export async function loadConfigWithVite({
 	value: Record<string, any>;
 	filePath?: string;
 }> {
-	let file: string;
-	if (configPath) {
-		// Go ahead and check if the file exists and throw if not.
-		await stat(fs, configPath, true);
-		file = configPath;
-	} else {
-		const found = await search(fs, root);
-		if (!found) {
-			// No config file found, return an empty config that will be populated with defaults
-			return {
-				value: {},
-				filePath: undefined,
-			};
-		} else {
-			file = found;
-		}
+	// No config file found, return an empty config that will be populated with defaults
+	if (!configPath) {
+		return {
+			value: {},
+			filePath: undefined,
+		};
 	}
 
 	// Try loading with Node import()
-	if (/\.[cm]?js$/.test(file)) {
+	if (/\.[cm]?js$/.test(configPath)) {
 		try {
-			const config = await import(pathToFileURL(file).toString());
+			const config = await import(pathToFileURL(configPath).toString());
 			return {
 				value: config.default ?? {},
-				filePath: file,
+				filePath: configPath,
 			};
 		} catch {
 			// We do not need to keep the error here because with fallback the error will be rethrown
-			// when/if it fails in Proload.
+			// when/if it fails in Vite.
 		}
 	}
 
@@ -127,22 +75,10 @@ export async function loadConfigWithVite({
 	let loader: ViteLoader | undefined;
 	try {
 		loader = await createViteLoader(root, fs);
-		const mod = await loader.viteServer.ssrLoadModule(file);
+		const mod = await loader.viteServer.ssrLoadModule(configPath);
 		return {
 			value: mod.default ?? {},
-			filePath: file,
-		};
-	} catch {
-		// Try loading with Proload
-		// TODO deprecate - this is only for legacy compatibility
-		const res = await load('astro', {
-			mustExist: true,
-			cwd: root,
-			filePath: file,
-		});
-		return {
-			value: res?.value ?? {},
-			filePath: file,
+			filePath: configPath,
 		};
 	} finally {
 		if (loader) {

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -7,7 +7,7 @@ import stripAnsi from 'strip-ansi';
 import { fileURLToPath } from 'url';
 import { sync } from '../dist/cli/sync/index.js';
 import build from '../dist/core/build/index.js';
-import { loadConfig } from '../dist/core/config/config.js';
+import { openConfig } from '../dist/core/config/config.js';
 import { createSettings } from '../dist/core/config/index.js';
 import dev from '../dist/core/dev/index.js';
 import { nodeLogDestination } from '../dist/core/logger/node.js';
@@ -86,7 +86,11 @@ export async function loadFixture(inlineConfig) {
 	const logging = defaultLogging;
 
 	// Load the config.
-	let config = await loadConfig({ cwd: fileURLToPath(cwd), logging });
+	let { astroConfig: config } = await openConfig({
+		cwd: fileURLToPath(cwd),
+		logging,
+		cmd: 'dev',
+	});
 	config = merge(config, { ...inlineConfig, root: cwd });
 
 	// HACK: the inline config doesn't run through config validation where these normalizations usually occur

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,8 +397,6 @@ importers:
       '@babel/traverse': ^7.18.2
       '@babel/types': ^7.18.4
       '@playwright/test': ^1.22.2
-      '@proload/core': ^0.3.3
-      '@proload/plugin-tsm': ^0.2.1
       '@types/babel__core': ^7.1.19
       '@types/babel__generator': ^7.6.4
       '@types/babel__traverse': ^7.17.1
@@ -496,8 +494,6 @@ importers:
       '@babel/plugin-transform-react-jsx': 7.20.7_@babel+core@7.20.12
       '@babel/traverse': 7.20.12
       '@babel/types': 7.20.7
-      '@proload/core': 0.3.3
-      '@proload/plugin-tsm': 0.2.1_@proload+core@0.3.3
       '@types/babel__core': 7.1.20
       '@types/html-escaper': 3.0.0
       '@types/yargs-parser': 21.0.0
@@ -1398,12 +1394,6 @@ importers:
       '@astrojs/svelte': link:../../../../integrations/svelte
       astro: link:../../..
 
-  packages/astro/test/fixtures/astro-markdown-css:
-    specifiers:
-      astro: workspace:*
-    dependencies:
-      astro: link:../../..
-
   packages/astro/test/fixtures/astro-markdown-drafts:
     specifiers:
       astro: workspace:*
@@ -1947,30 +1937,6 @@ importers:
       astro: workspace:*
     dependencies:
       astro: link:../../..
-
-  packages/astro/test/fixtures/legacy-astro-flavored-markdown:
-    specifiers:
-      '@astrojs/preact': workspace:*
-      '@astrojs/svelte': workspace:*
-      astro: workspace:*
-      preact: ^10.11.0
-      svelte: ^3.48.0
-    dependencies:
-      '@astrojs/preact': link:../../../../integrations/preact
-      '@astrojs/svelte': link:../../../../integrations/svelte
-      astro: link:../../..
-      preact: 10.11.3
-      svelte: 3.55.0
-
-  packages/astro/test/fixtures/legacy-build:
-    specifiers:
-      '@astrojs/vue': workspace:*
-      astro: workspace:*
-      preact: ~10.6.6
-    dependencies:
-      '@astrojs/vue': link:../../../../integrations/vue
-      astro: link:../../..
-      preact: 10.6.6
 
   packages/astro/test/fixtures/lit-element:
     specifiers:
@@ -13247,10 +13213,6 @@ packages:
 
   /preact/10.11.3:
     resolution: {integrity: sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==}
-
-  /preact/10.6.6:
-    resolution: {integrity: sha512-dgxpTFV2vs4vizwKohYKkk7g7rmp1wOOcfd4Tz3IB3Wi+ivZzsn/SpeKJhRENSE+n8sUfsAl4S3HiCVT923ABw==}
-    dev: false
 
   /prebuild-install/7.1.1:
     resolution: {integrity: sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==}

--- a/scripts/memory/index.js
+++ b/scripts/memory/index.js
@@ -1,7 +1,8 @@
 import { fileURLToPath } from 'url';
 import v8 from 'v8';
 import dev from '../../packages/astro/dist/core/dev/index.js';
-import { loadConfig } from '../../packages/astro/dist/core/config.js';
+import { openConfig } from '../../packages/astro/dist/core/config.js';
+import { nodeLogDestination } from '../../packages/astro/dist/core/logger/node.js';
 import prettyBytes from 'pretty-bytes';
 
 if (!global.gc) {
@@ -14,8 +15,13 @@ const isCI = process.argv.includes('--ci');
 /** URL directory containing the entire project. */
 const projDir = new URL('./project/', import.meta.url);
 
-let config = await loadConfig({
+let { astroConfig: config } = await openConfig({
 	cwd: fileURLToPath(projDir),
+	logging: {
+		dest: nodeLogDestination,
+		level: 'error',
+	},
+	cmd: 'dev',
 });
 
 const telemetry = {


### PR DESCRIPTION
## Changes

Close https://github.com/withastro/astro/issues/5748
Fix https://github.com/withastro/astro/issues/5459

- Remove proload, so only fallback to load with Vite only.
- Refactor `resolveConfigPath` to only search for a config path, and not load the config itself, this fixes #5459


Note: I tried to use Vite's `loadConfigFromFile` instead, but it doesn't bring much benefit for us, and prevents named exports from the Astro config if we ever need it. It's also harder to test with `createFs` since `loadConfigFromFile` always read from the actual filesystem.
## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing config loading test should work. Since this _removes_ a proload feature, I don't think there's new test to add.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. Ideally loading the config with Vite should always work, so this change shouldn't need a docs update.