### PR TITLE
Change `--open` flag minor to a patch

### DIFF
--- a/.changeset/hip-avocados-grow.md
+++ b/.changeset/hip-avocados-grow.md
@@ -1,5 +1,5 @@
 ---
-'astro': minor
+'astro': patch
 ---
 
 add new flag with open for dev and preview


### PR DESCRIPTION
## Changes

- Change minor introduced by https://github.com/withastro/astro/commit/adecda7d6009793c5d20519a997e3b7afb08ad57 to a patch. this change patches an expected API from Vite and doesn't need to trigger a 2.2.0 launch.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
