### PR TITLE
Wrap tag in example error message in code backticks

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -419,7 +419,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	 * @docs
 	 * @message
 	 * **Example error messages:**<br/>
-	 * InvalidComponentArgs: Invalid arguments passed to <MyAstroComponent> component.
+	 * InvalidComponentArgs: Invalid arguments passed to `<MyAstroComponent>` component.
 	 * @description
 	 * Astro components cannot be rendered manually via a function call, such as `Component()` or `{items.map(Component)}`. Prefer the component syntax `<Component />` or `{items.map(item => <Component {...item} />)}`.
 	 */


### PR DESCRIPTION
## Changes

- Fixes rendering in the error reference in docs where otherwise MDX tries to render `<MyAstroComponent>` as an actual component.
- Unblocks https://github.com/withastro/docs/pull/2518/

## Testing

Docs only

## Docs

/cc @withastro/maintainers-docs @Princesseuh for feedback!