### PR TITLE
Fix redundant image asset optimization

### DIFF
--- a/.changeset/many-hotels-change.md
+++ b/.changeset/many-hotels-change.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix redundant image asset optimization


### PR DESCRIPTION
## Changes

Hoist the `markdownAssetMap` loop outside of the `bundles` loop, so we don’t unnecessarily re-optimize every image for every bundle.

Fixes #6489; fixes #6564.

## Testing

Tested with my test case from #6564.

## Docs

No documentation change needed.