### PR TITLE
Add Astro as a peerDependency

### DIFF
--- a/.changeset/thin-seahorses-worry.md
+++ b/.changeset/thin-seahorses-worry.md
@@ -13,4 +13,4 @@
 
 Make astro a peerDependency of integrations
 
-This marks `astro` as a peerDependency of serveral packages that are already getting `major` version bumps. This is so we can more properly track the dependency between them and what version of Astro they are being used with.
+This marks `astro` as a peerDependency of several packages that are already getting `major` version bumps. This is so we can more properly track the dependency between them and what version of Astro they are being used with.

--- a/.changeset/thin-seahorses-worry.md
+++ b/.changeset/thin-seahorses-worry.md
@@ -1,0 +1,16 @@
+---
+'@astrojs/cloudflare': major
+'@astrojs/deno': major
+'@astrojs/netlify': major
+'@astrojs/node': major
+'@astrojs/svelte': major
+'@astrojs/tailwind': major
+'@astrojs/vercel': major
+'@astrojs/vue': major
+'@astrojs/markdown-remark': major
+'@astrojs/image': minor
+---
+
+Make astro a peerDependency of integrations
+
+This marks `astro` as a peerDependency of serveral packages that are already getting `major` version bumps. This is so we can more properly track the dependency between them and what version of Astro they are being used with.

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -38,7 +38,7 @@
     "tiny-glob": "^0.2.9"
   },
   "peerDependencies": {
-    "astro": "^2.0.0-beta.0"
+    "astro": "workspace:^2.0.0-beta.0"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/packages/integrations/deno/package.json
+++ b/packages/integrations/deno/package.json
@@ -32,7 +32,7 @@
     "esbuild": "^0.15.18"
   },
   "peerDependencies": {
-    "astro": "^2.0.0-beta.0"
+    "astro": "workspace:^2.0.0-beta.0"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -65,7 +65,8 @@
     "vite": "^4.0.3"
   },
   "peerDependencies": {
-    "sharp": ">=0.31.0"
+    "sharp": ">=0.31.0",
+    "astro": "workspace:^2.0.0-beta.0"
   },
   "peerDependenciesMeta": {
     "sharp": {

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -37,6 +37,9 @@
     "@astrojs/webapi": "^1.1.1",
     "esbuild": "^0.15.18"
   },
+  "peerDependencies": {
+    "astro": "workspace:^2.0.0-beta.0"
+  },
   "devDependencies": {
     "@netlify/edge-handler-types": "^0.34.1",
     "@netlify/functions": "^1.0.0",

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -34,7 +34,7 @@
     "send": "^0.18.0"
   },
   "peerDependencies": {
-    "astro": "^2.0.0-beta.0"
+    "astro": "workspace:^2.0.0-beta.0"
   },
   "devDependencies": {
     "@types/node-fetch": "^2.6.2",

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -43,7 +43,8 @@
     "vite": "^4.0.3"
   },
   "peerDependencies": {
-    "svelte": "^3.54.0"
+    "svelte": "^3.54.0",
+    "astro": "workspace:^2.0.0-beta.0"
   },
   "engines": {
     "node": "^14.18.0 || >=16.12.0"

--- a/packages/integrations/tailwind/package.json
+++ b/packages/integrations/tailwind/package.json
@@ -38,7 +38,8 @@
     "tailwindcss": "^3.0.24"
   },
   "peerDependencies": {
-    "tailwindcss": "^3.0.24"
+    "tailwindcss": "^3.0.24",
+    "astro": "workspace:^2.0.0-beta.0"
   },
   "pnpm": {
     "peerDependencyRules": {

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -49,6 +49,9 @@
     "fast-glob": "^3.2.11",
     "set-cookie-parser": "^2.5.1"
   },
+  "peerDependencies": {
+    "astro": "workspace:^2.0.0-beta.0"
+  },
   "devDependencies": {
     "@types/set-cookie-parser": "^2.4.2",
     "astro": "workspace:*",

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -50,7 +50,8 @@
     "vue": "^3.2.37"
   },
   "peerDependencies": {
-    "vue": "^3.2.30"
+    "vue": "^3.2.30",
+    "astro": "workspace:^2.0.0-beta.0"
   },
   "engines": {
     "node": "^14.18.0 || >=16.12.0"

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -24,6 +24,9 @@
     "dev": "astro-scripts dev \"src/**/*.ts\"",
     "test": "mocha --exit --timeout 20000"
   },
+  "peerDependencies": {
+    "astro": "workspace:^2.0.0"
+  },
   "dependencies": {
     "@astrojs/prism": "^1.0.0",
     "acorn": "^8.7.1",


### PR DESCRIPTION
## Changes

- This adds `astro` as a peerDependency to many of our integrations.
- Only adds for integrations that are already doing a `major` release, in order to avoid unnecessarily creating breaking releases for packages that are not otherwise changing.

## Testing

- N/A, I think.

## Docs

- N/A