### PR TITLE
Reduced Playwright test flakiness with click() events in few components

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "test:vite-ci": "turbo run test --filter=astro --output-logs=new-only --no-deps --concurrency=1",
     "test:e2e": "cd packages/astro && pnpm playwright install && pnpm run test:e2e",
     "test:e2e:match": "cd packages/astro && pnpm playwright install && pnpm run test:e2e:match",
+    "test:e2e:report": "cd packages/astro && pnpm run test:e2e:report",
+    "test:e2e:debug": "cd packages/astro && pnpm playwright install && pnpm run test:e2e:debug",
     "benchmark": "astro-benchmark",
     "lint": "eslint --cache .",
     "version": "changeset version && pnpm install --no-frozen-lockfile && pnpm run format",

--- a/packages/astro/e2e/client-only.test.js
+++ b/packages/astro/e2e/client-only.test.js
@@ -27,7 +27,7 @@ test.describe('Client only', () => {
 		await expect(children, 'children exist').toHaveText('react');
 
 		const increment = await counter.locator('.increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -45,7 +45,7 @@ test.describe('Client only', () => {
 		await expect(children, 'children exist').toHaveText('preact');
 
 		const increment = await counter.locator('.increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -63,7 +63,7 @@ test.describe('Client only', () => {
 		await expect(children, 'children exist').toHaveText('solid');
 
 		const increment = await counter.locator('.increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -81,7 +81,7 @@ test.describe('Client only', () => {
 		await expect(children, 'children exist').toHaveText('vue');
 
 		const increment = await counter.locator('.increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -99,7 +99,7 @@ test.describe('Client only', () => {
 		await expect(children, 'children exist').toHaveText('svelte');
 
 		const increment = await counter.locator('.increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});

--- a/packages/astro/e2e/lit-component.test.js
+++ b/packages/astro/e2e/lit-component.test.js
@@ -35,7 +35,7 @@ test.describe('Lit components', () => {
 			await expect(count, 'initial count is 10').toHaveText('Count: 10');
 
 			const inc = counter.locator('button');
-			await inc.click();
+			await inc.click({ delay: 150 });
 
 			await expect(count, 'count incremented by 1').toHaveText('Count: 11');
 		});
@@ -48,7 +48,7 @@ test.describe('Lit components', () => {
 			await expect(count, 'initial count is 10').toHaveText('Count: 10');
 
 			const inc = counter.locator('button');
-			await inc.click();
+			await inc.click({ delay: 150 });
 
 			await expect(count, 'count incremented by 1').toHaveText('Count: 11');
 		});
@@ -63,7 +63,7 @@ test.describe('Lit components', () => {
 			await expect(count, 'initial count is 10').toHaveText('Count: 10');
 
 			const inc = counter.locator('button');
-			await inc.click();
+			await inc.click({ delay: 150 });
 
 			await expect(count, 'count incremented by 1').toHaveText('Count: 11');
 		});
@@ -80,7 +80,7 @@ test.describe('Lit components', () => {
 			await expect(count, 'initial count is 10').toHaveText('Count: 10');
 
 			const inc = counter.locator('button');
-			await inc.click();
+			await inc.click({ delay: 150 });
 
 			await expect(count, 'count incremented by 1').toHaveText('Count: 11');
 		});
@@ -95,14 +95,14 @@ test.describe('Lit components', () => {
 			await expect(count, 'initial count is 10').toHaveText('Count: 10');
 
 			const inc = counter.locator('button');
-			await inc.click();
+			await inc.click({ delay: 150 });
 
 			await expect(count, 'component not hydrated yet').toHaveText('Count: 10');
 
 			// Reset the viewport to hydrate the component (max-width: 50rem)
 			await page.setViewportSize({ width: 414, height: 1124 });
 
-			await inc.click();
+			await inc.click({ delay: 150 });
 			await expect(count, 'count incremented by 1').toHaveText('Count: 11');
 		});
 

--- a/packages/astro/e2e/multiple-frameworks.test.js
+++ b/packages/astro/e2e/multiple-frameworks.test.js
@@ -24,7 +24,7 @@ test.skip('Multiple frameworks', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = counter.locator('.increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -39,7 +39,7 @@ test.skip('Multiple frameworks', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = counter.locator('.increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -54,7 +54,7 @@ test.skip('Multiple frameworks', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = counter.locator('.increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -69,7 +69,7 @@ test.skip('Multiple frameworks', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = counter.locator('.increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -84,7 +84,7 @@ test.skip('Multiple frameworks', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = counter.locator('.increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});

--- a/packages/astro/e2e/namespaced-component.test.js
+++ b/packages/astro/e2e/namespaced-component.test.js
@@ -30,7 +30,7 @@ test.describe('Hydrating namespaced components', () => {
 		await expect(namespacedChildren, 'children exist').toHaveText('preact (namespace import)');
 
 		const namespacedIncrement = await namespacedCounter.locator('.increment');
-		await namespacedIncrement.click();
+		await namespacedIncrement.click({ delay: 150 });
 
 		await expect(namespacedCount, 'count incremented by 1').toHaveText('1');
 
@@ -45,7 +45,7 @@ test.describe('Hydrating namespaced components', () => {
 		await expect(namedChildren, 'children exist').toHaveText('preact (named import)');
 
 		const namedIncrement = await namedCounter.locator('.increment');
-		await namedIncrement.click();
+		await namedIncrement.click({ delay: 150 });
 
 		await expect(namedCount, 'count incremented by 1').toHaveText('1');
 	});
@@ -64,7 +64,7 @@ test.describe('Hydrating namespaced components', () => {
 		await expect(namespacedChildren, 'children exist').toHaveText('preact (namespace import)');
 
 		const namespacedIncrement = await namespacedCounter.locator('.increment');
-		await namespacedIncrement.click();
+		await namespacedIncrement.click({ delay: 150 });
 
 		await expect(namespacedCount, 'count incremented by 1').toHaveText('1');
 
@@ -79,7 +79,7 @@ test.describe('Hydrating namespaced components', () => {
 		await expect(namedChildren, 'children exist').toHaveText('preact (named import)');
 
 		const namedIncrement = await namedCounter.locator('.increment');
-		await namedIncrement.click();
+		await namedIncrement.click({ delay: 150 });
 
 		await expect(namedCount, 'count incremented by 1').toHaveText('1');
 	});

--- a/packages/astro/e2e/nested-in-preact.test.js
+++ b/packages/astro/e2e/nested-in-preact.test.js
@@ -24,7 +24,7 @@ test.describe('Nested Frameworks in Preact', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#react-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -39,7 +39,7 @@ test.describe('Nested Frameworks in Preact', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#preact-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -54,7 +54,7 @@ test.describe('Nested Frameworks in Preact', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#solid-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -69,7 +69,7 @@ test.describe('Nested Frameworks in Preact', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#vue-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -84,7 +84,7 @@ test.describe('Nested Frameworks in Preact', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#svelte-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});

--- a/packages/astro/e2e/nested-in-react.test.js
+++ b/packages/astro/e2e/nested-in-react.test.js
@@ -24,7 +24,7 @@ test.describe('Nested Frameworks in React', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#react-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -39,7 +39,7 @@ test.describe('Nested Frameworks in React', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#preact-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -54,7 +54,7 @@ test.describe('Nested Frameworks in React', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#solid-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -69,7 +69,7 @@ test.describe('Nested Frameworks in React', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#vue-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -84,7 +84,7 @@ test.describe('Nested Frameworks in React', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#svelte-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});

--- a/packages/astro/e2e/nested-in-solid.test.js
+++ b/packages/astro/e2e/nested-in-solid.test.js
@@ -24,7 +24,7 @@ test.describe('Nested Frameworks in Solid', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#react-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -39,7 +39,7 @@ test.describe('Nested Frameworks in Solid', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#preact-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -54,7 +54,7 @@ test.describe('Nested Frameworks in Solid', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#solid-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -69,7 +69,7 @@ test.describe('Nested Frameworks in Solid', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#vue-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -84,7 +84,7 @@ test.describe('Nested Frameworks in Solid', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#svelte-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});

--- a/packages/astro/e2e/nested-in-svelte.test.js
+++ b/packages/astro/e2e/nested-in-svelte.test.js
@@ -24,7 +24,7 @@ test.describe('Nested Frameworks in Svelte', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#react-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -39,7 +39,7 @@ test.describe('Nested Frameworks in Svelte', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#preact-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -54,7 +54,7 @@ test.describe('Nested Frameworks in Svelte', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#solid-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -69,7 +69,7 @@ test.describe('Nested Frameworks in Svelte', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#vue-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -84,7 +84,7 @@ test.describe('Nested Frameworks in Svelte', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#svelte-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});

--- a/packages/astro/e2e/nested-in-vue.test.js
+++ b/packages/astro/e2e/nested-in-vue.test.js
@@ -24,7 +24,7 @@ test.describe('Nested Frameworks in Vue', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#react-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -39,7 +39,7 @@ test.describe('Nested Frameworks in Vue', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#preact-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -54,7 +54,7 @@ test.describe('Nested Frameworks in Vue', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#solid-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -69,7 +69,7 @@ test.describe('Nested Frameworks in Vue', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#vue-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -84,7 +84,7 @@ test.describe('Nested Frameworks in Vue', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#svelte-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});

--- a/packages/astro/e2e/nested-recursive.test.js
+++ b/packages/astro/e2e/nested-recursive.test.js
@@ -29,7 +29,7 @@ test.describe('Recursive Nested Frameworks', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#react-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -44,7 +44,7 @@ test.describe('Recursive Nested Frameworks', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#preact-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -59,7 +59,7 @@ test.describe('Recursive Nested Frameworks', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#solid-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -74,7 +74,7 @@ test.describe('Recursive Nested Frameworks', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#vue-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
@@ -89,7 +89,7 @@ test.describe('Recursive Nested Frameworks', () => {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const increment = await counter.locator('#svelte-counter-increment');
-		await increment.click();
+		await increment.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});

--- a/packages/astro/e2e/react-component.test.js
+++ b/packages/astro/e2e/react-component.test.js
@@ -30,7 +30,7 @@ test.describe('dev', () => {
 
 		const suffix = page.locator('#suffix');
 		expect(await suffix.textContent()).toBe('suffix toggle false');
-		await suffix.click();
+		await suffix.click({ delay: 150 });
 		expect(await suffix.textContent()).toBe('suffix toggle true');
 	});
 });

--- a/packages/astro/e2e/shared-component-tests.js
+++ b/packages/astro/e2e/shared-component-tests.js
@@ -25,7 +25,7 @@ export function prepareTestFactory(opts) {
 			await expect(count, 'initial count is 0').toHaveText('0');
 
 			const inc = counter.locator('.increment');
-			await inc.click();
+			await inc.click({ delay: 150 });
 
 			await expect(count, 'component not hydrated').toHaveText('0');
 		});
@@ -40,7 +40,7 @@ export function prepareTestFactory(opts) {
 			await expect(count, 'initial count is 0').toHaveText('0');
 
 			const inc = counter.locator('.increment');
-			await inc.click();
+			await inc.click({ delay: 150 });
 
 			await expect(count, 'count incremented by 1').toHaveText('1');
 		});
@@ -55,7 +55,7 @@ export function prepareTestFactory(opts) {
 			await expect(count, 'initial count is 0').toHaveText('0');
 
 			const inc = counter.locator('.increment');
-			await inc.click();
+			await inc.click({ delay: 150 });
 
 			await expect(count, 'count incremented by 1').toHaveText('1');
 		});
@@ -72,7 +72,7 @@ export function prepareTestFactory(opts) {
 			await expect(count, 'initial count is 0').toHaveText('0');
 
 			const inc = counter.locator('.increment');
-			await inc.click();
+			await inc.click({ delay: 150 });
 
 			await expect(count, 'count incremented by 1').toHaveText('1');
 		});
@@ -87,12 +87,12 @@ export function prepareTestFactory(opts) {
 			await expect(count, 'initial count is 0').toHaveText('0');
 
 			const inc = counter.locator('.increment');
-			await inc.click();
+			await inc.click({ delay: 150 });
 			await expect(count, 'component not hydrated yet').toHaveText('0');
 
 			// Reset the viewport to hydrate the component (max-width: 50rem)
 			await page.setViewportSize({ width: 414, height: 1124 });
-			await inc.click();
+			await inc.click({ delay: 150 });
 			await expect(count, 'count incremented by 1').toHaveText('1');
 		});
 

--- a/packages/astro/e2e/solid-recurse.test.js
+++ b/packages/astro/e2e/solid-recurse.test.js
@@ -23,7 +23,7 @@ test.describe('Recursive elements with Solid', () => {
 		const increment = page.locator('#case1-B');
 		await expect(increment, 'initial count is 0').toHaveText('B: 0');
 
-		await increment.click();
+		await increment.click({ delay: 150 });
 		await expect(increment, 'count is incremented').toHaveText('B: 1');
 	});
 });

--- a/packages/astro/e2e/svelte-component.test.js
+++ b/packages/astro/e2e/svelte-component.test.js
@@ -31,7 +31,7 @@ test.describe('Svelte components lifecycle', () => {
 
 		const toggle = page.locator('#toggle');
 		expect((await toggle.textContent()).trim()).toBe('close');
-		await toggle.click();
+		await toggle.click({ delay: 150 });
 		expect((await toggle.textContent()).trim()).toBe('open');
 	});
 });

--- a/packages/astro/e2e/ts-resolution.test.js
+++ b/packages/astro/e2e/ts-resolution.test.js
@@ -14,7 +14,7 @@ function runTest(it) {
 		await expect(count, 'initial count is 0').toHaveText('0');
 
 		const inc = counter.locator('.increment');
-		await inc.click();
+		await inc.click({ delay: 150 });
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -103,7 +103,9 @@
     "test": "pnpm run test:unit && mocha --exit --timeout 20000 --ignore **/lit-element.test.js && mocha --timeout 20000 **/lit-element.test.js",
     "test:match": "mocha --timeout 20000 -g",
     "test:e2e": "playwright test",
-    "test:e2e:match": "playwright test -g"
+    "test:e2e:match": "playwright test -g",
+    "test:e2e:report": "playwright show-report",
+    "test:e2e:debug": "playwright test --debug -g"
   },
   "dependencies": {
     "@astrojs/compiler": "^1.3.0",

--- a/packages/astro/playwright.config.js
+++ b/packages/astro/playwright.config.js
@@ -16,8 +16,8 @@ const config = {
 	},
 	/* Fail the build on CI if you accidentally left test in the source code. */
 	forbidOnly: !!process.env.CI,
-	/* Retry on CI only */
-	retries: process.env.CI ? 3 : 0,
+	/* Always retry due to flaky click() responsiveness of some components, even with a 150ms delay. */
+	retries: 3,
 	/* Opt out of parallel tests on CI. */
 	workers: 1,
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -40,6 +40,7 @@ const config = {
 			},
 		},
 	],
+	reporter: [['html', {open: 'never'}]],
 };
 
 export default config;


### PR DESCRIPTION
## Changes

- Reduced Playwright test flakiness with click() events by 150ms delay and enabling 3 retries by default
- Introduced few new script commands to analyse Playwright results:
  - pnpm run test:e2e:report
  - pnpm run test:e2e:debug <filter>
- HTML reports are enabled too, but not shown by default after test run

## Testing

This patch is about testing with Playwright. With this change, I have a more or less reliable test suite. Before no Playwright test run was successful. Now only 2 or 3 tests are affected by retries but run through.