### PR TITLE
Only inject Vercel analytics in production

### DIFF
--- a/.changeset/dull-wasps-decide.md
+++ b/.changeset/dull-wasps-decide.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Don’t inject analytics script in dev

--- a/packages/integrations/vercel/src/edge/adapter.ts
+++ b/packages/integrations/vercel/src/edge/adapter.ts
@@ -40,8 +40,8 @@ export default function vercelEdge({
 	return {
 		name: PACKAGE_NAME,
 		hooks: {
-			'astro:config:setup': ({ config, updateConfig, injectScript }) => {
-				if (analytics) {
+			'astro:config:setup': ({ command, config, updateConfig, injectScript }) => {
+				if (command === 'build' && analytics) {
 					injectScript('page', 'import "@astrojs/vercel/analytics"');
 				}
 				const outDir = getVercelOutput(config.root);

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -35,8 +35,8 @@ export default function vercelServerless({
 	return {
 		name: PACKAGE_NAME,
 		hooks: {
-			'astro:config:setup': ({ config, updateConfig, injectScript }) => {
-				if (analytics) {
+			'astro:config:setup': ({ command, config, updateConfig, injectScript }) => {
+				if (command === 'build' && analytics) {
 					injectScript('page', 'import "@astrojs/vercel/analytics"');
 				}
 				const outDir = getVercelOutput(config.root);

--- a/packages/integrations/vercel/src/static/adapter.ts
+++ b/packages/integrations/vercel/src/static/adapter.ts
@@ -19,8 +19,8 @@ export default function vercelStatic({ analytics }: VercelStaticConfig = {}): As
 	return {
 		name: '@astrojs/vercel',
 		hooks: {
-			'astro:config:setup': ({ config, injectScript }) => {
-				if (analytics) {
+			'astro:config:setup': ({ command, config, injectScript }) => {
+				if (command === 'build' && analytics) {
 					injectScript('page', 'import "@astrojs/vercel/analytics"');
 				}
 				config.outDir = new URL('./static/', getVercelOutput(config.root));


### PR DESCRIPTION
## Changes

- Only injects the script for Vercel analytics on `build`
- Vercel’s analytics scripts rely on some extra scripts Vercel injects magically to projects built on their platform but these aren’t available locally so 404 (reported in #6230 along with other stuff)
- Folks likely don’t want to track analytics locally anyway

Philosophical question: is this difference between dev and build OK? Generally differences between the two can trip people up — what if this script interferes with some other part of the project somehow and you only notice in production?

## Testing

Existing tests should pass. Do we want a test that asserts the script is _not_ included in `dev`?

## Docs

No docs needed I don’t think.
