### PR TITLE
Fix InferGetStaticParamsType and InferGetStaticPropsType not working with sync getStaticPaths

### DIFF
--- a/.changeset/odd-falcons-exist.md
+++ b/.changeset/odd-falcons-exist.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix InferGetStaticParamsType and InferGetStaticPropsType not working when getStaticPaths wasn't async

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1197,7 +1197,7 @@ export type GetStaticPaths = (
  *
  * @example
  * ```ts
- * import { GetStaticPaths } from 'astro';
+ * import type { GetStaticPaths } from 'astro';
  *
  * export const getStaticPaths = (() => {
  *   return results.map((entry) => ({
@@ -1224,7 +1224,7 @@ export type InferGetStaticParamsType<T> = T extends () => infer R | Promise<infe
  *
  * @example
  * ```ts
- * import { GetStaticPaths } from 'astro';
+ * import type { GetStaticPaths } from 'astro';
  *
  * export const getStaticPaths = (() => {
  *   return results.map((entry) => ({

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1197,11 +1197,13 @@ export type GetStaticPaths = (
  *
  * @example
  * ```ts
- * export async function getStaticPaths() {
+ * import { GetStaticPaths } from 'astro';
+ *
+ * export const getStaticPaths = (() => {
  *   return results.map((entry) => ({
  *     params: { slug: entry.slug },
  *   }));
- * }
+ * }) satisfies GetStaticPaths;
  *
  * type Params = InferGetStaticParamsType<typeof getStaticPaths>;
  * //   ^? { slug: string; }
@@ -1209,7 +1211,7 @@ export type GetStaticPaths = (
  * const { slug } = Astro.params as Params;
  * ```
  */
-export type InferGetStaticParamsType<T> = T extends () => Promise<infer R>
+export type InferGetStaticParamsType<T> = T extends () => infer R | Promise<infer R>
 	? R extends Array<infer U>
 		? U extends { params: infer P }
 			? P
@@ -1222,7 +1224,9 @@ export type InferGetStaticParamsType<T> = T extends () => Promise<infer R>
  *
  * @example
  * ```ts
- * export async function getStaticPaths() {
+ * import { GetStaticPaths } from 'astro';
+ *
+ * export const getStaticPaths = (() => {
  *   return results.map((entry) => ({
  *     params: { slug: entry.slug },
  *     props: {
@@ -1230,15 +1234,15 @@ export type InferGetStaticParamsType<T> = T extends () => Promise<infer R>
  *       propB: 42
  *     },
  *   }));
- * }
+ * }) satisfies GetStaticPaths;
  *
  * type Props = InferGetStaticPropsType<typeof getStaticPaths>;
  * //   ^? { propA: boolean; propB: number; }
  *
- * const { propA, propB } = Astro.props as Props;
+ * const { propA, propB } = Astro.props;
  * ```
  */
-export type InferGetStaticPropsType<T> = T extends () => Promise<infer R>
+export type InferGetStaticPropsType<T> = T extends () => infer R | Promise<infer R>
 	? R extends Array<infer U>
 		? U extends { props: infer P }
 			? P


### PR DESCRIPTION
## Changes

InferGetStaticParamsType and InferGetStaticPropsType always assumed that `getStaticPaths` was async, but it can be sync in some cases. This PR fixes this.

This PR additionally updates the JSDoc comments to show usage with `satisfies`, as trying to type `getStaticPaths` directly will cause InferGetStaticParamsType and InferGetStaticPropsType to not work (since they work by inferring the return value, which the type will overwrite. `satisfies` is great)

## Testing

Tested manually

## Docs

N/A
