### PR TITLE
Fix prerendered page handling on Deno

### DIFF
--- a/.changeset/shaggy-moons-judge.md
+++ b/.changeset/shaggy-moons-judge.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/deno': patch
+---
+
+Fix prerendered page behavior

--- a/examples/deno/package.json
+++ b/examples/deno/package.json
@@ -6,7 +6,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",
-    "preview": "deno run --allow-net --allow-read ./dist/server/entry.mjs",
+    "preview": "deno run --allow-net --allow-read --allow-env ./dist/server/entry.mjs",
     "astro": "astro"
   },
   "dependencies": {

--- a/examples/deno/src/pages/index.astro
+++ b/examples/deno/src/pages/index.astro
@@ -1,5 +1,7 @@
 ---
 import Layout from '../components/Layout.astro';
+
+export const prerender = true;
 ---
 
 <Layout title="Welcome to Astro (on Deno).">

--- a/packages/integrations/deno/package.json
+++ b/packages/integrations/deno/package.json
@@ -20,6 +20,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./server.js": "./dist/server.js",
+    "./__deno_imports.js": "./dist/__deno_imports.js",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/integrations/deno/src/__deno_imports.ts
+++ b/packages/integrations/deno/src/__deno_imports.ts
@@ -7,3 +7,4 @@ export class Server {
 }
 
 export function serveFile() {}
+export function fromFileUrl() {}

--- a/packages/integrations/deno/src/__deno_imports.ts
+++ b/packages/integrations/deno/src/__deno_imports.ts
@@ -1,0 +1,9 @@
+// This file is a shim for any Deno-specific imports!
+// It will be replaced in the final Deno build.
+// 
+// This allows us to prerender pages in Node.
+export class Server {
+	listenAndServe() {}
+}
+
+export function serveFile() {}

--- a/packages/integrations/deno/src/index.ts
+++ b/packages/integrations/deno/src/index.ts
@@ -68,8 +68,11 @@ export default function createIntegration(args?: Options): AstroIntegration {
 			'astro:build:setup': ({ vite, target }) => {
 				if (target === 'server') {
 					_vite = vite;
-					vite.resolve = vite.resolve || {};
-					vite.resolve.alias = vite.resolve.alias || {};
+					vite.resolve = vite.resolve ?? {};
+					vite.resolve.alias = vite.resolve.alias ?? {};
+					vite.build = vite.build ?? {};
+					vite.build.rollupOptions = vite.build.rollupOptions ?? {};
+					vite.build.rollupOptions.external = vite.build.rollupOptions.external ?? [];
 
 					const aliases = [{ find: 'react-dom/server', replacement: 'react-dom/server.browser' }];
 
@@ -83,7 +86,8 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					vite.ssr = {
 						noExternal: true,
 					};
-					vite.build.rollupOptions.external = [DENO_IMPORTS_SHIM]
+
+					vite.build.rollupOptions.external.push(DENO_IMPORTS_SHIM);
 				}
 			},
 			'astro:build:done': async () => {

--- a/packages/integrations/deno/src/index.ts
+++ b/packages/integrations/deno/src/index.ts
@@ -20,12 +20,15 @@ const SHIM = `globalThis.process = {
 	env: Deno.env.toObject(),
 };`;
 
+const DENO_VERSION = `0.177.0`
+
 // We shim deno-specific imports so we can run the code in Node
 // to prerender pages. In the final Deno build, this import is 
 // replaced with the Deno-specific contents listed below.
 const DENO_IMPORTS_SHIM = `@astrojs/deno/__deno_imports.js`;
-const DENO_IMPORTS = `export { Server } from "https://deno.land/std@0.177.0/http/server.ts"
-export { serveFile } from 'https://deno.land/std@0.177.0/http/file_server.ts';`
+const DENO_IMPORTS = `export { Server } from "https://deno.land/std@${DENO_VERSION}/http/server.ts"
+export { serveFile } from 'https://deno.land/std@${DENO_VERSION}/http/file_server.ts';
+export { fromFileUrl } from "https://deno.land/std@${DENO_VERSION}/path/mod.ts";`
 
 export function getAdapter(args?: Options): AstroAdapter {
 	return {

--- a/packages/integrations/deno/src/index.ts
+++ b/packages/integrations/deno/src/index.ts
@@ -87,7 +87,11 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						noExternal: true,
 					};
 
-					vite.build.rollupOptions.external.push(DENO_IMPORTS_SHIM);
+					if (Array.isArray(vite.build.rollupOptions.external)) {
+						vite.build.rollupOptions.external.push(DENO_IMPORTS_SHIM);		
+					} else if (typeof vite.build.rollupOptions.external !== 'function') {
+						vite.build.rollupOptions.external = [vite.build.rollupOptions.external, DENO_IMPORTS_SHIM]
+					}
 				}
 			},
 			'astro:build:done': async () => {

--- a/packages/integrations/deno/src/server.ts
+++ b/packages/integrations/deno/src/server.ts
@@ -15,6 +15,7 @@ let _server: Server | undefined = undefined;
 let _startPromise: Promise<void> | undefined = undefined;
 
 async function* getPrerenderedFiles(clientRoot: URL): AsyncGenerator<URL> {
+	// @ts-ignore
 	for await (const ent of Deno.readDir(clientRoot)) {
 		if (ent.isDirectory) {
 			yield* getPrerenderedFiles(new URL(`./${ent.name}/`, clientRoot))

--- a/packages/integrations/deno/src/server.ts
+++ b/packages/integrations/deno/src/server.ts
@@ -3,7 +3,7 @@ import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
 
 // @ts-ignore
-import { Server, serveFile } from '@astrojs/deno/__deno_imports.js';
+import { Server, serveFile, fromFileUrl } from '@astrojs/deno/__deno_imports.js';
 
 interface Options {
 	port?: number;
@@ -50,7 +50,7 @@ export function start(manifest: SSRManifest, options: Options) {
 		const url = new URL(request.url);
 		const localPath = new URL('./' + app.removeBase(url.pathname), clientRoot);
 
-		let fileResp = await serveFile(request, localPath.pathname);
+		let fileResp = await serveFile(request, fromFileUrl(localPath));
 
 		// Attempt to serve `index.html` if 404
 		if (fileResp.status == 404) {
@@ -63,7 +63,7 @@ export function start(manifest: SSRManifest, options: Options) {
 				}
 			}
 			if (fallback) {
-				fileResp = await serveFile(request, fallback.pathname);
+				fileResp = await serveFile(request, fromFileUrl(fallback));
 			}
 		}
 

--- a/packages/integrations/deno/test/basics.test.ts
+++ b/packages/integrations/deno/test/basics.test.ts
@@ -143,3 +143,23 @@ Deno.test({
 	sanitizeResources: false,
 	sanitizeOps: false,
 });
+
+Deno.test({
+	name: 'perendering',
+	permissions: defaultTestPermissions,
+	async fn() {
+		await startApp(async (baseUrl: URL) => {
+			const resp = await fetch(new URL('perender', baseUrl));
+			assertEquals(resp.status, 200);
+
+			const html = await resp.text();
+			assert(html);
+
+			const doc = new DOMParser().parseFromString(html, `text/html`);
+			const h1 = doc!.querySelector('h1');
+			assertEquals(h1!.innerText, 'test');
+		});
+	},
+	sanitizeResources: false,
+	sanitizeOps: false,
+});

--- a/packages/integrations/deno/test/basics.test.ts
+++ b/packages/integrations/deno/test/basics.test.ts
@@ -68,7 +68,7 @@ Deno.test({
 			resp = await fetch(new URL(href!, baseUrl));
 			assertEquals(resp.status, 200);
 			const ct = resp.headers.get('content-type');
-			assertEquals(ct, 'text/css');
+			assertEquals(ct, 'text/css; charset=UTF-8');
 			await resp.body!.cancel();
 		});
 	},
@@ -144,12 +144,13 @@ Deno.test({
 	sanitizeOps: false,
 });
 
+
 Deno.test({
 	name: 'perendering',
 	permissions: defaultTestPermissions,
 	async fn() {
 		await startApp(async (baseUrl: URL) => {
-			const resp = await fetch(new URL('perender', baseUrl));
+			const resp = await fetch(new URL('/prerender', baseUrl));
 			assertEquals(resp.status, 200);
 
 			const html = await resp.text();

--- a/packages/integrations/deno/test/fixtures/basics/src/pages/prerender.astro
+++ b/packages/integrations/deno/test/fixtures/basics/src/pages/prerender.astro
@@ -1,0 +1,9 @@
+---
+export const prerender = true; 
+---
+
+<html>
+	<body>
+		<h1>test</h1>
+	</body>
+</html>


### PR DESCRIPTION
## Changes

- Follow-up to https://github.com/withastro/astro/pull/6281, https://github.com/withastro/astro/pull/6248
- https://github.com/withastro/astro/pull/6248 was reverted because it special-cased Deno in `core` and caused some issues in practice.
- This PR takes a different approach by providing a shim for Deno-specific imports in Node so that pages can be prerendered, then replacing that shim with the actual Deno imports for the production server.
- Also switches to Deno's `std` `serveFile` function which can serve the file without loading the file into memory for optimal performance 🔥

## Testing

Test added

## Docs

N/A, bug fix only
