### PR TITLE
Add instructions on how to link the sitemap

### DIFF
--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -82,6 +82,22 @@ Now, [build your site for production](https://docs.astro.build/en/reference/cli-
 > **Warning**
 > If you forget to add a `site`, you'll get a friendly warning when you build, and the `sitemap-index.xml` file won't be generated.
 
+After verifying that the sitemaps are built, you can add them to your site's `<head>` and the `robots.txt` file for crawlers to pick up!
+
+```html ins={3}
+// src/layouts/Layout.astro
+<head>
+	<link rel="sitemap" href="/sitemap-index.xml">
+</head>
+```
+
+```txt ins={4} title="public/robots.txt"
+User-agent: *
+Allow: /
+
+Sitemap: https://<YOUR SITE>/sitemap-index.xml
+```
+
 ### Example of generated files for a two-page website
 
 **`sitemap-index.xml`**

--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -82,7 +82,7 @@ Now, [build your site for production](https://docs.astro.build/en/reference/cli-
 > **Warning**
 > If you forget to add a `site`, you'll get a friendly warning when you build, and the `sitemap-index.xml` file won't be generated.
 
-After verifying that the sitemaps are built, you can add them to your site's `<head>` and the `robots.txt` file for crawlers to pick up!
+After verifying that the sitemaps are built, you can add them to your site's `<head>` and the `robots.txt` file for crawlers to pick up.
 
 ```html ins={3}
 // src/layouts/Layout.astro


### PR DESCRIPTION
## Changes

Closes #6416 

## Testing

Only changes the `@astrojs/sitemap` readme

## Docs

Documents how to correctly link the sitemap, may need a look-over to see if the wording/placement can be improved.

![image](https://user-images.githubusercontent.com/55956895/223496826-3642f600-a53a-4573-a40f-10a51a7fe0f9.png)

