### PR TITLE
tailwind integrations guide: use <PackageManagerTabs> component

### DIFF
--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -30,15 +30,27 @@ https://user-images.githubusercontent.com/4033662/197398760-8fd30eff-4d13-449d-a
 ### Quick Install
   
 The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
-  
-```sh
-# Using NPM
-npx astro add tailwind
-# Using Yarn
-yarn astro add tailwind
-# Using PNPM
-pnpm astro add tailwind
-```
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  # Using NPM
+  npx astro add tailwind
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  # Using PNPM
+  pnpm astro add tailwind
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  # Using Yarn
+  yarn astro add tailwind
+  ```
+  </Fragment>
+</PackageManagerTabs>
   
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 


### PR DESCRIPTION
Update doc page to make use of the nicer looking \<PackageManagerTabs> for package manager selection.

Same as used in https://github.com/withastro/docs/blob/main/src/content/docs/en/install/auto.mdx?plain=1#L32
