### PR TITLE
fix(create-astro): Pin giget to 1.0.0

### DIFF
--- a/.changeset/rare-lizards-grin.md
+++ b/.changeset/rare-lizards-grin.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Revert to giget 1.0.0 until upstream issue is fixed

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -34,7 +34,7 @@
     "@astrojs/cli-kit": "^0.2.2",
     "chai": "^4.3.6",
     "execa": "^6.1.0",
-    "giget": "^1.0.0",
+    "giget": "1.0.0",
     "mocha": "^9.2.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2606,7 +2606,7 @@ importers:
       astro-scripts: workspace:*
       chai: ^4.3.6
       execa: ^6.1.0
-      giget: ^1.0.0
+      giget: 1.0.0
       mocha: ^9.2.2
       strip-ansi: ^7.0.1
       strip-json-comments: ^5.0.0


### PR DESCRIPTION
## Changes

An upstream issue in giget is causing `downloadTemplate` to cause a 400 when hitting GitHub. (see https://github.com/unjs/giget/issues/81 ) Their own CI caught this, but they unfortunately still released the update. This PR pins the version to 1.0.0 in the meantime

Fix https://github.com/withastro/astro/issues/6276

## Testing

Tested manually

## Docs

N/A
