### PR TITLE
Improve mobile support by adding initial-scale to the viewport meta tag

### DIFF
--- a/benchmark/make-project/server-stress-default.js
+++ b/benchmark/make-project/server-stress-default.js
@@ -18,7 +18,7 @@ const content = "${loremIpsum}"
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro</title>
 	</head>

--- a/examples/basics/src/layouts/Layout.astro
+++ b/examples/basics/src/layouts/Layout.astro
@@ -10,7 +10,7 @@ const { title } = Astro.props;
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
 		<title>{title}</title>

--- a/examples/deno/src/components/Layout.astro
+++ b/examples/deno/src/components/Layout.astro
@@ -10,7 +10,7 @@ const { title } = Astro.props as Props;
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<title>{title}</title>
 	</head>

--- a/examples/docs/src/components/HeadCommon.astro
+++ b/examples/docs/src/components/HeadCommon.astro
@@ -5,7 +5,7 @@ import '../styles/index.css';
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
 <meta name="generator" content={Astro.generator} />
 
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/examples/framework-alpine/src/pages/index.astro
+++ b/examples/framework-alpine/src/pages/index.astro
@@ -9,7 +9,7 @@ import Counter from '../components/Counter.astro';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<style>

--- a/examples/framework-lit/src/pages/index.astro
+++ b/examples/framework-lit/src/pages/index.astro
@@ -11,7 +11,7 @@ import { MyCounter } from '../components/my-counter.js';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<title>Demo</title>
 	</head>

--- a/examples/framework-multiple/src/pages/index.astro
+++ b/examples/framework-multiple/src/pages/index.astro
@@ -18,7 +18,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 	</head>

--- a/examples/framework-preact/src/pages/index.astro
+++ b/examples/framework-preact/src/pages/index.astro
@@ -13,7 +13,7 @@ const count = signal(0);
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<style>

