### PR TITLE
fix example Card component style

### DIFF
--- a/.changeset/neat-taxis-thank.md
+++ b/.changeset/neat-taxis-thank.md
@@ -1,5 +1,0 @@
----
-'astro': patch
----
-
-Fix hover styling of Card example component

--- a/.changeset/neat-taxis-thank.md
+++ b/.changeset/neat-taxis-thank.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix hover styling of Card example component

--- a/examples/basics/src/components/Card.astro
+++ b/examples/basics/src/components/Card.astro
@@ -23,11 +23,11 @@ const { href, title, body } = Astro.props;
 	.link-card {
 		list-style: none;
 		display: flex;
-		padding: 0.15rem;
+		padding: 0.25rem;
 		background-color: white;
-		background-image: var(--accent-gradient);
+		background-image: none;
 		background-size: 400%;
-		border-radius: 0.5rem;
+		border-radius: 0.6rem;
 		background-position: 100%;
 		transition: background-position 0.6s cubic-bezier(0.22, 1, 0.36, 1);
 		box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
@@ -55,6 +55,7 @@ const { href, title, body } = Astro.props;
 	}
 	.link-card:is(:hover, :focus-within) {
 		background-position: 0;
+		background-image: var(--accent-gradient);
 	}
 	.link-card:is(:hover, :focus-within) h2 {
 		color: rgb(var(--accent));


### PR DESCRIPTION
Card component has uneven border on hover, and in some cases the border is visible even when not hovering. This commit fixes those two issues. 
<details>
<summary>uneven border</summary>

![uneven_border](https://user-images.githubusercontent.com/42444300/216711694-f6c1622c-beda-4459-b1c9-31404ff5066e.gif)
</details>
<details>
<summary>background visible even when not hovering</summary>

![background_visible](https://user-images.githubusercontent.com/42444300/216711696-a95e44b2-7df7-47ca-817b-06f45d09e74d.gif)
See the right border, a thin line appears when not hovering
</details>



## Changes

For the example Card component styling, the following was changed:
* increase border size slightly so symmetry can be achieved
* hide background image and only show it on hover

<details>
<summary>appearance after fix</summary>

![issues_fixed](https://user-images.githubusercontent.com/42444300/216711686-20f00bcc-bae6-4ec2-8019-608cdb468052.gif)
</details>

## Testing

No tests added, this is a css change for one of the example components.

## Docs

No docs added, this is a css change for one of the example components.
