### PR TITLE
Handle unmatched 404 when using prerender in dev mode

### DIFF
--- a/.changeset/fluffy-cherries-shake.md
+++ b/.changeset/fluffy-cherries-shake.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a dev server edge case where prerender + getStaticPaths would not 404 on an unmatched route

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -47,7 +47,7 @@ export async function getParamsAndProps(
 			routeCache.set(route, routeCacheEntry);
 		}
 		const matchedStaticPath = findPathItemByKey(routeCacheEntry.staticPaths, params, route);
-		if (!matchedStaticPath && !ssr) {
+		if (!matchedStaticPath && (ssr ? mod.prerender : true)) {
 			return GetParamsAndPropsError.NoMatchingStaticPath;
 		}
 		// Note: considered using Object.create(...) for performance

--- a/packages/astro/test/ssr-prerender-get-static-paths.test.js
+++ b/packages/astro/test/ssr-prerender-get-static-paths.test.js
@@ -72,7 +72,9 @@ describe('prerender getStaticPaths - 404 behavior', () => {
 
 	it('resolves 404 on pattern match without static path - named params', async () => {
 		const res = await fixture.fetch('/pizza/provolone-pineapple');
+		const html = await res.text();
 		expect(res.status).to.equal(404);
+		expect(html).to.match(/404/);
 	});
 
 	it('resolves 200 on matching static path - rest params', async () => {
@@ -82,7 +84,9 @@ describe('prerender getStaticPaths - 404 behavior', () => {
 
 	it('resolves 404 on pattern match without static path - rest params', async () => {
 		const res = await fixture.fetch('/pizza/pizza-hut');
+		const html = await res.text();
 		expect(res.status).to.equal(404);
+		expect(html).to.match(/404/);
 	});
 });
 


### PR DESCRIPTION
## Changes

- Closes #5975
- In static mode, routes that match a dynamic route but don't match a returned `getStaticPaths` call return 404
- This was not the case when using `prerender` in server mode in the dev server
- This PR updates our logic to account for prerender when `ssr` is true

## Testing

Tests updated

## Docs

Bug fix only
