### PR TITLE
[Content collections] Improve content config handling

### DIFF
--- a/.changeset/fluffy-onions-wink.md
+++ b/.changeset/fluffy-onions-wink.md
@@ -1,0 +1,8 @@
+---
+'astro': patch
+---
+
+Better handle content type generation failures:
+- Generate types when content directory is empty
+- Log helpful error when running `astro sync` without a content directory
+- Avoid swallowing `config.ts` syntax errors from Vite

--- a/packages/astro/src/cli/sync/index.ts
+++ b/packages/astro/src/cli/sync/index.ts
@@ -21,7 +21,15 @@ export async function sync(
 			fs,
 			settings,
 		});
-		await contentTypesGenerator.init();
+		const typesResult = await contentTypesGenerator.init();
+		if (typesResult.typesGenerated === false) {
+			switch (typesResult.reason) {
+				case 'no-content-dir':
+				default:
+					info(logging, 'content', 'No content directory found. Skipping type generation.');
+					return 0;
+			}
+		}
 	} catch (e) {
 		throw new AstroError(AstroErrorData.GenerateContentTypesError);
 	}

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -260,13 +260,13 @@ export function getEntryType(
 	entryPath: string,
 	paths: ContentPaths
 ): 'content' | 'config' | 'unknown' | 'generated-types' {
-	const { dir: rawDir, ext, name, base } = path.parse(entryPath);
+	const { dir: rawDir, ext, base } = path.parse(entryPath);
 	const dir = appendForwardSlash(pathToFileURL(rawDir).href);
 	if ((contentFileExts as readonly string[]).includes(ext)) {
 		return 'content';
-	} else if (new URL(name, dir).pathname === paths.config.pathname) {
+	} else if (new URL(base, dir).href === paths.config.href) {
 		return 'config';
-	} else if (new URL(base, dir).pathname === new URL(CONTENT_TYPES_FILE, paths.cacheDir).pathname) {
+	} else if (new URL(base, dir).href === new URL(CONTENT_TYPES_FILE, paths.cacheDir).href) {
 		return 'generated-types';
 	} else {
 		return 'unknown';
@@ -314,6 +314,11 @@ async function writeContentFiles({
 	);
 	if (!isRelativePath(configPathRelativeToCacheDir))
 		configPathRelativeToCacheDir = './' + configPathRelativeToCacheDir;
+
+	// Remove `.ts` from import path
+	if (configPathRelativeToCacheDir.endsWith('.ts')) {
+		configPathRelativeToCacheDir = configPathRelativeToCacheDir.replace(/\.ts$/, '');
+	}
 
 	contentTypesBase = contentTypesBase.replace('// @@ENTRY_MAP@@', contentTypesStr);
 	contentTypesBase = contentTypesBase.replace(

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -56,8 +56,8 @@ export async function createContentTypesGenerator({
 	const contentTypesBase = await fs.promises.readFile(contentPaths.typesTemplate, 'utf-8');
 
 	async function init() {
-		await handleEvent({ name: 'add', entry: contentPaths.config }, { logLevel: 'warn' });
-		const globResult = await glob('./**/*.*', {
+		events.push(handleEvent({ name: 'add', entry: contentPaths.config }, { logLevel: 'warn' }));
+		const globResult = await glob('**', {
 			cwd: fileURLToPath(contentPaths.contentDir),
 			fs: {
 				readdir: fs.readdir.bind(fs),
@@ -109,10 +109,10 @@ export async function createContentTypesGenerator({
 		if (fileType === 'config') {
 			contentConfigObserver.set({ status: 'loading' });
 			const config = await loadContentConfig({ fs, settings });
-			if (config instanceof Error) {
-				contentConfigObserver.set({ status: 'error', error: config });
-			} else {
+			if (config) {
 				contentConfigObserver.set({ status: 'loaded', config });
+			} else {
+				contentConfigObserver.set({ status: 'error' });
 			}
 
 			return { shouldGenerateTypes: true };

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -292,6 +292,6 @@ export function getContentPaths({
 		contentDir: new URL('./content/', srcDir),
 		typesTemplate: new URL('types.d.ts', templateDir),
 		virtualModTemplate: new URL('virtual-mod.mjs', templateDir),
-		config: new URL('./content/config', srcDir),
+		config: new URL('./content/config.ts', srcDir),
 	};
 }

--- a/packages/astro/src/content/vite-plugin-content-server.ts
+++ b/packages/astro/src/content/vite-plugin-content-server.ts
@@ -7,11 +7,7 @@ import type { AstroSettings } from '../@types/astro.js';
 import { info, LogOptions } from '../core/logger/core.js';
 import { escapeViteEnvReferences, getFileInfo } from '../vite-plugin-utils/index.js';
 import { contentFileExts, CONTENT_FLAG } from './consts.js';
-import {
-	createContentTypesGenerator,
-	GenerateContentTypes,
-	getEntryType,
-} from './types-generator.js';
+import { createContentTypesGenerator, getEntryType } from './types-generator.js';
 import {
 	ContentConfig,
 	contentObservable,
@@ -37,7 +33,7 @@ export function astroContentServerPlugin({
 }: AstroContentServerPluginParams): Plugin[] {
 	const contentPaths = getContentPaths(settings.config);
 	let contentDirExists = false;
-	let contentGenerator: GenerateContentTypes;
+	let contentGenerator: Awaited<ReturnType<typeof createContentTypesGenerator>>;
 	const contentConfigObserver = contentObservable({ status: 'loading' });
 
 	return [


### PR DESCRIPTION
## Changes

- Resolves #5711 

Better handle content type generation failures:

- Generate types when content directory is empty
- Log helpful error when running `astro sync` without a content directory
- Avoid swallowing `config.ts` syntax errors from Vite
- Fix: Generate types when the `content/` dir is added in dev

## Testing

Manual testing: adding and removing the `content` directory, adding and modifying the `config.ts` file.

## Docs

https://github.com/withastro/docs/pull/2345/
