### PR TITLE
[Lit] render DSD attributes based on `shadowRootOptions`

### DIFF
--- a/.changeset/old-fireants-allow.md
+++ b/.changeset/old-fireants-allow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/lit': patch
+---
+
+Render DSD attributes based on `shadowRootOptions`

--- a/packages/integrations/lit/server.js
+++ b/packages/integrations/lit/server.js
@@ -62,7 +62,11 @@ function* render(Component, attrs, slots) {
 	yield `>`;
 	const shadowContents = instance.renderShadow({});
 	if (shadowContents !== undefined) {
-		yield '<template shadowroot="open" shadowrootmode="open">';
+		const { mode = 'open', delegatesFocus } = instance.shadowRootOptions ?? {};
+    // `delegatesFocus` is intentionally allowed to coerce to boolean to
+    // match web platform behavior.
+    const delegatesfocusAttr = delegatesFocus ? ' shadowrootdelegatesfocus' : '';
+		yield `<template shadowroot="${mode}" shadowrootmode="${mode}"${delegatesfocusAttr}>`;
 		yield* shadowContents;
 		yield '</template>';
 	}

--- a/packages/integrations/lit/test/server.test.js
+++ b/packages/integrations/lit/test/server.test.js
@@ -83,4 +83,15 @@ describe('renderToStaticMarkup', () => {
 		expect($(tagName).attr('attr1')).to.equal(attr1);
 		expect($(`${tagName} template`).text()).to.contain(`Hello ${prop1}`);
 	});
+
+	it('should render DSD attributes based on shadowRootOptions', async () => {
+		const tagName = 'lit-component';
+		customElements.define(tagName, class extends LitElement {
+			static shadowRootOptions = {...LitElement.shadowRootOptions, delegatesFocus: true};
+		});
+		const render = await renderToStaticMarkup(tagName);
+		expect(render).to.deep.equal({
+			html: `<${tagName}><template shadowroot=\"open\" shadowrootmode=\"open\" shadowrootdelegatesfocus><!--lit-part--><!--/lit-part--></template></${tagName}>`,
+		});
+	});
 });


### PR DESCRIPTION
## Changes

- Update `@astrojs/lit`’s `server.js` to properly render elements with `shadowRootOptions` that include setting [delegatesFocus](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus) to `true`.
- Logic is based on `@lit-labs/ssr` [latest implementation as found here](https://github.com/lit/lit/blob/b0c3f82ef0f97326a205e77e7e1043b75a5cc53f/packages/labs/ssr/src/lib/render-value.ts#L738-L748)

## Testing

A test was added to ensure an element with `delegatesFocus` set to `true` has this attribute properly included in the rendered static markup.

## Docs

No documentation changes are needed. This is expected functionality that currently isn't properly supported by `@astrojs/lit`.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
