### PR TITLE
fix(check): Dynamically import check command

### DIFF
--- a/.changeset/eight-stingrays-pull.md
+++ b/.changeset/eight-stingrays-pull.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Dynamically import check command to improve startup speed and prevent Astro from crashing due to language-server stuff

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -18,7 +18,6 @@ import { enableVerboseLogging, nodeLogDestination } from '../core/logger/node.js
 import { formatConfigErrorMessage, formatErrorMessage, printHelp } from '../core/messages.js';
 import * as event from '../events/index.js';
 import { eventConfigError, eventError, telemetry } from '../events/index.js';
-import { check } from './check/index.js';
 import { openInBrowser } from './open.js';
 
 type Arguments = yargs.Arguments;
@@ -228,6 +227,8 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 		}
 
 		case 'check': {
+			const { check } = await import('./check/index.js');
+
 			// We create a server to start doing our operations
 			const checkServer = await check(settings, { flags, logging });
 			if (checkServer) {


### PR DESCRIPTION
## Changes

In a past PR, we changed all the imports to other commands to be dynamically imported so the overall CLI run faster. There's still quite a bit of improvements to be made there, but still, it helped a lot.

A previous PR added `check` back as a normal import, so this PR fixes this.

## Testing

Tests still pass and tested manually!

## Docs

N/A