### PR TITLE
Fix for Node SSR with Express JSON middleware fails on POST

### DIFF
--- a/.changeset/spotty-islands-study.md
+++ b/.changeset/spotty-islands-study.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+Fix for Node SSR with Express JSON middleware fails on POST


### PR DESCRIPTION
## Changes

- This change is to allow SSR with Node.js and Express.js to utilize Express middleware, especially the JSON one, and not break the Astro end-points that handle a POST request.
- This change is related to [Issue 5602](https://github.com/withastro/astro/issues/5602#issue-1495169317)
- Also this change includes adding the original IncomingMessage (req) as a property of the Request that is created in createRequestFromNodeRequest, so that in Astro end-points there is a way to access the Express Session middleware.

## Testing

- There was no test added, just tested to make sure that the original behavior was not broken.

## Docs

- The documentation might need to be updated to include that in the Request that is available to Astro end-points that the original IncomingMessage request is available as the new property "req".
/cc @withastro/maintainers-docs for feedback!

https://github.com/withastro/docs
