### PR TITLE
Fix getViteConfig return type

### DIFF
--- a/.changeset/empty-moose-grin.md
+++ b/.changeset/empty-moose-grin.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `getViteConfig` return type

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -1,4 +1,5 @@
 type ViteUserConfig = import('vite').UserConfig;
+type ViteUserConfigFn = import('vite').UserConfigFn;
 type AstroUserConfig = import('./dist/@types/astro.js').AstroUserConfig;
 
 /**
@@ -10,4 +11,4 @@ export function defineConfig(config: AstroUserConfig): AstroUserConfig;
 /**
  * Use Astro to generate a fully resolved Vite config
  */
-export function getViteConfig(config: ViteUserConfig): ViteUserConfig;
+export function getViteConfig(config: ViteUserConfig): ViteUserConfigFn;


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/6750

`getViteConfig` returns a Vite config function, not the Vite config

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Manually tested the `with-vitest` example which uses this API, and it still works.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. it doesn't look like `getViteConfig` is documented currently.