### PR TITLE
fix(node): Fix http import to not be type-only

### DIFF
--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -2,7 +2,7 @@ import type { RouteData } from '../../@types/astro';
 import type { SerializedSSRManifest, SSRManifest } from './types';
 
 import * as fs from 'fs';
-import type { IncomingMessage } from 'http';
+import { IncomingMessage } from 'http';
 import { TLSSocket } from 'tls';
 import { deserializeManifest } from './common.js';
 import { App, type MatchOptions } from './index.js';


### PR DESCRIPTION
## Changes

This should fix the build failing on `main`

## Testing

Tested manually + CI will run

## Docs

N/A
