### PR TITLE
Prefer dynamic import for `image-size`

### DIFF
--- a/packages/astro/src/assets/utils/metadata.ts
+++ b/packages/astro/src/assets/utils/metadata.ts
@@ -1,4 +1,3 @@
-import sizeOf from 'image-size';
 import fs from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { ImageMetadata, InputFormat } from '../types.js';
@@ -7,10 +6,14 @@ export interface Metadata extends ImageMetadata {
 	orientation?: number;
 }
 
+let sizeOf: typeof import('image-size').default | undefined;
 export async function imageMetadata(
 	src: URL | string,
 	data?: Buffer
 ): Promise<Metadata | undefined> {
+	if (!sizeOf) {
+		sizeOf = await import('image-size').then(mod => mod.default);
+	}
 	let file = data;
 	if (!file) {
 		try {
@@ -20,7 +23,7 @@ export async function imageMetadata(
 		}
 	}
 
-	const { width, height, type, orientation } = await sizeOf(file);
+	const { width, height, type, orientation } = await sizeOf!(file);
 	const isPortrait = (orientation || 0) >= 5;
 
 	if (!width || !height || !type) {


### PR DESCRIPTION
## Changes

- Looks like https://github.com/withastro/astro/pull/6488 is breaking CI
- Switches to `import('image-size')` which seems to be passing locally

## Testing

Existing tests should pass

## Docs

N/A, bug fix only