### PR TITLE
Refactor `Props` of `Image` and `Picture` component to support type checking

### DIFF
--- a/.changeset/mean-suits-cover.md
+++ b/.changeset/mean-suits-cover.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/image': patch
+---
+
+- Refactor types to support props auto-completion for the `Image` and `Picture` components.
+- Pass previously missing `alt` prop to the `getPicture` function

--- a/packages/integrations/image/components/Image.astro
+++ b/packages/integrations/image/components/Image.astro
@@ -2,29 +2,11 @@
 // @ts-ignore
 import { getImage } from '../dist/index.js';
 import { warnForMissingAlt } from './index.js';
-import type { ImgHTMLAttributes } from './index.js';
-import type { ImageMetadata, TransformOptions, OutputFormat } from '../dist/index.js';
-
-interface LocalImageProps
-	extends Omit<TransformOptions, 'src'>,
-		Omit<ImgHTMLAttributes, 'src' | 'width' | 'height'> {
-	src: ImageMetadata | Promise<{ default: ImageMetadata }>;
-	/** Defines an alternative text description of the image. Set to an empty string (alt="") if the image is not a key part of the content (it's decoration or a tracking pixel). */
-	alt: string;
-}
-
-interface RemoteImageProps extends TransformOptions, astroHTML.JSX.ImgHTMLAttributes {
-	src: string;
-	/** Defines an alternative text description of the image. Set to an empty string (alt="") if the image is not a key part of the content (it's decoration or a tracking pixel). */
-	alt: string;
-	format?: OutputFormat;
-	width: number;
-	height: number;
-}
+import type { LocalImageProps, RemoteImageProps } from './index.js';
 
 export type Props = LocalImageProps | RemoteImageProps;
 
