### PR TITLE
fix: updating HTML attribute types for the <link> element

### DIFF
--- a/.changeset/perfect-rabbits-repair.md
+++ b/.changeset/perfect-rabbits-repair.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an attribute naming mismatch in the definition for <link> elements in astro.JSX

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -789,9 +789,9 @@ declare namespace astroHTML.JSX {
 		fetchpriority?: 'auto' | 'high' | 'low' | undefined | null;
 		integrity?: string | undefined | null;
 		media?: string | undefined | null;
-		imageSrcSet?: string | undefined | null;
-		imageSizes?: string | undefined | null;
-		referrerPolicy?: HTMLAttributeReferrerPolicy | undefined | null;
+		imagesrcset?: string | undefined | null;
+		imagesizes?: string | undefined | null;
+		referrerpolicy?: HTMLAttributeReferrerPolicy | undefined | null;
 		rel?: string | undefined | null;
 		sizes?: string | undefined | null;
 		type?: string | undefined | null;


### PR DESCRIPTION
## Changes

Fixes a few camel-cased attributes in the `astro.JSX.LinkHTMLAttributes` type

**Before**
<img width="736" alt="Screenshot 2023-03-23 at 1 31 41 PM" src="https://user-images.githubusercontent.com/15836226/227313539-4b9f892c-7458-4b95-86e3-93cebbcfcef5.png">

**After**
<img width="736" alt="Screenshot 2023-03-23 at 1 32 19 PM" src="https://user-images.githubusercontent.com/15836226/227313683-940552eb-b511-453d-a54b-bef940afc018.png">

## Testing

None, type definition update only

## Docs

None, bug fix in the type definition only

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