--- a/examples/framework-react/src/pages/index.astro
+++ b/examples/framework-react/src/pages/index.astro
@@ -12,7 +12,7 @@ const someProps = {
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<style>

--- a/examples/framework-solid/src/pages/index.astro
+++ b/examples/framework-solid/src/pages/index.astro
@@ -9,7 +9,7 @@ import Counter from '../components/Counter';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<style>

--- a/examples/framework-svelte/src/pages/index.astro
+++ b/examples/framework-svelte/src/pages/index.astro
@@ -9,7 +9,7 @@ import Counter from '../components/Counter.svelte';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<style>

--- a/examples/framework-vue/src/pages/index.astro
+++ b/examples/framework-vue/src/pages/index.astro
@@ -9,7 +9,7 @@ import Counter from '../components/Counter.vue';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<style>

--- a/examples/minimal/src/pages/index.astro
+++ b/examples/minimal/src/pages/index.astro
@@ -5,7 +5,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro</title>
 	</head>

--- a/examples/non-html-pages/src/pages/index.astro
+++ b/examples/non-html-pages/src/pages/index.astro
@@ -1,7 +1,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro</title>
 	</head>

--- a/examples/portfolio/src/components/MainHead.astro
+++ b/examples/portfolio/src/components/MainHead.astro
@@ -14,7 +14,7 @@ const {
 
 <meta charset="UTF-8" />
 <meta name="description" property="og:description" content={description} />
-<meta name="viewport" content="width=device-width" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
 <meta name="generator" content={Astro.generator} />
 <title>{title}</title>
 

--- a/examples/with-markdoc/src/layouts/Layout.astro
+++ b/examples/with-markdoc/src/layouts/Layout.astro
@@ -10,7 +10,7 @@ const { title } = Astro.props;
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
 		<title>{title}</title>

--- a/examples/with-markdown-plugins/src/layouts/main.astro
+++ b/examples/with-markdown-plugins/src/layouts/main.astro
@@ -7,7 +7,7 @@ const { content } = Astro.props;
 <html lang={content.lang || 'en'}>
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<title>{content.title}</title>
 		<style>

--- a/examples/with-markdown-shiki/src/layouts/main.astro
+++ b/examples/with-markdown-shiki/src/layouts/main.astro
@@ -7,7 +7,7 @@ const { content } = Astro.props;
 <html lang={content.lang || 'en'}>
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<title>{content.title}</title>
 	</head>

--- a/examples/with-nanostores/src/layouts/Layout.astro
+++ b/examples/with-nanostores/src/layouts/Layout.astro
@@ -13,7 +13,7 @@ const { title } = Astro.props;
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width">
+	<meta name="viewport" content="width=device-width,initial-scale=1">
 	<meta name="generator" content={Astro.generator} />
 	<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 	<title>{title}</title>

--- a/examples/with-tailwindcss/src/layouts/main.astro
+++ b/examples/with-tailwindcss/src/layouts/main.astro
@@ -5,7 +5,7 @@ const { content } = Astro.props;
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<title>{content.title}</title>
 	</head>

--- a/examples/with-tailwindcss/src/pages/index.astro
+++ b/examples/with-tailwindcss/src/pages/index.astro
@@ -9,7 +9,7 @@ import Button from '../components/Button.astro';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro + TailwindCSS</title>

--- a/examples/with-vite-plugin-pwa/src/pages/index.astro
+++ b/examples/with-vite-plugin-pwa/src/pages/index.astro
@@ -5,7 +5,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Welcome to Astro</title>
 	</head>

--- a/examples/with-vitest/src/pages/index.astro
+++ b/examples/with-vitest/src/pages/index.astro
@@ -5,7 +5,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro</title>
 	</head>

--- a/packages/astro/e2e/fixtures/client-only/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/client-only/src/pages/index.astro
@@ -12,7 +12,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 	</head>
 	<body>

--- a/packages/astro/e2e/fixtures/multiple-frameworks/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/multiple-frameworks/src/pages/index.astro
@@ -16,7 +16,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 	</head>
 	<body>

--- a/packages/astro/e2e/fixtures/namespaced-component/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/namespaced-component/src/pages/index.astro
@@ -6,7 +6,7 @@ import { components } from '../components/PreactCounter.tsx';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 	</head>
 	<body>

--- a/packages/astro/e2e/fixtures/nested-in-preact/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-preact/src/pages/index.astro
@@ -12,7 +12,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 	</head>
 	<body>

--- a/packages/astro/e2e/fixtures/nested-in-react/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-react/src/pages/index.astro
@@ -12,7 +12,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 	</head>
 	<body>

--- a/packages/astro/e2e/fixtures/nested-in-solid/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-solid/src/pages/index.astro
@@ -12,7 +12,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 	</head>
 	<body>

--- a/packages/astro/e2e/fixtures/nested-in-svelte/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-svelte/src/pages/index.astro
@@ -12,7 +12,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 	</head>
 	<body>

--- a/packages/astro/e2e/fixtures/nested-in-vue/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-vue/src/pages/index.astro
@@ -12,7 +12,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 	</head>
 	<body>

--- a/packages/astro/e2e/fixtures/nested-recursive/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-recursive/src/pages/index.astro
@@ -9,7 +9,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 	</head>
 	<body>

--- a/packages/astro/e2e/fixtures/pass-js/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/pass-js/src/pages/index.astro
@@ -25,7 +25,7 @@ set.add('test2');
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 	</head>
 	<body>

--- a/packages/astro/e2e/fixtures/solid-circular/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/solid-circular/src/pages/index.astro
@@ -5,7 +5,7 @@ import { ContextProvider } from "../components/ContextProvider.tsx";
 <html>
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 	</head>
 	<body>
 		<main>

--- a/packages/astro/e2e/fixtures/solid-recurse/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/solid-recurse/src/pages/index.astro
@@ -6,7 +6,7 @@ import WrapperA from "../components/WrapperA.jsx";
 <html>
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 	</head>
 	<body>
 		<main>

--- a/packages/astro/test/fixtures/alias-tsconfig/src/pages/index.astro
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/pages/index.astro
@@ -4,7 +4,7 @@ import Client from '@components/Client.svelte'
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Aliases using tsconfig</title>
   </head>
   <body>

--- a/packages/astro/test/fixtures/alias/src/pages/index.astro
+++ b/packages/astro/test/fixtures/alias/src/pages/index.astro
@@ -4,7 +4,7 @@ import Client from 'component:Client.svelte'
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Svelte Client</title>
     <style>
       html,

--- a/packages/astro/test/fixtures/alias/src/pages/two.astro
+++ b/packages/astro/test/fixtures/alias/src/pages/two.astro
@@ -4,7 +4,7 @@ import Client from '../components/Client.svelte'
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Svelte Client</title>
     <style>
       html,

--- a/packages/astro/test/fixtures/astro-dynamic/src/pages/media.astro
+++ b/packages/astro/test/fixtures/astro-dynamic/src/pages/media.astro
@@ -5,7 +5,7 @@ const MOBILE = "(max-width: 600px)";
 <html>
 <head>
   <title>Media hydration</title>
-  <meta name="viewport" content="width=device-width">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
 </head>
 <body>
   <!-- Inline value -->

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/food/[name].astro
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/food/[name].astro
@@ -17,7 +17,7 @@ export async function getStaticPaths() {
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Food</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/pizza/[...pizza].astro
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/pizza/[...pizza].astro
@@ -13,7 +13,7 @@ const { pizza } = Astro.params
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>{pizza ?? 'The landing page'}</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/pizza/[cheese]-[topping].astro
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/pizza/[cheese]-[topping].astro
@@ -11,7 +11,7 @@ const { cheese, topping } = Astro.params
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>{cheese}</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/posts/[page].astro
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/posts/[page].astro
@@ -20,7 +20,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Posts Page {page}</title>
 		<link rel="canonical" href={canonicalURL.href}>
 	</head>

--- a/packages/astro/test/fixtures/astro-head/src/components/Head.astro
+++ b/packages/astro/test/fixtures/astro-head/src/components/Head.astro
@@ -5,7 +5,7 @@ const { title } = Astro.props;
 
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   <title>{title}</title>
 </head>

--- a/packages/astro/test/fixtures/astro-scripts/src/pages/glob.astro
+++ b/packages/astro/test/fixtures/astro-scripts/src/pages/glob.astro
@@ -6,7 +6,7 @@ const MyComponent = components[0].default;
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Astro</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/content with spaces in folder name/src/pages/index.astro
+++ b/packages/astro/test/fixtures/content with spaces in folder name/src/pages/index.astro
@@ -4,7 +4,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>It's content time!</title>
     <style>
       html,

--- a/packages/astro/test/fixtures/content-collections-base/src/pages/docs.astro
+++ b/packages/astro/test/fixtures/content-collections-base/src/pages/docs.astro
@@ -6,7 +6,7 @@ const { Content } = await entry.render();
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>It's content time!</title>
   </head>
   <body>

--- a/packages/astro/test/fixtures/content-collections/src/pages/index.astro
+++ b/packages/astro/test/fixtures/content-collections/src/pages/index.astro
@@ -4,7 +4,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>It's content time!</title>
     <style>
       html,

--- a/packages/astro/test/fixtures/content-ssr-integration/src/pages/index.astro
+++ b/packages/astro/test/fixtures/content-ssr-integration/src/pages/index.astro
@@ -4,7 +4,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>It's content time!</title>
     <style>
       html,

--- a/packages/astro/test/fixtures/content-ssr-integration/src/pages/posts/[...slug].astro
+++ b/packages/astro/test/fixtures/content-ssr-integration/src/pages/posts/[...slug].astro
@@ -13,7 +13,7 @@ const { Content } = await post.render();
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>{post.data.title}</title>
     <style>
       html,

--- a/packages/astro/test/fixtures/content-static-paths-integration/src/pages/posts/[...slug].astro
+++ b/packages/astro/test/fixtures/content-static-paths-integration/src/pages/posts/[...slug].astro
@@ -16,7 +16,7 @@ const { Content } = await Astro.props.render();
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>{title}</title>
     <style>
       html,

--- a/packages/astro/test/fixtures/content/src/components/LayoutProp.astro
+++ b/packages/astro/test/fixtures/content/src/components/LayoutProp.astro
@@ -17,7 +17,7 @@ const {
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<title>With Layout Prop</title>
 	</head>

--- a/packages/astro/test/fixtures/css-inline/src/layouts/Layout.astro
+++ b/packages/astro/test/fixtures/css-inline/src/layouts/Layout.astro
@@ -10,7 +10,7 @@ const { title } = Astro.props;
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
 		<title>{title}</title>

--- a/packages/astro/test/fixtures/error-bad-js/src/pages/index.astro
+++ b/packages/astro/test/fixtures/error-bad-js/src/pages/index.astro
@@ -6,7 +6,7 @@ import something from '../something.js';
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro</title>
 	</head>

--- a/packages/astro/test/fixtures/fontsource-package/src/pages/index.astro
+++ b/packages/astro/test/fixtures/fontsource-package/src/pages/index.astro
@@ -5,7 +5,7 @@ import "@fontsource/monofett";
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Astro</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/get-static-paths-pages/src/pages/[...page].astro
+++ b/packages/astro/test/fixtures/get-static-paths-pages/src/pages/[...page].astro
@@ -21,7 +21,7 @@ const { page } = Astro.props;
 
 <head>
 	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width" />
+	<meta name="viewport" content="width=device-width,initial-scale=1" />
 	<meta name="generator" content={Astro.generator} />
 	<title>Astro</title>
 </head>

--- a/packages/astro/test/fixtures/large-array/src/pages/index.astro
+++ b/packages/astro/test/fixtures/large-array/src/pages/index.astro
@@ -9,7 +9,7 @@ for (let i = 0; i < 600; i++) {
 <html>
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 		<style>
 			html,

--- a/packages/astro/test/fixtures/lit-element/src/pages/[page].astro
+++ b/packages/astro/test/fixtures/lit-element/src/pages/[page].astro
@@ -20,7 +20,7 @@ const { page } = Astro.params
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Posts Page {page}</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/page-level-styles/src/layouts/Base.astro
+++ b/packages/astro/test/fixtures/page-level-styles/src/layouts/Base.astro
@@ -4,7 +4,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Astro</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/page-level-styles/src/layouts/Styled.astro
+++ b/packages/astro/test/fixtures/page-level-styles/src/layouts/Styled.astro
@@ -4,7 +4,7 @@ import "../styles/main.css";
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Astro</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/routing-priority/src/[id].astro
+++ b/packages/astro/test/fixtures/routing-priority/src/[id].astro
@@ -11,7 +11,7 @@ const { id } = Astro.params;
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Routing</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/routing-priority/src/_to-inject.astro
+++ b/packages/astro/test/fixtures/routing-priority/src/_to-inject.astro
@@ -3,7 +3,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Routing</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/routing-priority/src/pages/[lang]/[...catchall].astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/[lang]/[...catchall].astro
@@ -11,7 +11,7 @@
 
 <head>
 	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width" />
+	<meta name="viewport" content="width=device-width,initial-scale=1" />
 	<title>Routing</title>
 </head>
 

--- a/packages/astro/test/fixtures/routing-priority/src/pages/[lang]/index.astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/[lang]/index.astro
@@ -11,7 +11,7 @@
 
 <head>
 	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width" />
+	<meta name="viewport" content="width=device-width,initial-scale=1" />
 	<title>Routing</title>
 </head>
 

--- a/packages/astro/test/fixtures/routing-priority/src/pages/[page].astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/[page].astro
@@ -15,7 +15,7 @@
 
 <head>
 	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width" />
+	<meta name="viewport" content="width=device-width,initial-scale=1" />
 	<title>Routing</title>
 </head>
 

--- a/packages/astro/test/fixtures/routing-priority/src/pages/[slug].astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/[slug].astro
@@ -15,7 +15,7 @@
 
 <head>
 	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width" />
+	<meta name="viewport" content="width=device-width,initial-scale=1" />
 	<title>Routing</title>
 </head>
 

--- a/packages/astro/test/fixtures/routing-priority/src/pages/de/index.astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/de/index.astro
@@ -4,7 +4,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Routing</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/routing-priority/src/pages/empty-slug/[...slug].astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/empty-slug/[...slug].astro
@@ -12,7 +12,7 @@ const { slug } = Astro.params
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>{slug}</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/routing-priority/src/pages/index.astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/index.astro
@@ -3,7 +3,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Routing</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/routing-priority/src/pages/posts/[...slug].astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/posts/[...slug].astro
@@ -12,7 +12,7 @@
 
 <head>
 	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width" />
+	<meta name="viewport" content="width=device-width,initial-scale=1" />
 	<title>Routing</title>
 </head>
 

--- a/packages/astro/test/fixtures/routing-priority/src/pages/posts/[pid].astro
+++ b/packages/astro/test/fixtures/routing-priority/src/pages/posts/[pid].astro
@@ -11,7 +11,7 @@
 
 <head>
 	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width" />
+	<meta name="viewport" content="width=device-width,initial-scale=1" />
 	<title>Routing</title>
 </head>
 

--- a/packages/astro/test/fixtures/routing-priority/src/to-inject.astro
+++ b/packages/astro/test/fixtures/routing-priority/src/to-inject.astro
@@ -3,7 +3,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Routing</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/ssr-assets/src/pages/index.astro
+++ b/packages/astro/test/fixtures/ssr-assets/src/pages/index.astro
@@ -4,7 +4,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Astro</title>
 		<style is:global>
 			h1 {

--- a/packages/astro/test/fixtures/ssr-prerender-get-static-paths/src/pages/food/[name].astro
+++ b/packages/astro/test/fixtures/ssr-prerender-get-static-paths/src/pages/food/[name].astro
@@ -24,7 +24,7 @@ const { yum } = Astro.props;
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Food</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/ssr-prerender-get-static-paths/src/pages/pizza/[...pizza].astro
+++ b/packages/astro/test/fixtures/ssr-prerender-get-static-paths/src/pages/pizza/[...pizza].astro
@@ -14,7 +14,7 @@ const { pizza } = Astro.params
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>{pizza ?? 'The landing page'}</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/ssr-prerender-get-static-paths/src/pages/pizza/[cheese]-[topping].astro
+++ b/packages/astro/test/fixtures/ssr-prerender-get-static-paths/src/pages/pizza/[cheese]-[topping].astro
@@ -12,7 +12,7 @@ const { cheese, topping } = Astro.params
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>{cheese}</title>
 	</head>
 	<body>

--- a/packages/astro/test/fixtures/ssr-prerender-get-static-paths/src/pages/posts/[page].astro
+++ b/packages/astro/test/fixtures/ssr-prerender-get-static-paths/src/pages/posts/[page].astro
@@ -20,7 +20,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Posts Page {page}</title>
 		<link rel="canonical" href={canonicalURL.href}>
 	</head>

--- a/packages/astro/test/fixtures/static-build/src/components/MainHead.astro
+++ b/packages/astro/test/fixtures/static-build/src/components/MainHead.astro
@@ -5,7 +5,7 @@ const { title = 'Static Build', description = 'This is a demo of the static buil
 
 <meta charset="UTF-8" />
 <meta name="description" property="og:description" content={description} />
-<meta name="viewport" content="width=device-width" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
 <title>{title}</title>
 
 <link rel="icon" type="image/x-icon" href="/favicon.ico" />

--- a/packages/astro/test/fixtures/svelte-component/src/pages/typescript.astro
+++ b/packages/astro/test/fixtures/svelte-component/src/pages/typescript.astro
@@ -8,7 +8,7 @@ import Custom from '../components/Custom.sve'
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Svelte TypeScript</title>
     <style>
       html,

--- a/packages/astro/test/fixtures/third-party-astro/src/pages/astro-embed.astro
+++ b/packages/astro/test/fixtures/third-party-astro/src/pages/astro-embed.astro
@@ -4,7 +4,7 @@ import { YouTube } from 'astro-embed'
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Third-Party Package Test</title>
   </head>
   <body>

--- a/packages/astro/test/fixtures/type-imports/src/pages/index.astro
+++ b/packages/astro/test/fixtures/type-imports/src/pages/index.astro
@@ -4,7 +4,7 @@ import type { MarkdownInstance } from 'astro'
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Astro</title>
 		<style is:global>
 			h1 {

--- a/packages/integrations/image/test/fixtures/get-image-remote/src/pages/index.astro
+++ b/packages/integrations/image/test/fixtures/get-image-remote/src/pages/index.astro
@@ -14,7 +14,7 @@ const image = await getImage(i as any);
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro</title>
 	</head>

--- a/packages/integrations/markdoc/test/fixtures/entry-prop/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/entry-prop/src/pages/index.astro
@@ -9,7 +9,7 @@ const { Content } = await entry.render();
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro</title>
 	</head>

--- a/packages/integrations/markdoc/test/fixtures/image-assets/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/image-assets/src/pages/index.astro
@@ -9,7 +9,7 @@ const { Content } = await intro.render();
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro</title>
 	</head>

--- a/packages/integrations/mdx/test/fixtures/css-head-mdx/src/components/BaseHead.astro
+++ b/packages/integrations/mdx/test/fixtures/css-head-mdx/src/components/BaseHead.astro
@@ -2,7 +2,7 @@
 const { title } = Astro.props;
 ---
 <meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <meta name="generator" content={Astro.generator} />
 <title>{title}</title>

--- a/packages/integrations/mdx/test/fixtures/css-head-mdx/src/layouts/One.astro
+++ b/packages/integrations/mdx/test/fixtures/css-head-mdx/src/layouts/One.astro
@@ -5,7 +5,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro</title>
 	</head>

--- a/packages/integrations/mdx/test/fixtures/css-head-mdx/src/pages/DirectContentUsage.astro
+++ b/packages/integrations/mdx/test/fixtures/css-head-mdx/src/pages/DirectContentUsage.astro
@@ -6,7 +6,7 @@ import UsingMdx from '../components/UsingMdx.astro'
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro</title>
 	</head>

--- a/packages/integrations/netlify/test/functions/fixtures/dynamic-route/src/pages/pets/index.astro
+++ b/packages/integrations/netlify/test/functions/fixtures/dynamic-route/src/pages/pets/index.astro
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro</title>
 	</head>

--- a/packages/markdown/component/test/fixtures/astro-markdown/src/pages/nested-list.astro
+++ b/packages/markdown/component/test/fixtures/astro-markdown/src/pages/nested-list.astro
@@ -13,7 +13,7 @@ const content = `
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>Welcome to Astro</title>
 	</head>
 


### PR DESCRIPTION
## Changes

- Improve mobile support by adding initial-scale to the viewport meta tag.

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

The changes were tested locally by creating a new Astro project with `npm astro create@latest` and checking the mobile responsiveness of the page.

## Docs

This change should not affect user behavior, and no updates to the documentation are required.
