### PR TITLE
Backwards compatible fix for `--camelCase` css vars in `style` attribute

### DIFF
--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -27,7 +27,14 @@ const kebab = (k: string) =>
 	k.toLowerCase() === k ? k : k.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
 const toStyleString = (obj: Record<string, any>) =>
 	Object.entries(obj)
-		.map(([k, v]) => `${kebab(k)}:${v}`)
+		.map(([k, v]) => {
+			if (k[0] !== '-' && k[1] !== '-') return `${kebab(k)}:${v}`
+			// TODO: Remove in v3! See #6264
+			// We need to emit --kebab-case AND --camelCase for backwards-compat in v2,
+			// but we should be able to remove this workaround in v3.
+			if (kebab(k) !== k) return `${kebab(k)}:var(${k});${k}:${v}`;
+			return `${k}:${v}`;
+		})
 		.join(';');
 
 // Adds variables to an inline script.


### PR DESCRIPTION
## Changes

- Closes #6264 
- Removes a bug in our `style` logic that would convert `--camelCase` to `--camel-case`.
- This is done in a backwards-compatible way to avoid a breaking change.
- This should be removed in v3.

## Testing

Tested manually, small enough that we don't have tests

## Docs

Related to ...
/cc @withastro/maintainers-docs for feedback!
