### PR TITLE
Change URL Generation to correctly suppor base path

### DIFF
--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -79,8 +79,7 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 					}
 
 					let pageUrls = pages.map((p) => {
-						const path = finalSiteUrl.pathname + p.pathname;
-						return new URL(path, finalSiteUrl).href;
+            return finalSiteUrl.href + '/' + p.pathname
 					});
 
 					try {


### PR DESCRIPTION
What version of astro are you using?
2.1.2

Are you using an SSR adapter? If so, which one?
Vercel

What package manager are you using?
npm

What operating system are you using?
Linux, WSL2

What browser are you using?
Chrome

Describe the Bug
The bug i Am experiencing is with this minimal astro config

export default defineConfig({ site: "https://example.com", base: "/blog", output: "static", adapter: vercel(), integrations: [ sitemap(), ], trailingSlash: "never", });

This produce 2 sitemap files, the first one is sitemap-index.xml

`

https://example.com/sitemap-0.xml
`

Here we should have https://example.com/blog/sitemap-0.xml

then in the second file: sitemap-0.xml i have this:
`

https://sundes.com/blogpost/1
`

where i should have a url like https://sundes.com/blog/post/1

I think this is a bug in the plugin, i will try to fix this, but i am not sure if i could create a working PR for this

Link to Minimal Reproducible Example
https://stackblitz.com/edit/github-47cfzy?file=astro.config.mjs

Participation
 I am willing to submit a pull request for this issue.