### PR TITLE
Fix asset loading in dev mode

### DIFF
--- a/.changeset/red-candles-retire.md
+++ b/.changeset/red-candles-retire.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+In dev, load assets relative to the root

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -78,7 +78,7 @@ export default function assets({
 							return next();
 						}
 
-						const filePathURL = new URL(filePath, 'file:');
+						const filePathURL = new URL('.' + filePath, settings.config.root);
 						const file = await fs.readFile(filePathURL.pathname);
 
 						// Get the file's metadata from the URL

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -79,7 +79,7 @@ export default function assets({
 						}
 
 						const filePathURL = new URL('.' + filePath, settings.config.root);
-						const file = await fs.readFile(filePathURL.pathname);
+						const file = await fs.readFile(filePathURL);
 
 						// Get the file's metadata from the URL
 						let meta = getOrigQueryParams(filePathURL.searchParams);
@@ -109,7 +109,7 @@ export default function assets({
 							format = result.format;
 						}
 
-						res.setHeader('Content-Type', mime.getType(fileURLToPath(url)) || `image/${format}`);
+						res.setHeader('Content-Type', mime.getType(fileURLToPath(filePathURL)) || `image/${format}`);
 						res.setHeader('Cache-Control', 'max-age=360000');
 
 						const stream = Readable.from(data);

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -72,6 +72,13 @@ describe('astro:image', () => {
 				expect($img.attr('alt')).to.equal('a penguin');
 			});
 
+			it('middleware loads the file', async() => {
+				let $img = $('#local img');
+				let src = $img.attr('src');
+				let res = await fixture.fetch(src);
+				expect(res.status).to.equal(200);
+			});
+
 			it('errors on unsupported formats', async () => {
 				logs.length = 0;
 				let res = await fixture.fetch('/unsupported-format');


### PR DESCRIPTION
## Changes

- In https://github.com/withastro/astro/pull/6465 changed to using root-relative paths for ESM imported images.
- Caused regression b/c the dev server middleware expected a file path.

## Testing

- Added a test that exposes this.
- Tested in example path with dev + build now working.

## Docs

N/A, bug fix