### PR TITLE
chore: wrap the projectDir in quotes if it contains spaces

### DIFF
--- a/.changeset/tall-beans-own.md
+++ b/.changeset/tall-beans-own.md
@@ -1,0 +1,5 @@
+---
+'create-astro': minor
+---
+
+wrap projecDir in quptes if it contains spaces

--- a/.changeset/tall-beans-own.md
+++ b/.changeset/tall-beans-own.md
@@ -1,5 +1,5 @@
 ---
-'create-astro': minor
+'create-astro': patch
 ---
 
 wrap projecDir in quptes if it contains spaces

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -121,12 +121,10 @@ export const nextSteps = async ({ projectDir, devCmd }: { projectDir: string; de
 
 	await sleep(100);
 	if (projectDir !== '') {
-		if (projectDir.includes(' ')) {
-			projectDir = `"${projectDir}"`;
-		}
+		projectDir = projectDir.includes(' ') ? `"./${projectDir}"` : `./${projectDir}`;
 		const enter = [
 			`\n${prefix}Enter your project directory using`,
-			color.cyan(`cd ./${projectDir}`, ''),
+			color.cyan(`cd ${projectDir}`, ''),
 		];
 		const len = enter[0].length + stripAnsi(enter[1]).length;
 		log(enter.join(len > max ? '\n' + prefix : ' '));

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -121,6 +121,9 @@ export const nextSteps = async ({ projectDir, devCmd }: { projectDir: string; de
 
 	await sleep(100);
 	if (projectDir !== '') {
+		if (projectDir.includes(' ')) {
+			projectDir = `"${projectDir}"`;
+		}
 		const enter = [
 			`\n${prefix}Enter your project directory using`,
 			color.cyan(`cd ./${projectDir}`, ''),


### PR DESCRIPTION
## Changes
When outputting projectDir in the terminal, if it contains spaces, wrap it in quotes.

![image](https://user-images.githubusercontent.com/24516654/226514249-03410d5f-7859-4af3-aa57-f7769854668b.png)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
