### PR TITLE
Respect original `package.json` indentation

### DIFF
--- a/.changeset/real-balloons-cough.md
+++ b/.changeset/real-balloons-cough.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Respect original `package.json` indentation

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -50,17 +50,19 @@ const FILES_TO_UPDATE = {
 	'package.json': (file: string, overrides: { name: string }) =>
 		fs.promises
 			.readFile(file, 'utf-8')
-			.then((value) =>
+			.then((value) => {
+				// Match first indent in the file or fallback to `\t`
+				const indent = /(^\s+)/m.exec(value)?.[1] ?? '\t';
 				fs.promises.writeFile(
 					file,
 					JSON.stringify(
 						Object.assign(JSON.parse(value), Object.assign(overrides, { private: undefined })),
 						null,
-						'\t'
+						indent
 					),
 					'utf-8'
 				)
-			),
+			}),
 };
 
 export default async function copyTemplate(tmpl: string, ctx: Context) {


### PR DESCRIPTION
## Changes

- Closes #6338
- Follow-up to #6357
- Respects `package.json` indentation when updating the `package.json` file
- cc @rishi-raj-jain 

## Testing

Tested manually

## Docs

N/A, bug fix only