### PR TITLE
[Content collections] Fix "underscore to ignore" warnings

### DIFF
--- a/.changeset/grumpy-bees-worry.md
+++ b/.changeset/grumpy-bees-worry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Content collections: Fix accidental "use underscore to ignore" logs for `.DS_Store` files and underscored directory names.

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -126,7 +126,11 @@ export async function createContentTypesGenerator({
 
 			return { shouldGenerateTypes: true };
 		}
-		if (fileType === 'unsupported' && (event.name === 'add' || event.name === 'change')) {
+		if (fileType === 'unsupported') {
+			// Avoid warning if file was deleted.
+			if (event.name === 'unlink') {
+				return { shouldGenerateTypes: false };
+			}
 			const entryInfo = getEntryInfo({
 				entry: event.entry,
 				contentDir: contentPaths.contentDir,

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -292,7 +292,7 @@ export function getEntryType(
 	const dir = appendForwardSlash(pathToFileURL(rawDir).href);
 	const fileUrl = new URL(base, dir);
 
-	if (hasUnderscoreInPath(fileUrl)) {
+	if (hasUnderscoreInPath(fileUrl) || isOnIgnoreList(fileUrl)) {
 		return 'ignored';
 	} else if ((contentFileExts as readonly string[]).includes(ext)) {
 		return 'content';
@@ -301,6 +301,11 @@ export function getEntryType(
 	} else {
 		return 'unsupported';
 	}
+}
+
+function isOnIgnoreList(fileUrl: URL) {
+	const { base } = path.parse(fileURLToPath(fileUrl));
+	return ['.DS_Store'].includes(base);
 }
 
 function hasUnderscoreInPath(fileUrl: URL): boolean {

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -125,7 +125,7 @@ export async function createContentTypesGenerator({
 
 			return { shouldGenerateTypes: true };
 		}
-		if (fileType === 'unsupported') {
+		if (fileType === 'unsupported' && (event.name === 'add' || event.name === 'change')) {
 			const entryInfo = getEntryInfo({
 				entry: event.entry,
 				contentDir: contentPaths.contentDir,

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -6,8 +6,8 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { normalizePath, ViteDevServer } from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
 import { info, LogOptions, warn } from '../core/logger/core.js';
-import { appendForwardSlash, isRelativePath } from '../core/path.js';
-import { contentFileExts, CONTENT_TYPES_FILE } from './consts.js';
+import { isRelativePath } from '../core/path.js';
+import { CONTENT_TYPES_FILE } from './consts.js';
 import {
 	ContentConfig,
 	ContentObservable,
@@ -16,6 +16,7 @@ import {
 	getContentPaths,
 	getEntryInfo,
 	getEntrySlug,
+	getEntryType,
 	loadContentConfig,
 	NoCollectionError,
 	parseFrontmatter,
@@ -282,38 +283,6 @@ function setEntry(
 
 function removeEntry(contentTypes: ContentTypes, collectionKey: string, entryKey: string) {
 	delete contentTypes[collectionKey][entryKey];
-}
-
-export function getEntryType(
-	entryPath: string,
-	paths: ContentPaths
-): 'content' | 'config' | 'ignored' | 'unsupported' {
-	const { dir: rawDir, ext, base } = path.parse(entryPath);
-	const dir = appendForwardSlash(pathToFileURL(rawDir).href);
-	const fileUrl = new URL(base, dir);
-
-	if (hasUnderscoreInPath(fileUrl) || isOnIgnoreList(fileUrl)) {
-		return 'ignored';
-	} else if ((contentFileExts as readonly string[]).includes(ext)) {
-		return 'content';
-	} else if (fileUrl.href === paths.config.href) {
-		return 'config';
-	} else {
-		return 'unsupported';
-	}
-}
-
-function isOnIgnoreList(fileUrl: URL) {
-	const { base } = path.parse(fileURLToPath(fileUrl));
-	return ['.DS_Store'].includes(base);
-}
-
-function hasUnderscoreInPath(fileUrl: URL): boolean {
-	const parts = fileUrl.pathname.split('/');
-	for (const part of parts) {
-		if (part.startsWith('_')) return true;
-	}
-	return false;
 }
 
 async function writeContentFiles({

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -7,7 +7,7 @@ import { AstroErrorData } from '../core/errors/errors-data.js';
 import { AstroError } from '../core/errors/errors.js';
 import { escapeViteEnvReferences, getFileInfo } from '../vite-plugin-utils/index.js';
 import { contentFileExts, CONTENT_FLAG } from './consts.js';
-import { getEntryType } from './types-generator.js';
+import { getEntryType } from './utils.js';
 import {
 	ContentConfig,
 	getContentPaths,

--- a/packages/astro/test/units/content-collections/get-entry-type.test.js
+++ b/packages/astro/test/units/content-collections/get-entry-type.test.js
@@ -1,0 +1,62 @@
+import { getEntryType } from '../../../dist/content/utils.js';
+import { expect } from 'chai';
+import { fileURLToPath } from 'node:url';
+
+describe('Content Collections - getEntryType', () => {
+	const contentDir = new URL('src/content/', import.meta.url);
+	const contentPaths = {
+		config: new URL('src/content/config.ts', import.meta.url),
+	};
+
+	it('Returns "content" for Markdown files', () => {
+		for (const entryPath of ['blog/first-post.md', 'blog/first-post.mdx']) {
+			const entry = fileURLToPath(new URL(entryPath, contentDir));
+			const type = getEntryType(entry, contentPaths);
+			expect(type).to.equal('content');
+		}
+	});
+
+	it('Returns "content" for Markdown files in nested directories', () => {
+		for (const entryPath of ['blog/2021/01/01/index.md', 'blog/2021/01/01/index.mdx']) {
+			const entry = fileURLToPath(new URL(entryPath, contentDir));
+			const type = getEntryType(entry, contentPaths);
+			expect(type).to.equal('content');
+		}
+	});
+
+	it('Returns "config" for config files', () => {
+		const entry = fileURLToPath(contentPaths.config);
+		const type = getEntryType(entry, contentPaths);
+		expect(type).to.equal('config');
+	});
+
+	it('Returns "unsupported" for non-Markdown files', () => {
+		const entry = fileURLToPath(new URL('blog/robots.txt', contentDir));
+		const type = getEntryType(entry, contentPaths);
+		expect(type).to.equal('unsupported');
+	});
+
+	it('Returns "ignored" for .DS_Store', () => {
+		const entry = fileURLToPath(new URL('blog/.DS_Store', contentDir));
+		const type = getEntryType(entry, contentPaths);
+		expect(type).to.equal('ignored');
+	});
+
+	it('Returns "ignored" for unsupported files using an underscore', () => {
+		const entry = fileURLToPath(new URL('blog/_draft-robots.txt', contentDir));
+		const type = getEntryType(entry, contentPaths);
+		expect(type).to.equal('ignored');
+	});
+
+	it('Returns "ignored" when using underscore on file name', () => {
+		const entry = fileURLToPath(new URL('blog/_first-post.md', contentDir));
+		const type = getEntryType(entry, contentPaths);
+		expect(type).to.equal('ignored');
+	});
+
+	it('Returns "ignored" when using underscore on directory name', () => {
+		const entry = fileURLToPath(new URL('blog/_draft/first-post.md', contentDir));
+		const type = getEntryType(entry, contentPaths);
+		expect(type).to.equal('ignored');
+	});
+});


### PR DESCRIPTION
## Changes

- Resolves #6031 
- Check for underscores `_` anywhere in directory path, not just the file name
- Add "always ignore" list with `.DS_Store`

## Testing

- `getEntryType` unit tests

## Docs

N/A