### PR TITLE
fix(RSS): not filtered drafts when `items` is of type `RSSFeedItem[]`

### DIFF
--- a/packages/astro-rss/package.json
+++ b/packages/astro-rss/package.json
@@ -21,7 +21,8 @@
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "mocha --exit --timeout 20000"
+    "test": "mocha --exit --timeout 20000",
+    "test:match": "mocha --timeout 20000 -g"
   },
   "devDependencies": {
     "@types/chai": "^4.3.1",

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -93,7 +93,6 @@ export default async function getRSS(rssOptions: RSSOptions) {
 	if (isGlobResult(items)) {
 		items = await mapGlobResult(items);
 	}
-
 	if (!rssOptions.drafts) {
 		items = items.filter((item) => !item.draft);
 	}

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -92,9 +92,10 @@ export default async function getRSS(rssOptions: RSSOptions) {
 
 	if (isGlobResult(items)) {
 		items = await mapGlobResult(items);
-		if (!rssOptions.drafts) {
-			items = items.filter((item) => !item.draft);
-		}
+	}
+
+	if (!rssOptions.drafts) {
+		items = items.filter((item) => !item.draft);
 	}
 
 	return {

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -17,6 +17,7 @@ const phpFeedItem = {
 	description:
 		'PHP is a general-purpose scripting language geared toward web development. It was originally created by Danish-Canadian programmer Rasmus Lerdorf in 1994.',
 };
+
 const phpFeedItemWithContent = {
 	...phpFeedItem,
 	content: `<h1>${phpFeedItem.title}</h1><p>${phpFeedItem.description}</p>`,
@@ -113,6 +114,47 @@ describe('rss', () => {
 		});
 
 		chai.expect(body).xml.to.equal(validXmlWithXSLStylesheet);
+	});
+
+	describe('RSSFeedItem', () => {
+		it('should filter out draft', async () => {
+			const rssFeedItems = [
+				phpFeedItem,
+				{
+					...web1FeedItem,
+					draft: true,
+				},
+			];
+
+			const { body } = await rss({
+				title,
+				description,
+				items: rssFeedItems,
+				site,
+			});
+
+			chai.expect(body).xml.to.equal(validXmlWithoutWeb1FeedResult);
+		});
+
+		it('should respect drafts option', async () => {
+			const rssFeedItems = [
+				phpFeedItem,
+				{
+					...web1FeedItem,
+					draft: true,
+				},
+			];
+
+			const { body } = await rss({
+				title,
+				description,
+				items: rssFeedItems,
+				site,
+				drafts: true,
+			});
+
+			chai.expect(body).xml.to.equal(validXmlResult);
+		});
 	});
 
 	describe('glob result', () => {


### PR DESCRIPTION
## Changes

Fix #5865 

## Testing

Added tests using the `drafts` option of the `rssOptions` parameter when its `items` property is of type `RSSFeedItem[]`

## Docs

N/A, bug fix