### PR TITLE
Fix types for TableHTMLAttributes

### DIFF
--- a/.changeset/sixty-scissors-refuse.md
+++ b/.changeset/sixty-scissors-refuse.md
@@ -2,4 +2,5 @@
 'astro': patch
 ---
 
-Fix `TableHTMLAttributes` types
+Fix `border` and `frame` attributes in `TableHTMLAttributes` interface
+

--- a/.changeset/sixty-scissors-refuse.md
+++ b/.changeset/sixty-scissors-refuse.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `TableHTMLAttributes` types

--- a/.changeset/sixty-scissors-refuse.md
+++ b/.changeset/sixty-scissors-refuse.md
@@ -2,5 +2,5 @@
 'astro': patch
 ---
 
-Fix `border` and `frame` attributes in `TableHTMLAttributes` interface
+Fix `border` and `frame` attribute types on `TableHTMLAttributes` interface
 

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -936,10 +936,10 @@ declare namespace astroHTML.JSX {
 	interface TableHTMLAttributes extends HTMLAttributes {
 		align?: 'left' | 'center' | 'right' | undefined | null;
 		bgcolor?: string | undefined | null;
-		border?: number | undefined | null;
+		border?: string | number | undefined | null;
 		cellpadding?: number | string | undefined | null;
 		cellspacing?: number | string | undefined | null;
-		frame?: boolean | undefined | null;
+		frame?: boolean | 'false' | 'true' | undefined | null;
 		rules?: 'none' | 'groups' | 'rows' | 'columns' | 'all' | undefined | null;
 		summary?: string | undefined | null;
 		width?: number | string | undefined | null;


### PR DESCRIPTION
- Add `string` type to `border` attribute for `TableHTMLAttributes`
- Add `'false' | 'true'` types to `frame` attribute for `TableHTMLAttributes`

Thanks @Princesseuh  for helping

## Changes

**What does this change?**

Fix types for TableHTMLAttributes

## Testing

I am not sure if this needs testing

## Docs

I don't think this adds or changes any docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
