### PR TITLE
Fix unmount Svelte slots

### DIFF
--- a/.changeset/curvy-snakes-turn.md
+++ b/.changeset/curvy-snakes-turn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/svelte': patch
+---
+
+Fix unmounting slots passed to Svelte components

--- a/packages/astro/e2e/fixtures/svelte-component/src/components/ToggleSlots.svelte
+++ b/packages/astro/e2e/fixtures/svelte-component/src/components/ToggleSlots.svelte
@@ -1,0 +1,12 @@
+<script>
+  let isNavOpen = false;
+  const toggleNav = () => (isNavOpen = !isNavOpen);
+</script>
+
+<button id="toggle" on:click={toggleNav}>
+  {#if isNavOpen}
+      <slot name="open" />
+  {:else}
+      <slot name="close" />
+  {/if}
+</button>

--- a/packages/astro/e2e/fixtures/svelte-component/src/env.d.ts
+++ b/packages/astro/e2e/fixtures/svelte-component/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/packages/astro/e2e/fixtures/svelte-component/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/svelte-component/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Counter from '../components/Counter.svelte';
 import SvelteComponent from '../components/SvelteComponent.svelte';
+import ToggleSlots from '../components/ToggleSlots.svelte';
 
 const someProps = {
 	count: 0,
@@ -33,5 +34,14 @@ const someProps = {
 		</Counter>
 
 		<SvelteComponent id="client-only" client:only="svelte" />
+
+		<ToggleSlots client:load>
+			<div slot="open">
+				open
+			</div>
+			<div slot="close">
+				close
+			</div>
+		</ToggleSlots>
 	</body>
 </html>

--- a/packages/astro/e2e/svelte-component.test.js
+++ b/packages/astro/e2e/svelte-component.test.js
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { prepareTestFactory } from './shared-component-tests.js';
 
 const { test, createTests } = prepareTestFactory({ root: './fixtures/svelte-component/' });
@@ -21,5 +22,16 @@ test.describe('Svelte components in MDX files', () => {
 		...config,
 		pageUrl: '/mdx/',
 		pageSourceFilePath: './src/pages/mdx.mdx',
+	});
+});
+
+test.describe('Svelte components lifecycle', () => {
+	test('slot should unmount properly', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/'));
+
+		const toggle = page.locator('#toggle');
+		expect((await toggle.textContent()).trim()).toBe('close');
+		await toggle.click()
+		expect((await toggle.textContent()).trim()).toBe('open');
 	});
 });

--- a/packages/integrations/svelte/client.js
+++ b/packages/integrations/svelte/client.js
@@ -23,10 +23,12 @@ export default (target) => {
 };
 
 function createSlotDefinition(key, children) {
+	let parent;
 	return [
 		() => ({
 			// mount
 			m(target) {
+				parent = target;
 				target.insertAdjacentHTML(
 					'beforeend',
 					`<astro-slot${key === 'default' ? '' : ` name="${key}"`}>${children}</astro-slot>`
@@ -37,7 +39,13 @@ function createSlotDefinition(key, children) {
 			// hydrate
 			l: noop,
 			// destroy
-			d: noop,
+			d() {
+				if (!parent) return;
+				const slot = parent.querySelector(
+					`astro-slot${key === 'default' ? ':not([name])' : `[name="${key}"]`}`
+				);
+				if (slot) slot.remove();
+			},
 		}),
 		noop,
 		noop,


### PR DESCRIPTION
## Changes

Fix #5690 

Properly unmount a slot for Svelte integration. Previously it's unimplemented, so conditionally mounting them results to them being "stucked" in the DOM.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
added test to toggle slots

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.