### PR TITLE
feat: cache `getCollection()` calls in production

### DIFF
--- a/.changeset/nasty-cougars-double.md
+++ b/.changeset/nasty-cougars-double.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add caching to `getCollection()` queries for faster SSG production builds


### PR DESCRIPTION
## Changes

Follows up on a performance bottleneck we found while migrating [the Astro docs](https://github.com/withastro/docs) to content collections. @delucis noted that repeat calls to `getCollection('docs')` slowed production builds, and[ centralizing to a single, top-level `getCollection()` call](https://github.com/withastro/docs/blob/main/src/content.ts) resolved the issue. This PR introduces a production-only cache to mirror this experience.

## Testing

- Created a branch on the docs repo to measure production build changes in CI: https://github.com/withastro/docs/pull/2816 Found a ~10% improvement
- Built three times locally with caching and three times without. Noticed the same ~10% improvement
- Tracked memory usage building locally with and without caching. Each peeked at roughly the same 4.30 GB figure.

## Docs

N/A