### PR TITLE
REOPENED: Remove X-UA-Compability and fix meta tag attributes

### DIFF
--- a/examples/basics/src/layouts/Layout.astro
+++ b/examples/basics/src/layouts/Layout.astro
@@ -9,7 +9,7 @@ const { title } = Astro.props;
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />

--- a/examples/blog/src/components/BaseHead.astro
+++ b/examples/blog/src/components/BaseHead.astro
@@ -16,7 +16,7 @@ const { title, description, image = '/placeholder-social.jpg' } = Astro.props;
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="viewport" content="width=device-width" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <meta name="generator" content={Astro.generator} />
 

--- a/examples/deno/src/components/Layout.astro
+++ b/examples/deno/src/components/Layout.astro
@@ -9,7 +9,7 @@ const { title } = Astro.props as Props;
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<title>{title}</title>

--- a/examples/hackernews/src/layouts/Layout.astro
+++ b/examples/hackernews/src/layouts/Layout.astro
@@ -6,7 +6,7 @@ import Nav from '../components/Nav.astro';
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro - Hacker News</title>
 		<meta name="description" content="Hacker News Clone built with Astro" />

--- a/examples/portfolio/src/components/MainHead.astro
+++ b/examples/portfolio/src/components/MainHead.astro
@@ -12,7 +12,7 @@ const {
 } = Astro.props;
 ---
 
-<meta charset="UTF-8" />
+<meta charset="utf-8" />
 <meta name="description" property="og:description" content={description} />
 <meta name="viewport" content="width=device-width" />
 <meta name="generator" content={Astro.generator} />

--- a/examples/with-markdoc/src/layouts/Layout.astro
+++ b/examples/with-markdoc/src/layouts/Layout.astro
@@ -9,7 +9,7 @@ const { title } = Astro.props;
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />

--- a/examples/with-nanostores/src/layouts/Layout.astro
+++ b/examples/with-nanostores/src/layouts/Layout.astro
@@ -12,7 +12,7 @@ const { title } = Astro.props;
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
 	<meta name="generator" content={Astro.generator} />
 	<link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/packages/astro/e2e/fixtures/nested-styles/src/components/partials/Layout/index.astro
+++ b/packages/astro/e2e/fixtures/nested-styles/src/components/partials/Layout/index.astro
@@ -6,8 +6,7 @@ import '../../../styles/global.css'
 <html>
 	<head>
 		<meta charset="utf-8" />
-		<meta http-equiv="x-ua-compatible" content="ie=edge" />
-		<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no" />
+		<meta name="viewport" content="width=device-width,shrink-to-fit=no" />
 	</head>
 	<body>
 		<Header />

--- a/packages/astro/e2e/fixtures/tailwindcss/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/tailwindcss/src/pages/index.astro
@@ -6,7 +6,7 @@ import Complex from '../components/Complex.astro';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 		<title>Astro + TailwindCSS</title>
 	</head>

--- a/packages/astro/performance/fixtures/utils/RenderContent.astro
+++ b/packages/astro/performance/fixtures/utils/RenderContent.astro
@@ -10,9 +10,8 @@ const { posts, renderer: ContentRenderer } = Astro.props;
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Md render test</title>
 </head>
 <body>

