### PR TITLE
Fix configuration reference docs

### DIFF
--- a/.changeset/cyan-readers-wonder.md
+++ b/.changeset/cyan-readers-wonder.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Document `image.service` configuration option

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -721,7 +721,7 @@ export interface AstroUserConfig {
 		 * ```js
 		 * {
 		 *   image: {
-		 *     // Example: Enable the Sharp image processor
+		 *     // Example: Enable the Sharp-based image service
 		 *     service: 'astro/assets/services/sharp',
 		 *   },
 		 * }

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -706,6 +706,27 @@ export interface AstroUserConfig {
 	 * @name Image options
 	 */
 	image?: {
+		/**
+		 * @docs
+		 * @name image.service (Experimental)
+		 * @type {'astro/assets/services/sharp' | 'astro/assets/services/squoosh' | string}
+		 * @default `'astro/assets/services/squoosh'`
+		 * @version 2.1.0
+		 * @description
+		 * Set which image service is used for Astro’s experimental assets support.
+		 *
+		 * The value should be a module specifier for the image service to use:
+		 * either one of Astro’s two built-in services, or a third-party implementation.
+		 *
+		 * ```js
+		 * {
+		 *   image: {
+		 *     // Example: Enable the Sharp image processor
+		 *     service: 'astro/assets/services/sharp',
+		 *   },
+		 * }
+		 * ```
+		 */
 		// eslint-disable-next-line @typescript-eslint/ban-types
 		service: 'astro/assets/services/sharp' | 'astro/assets/services/squoosh' | (string & {});
 	};

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -947,6 +947,7 @@ export interface AstroUserConfig {
 	legacy?: object;
 
 	/**
+	 * @docs
 	 * @kind heading
 	 * @name Experimental Flags
 	 * @description


### PR DESCRIPTION
## Changes

- Adds documentation for the `image.service` config option
- Adds the `@docs` tag to include the “Experimental Flags” heading in docs

## Testing

n/a docs only

## Docs

/cc @withastro/maintainers-docs for feedback!
/cc @Princesseuh for feedback on how I documented `image.service`