### PR TITLE
[Content Collections] Add `slug` frontmatter field

### DIFF
--- a/.changeset/large-steaks-film.md
+++ b/.changeset/large-steaks-film.md
@@ -1,0 +1,43 @@
+---
+'astro': major
+---
+
+Replace the content collection `slug()` config with a new `slug` frontmatter field.
+
+This introduces a reserved `slug` property you can add to any Markdown or MDX collection entry. When present, this will override the generated slug for that entry.
+
+```diff
+# src/content/blog/post-1.md
+---
+title: Post 1
++ slug: post-1-custom-slug
+---
+```
+
+Astro will respect this slug in the generated `slug` type and when using the `getEntryBySlug()` utility:
+
+```astro
+---
+import { getEntryBySlug } from 'astro:content';
+
+// Retrieve `src/content/blog/post-1.md` by slug with type safety
+const post = await getEntryBySlug('blog', 'post-1-custom-slug');
+---
+```
+
+#### Migration
+
+If you relied on the `slug()` config option, we suggest moving all custom slugs to `slug` frontmatter properties in each collection entry.
+
+Additionally, Astro no longer allows `slug` as a collection schema property. This ensures Astro can manage the `slug` property for type generation and performance. Remove this property from your schema and any relevant `slug()` configuration:
+
+```diff
+const blog = defineCollection({
+  schema: z.object({
+-   slug: z.string().optional(),
+  }),
+- slug({ defaultSlug, data }) {
+-   return data.slug ?? defaultSlug;
+- },
+})
+```

--- a/.changeset/large-steaks-film.md
+++ b/.changeset/large-steaks-film.md
@@ -2,9 +2,9 @@
 'astro': major
 ---
 
-Replace the content collection `slug()` config with a new `slug` frontmatter field.
+Content collections: Introduce a new `slug` frontmatter field for overriding the generated slug. This replaces the previous `slug()` collection config option from Astro 1.X and the 2.0 beta.
 
-This introduces a reserved `slug` property you can add to any Markdown or MDX collection entry. When present, this will override the generated slug for that entry.
+When present in a Markdown or MDX file, this will override the generated slug for that entry.
 
 ```diff
 # src/content/blog/post-1.md

--- a/.changeset/large-steaks-film.md
+++ b/.changeset/large-steaks-film.md
@@ -27,7 +27,7 @@ const post = await getEntryBySlug('blog', 'post-1-custom-slug');
 
 #### Migration
 
-If you relied on the `slug()` config option, we suggest moving all custom slugs to `slug` frontmatter properties in each collection entry.
+If you relied on the `slug()` config option, you will need to move all custom slugs to `slug` frontmatter properties in each collection entry.
 
 Additionally, Astro no longer allows `slug` as a collection schema property. This ensures Astro can manage the `slug` property for type generation and performance. Remove this property from your schema and any relevant `slug()` configuration:
 

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -157,6 +157,11 @@ export async function createContentTypesGenerator({
 			return { shouldGenerateTypes: false };
 		}
 
+		// `slug` may be present in entry frontmatter.
+		// This should be respected by the generated `slug` type!
+		// Parse frontmatter and retrieve `slug` value for this.
+		// Note: will raise any YAML exceptions and `slug` parse errors (i.e. `slug` is a boolean)
+		// on dev server startup or production build init.
 		const rawContents = await fs.promises.readFile(event.entry, 'utf-8');
 		const { data: frontmatter } = parseFrontmatter(rawContents, fileURLToPath(event.entry));
 		const slug = getEntrySlug({ ...entryInfo, data: frontmatter });

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -171,7 +171,7 @@ export async function createContentTypesGenerator({
 					addCollection(contentTypes, collectionKey);
 				}
 				if (!(entryKey in contentTypes[collectionKey])) {
-					addEntry(contentTypes, collectionKey, entryKey, slug);
+					setEntry(contentTypes, collectionKey, entryKey, slug);
 				}
 				return { shouldGenerateTypes: true };
 			case 'unlink':
@@ -180,7 +180,12 @@ export async function createContentTypesGenerator({
 				}
 				return { shouldGenerateTypes: true };
 			case 'change':
-				// noop. Frontmatter types are inferred from collection schema import, so they won't change!
+				// User may modify `slug` in their frontmatter.
+				// Only regen types if this change is detected.
+				if (contentTypes[collectionKey]?.[entryKey]?.slug !== slug) {
+					setEntry(contentTypes, collectionKey, entryKey, slug);
+					return { shouldGenerateTypes: true };
+				}
 				return { shouldGenerateTypes: false };
 		}
 	}
@@ -249,7 +254,7 @@ function removeCollection(contentMap: ContentTypes, collectionKey: string) {
 	delete contentMap[collectionKey];
 }
 
-function addEntry(
+function setEntry(
 	contentTypes: ContentTypes,
 	collectionKey: string,
 	entryKey: string,

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -12,19 +12,6 @@ import { astroContentVirtualModPlugin } from './vite-plugin-content-virtual-mod.
 
 export const collectionConfigParser = z.object({
 	schema: z.any().optional(),
-	slug: z
-		.function()
-		.args(
-			z.object({
-				id: z.string(),
-				collection: z.string(),
-				defaultSlug: z.string(),
-				body: z.string(),
-				data: z.record(z.any()),
-			})
-		)
-		.returns(z.union([z.string(), z.promise(z.string())]))
-		.optional(),
 });
 
 export function getDotAstroTypeReference({ root, srcDir }: { root: URL; srcDir: URL }) {
@@ -63,7 +50,7 @@ export const msg = {
 		`${collection} does not have a config. We suggest adding one for type safety!`,
 };
 
-export function getEntrySlug({id, collection, slug, data: unparsedData}: Entry){ 
+export function getEntrySlug({id, collection, slug, data: unparsedData}: Pick<Entry, 'id' | 'collection' | 'slug' | 'data'>){ 
 	try {
 		return z.string().default(slug).parse(unparsedData.slug);
 	} catch {

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -60,12 +60,8 @@ export function getEntrySlug({
 		return z.string().default(slug).parse(unparsedData.slug);
 	} catch {
 		throw new AstroError({
-			title: 'Invalid content entry slug',
-			message: `${String(collection)} → ${String(
-				id
-			)} has an invalid frontmatter slug. \`slug\` must be a string.`,
-			hint: 'See our docs for more information about the reserved `slug` field: https://docs.astro.build/en/guides/content-collections/',
-			code: 99999,
+			...AstroErrorData.InvalidContentEntrySlugError,
+			message: AstroErrorData.InvalidContentEntrySlugError.message(collection, id),
 		});
 	}
 }
