### PR TITLE
fix(examples/docs): future-proof Discord link

### DIFF
--- a/examples/docs/src/content/docs/en/introduction.md
+++ b/examples/docs/src/content/docs/en/introduction.md
@@ -20,6 +20,6 @@ This is the `docs` starter template. It contains all of the features that you ne
 
 To get started with this theme, check out the `README.md` in your new project directory. It provides documentation on how to use and customize this template for your own project. Keep the README around so that you can always refer back to it as you build.
 
-Found a missing feature that you can't live without? Please suggest it on Discord [(#ideas-and-suggestions channel)](https://astro.build/chat) and even consider adding it yourself on GitHub! Astro is an open source project and contributions from developers like you are how we grow!
+Found a missing feature that you can't live without? Please suggest it [on our Discord](https://astro.build/chat) and even consider adding it yourself on GitHub! Astro is an open source project and contributions from developers like you are how we grow!
 
 Good luck out there, Astronaut. 🧑‍🚀


### PR DESCRIPTION
## Changes

Using the `docs` template, the `src/content/docs/en/introduction.md` file references a non-existent `#ideas-and-suggestions` channel in the Discord server.  New comment is more "future-proof"

## Testing

N/A (docs body change)

## Docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

N/A (change to docs template md)