### PR TITLE
Fix processing same image multiple times

### DIFF
--- a/.changeset/thirty-buses-bathe.md
+++ b/.changeset/thirty-buses-bathe.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix processing same image multiple times

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -107,8 +107,15 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 
 	if (opts.settings.config.experimental.assets) {
 		info(opts.logging, null, `\n${bgGreen(black(` generating optimized images `))}`);
+		// As keys of `globalThis.astroAsset.staticImages` are objects, values can be duplicated.
+		// `generatedImagePaths` is used to avoid processing & generating same image multiple time due to that `imageData` contain duplicated entries with same value (`imageData[1]`).
+		const generatedImagePaths = new Set();
 		for (const imageData of getStaticImageList()) {
+			if (generatedImagePaths.has(imageData[1])) {
+				continue;
+			}
 			await generateImage(opts, imageData[0], imageData[1]);
+			generatedImagePaths.add(imageData[1]);
 		}
 		delete globalThis.astroAsset.addStaticImage;
 	}


### PR DESCRIPTION
## Changes

- add a check before generating image with asset service to prevent generating same image multiple time

Fix #6564, close #6489

## Testing

I didn't test only this change.
I'm using astro with few more patches and just extracted only this part, but this changes are very simple and don't even need to verify, I think.

## Docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
No changes for usage