### PR TITLE
Fix `GetPictureResult` interface

### DIFF
--- a/.changeset/chilly-ads-roll.md
+++ b/.changeset/chilly-ads-roll.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+`getPicture()` return object with the correct image type

--- a/packages/integrations/image/src/lib/get-picture.ts
+++ b/packages/integrations/image/src/lib/get-picture.ts
@@ -17,7 +17,7 @@ export interface GetPictureParams {
 }
 
 export interface GetPictureResult {
-	image: astroHTML.JSX.HTMLAttributes;
+	image: astroHTML.JSX.ImgHTMLAttributes;
 	sources: { type: string; srcset: string }[];
 }
 


### PR DESCRIPTION
## Changes

`getPicture()` returns an object with the `GetPictureResult` interface.

This PR changes the `image` key type of that interface from `astroHTML.JSX.HTMLAttributes` to `astroHTML.JSX.ImgHTMLAttributes` .


`astroHTML.JSX.ImgHTMLAttributes` is the type set initially in the body of the `getPicture()` function and the return type for the `getImage()` function

https://github.com/withastro/astro/blob/dc2496f702e3b1b575a74c65db93f484ef95d097/packages/integrations/image/src/lib/get-picture.ts#L68


## Testing

## Docs

No changes needed
