### PR TITLE
[Lit] Forwards compatiblity for streaming Declarative Shadow DOM

### DIFF
--- a/packages/astro/test/fixtures/custom-elements/my-component-lib/server.js
+++ b/packages/astro/test/fixtures/custom-elements/my-component-lib/server.js
@@ -20,7 +20,7 @@ function renderToStaticMarkup(component, props, innerHTML) {
   const Component = getConstructor(component);
   const el = new Component();
   el.connectedCallback();
-  const html = `<${el.localName}><template shadowroot="open">${el.shadowRoot.innerHTML}</template>${el.innerHTML}</${el.localName}>`
+  const html = `<${el.localName}><template shadowroot="open" shadowrootmode="open">${el.shadowRoot.innerHTML}</template>${el.innerHTML}</${el.localName}>`
   return {
     html
   };

--- a/packages/renderers/renderer-lit/client-shim.js
+++ b/packages/renderers/renderer-lit/client-shim.js
@@ -3,7 +3,7 @@ async function polyfill() {
   hydrateShadowRoots(document.body);
 }
 
-const polyfillCheckEl = new DOMParser().parseFromString(`<p><template shadowroot="open"></template></p>`, 'text/html', { includeShadowRoots: true }).querySelector('p');
+const polyfillCheckEl = new DOMParser().parseFromString(`<p><template shadowroot="open" shadowrootmode="open"></template></p>`, 'text/html', { includeShadowRoots: true }).querySelector('p');
 
 if (!polyfillCheckEl || !polyfillCheckEl.shadowRoot) {
   polyfill();

--- a/packages/renderers/renderer-lit/server.js
+++ b/packages/renderers/renderer-lit/server.js
@@ -45,7 +45,7 @@ function* render(tagName, attrs, children) {
   yield `>`;
   const shadowContents = instance.renderShadow({});
   if (shadowContents !== undefined) {
-    yield '<template shadowroot="open">';
+    yield '<template shadowroot="open" shadowrootmode="open">';
     yield* shadowContents;
     yield '</template>';
   }


### PR DESCRIPTION
## Changes

-  Adds forwards compat for DSD
  - [Context](https://groups.google.com/a/chromium.org/g/blink-dev/c/xzT-vN-bx0s)
- Renders DSD templates with both the soon-to-be legacy `shadowroot` attribute and the `shadowrootmode` attribute
- This change to the spec is happening in Safari TP and Chrome 111

## Testing

Tests will continue to pass in Chrome 111 and Safari

## Docs

This is an implementation detail that doesn't need to be surfaced to the user.
