### PR TITLE
Support for prerendering in the Cloudflare integration

### DIFF
--- a/.changeset/good-avocados-repeat.md
+++ b/.changeset/good-avocados-repeat.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Support for prerendering in the Cloudflare integration
+
+This fixes prerendering in the Cloudflare adapter. Now any prerendered routes are added to the `_routes.json` config so that the worker script is skipped for those routes.

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -49,7 +49,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					build: {
 						client: new URL(`.${config.base}`, config.outDir),
 						server: new URL(`.${SERVER_BUILD_FOLDER}`, config.outDir),
-						serverEntry: '_worker.js',
+						serverEntry: '_worker.mjs',
 					},
 				});
 			},
@@ -89,9 +89,12 @@ export default function createIntegration(args?: Options): AstroIntegration {
 				}
 			},
 			'astro:build:done': async () => {
+				console.log('BUILD DONE');
 				const entryPath = fileURLToPath(new URL(_buildConfig.serverEntry, _buildConfig.server)),
 					entryUrl = new URL(_buildConfig.serverEntry, _config.outDir),
 					buildPath = fileURLToPath(entryUrl);
+
+				console.log("ENTRY", buildPath);
 				await esbuild.build({
 					target: 'es2020',
 					platform: 'browser',

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -88,13 +88,11 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					vite.ssr.target = vite.ssr.target || 'webworker';
 				}
 			},
-			'astro:build:done': async () => {
-				console.log('BUILD DONE');
+			'astro:build:done': async ({ pages }) => {
 				const entryPath = fileURLToPath(new URL(_buildConfig.serverEntry, _buildConfig.server)),
 					entryUrl = new URL(_buildConfig.serverEntry, _config.outDir),
 					buildPath = fileURLToPath(entryUrl);
 
-				console.log("ENTRY", buildPath);
 				await esbuild.build({
 					target: 'es2020',
 					platform: 'browser',
@@ -108,6 +106,9 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						js: SHIM,
 					},
 				});
+
+				// Rename to worker.js
+				await fs.promises.rename(buildPath, buildPath.replace(/\.mjs$/, '.js'));
 
 				// throw the server folder in the bin
 				const serverUrl = new URL(_buildConfig.server);
@@ -145,6 +146,10 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					)
 						.filter((file: string) => cloudflareSpecialFiles.indexOf(file) < 0)
 						.map((file: string) => `/${file}`);
+
+					for(let page of pages) {
+						staticPathList.push(prependForwardSlash(page.pathname));
+					}
 
 					const redirectsExists = await fs.promises
 						.stat(new URL('./_redirects', _config.outDir))
@@ -204,4 +209,8 @@ export default function createIntegration(args?: Options): AstroIntegration {
 			},
 		},
 	};
+}
+
+function prependForwardSlash(path: string) {
+	return path[0] === '/' ? path : '/' + path;
 }

--- a/packages/integrations/cloudflare/src/server.advanced.ts
+++ b/packages/integrations/cloudflare/src/server.advanced.ts
@@ -1,8 +1,10 @@
 import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
-import { getProcessEnvProxy } from './util.js';
+import { getProcessEnvProxy, isNode } from './util.js';
 