-const { loading = 'lazy', decoding = 'async', ...props } = Astro.props as Props;
+const { loading = 'lazy', decoding = 'async', ...props } = Astro.props;
 
 if (props.alt === undefined || props.alt === null) {
 	warnForMissingAlt();

--- a/packages/integrations/image/components/Image.astro
+++ b/packages/integrations/image/components/Image.astro
@@ -2,9 +2,9 @@
 // @ts-ignore
 import { getImage } from '../dist/index.js';
 import { warnForMissingAlt } from './index.js';
-import type { LocalImageProps, RemoteImageProps } from './index.js';
+import type { ImageComponentLocalImageProps, ImageComponentRemoteImageProps } from './index.js';
 
-export type Props = LocalImageProps | RemoteImageProps;
+export type Props = ImageComponentLocalImageProps | ImageComponentRemoteImageProps;
 
 const { loading = 'lazy', decoding = 'async', ...props } = Astro.props;
 

--- a/packages/integrations/image/components/Picture.astro
+++ b/packages/integrations/image/components/Picture.astro
@@ -32,6 +32,7 @@ const { image, sources } = await getPicture({
 	fit,
 	background,
 	position,
+	alt,
 });
 
 delete image.width;

--- a/packages/integrations/image/components/Picture.astro
+++ b/packages/integrations/image/components/Picture.astro
@@ -1,36 +1,9 @@
 ---
 import { getPicture } from '../dist/index.js';
 import { warnForMissingAlt } from './index.js';
-import type { ImgHTMLAttributes, HTMLAttributes } from './index.js';
-import type { ImageMetadata, OutputFormat, TransformOptions } from '../dist/index.js';
+import type { PictureComponentLocalImageProps, PictureComponentRemoteImageProps } from './index.js';
 
-interface LocalImageProps
-	extends Omit<HTMLAttributes, 'src' | 'width' | 'height'>,
-		Omit<TransformOptions, 'src'>,
-		Pick<astroHTML.JSX.ImgHTMLAttributes, 'loading' | 'decoding'> {
-	src: ImageMetadata | Promise<{ default: ImageMetadata }>;
-	/** Defines an alternative text description of the image. Set to an empty string (alt="") if the image is not a key part of the content (it's decoration or a tracking pixel). */
-	alt: string;
-	sizes: HTMLImageElement['sizes'];
-	widths: number[];
-	formats?: OutputFormat[];
-}
-
-interface RemoteImageProps
-	extends Omit<HTMLAttributes, 'src' | 'width' | 'height'>,
-		TransformOptions,
-		Pick<ImgHTMLAttributes, 'loading' | 'decoding'> {
-	src: string;
-	/** Defines an alternative text description of the image. Set to an empty string (alt="") if the image is not a key part of the content (it's decoration or a tracking pixel). */
-	alt: string;
-	sizes: HTMLImageElement['sizes'];
-	widths: number[];
-	aspectRatio: TransformOptions['aspectRatio'];
-	formats?: OutputFormat[];
-	background: TransformOptions['background'];
-}
-
-export type Props = LocalImageProps | RemoteImageProps;
+export type Props = PictureComponentLocalImageProps | PictureComponentRemoteImageProps;
 
 const {
 	src,
@@ -45,7 +18,7 @@ const {
 	loading = 'lazy',
 	decoding = 'async',
 	...attrs
-} = Astro.props as Props;
+} = Astro.props;
 
 if (alt === undefined || alt === null) {
 	warnForMissingAlt();

--- a/packages/integrations/image/components/index.ts
+++ b/packages/integrations/image/components/index.ts
@@ -5,7 +5,7 @@ import type { HTMLAttributes } from 'astro/types';
 
 import type { TransformOptions, OutputFormat } from '../dist/loaders/index.js';
 import type { ImageMetadata } from '../dist/vite-plugin-astro-image.js';
-import { AstroBuiltinAttributes } from 'astro';
+import type { AstroBuiltinAttributes } from 'astro';
 
 export interface ImageComponentLocalImageProps
 	extends Omit<TransformOptions, 'src'>,

--- a/packages/integrations/image/components/index.ts
+++ b/packages/integrations/image/components/index.ts
@@ -1,7 +1,7 @@
 /// <reference types="astro/astro-jsx" />
 export { default as Image } from './Image.astro';
 export { default as Picture } from './Picture.astro';
-import type { HTMLAttributes as AllHTMLAttributes } from '../../../astro/types';
+import type { HTMLAttributes as AllHTMLAttributes } from 'astro/types';
 
 import type { TransformOptions, OutputFormat } from '../dist/loaders/index.js';
 import type { ImageMetadata } from '../dist/vite-plugin-astro-image.js';

--- a/packages/integrations/image/components/index.ts
+++ b/packages/integrations/image/components/index.ts
@@ -2,6 +2,26 @@
 export { default as Image } from './Image.astro';
 export { default as Picture } from './Picture.astro';
 
+import type { TransformOptions, OutputFormat } from '../dist/loaders/index.js';
+import type { ImageMetadata } from '../dist/vite-plugin-astro-image.js';
+
+export interface LocalImageProps
+	extends Omit<TransformOptions, 'src'>,
+		Omit<ImgHTMLAttributes, 'src' | 'width' | 'height'> {
+	src: ImageMetadata | Promise<{ default: ImageMetadata }>;
+	/** Defines an alternative text description of the image. Set to an empty string (alt="") if the image is not a key part of the content (it's decoration or a tracking pixel). */
+	alt: string;
+}
+
+export interface RemoteImageProps extends TransformOptions, astroHTML.JSX.ImgHTMLAttributes {
+	src: string;
+	/** Defines an alternative text description of the image. Set to an empty string (alt="") if the image is not a key part of the content (it's decoration or a tracking pixel). */
+	alt: string;
+	format?: OutputFormat;
+	width: number;
+	height: number;
+}
+
 // TODO: should these directives be removed from astroHTML.JSX?
 export type ImgHTMLAttributes = Omit<
 	astroHTML.JSX.ImgHTMLAttributes,

--- a/packages/integrations/image/components/index.ts
+++ b/packages/integrations/image/components/index.ts
@@ -1,10 +1,11 @@
 /// <reference types="astro/astro-jsx" />
 export { default as Image } from './Image.astro';
 export { default as Picture } from './Picture.astro';
-import type { HTMLAttributes as AllHTMLAttributes } from 'astro/types';
+import type { HTMLAttributes } from 'astro/types';
 
 import type { TransformOptions, OutputFormat } from '../dist/loaders/index.js';
 import type { ImageMetadata } from '../dist/vite-plugin-astro-image.js';
+import { AstroBuiltinAttributes } from 'astro';
 
 export interface ImageComponentLocalImageProps
 	extends Omit<TransformOptions, 'src'>,
@@ -24,7 +25,7 @@ export interface ImageComponentRemoteImageProps extends TransformOptions, ImgHTM
 }
 
 export interface PictureComponentLocalImageProps
-	extends Omit<HTMLAttributes, 'src' | 'width' | 'height'>,
+	extends GlobalHTMLAttributes,
 		Omit<TransformOptions, 'src'>,
 		Pick<ImgHTMLAttributes, 'loading' | 'decoding'> {
 	src: ImageMetadata | Promise<{ default: ImageMetadata }>;
@@ -36,7 +37,7 @@ export interface PictureComponentLocalImageProps
 }
 
 export interface PictureComponentRemoteImageProps
-	extends Omit<HTMLAttributes, 'src' | 'width' | 'height'>,
+	extends GlobalHTMLAttributes,
 		TransformOptions,
 		Pick<ImgHTMLAttributes, 'loading' | 'decoding'> {
 	src: string;
@@ -49,9 +50,12 @@ export interface PictureComponentRemoteImageProps
 	background: TransformOptions['background'];
 }
 
-export type ImgHTMLAttributes = AllHTMLAttributes<'img'>;
+export type ImgHTMLAttributes = HTMLAttributes<'img'>;
 
-export type HTMLAttributes = Omit<astroHTML.JSX.HTMLAttributes, 'set:text' | 'set:html' | 'is:raw'>;
+export type GlobalHTMLAttributes = Omit<
+	astroHTML.JSX.HTMLAttributes,
+	keyof Omit<AstroBuiltinAttributes, 'class:list'>
+>;
 
 let altWarningShown = false;
 

--- a/packages/integrations/image/components/index.ts
+++ b/packages/integrations/image/components/index.ts
@@ -1,6 +1,7 @@
 /// <reference types="astro/astro-jsx" />
 export { default as Image } from './Image.astro';
 export { default as Picture } from './Picture.astro';
+import type { HTMLAttributes as AllHTMLAttributes } from '../../../astro/types';
 
 import type { TransformOptions, OutputFormat } from '../dist/loaders/index.js';
 import type { ImageMetadata } from '../dist/vite-plugin-astro-image.js';
@@ -13,9 +14,7 @@ export interface ImageComponentLocalImageProps
 	alt: string;
 }
 
