### PR TITLE
Remove duplicate CSS in dev

### DIFF
--- a/.changeset/rotten-cups-happen.md
+++ b/.changeset/rotten-cups-happen.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix duplicate CSS in dev mode when `vite.css.devSourcemap` is provided

--- a/packages/astro/e2e/css-sourcemaps.test.js
+++ b/packages/astro/e2e/css-sourcemaps.test.js
@@ -15,21 +15,8 @@ test.afterAll(async () => {
 	await devServer.stop();
 });
 
-test.describe('CSS HMR', () => {
+test.describe('CSS Sourcemap HMR', () => {
 	test.skip(isWindows, 'TODO: fix css hmr in windows');
-
-	test('edit CSS from @import', async ({ page, astro }) => {
-		await page.goto(astro.resolveUrl('/'));
-
-		const h = page.locator('h1');
-		expect(await getColor(h)).toBe('rgb(255, 0, 0)');
-
-		await astro.editFile('./src/styles/main.css', (original) =>
-			original.replace('--h1-color: red;', '--h1-color: green;')
-		);
-
-		expect(await getColor(h)).toBe('rgb(0, 128, 0)');
-	});
 
 	test('removes Astro-injected CSS once Vite-injected CSS loads', async ({ page, astro }) => {
 		const html = await astro.fetch('/').then(res => res.text());

--- a/packages/astro/e2e/fixtures/css-sourcemaps/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/css-sourcemaps/astro.config.mjs
@@ -1,0 +1,7 @@
+export default {
+	vite: {
+		css: {
+			devSourcemap: true,
+		}
+	}
+};

--- a/packages/astro/e2e/fixtures/css-sourcemaps/package.json
+++ b/packages/astro/e2e/fixtures/css-sourcemaps/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@e2e/css-sourcemaps",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/e2e/fixtures/css-sourcemaps/src/env.d.ts
+++ b/packages/astro/e2e/fixtures/css-sourcemaps/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/packages/astro/e2e/fixtures/css-sourcemaps/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/css-sourcemaps/src/pages/index.astro
@@ -1,0 +1,9 @@
+<h1>hello world</h1>
+
+<style>
+  @import "../styles/main.css";
+
+  h1 {
+    color: var(--h1-color);
+  }
+</style>

--- a/packages/astro/e2e/fixtures/css-sourcemaps/src/styles/main.css
+++ b/packages/astro/e2e/fixtures/css-sourcemaps/src/styles/main.css
@@ -1,0 +1,3 @@
+:root {
+  --h1-color: red;
+}

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -10,7 +10,7 @@ import { PAGE_SCRIPT_ID } from '../../../vite-plugin-scripts/index.js';
 import { enhanceViteSSRError } from '../../errors/dev/index.js';
 import { AggregateError, CSSError, MarkdownError } from '../../errors/index.js';
 import type { ModuleLoader } from '../../module-loader/index';
-import { isPage, resolveIdToUrl } from '../../util.js';
+import { isPage, resolveIdToUrl, viteID } from '../../util.js';
 import { createRenderContext, renderPage as coreRenderPage } from '../index.js';
 import { filterFoundRenderers, loadRenderer } from '../renderer.js';
 import { getStylesForURL } from './css.js';
@@ -133,7 +133,11 @@ async function getScriptsAndStyles({ env, filePath }: GetScriptsAndStylesParams)
 		});
 		// But we still want to inject the styles to avoid FOUC
 		styles.add({
-			props: {},
+			props: {
+				type: 'text/css',
+				// Track the ID so we can match it to Vite's injected style later
+				'data-astro-dev-id': viteID(new URL(`.${url}`, env.settings.config.root))
+			},
 			children: content,
 		});
 	});

--- a/packages/astro/src/runtime/client/hmr.ts
+++ b/packages/astro/src/runtime/client/hmr.ts
@@ -1,15 +1,15 @@
 /// <reference types="vite/client" />
 
 if (import.meta.hot) {
-	// Vite injects `<style type="text/css">` for ESM imports of styles
-	// but Astro also SSRs with `<style>` blocks. This MutationObserver
+	// Vite injects `<style type="text/css" data-vite-dev-id>` for ESM imports of styles
+	// but Astro also SSRs with `<style type="text/css" data-astro-dev-id>` blocks. This MutationObserver
 	// removes any duplicates as soon as they are hydrated client-side.
 	const injectedStyles = getInjectedStyles();
 	const mo = new MutationObserver((records) => {
 		for (const record of records) {
 			for (const node of record.addedNodes) {
 				if (isViteInjectedStyle(node)) {
-					injectedStyles.get(node.innerHTML.trim())?.remove();
+					injectedStyles.get(node.getAttribute('data-vite-dev-id')!)?.remove();
 				}
 			}
 		}
@@ -31,8 +31,8 @@ if (import.meta.hot) {
 
 function getInjectedStyles() {
 	const injectedStyles = new Map<string, Element>();
-	document.querySelectorAll<HTMLStyleElement>('style').forEach((el) => {
-		injectedStyles.set(el.innerHTML.trim(), el);
+	document.querySelectorAll<HTMLStyleElement>('style[data-astro-dev-id]').forEach((el) => {
+		injectedStyles.set(el.getAttribute('data-astro-dev-id')!, el);
 	});
 	return injectedStyles;
 }
@@ -42,5 +42,5 @@ function isStyle(node: Node): node is HTMLStyleElement {
 }
 
 function isViteInjectedStyle(node: Node): node is HTMLStyleElement {
-	return isStyle(node) && node.getAttribute('type') === 'text/css';
+	return isStyle(node) && node.getAttribute('type') === 'text/css' && !!node.getAttribute('data-vite-dev-id');
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -657,6 +657,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/e2e/fixtures/css-sourcemaps:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/e2e/fixtures/error-cyclic:
     specifiers:
       '@astrojs/preact': workspace:*


### PR DESCRIPTION
## Changes

- Closes #5817
- Better handling for CSS in dev
- Includes the Vite ID of SSR'd styles so they can be removed once Vite takes over on the client

## Testing

- E2E test added for default handling
- E2E test added to confirm this also works when `vite.css.devSourcemap` is enabled

## Docs

Bug fix only