### PR TITLE
fix: inserted space before namespaced attributes values

### DIFF
--- a/.changeset/sixty-islands-wash.md
+++ b/.changeset/sixty-islands-wash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+prevent preprending a space after namespaced attributes colon (`:`)

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -56,12 +56,17 @@ export function formatList(values: string[]): string {
 }
 
 // A helper used to turn expressions into attribute key/value
-export function addAttribute(value: any, key: string, shouldEscape = true, shouldAddSpace = true) {
+export function addAttribute(
+	value: any,
+	key: string,
+	shouldEscape = true,
+	shouldPreprendSpace = true
+) {
 	if (value == null) {
 		return '';
 	}
 
-	const maybeSpace = shouldAddSpace ? ' ' : '';
+	const maybeSpace = shouldPreprendSpace ? ' ' : '';
 
 	if (value === false) {
 		if (htmlEnumAttributes.test(key) || svgEnumAttributes.test(key)) {

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -56,14 +56,16 @@ export function formatList(values: string[]): string {
 }
 
 // A helper used to turn expressions into attribute key/value
-export function addAttribute(value: any, key: string, shouldEscape = true) {
+export function addAttribute(value: any, key: string, shouldEscape = true, shouldAddSpace = true) {
 	if (value == null) {
 		return '';
 	}
 
+	const maybeSpace = shouldAddSpace ? ' ' : '';
+
 	if (value === false) {
 		if (htmlEnumAttributes.test(key) || svgEnumAttributes.test(key)) {
-			return markHTMLString(` ${key}="false"`);
+			return markHTMLString(`${maybeSpace}${key}="false"`);
 		}
 		return '';
 	}
@@ -83,24 +85,26 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 		if (listValue === '') {
 			return '';
 		}
-		return markHTMLString(` ${key.slice(0, -5)}="${listValue}"`);
+		return markHTMLString(`${maybeSpace}${key.slice(0, -5)}="${listValue}"`);
 	}
 
 	// support object styles for better JSX compat
 	if (key === 'style' && !(value instanceof HTMLString) && typeof value === 'object') {
-		return markHTMLString(` ${key}="${toAttributeString(toStyleString(value), shouldEscape)}"`);
+		return markHTMLString(
+			`${maybeSpace}${key}="${toAttributeString(toStyleString(value), shouldEscape)}"`
+		);
 	}
 
 	// support `className` for better JSX compat
 	if (key === 'className') {
-		return markHTMLString(` class="${toAttributeString(value, shouldEscape)}"`);
+		return markHTMLString(`${maybeSpace}class="${toAttributeString(value, shouldEscape)}"`);
 	}
 
 	// Boolean values only need the key
 	if (value === true && (key.startsWith('data-') || htmlBooleanAttributes.test(key))) {
-		return markHTMLString(` ${key}`);
+		return markHTMLString(`${maybeSpace}${key}`);
 	} else {
-		return markHTMLString(` ${key}="${toAttributeString(value, shouldEscape)}"`);
+		return markHTMLString(`${maybeSpace}${key}="${toAttributeString(value, shouldEscape)}"`);
 	}
 }
 

--- a/packages/astro/test/astro-attrs.test.js
+++ b/packages/astro/test/astro-attrs.test.js
@@ -55,6 +55,13 @@ describe('Attributes', async () => {
 		expect($('img').attr('happy:smile')).to.equal('sweet');
 	});
 
+	it('Passes namespaced expression attributes as expected', async () => {
+		const html = await fixture.readFile('/namespaced-with-expression/index.html');
+		const $ = cheerio.load(html);
+
+		expect($('use').attr('xlink:href')).to.deep.equal('#test');
+	});
+
 	it('Passes namespaced attributes to components as expected', async () => {
 		const html = await fixture.readFile('/namespaced-component/index.html');
 		const $ = cheerio.load(html);

--- a/packages/astro/test/fixtures/astro-attrs/src/pages/namespaced-with-expression.astro
+++ b/packages/astro/test/fixtures/astro-attrs/src/pages/namespaced-with-expression.astro
@@ -1,0 +1,7 @@
+---
+  const iconId = "test"
+---
+
+<svg>
+    <use xlink:href={`#${iconId}`}></use>
+</svg>


### PR DESCRIPTION
## Changes

- Fix https://github.com/withastro/astro/issues/6316
- Adds an optional parameter to the `addAttribute` function that we can use to prevent adding a space before the attribute's key

To be merged after https://github.com/withastro/compiler/pull/732, then tests should pass

## Testing

Check if foreign element's namespaced attribute is present when rendered.
Tested with a compiler preview, encoutered one possibly unrelated issue, see in comments.

## Docs

Bug-fix only