### PR TITLE
Handle Vite 4.3 module graph changes

### DIFF
--- a/.changeset/selfish-adults-tie.md
+++ b/.changeset/selfish-adults-tie.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Handle Vite 4.3 module graph changes

--- a/packages/astro/src/core/module-loader/loader.ts
+++ b/packages/astro/src/core/module-loader/loader.ts
@@ -44,6 +44,10 @@ export interface ModuleNode {
 	ssrModule: Record<string, any> | null;
 	ssrError: Error | null;
 	importedModules: Set<ModuleNode>;
+	// Since Vite 4.3, `importedModules` strictly contains client-side imported modules only.
+	// For SSR, we need to use `ssrImportedModules` or `ssrTransformResult.deps` instead.
+	// The former is more ergonomic so we use it here.
+	ssrImportedModules?: Set<ModuleNode>;
 }
 
 export interface ModuleInfo {

--- a/packages/astro/src/core/render/dev/vite.ts
+++ b/packages/astro/src/core/render/dev/vite.ts
@@ -44,7 +44,8 @@ export async function* crawlGraph(
 		if (id === entry.id) {
 			scanned.add(id);
 			const entryIsStyle = isCSSRequest(id);
-			for (const importedModule of entry.importedModules) {
+			const entryImportedModules = entry.ssrImportedModules ?? entry.importedModules;
+			for (const importedModule of entryImportedModules) {
 				// some dynamically imported modules are *not* server rendered in time
 				// to only SSR modules that we can safely transform, we check against
 				// a list of file extensions based on our built-in vite plugins


### PR DESCRIPTION
## Changes

**DRAFT until the Vite PR is merged**

Handle the changes for https://github.com/vitejs/vite/pull/11973

We use the module graph to scan for CSS to prevent FOUC. We crawl it using `mod.importedModules`, but the field is meant for client-side imports only. Vite had mixed it with SSR and is now un-mixing it in https://github.com/vitejs/vite/pull/11973.

Although this feels like a breaking change, I think it can be justified that we should've used `mod.ssrTransformResult.deps` instead for SSR stuff, and that `mod.importedModules` were only supposed to be client-side only.

Vite 4.3 will introduce `mod.ssrImportedModules` instead so I've updated to anticipate it when we upgrade to Vite 4.3.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass. Though we're not using Vite 4.3 yet, vite-ecosystem-ci will test against it.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.