### PR TITLE
[RSS] Get ready for content collections

### DIFF
--- a/.changeset/fluffy-cups-travel.md
+++ b/.changeset/fluffy-cups-travel.md
@@ -1,0 +1,52 @@
+---
+'@astrojs/rss': major
+---
+
+Update RSS configuration with our content collections in mind.
+
+1. Expose an `rssSchema` for use with content collections. This ensures are RSS feed properties are present in your frontmatter:
+
+```ts
+import { defineCollection } from 'astro:content';
+import { rssSchema } from '@astrojs/rss';
+
+const blog = defineCollection({
+  schema: rssSchema,
+});
+
+export const collections = { blog };
+```
+
+2. Move implicit `import.meta.glob` handling to a separate `pagesGlobToRssItems()` helper. This simplifies our `items` configuration option to accept a single type, without losing existing functionality:
+
+```ts
+// src/pages/rss.xml.js
+import rss, { pagesGlobToRssItems } from '@astrojs/rss';
+
+export function get(context) {
+  return rss({
+    items: pagesGlobToRssItems(
+      import.meta.glob('./blog/*.{md,mdx}'),
+    ),
+  });
+}
+```
+
+#### Migration
+
+If you rely on our `import.meta.glob` handling, add the `pagesGlobToRssItems()` wrapper to your RSS config:
+
+```diff
+// src/pages/rss.xml.js
+import rss, {
++  pagesGlobToRssItems
+} from '@astrojs/rss';
+
+export function get(context) {
+  return rss({
++    items: pagesGlobToRssItems(
+      import.meta.glob('./blog/*.{md,mdx}'),
++    ),
+  });
+}
+```

--- a/.changeset/fluffy-cups-travel.md
+++ b/.changeset/fluffy-cups-travel.md
@@ -2,7 +2,7 @@
 '@astrojs/rss': major
 ---
 
-Update RSS configuration with our content collections in mind.
+Update RSS configuration with content collections in mind.
 
 1. Expose an `rssSchema` for use with content collections. This ensures are RSS feed properties are present in your frontmatter:
 

--- a/.changeset/fluffy-cups-travel.md
+++ b/.changeset/fluffy-cups-travel.md
@@ -4,7 +4,7 @@
 
 Update RSS configuration with content collections in mind.
 
-1. Expose an `rssSchema` for use with content collections. This ensures are RSS feed properties are present in your frontmatter:
+1. Expose an `rssSchema` for use with content collections. This ensures all RSS feed properties are present in your frontmatter:
 
 ```ts
 import { defineCollection } from 'astro:content';

--- a/.changeset/fluffy-cups-travel.md
+++ b/.changeset/fluffy-cups-travel.md
@@ -8,7 +8,7 @@ Update RSS config for readability and consistency with Astro 2.0.
 
 We have deprecated `items: import.meta.glob(...)` handling in favor of a separate `pagesGlobToRssItems()` helper. This simplifies our `items` configuration option to accept a single type, without losing existing functionality.
 
-If you rely on our `import.meta.glob()` handling, we suggest the `pagesGlobToRssItems()` wrapper to your RSS config:
+If you rely on our `import.meta.glob()` handling, we suggest adding the `pagesGlobToRssItems()` wrapper to your RSS config:
 
 ```diff
 // src/pages/rss.xml.js

--- a/.changeset/fluffy-cups-travel.md
+++ b/.changeset/fluffy-cups-travel.md
@@ -1,40 +1,14 @@
 ---
-'@astrojs/rss': major
+'@astrojs/rss': minor
 ---
 
-Update RSS configuration with content collections in mind.
+Update RSS config for readability and consistency with Astro 2.0.
 
-1. Expose an `rssSchema` for use with content collections. This ensures all RSS feed properties are present in your frontmatter:
+#### Migration - `import.meta.glob()` handling
 
-```ts
-import { defineCollection } from 'astro:content';
-import { rssSchema } from '@astrojs/rss';
+We have deprecated `items: import.meta.glob(...)` handling in favor of a separate `pagesGlobToRssItems()` helper. This simplifies our `items` configuration option to accept a single type, without losing existing functionality.
 
-const blog = defineCollection({
-  schema: rssSchema,
-});
-
-export const collections = { blog };
-```
-
-2. Move implicit `import.meta.glob` handling to a separate `pagesGlobToRssItems()` helper. This simplifies our `items` configuration option to accept a single type, without losing existing functionality:
-
-```ts
-// src/pages/rss.xml.js
-import rss, { pagesGlobToRssItems } from '@astrojs/rss';
-
-export function get(context) {
-  return rss({
-    items: pagesGlobToRssItems(
-      import.meta.glob('./blog/*.{md,mdx}'),
-    ),
-  });
-}
-```
-
-#### Migration
-
-If you rely on our `import.meta.glob` handling, add the `pagesGlobToRssItems()` wrapper to your RSS config:
+If you rely on our `import.meta.glob()` handling, we suggest the `pagesGlobToRssItems()` wrapper to your RSS config:
 
 ```diff
 // src/pages/rss.xml.js
@@ -49,4 +23,19 @@ export function get(context) {
 +    ),
   });
 }
+```
+
+#### New `rssSchema` for content collections
+
+`@astrojs/rss` now exposes an `rssSchema` for use with content collections. This ensures all RSS feed properties are present in your frontmatter:
+
+```ts
+import { defineCollection } from 'astro:content';
+import { rssSchema } from '@astrojs/rss';
+
+const blog = defineCollection({
+  schema: rssSchema,
+});
+
+export const collections = { blog };
 ```

