### PR TITLE
Fix 6206: Cloudflare function path resolving one step above

### DIFF
--- a/.changeset/lazy-coins-compete.md
+++ b/.changeset/lazy-coins-compete.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fix path file that was generated outside the functions folder

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -205,8 +205,9 @@ export default function createIntegration(args?: Options): AstroIntegration {
 				if (isModeDirectory) {
 					const functionsUrl = new URL('functions', _config.root);
 					await fs.promises.mkdir(functionsUrl, { recursive: true });
-					const directoryUrl = new URL('[[path]].js', functionsUrl);
-					await fs.promises.rename(finalBuildUrl, directoryUrl);
+
+					const directoryUrl = new URL('functions/[[path]].js', _config.root);
+					await fs.promises.rename(finalBuildUrl, directoryUrl.pathname);
 				}
 			},
 		},

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -203,10 +203,10 @@ export default function createIntegration(args?: Options): AstroIntegration {
 				}
 
 				if (isModeDirectory) {
-					const functionsUrl = new URL('functions', _config.root);
+					const functionsUrl = new URL('functions/', _config.root);
 					await fs.promises.mkdir(functionsUrl, { recursive: true });
 
-					const directoryUrl = new URL('functions/[[path]].js', _config.root);
+					const directoryUrl = new URL('[[path]].js', functionsUrl);
 					await fs.promises.rename(finalBuildUrl, directoryUrl);
 				}
 			},

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -207,7 +207,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					await fs.promises.mkdir(functionsUrl, { recursive: true });
 
 					const directoryUrl = new URL('functions/[[path]].js', _config.root);
-					await fs.promises.rename(finalBuildUrl, directoryUrl.pathname);
+					await fs.promises.rename(finalBuildUrl, directoryUrl);
 				}
 			},
 		},

--- a/packages/integrations/cloudflare/test/directory.test.js
+++ b/packages/integrations/cloudflare/test/directory.test.js
@@ -17,5 +17,6 @@ describe('mode: "directory"', () => {
 
 	it('generates functions folder inside the project root', async () => {
 		expect(await fixture.pathExists('../functions')).to.be.true;
+		expect(await fixture.pathExists('../functions/[[path]].js')).to.be.true;
 	});
 });


### PR DESCRIPTION
Fixes https://github.com/withastro/astro/issues/6206

## Changes

Make sure the `[[path]].js` file is generated inside the `functions` folder in cloudflare.

## Testing

Assertion on a test has been added

## Docs

I don't think it has an impact

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
