### PR TITLE
Update client types to match Vite

### DIFF
--- a/.changeset/fast-worms-agree.md
+++ b/.changeset/fast-worms-agree.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updated types to match newer Vite versions

--- a/packages/astro/client-base.d.ts
+++ b/packages/astro/client-base.d.ts
@@ -178,6 +178,10 @@ declare module '*.module.pcss' {
 	const classes: CSSModuleClasses;
 	export default classes;
 }
+declare module '*.module.sss' {
+	const classes: CSSModuleClasses;
+	export default classes;
+}
 
 // CSS
 declare module '*.css' {
@@ -208,9 +212,31 @@ declare module '*.pcss' {
 	const css: string;
 	export default css;
 }
+declare module '*.sss' {
+	const css: string;
+	export default css;
+}
 
 // Built-in asset types
-// see `src/constants.ts`
+// see `src/node/constants.ts`
+
+// images
+declare module '*.jfif' {
+	const src: string;
+	export default src;
+}
+declare module '*.pjpeg' {
+	const src: string;
+	export default src;
+}
+declare module '*.pjp' {
+	const src: string;
+	export default src;
+}
+declare module '*.ico' {
+	const src: string;
+	export default src;
+}
 
 // media
 declare module '*.mp4' {
@@ -242,6 +268,11 @@ declare module '*.aac' {
 	export default src;
 }
 
+declare module '*.opus' {
+	const src: string;
+	export default src;
+}
+
 // fonts
 declare module '*.woff' {
 	const src: string;
@@ -265,10 +296,6 @@ declare module '*.otf' {
 }
 
 // other
-declare module '*.wasm' {
-	const initWasm: (options: WebAssembly.Imports) => Promise<WebAssembly.Exports>;
-	export default initWasm;
-}
 declare module '*.webmanifest' {
 	const src: string;
 	export default src;
@@ -280,6 +307,12 @@ declare module '*.pdf' {
 declare module '*.txt' {
 	const src: string;
 	export default src;
+}
+
+// wasm?init
+declare module '*.wasm?init' {
+	const initWasm: (options: WebAssembly.Imports) => Promise<WebAssembly.Instance>;
+	export default initWasm;
 }
 
 // web worker
@@ -297,11 +330,28 @@ declare module '*?worker&inline' {
 	export default workerConstructor;
 }
 
+declare module '*?worker&url' {
+	const src: string;
+	export default src;
+}
+
 declare module '*?sharedworker' {
 	const sharedWorkerConstructor: {
 		new (): SharedWorker;
 	};
 	export default sharedWorkerConstructor;
+}
+
+declare module '*?sharedworker&inline' {
+	const sharedWorkerConstructor: {
+		new (): SharedWorker;
+	};
+	export default sharedWorkerConstructor;
+}
+
+declare module '*?sharedworker&url' {
+	const src: string;
+	export default src;
 }
 
 declare module '*?raw' {


### PR DESCRIPTION
## Changes

Our client types were severely outdated. We unfortunately cannot use Vite's since we need different types for images so we have to manually copy paste them

## Testing

Tested manually

## Docs

N/A