### PR TITLE
[astro/component] 

### DIFF
--- a/.changeset/orange-bottles-attack.md
+++ b/.changeset/orange-bottles-attack.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Adds an inline attribute to render code in the <Code /> component as inline code without the pre tag.

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -1,5 +1,6 @@
 ---
 import type * as shiki from 'shiki';
+import { renderToHtml } from 'shiki';
 import { getHighlighter } from './Shiki.js';
 
 export interface Props {
@@ -30,14 +31,30 @@ export interface Props {
 	 * @default false
 	 */
 	wrap?: boolean | null;
+	/**
+	 * Supports rendering for inline code, i.e. just code in a <code></code> tag.
+	 *  - true: removes the base pre tag.
+	 *  - false: uses the default shiki code-block, with the pre tag.
+	 *
+	 * @default false
+	 */
+	inline?: boolean;
 }
 
-const { code, lang = 'plaintext', theme = 'github-dark', wrap = false } = Astro.props;
+const {
+	code,
+	lang = 'plaintext',
+	theme = 'github-dark',
+	wrap = false,
+	inline = false,
+} = Astro.props;
 
 /** Replace the shiki class name with a custom astro class name. */
 function repairShikiTheme(html: string): string {
-	// Replace "shiki" class naming with "astro"
-	html = html.replace(/<pre class="(.*?)shiki(.*?)"/, '<pre class="$1astro-code$2"');
+	// Replace "shiki" class naming with "astro" only if it is a code block (not inline)
+	if (!inline) {
+		html = html.replace(/<pre class="(.*?)shiki(.*?)"/, '<pre class="$1astro-code$2"');
+	}
 	// Handle code wrapping
 	// if wrap=null, do nothing.
 	if (wrap === false) {
@@ -56,10 +73,27 @@ const highlighter = await getHighlighter({
 	// Load custom lang if passed an object, otherwise load the default
 	langs: typeof lang !== 'string' ? [lang] : undefined,
 });
-const _html = highlighter.codeToHtml(code, {
-	lang: typeof lang === 'string' ? lang : lang.id,
-	theme,
+
+// Find the name of the language used and theme
+const languageName = typeof lang === 'string' ? lang : lang.id;
+const _theme = highlighter.getTheme(theme);
+
+// We do this step manually instead of using highlighter.codeToHtml so as to parse inline code
+const tokens = highlighter.codeToThemedTokens(code, languageName, theme, {
+	includeExplanation: false,
 });
+const _html = renderToHtml(tokens, {
+	fg: _theme.fg,
+	bg: _theme.bg,
+	themeName: _theme.name,
+	// disables the usage of pre tag for inline codeblocks
+	elements: inline ? {
+		pre({ children }) {
+			return `${children}`;
+		},
+	} : undefined,
+});
+
 const html = repairShikiTheme(_html);
 ---
 

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -138,7 +138,7 @@
     "rehype": "^12.0.1",
     "semver": "^7.3.8",
     "server-destroy": "^1.0.1",
-    "shiki": "^0.11.1",
+    "shiki": "^0.12.1",
     "slash": "^4.0.0",
     "string-width": "^5.1.2",
     "strip-ansi": "^7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,7 +448,7 @@ importers:
       sass: ^1.52.2
       semver: ^7.3.8
       server-destroy: ^1.0.1
-      shiki: ^0.11.1
+      shiki: ^0.12.1
       slash: ^4.0.0
       srcset-parse: ^1.1.0
       string-width: ^5.1.2
@@ -504,7 +504,7 @@ importers:
       rehype: 12.0.1
       semver: 7.3.8
       server-destroy: 1.0.1
-      shiki: 0.11.1
+      shiki: 0.12.1
       slash: 4.0.0
       string-width: 5.1.2
       strip-ansi: 7.0.1
@@ -13884,6 +13884,14 @@ packages:
       vscode-oniguruma: 1.7.0
       vscode-textmate: 6.0.0
 
+  /shiki/0.12.1:
+    resolution: {integrity: sha512-aieaV1m349rZINEBkjxh2QbBvFFQOlgqYTNtCal82hHj4dDZ76oMlQIX+C7ryerBTDiga3e5NfH6smjdJ02BbQ==}
+    dependencies:
+      jsonc-parser: 3.2.0
+      vscode-oniguruma: 1.7.0
+      vscode-textmate: 8.0.0
+    dev: false
+
   /side-channel/1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
@@ -15333,6 +15341,10 @@ packages:
 
   /vscode-textmate/6.0.0:
     resolution: {integrity: sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==}
+
+  /vscode-textmate/8.0.0:
+    resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
+    dev: false
 
   /vscode-uri/2.1.2:
     resolution: {integrity: sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==}


### PR DESCRIPTION
## Changes
This adds an inline attribute to render code in the `<Code />` component as inline code without the pre tag.
This PR is related to the issue: #5912 

## Testing
No tests were present for the `<Code />` component.

## Docs
Is this, along with the other attributes necessary to be documented? The current docs on it is pretty barebones. I'm willing to add a PR, if necessary.
/cc @withastro/maintainers-docs for feedback!
