### PR TITLE
Add JSDOC `@message` param to broken error pages

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -629,6 +629,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	},
 	/**
 	 * @docs
+	 * @message `COLLECTION_NAME` → `ENTRY_ID` has an invalid slug. `slug` must be a string.
 	 * @see
 	 * - [The reserved entry `slug` field](https://docs.astro.build/en/guides/content-collections/)
 	 * @description
@@ -646,6 +647,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	},
 	/**
 	 * @docs
+	 * @message A content collection schema should not contain `slug` since it is reserved for slug generation. Remove this from your `COLLECTION_NAME` collection schema.
 	 * @see
 	 * - [The reserved entry `slug` field](https://docs.astro.build/en/guides/content-collections/)
 	 * @description


### PR DESCRIPTION
## Changes

Added JSDOC `@message` param to `InvalidContentEntrySlugError` & `ContentSchemaContainsSlugError` errors to fix their generated docs pages.

| Before | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/61414485/215871073-70d90877-d76a-4851-b013-5ad414decf77.png) | ![image](https://user-images.githubusercontent.com/61414485/215871716-7446b969-eb04-458c-bab4-03bc5f7baf90.png) |
| ![image](https://user-images.githubusercontent.com/61414485/215871862-fe326524-ff63-48a7-84be-bdc3790b5949.png) | ![image](https://user-images.githubusercontent.com/61414485/215871965-a49cc2c4-2bfd-4bc7-8055-8fe49a3fe59c.png) |

The function we use in docs to extract the error messages from this file expects functions to follow this style:

```ts
message: (params: string) => `Message ${params}`,
```

These and a few other errors follow this, instead:

```ts
message: (configFile: string) => {
        return message: (params: string) => `Message ${params}`;
},
```

Not sure if this function style makes a difference in the core side of things, if possible I'd advocate going with the former function style so we avoid possible errors (and if it can't be avoided, to use `@message` for these error messages).

When available, the docs doc gen script uses the JSDOC `@message` param instead, so I added it to the problematic functions as a fix. Also because they have dynamic values we can't bring to docs (like the current `collection` or `entryId`), in which case, it's better to use JSDoc anyway to overwrite these values with `COLLECTION_NAME` and `ENTRY_ID`, for extra clarity.

## Testing

Only JSDOC comments, shouldn't affect code behavior.

## Docs

It's all docs baby 😎 

cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
