### PR TITLE
Fix: remove `slug()` from `defineCollection()`

### DIFF
--- a/.changeset/good-gorillas-compare.md
+++ b/.changeset/good-gorillas-compare.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix: remove old `slug()` type from `defineCollection()` helper

--- a/packages/astro/src/content/template/types.d.ts
+++ b/packages/astro/src/content/template/types.d.ts
@@ -67,13 +67,6 @@ declare module 'astro:content' {
 
 	type BaseCollectionConfig<S extends BaseSchema> = {
 		schema?: S | ((context: SchemaContext) => S);
-		slug?: (entry: {
-			id: CollectionEntry<keyof typeof entryMap>['id'];
-			defaultSlug: string;
-			collection: string;
-			body: string;
-			data: import('astro/zod').infer<S>;
-		}) => string | Promise<string>;
 	};
 	export function defineCollection<S extends BaseSchema>(
 		input: BaseCollectionConfig<S>


### PR DESCRIPTION
## Changes

- Remove legacy `slug()` from `defineCollection()`. Was removed for 2.0 and missed in the type defs.
## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
