### PR TITLE
Fix image regeneration after changing image service

### DIFF
--- a/.changeset/lovely-owls-sniff.md
+++ b/.changeset/lovely-owls-sniff.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/image': patch
+---
+
+Invalidates cache when changing serviceEntryPoint

--- a/packages/astro/src/assets/utils/transformToPath.ts
+++ b/packages/astro/src/assets/utils/transformToPath.ts
@@ -4,7 +4,7 @@ import { shorthash } from '../../runtime/server/shorthash.js';
 import { isESMImportedImage } from '../internal.js';
 import type { ImageTransform } from '../types.js';
 
-export function propsToFilename(transform: ImageTransform) {
+export function propsToFilename(transform: ImageTransform, imageService: string) {
 	if (!isESMImportedImage(transform.src)) {
 		return transform.src;
 	}
@@ -12,6 +12,9 @@ export function propsToFilename(transform: ImageTransform) {
 	let filename = removeQueryString(transform.src.src);
 	const ext = extname(filename);
 	filename = basename(filename, ext);
+	// take everything from transform except alt, which is not used in the hash
+	const { alt, ...rest } = transform;
+	const hashFields = { ...rest, imageService };
 	const outputExt = transform.format ? `.${transform.format}` : ext;
-	return `/${filename}_${shorthash(JSON.stringify(transform))}${outputExt}`;
+	return `/${filename}_${shorthash(JSON.stringify(hashFields))}${outputExt}`;
 }

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -167,7 +167,10 @@ export default function assets({
 						}
 
 						filePath = prependForwardSlash(
-							joinPaths(settings.config.build.assets, propsToFilename(options))
+							joinPaths(
+								settings.config.build.assets,
+								propsToFilename(options, settings.config.image.service)
+							)
 						);
 						globalThis.astroAsset.staticImages.set(options, filePath);
 					}

--- a/packages/integrations/image/src/index.ts
+++ b/packages/integrations/image/src/index.ts
@@ -122,7 +122,7 @@ export default function integration(options: IntegrationOptions = {}): AstroInte
 						? staticImages.get(transform.src)!
 						: new Map<string, TransformOptions>();
 
-					const filename = propsToFilename(transform);
+					const filename = propsToFilename(transform, resolvedOptions.serviceEntryPoint);
 
 					srcTranforms.set(filename, transform);
 					staticImages.set(transform.src, srcTranforms);

--- a/packages/integrations/image/src/loaders/index.ts
+++ b/packages/integrations/image/src/loaders/index.ts
@@ -95,6 +95,11 @@ export interface TransformOptions {
 	 */
 	src: string;
 	/**
+	 * The alt tag of the image. This is used for accessibility and will be made required in a future version.
+	 * Empty string is allowed.
+	 */
+	alt?: string;
+	/**
 	 * The output format to be used in the optimized image.
 	 *
 	 * @default undefined The original image format will be used.

--- a/packages/integrations/image/src/utils/paths.ts
+++ b/packages/integrations/image/src/utils/paths.ts
@@ -35,16 +35,19 @@ function basename(src: string) {
 	return removeQueryString(src.replace(/^.*[\\\/]/, ''));
 }
 
-export function propsToFilename(transform: TransformOptions) {
+export function propsToFilename(transform: TransformOptions, serviceEntryPoint: string) {
 	// strip off the querystring first, then remove the file extension
 	let filename = removeQueryString(transform.src);
+	// take everything from transform except alt, which is not used in the hash
+	const { alt, ...rest } = transform;
+	const hashFields = { ...rest, serviceEntryPoint };
 	filename = basename(filename);
 	const ext = extname(filename);
 	filename = removeExtname(filename);
 
 	const outputExt = transform.format ? `.${transform.format}` : ext;
 
-	return `/${filename}_${shorthash(JSON.stringify(transform))}${outputExt}`;
+	return `/${filename}_${shorthash(JSON.stringify(hashFields))}${outputExt}`;
 }
 
 export function appendForwardSlash(path: string) {


### PR DESCRIPTION
## Changes
I experienced very strange behaviour which resulted in images being rotated or not depending on how i change the widths or alt tags of images. I tracked this down to the image cache not being regenerated after i switched to sharp.
The behaviour of sharp differs in some ways. In my case sharp rotates the image while removing the exif data. squoosh does remove the exif data without rotating the images. When my image was the exact same image as before I got served the cached version built previously by squoosh so some images were still up side down etc. Changing the alt tag invalidated the cache, as it is used for hashing.

- Don't use the alt tag for hashing as it has nothing to do with the actual content of the image
- Include the serviceEntryPoint in the hashKey to invalidate the image cache when changing from squoosh to sharp for example.

## Testing

I did not add unit tests as my experience in this repo is very slim right now.
I verified that the behaviour is as intended by reproducing the mentioned behaviour manually.

## Docs

Now the behaviour is as intended so i don't think with a fix like this we need any additional docs
