### PR TITLE
Do not apply user plugins when spawning temporary Vite server

### DIFF
--- a/.changeset/quick-items-switch.md
+++ b/.changeset/quick-items-switch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix regression that caused some stateful Vite plugins to assume they were running in `dev` mode during the `build`.

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -31,6 +31,7 @@ interface CreateViteOptions {
 	logging: LogOptions;
 	mode: 'dev' | 'build' | string;
 	fs?: typeof nodeFs;
+	allowUserPlugins?: boolean;
 }
 
 const ALWAYS_NOEXTERNAL = [
@@ -48,7 +49,7 @@ const ALWAYS_NOEXTERNAL = [
 /** Return a common starting point for all Vite actions */
 export async function createVite(
 	commandConfig: vite.InlineConfig,
-	{ settings, logging, mode, fs = nodeFs }: CreateViteOptions
+	{ settings, logging, mode, fs = nodeFs, allowUserPlugins = true }: CreateViteOptions
 ): Promise<vite.InlineConfig> {
 	const astroPkgsConfig = await crawlFrameworkPkgs({
 		root: fileURLToPath(settings.config.root),
@@ -170,7 +171,9 @@ export async function createVite(
 	//   3. integration-provided vite config, via the `config:setup` hook
 	//   4. command vite config, passed as the argument to this function
 	let result = commonConfig;
-	result = vite.mergeConfig(result, settings.config.vite || {});
+	if (allowUserPlugins) {
+		result = vite.mergeConfig(result, settings.config.vite || {});
+	}
 	result = vite.mergeConfig(result, commandConfig);
 	if (result.plugins) {
 		sortPlugins(result.plugins);

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -39,7 +39,8 @@ export async function sync(
 				optimizeDeps: { entries: [] },
 				logLevel: 'silent',
 			},
-			{ settings, logging, mode: 'build', fs }
+			// Important to disallow user-provided Vite plugins that might be stateful!
+			{ settings, logging, mode: 'build', fs, allowUserPlugins: false }
 		)
 	);
 


### PR DESCRIPTION
## Changes

- Closes #6364
- Adds flag to `createVite` that disallows user-provided plugins. We need to do this when spawning a temporary server during `astro build` because some Rollup/Vite plugins are stateful and have different behavior if a server is detected.
- cc @bholmesdev not sure if this has unintended consequences!

## Testing

Tested manually with `vite-plugin-pwa` repro

## Docs

Bug fix only