### PR TITLE
update node integration README with Fastify code example

### DIFF
--- a/packages/integrations/node/README.md
+++ b/packages/integrations/node/README.md
@@ -98,6 +98,27 @@ app.use(ssrHandler);
 app.listen(8080);
 ```
 
+Or, with Fastify (>4):
+
+```js
+import Fastify from 'fastify';
+import fastifyMiddie from '@fastify/middie';
+import fastifyStatic from '@fastify/static';
+import { fileURLToPath } from 'url';
+import { handler as ssrHandler } from './dist/server/entry.mjs';
+
+const app = Fastify({ logger: true });
+
+await app
+  .register(fastifyStatic, {
+    root: fileURLToPath(new URL('./dist/client', import.meta.url)),
+  })
+  .register(fastifyMiddie);
+app.use(ssrHandler);
+
+app.listen({ port: 8080 });
+```
+
 Note that middleware mode does not do file serving. You'll need to configure your HTTP framework to do that for you. By default the client assets are written to `./dist/client/`.
 
 ### Standalone


### PR DESCRIPTION
## Changes

Adding astrojs/node + Fastify minimal code example to the docs, with the same functionality as express example has.

## Docs

Will be automatically generated inside docs repo.