### PR TITLE
Makes the `AstroCookies` type importable directly from "astro"

### DIFF
--- a/.changeset/modern-colts-fix.md
+++ b/.changeset/modern-colts-fix.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Makes the `AstroCookies` type available as an import from the main "astro" package

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -28,6 +28,7 @@ export type {
 	ShikiConfig,
 } from '@astrojs/markdown-remark';
 export type { SSRManifest } from '../core/app/types';
+export type { AstroCookies } from '../core/cookies';
 
 export interface AstroBuiltinProps {
 	'client:load'?: boolean;


### PR DESCRIPTION
## Changes

This re-exports the `AstroCookies` type from the main `@types/astro.ts` type definitions.

**Current import syntax**
```ts
import type { AstroCookies } from "astro/dist/core/cookies/cookies.js"
```

**New import**
```ts
import type { AstroCookies } from "astro"
```

## Testing

Tested locally

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

None, typescript fix only

