### PR TITLE
fix: Don’t require `getCollection()` filter to be a type guard

### DIFF
--- a/.changeset/rotten-dogs-hide.md
+++ b/.changeset/rotten-dogs-hide.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Update `getCollection()` filter to support type guards _or_ unknown values

--- a/packages/astro/src/content/internal.ts
+++ b/packages/astro/src/content/internal.ts
@@ -40,7 +40,7 @@ export function createGetCollection({
 	collectionToEntryMap: CollectionToEntryMap;
 	collectionToRenderEntryMap: CollectionToEntryMap;
 }) {
-	return async function getCollection(collection: string, filter?: () => boolean) {
+	return async function getCollection(collection: string, filter?: (entry: any) => unknown) {
 		const lazyImports = Object.values(collectionToEntryMap[collection] ?? {});
 		const entries = Promise.all(
 			lazyImports.map(async (lazyImport) => {

--- a/packages/astro/src/content/template/types.d.ts
+++ b/packages/astro/src/content/template/types.d.ts
@@ -48,6 +48,10 @@ declare module 'astro:content' {
 		collection: C,
 		filter?: (entry: CollectionEntry<C>) => entry is E
 	): Promise<E[]>;
+	export function getCollection<C extends keyof typeof entryMap>(
+		collection: C,
+		filter?: (entry: CollectionEntry<C>) => unknown
+	): Promise<CollectionEntry<C>[]>;
 
 	type InferEntrySchema<C extends keyof typeof entryMap> = import('astro/zod').infer<
 		Required<ContentConfig['collections'][C]>['schema']


### PR DESCRIPTION
## Changes

Commit dabce6b8c684f851c3535f8acead06cbef6dce2a (#5970) broke the use of a plain boolean filter. Add an overload similar to TypeScript’s [`Array#filter` overload](https://github.com/microsoft/TypeScript/blob/v4.9.4/lib/lib.es5.d.ts#L1442-L1453).

https://github.com/withastro/astro/pull/5970#issuecomment-1405596846 (cc @bholmesdev)

## Testing

Tested with my company blog, which uses `const posts = await getCollection("posts", (post) => post.data.author === author)`.

## Docs

No documentation change needed.