### PR TITLE
Remove legacy compiler handling

### DIFF
--- a/.changeset/angry-spoons-flow.md
+++ b/.changeset/angry-spoons-flow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Remove legacy compiler error handling

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -124,31 +124,5 @@ async function enhanceCompileError({
 		}
 	}
 
-	// improve compiler errors
-	if (err.stack && err.stack.includes('wasm-function')) {
-		const search = new URLSearchParams({
-			labels: 'compiler',
-			title: '🐛 BUG: `@astrojs/compiler` panic',
-			template: '---01-bug-report.yml',
-			'bug-description': `\`@astrojs/compiler\` encountered an unrecoverable error when compiling the following file.
-
-**${id.replace(fileURLToPath(config.root), '')}**
-\`\`\`astro
-${source}
-\`\`\``,
-		});
-		(err as any).url = `https://github.com/withastro/astro/issues/new?${search.toString()}`;
-		err.message = `Error: Uh oh, the Astro compiler encountered an unrecoverable error!
-
-    Please open
-    a GitHub issue using the link below:
-    ${(err as any).url}`;
-
-		if (logging.level !== 'debug') {
-			// TODO: remove stack replacement when compiler throws better errors
-			err.stack = `    at ${id}`;
-		}
-	}
-
 	throw err;
 }


### PR DESCRIPTION
## Changes

- The compiler has been improved to the point where nobody really hits unexpected Wasm stacktraces anymore. We can remove our special handling of compiler wasm errors now.

## Testing

N/A, untested code path

## Docs

Refactor only