### PR TITLE
[@astrojs/image] Handle missing trailing slash in processStaticImage

### DIFF
--- a/.changeset/eleven-mugs-flash.md
+++ b/.changeset/eleven-mugs-flash.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Handle missing trailing slash in processStaticImage

--- a/packages/integrations/image/src/build/ssg.ts
+++ b/packages/integrations/image/src/build/ssg.ts
@@ -138,7 +138,7 @@ export async function ssgBuild({
 		// Vite will prefix a hashed image with the base path, we need to strip this
 		// off to find the actual file relative to /dist
 		if (config.base && src.startsWith(config.base)) {
-			src = src.substring(config.base.length - 1);
+			src = src.substring(config.base.length - +config.base.endsWith('/'));
 		}
 
 		if (isRemoteImage(src)) {


### PR DESCRIPTION
## Changes

The code path changed by this commit isn't only taken when running using Vite. If the site is configured with a base url which is different from `/` but does **not** end with `/` (for example, because `trailingSlash` is set to `never`), the `- 1` results in an off-by-one error when truncating the URL.

By checking if the base url ends with `/`, we can determine the right length for the prefix to truncate.

## Testing

<!-- How was this change tested? -->
Tested manually on a repository which exhibited the issue:
- With `config.base == '/'`, before change: working
- With `config.base == '/pr-preview/pr-5'`, before change: error messages in the log indicate that the integration is looking for files beginning with `5/path/to/the/image`
- With `config.base == '/'`, after change: working
- With `config.base == '/pr-preview/pr-5'`: after change: error messages are gone and images are generated as expected.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
No docs added since this is only a bug fix for a behavior that should have already been working.