### PR TITLE
Remove redundant comments when `astro add` update `astro.config.mjs`

### DIFF
--- a/.changeset/lovely-elephants-peel.md
+++ b/.changeset/lovely-elephants-peel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Remove redundant comments when `astro add` update `astro.config.mjs`

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -507,7 +507,7 @@ async function updateAstroConfig({
 	let output = await generate(ast);
 	const comment = '// https://astro.build/config';
 	const defaultExport = 'export default defineConfig';
-	output = output.replace(`${comment}`, '');
+	output = output.replace(`\n${comment}`, '');
 	output = output.replace(`${defaultExport}`, `\n${comment}\n${defaultExport}`);
 
 	if (input === output) {

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -507,7 +507,7 @@ async function updateAstroConfig({
 	let output = await generate(ast);
 	const comment = '// https://astro.build/config';
 	const defaultExport = 'export default defineConfig';
-	output = output.replace(` ${comment}`, '');
+	output = output.replace(`${comment}`, '');
 	output = output.replace(`${defaultExport}`, `\n${comment}\n${defaultExport}`);
 
 	if (input === output) {


### PR DESCRIPTION
## Changes

- `astro add svelte` will update `astro.config.mjs`, but will generate redundant comments `/ https://astro.build/config`.

![image](https://user-images.githubusercontent.com/25167721/222718830-d318fc2c-40d5-435c-81b0-ba7c116dfebf.png)

## Testing
None
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
None
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
