### PR TITLE
[docs] Fix Markdoc README links

### DIFF
--- a/packages/integrations/markdoc/README.md
+++ b/packages/integrations/markdoc/README.md
@@ -218,7 +218,7 @@ import Aside from './Aside';
 <Aside client:load />
 ```
 
-This component [can be applied via the `components` prop](#render-html-elements-as-astro-components):
+This component [can be applied via the `components` prop](#render-markdoc-nodes--html-elements-as-astro-components):
 
 ```astro
 ---
@@ -277,7 +277,7 @@ Now, you can call this function from any Markdoc content entry:
 ```
 
 :::note
-These options will be applied during [the Markdoc "transform" phase](https://markdoc.dev/docs/render#transform). This is run **at build time** (rather than server request time) both for static and SSR Astro projects. If you need to define configuration at runtime (ex. SSR variables), [see the next section](#Define-markdoc-configuration-at-runtime).
+These options will be applied during [the Markdoc "transform" phase](https://markdoc.dev/docs/render#transform). This is run **at build time** (rather than server request time) both for static and SSR Astro projects. If you need to define configuration at runtime (ex. SSR variables), [see the next section](#define-markdoc-configuration-at-runtime).
 :::
 
 📚 [See the Markdoc documentation](https://markdoc.dev/docs/functions#creating-a-custom-function) for more on using variables or functions in your content.


### PR DESCRIPTION
## Changes

Fixes some links that were breaking in docs

## Testing

No tests. Only docs update.

## Docs

Should make docs happy!
