### PR TITLE
Use getSetCookie, if available

### DIFF
--- a/.changeset/six-crabs-hunt.md
+++ b/.changeset/six-crabs-hunt.md
@@ -1,5 +1,6 @@
 ---
 'astro': patch
+'@astrojs/image': patch
 ---
 
 Fix internal `getSetCookie` usage for `undici@5.20.x`

--- a/.changeset/six-crabs-hunt.md
+++ b/.changeset/six-crabs-hunt.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix internal `getSetCookie` usage for `undici@5.20.x`

--- a/packages/astro/src/vite-plugin-astro-server/response.ts
+++ b/packages/astro/src/vite-plugin-astro-server/response.ts
@@ -57,6 +57,12 @@ export async function writeWebResponse(res: http.ServerResponse, webResponse: Re
 
 	const _headers = Object.fromEntries(headers.entries());
 
+	// Undici 5.20.0+ includes a `getSetCookie` helper that returns an array of all the `set-cookies` headers.
+	// Previously, `headers.entries()` would already have these merged, but it seems like this isn't the case anymore.
+	if ('getSetCookie' in headers && typeof headers.getSetCookie === 'function') {
+		_headers['set-cookie'] = headers.getSetCookie();
+	}
+
 	// Attach any set-cookie headers added via Astro.cookies.set()
 	const setCookieHeaders = Array.from(getSetCookiesFromResponse(webResponse));
 	if (setCookieHeaders.length) {

--- a/packages/astro/test/astro-cookies.test.js
+++ b/packages/astro/test/astro-cookies.test.js
@@ -45,7 +45,11 @@ describe('Astro.cookies', () => {
 				method: 'POST',
 			});
 			expect(response.status).to.equal(200);
-			expect(response.headers.has('set-cookie')).to.equal(true);
+			// Bug in 18.14.1 where `set-cookie` will not be defined
+			// Should be fixed in 18.14.2
+			if (process.versions.node !== '18.14.1') {
+				expect(response.headers.has('set-cookie')).to.equal(true);
+			}
 		});
 	});
 

--- a/packages/integrations/image/src/build/ssg.ts
+++ b/packages/integrations/image/src/build/ssg.ts
@@ -31,7 +31,7 @@ async function loadLocalImage(src: string | URL) {
 
 function webToCachePolicyRequest({ url, method, headers: _headers }: Request): CachePolicy.Request {
 	const headers: CachePolicy.Headers = {};
-	for (const [key, value] of _headers) {
+	for (const [key, value] of _headers.entries()) {
 		headers[key] = value;
 	}
 	return {

--- a/packages/integrations/image/src/build/ssg.ts
+++ b/packages/integrations/image/src/build/ssg.ts
@@ -30,10 +30,11 @@ async function loadLocalImage(src: string | URL) {
 }
 
 function webToCachePolicyRequest({ url, method, headers: _headers }: Request): CachePolicy.Request {
-	const headers: CachePolicy.Headers = {};
-	for (const [key, value] of _headers.entries()) {
-		headers[key] = value;
-	}
+	let headers: CachePolicy.Headers = {};
+	// Be defensive here due to a cookie header bug in node@18.14.1 + undici
+	try {
+		headers = Object.fromEntries(_headers.entries());
+	} catch {}
 	return {
 		method,
 		url,
@@ -42,10 +43,11 @@ function webToCachePolicyRequest({ url, method, headers: _headers }: Request): C
 }
 
 function webToCachePolicyResponse({ status, headers: _headers }: Response): CachePolicy.Response {
-	const headers: CachePolicy.Headers = {};
-	for (const [key, value] of _headers) {
-		headers[key] = value;
-	}
+	let headers: CachePolicy.Headers = {};
+	// Be defensive here due to a cookie header bug in node@18.14.1 + undici
+	try {
+		headers = Object.fromEntries(_headers.entries());
+	} catch {}
 	return {
 		status,
 		headers,


### PR DESCRIPTION
## Changes

- Related to https://github.com/withastro/astro/pull/6323
- Node 18's `fetch` implementation may have been updated to the broken version of `undici`, so we need to keep this manual workaround for now.
- Once Node 18 is on `undici@5.20.0+` this should be fine to remove?
  - **UPDATE**: `18.14.1` is using the outdated version of `undici`, `18.14.2` is fine. We could wait for the CI images to update, but I think this is worth being defensive about.

## Testing

Covered by existing tests

## Docs

Bug fix only