### PR TITLE
Prevent hydration mismatches in Preact

### DIFF
--- a/.changeset/orange-chicken-end.md
+++ b/.changeset/orange-chicken-end.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/preact': patch
+---
+
+Prevent hydration mismatches in Preact

--- a/packages/integrations/preact/src/client.ts
+++ b/packages/integrations/preact/src/client.ts
@@ -1,4 +1,4 @@
-import { h, render } from 'preact';
+import { h, type JSX, render } from 'preact';
 import StaticHtml from './static-html.js';
 import type { SignalLike } from './types';
 
@@ -26,8 +26,18 @@ export default (element: HTMLElement) =>
 				props[propName] = sharedSignalMap.get(signalId);
 			}
 		}
+
+		// eslint-disable-next-line @typescript-eslint/no-shadow
+		function Wrapper({ children }: { children:  JSX.Element }) {
+			let attrs = Object.fromEntries(Array.from(element.attributes).map(attr => [attr.name, attr.value]));
+			return h(element.localName, attrs, children);
+		}
+	
 		render(
-			h(Component, props, children != null ? h(StaticHtml, { value: children }) : children),
+			h(Wrapper, null,
+				h(Component, props, children != null ? h(StaticHtml, { value: children }) : children)
+			),
+			element.parentNode!,
 			element
 		);
 	};


### PR DESCRIPTION
## Changes

- Fix hydration mismatches by using the 3rd argument form of render().
- This provides the `<astro-island>` as wrapped as a Preact component, for the same of guaranteeing a root match in render. Doing this ensures that children will all be fixed in case of a mismatch.
- Fixes https://github.com/withastro/astro/issues/5937

## Testing

- Tested in the demo app. An automated test is not really possible as it takes CPU throttling to recreate.

https://user-images.githubusercontent.com/361671/218183429-09d0ba58-e7de-44a3-8e83-0a918a106448.mp4


## Docs

N/A, bug fix