### PR TITLE
Fix mixed usage of aliases and relative for client hydration

### DIFF
--- a/packages/astro/test/alias.test.js
+++ b/packages/astro/test/alias.test.js
@@ -51,5 +51,16 @@ describe('Aliases', () => {
 			const scripts = $('script').toArray();
 			expect(scripts.length).to.be.greaterThan(0);
 		});
+
+		it('can use aliases and relative in same project', async () => {
+			const html = await fixture.readFile('/two/index.html');
+			const $ = cheerio.load(html);
+
+			// Should render aliased element
+			expect($('#client').text()).to.equal('test');
+
+			const scripts = $('script').toArray();
+			expect(scripts.length).to.be.greaterThan(0);
+		});
 	});
 });

--- a/packages/astro/test/fixtures/alias/src/pages/two.astro
+++ b/packages/astro/test/fixtures/alias/src/pages/two.astro
@@ -1,0 +1,25 @@
+---
+import Client from '../components/Client.svelte'
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Svelte Client</title>
+    <style>
+      html,
+      body {
+        font-family: system-ui;
+        margin: 0;
+      }
+      body {
+        padding: 2rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <Client  client:load />
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/6162
- Projects that use relative imports for client components mixed with aliases can run into a problem where the build is unable to find the client component for hydration.
- Underlying cause is we assumed a 1-1 relationship between final resolved id and the specifier used. This fixes that false assumption.

## Testing

- Updated the alias test to add a case where we had relative usage.

## Docs

N/A, bug fix