### PR TITLE
[Content collections] Better error formatting

### DIFF
--- a/.changeset/quick-turtles-decide.md
+++ b/.changeset/quick-turtles-decide.md
@@ -1,0 +1,8 @@
+---
+'astro': patch
+---
+
+Improve content collection error formatting:
+- Bold the collection and entry that failed
+- Consistently list the frontmatter key at the start of every error
+- Rich errors for union types

--- a/packages/astro/src/content/error-map.ts
+++ b/packages/astro/src/content/error-map.ts
@@ -71,7 +71,7 @@ export const errorMap: ZodErrorMap = (baseError, ctx) => {
 };
 
 const getTypeOrLiteralMsg = (error: TypeOrLiteralErrByPathEntry): string => {
-	if (error.received === 'undefined') return isRequiredMsg('');
+	if (error.received === 'undefined') return 'Required';
 	const expectedDeduped = new Set(error.expected);
 	switch (error.code) {
 		case 'invalid_type':
@@ -84,8 +84,6 @@ const getTypeOrLiteralMsg = (error: TypeOrLiteralErrByPathEntry): string => {
 			)}`;
 	}
 };
-
-const isRequiredMsg = (key: string) => prefix(key, 'Required.');
 
 const prefix = (key: string, msg: string) => (key.length ? `**${key}**: ${msg}` : msg);
 

--- a/packages/astro/src/content/error-map.ts
+++ b/packages/astro/src/content/error-map.ts
@@ -1,0 +1,99 @@
+import type { ZodErrorMap, ZodInvalidLiteralIssue, ZodInvalidTypeIssue } from 'zod';
+
+export const errorMap: ZodErrorMap = (error, ctx) => {
+	if (error.code === 'invalid_union') {
+		console.log('union', error);
+		let expectedByErrorPath: Map<
+			string,
+			{ code: 'invalid_type' | 'invalid_literal'; received: unknown; expected: unknown[] }
+		> = new Map();
+		let messages: string[] = [];
+		for (const unionError of error.unionErrors.map((e) => e.errors).flat()) {
+			if (unionError.code === 'invalid_type' || unionError.code === 'invalid_literal') {
+				const flattenedErrorPath = flattenErrorPath(unionError.path);
+				if (expectedByErrorPath.has(flattenedErrorPath)) {
+					expectedByErrorPath.get(flattenedErrorPath)!.expected.push(unionError.expected);
+				} else {
+					expectedByErrorPath.set(flattenedErrorPath, {
+						code: unionError.code,
+						received: unionError.received,
+						expected: [unionError.expected],
+					});
+				}
+			}
+		}
+		return {
+			message: messages
+				// Format invalid type and invalid literal errors
+				.concat(
+					[...expectedByErrorPath.entries()].map(([key, error]) =>
+						getFormattedErrorMsg({ key, error })
+					)
+				)
+				.concat(
+					// Format remaining errors recursively with errorMap
+					error.unionErrors.flatMap((unionError) =>
+						unionError.errors
+							.filter((e) => !formattedErrorTypes.has(e.code))
+							.map((e) => errorMap(e, ctx).message)
+					)
+				)
+				.join('\n'),
+		};
+	}
+	const key = flattenErrorPath(error.path);
+	if (error.message) {
+		return { message: prefix(key, error.message) };
+	}
+	return { message: prefix(key, ctx.defaultError) };
+};
+
+const formattedErrorTypes = new Set(['invalid_type', 'invalid_literal']);
+
+const getFormattedErrorMsg = ({
+	key,
+	error,
+}: {
+	key: string;
+	error: Pick<ZodInvalidLiteralIssue | ZodInvalidTypeIssue, 'code' | 'expected' | 'received'>;
+}): string => {
+	switch (error.code) {
+		case 'invalid_type':
+			if (error.received === 'undefined') return isRequiredMsg(key);
+			return prefix(
+				key,
+				`Expected type ${unionExpectedVals(String(error.expected))}, received ${singleQuote(
+					String(error.received)
+				)}`
+			);
+		case 'invalid_literal':
+			if (typeof error.received === 'undefined') return isRequiredMsg(key);
+			return prefix(
+				key,
+				`Expected ${unionExpectedVals(String(error.expected))}, received ${singleQuote(
+					String(error.received)
+				)}`
+			);
+	}
+};
+
+const isRequiredMsg = (key: string) => prefix(key, 'Required.');
+
+const prefix = (key: string, msg: string) => `${key}: ${msg}`;
+
+// Wrap identifiers in single quotes
+// to match Zod's default error messages
+const singleQuote = (str: string) => `'${str}'`;
+
+const unionExpectedVals = (expectedVals: string | string[]) => {
+	const arr = Array.isArray(expectedVals) ? expectedVals : [expectedVals];
+	return arr
+		.map((expectedVal, idx) => {
+			if (idx === 0) return singleQuote(expectedVal);
+			const sep = ' | ';
+			return `${sep}${singleQuote(expectedVal)}`;
+		})
+		.join('');
+};
+
+const flattenErrorPath = (errorPath: (string | number)[]) => errorPath.join('.');

--- a/packages/astro/src/content/error-map.ts
+++ b/packages/astro/src/content/error-map.ts
@@ -30,7 +30,10 @@ export const errorMap: ZodErrorMap = (baseError, ctx) => {
 			}
 		}
 		let messages: string[] = [
-			typeOrLiteralErrByPath.size ? 'Did not match union:' : 'Did not match union.',
+			prefix(
+				baseErrorPath,
+				typeOrLiteralErrByPath.size ? 'Did not match union:' : 'Did not match union.'
+			),
 		];
 		return {
 			message: messages

--- a/packages/astro/src/content/index.ts
+++ b/packages/astro/src/content/index.ts
@@ -4,3 +4,4 @@ export { contentObservable, getContentPaths, getDotAstroTypeReference } from './
 export { astroContentAssetPropagationPlugin } from './vite-plugin-content-assets.js';
 export { astroContentImportPlugin } from './vite-plugin-content-imports.js';
 export { astroContentVirtualModPlugin } from './vite-plugin-content-virtual-mod.js';
+export { errorMap } from './error-map.js';

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -10,6 +10,7 @@ import { AstroConfig, AstroSettings } from '../@types/astro.js';
 import { emitESMImage } from '../assets/internal.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { CONTENT_TYPES_FILE } from './consts.js';
+import { errorMap } from './error-map.js';
 
 export const collectionConfigParser = z.object({
 	schema: z.any().optional(),
@@ -220,20 +221,6 @@ function hasUnderscoreBelowContentDirectoryPath(
 	}
 	return false;
 }
-
-const flattenErrorPath = (errorPath: (string | number)[]) => errorPath.join('.');
-
-const errorMap: z.ZodErrorMap = (error, ctx) => {
-	if (error.code === 'invalid_type') {
-		const badKeyPath = JSON.stringify(flattenErrorPath(error.path));
-		if (error.received === 'undefined') {
-			return { message: `${badKeyPath} is required.` };
-		} else {
-			return { message: `${badKeyPath} should be ${error.expected}, not ${error.received}.` };
-		}
-	}
-	return { message: ctx.defaultError };
-};
 
 function getFrontmatterErrorLine(rawFrontmatter: string, frontmatterKey: string) {
 	const indexOfFrontmatterKey = rawFrontmatter.indexOf(`\n${frontmatterKey}`);

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -771,7 +771,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 		code: 9001,
 		message: (collection: string, entryId: string, error: ZodError) => {
 			return [
-				`${String(collection)} → ${String(entryId)} frontmatter does not match collection schema.`,
+				`**${String(collection)} → ${String(entryId)}** frontmatter is invalid.`,
 				...error.errors.map((zodError) => zodError.message),
 			].join('\n');
 		},

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -771,7 +771,9 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 		code: 9001,
 		message: (collection: string, entryId: string, error: ZodError) => {
 			return [
-				`**${String(collection)} → ${String(entryId)}** frontmatter is invalid.`,
+				`**${String(collection)} → ${String(
+					entryId
+				)}** frontmatter does not match collection schema.`,
 				...error.errors.map((zodError) => zodError.message),
 			].join('\n');
 		},

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -210,7 +210,6 @@ describe('Content Collections', () => {
 			} catch (e) {
 				error = e.message;
 			}
-			console.log(error);
 			expect(error).to.include('**title**: Expected type `"string"`, received "number"');
 		});
 	});

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -210,7 +210,8 @@ describe('Content Collections', () => {
 			} catch (e) {
 				error = e.message;
 			}
-			expect(error).to.include('"title" should be string, not number.');
+			console.log(error);
+			expect(error).to.include('**title**: Expected type `"string"`, received "number"');
 		});
 	});
 

--- a/packages/astro/test/units/content-collections/error-map.test.js
+++ b/packages/astro/test/units/content-collections/error-map.test.js
@@ -1,0 +1,87 @@
+import { z } from '../../../zod.mjs';
+import { errorMap } from '../../../dist/content/index.js';
+import { fixLineEndings } from '../../test-utils.js';
+import { expect } from 'chai';
+
+describe('Content Collections - error map', () => {
+	it('Prefixes messages with object key', () => {
+		const error = getParseError(
+			z.object({
+				base: z.string(),
+				nested: z.object({
+					key: z.string(),
+				}),
+				union: z.union([z.string(), z.number()]),
+			}),
+			{ base: 1, nested: { key: 2 }, union: true }
+		);
+		const msgs = messages(error).sort();
+		console.log({ msgs });
+		expect(msgs).to.have.length(3);
+		// expect "**" for bolding
+		expect(msgs[0].startsWith('**base**')).to.equal(true);
+		expect(msgs[1].startsWith('**nested.key**')).to.equal(true);
+		expect(msgs[2].startsWith('**union**')).to.equal(true);
+	});
+	it('Returns formatted error for type mismatch', () => {
+		const error = getParseError(
+			z.object({
+				foo: z.string(),
+			}),
+			{ foo: 1 }
+		);
+		expect(messages(error)).to.deep.equal(['**foo**: Expected type `"string"`, received "number"']);
+	});
+	it('Returns formatted error for literal mismatch', () => {
+		const error = getParseError(
+			z.object({
+				lang: z.literal('en'),
+			}),
+			{ lang: 'es' }
+		);
+		expect(messages(error)).to.deep.equal(['**lang**: Expected `"en"`, received "es"']);
+	});
+	it('Returns formatted error for basic union mismatch', () => {
+		const error = getParseError(
+			z.union([z.boolean(), z.number()]),
+			'not a boolean or a number, oops!'
+		);
+		expect(messages(error)).to.deep.equal([
+			fixLineEndings(
+				'Did not match union:\n> Expected type `"boolean" | "number"`, received "string"'
+			),
+		]);
+	});
+	it('Returns formatted error for union mismatch on nested object properties', () => {
+		const error = getParseError(
+			z.union([
+				z.object({
+					type: z.literal('tutorial'),
+				}),
+				z.object({
+					type: z.literal('article'),
+				}),
+			]),
+			{ type: 'integration-guide' }
+		);
+		expect(messages(error)).to.deep.equal([
+			fixLineEndings(
+				'Did not match union:\n> **type**: Expected `"tutorial" | "article"`, received "integration-guide"'
+			),
+		]);
+	});
+});
+
+/**
+ * @param {z.ZodError} error
+ * @returns string[]
+ */
+function messages(error) {
+	return error.errors.map((e) => e.message);
+}
+
+function getParseError(schema, entry, parseOpts = { errorMap }) {
+	const res = schema.safeParse(entry, parseOpts);
+	expect(res.success).to.equal(false, 'Schema should raise error');
+	return res.error;
+}

--- a/packages/astro/test/units/content-collections/error-map.test.js
+++ b/packages/astro/test/units/content-collections/error-map.test.js
@@ -16,7 +16,6 @@ describe('Content Collections - error map', () => {
 			{ base: 1, nested: { key: 2 }, union: true }
 		);
 		const msgs = messages(error).sort();
-		console.log({ msgs });
 		expect(msgs).to.have.length(3);
 		// expect "**" for bolding
 		expect(msgs[0].startsWith('**base**')).to.equal(true);
@@ -40,6 +39,16 @@ describe('Content Collections - error map', () => {
 			{ lang: 'es' }
 		);
 		expect(messages(error)).to.deep.equal(['**lang**: Expected `"en"`, received "es"']);
+	});
+	it('Replaces undefined errors with "Required"', () => {
+		const error = getParseError(
+			z.object({
+				foo: z.string(),
+				bar: z.string(),
+			}),
+			{ foo: 'foo' }
+		);
+		expect(messages(error)).to.deep.equal(['**bar**: Required']);
 	});
 	it('Returns formatted error for basic union mismatch', () => {
 		const error = getParseError(
@@ -68,6 +77,17 @@ describe('Content Collections - error map', () => {
 			fixLineEndings(
 				'Did not match union:\n> **type**: Expected `"tutorial" | "article"`, received "integration-guide"'
 			),
+		]);
+	});
+	it('Lets unhandled errors fall through', () => {
+		const error = getParseError(
+			z.object({
+				lang: z.enum(['en', 'fr']),
+			}),
+			{ lang: 'jp' }
+		);
+		expect(messages(error)).to.deep.equal([
+			"**lang**: Invalid enum value. Expected 'en' | 'fr', received 'jp'",
 		]);
 	});
 });


### PR DESCRIPTION
## Changes

This fixes a few problems in today's error formatter:
- The collection -> entry path is bolded for visibility
- Frontmatter keys are now always placed at the start of an error message. This fixes inconsistencies where the key name could be at the start of the end of a message.
- Union errors now log "Did not match union" instead of "Invalid input." Will also log "type" and "invalid literal" errors for keys shared by all members of a union.
- Unhandled errors now correctly fall through to Zod's error message. This would log "Invalid Input" for all unhandled messages before.

Example: a union between `{ key: z.literal('tutorial') }` and `{ key: z.literal('blog') }` will raise a single error when `key` does not match:
```md
Did not match union.
> key: Expected `'tutorial' | 'blog'`, received 'foo'
```

### Before / after

Here is a before and after of the error experience when authoring in docs.astro.build. These errors are [based on the union schema configured here](https://github.com/withastro/docs/blob/main/src/content/config.ts#L107-L117).

Example invalid frontmatter:

```yaml
---
type: guide
i18nReady: maybe?
---
```

**Before**

<img width="1223" alt="image" src="https://user-images.githubusercontent.com/51384119/224427487-4298858e-089b-4c0a-a1e5-f7d4cb2e7f51.png">

**After**

<img width="1216" alt="image" src="https://user-images.githubusercontent.com/51384119/224427628-d94ab52a-ebb8-4988-8a10-bda188cbbfc6.png">


## Testing

- Unit test error map

## Docs

- Small change to errors data: formatting and slight message change
