### PR TITLE
ci: use correct issue number

### DIFF
--- a/.github/workflows/check-merge.yml
+++ b/.github/workflows/check-merge.yml
@@ -67,7 +67,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v2
         continue-on-error: true
         with:
-          issue-number: ${{ github.event.issue.number }}
+          issue-number: ${{ github.event.number }}
           body: |
             This PR is blocked because it contains a `minor` changeset. A reviewer will merge this at the next release if approved.
           edit-mode: replace


### PR DESCRIPTION
## Changes

This PR fixes our `Check mergeability` workflow. We were querying the incorrect info for the info number. 
The new content is valid because that's what we use for the `curl` script, which shows the correct information


## Testing

Merge and see if next time doesn't throw an error

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
N/A
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
