### PR TITLE
Pin undici

### DIFF
--- a/.changeset/beige-chairs-compare.md
+++ b/.changeset/beige-chairs-compare.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/webapi': patch
+---
+
+Temporarily pin undici to fix Header regression

--- a/packages/webapi/package.json
+++ b/packages/webapi/package.json
@@ -50,7 +50,7 @@
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://github.com/withastro/astro/tree/main/packages/webapi#readme",
   "dependencies": {
-    "undici": "^5.14.0"
+    "undici": "5.18.0"
   },
   "devDependencies": {
     "@rollup/plugin-alias": "^3.1.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3662,7 +3662,7 @@ importers:
       rollup: ^2.79.1
       tslib: ^2.4.0
       typescript: ~4.7.3
-      undici: ^5.14.0
+      undici: 5.18.0
       urlpattern-polyfill: ^1.0.0-rc5
     dependencies:
       undici: 5.18.0


### PR DESCRIPTION
## Changes

- A header change in undici broke set-cookie usage. This breaks the image component currently.
- There is a fix upstream but until that is released, pinning prevents the new version from surfacing.

## Testing

N/A

## Docs

N/A