### PR TITLE
Fix MDX heading IDs generation when using a frontmatter reference

### DIFF
--- a/.changeset/eighty-knives-remain.md
+++ b/.changeset/eighty-knives-remain.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/mdx': patch
+'@astrojs/markdown-remark': patch
+---
+
+Fix MDX heading IDs generation when using a frontmatter reference

--- a/packages/integrations/mdx/test/fixtures/mdx-get-headings/src/pages/test-with-frontmatter.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-get-headings/src/pages/test-with-frontmatter.mdx
@@ -1,0 +1,45 @@
+---
+title: The Frontmatter Title
+keywords: [Keyword 1, Keyword 2, Keyword 3]
+tags:
+  - Tag 1
+  - Tag 2
+  - Tag 3
+items:
+  - value: Item 1
+  - value: Item 2
+  - value: Item 3
+nested_items:
+  nested:
+    - value: Nested Item 1
+    - value: Nested Item 2
+    - value: Nested Item 3
+---
+
+# {frontmatter.title}
+
+This ID should be the frontmatter title.
+
+## frontmatter.title
+
+The ID should not be the frontmatter title.
+
+### {frontmatter.keywords[1]}
+
+The ID should be the frontmatter keyword #2.
+
+### {frontmatter.tags[0]}
+
+The ID should be the frontmatter tag #1.
+
+#### {frontmatter.items[1].value}
+
+The ID should be the frontmatter item #2.
+
+##### {frontmatter.nested_items.nested[2].value}
+
+The ID should be the frontmatter nested item #3.
+
+###### {frontmatter.unknown}
+
+This ID should not reference the frontmatter.

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.1",
+    "@types/estree": "^1.0.0",
     "@types/github-slugger": "^1.3.0",
     "@types/hast": "^2.3.4",
     "@types/mdast": "^3.0.10",
@@ -51,6 +52,7 @@
     "@types/unist": "^2.0.6",
     "astro-scripts": "workspace:*",
     "chai": "^4.3.6",
+    "mdast-util-mdx-expression": "^1.3.1",
     "mocha": "^9.2.2"
   }
 }

