### PR TITLE
Fix scanning sourcemap handling

### DIFF
--- a/.changeset/lemon-flies-clean.md
+++ b/.changeset/lemon-flies-clean.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix sourcemap generation when scanning files

--- a/packages/astro/src/vite-plugin-scanner/index.ts
+++ b/packages/astro/src/vite-plugin-scanner/index.ts
@@ -29,6 +29,7 @@ export default function astroScannerPlugin({ settings }: { settings: AstroSettin
 			const { meta = {} } = this.getModuleInfo(id) ?? {};
 			return {
 				code,
+				map: null,
 				meta: {
 					...meta,
 					astro: {


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/6058

According to https://rollupjs.org/plugin-development/#transform, returning `map: null` means `code` doesn't change and preserve the current sourcemap. This PR adds the `map: null` as it's the case for us.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Manual testing in basics example.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.
