### PR TITLE
Preserve `--root` CLI flag on restart

### DIFF
--- a/.changeset/tasty-planes-knock.md
+++ b/.changeset/tasty-planes-knock.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Preserve `--root` CLI flag when restarting dev server

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -44,6 +44,7 @@ export default async function dev(
 		beforeRestart: () => console.clear(),
 		params: {
 			settings,
+			root: options.flags?.root,
 			logging: options.logging,
 			isRestart: options.isRestart,
 		},

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -76,6 +76,7 @@ export async function restartContainer({
 	beforeRestart,
 }: RestartContainerParams): Promise<{ container: Container; error: Error | null }> {
 	const { logging, close, resolvedRoot, settings: existingSettings } = container;
+	const root = flags.root || resolvedRoot;
 	container.restartInFlight = true;
 
 	if (beforeRestart) {
@@ -84,7 +85,7 @@ export async function restartContainer({
 	const needsStart = isStarted(container);
 	try {
 		const newConfig = await openConfig({
-			cwd: resolvedRoot,
+			cwd: root,
 			flags,
 			cmd: 'dev',
 			logging,
@@ -93,7 +94,7 @@ export async function restartContainer({
 		});
 		info(logging, 'astro', logMsg + '\n');
 		let astroConfig = newConfig.astroConfig;
-		const settings = createSettings(astroConfig, resolvedRoot);
+		const settings = createSettings(astroConfig, root);
 		await close();
 		return {
 			container: await createRestartedContainer(container, settings, needsStart),

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -1,10 +1,8 @@
-import { fileURLToPath, pathToFileURL } from 'url';
 import * as vite from 'vite';
 import type { AstroSettings } from '../../@types/astro';
 import { createSettings, openConfig } from '../config/index.js';
 import { createSafeError } from '../errors/index.js';
 import { info } from '../logger/core.js';
-import { prependForwardSlash, appendForwardSlash } from '../path.js';
 import type { Container, CreateContainerParams } from './container';
 import { createContainer, isStarted, startContainer } from './container.js';
 
@@ -79,8 +77,6 @@ export async function restartContainer({
 }: RestartContainerParams): Promise<{ container: Container; error: Error | null }> {
 	const { logging, close, resolvedRoot, settings: existingSettings } = container;
 	container.restartInFlight = true;
-	// Resolve `flags.root` relative to `resolvedRoot`
-	const root = flags.root ? fileURLToPath(new URL('.' + prependForwardSlash(appendForwardSlash(flags.root)), pathToFileURL(resolvedRoot))) : resolvedRoot;
 
 	if (beforeRestart) {
 		beforeRestart();
@@ -88,7 +84,7 @@ export async function restartContainer({
 	const needsStart = isStarted(container);
 	try {
 		const newConfig = await openConfig({
-			cwd: root,
+			cwd: resolvedRoot,
 			flags,
 			cmd: 'dev',
 			logging,
@@ -97,7 +93,7 @@ export async function restartContainer({
 		});
 		info(logging, 'astro', logMsg + '\n');
 		let astroConfig = newConfig.astroConfig;
-		const settings = createSettings(astroConfig, root);
+		const settings = createSettings(astroConfig, resolvedRoot);
 		await close();
 		return {
 			container: await createRestartedContainer(container, settings, needsStart),

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -1,8 +1,10 @@
+import { fileURLToPath, pathToFileURL } from 'url';
 import * as vite from 'vite';
 import type { AstroSettings } from '../../@types/astro';
 import { createSettings, openConfig } from '../config/index.js';
 import { createSafeError } from '../errors/index.js';
 import { info } from '../logger/core.js';
+import { prependForwardSlash, appendForwardSlash } from '../path.js';
 import type { Container, CreateContainerParams } from './container';
 import { createContainer, isStarted, startContainer } from './container.js';
 
@@ -76,8 +78,9 @@ export async function restartContainer({
 	beforeRestart,
 }: RestartContainerParams): Promise<{ container: Container; error: Error | null }> {
 	const { logging, close, resolvedRoot, settings: existingSettings } = container;
-	const root = flags.root || resolvedRoot;
 	container.restartInFlight = true;
+	// Resolve `flags.root` relative to `resolvedRoot`
+	const root = flags.root ? fileURLToPath(new URL('.' + prependForwardSlash(appendForwardSlash(flags.root)), pathToFileURL(resolvedRoot))) : resolvedRoot;
 
 	if (beforeRestart) {
 		beforeRestart();


### PR DESCRIPTION
## Changes

- Fixes #5985
- We would persist the `flags` between restarts, but the new container did not read from `--root` and always read the initial `resolvedRoot` instead.
- This PR updates it so that CLI restarts read from `--root` and fallback to `resolvedRoot` if necessary

## Testing

Tested manually since this is a hard one to automate

## Docs

N/A, bug fix only