### PR TITLE
Add back support for Astro.clientAddress to Vercel serverless

### DIFF
--- a/.changeset/lemon-steaks-care.md
+++ b/.changeset/lemon-steaks-care.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Add back support for Astro.clientAddress


### PR DESCRIPTION
## Changes

- Adds back support for `Astro.clientAddress` that was removed in https://github.com/withastro/astro/commit/0e378c3b87627ca2764872a426dfba0a1606f991

## Testing

- Testing manually

## Docs

N/A, bug fix