### PR TITLE
Fix astro sync config merge

### DIFF
--- a/.changeset/cold-mirrors-joke.md
+++ b/.changeset/cold-mirrors-joke.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Run astro sync in build mode

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -30,8 +30,7 @@ interface CreateViteOptions {
 	settings: AstroSettings;
 	logging: LogOptions;
 	mode: 'dev' | 'build' | string;
-	// will be undefined when using `sync`
-	command?: 'dev' | 'build';
+	command: 'dev' | 'build';
 	fs?: typeof nodeFs;
 }
 
@@ -180,32 +179,28 @@ export async function createVite(
 	// We also need to filter out the plugins that are not meant to be applied to the current command:
 	// - If the command is `build`, we filter out the plugins that are meant to be applied for `serve`.
 	// - If the command is `dev`, we filter out the plugins that are meant to be applied for `build`.
-	if (command) {
-		let plugins = settings.config.vite?.plugins;
-		if (plugins) {
-			const { plugins: _, ...rest } = settings.config.vite;
-			const applyToFilter = command === 'build' ? 'serve' : 'build';
-			const applyArgs = [
-				{ ...settings.config.vite, mode },
-				{ command, mode },
-			];
-			// @ts-expect-error ignore TS2589: Type instantiation is excessively deep and possibly infinite.
-			plugins = plugins.flat(Infinity).filter((p) => {
-				if (!p || p?.apply === applyToFilter) {
-					return false;
-				}
+	if (settings.config.vite?.plugins) {
+		let { plugins, ...rest } = settings.config.vite;
+		const applyToFilter = command === 'build' ? 'serve' : 'build';
+		const applyArgs = [
+			{ ...settings.config.vite, mode },
+			{ command, mode },
+		];
+		// @ts-expect-error ignore TS2589: Type instantiation is excessively deep and possibly infinite.
+		plugins = plugins.flat(Infinity).filter((p) => {
+			if (!p || p?.apply === applyToFilter) {
+				return false;
+			}
 
-				if (typeof p.apply === 'function') {
-					return p.apply(applyArgs[0], applyArgs[1]);
-				}
+			if (typeof p.apply === 'function') {
+				return p.apply(applyArgs[0], applyArgs[1]);
+			}
 
-				return true;
-			});
-
-			result = vite.mergeConfig(result, { ...rest, plugins });
-		} else {
-			result = vite.mergeConfig(result, settings.config.vite || {});
-		}
+			return true;
+		});
+		result = vite.mergeConfig(result, { ...rest, plugins });
+	} else {
+		result = vite.mergeConfig(result, settings.config.vite || {});
 	}
 	result = vite.mergeConfig(result, commandConfig);
 	if (result.plugins) {

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -30,7 +30,8 @@ interface CreateViteOptions {
 	settings: AstroSettings;
 	logging: LogOptions;
 	mode: 'dev' | 'build' | string;
-	command: 'dev' | 'build';
+	// will be undefined when using `getViteConfig`
+	command?: 'dev' | 'build';
 	fs?: typeof nodeFs;
 }
 
@@ -179,7 +180,7 @@ export async function createVite(
 	// We also need to filter out the plugins that are not meant to be applied to the current command:
 	// - If the command is `build`, we filter out the plugins that are meant to be applied for `serve`.
 	// - If the command is `dev`, we filter out the plugins that are meant to be applied for `build`.
-	if (settings.config.vite?.plugins) {
+	if (command && settings.config.vite?.plugins) {
 		let { plugins, ...rest } = settings.config.vite;
 		const applyToFilter = command === 'build' ? 'serve' : 'build';
 		const applyArgs = [

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -39,7 +39,7 @@ export async function sync(
 				optimizeDeps: { entries: [] },
 				logLevel: 'silent',
 			},
-			{ settings, logging, mode: 'build', fs }
+			{ settings, logging, mode: 'build', command: 'build', fs }
 		)
 	);
 


### PR DESCRIPTION
## Changes

Recently merged but unreleased change https://github.com/withastro/astro/pull/6368 regresses https://github.com/withastro/astro/pull/6238. Causing docs to fail to build because integrations that updates the Vite config isn't affecting Astro's internal Vite config.

This PR makes `astro sync` to run in `build` mode, meaning plugins with `apply: 'serve'` will not run in `astro sync`. I _think_ this is what https://github.com/withastro/astro/pull/6368 was trying to fix (the issue:  https://github.com/withastro/astro/issues/6364), so this shouldn't be regressing that. And opens up the path for `astro sync` to update Astro's internal Vite config.

cc @userquin 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
I made sure the test added in https://github.com/withastro/astro/pull/6368 still passed

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.