### PR TITLE
Support streaming inside of slots

### DIFF
--- a/.changeset/old-bugs-watch.md
+++ b/.changeset/old-bugs-watch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Support streaming inside of slots

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -106,7 +106,7 @@
     "test:e2e:match": "playwright test -g"
   },
   "dependencies": {
-    "@astrojs/compiler": "^1.3.0",
+    "@astrojs/compiler": "0.0.0-slot-stream-20230406173443",
     "@astrojs/language-server": "^0.28.3",
     "@astrojs/markdown-remark": "^2.1.3",
     "@astrojs/telemetry": "^2.1.0",

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -9,7 +9,7 @@ import type {
 	SSRLoadedRenderer,
 	SSRResult,
 } from '../../@types/astro';
-import { renderSlot, stringifyChunk, type ComponentSlots } from '../../runtime/server/index.js';
+import { renderSlotToString, stringifyChunk, type ComponentSlots } from '../../runtime/server/index.js';
 import { renderJSX } from '../../runtime/server/jsx.js';
 import { AstroCookies } from '../cookies/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
@@ -105,7 +105,7 @@ class Slots {
 			const expression = getFunctionExpression(component);
 			if (expression) {
 				const slot = () => expression(...args);
-				return await renderSlot(result, slot).then((res) => (res != null ? String(res) : res));
+				return await renderSlotToString(result, slot).then((res) => (res != null ? String(res) : res));
 			}
 			// JSX
 			if (typeof component === 'function') {
@@ -115,7 +115,7 @@ class Slots {
 			}
 		}
 
-		const content = await renderSlot(result, this.#slots[name]);
+		const content = await renderSlotToString(result, this.#slots[name]);
 		const outHTML = stringifyChunk(result, content);
 
 		return outHTML;

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -17,7 +17,7 @@ export {
 	renderHTMLElement,
 	renderPage,
 	renderScriptElement,
-	renderSlot,
+	renderSlotToString,
 	renderStyleElement,
 	renderTemplate as render,
 	renderTemplate,

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -18,6 +18,7 @@ export {
 	renderPage,
 	renderScriptElement,
 	renderSlotToString,
+	renderSlot,
 	renderStyleElement,
 	renderTemplate as render,
 	renderTemplate,

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -17,7 +17,7 @@ import {
 } from './astro/index.js';
 import { Fragment, Renderer, stringifyChunk } from './common.js';
 import { componentIsHTMLElement, renderHTMLElement } from './dom.js';
-import { renderSlot, renderSlots, type ComponentSlots } from './slot.js';
+import { renderSlotToString, renderSlots, type ComponentSlots } from './slot.js';
 import { formatList, internalSpreadAttributes, renderElement, voidElementNames } from './util.js';
 
 const rendererAliases = new Map([['solid', 'solid-js']]);
@@ -207,7 +207,7 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 		}
 	} else {
 		if (metadata.hydrate === 'only') {
-			html = await renderSlot(result, slots?.fallback);
+			html = await renderSlotToString(result, slots?.fallback);
 		} else {
 			({ html, attrs } = await renderer.ssr.renderToStaticMarkup.call(
 				{ result },
@@ -332,7 +332,7 @@ function sanitizeElementName(tag: string) {
 }
 
 async function renderFragmentComponent(result: SSRResult, slots: ComponentSlots = {}) {
-	const children = await renderSlot(result, slots?.default);
+	const children = await renderSlotToString(result, slots?.default);
 	if (children == null) {
 		return children;
 	}

--- a/packages/astro/src/runtime/server/render/dom.ts
+++ b/packages/astro/src/runtime/server/render/dom.ts
@@ -1,7 +1,7 @@
 import type { SSRResult } from '../../../@types/astro';
 
 import { markHTMLString } from '../escape.js';
-import { renderSlot } from './slot.js';
+import { renderSlotToString } from './slot.js';
 import { toAttributeString } from './util.js';
 
 export function componentIsHTMLElement(Component: unknown) {
@@ -23,7 +23,7 @@ export async function renderHTMLElement(
 	}
 
 	return markHTMLString(
-		`<${name}${attrHTML}>${await renderSlot(result, slots?.default)}</${name}>`
+		`<${name}${attrHTML}>${await renderSlotToString(result, slots?.default)}</${name}>`
 	);
 }
 

--- a/packages/astro/src/runtime/server/render/index.ts
+++ b/packages/astro/src/runtime/server/render/index.ts
@@ -10,7 +10,7 @@ export { renderComponent, renderComponentToIterable } from './component.js';
 export { renderHTMLElement } from './dom.js';
 export { maybeRenderHead, renderHead } from './head.js';
 export { renderPage } from './page.js';
-export { renderSlotToString, type ComponentSlots } from './slot.js';
+export { renderSlotToString, renderSlot, type ComponentSlots } from './slot.js';
 export { renderScriptElement, renderStyleElement, renderUniqueStylesheet } from './tags.js';
 export type { RenderInstruction } from './types';
 export { addAttribute, defineScriptVars, voidElementNames } from './util.js';

--- a/packages/astro/src/runtime/server/render/index.ts
+++ b/packages/astro/src/runtime/server/render/index.ts
@@ -10,7 +10,7 @@ export { renderComponent, renderComponentToIterable } from './component.js';
 export { renderHTMLElement } from './dom.js';
 export { maybeRenderHead, renderHead } from './head.js';
 export { renderPage } from './page.js';
-export { renderSlot, type ComponentSlots } from './slot.js';
+export { renderSlotToString, type ComponentSlots } from './slot.js';
 export { renderScriptElement, renderStyleElement, renderUniqueStylesheet } from './tags.js';
 export type { RenderInstruction } from './types';
 export { addAttribute, defineScriptVars, voidElementNames } from './util.js';

--- a/packages/astro/src/runtime/server/render/slot.ts
+++ b/packages/astro/src/runtime/server/render/slot.ts
@@ -25,35 +25,41 @@ export function isSlotString(str: string): str is any {
 	return !!(str as any)[slotString];
 }
 
+export async function * renderSlot(
+	result: SSRResult,
+	slotted: ComponentSlotValue | RenderTemplateResult,
+	fallback?: ComponentSlotValue | RenderTemplateResult
+): AsyncGenerator<any, void, undefined> {
+	if (slotted) {
+		let iterator = renderChild(typeof slotted === 'function' ? slotted(result) : slotted);
+		yield * iterator;
+	}
+
+	if (fallback) {
+		yield * renderSlot(result, fallback);
+	}
+}
+
 export async function renderSlotToString(
 	result: SSRResult,
 	slotted: ComponentSlotValue | RenderTemplateResult,
 	fallback?: ComponentSlotValue | RenderTemplateResult
 ): Promise<string> {
-	if (slotted) {
-		let iterator = renderChild(typeof slotted === 'function' ? slotted(result) : slotted);
-		let content = '';
-		let instructions: null | RenderInstruction[] = null;
-		for await (const chunk of iterator) {
-			if (typeof (chunk as any).type === 'string') {
-				if (instructions === null) {
-					instructions = [];
-				}
-				instructions.push(chunk);
-			} else {
-				content += chunk;
+	let content = '';
+	let instructions: null | RenderInstruction[] = null;
+	let iterator = renderSlot(result, slotted, fallback);
+	for await (const chunk of iterator) {
+		if (typeof (chunk as any).type === 'string') {
+			if (instructions === null) {
+				instructions = [];
 			}
+			instructions.push(chunk);
+		} else {
+			content += chunk;
 		}
-		return markHTMLString(new SlotString(content, instructions));
 	}
-
-	if (fallback) {
-		return renderSlotToString(result, fallback);
-	}
-	return '';
+	return markHTMLString(new SlotString(content, instructions));
 }
-
-export const renderSlot = renderSlotToString;
 
 interface RenderSlotsResult {
 	slotInstructions: null | RenderInstruction[];

--- a/packages/astro/src/runtime/server/render/slot.ts
+++ b/packages/astro/src/runtime/server/render/slot.ts
@@ -25,7 +25,7 @@ export function isSlotString(str: string): str is any {
 	return !!(str as any)[slotString];
 }
 
-export async function renderSlot(
+export async function renderSlotToString(
 	result: SSRResult,
 	slotted: ComponentSlotValue | RenderTemplateResult,
 	fallback?: ComponentSlotValue | RenderTemplateResult
@@ -48,10 +48,12 @@ export async function renderSlot(
 	}
 
 	if (fallback) {
-		return renderSlot(result, fallback);
+		return renderSlotToString(result, fallback);
 	}
 	return '';
 }
+
+export const renderSlot = renderSlotToString;
 
 interface RenderSlotsResult {
 	slotInstructions: null | RenderInstruction[];
@@ -67,7 +69,7 @@ export async function renderSlots(
 	if (slots) {
 		await Promise.all(
 			Object.entries(slots).map(([key, value]) =>
-				renderSlot(result, value).then((output: any) => {
+				renderSlotToString(result, value).then((output: any) => {
 					if (output.instructions) {
 						if (slotInstructions === null) {
 							slotInstructions = [];

--- a/packages/astro/test/fixtures/streaming/src/components/BareComponent.astro
+++ b/packages/astro/test/fixtures/streaming/src/components/BareComponent.astro
@@ -1,0 +1,3 @@
+<section>
+	<slot />
+</section>

--- a/packages/astro/test/fixtures/streaming/src/components/Wait.astro
+++ b/packages/astro/test/fixtures/streaming/src/components/Wait.astro
@@ -1,0 +1,6 @@
+---
+import { wait } from '../wait';
+const { ms } = Astro.props;
+await wait(ms);
+---
+<slot></slot>

--- a/packages/astro/test/fixtures/streaming/src/pages/slot.astro
+++ b/packages/astro/test/fixtures/streaming/src/pages/slot.astro
@@ -1,0 +1,24 @@
+---
+import BareComponent from '../components/BareComponent.astro';
+import Wait from '../components/Wait.astro';
+---
+
+<html>
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<h1>Testing</h1>
+		<BareComponent>
+			<h1>Section title</h1>
+			<Wait ms={10}>
+				<p>Section content</p>
+			</Wait>
+			<h2>Next section</h2>
+			<Wait ms={10}>
+				<p>Section content</p>
+			</Wait>
+			<p>Paragraph 3</p>
+		</BareComponent>
+	</body>
+</html>

--- a/packages/astro/test/streaming.test.js
+++ b/packages/astro/test/streaming.test.js
@@ -9,6 +9,8 @@ describe('Streaming', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
 
+	let decoder = new TextDecoder();
+
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/streaming/',
@@ -33,10 +35,20 @@ describe('Streaming', () => {
 			let res = await fixture.fetch('/');
 			let chunks = [];
 			for await (const bytes of streamAsyncIterator(res.body)) {
-				let chunk = bytes.toString('utf-8');
+				let chunk = decoder.decode(bytes);
 				chunks.push(chunk);
 			}
 			expect(chunks.length).to.be.greaterThan(1);
+		});
+
+		it('Body of slots is chunked', async () => {
+			let res = await fixture.fetch('/slot');
+			let chunks = [];
+			for await (const bytes of streamAsyncIterator(res.body)) {
+				let chunk = decoder.decode(bytes);
+				chunks.push(chunk);
+			}
+			expect(chunks.length).to.be.greaterThan(2);
 		});
 	});
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,7 +426,7 @@ importers:
 
   packages/astro:
     specifiers:
-      '@astrojs/compiler': ^1.3.0
+      '@astrojs/compiler': 0.0.0-slot-stream-20230406173443
       '@astrojs/language-server': ^0.28.3
       '@astrojs/markdown-remark': ^2.1.3
       '@astrojs/telemetry': ^2.1.0
@@ -519,7 +519,7 @@ importers:
       yargs-parser: ^21.0.1
       zod: ^3.17.3
     dependencies:
-      '@astrojs/compiler': 1.3.0
+      '@astrojs/compiler': 0.0.0-slot-stream-20230406173443
       '@astrojs/language-server': 0.28.3
       '@astrojs/markdown-remark': link:../markdown/remark
       '@astrojs/telemetry': link:../telemetry
@@ -4266,12 +4266,12 @@ packages:
       sisteransi: 1.0.5
     dev: false
 
+  /@astrojs/compiler/0.0.0-slot-stream-20230406173443:
+    resolution: {integrity: sha512-DeExBk+VmELL+3zVyGUVuwyVkSsJua4XwSvz5zVVm+P03JzZ1c8VUykP/wxCwOARLSGIOsB84SkPiQEZaFUW1g==}
+    dev: false
+
   /@astrojs/compiler/0.31.4:
     resolution: {integrity: sha512-6bBFeDTtPOn4jZaiD3p0f05MEGQL9pw2Zbfj546oFETNmjJFWO3nzHz6/m+P53calknCvyVzZ5YhoBLIvzn5iw==}
-
-  /@astrojs/compiler/1.3.0:
-    resolution: {integrity: sha512-VxSj3gh/UTB/27rkRCT7SvyGjWtuxUO7Jf7QqDduch7j/gr/uA5P/Q5I/4zIIrZjy2yQAKyKLoox2QI2mM/BSA==}
-    dev: false
 
   /@astrojs/language-server/0.28.3:
     resolution: {integrity: sha512-fPovAX/X46eE2w03jNRMpQ7W9m2mAvNt4Ay65lD9wl1Z5vIQYxlg7Enp9qP225muTr4jSVB5QiLumFJmZMAaVA==}


### PR DESCRIPTION
## Changes

- In order to support the `Astro.slots.render('name')` API previously `renderSlot` returned a string. This meant no streaming of slots.
- Refactored that function to `renderSlotToString`. It's still used a bit internally.
- Changed `renderSlot`, which is now just used inside the template (for `<slot></slot>`) to stream.
- Depends on the compiler fix to preserve whitespace and newlines inside slots: https://github.com/withastro/compiler/pull/770
- Closes https://github.com/withastro/astro/issues/6561

## Testing

- Added test case to our existing streaming tests

## Docs

N/A, bug fix