### PR TITLE
ci: add workflow_dispatch to workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,7 @@ name: Benchmark
 on:
   issue_comment:
     types: [created]
+  workflow_dispatch:
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,7 @@
 name: Examples astro check
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,6 +1,7 @@
 name: "Format Code"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: Main Checks
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -1,6 +1,7 @@
 name: Scripts
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -1,6 +1,7 @@
 name: Create a Snapshot Release
 
 on:
+  workflow_dispatch:
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
## Changes

This is a housekeeping PR. It adds the `workflow_dispatch:` to some of our workflows. This enables the possibility to run workflows manually against specific branches. This help us with debugging github actions using a PR. 

This a screenshot of the menu we can have under the actions that have `workflow_dispatch:`

![Screenshot 2023-02-28 at 17 12 07](https://user-images.githubusercontent.com/602478/221927510-e61947f0-1cd7-4918-b2db-afb9e7c2fcde.png)


I added the new property only to the workflows that seemed more "internal". Let me know which workflows need to be updated.

## Testing

After merging the PR, we should see the new dropdown in the workflows that are updated.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
