### PR TITLE
feat(all): Migrate to TypeScript 5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,10 +84,10 @@
     "@changesets/cli": "2.23.0",
     "@octokit/action": "^3.18.1",
     "@types/node": "^18.7.21",
-    "@typescript-eslint/eslint-plugin": "^5.27.1",
-    "@typescript-eslint/parser": "^5.27.1",
+    "@typescript-eslint/eslint-plugin": "^5.55.0",
+    "@typescript-eslint/parser": "^5.55.0",
     "del": "^7.0.0",
-    "esbuild": "^0.15.18",
+    "esbuild": "^0.17.12",
     "eslint": "^8.17.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-no-only-tests": "^2.6.0",
@@ -100,6 +100,6 @@
     "pretty-bytes": "^6.0.0",
     "tiny-glob": "^0.2.9",
     "turbo": "1.2.5",
-    "typescript": "~4.7.3"
+    "typescript": "~5.0.2"
   }
 }

--- a/packages/astro/src/@types/typed-emitter.ts
+++ b/packages/astro/src/@types/typed-emitter.ts
@@ -24,7 +24,7 @@ export type EventMap = {
  * myEmitter.emit("error", "x")  // <- Will catch this type error;
  * ```
  */
-interface TypedEventEmitter<Events extends EventMap> {
+export interface TypedEventEmitter<Events extends EventMap> {
 	addListener<E extends keyof Events>(event: E, listener: Events[E]): this;
 	on<E extends keyof Events>(event: E, listener: Events[E]): this;
 	once<E extends keyof Events>(event: E, listener: Events[E]): this;
@@ -45,5 +45,3 @@ interface TypedEventEmitter<Events extends EventMap> {
 	getMaxListeners(): number;
 	setMaxListeners(maxListeners: number): this;
 }
-
-export default TypedEventEmitter;

--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import type { StaticBuildOptions } from '../core/build/types.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
-import { ImageService, isLocalService, LocalImageService } from './services/service.js';
+import { isLocalService, type ImageService, type LocalImageService } from './services/service.js';
 import type { ImageMetadata, ImageTransform } from './types.js';
 
 export function isESMImportedImage(src: ImageMetadata | string): src is ImageMetadata {

--- a/packages/astro/src/assets/services/sharp.ts
+++ b/packages/astro/src/assets/services/sharp.ts
@@ -1,6 +1,11 @@
 import type { FormatEnum } from 'sharp';
 import type { ImageQualityPreset, OutputFormat } from '../types.js';
-import { baseService, BaseServiceTransform, LocalImageService, parseQuality } from './service.js';
+import {
+	baseService,
+	parseQuality,
+	type BaseServiceTransform,
+	type LocalImageService,
+} from './service.js';
 
 let sharp: typeof import('sharp');
 

--- a/packages/astro/src/assets/services/squoosh.ts
+++ b/packages/astro/src/assets/services/squoosh.ts
@@ -1,7 +1,12 @@
 // TODO: Investigate removing this service once sharp lands WASM support, as libsquoosh is deprecated
 
 import type { ImageQualityPreset, OutputFormat } from '../types.js';
-import { baseService, BaseServiceTransform, LocalImageService, parseQuality } from './service.js';
+import {
+	baseService,
+	parseQuality,
+	type BaseServiceTransform,
+	type LocalImageService,
+} from './service.js';
 import { processBuffer } from './vendor/squoosh/image-pool.js';
 import type { Operation } from './vendor/squoosh/image.js';
 

--- a/packages/astro/src/assets/vendor/image-size/detector.ts
+++ b/packages/astro/src/assets/vendor/image-size/detector.ts
@@ -1,4 +1,4 @@
-import { imageType, typeHandlers } from './types.js'
+import { typeHandlers, type imageType } from './types.js'
 
 const keys = Object.keys(typeHandlers) as imageType[]
 

--- a/packages/astro/src/assets/vendor/image-size/index.ts
+++ b/packages/astro/src/assets/vendor/image-size/index.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import Queue from "../queue/queue.js";
 import { detector } from "./detector.js";
-import { imageType, typeHandlers } from "./types.js";
+import { typeHandlers, type imageType } from "./types.js";
 import type { ISizeCalculationResult } from "./types/interface.js";
 
 type CallbackFn = (e: Error | null, r?: ISizeCalculationResult) => void;

--- a/packages/astro/src/cli/check/index.ts
+++ b/packages/astro/src/cli/check/index.ts
@@ -1,5 +1,9 @@
 /* eslint-disable no-console */
-import { AstroCheck, DiagnosticSeverity, GetDiagnosticsResult } from '@astrojs/language-server';
+import {
+	AstroCheck,
+	DiagnosticSeverity,
+	type GetDiagnosticsResult,
+} from '@astrojs/language-server';
 import type { FSWatcher } from 'chokidar';
 import glob from 'fast-glob';
 import fsMod, * as fs from 'fs';

--- a/packages/astro/src/cli/check/print.ts
+++ b/packages/astro/src/cli/check/print.ts
@@ -1,4 +1,4 @@
-import { Diagnostic, DiagnosticSeverity, offsetAt } from '@astrojs/language-server';
+import { DiagnosticSeverity, offsetAt, type Diagnostic } from '@astrojs/language-server';
 import {
 	bgRed,
 	bgWhite,

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -13,7 +13,7 @@ import {
 import { ASTRO_VERSION } from '../core/constants.js';
 import { collectErrorMetadata } from '../core/errors/dev/index.js';
 import { createSafeError } from '../core/errors/index.js';
-import { debug, error, info, LogOptions } from '../core/logger/core.js';
+import { debug, error, info, type LogOptions } from '../core/logger/core.js';
 import { enableVerboseLogging, nodeLogDestination } from '../core/logger/node.js';
 import { formatConfigErrorMessage, formatErrorMessage, printHelp } from '../core/messages.js';
 import * as event from '../events/index.js';

--- a/packages/astro/src/content/server-listeners.ts
+++ b/packages/astro/src/content/server-listeners.ts
@@ -5,10 +5,10 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { ViteDevServer } from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
 import { loadTSConfig } from '../core/config/tsconfig.js';
-import { info, LogOptions, warn } from '../core/logger/core.js';
+import { info, warn, type LogOptions } from '../core/logger/core.js';
 import { appendForwardSlash } from '../core/path.js';
 import { createContentTypesGenerator } from './types-generator.js';
-import { ContentPaths, getContentPaths, globalContentConfigObserver } from './utils.js';
+import { getContentPaths, globalContentConfigObserver, type ContentPaths } from './utils.js';
 
 interface ContentServerListenerParams {
 	fs: typeof fsMod;

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -3,25 +3,25 @@ import { cyan } from 'kleur/colors';
 import type fsMod from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { normalizePath, ViteDevServer } from 'vite';
+import { normalizePath, type ViteDevServer } from 'vite';
 import type { AstroSettings, ContentEntryType } from '../@types/astro.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
-import { info, LogOptions, warn } from '../core/logger/core.js';
+import { info, warn, type LogOptions } from '../core/logger/core.js';
 import { isRelativePath } from '../core/path.js';
 import { CONTENT_TYPES_FILE } from './consts.js';
 import {
-	ContentConfig,
-	ContentObservable,
-	ContentPaths,
-	EntryInfo,
+	NoCollectionError,
 	getContentEntryExts,
 	getContentPaths,
 	getEntryInfo,
 	getEntrySlug,
 	getEntryType,
 	loadContentConfig,
-	NoCollectionError,
 	parseFrontmatter,
+	type ContentConfig,
+	type ContentObservable,
+	type ContentPaths,
+	type EntryInfo,
 } from './utils.js';
 
 type ChokidarEvent = 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir';

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -4,7 +4,7 @@ import fsMod from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { EmitFile } from 'rollup';
-import { ErrorPayload as ViteErrorPayload, normalizePath, ViteDevServer } from 'vite';
+import { normalizePath, type ViteDevServer, type ErrorPayload as ViteErrorPayload } from 'vite';
 import { z } from 'zod';
 import type { AstroConfig, AstroSettings } from '../@types/astro.js';
 import { emitESMImage } from '../assets/utils/emitAsset.js';

--- a/packages/astro/src/content/vite-plugin-content-assets.ts
+++ b/packages/astro/src/content/vite-plugin-content-assets.ts
@@ -3,7 +3,7 @@ import { pathToFileURL } from 'url';
 import type { Plugin } from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
 import { moduleIsTopLevelPage, walkParentInfos } from '../core/build/graph.js';
-import { BuildInternals, getPageDataByViteID } from '../core/build/internal.js';
+import { getPageDataByViteID, type BuildInternals } from '../core/build/internal.js';
 import type { AstroBuildPlugin } from '../core/build/plugin.js';
 import type { StaticBuildOptions } from '../core/build/types';
 import type { ModuleLoader } from '../core/module-loader/loader.js';

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -9,7 +9,6 @@ import { AstroError } from '../core/errors/errors.js';
 import { escapeViteEnvReferences, getFileInfo } from '../vite-plugin-utils/index.js';
 import { CONTENT_FLAG } from './consts.js';
 import {
-	ContentConfig,
 	getContentEntryExts,
 	getContentPaths,
 	getEntryData,
@@ -18,6 +17,7 @@ import {
 	getEntryType,
 	globalContentConfigObserver,
 	patchAssets,
+	type ContentConfig,
 } from './utils.js';
 function isContentFlagImport(viteId: string, contentEntryExts: string[]) {
 	const { searchParams, pathname } = new URL(viteId, 'file://');

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -13,11 +13,11 @@ import type yargs from 'yargs-parser';
 import { loadTSConfig, resolveConfigPath } from '../config/index.js';
 import {
 	defaultTSConfig,
-	frameworkWithTSSettings,
 	presets,
 	updateTSConfigForFramework,
+	type frameworkWithTSSettings,
 } from '../config/tsconfig.js';
-import { debug, info, LogOptions } from '../logger/core.js';
+import { debug, info, type LogOptions } from '../logger/core.js';
 import * as msg from '../messages.js';
 import { printHelp } from '../messages.js';
 import { appendForwardSlash } from '../path.js';
@@ -62,7 +62,7 @@ export default {
 `;
 const LIT_NPMRC_STUB = `\
 # Lit libraries are required to be hoisted due to dependency issues.
-public-hoist-pattern[]=*lit* 
+public-hoist-pattern[]=*lit*
 `;
 
 const OFFICIAL_ADAPTER_TO_IMPORT_MAP: Record<string, string> = {

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -5,7 +5,7 @@ import type {
 	RouteData,
 	SSRElement,
 } from '../../@types/astro';
-import type { RouteInfo, SSRManifest as Manifest } from './types';
+import type { SSRManifest as Manifest, RouteInfo } from './types';
 
 import mime from 'mime';
 import { attachToResponse, getSetCookiesFromResponse } from '../cookies/index.js';
@@ -16,8 +16,8 @@ import { joinPaths, prependForwardSlash, removeTrailingForwardSlash } from '../p
 import {
 	createEnvironment,
 	createRenderContext,
-	Environment,
 	renderPage,
+	type Environment,
 } from '../render/index.js';
 import { RouteCache } from '../render/route-cache.js';
 import {

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import type { IncomingMessage } from 'http';
 import { TLSSocket } from 'tls';
 import { deserializeManifest } from './common.js';
-import { App, MatchOptions } from './index.js';
+import { App, type MatchOptions } from './index.js';
 
 const clientAddressSymbol = Symbol.for('astro.clientAddress');
 

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -18,7 +18,7 @@ import {
 	generateImage as generateImageInternal,
 	getStaticImageList,
 } from '../../assets/internal.js';
-import { BuildInternals, hasPrerenderedPages } from '../../core/build/internal.js';
+import { hasPrerenderedPages, type BuildInternals } from '../../core/build/internal.js';
 import {
 	prependForwardSlash,
 	removeLeadingForwardSlash,

--- a/packages/astro/src/core/build/plugins/plugin-css.ts
+++ b/packages/astro/src/core/build/plugins/plugin-css.ts
@@ -1,7 +1,7 @@
 import * as crypto from 'node:crypto';
 import * as npath from 'node:path';
 import type { GetModuleInfo } from 'rollup';
-import { Plugin as VitePlugin, ResolvedConfig, transformWithEsbuild } from 'vite';
+import { transformWithEsbuild, type ResolvedConfig, type Plugin as VitePlugin } from 'vite';
 import { isBuildableCSSRequest } from '../../render/dev/util.js';
 import type { BuildInternals } from '../internal';
 import type { AstroBuildPlugin } from '../plugin';

--- a/packages/astro/src/core/build/plugins/plugin-pages.ts
+++ b/packages/astro/src/core/build/plugins/plugin-pages.ts
@@ -4,7 +4,7 @@ import type { StaticBuildOptions } from '../types';
 
 import { pagesVirtualModuleId, resolvedPagesVirtualModuleId } from '../../app/index.js';
 import { addRollupInput } from '../add-rollup-input.js';
-import { BuildInternals, eachPageData, hasPrerenderedPages } from '../internal.js';
+import { eachPageData, hasPrerenderedPages, type BuildInternals } from '../internal.js';
 
 export function vitePluginPages(opts: StaticBuildOptions, internals: BuildInternals): VitePlugin {
 	return {

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -6,9 +6,9 @@ import { bgGreen, bgMagenta, black, dim } from 'kleur/colors';
 import { fileURLToPath } from 'url';
 import * as vite from 'vite';
 import {
-	BuildInternals,
 	createBuildInternals,
 	eachPrerenderedPageData,
+	type BuildInternals,
 } from '../../core/build/internal.js';
 import { emptyDir, removeEmptyDirs } from '../../core/fs/index.js';
 import { appendForwardSlash, prependForwardSlash } from '../../core/path.js';
@@ -21,7 +21,7 @@ import { info } from '../logger/core.js';
 import { getOutDirWithinCwd } from './common.js';
 import { generatePages } from './generate.js';
 import { trackPageData } from './internal.js';
-import { AstroBuildPluginContainer, createPluginContainer } from './plugin.js';
+import { createPluginContainer, type AstroBuildPluginContainer } from './plugin.js';
 import { registerAllPlugins } from './plugins/index.js';
 import type { PageBuildData, StaticBuildOptions } from './types';
 import { getTimeStat } from './util.js';

--- a/packages/astro/src/core/compile/cache.ts
+++ b/packages/astro/src/core/compile/cache.ts
@@ -1,5 +1,5 @@
 import type { AstroConfig } from '../../@types/astro';
-import { compile, CompileProps, CompileResult } from './compile.js';
+import { compile, type CompileProps, type CompileResult } from './compile.js';
 
 type CompilationCache = Map<string, CompileResult>;
 

--- a/packages/astro/src/core/compile/style.ts
+++ b/packages/astro/src/core/compile/style.ts
@@ -1,6 +1,6 @@
 import type { TransformOptions } from '@astrojs/compiler';
 import fs from 'fs';
-import { preprocessCSS, ResolvedConfig } from 'vite';
+import { preprocessCSS, type ResolvedConfig } from 'vite';
 import { AstroErrorData, CSSError, positionAt } from '../errors/index.js';
 
 export function createStylePreprocessor({

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -7,7 +7,7 @@ import type * as vite from 'vite';
 import type yargs from 'yargs-parser';
 import type { AstroSettings } from '../../@types/astro';
 import { attachContentServerListeners } from '../../content/index.js';
-import { info, LogOptions, warn } from '../logger/core.js';
+import { info, warn, type LogOptions } from '../logger/core.js';
 import * as msg from '../messages.js';
 import { printHelp } from '../messages.js';
 import { startContainer } from './container.js';

--- a/packages/astro/src/core/endpoint/index.ts
+++ b/packages/astro/src/core/endpoint/index.ts
@@ -5,8 +5,8 @@ import { renderEndpoint } from '../../runtime/server/index.js';
 import { ASTRO_VERSION } from '../constants.js';
 import { AstroCookies, attachToResponse } from '../cookies/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
-import { LogOptions, warn } from '../logger/core.js';
-import { getParamsAndProps, GetParamsAndPropsError } from '../render/core.js';
+import { warn, type LogOptions } from '../logger/core.js';
+import { GetParamsAndPropsError, getParamsAndProps } from '../render/core.js';
 
 const clientAddressSymbol = Symbol.for('astro.clientAddress');
 

--- a/packages/astro/src/core/errors/dev/utils.ts
+++ b/packages/astro/src/core/errors/dev/utils.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import stripAnsi from 'strip-ansi';
 import type { ESBuildTransformResult } from 'vite';
 import type { SSRError } from '../../../@types/astro.js';
-import { AggregateError, ErrorWithMetadata } from '../errors.js';
+import { AggregateError, type ErrorWithMetadata } from '../errors.js';
 import { codeFrame } from '../printer.js';
 import { normalizeLF } from '../utils.js';
 

--- a/packages/astro/src/core/errors/dev/vite.ts
+++ b/packages/astro/src/core/errors/dev/vite.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url';
 import type { ErrorPayload } from 'vite';
 import type { ModuleLoader } from '../../module-loader/index.js';
 import { AstroErrorData } from '../errors-data.js';
-import { AstroError, ErrorWithMetadata } from '../errors.js';
+import { AstroError, type ErrorWithMetadata } from '../errors.js';
 import { createSafeError } from '../utils.js';
 import type { SSRLoadedRenderer } from './../../../@types/astro.js';
 import { renderErrorMarkdown } from './utils.js';

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -11,9 +11,7 @@ export interface ErrorData {
 	hint?: string | ((...params: any) => string);
 }
 
-// TODO: Replace with `satisfies` once TS 4.9 is out
-const defineErrors = <T extends Record<string, ErrorData>>(errs: T) => errs;
-export const AstroErrorData = defineErrors({
+export const AstroErrorData = {
 	/**
 	 * @docs
 	 * @kind heading
@@ -819,7 +817,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 		title: 'Unknown Error.',
 		code: 99999,
 	},
-} as const);
+} as const satisfies Record<string, ErrorData>;
 
 type ValueOf<T> = T[keyof T];
 export type AstroErrorCodes = ValueOf<{

--- a/packages/astro/src/core/errors/utils.ts
+++ b/packages/astro/src/core/errors/utils.ts
@@ -1,6 +1,6 @@
 import type { DiagnosticCode } from '@astrojs/compiler/shared/diagnostics.js';
 import type { SSRError } from '../../@types/astro.js';
-import { AstroErrorCodes, AstroErrorData, ErrorData } from './errors-data.js';
+import { AstroErrorData, type AstroErrorCodes, type ErrorData } from './errors-data.js';
 
 /**
  * Get the line and character based on the offset

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -17,7 +17,7 @@ import {
 import type { ResolvedServerUrls } from 'vite';
 import type { ZodError } from 'zod';
 import { renderErrorMarkdown } from './errors/dev/utils.js';
-import { AstroError, CompilerError, ErrorWithMetadata } from './errors/index.js';
+import { AstroError, CompilerError, type ErrorWithMetadata } from './errors/index.js';
 import { emoji, padMultilineString } from './util.js';
 
 const PREFIX_PADDING = 6;

--- a/packages/astro/src/core/module-loader/loader.ts
+++ b/packages/astro/src/core/module-loader/loader.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import type * as fs from 'fs';
-import type TypedEmitter from '../../@types/typed-emitter';
+import type { TypedEventEmitter } from '../../@types/typed-emitter';
 
 // This is a generic interface for a module loader. In the astro cli this is
 // fulfilled by Vite, see vite.ts
@@ -18,7 +18,7 @@ export type LoaderEvents = {
 	}) => void;
 };
 
-export type ModuleLoaderEventEmitter = TypedEmitter<LoaderEvents>;
+export type ModuleLoaderEventEmitter = TypedEventEmitter<LoaderEvents>;
 
 export interface ModuleLoader {
 	import: (src: string) => Promise<Record<string, any>>;
@@ -35,7 +35,7 @@ export interface ModuleLoader {
 	clientReload: () => void;
 	webSocketSend: (msg: any) => void;
 	isHttps: () => boolean;
-	events: TypedEmitter<LoaderEvents>;
+	events: TypedEventEmitter<LoaderEvents>;
 }
 
 export interface ModuleNode {

--- a/packages/astro/src/core/render/index.ts
+++ b/packages/astro/src/core/render/index.ts
@@ -1,6 +1,6 @@
-export type { RenderContext } from './context';
 export { createRenderContext } from './context.js';
-export { getParamsAndProps, GetParamsAndPropsError, renderPage } from './core.js';
+export type { RenderContext } from './context.js';
+export { GetParamsAndPropsError, getParamsAndProps, renderPage } from './core.js';
 export type { Environment } from './environment';
 export { createBasicEnvironment, createEnvironment } from './environment.js';
 export { loadRenderer } from './renderer.js';

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -10,16 +10,16 @@ import type {
 	SSRResult,
 } from '../../@types/astro';
 import {
-	ComponentSlots,
+	ScopeFlags,
 	createScopedResult,
 	renderSlot,
-	ScopeFlags,
 	stringifyChunk,
+	type ComponentSlots,
 } from '../../runtime/server/index.js';
 import { renderJSX } from '../../runtime/server/jsx.js';
 import { AstroCookies } from '../cookies/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
-import { LogOptions, warn } from '../logger/core.js';
+import { warn, type LogOptions } from '../logger/core.js';
 
 const clientAddressSymbol = Symbol.for('astro.clientAddress');
 

--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -8,7 +8,7 @@ import type {
 	RuntimeMode,
 } from '../../@types/astro';
 import { AstroError, AstroErrorData } from '../errors/index.js';
-import { debug, LogOptions, warn } from '../logger/core.js';
+import { debug, warn, type LogOptions } from '../logger/core.js';
 
 import { stringifyParams } from '../routing/params.js';
 import { validateDynamicRouteModule, validateGetStaticPathsResult } from '../routing/validation.js';

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -11,7 +11,7 @@ import { setUpEnvTs } from '../../vite-plugin-inject-env-ts/index.js';
 import { getTimeStat } from '../build/util.js';
 import { createVite } from '../create-vite.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
-import { info, LogOptions } from '../logger/core.js';
+import { info, type LogOptions } from '../logger/core.js';
 import { printHelp } from '../messages.js';
 
 export type ProcessExit = 0 | 1;

--- a/packages/astro/src/events/error.ts
+++ b/packages/astro/src/events/error.ts
@@ -1,5 +1,5 @@
 import type { ZodError } from 'zod';
-import { AstroError, AstroErrorData, ErrorWithMetadata } from '../core/errors/index.js';
+import { AstroError, AstroErrorData, type ErrorWithMetadata } from '../core/errors/index.js';
 import { getErrorDataByCode } from '../core/errors/utils.js';
 
 const EVENT_ERROR = 'ASTRO_CLI_ERROR';

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -15,7 +15,7 @@ import type {
 import type { SerializedSSRManifest } from '../core/app/types';
 import type { PageBuildData } from '../core/build/types';
 import { mergeConfig } from '../core/config/config.js';
-import { info, LogOptions } from '../core/logger/core.js';
+import { info, type LogOptions } from '../core/logger/core.js';
 import { mdxContentEntryType } from '../vite-plugin-markdown/content-entry-type.js';
 
 async function withTakingALongTimeMsg<T>({

--- a/packages/astro/src/runtime/server/jsx.ts
+++ b/packages/astro/src/runtime/server/jsx.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
 import type { SSRResult } from '../../@types/astro.js';
-import { AstroJSX, AstroVNode, isVNode } from '../../jsx-runtime/index.js';
+import { AstroJSX, isVNode, type AstroVNode } from '../../jsx-runtime/index.js';
 import {
-	escapeHTML,
 	HTMLString,
+	escapeHTML,
 	markHTMLString,
 	renderComponentToIterable,
 	renderToString,
@@ -12,7 +12,7 @@ import {
 } from './index.js';
 import { HTMLParts } from './render/common.js';
 import type { ComponentIterable } from './render/component';
-import { createScopedResult, ScopeFlags } from './render/scope.js';
+import { ScopeFlags, createScopedResult } from './render/scope.js';
 
 const ClientOnlyPlaceholder = 'astro-client-only';
 

--- a/packages/astro/src/runtime/server/render/common.ts
+++ b/packages/astro/src/runtime/server/render/common.ts
@@ -6,10 +6,10 @@ import {
 	determineIfNeedsHydrationScript,
 	determinesIfNeedsDirectiveScript,
 	getPrescripts,
-	PrescriptType,
+	type PrescriptType,
 } from '../scripts.js';
 import { renderAllHeadContent } from './head.js';
-import { hasScopeFlag, ScopeFlags } from './scope.js';
+import { ScopeFlags, hasScopeFlag } from './scope.js';
 import { isSlotString, type SlotString } from './slot.js';
 
 export const Fragment = Symbol.for('astro:fragment');

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -17,7 +17,7 @@ import {
 } from './astro/index.js';
 import { Fragment, Renderer, stringifyChunk } from './common.js';
 import { componentIsHTMLElement, renderHTMLElement } from './dom.js';
-import { ComponentSlots, renderSlot, renderSlots } from './slot.js';
+import { renderSlot, renderSlots, type ComponentSlots } from './slot.js';
 import { formatList, internalSpreadAttributes, renderElement, voidElementNames } from './util.js';
 
 const rendererAliases = new Map([['solid', 'solid-js']]);

--- a/packages/astro/src/vite-plugin-astro-server/base.ts
+++ b/packages/astro/src/vite-plugin-astro-server/base.ts
@@ -2,7 +2,7 @@ import type * as vite from 'vite';
 import type { AstroSettings } from '../@types/astro';
 
 import * as fs from 'fs';
-import { LogOptions, warn } from '../core/logger/core.js';
+import { warn, type LogOptions } from '../core/logger/core.js';
 import notFoundTemplate, { subpathNotUsedTemplate } from '../template/4xx.js';
 import { log404 } from './common.js';
 import { writeHtmlResponse } from './response.js';

--- a/packages/astro/src/vite-plugin-astro-server/common.ts
+++ b/packages/astro/src/vite-plugin-astro-server/common.ts
@@ -1,4 +1,4 @@
-import { info, LogOptions } from '../core/logger/core.js';
+import { info, type LogOptions } from '../core/logger/core.js';
 import * as msg from '../core/messages.js';
 
 export function log404(logging: LogOptions, pathname: string) {

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -1,6 +1,6 @@
-import { ESBuildTransformResult, transformWithEsbuild } from 'vite';
+import { transformWithEsbuild, type ESBuildTransformResult } from 'vite';
 import type { AstroConfig } from '../@types/astro';
-import { cachedCompilation, CompileProps, CompileResult } from '../core/compile/index.js';
+import { cachedCompilation, type CompileProps, type CompileResult } from '../core/compile/index.js';
 import type { LogOptions } from '../core/logger/core.js';
 import { getFileInfo } from '../vite-plugin-utils/index.js';
 

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -3,9 +3,9 @@ import type { HmrContext, ModuleNode } from 'vite';
 import type { AstroConfig } from '../@types/astro';
 import {
 	cachedCompilation,
-	CompileResult,
 	invalidateCompilation,
 	isCached,
+	type CompileResult,
 } from '../core/compile/index.js';
 import type { LogOptions } from '../core/logger/core.js';
 import { info } from '../core/logger/core.js';

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -5,7 +5,11 @@ import type { LogOptions } from '../core/logger/core.js';
 import type { PluginMetadata as AstroPluginMetadata } from './types';
 
 import { normalizePath } from 'vite';
-import { cachedCompilation, CompileProps, getCachedCompileResult } from '../core/compile/index.js';
+import {
+	cachedCompilation,
+	getCachedCompileResult,
+	type CompileProps,
+} from '../core/compile/index.js';
 import { isRelativePath } from '../core/path.js';
 import { normalizeFilename } from '../vite-plugin-utils/index.js';
 import { cachedFullCompilation } from './compile.js';

--- a/packages/astro/src/vite-plugin-inject-env-ts/index.ts
+++ b/packages/astro/src/vite-plugin-inject-env-ts/index.ts
@@ -2,10 +2,10 @@ import { bold } from 'kleur/colors';
 import type fsMod from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { normalizePath, Plugin } from 'vite';
+import { normalizePath, type Plugin } from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
 import { getContentPaths, getDotAstroTypeReference } from '../content/index.js';
-import { info, LogOptions } from '../core/logger/core.js';
+import { info, type LogOptions } from '../core/logger/core.js';
 
 export function getEnvTsPath({ srcDir }: { srcDir: URL }) {
 	return new URL('env.d.ts', srcDir);

--- a/packages/astro/src/vite-plugin-jsx/index.ts
+++ b/packages/astro/src/vite-plugin-jsx/index.ts
@@ -1,5 +1,10 @@
 import type { TransformResult } from 'rollup';
-import { EsbuildTransformOptions, Plugin, ResolvedConfig, transformWithEsbuild } from 'vite';
+import {
+	transformWithEsbuild,
+	type EsbuildTransformOptions,
+	type Plugin,
+	type ResolvedConfig,
+} from 'vite';
 import type { AstroRenderer, AstroSettings } from '../@types/astro';
 import type { LogOptions } from '../core/logger/core.js';
 import type { PluginMetadata } from '../vite-plugin-astro/types';

--- a/packages/astro/src/vite-plugin-scanner/index.ts
+++ b/packages/astro/src/vite-plugin-scanner/index.ts
@@ -1,4 +1,4 @@
-import { normalizePath, Plugin as VitePlugin } from 'vite';
+import { normalizePath, type Plugin as VitePlugin } from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
 import { isEndpoint, isPage } from '../core/util.js';
 

--- a/packages/astro/src/vite-plugin-scripts/page-ssr.ts
+++ b/packages/astro/src/vite-plugin-scripts/page-ssr.ts
@@ -1,5 +1,5 @@
 import MagicString from 'magic-string';
-import { normalizePath, Plugin as VitePlugin } from 'vite';
+import { normalizePath, type Plugin as VitePlugin } from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
 import { isPage } from '../core/util.js';
 import { PAGE_SSR_SCRIPT_ID } from './index.js';

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -34,7 +34,7 @@
     "test": "mocha --exit --timeout 30000 test/"
   },
   "dependencies": {
-    "esbuild": "^0.15.18",
+    "esbuild": "^0.17.12",
     "tiny-glob": "^0.2.9"
   },
   "peerDependencies": {

--- a/packages/integrations/image/src/build/ssg.ts
+++ b/packages/integrations/image/src/build/ssg.ts
@@ -7,7 +7,7 @@ import OS from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { SSRImageService, TransformOptions } from '../loaders/index.js';
-import { debug, info, LoggerLevel, warn } from '../utils/logger.js';
+import { debug, info, warn, type LoggerLevel } from '../utils/logger.js';
 import { isRemoteImage } from '../utils/paths.js';
 import { ImageCache } from './cache.js';
 

--- a/packages/integrations/image/src/lib/get-picture.ts
+++ b/packages/integrations/image/src/lib/get-picture.ts
@@ -1,6 +1,6 @@
 /// <reference types="astro/astro-jsx" />
 import mime from 'mime';
-import { OutputFormat, parseAspectRatio, TransformOptions } from '../loaders/index.js';
+import { parseAspectRatio, type OutputFormat, type TransformOptions } from '../loaders/index.js';
 import { extname } from '../utils/paths.js';
 import type { ImageMetadata } from '../vite-plugin-astro-image.js';
 import { getImage } from './get-image.js';

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -2,7 +2,7 @@ import { markdownConfigDefaults } from '@astrojs/markdown-remark';
 import { toRemarkInitializeAstroData } from '@astrojs/markdown-remark/dist/internal.js';
 import { compile as mdxCompile } from '@mdx-js/mdx';
 import type { PluggableList } from '@mdx-js/mdx/lib/core.js';
-import mdxPlugin, { Options as MdxRollupPluginOptions } from '@mdx-js/rollup';
+import mdxPlugin, { type Options as MdxRollupPluginOptions } from '@mdx-js/rollup';
 import type { AstroIntegration, ContentEntryType, HookParameters } from 'astro';
 import { parse as parseESM } from 'es-module-lexer';
 import fs from 'node:fs/promises';

--- a/packages/integrations/netlify/src/netlify-functions.ts
+++ b/packages/integrations/netlify/src/netlify-functions.ts
@@ -1,5 +1,5 @@
 import { polyfill } from '@astrojs/webapi';
-import { builder, Handler } from '@netlify/functions';
+import { builder, type Handler } from '@netlify/functions';
 import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
 

--- a/packages/integrations/node/src/response-iterator.ts
+++ b/packages/integrations/node/src/response-iterator.ts
@@ -4,6 +4,7 @@
  *  - https://github.com/apollographql/apollo-client/blob/main/src/utilities/common/responseIterator.ts
  */
 
+import type { ReadableStreamDefaultReadResult } from 'node:stream/web';
 import { Readable as NodeReadableStream } from 'stream';
 import type { Response as NodeResponse } from 'undici';
 
@@ -63,6 +64,7 @@ function isNodeReadableStream(value: any): value is NodeReadableStream {
 
 function readerIterator<T>(reader: ReadableStreamDefaultReader<T>): AsyncIterableIterator<T> {
 	const iterator: ReaderIterator<T> = {
+		//@ts-expect-error
 		next() {
 			return reader.read();
 		},

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -1,9 +1,9 @@
 import type { AstroConfig, AstroIntegration } from 'astro';
 import {
 	EnumChangefreq,
-	LinkItem as LinkItemBase,
 	simpleSitemapAndIndex,
-	SitemapItemLoose,
+	type LinkItem as LinkItemBase,
+	type SitemapItemLoose,
 } from 'sitemap';
 import { fileURLToPath } from 'url';
 import { ZodError } from 'zod';

--- a/packages/integrations/tailwind/src/index.ts
+++ b/packages/integrations/tailwind/src/index.ts
@@ -3,7 +3,7 @@ import type { AstroIntegration } from 'astro';
 import autoprefixerPlugin from 'autoprefixer';
 import fs from 'fs/promises';
 import path from 'path';
-import tailwindPlugin, { Config as TailwindConfig } from 'tailwindcss';
+import tailwindPlugin, { type Config as TailwindConfig } from 'tailwindcss';
 import resolveConfig from 'tailwindcss/resolveConfig.js';
 import { fileURLToPath } from 'url';
 import type { CSSOptions, UserConfig } from 'vite';

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -4,8 +4,8 @@ import { randomBytes } from 'node:crypto';
 import * as KEY from './config-keys.js';
 import { GlobalConfig } from './config.js';
 import { post } from './post.js';
-import { getProjectInfo, ProjectInfo } from './project-info.js';
-import { getSystemInfo, SystemInfo } from './system-info.js';
+import { getProjectInfo, type ProjectInfo } from './project-info.js';
+import { getSystemInfo, type SystemInfo } from './system-info.js';
 
 export type AstroTelemetryOptions = { astroVersion: string; viteVersion: string };
 export type TelemetryEvent = { eventName: string; payload: Record<string, any> };

--- a/packages/webapi/package.json
+++ b/packages/webapi/package.json
@@ -66,8 +66,8 @@
     "magic-string": "^0.27.0",
     "mocha": "^9.2.2",
     "rollup": "^2.79.1",
-    "tslib": "^2.4.0",
-    "typescript": "~4.7.3",
+    "tslib": "^2.5.0",
+    "typescript": "~5.0.2",
     "urlpattern-polyfill": "^1.0.0-rc5"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,11 +19,11 @@ importers:
       '@changesets/cli': 2.23.0
       '@octokit/action': ^3.18.1
       '@types/node': ^18.7.21
-      '@typescript-eslint/eslint-plugin': ^5.27.1
-      '@typescript-eslint/parser': ^5.27.1
+      '@typescript-eslint/eslint-plugin': ^5.55.0
+      '@typescript-eslint/parser': ^5.55.0
       astro-benchmark: workspace:*
       del: ^7.0.0
-      esbuild: ^0.15.18
+      esbuild: ^0.17.12
       eslint: ^8.17.0
       eslint-config-prettier: ^8.5.0
       eslint-plugin-no-only-tests: ^2.6.0
@@ -36,7 +36,7 @@ importers:
       pretty-bytes: ^6.0.0
       tiny-glob: ^0.2.9
       turbo: 1.2.5
-      typescript: ~4.7.3
+      typescript: ~5.0.2
     dependencies:
       '@astrojs/webapi': link:packages/webapi
       astro-benchmark: link:benchmark
@@ -45,10 +45,10 @@ importers:
       '@changesets/cli': 2.23.0_kcozqtpxuwjzskw6zg5royevn4
       '@octokit/action': 3.18.1
       '@types/node': 18.13.0
-      '@typescript-eslint/eslint-plugin': 5.51.0_mgna7bo5ee6kaz3xjpj7gzesei
-      '@typescript-eslint/parser': 5.51.0_l36yidrw337hwf2rtnamh77lgq
+      '@typescript-eslint/eslint-plugin': 5.55.0_hd2arqmmbp3cnphrhq74vsuqbq
+      '@typescript-eslint/parser': 5.55.0_qesohl5arz7pvqyycxtsqomlr4
       del: 7.0.0
-      esbuild: 0.15.18
+      esbuild: 0.17.12
       eslint: 8.33.0
       eslint-config-prettier: 8.6.0_eslint@8.33.0
       eslint-plugin-no-only-tests: 2.6.0
@@ -61,7 +61,7 @@ importers:
       pretty-bytes: 6.1.0
       tiny-glob: 0.2.9
       turbo: 1.2.5
-      typescript: 4.7.4
+      typescript: 5.0.2
 
   benchmark:
     specifiers:
@@ -563,7 +563,7 @@ importers:
       strip-ansi: 7.0.1
       supports-esm: 1.0.0
       tsconfig-resolver: 3.0.1
-      typescript: 4.9.5
+      typescript: 5.0.2
       unist-util-visit: 4.1.2
       vfile: 5.3.7
       vite: 4.1.2_sass@1.58.0
@@ -2817,12 +2817,12 @@ importers:
       astro-scripts: workspace:*
       chai: ^4.3.6
       cheerio: ^1.0.0-rc.11
-      esbuild: ^0.15.18
+      esbuild: ^0.17.12
       mocha: ^9.2.2
       tiny-glob: ^0.2.9
       wrangler: ^2.0.23
     dependencies:
-      esbuild: 0.15.18
+      esbuild: 0.17.12
       tiny-glob: 0.2.9
     devDependencies:
       astro: link:../../astro
@@ -3900,8 +3900,8 @@ importers:
       magic-string: ^0.27.0
       mocha: ^9.2.2
       rollup: ^2.79.1
-      tslib: ^2.4.0
-      typescript: ~4.7.3
+      tslib: ^2.5.0
+      typescript: ~5.0.2
       undici: 5.20.0
       urlpattern-polyfill: ^1.0.0-rc5
     dependencies:
@@ -3910,7 +3910,7 @@ importers:
       '@rollup/plugin-alias': 3.1.9_rollup@2.79.1
       '@rollup/plugin-inject': 4.0.4_rollup@2.79.1
       '@rollup/plugin-node-resolve': 13.3.0_rollup@2.79.1
-      '@rollup/plugin-typescript': 8.5.0_zg3dbtkqnuqypg3tuw3rnargrq
+      '@rollup/plugin-typescript': 8.5.0_gta7oowp4j2tir46rvp4skcu5a
       '@types/chai': 4.3.4
       '@types/mocha': 9.1.1
       '@types/node': 14.18.36
@@ -3921,7 +3921,7 @@ importers:
       mocha: 9.2.2
       rollup: 2.79.1
       tslib: 2.5.0
-      typescript: 4.7.4
+      typescript: 5.0.2
       urlpattern-polyfill: 1.0.0-rc5
 
   scripts:
@@ -3929,7 +3929,7 @@ importers:
       '@astrojs/webapi': workspace:*
       adm-zip: ^0.5.9
       arg: ^5.0.2
-      esbuild: ^0.15.18
+      esbuild: ^0.17.12
       esbuild-plugin-copy: ^2.0.2
       globby: ^12.2.0
       kleur: ^4.1.4
@@ -3940,13 +3940,13 @@ importers:
       '@astrojs/webapi': link:../packages/webapi
       adm-zip: 0.5.10
       arg: 5.0.2
-      esbuild: 0.15.18
+      esbuild: 0.17.12
       globby: 12.2.0
       kleur: 4.1.5
       svelte: 3.55.1
       tar: 6.1.13
     devDependencies:
-      esbuild-plugin-copy: 2.0.2_esbuild@0.15.18
+      esbuild-plugin-copy: 2.0.2_esbuild@0.17.12
       tsconfig-resolver: 3.0.1
 
 packages:
@@ -6163,6 +6163,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/android-arm/0.16.17:
@@ -6182,6 +6183,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm/0.17.12:
+    resolution: {integrity: sha512-E/sgkvwoIfj4aMAPL2e35VnUJspzVYl7+M1B2cqeubdBhADV4uPon0KCc8p2G+LqSJ6i8ocYPCqY3A4GGq0zkQ==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/android-arm64/0.16.17:
     resolution: {integrity: sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==}
     engines: {node: '>=12'}
@@ -6197,6 +6206,14 @@ packages:
     os: [android]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/android-arm64/0.17.12:
+    resolution: {integrity: sha512-WQ9p5oiXXYJ33F2EkE3r0FRDFVpEdcDiwNX3u7Xaibxfx6vQE0Sb8ytrfQsA5WO6kDn6mDfKLh6KrPBjvkk7xA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
     optional: true
 
   /@esbuild/android-x64/0.16.17:
@@ -6216,6 +6233,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-x64/0.17.12:
+    resolution: {integrity: sha512-m4OsaCr5gT+se25rFPHKQXARMyAehHTQAz4XX1Vk3d27VtqiX0ALMBPoXZsGaB6JYryCLfgGwUslMqTfqeLU0w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/darwin-arm64/0.16.17:
     resolution: {integrity: sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==}
     engines: {node: '>=12'}
@@ -6231,6 +6256,14 @@ packages:
     os: [darwin]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64/0.17.12:
+    resolution: {integrity: sha512-O3GCZghRIx+RAN0NDPhyyhRgwa19MoKlzGonIb5hgTj78krqp9XZbYCvFr9N1eUxg0ZQEpiiZ4QvsOQwBpP+lg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
     optional: true
 
   /@esbuild/darwin-x64/0.16.17:
@@ -6250,6 +6283,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-x64/0.17.12:
+    resolution: {integrity: sha512-5D48jM3tW27h1qjaD9UNRuN+4v0zvksqZSPZqeSWggfMlsVdAhH3pwSfQIFJwcs9QJ9BRibPS4ViZgs3d2wsCA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/freebsd-arm64/0.16.17:
     resolution: {integrity: sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==}
     engines: {node: '>=12'}
@@ -6265,6 +6306,14 @@ packages:
     os: [freebsd]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64/0.17.12:
+    resolution: {integrity: sha512-OWvHzmLNTdF1erSvrfoEBGlN94IE6vCEaGEkEH29uo/VoONqPnoDFfShi41Ew+yKimx4vrmmAJEGNoyyP+OgOQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
     optional: true
 
   /@esbuild/freebsd-x64/0.16.17:
@@ -6284,6 +6333,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-x64/0.17.12:
+    resolution: {integrity: sha512-A0Xg5CZv8MU9xh4a+7NUpi5VHBKh1RaGJKqjxe4KG87X+mTjDE6ZvlJqpWoeJxgfXHT7IMP9tDFu7IZ03OtJAw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-arm/0.16.17:
     resolution: {integrity: sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==}
     engines: {node: '>=12'}
@@ -6299,6 +6356,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-arm/0.17.12:
+    resolution: {integrity: sha512-WsHyJ7b7vzHdJ1fv67Yf++2dz3D726oO3QCu8iNYik4fb5YuuReOI9OtA+n7Mk0xyQivNTPbl181s+5oZ38gyA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-arm64/0.16.17:
@@ -6318,6 +6383,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64/0.17.12:
+    resolution: {integrity: sha512-cK3AjkEc+8v8YG02hYLQIQlOznW+v9N+OI9BAFuyqkfQFR+DnDLhEM5N8QRxAUz99cJTo1rLNXqRrvY15gbQUg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-ia32/0.16.17:
     resolution: {integrity: sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==}
     engines: {node: '>=12'}
@@ -6335,12 +6408,21 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32/0.17.12:
+    resolution: {integrity: sha512-jdOBXJqcgHlah/nYHnj3Hrnl9l63RjtQ4vn9+bohjQPI2QafASB5MtHAoEv0JQHVb/xYQTFOeuHnNYE1zF7tYw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-loong64/0.15.18:
     resolution: {integrity: sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/linux-loong64/0.16.17:
@@ -6360,6 +6442,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-loong64/0.17.12:
+    resolution: {integrity: sha512-GTOEtj8h9qPKXCyiBBnHconSCV9LwFyx/gv3Phw0pa25qPYjVuuGZ4Dk14bGCfGX3qKF0+ceeQvwmtI+aYBbVA==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-mips64el/0.16.17:
     resolution: {integrity: sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==}
     engines: {node: '>=12'}
@@ -6375,6 +6465,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el/0.17.12:
+    resolution: {integrity: sha512-o8CIhfBwKcxmEENOH9RwmUejs5jFiNoDw7YgS0EJTF6kgPgcqLFjgoc5kDey5cMHRVCIWc6kK2ShUePOcc7RbA==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-ppc64/0.16.17:
@@ -6394,6 +6492,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ppc64/0.17.12:
+    resolution: {integrity: sha512-biMLH6NR/GR4z+ap0oJYb877LdBpGac8KfZoEnDiBKd7MD/xt8eaw1SFfYRUeMVx519kVkAOL2GExdFmYnZx3A==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-riscv64/0.16.17:
     resolution: {integrity: sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==}
     engines: {node: '>=12'}
@@ -6409,6 +6515,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64/0.17.12:
+    resolution: {integrity: sha512-jkphYUiO38wZGeWlfIBMB72auOllNA2sLfiZPGDtOBb1ELN8lmqBrlMiucgL8awBw1zBXN69PmZM6g4yTX84TA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-s390x/0.16.17:
@@ -6428,6 +6542,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-s390x/0.17.12:
+    resolution: {integrity: sha512-j3ucLdeY9HBcvODhCY4b+Ds3hWGO8t+SAidtmWu/ukfLLG/oYDMaA+dnugTVAg5fnUOGNbIYL9TOjhWgQB8W5g==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-x64/0.16.17:
     resolution: {integrity: sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==}
     engines: {node: '>=12'}
@@ -6443,6 +6565,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-x64/0.17.12:
+    resolution: {integrity: sha512-uo5JL3cgaEGotaqSaJdRfFNSCUJOIliKLnDGWaVCgIKkHxwhYMm95pfMbWZ9l7GeW9kDg0tSxcy9NYdEtjwwmA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/netbsd-x64/0.16.17:
@@ -6462,6 +6592,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/netbsd-x64/0.17.12:
+    resolution: {integrity: sha512-DNdoRg8JX+gGsbqt2gPgkgb00mqOgOO27KnrWZtdABl6yWTST30aibGJ6geBq3WM2TIeW6COs5AScnC7GwtGPg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/openbsd-x64/0.16.17:
     resolution: {integrity: sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==}
     engines: {node: '>=12'}
@@ -6477,6 +6615,14 @@ packages:
     os: [openbsd]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64/0.17.12:
+    resolution: {integrity: sha512-aVsENlr7B64w8I1lhHShND5o8cW6sB9n9MUtLumFlPhG3elhNWtE7M1TFpj3m7lT3sKQUMkGFjTQBrvDDO1YWA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
     optional: true
 
   /@esbuild/sunos-x64/0.16.17:
@@ -6496,6 +6642,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/sunos-x64/0.17.12:
+    resolution: {integrity: sha512-qbHGVQdKSwi0JQJuZznS4SyY27tYXYF0mrgthbxXrZI3AHKuRvU+Eqbg/F0rmLDpW/jkIZBlCO1XfHUBMNJ1pg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/win32-arm64/0.16.17:
     resolution: {integrity: sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==}
     engines: {node: '>=12'}
@@ -6511,6 +6665,14 @@ packages:
     os: [win32]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/win32-arm64/0.17.12:
+    resolution: {integrity: sha512-zsCp8Ql+96xXTVTmm6ffvoTSZSV2B/LzzkUXAY33F/76EajNw1m+jZ9zPfNJlJ3Rh4EzOszNDHsmG/fZOhtqDg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
     optional: true
 
   /@esbuild/win32-ia32/0.16.17:
@@ -6530,6 +6692,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32/0.17.12:
+    resolution: {integrity: sha512-FfrFjR4id7wcFYOdqbDfDET3tjxCozUgbqdkOABsSFzoZGFC92UK7mg4JKRc/B3NNEf1s2WHxJ7VfTdVDPN3ng==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/win32-x64/0.16.17:
     resolution: {integrity: sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==}
     engines: {node: '>=12'}
@@ -6546,6 +6716,29 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@esbuild/win32-x64/0.17.12:
+    resolution: {integrity: sha512-JOOxw49BVZx2/5tW3FqkdjSD/5gXYeVGPDcB0lvap0gLQshkh1Nyel1QazC+wNxus3xPlsYAgqU1BUmrmCvWtw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
+  /@eslint-community/eslint-utils/4.3.0_eslint@8.33.0:
+    resolution: {integrity: sha512-v3oplH6FYCULtFuCeqyuTd9D2WKO937Dxdq+GmHOLL72TTRriLxz2VLlNfkZRsvj6PKnOPAtuT6dwrs/pA5DvA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 8.33.0
+      eslint-visitor-keys: 3.3.0
+    dev: true
+
+  /@eslint-community/regexpp/4.4.0:
+    resolution: {integrity: sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: true
 
   /@eslint/eslintrc/1.4.1:
     resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
@@ -7303,7 +7496,7 @@ packages:
       rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-typescript/8.5.0_zg3dbtkqnuqypg3tuw3rnargrq:
+  /@rollup/plugin-typescript/8.5.0_gta7oowp4j2tir46rvp4skcu5a:
     resolution: {integrity: sha512-wMv1/scv0m/rXx21wD2IsBbJFba8wGF3ErJIr6IKRfRj49S85Lszbxb4DCo8iILpluTjk2GAAu9CoZt4G3ppgQ==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -7320,7 +7513,7 @@ packages:
       resolve: 1.22.1
       rollup: 2.79.1
       tslib: 2.5.0
-      typescript: 4.7.4
+      typescript: 5.0.2
     dev: true
 
   /@rollup/pluginutils/3.1.0_rollup@2.79.1:
@@ -7810,8 +8003,8 @@ packages:
   /@types/yargs-parser/21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
 
-  /@typescript-eslint/eslint-plugin/5.51.0_mgna7bo5ee6kaz3xjpj7gzesei:
-    resolution: {integrity: sha512-wcAwhEWm1RgNd7dxD/o+nnLW8oH+6RK1OGnmbmkj/GGoDPV1WWMVP0FXYQBivKHdwM1pwii3bt//RC62EriIUQ==}
+  /@typescript-eslint/eslint-plugin/5.55.0_hd2arqmmbp3cnphrhq74vsuqbq:
+    resolution: {integrity: sha512-IZGc50rtbjk+xp5YQoJvmMPmJEYoC53SiKPXyqWfv15XoD2Y5Kju6zN0DwlmaGJp1Iw33JsWJcQ7nw0lGCGjVg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -7821,25 +8014,25 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.51.0_l36yidrw337hwf2rtnamh77lgq
-      '@typescript-eslint/scope-manager': 5.51.0
-      '@typescript-eslint/type-utils': 5.51.0_l36yidrw337hwf2rtnamh77lgq
-      '@typescript-eslint/utils': 5.51.0_l36yidrw337hwf2rtnamh77lgq
+      '@eslint-community/regexpp': 4.4.0
+      '@typescript-eslint/parser': 5.55.0_qesohl5arz7pvqyycxtsqomlr4
+      '@typescript-eslint/scope-manager': 5.55.0
+      '@typescript-eslint/type-utils': 5.55.0_qesohl5arz7pvqyycxtsqomlr4
+      '@typescript-eslint/utils': 5.55.0_qesohl5arz7pvqyycxtsqomlr4
       debug: 4.3.4
       eslint: 8.33.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
-      regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@5.0.2
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.51.0_l36yidrw337hwf2rtnamh77lgq:
-    resolution: {integrity: sha512-fEV0R9gGmfpDeRzJXn+fGQKcl0inIeYobmmUWijZh9zA7bxJ8clPhV9up2ZQzATxAiFAECqPQyMDB4o4B81AaA==}
+  /@typescript-eslint/parser/5.55.0_qesohl5arz7pvqyycxtsqomlr4:
+    resolution: {integrity: sha512-ppvmeF7hvdhUUZWSd2EEWfzcFkjJzgNQzVST22nzg958CR+sphy8A6K7LXQZd6V75m1VKjp+J4g/PCEfSCmzhw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -7848,26 +8041,26 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.51.0
-      '@typescript-eslint/types': 5.51.0
-      '@typescript-eslint/typescript-estree': 5.51.0_typescript@4.7.4
+      '@typescript-eslint/scope-manager': 5.55.0
+      '@typescript-eslint/types': 5.55.0
+      '@typescript-eslint/typescript-estree': 5.55.0_typescript@5.0.2
       debug: 4.3.4
       eslint: 8.33.0
-      typescript: 4.7.4
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager/5.51.0:
-    resolution: {integrity: sha512-gNpxRdlx5qw3yaHA0SFuTjW4rxeYhpHxt491PEcKF8Z6zpq0kMhe0Tolxt0qjlojS+/wArSDlj/LtE69xUJphQ==}
+  /@typescript-eslint/scope-manager/5.55.0:
+    resolution: {integrity: sha512-OK+cIO1ZGhJYNCL//a3ROpsd83psf4dUJ4j7pdNVzd5DmIk+ffkuUIX2vcZQbEW/IR41DYsfJTB19tpCboxQuw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.51.0
-      '@typescript-eslint/visitor-keys': 5.51.0
+      '@typescript-eslint/types': 5.55.0
+      '@typescript-eslint/visitor-keys': 5.55.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.51.0_l36yidrw337hwf2rtnamh77lgq:
-    resolution: {integrity: sha512-QHC5KKyfV8sNSyHqfNa0UbTbJ6caB8uhcx2hYcWVvJAZYJRBo5HyyZfzMdRx8nvS+GyMg56fugMzzWnojREuQQ==}
+  /@typescript-eslint/type-utils/5.55.0_qesohl5arz7pvqyycxtsqomlr4:
+    resolution: {integrity: sha512-ObqxBgHIXj8rBNm0yh8oORFrICcJuZPZTqtAFh0oZQyr5DnAHZWfyw54RwpEEH+fD8suZaI0YxvWu5tYE/WswA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -7876,23 +8069,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.51.0_typescript@4.7.4
-      '@typescript-eslint/utils': 5.51.0_l36yidrw337hwf2rtnamh77lgq
+      '@typescript-eslint/typescript-estree': 5.55.0_typescript@5.0.2
+      '@typescript-eslint/utils': 5.55.0_qesohl5arz7pvqyycxtsqomlr4
       debug: 4.3.4
       eslint: 8.33.0
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@5.0.2
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types/5.51.0:
-    resolution: {integrity: sha512-SqOn0ANn/v6hFn0kjvLwiDi4AzR++CBZz0NV5AnusT2/3y32jdc0G4woXPWHCumWtUXZKPAS27/9vziSsC9jnw==}
+  /@typescript-eslint/types/5.55.0:
+    resolution: {integrity: sha512-M4iRh4AG1ChrOL6Y+mETEKGeDnT7Sparn6fhZ5LtVJF1909D5O4uqK+C5NPbLmpfZ0XIIxCdwzKiijpZUOvOug==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.51.0_typescript@4.7.4:
-    resolution: {integrity: sha512-TSkNupHvNRkoH9FMA3w7TazVFcBPveAAmb7Sz+kArY6sLT86PA5Vx80cKlYmd8m3Ha2SwofM1KwraF24lM9FvA==}
+  /@typescript-eslint/typescript-estree/5.55.0_typescript@5.0.2:
+    resolution: {integrity: sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -7900,43 +8093,43 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.51.0
-      '@typescript-eslint/visitor-keys': 5.51.0
+      '@typescript-eslint/types': 5.55.0
+      '@typescript-eslint/visitor-keys': 5.55.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@5.0.2
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.51.0_l36yidrw337hwf2rtnamh77lgq:
-    resolution: {integrity: sha512-76qs+5KWcaatmwtwsDJvBk4H76RJQBFe+Gext0EfJdC3Vd2kpY2Pf//OHHzHp84Ciw0/rYoGTDnIAr3uWhhJYw==}
+  /@typescript-eslint/utils/5.55.0_qesohl5arz7pvqyycxtsqomlr4:
+    resolution: {integrity: sha512-FkW+i2pQKcpDC3AY6DU54yl8Lfl14FVGYDgBTyGKB75cCwV3KpkpTMFi9d9j2WAJ4271LR2HeC5SEWF/CZmmfw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
+      '@eslint-community/eslint-utils': 4.3.0_eslint@8.33.0
       '@types/json-schema': 7.0.11
       '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.51.0
-      '@typescript-eslint/types': 5.51.0
-      '@typescript-eslint/typescript-estree': 5.51.0_typescript@4.7.4
+      '@typescript-eslint/scope-manager': 5.55.0
+      '@typescript-eslint/types': 5.55.0
+      '@typescript-eslint/typescript-estree': 5.55.0_typescript@5.0.2
       eslint: 8.33.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.33.0
       semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys/5.51.0:
-    resolution: {integrity: sha512-Oh2+eTdjHjOFjKA27sxESlA87YPSOJafGCR0md5oeMdh1ZcCfAGCIOL216uTBAkAIptvLIfKQhl7lHxMJet4GQ==}
+  /@typescript-eslint/visitor-keys/5.55.0:
+    resolution: {integrity: sha512-q2dlHHwWgirKh1D3acnuApXG+VNXpEY5/AwRxDVuEQpxWaB0jCDe0jFMVMALJ3ebSfuOVE8/rMS+9ZOYGg1GWw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.51.0
+      '@typescript-eslint/types': 5.55.0
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -9847,6 +10040,7 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-android-arm64/0.15.18:
@@ -9855,6 +10049,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-darwin-64/0.15.18:
@@ -9863,6 +10058,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-darwin-arm64/0.15.18:
@@ -9871,6 +10067,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-freebsd-64/0.15.18:
@@ -9879,6 +10076,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-freebsd-arm64/0.15.18:
@@ -9887,6 +10085,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-32/0.15.18:
@@ -9895,6 +10094,7 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-64/0.15.18:
@@ -9903,6 +10103,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-arm/0.15.18:
@@ -9911,6 +10112,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-arm64/0.15.18:
@@ -9919,6 +10121,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-mips64le/0.15.18:
@@ -9927,6 +10130,7 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-ppc64le/0.15.18:
@@ -9935,6 +10139,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-riscv64/0.15.18:
@@ -9943,6 +10148,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-s390x/0.15.18:
@@ -9951,6 +10157,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-netbsd-64/0.15.18:
@@ -9959,6 +10166,7 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-openbsd-64/0.15.18:
@@ -9967,15 +10175,16 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: false
     optional: true
 
-  /esbuild-plugin-copy/2.0.2_esbuild@0.15.18:
+  /esbuild-plugin-copy/2.0.2_esbuild@0.17.12:
     resolution: {integrity: sha512-HlDgkHXagBCwaoB8tlQFeH08/i5a2ey6Pc26annV1YcG5CkAHzzRzmCwp3wdi5KHI//HVUgipS+Zsy2tQmn9gQ==}
     peerDependencies:
       esbuild: '>= 0.14.0'
     dependencies:
       chalk: 4.1.2
-      esbuild: 0.15.18
+      esbuild: 0.17.12
       fs-extra: 10.1.0
       globby: 11.1.0
     dev: true
@@ -9986,6 +10195,7 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-windows-32/0.15.18:
@@ -9994,6 +10204,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-windows-64/0.15.18:
@@ -10002,6 +10213,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-windows-arm64/0.15.18:
@@ -10010,6 +10222,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild/0.15.18:
@@ -10040,6 +10253,7 @@ packages:
       esbuild-windows-32: 0.15.18
       esbuild-windows-64: 0.15.18
       esbuild-windows-arm64: 0.15.18
+    dev: false
 
   /esbuild/0.16.17:
     resolution: {integrity: sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==}
@@ -10099,6 +10313,35 @@ packages:
       '@esbuild/win32-ia32': 0.16.3
       '@esbuild/win32-x64': 0.16.3
     dev: true
+
+  /esbuild/0.17.12:
+    resolution: {integrity: sha512-bX/zHl7Gn2CpQwcMtRogTTBf9l1nl+H6R8nUbjk+RuKqAE3+8FDulLA+pHvX7aA7Xe07Iwa+CWvy9I8Y2qqPKQ==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.17.12
+      '@esbuild/android-arm64': 0.17.12
+      '@esbuild/android-x64': 0.17.12
+      '@esbuild/darwin-arm64': 0.17.12
+      '@esbuild/darwin-x64': 0.17.12
+      '@esbuild/freebsd-arm64': 0.17.12
+      '@esbuild/freebsd-x64': 0.17.12
+      '@esbuild/linux-arm': 0.17.12
+      '@esbuild/linux-arm64': 0.17.12
+      '@esbuild/linux-ia32': 0.17.12
+      '@esbuild/linux-loong64': 0.17.12
+      '@esbuild/linux-mips64el': 0.17.12
+      '@esbuild/linux-ppc64': 0.17.12
+      '@esbuild/linux-riscv64': 0.17.12
+      '@esbuild/linux-s390x': 0.17.12
+      '@esbuild/linux-x64': 0.17.12
+      '@esbuild/netbsd-x64': 0.17.12
+      '@esbuild/openbsd-x64': 0.17.12
+      '@esbuild/sunos-x64': 0.17.12
+      '@esbuild/win32-arm64': 0.17.12
+      '@esbuild/win32-ia32': 0.17.12
+      '@esbuild/win32-x64': 0.17.12
 
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -14472,7 +14715,7 @@ packages:
       shiki: 0.10.1
       shiki-twoslash: 3.1.0
       tslib: 2.1.0
-      typescript: 4.9.5
+      typescript: 5.0.2
       unist-util-visit: 2.0.3
     transitivePeerDependencies:
       - supports-color
@@ -14865,7 +15108,7 @@ packages:
       '@typescript/twoslash': 3.1.0
       '@typescript/vfs': 1.3.4
       shiki: 0.10.1
-      typescript: 4.9.5
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -15568,14 +15811,14 @@ packages:
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
 
-  /tsutils/3.21.0_typescript@4.7.4:
+  /tsutils/3.21.0_typescript@5.0.2:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.7.4
+      typescript: 5.0.2
     dev: true
 
   /tty-table/4.1.6:
@@ -15787,15 +16030,9 @@ packages:
       for-each: 0.3.3
       is-typed-array: 1.1.10
 
-  /typescript/4.7.4:
-    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: true
-
-  /typescript/4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  /typescript/5.0.2:
+    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
+    engines: {node: '>=12.20'}
     hasBin: true
 
   /uhyphen/0.1.0:

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,7 +11,7 @@
     "@astrojs/webapi": "workspace:*",
     "adm-zip": "^0.5.9",
     "arg": "^5.0.2",
-    "esbuild": "^0.15.18",
+    "esbuild": "^0.17.12",
     "globby": "^12.2.0",
     "kleur": "^4.1.4",
     "svelte": "^3.48.0",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,6 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "importsNotUsedAsValues": "error"
+    "verbatimModuleSyntax": true
   }
 }


### PR DESCRIPTION
## Changes

This migrates the codebase to use TS 5.0 and the new settings it provides.

Unfortunately, we cannot use `node16` `moduleResolution` at this time because it breaks a lot of our deps and required more time than I had to fix. Probably worth exploring, though.

This makes our builds slightly faster, but it's not THAT noticeable either. The diff looks big because esbuild needed to be upgraded and they added support for more archs

## Testing

Tests should pass!

## Docs

N/A
