### PR TITLE
Add missing `noPropertyAccessFromIndexSignature` to strictest tsconfig profile

### DIFF
--- a/.changeset/smooth-cycles-sing.md
+++ b/.changeset/smooth-cycles-sing.md
@@ -1,5 +1,5 @@
 ---
-'astro': minor
+'astro': patch
 ---
 
 The `noPropertyAccessFromIndexSignature` typescript configuration option was added to the `strictest` profile.

--- a/.changeset/smooth-cycles-sing.md
+++ b/.changeset/smooth-cycles-sing.md
@@ -1,0 +1,7 @@
+---
+'astro': minor
+---
+
+The `noPropertyAccessFromIndexSignature` typescript configuration option was added to the `strictest` profile.
+
+This will have no impact at runtime, but may affect code checks on codebases which do not already use this check.

--- a/packages/astro/tsconfigs/strictest.json
+++ b/packages/astro/tsconfigs/strictest.json
@@ -8,6 +8,8 @@
     "noImplicitOverride": true,
     // Force functions to specify that they can return `undefined` if a possible code path does not return a value.
     "noImplicitReturns": true,
+    // Ensures consistency between accessing a field via the “dot” (obj.key) syntax, and “indexed” (obj["key"]) and the way which the property is declared in the type.
+    "noPropertyAccessFromIndexSignature": true,
     // Report an error when a variable is declared but never used.
     "noUnusedLocals": true,
     // Report an error when a parameter is declared but never used.


### PR DESCRIPTION
Add missing `noPropertyAccessFromIndexSignature` to strictest tsconfig profile

Fixes #5861.

cc @Princesseuh 