### PR TITLE
Make image and mdx changesets be minor instead of major

### DIFF
--- a/.changeset/lovely-worms-invite.md
+++ b/.changeset/lovely-worms-invite.md
@@ -1,7 +1,7 @@
 ---
 '@astrojs/deno': major
 '@astrojs/netlify': major
-'@astrojs/image': major
+'@astrojs/image': minor
 'astro': major
 ---
 

--- a/.changeset/spicy-tips-dream.md
+++ b/.changeset/spicy-tips-dream.md
@@ -1,7 +1,7 @@
 ---
 '@astrojs/deno': major
 '@astrojs/netlify': major
-'@astrojs/image': major
+'@astrojs/image': minor
 'astro': major
 ---
 

--- a/.changeset/thin-beers-drive.md
+++ b/.changeset/thin-beers-drive.md
@@ -1,6 +1,6 @@
 ---
 'astro': major
-'@astrojs/mdx': major
+'@astrojs/mdx': minor
 '@astrojs/markdown-remark': major
 ---
 


### PR DESCRIPTION
## Changes

- `@astrojs/image` and `@astrojs/mdx` were not intended to go 1.0. They were made so by mistake.
- This change the changesets to `minor` so that the changes are breaking but not major.

## Testing

N/A

## Docs

N/A