### PR TITLE
Only apply head propagation in trees that need it

### DIFF
--- a/.changeset/orange-cheetahs-hide.md
+++ b/.changeset/orange-cheetahs-hide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes cases where head is injected in body when using Astro.slots.render()

--- a/packages/astro/src/vite-plugin-head-propagation/index.ts
+++ b/packages/astro/src/vite-plugin-head-propagation/index.ts
@@ -92,11 +92,11 @@ export function astroHeadPropagationBuildPlugin(
 										for (const [info] of walkParentInfos(id, this)) {
 											appendPropagation(info);
 										}
-									}
 
-									const info = this.getModuleInfo(id);
-									if (info) {
-										appendPropagation(info);
+										const info = this.getModuleInfo(id);
+										if (info) {
+											appendPropagation(info);
+										}
 									}
 								}
 							}

--- a/packages/astro/test/fixtures/head-injection/src/components/with-slot-render2/inner.astro
+++ b/packages/astro/test/fixtures/head-injection/src/components/with-slot-render2/inner.astro
@@ -1,0 +1,10 @@
+---
+---
+
+<p>View link tag position</p>
+
+<style>
+  p {
+    background: red;
+  }
+</style>

--- a/packages/astro/test/fixtures/head-injection/src/components/with-slot-render2/slots-render-outer.astro
+++ b/packages/astro/test/fixtures/head-injection/src/components/with-slot-render2/slots-render-outer.astro
@@ -1,0 +1,5 @@
+---
+const content = await Astro.slots.render('default')
+---
+
+<Fragment set:html={content} />

--- a/packages/astro/test/fixtures/head-injection/src/pages/with-slot-render2.astro
+++ b/packages/astro/test/fixtures/head-injection/src/pages/with-slot-render2.astro
@@ -1,0 +1,19 @@
+---
+import Inner from '../components/with-slot-render2/inner.astro'
+import SlotsRenderOuter from '../components/with-slot-render2/slots-render-outer.astro'
+---
+
+<html lang='en'>
+  <head>
+    <meta charset='utf-8' />
+    <link rel='icon' type='image/svg+xml' href='/favicon.svg' />
+    <meta name='viewport' content='width=device-width' />
+    <meta name='generator' content={Astro.generator} />
+    <title>Astro</title>
+  </head>
+  <body>
+    <SlotsRenderOuter>
+      <Inner />
+    </SlotsRenderOuter>
+  </body>
+</html>

--- a/packages/astro/test/head-injection.test.js
+++ b/packages/astro/test/head-injection.test.js
@@ -58,6 +58,14 @@ describe('Head injection', () => {
 				expect($('head link[rel=stylesheet]')).to.have.a.lengthOf(2);
 				expect($('body link[rel=stylesheet]')).to.have.a.lengthOf(0);
 			});
+
+			it('Using slots with Astro.slots.render() (layout)', async () => {
+				const html = await fixture.readFile('/with-slot-render2/index.html');
+				const $ = cheerio.load(html);
+
+				expect($('head link[rel=stylesheet]')).to.have.a.lengthOf(1);
+				expect($('body link[rel=stylesheet]')).to.have.a.lengthOf(0);
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/6318
- Fixes https://github.com/withastro/astro/issues/6336
- We were mistakenly marking *all* modules as need head propagation. This should only be applied to those that have head propagation in their tree (currently this is only content collection usage).

## Testing

- New test case added.

## Docs

N/A, bug fix