### PR TITLE
Fix `edit this Page` on `examples/docs`

### DIFF
--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -11,7 +11,6 @@ npm create astro@latest -- --template docs
 
 ![docs](https://user-images.githubusercontent.com/4677417/186189283-0831b9ab-d6b9-485d-8955-3057e532ab31.png)
 
-
 ## Features
 
 - ✅ **Full Markdown support**
@@ -104,10 +103,10 @@ Note the top-level `en` key: This is needed for multi-language support. You can 
 
 The Astro docs template supports multiple languages out of the box. The default theme only shows `en` documentation, but you can enable multi-language support features by adding a second language to your project.
 
-To add a new language to your project, you'll want to extend the current `src/pages/[lang]/...` layout:
+To add a new language to your project, you'll want to extend the current `src/content/docs/[lang]/...` layout:
 
 ```diff
- 📂 src/pages
+ 📂 src/content/docs
  ┣ 📂 en
  ┃ ┣ 📜 page-1.md
  ┃ ┣ 📜 page-2.md

--- a/examples/docs/src/layouts/MainLayout.astro
+++ b/examples/docs/src/layouts/MainLayout.astro
@@ -17,7 +17,7 @@ type Props = CollectionEntry<'docs'>['data'] & {
 const { headings, ...data } = Astro.props;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const currentPage = Astro.url.pathname;
-const currentFile = `src/pages${currentPage.replace(/\/$/, '')}.md`;
+const currentFile = `src/content/docs${currentPage.replace(/\/$/, '')}.md`;
 const githubEditUrl = `${GITHUB_EDIT_URL}/${currentFile}`;
 ---
 


### PR DESCRIPTION
## Changes

Match current `src/content/docs/[lang]/...` layout with `edit this Page` url
  
  - https://github.com/withastro/astro/blob/main/examples/docs/src/content/docs/en/introduction.md

## Testing

Compare
  - [ ] https://codesandbox.io/s/github/withastro/astro/tree/latest/examples/docs
    - 404 https://github.com/withastro/astro/blob/main/examples/docs/src/pages/en/introduction.md
  - [x] https://codesandbox.io/s/github/advanced-astro/astro-docs-template/tree/latest
    - 200 https://github.com/withastro/astro/blob/main/examples/docs/src/content/docs/en/introduction.md

## Docs

`README` updated accordingly
