### PR TITLE
Revert "Add missing `noPropertyAccessFromIndexSignature` to strictest tsconfig profile"

### DIFF
--- a/.changeset/smooth-cycles-sing.md
+++ b/.changeset/smooth-cycles-sing.md
@@ -1,7 +1,0 @@
----
-'astro': patch
----
-
-The `noPropertyAccessFromIndexSignature` typescript configuration option was added to the `strictest` profile.
-
-This will have no impact at runtime, but may affect code checks on codebases which do not already use this check.

--- a/packages/astro/tsconfigs/strictest.json
+++ b/packages/astro/tsconfigs/strictest.json
@@ -8,8 +8,6 @@
     "noImplicitOverride": true,
     // Force functions to specify that they can return `undefined` if a possible code path does not return a value.
     "noImplicitReturns": true,
-    // Ensures consistency between accessing a field via the “dot” (obj.key) syntax, and “indexed” (obj["key"]) and the way which the property is declared in the type.
-    "noPropertyAccessFromIndexSignature": true,
     // Report an error when a variable is declared but never used.
     "noUnusedLocals": true,
     // Report an error when a parameter is declared but never used.


### PR DESCRIPTION
Reverts withastro/astro#5864

Revert for now per https://github.com/withastro/astro/pull/5864#issuecomment-1384782830