### PR TITLE
ci: use one action for comments

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -91,11 +91,13 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v1
+        uses: peter-evans/create-or-update-comment@v2
+        continue-on-error: true
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          pr_number: ${{ github.event.issue.number }}
+          issue-number: ${{ github.event.issue.number }}
           message: |
             ${{ needs.benchmark.outputs.PR-BENCH }}
 
             ${{ needs.benchmark.outputs.MAIN-BENCH }}
+            - name: Send PR review
+          edit-mode: replace

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -99,5 +99,4 @@ jobs:
             ${{ needs.benchmark.outputs.PR-BENCH }}
 
             ${{ needs.benchmark.outputs.MAIN-BENCH }}
-            - name: Send PR review
           edit-mode: replace


### PR DESCRIPTION
## Changes

Chore PR.  Follow up of #6397 

It updates the benchmark workflow to use the same action we use for comments.

cc @bluwy 

## Testing

I should be able to trigger the action manually and see the message, although I am unsure if that will work. Alternatively, we would need to merge it and then use the magic comment to trigger the benchmark.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
