### PR TITLE
Teardown compiler to improve rendering perf

### DIFF
--- a/.changeset/bright-forks-add.md
+++ b/.changeset/bright-forks-add.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Teardown compiler after Vite build to free up memory when rendering pages

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -99,7 +99,7 @@
     "test:e2e:match": "playwright test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "next--teardown",
+    "@astrojs/compiler": "^1.2.0",
     "@astrojs/language-server": "^0.28.3",
     "@astrojs/markdown-remark": "^2.0.1",
     "@astrojs/telemetry": "^2.0.1",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -99,7 +99,7 @@
     "test:e2e:match": "playwright test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "^1.1.0",
+    "@astrojs/compiler": "next--teardown",
     "@astrojs/language-server": "^0.28.3",
     "@astrojs/markdown-remark": "^2.0.1",
     "@astrojs/telemetry": "^2.0.1",

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -203,7 +203,7 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 		case 'build': {
 			const { default: build } = await import('../core/build/index.js');
 
-			return await build(settings, { ...flags, logging, telemetry });
+			return await build(settings, { ...flags, logging, telemetry, teardownCompiler: true });
 		}
 
 		case 'check': {

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -18,8 +18,9 @@ import { apply as applyPolyfill } from '../polyfill.js';
 import { RouteCache } from '../render/route-cache.js';
 import { createRouteManifest } from '../routing/index.js';
 import { collectPagesData } from './page-data.js';
-import { staticBuild } from './static-build.js';
+import { staticBuild, viteBuild } from './static-build.js';
 import { getTimeStat } from './util.js';
+import { StaticBuildOptions } from './types.js';
 
 export interface BuildOptions {
 	mode?: RuntimeMode;
@@ -126,7 +127,7 @@ class AstroBuilder {
 			colors.dim(`Completed in ${getTimeStat(this.timer.init, performance.now())}.`)
 		);
 
-		await staticBuild({
+		const opts: StaticBuildOptions = {
 			allPages,
 			settings: this.settings,
 			logging: this.logging,
@@ -137,7 +138,10 @@ class AstroBuilder {
 			routeCache: this.routeCache,
 			viteConfig,
 			buildConfig,
-		});
+		};
+
+		const { internals } = await viteBuild(opts);
+		await staticBuild(opts, internals);
 
 		// Write any additionally generated assets to disk.
 		this.timer.assetsStart = performance.now();

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -26,6 +26,11 @@ export interface BuildOptions {
 	mode?: RuntimeMode;
 	logging: LogOptions;
 	telemetry: AstroTelemetry;
+	/**
+	 * Teardown the compiler WASM instance after build. This can improve performance when
+	 * building once, but may cause a performance hit if building multiple times in a row.
+	 */
+	teardownCompiler?: boolean;
 }
 
 /** `astro build` */
@@ -43,6 +48,7 @@ class AstroBuilder {
 	private routeCache: RouteCache;
 	private manifest: ManifestData;
 	private timer: Record<string, number>;
+	private teardownCompiler: boolean;
 
 	constructor(settings: AstroSettings, options: BuildOptions) {
 		if (options.mode) {
@@ -50,6 +56,7 @@ class AstroBuilder {
 		}
 		this.settings = settings;
 		this.logging = options.logging;
+		this.teardownCompiler = options.teardownCompiler ?? false;
 		this.routeCache = new RouteCache(this.logging);
 		this.origin = settings.config.site
 			? new URL(settings.config.site).origin
@@ -136,6 +143,7 @@ class AstroBuilder {
 			origin: this.origin,
 			pageNames,
 			routeCache: this.routeCache,
+			teardownCompiler: this.teardownCompiler,
 			viteConfig,
 			buildConfig,
 		};

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -99,9 +99,11 @@ export async function viteBuild(opts: StaticBuildOptions) {
 
 	settings.timer.end('Client build');
 
-	// Free up memory
-	internals.ssrEntryChunk = undefined;
-	teardown();
+	// Free up memory, skip if running in tests
+	if (!process.env.TEST) {
+		internals.ssrEntryChunk = undefined;
+		teardown();
+	}
 
 	return { internals };
 }

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -99,9 +99,9 @@ export async function viteBuild(opts: StaticBuildOptions) {
 
 	settings.timer.end('Client build');
 
-	// Free up memory, skip if running in tests
-	if (!process.env.TEST) {
-		internals.ssrEntryChunk = undefined;
+	// Free up memory
+	internals.ssrEntryChunk = undefined;
+	if (opts.teardownCompiler) {
 		teardown();
 	}
 

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -1,3 +1,4 @@
+import { teardown } from '@astrojs/compiler';
 import * as eslexer from 'es-module-lexer';
 import glob from 'fast-glob';
 import fs from 'fs';
@@ -25,7 +26,7 @@ import { registerAllPlugins } from './plugins/index.js';
 import type { PageBuildData, StaticBuildOptions } from './types';
 import { getTimeStat } from './util.js';
 
-export async function staticBuild(opts: StaticBuildOptions) {
+export async function viteBuild(opts: StaticBuildOptions) {
 	const { allPages, settings } = opts;
 
 	// Make sure we have an adapter before building
@@ -98,6 +99,15 @@ export async function staticBuild(opts: StaticBuildOptions) {
 
 	settings.timer.end('Client build');
 
+	// Free up memory
+	internals.ssrEntryChunk = undefined;
+	teardown();
+
+	return { internals };
+}
+
+export async function staticBuild(opts: StaticBuildOptions, internals: BuildInternals) {
+	const { settings } = opts;
 	switch (settings.config.output) {
 		case 'static': {
 			settings.timer.start('Static generate');

--- a/packages/astro/src/core/build/types.ts
+++ b/packages/astro/src/core/build/types.ts
@@ -39,6 +39,7 @@ export interface StaticBuildOptions {
 	pageNames: string[];
 	routeCache: RouteCache;
 	viteConfig: InlineConfig;
+	teardownCompiler: boolean;
 }
 
 export interface SingleFileBuiltModule {

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -144,8 +144,6 @@ export async function loadFixture(inlineConfig) {
 
 	return {
 		build: (opts = {}) => {
-			// Set TEST env var true to prevent compiler teardown
-			process.env.TEST = true;
 			process.env.NODE_ENV = 'production';
 			return build(settings, { logging, telemetry, ...opts });
 		},

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -144,6 +144,8 @@ export async function loadFixture(inlineConfig) {
 
 	return {
 		build: (opts = {}) => {
+			// Set TEST env var true to prevent compiler teardown
+			process.env.TEST = true;
 			process.env.NODE_ENV = 'production';
 			return build(settings, { logging, telemetry, ...opts });
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,7 +395,7 @@ importers:
 
   packages/astro:
     specifiers:
-      '@astrojs/compiler': next--teardown
+      '@astrojs/compiler': ^1.2.0
       '@astrojs/language-server': ^0.28.3
       '@astrojs/markdown-remark': ^2.0.1
       '@astrojs/telemetry': ^2.0.1
@@ -485,7 +485,7 @@ importers:
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
-      '@astrojs/compiler': 0.0.0-teardown-20230228094908
+      '@astrojs/compiler': 1.2.0
       '@astrojs/language-server': 0.28.3
       '@astrojs/markdown-remark': link:../markdown/remark
       '@astrojs/telemetry': link:../telemetry
@@ -3953,12 +3953,12 @@ packages:
       sisteransi: 1.0.5
     dev: false
 
-  /@astrojs/compiler/0.0.0-teardown-20230228094908:
-    resolution: {integrity: sha512-xIC0mO05P6ZHbKZVo94oJpiiWCpFwSWRdhtPXT3SgDod64D0+Dp7qKSkED2ZC1HrRzK2rRv1HwSDArH6CWmpww==}
-    dev: false
-
   /@astrojs/compiler/0.31.4:
     resolution: {integrity: sha512-6bBFeDTtPOn4jZaiD3p0f05MEGQL9pw2Zbfj546oFETNmjJFWO3nzHz6/m+P53calknCvyVzZ5YhoBLIvzn5iw==}
+
+  /@astrojs/compiler/1.2.0:
+    resolution: {integrity: sha512-O8yPCyuq+PU9Fjht2tIW6WzSWiq8qDF1e8uAX2x+SOGFzKqOznp52UlDG2mSf+ekf0Z3R34sb64O7SgX+asTxg==}
+    dev: false
 
   /@astrojs/language-server/0.28.3:
     resolution: {integrity: sha512-fPovAX/X46eE2w03jNRMpQ7W9m2mAvNt4Ay65lD9wl1Z5vIQYxlg7Enp9qP225muTr4jSVB5QiLumFJmZMAaVA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,7 +395,7 @@ importers:
 
   packages/astro:
     specifiers:
-      '@astrojs/compiler': ^1.1.0
+      '@astrojs/compiler': next--teardown
       '@astrojs/language-server': ^0.28.3
       '@astrojs/markdown-remark': ^2.0.1
       '@astrojs/telemetry': ^2.0.1
@@ -485,7 +485,7 @@ importers:
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
-      '@astrojs/compiler': 1.1.0
+      '@astrojs/compiler': 0.0.0-teardown-20230228094908
       '@astrojs/language-server': 0.28.3
       '@astrojs/markdown-remark': link:../markdown/remark
       '@astrojs/telemetry': link:../telemetry
@@ -3953,12 +3953,12 @@ packages:
       sisteransi: 1.0.5
     dev: false
 
+  /@astrojs/compiler/0.0.0-teardown-20230228094908:
+    resolution: {integrity: sha512-xIC0mO05P6ZHbKZVo94oJpiiWCpFwSWRdhtPXT3SgDod64D0+Dp7qKSkED2ZC1HrRzK2rRv1HwSDArH6CWmpww==}
+    dev: false
+
   /@astrojs/compiler/0.31.4:
     resolution: {integrity: sha512-6bBFeDTtPOn4jZaiD3p0f05MEGQL9pw2Zbfj546oFETNmjJFWO3nzHz6/m+P53calknCvyVzZ5YhoBLIvzn5iw==}
-
-  /@astrojs/compiler/1.1.0:
-    resolution: {integrity: sha512-C4kTwirys+HafufMqaxCbML2wqkGaXJM+5AekXh/v1IIOnMIdcEON9GBYsG6qa8aAmLhZ58aUZGPhzcA3Dx7Uw==}
-    dev: false
 
   /@astrojs/language-server/0.28.3:
     resolution: {integrity: sha512-fPovAX/X46eE2w03jNRMpQ7W9m2mAvNt4Ay65lD9wl1Z5vIQYxlg7Enp9qP225muTr4jSVB5QiLumFJmZMAaVA==}


### PR DESCRIPTION
## Changes

Use `@astrojs/compiler` `teardown()` API to remove the internal WASM instance and cache after we're finished with the Vite build.

## Testing

All existing test should pass. `!bench memory` _should_ show an improvement too, but it doesn't because the technique to capture "heap used" includes the garbage collection root (for some reason).

But when testing with docs locally, I can see the optimization working where Vite build memory gets offloaded during rendering.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. internal refactor.
