### PR TITLE
Update doc link in non-html-pages example README

### DIFF
--- a/examples/non-html-pages/README.md
+++ b/examples/non-html-pages/README.md
@@ -2,7 +2,7 @@
 
 Documentation for "Non-HTML Pages":
 
-https://docs.astro.build/en/core-concepts/astro-pages/#non-html-pages
+https://docs.astro.build/en/core-concepts/endpoints/#static-file-endpoints
 
 ```
 npm create astro@latest -- --template non-html-pages
@@ -28,7 +28,7 @@ Inside of your Astro project, you'll see the following folders and files:
 └── package.json
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+Astro looks for `.astro`, `.js` or `.ts` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
 
 There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
 


### PR DESCRIPTION
## Changes

Replace the following dead link:

/en/core-concepts/astro-pages/#non-html-pages

Also, mentions `.js` or `.ts` instead of `.md`,
since this is a non-html-pages example (`.md` are for html pages). 


## Testing

Update README, thus no tests are added.

## Docs

This commit itself is a documentation change.