### PR TITLE
Bumps partytown version to fix deprecation warning

### DIFF
--- a/.changeset/fuzzy-phones-rule.md
+++ b/.changeset/fuzzy-phones-rule.md
@@ -1,5 +1,0 @@
----
-'@astrojs/partytown': minor
----
-
-Bumps `@builder.io/partytown` version in partytown integration to fix deprecation warning in pagespeed insights

--- a/.changeset/fuzzy-phones-rule.md
+++ b/.changeset/fuzzy-phones-rule.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/partytown': minor
+---
+
+Bumps `@builder.io/partytown` version in partytown integration to fix deprecation warning in pagespeed insights

--- a/.changeset/gold-baboons-tie.md
+++ b/.changeset/gold-baboons-tie.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/partytown': patch
+---
+
+Bumps `@builder.io/partytown` version in partytown integration to fix deprecation warning in pagespeed insights

--- a/packages/integrations/partytown/package.json
+++ b/packages/integrations/partytown/package.json
@@ -29,7 +29,7 @@
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {
-    "@builder.io/partytown": "^0.7.1",
+    "@builder.io/partytown": "^0.7.4",
     "mrmime": "^1.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3099,7 +3099,7 @@ importers:
 
   packages/integrations/partytown:
     specifiers:
-      '@builder.io/partytown': ^0.7.1
+      '@builder.io/partytown': ^0.7.4
       astro: workspace:*
       astro-scripts: workspace:*
       mrmime: ^1.0.0


### PR DESCRIPTION
## Changes

This PR fixes #5819.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
No tests were added since it was only a version bump

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
No need to update docs.

<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
