### PR TITLE
update `ChangeFreq` to support typescript configurations with string literal

### DIFF
--- a/.changeset/shiny-years-beg.md
+++ b/.changeset/shiny-years-beg.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/sitemap': minor
+---
+
+update `ChangeFreq` to support typescript configurations with string literal or predefined value.

--- a/packages/integrations/sitemap/src/generate-sitemap.ts
+++ b/packages/integrations/sitemap/src/generate-sitemap.ts
@@ -1,3 +1,4 @@
+import { EnumChangefreq } from 'sitemap';
 import type { SitemapItem, SitemapOptions } from './index.js';
 import { parseUrl } from './utils/parse-url.js';
 
@@ -44,7 +45,7 @@ export function generateSitemap(pages: string[], finalSiteUrl: string, opts: Sit
 			links,
 			lastmod,
 			priority,
-			changefreq,
+			changefreq: changefreq as EnumChangefreq,
 		};
 	});
 

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -12,7 +12,7 @@ import { generateSitemap } from './generate-sitemap.js';
 import { Logger } from './utils/logger.js';
 import { validateOptions } from './validate-options.js';
 
-export type ChangeFreq = `${EnumChangefreq}`;
+export const ChangeFreq = { ...EnumChangefreq } as const;
 export type SitemapItem = Pick<
 	SitemapItemLoose,
 	'url' | 'lastmod' | 'changefreq' | 'priority' | 'links'
@@ -32,7 +32,7 @@ export type SitemapOptions =
 			entryLimit?: number;
 
 			// sitemap specific
-			changefreq?: ChangeFreq;
+			changefreq?: EnumChangefreq;
 			lastmod?: Date;
 			priority?: number;
 

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -12,7 +12,7 @@ import { generateSitemap } from './generate-sitemap.js';
 import { Logger } from './utils/logger.js';
 import { validateOptions } from './validate-options.js';
 
-export const ChangeFreq = { ...EnumChangefreq } as const;
+export type ChangeFreq = `${EnumChangefreq}`;
 export type SitemapItem = Pick<
 	SitemapItemLoose,
 	'url' | 'lastmod' | 'changefreq' | 'priority' | 'links'
@@ -32,7 +32,7 @@ export type SitemapOptions =
 			entryLimit?: number;
 
 			// sitemap specific
-			changefreq?: EnumChangefreq;
+			changefreq?: ChangeFreq;
 			lastmod?: Date;
 			priority?: number;
 

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -12,7 +12,7 @@ import { generateSitemap } from './generate-sitemap.js';
 import { Logger } from './utils/logger.js';
 import { validateOptions } from './validate-options.js';
 
-export type ChangeFreq = EnumChangefreq;
+export const ChangeFreq = { ...EnumChangefreq } as const;
 export type SitemapItem = Pick<
 	SitemapItemLoose,
 	'url' | 'lastmod' | 'changefreq' | 'priority' | 'links'
@@ -32,7 +32,7 @@ export type SitemapOptions =
 			entryLimit?: number;
 
 			// sitemap specific
-			changefreq?: ChangeFreq;
+			changefreq?: EnumChangefreq;
 			lastmod?: Date;
 			priority?: number;
 


### PR DESCRIPTION
ATM if you wish to configure the integration in a typescript file like so you get an error :
```ts
/* ... */
sitemap({
  changefreq: 'daily' // Type '"daily"' is not assignable to type 'EnumChangefreq | undefined'. ts(2322)
})
/* ... */
```
This is due to how enums (and types made from enums) work in typescript. 

To get it working the user has to use an `as ChangeFreq` which isn't great.
```ts
changefreq: 'daily' as ChangeFreq
```
Or he can access `EnumChangefreq` by adding `sitemap` as a project dependency
```ts
changefreq: EnumChangefreq.DAILY
```
I'm not a big fan of it since `sitemap` is a dependency of this integration (could lead to version mismatch).

---
I'd like to get autocomplete without risking an version mismatch, to do so I thought of two solutions :
- re-exporting the `EnumChangefreq` enum from `sitemap`.
- the proposed change.

Re-exporting the enum will force the config to be `changefreq: EnumChangefreq.<DURATION>` and prevent the use of a string literal (and the `ChangeFreq` becomes useless). It's fine but would, IMO, require a note in the readme and an edit to the CLI `astro add sitemap`.

The proposed change allows to set `changefreq` with a string literal or via `ChangeFreq.<DURATION>`.

## Testing

I simply tested it by modifying the `index.d.ts` inside the `node_modules` of one of my project. Since the type is never used outside of the config type definition it can't really affect anything.
It wasn't enough hence the force push and failed first build, sorry about that.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

I don't think this change need any documentation since everything should be transparent to the user since it's just adding support for the string literal.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
