### PR TITLE
fix(cookies): Update Undici to 5.20 and fix cookies behaviour

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -188,7 +188,7 @@
     "rollup": "^3.9.0",
     "sass": "^1.52.2",
     "srcset-parse": "^1.1.0",
-    "undici": "^5.14.0",
+    "undici": "^5.20.0",
     "unified": "^10.1.2"
   },
   "engines": {

--- a/packages/astro/src/vite-plugin-astro-server/response.ts
+++ b/packages/astro/src/vite-plugin-astro-server/response.ts
@@ -57,12 +57,6 @@ export async function writeWebResponse(res: http.ServerResponse, webResponse: Re
 
 	const _headers = Object.fromEntries(headers.entries());
 
-	// Undici 5.19.1 includes a `getSetCookie` helper that returns an array of all the `set-cookies` headers.
-	// Previously, `headers.entries()` would already have those merged, but it seems like this isn't the case anymore, weird.
-	if ((headers as any)['getSetCookie']) {
-		_headers['set-cookie'] = (headers as any).getSetCookie();
-	}
-
 	// Attach any set-cookie headers added via Astro.cookies.set()
 	const setCookieHeaders = Array.from(getSetCookiesFromResponse(webResponse));
 	if (setCookieHeaders.length) {

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -46,6 +46,6 @@
     "cheerio": "^1.0.0-rc.11",
     "mocha": "^9.2.2",
     "node-mocks-http": "^1.11.0",
-    "undici": "^5.14.0"
+    "undici": "^5.20.0"
   }
 }

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -32,7 +32,7 @@
     "dset": "^3.1.2",
     "is-docker": "^3.0.0",
     "is-wsl": "^2.2.0",
-    "undici": "^5.14.0",
+    "undici": "^5.20.0",
     "which-pm-runs": "^1.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,7 +456,7 @@ importers:
       supports-esm: ^1.0.0
       tsconfig-resolver: ^3.0.1
       typescript: '*'
-      undici: ^5.14.0
+      undici: ^5.20.0
       unified: ^10.1.2
       unist-util-visit: ^4.1.0
       vfile: ^5.3.2
@@ -553,7 +553,7 @@ importers:
       rollup: 3.14.0
       sass: 1.58.0
       srcset-parse: 1.1.0
-      undici: 5.18.0
+      undici: 5.20.0
       unified: 10.1.2
 
   packages/astro-prism:
@@ -3117,7 +3117,7 @@ importers:
       node-mocks-http: ^1.11.0
       send: ^0.18.0
       server-destroy: ^1.0.1
-      undici: ^5.14.0
+      undici: ^5.20.0
     dependencies:
       '@astrojs/webapi': link:../../webapi
       send: 0.18.0
@@ -3131,7 +3131,7 @@ importers:
       cheerio: 1.0.0-rc.12
       mocha: 9.2.2
       node-mocks-http: 1.12.1
-      undici: 5.18.0
+      undici: 5.20.0
 
   packages/integrations/node/test/fixtures/api-route:
     specifiers:
@@ -3624,7 +3624,7 @@ importers:
       is-docker: ^3.0.0
       is-wsl: ^2.2.0
       mocha: ^9.2.2
-      undici: ^5.14.0
+      undici: ^5.20.0
       which-pm-runs: ^1.1.0
     dependencies:
       ci-info: 3.7.1
@@ -3633,7 +3633,7 @@ importers:
       dset: 3.1.2
       is-docker: 3.0.0
       is-wsl: 2.2.0
-      undici: 5.18.0
+      undici: 5.20.0
       which-pm-runs: 1.1.0
     devDependencies:
       '@types/debug': 4.1.7
@@ -14861,6 +14861,13 @@ packages:
 
   /undici/5.18.0:
     resolution: {integrity: sha512-1iVwbhonhFytNdg0P4PqyIAXbdlVZVebtPDvuM36m66mRw4OGrCm2MYynJv/UENFLdP13J1nPVQzVE2zTs1OeA==}
+    engines: {node: '>=12.18'}
+    dependencies:
+      busboy: 1.6.0
+    dev: false
+
+  /undici/5.20.0:
+    resolution: {integrity: sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==}
     engines: {node: '>=12.18'}
     dependencies:
       busboy: 1.6.0


### PR DESCRIPTION
## Changes

Now that Undici released 5.20, we can upgrade again. This fix the `npm audit` warning

## Testing

Tests will pass!

## Docs

N/A