### PR TITLE
Fix plugin apply args when filtering

### DIFF
--- a/.changeset/tame-taxis-perform.md
+++ b/.changeset/tame-taxis-perform.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix plugin apply args when filtering

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -196,7 +196,7 @@ export async function createVite(
 		const applyToFilter = command === 'build' ? 'serve' : 'build';
 		const applyArgs = [
 			{ ...settings.config.vite, mode },
-			{ command, mode },
+			{ command: command === 'dev' ? 'serve' : command, mode },
 		];
 		// @ts-expect-error ignore TS2589: Type instantiation is excessively deep and possibly infinite.
 		plugins = plugins.flat(Infinity).filter((p) => {


### PR DESCRIPTION
## Changes

`vite-plugin-inspect` relies on the `command` arg to return a value for `apply`. In Astro, it's `'dev' | 'build'`, but in Vite, it's `'serve' | 'build'`.

This PR normalizes to Vite's convention before apply it to the plugin when we filter the plugins.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested manually with `vite-plugin-inspect`

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.