### PR TITLE
fix(assets): Fix usage of custom service resulting in Invalid Input error

### DIFF
--- a/.changeset/gorgeous-beds-tickle.md
+++ b/.changeset/gorgeous-beds-tickle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix Invalid Input error when trying to use a custom Image Service

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -123,7 +123,7 @@ export const AstroConfigSchema = z.object({
 			service: z.union([
 				z.literal('astro/assets/services/sharp'),
 				z.literal('astro/assets/services/squoosh'),
-				z.string().and(z.object({})),
+				z.string(),
 			]),
 		})
 		.default({


### PR DESCRIPTION
## Changes

I unnecessarily tried to think like TS in Zod when I didn't need to since we don't use the schema anyway to do the types, oops.

Fix https://github.com/withastro/astro/issues/6545

## Testing

Tested manually

## Docs

N/A
