### PR TITLE
`create-astro` help info add `--typescript` flag

### DIFF
--- a/.changeset/rare-pumpkins-end.md
+++ b/.changeset/rare-pumpkins-end.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+create-astro help info add --typescript flag

--- a/.changeset/rare-pumpkins-end.md
+++ b/.changeset/rare-pumpkins-end.md
@@ -2,4 +2,4 @@
 'create-astro': patch
 ---
 
-create-astro help info add --typescript flag
+`create-astro` help info add `--typescript` flag

--- a/packages/create-astro/README.md
+++ b/packages/create-astro/README.md
@@ -47,6 +47,7 @@ May be provided in place of prompts
 | `--no` (`-n`) | Skip all prompt by declining defaults. |
 | `--dry-run` | Walk through steps without executing. |
 | `--skip-houston` | Skip Houston animation. |
+| `--typescript <option>` | TypeScript option: `strict` / `strictest` / `relaxed`. |
 
 [examples]: https://github.com/withastro/astro/tree/main/examples
 [typescript]: https://github.com/withastro/astro/tree/main/packages/astro/tsconfigs

--- a/packages/create-astro/src/actions/help.ts
+++ b/packages/create-astro/src/actions/help.ts
@@ -14,6 +14,7 @@ export function help() {
 				['--no (-n)', 'Skip all prompt by declining defaults.'],
 				['--dry-run', 'Walk through steps without executing.'],
 				['--skip-houston', 'Skip Houston animation.'],
+				['--typescript <option>', 'TypeScript option: strict | strictest | relaxed.'],
 			],
 		},
 	});


### PR DESCRIPTION
## Changes

- `create-astro` help info add `--typescript` flag

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
No tests. Just help info.
## Docs

README updated.
