### PR TITLE
Update magic-string used by @astrojs/image and @astrojs/webapi 

### DIFF
--- a/.changeset/lucky-tigers-know.md
+++ b/.changeset/lucky-tigers-know.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/image': patch
+'@astrojs/webapi': patch
+---
+
+Update magic-string from 0.25.9 to 0.27.0

--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -46,7 +46,7 @@
     "http-cache-semantics": "^4.1.0",
     "image-size": "^1.0.2",
     "kleur": "^4.1.5",
-    "magic-string": "^0.25.9",
+    "magic-string": "^0.27.0",
     "mime": "^3.0.0",
     "slash": "^4.0.0"
   },
@@ -64,8 +64,8 @@
     "vite": "^4.0.3"
   },
   "peerDependencies": {
-    "sharp": ">=0.31.0",
-    "astro": "workspace:^2.0.0-beta.3"
+    "astro": "workspace:^2.0.0-beta.3",
+    "sharp": ">=0.31.0"
   },
   "peerDependenciesMeta": {
     "sharp": {

--- a/packages/webapi/package.json
+++ b/packages/webapi/package.json
@@ -64,7 +64,7 @@
     "chai": "^4.3.6",
     "event-target-shim": "^6.0.2",
     "formdata-polyfill": "^4.0.10",
-    "magic-string": "^0.25.9",
+    "magic-string": "^0.27.0",
     "mocha": "^9.2.2",
     "rollup": "^2.79.1",
     "tslib": "^2.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2679,7 +2679,7 @@ importers:
       http-cache-semantics: ^4.1.0
       image-size: ^1.0.2
       kleur: ^4.1.5
-      magic-string: ^0.25.9
+      magic-string: ^0.27.0
       mime: ^3.0.0
       mocha: ^9.2.2
       rollup-plugin-copy: ^3.4.0
@@ -2691,7 +2691,7 @@ importers:
       http-cache-semantics: 4.1.0
       image-size: 1.0.2
       kleur: 4.1.5
-      magic-string: 0.25.9
+      magic-string: 0.27.0
       mime: 3.0.0
       slash: 4.0.0
     devDependencies:
@@ -3567,7 +3567,7 @@ importers:
       chai: ^4.3.6
       event-target-shim: ^6.0.2
       formdata-polyfill: ^4.0.10
-      magic-string: ^0.25.9
+      magic-string: ^0.27.0
       mocha: ^9.2.2
       rollup: ^2.79.1
       tslib: ^2.4.0
@@ -3588,7 +3588,7 @@ importers:
       chai: 4.3.7
       event-target-shim: 6.0.2
       formdata-polyfill: 4.0.10
-      magic-string: 0.25.9
+      magic-string: 0.27.0
       mocha: 9.2.2
       rollup: 2.79.1
       tslib: 2.4.1
@@ -6034,7 +6034,6 @@ packages:
 
   /@jridgewell/sourcemap-codec/1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
-    dev: false
 
   /@jridgewell/trace-mapping/0.3.17:
     resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
@@ -11242,7 +11241,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.14
-    dev: false
 
   /make-dir/3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}


### PR DESCRIPTION
## Changes

- Updated the required version of magic-string used in `@astrojs/image` and `@astrojs/webapi` to fix #5929

## Testing

Current tests passed.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

No changes.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
