### PR TITLE
Fix duplicate alt attribute on Picture component.

### DIFF
--- a/.changeset/tidy-buses-mate.md
+++ b/.changeset/tidy-buses-mate.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/image": patch
+---
+
+Fix duplicate `alt` attribute on Picture component.

--- a/packages/integrations/image/components/Picture.astro
+++ b/packages/integrations/image/components/Picture.astro
@@ -41,5 +41,5 @@ delete image.height;
 
 <picture>
 	{sources.map((attrs) => <source {...attrs} {sizes} />)}
-	<img {...image} {loading} {decoding} {alt} {...attrs} />
+	<img {...image} {loading} {decoding} {...attrs} />
 </picture>


### PR DESCRIPTION
## Changes

In `packages/integrations/image/components/Picture.astro` on line 44, `{...image}` already includes the `alt` attribute, so including it again creates a duplicate which causes the output to fail HTML validation: `<img alt="" alt="" ...`

Removing `{alt}` (see changes below) solves the problem.

## Testing

Do you really want to add a test to test for duplicate attributes? The current tests should confirm that the `alt` attribute is not missing, which should be sufficient to prove that the `{alt}` code mentioned above was superfluous.

I ran the tests (thank you for using pnpm!) and they passed. I'm sure you'll run them, too.

## Docs

There is no reason for this to be discussed in the docs. It's a simple mistake, and this PR fixes it.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
