### PR TITLE
Fix static images on prefetch pages for SSR

### DIFF
--- a/.changeset/tasty-pugs-pay.md
+++ b/.changeset/tasty-pugs-pay.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Fix static images for prefetched pages with SSR mode. Images on prefetched pages will now be pulled in their post-processed form from ~/assets, instead of being processed server-side with each request.

--- a/packages/integrations/image/src/build/ssg.ts
+++ b/packages/integrations/image/src/build/ssg.ts
@@ -146,7 +146,11 @@ export async function ssgBuild({
 			inputBuffer = res?.data;
 			expires = res?.expires || 0;
 		} else {
-			const inputFileURL = new URL(`.${src}`, outDir);
+			let inputFileBase = outDir;
+			if (config.output === 'server') {
+				inputFileBase = inputFileBase.toString().replace(/client\/$/, 'server/');
+			}
+			const inputFileURL = new URL(`.${src}`, inputFileBase);
 			inputFile = fileURLToPath(inputFileURL);
 
 			const res = await loadLocalImage(inputFile);

--- a/packages/integrations/image/src/build/ssg.ts
+++ b/packages/integrations/image/src/build/ssg.ts
@@ -146,9 +146,9 @@ export async function ssgBuild({
 			inputBuffer = res?.data;
 			expires = res?.expires || 0;
 		} else {
-			let inputFileBase = outDir;
+			let inputFileBase = outDir.toString();
 			if (config.output === 'server') {
-				inputFileBase = inputFileBase.toString().replace(/client\/$/, 'server/');
+				inputFileBase = inputFileBase.replace(/client\/$/, 'server/');
 			}
 			const inputFileURL = new URL(`.${src}`, inputFileBase);
 			inputFile = fileURLToPath(inputFileURL);

--- a/packages/integrations/image/src/index.ts
+++ b/packages/integrations/image/src/index.ts
@@ -135,7 +135,7 @@ export default function integration(options: IntegrationOptions = {}): AstroInte
 				}
 
 				// Helpers for building static images should only be available for SSG
-				if (_config.output === 'static') {
+				if (_config.output === 'static' || _config.output === 'server') {
 					globalThis.astroImage.addStaticImage = addStaticImage;
 				}
 			},


### PR DESCRIPTION
## Changes

This change fixes the `@astrojs/images` static image build/cache for prefetched pages when using server (SSR) mode. Previously, this was only working for static mode. Now, the build will process and cache static images with server mode for prefetched pages.

This isn't the most graceful change, but it's functional. If there is a better way to handle this, please let me know. I'm still very unfamiliar with astro.

## Testing

I tested this locally with my SSR astro project. Before the change, all image requests were being processed on-demand server-side. With the change, the images are processed at build time and pulled from ~/assets.

## Docs

/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
