### PR TITLE
Fix changeset run

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@example/*", "@test/*", "@benchmark/*", "astro-scripts", "astro-benchmark"],
+  "ignore": ["@example/*", "@test/*"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }


### PR DESCRIPTION
## Changes

My recent PR broke changesets (https://github.com/withastro/astro/pull/6433) 😬 This PR reverts the change to the changeset config and it should work again. The downside is that it bumps and generates changelogs for private packages, but I don't think there's a way around it for now.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested manually locally with `pnpm changeset version --dry-run` to make sure the error goes away.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. fixes changeset.