### PR TITLE
Fix: Add additional null check for req.body in NodeApp.render

### DIFF
--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -48,7 +48,7 @@ export class NodeApp extends App {
 			);
 		}
 
-		if (typeof req.body === 'object' && Object.keys(req.body).length > 0) {
+		if (typeof req.body === 'object' && req.body !== null && Object.keys(req.body).length > 0) {
 			return super.render(
 				req instanceof Request
 					? req


### PR DESCRIPTION
## Changes

This PR introduces a additional check for null on the `req.body` check. Currently the body gets check for string or for object, but `typeof req.body === 'object'` will return `true` if `req.body` is `null`. For example this is the case if you are using Astro in a AWS Lambda function.
This will cause the subsequent check of `req.body !== null && Object.keys(req.body).length > 0` to throw, since `req.body` is `null`.

---
'astro': patch
---

Add a additional check for `null` on the `req.body` check in `NodeApp.render`.

## Testing

Since I couldn't find any tests for the class itself I didn't add any. Let me know if I should add tests for it.

## Docs

No docs needed since it is internal behavior