### PR TITLE
gitignore env.d.ts files in e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ packages/integrations/**/.netlify/
 # ignore content collection generated files
 packages/**/test/**/fixtures/**/.astro/
 packages/**/test/**/fixtures/**/env.d.ts
+packages/**/e2e/**/fixtures/**/env.d.ts


### PR DESCRIPTION
## Changes

Tiny chore to gitignore the generated e2e `env.d.ts` files when running e2e tests locally.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
n/a

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a