### PR TITLE
fix: solidjs integration for vercel edge build (adopting same mechanics as cloudflare)

### DIFF
--- a/.changeset/wild-seas-happen.md
+++ b/.changeset/wild-seas-happen.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/vercel': major
+'@astrojs/vercel': patch
 ---
 
 Added second build step through esbuild, to allow framework defined build (vite build) and target defined bundling (esbuilt step)

--- a/.changeset/wild-seas-happen.md
+++ b/.changeset/wild-seas-happen.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': major
+---
+
+Added second build step through esbuild, to allow framework defined build (vite build) and target defined bundling (esbuilt step)

--- a/packages/integrations/vercel/src/edge/adapter.ts
+++ b/packages/integrations/vercel/src/edge/adapter.ts
@@ -1,4 +1,5 @@
 import type { AstroAdapter, AstroConfig, AstroIntegration } from 'astro';
+import esbuild from 'esbuild';
 import { relative as relativePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -74,18 +75,25 @@ export default function vercelEdge({ includeFiles = [] }: VercelEdgeConfig = {})
 						}
 					}
 
-					vite.ssr = {
-						target: 'webworker',
-						noExternal: true,
-					};
-
-					vite.build ||= {};
-					vite.build.minify = true;
+          vite.ssr ||= {};
+          vite.ssr.target ||= 'webworker';
 				}
 			},
 			'astro:build:done': async ({ routes }) => {
 				const entry = new URL(serverEntry, buildTempFolder);
 				const generatedFiles = await getFilesFromFolder(buildTempFolder);
+        const entryPath = fileURLToPath(entry);
+
+        await esbuild.build({
+					target: 'es2020',
+					platform: 'browser',
+					entryPoints: [entryPath],
+					outfile: entryPath,
+					allowOverwrite: true,
+					format: 'esm',
+					bundle: true,
+					minify: true,
+				});
 
 				// Copy entry and other server files
 				const commonAncestor = await copyFilesToFunction(
@@ -100,7 +108,7 @@ export default function vercelEdge({ includeFiles = [] }: VercelEdgeConfig = {})
 				// https://vercel.com/docs/build-output-api/v3#vercel-primitives/edge-functions/configuration
 				await writeJson(new URL(`./.vc-config.json`, functionFolder), {
 					runtime: 'edge',
-					entrypoint: relativePath(commonAncestor, fileURLToPath(entry)),
+					entrypoint: relativePath(commonAncestor, entryPath),
 				});
 
 				// Output configuration


### PR DESCRIPTION
## Changes

- A second build step has been added to allow the separation of framework and library builds
- Resolves #5915 

## Testing

With the example react and solid projects from the repo.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
