### PR TITLE
fix: Failed to execute 'encode' on 'TextEncoder': parameter 1 is not of type 'String' in Edge Runtime SSR

### DIFF
--- a/.changeset/curvy-owls-grow.md
+++ b/.changeset/curvy-owls-grow.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+---
+
+* safe guard against TextEncode.encode(HTMLString) [errors on vercel edge]
+* safe guard against html.replace when html is undefined

--- a/packages/astro/src/runtime/server/render/common.ts
+++ b/packages/astro/src/runtime/server/render/common.ts
@@ -93,5 +93,7 @@ export function chunkToByteArray(
 	if (chunk instanceof Uint8Array) {
 		return chunk as Uint8Array;
 	}
-	return encoder.encode(stringifyChunk(result, chunk));
+  // stringify chunk might return a HTMLString
+  let stringified = stringifyChunk(result, chunk);
+	return encoder.encode(stringified.toString());
 }

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -261,9 +261,11 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 
 			if (isPage || renderer?.name === 'astro:jsx') {
 				yield html;
-			} else if (html) {
+			} else if(html && html.length > 0) {
 				yield markHTMLString(html.replace(/\<\/?astro-slot\>/g, ''));
-			}
+			} else {
+        yield '';
+       }
 		})();
 	}
 

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -261,7 +261,7 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 
 			if (isPage || renderer?.name === 'astro:jsx') {
 				yield html;
-			} else {
+			} else if (html) {
 				yield markHTMLString(html.replace(/\<\/?astro-slot\>/g, ''));
 			}
 		})();


### PR DESCRIPTION
## Changes

- fix small issue in SSR mode #5915
- this is not fixing the Solid build for vercel, so for Solid it will still state something like `Error: Pa is not supported in the browser, returning undefined` that is a vercel adapter issue only and we need to update the build steps there.

## Testing

Tested example applications for react and solid on vercel.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
