### PR TITLE
chore: bump vitefu for @astrojs/solid-js

### DIFF
--- a/.changeset/cold-maps-wash.md
+++ b/.changeset/cold-maps-wash.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/solid-js': patch
+---
+
+Bump vitefu for peerDep warning with Vite 4

--- a/packages/integrations/solid/package.json
+++ b/packages/integrations/solid/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "babel-preset-solid": "^1.4.2",
-    "vitefu": "^0.2.1"
+    "vitefu": "^0.2.4"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3256,7 +3256,7 @@ importers:
       astro-scripts: workspace:*
       babel-preset-solid: ^1.4.2
       solid-js: ^1.5.1
-      vitefu: ^0.2.1
+      vitefu: ^0.2.4
     dependencies:
       babel-preset-solid: 1.6.10
       vitefu: 0.2.4


### PR DESCRIPTION
## Changes

- Since [vitefu started supporting Vite 4](https://github.com/svitejs/vitefu/releases/tag/v0.2.3), and astro package itself [uses vitefu@0.2.4](https://github.com/withastro/astro/blob/main/packages/astro/package.json#L151), this PR should bump it as well in @astrojs/solid to avoid peerDep warning.
<img width="366" alt="image" src="https://user-images.githubusercontent.com/20513793/216342794-59a2cd78-d54a-4662-a57c-a22ca01ee515.png">

## Testing
- No tests needed, Vite4 is already being installed for astro V2
 
## Docs

- No docs needed, just a package patch bump.