### PR TITLE
fix: remove duplicate exit key from create template

### DIFF
--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -8,7 +8,7 @@ import path from 'node:path';
 import { error, info, spinner, title } from '../messages.js';
 
 export async function template(
-	ctx: Pick<Context, 'template' | 'prompt' | 'dryRun' | 'exit' | 'exit'>
+	ctx: Pick<Context, 'template' | 'prompt' | 'dryRun' | 'exit'>
 ) {
 	if (!ctx.template) {
 		const { template: tmpl } = await ctx.prompt({


### PR DESCRIPTION
## Changes

Remove duplicate `exit` key from template function.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Manual

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