@@ -108,8 +104,8 @@ export async function getEntryData(entry: Entry, collectionConfig: CollectionCon
 			data = parsed.data;
 		} else {
 			const formattedError = new AstroError({
-				...AstroErrorData.MarkdownContentSchemaValidationError,
-				message: AstroErrorData.MarkdownContentSchemaValidationError.message(
+				...AstroErrorData.InvalidContentEntryFrontmatterError,
+				message: AstroErrorData.InvalidContentEntryFrontmatterError.message(
 					entry.collection,
 					entry.id,
 					parsed.error

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -50,13 +50,20 @@ export const msg = {
 		`${collection} does not have a config. We suggest adding one for type safety!`,
 };
 
-export function getEntrySlug({id, collection, slug, data: unparsedData}: Pick<Entry, 'id' | 'collection' | 'slug' | 'data'>){ 
+export function getEntrySlug({
+	id,
+	collection,
+	slug,
+	data: unparsedData,
+}: Pick<Entry, 'id' | 'collection' | 'slug' | 'data'>) {
 	try {
 		return z.string().default(slug).parse(unparsedData.slug);
 	} catch {
 		throw new AstroError({
 			title: 'Invalid content entry slug',
-			message: `${String(collection)} → ${String(id)} has an invalid frontmatter slug. \`slug\` must be a string.`,
+			message: `${String(collection)} → ${String(
+				id
+			)} has an invalid frontmatter slug. \`slug\` must be a string.`,
 			hint: 'See our docs for more information about the reserved `slug` field: https://docs.astro.build/en/guides/content-collections/',
 			code: 99999,
 		});
@@ -81,10 +88,16 @@ export async function getEntryData(entry: Entry, collectionConfig: CollectionCon
 		}
 		// Catch reserved `slug` field inside schema
 		// Note: will not warn for `z.union` or `z.intersection` schemas
-		if (typeof collectionConfig.schema === 'object' && 'shape' in collectionConfig.schema && collectionConfig.schema.shape.slug) {
+		if (
+			typeof collectionConfig.schema === 'object' &&
+			'shape' in collectionConfig.schema &&
+			collectionConfig.schema.shape.slug
+		) {
 			throw new AstroError({
 				title: 'Invalid content collection config',
-				message: `\`slug\` is a reserved frontmatter property for slug generation. Remove it from your ${JSON.stringify(entry.collection)} collection schema.`,
+				message: `\`slug\` is a reserved frontmatter property for slug generation. Remove it from your ${JSON.stringify(
+					entry.collection
+				)} collection schema.`,
 				hint: 'See https://docs.astro.build/en/guides/content-collections/ for more on the `slug` frontmatter property',
 				code: 99999,
 			});

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -90,12 +90,8 @@ export async function getEntryData(entry: Entry, collectionConfig: CollectionCon
 			collectionConfig.schema.shape.slug
 		) {
 			throw new AstroError({
-				title: 'Invalid content collection config',
-				message: `\`slug\` is a reserved frontmatter property for slug generation. Remove it from your ${JSON.stringify(
-					entry.collection
-				)} collection schema.`,
-				hint: 'See https://docs.astro.build/en/guides/content-collections/ for more on the `slug` frontmatter property',
-				code: 99999,
+				...AstroErrorData.ContentSchemaContainsSlugError,
+				message: AstroErrorData.ContentSchemaContainsSlugError.message(entry.collection),
 			});
 		}
 		// Use `safeParseAsync` to allow async transforms

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -63,16 +63,17 @@ export const msg = {
 		`${collection} does not have a config. We suggest adding one for type safety!`,
 };
 
-export async function getEntrySlug(entry: Entry, collectionConfig: CollectionConfig) {
-	return (
-		collectionConfig.slug?.({
-			id: entry.id,
-			data: entry.data,
-			defaultSlug: entry.slug,
-			collection: entry.collection,
-			body: entry.body,
-		}) ?? entry.slug
-	);
+export function getEntrySlug({id, collection, slug, data: unparsedData}: Entry){ 
+	try {
+		return z.string().default(slug).parse(unparsedData.slug);
+	} catch {
+		throw new AstroError({
+			title: 'Invalid content entry slug',
+			message: `${String(collection)} → ${String(id)} has an invalid frontmatter slug. \`slug\` must be a string.`,
+			hint: 'See our docs for more information about the reserved `slug` field: https://docs.astro.build/en/guides/content-collections/',
+			code: 99999,
+		});
+	}
 }
 
 export async function getEntryData(entry: Entry, collectionConfig: CollectionConfig) {

--- a/packages/astro/src/content/vite-plugin-content-server.ts
+++ b/packages/astro/src/content/vite-plugin-content-server.ts
@@ -137,13 +137,12 @@ export function astroContentServerPlugin({
 
 					const _internal = { filePath: fileId, rawData };
 					const partialEntry = { data: unparsedData, body, _internal, ...entryInfo };
+					const slug = getEntrySlug(partialEntry);
+					
 					const collectionConfig = contentConfig?.collections[entryInfo.collection];
 					const data = collectionConfig
 						? await getEntryData(partialEntry, collectionConfig)
 						: unparsedData;
-					const slug = collectionConfig
-						? await getEntrySlug({ ...partialEntry, data }, collectionConfig)
-						: entryInfo.slug;
 
 					const code = escapeViteEnvReferences(`
 export const id = ${JSON.stringify(entryInfo.id)};

--- a/packages/astro/src/content/vite-plugin-content-server.ts
+++ b/packages/astro/src/content/vite-plugin-content-server.ts
@@ -137,6 +137,8 @@ export function astroContentServerPlugin({
 
 					const _internal = { filePath: fileId, rawData };
 					const partialEntry = { data: unparsedData, body, _internal, ...entryInfo };
+					// TODO: move slug calculation to the start of the build
+					// to generate a performant lookup map for `getEntryBySlug`
 					const slug = getEntrySlug(partialEntry);
 					
 					const collectionConfig = contentConfig?.collections[entryInfo.collection];

--- a/packages/astro/src/content/vite-plugin-content-server.ts
+++ b/packages/astro/src/content/vite-plugin-content-server.ts
@@ -140,7 +140,7 @@ export function astroContentServerPlugin({
 					// TODO: move slug calculation to the start of the build
 					// to generate a performant lookup map for `getEntryBySlug`
 					const slug = getEntrySlug(partialEntry);
-					
+
 					const collectionConfig = contentConfig?.collections[entryInfo.collection];
 					const data = collectionConfig
 						? await getEntryData(partialEntry, collectionConfig)

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -499,30 +499,6 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	},
 	/**
 	 * @docs
-	 * @message
-	 * **Example error message:**<br/>
-	 * Could not parse frontmatter in **blog** → **post.md**<br/>
-	 * "title" is required.<br/>
-	 * "date" must be a valid date.
-	 * @description
-	 * A Markdown document's frontmatter in `src/content/` does not match its collection schema.
-	 * Make sure that all required fields are present, and that all fields are of the correct type.
-	 * You can check against the collection schema in your `src/content/config.*` file.
-	 * See the [Content collections documentation](https://docs.astro.build/en/guides/content-collections/) for more information.
-	 */
-	MarkdownContentSchemaValidationError: {
-		title: 'Content collection frontmatter invalid.',
-		code: 6002,
-		message: (collection: string, entryId: string, error: ZodError) => {
-			return [
-				`${String(collection)} → ${String(entryId)} frontmatter does not match collection schema.`,
-				...error.errors.map((zodError) => zodError.message),
-			].join('\n');
-		},
-		hint: 'See https://docs.astro.build/en/guides/content-collections/ for more information on content schemas.',
-	},
-	/**
-	 * @docs
 	 * @see
 	 * - [Modifying frontmatter programmatically](https://docs.astro.build/en/guides/markdown-content/#modifying-frontmatter-programmatically)
 	 * @description
@@ -602,6 +578,57 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 		code: 8001,
 		message: '`astro sync` command failed to generate content collection types.',
 		hint: 'Check your `src/content/config.*` file for typos.',
+	},
+	/**
+	 * @docs
+	 * @kind heading
+	 * @name Content Collection Errors
+	 */
+	// Content Collection Errors - 9xxx
+	UnknownContentCollectionError: {
+		title: 'Unknown Content Collection Error.',
+		code: 9000,
+	},
+	/**
+	 * @docs
+	 * @message
+	 * **Example error message:**<br/>
+	 * **blog** → **post.md** frontmatter does not match collection schema.<br/>
+	 * "title" is required.<br/>
+	 * "date" must be a valid date.
+	 * @description
+	 * A Markdown or MDX entry in `src/content/` does not match its collection schema.
+	 * Make sure that all required fields are present, and that all fields are of the correct type.
+	 * You can check against the collection schema in your `src/content/config.*` file.
+	 * See the [Content collections documentation](https://docs.astro.build/en/guides/content-collections/) for more information.
+	 */
+	InvalidContentEntryFrontmatterError: {
+		title: 'Content entry frontmatter does not match schema.',
+		code: 9001,
+		message: (collection: string, entryId: string, error: ZodError) => {
+			return [
+				`${String(collection)} → ${String(entryId)} frontmatter does not match collection schema.`,
+				...error.errors.map((zodError) => zodError.message),
+			].join('\n');
+		},
+		hint: 'See https://docs.astro.build/en/guides/content-collections/ for more information on content schemas.',
+	},
+	/**
+	 * @docs
+	 * @see
+	 * - [The reserved entry `slug` field](https://docs.astro.build/en/guides/content-collections/)
+	 * @description
+	 * An entry in `src/content/` has an invalid `slug`. This field is reserved for generating entry slugs, and must be a string when present.
+	 */
+	InvalidContentEntrySlugError: {
+		title: 'Invalid content entry slug.',
+		code: 9002,
+		message: (collection: string, entryId: string) => {
+			return `${String(collection)} → ${String(
+				entryId
+			)} has an invalid slug. \`slug\` must be a string.`;
+		},
+		hint: 'See our docs for more information about the reserved `slug` field: https://docs.astro.build/en/guides/content-collections/',
 	},
 
 	// Generic catch-all

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -628,7 +628,22 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 				entryId
 			)} has an invalid slug. \`slug\` must be a string.`;
 		},
-		hint: 'See our docs for more information about the reserved `slug` field: https://docs.astro.build/en/guides/content-collections/',
+		hint: 'See https://docs.astro.build/en/guides/content-collections/ for more on the `slug` field.',
+	},
+	/**
+	 * @docs
+	 * @see
+	 * - [The reserved entry `slug` field](https://docs.astro.build/en/guides/content-collections/)
+	 * @description
+	 * A content collection schema should not contain the `slug` field. This is reserved by Astro for generating entry slugs. Remove the `slug` field from your schema, or choose a different name.
+	 */
+	ContentSchemaContainsSlugError: {
+		title: 'Content Schema should not contain `slug`.',
+		code: 9003,
+		message: (collection: string) => {
+			return `A content collection schema should not contain \`slug\` since it is reserved for slug generation. Remove this from your ${collection} collection schema.`;
+		},
+		hint: 'See https://docs.astro.build/en/guides/content-collections/ for more on the `slug` field.',
 	},
 
 	// Generic catch-all

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -70,7 +70,7 @@ describe('Content Collections', () => {
 				expect(Array.isArray(json.withSlugConfig)).to.equal(true);
 
 				const slugs = json.withSlugConfig.map((item) => item.slug);
-				expect(slugs).to.deep.equal(['fancy-one.md', 'excellent-three.md', 'interesting-two.md']);
+				expect(slugs).to.deep.equal(['fancy-one', 'excellent-three', 'interesting-two']);
 			});
 
 			it('Returns `with union schema` collection', async () => {
@@ -116,7 +116,7 @@ describe('Content Collections', () => {
 
 			it('Returns `with custom slugs` collection entry', async () => {
 				expect(json).to.haveOwnProperty('twoWithSlugConfig');
-				expect(json.twoWithSlugConfig.slug).to.equal('interesting-two.md');
+				expect(json.twoWithSlugConfig.slug).to.equal('interesting-two');
 			});
 
 			it('Returns `with union schema` collection entry', async () => {

--- a/packages/astro/test/fixtures/content-collections/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections/src/content/config.ts
@@ -1,12 +1,7 @@
 import { z, defineCollection } from 'astro:content';
 
-const withSlugConfig = defineCollection({
-	slug({ id, data }) {
-		return `${data.prefix}-${id}`;
-	},
-	schema: z.object({
-		prefix: z.string(),
-	}),
+const withCustomSlugs = defineCollection({
+	schema: z.object({}),
 });
 
 const withSchemaConfig = defineCollection({
@@ -33,7 +28,7 @@ const withUnionSchema = defineCollection({
 });
 
 export const collections = {
-	'with-slug-config': withSlugConfig,
+	'with-custom-slugs': withCustomSlugs,
 	'with-schema-config': withSchemaConfig,
 	'with-union-schema': withUnionSchema,
 }

--- a/packages/astro/test/fixtures/content-collections/src/content/with-custom-slugs/one.md
+++ b/packages/astro/test/fixtures/content-collections/src/content/with-custom-slugs/one.md
@@ -1,5 +1,5 @@
 ---
-prefix: fancy
+slug: fancy-one
 ---
 
 # It's the first page, fancy!

--- a/packages/astro/test/fixtures/content-collections/src/content/with-custom-slugs/three.md
+++ b/packages/astro/test/fixtures/content-collections/src/content/with-custom-slugs/three.md
@@ -1,5 +1,5 @@
 ---
-prefix: excellent
+slug: excellent-three
 ---
 
 # It's the third page, excellent!

--- a/packages/astro/test/fixtures/content-collections/src/content/with-custom-slugs/two.md
+++ b/packages/astro/test/fixtures/content-collections/src/content/with-custom-slugs/two.md
@@ -1,5 +1,5 @@
 ---
-prefix: interesting
+slug: interesting-two
 ---
 
 # It's the second page, interesting!

--- a/packages/astro/test/fixtures/content-collections/src/pages/collections.json.js
+++ b/packages/astro/test/fixtures/content-collections/src/pages/collections.json.js
@@ -5,7 +5,7 @@ import { stripAllRenderFn } from '../utils.js';
 export async function get() {
 	const withoutConfig = stripAllRenderFn(await getCollection('without-config'));
 	const withSchemaConfig = stripAllRenderFn(await getCollection('with-schema-config'));
-	const withSlugConfig = stripAllRenderFn(await getCollection('with-slug-config'));
+	const withSlugConfig = stripAllRenderFn(await getCollection('with-custom-slugs'));
 	const withUnionSchema = stripAllRenderFn(await getCollection('with-union-schema'));
 
 	return {

--- a/packages/astro/test/fixtures/content-collections/src/pages/entries.json.js
+++ b/packages/astro/test/fixtures/content-collections/src/pages/entries.json.js
@@ -5,7 +5,7 @@ import { stripRenderFn } from '../utils.js';
 export async function get() {
 	const columbiaWithoutConfig = stripRenderFn(await getEntryBySlug('without-config', 'columbia'));
 	const oneWithSchemaConfig = stripRenderFn(await getEntryBySlug('with-schema-config', 'one'));
-	const twoWithSlugConfig = stripRenderFn(await getEntryBySlug('with-slug-config', 'interesting-two.md'));
+	const twoWithSlugConfig = stripRenderFn(await getEntryBySlug('with-custom-slugs', 'interesting-two'));
 	const postWithUnionSchema = stripRenderFn(await getEntryBySlug('with-union-schema', 'post'));
 
 	return {


### PR DESCRIPTION
## Changes

- Remove `slug()` collection configuration option
- Add special handling for the `slug` frontmatter property
  - Override generated slug with the `slug` frontmatter property when present
  - Respect `slug` during type generation
  - Exclude `slug` from schema parsing
- Raise error when `slug` is present in a schema. Otherwise, users may attempt to use `.transform()` to manipulate slugs, and be surprised when this is not respected
- Chore: add new 9xxx error heading for content collection errors

## Testing

Update tests to use `slug` frontmatter property

## Docs

- New error messages
- TODO: docs updates