### PR TITLE
fix(examples/docs): Styles for left sidebar's group titles are not applied.

### DIFF
--- a/examples/docs/src/components/LeftSidebar/LeftSidebar.astro
+++ b/examples/docs/src/components/LeftSidebar/LeftSidebar.astro
@@ -20,7 +20,7 @@ const sidebar = SIDEBAR[langCode];
 			Object.entries(sidebar).map(([header, children]) => (
 				<li>
 					<div class="nav-group">
-						<h2>{header}</h2>
+						<h2 class="nav-group-title">{header}</h2>
 						<ul>
 							{children.map((child) => {
 								const url = Astro.site?.pathname + child.link;


### PR DESCRIPTION
## Changes

- Fix left sidebar group titles css.

*Before*
<img width="326" alt="image" src="https://user-images.githubusercontent.com/4998293/219778169-c1933c18-1dd9-49aa-9408-780959454dfe.png">
*After*
<img width="316" alt="image" src="https://user-images.githubusercontent.com/4998293/219778283-480def73-eb97-49ca-8fc2-463e604f17ae.png">

> Another way to fix this would be to use the `heading` class defined in `examples/docs/src/styles/index.css` that is equivalent to `nav-group-title` and is used in the right sidebar. This would avoid having duplicate code, but would couple heading styles in left and right sidebars.


## Testing

- tested manually, minor visual fix.

## Docs

- no new docs needed.
