### PR TITLE
Pass --mode flag to build

### DIFF
--- a/.changeset/smart-wombats-peel.md
+++ b/.changeset/smart-wombats-peel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix --mode flag for builds

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -218,7 +218,13 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 		case 'build': {
 			const { default: build } = await import('../core/build/index.js');
 
-			return await build(settings, { flags, logging, telemetry, teardownCompiler: true });
+			return await build(settings, {
+				flags,
+				logging,
+				telemetry,
+				teardownCompiler: true,
+				mode: flags.mode,
+			});
 		}
 
 		case 'check': {


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/6645

`mode` flag wasn't pass to `build()` for it to take effect.

Regression from https://github.com/withastro/astro/pull/6394/files#diff-4585793503f675c4554733f25418e03ec1938af33dbc9d279442beef8f205741L206-R221

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
n/a 😬 it was easier to test with the repro, which I confirmed works with this change.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.