### PR TITLE
Add RSS feed discovery link to head

### DIFF
--- a/examples/blog/src/components/BaseHead.astro
+++ b/examples/blog/src/components/BaseHead.astro
@@ -22,6 +22,9 @@ const { title, description, image = '/placeholder-social.jpg' } = Astro.props;
 
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />
+	
+<!-- RSS Feed Discovery -->
+<link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml" />
 
 <!-- Primary Meta Tags -->
 <title>{title}</title>


### PR DESCRIPTION
A reader of my blog [pointed out](https://github.com/chromakode/blog/issues/1#issuecomment-1447341669) that I was missing an [RSS discovery](https://www.petefreitag.com/item/384.cfm) `<link>`. When I opened this repo looking for an example, I noticed it was missing one too. Here's a quick addition.