### PR TITLE
fix: undefined remarkPluginFrontmatter after calling render method

### DIFF
--- a/.changeset/lazy-buttons-prove.md
+++ b/.changeset/lazy-buttons-prove.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix undefined `remarkPluginFrontmatter` after calling `render` method

--- a/packages/astro/src/content/vite-plugin-content-assets.ts
+++ b/packages/astro/src/content/vite-plugin-content-assets.ts
@@ -34,7 +34,7 @@ export function astroDelayedAssetPlugin({ mode }: { mode: string }): Plugin {
 			if (isDelayedAsset(id)) {
 				const basePath = id.split('?')[0];
 				const code = `
-					export { Content, getHeadings } from ${JSON.stringify(basePath)};
+					export { Content, getHeadings, frontmatter } from ${JSON.stringify(basePath)};
 					export const collectedLinks = ${JSON.stringify(LINKS_PLACEHOLDER)};
 					export const collectedStyles = ${JSON.stringify(STYLES_PLACEHOLDER)};
 				`;


### PR DESCRIPTION
## Changes

Fixes #5859 where `frontmatter` is not exported but is used in 
https://github.com/withastro/astro/blob/02ba7c2250a950593961d833201e46adb3e0873c/packages/astro/src/content/internal.ts#L155

## Testing

no tests

## Docs

nothing changed
