### PR TITLE
fix(content-collections): warn about `allowJs` only when `content` directory exists

### DIFF
--- a/.changeset/kind-cameras-type.md
+++ b/.changeset/kind-cameras-type.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Warn about setting the `allowJs` compiler option only when the `content` directory exists.

--- a/packages/astro/src/content/server-listeners.ts
+++ b/packages/astro/src/content/server-listeners.ts
@@ -25,9 +25,6 @@ export async function attachContentServerListeners({
 }: ContentServerListenerParams) {
 	const contentPaths = getContentPaths(settings.config, fs);
 
-	const maybeTsConfigStats = getTSConfigStatsWhenAllowJsFalse({ contentPaths, settings });
-	if (maybeTsConfigStats) warnAllowJsIsFalse({ ...maybeTsConfigStats, logging });
-
 	if (fs.existsSync(contentPaths.contentDir)) {
 		info(
 			logging,
@@ -36,6 +33,8 @@ export async function attachContentServerListeners({
 				contentPaths.contentDir.href.replace(settings.config.root.href, '')
 			)} for changes`
 		);
+		const maybeTsConfigStats = getTSConfigStatsWhenAllowJsFalse({ contentPaths, settings });
+		if (maybeTsConfigStats) warnAllowJsIsFalse({ ...maybeTsConfigStats, logging });
 		await attachListeners();
 	} else {
 		viteServer.watcher.on('addDir', contentDirListener);


### PR DESCRIPTION
## Changes

Warn about setting the `allowJs` compiler option only when the `content` directory exists.

## Testing

Tested locally

## Docs

N/A fixes unexpected warning