### PR TITLE
Content Collections: remove `data` and `body` from custom `slug()`

### DIFF
--- a/.changeset/happy-peaches-divide.md
+++ b/.changeset/happy-peaches-divide.md
@@ -1,0 +1,19 @@
+---
+'astro': major
+---
+
+Remove `data` and `body` from the custom collection `slug()` mapper.
+
+### Migration
+
+If you computed slugs based on frontmatter data, we suggest reading this property separately where your content is used:
+
+```ts
+
+export function getStaticPaths() {
+  const posts = await getCollection('blog');
+  posts.map(post => ({
+    params: { slug: post.data.slug ?? post.slug },
+  }))
+}
+```

--- a/packages/astro/src/content/template/types.d.ts
+++ b/packages/astro/src/content/template/types.d.ts
@@ -21,9 +21,6 @@ declare module 'astro:content' {
 		slug?: (entry: {
 			id: CollectionEntry<keyof typeof entryMap>['id'];
 			defaultSlug: string;
-			collection: string;
-			body: string;
-			data: import('astro/zod').infer<S>;
 		}) => string | Promise<string>;
 	};
 	export function defineCollection<S extends BaseSchema>(

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -17,10 +17,7 @@ export const collectionConfigParser = z.object({
 		.args(
 			z.object({
 				id: z.string(),
-				collection: z.string(),
 				defaultSlug: z.string(),
-				body: z.string(),
-				data: z.record(z.any()),
 			})
 		)
 		.returns(z.union([z.string(), z.promise(z.string())]))
@@ -67,10 +64,7 @@ export async function getEntrySlug(entry: Entry, collectionConfig: CollectionCon
 	return (
 		collectionConfig.slug?.({
 			id: entry.id,
-			data: entry.data,
 			defaultSlug: entry.slug,
-			collection: entry.collection,
-			body: entry.body,
 		}) ?? entry.slug
 	);
 }

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -70,7 +70,7 @@ describe('Content Collections', () => {
 				expect(Array.isArray(json.withSlugConfig)).to.equal(true);
 
 				const slugs = json.withSlugConfig.map((item) => item.slug);
-				expect(slugs).to.deep.equal(['fancy-one.md', 'excellent-three.md', 'interesting-two.md']);
+				expect(slugs).to.deep.equal(['custom-one.md', 'custom-three.md', 'custom-two.md']);
 			});
 
 			it('Returns `with union schema` collection', async () => {

--- a/packages/astro/test/fixtures/content-collections/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections/src/content/config.ts
@@ -4,9 +4,6 @@ const withSlugConfig = defineCollection({
 	slug({ id }) {
 		return `custom-${id}`;
 	},
-	schema: z.object({
-		prefix: z.string(),
-	}),
 });
 
 const withSchemaConfig = defineCollection({

--- a/packages/astro/test/fixtures/content-collections/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections/src/content/config.ts
@@ -1,8 +1,8 @@
 import { z, defineCollection } from 'astro:content';
 
 const withSlugConfig = defineCollection({
-	slug({ id, data }) {
-		return `${data.prefix}-${id}`;
+	slug({ id }) {
+		return `custom-${id}`;
 	},
 	schema: z.object({
 		prefix: z.string(),

--- a/packages/astro/test/fixtures/content-collections/src/content/with-slug-config/one.md
+++ b/packages/astro/test/fixtures/content-collections/src/content/with-slug-config/one.md
@@ -1,5 +1,1 @@
----
-prefix: fancy
----
-
 # It's the first page, fancy!

--- a/packages/astro/test/fixtures/content-collections/src/content/with-slug-config/three.md
+++ b/packages/astro/test/fixtures/content-collections/src/content/with-slug-config/three.md
@@ -1,5 +1,1 @@
----
-prefix: excellent
----
-
 # It's the third page, excellent!

--- a/packages/astro/test/fixtures/content-collections/src/content/with-slug-config/two.md
+++ b/packages/astro/test/fixtures/content-collections/src/content/with-slug-config/two.md
@@ -1,5 +1,1 @@
----
-prefix: interesting
----
-
 # It's the second page, interesting!


### PR DESCRIPTION
## Changes

- Removes `data` and `body` from the custom `slug()` configuration option

### Why remove this?

Allowing access to the parsed Zod schema introduces a bottleneck when looking up entries by slug. Today, this function is slower than we'd like it to be, since it needs to look through all items in a collection to give you the right one. By allowing access to the data object, it is more difficult (though not impossible) to make this function more performant in a non-breaking way.

We recognize the usefulness of looking up entries by custom `data` attributes. However, for the most performant and futureproof story in Astro 2.0, removing this to revisit in a future minor feels like the best path.

## Testing

Update tests expecting `data`

## Docs

TODO: docs updates