### PR TITLE
Add option to disable streaming

### DIFF
--- a/.changeset/gold-dolphins-burn.md
+++ b/.changeset/gold-dolphins-burn.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Add `server.streaming` config

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -399,7 +399,7 @@ async function generatePath(
 			? new URL(settings.config.base, settings.config.site).toString()
 			: settings.config.site,
 		ssr,
-		streaming: true,
+		streaming: opts.settings.config.server.streaming,
 	});
 	const ctx = createRenderContext({
 		origin,

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -114,6 +114,7 @@ export const AstroConfigSchema = z.object({
 					.default(ASTRO_CONFIG_DEFAULTS.server.host),
 				port: z.number().optional().default(ASTRO_CONFIG_DEFAULTS.server.port),
 				headers: z.custom<OutgoingHttpHeaders>().optional(),
+				streaming: z.boolean().optional().default(true),
 			})
 			.optional()
 			.default({})


### PR DESCRIPTION
## Changes

- Add `server.streaming` config (default: `true`)

## Testing

No testing done. 

An option to disable streaming already exists internally so this PR just exposes it.

## Docs

- Update config reference: https://docs.astro.build/en/reference/configuration-reference/
