### PR TITLE
Run integration config hook on `astro sync`

### DIFF
--- a/packages/astro/src/cli/check/index.ts
+++ b/packages/astro/src/cli/check/index.ts
@@ -21,7 +21,7 @@ interface Result {
 export async function check(settings: AstroSettings, { logging }: { logging: LogOptions }) {
 	console.log(bold('astro check'));
 
-	const { sync } = await import('../sync/index.js');
+	const { sync } = await import('../../core/sync/index.js');
 	const syncRet = await sync(settings, { logging, fs });
 	// early exit on sync failure
 	if (syncRet === 1) return syncRet;

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -212,9 +212,9 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 		}
 
 		case 'sync': {
-			const { sync } = await import('../core/sync/index.js');
+			const { syncCli } = await import('../core/sync/index.js');
 
-			const ret = await sync(settings, { logging, fs });
+			const ret = await syncCli(settings, { logging, fs });
 			return process.exit(ret);
 		}
 

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -212,7 +212,7 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 		}
 
 		case 'sync': {
-			const { sync } = await import('./sync/index.js');
+			const { sync } = await import('../core/sync/index.js');
 
 			const ret = await sync(settings, { logging, fs });
 			return process.exit(ret);

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -81,7 +81,7 @@ class AstroBuilder {
 		);
 		await runHookConfigDone({ settings: this.settings, logging });
 
-		const { sync } = await import('../../cli/sync/index.js');
+		const { sync } = await import('../sync/index.js');
 		const syncRet = await sync(this.settings, { logging, fs });
 		if (syncRet !== 0) {
 			return process.exit(syncRet);

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -5,10 +5,10 @@ import { createServer } from 'vite';
 import type { AstroSettings } from '../../@types/astro';
 import { createContentTypesGenerator } from '../../content/index.js';
 import { globalContentConfigObserver } from '../../content/utils.js';
-import { getTimeStat } from '../../core/build/util.js';
-import { createVite } from '../../core/create-vite.js';
-import { AstroError, AstroErrorData } from '../../core/errors/index.js';
-import { info, LogOptions } from '../../core/logger/core.js';
+import { getTimeStat } from '../build/util.js';
+import { createVite } from '../create-vite.js';
+import { AstroError, AstroErrorData } from '../errors/index.js';
+import { info, LogOptions } from '../logger/core.js';
 import { setUpEnvTs } from '../../vite-plugin-inject-env-ts/index.js';
 
 export async function sync(

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -7,14 +7,29 @@ import { createContentTypesGenerator } from '../../content/index.js';
 import { globalContentConfigObserver } from '../../content/utils.js';
 import { getTimeStat } from '../build/util.js';
 import { createVite } from '../create-vite.js';
+import { runHookConfigSetup } from '../../integrations/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 import { info, LogOptions } from '../logger/core.js';
 import { setUpEnvTs } from '../../vite-plugin-inject-env-ts/index.js';
 
+type ProcessExit = 0 | 1;
+
+export async function syncCli(
+	settings: AstroSettings,
+	{ logging, fs }: { logging: LogOptions; fs: typeof fsMod }
+): Promise<ProcessExit> {
+	const resolvedSettings = await runHookConfigSetup({
+		settings,
+		logging,
+		command: 'build',
+	});
+	return sync(resolvedSettings, { logging, fs });
+}
+
 export async function sync(
 	settings: AstroSettings,
 	{ logging, fs }: { logging: LogOptions; fs: typeof fsMod }
-): Promise<0 | 1> {
+): Promise<ProcessExit> {
 	const timerStart = performance.now();
 	// Needed to load content config
 	const tempViteServer = await createServer(


### PR DESCRIPTION
## Changes

- Run `astro:config:setup` hooks on `astro sync`. This was preventing `preact-compat` from mounting in the docs repo
- Refactor: move `sync` out of `cli/` into `core/`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
