### PR TITLE
Ignore `types.generated.d.ts` in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ packages/integrations/**/.netlify/
 # ignore content collection generated files
 packages/**/test/**/fixtures/**/.astro/
 packages/**/test/**/fixtures/**/env.d.ts
+packages/**/test/**/fixtures/**/types.generated.d.ts


### PR DESCRIPTION
## Changes

- Adds some generated type files to the gitignore. Normally these should be checked in I believe? But for these tests I don't think we want them checked in.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

n/a

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

n/a
