### PR TITLE
esbuild respects `vite.build.minify` option

### DIFF
--- a/.changeset/many-eels-wait.md
+++ b/.changeset/many-eels-wait.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+add option to compile unminified code

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -40,7 +40,6 @@ const SERVER_BUILD_FOLDER = '/$server_build/';
 export default function createIntegration(args?: Options): AstroIntegration {
 	let _config: AstroConfig;
 	let _buildConfig: BuildConfig;
-  let _viteConfig: ViteUserConfig;
 	const isModeDirectory = args?.mode === 'directory';
 
 	return {
@@ -73,7 +72,6 @@ export default function createIntegration(args?: Options): AstroIntegration {
 				}
 			},
 			'astro:build:setup': ({ vite, target }) => {
-        _viteConfig = vite;
 				if (target === 'server') {
 					vite.resolve = vite.resolve || {};
 					vite.resolve.alias = vite.resolve.alias || {};
@@ -98,7 +96,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 				// A URL for the final build path after renaming
 				const finalBuildUrl = pathToFileURL(buildPath.replace(/\.mjs$/, '.js'));
 
-				await esbuild.build({
+        await esbuild.build({
 					target: 'es2020',
 					platform: 'browser',
 					entryPoints: [entryPath],
@@ -106,7 +104,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					allowOverwrite: true,
 					format: 'esm',
 					bundle: true,
-					minify: !!_viteConfig.build?.minify,
+					minify: _config.vite?.build?.minify !== false,
 					banner: {
 						js: SHIM,
 					},

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -1,4 +1,5 @@
 import type { AstroAdapter, AstroConfig, AstroIntegration } from 'astro';
+import { ViteUserConfig } from 'astro';
 import esbuild from 'esbuild';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -39,6 +40,7 @@ const SERVER_BUILD_FOLDER = '/$server_build/';
 export default function createIntegration(args?: Options): AstroIntegration {
 	let _config: AstroConfig;
 	let _buildConfig: BuildConfig;
+  let _viteConfig: ViteUserConfig;
 	const isModeDirectory = args?.mode === 'directory';
 
 	return {
@@ -71,6 +73,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 				}
 			},
 			'astro:build:setup': ({ vite, target }) => {
+        _viteConfig = vite;
 				if (target === 'server') {
 					vite.resolve = vite.resolve || {};
 					vite.resolve.alias = vite.resolve.alias || {};
@@ -103,7 +106,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					allowOverwrite: true,
 					format: 'esm',
 					bundle: true,
-					minify: true,
+					minify: !!_viteConfig.build?.minify,
 					banner: {
 						js: SHIM,
 					},


### PR DESCRIPTION
## Changes

- now `esbuild` respects the `vite.build.minify` option from astro config

## Testing

tested with the test projects inside the cloudflare package

## Docs

we can add a little info on how to better debug issues during dev
/cc @withastro/maintainers-docs for feedback!