### PR TITLE
Fix `@astrojs/prism` edgecase with pnpm

### DIFF
--- a/.changeset/tall-taxis-exercise.md
+++ b/.changeset/tall-taxis-exercise.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `@astrojs/prism` edgecase with strict package managers

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -49,6 +49,16 @@ const ALWAYS_NOEXTERNAL = [
 	'@fontsource/*',
 ];
 
+// These specifiers are usually dependencies written in CJS, but loaded through Vite's transform
+// pipeline, which Vite doesn't support in development time. This hardcoded list temporarily
+// fixes things until Vite can properly handle them, or when they support ESM.
+const ONLY_DEV_EXTERNAL = [
+	// Imported by `<Code/>` which is processed by Vite
+	'shiki',
+	// Imported by `@astrojs/prism` which exposes `<Prism/>` that is processed by Vite
+	'prismjs/components/index.js',
+];
+
 /** Return a common starting point for all Vite actions */
 export async function createVite(
 	commandConfig: vite.InlineConfig,
@@ -162,10 +172,7 @@ export async function createVite(
 		},
 		ssr: {
 			noExternal: [...ALWAYS_NOEXTERNAL, ...astroPkgsConfig.ssr.noExternal],
-			// shiki is imported by Code.astro, which is no-externalized (processed by Vite).
-			// However, shiki's deps are in CJS and trips up Vite's dev SSR transform, externalize
-			// shiki to load it with node instead.
-			external: [...(mode === 'dev' ? ['shiki'] : []), ...astroPkgsConfig.ssr.external],
+			external: [...(mode === 'dev' ? ONLY_DEV_EXTERNAL : []), ...astroPkgsConfig.ssr.external],
 		},
 	};
 


### PR DESCRIPTION
## Changes

Fixes https://github.com/withastro/astro/issues/6402

Firstly, I don't like what I'm doing, but it's the best solution at the mean time 😬 

This PR makes `astro` add `prismjs/components/index.js` to `vite.ssr.external` in dev time to fix using `@astrojs/prism` in a pnpm setup.

This is needed because while we do [automatic externalizing](https://github.com/withastro/astro/blob/0438458d530fb6dfdff63b89a2cb58a04fabe699/packages/astro/src/core/create-vite.ts#L67-L97) of transitive deps of Astro libraries, in which case we externalize `prismjs` by default, `prismjs/components/index.js` is not covered. In this case, when Vite decides whether to `external` or `noExternal` this import, it checks whether it's import-able from the project root. With pnpm, it's not, so it gets `noExternal` and that doesn't work with CJS files.

Ideally the fix would be in Vite to externalize things base on the real import path, in which case should be `@astrojs/prism` instead of the project root.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested manually with the issue repo.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
This PR fixes this edgecase so I think we don't need docs for it. The issue in general is a bit hard to explain in docs without digging into Vite internals.