### PR TITLE
Add validation for non-printable chars in CLI

### DIFF
--- a/.changeset/four-ads-clap.md
+++ b/.changeset/four-ads-clap.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+add validation for non-printable characters

--- a/packages/create-astro/src/actions/project-name.ts
+++ b/packages/create-astro/src/actions/project-name.ts
@@ -24,6 +24,9 @@ export async function projectName(ctx: Pick<Context, 'cwd' | 'prompt' | 'project
 				if (!isEmpty(value)) {
 					return `Directory is not empty!`;
 				}
+				// Check for non-printable characters
+				if (value.match(/[^\x20-\x7E]/g) !== null)
+					return `Invalid non-printable character present!`;
 				return true;
 			},
 		});


### PR DESCRIPTION
## Changes

fixes #6609 

Add a validation, when you set your project's name, that verifies if there is any non-printable characters in the input buffer.

- Just a regex that matches any non-printable character from ASCII table like Ctrl characters.

![Peek 2023-03-27 20-35](https://user-images.githubusercontent.com/71379045/228090308-59506777-4599-44af-80c6-6d741c185bb6.gif)

- Is this response message good? I'm accepting suggestions.

## Testing

No, I didn't find a way to test the validation that comes from the prompt.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
No docs necessary.
