### PR TITLE
fix(cloudflare): base strip logic

### DIFF
--- a/.changeset/early-kangaroos-invent.md
+++ b/.changeset/early-kangaroos-invent.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+fix `config.base` trimming logic for cloudflare integration `_routes.json` generation

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -156,7 +156,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						let pagePath = prependForwardSlash(page.pathname);
 						if (_config.base !== '/') {
 							const base = _config.base.endsWith('/')
-								? _config.base.substring(0, _config.base.length - 1)
+								? _config.base.slice(0, -1)
 								: _config.base;
 							pagePath = `${base}${pagePath}`;
 						}

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -156,7 +156,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						let pagePath = prependForwardSlash(page.pathname);
 						if (_config.base !== '/') {
 							const base = _config.base.endsWith('/')
-								? _config.base.substring(0, -1)
+								? _config.base.substring(0, _config.base.length - 1)
 								: _config.base;
 							pagePath = `${base}${pagePath}`;
 						}


### PR DESCRIPTION
## Changes

Fixes the strip logic for _config.base. Apparently the negative indexing is a feature of the deprecated substr, not substring.

Apologies for not catching this the first time around.

## Testing

Manually tested via `patch-package` locally. Verified behavior is correct now.

## Docs

N/A
