### PR TITLE
Fix error in empty markdown files with content

### DIFF
--- a/.changeset/tidy-crabs-warn.md
+++ b/.changeset/tidy-crabs-warn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Properly handle empty markdown files in content collections

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -32,7 +32,7 @@ export const contentConfigParser = z.object({
 export type CollectionConfig = z.infer<typeof collectionConfigParser>;
 export type ContentConfig = z.infer<typeof contentConfigParser>;
 
-type EntryInternal = { rawData: string; filePath: string };
+type EntryInternal = { rawData: string | undefined; filePath: string };
 
 export type EntryInfo = {
 	id: string;
@@ -222,7 +222,8 @@ function hasUnderscoreBelowContentDirectoryPath(
 	return false;
 }
 
-function getFrontmatterErrorLine(rawFrontmatter: string, frontmatterKey: string) {
+function getFrontmatterErrorLine(rawFrontmatter: string | undefined, frontmatterKey: string) {
+	if (!rawFrontmatter) return 0;
 	const indexOfFrontmatterKey = rawFrontmatter.indexOf(`\n${frontmatterKey}`);
 	if (indexOfFrontmatterKey === -1) return 0;
 

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -215,6 +215,21 @@ describe('Content Collections', () => {
 		});
 	});
 
+	describe('With empty markdown file', () => {
+		it('Throws the right error', async () => {
+			const fixture = await loadFixture({
+				root: './fixtures/content-collections-empty-md-file/',
+			});
+			let error;
+			try {
+				await fixture.build();
+			} catch (e) {
+				error = e.message;
+			}
+			expect(error).to.include('**title**: Required');
+		});
+	});
+
 	describe('SSR integration', () => {
 		let app;
 

--- a/packages/astro/test/fixtures/content-collections-empty-md-file/package.json
+++ b/packages/astro/test/fixtures/content-collections-empty-md-file/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/content-collections-empty-md-file",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/content-collections-empty-md-file/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections-empty-md-file/src/content/config.ts
@@ -1,0 +1,11 @@
+import { z, defineCollection } from 'astro:content';
+
+const blog = defineCollection({
+	schema: z.object({
+		title: z.string(),
+	}),
+});
+
+export const collections = {
+	blog,
+};

--- a/packages/astro/test/fixtures/content-collections-empty-md-file/src/pages/index.astro
+++ b/packages/astro/test/fixtures/content-collections-empty-md-file/src/pages/index.astro
@@ -1,0 +1,6 @@
+---
+import { getEntryBySlug } from 'astro:content';
+const blogEntry = await getEntryBySlug('blog', 'empty');
+---
+
+{blogEntry.data.title}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1835,6 +1835,12 @@ importers:
       '@astrojs/mdx': link:../../../../integrations/mdx
       astro: link:../../..
 
+  packages/astro/test/fixtures/content-collections-empty-md-file:
+    specifiers:
+      astro: workspace:*
+    dependencies:
+      astro: link:../../..
+
   packages/astro/test/fixtures/content-collections-with-config-mjs:
     specifiers:
       astro: workspace:*


### PR DESCRIPTION
## Changes

When the markdown page is empty, `rawFrontmatter` is undefined which causes `rawFrontmatter.indexOf` to throw
![image-raw-fm](https://user-images.githubusercontent.com/81974850/225763508-8f9b7db8-e3ca-4d75-b7b3-3517e9d44eed.png)

The fix is to return early when the frontmatter is falsy.

## Testing

Check that we get a correct error
## Docs


Bug fix only