### PR TITLE
Fix `Code.astro` shiki css class replace logic

### DIFF
--- a/.changeset/sweet-rocks-count.md
+++ b/.changeset/sweet-rocks-count.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `Code.astro` shiki css class replace logic

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -37,7 +37,7 @@ const { code, lang = 'plaintext', theme = 'github-dark', wrap = false } = Astro.
 /** Replace the shiki class name with a custom astro class name. */
 function repairShikiTheme(html: string): string {
 	// Replace "shiki" class naming with "astro"
-	html = html.replace('<pre class="shiki"', '<pre class="astro-code"');
+	html = html.replace(/<pre class="(.*)shiki(.*)"/, '<pre class="$1astro-code$2"');
 	// Handle code wrapping
 	// if wrap=null, do nothing.
 	if (wrap === false) {

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -37,7 +37,7 @@ const { code, lang = 'plaintext', theme = 'github-dark', wrap = false } = Astro.
 /** Replace the shiki class name with a custom astro class name. */
 function repairShikiTheme(html: string): string {
 	// Replace "shiki" class naming with "astro"
-	html = html.replace(/<pre class="(.*)shiki(.*)"/, '<pre class="$1astro-code$2"');
+	html = html.replace(/<pre class="(.*?)shiki(.*?)"/, '<pre class="$1astro-code$2"');
 	// Handle code wrapping
 	// if wrap=null, do nothing.
 	if (wrap === false) {


### PR DESCRIPTION
## Changes
The replace uses a regex witch matches anything extra and adds it back to the css class.

Closes #5828

## Testing
As mentioned in the linked issue #5828, the actual pinned shiki version v0.11 does work. The v0.12 causes the bug, as a new feature https://github.com/shikijs/shiki/pull/376 adds an extra css class, making the actual logic to fail.

There's a test already in place https://github.com/withastro/astro/blob/4b16e9ec9929269a16e7950d8fed78779149b0fc/packages/astro/test/astro-component-code.test.js#L37-L41 and it will fail when shiki gets updated to v0.12. This PR resolves the issue.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->