### PR TITLE
Enable `merge_group` CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   pull_request:
     paths:
       - "examples/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   pull_request:
     paths-ignore:
       - ".vscode/**"


### PR DESCRIPTION
## Changes

- Needed for Merge Queue functionality
- See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

## Testing

CI only

## Docs

CI only