### PR TITLE
Handle server restart from Vite plugins

### DIFF
--- a/.changeset/poor-ladybugs-thank.md
+++ b/.changeset/poor-ladybugs-thank.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Handle server restart from Vite plugins

--- a/packages/astro/test/units/dev/restart.test.js
+++ b/packages/astro/test/units/dev/restart.test.js
@@ -180,4 +180,35 @@ describe('dev container restarts', () => {
 			await restart.container.close();
 		}
 	});
+
+	it('Is able to restart on viteServer.restart API call', async () => {
+		const fs = createFs(
+			{
+				'/src/pages/index.astro': ``,
+			},
+			root
+		);
+
+		const { astroConfig } = await openConfig({
+			cwd: root,
+			flags: {},
+			cmd: 'dev',
+			logging: defaultLogging,
+		});
+		const settings = createSettings(astroConfig, fileURLToPath(root));
+
+		let restart = await createContainerWithAutomaticRestart({
+			params: { fs, root, settings },
+		});
+		await startContainer(restart.container);
+		expect(isStarted(restart.container)).to.equal(true);
+
+		try {
+			let restartComplete = restart.restarted();
+			await restart.container.viteServer.restart();
+			await restartComplete;
+		} finally {
+			await restart.container.close();
+		}
+	});
 });


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/5783

Override Vite's `server.restart` API with our implementation.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added a unit test, and manually tested the repro that it works.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.