### PR TITLE
Add default .npmrc for `astro add lit`

### DIFF
--- a/.changeset/tough-tigers-drum.md
+++ b/.changeset/tough-tigers-drum.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Add default `.npmrc` file when adding the lit integration through `astro add lit` and using `pnpm`
+Add default `.npmrc` file when adding the Lit integration through `astro add lit` and using `pnpm`.

--- a/.changeset/tough-tigers-drum.md
+++ b/.changeset/tough-tigers-drum.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add default `.npmrc` file when adding the lit integration through `astro add lit` and using `pnpm`

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -61,7 +61,7 @@ export default {
 };
 `;
 const LIT_NPMRC_STUB = `\
-# Lit libraries are required to be hoisted for now due to dependency issues
+# Lit libraries are required to be hoisted due to dependency issues.
 public-hoist-pattern[]=*lit* 
 `;
 

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -60,6 +60,10 @@ export default {
 	preprocess: vitePreprocess(),
 };
 `;
+const LIT_NPMRC_STUB = `\
+# Lit libraries are required to be hoisted for now due to dependency issues
+public-hoist-pattern[]=*lit* 
+`;
 
 const OFFICIAL_ADAPTER_TO_IMPORT_MAP: Record<string, string> = {
 	netlify: '@astrojs/netlify/functions',
@@ -144,6 +148,22 @@ export default async function add(names: string[], { cwd, flags, logging, teleme
 					possibleConfigFiles: ['./svelte.config.js', './svelte.config.cjs', './svelte.config.mjs'],
 					defaultConfigFile: './svelte.config.js',
 					defaultConfigContent: SVELTE_CONFIG_STUB,
+				});
+			}
+			// Some lit dependencies needs to be hoisted, so for strict package managers like pnpm,
+			// we add an .npmrc to hoist them
+			if (
+				integrations.find((integration) => integration.id === 'lit') &&
+				(await preferredPM(fileURLToPath(root)))?.name === 'pnpm'
+			) {
+				await setupIntegrationConfig({
+					root,
+					logging,
+					flags,
+					integrationName: 'Lit',
+					possibleConfigFiles: ['./.npmrc'],
+					defaultConfigFile: './.npmrc',
+					defaultConfigContent: LIT_NPMRC_STUB,
 				});
 			}
 			break;

--- a/packages/integrations/lit/README.md
+++ b/packages/integrations/lit/README.md
@@ -143,7 +143,7 @@ The correct order might be different depending on the underlying cause of the pr
 
 ### Strict package managers
 
-When using a [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) like `pnpm`, you may get an error like `ReferenceError: module is not defined` when running your site. To fix this, you can hoist Lit dependencies with an `.npmrc` file:
+When using a [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) like `pnpm`, you may get an error such as `ReferenceError: module is not defined` when running your site. To fix this, hoist Lit dependencies with an `.npmrc` file:
 
 ```ini title=".npmrc"
 public-hoist-pattern[]=*lit* 

--- a/packages/integrations/lit/README.md
+++ b/packages/integrations/lit/README.md
@@ -141,6 +141,14 @@ export default defineConfig({
 
 The correct order might be different depending on the underlying cause of the problem. This is not guaranteed to fix every issue however, and some libraries cannot be used if you are using the Lit integration because of this.
 
+### Strict package managers
+
+When using a [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) like `pnpm`, you may get an error like `ReferenceError: module is not defined` when running your site. To fix this, you can hoist Lit dependencies with an `.npmrc` file:
+
+```ini title=".npmrc"
+public-hoist-pattern[]=*lit* 
+```
+
 ### Limitations
 
 The Lit integration is powered by `@lit-labs/ssr` which has some limitations. See their [limitations documentation](https://www.npmjs.com/package/@lit-labs/ssr#user-content-notes-and-limitations) to learn more.


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/6444

Lit dependencies need to be hoisted to work at the meantime. This PR surfaces this requirement in a few more places.

Currently it doesn't edit the `.npmrc` if there's an existing one, but I think this would be enough for now.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested the CLI manually in the examples folder. Confirmed that it works for pnpm only.

## Docs

Updated the lit integration readme to note this workaround in its troubleshooting section.

 /cc @withastro/maintainers-docs for feedback!
