### PR TITLE
Remove false-positive warnings from Cloudflare's build

### DIFF
--- a/.changeset/fair-emus-taste.md
+++ b/.changeset/fair-emus-taste.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Remove false-positive warnings from Cloudflare's build.
+
+Cloudflare includes warnings when it bundles the already-built output from astro.build. Those warnings are mostly due to `"sideEffects": false` packages that are included in the Vite built output because they are marked as external. Rollup will remove unused imports from these packages but will not remove the actual import, causing the false-positive warning.

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -107,6 +107,9 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					banner: {
 						js: SHIM,
 					},
+					logOverride: {
+						'ignored-bare-import': 'silent'
+					},
 				});
 
 				// Rename to worker.js


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/astro/issues/6291
- Removes a known false-positive warning. changeset includes the info.

## Testing

- No

## Docs

N/A