### PR TITLE
Add warning when using assets with non-node adapters

### DIFF
--- a/.changeset/famous-games-warn.md
+++ b/.changeset/famous-games-warn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Added a warning when trying to use `experimental.assets` with a not compatible adapter

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -1,3 +1,4 @@
+import { bold } from 'kleur/colors';
 import MagicString from 'magic-string';
 import mime from 'mime';
 import fs from 'node:fs/promises';
@@ -27,6 +28,30 @@ export default function assets({
 	let resolvedConfig: vite.ResolvedConfig;
 
 	globalThis.astroAsset = {};
+
+	const UNSUPPORTED_ADAPTERS = new Set([
+		'@astrojs/cloudflare',
+		'@astrojs/deno',
+		'@astrojs/netlify/edge-functions',
+		'@astrojs/vercel/edge',
+	]);
+
+	const adapterName = settings.config.adapter?.name;
+	if (
+		['astro/assets/services/sharp', 'astro/assets/services/squoosh'].includes(
+			settings.config.image.service
+		) &&
+		adapterName &&
+		UNSUPPORTED_ADAPTERS.has(adapterName)
+	) {
+		error(
+			logging,
+			'assets',
+			`The currently selected adapter \`${adapterName}\` does not run on Node, however the currently used image service depends on Node built-ins. ${bold(
+				'Your project will NOT be able to build.'
+			)}`
+		);
+	}
 
 	return [
 		// Expose the components and different utilities from `astro:assets` and handle serving images from `/_image` in dev


### PR DESCRIPTION
## Changes

What the title says!

Closes https://github.com/withastro/astro/issues/6529

## Testing

N/A, just a warning

## Docs

/cc @withastro/maintainers-docs for feedback!