--- a/packages/astro/src/template/4xx.ts
+++ b/packages/astro/src/template/4xx.ts
@@ -25,7 +25,7 @@ export default function template({
 	return `<!doctype html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<title>${tabTitle}</title>
 		<style>
 			${baseCSS}

--- a/packages/astro/test/fixtures/0-css/src/pages/index.astro
+++ b/packages/astro/test/fixtures/0-css/src/pages/index.astro
@@ -28,7 +28,7 @@ import raw from '../styles/raw.css?raw'
 
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="uttf-8" />
     <style lang="scss">
       .wrapper {
         margin-left: auto;

--- a/packages/astro/test/fixtures/astro-check-errors/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-check-errors/src/pages/index.astro
@@ -4,9 +4,8 @@
 
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Document</title>
 </head>
 <body>

--- a/packages/astro/test/fixtures/astro-check-no-errors/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-check-no-errors/src/pages/index.astro
@@ -1,8 +1,7 @@
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Document</title>
 </head>
 <body>

--- a/packages/astro/test/fixtures/astro-head/src/components/Head.astro
+++ b/packages/astro/test/fixtures/astro-head/src/components/Head.astro
@@ -4,7 +4,7 @@ const { title } = Astro.props;
 ---
 
 <head>
-  <meta charset="UTF-8">
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   <title>{title}</title>

--- a/packages/astro/test/fixtures/astro-markdown/src/layouts/Base.astro
+++ b/packages/astro/test/fixtures/astro-markdown/src/layouts/Base.astro
@@ -18,9 +18,8 @@ const {
 <html lang="en">
 
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 </head>
 
 <body>

--- a/packages/astro/test/fixtures/css-inline/src/layouts/Layout.astro
+++ b/packages/astro/test/fixtures/css-inline/src/layouts/Layout.astro
@@ -9,7 +9,7 @@ const { title } = Astro.props;
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />

--- a/packages/astro/test/fixtures/css-no-code-split/src/pages/index.astro
+++ b/packages/astro/test/fixtures/css-no-code-split/src/pages/index.astro
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="utf-8" />
   </head>
   <body>
     <h1>css no code split</h1>

--- a/packages/astro/test/fixtures/css-order-layout/src/components/MainHead.astro
+++ b/packages/astro/test/fixtures/css-order-layout/src/components/MainHead.astro
@@ -2,4 +2,4 @@
 import "../styles/global.css";
 ---
 
-<meta charset="UTF-8" />
+<meta charset="utf-8" />

--- a/packages/astro/test/fixtures/static-build/src/components/MainHead.astro
+++ b/packages/astro/test/fixtures/static-build/src/components/MainHead.astro
@@ -3,7 +3,7 @@ import '../styles/main.scss';
 const { title = 'Static Build', description = 'This is a demo of the static build' } = Astro.props;
 ---
 
-<meta charset="UTF-8" />
+<meta charset="utf-8" />
 <meta name="description" property="og:description" content={description} />
 <meta name="viewport" content="width=device-width" />
 <title>{title}</title>

--- a/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
+++ b/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
@@ -6,7 +6,7 @@ import Complex from '../components/Complex.astro';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 		<title>Astro + TailwindCSS</title>
 	</head>

--- a/packages/integrations/markdoc/test/fixtures/render-simple/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-simple/src/pages/index.astro
@@ -8,9 +8,8 @@ const { Content } = await post.render();
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Content</title>
 </head>
 <body>

--- a/packages/integrations/markdoc/test/fixtures/render-with-components/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-components/src/pages/index.astro
@@ -8,9 +8,8 @@ const { Content } = await post.render();
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Content</title>
 </head>
 <body>

--- a/packages/integrations/markdoc/test/fixtures/render-with-config/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-config/src/pages/index.astro
@@ -8,9 +8,8 @@ const { Content } = await post.render();
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Content</title>
 </head>
 <body>

--- a/packages/integrations/mdx/test/fixtures/css-head-mdx/src/components/BaseHead.astro
+++ b/packages/integrations/mdx/test/fixtures/css-head-mdx/src/components/BaseHead.astro
@@ -1,7 +1,7 @@
 ---
 const { title } = Astro.props;
 ---
-<meta charset="UTF-8" />
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <meta name="generator" content={Astro.generator} />

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/layouts/Base.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/layouts/Base.astro
@@ -6,9 +6,8 @@ const { frontmatter = defaults, content = defaults } = Astro.props;
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
   <title>{frontmatter.title}</title>
 </head>
 <body>

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter/src/layouts/Base.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter/src/layouts/Base.astro
@@ -16,9 +16,8 @@ const {
 <html lang="en">
 
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 </head>
 
 <body>

--- a/packages/integrations/node/test/fixtures/node-middleware/src/pages/404.astro
+++ b/packages/integrations/node/test/fixtures/node-middleware/src/pages/404.astro
@@ -4,9 +4,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
   <title>404</title>
 </head>
 <body><h1>404!!!!!!!!!!</h1></body>

--- a/packages/integrations/prefetch/test/fixtures/style-prefetch/src/pages/index.astro
+++ b/packages/integrations/prefetch/test/fixtures/style-prefetch/src/pages/index.astro
@@ -3,9 +3,8 @@
 
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
     <title>Home</title>
 </head>
 <body>

--- a/packages/integrations/prefetch/test/fixtures/style-prefetch/src/pages/style1.astro
+++ b/packages/integrations/prefetch/test/fixtures/style-prefetch/src/pages/style1.astro
@@ -3,9 +3,8 @@
 
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
     <title>Style1</title>
     <link rel="stylesheet" href="/main.css">
 </head>

--- a/packages/integrations/prefetch/test/fixtures/style-prefetch/src/pages/style2.astro
+++ b/packages/integrations/prefetch/test/fixtures/style-prefetch/src/pages/style2.astro
@@ -3,9 +3,8 @@
 
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
     <title>Style2</title>
     <link rel="stylesheet" href="/main.css">
 </head>


### PR DESCRIPTION
## Changes


- Removed X-UA-Compability meta tag.
- Changed charset attribute to use lowercase 'utf-8'.
- Removed initial-scale attribute from viewport meta tag as it's set to 1 by default.

## Testing

This change was manually tested in various browsers.

## Docs

This change does not affect user behavior and does not require documentation updates.
