### PR TITLE
[RSS] Fix: Preserve self-closing tags in `customData`

### DIFF
--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -142,7 +142,13 @@ async function generateRSS(rssOptions: ValidatedRSSOptions): Promise<string> {
 		? rssOptions.items
 		: rssOptions.items.filter((item) => !item.draft);
 
-	const xmlOptions = { ignoreAttributes: false };
+	const xmlOptions = {
+		ignoreAttributes: false,
+		// Avoid correcting self-closing tags to standard tags
+		// when using `customData`
+		// https://github.com/withastro/astro/issues/5794
+		suppressEmptyNode: true,
+	};
 	const parser = new XMLParser(xmlOptions);
 	const root: any = { '?xml': { '@_version': '1.0', '@_encoding': 'UTF-8' } };
 	if (typeof rssOptions.stylesheet === 'string') {

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -92,6 +92,23 @@ describe('rss', () => {
 		chai.expect(body).xml.to.equal(validXmlWithXSLStylesheet);
 	});
 
+	it('should preserve self-closing tags on `customData`', async () => {
+		const customData =
+			'<atom:link href="https://example.com/feed.xml" rel="self" type="application/rss+xml"/>';
+		const { body } = await rss({
+			title,
+			description,
+			items: [],
+			site,
+			xmlns: {
+				atom: 'http://www.w3.org/2005/Atom',
+			},
+			customData,
+		});
+
+		chai.expect(body).to.contain(customData);
+	});
+
 	it('should filter out entries marked as `draft`', async () => {
 		const { body } = await rss({
 			title,


### PR DESCRIPTION
## Changes

- Resolves #5794

## Testing

- Test that `customData` is preserved as-written

## Docs

N/A