### PR TITLE
Fix no edge functions deployed to netlify

### DIFF
--- a/.changeset/strong-hairs-sort.md
+++ b/.changeset/strong-hairs-sort.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+fix: no edge functions deployed to netlify

--- a/packages/integrations/netlify/src/integration-edge-functions.ts
+++ b/packages/integrations/netlify/src/integration-edge-functions.ts
@@ -122,7 +122,7 @@ export function netlifyEdgeFunctions({ dist }: NetlifyEdgeFunctionsOptions = {})
 					build: {
 						client: outDir,
 						server: new URL('./.netlify/edge-functions/', config.root),
-						serverEntry: 'entry.mjs',
+						serverEntry: 'entry.js',
 					},
 				});
 			},

--- a/packages/integrations/netlify/src/integration-edge-functions.ts
+++ b/packages/integrations/netlify/src/integration-edge-functions.ts
@@ -122,6 +122,7 @@ export function netlifyEdgeFunctions({ dist }: NetlifyEdgeFunctionsOptions = {})
 					build: {
 						client: outDir,
 						server: new URL('./.netlify/edge-functions/', config.root),
+						// Netlify expects .js and will always interpret as ESM
 						serverEntry: 'entry.js',
 					},
 				});

--- a/packages/integrations/netlify/test/edge-functions/prerender.test.ts
+++ b/packages/integrations/netlify/test/edge-functions/prerender.test.ts
@@ -9,7 +9,7 @@ Deno.test({
 	async fn() {
 		let close = await runBuild('./fixtures/prerender/');
 		const { default: handler } = await import(
-			'./fixtures/prerender/.netlify/edge-functions/entry.mjs'
+			'./fixtures/prerender/.netlify/edge-functions/entry.js'
 		);
 		const response = await handler(new Request('http://example.com/index.html'));
 		assertEquals(response, undefined, 'No response because this is an asset');


### PR DESCRIPTION
## Changes

fixes #6506

- This commit changes the generated edge function file from `entry.mjs`
 back to `entry.js`
- Apparently Netlify doesn't identify edge functions when the file extension is `.mjs`
- The issue started in version 2.1.3 when the file extension was changed.
- The extension was changed because of this issue #6299 that was affecting Vercel and maybe could affect Netlify.
- But I tested version 2.1.2 of `@astrojs/netlify` using `type: "commonjs"` inside `package.json` and found no errors.

## Testing

I just changed one test that was expecting `.mjs`.

## Docs

n/a
