### PR TITLE
feat(prerender): support quoted true / false values and 0 / 1

### DIFF
--- a/.changeset/cuddly-eels-melt.md
+++ b/.changeset/cuddly-eels-melt.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow `import.meta.env` values of `0`, `1`, `true`, and `false` to be used for `export const prerender` statements

--- a/packages/astro/src/vite-plugin-scanner/scan.ts
+++ b/packages/astro/src/vite-plugin-scanner/scan.ts
@@ -13,6 +13,25 @@ function includesExport(code: string) {
 	return false;
 }
 
+// Support quoted values to allow statically known `import.meta.env` variables to be used
+function isQuoted(value: string) {
+	return (value[0] === '"' || value[0] === "'") && value[value.length - 1] === value[0]
+}
+
+function isTruthy(value: string) {
+	if (isQuoted(value)) {
+		value = value.slice(1, -1);
+	}
+	return value === 'true' || value === '1';
+}
+
+function isFalsy(value: string) {
+	if (isQuoted(value)) {
+		value = value.slice(1, -1);
+	}
+	return value === 'false' || value === '0';
+}
+
 let didInit = false;
 
 export async function scan(code: string, id: string): Promise<PageOptions> {
@@ -39,14 +58,14 @@ export async function scan(code: string, id: string): Promise<PageOptions> {
 			// For a given export, check the value of the first non-whitespace token.
 			// Basically extract the `true` from the statement `export const prerender = true`
 			const suffix = code.slice(endOfLocalName).trim().replace(/\=/, '').trim().split(/[;\n]/)[0];
-			if (prefix !== 'const' || !(suffix === 'true' || suffix === 'false')) {
+			if (prefix !== 'const' || !(isTruthy(suffix) || isFalsy(suffix))) {
 				throw new AstroError({
 					...AstroErrorData.InvalidPrerenderExport,
 					message: AstroErrorData.InvalidPrerenderExport.message(prefix, suffix),
 					location: { file: id },
 				});
 			} else {
-				pageOptions[name as keyof PageOptions] = suffix === 'true';
+				pageOptions[name as keyof PageOptions] = isTruthy(suffix);
 			}
 		}
 	}

--- a/packages/astro/test/units/vite-plugin-scanner/scan.test.js
+++ b/packages/astro/test/units/vite-plugin-scanner/scan.test.js
@@ -17,6 +17,36 @@ describe('astro scan', () => {
 		expect(result.prerender).to.equal(false);
 	});
 
+	it('recognizes single quoted boolean (\'true\')', async () => {
+		const result = await scan(`export const prerender = 'true';`, '/src/components/index.astro');
+		expect(result.prerender).to.equal(true);
+	});
+
+	it('recognizes double quoted boolean ("true")', async () => {
+		const result = await scan(`export const prerender = "true";`, '/src/components/index.astro');
+		expect(result.prerender).to.equal(true);
+	});
+
+	it('recognizes double quoted boolean ("false")', async () => {
+		const result = await scan(`export const prerender = "false";`, '/src/components/index.astro');
+		expect(result.prerender).to.equal(false);
+	});
+
+	it('recognizes single quoted boolean (\'false\')', async () => {
+		const result = await scan(`export const prerender = 'false';`, '/src/components/index.astro');
+		expect(result.prerender).to.equal(false);
+	});
+
+	it('recognizes number (1)', async () => {
+		const result = await scan(`export const prerender = 1;`, '/src/components/index.astro');
+		expect(result.prerender).to.equal(true);
+	});
+
+	it('recognizes number (0)', async () => {
+		const result = await scan(`export const prerender = 0;`, '/src/components/index.astro');
+		expect(result.prerender).to.equal(false);
+	});
+
 	it('throws on let boolean literal', async () => {
 		try {
 			const result = await scan(`export let prerender = true;`, '/src/components/index.astro');


### PR DESCRIPTION
## Changes

- Adds `export const prerender` support for quoted values of `"true" | "false" | 'true' | 'false'` as well as the literal values `0`, `1`.
- This is helpful because Astro replaces `import.meta.env.MY_VALUE` values statically before `prerender` is scanned for.
- This should unblock users to control prerendering by using an environment variable like 
  ```
  PRERENDER_ENABLED=true
  ```
  ```astro
  ---
  export const prerender = import.meta.env.PRERENDER_ENABLED
  ---
  ```

## Testing

Scan function unit tests have been updated to check `"true" | "false" | 'true' | 'false'` and `0 | 1`. Did not test `import.meta.env.MY_VALUE` replacement directly, but can if that seems wise.

## Docs

This is mostly intended to unblock users that have tried this already, not sure if we want to document this as an explicit feature yet since we might end up with a different pattern for "preview deploys".