### PR TITLE
Fix `Astro.url.protocol` when using the @astrojs/node SSR adapter with HTTPS

### DIFF
--- a/.changeset/odd-rats-drop.md
+++ b/.changeset/odd-rats-drop.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/node': patch
+---
+
+Fix `Astro.url.protocol` when using the @astrojs/node SSR adapter with HTTPS

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -3,13 +3,18 @@ import type { SerializedSSRManifest, SSRManifest } from './types';
 
 import * as fs from 'fs';
 import { IncomingMessage } from 'http';
+import { TLSSocket } from 'tls';
 import { deserializeManifest } from './common.js';
 import { App, MatchOptions } from './index.js';
 
 const clientAddressSymbol = Symbol.for('astro.clientAddress');
 
 function createRequestFromNodeRequest(req: IncomingMessage, body?: Uint8Array): Request {
-	let url = `http://${req.headers.host}${req.url}`;
+	const protocol =
+		req.socket instanceof TLSSocket || req.headers['x-forwarded-proto'] === 'https'
+			? 'https'
+			: 'http';
+	let url = `${protocol}://${req.headers.host}${req.url}`;
 	let rawHeaders = req.headers as Record<string, any>;
 	const entries = Object.entries(rawHeaders);
 	const method = req.method || 'GET';

--- a/packages/integrations/node/src/standalone.ts
+++ b/packages/integrations/node/src/standalone.ts
@@ -1,4 +1,5 @@
 import type { NodeApp } from 'astro/app/node';
+import https from 'https';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { createServer } from './http-server.js';
@@ -53,8 +54,9 @@ export default function startServer(app: NodeApp, options: Options) {
 		handler
 	);
 
+	const protocol = server.server instanceof https.Server ? 'https' : 'http';
 	// eslint-disable-next-line no-console
-	console.log(`Server listening on http://${host}:${port}`);
+	console.log(`Server listening on ${protocol}://${host}:${port}`);
 
 	return server.closed();
 }

--- a/packages/integrations/node/test/fixtures/url-protocol/package.json
+++ b/packages/integrations/node/test/fixtures/url-protocol/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/url-protocol",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/node": "workspace:*"
+  }
+}

--- a/packages/integrations/node/test/fixtures/url-protocol/src/pages/index.astro
+++ b/packages/integrations/node/test/fixtures/url-protocol/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+---
+
+<html lang="en">
+  <head>
+    <title>url-protocol</title>
+  </head>
+  <body>
+    {Astro.url.protocol}
+  </body>
+</html>

--- a/packages/integrations/node/test/url-protocol.test.js
+++ b/packages/integrations/node/test/url-protocol.test.js
@@ -1,0 +1,73 @@
+import { TLSSocket } from 'tls';
+import nodejs from '../dist/index.js';
+import { loadFixture, createRequestAndResponse } from './test-utils.js';
+import { expect } from 'chai';
+
+describe('URL protocol', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/url-protocol/',
+			output: 'server',
+			adapter: nodejs({ mode: 'standalone' }),
+		});
+		await fixture.build();
+	});
+
+	it('return http when non-secure', async () => {
+		const { handler } = await import('./fixtures/url-protocol/dist/server/entry.mjs');
+		let { req, res, text } = createRequestAndResponse({
+			url: '/',
+		});
+
+		handler(req, res);
+		req.send();
+
+		const html = await text();
+		expect(html).to.include('http:');
+	});
+
+	it('return https when secure', async () => {
+		const { handler } = await import('./fixtures/url-protocol/dist/server/entry.mjs');
+		let { req, res, text } = createRequestAndResponse({
+			socket: new TLSSocket(),
+			url: '/',
+		});
+
+		handler(req, res);
+		req.send();
+
+		const html = await text();
+		expect(html).to.include('https:');
+	});
+
+	it('return http when the X-Forwarded-Proto header is set to http', async () => {
+		const { handler } = await import('./fixtures/url-protocol/dist/server/entry.mjs');
+		let { req, res, text } = createRequestAndResponse({
+			headers: { 'X-Forwarded-Proto': 'http' },
+			url: '/',
+		});
+
+		handler(req, res);
+		req.send();
+
+		const html = await text();
+		expect(html).to.include('http:');
+	});
+
+	it('return https when the X-Forwarded-Proto header is set to https', async () => {
+		const { handler } = await import('./fixtures/url-protocol/dist/server/entry.mjs');
+		let { req, res, text } = createRequestAndResponse({
+			headers: { 'X-Forwarded-Proto': 'https' },
+			url: '/',
+		});
+
+		handler(req, res);
+		req.send();
+
+		const html = await text();
+		expect(html).to.include('https:');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3109,6 +3109,14 @@ importers:
       '@astrojs/node': link:../../..
       astro: link:../../../../../astro
 
+  packages/integrations/node/test/fixtures/url-protocol:
+    specifiers:
+      '@astrojs/node': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/node': link:../../..
+      astro: link:../../../../../astro
+
   packages/integrations/node/test/fixtures/well-known-locations:
     specifiers:
       '@astrojs/node': workspace:*


### PR DESCRIPTION
## Changes

This PR fixes #5890.

When using Astro with the `@astrojs/node` SSR adapter, `Astro.url.protocol` is always `http:` even when the server is running with HTTPS.

When creating the request used during rendering based on the Node.js request, the protocol is currently [hardcoded to `http:`](https://github.com/withastro/astro/blob/d47a9075bf13617fb5545aec50b46a76044bf85d/packages/astro/src/core/app/node.ts#L12).

This pull request fixes this issue by checking if the Node.js request is using HTTPS and updating the protocol accordingly. To do so, we check if the request socket is either an instance of `tls.TLSSocket` or if the [`X-Forwarded-Proto` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto) is set to `https`.

While testing this, I also realised that when starting the server, the console is always logging a URL with the HTTP protocol, e.g. `Server listening on http://127.0.0.1:3000`. I decided to include a small change in this PR to log the proper protocol by checking if the server is an instance of `https.Server` or not. I thought this was not worth a different PR or even mentioning it in the changeset but maybe I was wrong?

## Testing

I added new `@astrojs/node` tests in a `url-protocol` suite using a fixture rendering a page with `Astro.url.protocol` and checking the rendered HTML based on the protocol of the Node.js request.

I also manually tested locally this change in a local repro using the `file:` pnpm protocol and confirmed that logging `Astro.url.protocol` correctly return `https:` when running with `SERVER_KEY_PATH=./key.pem SERVER_CERT_PATH=./cert.pem node ./dist/server/entry.mjs`

## Docs

I don't think this change needs to be documented.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->