### PR TITLE
Fix image integration not working on Node 18+

### DIFF
--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -48,8 +48,7 @@
     "kleur": "^4.1.5",
     "magic-string": "^0.25.9",
     "mime": "^3.0.0",
-    "slash": "^4.0.0",
-    "web-streams-polyfill": "^3.2.1"
+    "slash": "^4.0.0"
   },
   "devDependencies": {
     "@types/http-cache-semantics": "^4.0.1",

--- a/packages/integrations/image/src/utils/workerPool.ts
+++ b/packages/integrations/image/src/utils/workerPool.ts
@@ -1,5 +1,4 @@
 /* tslint-disable ban-types */
-import { TransformStream } from 'web-streams-polyfill';
 import { parentPort, Worker } from 'worker_threads';
 
 function uuid() {

--- a/packages/integrations/image/src/vendor/squoosh/avif/avif_node_dec.ts
+++ b/packages/integrations/image/src/vendor/squoosh/avif/avif_node_dec.ts
@@ -384,22 +384,6 @@ var Module = (function () {
       }
     }
     function getBinaryPromise() {
-      if (!wasmBinary && (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER)) {
-        if (typeof fetch === 'function') {
-          return fetch(wasmBinaryFile, { credentials: 'same-origin' })
-            .then(function (response) {
-              if (!response['ok']) {
-                throw (
-                  "failed to load wasm binary file at '" + wasmBinaryFile + "'"
-                )
-              }
-              return response['arrayBuffer']()
-            })
-            .catch(function () {
-              return getBinary(wasmBinaryFile)
-            })
-        }
-      }
       return Promise.resolve().then(function () {
         return getBinary(wasmBinaryFile)
       })
@@ -431,25 +415,7 @@ var Module = (function () {
           })
       }
       function instantiateAsync() {
-        if (
-          !wasmBinary &&
-          typeof WebAssembly.instantiateStreaming === 'function' &&
-          !isDataURI(wasmBinaryFile) &&
-          typeof fetch === 'function'
-        ) {
-          return fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(
-            function (response) {
-              var result = WebAssembly.instantiateStreaming(response, info)
-              return result.then(receiveInstantiationResult, function (reason) {
-                err('wasm streaming compile failed: ' + reason)
-                err('falling back to ArrayBuffer instantiation')
-                return instantiateArrayBuffer(receiveInstantiationResult)
-              })
-            }
-          )
-        } else {
-          return instantiateArrayBuffer(receiveInstantiationResult)
-        }
+        return instantiateArrayBuffer(receiveInstantiationResult)
       }
       if (Module['instantiateWasm']) {
         try {

--- a/packages/integrations/image/src/vendor/squoosh/avif/avif_node_enc.ts
+++ b/packages/integrations/image/src/vendor/squoosh/avif/avif_node_enc.ts
@@ -384,22 +384,6 @@ var Module = (function () {
       }
     }
     function getBinaryPromise() {
-      if (!wasmBinary && (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER)) {
-        if (typeof fetch === 'function') {
-          return fetch(wasmBinaryFile, { credentials: 'same-origin' })
-            .then(function (response) {
-              if (!response['ok']) {
-                throw (
-                  "failed to load wasm binary file at '" + wasmBinaryFile + "'"
-                )
-              }
-              return response['arrayBuffer']()
-            })
-            .catch(function () {
-              return getBinary(wasmBinaryFile)
-            })
-        }
-      }
       return Promise.resolve().then(function () {
         return getBinary(wasmBinaryFile)
       })
@@ -431,25 +415,7 @@ var Module = (function () {
           })
       }
       function instantiateAsync() {
-        if (
-          !wasmBinary &&
-          typeof WebAssembly.instantiateStreaming === 'function' &&
-          !isDataURI(wasmBinaryFile) &&
-          typeof fetch === 'function'
-        ) {
-          return fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(
-            function (response) {
-              var result = WebAssembly.instantiateStreaming(response, info)
-              return result.then(receiveInstantiationResult, function (reason) {
-                err('wasm streaming compile failed: ' + reason)
-                err('falling back to ArrayBuffer instantiation')
-                return instantiateArrayBuffer(receiveInstantiationResult)
-              })
-            }
-          )
-        } else {
-          return instantiateArrayBuffer(receiveInstantiationResult)
-        }
+        return instantiateArrayBuffer(receiveInstantiationResult)
       }
       if (Module['instantiateWasm']) {
         try {

--- a/packages/integrations/image/src/vendor/squoosh/mozjpeg/mozjpeg_node_dec.ts
+++ b/packages/integrations/image/src/vendor/squoosh/mozjpeg/mozjpeg_node_dec.ts
@@ -391,22 +391,6 @@ var Module = (function () {
       }
     }
     function getBinaryPromise() {
-      if (!wasmBinary && (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER)) {
-        if (typeof fetch === 'function') {
-          return fetch(wasmBinaryFile, { credentials: 'same-origin' })
-            .then(function (response) {
-              if (!response['ok']) {
-                throw (
-                  "failed to load wasm binary file at '" + wasmBinaryFile + "'"
-                )
-              }
-              return response['arrayBuffer']()
-            })
-            .catch(function () {
-              return getBinary(wasmBinaryFile)
-            })
-        }
-      }
       return Promise.resolve().then(function () {
         return getBinary(wasmBinaryFile)
       })
@@ -438,25 +422,7 @@ var Module = (function () {
           })
       }
       function instantiateAsync() {
-        if (
-          !wasmBinary &&
-          typeof WebAssembly.instantiateStreaming === 'function' &&
-          !isDataURI(wasmBinaryFile) &&
-          typeof fetch === 'function'
-        ) {
-          return fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(
-            function (response) {
-              var result = WebAssembly.instantiateStreaming(response, info)
-              return result.then(receiveInstantiationResult, function (reason) {
-                err('wasm streaming compile failed: ' + reason)
-                err('falling back to ArrayBuffer instantiation')
-                return instantiateArrayBuffer(receiveInstantiationResult)
-              })
-            }
-          )
-        } else {
-          return instantiateArrayBuffer(receiveInstantiationResult)
-        }
+        return instantiateArrayBuffer(receiveInstantiationResult)
       }
       if (Module['instantiateWasm']) {
         try {

--- a/packages/integrations/image/src/vendor/squoosh/mozjpeg/mozjpeg_node_enc.ts
+++ b/packages/integrations/image/src/vendor/squoosh/mozjpeg/mozjpeg_node_enc.ts
@@ -391,22 +391,6 @@ var Module = (function () {
       }
     }
     function getBinaryPromise() {
-      if (!wasmBinary && (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER)) {
-        if (typeof fetch === 'function') {
-          return fetch(wasmBinaryFile, { credentials: 'same-origin' })
-            .then(function (response) {
-              if (!response['ok']) {
-                throw (
-                  "failed to load wasm binary file at '" + wasmBinaryFile + "'"
-                )
-              }
-              return response['arrayBuffer']()
-            })
-            .catch(function () {
-              return getBinary(wasmBinaryFile)
-            })
-        }
-      }
       return Promise.resolve().then(function () {
         return getBinary(wasmBinaryFile)
       })
@@ -438,25 +422,7 @@ var Module = (function () {
           })
       }
       function instantiateAsync() {
-        if (
-          !wasmBinary &&
-          typeof WebAssembly.instantiateStreaming === 'function' &&
-          !isDataURI(wasmBinaryFile) &&
-          typeof fetch === 'function'
-        ) {
-          return fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(
-            function (response) {
-              var result = WebAssembly.instantiateStreaming(response, info)
-              return result.then(receiveInstantiationResult, function (reason) {
-                err('wasm streaming compile failed: ' + reason)
-                err('falling back to ArrayBuffer instantiation')
-                return instantiateArrayBuffer(receiveInstantiationResult)
-              })
-            }
-          )
-        } else {
-          return instantiateArrayBuffer(receiveInstantiationResult)
-        }
+        return instantiateArrayBuffer(receiveInstantiationResult)
       }
       if (Module['instantiateWasm']) {
         try {

--- a/packages/integrations/image/src/vendor/squoosh/webp/webp_node_dec.ts
+++ b/packages/integrations/image/src/vendor/squoosh/webp/webp_node_dec.ts
@@ -367,22 +367,6 @@ var Module = (function () {
       }
     }
     function getBinaryPromise() {
-      if (!wasmBinary && (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER)) {
-        if (typeof fetch === 'function') {
-          return fetch(wasmBinaryFile, { credentials: 'same-origin' })
-            .then(function (response) {
-              if (!response['ok']) {
-                throw (
-                  "failed to load wasm binary file at '" + wasmBinaryFile + "'"
-                )
-              }
-              return response['arrayBuffer']()
-            })
-            .catch(function () {
-              return getBinary(wasmBinaryFile)
-            })
-        }
-      }
       return Promise.resolve().then(function () {
         return getBinary(wasmBinaryFile)
       })
@@ -414,25 +398,7 @@ var Module = (function () {
           })
       }
       function instantiateAsync() {
-        if (
-          !wasmBinary &&
-          typeof WebAssembly.instantiateStreaming === 'function' &&
-          !isDataURI(wasmBinaryFile) &&
-          typeof fetch === 'function'
-        ) {
-          return fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(
-            function (response) {
-              var result = WebAssembly.instantiateStreaming(response, info)
-              return result.then(receiveInstantiationResult, function (reason) {
-                err('wasm streaming compile failed: ' + reason)
-                err('falling back to ArrayBuffer instantiation')
-                return instantiateArrayBuffer(receiveInstantiationResult)
-              })
-            }
-          )
-        } else {
-          return instantiateArrayBuffer(receiveInstantiationResult)
-        }
+        return instantiateArrayBuffer(receiveInstantiationResult)
       }
       if (Module['instantiateWasm']) {
         try {

--- a/packages/integrations/image/src/vendor/squoosh/webp/webp_node_enc.ts
+++ b/packages/integrations/image/src/vendor/squoosh/webp/webp_node_enc.ts
@@ -367,22 +367,6 @@ var Module = (function () {
       }
     }
     function getBinaryPromise() {
-      if (!wasmBinary && (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER)) {
-        if (typeof fetch === 'function') {
-          return fetch(wasmBinaryFile, { credentials: 'same-origin' })
-            .then(function (response) {
-              if (!response['ok']) {
-                throw (
-                  "failed to load wasm binary file at '" + wasmBinaryFile + "'"
-                )
-              }
-              return response['arrayBuffer']()
-            })
-            .catch(function () {
-              return getBinary(wasmBinaryFile)
-            })
-        }
-      }
       return Promise.resolve().then(function () {
         return getBinary(wasmBinaryFile)
       })
@@ -414,25 +398,7 @@ var Module = (function () {
           })
       }
       function instantiateAsync() {
-        if (
-          !wasmBinary &&
-          typeof WebAssembly.instantiateStreaming === 'function' &&
-          !isDataURI(wasmBinaryFile) &&
-          typeof fetch === 'function'
-        ) {
-          return fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(
-            function (response) {
-              var result = WebAssembly.instantiateStreaming(response, info)
-              return result.then(receiveInstantiationResult, function (reason) {
-                err('wasm streaming compile failed: ' + reason)
-                err('falling back to ArrayBuffer instantiation')
-                return instantiateArrayBuffer(receiveInstantiationResult)
-              })
-            }
-          )
-        } else {
-          return instantiateArrayBuffer(receiveInstantiationResult)
-        }
+        return instantiateArrayBuffer(receiveInstantiationResult)
       }
       if (Module['instantiateWasm']) {
         try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2694,7 +2694,6 @@ importers:
       sharp: ^0.31.0
       slash: ^4.0.0
       vite: ^4.0.3
-      web-streams-polyfill: ^3.2.1
     dependencies:
       '@altano/tiny-async-pool': 1.0.2
       http-cache-semantics: 4.1.0
@@ -2703,7 +2702,6 @@ importers:
       magic-string: 0.25.9
       mime: 3.0.0
       slash: 4.0.0
-      web-streams-polyfill: 3.2.1
     devDependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/mime': 2.0.3


### PR DESCRIPTION
## Changes

When we removed support for Node 14, we migrated to undici. This caused an issue with our image integration because `squoosh` uses a fetch to load a local `.wasm` file, which is not supported by undici (and is unlikely to be for some time). 

This PR removes the code for that and instead opt to use the fallback only. This is also what Next.js does, so it should be okay!

## Testing

Tests still pass + manual tests

## Docs

N/A
