### PR TITLE
Fix importing client-side components with alias

### DIFF
--- a/.changeset/ninety-garlics-fly.md
+++ b/.changeset/ninety-garlics-fly.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix importing client-side components with alias

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -22,6 +22,7 @@ import { generatePages } from './generate.js';
 import { trackPageData } from './internal.js';
 import type { PageBuildData, StaticBuildOptions } from './types';
 import { getTimeStat } from './util.js';
+import { vitePluginAliasResolve } from './vite-plugin-alias-resolve.js';
 import { vitePluginAnalyzer } from './vite-plugin-analyzer.js';
 import { rollupPluginAstroBuildCSS } from './vite-plugin-css.js';
 import { vitePluginHoistedScripts } from './vite-plugin-hoisted-scripts.js';
@@ -221,6 +222,7 @@ async function clientBuild(
 			},
 		},
 		plugins: [
+			vitePluginAliasResolve(internals),
 			vitePluginInternals(input, internals),
 			vitePluginHoistedScripts(settings, internals),
 			rollupPluginAstroBuildCSS({

--- a/packages/astro/src/core/build/vite-plugin-alias-resolve.ts
+++ b/packages/astro/src/core/build/vite-plugin-alias-resolve.ts
@@ -1,32 +1,50 @@
-import type { Plugin as VitePlugin } from 'vite';
+import type { Alias, Plugin as VitePlugin } from 'vite';
 import type { BuildInternals } from '../../core/build/internal.js';
 
 /**
- * `@rollup/plugin-alias` doesn't resolve aliases in Rollup input by default. This plugin fixes it.
+ * `@rollup/plugin-alias` doesn't resolve aliases in Rollup input by default. This plugin fixes it
+ * with a partial fork of it's resolve function. https://github.com/rollup/plugins/blob/master/packages/alias/src/index.ts
  * When https://github.com/rollup/plugins/pull/1402 is merged, we can remove this plugin.
  */
 export function vitePluginAliasResolve(internals: BuildInternals): VitePlugin {
-	let inputResolve: (id: string) => Promise<string>;
+	let aliases: Alias[];
 
 	return {
 		name: '@astro/plugin-alias-resolve',
 		enforce: 'pre',
 		configResolved(config) {
-			const viteResolve = config.createResolver();
-			inputResolve = async (id) => {
-				const resolved = await viteResolve(id, ' ', true);
-				return resolved || id;
-			};
+			aliases = config.resolve.alias;
 		},
-		async resolveId(id, importer) {
+		async resolveId(id, importer, opts) {
 			if (
 				!importer &&
 				(internals.discoveredHydratedComponents.has(id) ||
 					internals.discoveredClientOnlyComponents.has(id))
 			) {
-				const resolved = await inputResolve(id);
-				return await this.resolve(resolved, importer, { skipSelf: true });
+				const matchedEntry = aliases.find((entry) => matches(entry.find, id));
+				if (!matchedEntry) {
+					return null;
+				}
+
+				const updatedId = id.replace(matchedEntry.find, matchedEntry.replacement);
+
+				return this.resolve(updatedId, importer, Object.assign({ skipSelf: true }, opts)).then(
+					(resolved) => resolved || { id: updatedId }
+				);
 			}
 		},
 	};
+}
+
+function matches(pattern: string | RegExp, importee: string) {
+	if (pattern instanceof RegExp) {
+		return pattern.test(importee);
+	}
+	if (importee.length < pattern.length) {
+		return false;
+	}
+	if (importee === pattern) {
+		return true;
+	}
+	return importee.startsWith(pattern + '/');
 }

--- a/packages/astro/src/core/build/vite-plugin-alias-resolve.ts
+++ b/packages/astro/src/core/build/vite-plugin-alias-resolve.ts
@@ -1,0 +1,32 @@
+import type { Plugin as VitePlugin } from 'vite';
+import type { BuildInternals } from '../../core/build/internal.js';
+
+/**
+ * `@rollup/plugin-alias` doesn't resolve aliases in Rollup input by default. This plugin fixes it.
+ * When https://github.com/rollup/plugins/pull/1402 is merged, we can remove this plugin.
+ */
+export function vitePluginAliasResolve(internals: BuildInternals): VitePlugin {
+	let inputResolve: (id: string) => Promise<string>;
+
+	return {
+		name: '@astro/plugin-alias-resolve',
+		enforce: 'pre',
+		configResolved(config) {
+			const viteResolve = config.createResolver();
+			inputResolve = async (id) => {
+				const resolved = await viteResolve(id, ' ', true);
+				return resolved || id;
+			};
+		},
+		async resolveId(id, importer) {
+			if (
+				!importer &&
+				(internals.discoveredHydratedComponents.has(id) ||
+					internals.discoveredClientOnlyComponents.has(id))
+			) {
+				const resolved = await inputResolve(id);
+				return await this.resolve(resolved, importer, { skipSelf: true });
+			}
+		},
+	};
+}

--- a/packages/astro/test/alias.test.js
+++ b/packages/astro/test/alias.test.js
@@ -35,4 +35,21 @@ describe('Aliases', () => {
 			expect(scripts.length).to.be.greaterThan(0);
 		});
 	});
+
+	describe('build', () => {
+		before(async () => {
+			await fixture.build();
+		});
+
+		it('can load client components', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+
+			// Should render aliased element
+			expect($('#client').text()).to.equal('test');
+
+			const scripts = $('script').toArray();
+			expect(scripts.length).to.be.greaterThan(0);
+		});
+	});
 });


### PR DESCRIPTION
## Changes

fix #5821

Add a Vite plugin to resolve aliases for client build input entries.

This is a workaround for now until the upstream Rollup fix: https://github.com/rollup/plugins/pull/1402


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added a test for alias build. There was only dev.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
n/a. bug fix.
<!-- https://github.com/withastro/docs -->
