### PR TITLE
Set the AdapterModeNotInitialized error to the proper way

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -49,6 +49,7 @@
     "./components/*": "./components/*",
     "./content/internal": "./dist/content/internal.js",
     "./debug": "./components/Debug.astro",
+    "./errors": "./dist/core/errors/index.js",
     "./internal/*": "./dist/runtime/server/*",
     "./package.json": "./package.json",
     "./runtime/*": "./dist/runtime/*",

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -414,6 +414,20 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 		},
 		hint: 'Mutable values declared at runtime are not supported. Please make sure to use exactly `export const prerender = true`.',
 	},
+	/**
+	 * @docs
+	 * @see
+	 * - [Node Adapter](https://docs.astro.build/en/guides/server-side-rendering/)
+	 * - [Node Adapter Mode](https://docs.astro.build/en/guides/integrations-guide/node/#mode)
+	 * @description
+	 * To use node adapter, a mode needs to be initialized so Astro knows how to generate the proper output for your project.
+	 */
+	AdapterModeNotInitialized: {
+		title: 'Cannot use node adapter without a mode.',
+		code: 3020,
+		message: `Cannot use an adapter without a mode. Please initialize the appropriate adapter mode for your project.`,
+		hint: 'See https://docs.astro.build/en/guides/integrations-guide/node/#mode for more information.',
+	},
 	// Vite Errors - 4xxx
 	UnknownViteError: {
 		title: 'Unknown Vite Error.',

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -423,7 +423,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	 * To use node adapter, a mode needs to be initialized so Astro knows how to generate the proper output for your project.
 	 */
 	AdapterModeNotInitialized: {
-		title: 'Cannot use node adapter without a mode.',
+		title: '[@astrojs/node] Cannot use node adapter without a mode.',
 		code: 3020,
 		message: `Cannot use an adapter without a mode. Please initialize the appropriate adapter mode for your project.`,
 		hint: 'See https://docs.astro.build/en/guides/integrations-guide/node/#mode for more information.',

--- a/packages/integrations/node/src/index.ts
+++ b/packages/integrations/node/src/index.ts
@@ -1,5 +1,6 @@
 import type { AstroAdapter, AstroIntegration } from 'astro';
 import type { Options, UserOptions } from './types';
+import { AstroError, AstroErrorData } from "astro/errors";
 
 export function getAdapter(options: Options): AstroAdapter {
 	return {
@@ -13,7 +14,7 @@ export function getAdapter(options: Options): AstroAdapter {
 
 export default function createIntegration(userOptions: UserOptions): AstroIntegration {
 	if (!userOptions?.mode) {
-		throw new Error(`[@astrojs/node] Setting the 'mode' option is required.`);
+		throw new AstroError(AstroErrorData.AdapterModeNotInitialized);
 	}
 
 	let _options: Options;


### PR DESCRIPTION
## Changes

- replaced node mode error with one in errors-data
- added errors to the exports so adapters can use the official errors

## known problems
the added error title and message are statically typed with node adapter,
so when a new adapter uses the mode property we should make dynamic

## Testing

i will test with github actions

## Docs
https://docs.astro.build/en/guides/integrations-guide/node/#mode
