### PR TITLE
Fix check CLI fs load fallback behaviour

### DIFF
--- a/.changeset/angry-experts-compete.md
+++ b/.changeset/angry-experts-compete.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix check CLI fs load fallback behaviour

--- a/packages/astro/src/cli/check/index.ts
+++ b/packages/astro/src/cli/check/index.ts
@@ -6,7 +6,7 @@ import {
 } from '@astrojs/language-server';
 import type { FSWatcher } from 'chokidar';
 import glob from 'fast-glob';
-import fsMod, * as fs from 'fs';
+import fs from 'fs';
 import { bold, dim, red, yellow } from 'kleur/colors';
 import { createRequire } from 'module';
 import { join } from 'node:path';
@@ -136,7 +136,7 @@ type CheckerConstructor = {
 
 	logging: Readonly<LogOptions>;
 
-	fileSystem: typeof fsMod;
+	fileSystem: typeof fs;
 };
 
 /**
@@ -153,7 +153,7 @@ export class AstroChecker {
 	readonly #settings: AstroSettings;
 
 	readonly #logging: LogOptions;
-	readonly #fs: typeof fsMod;
+	readonly #fs: typeof fs;
 	#watcher?: FSWatcher;
 
 	#filesCount: number;


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/6629

In `vite-plugin-load-fallback`, the `fs` check wasn't right when the `fs` is from `import * as fs from 'fs'`. This PR fixes it. 

I also simplified the `resolveId` hook as the `this.resolve` and always `slashify` part doesn't seem necessary. Other plugins should've already resolve before the `load-fallback` plugin, and always `slashify` makes it impossible for a plugin to run `this.resolve` to check if an id is resolveable (e.g. `tsconfig-alias` plugin `baseUrl`)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass. The edgecase in #6629 is a little hard to test, but once I do some tsconfig aliases soon, the regression shouldn't happen again.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.