### PR TITLE
Show the actual error when there was an error while generating types

### DIFF
--- a/.changeset/metal-lizards-arrive.md
+++ b/.changeset/metal-lizards-arrive.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improved error message when an error was encountered while generating types

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -828,7 +828,8 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	GenerateContentTypesError: {
 		title: 'Failed to generate content types.',
 		code: 8001,
-		message: '`astro sync` command failed to generate content collection types.',
+		message: (errorMessage: string) =>
+			`\`astro sync\` command failed to generate content collection types: ${errorMessage}`,
 		hint: 'Check your `src/content/config.*` file for typos.',
 	},
 	/**

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -10,7 +10,7 @@ import { runHookConfigSetup } from '../../integrations/index.js';
 import { setUpEnvTs } from '../../vite-plugin-inject-env-ts/index.js';
 import { getTimeStat } from '../build/util.js';
 import { createVite } from '../create-vite.js';
-import { AstroError, AstroErrorData } from '../errors/index.js';
+import { AstroError, AstroErrorData, createSafeError } from '../errors/index.js';
 import { info, type LogOptions } from '../logger/core.js';
 import { printHelp } from '../messages.js';
 
@@ -98,7 +98,14 @@ export async function sync(
 			}
 		}
 	} catch (e) {
-		throw new AstroError(AstroErrorData.GenerateContentTypesError);
+		const safeError = createSafeError(e);
+		throw new AstroError(
+			{
+				...AstroErrorData.GenerateContentTypesError,
+				message: AstroErrorData.GenerateContentTypesError.message(safeError.message),
+			},
+			{ cause: e }
+		);
 	} finally {
 		await tempViteServer.close();
 	}


### PR DESCRIPTION
## Changes

We previously swallowed the error message when there was an error while generating content collection types. This PR fixes that

## Testing

Tested manually

## Docs

N/A