### PR TITLE
feat(content): bring back contentConfig.slug

### DIFF
--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -172,6 +172,15 @@ export async function createContentTypesGenerator({
 
 		const { id, collection } = entryInfo;
 
+		// not sure this is the best way
+		const { collections = {} } = await loadContentConfig({
+			fs,
+			settings,
+			viteServer,
+		})
+		const collectionConfig = collections[collection] ?? {}
+		if (collectionConfig.slug) entryInfo.slug = collectionConfig.slug(entryInfo)
+
 		const collectionKey = JSON.stringify(collection);
 		const entryKey = JSON.stringify(id);
 

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -23,7 +23,8 @@ export function getDotAstroTypeReference({ root, srcDir }: { root: URL; srcDir: 
 }
 
 export const contentConfigParser = z.object({
-	collections: z.record(collectionConfigParser),
+  collections: z.record(collectionConfigParser),
+  slug: z.function(),
 });
 
 export type CollectionConfig = z.infer<typeof collectionConfigParser>;

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -80,13 +80,19 @@ export function astroContentImportPlugin({
 				});
 				if (entryInfo instanceof Error) return;
 
+				const collectionConfig =
+          contentConfig?.collections[entryInfo.collection]
+
 				const _internal = { filePath: fileId, rawData };
 				const partialEntry = { data: unparsedData, body, _internal, ...entryInfo };
+				partialEntry.defaultSlug = getEntrySlug(partialEntry)
 				// TODO: move slug calculation to the start of the build
 				// to generate a performant lookup map for `getEntryBySlug`
-				const slug = getEntrySlug(partialEntry);
 
-				const collectionConfig = contentConfig?.collections[entryInfo.collection];
+        const slug = collectionConfig?.slug
+          ? await collectionConfig.slug(partialEntry)
+          : partialEntry.defaultSlug
+
 				const data = collectionConfig
 					? await getEntryData(partialEntry, collectionConfig)
 					: unparsedData;


### PR DESCRIPTION
Hello :) I've been talking a little about this on the community discord.

I was first interested to find a way to organize my content in my filesystem, which started to be messy because of growing amount of entries for a single collection.

At first I found that you can pass `slug:` in frontmatter ([as documented here](https://docs.astro.build/en/guides/content-collections/#defining-custom-slugs)) but having _many_ entries i was rather looking for something programmatic.

By chance I found that my content collection had a `slug: (entry: EntryInfo) => string | Promise<string>` type defined and tried to use it... but it didn't do anything!

After asking on Discord it seems like this feature was "removed at the 2.0 release"
<img width="842" alt="image" src="https://user-images.githubusercontent.com/411625/219932724-2ba5ffa7-57be-4aaa-b4a1-dc9b65a01c15.png">
but **i'm opening this PR to open a discussion with the Astro crew to propose to bring it back.**

My primary usecase is to keep my filesystem tidy by sorting entries by filename (`000-slug.md`), but also would prefer not to have the `000-` in the urls.

Of course i could go over each of my entries and inject the proper frontmatter data with a shell script, but i think it seems like a reasonable usecase, which could also be useful for people interested in having dates in frontmatter (`pubDate: 2022-02-19`) and generate slugs with dates inside it (a la wordpress) without having to duplicate the data in the filename (or the other way around!).

I did not fix (yet) the types and the `getEntryBySlug` part, but this minimal amount of code looks promising (at least to my knowledge). I've been patching my node_modules/ and it seems like working, at least for generating the types and serving content in SSG with `getCollection`.

I'll be happy to complete more tasks related to this if it seems something you'd like to bring back, otherwise i can just flip my PR to remove the generated `slug()` type in the `astro/src/content/templates/types.d.ts`.