### PR TITLE
Fix root directory spread pagination `url.prev` for first page

### DIFF
--- a/.changeset/calm-readers-learn.md
+++ b/.changeset/calm-readers-learn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the first-page value of `url.prev` when paginating a spread route at the root

--- a/packages/astro/src/core/render/paginate.ts
+++ b/packages/astro/src/core/render/paginate.ts
@@ -63,9 +63,7 @@ export function generatePaginateFunction(routeMatch: RouteData): PaginateFunctio
 									: routeMatch.generate({
 											...params,
 											page:
-												!includesFirstPageNumber && pageNum - 1 === 1
-													? undefined
-													: String(pageNum - 1),
+												!includesFirstPageNumber && pageNum - 1 === 1 ? '' : String(pageNum - 1),
 									  }),
 						},
 					} as Page,

--- a/packages/astro/test/astro-pagination-root-spread.test.js
+++ b/packages/astro/test/astro-pagination-root-spread.test.js
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Pagination root', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/astro-pagination-root-spread/',
+			site: 'https://mysite.dev/',
+			base: '/blog',
+		});
+		await fixture.build();
+	});
+
+	it('correct prev url in root spread', async () => {
+		const prevMap = {
+			'/4/': '/3',
+			'/3/': '/2',
+			'/2/': '/',
+			'/': undefined,
+		};
+
+		await Promise.all(
+			Object.entries(prevMap).map(async ([curr, prev]) => {
+				const html = await fixture.readFile(curr + 'index.html');
+				const $ = cheerio.load(html);
+				expect($('#prev').attr('href')).to.equal(prev);
+			})
+		);
+	});
+});

--- a/packages/astro/test/fixtures/astro-pagination-root-spread/package.json
+++ b/packages/astro/test/fixtures/astro-pagination-root-spread/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/astro-pagination-root",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/astro-pagination-root-spread/src/pages/[...page].astro
+++ b/packages/astro/test/fixtures/astro-pagination-root-spread/src/pages/[...page].astro
@@ -1,0 +1,16 @@
+---
+export async function getStaticPaths({ paginate }) {
+  const astronautPages = [{
+    astronaut: 'Neil Armstrong',
+  }, {
+    astronaut: 'Buzz Aldrin',
+  }, {
+    astronaut: 'Sally Ride',
+  }, {
+    astronaut: 'John Glenn',
+  }];
+  return paginate(astronautPages, { pageSize: 1 });
+}
+const { page } = Astro.props;
+---
+<a id="prev" href={page.url.prev}>Back</a>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1482,6 +1482,12 @@ importers:
     dependencies:
       astro: link:../../..
 
+  packages/astro/test/fixtures/astro-pagination-root-spread:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/astro-partial-html:
     specifiers:
       '@astrojs/react': workspace:*


### PR DESCRIPTION
## Changes

- Closes #6147
- Closes https://github.com/withastro/docs/issues/2517
- When we're in "spread mode" (i.e., `includesFirstPageNumber` is set to `false`), and we're returning the `prev` value that refers to the first page, return an empty string. This gets `/` appended to it.
Previously, we returned `undefined`, which caused the bug.

## Testing

- Created an `astro-pagination-root-spread` test fixture

## Docs

Removes the need for [#2517](https://github.com/withastro/docs/issues/2517)
