### PR TITLE
@astrojs/vercel: Fix vercel analytics id not being provided

### DIFF
--- a/.changeset/cyan-fireants-care.md
+++ b/.changeset/cyan-fireants-care.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Fix vercel analytics id not being set

--- a/packages/integrations/vercel/src/analytics.ts
+++ b/packages/integrations/vercel/src/analytics.ts
@@ -39,7 +39,7 @@ const sendToAnalytics = (metric: Metric, options: Options) => {
 };
 
 function webVitals() {
-	const analyticsId = (import.meta as any).env.PUBLIC_VERCEL_ANALYTICS_ID;
+	const analyticsId = (import.meta as any).env.VERCEL_ANALYTICS_ID;
 	if (!analyticsId) {
 		console.error('[Analytics] VERCEL_ANALYTICS_ID not found');
 		return;


### PR DESCRIPTION
While testing out vercel analytics using the vercel adapter, I noticed there was an error in my console stating that `VERCEL_ANALYTICS_ID` has not been provided.

After some research it looks as though it is looking for `PUBLIC_VERCEL_ANALYTICS_ID` but it is never provided. I believe this is likely the cause of the error.

[packages/integrations/vercel/src/analytics.ts](https://github.com/withastro/astro/blob/main/packages/integrations/vercel/src/analytics.ts#L42)

Running `vc pull` with the analytics enabled downloads an environment locally which contains `VERCEL_ANALYTICS_ID` and not `PUBLIC_VERCEL_ANALYTICS_ID`. The documentation also mentions that the environment variable is inlined at build time.

https://vercel.com/docs/concepts/analytics/api#getting-started

> To use the Web Vitals API, you'll need to retrieve the analytics ID for your Vercel project. This value is exposed during the build and can be accessed by process.env.VERCEL_ANALYTICS_ID inside Node.js.

## Changes

- Fix wrong environment variable being used
- Added changeset

## Testing

- Added the missing environment variable to my build and redeployed, and it worked. 
- Ran test suite and one test fails, which I believe falls outside the scope of this change.
- I have kept the builds up which demonstrate the workaround I put together before making any changes.

Before fix: https://welcome-to-astro-7lrfynd8t-nblackburn.vercel.app/
After fix: https://welcome-to-astro-irzdnom89-nblackburn.vercel.app/

![before-fix](https://user-images.githubusercontent.com/2931085/229931526-3e492f49-4c7d-439d-acac-649d10179742.png)
![during-fix](https://user-images.githubusercontent.com/2931085/229931531-8897d875-1c02-4d07-9bf1-ad384d4f625f.png)
![not-working](https://user-images.githubusercontent.com/2931085/229931534-934ef65c-01e7-41fc-a6fb-d8b281da6e78.png)
![post-fix](https://user-images.githubusercontent.com/2931085/229931539-37c29af0-ad80-4bfc-b02e-5e0c94a05913.png)

## Docs

With this being, an internal change, I don't believe it requires any changes to the documentation.

/cc @withastro/maintainers-docs for feedback!
