### PR TITLE
fix(cookies): Fix cookies not being all returned on Node 16 after Undici upgrade

### DIFF
--- a/packages/astro/test/ssr-api-route.test.js
+++ b/packages/astro/test/ssr-api-route.test.js
@@ -94,7 +94,7 @@ describe('API routes in SSR', () => {
 			expect(response.headers.get('Content-Type')).to.equal('application/json;charset=utf-8');
 		});
 
-		it('Can set multiple headers of the same type', async () => {
+		it('Can set multiple headers of the same type fsdds', async () => {
 			const response = await fixture.fetch('/login', {
 				method: 'POST',
 			});

--- a/packages/astro/test/ssr-api-route.test.js
+++ b/packages/astro/test/ssr-api-route.test.js
@@ -94,7 +94,7 @@ describe('API routes in SSR', () => {
 			expect(response.headers.get('Content-Type')).to.equal('application/json;charset=utf-8');
 		});
 
-		it('Can set multiple headers of the same type fsdds', async () => {
+		it('Can set multiple headers of the same type', async () => {
 			const response = await fixture.fetch('/login', {
 				method: 'POST',
 			});


### PR DESCRIPTION

## Changes

Undici 5.19.0 changes how `headers.entries()` return `set-cookies` headers, previously they were merged together and now they're separated. Super weird random change, but people probably smarter than me have debated this and decided that it's okay, I think.

This PR also removes some old code for node-fetch, unnecessary since we don't use it anymore

## Testing

Tests will pass! Tested manually that this works on Node 16 after the upgrade, the CI on the lockfile PR will also reflect this

## Docs

N/A
