### PR TITLE
Upgrade semver dependency

### DIFF
--- a/.changeset/swift-toes-divide.md
+++ b/.changeset/swift-toes-divide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Correctly detect Node.js version

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -136,7 +136,7 @@
     "preferred-pm": "^3.0.3",
     "prompts": "^2.4.2",
     "rehype": "^12.0.1",
-    "semver": "^7.3.7",
+    "semver": "^7.3.8",
     "server-destroy": "^1.0.1",
     "shiki": "^0.11.1",
     "slash": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,7 +446,7 @@ importers:
       remark-code-titles: ^0.1.2
       rollup: ^3.9.0
       sass: ^1.52.2
-      semver: ^7.3.7
+      semver: ^7.3.8
       server-destroy: ^1.0.1
       shiki: ^0.11.1
       slash: ^4.0.0


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/5967

Upgrade semver to bring in the fix from https://github.com/npm/node-semver/pull/383, to allow `await import` to work properly.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested manually.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.