### PR TITLE
chore: Fix image integration version's number to get out of 1.0

### DIFF
--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@astrojs/image",
   "description": "Load and transform images in your Astro site.",
-  "version": "1.0.0-beta.2",
+  "version": "0.12.1",
   "type": "module",
   "types": "./dist/index.d.ts",
   "author": "withastro",


### PR DESCRIPTION
## Changes

The image integration was mistakenly upgraded to 1.0, we're not ready for that yet!

## Testing

N/A

## Docs

N/A
