### PR TITLE
Fix Tailwind README code block

### DIFF
--- a/packages/integrations/tailwind/README.md
+++ b/packages/integrations/tailwind/README.md
@@ -147,7 +147,7 @@ You can now [import your own `base.css` as a local stylesheet](https://docs.astr
 
 When using the `@apply` directive in an Astro, Vue, Svelte, or another component integration's `<style>` tag, it may generate errors about your custom Tailwind class not existing and cause your build to fail.
 
-```
+```sh
 error   The `text-special` class does not exist. If `text-special` is a custom class, make sure it is defined within a `@layer` directive.
 ```
 


### PR DESCRIPTION
## Changes

**Closes**: [#2957](https://github.com/withastro/docs/issues/2957)

- Add `sh` language to code block in Tailwind README

## Testing

None

## Docs

- Fixes formatting error in Docs: https://docs.astro.build/en/guides/integrations-guide/tailwind/#class-does-not-exist-with-apply-directives

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
