### PR TITLE
fix(portfolio): keyboard a11y for ThemeToggle

### DIFF
--- a/examples/portfolio/src/components/ThemeToggle.astro
+++ b/examples/portfolio/src/components/ThemeToggle.astro
@@ -19,8 +19,6 @@ import Icon from './Icon.astro';
 		background-color: var(--gray-999);
 		box-shadow: inset 0 0 0 1px var(--accent-overlay);
 		cursor: pointer;
-		/* Outline visible only to high contrast users */
-		outline: 1px solid transparent;
 	}
 
 	.icon {


### PR DESCRIPTION
## Changes

Fixed keyboard accessibility for the Portfolio example's ThemeToggle.

Making the focus outline transparent for the ThemeToggle button “except for Windows High Contrast Mode” makes this component inaccessible to keyboard users. Removing the CSS declaration allows the default focus outline to show.

The example previously failed WCAG 2.4.7 Focus Visible (Level A in WCAG 2.2).

Before (with Chrome DevTools open):

<img width="1227" alt="Portoflio page with focus forced on ThemeToggle, showing a transparent outline by default" src="https://user-images.githubusercontent.com/1045233/216752880-5c8edc3c-7623-46d2-acdc-be15a6b68a78.png">

After (focus is on the ThemeToggle button):

<img width="1230" alt="Cropped shot of the header on the Portfolio example, with focus visible on the ThemeToggle" src="https://user-images.githubusercontent.com/1045233/216752935-b9c77319-dba4-4244-afe1-032e43d3adf3.png">

## Testing

Tested locally with the keyboard in-browser before and after the change. I also ran the e2e tests but all the failures looked unrelated (framework/cross-platform errors).

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
