### PR TITLE
Fix mdx and markdoc integrations return type

### DIFF
--- a/.changeset/small-pens-knock.md
+++ b/.changeset/small-pens-knock.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/markdoc': patch
+'@astrojs/mdx': patch
+---
+
+Fix integration return type

--- a/packages/integrations/markdoc/src/index.ts
+++ b/packages/integrations/markdoc/src/index.ts
@@ -11,24 +11,19 @@ import {
 	prependForwardSlash,
 } from './utils.js';
 
-type IntegrationWithPrivateHooks = {
-	name: string;
-	hooks: Omit<AstroIntegration['hooks'], 'astro:config:setup'> & {
-		'astro:config:setup': (
-			params: HookParameters<'astro:config:setup'> & {
-				// `contentEntryType` is not a public API
-				// Add type defs here
-				addContentEntryType: (contentEntryType: ContentEntryType) => void;
-			}
-		) => void | Promise<void>;
-	};
+type SetupHookParams = HookParameters<'astro:config:setup'> & {
+	// `contentEntryType` is not a public API
+	// Add type defs here
+	addContentEntryType: (contentEntryType: ContentEntryType) => void;
 };
 
-export default function markdoc(markdocConfig: Config = {}): IntegrationWithPrivateHooks {
+export default function markdoc(markdocConfig: Config = {}): AstroIntegration {
 	return {
 		name: '@astrojs/markdoc',
 		hooks: {
-			'astro:config:setup': async ({ updateConfig, config, addContentEntryType }) => {
+			'astro:config:setup': async (params) => {
+				const { updateConfig, config, addContentEntryType } = params as SetupHookParams;
+
 				function getEntryInfo({ fileUrl, contents }: { fileUrl: URL; contents: string }) {
 					const parsed = parseFrontmatter(contents, fileURLToPath(fileUrl));
 					return {

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -23,33 +23,21 @@ export type MdxOptions = Omit<typeof markdownConfigDefaults, 'remarkPlugins' | '
 	remarkRehype: RemarkRehypeOptions;
 };
 
-type IntegrationWithPrivateHooks = {
-	name: string;
-	hooks: Omit<AstroIntegration['hooks'], 'astro:config:setup'> & {
-		'astro:config:setup': (
-			params: HookParameters<'astro:config:setup'> & {
-				// `addPageExtension` and `contentEntryType` are not a public APIs
-				// Add type defs here
-				addPageExtension: (extension: string) => void;
-				addContentEntryType: (contentEntryType: ContentEntryType) => void;
-			}
-		) => void | Promise<void>;
-	};
+type SetupHookParams = HookParameters<'astro:config:setup'> & {
+	// `addPageExtension` and `contentEntryType` are not a public APIs
+	// Add type defs here
+	addPageExtension: (extension: string) => void;
+	addContentEntryType: (contentEntryType: ContentEntryType) => void;
 };
 
-export default function mdx(
-	partialMdxOptions: Partial<MdxOptions> = {}
-): IntegrationWithPrivateHooks {
+export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroIntegration {
 	return {
 		name: '@astrojs/mdx',
 		hooks: {
-			'astro:config:setup': async ({
-				updateConfig,
-				config,
-				addPageExtension,
-				addContentEntryType,
-				command,
-			}) => {
+			'astro:config:setup': async (params) => {
+				const { updateConfig, config, addPageExtension, addContentEntryType, command } =
+					params as SetupHookParams;
+
 				addPageExtension('.mdx');
 				addContentEntryType({
 					extensions: ['.mdx'],


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/6520

Return the integrations with `AstroIntegration` type, and type the private APIs used by the integrations internally only.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Manually check the `.d.ts` generated export as `AstroIntegration` and not `IntegrationWithPrivateHooks`

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.
