### PR TITLE
chore: use directive `@ts-expect-error` instead of `@ts-ignore`

### DIFF
--- a/packages/astro/src/core/add/babel.ts
+++ b/packages/astro/src/core/add/babel.ts
@@ -3,12 +3,12 @@ import parser from '@babel/parser';
 import traverse from '@babel/traverse';
 import * as t from '@babel/types';
 
-// @ts-ignore @babel/traverse isn't ESM and needs this trick
+// @ts-expect-error @babel/traverse isn't ESM and needs this trick
 export const visit = traverse.default as typeof traverse;
 export { t };
 
 export async function generate(ast: t.File) {
-	// @ts-ignore @babel/generator isn't ESM and needs this trick
+	// @ts-expect-error @babel/generator isn't ESM and needs this trick
 	const astToText = generator.default as typeof generator;
 	const { code } = astToText(ast);
 	return code;

--- a/packages/astro/src/core/build/plugins/plugin-internals.ts
+++ b/packages/astro/src/core/build/plugins/plugin-internals.ts
@@ -15,7 +15,6 @@ export function vitePluginInternals(input: Set<string>, internals: BuildInternal
 				external.push('shiki');
 			}
 
-			// @ts-ignore
 			extra.ssr = {
 				external,
 				noExternal,

--- a/packages/astro/src/core/endpoint/index.ts
+++ b/packages/astro/src/core/endpoint/index.ts
@@ -51,7 +51,7 @@ function createAPIContext({
 			});
 		},
 		url: new URL(request.url),
-		// @ts-ignore
+		// @ts-expect-error
 		get clientAddress() {
 			if (!(clientAddressSymbol in request)) {
 				if (adapterName) {

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -174,7 +174,6 @@ export function createResult(args: CreateResultArgs): SSRResult {
 			const Astro: AstroGlobal = {
 				// @ts-expect-error
 				__proto__: astroGlobal,
-				// @ts-ignore
 				get clientAddress() {
 					if (!(clientAddressSymbol in request)) {
 						if (args.adapterName) {
@@ -221,7 +220,7 @@ export function createResult(args: CreateResultArgs): SSRResult {
 				writable: false,
 				// TODO: Remove this hole "Deno" logic once our plugin gets Deno support
 				value: async function (content: string, opts: MarkdownRenderingOptions) {
-					// @ts-ignore
+					// @ts-expect-error
 					if (typeof Deno !== 'undefined') {
 						throw new Error('Markdown is not supported in Deno SSR');
 					}

--- a/packages/astro/src/jsx/renderer.ts
+++ b/packages/astro/src/jsx/renderer.ts
@@ -5,7 +5,7 @@ const renderer = {
 	jsxTransformOptions: async () => {
 		const {
 			default: { default: jsx },
-			// @ts-ignore
+			// @ts-expect-error
 		} = await import('@babel/plugin-transform-react-jsx');
 		const { default: astroJSX } = await import('./babel.js');
 		return {

--- a/packages/integrations/deno/src/server.ts
+++ b/packages/integrations/deno/src/server.ts
@@ -2,7 +2,7 @@
 import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
 
-// @ts-ignore
+// @ts-expect-error
 import { fromFileUrl, serveFile, Server } from '@astrojs/deno/__deno_imports.js';
 
 interface Options {
@@ -15,7 +15,7 @@ let _server: Server | undefined = undefined;
 let _startPromise: Promise<void> | undefined = undefined;
 
 async function* getPrerenderedFiles(clientRoot: URL): AsyncGenerator<URL> {
-	// @ts-ignore
+	// @ts-expect-error
 	for await (const ent of Deno.readDir(clientRoot)) {
 		if (ent.isDirectory) {
 			yield* getPrerenderedFiles(new URL(`./${ent.name}/`, clientRoot));

--- a/packages/integrations/image/src/endpoint.ts
+++ b/packages/integrations/image/src/endpoint.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import mime from 'mime';
-// @ts-ignore
+// @ts-expect-error
 import loader from 'virtual:image-loader';
 import { etag } from './utils/etag.js';
 import { isRemoteImage } from './utils/paths.js';

--- a/packages/integrations/image/src/lib/get-image.ts
+++ b/packages/integrations/image/src/lib/get-image.ts
@@ -111,7 +111,7 @@ export async function getImage(
 	let loader = globalThis.astroImage?.loader;
 
 	if (!loader) {
-		// @ts-ignore
+		// @ts-expect-error
 		const { default: mod } = await import('virtual:image-loader').catch(() => {
 			throw new Error(
 				'[@astrojs/image] Builtin image loader not found. (Did you remember to add the integration to your Astro config?)'
@@ -127,7 +127,7 @@ export async function getImage(
 	const attributes = await loader.getImageAttributes(resolved);
 
 	// `.env` must be optional to support running in environments outside of `vite` (such as `astro.config`)
-	// @ts-ignore
+	// @ts-expect-error
 	const isDev = import.meta.env?.DEV;
 	const isLocalImage = !isRemoteImage(resolved.src);
 

--- a/packages/integrations/image/src/loaders/squoosh.ts
+++ b/packages/integrations/image/src/loaders/squoosh.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { red } from 'kleur/colors';
 import { error } from '../utils/logger.js';
 import { metadata } from '../utils/metadata.js';

--- a/packages/integrations/image/src/vendor/squoosh/codecs.ts
+++ b/packages/integrations/image/src/vendor/squoosh/codecs.ts
@@ -35,46 +35,37 @@ export interface RotateOptions {
 
 // MozJPEG
 import type { MozJPEGModule as MozJPEGEncodeModule } from './mozjpeg/mozjpeg_enc'
-// @ts-ignore
 import mozEnc from './mozjpeg/mozjpeg_node_enc.js'
 const mozEncWasm = new URL('./mozjpeg/mozjpeg_node_enc.wasm', getModuleURL(import.meta.url))
-// @ts-ignore
 import mozDec from './mozjpeg/mozjpeg_node_dec.js'
 const mozDecWasm = new URL('./mozjpeg/mozjpeg_node_dec.wasm', getModuleURL(import.meta.url))
 
 // WebP
 import type { WebPModule as WebPEncodeModule } from './webp/webp_enc'
-// @ts-ignore
 import webpEnc from './webp/webp_node_enc.js'
 const webpEncWasm = new URL('./webp/webp_node_enc.wasm', getModuleURL(import.meta.url))
-// @ts-ignore
 import webpDec from './webp/webp_node_dec.js'
 const webpDecWasm = new URL('./webp/webp_node_dec.wasm', getModuleURL(import.meta.url))
 
 // AVIF
 import type { AVIFModule as AVIFEncodeModule } from './avif/avif_enc'
-// @ts-ignore
 import avifEnc from './avif/avif_node_enc.js'
 const avifEncWasm = new URL('./avif/avif_node_enc.wasm', getModuleURL(import.meta.url))
-// @ts-ignore
 import avifDec from './avif/avif_node_dec.js'
 const avifDecWasm = new URL('./avif/avif_node_dec.wasm', getModuleURL(import.meta.url))
 
 // PNG
-// @ts-ignore
 import * as pngEncDec from './png/squoosh_png.js'
 const pngEncDecWasm = new URL('./png/squoosh_png_bg.wasm', getModuleURL(import.meta.url))
 const pngEncDecInit = () =>
   pngEncDec.default(fsp.readFile(pathify(pngEncDecWasm.toString())))
 
 // OxiPNG
-// @ts-ignore
 import * as oxipng from './png/squoosh_oxipng.js'
 const oxipngWasm = new URL('./png/squoosh_oxipng_bg.wasm', getModuleURL(import.meta.url))
 const oxipngInit = () => oxipng.default(fsp.readFile(pathify(oxipngWasm.toString())))
 
 // Resize
-// @ts-ignore
 import * as resize from './resize/squoosh_resize.js'
 const resizeWasm = new URL('./resize/squoosh_resize_bg.wasm', getModuleURL(import.meta.url))
 const resizeInit = () => resize.default(fsp.readFile(pathify(resizeWasm.toString())))

--- a/packages/integrations/image/src/vendor/squoosh/image-pool.ts
+++ b/packages/integrations/image/src/vendor/squoosh/image-pool.ts
@@ -91,7 +91,6 @@ export async function processBuffer(
 	encoding: OutputFormat,
 	quality?: number
 ): Promise<Uint8Array> {
-	// @ts-ignore
 	const worker = await getWorker();
 
 	let imageData = await worker.dispatchJob({

--- a/packages/integrations/image/src/vendor/squoosh/impl.ts
+++ b/packages/integrations/image/src/vendor/squoosh/impl.ts
@@ -44,7 +44,6 @@ export async function decodeBuffer(
   const encoder = supportedFormats[key]
   const mod = await encoder.dec()
   const rgba = mod.decode(new Uint8Array(buffer))
-	// @ts-ignore
   return rgba
 }
 

--- a/packages/integrations/netlify/test/edge-functions/edge-basic.test.ts
+++ b/packages/integrations/netlify/test/edge-functions/edge-basic.test.ts
@@ -1,12 +1,12 @@
-// @ts-ignore
+// @ts-expect-error
 import { runBuild } from './test-utils.ts';
-// @ts-ignore
+// @ts-expect-error
 import { assertEquals, assert, DOMParser } from './deps.ts';
 
-// @ts-ignore
+// @ts-expect-error
 Deno.env.set('SECRET_STUFF', 'secret');
 
-// @ts-ignore
+// @ts-expect-error
 Deno.test({
 	// TODO: debug why build cannot be found in "await import"
 	ignore: true,

--- a/packages/integrations/netlify/test/edge-functions/prerender.test.ts
+++ b/packages/integrations/netlify/test/edge-functions/prerender.test.ts
@@ -1,9 +1,9 @@
-// @ts-ignore
+// @ts-expect-error
 import { runBuild } from './test-utils.ts';
-// @ts-ignore
+// @ts-expect-error
 import { assertEquals } from './deps.ts';
 
-// @ts-ignore
+// @ts-expect-error
 Deno.test({
 	name: 'Prerender',
 	async fn() {

--- a/packages/integrations/netlify/test/edge-functions/root-dynamic.test.ts
+++ b/packages/integrations/netlify/test/edge-functions/root-dynamic.test.ts
@@ -1,9 +1,9 @@
-// @ts-ignore
+// @ts-expect-error
 import { runBuild } from './test-utils.ts';
-// @ts-ignore
+// @ts-expect-error
 import { assertEquals, assert, DOMParser } from './deps.ts';
 
-// @ts-ignore
+// @ts-expect-error
 Deno.test({
 	// TODO: debug why build cannot be found in "await import"
 	ignore: true,

--- a/packages/integrations/netlify/test/edge-functions/test-utils.ts
+++ b/packages/integrations/netlify/test/edge-functions/test-utils.ts
@@ -1,9 +1,9 @@
-// @ts-ignore
+// @ts-expect-error
 import { fromFileUrl, readableStreamFromReader } from './deps.ts';
 const dir = new URL('./', import.meta.url);
 
 export async function runBuild(fixturePath: string) {
-	// @ts-ignore
+	// @ts-expect-error
 	let proc = Deno.run({
 		cmd: ['node', '../../../../../../astro/astro.js', 'build', '--silent'],
 		cwd: fromFileUrl(new URL(fixturePath, dir)),

--- a/packages/integrations/node/src/response-iterator.ts
+++ b/packages/integrations/node/src/response-iterator.ts
@@ -70,7 +70,7 @@ function readerIterator<T>(reader: ReadableStreamDefaultReader<T>): AsyncIterabl
 
 	if (canUseAsyncIteratorSymbol) {
 		iterator[Symbol.asyncIterator] = function (): AsyncIterator<T> {
-			//@ts-ignore
+			//@ts-expect-error
 			return this;
 		};
 	}

--- a/packages/integrations/preact/src/client-dev.ts
+++ b/packages/integrations/preact/src/client-dev.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import 'preact/debug';
 import clientFn from './client.js';
 

--- a/packages/markdown/remark/src/index.ts
+++ b/packages/markdown/remark/src/index.ts
@@ -144,7 +144,7 @@ function prefixError(err: any, prefix: string) {
 	const wrappedError = new Error(`${prefix}${err ? `: ${err}` : ''}`);
 	try {
 		wrappedError.stack = err.stack;
-		// @ts-ignore
+		// @ts-expect-error
 		wrappedError.cause = err;
 	} catch (error) {
 		// It's ok if we could not set the stack or cause - the message is the most important part

--- a/packages/webapi/src/lib/Image.ts
+++ b/packages/webapi/src/lib/Image.ts
@@ -2,7 +2,7 @@ import { HTMLImageElement } from './HTMLImageElement'
 import * as _ from './utils'
 
 export function Image() {
-	// @ts-ignore
+	// @ts-expect-error
 	_.INTERNALS.set(this, {
 		attributes: {},
 		localName: 'img',

--- a/packages/webapi/src/lib/utils.ts
+++ b/packages/webapi/src/lib/utils.ts
@@ -17,7 +17,7 @@ export const __object_isPrototypeOf = Function.call.bind(
 /** Current high resolution millisecond timestamp. */
 export const __performance_now = performance.now as () => number
 
-// @ts-ignore
+// @ts-expect-error
 export const INTERNALS = new WeakMap<unknown, any>()
 
 export const internalsOf = <T extends object>(


### PR DESCRIPTION
## Changes

This is a maintenance PR. It replaces `@ts-ignore` with `@ts-expect-error`.

The benefit of `@ts-expect-error` is that it tells the compiler that a compiler error is expected in the next line, and **if there isn't any error**, the compiler fails.

This directive is useful in cases the "compiler is not powerful enough", but then a new version comes around and fixes the issue.

The places where `@ts-ignore` was removed were the places where there wasn't a compiler error anymore.

## Testing

The CI should pass, there's not change in logic.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
