### PR TITLE
Add `@version` metadata to config reference types

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -773,6 +773,7 @@ export interface AstroUserConfig {
 		 * @name markdown.gfm
 		 * @type {boolean}
 		 * @default `true`
+		 * @version 2.0.0
 		 * @description
 		 * Astro uses [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) by default. To disable this, set the `gfm` flag to `false`:
 		 *
@@ -790,6 +791,7 @@ export interface AstroUserConfig {
 		 * @name markdown.smartypants
 		 * @type {boolean}
 		 * @default `true`
+		 * @version 2.0.0
 		 * @description
 		 * Astro uses the [SmartyPants formatter](https://daringfireball.net/projects/smartypants/) by default. To disable this, set the `smartypants` flag to `false`:
 		 *


### PR DESCRIPTION
## Changes

Adds `@version 2.0.0` to the JSDoc blocks for new Markdown config options `gfm` and `smartypants`. This helps indicate when these were added in case someone using Astro v1 tries to enable them. The docs site will also pick these up and label these reference entries with “Added in: 2.0.0”.

## Testing

Docs only, no tests

## Docs

/cc @withastro/maintainers-docs for feedback!