### PR TITLE
Move pagination error to AstroErrorData

### DIFF
--- a/.changeset/breezy-worms-retire.md
+++ b/.changeset/breezy-worms-retire.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Moved pagination error to AstroErrorData

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -429,6 +429,19 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 		message: (name: string) => `Invalid arguments passed to${name ? ` <${name}>` : ''} component.`,
 		hint: 'Astro components cannot be rendered directly via function call, such as `Component()` or `{items.map(Component)}`.',
 	},
+	/**
+	 * @docs
+	 * @see
+	 * - [Pagination](https://docs.astro.build/en/core-concepts/routing/#pagination)
+	 * @description
+	 * The page number parameter was not found in your filepath.
+	 */
+	PageNumberParamNotFound: {
+		title: 'Page number param not found.',
+		code: 3021,
+		message: (paramName: string) => `[paginate()] page number param \`${paramName}\` not found in your filepath.`,
+		hint: 'Rename your file to \`[page].astro\` or \`[...page].astro\`.'
+	},
 	// Vite Errors - 4xxx
 	UnknownViteError: {
 		title: 'Unknown Vite Error.',

--- a/packages/astro/src/core/render/paginate.ts
+++ b/packages/astro/src/core/render/paginate.ts
@@ -6,6 +6,7 @@ import {
 	Props,
 	RouteData,
 } from '../../@types/astro';
+import { AstroError, AstroErrorData } from '../errors/index.js';
 
 export function generatePaginateFunction(routeMatch: RouteData): PaginateFunction {
 	return function paginateUtility(
@@ -23,9 +24,10 @@ export function generatePaginateFunction(routeMatch: RouteData): PaginateFunctio
 		} else if (routeMatch.params.includes(`${paramName}`)) {
 			includesFirstPageNumber = true;
 		} else {
-			throw new Error(
-				`[paginate()] page number param \`${paramName}\` not found in your filepath.\nRename your file to \`[page].astro\` or \`[...page].astro\`.`
-			);
+			throw new AstroError({
+				...AstroErrorData.PageNumberParamNotFound,
+				message: AstroErrorData.PageNumberParamNotFound.message(paramName),
+			});
 		}
 		const lastPage = Math.max(1, Math.ceil(data.length / pageSize));
 


### PR DESCRIPTION
## Changes

This PR moves the error message in the `paginate()` function into `AstroErrorData` for consistency.

![image](https://user-images.githubusercontent.com/20733264/216980935-802d600d-3891-48a2-83c5-c137414b1d22.png)

## Testing

Manually tested using the `blog` demo project. Can add test file if necessary.

## Docs

I haven't been terribly creative and have kept the error message as is. However I believe that this refactor means that it will appear on the docs so I would appreciate some eyes on this from the doc team 🙏 

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
