### PR TITLE
fix: add property name to rss errors

### DIFF
--- a/.changeset/good-snails-attend.md
+++ b/.changeset/good-snails-attend.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/rss": patch
+---
+
+Improve RSS schema errors with additional property name context

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -93,11 +93,13 @@ async function validateRssOptions(rssOptions: RSSOptions) {
 		return parsedResult.data;
 	}
 	const formattedError = new Error(
-		[
-			`[RSS] Invalid or missing options:`,
-			...parsedResult.error.errors.map((zodError) => zodError.message),
-		].join('\n')
-	);
+    [
+      `[RSS] Invalid or missing options:`,
+      ...parsedResult.error.errors.map(
+        zodError => `${zodError.message} (${zodError.path.join('.')})`
+      ),
+    ].join('\n')
+  )
 	throw formattedError;
 }
 


### PR DESCRIPTION
## Changes

- What does this change?
Add more information to zod error report

- Be short and concise. Bullet points can help!
When generating a rss feed with the rss function, if one prop of an item is missing, the only feedback will be `Invalid input` without much of _where_ is the invalid input.

## Testing

I've added a prop on a string based on zod's doc here: https://github.com/colinhacks/zod/blob/master/ERROR_HANDLING.md#zodissue

Not sure if this must be tested.

## Docs

No doc as well, it's rather enhanced error handling.