### PR TITLE
Fix `image()` type to be compatible with ImageMetadata

### DIFF
--- a/.changeset/perfect-humans-wink.md
+++ b/.changeset/perfect-humans-wink.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix image() type to be compatible with ImageMetadata

--- a/packages/astro/src/content/template/types.d.ts
+++ b/packages/astro/src/content/template/types.d.ts
@@ -13,11 +13,22 @@ declare module 'astro:content' {
 	export type CollectionEntry<C extends keyof typeof entryMap> =
 		(typeof entryMap)[C][keyof (typeof entryMap)[C]];
 
+	// This needs to be in sync with ImageMetadata
 	export const image: () => import('astro/zod').ZodObject<{
 		src: import('astro/zod').ZodString;
 		width: import('astro/zod').ZodNumber;
 		height: import('astro/zod').ZodNumber;
-		format: import('astro/zod').ZodString;
+		format: import('astro/zod').ZodUnion<
+			[
+				import('astro/zod').ZodLiteral<'png'>,
+				import('astro/zod').ZodLiteral<'jpg'>,
+				import('astro/zod').ZodLiteral<'jpeg'>,
+				import('astro/zod').ZodLiteral<'tiff'>,
+				import('astro/zod').ZodLiteral<'webp'>,
+				import('astro/zod').ZodLiteral<'gif'>,
+				import('astro/zod').ZodLiteral<'svg'>
+			]
+		>;
 	}>;
 
 	type BaseSchemaWithoutEffects =


### PR DESCRIPTION
## Changes

What the title says

## Testing

Types only, tested manually

## Docs

N/A
