### PR TITLE
Rename getEntry to getEntryBySlug

### DIFF
--- a/.changeset/neat-eagles-trade.md
+++ b/.changeset/neat-eagles-trade.md
@@ -1,0 +1,24 @@
+---
+'astro': major
+---
+
+Move getEntry to getEntryBySlug
+
+This change moves `getEntry` to `getEntryBySlug` and accepts a slug rather than an id.
+
+In order to improve support in `[id].astro` routes, particularly in SSR where you do not know what the id of a collection is. Using `getEntryBySlug` instead allows you to map the `[id]` param in your route to the entry. You can use it like this:
+
+```astro
+---
+import { getEntryBySlug } from 'astro:content';
+
+const entry = await getEntryBySlug('docs', Astro.params.id);
+
+if(!entry) {
+  return new Response(null, {
+    status: 404
+  });
+}
+---
+<!-- You have an entry! Use it! -->
+```

--- a/packages/astro/src/content/internal.ts
+++ b/packages/astro/src/content/internal.ts
@@ -69,18 +69,28 @@ export function createGetCollection({
 	};
 }
 
-export function createGetEntry({
-	collectionToEntryMap,
+export function createGetEntryBySlug({
+	getCollection,
 	collectionToRenderEntryMap,
 }: {
-	collectionToEntryMap: CollectionToEntryMap;
+	getCollection: ReturnType<typeof createGetCollection>;
 	collectionToRenderEntryMap: CollectionToEntryMap;
 }) {
-	return async function getEntry(collection: string, entryId: string) {
-		const lazyImport = collectionToEntryMap[collection]?.[entryId];
-		if (!lazyImport) throw new Error(`Failed to import ${JSON.stringify(entryId)}.`);
+	return async function getEntryBySlug(collection: string, slug: string) {
+		const entries = await getCollection(collection);
+		let candidate: typeof entries[number] | undefined = undefined;
+		for(let entry of entries) {
+			if(entry.slug === slug) {
+				candidate = entry;
+				break;
+			}
+		}
 
-		const entry = await lazyImport();
+		if(typeof candidate === 'undefined') {
+			throw new Error(`Failed to find slug ${JSON.stringify(slug)}.`);
+		}
+
+		const entry = candidate;
 		return {
 			id: entry.id,
 			slug: entry.slug,

--- a/packages/astro/src/content/internal.ts
+++ b/packages/astro/src/content/internal.ts
@@ -87,7 +87,7 @@ export function createGetEntryBySlug({
 		}
 
 		if(typeof candidate === 'undefined') {
-			throw new Error(`Failed to find slug ${JSON.stringify(slug)}.`);
+			return undefined;
 		}
 
 		const entry = candidate;

--- a/packages/astro/src/content/internal.ts
+++ b/packages/astro/src/content/internal.ts
@@ -77,6 +77,8 @@ export function createGetEntryBySlug({
 	collectionToRenderEntryMap: CollectionToEntryMap;
 }) {
 	return async function getEntryBySlug(collection: string, slug: string) {
+		// This is not an optimized lookup. Should look into an O(1) implementation
+		// as it's probably that people will have very large collections.
 		const entries = await getCollection(collection);
 		let candidate: typeof entries[number] | undefined = undefined;
 		for(let entry of entries) {

--- a/packages/astro/src/content/template/types.d.ts
+++ b/packages/astro/src/content/template/types.d.ts
@@ -41,10 +41,9 @@ declare module 'astro:content' {
 	): entrySlug extends ValidEntrySlug<C> ? Promise<CollectionEntry<C>> : Promise<CollectionEntry<C> | undefined>;
 	export function getCollection<
 		C extends keyof typeof entryMap,
-		E extends keyof (typeof entryMap)[C]
 	>(
 		collection: C,
-		filter?: (data: (typeof entryMap)[C][E]) => boolean
+		filter?: (data: CollectionEntry<C>) => boolean
 	): Promise<CollectionEntry<C>[]>;
 
 	type InferEntrySchema<C extends keyof typeof entryMap> = import('astro/zod').infer<

--- a/packages/astro/src/content/template/types.d.ts
+++ b/packages/astro/src/content/template/types.d.ts
@@ -30,10 +30,15 @@ declare module 'astro:content' {
 		input: BaseCollectionConfig<S>
 	): BaseCollectionConfig<S>;
 
+	type EntryMapKeys = keyof typeof entryMap;
+	type AllValuesOf<T> = T extends any ? T[keyof T] : never;
+	type ValidEntrySlug<C extends EntryMapKeys> = AllValuesOf<typeof entryMap[C]>['slug'];
+
 	export function getEntryBySlug<C extends keyof typeof entryMap>(
 		collection: C,
-		entrySlug: string
-	): Promise<CollectionEntry<C>>;
+		// Note that this has to accept a regular string too, for SSR
+		entrySlug: ValidEntrySlug<C> | string
+	): entrySlug extends ValidEntrySlug<C> ? Promise<CollectionEntry<C>> : Promise<CollectionEntry<C> | undefined>;
 	export function getCollection<
 		C extends keyof typeof entryMap,
 		E extends keyof (typeof entryMap)[C]

--- a/packages/astro/src/content/template/types.d.ts
+++ b/packages/astro/src/content/template/types.d.ts
@@ -34,11 +34,11 @@ declare module 'astro:content' {
 	type AllValuesOf<T> = T extends any ? T[keyof T] : never;
 	type ValidEntrySlug<C extends EntryMapKeys> = AllValuesOf<typeof entryMap[C]>['slug'];
 
-	export function getEntryBySlug<C extends keyof typeof entryMap>(
+	export function getEntryBySlug<C extends keyof typeof entryMap, E extends ValidEntrySlug<C> | (string & {})>(
 		collection: C,
 		// Note that this has to accept a regular string too, for SSR
-		entrySlug: ValidEntrySlug<C> | string
-	): entrySlug extends ValidEntrySlug<C> ? Promise<CollectionEntry<C>> : Promise<CollectionEntry<C> | undefined>;
+		entrySlug: E
+	): E extends ValidEntrySlug<C> ? Promise<CollectionEntry<C>> : Promise<CollectionEntry<C> | undefined>;
 	export function getCollection<
 		C extends keyof typeof entryMap,
 	>(

--- a/packages/astro/src/content/template/types.d.ts
+++ b/packages/astro/src/content/template/types.d.ts
@@ -30,17 +30,17 @@ declare module 'astro:content' {
 		input: BaseCollectionConfig<S>
 	): BaseCollectionConfig<S>;
 
-	export function getEntry<C extends keyof typeof entryMap, E extends keyof (typeof entryMap)[C]>(
+	export function getEntryBySlug<C extends keyof typeof entryMap>(
 		collection: C,
-		entryKey: E
-	): Promise<(typeof entryMap)[C][E] & Render>;
+		entrySlug: string
+	): Promise<CollectionEntry<C>>;
 	export function getCollection<
 		C extends keyof typeof entryMap,
 		E extends keyof (typeof entryMap)[C]
 	>(
 		collection: C,
 		filter?: (data: (typeof entryMap)[C][E]) => boolean
-	): Promise<((typeof entryMap)[C][E] & Render)[]>;
+	): Promise<CollectionEntry<C>[]>;
 
 	type InferEntrySchema<C extends keyof typeof entryMap> = import('astro/zod').infer<
 		Required<ContentConfig['collections'][C]>['schema']

--- a/packages/astro/src/content/template/virtual-mod.mjs
+++ b/packages/astro/src/content/template/virtual-mod.mjs
@@ -2,7 +2,7 @@
 import {
 	createCollectionToGlobResultMap,
 	createGetCollection,
-	createGetEntry,
+	createGetEntryBySlug,
 } from 'astro/content/internal';
 
 export { z } from 'astro/zod';
@@ -34,7 +34,7 @@ export const getCollection = createGetCollection({
 	collectionToRenderEntryMap,
 });
 
-export const getEntry = createGetEntry({
-	collectionToEntryMap,
+export const getEntryBySlug = createGetEntryBySlug({
+	getCollection,
 	collectionToRenderEntryMap,
 });

--- a/packages/astro/test/fixtures/content-collections/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections/src/content/config.ts
@@ -2,7 +2,6 @@ import { z, defineCollection } from 'astro:content';
 
 const withSlugConfig = defineCollection({
 	slug({ id, data }) {
-		console.log({id, data})
 		return `${data.prefix}-${id}`;
 	},
 	schema: z.object({

--- a/packages/astro/test/fixtures/content-collections/src/pages/entries.json.js
+++ b/packages/astro/test/fixtures/content-collections/src/pages/entries.json.js
@@ -1,12 +1,12 @@
-import { getEntry } from 'astro:content';
+import { getEntryBySlug } from 'astro:content';
 import * as devalue from 'devalue';
 import { stripRenderFn } from '../utils.js';
 
 export async function get() {
-	const columbiaWithoutConfig = stripRenderFn(await getEntry('without-config', 'columbia.md'));
-	const oneWithSchemaConfig = stripRenderFn(await getEntry('with-schema-config', 'one.md'));
-	const twoWithSlugConfig = stripRenderFn(await getEntry('with-slug-config', 'two.md'));
-	const postWithUnionSchema = stripRenderFn(await getEntry('with-union-schema', 'post.md'));
+	const columbiaWithoutConfig = stripRenderFn(await getEntryBySlug('without-config', 'columbia'));
+	const oneWithSchemaConfig = stripRenderFn(await getEntryBySlug('with-schema-config', 'one'));
+	const twoWithSlugConfig = stripRenderFn(await getEntryBySlug('with-slug-config', 'interesting-two.md'));
+	const postWithUnionSchema = stripRenderFn(await getEntryBySlug('with-union-schema', 'post'));
 
 	return {
 		body: devalue.stringify({columbiaWithoutConfig, oneWithSchemaConfig, twoWithSlugConfig, postWithUnionSchema}),


### PR DESCRIPTION
## Changes

- Rename `getEntry` to `getEntryBySlug`.
  - The new function takes a slug as the second argument instead of an id.
  - It loops over the collection and finds a matching entry that has the provided slug.
- The types here could maybe be better? I could figure out a way to type it so that the provided slug matches an entry with that slug. I think the fact that a slug can be any `string` is a blocker here. Happy to be proven otherwise.

## Testing

- Tests updated

## Docs

- PR https://github.com/withastro/docs/pull/2408