### PR TITLE
Improve top-level return error

### DIFF
--- a/.changeset/neat-actors-switch.md
+++ b/.changeset/neat-actors-switch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve error handling when top-level `return` is present


### PR DESCRIPTION
## Changes

- Closes #5922
- Fixes some problems with our error handling in `dev`. We "enhance" compiler errors by doing a second `esbuild` pass for possible frontmatter errors, but there were two problems here:
  1. We weren't checking if the error actually came from the frontmatter first.
  2. `esbuild` doesn't support top-level return (for obvious reasons) so any code using `return Astro.redirect()` would always fail with this message. As a fix, we now replace all instances of `return` with `throw` before scanning with `esbuild`.

## Testing

Tested manually as the exact error messages here are subject to change

## Docs

QoL improvement only