### PR TITLE
Fix `?inline` and `?raw` css query suffixes inlined in style tags in development

### DIFF
--- a/.changeset/witty-taxis-accept.md
+++ b/.changeset/witty-taxis-accept.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent `?inline` and `?raw` css query suffixes from injecting style tags in development

--- a/packages/astro/src/core/render/dev/css.ts
+++ b/packages/astro/src/core/render/dev/css.ts
@@ -2,7 +2,7 @@ import type { ModuleLoader } from '../../module-loader/index';
 
 import { RuntimeMode } from '../../../@types/astro.js';
 import { viteID } from '../../util.js';
-import { isCSSRequest } from './util.js';
+import { isBuildableCSSRequest } from './util.js';
 import { crawlGraph } from './vite.js';
 
 /** Given a filePath URL, crawl Vite’s module graph to find all style imports. */
@@ -15,7 +15,7 @@ export async function getStylesForURL(
 	const importedStylesMap = new Map<string, string>();
 
 	for await (const importedModule of crawlGraph(loader, viteID(filePath), true)) {
-		if (isCSSRequest(importedModule.url)) {
+		if (isBuildableCSSRequest(importedModule.url)) {
 			let ssrModule: Record<string, any>;
 			try {
 				// The SSR module is possibly not loaded. Load it if it's null.

--- a/packages/astro/test/css-inline.test.js
+++ b/packages/astro/test/css-inline.test.js
@@ -4,25 +4,61 @@ import { loadFixture } from './test-utils.js';
 
 describe('Importing raw/inlined CSS', () => {
 	let fixture;
-
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/css-inline/',
 		});
-		await fixture.build();
+	});
+	describe('Build', () => {
+		before(async () => {
+			await fixture.build();
+		});
+		it('?inline is imported as a string', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+
+			expect($('#inline').text()).to.contain('tomato');
+		});
+
+		it('?raw is imported as a string', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+
+			expect($('#raw').text()).to.contain('plum');
+		});
 	});
 
-	it('?inline is imported as a string', async () => {
-		const html = await fixture.readFile('/index.html');
-		const $ = cheerio.load(html);
+	describe('Dev', () => {
+		/** @type {import('./test-utils').DevServer} */
+		let devServer;
 
-		expect($('#inline').text()).to.contain('tomato');
-	});
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
 
-	it('?raw is imported as a string', async () => {
-		const html = await fixture.readFile('/index.html');
-		const $ = cheerio.load(html);
+		after(async () => {
+			await devServer.stop();
+		});
 
-		expect($('#raw').text()).to.contain('plum');
+		it("?inline is imported as string and doesn't make css bundled ", async () => {
+			const response = await fixture.fetch('/');
+			const html = await response.text();
+			console.log(html);
+			const $ = cheerio.load(html);
+
+			expect($('#inline').text()).to.contain('tomato');
+			expect($('link[rel=stylesheet]')).to.have.lengthOf(0);
+			expect($('style')).to.have.lengthOf(1);
+		});
+
+		it("?raw is imported as a string and doesn't make css bundled", async () => {
+			const response = await fixture.fetch('/');
+			const html = await response.text();
+			const $ = cheerio.load(html);
+
+			expect($('#raw').text()).to.contain('plum');
+			expect($('link[rel=stylesheet]')).to.have.lengthOf(0);
+			expect($('style')).to.have.lengthOf(1);
+		});
 	});
 });

--- a/packages/astro/test/css-inline.test.js
+++ b/packages/astro/test/css-inline.test.js
@@ -18,6 +18,8 @@ describe('Importing raw/inlined CSS', () => {
 			const $ = cheerio.load(html);
 
 			expect($('#inline').text()).to.contain('tomato');
+			expect($('link[rel=stylesheet]')).to.have.lengthOf(1);
+			expect($('style')).to.have.lengthOf(0);
 		});
 
 		it('?raw is imported as a string', async () => {
@@ -25,6 +27,8 @@ describe('Importing raw/inlined CSS', () => {
 			const $ = cheerio.load(html);
 
 			expect($('#raw').text()).to.contain('plum');
+			expect($('link[rel=stylesheet]')).to.have.lengthOf(1);
+			expect($('style')).to.have.lengthOf(0);
 		});
 	});
 
@@ -43,7 +47,6 @@ describe('Importing raw/inlined CSS', () => {
 		it("?inline is imported as string and doesn't make css bundled ", async () => {
 			const response = await fixture.fetch('/');
 			const html = await response.text();
-			console.log(html);
 			const $ = cheerio.load(html);
 
 			expect($('#inline').text()).to.contain('tomato');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1120,14 +1120,6 @@ importers:
       astro: link:../../..
       vue: 3.2.47
 
-  packages/astro/test/benchmark/simple:
-    specifiers:
-      '@astrojs/node': workspace:*
-      astro: workspace:*
-    dependencies:
-      '@astrojs/node': link:../../../../integrations/node
-      astro: link:../../..
-
   packages/astro/test/fixtures/0-css:
     specifiers:
       '@astrojs/react': workspace:*


### PR DESCRIPTION
## Changes
Fix https://github.com/withastro/astro/issues/6422

Use the [`isBuildableCssRequest`](https://github.com/withastro/astro/blob/9f85fb4ac2430231217e9b02579f596f68736bb7/packages/astro/src/core/render/dev/util.ts#L8) helper instead of [`isCssRequest`](https://github.com/vitejs/vite/blob/a55d0b34400e3360c4100d05e422ae9cf10fa07b/packages/vite/src/node/plugins/splitVendorChunk.ts#L16) so that imported css with `?raw` and `?inline` query suffixes aren't included in the imported styles map and inlined in style tags

## Testing

- In production:
  - Check that there's exactly one link tag
  - Check that there's no style tag

- In development, in addition to the previously existing prod tests:
  - Check that there's no link tag
  - Check that there's exactly one style tag

## Docs

Bug fix only