### PR TITLE
`EntryKey` public type

### DIFF
--- a/packages/astro/src/content/template/types.generated.d.ts
+++ b/packages/astro/src/content/template/types.generated.d.ts
@@ -2,15 +2,16 @@ declare module 'astro:content' {
 	export { z } from 'astro/zod';
 	export type CollectionEntry<C extends keyof typeof entryMap> =
 		(typeof entryMap)[C][keyof (typeof entryMap)[C]] & Render;
+	export type EntryKey<C extends keyof typeof entryMap> = keyof typeof entryMap[C];
 
 	type BaseSchemaWithoutEffects =
 		| import('astro/zod').AnyZodObject
 		| import('astro/zod').ZodUnion<import('astro/zod').AnyZodObject[]>
 		| import('astro/zod').ZodDiscriminatedUnion<string, import('astro/zod').AnyZodObject[]>
 		| import('astro/zod').ZodIntersection<
-				import('astro/zod').AnyZodObject,
-				import('astro/zod').AnyZodObject
-		  >;
+			import('astro/zod').AnyZodObject,
+			import('astro/zod').AnyZodObject
+		>;
 
 	type BaseSchema =
 		| BaseSchemaWithoutEffects

--- a/packages/astro/src/content/template/types.generated.d.ts
+++ b/packages/astro/src/content/template/types.generated.d.ts
@@ -9,8 +9,8 @@ declare module 'astro:content' {
 		| import('astro/zod').ZodUnion<import('astro/zod').AnyZodObject[]>
 		| import('astro/zod').ZodDiscriminatedUnion<string, import('astro/zod').AnyZodObject[]>
 		| import('astro/zod').ZodIntersection<
-			import('astro/zod').AnyZodObject,
-			import('astro/zod').AnyZodObject
+				import('astro/zod').AnyZodObject,
+				import('astro/zod').AnyZodObject
 		>;
 
 	type BaseSchema =

--- a/packages/astro/src/content/template/types.generated.d.ts
+++ b/packages/astro/src/content/template/types.generated.d.ts
@@ -11,7 +11,7 @@ declare module 'astro:content' {
 		| import('astro/zod').ZodIntersection<
 				import('astro/zod').AnyZodObject,
 				import('astro/zod').AnyZodObject
-		>;
+			>;
 
 	type BaseSchema =
 		| BaseSchemaWithoutEffects


### PR DESCRIPTION
## Changes

It adds a a new public type for EntryKey.
It makes it possible to extend `getEntry`, such as:

```typescript
export const getBySlug = (slug: EntryKey<'articles'>) => {
  // ˜Validation of which keys can or cannot be acessed
  const entry = getEntry('articles', slug);
  // Some logic to extend it into a new object
  return newEntry;
};
```

## Testing

Just added a new type.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
