### PR TITLE
Expose partytown config options from astro plugin

### DIFF
--- a/.changeset/chilly-dingos-eat.md
+++ b/.changeset/chilly-dingos-eat.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/partytown': minor
+---
+
+Expose more partytown config properties

--- a/packages/integrations/partytown/README.md
+++ b/packages/integrations/partytown/README.md
@@ -85,7 +85,7 @@ export default defineConfig({
 });
 ```
 
-This mirrors the [Partytown config object](https://partytown.builder.io/configuration), but only `debug` and `forward` are exposed by this integration.
+This mirrors the [Partytown config object](https://partytown.builder.io/configuration).
 
 ### config.debug
 

--- a/packages/integrations/partytown/src/index.ts
+++ b/packages/integrations/partytown/src/index.ts
@@ -1,4 +1,5 @@
 import { partytownSnippet } from '@builder.io/partytown/integration';
+import type { PartytownConfig } from '@builder.io/partytown/integration';
 import { copyLibFiles, libDirPath } from '@builder.io/partytown/utils';
 import type { AstroConfig, AstroIntegration } from 'astro';
 import * as fs from 'fs';
@@ -10,10 +11,7 @@ const resolve = createRequire(import.meta.url).resolve;
 
 type PartytownOptions =
 	| {
-			config?: {
-				forward?: string[];
-				debug?: boolean;
-			};
+			config?: PartytownConfig;
 	  }
 	| undefined;
 
@@ -31,9 +29,12 @@ export default function createPlugin(options: PartytownOptions): AstroIntegratio
 		hooks: {
 			'astro:config:setup': ({ config: _config, command, injectScript }) => {
 				const lib = `${appendForwardSlash(_config.base)}~partytown/`;
-				const forward = options?.config?.forward || [];
-				const debug = options?.config?.debug || command === 'dev';
-				partytownSnippetHtml = partytownSnippet({ lib, debug, forward });
+				const partytownConfig = {
+					...options?.config,
+					lib,
+					debug: options?.config?.debug ?? command === 'dev',
+				};
+				partytownSnippetHtml = partytownSnippet(partytownConfig);
 				injectScript('head-inline', partytownSnippetHtml);
 			},
 			'astro:config:done': ({ config: _config }) => {


### PR DESCRIPTION
## Changes

- Allows developers to use the original properties defined by [partytown](https://github.com/BuilderIO/partytown/blob/main/src/lib/types.ts#L384)

## Testing
I didn't see any test's setup for the package. Do we need one?
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Removed the content that explicitly mentioned about the `debug` and `forward` properties.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
