### PR TITLE
Add postbuild to build:ci command

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -93,7 +93,7 @@
   "scripts": {
     "prebuild": "astro-scripts prebuild --to-string \"src/runtime/server/astro-island.ts\" \"src/runtime/client/{idle,load,media,only,visible}.ts\"",
     "build": "pnpm run prebuild && astro-scripts build \"src/**/*.ts\" && tsc && pnpm run postbuild",
-    "build:ci": "pnpm run prebuild && astro-scripts build \"src/**/*.ts\"",
+    "build:ci": "pnpm run prebuild && astro-scripts build \"src/**/*.ts\" && pnpm run postbuild",
     "dev": "astro-scripts dev --copy-wasm --prebuild \"src/runtime/server/astro-island.ts\" --prebuild \"src/runtime/client/{idle,load,media,only,visible}.ts\" \"src/**/*.ts\"",
     "postbuild": "astro-scripts copy \"src/**/*.astro\" && astro-scripts copy \"src/**/*.wasm\"",
     "test:unit": "mocha --exit --timeout 30000 ./test/units/**/*.test.js",


### PR DESCRIPTION
## Changes

Add `pnpm run postbuild` to the `build:ci` command as `vite-ecosystem-ci` uses that and there's wasm copying errors currently. This should fix it.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
n/a

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. internal command change.