### PR TITLE
Fix UI frameworks on Vercel edge

### DIFF
--- a/packages/integrations/vercel/src/edge/adapter.ts
+++ b/packages/integrations/vercel/src/edge/adapter.ts
@@ -75,7 +75,6 @@ export default function vercelEdge({ includeFiles = [] }: VercelEdgeConfig = {})
 					}
 
 					vite.ssr = {
-						target: 'webworker',
 						noExternal: true,
 					};
 


### PR DESCRIPTION
## Changes

- Resolves #5915 
- Remove `target: 'webworker'`. This follows the Netlify and Cloudflare edge renderer configs.

## Testing

Manual testing

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
