### PR TITLE
fix(error-overlay): force error overlay direction to be LTR

### DIFF
--- a/.changeset/beige-humans-study.md
+++ b/.changeset/beige-humans-study.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Force error overlay direction to be LTR

--- a/packages/astro/src/core/errors/overlay.ts
+++ b/packages/astro/src/core/errors/overlay.ts
@@ -584,6 +584,7 @@ class ErrorOverlay extends HTMLElement {
 		super();
 		this.root = this.attachShadow({ mode: 'open' });
 		this.root.innerHTML = overlayTemplate;
+		this.dir = 'ltr';
 
 		// theme toggle logic
 		const themeToggle = this.root.querySelector<HTMLInputElement>('.theme-toggle-checkbox');


### PR DESCRIPTION
## Changes

The error overlay is designed for LTR (Left to Right) documents so when I change my document's direction to RTL (`<html dir="rtl"`) it breaks. I forced the direction to be LTR because it doesn't make sense to be RTL. The error message and the codes would be hard to read in RTL.

Before:

![Screenshot from 2023-04-07 18-21-51](https://user-images.githubusercontent.com/87268103/230629837-c310e7d7-e946-43a1-b9c7-e5c1f53199b1.png)


After:

![Screenshot from 2023-04-07 18-22-38](https://user-images.githubusercontent.com/87268103/230629798-a08fcdbb-fca7-4343-a3d9-ea70348da8a4.png)

## Testing

Not needed

## Docs

Not needed