### PR TITLE
Get rid of ‘txt not found’

### DIFF
--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -91,7 +91,7 @@ After verifying that the sitemaps are built, you can add them to your site's `<h
 </head>
 ```
 
-```txt ins={4} title="public/robots.txt"
+```yaml ins={4} title="public/robots.txt"
 User-agent: *
 Allow: /
 


### PR DESCRIPTION
## Changes

Switch syntax highlighting to yaml in docs


replaces <https://github.com/withastro/docs/pull/2812>

## Testing

Doesn't need te be tested

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

doesn't need docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
