### PR TITLE
Fix #6618: sitemap urls generated without slash 

### DIFF
--- a/.changeset/chatty-parrots-compare.md
+++ b/.changeset/chatty-parrots-compare.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/sitemap': patch
+---
+
+Fix sitemap generation with a base path

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -79,7 +79,7 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 					}
 
 					let pageUrls = pages.map((p) => {
-						if (p.pathname != '' && !finalSiteUrl.pathname.endsWith('/'))
+						if (p.pathname !== '' && !finalSiteUrl.pathname.endsWith('/'))
 							finalSiteUrl.pathname += '/';
 						const path = finalSiteUrl.pathname + p.pathname;
 						return new URL(path, finalSiteUrl).href;

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -79,6 +79,8 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 					}
 
 					let pageUrls = pages.map((p) => {
+						if (p.pathname != '' && !finalSiteUrl.pathname.endsWith('/'))
+							finalSiteUrl.pathname += '/';
 						const path = finalSiteUrl.pathname + p.pathname;
 						return new URL(path, finalSiteUrl).href;
 					});

--- a/packages/integrations/sitemap/test/trailing-slash.test.js
+++ b/packages/integrations/sitemap/test/trailing-slash.test.js
@@ -59,6 +59,22 @@ describe('Trailing slash', () => {
 			const urls = data.urlset.url;
 			expect(urls[0].loc[0]).to.equal('http://example.com/one');
 		});
+		describe('with base path', () => {
+			before(async () => {
+				fixture = await loadFixture({
+					root: './fixtures/trailing-slash/',
+					trailingSlash: 'never',
+					base: '/base',
+				});
+				await fixture.build();
+			});
+
+			it('URLs do not end with trailing slash', async () => {
+				const data = await readXML(fixture.readFile('/sitemap-0.xml'));
+				const urls = data.urlset.url;
+				expect(urls[0].loc[0]).to.equal('http://example.com/base/one');
+			});
+		});
 	});
 
 	describe('trailingSlash: always', () => {
@@ -74,6 +90,22 @@ describe('Trailing slash', () => {
 			const data = await readXML(fixture.readFile('/sitemap-0.xml'));
 			const urls = data.urlset.url;
 			expect(urls[0].loc[0]).to.equal('http://example.com/one/');
+		});
+		describe('with base path', () => {
+			before(async () => {
+				fixture = await loadFixture({
+					root: './fixtures/trailing-slash/',
+					trailingSlash: 'always',
+					base: '/base',
+				});
+				await fixture.build();
+			});
+
+			it('URLs end with trailing slash', async () => {
+				const data = await readXML(fixture.readFile('/sitemap-0.xml'));
+				const urls = data.urlset.url;
+				expect(urls[0].loc[0]).to.equal('http://example.com/base/one/');
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Changes

closes #6618 

I added a condition to check whether the base path has a trailing slash or not (when the base path and page path are concatenated) and add the trailing slash if it's missing. 

I tested using the `@example/blog` with this configuration:

```ts
export default defineConfig({
	site: 'https://example.com',
	integrations: [mdx(), sitemap()],
	base: '/base',
	trailingSlash: 'never',
});
```

## Before:

- sitemap-index.xml
```xml
<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><sitemap><loc>https://example.com/sitemap-0.xml</loc></sitemap></sitemapindex>
```
- sitemap-0.xml
```xml
<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1"><url><loc>https://example.com/base</loc></url><url><loc>https://example.com/baseabout</loc></url><url><loc>https://example.com/baseblog</loc></url><url><loc>https://example.com/baseblog/first-post</loc></url><url><loc>https://example.com/baseblog/markdown-style-guide</loc></url><url><loc>https://example.com/baseblog/second-post</loc></url><url><loc>https://example.com/baseblog/third-post</loc></url><url><loc>https://example.com/baseblog/using-mdx</loc></url></urlset>
```

## After:


- sitemap-index.xml
```xml
<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><sitemap><loc>https://example.com/base/sitemap-0.xml</loc></sitemap></sitemapindex>
```
- sitemap-0.xml
```xml
<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1"><url><loc>https://example.com/base</loc></url><url><loc>https://example.com/base/about</loc></url><url><loc>https://example.com/base/blog</loc></url><url><loc>https://example.com/base/blog/first-post</loc></url><url><loc>https://example.com/base/blog/markdown-style-guide</loc></url><url><loc>https://example.com/base/blog/second-post</loc></url><url><loc>https://example.com/base/blog/third-post</loc></url><url><loc>https://example.com/base/blog/using-mdx</loc></url></urlset>
```

## Testing

I added two new tests for cases were you have a base URL.

- One to test base URL + `trailingSlash: never`
- And the other to test base URL + `trailingSlash: always`

## Docs

No docs needed, just a bug fix
