### PR TITLE
Update blog example env name

### DIFF
--- a/examples/docs/src/components/Footer/AvatarList.astro
+++ b/examples/docs/src/components/Footer/AvatarList.astro
@@ -17,11 +17,9 @@ type Commit = {
 
 async function getCommits(url: string) {
 	try {
-		const token = import.meta.env.SNOWPACK_PUBLIC_GITHUB_TOKEN ?? 'hello';
+		const token = import.meta.env.GITHUB_TOKEN ?? 'hello';
 		if (!token) {
-			throw new Error(
-				'Cannot find "SNOWPACK_PUBLIC_GITHUB_TOKEN" used for escaping rate-limiting.'
-			);
+			throw new Error('Cannot find "GITHUB_TOKEN" used for escaping rate-limiting.');
 		}
 
 		const auth = `Basic ${Buffer.from(token, 'binary').toString('base64')}`;

--- a/examples/docs/src/env.d.ts
+++ b/examples/docs/src/env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="astro/client" />
+
+interface ImportMetaEnv {
+	readonly GITHUB_TOKEN: string | undefined;
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Changes

Made a small update to remove the "snowpack" keyword, and add autocompletion for `import.meta.env` for the blog example.

Stumbled on this while debugging https://github.com/withastro/astro/pull/5864

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested autocompletion manually.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a