### PR TITLE
[Content collections] Surface content config errors in overlay

### DIFF
--- a/packages/astro/src/cli/sync/index.ts
+++ b/packages/astro/src/cli/sync/index.ts
@@ -37,6 +37,12 @@ export async function sync(
 			viteServer: tempViteServer,
 		});
 		const typesResult = await contentTypesGenerator.init();
+
+		const contentConfig = globalContentConfigObserver.get();
+		if (contentConfig.status === 'error') {
+			throw contentConfig.error;
+		}
+
 		if (typesResult.typesGenerated === false) {
 			switch (typesResult.reason) {
 				case 'no-content-dir':

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -5,6 +5,8 @@ import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { normalizePath, ViteDevServer } from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
+import { AstroErrorData } from '../core/errors/errors-data.js';
+import { AstroError } from '../core/errors/index.js';
 import { info, LogOptions, warn } from '../core/logger/core.js';
 import { isRelativePath } from '../core/path.js';
 import { CONTENT_TYPES_FILE } from './consts.js';
@@ -117,11 +119,19 @@ export async function createContentTypesGenerator({
 		}
 		if (fileType === 'config') {
 			contentConfigObserver.set({ status: 'loading' });
-			const config = await loadContentConfig({ fs, settings, viteServer });
-			if (config) {
-				contentConfigObserver.set({ status: 'loaded', config });
-			} else {
-				contentConfigObserver.set({ status: 'error' });
+			try {
+				const config = await loadContentConfig({ fs, settings, viteServer });
+				if (config) {
+					contentConfigObserver.set({ status: 'loaded', config });
+				} else {
+					contentConfigObserver.set({ status: 'does-not-exist' });
+				}
+			} catch (e) {
+				contentConfigObserver.set({
+					status: 'error',
+					error:
+						e instanceof Error ? e : new AstroError(AstroErrorData.UnknownContentCollectionError),
+				});
 			}
 
 			return { shouldGenerateTypes: true };

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -275,8 +275,9 @@ export async function loadContentConfig({
 type ContentCtx =
 	| { status: 'init' }
 	| { status: 'loading' }
-	| { status: 'error' }
-	| { status: 'loaded'; config: ContentConfig };
+	| { status: 'does-not-exist' }
+	| { status: 'loaded'; config: ContentConfig }
+	| { status: 'error'; error: Error };
 
 type Observable<C> = {
 	get: () => C;

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -46,6 +46,9 @@ export function astroContentImportPlugin({
 						message: 'Content config failed to load.',
 					});
 				}
+				if (observable.status === 'error') {
+					throw observable.error;
+				}
 
 				let contentConfig: ContentConfig | undefined =
 					observable.status === 'loaded' ? observable.config : undefined;


### PR DESCRIPTION
## Changes

- Resolves #6164
- Separate "does not exist" from actual config errors
- Bubble config error throwing to the `imports` step. This makes errors catch-able by the overlay
- Check the config status from `astro sync` to throw appropriately

## Testing

Manual testing

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
