### PR TITLE
Support rehype plugins that inject namespaced attributes

### DIFF
--- a/.changeset/moody-cats-train.md
+++ b/.changeset/moody-cats-train.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Support rehype plugins that inject namespaced attributes

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -32,8 +32,8 @@
   "dependencies": {
     "@astrojs/markdown-remark": "^2.0.1",
     "@astrojs/prism": "^2.0.0",
-    "@mdx-js/mdx": "^2.1.2",
-    "@mdx-js/rollup": "^2.1.1",
+    "@mdx-js/mdx": "^2.3.0",
+    "@mdx-js/rollup": "^2.3.0",
     "acorn": "^8.8.0",
     "es-module-lexer": "^0.10.5",
     "estree-util-visit": "^1.2.0",

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -74,6 +74,7 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 									const { data: frontmatter, content: pageContent } = parseFrontmatter(code, id);
 									const compiled = await mdxCompile(new VFile({ value: pageContent, path: id }), {
 										...mdxPluginOpts,
+										elementAttributeNameCase: 'html',
 										remarkPlugins: [
 											// Ensure `data.astro` is available to all remark plugins
 											toRemarkInitializeAstroData({ userFrontmatter: frontmatter }),

--- a/packages/integrations/mdx/test/mdx-plugins.test.js
+++ b/packages/integrations/mdx/test/mdx-plugins.test.js
@@ -63,6 +63,20 @@ describe('MDX plugins', () => {
 		expect(selectRehypeExample(document)).to.not.be.null;
 	});
 
+	it('supports custom rehype plugins with namespaced attributes', async () => {
+		const fixture = await buildFixture({
+			integrations: [
+				mdx({
+					rehypePlugins: [rehypeSvgPlugin],
+				}),
+			],
+		});
+		const html = await fixture.readFile(FILE);
+		const { document } = parseHTML(html);
+
+		expect(selectRehypeSvg(document)).to.not.be.null;
+	});
+
 	it('extends markdown config by default', async () => {
 		const fixture = await buildFixture({
 			markdown: {
@@ -207,6 +221,23 @@ function rehypeExamplePlugin() {
 	};
 }
 
+function rehypeSvgPlugin() {
+	return (tree) => {
+		tree.children.push({
+			type: 'element',
+			tagName: 'svg',
+			properties: { xmlns:"http://www.w3.org/2000/svg" },
+			children: [
+				{
+					type: 'element',
+					tagName: 'use',
+					properties: { 'xlink:href': '#icon' }
+				}
+			]
+		});
+	};
+}
+
 function recmaExamplePlugin() {
 	return (tree) => {
 		estreeVisit(tree, (node) => {
@@ -243,6 +274,10 @@ function selectRemarkExample(document) {
 
 function selectRehypeExample(document) {
 	return document.querySelector('div[data-rehype-plugin-works]');
+}
+
+function selectRehypeSvg(document) {
+	return document.querySelector('svg > use[xlink\\:href]');
 }
 
 function selectRecmaExample(document) {

--- a/packages/integrations/mdx/test/mdx-plugins.test.js
+++ b/packages/integrations/mdx/test/mdx-plugins.test.js
@@ -231,7 +231,7 @@ function rehypeSvgPlugin() {
 				{
 					type: 'element',
 					tagName: 'use',
-					properties: { 'xlink:href': '#icon' }
+					properties: { 'xLinkHref': '#icon' }
 				}
 			]
 		});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2877,8 +2877,8 @@ importers:
     specifiers:
       '@astrojs/markdown-remark': ^2.0.1
       '@astrojs/prism': ^2.0.0
-      '@mdx-js/mdx': ^2.1.2
-      '@mdx-js/rollup': ^2.1.1
+      '@mdx-js/mdx': ^2.3.0
+      '@mdx-js/rollup': ^2.3.0
       '@types/chai': ^4.3.1
       '@types/estree': ^1.0.0
       '@types/github-slugger': ^1.3.0
@@ -2915,8 +2915,8 @@ importers:
     dependencies:
       '@astrojs/markdown-remark': link:../../markdown/remark
       '@astrojs/prism': link:../../astro-prism
-      '@mdx-js/mdx': 2.2.1
-      '@mdx-js/rollup': 2.2.1
+      '@mdx-js/mdx': 2.3.0
+      '@mdx-js/rollup': 2.3.0
       acorn: 8.8.2
       es-module-lexer: 0.10.5
       estree-util-visit: 1.2.1
@@ -6401,8 +6401,8 @@ packages:
       - supports-color
     dev: false
 
-  /@mdx-js/mdx/2.2.1:
-    resolution: {integrity: sha512-hZ3ex7exYLJn6FfReq8yTvA6TE53uW9UHJQM9IlSauOuS55J9y8RtA7W+dzp6Yrzr00/U1sd7q+Wf61q6SfiTQ==}
+  /@mdx-js/mdx/2.3.0:
+    resolution: {integrity: sha512-jLuwRlz8DQfQNiUCJR50Y09CGPq3fLtmtUQfVrj79E0JWu3dvsVcxVIcfhR5h0iXu+/z++zDrYeiJqifRynJkA==}
     dependencies:
       '@types/estree-jsx': 1.0.0
       '@types/mdx': 2.0.3
@@ -6425,15 +6425,15 @@ packages:
       - supports-color
     dev: false
 
-  /@mdx-js/rollup/2.2.1:
-    resolution: {integrity: sha512-wpGeK9iO7gPEIyC/ZTiggLY/MkEWDj5IWSsjlpkefgjb5RbmUukXU6/D2rHA+VAopxigS3NlaIL2ctpYBi4fmg==}
+  /@mdx-js/rollup/2.3.0:
+    resolution: {integrity: sha512-wLvRfJS/M4UmdqTd+WoaySEE7q4BIejYf1xAHXYvtT1du/1Tl/z2450Gg2+Hu7fh05KwRRiehiTP9Yc/Dtn0fA==}
     peerDependencies:
       rollup: '>=2'
     peerDependenciesMeta:
       rollup:
         optional: true
     dependencies:
-      '@mdx-js/mdx': 2.2.1
+      '@mdx-js/mdx': 2.3.0
       '@rollup/pluginutils': 5.0.2
       source-map: 0.7.4
       vfile: 5.3.7


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/5796

Thanks to https://github.com/mdx-js/mdx/pull/2255, there's a way to properly render namespaced attributes injected by rehype plugins, without Astro needing to manually map camelCase namespaced attributes, to the normal ones.

With this PR, Astro should render `<use xlink:href` instead of `<use xlinkhref`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added test to mdx integration

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.