### PR TITLE
error overlay: show `cause` if available

### DIFF
--- a/.changeset/clever-panthers-end.md
+++ b/.changeset/clever-panthers-end.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Error overlay will now show the error's `cause` if available.

--- a/packages/astro/src/core/errors/dev/vite.ts
+++ b/packages/astro/src/core/errors/dev/vite.ts
@@ -118,6 +118,7 @@ export interface AstroErrorPayload {
 			line?: number;
 			column?: number;
 		};
+		cause?: unknown;
 	};
 }
 
@@ -174,6 +175,7 @@ export async function getViteErrorPayload(err: ErrorWithMetadata): Promise<Astro
 			},
 			plugin,
 			stack: err.stack,
+			cause: err.cause
 		},
 	};
 

--- a/packages/astro/src/core/errors/overlay.ts
+++ b/packages/astro/src/core/errors/overlay.ts
@@ -321,7 +321,8 @@ const style = /* css */ `
 
 #message-hints,
 #stack,
-#code {
+#code,
+#cause {
   border-radius: var(--roundiness);
   background-color: var(--box-background);
 }
@@ -606,8 +607,13 @@ class ErrorOverlay extends HTMLElement {
 
     const cause = this.root.querySelector<HTMLElement>('#cause');
     if (cause && err.cause) {
-      this.text('#cause', `${err.cause}`, true);
-      cause.style.display = 'flex';
+      if (typeof err.cause === 'string') {
+        this.text('#cause-content', err.cause);
+        cause.style.display = 'block';
+      } else {
+        this.text('#cause-content', JSON.stringify(err.cause, null, 2));
+        cause.style.display = 'block';
+      }
     }
 
 		const hint = this.root.querySelector<HTMLElement>('#hint');

--- a/packages/astro/src/core/errors/overlay.ts
+++ b/packages/astro/src/core/errors/overlay.ts
@@ -471,7 +471,8 @@ const style = /* css */ `
   color: var(--error-text);
 }
 
-#stack h2 {
+#stack h2,
+#cause h2 {
   color: var(--title-text);
   font-family: var(--font-normal);
   font-size: 22px;
@@ -480,13 +481,18 @@ const style = /* css */ `
   border-bottom: 1px solid var(--border);
 }
 
-#stack-content {
+#stack-content,
+#cause-content {
   font-size: 14px;
   white-space: pre;
   line-height: 21px;
   overflow: auto;
   padding: 24px;
   color: var(--stack-text);
+}
+
+#cause {
+  display: none;
 }
 `;
 
@@ -552,6 +558,11 @@ ${style.trim()}
       <h2>Stack Trace</h2>
       <div id="stack-content"></div>
     </section>
+
+    <section id="cause">
+      <h2>Cause</h2>
+      <div id="cause-content"></div>
+    </section>
   </div>
 </div>
 `;
@@ -592,6 +603,12 @@ class ErrorOverlay extends HTMLElement {
 		this.text('#name', err.name);
 		this.text('#title', err.title);
 		this.text('#message-content', err.message, true);
+
+    const cause = this.root.querySelector<HTMLElement>('#cause');
+    if (cause && err.cause) {
+      this.text('#cause', `${err.cause}`, true);
+      cause.style.display = 'flex';
+    }
 
 		const hint = this.root.querySelector<HTMLElement>('#hint');
 		if (hint && err.hint) {


### PR DESCRIPTION
## Changes

Added ability to display an error's [`cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) if available. Closes #6027

## Testing

Tested in a local project by changing code inside node modules.

![](https://user-images.githubusercontent.com/9084735/215624319-ae5b5c47-9a67-4ddd-b17e-bc7fa1ad3d74.png)

Test fixture currently pending.

## Docs

Not needed I think? I guess we could document how to use the `cause` property.