### PR TITLE
Enable skipLibCheck by default

### DIFF
--- a/.changeset/witty-pugs-drum.md
+++ b/.changeset/witty-pugs-drum.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Enable `skipLibCheck` by default

--- a/packages/astro/tsconfigs/base.json
+++ b/packages/astro/tsconfigs/base.json
@@ -15,6 +15,8 @@
     // Report an error when importing a file using a casing different from the casing on disk.
     "forceConsistentCasingInFileNames": true,
     // Properly support importing CJS modules in ESM
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    // Skip typechecking libraries and .d.ts files
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/5061

Disable typechecking libraries and .d.ts files. This change was also debatable in Vite before, but the tradeoff (of not typechecking local .d.ts files) was worth it as it's otherwise surfacing type errors unintentionally from a library. (More context: https://github.com/vitejs/vite/issues/7867)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
n/a

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a