### PR TITLE
Add required `alt` to Picture example

### DIFF
--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -333,7 +333,7 @@ The list of sizes that should be built for responsive images. This is combined w
 
 ```astro
 // Builds three images: 400x400, 800x800, and 1200x1200
-<Picture src={...} widths={[400, 800, 1200]} aspectRatio="1:1" />
+<Picture src={...} widths={[400, 800, 1200]} aspectRatio="1:1" alt="descriptive text" />
 ```
 
 #### aspectRatio


### PR DESCRIPTION
## Changes

Add required `alt` prop to `<Picture>` example

[Docs for `alt`](https://docs.astro.build/en/guides/integrations-guide/image/#alt)

## Testing

No tests, change to docs

## Docs


/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Update example with required prop
