### PR TITLE
Fix/scoped css does not apply to Picture

### DIFF
--- a/.changeset/sour-dryers-guess.md
+++ b/.changeset/sour-dryers-guess.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+fix: scoped css does not apply to Picture

--- a/packages/integrations/image/components/Picture.astro
+++ b/packages/integrations/image/components/Picture.astro
@@ -17,6 +17,7 @@ const {
 	formats = ['avif', 'webp'],
 	loading = 'lazy',
 	decoding = 'async',
+	class: className,
 	...attrs
 } = Astro.props;
 
@@ -39,7 +40,7 @@ delete image.width;
 delete image.height;
 ---
 
-<picture>
+<picture class={className}>
 	{sources.map((attrs) => <source {...attrs} {sizes} />)}
-	<img {...image} {loading} {decoding} {...attrs} />
+	<img {...image} {loading} {decoding} class={className} {...attrs} />
 </picture>


### PR DESCRIPTION
## Changes

fixes #6574

- Pass class attribute to the `<Picture />` component so the scope class is applied.
- I used className as the variable name to prevent any issue with the class keyword.

## Compiled HTML

### Before
```html
<picture>
   <source type="image/avif" srcset="/_astro/mypicture_ZeFaVg.avif 400w,/_astro/mypicture_1Hh42H.avif 800w,/_astro/mypicture_Z2c6PSF.avif 1200w" sizes="(max-width: 375px) 50vw, 75vw">
   <source type="image/webp" srcset="/_astro/mypicture_1tYFrG.webp 400w,/_astro/mypicture_Z1Dfdnh.webp 800w,/_astro/mypicture_ZkvIfu.webp 1200w" sizes="(max-width: 375px) 50vw, 75vw">
   <source type="image/png" srcset="/_astro/mypicture_FXu5O.png 400w,/_astro/mypicture_Z2rgoJ9.png 800w,/_astro/mypicture_m3iDz.png 1200w" sizes="(max-width: 375px) 50vw, 75vw">
   <img alt="image" src="/_astro/mypicture_m3iDz.png" loading="lazy" decoding="async" class="astro-J7PV25F6">
</picture>
```

### After
```html
<picture class="astro-J7PV25F6">
   <source type="image/avif" srcset="/_astro/mypicture_ZeFaVg.avif 400w,/_astro/mypicture_1Hh42H.avif 800w,/_astro/mypicture_Z2c6PSF.avif 1200w" sizes="(max-width: 375px) 50vw, 75vw">
   <source type="image/webp" srcset="/_astro/mypicture_1tYFrG.webp 400w,/_astro/mypicture_Z1Dfdnh.webp 800w,/_astro/mypicture_ZkvIfu.webp 1200w" sizes="(max-width: 375px) 50vw, 75vw">
   <source type="image/png" srcset="/_astro/mypicture_FXu5O.png 400w,/_astro/mypicture_Z2rgoJ9.png 800w,/_astro/mypicture_m3iDz.png 1200w" sizes="(max-width: 375px) 50vw, 75vw">
   <img alt="image" src="/_astro/mypicture_m3iDz.png" loading="lazy" decoding="async" class="astro-J7PV25F6">
</picture>
```

## Testing

O think it's no necessary because the change is simple.

## Docs

No docs necessary.
