### PR TITLE
fix(astro): add define:vars to HTMLAttributes

### DIFF
--- a/.changeset/beige-dots-pay.md
+++ b/.changeset/beige-dots-pay.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Include missing `define:vars` within `HTMLAttributes` type

--- a/packages/astro/types.d.ts
+++ b/packages/astro/types.d.ts
@@ -6,7 +6,7 @@ export type HTMLTag = keyof astroHTML.JSX.DefinedIntrinsicElements;
 /** The built-in attributes for any known HTML or SVG element name */
 export type HTMLAttributes<Tag extends HTMLTag> = Omit<
 	astroHTML.JSX.IntrinsicElements[Tag],
-	keyof Omit<AstroBuiltinAttributes, 'class:list'>
+	keyof Omit<AstroBuiltinAttributes, 'class:list' | 'define:vars'>
 >;
 
 // TODO: Enable generic/polymorphic types once compiler output stabilizes in the Language Server


### PR DESCRIPTION
## Changes

- This adds the missing `define:vars` to the `HTMLAttributes` type as explained the same in #5284

## Testing

Was not tested.

## Docs

The docs don't explicitly mention any props of HTMLAttributes.
