### PR TITLE
Integration readme: Replace tabs with double spaces

### DIFF
--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -116,18 +116,18 @@ When providing a formatted RSS item list, see the `RSSFeedItem` type reference b
 
 ```ts
 type RSSFeedItem = {
-	/** Link to item */
-	link: string;
-	/** Title of item */
-	title: string;
-	/** Publication date of item */
-	pubDate: Date;
-	/** Item description */
-	description?: string;
-	/** Full content of the item, should be valid HTML */
-	content?: string;
-	/** Append some other XML-valid data to this item */
-	customData?: string;
+  /** Link to item */
+  link: string;
+  /** Title of item */
+  title: string;
+  /** Publication date of item */
+  pubDate: Date;
+  /** Item description */
+  description?: string;
+  /** Full content of the item, should be valid HTML */
+  content?: string;
+  /** Append some other XML-valid data to this item */
+  customData?: string;
 };
 ```
 

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -506,7 +506,7 @@ import { defineConfig } from 'astro/config';
 import image from '@astrojs/image';
 
 export default defineConfig({
-	integrations: [image({
+  integrations: [image({
     // may be useful if your hosting provider allows caching between CI builds
     cacheDir: "./.cache/image"
   })]

--- a/packages/integrations/markdoc/README.md
+++ b/packages/integrations/markdoc/README.md
@@ -113,21 +113,21 @@ import markdoc from '@astrojs/markdoc';
 
 // https://astro.build/config
 export default defineConfig({
-	integrations: [
-		markdoc({
-			tags: {
-				aside: {
-					render: 'Aside',
+  integrations: [
+    markdoc({
+      tags: {
+        aside: {
+          render: 'Aside',
           attributes: {
             // Component props as attribute definitions
             // See Markdoc's documentation on defining attributes
             // https://markdoc.dev/docs/attributes#defining-attributes
             type: { type: String },
           }
-				},
-			},
-		}),
-	],
+        },
+      },
+    }),
+  ],
 });
 ```
 
@@ -159,11 +159,11 @@ import markdoc from '@astrojs/markdoc';
 
 // https://astro.build/config
 export default defineConfig({
-	integrations: [
-		markdoc({
-			nodes: {
-				heading: {
-					render: 'Heading',
+  integrations: [
+    markdoc({
+      nodes: {
+        heading: {
+          render: 'Heading',
           // Markdoc requires type defs for each attribute.
           // These should mirror the `Props` type of the component
           // you are rendering. 
@@ -172,10 +172,10 @@ export default defineConfig({
           attributes: {
             level: { type: String },
           }
-				},
-			},
-		}),
-	],
+        },
+      },
+    }),
+  ],
 });
 ```
 

--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -87,7 +87,7 @@ After verifying that the sitemaps are built, you can add them to your site's `<h
 ```html ins={3}
 // src/layouts/Layout.astro
 <head>
-	<link rel="sitemap" href="/sitemap-index.xml">
+  <link rel="sitemap" href="/sitemap-index.xml">
 </head>
 ```
 

--- a/packages/integrations/svelte/README.md
+++ b/packages/integrations/svelte/README.md
@@ -126,7 +126,7 @@ __`svelte.config.js`__
 import { vitePreprocess } from '@astrojs/svelte';
 
 export default {
-	preprocess: vitePreprocess(),
+  preprocess: vitePreprocess(),
 };
 ```
 

--- a/packages/webapi/README.md
+++ b/packages/webapi/README.md
@@ -108,8 +108,8 @@ The `exclude` option receives a list of WebAPIs to exclude from polyfilling.
 
 ```js
 polyfill(globalThis, {
-	// disables polyfills for setTimeout clearTimeout
-	exclude: 'setTimeout clearTimeout',
+  // disables polyfills for setTimeout clearTimeout
+  exclude: 'setTimeout clearTimeout',
 })
 ```
 
@@ -117,22 +117,22 @@ The `exclude` option accepts shorthands to exclude multiple polyfills. These sho
 
 ```js
 polyfill(globalThis, {
-	// disables polyfills for setTimeout clearTimeout
-	exclude: 'Timeout+',
+  // disables polyfills for setTimeout clearTimeout
+  exclude: 'Timeout+',
 })
 ```
 
 ```js
 polyfill(globalThis, {
-	// disables polyfills for Node, Window, Document, HTMLElement, etc.
-	exclude: 'Node+',
+  // disables polyfills for Node, Window, Document, HTMLElement, etc.
+  exclude: 'Node+',
 })
 ```
 
 ```js
 polyfill(globalThis, {
-	// disables polyfills for Event, EventTarget, Node, Window, Document, HTMLElement, etc.
-	exclude: 'Event+',
+  // disables polyfills for Event, EventTarget, Node, Window, Document, HTMLElement, etc.
+  exclude: 'Event+',
 })
 ```
 


### PR DESCRIPTION
## Changes

In multiple `README`s there was a mix of spaces and tabs used, this caused weird and incosistent formatting like seen here in npm:
![image](https://user-images.githubusercontent.com/55956895/225400960-15508c2f-6412-4b94-848b-27d33a0cf572.png)

Docs site seems to convert tabs, so was not affected. 

This PR replaces all `/src/packages/**/README.md` tabs with double spaces, making it consistent (as far as I can tell) with the rest of the docs.

## Testing

Docs change, no testing needed

## Docs

This should only affect github and npm, https://docs.astro.build/ should remain the same.
