### PR TITLE
Add headless support to create-astro

### DIFF
--- a/.changeset/kind-panthers-doubt.md
+++ b/.changeset/kind-panthers-doubt.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Support headless runs with `-y` / `--yes`

--- a/packages/create-astro/README.md
+++ b/packages/create-astro/README.md
@@ -43,6 +43,8 @@ May be provided in place of prompts
 | `--template` | Specify the template name ([list][examples])        |
 | `--commit`   | Specify a specific Git commit or branch to use from this repo (by default, `main` branch of this repo will be used) |
 | `--fancy`    | For Windows users, `--fancy` will enable full unicode support |
+| `--typescript` | Specify the [tsconfig][typescript] to use            |
+| `--yes`/`-y` | Skip prompts and use default values                 |
 
 ### Debugging
 
@@ -60,3 +62,4 @@ yarn create astro my-astro-project --verbose
 ```
 
 [examples]: https://github.com/withastro/astro/tree/main/examples
+[typescript]: https://github.com/withastro/astro/tree/main/packages/astro/tsconfigs


### PR DESCRIPTION
## Changes

- Support headless runs with `-y` / `--yes` in the create-astro cli

## Testing

No testing was added. All existing tests pass. I can add testing if needed

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

No need for docs updates, because as far as I'm aware there are no reference docs for `create-astro` besides the `README.md` file in the root of the package.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
