### PR TITLE
fix(tsconfig): Update tsconfig templates to ignore 5.0 deprecations

### DIFF
--- a/.changeset/tiny-worms-joke.md
+++ b/.changeset/tiny-worms-joke.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Update tsconfig.json templates to ignore TypeScript 5.0 deprecations for the moment

--- a/packages/astro/tsconfigs/base.json
+++ b/packages/astro/tsconfigs/base.json
@@ -22,6 +22,9 @@
     "baseUrl": ".",
     "paths": {
       "~/assets/*": ["src/assets/*"]
-    }
+    },
+    // TypeScript 5.0 changed how `isolatedModules` and `importsNotUsedAsValues` works, deprecating the later
+    // Until the majority of users are on TypeScript 5.0, we'll have to supress those deprecation errors
+    "ignoreDeprecations": "5.0"
   }
 }


### PR DESCRIPTION
## Changes

TS 5.0 deprecated `importsNotUsedAsValues`, which we use in our strict tsconfig template. Unfortunately, we can't migrate to the new option `verbatimModuleSyntax` until a majority of our users are on TS 5.0+ because the option is incompatible with `isolatedModules`, which we also use (having both is redundant together, that's why they're incompatible)

So, we'll just ignore the deprecations for a few TS version and upgrade our templates then. Once VS Code ships TS 5.0 (in a month or so), a big part of our users will be on TS 5.0 already, so shouldn't take long

Close https://github.com/withastro/astro/issues/6599

## Testing

Tested manually

## Docs

N/A