### PR TITLE
Fix CI = specify astro peer dep version for Markdoc

### DIFF
--- a/packages/integrations/markdoc/package.json
+++ b/packages/integrations/markdoc/package.json
@@ -41,7 +41,7 @@
     "zod": "^3.17.3"
   },
   "peerDependencies": {
-    "astro": "workspace:*"
+    "astro": "workspace:^2.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.1",


### PR DESCRIPTION
## Changes

- Specify `"astro"` peer dep version for Markdoc. Matches existing integrations, and hopefully fixes the 1.0.0 bump here https://github.com/withastro/astro/pull/6652

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
