### PR TITLE
Fix marketing typo by just removing extra info

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Contribute to Astro CodeSpaces",
+  "name": "Contribute to Astro",
   "build": {
     "dockerfile": "Dockerfile"
   },


### PR DESCRIPTION
## Changes
Noticed there was a typo ported over from the original devcontainer with "Codespaces" written "CodeSpaces". I was going to just correct the casing but realized the extra context is probably unnecessary now so instead I just opted to remove it instead.

## Testing
N/A

## Docs
N/A
