### PR TITLE
Sitemap: support SSR routes

### DIFF
--- a/.changeset/chatty-dolls-visit.md
+++ b/.changeset/chatty-dolls-visit.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/sitemap': minor
+---
+
+Adds support to SSR routes to sitemap generation.

--- a/packages/integrations/sitemap/package.json
+++ b/packages/integrations/sitemap/package.json
@@ -37,6 +37,7 @@
     "zod": "^3.17.3"
   },
   "devDependencies": {
+    "@astrojs/node": "workspace:*",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "chai": "^4.3.6",

--- a/packages/integrations/sitemap/package.json
+++ b/packages/integrations/sitemap/package.json
@@ -33,7 +33,6 @@
     "test": "mocha --timeout 20000"
   },
   "dependencies": {
-    "fast-glob": "^3.2.11",
     "sitemap": "^7.1.1",
     "zod": "^3.17.3"
   },

--- a/packages/integrations/sitemap/package.json
+++ b/packages/integrations/sitemap/package.json
@@ -33,6 +33,7 @@
     "test": "mocha --timeout 20000"
   },
   "dependencies": {
+    "fast-glob": "^3.2.11",
     "sitemap": "^7.1.1",
     "zod": "^3.17.3"
   },

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -94,7 +94,7 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 							 * remove the initial slash from relative pathname
 							 * because `finalSiteUrl` always has trailing slash
 							 */
-							const path = finalSiteUrl.pathname + r.pathname.substring(1);
+							const path = finalSiteUrl.pathname + r.generate(r.pathname).substring(1);
 							const newUrl = new URL(path, finalSiteUrl).href;
 							urls.push(newUrl);
 						}

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -95,8 +95,16 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 							 * because `finalSiteUrl` always has trailing slash
 							 */
 							const path = finalSiteUrl.pathname + r.generate(r.pathname).substring(1);
-							const newUrl = new URL(path, finalSiteUrl).href;
-							urls.push(newUrl);
+
+							let newUrl = new URL(path, finalSiteUrl).href;
+
+							if (config.trailingSlash === 'never') {
+								urls.push(newUrl);
+							} else if (config.build.format === 'directory' && !newUrl.endsWith('/')) {
+								urls.push(newUrl + '/');
+							} else {
+								urls.push(newUrl);
+							}
 						}
 
 						return urls;

--- a/packages/integrations/sitemap/src/utils/is-route-prerendered.ts
+++ b/packages/integrations/sitemap/src/utils/is-route-prerendered.ts
@@ -1,0 +1,8 @@
+const REGEX_PRERENDER = /const prerender = true/g;
+import { readFile } from 'fs/promises';
+
+export async function isRoutePrerendered(filePath: string) {
+	const contents = await readFile(filePath, 'utf-8');
+
+	return REGEX_PRERENDER.test(contents);
+}

--- a/packages/integrations/sitemap/src/utils/is-route-prerendered.ts
+++ b/packages/integrations/sitemap/src/utils/is-route-prerendered.ts
@@ -1,8 +1,0 @@
-const REGEX_PRERENDER = /const prerender = true/g;
-import { readFile } from 'fs/promises';
-
-export async function isRoutePrerendered(filePath: string) {
-	const contents = await readFile(filePath, 'utf-8');
-
-	return REGEX_PRERENDER.test(contents);
-}

--- a/packages/integrations/sitemap/test/fixtures/ssr/astro.config.mjs
+++ b/packages/integrations/sitemap/test/fixtures/ssr/astro.config.mjs
@@ -1,0 +1,12 @@
+import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
+import nodeServer from '@astrojs/node'
+
+export default defineConfig({
+  integrations: [sitemap()],
+	site: 'http://example.com',
+	output: 'server',
+	adapter: nodeServer({
+		mode: "standalone"
+	})
+})

--- a/packages/integrations/sitemap/test/fixtures/ssr/package.json
+++ b/packages/integrations/sitemap/test/fixtures/ssr/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/sitemap-trailing-slash",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/sitemap": "workspace:*"
+  }
+}

--- a/packages/integrations/sitemap/test/fixtures/ssr/src/pages/one.astro
+++ b/packages/integrations/sitemap/test/fixtures/ssr/src/pages/one.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>One</title>
+	</head>
+	<body>
+		<h1>One</h1>
+	</body>
+</html>

