### PR TITLE
[error docs] update link for client-side scripts

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -75,7 +75,7 @@ export const AstroErrorData = defineErrors({
 	 * @description
 	 * The `Astro.clientAddress` property is only available when [Server-side rendering](https://docs.astro.build/en/guides/server-side-rendering/) is enabled.
 	 *
-	 * To get the user's IP address in static mode, different APIs such as [Ipify](https://www.ipify.org/) can be used in a [Client-side script](https://docs.astro.build/en/core-concepts/astro-components/#client-side-scripts) or it may be possible to get the user's IP using a serverless function hosted on your hosting provider.
+	 * To get the user's IP address in static mode, different APIs such as [Ipify](https://www.ipify.org/) can be used in a [Client-side script](https://docs.astro.build/en/guides/client-side-scripts/) or it may be possible to get the user's IP using a serverless function hosted on your hosting provider.
 	 */
 	StaticClientAddressNotAvailable: {
 		title: '`Astro.clientAddress` is not available in static mode.',


### PR DESCRIPTION
## Changes

Updates a docs link to client-side scripts in prep for Docs reorg PR https://github.com/withastro/docs/pull/2550

- Links to an existing page for Scripts and Event handling instead of a section that will soon no longer exist. (So, no problem to merge before 2550 is merged. New link is already operational in docs.)

## Testing

No tests, Docs.

## Docs

Just affects error docs! cc @Yan-Thomas for review!
