### PR TITLE
edit commands for installing @markdoc/markdoc

### DIFF
--- a/.changeset/twenty-islands-protect.md
+++ b/.changeset/twenty-islands-protect.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/markdoc": patch
+---
+
+Fix README instructions for installing Markdoc manually.

--- a/packages/integrations/markdoc/README.md
+++ b/packages/integrations/markdoc/README.md
@@ -306,11 +306,11 @@ You will need to install the `@markdoc/markdoc` package into your project first:
 
 ```sh
 # Using NPM
-npx astro add @markdoc/markdoc
+npm install @markdoc/markdoc
 # Using Yarn
-yarn astro add @markdoc/markdoc
+yarn add @markdoc/markdoc
 # Using PNPM
-pnpm astro add @markdoc/markdoc
+pnpm add @markdoc/markdoc
 ```
 
 Now, you can define Markdoc configuration options using `Markdock.transform()`.


### PR DESCRIPTION
## Changes

The commands for installing `@markdoc/markdoc` were using `astro`, but this didn't work. I'm assuming that what's required is to actually use a package manager to install it.

- added the appropriate `npm`, `yarn`, and `pnpm` commands

## Testing

Running the given command (e.g., `pnpm astro add @markdoc/markdoc`) threw an error:
```
@markdoc/markdoc doesn't appear to be an integration or an adapter. Find our official integrations at https://astro.build/integrations
```

Running `pnpm add @markdoc/markdoc` worked: `import { Tag } from '@markdoc/markdoc'` did not throw an error.

## Docs

This is a change in docs.

/cc @withastro/maintainers-docs for feedback! 

<!-- https://github.com/withastro/docs -->
