### PR TITLE
Migrate CHANGELOGs from `1-legacy` branch

### DIFF
--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -378,6 +378,18 @@
 - Updated dependencies [[`e2019be6f`](https://github.com/withastro/astro/commit/e2019be6ffa46fa33d92cfd346f9ecbe51bb7144), [`a9c292026`](https://github.com/withastro/astro/commit/a9c2920264e36cc5dc05f4adc1912187979edb0d)]:
   - @astrojs/markdown-remark@2.0.0-beta.0
 
+## 1.9.2
+
+### Patch Changes
+
+- [#5776](https://github.com/withastro/astro/pull/5776) [`6a31433ed`](https://github.com/withastro/astro/commit/6a31433ed79c7f84fd3ce602005b42ad95007d84) Thanks [@ba55ie](https://github.com/ba55ie)! - Fix Lit slotted content
+
+## 1.9.1
+
+### Patch Changes
+
+- [`adad7e966`](https://github.com/withastro/astro/commit/adad7e96680640e1d0a5ec270cd2516f350c7652) Thanks [@matthewp](https://github.com/matthewp)! - Fix for hoisted scripts in project with spaces in the file path
+
 ## 1.9.0
 
 ### Minor Changes

--- a/packages/integrations/lit/CHANGELOG.md
+++ b/packages/integrations/lit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @astrojs/lit
 
+## 1.0.2
+
+### Patch Changes
+
+- [#5776](https://github.com/withastro/astro/pull/5776) [`6a31433ed`](https://github.com/withastro/astro/commit/6a31433ed79c7f84fd3ce602005b42ad95007d84) Thanks [@ba55ie](https://github.com/ba55ie)! - Fix Lit slotted content
+
 ## 1.0.2-beta.0
 
 ### Patch Changes


### PR DESCRIPTION
## Changes

- Copies over changes merged into `1-legacy`
- Changesets respects these manual changes, so they won't be wiped out by the automatic updates when we release.

## Testing

N/A

## Docs

N/A