### PR TITLE
Simplify internal resolver in dev

### DIFF
--- a/.changeset/soft-plants-hope.md
+++ b/.changeset/soft-plants-hope.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Simplify internal resolver in dev

--- a/packages/astro/src/core/render/dev/resolve.ts
+++ b/packages/astro/src/core/render/dev/resolve.ts
@@ -8,13 +8,6 @@ export function createResolve(loader: ModuleLoader, root: URL) {
 	// - /Users/macos/project/src/Foo.vue
 	// - C:/Windows/project/src/Foo.vue (normalized slash)
 	return async function (s: string) {
-		const url = await resolveIdToUrl(loader, s, root);
-		// Vite does not resolve .jsx -> .tsx when coming from hydration script import,
-		// clip it so Vite is able to resolve implicitly.
-		if (url.startsWith('/') && url.endsWith('.jsx')) {
-			return url.slice(0, -4);
-		} else {
-			return url;
-		}
+		return await resolveIdToUrl(loader, s, root);
 	};
 }


### PR DESCRIPTION
## Changes

This cleans up our `.jsx` -> `.tsx` handling. The code is removed since it's already handled at

https://github.com/withastro/astro/blob/36253f47add6f6eb927407dacc6a645d9e48d48e/packages/astro/src/core/util.ts#L176-L179

This should prevent Vite's perf PR (https://github.com/vitejs/vite/pull/12450) from breaking for a specific case, where the user project imports `.tsx` components that's outside of the project root.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
n/a. Existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. code refactor and cleanup.