### PR TITLE
Fix order-of-execution bug when generating pages

### DIFF
--- a/.changeset/beige-beds-smile.md
+++ b/.changeset/beige-beds-smile.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix edge case with bundle generation by emitting a single chunk for pages

--- a/packages/astro/src/core/build/vite-plugin-prerender.ts
+++ b/packages/astro/src/core/build/vite-plugin-prerender.ts
@@ -34,8 +34,8 @@ export function vitePluginPrerender(
 					if (api.getModuleInfo(id)?.meta.astro?.pageOptions?.prerender) {
 						return `prerender`;
 					}
-					// pages should go in their own chunks/pages/* directory
-					return `pages${pageInfo.route.route.replace(/\/$/, '/index')}`;
+					// dynamic pages should all go in their own chunk in the pages/* directory
+					return `pages/all`;
 				}
 			};
 		},


### PR DESCRIPTION
## Changes

- Fixes #5754
- Manually splitting each page into a separate chunk causes some issues with execution order
- This fix emits a single chunk for all dynamic pages

## Testing

Tested manually, reproduction is fixed

## Docs

N/A, bug fix only