### PR TITLE
Correct usage of `getImage` function

### DIFF
--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -422,7 +422,10 @@ This can be helpful if you need to add preload links to a page's `<head>`.
 ---
 import { getImage } from '@astrojs/image';
 
-const { src } = await getImage({src: '../assets/hero.png'});
+const { src } = await getImage({
+    src: import('../assets/hero.png'),
+    alt: "My hero image"
+  });
 ---
 
 <html>


### PR DESCRIPTION
## Changes

Show correct usage or `getImage` function.

When providing a string to the `getImage` function, it is taken as a remote image. To use local images we need to import them.
We need to provide `alt` too as it's required

## Testing

N/A docs change only

## Docs

Docs change to match correct usage
