### PR TITLE
Fix import of type HTMLAttributes in blog example

### DIFF
--- a/examples/blog/src/components/HeaderLink.astro
+++ b/examples/blog/src/components/HeaderLink.astro
@@ -1,9 +1,7 @@
 ---
 import type { HTMLAttributes } from 'astro/types';
 
-interface Props extends HTMLAttributes<'a'> {
-	class?: string;
-}
+type Props = HTMLAttributes<'a'>;
 
 const { href, class: className, ...props } = Astro.props;
 

--- a/examples/blog/src/components/HeaderLink.astro
+++ b/examples/blog/src/components/HeaderLink.astro
@@ -1,5 +1,9 @@
 ---
-export interface Props extends astroHTML.JSX.AnchorHTMLAttributes {}
+import type { HTMLAttributes } from 'astro/types';
+
+interface Props extends HTMLAttributes<'a'> {
+	class?: string;
+}
 
 const { href, class: className, ...props } = Astro.props;
 


### PR DESCRIPTION
## Changes

- Use `import type` for `HTMLAttributes` in the "Headerlink" component from Blog examples. This conforms with docs examples [Typescript: Built-in HTML attributes](https://docs.astro.build/en/guides/typescript/#built-in-html-attributes)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

No tests added. Change only affect examples.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
