### PR TITLE
fix(images): Fix empty frontmatter keys crashing Astro

### DIFF
--- a/.changeset/loud-cameras-camp.md
+++ b/.changeset/loud-cameras-camp.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix Astro crashing when a frontmatter value was empty (null)

--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -5,7 +5,7 @@ import { ImageService, isLocalService, LocalImageService } from './services/serv
 import type { ImageMetadata, ImageTransform } from './types.js';
 
 export function isESMImportedImage(src: ImageMetadata | string): src is ImageMetadata {
-	return typeof src === 'object';
+	return typeof src === 'object' && !Array.isArray(src) && src !== null;
 }
 
 export async function getConfiguredImageService(): Promise<ImageService> {

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -46,7 +46,7 @@ export const msg = {
 export function extractFrontmatterAssets(data: Record<string, any>): string[] {
 	function findAssets(potentialAssets: Record<string, any>): ImageMetadata[] {
 		return Object.values(potentialAssets).reduce((acc, curr) => {
-			if (typeof curr === 'object') {
+			if (typeof curr === 'object' && !Array.isArray(curr) && curr !== null) {
 				if (curr.__astro === true) {
 					acc.push(curr);
 				} else {

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/empty-value.md
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/empty-value.md
@@ -1,0 +1,5 @@
+---
+title:
+---
+
+Hello! I have no title!


### PR DESCRIPTION
## Changes

This would've never had happened in Rust

Fix https://github.com/withastro/astro/issues/6469

## Testing

Added one. That fixture gets built, so the build will fail if we don't handle this correctly. We could test in the dev server too presumably, but it's the same codepath either ways...

## Docs

N/A
