### PR TITLE
fix(errors): Add simplified message for MarkdownImageNotFound

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -600,6 +600,8 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	},
 	/**
 	 * @docs
+	 * @message
+	 * Could not find requested image IMAGE_PATH at FULL_IMAGE_PATH.
 	 * @see
 	 * - [Assets (Experimental)](https://docs.astro.build/en/guides/assets/)
 	 * @description

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -601,7 +601,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	/**
 	 * @docs
 	 * @message
-	 * Could not find requested image IMAGE_PATH at FULL_IMAGE_PATH.
+	 * Could not find requested image `IMAGE_PATH` at `FULL_IMAGE_PATH`.
 	 * @see
 	 * - [Assets (Experimental)](https://docs.astro.build/en/guides/assets/)
 	 * @description


### PR DESCRIPTION
## Changes

Error references was broken because of the complex message, oops. I of all people should know this.

## Testing

N/A

## Docs

N/A
