### PR TITLE
Fix `getEntryType` failure on spaces in file name

### DIFF
--- a/.changeset/orange-sheep-deliver.md
+++ b/.changeset/orange-sheep-deliver.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix: internal content collection error on spaces in file name

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -163,11 +163,10 @@ export function getEntryType(
 	entryPath: string,
 	paths: Pick<ContentPaths, 'config'>
 ): 'content' | 'config' | 'ignored' | 'unsupported' {
-	const { dir: rawDir, ext, base } = path.parse(entryPath);
-	const dir = appendForwardSlash(pathToFileURL(rawDir).href);
-	const fileUrl = new URL(base, dir);
+	const { ext, base } = path.parse(entryPath);
+	const fileUrl = pathToFileURL(entryPath);
 
-	if (hasUnderscoreInPath(fileUrl) || isOnIgnoreList(fileUrl)) {
+	if (hasUnderscoreInPath(fileUrl) || isOnIgnoreList(base)) {
 		return 'ignored';
 	} else if ((contentFileExts as readonly string[]).includes(ext)) {
 		return 'content';
@@ -178,9 +177,8 @@ export function getEntryType(
 	}
 }
 
-function isOnIgnoreList(fileUrl: URL) {
-	const { base } = path.parse(fileURLToPath(fileUrl));
-	return ['.DS_Store'].includes(base);
+function isOnIgnoreList(fileName: string) {
+	return ['.DS_Store'].includes(fileName);
 }
 
 function hasUnderscoreInPath(fileUrl: URL): boolean {


### PR DESCRIPTION
## Changes

Refactor: Remove legacy code that separated the dir and stitched back together. This caused a user issue when parsing the URL under `isOnIgnoreList` (sadly unable to reproduce in a test environment).

## Testing

N/A - refactor

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
