### PR TITLE
Improve server-stress benchmark comment

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -13,6 +13,7 @@
     "execa": "^6.1.0",
     "markdown-table": "^3.0.3",
     "mri": "^1.2.0",
-    "port-authority": "^2.0.1"
+    "port-authority": "^2.0.1",
+    "pretty-bytes": "^6.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,7 @@ importers:
       markdown-table: ^3.0.3
       mri: ^1.2.0
       port-authority: ^2.0.1
+      pretty-bytes: ^6.0.0
     dependencies:
       '@astrojs/node': link:../packages/integrations/node
       astro: link:../packages/astro
@@ -80,6 +81,7 @@ importers:
       markdown-table: 3.0.3
       mri: 1.2.0
       port-authority: 2.0.1
+      pretty-bytes: 6.1.0
 
   examples/basics:
     specifiers:
@@ -13377,7 +13379,6 @@ packages:
   /pretty-bytes/6.1.0:
     resolution: {integrity: sha512-Rk753HI8f4uivXi4ZCIYdhmG1V+WKzvRMg/X+M42a6t7D07RcmopXJMDNk6N++7Bl75URRGsb40ruvg7Hcp2wQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
-    dev: true
 
   /pretty-format/3.8.0:
     resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}


### PR DESCRIPTION
## Changes

Improve `!bench server-stress` comment output. It should print a nicer markdown table now:

**Before:**


18k requests in 30.05s, 1.23 GB read


**After:**

|         |       Avg |     Stdev |     Max |
| :------ | --------: | --------: | ------: |
| Latency | 680.22 ms | 220.43 ms | 1398 ms |

|           |     Avg |   Stdev |     Min |   Total in 30s |
| :-------- | ------: | ------: | ------: | -------------: |
| Req/Sec   | 1449.54 |   73.74 |    1192 | 43.5k requests |
| Bytes/Sec |  103 MB | 5.24 MB | 84.8 MB |   3.09 GB read |


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested by running `pnpm benchmark server-stress` locally.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. internal tooling.