### PR TITLE
Improve `create-astro` error handling

### DIFF
--- a/.changeset/tall-geese-end.md
+++ b/.changeset/tall-geese-end.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Improve error handling during tasks that display a spinner

--- a/packages/create-astro/src/actions/dependencies.ts
+++ b/packages/create-astro/src/actions/dependencies.ts
@@ -1,7 +1,7 @@
 import type { Context } from './context';
 
 import { execa } from 'execa';
-import { info, spinner, title } from '../messages.js';
+import { info, error, spinner, title } from '../messages.js';
 
 export async function dependencies(
 	ctx: Pick<Context, 'install' | 'yes' | 'prompt' | 'pkgManager' | 'cwd' | 'dryRun'>
@@ -25,7 +25,12 @@ export async function dependencies(
 		await spinner({
 			start: `Dependencies installing with ${ctx.pkgManager}...`,
 			end: 'Dependencies installed',
-			while: () => install({ pkgManager: ctx.pkgManager, cwd: ctx.cwd }),
+			while: () =>
+				install({ pkgManager: ctx.pkgManager, cwd: ctx.cwd }).catch((e) => {
+					// eslint-disable-next-line no-console
+					error('error', e);
+					process.exit(1);
+				}),
 		});
 	} else {
 		await info(
@@ -38,7 +43,8 @@ export async function dependencies(
 async function install({ pkgManager, cwd }: { pkgManager: string; cwd: string }) {
 	const installExec = execa(pkgManager, ['install'], { cwd });
 	return new Promise<void>((resolve, reject) => {
-		installExec.on('error', (error) => reject(error));
+		setTimeout(() => reject(`Request timed out after 30s`), 30000);
+		installExec.on('error', (e) => reject(e));
 		installExec.on('close', () => resolve());
 	});
 }

--- a/packages/create-astro/src/actions/dependencies.ts
+++ b/packages/create-astro/src/actions/dependencies.ts
@@ -43,7 +43,7 @@ export async function dependencies(
 async function install({ pkgManager, cwd }: { pkgManager: string; cwd: string }) {
 	const installExec = execa(pkgManager, ['install'], { cwd });
 	return new Promise<void>((resolve, reject) => {
-		setTimeout(() => reject(`Request timed out after 30s`), 30000);
+		setTimeout(() => reject(`Request timed out after one minute`), 60_000);
 		installExec.on('error', (e) => reject(e));
 		installExec.on('close', () => resolve());
 	});

--- a/packages/create-astro/src/actions/git.ts
+++ b/packages/create-astro/src/actions/git.ts
@@ -4,7 +4,7 @@ import type { Context } from './context';
 
 import { color } from '@astrojs/cli-kit';
 import { execa } from 'execa';
-import { info, spinner, title } from '../messages.js';
+import { info, spinner, error, title } from '../messages.js';
 
 export async function git(ctx: Pick<Context, 'cwd' | 'git' | 'yes' | 'prompt' | 'dryRun'>) {
 	if (fs.existsSync(path.join(ctx.cwd, '.git'))) {
@@ -29,7 +29,11 @@ export async function git(ctx: Pick<Context, 'cwd' | 'git' | 'yes' | 'prompt' | 
 		await spinner({
 			start: 'Git initializing...',
 			end: 'Git initialized',
-			while: () => init({ cwd: ctx.cwd }),
+			while: () => init({ cwd: ctx.cwd }).catch((e) => {
+					// eslint-disable-next-line no-console
+					error('error', e);
+					process.exit(1);
+				}),
 		});
 	} else {
 		await info(

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -34,7 +34,11 @@ export async function template(
 		await spinner({
 			start: 'Template copying...',
 			end: 'Template copied',
-			while: () => copyTemplate(ctx.template!, ctx as Context),
+			while: () => copyTemplate(ctx.template!, ctx as Context).catch((e) => {
+				// eslint-disable-next-line no-console
+				error('error', e);
+				process.exit(1);
+			}),
 		});
 	} else {
 		ctx.exit(1);

--- a/packages/create-astro/src/actions/typescript.ts
+++ b/packages/create-astro/src/actions/typescript.ts
@@ -61,7 +61,11 @@ export async function typescript(
 		await spinner({
 			start: 'TypeScript customizing...',
 			end: 'TypeScript customized',
-			while: () => setupTypeScript(ts!, { cwd: ctx.cwd }),
+			while: () => setupTypeScript(ts!, { cwd: ctx.cwd }).catch((e) => {
+					// eslint-disable-next-line no-console
+					error('error', e);
+					process.exit(1);
+				}),
 		});
 	} else {
 	}


### PR DESCRIPTION
## Changes

- Closes #6166
- Tasks that would use the `spinner` display could throw an unhandled exception, but now they'll print the error and exit gracefully (with an error code of `1`).
- Adds a timeout to `npm install` to exit after one minute.

## Testing

Tested manually

## Docs

N/A, bug fix only