### PR TITLE
Remove unnecessary transform for content imports

### DIFF
--- a/.changeset/ninety-frogs-impress.md
+++ b/.changeset/ninety-frogs-impress.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Remove unnecessary escape transform for content imports

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -108,13 +108,6 @@ export const _internal = {
 					}
 				});
 			},
-			async transform(code, id) {
-				if (isContentFlagImport(id, contentEntryExts)) {
-					// Escape before Rollup internal transform.
-					// Base on MUCH trial-and-error, inspired by MDX integration 2-step transform.
-					return { code: escapeViteEnvReferences(code) };
-				}
-			},
 		},
 	];
 


### PR DESCRIPTION
## Changes

In `vite-plugin-content-imports`, there's a transform to escape Vite references. However, in the load hook we already did that, so we should be able to remove the transform hook.

Fix https://github.com/withastro/astro/issues/6058 (there was a sourcemap warning in the transform hook)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.