--- a/packages/markdown/remark/src/rehype-collect-headings.ts
+++ b/packages/markdown/remark/src/rehype-collect-headings.ts
@@ -14,6 +14,7 @@ export function rehypeHeadingIds(): ReturnType<RehypePlugin> {
 		const headings: MarkdownHeading[] = [];
 		const slugger = new Slugger();
 		const isMDX = isMDXFile(file);
+		const astroData = safelyGetAstroData(file.data);
 		visit(tree, (node) => {
 			if (node.type !== 'element') return;
 			const { tagName } = node;
@@ -35,7 +36,6 @@ export function rehypeHeadingIds(): ReturnType<RehypePlugin> {
 				if (rawNodeTypes.has(child.type)) {
 					if (isMDX || codeTagNames.has(parent.tagName)) {
 						let value = child.value;
-						const astroData = safelyGetAstroData(file.data);
 						if (isMdxTextExpression(child) && !(astroData instanceof InvalidAstroDataError)) {
 							const frontmatterPath = getMdxFrontmatterVariablePath(child);
 							if (Array.isArray(frontmatterPath) && frontmatterPath.length > 0) {
@@ -82,7 +82,7 @@ function getMdxFrontmatterVariablePath(node: MdxTextExpression): string[] | Erro
 	const statement = node.data.estree.body[0];
 
 	// Check for "[ANYTHING].[ANYTHING]".
-	if (statement.type !== 'ExpressionStatement' || statement.expression.type !== 'MemberExpression')
+	if (statement?.type !== 'ExpressionStatement' || statement.expression.type !== 'MemberExpression')
 		return new Error();
 
 	let expression: Expression | Super = statement.expression;

--- a/packages/markdown/remark/src/rehype-collect-headings.ts
+++ b/packages/markdown/remark/src/rehype-collect-headings.ts
@@ -1,7 +1,10 @@
+import { type Expression, type Super } from 'estree';
 import Slugger from 'github-slugger';
-import { visit } from 'unist-util-visit';
+import { type MdxTextExpression } from 'mdast-util-mdx-expression';
+import { visit, type Node } from 'unist-util-visit';
 
-import type { MarkdownHeading, MarkdownVFile, RehypePlugin } from './types.js';
+import { InvalidAstroDataError, safelyGetAstroData } from './frontmatter-injection.js';
+import type { MarkdownAstroData, MarkdownHeading, MarkdownVFile, RehypePlugin } from './types.js';
 
 const rawNodeTypes = new Set(['text', 'raw', 'mdxTextExpression']);
 const codeTagNames = new Set(['code', 'pre']);
@@ -31,7 +34,18 @@ export function rehypeHeadingIds(): ReturnType<RehypePlugin> {
 				}
 				if (rawNodeTypes.has(child.type)) {
 					if (isMDX || codeTagNames.has(parent.tagName)) {
-						text += child.value;
+						let value = child.value;
+						const astroData = safelyGetAstroData(file.data);
+						if (isMdxTextExpression(child) && !(astroData instanceof InvalidAstroDataError)) {
+							const frontmatterPath = getMdxFrontmatterVariablePath(child);
+							if (Array.isArray(frontmatterPath) && frontmatterPath.length > 0) {
+								const frontmatterValue = getMdxFrontmatterVariableValue(astroData, frontmatterPath);
+								if (typeof frontmatterValue === 'string') {
+									value = frontmatterValue;
+								}
+							}
+						}
+						text += value;
 					} else {
 						text += child.value.replace(/\{/g, '${');
 					}
@@ -57,3 +71,58 @@ export function rehypeHeadingIds(): ReturnType<RehypePlugin> {
 function isMDXFile(file: MarkdownVFile) {
 	return Boolean(file.history[0]?.endsWith('.mdx'));
 }
+
+/**
+ * Check if an ESTree entry is `frontmatter.*.VARIABLE`.
+ * If it is, return the variable path (i.e. `["*", ..., "VARIABLE"]`) minus the `frontmatter` prefix.
+ */
+function getMdxFrontmatterVariablePath(node: MdxTextExpression): string[] | Error {
+	if (!node.data?.estree || node.data.estree.body.length !== 1) return new Error();
+
+	const statement = node.data.estree.body[0];
+
+	// Check for "[ANYTHING].[ANYTHING]".
+	if (statement.type !== 'ExpressionStatement' || statement.expression.type !== 'MemberExpression')
+		return new Error();
+
+	let expression: Expression | Super = statement.expression;
+	const expressionPath: string[] = [];
+
+	// Traverse the expression, collecting the variable path.
+	while (
+		expression.type === 'MemberExpression' &&
+		expression.property.type === (expression.computed ? 'Literal' : 'Identifier')
+	) {
+		expressionPath.push(
+			expression.property.type === 'Literal'
+				? String(expression.property.value)
+				: expression.property.name
+		);
+
+		expression = expression.object;
+	}
+
+	// Check for "frontmatter.[ANYTHING]".
+	if (expression.type !== 'Identifier' || expression.name !== 'frontmatter') return new Error();
+
+	return expressionPath.reverse();
+}
+
+function getMdxFrontmatterVariableValue(astroData: MarkdownAstroData, path: string[]) {
+	let value: MdxFrontmatterVariableValue = astroData.frontmatter;
+
+	for (const key of path) {
+		if (!value[key]) return undefined;
+
+		value = value[key];
+	}
+
+	return value;
+}
+
+function isMdxTextExpression(node: Node): node is MdxTextExpression {
+	return node.type === 'mdxTextExpression';
+}
+
+type MdxFrontmatterVariableValue =
+	MarkdownAstroData['frontmatter'][keyof MarkdownAstroData['frontmatter']];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3492,6 +3492,7 @@ importers:
     specifiers:
       '@astrojs/prism': ^2.0.0
       '@types/chai': ^4.3.1
+      '@types/estree': ^1.0.0
       '@types/github-slugger': ^1.3.0
       '@types/hast': ^2.3.4
       '@types/mdast': ^3.0.10
@@ -3501,6 +3502,7 @@ importers:
       chai: ^4.3.6
       github-slugger: ^1.4.0
       import-meta-resolve: ^2.1.0
+      mdast-util-mdx-expression: ^1.3.1
       mocha: ^9.2.2
       rehype-raw: ^6.1.1
       rehype-stringify: ^9.0.3
@@ -3528,6 +3530,7 @@ importers:
       vfile: 5.3.6
     devDependencies:
       '@types/chai': 4.3.4
+      '@types/estree': 1.0.0
       '@types/github-slugger': 1.3.0
       '@types/hast': 2.3.4
       '@types/mdast': 3.0.10
@@ -3535,6 +3538,7 @@ importers:
       '@types/unist': 2.0.6
       astro-scripts: link:../../../scripts
       chai: 4.3.7
+      mdast-util-mdx-expression: 1.3.1
       mocha: 9.2.2
 
   packages/telemetry:


### PR DESCRIPTION
## Changes

This PR fixes #5780.

When using a frontmatter reference in a MDX heading, the ID generated for the heading is not using the reference value. For example,

```mdx
---
title: The Title
---

# {frontmatter.title}
```

would generate `<h1 id="frontmattertitle">The Title</h1>` instead of `<h1 id="the-title">The Title</h1>`.

This pull request updates the `@astrojs/markdown-remark` rehype plugin generating these IDs to fix this behavior:

1. For MDX document, if the heading is a `MDXTextExpression`, e.g. `# {frontmatter.title}`, the plugin will use the associated ESTree entry to get the variable path, e.g. `['frontmatter', 'title']`.
2. If the variable is referencing a frontmatter value, the plugin try to get the value from the Astro data containing the frontmatter.
3. If the value is found, the plugin will use it to generate the heading ID.

*Note: the added dev dependencies to `@astrojs/markdown-remark` are only used to reference types.*

## Testing

I added a new fixtures `test-with-frontmatter.mdx` to the `@astrojs/mdx` test suite to test the changes.

The tests covers various cases and syntaxes from a basic variable to nested list items:

```mdx
---
title: The Frontmatter Title
keywords: [Keyword 1, Keyword 2, Keyword 3]
tags:
  - Tag 1
  - Tag 2
  - Tag 3
items:
  - value: Item 1
  - value: Item 2
  - value: Item 3
nested_items:
  nested:
    - value: Nested Item 1
    - value: Nested Item 2
    - value: Nested Item 3
---

# {frontmatter.title}
## frontmatter.title
### {frontmatter.keywords[1]}
### {frontmatter.tags[0]}
#### {frontmatter.items[1].value}
##### {frontmatter.nested_items.nested[2].value}
###### {frontmatter.unknown}
```

## Docs

I could not find any specific mention regarding this specific behavior in the docs and I'm not sure if it's worth mentioning it.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->