-process.env = getProcessEnvProxy();
+if(!isNode) {
+	process.env = getProcessEnvProxy();
+}
 
 type Env = {
 	ASSETS: { fetch: (req: Request) => Promise<Response> };

--- a/packages/integrations/cloudflare/src/server.advanced.ts
+++ b/packages/integrations/cloudflare/src/server.advanced.ts
@@ -2,7 +2,7 @@ import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
 import { getProcessEnvProxy } from './util.js';
 
-process.env = getProcessEnvProxy();
+//process.env = getProcessEnvProxy();
 
 type Env = {
 	ASSETS: { fetch: (req: Request) => Promise<Response> };

--- a/packages/integrations/cloudflare/src/server.advanced.ts
+++ b/packages/integrations/cloudflare/src/server.advanced.ts
@@ -2,7 +2,7 @@ import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
 import { getProcessEnvProxy } from './util.js';
 
-//process.env = getProcessEnvProxy();
+process.env = getProcessEnvProxy();
 
 type Env = {
 	ASSETS: { fetch: (req: Request) => Promise<Response> };

--- a/packages/integrations/cloudflare/src/server.directory.ts
+++ b/packages/integrations/cloudflare/src/server.directory.ts
@@ -1,8 +1,10 @@
 import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
-import { getProcessEnvProxy } from './util.js';
+import { getProcessEnvProxy, isNode } from './util.js';
 
-process.env = getProcessEnvProxy();
+if(!isNode) {
+	process.env = getProcessEnvProxy();
+}
 
 export function createExports(manifest: SSRManifest) {
 	const app = new App(manifest);

--- a/packages/integrations/cloudflare/src/server.directory.ts
+++ b/packages/integrations/cloudflare/src/server.directory.ts
@@ -2,7 +2,7 @@ import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
 import { getProcessEnvProxy } from './util.js';
 
-//process.env = getProcessEnvProxy();
+process.env = getProcessEnvProxy();
 
 export function createExports(manifest: SSRManifest) {
 	const app = new App(manifest);

--- a/packages/integrations/cloudflare/src/server.directory.ts
+++ b/packages/integrations/cloudflare/src/server.directory.ts
@@ -2,7 +2,7 @@ import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
 import { getProcessEnvProxy } from './util.js';
 
-process.env = getProcessEnvProxy();
+//process.env = getProcessEnvProxy();
 
 export function createExports(manifest: SSRManifest) {
 	const app = new App(manifest);

--- a/packages/integrations/cloudflare/src/util.ts
+++ b/packages/integrations/cloudflare/src/util.ts
@@ -1,3 +1,5 @@
+export const isNode = typeof process === 'object' && Object.prototype.toString.call(process) === '[object process]';
+
 export function getProcessEnvProxy() {
 	return new Proxy(
 		{},

--- a/packages/integrations/cloudflare/test/fixtures/prerender/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/prerender/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import cloudflare from '@astrojs/cloudflare';
+
+export default defineConfig({
+	adapter: cloudflare(),
+	output: 'server',
+});

--- a/packages/integrations/cloudflare/test/fixtures/prerender/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/prerender/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/astro-cloudflare-prerender",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/cloudflare": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/cloudflare/test/fixtures/prerender/src/pages/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/prerender/src/pages/index.astro
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Testing</title>
+</head>
+<body>
+	<h1>Testing</h1>
+</body>
+</html>

--- a/packages/integrations/cloudflare/test/fixtures/prerender/src/pages/one.astro
+++ b/packages/integrations/cloudflare/test/fixtures/prerender/src/pages/one.astro
@@ -1,0 +1,11 @@
+---
+export const prerender = true;
+---
+<html>
+<head>
+	<title>Testing</title>
+</head>
+<body>
+	<h1>Testing</h1>
+</body>
+</html>

--- a/packages/integrations/cloudflare/test/prerender.test.js
+++ b/packages/integrations/cloudflare/test/prerender.test.js
@@ -1,18 +1,6 @@
 import { loadFixture } from './test-utils.js';
 import { expect } from 'chai';
 
-process.on('exit', () => {
-	console.log('process [exit]');
-});
-
-process.on('uncaughtException', err => {
-	console.log('uncaughtException');
-});
-
-process.on('unhandledRejection', rej => {
-	console.log('unhandledRejection');
-});
-
 describe('Prerendering', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
@@ -21,16 +9,11 @@ describe('Prerendering', () => {
 		fixture = await loadFixture({
 			root: './fixtures/prerender/',
 		});
-		try {
-			console.log("BEFORE");
-			await fixture.build();
-			console.log('done');
-		} catch(err) {
-			console.log('after build', err);
-		}
+		await fixture.build();
 	});
 
-	it('works', async () => {
-		console.log('works');
+	it('includes prerendered routes in the routes.json config', async () => {
+		const routes = JSON.parse(await fixture.readFile('/_routes.json'));
+		expect(routes.exclude).to.include('/one/');
 	});
 });

--- a/packages/integrations/cloudflare/test/prerender.test.js
+++ b/packages/integrations/cloudflare/test/prerender.test.js
@@ -1,0 +1,36 @@
+import { loadFixture } from './test-utils.js';
+import { expect } from 'chai';
+
+process.on('exit', () => {
+	console.log('process [exit]');
+});
+
+process.on('uncaughtException', err => {
+	console.log('uncaughtException');
+});
+
+process.on('unhandledRejection', rej => {
+	console.log('unhandledRejection');
+});
+
+describe('Prerendering', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/prerender/',
+		});
+		try {
+			console.log("BEFORE");
+			await fixture.build();
+			console.log('done');
+		} catch(err) {
+			console.log('after build', err);
+		}
+	});
+
+	it('works', async () => {
+		console.log('works');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2645,6 +2645,14 @@ importers:
       '@astrojs/cloudflare': link:../../..
       astro: link:../../../../../astro
 
+  packages/integrations/cloudflare/test/fixtures/prerender:
+    specifiers:
+      '@astrojs/cloudflare': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/cloudflare': link:../../..
+      astro: link:../../../../../astro
+
   packages/integrations/deno:
     specifiers:
       astro: workspace:*


### PR DESCRIPTION
## Changes

- Fixes the Cloudflare integration to support prerendering

## Testing

- Test added that checks the generated `_routes.json`, verifies that prerendered route is included in the `excludes` config. This makes it so that the worker is bypassed in that route.
- Fixes https://github.com/withastro/astro/issues/5831

## Docs

N/A, bug fix
