### PR TITLE
Prevent astro:content from depending on Node builtins

### DIFF
--- a/.changeset/four-planets-smoke.md
+++ b/.changeset/four-planets-smoke.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent astro:content from depending on Node builtins

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -53,6 +53,8 @@
     "./assets/services/sharp": "./dist/assets/services/sharp.js",
     "./assets/services/squoosh": "./dist/assets/services/squoosh.js",
     "./content/internal": "./dist/content/internal.js",
+    "./content/runtime": "./dist/content/runtime.js",
+    "./content/runtime-assets": "./dist/content/runtime-assets.js",
     "./debug": "./components/Debug.astro",
     "./internal/*": "./dist/runtime/server/*",
     "./package.json": "./package.json",

--- a/packages/astro/src/content/runtime-assets.ts
+++ b/packages/astro/src/content/runtime-assets.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { imageMetadata, type Metadata } from '../assets/utils/metadata.js';
+
+export function createImage(options: { assetsDir: string; relAssetsDir: string }) {
+	return () => {
+		if (options.assetsDir === 'undefined') {
+			throw new Error('Enable `experimental.assets` in your Astro config to use image()');
+		}
+
+		return z.string().transform(async (imagePath) => {
+			const fullPath = new URL(imagePath, options.assetsDir);
+			return await getImageMetadata(fullPath);
+		});
+	};
+}
+
+async function getImageMetadata(
+	imagePath: URL
+): Promise<(Metadata & { __astro_asset: true }) | undefined> {
+	const meta = await imageMetadata(imagePath);
+
+	if (!meta) {
+		return undefined;
+	}
+
+	delete meta.orientation;
+	return { ...meta, __astro_asset: true };
+}

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -1,5 +1,3 @@
-import { z } from 'zod';
-import { imageMetadata, type Metadata } from '../assets/utils/metadata.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { prependForwardSlash } from '../core/path.js';
 
@@ -198,30 +196,4 @@ async function render({
 		headings: mod.getHeadings?.() ?? [],
 		remarkPluginFrontmatter: mod.frontmatter ?? {},
 	};
-}
-
-export function createImage(options: { assetsDir: string; relAssetsDir: string }) {
-	return () => {
-		if (options.assetsDir === 'undefined') {
-			throw new Error('Enable `experimental.assets` in your Astro config to use image()');
-		}
-
-		return z.string().transform(async (imagePath) => {
-			const fullPath = new URL(imagePath, options.assetsDir);
-			return await getImageMetadata(fullPath);
-		});
-	};
-}
-
-async function getImageMetadata(
-	imagePath: URL
-): Promise<(Metadata & { __astro_asset: true }) | undefined> {
-	const meta = await imageMetadata(imagePath);
-
-	if (!meta) {
-		return undefined;
-	}
-
-	delete meta.orientation;
-	return { ...meta, __astro_asset: true };
 }

--- a/packages/astro/src/content/template/virtual-mod-assets.mjs
+++ b/packages/astro/src/content/template/virtual-mod-assets.mjs
@@ -1,0 +1,9 @@
+import {
+	createImage
+} from 'astro/content/runtime-assets';
+
+const assetsDir = '@@ASSETS_DIR@@';
+
+export const image = createImage({
+	assetsDir,
+});

--- a/packages/astro/src/content/template/virtual-mod.mjs
+++ b/packages/astro/src/content/template/virtual-mod.mjs
@@ -3,8 +3,7 @@ import {
 	createCollectionToGlobResultMap,
 	createGetCollection,
 	createGetEntryBySlug,
-	createImage,
-} from 'astro/content/internal';
+} from 'astro/content/runtime';
 
 export { z } from 'astro/zod';
 
@@ -13,7 +12,6 @@ export function defineCollection(config) {
 }
 
 const contentDir = '@@CONTENT_DIR@@';
