### PR TITLE
[create-astro] Execute the 'git' step as the final interaction

### DIFF
--- a/.changeset/great-colts-accept.md
+++ b/.changeset/great-colts-accept.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Prompt for git initialization last, so all configurations can get added to the initial commit

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -29,7 +29,17 @@ export async function main() {
 		return;
 	}
 
-	const steps = [intro, projectName, template, dependencies, git, typescript, next];
+	const steps = [
+		intro,
+		projectName,
+		template,
+		dependencies,
+		typescript,
+
+		// Steps which write to files need to go above git
+ 		git,
+		next
+	];
 
 	for (const step of steps) {
 		await step(ctx);


### PR DESCRIPTION
This ensures the initialized repository has all configuration changes commited in the first commit

## Changes

Changes the order of the `create-astro` interactive steps.  Previously, it would run `git init`, `git add`, `git commit` *before* prompting for which tsconfig schema the project would use.  If `strict` or `strictest` are selected, this would mean that `tsconfig.json` would then be modified, and the initial repo is dirty.

## Testing

pnpm install && pnpm build && pnpm test: All (47) tests passed.

There could likely be an additional test for this, though I'm not entirely sure how to start writing tests for this ATM.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Docs should not be needed.
Only affects ordering of the interactive script. Anyone using create-astro programmatically should be using the CLI --flags