### PR TITLE
Revert vercel env fix

### DIFF
--- a/.changeset/shaggy-chefs-build.md
+++ b/.changeset/shaggy-chefs-build.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Revert change to environment variable

--- a/packages/integrations/vercel/src/analytics.ts
+++ b/packages/integrations/vercel/src/analytics.ts
@@ -39,7 +39,7 @@ const sendToAnalytics = (metric: Metric, options: Options) => {
 };
 
 function webVitals() {
-	const analyticsId = (import.meta as any).env.VERCEL_ANALYTICS_ID;
+	const analyticsId = (import.meta as any).env.PUBLIC_VERCEL_ANALYTICS_ID;
 	if (!analyticsId) {
 		console.error('[Analytics] VERCEL_ANALYTICS_ID not found');
 		return;


### PR DESCRIPTION
Apologies, in my efforts to find out why the key wasn't being included, allowed myself to lose track of the fact that only environment variables that are prefixed with PUBLIC_ will be bundled at build time.

## Changes

- Reverts #6751 

## Testing

Didn't have the desired effect, this simply reverts it back to how it was.

## Docs

- Fixes a previously unfixed patch (specifically in the case where it was working before)
- Remains broken for those it was broken for before

/cc @withastro/maintainers-docs for feedback!
