### PR TITLE
Remove old migration guide link from error docs

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -570,7 +570,6 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	 * @docs
 	 * @see
 	 * - [Configuration reference](https://docs.astro.build/en/reference/configuration-reference/)
-	 * - [Migration guide](https://docs.astro.build/en/migrate/)
 	 * @description
 	 * Astro detected a legacy configuration option in your configuration file.
 	 */


### PR DESCRIPTION
## Changes

The current migration docs (pre-v1) is going to be replaced by a new page, and although we have a redirect for it, the generated error pages in docs trigger an error in our link checker now that the page doesn't exist anymore, therefore we need to remove this link for now (we can later add the new migration docs page).

## Docs

100% docs!