### PR TITLE
fix: Add missing --watch flag when running astro check --help

### DIFF
--- a/.changeset/tender-emus-eat.md
+++ b/.changeset/tender-emus-eat.md
@@ -1,5 +1,5 @@
 ---
-'astro': minor
+'astro': patch
 ---
 
 fix: Add missing --watch flag for astro check when running astro check --help

--- a/.changeset/tender-emus-eat.md
+++ b/.changeset/tender-emus-eat.md
@@ -1,5 +1,5 @@
 ---
-'astro': major
+'astro': minor
 ---
 
 fix: Add missing --watch flag for astro check when running astro check --help

--- a/.changeset/tender-emus-eat.md
+++ b/.changeset/tender-emus-eat.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+fix: Add missing --watch flag for astro check when running astro check --help

--- a/packages/astro/src/cli/check/index.ts
+++ b/packages/astro/src/cli/check/index.ts
@@ -85,7 +85,10 @@ export async function check(
 			commandName: 'astro check',
 			usage: '[...flags]',
 			tables: {
-				Flags: [['--help (-h)', 'See all available flags.']],
+				Flags: [
+					['--watch', 'Check input files in watch mode.'],
+					['--help (-h)', 'See all available flags.']
+				],
 			},
 			description: `Runs diagnostics against your project and reports errors to the console.`,
 		});

--- a/packages/astro/src/cli/check/index.ts
+++ b/packages/astro/src/cli/check/index.ts
@@ -86,7 +86,7 @@ export async function check(
 			usage: '[...flags]',
 			tables: {
 				Flags: [
-					['--watch', 'Check input files in watch mode.'],
+					['--watch', 'Watch Astro files for changes and re-run checks.'],
 					['--help (-h)', 'See all available flags.']
 				],
 			},


### PR DESCRIPTION
## Changes

**What does this change?**
- The following change adds the missing `--watch` flag for `astro check` when one runs `astro check --help`.

## Testing

N/A

## Docs

N/A

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
