### PR TITLE
Improve error message for third-party template 404s

### DIFF
--- a/.changeset/large-hotels-give.md
+++ b/.changeset/large-hotels-give.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Improve error message for third-party template 404s

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -192,7 +192,20 @@ export async function main() {
 		} catch (err: any) {
 			fs.rmdirSync(cwd);
 			if (err.message.includes('404')) {
-				console.error(`Template ${color.underline(options.template)} does not exist!`);
+				console.error(`Could not find template ${color.underline(options.template)}!`);
+				if (isThirdParty) {
+					const hasBranch = options.template.includes('#');
+					if (hasBranch) {
+						console.error('Are you sure this GitHub repo and branch exist?');
+					} else {
+						console.error(
+							`Are you sure this GitHub repo exists?` +
+								`This command uses the ${color.bold('main')} branch by default.\n` +
+								`If the repo doesn't have a main branch, specify a custom branch name:\n` +
+								color.underline(options.template + color.bold('#branch-name'))
+						);
+					}
+				}
 			} else {
 				console.error(err.message);
 			}


### PR DESCRIPTION
## Changes

- Adds a helpful error message when a third-party template passed to `create astro` is not found.

- Inspired by https://github.com/withastro/docs/issues/2372

- Currently if a user passes `--template username/repo` and `giget` fails to load that repo, the command fails and says "does not exist!":
    <img width="789" alt="image" src="https://user-images.githubusercontent.com/357379/213816244-9cf19062-95b7-4a4b-97a4-b857e1dd16e2.png">

- A common cause is that the template repo does not have a `main` branch (which `giget` assumes by default and we have no way of guessing without calling the GitHub API), so the updated error message adds some pointers

    > Could not find template **username/repo**!
    > Are you sure this GitHub repo exists? This command uses the **main** branch by default.
    > If the repo doesn't have a main branch, specify a custom branch name:
    > **username/repo#branch-name**

## Testing

Don’t think this needs tests as it’s just a log message?

## Docs

Arguably entirely docs!