### PR TITLE
Exporting ImageFunction from astro:content

### DIFF
--- a/.changeset/big-poems-march.md
+++ b/.changeset/big-poems-march.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Exporting the ImageFunction in astro:content and grouping it under a SchemaContext

--- a/packages/astro/src/content/template/types.d.ts
+++ b/packages/astro/src/content/template/types.d.ts
@@ -33,7 +33,7 @@ declare module 'astro:content' {
 	export const image: never;
 
 	// This needs to be in sync with ImageMetadata
-	type ImageFunction = () => import('astro/zod').ZodObject<{
+	export type ImageFunction = () => import('astro/zod').ZodObject<{
 		src: import('astro/zod').ZodString;
 		width: import('astro/zod').ZodNumber;
 		height: import('astro/zod').ZodNumber;
@@ -63,8 +63,10 @@ declare module 'astro:content' {
 		| BaseSchemaWithoutEffects
 		| import('astro/zod').ZodEffects<BaseSchemaWithoutEffects>;
 
+	export type SchemaContext = { image: ImageFunction };
+
 	type BaseCollectionConfig<S extends BaseSchema> = {
-		schema?: S | (({ image }: { image: ImageFunction }) => S);
+		schema?: S | ((context: SchemaContext) => S);
 		slug?: (entry: {
 			id: CollectionEntry<keyof typeof entryMap>['id'];
 			defaultSlug: string;


### PR DESCRIPTION
As of now, if you want to declare your schemas separate from the collection function, some hacks like these are needed:

```ts
type Schema = Parameters<typeof defineCollection>[0]['schema']

const blogSchema: Schema = ({ image }) => z.object({
  title: z.string(),
  date: z.coerce.date(),
  description: z.string(),
  tags: z.array(z.string()),
  draft: z.boolean().default(false),
  banner: image(),
})
```

Doing this might be needed if you want to use the schema in other places so you can export the type of the schema.

## Changes

Exports the `ImageFunction` and gives the object passed to the schema function a name.

## Testing

Just a type change so no tests should be needed.

## Docs

This should be more of a QoL update and types aren't documented in general from what I know.
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
