### PR TITLE
Add fallback for hosts without import.meta.url

### DIFF
--- a/.changeset/lucky-shoes-mate.md
+++ b/.changeset/lucky-shoes-mate.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add fallback for hosts without import.meta.url

--- a/packages/astro/src/assets/utils/metadata.ts
+++ b/packages/astro/src/assets/utils/metadata.ts
@@ -1,8 +1,8 @@
 import { createRequire } from 'module';
 import fs from 'node:fs/promises';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { ImageMetadata, InputFormat } from '../types.js';
-const require = createRequire(import.meta.url);
+const require = createRequire(getModuleURL(import.meta.url));
 const sizeOf = require('image-size');
 
 export interface Metadata extends ImageMetadata {
@@ -36,4 +36,17 @@ export async function imageMetadata(
 		format: type as InputFormat,
 		orientation,
 	};
+}
+
+/**
+* On certain serverless hosts, our ESM bundle is transpiled to CJS before being run, which means
+* import.meta.url is undefined, so we'll fall back to __dirname in those cases
+* We should be able to remove this once https://github.com/netlify/zip-it-and-ship-it/issues/750 is fixed
+*/
+export function getModuleURL(url: string | undefined): string {
+	if (!url) {
+		return pathToFileURL(__dirname).toString();
+	}
+
+ return url
 }


### PR DESCRIPTION
## Changes

- Fixes bug reported in discord: https://discord.com/channels/830184174198718474/1083154052264759398

## Testing

- Just manually. Not sure if there aren't other Netlify bugs underneath this.

## Docs

N/A, bug fix