### PR TITLE
Fix announcements CI actions when 2000+ characters

### DIFF
--- a/scripts/notify/index.js
+++ b/scripts/notify/index.js
@@ -2,7 +2,8 @@ import { globby as glob } from 'globby';
 import { fileURLToPath } from 'node:url';
 import { readFile } from 'node:fs/promises';
 
-const baseUrl = new URL('https://github.com/withastro/astro/blob/main/');
+const { GITHUB_REF = 'main' } = process.env;
+const baseUrl = new URL(`https://github.com/withastro/astro/blob/${GITHUB_REF}/`);
 
 const emojis = ['🎉', '🥳', '🚀', '🧑‍🚀', '🎊', '🏆', '✅', '🤩', '🤖', '🙌'];
 const descriptors = [
@@ -50,7 +51,7 @@ const extraVerbs = [
 	'here',
 	'released',
 	'freshly made',
-	'going out;',
+	'going out',
 	'hitting the registry',
 	'available',
 	'live now',
@@ -132,24 +133,20 @@ async function run() {
 	} else {
 		const { name, version, url } = packages.find(pkg => pkg.name === 'astro') ?? packages[0];
 		message = `${emoji} Some ${descriptor} ${pluralize(verb)}\n\n`;
-		message += `${emoji} \`${name}@${version}\` Read the [release notes →](<${url}>)\n`
+		message += `• \`${name}@${version}\` Read the [release notes →](<${url}>)\n`
 
-		message += `\n\nAlso ${item(extraVerbs)}:\n`
+		message += `\nAlso ${item(extraVerbs)}:`
 
 		const remainingPackages = packages.filter(p => p.name !== name);
-		let i = 0;
 		for (const { name, version, url } of remainingPackages) {
-			if (i !== 0) message += ', '
-			if (i === remainingPackages.length - 1) message += 'and '
-			message += `\`${name}@${version}\``;
-			i++;
+			message += `\n• \`${name}@${version}\``;
 		}
 
 		if (message.length < 2000) {
 			console.log(message);
 		} else {
 			message = `${emoji} Some ${descriptor} ${pluralize(verb)}\n\n`;
-			message += `${emoji} \`${name}@${version}\` Read the [release notes →](<${url}>)\n`
+			message += `• \`${name}@${version}\` Read the [release notes →](<${url}>)\n`
 
 			message += `\n\nAlso ${item(extraVerbs)}: ${remainingPackages.length} other packages!`;
 			console.log(message);

--- a/scripts/notify/index.js
+++ b/scripts/notify/index.js
@@ -45,6 +45,19 @@ const verbs = [
 	'– from our family to yours.',
 	'– go forth and build!',
 ];
+const extraVerbs = [
+	'new',
+	'here',
+	'released',
+	'freshly made',
+	'going out;',
+	'hitting the registry',
+	'available',
+	'live now',
+	'hot and fresh',
+	'for you',
+	'comin\' atcha',
+]
 
 function item(items) {
 	return items[Math.floor(Math.random() * items.length)];
@@ -102,15 +115,44 @@ async function run() {
 	const descriptor = item(descriptors);
 	const verb = item(verbs);
 
+	let message = '';
+
 	if (packages.length === 1) {
 		const { name, version, url } = packages[0];
-		console.log(
-			`${emoji} \`${name}@${version}\` ${singularlize(verb)}\nRead the [release notes →](<${url}>)`
-		);
+		message += `${emoji} \`${name}@${version}\` ${singularlize(verb)}\nRead the [release notes →](<${url}>)\n`
 	} else {
-		console.log(`${emoji} Some ${descriptor} ${pluralize(verb)}\n`);
+		message += `${emoji} Some ${descriptor} ${pluralize(verb)}\n\n`;
 		for (const { name, version, url } of packages) {
-			console.log(`• \`${name}@${version}\` Read the [release notes →](<${url}>)`);
+			message += `• \`${name}@${version}\` Read the [release notes →](<${url}>)\n`;
+		}
+	}
+
+	if (message.length < 2000) {
+		console.log(message);
+	} else {
+		const { name, version, url } = packages.find(pkg => pkg.name === 'astro') ?? packages[0];
+		message = `${emoji} Some ${descriptor} ${pluralize(verb)}\n\n`;
+		message += `${emoji} \`${name}@${version}\` Read the [release notes →](<${url}>)\n`
+
+		message += `\n\nAlso ${item(extraVerbs)}:\n`
+
+		const remainingPackages = packages.filter(p => p.name !== name);
+		let i = 0;
+		for (const { name, version, url } of remainingPackages) {
+			if (i !== 0) message += ', '
+			if (i === remainingPackages.length - 1) message += 'and '
+			message += `\`${name}@${version}\``;
+			i++;
+		}
+
+		if (message.length < 2000) {
+			console.log(message);
+		} else {
+			message = `${emoji} Some ${descriptor} ${pluralize(verb)}\n\n`;
+			message += `${emoji} \`${name}@${version}\` Read the [release notes →](<${url}>)\n`
+
+			message += `\n\nAlso ${item(extraVerbs)}: ${remainingPackages.length} other packages!`;
+			console.log(message);
 		}
 	}
 }


### PR DESCRIPTION
## Changes

- Our announcement script [would fail](https://github.com/withastro/astro/actions/runs/3904214156/jobs/6669686822) when the messages were >= 2000 characters.
- This adds some special handling to reformat the message if the original message is too large.

## Testing

**Before**

Failed 😥

**After**
```
🥳 Some awesome updates now out. Be the first on your block to download!

• `astro@2.0.0-beta.2` Read the [release notes →](<https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md#200-beta2>)

Also hot and fresh:
• `@astrojs/prism@2.0.0-beta.0`
• `create-astro@2.0.0-beta.0`
• `@astrojs/cloudflare@6.0.0-beta.1`
• `@astrojs/deno@4.0.0-beta.2`
• `@astrojs/image@1.0.0-beta.2`
• `@astrojs/lit@1.0.2-beta.0`
• `@astrojs/mdx@1.0.0-beta.2`
• `@astrojs/netlify@2.0.0-beta.2`
• `@astrojs/node@5.0.0-beta.1`
• `@astrojs/partytown@1.0.3-beta.0`
• `@astrojs/preact@2.0.0-beta.0`
• `@astrojs/react@2.0.0-beta.0`
• `@astrojs/solid-js@2.0.0-beta.0`
• `@astrojs/svelte@2.0.0-beta.1`
• `@astrojs/tailwind@3.0.0-beta.1`
• `@astrojs/vercel@3.0.0-beta.1`
• `@astrojs/vue@2.0.0-beta.1`
• `@astrojs/markdown-remark@2.0.0-beta.2`
• `@astrojs/telemetry@2.0.0-beta.0`
• `@astrojs/webapi@2.0.0-beta.0`
```

## Docs

N/A
