### PR TITLE
Cleanup deprecated Markdown APIs from 0.X

### DIFF
--- a/.changeset/calm-emus-raise.md
+++ b/.changeset/calm-emus-raise.md
@@ -1,6 +1,6 @@
 ---
-'astro': patch
-'@astrojs/mdx': patch
+'astro': major
+'@astrojs/mdx': minor
 ---
 
 Remove deprecated Markdown APIs from Astro v0.X. This includes `getHeaders()`, the `.astro` property for layouts, and the `rawContent()` and `compiledContent()` error messages for MDX.

--- a/.changeset/calm-emus-raise.md
+++ b/.changeset/calm-emus-raise.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/mdx': patch
+---
+
+Remove deprecated Markdown APIs from Astro v0.X. This includes `getHeaders()`, the `.astro` property for layouts, and the `rawContent()` and `compiledContent()` error messages for MDX.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1033,7 +1033,7 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 
 type MD = MarkdownInstance<Record<string, any>>;
 
-export interface MDXInstance<T extends Record<string, any>> extends Omit<MarkdownInstance<T>, 'rawContent' | 'compiledContent'> {};
+export type MDXInstance<T extends Record<string, any>> = Omit<MarkdownInstance<T>, 'rawContent' | 'compiledContent'>;
 
 export interface MarkdownLayoutProps<T extends Record<string, any>> {
 	frontmatter: {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1033,13 +1033,7 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 
 type MD = MarkdownInstance<Record<string, any>>;
 
-export interface MDXInstance<T extends Record<string, any>>
-	extends Omit<MarkdownInstance<T>, 'rawContent' | 'compiledContent'> {
-	/** MDX does not support rawContent! If you need to read the Markdown contents to calculate values (ex. reading time), we suggest injecting frontmatter via remark plugins. Learn more on our docs: https://docs.astro.build/en/guides/integrations-guide/mdx/#inject-frontmatter-via-remark-or-rehype-plugins */
-	rawContent: never;
-	/** MDX does not support compiledContent! If you need to read the HTML contents to calculate values (ex. reading time), we suggest injecting frontmatter via rehype plugins. Learn more on our docs: https://docs.astro.build/en/guides/integrations-guide/mdx/#inject-frontmatter-via-remark-or-rehype-plugins */
-	compiledContent: never;
-}
+export interface MDXInstance<T extends Record<string, any>> extends Omit<MarkdownInstance<T>, 'rawContent' | 'compiledContent'> {};
 
 export interface MarkdownLayoutProps<T extends Record<string, any>> {
 	frontmatter: {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1028,8 +1028,6 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 	compiledContent(): string;
 	/** List of headings (h1 -> h6) with associated metadata */
 	getHeadings(): MarkdownHeading[];
-	/** @deprecated Renamed to `getHeadings()` */
-	getHeaders(): void;
 	default: AstroComponentFactory;
 }
 

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -115,22 +115,6 @@ export default function markdown({ settings, logging }: AstroPluginOptions): Plu
 					const { layout, ...content } = frontmatter;
 					content.file = file;
 					content.url = url;
-					content.astro = {};
-					Object.defineProperty(content.astro, 'headings', {
-						get() {
-							throw new Error('The "astro" property is no longer supported! To access "headings" from your layout, try using "Astro.props.headings."')
-						}
-					});
-					Object.defineProperty(content.astro, 'html', {
-						get() {
-							throw new Error('The "astro" property is no longer supported! To access "html" from your layout, try using "Astro.props.compiledContent()."')
-						}
-					});
-					Object.defineProperty(content.astro, 'source', {
-						get() {
-							throw new Error('The "astro" property is no longer supported! To access "source" from your layout, try using "Astro.props.rawContent()."')
-						}
-					});
 					const contentFragment = h(Fragment, { 'set:html': html });
 					return ${
 						layout

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -111,10 +111,6 @@ export default function markdown({ settings, logging }: AstroPluginOptions): Plu
 				export function getHeadings() {
 					return ${JSON.stringify(headings)};
 				}
-				export function getHeaders() {
-					console.warn('getHeaders() have been deprecated. Use getHeadings() function instead.');
-					return getHeadings();
-				};
 				export async function Content() {
 					const { layout, ...content } = frontmatter;
 					content.file = file;

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -12,12 +12,6 @@ import type { Plugin as VitePlugin } from 'vite';
 import { getRehypePlugins, getRemarkPlugins, recmaInjectImportMetaEnvPlugin } from './plugins.js';
 import { getFileInfo, parseFrontmatter } from './utils.js';
 
-const RAW_CONTENT_ERROR =
-	'MDX does not support rawContent()! If you need to read the Markdown contents to calculate values (ex. reading time), we suggest injecting frontmatter via remark plugins. Learn more on our docs: https://docs.astro.build/en/guides/integrations-guide/mdx/#inject-frontmatter-via-remark-or-rehype-plugins';
-
-const COMPILED_CONTENT_ERROR =
-	'MDX does not support compiledContent()! If you need to read the HTML contents to calculate values (ex. reading time), we suggest injecting frontmatter via rehype plugins. Learn more on our docs: https://docs.astro.build/en/guides/integrations-guide/mdx/#inject-frontmatter-via-remark-or-rehype-plugins';
-
 export type MdxOptions = Omit<typeof markdownConfigDefaults, 'remarkPlugins' | 'rehypePlugins'> & {
 	extendMarkdownConfig: boolean;
 	recmaPlugins: PluggableList;
@@ -122,16 +116,6 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 									}
 									if (!moduleExports.includes('file')) {
 										code += `\nexport const file = ${JSON.stringify(fileId)};`;
-									}
-									if (!moduleExports.includes('rawContent')) {
-										code += `\nexport function rawContent() { throw new Error(${JSON.stringify(
-											RAW_CONTENT_ERROR
-										)}) };`;
-									}
-									if (!moduleExports.includes('compiledContent')) {
-										code += `\nexport function compiledContent() { throw new Error(${JSON.stringify(
-											COMPILED_CONTENT_ERROR
-										)}) };`;
 									}
 									if (!moduleExports.includes('Content')) {
 										// Make `Content` the default export so we can wrap `MDXContent` and pass in `Fragment`

--- a/packages/integrations/mdx/src/plugins.ts
+++ b/packages/integrations/mdx/src/plugins.ts
@@ -79,22 +79,6 @@ export function rehypeApplyFrontmatterExport() {
 					const { layout, ...content } = frontmatter;
 					content.file = file;
 					content.url = url;
-					content.astro = {};
-					Object.defineProperty(content.astro, 'headings', {
-						get() {
-							throw new Error('The "astro" property is no longer supported! To access "headings" from your layout, try using "Astro.props.headings."')
-						}
-					});
-					Object.defineProperty(content.astro, 'html', {
-						get() {
-							throw new Error('The "astro" property is no longer supported! To access "html" from your layout, try using "Astro.props.compiledContent()."')
-						}
-					});
-					Object.defineProperty(content.astro, 'source', {
-						get() {
-							throw new Error('The "astro" property is no longer supported! To access "source" from your layout, try using "Astro.props.rawContent()."')
-						}
-					});
 					return layoutJsx(Layout, {
 						file,
 						url,


### PR DESCRIPTION
## Changes

- Remove `content.astro` warning messages
- Remote deprecated `getHeaders()` function
- Remove `rawContent()` and `compiledContent()` errors from MDX and type signature. Users expect that checking `file.rawContent === undefined` will allow safe calling on MD and MDX files. By exporting these functions _just_ to throw errors, we made it harder to use them safely!

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

All deprecated APIs, so no docs changes!
