### PR TITLE
Ignore `@astrojs/timer` in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@example/*", "@test/*"],
+  "ignore": ["@example/*", "@test/*", "@astrojs/timer"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }


### PR DESCRIPTION
## Changes

Looks like `@astrojs/timer` (private package for benchmark only) is still handled in changeset's release: https://github.com/withastro/astro/pull/6414. Hopefully setting this ignore will not bump its version and generate changelogs.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
n/a

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. tweaks to changesets workflow.