### PR TITLE
Fix lit integration nested component rendering

### DIFF
--- a/.changeset/angry-hounds-train.md
+++ b/.changeset/angry-hounds-train.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/lit': patch
+---
+
+Provide `renderInfo` when rendering Lit components. Fixes issue with rendering nested components.

--- a/packages/integrations/lit/server.js
+++ b/packages/integrations/lit/server.js
@@ -59,7 +59,12 @@ function* render(Component, attrs, slots) {
 	yield `<${tagName}${shouldDeferHydration ? ' defer-hydration' : ''}`;
 	yield* instance.renderAttributes();
 	yield `>`;
-	const shadowContents = instance.renderShadow({});
+	const shadowContents = instance.renderShadow({
+		elementRenderers: [LitElementRenderer],
+		customElementInstanceStack: [instance],
+		customElementHostStack: [],
+		deferHydration: false,
+	});
 	if (shadowContents !== undefined) {
 		const { mode = 'open', delegatesFocus } = instance.shadowRootOptions ?? {};
 		// `delegatesFocus` is intentionally allowed to coerce to boolean to

--- a/packages/integrations/lit/test/server.test.js
+++ b/packages/integrations/lit/test/server.test.js
@@ -90,6 +90,30 @@ describe('renderToStaticMarkup', () => {
 		expect($(`${tagName} template`).text()).to.contain(`Hello ${prop1}`);
 	});
 
+	it('should render nested components', async () => {
+		const tagName = 'parent-component';
+		const childTagName = 'child-component';
+		customElements.define(
+			childTagName,
+			class extends LitElement {
+				render() {
+					return html`<p>child</p>`;
+				}
+			}
+		);
+		customElements.define(
+			tagName,
+			class extends LitElement {
+				render() {
+					return html`<child-component></child-component>`;
+				}
+			}
+		);
+		const render = await renderToStaticMarkup(tagName);
+		const $ = cheerio.load(render.html);
+		expect($(`${tagName} template`).text()).to.contain('child');
+	});
+
 	it('should render DSD attributes based on shadowRootOptions', async () => {
 		const tagName = 'shadow-root-options-component';
 		customElements.define(


### PR DESCRIPTION
## Changes

Provides a `renderInfo` object to `renderShadow` to properly handle nested component rendering.
Fixes #6743 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added a case for it in the mocha test.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A