### PR TITLE
Bump undici to 5.20.0 (Fix ReDoS)

### DIFF
--- a/.changeset/curly-ducks-attend.md
+++ b/.changeset/curly-ducks-attend.md
@@ -1,0 +1,8 @@
+---
+'astro': minor
+'@astrojs/node': minor
+'@astrojs/telemetry': minor
+'@astrojs/webapi': minor
+---
+
+Bump undici to 5.20.0 (Fix ReDoS)

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -188,7 +188,7 @@
     "rollup": "^3.9.0",
     "sass": "^1.52.2",
     "srcset-parse": "^1.1.0",
-    "undici": "^5.14.0",
+    "undici": "^5.20.0",
     "unified": "^10.1.2"
   },
   "engines": {

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -46,6 +46,6 @@
     "cheerio": "^1.0.0-rc.11",
     "mocha": "^9.2.2",
     "node-mocks-http": "^1.11.0",
-    "undici": "^5.14.0"
+    "undici": "^5.20.0"
   }
 }

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -32,7 +32,7 @@
     "dset": "^3.1.2",
     "is-docker": "^3.0.0",
     "is-wsl": "^2.2.0",
-    "undici": "^5.14.0",
+    "undici": "^5.20.0",
     "which-pm-runs": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/webapi/package.json
+++ b/packages/webapi/package.json
@@ -50,7 +50,7 @@
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://github.com/withastro/astro/tree/main/packages/webapi#readme",
   "dependencies": {
-    "undici": "5.18.0"
+    "undici": "5.20.0"
   },
   "devDependencies": {
     "@rollup/plugin-alias": "^3.1.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,7 +456,7 @@ importers:
       supports-esm: ^1.0.0
       tsconfig-resolver: ^3.0.1
       typescript: '*'
-      undici: ^5.14.0
+      undici: ^5.20.0
       unified: ^10.1.2
       unist-util-visit: ^4.1.0
       vfile: ^5.3.2
@@ -553,7 +553,7 @@ importers:
       rollup: 3.14.0
       sass: 1.58.0
       srcset-parse: 1.1.0
-      undici: 5.18.0
+      undici: 5.20.0
       unified: 10.1.2
 
   packages/astro-prism:
@@ -3117,7 +3117,7 @@ importers:
       node-mocks-http: ^1.11.0
       send: ^0.18.0
       server-destroy: ^1.0.1
-      undici: ^5.14.0
+      undici: ^5.20.0
     dependencies:
       '@astrojs/webapi': link:../../webapi
       send: 0.18.0
@@ -3131,7 +3131,7 @@ importers:
       cheerio: 1.0.0-rc.12
       mocha: 9.2.2
       node-mocks-http: 1.12.1
-      undici: 5.18.0
+      undici: 5.20.0
 
   packages/integrations/node/test/fixtures/api-route:
     specifiers:
@@ -3624,7 +3624,7 @@ importers:
       is-docker: ^3.0.0
       is-wsl: ^2.2.0
       mocha: ^9.2.2
-      undici: ^5.14.0
+      undici: ^5.20.0
       which-pm-runs: ^1.1.0
     dependencies:
       ci-info: 3.7.1
@@ -3633,7 +3633,7 @@ importers:
       dset: 3.1.2
       is-docker: 3.0.0
       is-wsl: 2.2.0
-      undici: 5.18.0
+      undici: 5.20.0
       which-pm-runs: 1.1.0
     devDependencies:
       '@types/debug': 4.1.7
@@ -3662,10 +3662,10 @@ importers:
       rollup: ^2.79.1
       tslib: ^2.4.0
       typescript: ~4.7.3
-      undici: 5.18.0
+      undici: 5.20.0
       urlpattern-polyfill: ^1.0.0-rc5
     dependencies:
-      undici: 5.18.0
+      undici: 5.20.0
     devDependencies:
       '@rollup/plugin-alias': 3.1.9_rollup@2.79.1
       '@rollup/plugin-inject': 4.0.4_rollup@2.79.1
@@ -14859,8 +14859,8 @@ packages:
       jiti: 1.17.0
     dev: false
 
-  /undici/5.18.0:
-    resolution: {integrity: sha512-1iVwbhonhFytNdg0P4PqyIAXbdlVZVebtPDvuM36m66mRw4OGrCm2MYynJv/UENFLdP13J1nPVQzVE2zTs1OeA==}
+  /undici/5.20.0:
+    resolution: {integrity: sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==}
     engines: {node: '>=12.18'}
     dependencies:
       busboy: 1.6.0


### PR DESCRIPTION
## Changes
- Bump undici to 5.20.0. Fixes [CVE-2023-24807](https://www.cve.org/CVERecord?id=CVE-2023-24807)

## Testing

- Tested locally

## Docs

N/A - Fixes [CVE-2023-24807](https://www.cve.org/CVERecord?id=CVE-2023-24807)

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
