### PR TITLE
[Content collections] Support type guards on `getCollection()` filter

### DIFF
--- a/.changeset/strong-hotels-sort.md
+++ b/.changeset/strong-hotels-sort.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add type guard support to filters on `getCollection()`

--- a/packages/astro/src/content/template/types.d.ts
+++ b/packages/astro/src/content/template/types.d.ts
@@ -44,10 +44,10 @@ declare module 'astro:content' {
 	): E extends ValidEntrySlug<C>
 		? Promise<CollectionEntry<C>>
 		: Promise<CollectionEntry<C> | undefined>;
-	export function getCollection<C extends keyof typeof entryMap>(
+	export function getCollection<C extends keyof typeof entryMap, E extends CollectionEntry<C>>(
 		collection: C,
-		filter?: (data: CollectionEntry<C>) => boolean
-	): Promise<CollectionEntry<C>[]>;
+		filter?: (entry: CollectionEntry<C>) => entry is E
+	): Promise<E[]>;
 
 	type InferEntrySchema<C extends keyof typeof entryMap> = import('astro/zod').infer<
 		Required<ContentConfig['collections'][C]>['schema']


### PR DESCRIPTION
## Changes

- Add type guard support for `getCollection()` filters

## Testing

Manual testing

## Docs

N/A