### PR TITLE
Fix image integration crash on Netlify Functions due to `import.meta.url`

### DIFF
--- a/.changeset/twenty-boxes-know.md
+++ b/.changeset/twenty-boxes-know.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Fix crash on Netlify Functions due to `import.meta.url`

--- a/packages/integrations/image/src/vendor/squoosh/avif/avif_node_dec.ts
+++ b/packages/integrations/image/src/vendor/squoosh/avif/avif_node_dec.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
 // @ts-nocheck
 import { createRequire } from 'module';
-import { dirname } from '../emscripten-utils.js';
-const require = createRequire(import.meta.url);
+import { dirname, getModuleURL } from '../emscripten-utils.js';
+const require = createRequire(getModuleURL(import.meta.url));
 
 var Module = (function () {
   return function (Module) {
@@ -43,7 +43,7 @@ var Module = (function () {
       if (ENVIRONMENT_IS_WORKER) {
         scriptDirectory = require('path').dirname(scriptDirectory) + '/'
       } else {
-        scriptDirectory = dirname(import.meta.url) + '/'
+        scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
         if (!nodeFS) nodeFS = require('fs')

--- a/packages/integrations/image/src/vendor/squoosh/avif/avif_node_enc.ts
+++ b/packages/integrations/image/src/vendor/squoosh/avif/avif_node_enc.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
 // @ts-nocheck
 import { createRequire } from 'module';
-import { dirname } from '../emscripten-utils.js';
-const require = createRequire(import.meta.url);
+import { dirname, getModuleURL } from '../emscripten-utils.js';
+const require = createRequire(getModuleURL(import.meta.url));
 
 var Module = (function () {
   return function (Module) {
@@ -43,7 +43,7 @@ var Module = (function () {
       if (ENVIRONMENT_IS_WORKER) {
         scriptDirectory = require('path').dirname(scriptDirectory) + '/'
       } else {
-        scriptDirectory = dirname(import.meta.url) + '/'
+        scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
         if (!nodeFS) nodeFS = require('fs')

--- a/packages/integrations/image/src/vendor/squoosh/codecs.ts
+++ b/packages/integrations/image/src/vendor/squoosh/codecs.ts
@@ -1,5 +1,5 @@
 import { promises as fsp } from 'node:fs'
-import { instantiateEmscriptenWasm, pathify } from './emscripten-utils.js'
+import { getModuleURL, instantiateEmscriptenWasm, pathify } from './emscripten-utils.js'
 
 interface DecodeModule extends EmscriptenWasm.Module {
   decode: (data: Uint8Array) => ImageData
@@ -37,50 +37,50 @@ export interface RotateOptions {
 import type { MozJPEGModule as MozJPEGEncodeModule } from './mozjpeg/mozjpeg_enc'
 // @ts-ignore
 import mozEnc from './mozjpeg/mozjpeg_node_enc.js'
-const mozEncWasm = new URL('./mozjpeg/mozjpeg_node_enc.wasm', import.meta.url)
+const mozEncWasm = new URL('./mozjpeg/mozjpeg_node_enc.wasm', getModuleURL(import.meta.url))
 // @ts-ignore
 import mozDec from './mozjpeg/mozjpeg_node_dec.js'
-const mozDecWasm = new URL('./mozjpeg/mozjpeg_node_dec.wasm', import.meta.url)
+const mozDecWasm = new URL('./mozjpeg/mozjpeg_node_dec.wasm', getModuleURL(import.meta.url))
 
 // WebP
 import type { WebPModule as WebPEncodeModule } from './webp/webp_enc'
 // @ts-ignore
 import webpEnc from './webp/webp_node_enc.js'
-const webpEncWasm = new URL('./webp/webp_node_enc.wasm', import.meta.url)
+const webpEncWasm = new URL('./webp/webp_node_enc.wasm', getModuleURL(import.meta.url))
 // @ts-ignore
 import webpDec from './webp/webp_node_dec.js'
-const webpDecWasm = new URL('./webp/webp_node_dec.wasm', import.meta.url)
+const webpDecWasm = new URL('./webp/webp_node_dec.wasm', getModuleURL(import.meta.url))
 
 // AVIF
 import type { AVIFModule as AVIFEncodeModule } from './avif/avif_enc'
 // @ts-ignore
 import avifEnc from './avif/avif_node_enc.js'
-const avifEncWasm = new URL('./avif/avif_node_enc.wasm', import.meta.url)
+const avifEncWasm = new URL('./avif/avif_node_enc.wasm', getModuleURL(import.meta.url))
 // @ts-ignore
 import avifDec from './avif/avif_node_dec.js'
-const avifDecWasm = new URL('./avif/avif_node_dec.wasm', import.meta.url)
+const avifDecWasm = new URL('./avif/avif_node_dec.wasm', getModuleURL(import.meta.url))
 
 // PNG
 // @ts-ignore
 import * as pngEncDec from './png/squoosh_png.js'
-const pngEncDecWasm = new URL('./png/squoosh_png_bg.wasm', import.meta.url)
+const pngEncDecWasm = new URL('./png/squoosh_png_bg.wasm', getModuleURL(import.meta.url))
 const pngEncDecInit = () =>
   pngEncDec.default(fsp.readFile(pathify(pngEncDecWasm.toString())))
 
 // OxiPNG
 // @ts-ignore
 import * as oxipng from './png/squoosh_oxipng.js'
-const oxipngWasm = new URL('./png/squoosh_oxipng_bg.wasm', import.meta.url)
+const oxipngWasm = new URL('./png/squoosh_oxipng_bg.wasm', getModuleURL(import.meta.url))
 const oxipngInit = () => oxipng.default(fsp.readFile(pathify(oxipngWasm.toString())))
 
 // Resize
 // @ts-ignore
 import * as resize from './resize/squoosh_resize.js'
-const resizeWasm = new URL('./resize/squoosh_resize_bg.wasm', import.meta.url)
+const resizeWasm = new URL('./resize/squoosh_resize_bg.wasm', getModuleURL(import.meta.url))
 const resizeInit = () => resize.default(fsp.readFile(pathify(resizeWasm.toString())))
 
 // rotate
-const rotateWasm = new URL('./rotate/rotate.wasm', import.meta.url)
+const rotateWasm = new URL('./rotate/rotate.wasm', getModuleURL(import.meta.url))
 
 // Our decoders currently rely on a `ImageData` global.
 import ImageData from './image_data.js'

--- a/packages/integrations/image/src/vendor/squoosh/emscripten-utils.ts
+++ b/packages/integrations/image/src/vendor/squoosh/emscripten-utils.ts
@@ -1,5 +1,5 @@
-// 
-import { fileURLToPath } from 'node:url'
+//
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 export function pathify(path: string): string {
   if (path.startsWith('file://')) {
@@ -28,4 +28,17 @@ export function instantiateEmscriptenWasm<T extends EmscriptenWasm.Module>(
 
 export function dirname(url: string) {
 	return url.substring(0, url.lastIndexOf('/'))
+}
+
+/**
+ * On certain serverless hosts, our ESM bundle is transpiled to CJS before being run, which means
+ * import.meta.url is undefined, so we'll fall back to __dirname in those cases
+ * We should be able to remove this once https://github.com/netlify/zip-it-and-ship-it/issues/750 is fixed
+ */
+export function getModuleURL(url: string | undefined): string {
+	if (!url) {
+		return pathToFileURL(__dirname).toString();
+	}
+
+	return url
 }

--- a/packages/integrations/image/src/vendor/squoosh/mozjpeg/mozjpeg_node_dec.ts
+++ b/packages/integrations/image/src/vendor/squoosh/mozjpeg/mozjpeg_node_dec.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
 // @ts-nocheck
 import { createRequire } from 'module';
-import { dirname } from '../emscripten-utils.js';
-const require = createRequire(import.meta.url);
+import { dirname, getModuleURL } from '../emscripten-utils.js';
+const require = createRequire(getModuleURL(import.meta.url));
 
 var Module = (function () {
   return function (Module) {
@@ -43,7 +43,7 @@ var Module = (function () {
       if (ENVIRONMENT_IS_WORKER) {
         scriptDirectory = require('path').dirname(scriptDirectory) + '/'
       } else {
-        scriptDirectory = dirname(import.meta.url) + '/'
+        scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
         if (!nodeFS) nodeFS = require('fs')

--- a/packages/integrations/image/src/vendor/squoosh/mozjpeg/mozjpeg_node_enc.ts
+++ b/packages/integrations/image/src/vendor/squoosh/mozjpeg/mozjpeg_node_enc.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
 // @ts-nocheck
 import { createRequire } from 'module';
-import { dirname } from '../emscripten-utils.js';
-const require = createRequire(import.meta.url);
+import { dirname, getModuleURL } from '../emscripten-utils.js';
+const require = createRequire(getModuleURL(import.meta.url));
 
 var Module = (function () {
   return function (Module) {
@@ -43,7 +43,7 @@ var Module = (function () {
       if (ENVIRONMENT_IS_WORKER) {
         scriptDirectory = require('path').dirname(scriptDirectory) + '/'
       } else {
-        scriptDirectory = dirname(import.meta.url) + '/'
+        scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
         if (!nodeFS) nodeFS = require('fs')

--- a/packages/integrations/image/src/vendor/squoosh/webp/webp_node_dec.ts
+++ b/packages/integrations/image/src/vendor/squoosh/webp/webp_node_dec.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
 // @ts-nocheck
 import { createRequire } from 'module';
-import { dirname } from '../emscripten-utils.js';
-const require = createRequire(import.meta.url);
+import { dirname, getModuleURL } from '../emscripten-utils.js';
+const require = createRequire(getModuleURL(import.meta.url));
 
 var Module = (function () {
   return function (Module) {
@@ -43,7 +43,7 @@ var Module = (function () {
       if (ENVIRONMENT_IS_WORKER) {
         scriptDirectory = require('path').dirname(scriptDirectory) + '/'
       } else {
-        scriptDirectory = dirname(import.meta.url) + '/'
+        scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
         if (!nodeFS) nodeFS = require('fs')

--- a/packages/integrations/image/src/vendor/squoosh/webp/webp_node_enc.ts
+++ b/packages/integrations/image/src/vendor/squoosh/webp/webp_node_enc.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
 // @ts-nocheck
 import { createRequire } from 'module';
-import { dirname } from '../emscripten-utils.js';
-const require = createRequire(import.meta.url);
+import { dirname, getModuleURL } from '../emscripten-utils.js';
+const require = createRequire(getModuleURL(import.meta.url));
 
 var Module = (function () {
   return function (Module) {
@@ -43,7 +43,7 @@ var Module = (function () {
       if (ENVIRONMENT_IS_WORKER) {
         scriptDirectory = require('path').dirname(scriptDirectory) + '/'
       } else {
-        scriptDirectory = dirname(import.meta.url) + '/'
+        scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
         if (!nodeFS) nodeFS = require('fs')


### PR DESCRIPTION
## Changes

Netlify Functions are still on CJS, however they support ESM files by running them through `esbuild`, this is great, but `esbuild` doesn't polyfill `import.meta.url` so our function just immediately crash. 

This PR add a helper that either return `import.meta.url` if supported, or an URL using `__dirname` so it works both directly in ESM and hazardly transpiled CJS

**Note**

There's apparently a way to get Netlify functions to run in pure ESM mode already, using a per-function config file, but it's undocumented and I could never get it to work despite multiple attempts 🤷‍♀️

Netlify is shipping pure ESM functions natively with no hidden flag soon, so this is really just a temporary workaround that we'll be able to remove in the future (or keep if it affects other hosts, who knows)

## Testing

Tested manually, this issue only shows up when running directly on Netlify

## Docs

N/A
