### PR TITLE
Update compilation target for Node 16

### DIFF
--- a/.changeset/wicked-pumpkins-punch.md
+++ b/.changeset/wicked-pumpkins-punch.md
@@ -1,0 +1,30 @@
+---
+'astro': minor
+'@astrojs/prism': minor
+'@astrojs/rss': minor
+'create-astro': minor
+'@astrojs/alpinejs': minor
+'@astrojs/cloudflare': minor
+'@astrojs/deno': minor
+'@astrojs/image': minor
+'@astrojs/lit': minor
+'@astrojs/mdx': minor
+'@astrojs/netlify': minor
+'@astrojs/node': minor
+'@astrojs/partytown': minor
+'@astrojs/preact': minor
+'@astrojs/prefetch': minor
+'@astrojs/react': minor
+'@astrojs/sitemap': minor
+'@astrojs/solid-js': minor
+'@astrojs/svelte': minor
+'@astrojs/tailwind': minor
+'@astrojs/turbolinks': minor
+'@astrojs/vercel': minor
+'@astrojs/vue': minor
+'@astrojs/markdown-remark': minor
+'@astrojs/telemetry': minor
+'@astrojs/webapi': minor
+---
+
+Updated compilation settings to disable downlevelling for Node 14

--- a/examples/images/src/env.d.ts
+++ b/examples/images/src/env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="astro/client" />

--- a/examples/images/src/env.d.ts
+++ b/examples/images/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "packages/astro/test/fixtures/static build/pkg"
   ],
   "engines": {
-    "node": "^14.18.0 || >=16.12.0",
+    "node": ">=16.12.0",
     "pnpm": ">=7.9.5"
   },
   "packageManager": "pnpm@7.12.2",

--- a/packages/astro-prism/tsconfig.json
+++ b/packages/astro-prism/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "target": "ES2020",
-    "module": "ES2020",
+    "target": "ES2021",
+    "module": "ES2022",
     "outDir": "./dist"
   }
 }

--- a/packages/astro-rss/tsconfig.json
+++ b/packages/astro-rss/tsconfig.json
@@ -3,9 +3,9 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020",
+    "target": "ES2021",
     "strictNullChecks": true
   }
 }

--- a/packages/astro/tsconfig.json
+++ b/packages/astro/tsconfig.json
@@ -4,8 +4,8 @@
   "compilerOptions": {
     "allowJs": true,
     "declarationDir": "./dist",
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/create-astro/tsconfig.json
+++ b/packages/create-astro/tsconfig.json
@@ -5,8 +5,8 @@
     "allowJs": true,
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "target": "ES2020",
-    "module": "ES2020",
+    "target": "ES2021",
+    "module": "ES2022",
     "outDir": "./dist",
     "declarationDir": "./dist/types"
   }

--- a/packages/integrations/alpinejs/tsconfig.json
+++ b/packages/integrations/alpinejs/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/cloudflare/tsconfig.json
+++ b/packages/integrations/cloudflare/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/deno/tsconfig.json
+++ b/packages/integrations/deno/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/image/tsconfig.json
+++ b/packages/integrations/image/tsconfig.json
@@ -3,9 +3,9 @@
   "include": ["src", "types.d.ts"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020",
+    "target": "ES2021",
     "typeRoots": ["node_modules/@types", "node_modules/@netlify"]
   }
 }

--- a/packages/integrations/lit/tsconfig.json
+++ b/packages/integrations/lit/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/mdx/tsconfig.json
+++ b/packages/integrations/mdx/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/netlify/tsconfig.json
+++ b/packages/integrations/netlify/tsconfig.json
@@ -3,9 +3,9 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020",
+    "target": "ES2021",
     "typeRoots": ["node_modules/@types", "node_modules/@netlify"]
   }
 }

--- a/packages/integrations/node/tsconfig.json
+++ b/packages/integrations/node/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/partytown/tsconfig.json
+++ b/packages/integrations/partytown/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/preact/tsconfig.json
+++ b/packages/integrations/preact/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/prefetch/tsconfig.json
+++ b/packages/integrations/prefetch/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src", "@types"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/react/tsconfig.json
+++ b/packages/integrations/react/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/sitemap/tsconfig.json
+++ b/packages/integrations/sitemap/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/solid/tsconfig.json
+++ b/packages/integrations/solid/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/svelte/tsconfig.json
+++ b/packages/integrations/svelte/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/tailwind/tsconfig.json
+++ b/packages/integrations/tailwind/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/turbolinks/tsconfig.json
+++ b/packages/integrations/turbolinks/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/vercel/tsconfig.json
+++ b/packages/integrations/vercel/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/integrations/vue/tsconfig.json
+++ b/packages/integrations/vue/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "module": "ES2020",
+    "module": "ES2022",
     "outDir": "./dist",
-    "target": "ES2020"
+    "target": "ES2021"
   }
 }

--- a/packages/markdown/remark/tsconfig.json
+++ b/packages/markdown/remark/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "target": "ES2020",
-    "module": "ES2020",
+    "target": "ES2021",
+    "module": "ES2022",
     "outDir": "./dist"
   }
 }

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -3,8 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
-    "target": "ES2020",
-    "module": "ES2020",
+    "target": "ES2021",
+    "module": "ES2022",
     "outDir": "./dist",
     "declarationDir": "./dist/types"
   }

--- a/packages/webapi/tsconfig.json
+++ b/packages/webapi/tsconfig.json
@@ -3,7 +3,7 @@
   "exclude": ["node_modules"],
   "compilerOptions": {
     "target": "ES2021",
-    "module": "ES2020",
+    "module": "ES2022",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "declaration": true,

--- a/scripts/cmd/build.js
+++ b/scripts/cmd/build.js
@@ -1,9 +1,9 @@
-import esbuild from 'esbuild';
-import svelte from '../utils/svelte-plugin.js';
 import { deleteAsync } from 'del';
+import esbuild from 'esbuild';
 import { promises as fs } from 'fs';
 import { dim, green, red, yellow } from 'kleur/colors';
 import glob from 'tiny-glob';
+import svelte from '../utils/svelte-plugin.js';
 import prebuild from './prebuild.js';
 
 /** @type {import('esbuild').BuildOptions} */
@@ -11,7 +11,7 @@ const defaultConfig = {
 	minify: false,
 	format: 'esm',
 	platform: 'node',
-	target: 'node14',
+	target: 'node16',
 	sourcemap: false,
 	sourcesContent: false,
 };


### PR DESCRIPTION
## Changes

Despite dropping support for Node 14, we were still building for that target. This fixes that.

This is (hopefully) the final nail in the Node 14 coffin, as after this, Astro won't include the downlevelling necessary to run on Node 14 at all

This makes Astro slightly smaller: Before: `794kb` and after: `743kb` and the build slightly faster.

## Testing

Hopefully the CI pass 🤞 

## Docs

N/A