### PR TITLE
Add ttl option to netlify adapter for builders

### DIFF
--- a/packages/integrations/netlify/README.md
+++ b/packages/integrations/netlify/README.md
@@ -13,7 +13,6 @@ Learn how to deploy your Astro site in our [Netlify deployment guide](https://do
 - <strong>[Contributing](#contributing)</strong>
 - <strong>[Changelog](#changelog)</strong>
 
-
 ## Why Astro Netlify
 
 If you're using Astro as a static site builder—its behavior out of the box—you don't need an adapter.
@@ -21,7 +20,6 @@ If you're using Astro as a static site builder—its behavior out of the box—y
 If you wish to [use server-side rendering (SSR)](https://docs.astro.build/en/guides/server-side-rendering/), Astro requires an adapter that matches your deployment runtime.
 
 [Netlify](https://www.netlify.com/) is a deployment platform that allows you to host your site by connecting directly to your GitHub repository. This adapter enhances the Astro build process to prepare your project for deployment through Netlify.
-
 
 ## Installation
 
@@ -40,22 +38,22 @@ If you prefer to install the adapter manually instead, complete the following tw
 
 1. Install the Netlify adapter to your project’s dependencies using your preferred package manager. If you’re using npm or aren’t sure, run this in the terminal:
 
-    ```bash
-      npm install @astrojs/netlify
-    ```
+   ```bash
+     npm install @astrojs/netlify
+   ```
 
 1. Add two new lines to your `astro.config.mjs` project configuration file.
 
-    ```js ins={3, 6-7}
-    // astro.config.mjs
-    import { defineConfig } from 'astro/config';
-    import netlify from '@astrojs/netlify/functions';
+   ```js ins={3, 6-7}
+   // astro.config.mjs
+   import { defineConfig } from 'astro/config';
+   import netlify from '@astrojs/netlify/functions';
 
-    export default defineConfig({
-      output: 'server',
-      adapter: netlify(),
-    });
-    ```
+   export default defineConfig({
+     output: 'server',
+     adapter: netlify(),
+   });
+   ```
 
 ### Edge Functions
 
@@ -88,7 +86,6 @@ netlify deploy --build
 
 The [Netlify Blog post on Astro](https://www.netlify.com/blog/how-to-deploy-astro/) and the [Netlify Documentation](https://docs.netlify.com/integrations/frameworks/astro/) provide more information on how to use this integration to deploy to Netlify.
 
-
 ## Configuration
 
 To configure this adapter, pass an object to the `netlify()` function call in `astro.config.mjs` - there's only one possible configuration option:
@@ -105,8 +102,8 @@ import netlify from '@astrojs/netlify/functions';
 export default defineConfig({
   output: 'server',
   adapter: netlify({
-    dist: new URL('./dist/', import.meta.url)
-  })
+    dist: new URL('./dist/', import.meta.url),
+  }),
 });
 ```
 
@@ -129,14 +126,31 @@ import netlify from '@astrojs/netlify/functions';
 export default defineConfig({
   output: 'server',
   adapter: netlify({
-    builders: true
+    builders: true,
+  }),
+});
+```
+
+On-demand Builders optionally let you return a [TTL](https://docs.netlify.com/configure-builds/on-demand-builders/#time-to-live-ttl) (time-to-live) value for the cached page. The astro adapter allows you to set a default TTL value for all pages, or a custom TTL value for specific pages via a function call.
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import netlify from '@astrojs/netlify/functions';
+
+export default defineConfig({
+  output: 'server',
+  adapter: netlify({
+    builders: {
+      ttl(event) {
+        return event.path.startsWith('/blog') ? 3600 : undefined;
+      },
+    },
   }),
 });
 ```
 
 On-demand Builders are only available with the `@astrojs/netlify/functions` adapter and are not compatible with Edge Functions.
-
-
 
 ### binaryMediaTypes
 
@@ -158,8 +172,8 @@ export function get() {
   return new Response(buffer, {
     status: 200,
     headers: {
-      'content-type': 'image/jpeg'
-    }
+      'content-type': 'image/jpeg',
+    },
   });
 }
 ```
@@ -185,4 +199,3 @@ This package is maintained by Astro's Core team. You're welcome to submit an iss
 See [CHANGELOG.md](CHANGELOG.md) for a history of changes to this integration.
 
 [astro-integration]: https://docs.astro.build/en/guides/integrations-guide/
-

--- a/packages/integrations/netlify/src/integration-functions.ts
+++ b/packages/integrations/netlify/src/integration-functions.ts
@@ -1,4 +1,5 @@
 import type { AstroAdapter, AstroConfig, AstroIntegration } from 'astro';
+import type { HandlerEvent } from '@netlify/functions';
 import type { Args } from './netlify-functions.js';
 import { createRedirects } from './shared.js';
 
@@ -13,7 +14,11 @@ export function getAdapter(args: Args = {}): AstroAdapter {
 
 interface NetlifyFunctionsOptions {
 	dist?: URL;
-	builders?: boolean;
+	builders?:
+		| boolean
+		| {
+				ttl?: number | ((event: HandlerEvent) => number | undefined);
+		  };
 	binaryMediaTypes?: string[];
 }
 


### PR DESCRIPTION
## Changes

https://github.com/withastro/astro/pull/5874 added an option to render astro pages via Netlify On-Demand Builders.

- Extends new builders option for Netlify adapter
- Allows to set a TTL (Time to Live) option:
    - As a number for all pages / routes
    - As a function per request

```js
// astro.config.mjs
import { defineConfig } from 'astro/config';
import netlify from '@astrojs/netlify/functions';

export default defineConfig({
  output: 'server',
  adapter: netlify({
    builders: {
      ttl(event) {
        return event.path.startsWith('/blog') ? 3600 : undefined;
      },
    },
  }),
});
```


## Testing

I honestly don't know how to test this. I was not even able to try it out by myself, as I don't know how to link a git subpackage as a dependency. If anybody can hint me on how to do this, I'm happy to test things with an actual project.

## Docs

@withastro/maintainers-docs I have updated the Readme with instructions.
