### PR TITLE
File abstraction

### DIFF
--- a/.changeset/tender-doors-poke.md
+++ b/.changeset/tender-doors-poke.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Internal refactor for how files are treated

--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -4,7 +4,7 @@ import { pathToFileURL } from 'node:url';
 import { AstroSettings } from '../@types/astro.js';
 import { StaticBuildOptions } from '../core/build/types.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
-import { rootRelativePath } from '../core/util.js';
+import File from '../core/file/index.js';
 import { ImageService, isLocalService, LocalImageService } from './services/service.js';
 import type { ImageMetadata, ImageTransform } from './types.js';
 import { imageMetadata } from './utils/metadata.js';
@@ -127,7 +127,8 @@ export async function emitESMImage(
 	fileEmitter: any,
 	settings: AstroSettings
 ) {
-	const url = pathToFileURL(id);
+	const file = new File(id, settings.config);
+	const url = file.toFileURL();
 	const meta = await imageMetadata(url);
 
 	if (!meta) {
@@ -152,7 +153,7 @@ export async function emitESMImage(
 		url.searchParams.append('origHeight', meta.height.toString());
 		url.searchParams.append('origFormat', meta.format);
 
-		meta.src = rootRelativePath(settings.config, url);
+		meta.src = file.toRootRelativePath();
 	}
 
 	return meta;

--- a/packages/astro/src/content/vite-plugin-content-assets.ts
+++ b/packages/astro/src/content/vite-plugin-content-assets.ts
@@ -68,10 +68,11 @@ export function astroContentAssetPropagationPlugin({
 				const { stylesMap, urls } = await getStylesForURL(
 					pathToFileURL(basePath),
 					devModuleLoader,
-					'development'
+					'development',
+					settings.config
 				);
 
-				const hoistedScripts = await getScriptsForURL(pathToFileURL(basePath), devModuleLoader);
+				const hoistedScripts = await getScriptsForURL(pathToFileURL(basePath), devModuleLoader, settings.config);
 
 				return {
 					code: code

--- a/packages/astro/src/core/build/plugins/plugin-hoisted-scripts.ts
+++ b/packages/astro/src/core/build/plugins/plugin-hoisted-scripts.ts
@@ -1,10 +1,10 @@
 import type { Plugin as VitePlugin } from 'vite';
 import type { AstroSettings } from '../../../@types/astro';
-import { viteID } from '../../util.js';
 import type { BuildInternals } from '../internal.js';
 import { getPageDataByViteID } from '../internal.js';
 import { AstroBuildPlugin } from '../plugin';
 import { StaticBuildOptions } from '../types';
+import File from '../../file/index.js';
 
 function virtualHoistedEntry(id: string) {
 	return id.startsWith('/astro/hoisted.js?q=');
@@ -66,8 +66,8 @@ export function vitePluginHoistedScripts(
 					const facadeId = output.facadeModuleId!;
 					const pages = internals.hoistedScriptIdToPagesMap.get(facadeId)!;
 					for (const pathname of pages) {
-						const vid = viteID(new URL('.' + pathname, settings.config.root));
-						const pageInfo = getPageDataByViteID(internals, vid);
+						const file = new File(pathname, settings.config);
+						const pageInfo = getPageDataByViteID(internals, file.toViteID());
 						if (pageInfo) {
 							if (canBeInlined) {
 								pageInfo.hoistedScript = {

--- a/packages/astro/src/core/file/index.ts
+++ b/packages/astro/src/core/file/index.ts
@@ -80,6 +80,13 @@ class File {
 		return '/@fs' + abs;
 	}
 
+	/**
+	 * Converts to an id that is used as the key in Vite's module graph
+	 */
+	toViteID() {
+		return viteID(this.toFileURL());
+	}
+
 	static getPathType(raw: string, root: URL): PathType {
 		if(raw.startsWith('/@fs')) {
 			return 'vite-fs-path';

--- a/packages/astro/src/core/file/index.ts
+++ b/packages/astro/src/core/file/index.ts
@@ -1,0 +1,113 @@
+import type { AstroConfig } from '../../@types/astro';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import { normalizePath } from 'vite';
+import { prependForwardSlash } from '../path.js';
+import { unwrapId, viteID } from '../util.js';
+
+export type PathType =
+	/**
+	 * file:///Users/name/projects/todos/src/pages/index.astro
+	 */
+	'url' |
+	/**
+	 * /Users/name/projects/todos/src/pages/index.astro
+	 */
+	'absolute' |
+	/**
+	 * /@fs/Users/name/projects/todos/src/pages/index.astro
+	 */
+	'vite-fs-path' |
+	/**
+	 * /src/pages/index.astro
+	 */
+	'root-relative' |
+	/**
+	 * We don't know
+	 */
+	'unknown';
+
+class File {
+	public raw: string;
+	public root: URL;
+	public type: PathType;
+	constructor(raw: string | URL, rootOrConfig: URL | Pick<AstroConfig, 'root'>) {
+		this.raw = typeof raw === 'string' ? raw : raw.toString();
+		this.root = rootOrConfig instanceof URL ? rootOrConfig : rootOrConfig.root;
+		this.type = File.getPathType(this.raw, this.root);
+	}
+
+	/**
+	 * Convert a raw path to a File URL
+	 */
+	toFileURL(): URL {
+		switch(this.type) {
+			case 'url': return new URL(this.raw);
+			case 'absolute': return pathToFileURL(this.raw);
+			case 'vite-fs-path': {
+				const fsPath = this.raw.slice('/@fs'.length);
+				return pathToFileURL(fsPath);
+			}
+			case 'root-relative': {
+				return new URL('.' + this.raw, this.root);
+			}
+			default: {
+				throw new Error(`Cannot create file URL for an unknown path type: ${this.raw}`);
+			}
+		}
+	}
+
+	/**
+	 * Converts to a path that is relative to the root, for use in browser paths
+	 */
+	toRootRelativePath() {
+		const url = this.toFileURL();
+		const id = unwrapId(viteID(url));
+		return prependForwardSlash(id.slice(normalizePath(fileURLToPath(this.root)).length));
+	}
+
+	/**
+	 * Converts to the absolute (string) path. Uses the platform's path separator.
+	 */
+	toAbsolutePath() {
+		return fileURLToPath(this.toFileURL());
+	}
+
+	/**
+	 * Converts to a path for use in browser, contains the `/@fs` prefix understood by Vite.
+	 */
+	toViteFSPath() {
+		const abs = prependForwardSlash(normalizePath(this.toAbsolutePath()));
+		return '/@fs' + abs;
+	}
+
+	static getPathType(raw: string, root: URL): PathType {
+		if(raw.startsWith('/@fs')) {
+			return 'vite-fs-path';
+		}
+		
+		if(raw.startsWith('/')) {
+			const normalRoot = normalizePath(fileURLToPath(root))
+			if(raw.startsWith(normalRoot)) {
+				return 'absolute';
+			} else {
+				return 'root-relative';
+			}
+		}
+
+		if(raw.startsWith('file://')) {
+			return 'url';
+		}
+
+		// Windows drive
+		if(/[A-Z]:/.test(raw)) {
+			return 'absolute';
+		}
+
+		return 'unknown';
+	}
+}
+
+export {
+	File,
+	File as default
+}

--- a/packages/astro/src/core/render/dev/css.ts
+++ b/packages/astro/src/core/render/dev/css.ts
@@ -1,7 +1,7 @@
 import type { ModuleLoader } from '../../module-loader/index';
+import type { AstroConfig, RuntimeMode } from '../../../@types/astro.js';
 
-import { RuntimeMode } from '../../../@types/astro.js';
-import { viteID } from '../../util.js';
+import File from '../../file/index.js';
 import { isBuildableCSSRequest } from './util.js';
 import { crawlGraph } from './vite.js';
 
@@ -9,12 +9,14 @@ import { crawlGraph } from './vite.js';
 export async function getStylesForURL(
 	filePath: URL,
 	loader: ModuleLoader,
-	mode: RuntimeMode
+	mode: RuntimeMode,
+	config: AstroConfig,
 ): Promise<{ urls: Set<string>; stylesMap: Map<string, string> }> {
 	const importedCssUrls = new Set<string>();
 	const importedStylesMap = new Map<string, string>();
 
-	for await (const importedModule of crawlGraph(loader, viteID(filePath), true)) {
+	const file = new File(filePath, config);
+	for await (const importedModule of crawlGraph(loader, file.toViteID(), true)) {
 		if (isBuildableCSSRequest(importedModule.url)) {
 			let ssrModule: Record<string, any>;
 			try {

--- a/packages/astro/src/core/render/dev/index.ts
+++ b/packages/astro/src/core/render/dev/index.ts
@@ -76,7 +76,7 @@ interface GetScriptsAndStylesParams {
 
 async function getScriptsAndStyles({ env, filePath }: GetScriptsAndStylesParams) {
 	// Add hoisted script tags
-	const scripts = await getScriptsForURL(filePath, env.loader);
+	const scripts = await getScriptsForURL(filePath, env.loader, env.settings.config);
 
 	// Inject HMR scripts
 	if (isPage(filePath, env.settings) && env.mode === 'development') {
@@ -109,7 +109,7 @@ async function getScriptsAndStyles({ env, filePath }: GetScriptsAndStylesParams)
 	}
 
 	// Pass framework CSS in as style tags to be appended to the page.
-	const { urls: styleUrls, stylesMap } = await getStylesForURL(filePath, env.loader, env.mode);
+	const { urls: styleUrls, stylesMap } = await getStylesForURL(filePath, env.loader, env.mode, env.settings.config);
 	let links = new Set<SSRElement>();
 	[...styleUrls].forEach((href) => {
 		links.add({

--- a/packages/astro/src/core/render/dev/scripts.ts
+++ b/packages/astro/src/core/render/dev/scripts.ts
@@ -1,17 +1,18 @@
-import type { SSRElement } from '../../../@types/astro';
+import type { AstroConfig, SSRElement } from '../../../@types/astro';
 import type { PluginMetadata as AstroPluginMetadata } from '../../../vite-plugin-astro/types';
 import type { ModuleInfo, ModuleLoader } from '../../module-loader/index';
 
-import { viteID } from '../../util.js';
+import File from '../../file/index.js';
 import { createModuleScriptElementWithSrc } from '../ssr-element.js';
 import { crawlGraph } from './vite.js';
 
 export async function getScriptsForURL(
 	filePath: URL,
-	loader: ModuleLoader
+	loader: ModuleLoader,
+	config: AstroConfig,
 ): Promise<Set<SSRElement>> {
 	const elements = new Set<SSRElement>();
-	const rootID = viteID(filePath);
+	const rootID = new File(filePath, config).toViteID();
 	const modInfo = loader.getModuleInfo(rootID);
 	addHoistedScripts(elements, modInfo);
 	for await (const moduleNode of crawlGraph(loader, rootID, true)) {

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -151,16 +151,6 @@ export function relativeToSrcDir(config: AstroConfig, idOrUrl: URL | string) {
 	return id.slice(slash(fileURLToPath(config.srcDir)).length);
 }
 
-export function rootRelativePath(config: AstroConfig, idOrUrl: URL | string) {
-	let id: string;
-	if (typeof idOrUrl !== 'string') {
-		id = unwrapId(viteID(idOrUrl));
-	} else {
-		id = idOrUrl;
-	}
-	return prependForwardSlash(id.slice(normalizePath(fileURLToPath(config.root)).length));
-}
-
 export function emoji(char: string, fallback: string) {
 	return process.platform !== 'win32' ? char : fallback;
 }

--- a/packages/astro/test/units/file/file.test.js
+++ b/packages/astro/test/units/file/file.test.js
@@ -1,0 +1,96 @@
+import { expect } from 'chai';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import File from '../../../dist/core/file/index.js';
+
+
+describe('File abstraction', () => {
+	describe('constructor', () => {
+		it('can take a file url', () => {
+			let root = new URL('./', import.meta.url);
+			let file = new File(import.meta.url, root);
+			expect(file.type).to.equal('url');
+		});
+	
+		it('can take an absolute path', () => {
+			let root = new URL('./', import.meta.url);
+			let path = fileURLToPath(import.meta.url);
+			let file = new File(path, root);
+			expect(file.type).to.equal('absolute');
+		});
+	
+		it('can take a Vite fs path', () => {
+			let root = new URL('./', import.meta.url);
+			let path = '/@fs/some/path';
+			let file = new File(path, root);
+			expect(file.type).to.equal('vite-fs-path');
+		});
+	
+		it('can take a path relative to the root', () => {
+			let root = new URL('./', import.meta.url);
+			let path = '/src/pages/index.astro';
+			let file = new File(path, root);
+			expect(file.type).to.equal('root-relative');
+		});
+	
+		it('Defaults to unknown', () => {
+			let root = new URL('./', import.meta.url);
+			let path = 'some-virtual-id';
+			let file = new File(path, root);
+			expect(file.type).to.equal('unknown');
+		});
+
+		it('Can take an AstroConfig as the second argument', () => {
+			let root = new URL('./', import.meta.url);
+			let path = fileURLToPath(import.meta.url);
+			let file = new File(path, { root });
+			expect(file.type).to.equal('absolute');
+		});
+	});
+
+	describe('toFileURL', () => {
+		it('converts from a file URL', () => {
+			let root = new URL('./', import.meta.url);
+			let file = new File(import.meta.url, root);
+			let url = file.toFileURL();
+			expect(url.toString()).to.equal(import.meta.url);
+		});
+	
+		it('converts from an absolute path', () => {
+			let root = new URL('./', import.meta.url);
+			let path = fileURLToPath(import.meta.url);
+			let file = new File(path, root);
+			let url = file.toFileURL();
+			expect(url.toString()).to.equal(pathToFileURL(path).toString());
+		});
+	
+		it('converts from an Vite fs path', () => {
+			let root = new URL('./', import.meta.url);
+			let path = '/@fs/some/path';
+			let file = new File(path, root);
+			expect(file.toFileURL().toString()).to.equal('file:///some/path');
+		});
+	
+		it('converts from a path relative to the root', () => {
+			let root = new URL('./', import.meta.url);
+			let path = '/src/pages/index.astro';
+			let file = new File(path, root);
+
+			let expected = new URL('.' + path, root).toString();
+			expect(file.toFileURL().toString()).to.equal(expected);
+		});
+	
+		it('Throws converting an unknown', () => {
+			let root = new URL('./', import.meta.url);
+			let path = 'some-virtual-id';
+			let file = new File(path, root);
+			try {
+				file.toFileURL();
+				expect(false).to.equal(true);
+			} catch(err) {
+				expect(err).to.be.an.instanceOf(Error);
+				expect(err.message.startsWith('Cannot create file URL')).to.equal(true);
+			}
+		});
+	})
+});


### PR DESCRIPTION
## Changes

- Adds a new abstract, a `File` that is intended to be used any time we are receiving a string that we *think* is a file. It can take files in the form of:
  - File URLs (string and object)
  - Absolute filesystem paths.
  - Root-relative paths
  - Vite's `/@fs` file path prefixed paths.
- And then convert from and to any of the above. 

## Testing

- Testing the class itself in unit tests
- Updated some of the usage that felt safe to swap out, should not break existing tests of course.

## Docs

N/A, internal refactor