### PR TITLE
Handle invalid argument errors

### DIFF
--- a/.changeset/happy-fireants-occur.md
+++ b/.changeset/happy-fireants-occur.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve error handling when an Astro component is rendered manually

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -415,6 +415,20 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 		},
 		hint: 'Mutable values declared at runtime are not supported. Please make sure to use exactly `export const prerender = true`.',
 	},
+	/**
+	 * @docs
+	 * @message
+	 * **Example error messages:**<br/>
+	 * InvalidComponentArgs: Invalid arguments passed to <MyAstroComponent> component.
+	 * @description
+	 * Astro components cannot be rendered manually via function call, such as `Component()` or `{items.map(Component)}`. Prefer the component syntax `<Component />` or `{items.map(item => <Component {...item} />)}`.
+	 */
+	InvalidComponentArgs: {
+		title: 'Invalid component arguments.',
+		code: 3020,
+		message: (name: string) => `Invalid arguments passed to${name ? ` <${name}>` : ''} component.`,
+		hint: 'Astro components cannot be rendered directly via function call, such as `Component()` or `{items.map(Component)}`.',
+	},
 	// Vite Errors - 4xxx
 	UnknownViteError: {
 		title: 'Unknown Vite Error.',

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -421,7 +421,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	 * **Example error messages:**<br/>
 	 * InvalidComponentArgs: Invalid arguments passed to <MyAstroComponent> component.
 	 * @description
-	 * Astro components cannot be rendered manually via function call, such as `Component()` or `{items.map(Component)}`. Prefer the component syntax `<Component />` or `{items.map(item => <Component {...item} />)}`.
+	 * Astro components cannot be rendered manually via a function call, such as `Component()` or `{items.map(Component)}`. Prefer the component syntax `<Component />` or `{items.map(item => <Component {...item} />)}`.
 	 */
 	InvalidComponentArgs: {
 		title: 'Invalid component arguments.',


### PR DESCRIPTION
## Changes

- Previously, the dev server completely crashed when doing something like
```astro
---
import Foo from '../components/Foo.astro';
// Called directly via function call
console.log(Foo())
---
// Called inside an expression without `<Foo />` syntax
{items.map(Foo)}
```
- This PR fixes this situation by validating the input arguments before attempting to render
- If the arguments are invalid, we now throw a new `InvalidComponentArgs` error with helpful info
- 
<img width="962" alt="CleanShot 2023-01-30 at 13 20 57@2x" src="https://user-images.githubusercontent.com/7118177/215574897-be5ec2a5-6f40-475b-bf09-96de61d8fe42.png">


## Testing

Tested manually since this is a smaller one. Can add a test if needed

## Docs

/cc @withastro/maintainers-docs for feedback!
