### PR TITLE
Support passing `children` as props to a React component

### DIFF
--- a/.changeset/fresh-eels-speak.md
+++ b/.changeset/fresh-eels-speak.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': patch
+---
+
+Support passing `children` as props to a React component

--- a/packages/astro/test/fixtures/react-component/src/components/WithChildren.jsx
+++ b/packages/astro/test/fixtures/react-component/src/components/WithChildren.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function ({ children }) {
+  return <div className="with-children">{children}</div>;
+}

--- a/packages/astro/test/fixtures/react-component/src/pages/index.astro
+++ b/packages/astro/test/fixtures/react-component/src/pages/index.astro
@@ -7,6 +7,7 @@ import {Research2} from '../components/Research.jsx';
 import Pure from '../components/Pure.jsx';
 import TypeScriptComponent from '../components/TypeScriptComponent';
 import CloneElement from '../components/CloneElement';
+import WithChildren from '../components/WithChildren';
 
 const someProps = {
   text: 'Hello world!',
@@ -31,5 +32,7 @@ const someProps = {
     <TypeScriptComponent client:load />
     <Pure />
 		<CloneElement />
+		<WithChildren client:load>test</WithChildren>
+		<WithChildren client:load children="test" />
   </body>
 </html>

--- a/packages/astro/test/react-component.test.js
+++ b/packages/astro/test/react-component.test.js
@@ -42,11 +42,16 @@ describe('React Components', () => {
 			expect($('#pure')).to.have.lengthOf(1);
 
 			// test 8: Check number of islands
-			expect($('astro-island[uid]')).to.have.lengthOf(5);
+			expect($('astro-island[uid]')).to.have.lengthOf(7);
 
 			// test 9: Check island deduplication
 			const uniqueRootUIDs = new Set($('astro-island').map((i, el) => $(el).attr('uid')));
-			expect(uniqueRootUIDs.size).to.equal(4);
+			expect(uniqueRootUIDs.size).to.equal(6);
+
+			// test 10: Should properly render children passed as props
+			const islandsWithChildren = $('.with-children');
+			expect(islandsWithChildren).to.have.lengthOf(2);
+			expect($(islandsWithChildren[0]).html()).to.equal($(islandsWithChildren[1]).html());
 		});
 
 		it('Can load Vue', async () => {

--- a/packages/integrations/react/server-v17.js
+++ b/packages/integrations/react/server-v17.js
@@ -62,8 +62,11 @@ function renderToStaticMarkup(Component, props, { default: children, ...slotted 
 	const newProps = {
 		...props,
 		...slots,
-		children: children != null ? React.createElement(StaticHtml, { value: children }) : undefined,
 	};
+	const newChildren = children ?? props.children;
+	if (newChildren != null) {
+		newProps.children = React.createElement(StaticHtml, { value: newChildren });
+	}
 	const vnode = React.createElement(Component, newProps);
 	let html;
 	if (metadata && metadata.hydrate) {

--- a/packages/integrations/react/server.js
+++ b/packages/integrations/react/server.js
@@ -69,8 +69,9 @@ async function renderToStaticMarkup(Component, props, { default: children, ...sl
 		...props,
 		...slots,
 	};
-	if (children != null) {
-		newProps.children = React.createElement(StaticHtml, { value: children });
+	const newChildren = children ?? props.children;
+	if (newChildren != null) {
+		newProps.children = React.createElement(StaticHtml, { value: newChildren });
 	}
 	const vnode = React.createElement(Component, newProps);
 	let html;


### PR DESCRIPTION
## Changes

This PR fixes #5493.

Passing `children` as props to a React component, e.g. `<WithChildren client:load children="test" />` would break in production with the component disappearing after hydration and React complaining with the following error:

```
Hydration failed because the initial UI does not match what was rendered on the server.
```

When creating the static HTML element for `children`, the `props.children` props was [previously ignored](https://github.com/withastro/astro/blob/28556a89fe1b63c88951834effd39630c7a52f90/packages/integrations/react/server.js#L73). This PR introduces a change to fallback to `props.children` if `children` is not defined which fixes the issue.

This PR also adds this change to `packages/integrations/react/server-v17.js` for the React 17 integration, altho, while adding this, I noticed that the changes introduced in #4756 were not applied to the React 17 integration so I added them as well.

## Testing

I updated the `react-component` fixture for `astro` to include a new `WithChildren` component rendering the `children` props and updated the associated test to render this component twice, once with `children` and once with `props.children` and assert that the rendered HTML is the same (which would fail without the changes in this PR as the `<astro-slot>` was missing in the second case).

I also manually tested locally this change in a local repro using the `file:` pnpm protocol and confirmed a component using `children` passed down as props is now properly rendered in production and the React hydration error is gone.

## Docs

I could not find any specific mention regarding this specific behavior in the docs and I'm not sure if it's worth mentioning it.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->