### PR TITLE
Added prop type definition for FormattedDate in Blog example

### DIFF
--- a/examples/blog/src/components/FormattedDate.astro
+++ b/examples/blog/src/components/FormattedDate.astro
@@ -1,4 +1,8 @@
 ---
+export interface Props {
+	date: Date;
+}
+
 const { date } = Astro.props;
 ---
 


### PR DESCRIPTION
## Changes
Added a type definition for `FormattedDate` in the Blog template. This will ensure users of the template have their `date` prop correctly typed.

## Testing
No new functionality added.

## Docs
I don't believe docs should need to be updated. This does not affect behaviour in any way.
/cc @withastro/maintainers-docs for feedback!
