### PR TITLE
test: remove outdated image() import

### DIFF
--- a/packages/astro/test/fixtures/astro-assets-prefix/src/content/config.ts
+++ b/packages/astro/test/fixtures/astro-assets-prefix/src/content/config.ts
@@ -1,7 +1,7 @@
-import { defineCollection, z, image } from "astro:content";
+import { defineCollection, z } from "astro:content";
 
 const blogCollection = defineCollection({
-  schema: z.object({
+  schema: ({image}) => z.object({
     title: z.string(),
     cover: image(),
   }),


### PR DESCRIPTION
## Changes

A test still used the old image() import, this caused CI to fail

## Testing

CI should pass!

## Docs

N/A