-export interface ImageComponentRemoteImageProps
-	extends TransformOptions,
-		astroHTML.JSX.ImgHTMLAttributes {
+export interface ImageComponentRemoteImageProps extends TransformOptions, ImgHTMLAttributes {
 	src: string;
 	/** Defines an alternative text description of the image. Set to an empty string (alt="") if the image is not a key part of the content (it's decoration or a tracking pixel). */
 	alt: string;
@@ -27,7 +26,7 @@ export interface ImageComponentRemoteImageProps
 export interface PictureComponentLocalImageProps
 	extends Omit<HTMLAttributes, 'src' | 'width' | 'height'>,
 		Omit<TransformOptions, 'src'>,
-		Pick<astroHTML.JSX.ImgHTMLAttributes, 'loading' | 'decoding'> {
+		Pick<ImgHTMLAttributes, 'loading' | 'decoding'> {
 	src: ImageMetadata | Promise<{ default: ImageMetadata }>;
 	/** Defines an alternative text description of the image. Set to an empty string (alt="") if the image is not a key part of the content (it's decoration or a tracking pixel). */
 	alt: string;
@@ -50,15 +49,9 @@ export interface PictureComponentRemoteImageProps
 	background: TransformOptions['background'];
 }
 
-// TODO: should these directives be removed from astroHTML.JSX?
-export type ImgHTMLAttributes = Omit<
-	astroHTML.JSX.ImgHTMLAttributes,
-	'client:list' | 'set:text' | 'set:html' | 'is:raw'
->;
-export type HTMLAttributes = Omit<
-	astroHTML.JSX.HTMLAttributes,
-	'client:list' | 'set:text' | 'set:html' | 'is:raw'
->;
+export type ImgHTMLAttributes = AllHTMLAttributes<'img'>;
+
+export type HTMLAttributes = Omit<astroHTML.JSX.HTMLAttributes, 'set:text' | 'set:html' | 'is:raw'>;
 
 let altWarningShown = false;
 

--- a/packages/integrations/image/components/index.ts
+++ b/packages/integrations/image/components/index.ts
@@ -5,7 +5,7 @@ export { default as Picture } from './Picture.astro';
 import type { TransformOptions, OutputFormat } from '../dist/loaders/index.js';
 import type { ImageMetadata } from '../dist/vite-plugin-astro-image.js';
 
-export interface LocalImageProps
+export interface ImageComponentLocalImageProps
 	extends Omit<TransformOptions, 'src'>,
 		Omit<ImgHTMLAttributes, 'src' | 'width' | 'height'> {
 	src: ImageMetadata | Promise<{ default: ImageMetadata }>;
@@ -13,13 +13,41 @@ export interface LocalImageProps
 	alt: string;
 }
 
-export interface RemoteImageProps extends TransformOptions, astroHTML.JSX.ImgHTMLAttributes {
+export interface ImageComponentRemoteImageProps
+	extends TransformOptions,
+		astroHTML.JSX.ImgHTMLAttributes {
 	src: string;
 	/** Defines an alternative text description of the image. Set to an empty string (alt="") if the image is not a key part of the content (it's decoration or a tracking pixel). */
 	alt: string;
 	format?: OutputFormat;
 	width: number;
 	height: number;
+}
+
+export interface PictureComponentLocalImageProps
+	extends Omit<HTMLAttributes, 'src' | 'width' | 'height'>,
+		Omit<TransformOptions, 'src'>,
+		Pick<astroHTML.JSX.ImgHTMLAttributes, 'loading' | 'decoding'> {
+	src: ImageMetadata | Promise<{ default: ImageMetadata }>;
+	/** Defines an alternative text description of the image. Set to an empty string (alt="") if the image is not a key part of the content (it's decoration or a tracking pixel). */
+	alt: string;
+	sizes: HTMLImageElement['sizes'];
+	widths: number[];
+	formats?: OutputFormat[];
+}
+
+export interface PictureComponentRemoteImageProps
+	extends Omit<HTMLAttributes, 'src' | 'width' | 'height'>,
+		TransformOptions,
+		Pick<ImgHTMLAttributes, 'loading' | 'decoding'> {
+	src: string;
+	/** Defines an alternative text description of the image. Set to an empty string (alt="") if the image is not a key part of the content (it's decoration or a tracking pixel). */
+	alt: string;
+	sizes: HTMLImageElement['sizes'];
+	widths: number[];
+	aspectRatio: TransformOptions['aspectRatio'];
+	formats?: OutputFormat[];
+	background: TransformOptions['background'];
 }
 
 // TODO: should these directives be removed from astroHTML.JSX?

--- a/packages/integrations/image/test/fixtures/basic-image/src/pages/index.astro
+++ b/packages/integrations/image/test/fixtures/basic-image/src/pages/index.astro
@@ -10,7 +10,7 @@ const publicImage = new URL('./hero.jpg', Astro.url);
     <!-- Head Stuff -->
   </head>
   <body>
-		<Image id="hero" src={publicImage.pathname} width={768} height={414} format="webp" alt="hero" />
+		<Image id="hero" src={publicImage.pathname} width={768} height={414} format="webp" alt="hero"  />
 		<br />
 		<Image id="spaces" src={introJpg} width={768} height={414} format="webp" alt="spaces" />
 		<br />


### PR DESCRIPTION
## Changes

- Refactor types to support props auto-completion for the `Image` and `Picture` components.
- Pass previously missing `alt` prop to the `getPicture` function

## Testing

Tested locally. There's only a small runtime change (see `alt` prop passed to the `getPicture` function). All tests should pass

## Docs

N/A