-const assetsDir = '@@ASSETS_DIR@@';
 
 const entryGlob = import.meta.glob('@@ENTRY_GLOB_PATH@@', {
 	query: { astroContent: true },
@@ -39,8 +37,4 @@ export const getCollection = createGetCollection({
 export const getEntryBySlug = createGetEntryBySlug({
 	getCollection,
 	collectionToRenderEntryMap,
-});
-
-export const image = createImage({
-	assetsDir,
 });

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -347,6 +347,7 @@ export type ContentPaths = {
 	cacheDir: URL;
 	typesTemplate: URL;
 	virtualModTemplate: URL;
+	virtualAssetsModTemplate: URL;
 	config: {
 		exists: boolean;
 		url: URL;
@@ -365,6 +366,7 @@ export function getContentPaths(
 		assetsDir: new URL('./assets/', srcDir),
 		typesTemplate: new URL('types.d.ts', templateDir),
 		virtualModTemplate: new URL('virtual-mod.mjs', templateDir),
+		virtualAssetsModTemplate: new URL('virtual-mod-assets.mjs', templateDir),
 		config: configStats,
 	};
 }

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -39,7 +39,7 @@ export function astroContentVirtualModPlugin({
 		.replace('@@ENTRY_GLOB_PATH@@', entryGlob)
 		.replace('@@RENDER_ENTRY_GLOB_PATH@@', entryGlob);
 	const virtualAssetsModContents = fsMod
-		.readFileSync(contentPaths.virtualModTemplate, 'utf-8')
+		.readFileSync(contentPaths.virtualAssetsModTemplate, 'utf-8')
 		.replace('@@ASSETS_DIR@@', assetsDir);
 
 	const astroContentVirtualModuleId = '\0' + VIRTUAL_MODULE_ID;

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -36,11 +36,16 @@ export function astroContentVirtualModPlugin({
 	const virtualModContents = fsMod
 		.readFileSync(contentPaths.virtualModTemplate, 'utf-8')
 		.replace('@@CONTENT_DIR@@', relContentDir)
-		.replace('@@ASSETS_DIR@@', assetsDir)
 		.replace('@@ENTRY_GLOB_PATH@@', entryGlob)
 		.replace('@@RENDER_ENTRY_GLOB_PATH@@', entryGlob);
+	const virtualAssetsModContents = fsMod
+		.readFileSync(contentPaths.virtualModTemplate, 'utf-8')
+		.replace('@@ASSETS_DIR@@', assetsDir);
 
 	const astroContentVirtualModuleId = '\0' + VIRTUAL_MODULE_ID;
+	const allContents = settings.config.experimental.assets ?
+		(virtualModContents + virtualAssetsModContents) :
+		virtualModContents;
 
 	return {
 		name: 'astro-content-virtual-mod-plugin',
@@ -53,7 +58,7 @@ export function astroContentVirtualModPlugin({
 		load(id) {
 			if (id === astroContentVirtualModuleId) {
 				return {
-					code: virtualModContents,
+					code: allContents,
 				};
 			}
 		},

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -222,6 +222,24 @@ describe('Content Collections', () => {
 				root: './fixtures/content-ssr-integration/',
 				output: 'server',
 				adapter: testAdapter(),
+				vite: {
+					plugins: [
+						// Verifies that `astro:content` does not have a hard dependency on Node builtins.
+						// This is to verify it will run on Cloudflare and Deno
+						{
+							name: 'verify-no-node-stuff',
+							generateBundle() {
+								const nodeModules = ['node:fs', 'node:url', 'node:worker_threads', 'node:path'];
+								nodeModules.forEach(name => {
+									const mod = this.getModuleInfo(name);
+									if(mod) {
+										throw new Error(`Node builtins snuck in: ${name}`)
+									}
+								});
+							}
+						},
+					]
+				}
 			});
 			await fixture.build();
 			app = await fixture.loadTestAdapterApp();

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -3,6 +3,7 @@ import * as cheerio from 'cheerio';
 import { expect } from 'chai';
 import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { preventNodeBuiltinDependencyPlugin } from './test-plugins.js';
 
 describe('Content Collections', () => {
 	describe('Query', () => {
@@ -224,20 +225,7 @@ describe('Content Collections', () => {
 				adapter: testAdapter(),
 				vite: {
 					plugins: [
-						// Verifies that `astro:content` does not have a hard dependency on Node builtins.
-						// This is to verify it will run on Cloudflare and Deno
-						{
-							name: 'verify-no-node-stuff',
-							generateBundle() {
-								const nodeModules = ['node:fs', 'node:url', 'node:worker_threads', 'node:path'];
-								nodeModules.forEach(name => {
-									const mod = this.getModuleInfo(name);
-									if(mod) {
-										throw new Error(`Node builtins snuck in: ${name}`)
-									}
-								});
-							}
-						},
+						preventNodeBuiltinDependencyPlugin()
 					]
 				}
 			});

--- a/packages/astro/test/test-plugins.js
+++ b/packages/astro/test/test-plugins.js
@@ -1,0 +1,17 @@
+
+export function preventNodeBuiltinDependencyPlugin() {
+	// Verifies that `astro:content` does not have a hard dependency on Node builtins.
+	// This is to verify it will run on Cloudflare and Deno
+	return {
+		name: 'verify-no-node-stuff',
+		generateBundle() {
+			const nodeModules = ['node:fs', 'node:url', 'node:worker_threads', 'node:path'];
+			nodeModules.forEach(name => {
+				const mod = this.getModuleInfo(name);
+				if(mod) {
+					throw new Error(`Node builtins snuck in: ${name}`)
+				}
+			});
+		}
+	};
+}


### PR DESCRIPTION
## Changes

- Fixes issue where non-Node runtimes were breaking when using astro:content due to the Node dependency that `--experimental-assets` has.

## Testing

- In the content collections test, add a plugin that verifies that no Node builtins are depended on in the build.

## Docs

N/A, bug fix