--- a/examples/blog/src/pages/rss.xml.js
+++ b/examples/blog/src/pages/rss.xml.js
@@ -7,7 +7,7 @@ export async function get(context) {
 	return rss({
 		title: SITE_TITLE,
 		description: SITE_DESCRIPTION,
-		site: context.site.href,
+		site: context.site,
 		items: posts.map((post) => ({
 			...post.data,
 			link: `/blog/${post.slug}/`,

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -190,6 +190,8 @@ import { rssSchema } from '@astrojs/rss';
 const blog = defineCollection({
   schema: rssSchema,
 });
+
+export const collections = { blog };
 ```
 
 If you have an existing schema, you can merge extra properties using `extends()`:

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -217,9 +217,9 @@ This assumes a) you are globbing for items inside `src/pages/`, and b) all neces
 // src/pages/rss.xml.js
 import rss, { pagesGlobToRssItems } from '@astrojs/rss';
 
-export function get(context) {
+export async function get(context) {
   return rss({
-    items: pagesGlobToRssItems(
+    items: await pagesGlobToRssItems(
       import.meta.glob('./blog/*.{md,mdx}'),
     ),
   });

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -179,9 +179,7 @@ Will inject the following XML:
 
 ## `rssSchema`
 
-The `@astrojs/rss` package exposes an `rssSchema` for use with [content collections](https://docs.astro.build/en/guides/content-collections/). This ensures your frontmatter contains all properties expected by [an `RSSFeedItem`](#items).
-
-Apply this to your collection schema like so:
+When using content collections, you can configure your collection schema to enforce expected [`RSSFeedItem`](#items) properties. Import and apply `rssSchema` to ensure that each collection entry produces a valid RSS feed item:
 
 ```ts "schema: rssSchema,"
 import { defineCollection } from 'astro:content';

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -211,7 +211,7 @@ You may generate an RSS feed from documents in `src/pages/`. Since `Astro.glob` 
 This assumes a) you are globbing for items inside `src/pages/`, and b) all necessary feed properties are present in each document's frontmatter.
 :::
 
-```ts ".extends({ extraProperty: z.string() }),"
+```ts "pagesGlobToRssItems"
 // src/pages/rss.xml.js
 import rss, { pagesGlobToRssItems } from '@astrojs/rss';
 

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -108,7 +108,7 @@ export const get = (context) => rss({
 
 Type: `RSSFeedItem[] (required)`
 
-Aa list of formatted RSS feed items. See [Astro's RSS items documentation](https://docs.astro.build/en/guides/rss/#generating-items) for usage examples to choose the best option for you.
+A list of formatted RSS feed items. See [Astro's RSS items documentation](https://docs.astro.build/en/guides/rss/#generating-items) for usage examples to choose the best option for you.
 
 When providing a formatted RSS item list, see the `RSSFeedItem` type reference below:
 
@@ -181,7 +181,7 @@ Will inject the following XML:
 
 The `@astrojs/rss` package exposes an `rssSchema` for use with [content collections](https://docs.astro.build/en/guides/content-collections/). This ensures your frontmatter contains all properties expected by [an `RSSFeedItem`](#items).
 
-Apply this to an existing collection schema like so:
+Apply this to your collection schema like so:
 
 ```ts "schema: rssSchema,"
 import { defineCollection } from 'astro:content';

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -42,7 +42,7 @@ export async function get(context) {
       // Generate a `url` from each post `slug`
       // This assumes all blog posts are rendered as `/blog/[slug]` routes
       // https://docs.astro.build/en/guides/content-collections/#generating-pages-from-content-collections
-      url: `/blog/${post.slug}/`,
+      link: `/blog/${post.slug}/`,
     }))
   })
 }

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -175,6 +175,32 @@ Will inject the following XML:
 <rss xmlns:h="http://www.w3.org/TR/html4/"...
 ```
 
+## `rssSchema`
+
+The `@astrojs/rss` package exposes an `rssSchema` for use with [content collections](https://docs.astro.build/en/guides/content-collections/). This ensures your frontmatter contains all properties expected by [an `RSSFeedItem`](#items).
+
+Apply this to an existing collection schema like so:
+
+```ts "schema: rssSchema,"
+import { defineCollection } from 'astro:content';
+import { rssSchema } from '@astrojs/rss';
+
+const blog = defineCollection({
+  schema: rssSchema,
+});
+```
+
+If you have an existing schema, you can merge extra properties using `extends()`:
+
+```ts ".extends({ extraProperty: z.string() }),"
+import { defineCollection } from 'astro:content';
+import { rssSchema } from '@astrojs/rss';
+
+const blog = defineCollection({
+  schema: rssSchema.extends({ extraProperty: z.string() }),
+});
+```
+
 ---
 
 For more on building with Astro, [visit the Astro docs][astro-rss].

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -203,6 +203,27 @@ const blog = defineCollection({
 });
 ```
 
+## `pagesGlobToRssItems()`
+
+You may generate an RSS feed from documents in `src/pages/`. Since `Astro.glob` is not available from endpoint routes, we've included a `pagesGlobToRssItems()` helper. This accepts an `import.meta.glob` result ([see Vite documentation](https://vitejs.dev/guide/features.html#glob-import)) and outputs an array of valid [`RSSFeedItem`s](#items).
+
+:::note
+This assumes a) you are globbing for items inside `src/pages/`, and b) all necessary feed properties are present in each document's frontmatter.
+:::
+
+```ts ".extends({ extraProperty: z.string() }),"
+// src/pages/rss.xml.js
+import rss, { pagesGlobToRssItems } from '@astrojs/rss';
+
+export function get(context) {
+  return rss({
+    items: pagesGlobToRssItems(
+      import.meta.glob('./blog/*.{md,mdx}'),
+    ),
+  });
+}
+```
+
 ---
 
 For more on building with Astro, [visit the Astro docs][astro-rss].

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -25,11 +25,12 @@ For instance, say you need to generate an RSS feed for all posts under `src/page
 // src/pages/rss.xml.js
 import rss from '@astrojs/rss';
 
-export const get = () => rss({
+export const get = (context) => rss({
     title: 'Buzz’s Blog',
     description: 'A humble Astronaut’s guide to the stars',
-    // pull in the "site" from your project's astro.config
-    site: import.meta.env.SITE,
+    // pull in your project "site" from the API context
+    // https://docs.astro.build/en/reference/api-reference/#contextsite
+    site: context.site,
     items: import.meta.glob('./blog/**/*.md'),
   });
 ```
@@ -41,13 +42,13 @@ Read **[Astro's RSS docs][astro-rss]** for full usage examples.
 The `rss` default export offers a number of configuration options. Here's a quick reference:
 
 ```js
-rss({
+export const get = (context) => rss({
   // `<title>` field in output xml
   title: 'Buzz’s Blog',
   // `<description>` field in output xml
   description: 'A humble Astronaut’s guide to the stars',
   // provide a base URL for RSS <item> links
-  site: import.meta.env.SITE,
+  site: context.site,
   // list of `<item>`s in output xml
   items: import.meta.glob('./**/*.md'),
   // include draft posts in the feed (default: false)
@@ -77,7 +78,16 @@ The `<description>` attribute of your RSS feed's output xml.
 
 Type: `string (required)`
 
-The base URL to use when generating RSS item links. We recommend using `import.meta.env.SITE` to pull in the "site" from your project's astro.config. Still, feel free to use a custom base URL if necessary.
+The base URL to use when generating RSS item links. We recommend using the [endpoint context object](https://docs.astro.build/en/reference/api-reference/#contextsite), which includes the `site` configured in your project's `astro.config.*`:
+
+```ts
+import rss from '@astrojs/rss';
+
+export const get = (context) => rss({
+    site: context.site,
+    ...
+  });
+```
 
 ### items
 

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -205,11 +205,9 @@ const blog = defineCollection({
 
 ## `pagesGlobToRssItems()`
 
-You may generate an RSS feed from documents in `src/pages/`. Since `Astro.glob` is not available from endpoint routes, we've included a `pagesGlobToRssItems()` helper. This accepts an `import.meta.glob` result ([see Vite documentation](https://vitejs.dev/guide/features.html#glob-import)) and outputs an array of valid [`RSSFeedItem`s](#items).
+To create an RSS feed from documents in `src/pages/`, use the `pagesGlobToRssItems()` helper. This accepts an `import.meta.glob` result ([see Vite documentation](https://vitejs.dev/guide/features.html#glob-import)) and outputs an array of valid [`RSSFeedItem`s](#items).
 
-:::note
-This assumes a) you are globbing for items inside `src/pages/`, and b) all necessary feed properties are present in each document's frontmatter.
-:::
+This function assumes, but does not verify, you are globbing for items inside `src/pages/`, and all necessary feed properties are present in each document's frontmatter. If you encounter errors, verify each page frontmatter manually.
 
 ```ts "pagesGlobToRssItems"
 // src/pages/rss.xml.js
@@ -217,6 +215,9 @@ import rss, { pagesGlobToRssItems } from '@astrojs/rss';
 
 export async function get(context) {
   return rss({
+    title: 'Buzz’s Blog',
+    description: 'A humble Astronaut’s guide to the stars',
+    site: context.site,
     items: await pagesGlobToRssItems(
       import.meta.glob('./blog/*.{md,mdx}'),
     ),

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -181,7 +181,7 @@ Will inject the following XML:
 
 The `content` key contains the full content of the post as HTML. This allows you to make your entire post content available to RSS feed readers.
 
-**Note:** Whenever you're using HTML content in XML, suggest using a package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) in order to make sure that your content is properly sanitized, escaped, and encoded.
+**Note:** Whenever you're using HTML content in XML, we suggest using a package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) in order to make sure that your content is properly sanitized, escaped, and encoded.
 
 [See our RSS documentation](https://docs.astro.build/en/guides/rss/#including-full-post-content) for examples using content collections and glob imports.
 

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -44,7 +44,7 @@ export async function get(context) {
       // https://docs.astro.build/en/guides/content-collections/#generating-pages-from-content-collections
       link: `/blog/${post.slug}/`,
     }))
-  })
+  });
 }
 ```
 
@@ -55,24 +55,26 @@ Read **[Astro's RSS docs][astro-rss]** for more on using content collections, an
 The `rss` default export offers a number of configuration options. Here's a quick reference:
 
 ```js
-export const get = (context) => rss({
-  // `<title>` field in output xml
-  title: 'Buzz’s Blog',
-  // `<description>` field in output xml
-  description: 'A humble Astronaut’s guide to the stars',
-  // provide a base URL for RSS <item> links
-  site: context.site,
-  // list of `<item>`s in output xml
-  items: [...],
-  // include draft posts in the feed (default: false)
-  drafts: true,
-  // (optional) absolute path to XSL stylesheet in your project
-  stylesheet: '/rss-styles.xsl',
-  // (optional) inject custom xml
-  customData: '<language>en-us</language>',
-  // (optional) add arbitrary metadata to opening <rss> tag
-  xmlns: { h: 'http://www.w3.org/TR/html4/' },
-});
+export function get(context) {
+  return rss({
+    // `<title>` field in output xml
+    title: 'Buzz’s Blog',
+    // `<description>` field in output xml
+    description: 'A humble Astronaut’s guide to the stars',
+    // provide a base URL for RSS <item> links
+    site: context.site,
+    // list of `<item>`s in output xml
+    items: [...],
+    // include draft posts in the feed (default: false)
+    drafts: true,
+    // (optional) absolute path to XSL stylesheet in your project
+    stylesheet: '/rss-styles.xsl',
+    // (optional) inject custom xml
+    customData: '<language>en-us</language>',
+    // (optional) add arbitrary metadata to opening <rss> tag
+    xmlns: { h: 'http://www.w3.org/TR/html4/' },
+  });
+}
 ```
 
 ### title

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -183,51 +183,7 @@ The `content` key contains the full content of the post as HTML. This allows you
 
 **Note:** Whenever you're using HTML content in XML, suggest using a package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) in order to make sure that your content is properly sanitized, escaped, and encoded.
 
-When using content collections, render the post `body` using a standard Markdown parser like [`markdown-it`](https://github.com/markdown-it/markdown-it) and sanitize the result:
-
-```js title="src/pages/rss.xml.js" ins={2, 3, 4, 14}
-import rss from '@astrojs/rss';
-import sanitizeHtml from 'sanitize-html';
-import MarkdownIt from 'markdown-it';
-const parser = new MarkdownIt();
-
-export async function get(context) {
-  const blog = await getCollection('blog');
-  return rss({
-    title: 'Buzz’s Blog',
-    description: 'A humble Astronaut’s guide to the stars',
-    site: context.site,
-    items: blog.map((post) => ({
-      link: `/blog/${post.slug}/`,
-      // Note: this will not process components or JSX expressions in MDX files.
-      content: sanitizeHtml(parser.render(post.body)),
-      ...post.data,
-    })),
-  });
-}
-```
-
-When using glob imports with Markdown, we suggest using the `compiledContent()` helper to retrieve the rendered HTML for sanitization. Note this feature is **not** supported for MDX files.
-
-```js title="src/pages/rss.xml.js" ins={2, 13}
-import rss from '@astrojs/rss';
-import sanitizeHtml from 'sanitize-html';
-
-export function get(context) {
-  const postImportResult = import.meta.glob('../posts/**/*.md', { eager: true }); 
-  const posts = Object.values(postImportResult);
-  return rss({
-    title: 'Buzz’s Blog',
-    description: 'A humble Astronaut’s guide to the stars',
-    site: context.site,
-    items: posts.map((post) => ({
-      link: post.url,
-      content: sanitizeHtml(post.compiledContent()),
-      ...post.frontmatter,
-    })),
-  });
-}
-```
+[See our RSS documentation](https://docs.astro.build/en/guides/rss/#including-full-post-content) for examples using content collections and glob imports.
 
 ## `rssSchema`
 

--- a/packages/astro-rss/package.json
+++ b/packages/astro-rss/package.json
@@ -35,6 +35,7 @@
     "mocha": "^9.2.2"
   },
   "dependencies": {
-    "fast-xml-parser": "^4.0.8"
+    "fast-xml-parser": "^4.0.8",
+    "kleur": "^4.1.5"
   }
 }

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -7,29 +7,28 @@ export { rssSchema };
 
 export type RSSOptions = {
 	/** (required) Title of the RSS Feed */
-	title: RSSOptionsSchema['title'];
+	title: z.infer<typeof rssOptionsValidator>['title'];
 	/** (required) Description of the RSS Feed */
-	description: RSSOptionsSchema['description'];
+	description: z.infer<typeof rssOptionsValidator>['description'];
 	/**
 	 * Specify the base URL to use for RSS feed links.
 	 * We recommend "import.meta.env.SITE" to pull in the "site"
 	 * from your project's astro.config.
 	 */
-	site: RSSOptionsSchema['site'];
+	site: z.infer<typeof rssOptionsValidator>['site'];
 	/** List of RSS feed items to render. */
 	items: RSSFeedItem[];
 	/** Specify arbitrary metadata on opening <xml> tag */
-	xmlns?: RSSOptionsSchema['xmlns'];
+	xmlns?: z.infer<typeof rssOptionsValidator>['xmlns'];
 	/**
 	 * Specifies a local custom XSL stylesheet. Ex. '/public/custom-feed.xsl'
 	 */
-	stylesheet?: RSSOptionsSchema['stylesheet'];
+	stylesheet?: z.infer<typeof rssOptionsValidator>['stylesheet'];
 	/** Specify custom data in opening of file */
-	customData?: RSSOptionsSchema['customData'];
+	customData?: z.infer<typeof rssOptionsValidator>['customData'];
 	/** Whether to include drafts or not */
-	drafts?: RSSOptionsSchema['drafts'];
+	drafts?: z.infer<typeof rssOptionsValidator>['drafts'];
 };
-type RSSOptionsSchema = z.infer<typeof rssOptionsValidator>;
 
 type RSSFeedItem = {
 	/** Link to item */

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -57,7 +57,10 @@ const globResultValidator = z.record(z.function().returns(z.promise(z.any())));
 const rssOptionsValidator = z.object({
 	title: z.string(),
 	description: z.string(),
-	site: z.string(),
+	site: z.preprocess(
+		url => url instanceof URL ? url.href : url,
+		z.string().url(),
+	),
 	items: z
 		.array(rssFeedItemValidator)
 		.or(globResultValidator)

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -1,5 +1,8 @@
 import { XMLBuilder, XMLParser } from 'fast-xml-parser';
-import { createCanonicalURL, isValidURL } from './util.js';
+import { rssSchema, rssOptionsSchema } from './schema.js';
+import { createCanonicalURL, errorMap, isValidURL } from './util.js';
+
+export { rssSchema };
 
 type GlobResult = Record<string, () => Promise<{ [key: string]: any }>>;
 

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -1,3 +1,4 @@
+import { z } from 'astro/zod';
 import { XMLBuilder, XMLParser } from 'fast-xml-parser';
 import { rssSchema, rssOptionsSchema } from './schema.js';
 import { createCanonicalURL, errorMap, isValidURL } from './util.js';
@@ -8,49 +9,51 @@ type GlobResult = Record<string, () => Promise<{ [key: string]: any }>>;
 
 type RSSOptions = {
 	/** (required) Title of the RSS Feed */
-	title: string;
+	title: RSSOptionsSchema['title'];
 	/** (required) Description of the RSS Feed */
-	description: string;
+	description: RSSOptionsSchema['description'];
 	/**
 	 * Specify the base URL to use for RSS feed links.
 	 * We recommend "import.meta.env.SITE" to pull in the "site"
 	 * from your project's astro.config.
 	 */
-	site: string;
+	site: RSSOptionsSchema['site'];
 	/**
 	 * List of RSS feed items to render. Accepts either:
 	 * a) list of RSSFeedItems
 	 * b) import.meta.glob result. You can only glob ".md" (or alternative extensions for markdown files like ".markdown") files within src/pages/ when using this method!
 	 */
-	items: RSSFeedItem[] | GlobResult;
+	items: RSSFeedItem[];
 	/** Specify arbitrary metadata on opening <xml> tag */
-	xmlns?: Record<string, string>;
+	xmlns?: RSSOptionsSchema['xmlns'];
 	/**
 	 * Specifies a local custom XSL stylesheet. Ex. '/public/custom-feed.xsl'
 	 */
-	stylesheet?: string | boolean;
+	stylesheet?: RSSOptionsSchema['stylesheet'];
 	/** Specify custom data in opening of file */
-	customData?: string;
+	customData?: RSSOptionsSchema['customData'];
 	/** Whether to include drafts or not */
-	drafts?: boolean;
+	drafts?: RSSOptionsSchema['drafts'];
 };
+type RSSOptionsSchema = z.infer<typeof rssOptionsSchema>;
 
 type RSSFeedItem = {
 	/** Link to item */
 	link: string;
-	/** Title of item */
-	title: string;
-	/** Publication date of item */
-	pubDate: Date;
-	/** Item description */
-	description?: string;
-	/** Full content of the item, should be valid HTML */
+	/** Full content of the item. Should be valid HTML */
 	content?: string;
+	/** Title of item */
+	title: RSSSchema['title'];
+	/** Publication date of item */
+	pubDate: RSSSchema['pubDate'];
+	/** Item description */
+	description?: RSSSchema['description'];
 	/** Append some other XML-valid data to this item */
-	customData?: string;
+	customData?: RSSSchema['customData'];
 	/** Whether draft or not */
-	draft?: boolean;
+	draft?: RSSSchema['draft'];
 };
+type RSSSchema = z.infer<typeof rssSchema>;
 
 type GenerateRSSArgs = {
 	rssOptions: RSSOptions;

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -78,7 +78,7 @@ function validateRssOptions(rssOptions: RSSOptions) {
 
 type GlobResult = Record<string, () => Promise<{ [key: string]: any }>>;
 
-export function globToRssItems(items: GlobResult): Promise<ValidatedRSSFeedItem[]> {
+export function pagesGlobToRssItems(items: GlobResult): Promise<ValidatedRSSFeedItem[]> {
 	return Promise.all(
 		Object.entries(items).map(async ([filePath, getInfo]) => {
 			const { url, frontmatter } = await getInfo();

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -183,7 +183,9 @@ function globToRssItems(
 			}
 			const formattedError = new Error(
 				[
-					`[RSS] ${filePath} has invalid or missing frontmatter.\nFix the following properties:`,
+					`[RSS] ${JSON.stringify(
+						filePath
+					)} has invalid or missing frontmatter.\nFix the following properties:`,
 					...parsedResult.error.errors.map((zodError) => zodError.message),
 				].join('\n')
 			);

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -12,8 +12,8 @@ export type RSSOptions = {
 	description: z.infer<typeof rssOptionsValidator>['description'];
 	/**
 	 * Specify the base URL to use for RSS feed links.
-	 * We recommend "import.meta.env.SITE" to pull in the "site"
-	 * from your project's astro.config.
+	 * We recommend using the [endpoint context object](https://docs.astro.build/en/reference/api-reference/#contextsite),
+	 * which includes the `site` configured in your project's `astro.config.*`
 	 */
 	site: z.infer<typeof rssOptionsValidator>['site'];
 	/** List of RSS feed items to render. */

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -38,7 +38,7 @@ type RSSFeedItem = {
 	/** Title of item */
 	title: z.infer<typeof rssSchema>['title'];
 	/** Publication date of item */
-	pubDate: string;
+	pubDate: z.infer<typeof rssSchema>['pubDate'];
 	/** Item description */
 	description?: z.infer<typeof rssSchema>['description'];
 	/** Append some other XML-valid data to this item */

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -17,7 +17,7 @@ export type RSSOptions = {
 	 */
 	site: z.infer<typeof rssOptionsValidator>['site'];
 	/** List of RSS feed items to render. */
-	items: RSSFeedItem[];
+	items: RSSFeedItem[] | z.infer<typeof globResultValidator>;
 	/** Specify arbitrary metadata on opening <xml> tag */
 	xmlns?: z.infer<typeof rssOptionsValidator>['xmlns'];
 	/**
@@ -50,62 +50,18 @@ type RSSFeedItem = {
 type ValidatedRSSFeedItem = z.infer<typeof rssFeedItemValidator>;
 type ValidatedRSSOptions = z.infer<typeof rssOptionsValidator>;
 
+const globResultValidator = z.record(z.function().returns(z.promise(z.any())));
 const rssFeedItemValidator = rssSchema.extend({ link: z.string(), content: z.string().optional() });
 const rssOptionsValidator = z.object({
 	title: z.string(),
 	description: z.string(),
 	site: z.string(),
-	items: z.array(rssFeedItemValidator),
+	items: z.union([globResultValidator, z.array(rssFeedItemValidator)]),
 	xmlns: z.record(z.string()).optional(),
 	drafts: z.boolean().default(false),
 	stylesheet: z.union([z.string(), z.boolean()]).optional(),
 	customData: z.string().optional(),
 });
-
-function validateRssOptions(rssOptions: RSSOptions) {
-	const parsedResult = rssOptionsValidator.safeParse(rssOptions, { errorMap });
-	if (parsedResult.success) {
-		return parsedResult.data;
-	}
-	const formattedError = new Error(
-		[
-			`[RSS] Invalid or missing options:`,
-			...parsedResult.error.errors.map((zodError) => zodError.message),
-		].join('\n')
-	);
-	throw formattedError;
-}
-
-type GlobResult = Record<string, () => Promise<{ [key: string]: any }>>;
-
-export function globToRssItems(items: GlobResult): Promise<ValidatedRSSFeedItem[]> {
-	return Promise.all(
-		Object.entries(items).map(async ([filePath, getInfo]) => {
-			const { url, frontmatter } = await getInfo();
-			if (url === undefined || url === null) {
-				throw new Error(
-					`[RSS] You can only glob entries within 'src/pages/' when passing import.meta.glob() directly. Consider mapping the result to an array of RSSFeedItems. See the RSS docs for usage examples: https://docs.astro.build/en/guides/rss/#2-list-of-rss-feed-objects`
-				);
-			}
-			const parsedResult = rssFeedItemValidator.safeParse(
-				{ ...frontmatter, link: url },
-				{ errorMap }
-			);
-
-			if (parsedResult.success) {
-				return parsedResult.data;
-			}
-			const formattedError = new Error(
-				[
-					`[RSS] ${filePath} has invalid or missing frontmatter.\nFix the following properties:`,
-					...parsedResult.error.errors.map((zodError) => zodError.message),
-				].join('\n')
-			);
-			(formattedError as any).file = filePath;
-			throw formattedError;
-		})
-	);
-}
 
 export default async function getRSS(rssOptions: RSSOptions) {
 	const validatedRssOptions = validateRssOptions(rssOptions);
@@ -118,9 +74,10 @@ export default async function getRSS(rssOptions: RSSOptions) {
 /** Generate RSS 2.0 feed */
 async function generateRSS(rssOptions: ValidatedRSSOptions): Promise<string> {
 	const { site } = rssOptions;
-	const items = rssOptions.drafts
+	const unfilteredItems = Array.isArray(rssOptions.items)
 		? rssOptions.items
-		: rssOptions.items.filter((item) => !item.draft);
+		: await globToRssItems(rssOptions.items);
+	const items = rssOptions.drafts ? unfilteredItems : unfilteredItems.filter((item) => !item.draft);
 
 	const xmlOptions = { ignoreAttributes: false };
 	const parser = new XMLParser(xmlOptions);
@@ -189,4 +146,49 @@ async function generateRSS(rssOptions: ValidatedRSSOptions): Promise<string> {
 	});
 
 	return new XMLBuilder(xmlOptions).build(root);
+}
+
+function validateRssOptions(rssOptions: RSSOptions) {
+	const parsedResult = rssOptionsValidator.safeParse(rssOptions, { errorMap });
+	if (parsedResult.success) {
+		return parsedResult.data;
+	}
+	const formattedError = new Error(
+		[
+			`[RSS] Invalid or missing options:`,
+			...parsedResult.error.errors.map((zodError) => zodError.message),
+		].join('\n')
+	);
+	throw formattedError;
+}
+
+function globToRssItems(
+	items: z.infer<typeof globResultValidator>
+): Promise<ValidatedRSSFeedItem[]> {
+	return Promise.all(
+		Object.entries(items).map(async ([filePath, getInfo]) => {
+			const { url, frontmatter } = await getInfo();
+			if (url === undefined || url === null) {
+				throw new Error(
+					`[RSS] You can only glob entries within 'src/pages/' when passing import.meta.glob() directly. Consider mapping the result to an array of RSSFeedItems. See the RSS docs for usage examples: https://docs.astro.build/en/guides/rss/#2-list-of-rss-feed-objects`
+				);
+			}
+			const parsedResult = rssFeedItemValidator.safeParse(
+				{ ...frontmatter, link: url },
+				{ errorMap }
+			);
+
+			if (parsedResult.success) {
+				return parsedResult.data;
+			}
+			const formattedError = new Error(
+				[
+					`[RSS] ${filePath} has invalid or missing frontmatter.\nFix the following properties:`,
+					...parsedResult.error.errors.map((zodError) => zodError.message),
+				].join('\n')
+			);
+			(formattedError as any).file = filePath;
+			throw formattedError;
+		})
+	);
 }

--- a/packages/astro-rss/src/schema.ts
+++ b/packages/astro-rss/src/schema.ts
@@ -1,0 +1,24 @@
+import { z } from 'astro/zod';
+
+export const rssSchema = z.object({
+	title: z.string(),
+	pubDate: z.string().transform((value) => new Date(value)),
+	description: z.string().optional(),
+	customData: z.string().optional(),
+	draft: z.boolean().optional(),
+});
+
+export const rssOptionsSchema = z.object({
+	title: z.string(),
+	description: z.string(),
+	site: z.string(),
+	items: z.union([
+		z.array(rssSchema),
+		// Can also pass `import.meta.glob` result
+		z.record(z.function().returns(z.promise(z.record(z.any())))),
+	]),
+	xmlns: z.record(z.string()).optional(),
+	drafts: z.boolean().optional(),
+	stylesheet: z.union([z.string(), z.boolean()]).optional(),
+	customData: z.string().optional(),
+});

--- a/packages/astro-rss/src/schema.ts
+++ b/packages/astro-rss/src/schema.ts
@@ -2,7 +2,7 @@ import { z } from 'astro/zod';
 
 export const rssSchema = z.object({
 	title: z.string(),
-	pubDate: z.string().transform((value) => new Date(value)),
+	pubDate: z.union([z.string(), z.number(), z.date()]).transform((value) => new Date(value)),
 	description: z.string().optional(),
 	customData: z.string().optional(),
 	draft: z.boolean().optional(),

--- a/packages/astro-rss/src/schema.ts
+++ b/packages/astro-rss/src/schema.ts
@@ -7,18 +7,3 @@ export const rssSchema = z.object({
 	customData: z.string().optional(),
 	draft: z.boolean().optional(),
 });
-
-export const rssOptionsSchema = z.object({
-	title: z.string(),
-	description: z.string(),
-	site: z.string(),
-	items: z.union([
-		z.array(rssSchema),
-		// Can also pass `import.meta.glob` result
-		z.record(z.function().returns(z.promise(z.record(z.any())))),
-	]),
-	xmlns: z.record(z.string()).optional(),
-	drafts: z.boolean().optional(),
-	stylesheet: z.union([z.string(), z.boolean()]).optional(),
-	customData: z.string().optional(),
-});

--- a/packages/astro-rss/src/util.ts
+++ b/packages/astro-rss/src/util.ts
@@ -1,3 +1,5 @@
+import { z } from 'astro/zod';
+
 /** Normalize URL to its canonical form */
 export function createCanonicalURL(url: string, base?: string): URL {
 	let pathname = url.replace(/\/index.html$/, ''); // index.html is not canonical
@@ -21,3 +23,17 @@ function getUrlExtension(url: string) {
 	const lastSlash = url.lastIndexOf('/');
 	return lastDot > lastSlash ? url.slice(lastDot + 1) : '';
 }
+
+const flattenErrorPath = (errorPath: (string | number)[]) => errorPath.join('.');
+
+export const errorMap: z.ZodErrorMap = (error, ctx) => {
+	if (error.code === 'invalid_type') {
+		const badKeyPath = JSON.stringify(flattenErrorPath(error.path));
+		if (error.received === 'undefined') {
+			return { message: `${badKeyPath} is required.` };
+		} else {
+			return { message: `${badKeyPath} should be ${error.expected}, not ${error.received}.` };
+		}
+	}
+	return { message: ctx.defaultError };
+};

--- a/packages/astro-rss/test/pagesGlobToRssItems.test.js
+++ b/packages/astro-rss/test/pagesGlobToRssItems.test.js
@@ -1,0 +1,85 @@
+import chai from 'chai';
+import chaiPromises from 'chai-as-promised';
+import { phpFeedItem, web1FeedItem } from './test-utils.js';
+import { pagesGlobToRssItems } from '../dist/index.js';
+
+chai.use(chaiPromises);
+
+describe('pagesGlobToRssItems', () => {
+	it('should generate on valid result', async () => {
+		const globResult = {
+			'./posts/php.md': () =>
+				new Promise((resolve) =>
+					resolve({
+						url: phpFeedItem.link,
+						frontmatter: {
+							title: phpFeedItem.title,
+							pubDate: phpFeedItem.pubDate,
+							description: phpFeedItem.description,
+						},
+					})
+				),
+			'./posts/nested/web1.md': () =>
+				new Promise((resolve) =>
+					resolve({
+						url: web1FeedItem.link,
+						frontmatter: {
+							title: web1FeedItem.title,
+							pubDate: web1FeedItem.pubDate,
+							description: web1FeedItem.description,
+						},
+					})
+				),
+		};
+
+		const items = await pagesGlobToRssItems(globResult);
+
+		chai.expect(items.sort((a, b) => a.pubDate - b.pubDate)).to.deep.equal([
+			{
+				title: phpFeedItem.title,
+				link: phpFeedItem.link,
+				pubDate: new Date(phpFeedItem.pubDate),
+				description: phpFeedItem.description,
+			},
+			{
+				title: web1FeedItem.title,
+				link: web1FeedItem.link,
+				pubDate: new Date(web1FeedItem.pubDate),
+				description: web1FeedItem.description,
+			},
+		]);
+	});
+
+	it('should fail on missing "url"', () => {
+		const globResult = {
+			'./posts/php.md': () =>
+				new Promise((resolve) =>
+					resolve({
+						url: undefined,
+						frontmatter: {
+							pubDate: phpFeedItem.pubDate,
+							description: phpFeedItem.description,
+						},
+					})
+				),
+		};
+		return chai.expect(pagesGlobToRssItems(globResult)).to.be.rejected;
+	});
+
+	it('should fail on missing "title" key', () => {
+		const globResult = {
+			'./posts/php.md': () =>
+				new Promise((resolve) =>
+					resolve({
+						url: phpFeedItem.link,
+						frontmatter: {
+							title: undefined,
+							pubDate: phpFeedItem.pubDate,
+							description: phpFeedItem.description,
+						},
+					})
+				),
+		};
+		return chai.expect(pagesGlobToRssItems(globResult)).to.be.rejected;
+	});
+});

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -1,43 +1,20 @@
-import rss, { globToRssItems } from '../dist/index.js';
+import rss from '../dist/index.js';
 import chai from 'chai';
 import chaiPromises from 'chai-as-promised';
 import chaiXml from 'chai-xml';
+import {
+	title,
+	description,
+	site,
+	phpFeedItem,
+	phpFeedItemWithContent,
+	phpFeedItemWithCustomData,
+	web1FeedItem,
+	web1FeedItemWithContent,
+} from './test-utils.js';
 
 chai.use(chaiPromises);
 chai.use(chaiXml);
-
-const title = 'My RSS feed';
-const description = 'This sure is a nice RSS feed';
-const site = 'https://example.com';
-
-const phpFeedItem = {
-	link: '/php',
-	title: 'Remember PHP?',
-	pubDate: '1994-05-03',
-	description:
-		'PHP is a general-purpose scripting language geared toward web development. It was originally created by Danish-Canadian programmer Rasmus Lerdorf in 1994.',
-};
-const phpFeedItemWithContent = {
-	...phpFeedItem,
-	content: `<h1>${phpFeedItem.title}</h1><p>${phpFeedItem.description}</p>`,
-};
-const phpFeedItemWithCustomData = {
-	...phpFeedItem,
-	customData: '<dc:creator><![CDATA[Buster Bluth]]></dc:creator>',
-};
-
-const web1FeedItem = {
-	// Should support empty string as a URL (possible for homepage route)
-	link: '',
-	title: 'Web 1.0',
-	pubDate: '1997-05-03',
-	description:
-		'Web 1.0 is the term used for the earliest version of the Internet as it emerged from its origins with Defense Advanced Research Projects Agency (DARPA) and became, for the first time, a global network representing the future of digital communications.',
-};
-const web1FeedItemWithContent = {
-	...web1FeedItem,
-	content: `<h1>${web1FeedItem.title}</h1><p>${web1FeedItem.description}</p>`,
-};
 
 // note: I spent 30 minutes looking for a nice node-based snapshot tool
 // ...and I gave up. Enjoy big strings!
@@ -137,98 +114,5 @@ describe('rss', () => {
 		});
 
 		chai.expect(body).xml.to.equal(validXmlResult);
-	});
-});
-
-describe('globToRssItems', () => {
-	it('should generate on valid result', async () => {
-		const globResult = {
-			'./posts/php.md': () =>
-				new Promise((resolve) =>
-					resolve({
-						url: phpFeedItem.link,
-						frontmatter: {
-							title: phpFeedItem.title,
-							pubDate: phpFeedItem.pubDate,
-							description: phpFeedItem.description,
-						},
-					})
-				),
-			'./posts/nested/web1.md': () =>
-				new Promise((resolve) =>
-					resolve({
-						url: web1FeedItem.link,
-						frontmatter: {
-							title: web1FeedItem.title,
-							pubDate: web1FeedItem.pubDate,
-							description: web1FeedItem.description,
-						},
-					})
-				),
-		};
-
-		const items = await globToRssItems(globResult);
-
-		chai.expect(items.sort((a, b) => a.pubDate - b.pubDate)).to.deep.equal([
-			{
-				title: phpFeedItem.title,
-				link: phpFeedItem.link,
-				pubDate: new Date(phpFeedItem.pubDate),
-				description: phpFeedItem.description,
-			},
-			{
-				title: web1FeedItem.title,
-				link: web1FeedItem.link,
-				pubDate: new Date(web1FeedItem.pubDate),
-				description: web1FeedItem.description,
-			},
-		]);
-	});
-
-	it('should fail on missing "url"', () => {
-		const globResult = {
-			'./posts/php.md': () =>
-				new Promise((resolve) =>
-					resolve({
-						url: undefined,
-						frontmatter: {
-							pubDate: phpFeedItem.pubDate,
-							description: phpFeedItem.description,
-						},
-					})
-				),
-		};
-		return chai.expect(
-			rss({
-				title,
-				description,
-				items: globResult,
-				site,
-			})
-		).to.be.rejected;
-	});
-
-	it('should fail on missing "title" key', () => {
-		const globResult = {
-			'./posts/php.md': () =>
-				new Promise((resolve) =>
-					resolve({
-						url: phpFeedItem.link,
-						frontmatter: {
-							title: undefined,
-							pubDate: phpFeedItem.pubDate,
-							description: phpFeedItem.description,
-						},
-					})
-				),
-		};
-		return chai.expect(
-			rss({
-				title,
-				description,
-				items: globResult,
-				site,
-			})
-		).to.be.rejected;
 	});
 });

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -1,4 +1,4 @@
-import rss from '../dist/index.js';
+import rss, { globToRssItems } from '../dist/index.js';
 import chai from 'chai';
 import chaiPromises from 'chai-as-promised';
 import chaiXml from 'chai-xml';
@@ -138,89 +138,96 @@ describe('rss', () => {
 
 		chai.expect(body).xml.to.equal(validXmlResult);
 	});
+});
 
-	describe('with `import.meta.glob` result', () => {
-		it('should generate on valid result', async () => {
-			const globResult = {
-				'./posts/php.md': () =>
-					new Promise((resolve) =>
-						resolve({
-							url: phpFeedItem.link,
-							frontmatter: {
-								title: phpFeedItem.title,
-								pubDate: phpFeedItem.pubDate,
-								description: phpFeedItem.description,
-							},
-						})
-					),
-				'./posts/nested/web1.md': () =>
-					new Promise((resolve) =>
-						resolve({
-							url: web1FeedItem.link,
-							frontmatter: {
-								title: web1FeedItem.title,
-								pubDate: web1FeedItem.pubDate,
-								description: web1FeedItem.description,
-							},
-						})
-					),
-			};
+describe('globToRssItems', () => {
+	it('should generate on valid result', async () => {
+		const globResult = {
+			'./posts/php.md': () =>
+				new Promise((resolve) =>
+					resolve({
+						url: phpFeedItem.link,
+						frontmatter: {
+							title: phpFeedItem.title,
+							pubDate: phpFeedItem.pubDate,
+							description: phpFeedItem.description,
+						},
+					})
+				),
+			'./posts/nested/web1.md': () =>
+				new Promise((resolve) =>
+					resolve({
+						url: web1FeedItem.link,
+						frontmatter: {
+							title: web1FeedItem.title,
+							pubDate: web1FeedItem.pubDate,
+							description: web1FeedItem.description,
+						},
+					})
+				),
+		};
 
-			const { body } = await rss({
+		const items = await globToRssItems(globResult);
+
+		chai.expect(items.sort((a, b) => a.pubDate - b.pubDate)).to.deep.equal([
+			{
+				title: phpFeedItem.title,
+				link: phpFeedItem.link,
+				pubDate: new Date(phpFeedItem.pubDate),
+				description: phpFeedItem.description,
+			},
+			{
+				title: web1FeedItem.title,
+				link: web1FeedItem.link,
+				pubDate: new Date(web1FeedItem.pubDate),
+				description: web1FeedItem.description,
+			},
+		]);
+	});
+
+	it('should fail on missing "title" key', () => {
+		const globResult = {
+			'./posts/php.md': () =>
+				new Promise((resolve) =>
+					resolve({
+						url: phpFeedItem.link,
+						frontmatter: {
+							pubDate: phpFeedItem.pubDate,
+							description: phpFeedItem.description,
+						},
+					})
+				),
+		};
+		return chai.expect(
+			rss({
 				title,
 				description,
-				site,
 				items: globResult,
-			});
+				site,
+			})
+		).to.be.rejected;
+	});
 
-			chai.expect(body).xml.to.equal(validXmlResult);
-		});
-
-		it('should fail on missing "url"', () => {
-			const globResult = {
-				'./posts/php.md': () =>
-					new Promise((resolve) =>
-						resolve({
-							url: undefined,
-							frontmatter: {
-								pubDate: phpFeedItem.pubDate,
-								description: phpFeedItem.description,
-							},
-						})
-					),
-			};
-			return chai.expect(
-				rss({
-					title,
-					description,
-					items: globResult,
-					site,
-				})
-			).to.be.rejected;
-		});
-
-		it('should fail on missing "title" key', () => {
-			const globResult = {
-				'./posts/php.md': () =>
-					new Promise((resolve) =>
-						resolve({
-							url: phpFeedItem.link,
-							frontmatter: {
-								title: undefined,
-								pubDate: phpFeedItem.pubDate,
-								description: phpFeedItem.description,
-							},
-						})
-					),
-			};
-			return chai.expect(
-				rss({
-					title,
-					description,
-					items: globResult,
-					site,
-				})
-			).to.be.rejected;
-		});
+	it('should fail on missing "pubDate" key', () => {
+		const globResult = {
+			'./posts/php.md': () =>
+				new Promise((resolve) =>
+					resolve({
+						url: phpFeedItem.link,
+						frontmatter: {
+							title: phpFeedItem.title,
+							description: phpFeedItem.description,
+						},
+					})
+				),
+		};
+		return chai.expect(
+			rss({
+				title,
+				description,
+				items: globResult,
+				site,
+			})
+		).to.be.rejected;
 	});
 });

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -1,4 +1,4 @@
-import rss, { globToRssItems } from '../dist/index.js';
+import rss from '../dist/index.js';
 import chai from 'chai';
 import chaiPromises from 'chai-as-promised';
 import chaiXml from 'chai-xml';
@@ -138,96 +138,89 @@ describe('rss', () => {
 
 		chai.expect(body).xml.to.equal(validXmlResult);
 	});
-});
 
-describe('globToRssItems', () => {
-	it('should generate on valid result', async () => {
-		const globResult = {
-			'./posts/php.md': () =>
-				new Promise((resolve) =>
-					resolve({
-						url: phpFeedItem.link,
-						frontmatter: {
-							title: phpFeedItem.title,
-							pubDate: phpFeedItem.pubDate,
-							description: phpFeedItem.description,
-						},
-					})
-				),
-			'./posts/nested/web1.md': () =>
-				new Promise((resolve) =>
-					resolve({
-						url: web1FeedItem.link,
-						frontmatter: {
-							title: web1FeedItem.title,
-							pubDate: web1FeedItem.pubDate,
-							description: web1FeedItem.description,
-						},
-					})
-				),
-		};
+	describe('with `import.meta.glob` result', () => {
+		it('should generate on valid result', async () => {
+			const globResult = {
+				'./posts/php.md': () =>
+					new Promise((resolve) =>
+						resolve({
+							url: phpFeedItem.link,
+							frontmatter: {
+								title: phpFeedItem.title,
+								pubDate: phpFeedItem.pubDate,
+								description: phpFeedItem.description,
+							},
+						})
+					),
+				'./posts/nested/web1.md': () =>
+					new Promise((resolve) =>
+						resolve({
+							url: web1FeedItem.link,
+							frontmatter: {
+								title: web1FeedItem.title,
+								pubDate: web1FeedItem.pubDate,
+								description: web1FeedItem.description,
+							},
+						})
+					),
+			};
 
-		const items = await globToRssItems(globResult);
-
-		chai.expect(items.sort((a, b) => a.pubDate - b.pubDate)).to.deep.equal([
-			{
-				title: phpFeedItem.title,
-				link: phpFeedItem.link,
-				pubDate: new Date(phpFeedItem.pubDate),
-				description: phpFeedItem.description,
-			},
-			{
-				title: web1FeedItem.title,
-				link: web1FeedItem.link,
-				pubDate: new Date(web1FeedItem.pubDate),
-				description: web1FeedItem.description,
-			},
-		]);
-	});
-
-	it('should fail on missing "title" key', () => {
-		const globResult = {
-			'./posts/php.md': () =>
-				new Promise((resolve) =>
-					resolve({
-						url: phpFeedItem.link,
-						frontmatter: {
-							pubDate: phpFeedItem.pubDate,
-							description: phpFeedItem.description,
-						},
-					})
-				),
-		};
-		return chai.expect(
-			rss({
+			const { body } = await rss({
 				title,
 				description,
-				items: globResult,
 				site,
-			})
-		).to.be.rejected;
-	});
+				items: globResult,
+			});
 
-	it('should fail on missing "pubDate" key', () => {
-		const globResult = {
-			'./posts/php.md': () =>
-				new Promise((resolve) =>
-					resolve({
-						url: phpFeedItem.link,
-						frontmatter: {
-							title: phpFeedItem.title,
-							description: phpFeedItem.description,
-						},
-					})
-				),
-		};
-		return chai.expect(
-			rss({
-				title,
-				description,
-				items: globResult,
-				site,
-			})
-		).to.be.rejected;
+			chai.expect(body).xml.to.equal(validXmlResult);
+		});
+
+		it('should fail on missing "url"', () => {
+			const globResult = {
+				'./posts/php.md': () =>
+					new Promise((resolve) =>
+						resolve({
+							url: undefined,
+							frontmatter: {
+								pubDate: phpFeedItem.pubDate,
+								description: phpFeedItem.description,
+							},
+						})
+					),
+			};
+			return chai.expect(
+				rss({
+					title,
+					description,
+					items: globResult,
+					site,
+				})
+			).to.be.rejected;
+		});
+
+		it('should fail on missing "title" key', () => {
+			const globResult = {
+				'./posts/php.md': () =>
+					new Promise((resolve) =>
+						resolve({
+							url: phpFeedItem.link,
+							frontmatter: {
+								title: undefined,
+								pubDate: phpFeedItem.pubDate,
+								description: phpFeedItem.description,
+							},
+						})
+					),
+			};
+			return chai.expect(
+				rss({
+					title,
+					description,
+					items: globResult,
+					site,
+				})
+			).to.be.rejected;
+		});
 	});
 });

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -185,12 +185,12 @@ describe('globToRssItems', () => {
 		]);
 	});
 
-	it('should fail on missing "title" key', () => {
+	it('should fail on missing "url"', () => {
 		const globResult = {
 			'./posts/php.md': () =>
 				new Promise((resolve) =>
 					resolve({
-						url: phpFeedItem.link,
+						url: undefined,
 						frontmatter: {
 							pubDate: phpFeedItem.pubDate,
 							description: phpFeedItem.description,
@@ -208,14 +208,15 @@ describe('globToRssItems', () => {
 		).to.be.rejected;
 	});
 
-	it('should fail on missing "pubDate" key', () => {
+	it('should fail on missing "title" key', () => {
 		const globResult = {
 			'./posts/php.md': () =>
 				new Promise((resolve) =>
 					resolve({
 						url: phpFeedItem.link,
 						frontmatter: {
-							title: phpFeedItem.title,
+							title: undefined,
+							pubDate: phpFeedItem.pubDate,
 							description: phpFeedItem.description,
 						},
 					})

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -115,4 +115,40 @@ describe('rss', () => {
 
 		chai.expect(body).xml.to.equal(validXmlResult);
 	});
+
+	it('Deprecated import.meta.glob mapping still works', async () => {
+		const globResult = {
+			'./posts/php.md': () =>
+				new Promise((resolve) =>
+					resolve({
+						url: phpFeedItem.link,
+						frontmatter: {
+							title: phpFeedItem.title,
+							pubDate: phpFeedItem.pubDate,
+							description: phpFeedItem.description,
+						},
+					})
+				),
+			'./posts/nested/web1.md': () =>
+				new Promise((resolve) =>
+					resolve({
+						url: web1FeedItem.link,
+						frontmatter: {
+							title: web1FeedItem.title,
+							pubDate: web1FeedItem.pubDate,
+							description: web1FeedItem.description,
+						},
+					})
+				),
+		};
+
+		const { body } = await rss({
+			title,
+			description,
+			items: globResult,
+			site,
+		});
+
+		chai.expect(body).xml.to.equal(validXmlResult);
+	});
 });

--- a/packages/astro-rss/test/test-utils.js
+++ b/packages/astro-rss/test/test-utils.js
@@ -1,0 +1,32 @@
+export const title = 'My RSS feed';
+export const description = 'This sure is a nice RSS feed';
+export const site = 'https://example.com';
+
+export const phpFeedItem = {
+	link: '/php',
+	title: 'Remember PHP?',
+	pubDate: '1994-05-03',
+	description:
+		'PHP is a general-purpose scripting language geared toward web development. It was originally created by Danish-Canadian programmer Rasmus Lerdorf in 1994.',
+};
+export const phpFeedItemWithContent = {
+	...phpFeedItem,
+	content: `<h1>${phpFeedItem.title}</h1><p>${phpFeedItem.description}</p>`,
+};
+export const phpFeedItemWithCustomData = {
+	...phpFeedItem,
+	customData: '<dc:creator><![CDATA[Buster Bluth]]></dc:creator>',
+};
+
+export const web1FeedItem = {
+	// Should support empty string as a URL (possible for homepage route)
+	link: '',
+	title: 'Web 1.0',
+	pubDate: '1997-05-03',
+	description:
+		'Web 1.0 is the term used for the earliest version of the Internet as it emerged from its origins with Defense Advanced Research Projects Agency (DARPA) and became, for the first time, a global network representing the future of digital communications.',
+};
+export const web1FeedItemWithContent = {
+	...web1FeedItem,
+	content: `<h1>${web1FeedItem.title}</h1><p>${web1FeedItem.description}</p>`,
+};

--- a/packages/astro-rss/tsconfig.json
+++ b/packages/astro-rss/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "module": "ES2020",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2020",
+    "strictNullChecks": true
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,9 +588,11 @@ importers:
       chai-as-promised: ^7.1.1
       chai-xml: ^0.4.0
       fast-xml-parser: ^4.0.8
+      kleur: ^4.1.5
       mocha: ^9.2.2
     dependencies:
       fast-xml-parser: 4.0.13
+      kleur: 4.1.5
     devDependencies:
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5


### PR DESCRIPTION
## Changes

- Expose `rssSchema` to type-check content collections for RSS feeds
- Deprecate internal `import.meta.glob` handling and move to a `pagesGlobToRssItems()` helper. This has a few benefits:
  - Simplifies our `items` array to accept a single type. Better for JS docs and docs.astro.build.
  - Makes the "only glob `src/pages/` entries" requirement more explicit with the function name.
  - Makes handling globs and handling content collections feel equally supported. When `import.meta.glob` handling was implicit, this felt like the more encouraged solution.
- Refactor internals to use Zod all the way down. This makes error handling on bad config much clearer!

### README changes

- Change glob example to a content collections example
- Add `rssSchema` and `pagesGlobToRssItems()` reference
- Chore: change `import.meta.env.SITE` recommendation to new `context.site`

## Testing

- Update testing for new APIs
- Migrate glob testing to separate `pagesGlobToRssItems()` tests

## Docs

- update README
- update docs and tutorial https://github.com/withastro/docs/pull/2401