### PR TITLE
Fix `env.d.ts` switching back between types on every restart when assets are enabled

### DIFF
--- a/.changeset/tough-sheep-grab.md
+++ b/.changeset/tough-sheep-grab.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `env.d.ts` changing types wrongly on every restart when `experimental.assets` is enabled

--- a/packages/astro/src/vite-plugin-inject-env-ts/index.ts
+++ b/packages/astro/src/vite-plugin-inject-env-ts/index.ts
@@ -49,18 +49,25 @@ export async function setUpEnvTs({
 
 	if (fs.existsSync(envTsPath)) {
 		let typesEnvContents = await fs.promises.readFile(envTsPath, 'utf-8');
+
+		// TODO: Remove this logic in 3.0, as `astro/client-image` will be merged into `astro/client`
 		if (settings.config.experimental.assets && typesEnvContents.includes('types="astro/client"')) {
 			typesEnvContents = typesEnvContents.replace(
 				'types="astro/client"',
 				'types="astro/client-image"'
 			);
 			await fs.promises.writeFile(envTsPath, typesEnvContents, 'utf-8');
-		} else if (typesEnvContents.includes('types="astro/client-image"')) {
+			info(logging, 'assets', `Added ${bold(envTsPathRelativetoRoot)} types`);
+		} else if (
+			!settings.config.experimental.assets &&
+			typesEnvContents.includes('types="astro/client-image"')
+		) {
 			typesEnvContents = typesEnvContents.replace(
 				'types="astro/client-image"',
 				'types="astro/client"'
 			);
 			await fs.promises.writeFile(envTsPath, typesEnvContents, 'utf-8');
+			info(logging, 'assets', `Removed ${bold(envTsPathRelativetoRoot)} types`);
 		}
 
 		if (!fs.existsSync(dotAstroDir))


### PR DESCRIPTION
## Changes

I got my logic wrong and on every restart, the types would switch between `astro/client` and `astro/client-image`, hilarious really. I added some logging as well to make this clearer on the user's end that types were updated when enabling the feature (just like content collections do when updating the types)

## Testing

Tested manually, we don't test this part of the code. This "feature" will go away in the future when assets are not experimental, so testing it seems unnecessary

## Docs

N/A
