### PR TITLE
Fix 6156: remove warning when child component redirects

### DIFF
--- a/packages/astro/src/runtime/server/render/common.ts
+++ b/packages/astro/src/runtime/server/render/common.ts
@@ -136,5 +136,9 @@ export function chunkToByteArray(
 	}
 	// stringify chunk might return a HTMLString
 	let stringified = stringifyChunk(result, chunk);
-	return encoder.encode(stringified.toString());
+	if (stringified) {
+		return encoder.encode(stringified.toString());
+	}
+
+	return new Uint8Array();
 }


### PR DESCRIPTION
Fixes https://github.com/withastro/astro/issues/6156

## Changes

Safeguard against a value that could not be defined when converting a chunk into a byte array

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