--- a/packages/integrations/sitemap/test/fixtures/ssr/src/pages/two.astro
+++ b/packages/integrations/sitemap/test/fixtures/ssr/src/pages/two.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>Two</title>
+	</head>
+	<body>
+		<h1>Two</h1>
+	</body>
+</html>

--- a/packages/integrations/sitemap/test/ssr.test.js
+++ b/packages/integrations/sitemap/test/ssr.test.js
@@ -1,0 +1,22 @@
+import { loadFixture, readXML } from './test-utils.js';
+import { expect } from 'chai';
+
+describe('SSR support', () => {
+	/** @type {import('./test-utils.js').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/ssr/',
+		});
+		await fixture.build();
+	});
+
+	it('SSR pages require zero config', async () => {
+		const data = await readXML(fixture.readFile('/client/sitemap-0.xml'));
+		const urls = data.urlset.url;
+
+		expect(urls[0].loc[0]).to.equal('http://example.com/one/');
+		expect(urls[1].loc[0]).to.equal('http://example.com/two/');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -668,7 +668,7 @@ importers:
         version: 3.0.1
       typescript:
         specifier: '*'
-        version: 4.9.5
+        version: 5.0.2
       unist-util-visit:
         specifier: ^4.1.0
         version: 4.1.0
@@ -15581,7 +15581,7 @@ packages:
       shiki: 0.10.1
       shiki-twoslash: 3.1.0
       tslib: 2.1.0
-      typescript: 4.9.5
+      typescript: 5.0.2
       unist-util-visit: 2.0.3
     transitivePeerDependencies:
       - supports-color
@@ -16889,11 +16889,6 @@ packages:
       call-bind: 1.0.2
       for-each: 0.3.3
       is-typed-array: 1.1.10
-
-  /typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
 
   /typescript@5.0.2:
     resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -668,7 +668,7 @@ importers:
         version: 3.0.1
       typescript:
         specifier: '*'
-        version: 5.0.2
+        version: 4.9.5
       unist-util-visit:
         specifier: ^4.1.0
         version: 4.1.0
@@ -4492,6 +4492,9 @@ importers:
 
   packages/integrations/sitemap:
     dependencies:
+      fast-glob:
+        specifier: ^3.2.11
+        version: 3.2.12
       sitemap:
         specifier: ^7.1.1
         version: 7.1.1
@@ -15581,7 +15584,7 @@ packages:
       shiki: 0.10.1
       shiki-twoslash: 3.1.0
       tslib: 2.1.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       unist-util-visit: 2.0.3
     transitivePeerDependencies:
       - supports-color
@@ -16889,6 +16892,11 @@ packages:
       call-bind: 1.0.2
       for-each: 0.3.3
       is-typed-array: 1.1.10
+
+  /typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
 
   /typescript@5.0.2:
     resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4492,9 +4492,6 @@ importers:
 
   packages/integrations/sitemap:
     dependencies:
-      fast-glob:
-        specifier: ^3.2.11
-        version: 3.2.12
       sitemap:
         specifier: ^7.1.1
         version: 7.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4499,6 +4499,9 @@ importers:
         specifier: ^3.17.3
         version: 3.20.6
     devDependencies:
+      '@astrojs/node':
+        specifier: workspace:*
+        version: link:../node
       astro:
         specifier: workspace:*
         version: link:../../astro
@@ -4514,6 +4517,15 @@ importers:
       xml2js:
         specifier: 0.5.0
         version: 0.5.0
+
+  packages/integrations/sitemap/test/fixtures/ssr:
+    dependencies:
+      '@astrojs/sitemap':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
 
   packages/integrations/sitemap/test/fixtures/trailing-slash:
     dependencies:


### PR DESCRIPTION
## Changes

- [x] Adds support for SSR routes
- [x] Changeset added

## Testing

I tested using the examples, replacing in `package.json` the `@astrojs/sitemap` version with `workspace:*` and making sure it's using `output: "server"` in the `astro.config.mjs`.

Optional: adding `const prerender = true` to a few routes.

Run `astro build` and make sure a `sitemap.xml` is created with no duplicated routes and every SSR route is created.

Optional-2: Add a hardcoded `customPages` definition to sitemap `options`.

## Docs

If you wish to use this implementation, I'm happy to update the docs.
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
 /cc @withastro/maintainers-docs for feedback!

