### PR TITLE
feat: Expose `$entry` variable to Markdoc

### DIFF
--- a/.changeset/lazy-mice-fetch.md
+++ b/.changeset/lazy-mice-fetch.md
@@ -1,0 +1,14 @@
+---
+'astro': patch
+'@astrojs/markdoc': patch
+---
+
+Allow access to content collection entry information (including parsed frontmatter and the entry slug) from your Markdoc using the `$entry` variable:
+
+```mdx
+---
+title: Hello Markdoc!
+---
+
+# {% $entry.data.title %}
+```

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1053,7 +1053,9 @@ export interface ContentEntryType {
 		fileUrl: URL;
 		contents: string;
 	}): GetEntryInfoReturnType | Promise<GetEntryInfoReturnType>;
-	getModule?(params: { entry: ContentEntryModule }): rollup.LoadResult | Promise<rollup.LoadResult>;
+	getRenderModule?(params: {
+		entry: ContentEntryModule;
+	}): rollup.LoadResult | Promise<rollup.LoadResult>;
 	contentModuleTypes?: string;
 }
 

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -10,6 +10,7 @@ import type {
 import type * as babel from '@babel/core';
 import type { OutgoingHttpHeaders } from 'http';
 import type { AddressInfo } from 'net';
+import type * as rollup from 'rollup';
 import type { TsConfigJson } from 'tsconfig-resolver';
 import type * as vite from 'vite';
 import type { z } from 'zod';
@@ -1034,12 +1035,25 @@ export interface AstroConfig extends z.output<typeof AstroConfigSchema> {
 	integrations: AstroIntegration[];
 }
 
+export type ContentEntryModule = {
+	id: string;
+	collection: string;
+	slug: string;
+	body: string;
+	data: Record<string, unknown>;
+	_internal: {
+		rawData: string;
+		filePath: string;
+	};
+};
+
 export interface ContentEntryType {
 	extensions: string[];
 	getEntryInfo(params: {
 		fileUrl: URL;
 		contents: string;
 	}): GetEntryInfoReturnType | Promise<GetEntryInfoReturnType>;
+	getModule?(params: { entry: ContentEntryModule }): rollup.LoadResult | Promise<rollup.LoadResult>;
 	contentModuleTypes?: string;
 }
 

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -285,7 +285,8 @@ async function getContentConfigFromGlobal() {
 				if (ctx.status === 'loaded') {
 					resolve(ctx.config);
 					unsubscribe();
-				} else if (ctx.status === 'error') {
+				}
+				if (ctx.status === 'error') {
 					resolve(undefined);
 					unsubscribe();
 				}

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -45,6 +45,8 @@ function idHandledByContentRenderPlugin(
 	return false;
 }
 
+const CHOKIDAR_MODIFIED_EVENTS = ['add', 'unlink', 'change'];
+
 export function astroContentImportPlugin({
 	fs,
 	settings,
@@ -90,7 +92,7 @@ export const _internal = {
 			configureServer(viteServer) {
 				viteServer.watcher.on('all', async (event, entry) => {
 					if (
-						['add', 'unlink', 'change'].includes(event) &&
+						CHOKIDAR_MODIFIED_EVENTS.includes(event) &&
 						getEntryType(entry, contentPaths, contentEntryExts) === 'config'
 					) {
 						// Content modules depend on config, so we need to invalidate them.

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -44,16 +44,13 @@ export function astroContentImportPlugin({
 		}
 	}
 
-	// Used by the `render-module` plugin to avoid double-parsing your schema
-	const contentEntryModuleByIdCache = new Map<string, ContentEntryModule>();
-
 	const plugins: Plugin[] = [
 		{
 			name: 'astro:content-imports',
 			async load(viteId) {
 				if (isContentFlagImport(viteId, contentEntryExts)) {
 					const { fileId } = getFileInfo(viteId, settings.config);
-					const { id, slug, collection, body, data, _internal } = await getContentEntryModule({
+					const { id, slug, collection, body, data, _internal } = await setContentEntryModuleCache({
 						fileId,
 						pluginContext: this,
 					});
@@ -113,7 +110,9 @@ export const _internal = {
 				const { fileId } = getFileInfo(viteId, settings.config);
 				for (const contentEntryType of settings.contentEntryTypes) {
 					if (contentEntryType.getRenderModule) {
-						const entry = await contentEntryModuleByIdCache.get(fileId);
+						const entry = await getContentEntryModuleFromCache(fileId);
+						// Cached entry must exist (or be in-flight) when importing the module via content collections.
+						// This is ensured by the `astro:content-imports` plugin.
 						if (!entry)
 							throw new AstroError({
 								...AstroErrorData.UnknownContentCollectionError,
@@ -129,13 +128,34 @@ export const _internal = {
 		});
 	}
 
-	async function getContentEntryModule({
+	// Used by the `render-module` plugin to avoid double-parsing your schema
+	const contentEntryModuleByIdCache = new Map<string, ContentEntryModule | 'loading'>();
+	const awaitingCacheById = new Map<string, ((val: ContentEntryModule) => void)[]>();
+	function getContentEntryModuleFromCache(id: string) {
+		const value = contentEntryModuleByIdCache.get(id);
+		// It's possible for Vite to load modules that depend on this cache
+		// before the cache is populated. In that case, we queue a promise
+		// to be resolved by `setContentEntryModuleCache`.
+		if (value === 'loading') {
+			return new Promise<ContentEntryModule>((resolve, reject) => {
+				const awaiting = awaitingCacheById.get(id) ?? [];
+				awaiting.push(resolve);
+				awaitingCacheById.set(id, awaiting);
+			});
+		} else if (value) {
+			return Promise.resolve(value);
+		}
+		return Promise.resolve(undefined);
+	}
+
+	async function setContentEntryModuleCache({
 		fileId,
 		pluginContext,
 	}: {
 		fileId: string;
 		pluginContext: PluginContext;
 	}): Promise<ContentEntryModule> {
+		contentEntryModuleByIdCache.set(fileId, 'loading');
 		const observable = globalContentConfigObserver.get();
 
 		// Content config should be loaded before this plugin is used
@@ -210,6 +230,13 @@ export const _internal = {
 			body: info.body,
 		};
 		contentEntryModuleByIdCache.set(fileId, contentEntryModule);
+		const awaiting = awaitingCacheById.get(fileId);
+		if (awaiting) {
+			for (const resolve of awaiting) {
+				resolve(contentEntryModule);
+			}
+			awaitingCacheById.delete(fileId);
+		}
 		return contentEntryModule;
 	}
 

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -44,10 +44,98 @@ export function astroContentImportPlugin({
 		}
 	}
 
-	async function getEntryDataById(
-		fileId: string,
-		pluginContext: PluginContext
-	): Promise<ContentEntryModule> {
+	// Used by the `render-module` plugin to avoid double-parsing your schema
+	const contentEntryModuleByIdCache = new Map<string, ContentEntryModule>();
+
+	const plugins: Plugin[] = [
+		{
+			name: 'astro:content-imports',
+			async load(viteId) {
+				if (isContentFlagImport(viteId, contentEntryExts)) {
+					const { fileId } = getFileInfo(viteId, settings.config);
+					const { id, slug, collection, body, data, _internal } = await getContentEntryModule({
+						fileId,
+						pluginContext: this,
+					});
+
+					const code = escapeViteEnvReferences(`
+export const id = ${JSON.stringify(id)};
+export const collection = ${JSON.stringify(collection)};
+export const slug = ${JSON.stringify(slug)};
+export const body = ${JSON.stringify(body)};
+export const data = ${devalue.uneval(data) /* TODO: reuse astro props serializer */};
+export const _internal = {
+	filePath: ${JSON.stringify(_internal.filePath)},
+	rawData: ${JSON.stringify(_internal.rawData)},
+};
+`);
+					return { code };
+				}
+			},
+			configureServer(viteServer) {
+				viteServer.watcher.on('all', async (event, entry) => {
+					if (
+						['add', 'unlink', 'change'].includes(event) &&
+						getEntryType(entry, contentPaths, contentEntryExts) === 'config'
+					) {
+						// Content modules depend on config, so we need to invalidate them.
+						for (const modUrl of viteServer.moduleGraph.urlToModuleMap.keys()) {
+							if (
+								isContentFlagImport(modUrl, contentEntryExts) ||
+								// TODO: refine to content types with getModule
+								contentEntryExts.some((ext) => modUrl.endsWith(ext))
+							) {
+								const mod = await viteServer.moduleGraph.getModuleByUrl(modUrl);
+								if (mod) {
+									viteServer.moduleGraph.invalidateModule(mod);
+								}
+							}
+						}
+					}
+				});
+			},
+			async transform(code, id) {
+				if (isContentFlagImport(id, contentEntryExts)) {
+					// Escape before Rollup internal transform.
+					// Base on MUCH trial-and-error, inspired by MDX integration 2-step transform.
+					return { code: escapeViteEnvReferences(code) };
+				}
+			},
+		},
+	];
+
+	if (settings.contentEntryTypes.some((t) => t.getRenderModule)) {
+		plugins.push({
+			name: 'astro:content-render-imports',
+			async load(viteId) {
+				if (!contentEntryExts.some((ext) => viteId.endsWith(ext))) return;
+
+				const { fileId } = getFileInfo(viteId, settings.config);
+				for (const contentEntryType of settings.contentEntryTypes) {
+					if (contentEntryType.getRenderModule) {
+						const entry = await contentEntryModuleByIdCache.get(fileId);
+						if (!entry)
+							throw new AstroError({
+								...AstroErrorData.UnknownContentCollectionError,
+								message: `Unable to render ${JSON.stringify(
+									fileId
+								)}. Did you import this module directly without using a content collection query?`,
+							});
+
+						return contentEntryType.getRenderModule({ entry });
+					}
+				}
+			},
+		});
+	}
+
+	async function getContentEntryModule({
+		fileId,
+		pluginContext,
+	}: {
+		fileId: string;
+		pluginContext: PluginContext;
+	}): Promise<ContentEntryModule> {
 		const observable = globalContentConfigObserver.get();
 
 		// Content config should be loaded before this plugin is used
@@ -121,82 +209,9 @@ export function astroContentImportPlugin({
 			data,
 			body: info.body,
 		};
-
+		contentEntryModuleByIdCache.set(fileId, contentEntryModule);
 		return contentEntryModule;
 	}
 
-	const plugins: Plugin[] = [
-		{
-			name: 'astro:content-imports',
-			async load(viteId) {
-				const { fileId } = getFileInfo(viteId, settings.config);
-				if (isContentFlagImport(viteId, contentEntryExts)) {
-					const { id, slug, collection, body, data, _internal } = await getEntryDataById(
-						fileId,
-						this
-					);
-
-					const code = escapeViteEnvReferences(`
-export const id = ${JSON.stringify(id)};
-export const collection = ${JSON.stringify(collection)};
-export const slug = ${JSON.stringify(slug)};
-export const body = ${JSON.stringify(body)};
-export const data = ${devalue.uneval(data) /* TODO: reuse astro props serializer */};
-export const _internal = {
-	filePath: ${JSON.stringify(_internal.filePath)},
-	rawData: ${JSON.stringify(_internal.rawData)},
-};
-`);
-					return { code };
-				}
-			},
-			configureServer(viteServer) {
-				viteServer.watcher.on('all', async (event, entry) => {
-					if (
-						['add', 'unlink', 'change'].includes(event) &&
-						getEntryType(entry, contentPaths, contentEntryExts) === 'config'
-					) {
-						// Content modules depend on config, so we need to invalidate them.
-						for (const modUrl of viteServer.moduleGraph.urlToModuleMap.keys()) {
-							if (
-								isContentFlagImport(modUrl, contentEntryExts) ||
-								// TODO: refine to content types with getModule
-								contentEntryExts.some((ext) => modUrl.endsWith(ext))
-							) {
-								const mod = await viteServer.moduleGraph.getModuleByUrl(modUrl);
-								if (mod) {
-									viteServer.moduleGraph.invalidateModule(mod);
-								}
-							}
-						}
-					}
-				});
-			},
-			async transform(code, id) {
-				if (isContentFlagImport(id, contentEntryExts)) {
-					// Escape before Rollup internal transform.
-					// Base on MUCH trial-and-error, inspired by MDX integration 2-step transform.
-					return { code: escapeViteEnvReferences(code) };
-				}
-			},
-		},
-	];
-
-	if (settings.contentEntryTypes.some((t) => t.getModule)) {
-		plugins.push({
-			name: 'astro:content-render-modules',
-			async load(viteId) {
-				if (!contentEntryExts.some((ext) => viteId.endsWith(ext))) return;
-
-				const { fileId } = getFileInfo(viteId, settings.config);
-				for (const contentEntryType of settings.contentEntryTypes) {
-					if (contentEntryType.getModule) {
-						const entry = await getEntryDataById(fileId, this);
-						return contentEntryType.getModule({ entry });
-					}
-				}
-			},
-		});
-	}
 	return plugins;
 }

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -105,6 +105,7 @@ export const _internal = {
 		plugins.push({
 			name: 'astro:content-render-imports',
 			async load(viteId) {
+				// Skip if module is not handled by content collections
 				if (!contentEntryExts.some((ext) => viteId.endsWith(ext))) return;
 
 				const { fileId } = getFileInfo(viteId, settings.config);

--- a/packages/astro/src/core/errors/dev/vite.ts
+++ b/packages/astro/src/core/errors/dev/vite.ts
@@ -125,6 +125,7 @@ export interface AstroErrorPayload {
 // Shiki does not support `mjs` or `cjs` aliases by default.
 // Map these to `.js` during error highlighting.
 const ALTERNATIVE_JS_EXTS = ['cjs', 'mjs'];
+const ALTERNATIVE_MD_EXTS = ['mdoc'];
 
 /**
  * Generate a payload for Vite's error overlay
@@ -157,6 +158,9 @@ export async function getViteErrorPayload(err: ErrorWithMetadata): Promise<Astro
 	let highlighterLang = err.loc?.file?.split('.').pop();
 	if (ALTERNATIVE_JS_EXTS.includes(highlighterLang ?? '')) {
 		highlighterLang = 'js';
+	}
+	if (ALTERNATIVE_MD_EXTS.includes(highlighterLang ?? '')) {
+		highlighterLang = 'md';
 	}
 	const highlightedCode = err.fullCode
 		? highlighter.codeToHtml(err.fullCode, {

--- a/packages/integrations/markdoc/README.md
+++ b/packages/integrations/markdoc/README.md
@@ -249,7 +249,7 @@ title: Welcome to Markdoc 👋
 # {% $entry.data.title %}
 ```
 
-The `$entry` object matches [the `CollectionEntry`type](https://docs.astro.build/en/reference/api-reference/#collection-entry-type), excluding the `.render()` property.
+The `$entry` object matches [the `CollectionEntry` type](https://docs.astro.build/en/reference/api-reference/#collection-entry-type), excluding the `.render()` property.
 
 ### Markdoc config
 

--- a/packages/integrations/markdoc/README.md
+++ b/packages/integrations/markdoc/README.md
@@ -237,6 +237,20 @@ const { Content } = await entry.render();
 />
 ```
 
+### Access frontmatter and content collection information from your templates
+
+You can access content collection information from your Markdoc templates using the `$entry` variable. This includes the entry `slug`, `collection` name, and frontmatter `data` parsed by your content collection schema (if any). This example renders the `title` frontmatter property as a heading:
+
+```md
+---
+title: Welcome to Markdoc 👋
+---
+
+# {% $entry.data.title %}
+```
+
+The `$entry` object matches [the `CollectionEntry`type](https://docs.astro.build/en/reference/api-reference/#collection-entry-type), excluding the `.render()` property.
+
 ### Markdoc config
 
 The Markdoc integration accepts [all Markdoc configuration options](https://markdoc.dev/docs/config), including [tags](https://markdoc.dev/docs/tags) and [functions](https://markdoc.dev/docs/functions).

--- a/packages/integrations/markdoc/package.json
+++ b/packages/integrations/markdoc/package.json
@@ -46,6 +46,7 @@
     "devalue": "^4.2.0",
     "linkedom": "^0.14.12",
     "mocha": "^9.2.2",
+    "rollup": "^3.19.1",
     "vite": "^4.0.3"
   },
   "engines": {

--- a/packages/integrations/markdoc/package.json
+++ b/packages/integrations/markdoc/package.json
@@ -46,7 +46,6 @@
     "devalue": "^4.2.0",
     "linkedom": "^0.14.12",
     "mocha": "^9.2.2",
-    "rollup": "^3.19.1",
     "vite": "^4.0.3"
   },
   "engines": {

--- a/packages/integrations/markdoc/src/index.ts
+++ b/packages/integrations/markdoc/src/index.ts
@@ -3,7 +3,7 @@ import Markdoc from '@markdoc/markdoc';
 import type { AstroConfig, AstroIntegration, ContentEntryType, HookParameters } from 'astro';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import type { InlineConfig } from 'vite';
+import type { InlineConfig, TransformResult } from 'vite';
 import {
 	getAstroConfigPath,
 	MarkdocError,
@@ -36,36 +36,27 @@ export default function markdoc(markdocConfig: Config = {}): AstroIntegration {
 				addContentEntryType({
 					extensions: ['.mdoc'],
 					getEntryInfo,
+					getModule(entry: any /* TODO: typing */): Partial<TransformResult> {
+						validateRenderProperties(markdocConfig, config);
+						const ast = Markdoc.parse(entry.body);
+						const content = Markdoc.transform(ast, {
+							...markdocConfig,
+							variables: {
+								...markdocConfig.variables,
+								entry,
+							}
+						});
+						return {
+							code: `import { jsx as h } from 'astro/jsx-runtime';\nimport { Renderer } from '@astrojs/markdoc/components';\nconst transformedContent = ${JSON.stringify(
+								content
+							)};\nexport async function Content ({ components }) { return h(Renderer, { content: transformedContent, components }); }\nContent[Symbol.for('astro.needsHeadRendering')] = true;`;
+						}
+					},
 					contentModuleTypes: await fs.promises.readFile(
 						new URL('../template/content-module-types.d.ts', import.meta.url),
 						'utf-8'
 					),
 				});
-
-				const viteConfig: InlineConfig = {
-					plugins: [
-						{
-							name: '@astrojs/markdoc',
-							async transform(code, id) {
-								if (!id.endsWith('.mdoc')) return;
-
-								validateRenderProperties(markdocConfig, config);
-								const body = getEntryInfo({
-									// Can't use `pathToFileUrl` - Vite IDs are not plain file paths
-									fileUrl: new URL(prependForwardSlash(id), 'file://'),
-									contents: code,
-								}).body;
-								const ast = Markdoc.parse(body);
-								const content = Markdoc.transform(ast, markdocConfig);
-
-								return `import { jsx as h } from 'astro/jsx-runtime';\nimport { Renderer } from '@astrojs/markdoc/components';\nconst transformedContent = ${JSON.stringify(
-									content
-								)};\nexport async function Content ({ components }) { return h(Renderer, { content: transformedContent, components }); }\nContent[Symbol.for('astro.needsHeadRendering')] = true;`;
-							},
-						},
-					],
-				};
-				updateConfig({ vite: viteConfig });
 			},
 		},
 	};

--- a/packages/integrations/markdoc/src/index.ts
+++ b/packages/integrations/markdoc/src/index.ts
@@ -3,7 +3,6 @@ import Markdoc from '@markdoc/markdoc';
 import type { AstroConfig, AstroIntegration, ContentEntryType, HookParameters } from 'astro';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import type * as rollup from 'rollup';
 import { getAstroConfigPath, MarkdocError, parseFrontmatter } from './utils.js';
 
 type SetupHookParams = HookParameters<'astro:config:setup'> & {
@@ -31,7 +30,7 @@ export default function markdoc(markdocConfig: Config = {}): AstroIntegration {
 				addContentEntryType({
 					extensions: ['.mdoc'],
 					getEntryInfo,
-					getRenderModule({ entry }: any): Partial<rollup.LoadResult> {
+					getRenderModule({ entry }) {
 						validateRenderProperties(markdocConfig, config);
 						const ast = Markdoc.parse(entry.body);
 						const content = Markdoc.transform(ast, {

--- a/packages/integrations/markdoc/src/index.ts
+++ b/packages/integrations/markdoc/src/index.ts
@@ -31,7 +31,7 @@ export default function markdoc(markdocConfig: Config = {}): AstroIntegration {
 				addContentEntryType({
 					extensions: ['.mdoc'],
 					getEntryInfo,
-					getModule({ entry }: any): Partial<rollup.LoadResult> {
+					getRenderModule({ entry }: any): Partial<rollup.LoadResult> {
 						validateRenderProperties(markdocConfig, config);
 						const ast = Markdoc.parse(entry.body);
 						const content = Markdoc.transform(ast, {

--- a/packages/integrations/markdoc/test/entry-prop.test.js
+++ b/packages/integrations/markdoc/test/entry-prop.test.js
@@ -1,0 +1,58 @@
+import { parseHTML } from 'linkedom';
+import { expect } from 'chai';
+import { loadFixture } from '../../../astro/test/test-utils.js';
+import markdoc from '../dist/index.js';
+
+const root = new URL('./fixtures/entry-prop/', import.meta.url);
+
+describe('Markdoc - Entry prop', () => {
+	let baseFixture;
+
+	before(async () => {
+		baseFixture = await loadFixture({
+			root,
+			integrations: [markdoc()],
+		});
+	});
+
+	describe('dev', () => {
+		let devServer;
+
+		before(async () => {
+			devServer = await baseFixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('has expected entry properties', async () => {
+			const res = await baseFixture.fetch('/');
+			const html = await res.text();
+			const { document } = parseHTML(html);
+			expect(document.querySelector('h1')?.textContent).to.equal('Processed by schema: Test entry');
+			expect(document.getElementById('id')?.textContent?.trim()).to.equal('id: entry.mdoc');
+			expect(document.getElementById('slug')?.textContent?.trim()).to.equal('slug: entry');
+			expect(document.getElementById('collection')?.textContent?.trim()).to.equal(
+				'collection: blog'
+			);
+		});
+	});
+
+	describe('build', () => {
+		before(async () => {
+			await baseFixture.build();
+		});
+
+		it('has expected entry properties', async () => {
+			const html = await baseFixture.readFile('/index.html');
+			const { document } = parseHTML(html);
+			expect(document.querySelector('h1')?.textContent).to.equal('Processed by schema: Test entry');
+			expect(document.getElementById('id')?.textContent?.trim()).to.equal('id: entry.mdoc');
+			expect(document.getElementById('slug')?.textContent?.trim()).to.equal('slug: entry');
+			expect(document.getElementById('collection')?.textContent?.trim()).to.equal(
+				'collection: blog'
+			);
+		});
+	});
+});

--- a/packages/integrations/markdoc/test/fixtures/entry-prop/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/entry-prop/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import markdoc from '@astrojs/markdoc';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [markdoc()],
+});

--- a/packages/integrations/markdoc/test/fixtures/entry-prop/package.json
+++ b/packages/integrations/markdoc/test/fixtures/entry-prop/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/markdoc-entry-prop",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/markdoc": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/markdoc/test/fixtures/entry-prop/src/content/blog/entry.mdoc
+++ b/packages/integrations/markdoc/test/fixtures/entry-prop/src/content/blog/entry.mdoc
@@ -1,0 +1,9 @@
+---
+title: Test entry
+---
+
+# {% $entry.data.title %}
+
+- id: {% $entry.id %} {% #id %}
+- slug: {% $entry.slug %} {% #slug %}
+- collection: {% $entry.collection %} {% #collection %}

--- a/packages/integrations/markdoc/test/fixtures/entry-prop/src/content/config.ts
+++ b/packages/integrations/markdoc/test/fixtures/entry-prop/src/content/config.ts
@@ -1,0 +1,9 @@
+import { defineCollection, z } from 'astro:content';
+
+const blog = defineCollection({
+	schema: z.object({
+		title: z.string().transform(v => 'Processed by schema: ' + v),
+	}),
+});
+
+export const collections = { blog }

--- a/packages/integrations/markdoc/test/fixtures/entry-prop/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/entry-prop/src/pages/index.astro
@@ -1,0 +1,19 @@
+---
+import { getEntryBySlug } from 'astro:content';
+
+const entry = await getEntryBySlug('blog', 'entry');
+const { Content } = await entry.render();
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={Astro.generator} />
+		<title>Astro</title>
+	</head>
+	<body>
+		<Content />
+	</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3078,6 +3078,7 @@ importers:
       gray-matter: ^4.0.3
       linkedom: ^0.14.12
       mocha: ^9.2.2
+      rollup: ^3.19.1
       stringify-attributes: ^3.0.0
       vite: ^4.0.3
       zod: ^3.17.3
@@ -3096,6 +3097,7 @@ importers:
       devalue: 4.2.3
       linkedom: 0.14.21
       mocha: 9.2.2
+      rollup: 3.19.1
       vite: 4.1.2
 
   packages/integrations/markdoc/test/fixtures/content-collections:
@@ -14913,6 +14915,13 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
+  /rollup/3.19.1:
+    resolution: {integrity: sha512-lAbrdN7neYCg/8WaoWn/ckzCtz+jr70GFfYdlf50OF7387HTg+wiuiqJRFYawwSPpqfqDNYqK7smY/ks2iAudg==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -16449,7 +16458,7 @@ packages:
       esbuild: 0.16.17
       postcss: 8.4.21
       resolve: 1.22.1
-      rollup: 3.14.0
+      rollup: 3.19.1
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3113,6 +3113,14 @@ importers:
     devDependencies:
       shiki: 0.11.1
 
+  packages/integrations/markdoc/test/fixtures/entry-prop:
+    specifiers:
+      '@astrojs/markdoc': workspace:*
+      astro: workspace:*
+    dependencies:
+      '@astrojs/markdoc': link:../../..
+      astro: link:../../../../../astro
+
   packages/integrations/mdx:
     specifiers:
       '@astrojs/markdown-remark': ^2.1.0
@@ -14921,6 +14929,7 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -16458,7 +16467,7 @@ packages:
       esbuild: 0.16.17
       postcss: 8.4.21
       resolve: 1.22.1
-      rollup: 3.19.1
+      rollup: 3.14.0
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3078,7 +3078,6 @@ importers:
       gray-matter: ^4.0.3
       linkedom: ^0.14.12
       mocha: ^9.2.2
-      rollup: ^3.19.1
       stringify-attributes: ^3.0.0
       vite: ^4.0.3
       zod: ^3.17.3
@@ -3097,7 +3096,6 @@ importers:
       devalue: 4.2.3
       linkedom: 0.14.21
       mocha: 9.2.2
-      rollup: 3.19.1
       vite: 4.1.2
 
   packages/integrations/markdoc/test/fixtures/content-collections:
@@ -14922,14 +14920,6 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-
-  /rollup/3.19.1:
-    resolution: {integrity: sha512-lAbrdN7neYCg/8WaoWn/ckzCtz+jr70GFfYdlf50OF7387HTg+wiuiqJRFYawwSPpqfqDNYqK7smY/ks2iAudg==}
-    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
 
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}


### PR DESCRIPTION
## Changes

- Expose content collection entry information to Markdoc files. This allows you to render the parsed frontmatter based on your schema, alongside the generated `id`, `slug`, and `collection` name.

```mdx
---
title: Hello Markdoc!
---

# {% $entry.data.title %}
```

- Introduce a new `getRenderModule()` helper on our internal `addContentEntryType` API. This exposes the parsed `entry` to your Vite loader for use while generating the module (ex. to expose an `$entry` variable to the Markdoc transformer). This also standardizes how the result of `.render()` is generated. Before, integration authors would need to wire up a separate Vite plugin that resolves modules of your preferred extension and hope this meshes with Astro's content collection API ([see diff here](https://github.com/withastro/astro/compare/feat/markdoc-entry-data?expand=1#diff-6f1a5db26f5ed6e5118cf55b197f2368253e83450989fcd71540ebfe56b5eb38L43-L73)). By standardizing this, we can change how and when rendered modules are loaded in the future without breaking changes.
- Introduce a caching layer for entry info, so this information can be passed to `getRenderModule()`.

## Testing

- Add Markdoc integration test for using the `$entry` variable

## Docs

- README section on `$entry`
