### PR TITLE
Add more tsconfig alias tests

### DIFF
--- a/packages/astro/test/alias-tsconfig.test.js
+++ b/packages/astro/test/alias-tsconfig.test.js
@@ -34,5 +34,29 @@ describe('Aliases with tsconfig.json', () => {
 			const scripts = $('script').toArray();
 			expect(scripts.length).to.be.greaterThan(0);
 		});
+
+		it('can load via baseUrl', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			const $ = cheerio.load(html);
+
+			expect($('#foo').text()).to.equal('foo');
+			expect($('#constants-foo').text()).to.equal('foo');
+		});
+
+		it('can load namespace packages with @* paths', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			const $ = cheerio.load(html);
+
+			expect($('#namespace').text()).to.equal('namespace');
+		});
+
+		// TODO: fix this https://github.com/withastro/astro/issues/6551
+		it.skip('works in css @import', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			console.log(html);
+			// imported css should be bundled
+			expect(html).to.include('#style-red');
+			expect(html).to.include('#style-blue');
+		});
 	});
 });

--- a/packages/astro/test/fixtures/alias-tsconfig/deps/namespace-package/index.js
+++ b/packages/astro/test/fixtures/alias-tsconfig/deps/namespace-package/index.js
@@ -1,0 +1,1 @@
+export const namespace = 'namespace';

--- a/packages/astro/test/fixtures/alias-tsconfig/deps/namespace-package/package.json
+++ b/packages/astro/test/fixtures/alias-tsconfig/deps/namespace-package/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/namespace-package",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": "./index.js"
+}

--- a/packages/astro/test/fixtures/alias-tsconfig/package.json
+++ b/packages/astro/test/fixtures/alias-tsconfig/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@astrojs/svelte": "workspace:*",
+    "@test/namespace-package": "workspace:*",
     "astro": "workspace:*",
     "svelte": "^3.48.0"
   }

--- a/packages/astro/test/fixtures/alias-tsconfig/src/components/Foo.astro
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/components/Foo.astro
@@ -1,0 +1,1 @@
+<p id="foo">foo</p>

--- a/packages/astro/test/fixtures/alias-tsconfig/src/components/Style.astro
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/components/Style.astro
@@ -1,0 +1,2 @@
+<p id="style-blue">i am blue</p>
+<p id="style-red">i am red</p>

--- a/packages/astro/test/fixtures/alias-tsconfig/src/pages/index.astro
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/pages/index.astro
@@ -1,5 +1,11 @@
 ---
 import Client from '@components/Client.svelte'
+import Foo from 'src/components/Foo.astro';
+import StyleComp from 'src/components/Style.astro';
+import { namespace } from '@test/namespace-package'
+import { foo } from 'src/utils/constants';
+// TODO: support alias in @import https://github.com/withastro/astro/issues/6551
+// import '@styles/main.css';
 ---
 <html lang="en">
   <head>
@@ -10,6 +16,10 @@ import Client from '@components/Client.svelte'
   <body>
     <main>
       <Client client:load />
+      <Foo />
+      <StyleComp />
+      <p id="namespace">{namespace}</p>
+      <p id="constants-foo">{foo}</p>
     </main>
   </body>
 </html>

--- a/packages/astro/test/fixtures/alias-tsconfig/src/styles/extra.css
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/styles/extra.css
@@ -1,0 +1,3 @@
+#style-red {
+  color: red;
+}

--- a/packages/astro/test/fixtures/alias-tsconfig/src/styles/main.css
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/styles/main.css
@@ -1,0 +1,5 @@
+@import "@styles/extra.css";
+
+#style-blue {
+  color: blue;
+}

--- a/packages/astro/test/fixtures/alias-tsconfig/src/utils/constants.js
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/utils/constants.js
@@ -1,0 +1,1 @@
+export const foo = 'foo'

--- a/packages/astro/test/fixtures/alias-tsconfig/tsconfig.json
+++ b/packages/astro/test/fixtures/alias-tsconfig/tsconfig.json
@@ -5,12 +5,13 @@
       "@components/*": [
         "src/components/*"
       ],
-      "@layouts/*": [
-        "src/layouts/*"
+      "@styles/*": [
+        "src/styles/*"
       ],
-      "@assets/*": [
-        "src/assets/*"
-      ],
+      // this can really trip up namespaced packages
+      "@*": [
+        "src/*"
+      ]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1270,12 +1270,17 @@ importers:
   packages/astro/test/fixtures/alias-tsconfig:
     specifiers:
       '@astrojs/svelte': workspace:*
+      '@test/namespace-package': workspace:*
       astro: workspace:*
       svelte: ^3.48.0
     dependencies:
       '@astrojs/svelte': link:../../../../integrations/svelte
+      '@test/namespace-package': link:deps/namespace-package
       astro: link:../../..
       svelte: 3.55.1
+
+  packages/astro/test/fixtures/alias-tsconfig/deps/namespace-package:
+    specifiers: {}
 
   packages/astro/test/fixtures/api-routes:
     specifiers:


### PR DESCRIPTION
## Changes

Add more tests to tsconfig aliases, which covers previous regressions from:
- https://github.com/withastro/astro/issues/6620
- https://github.com/withastro/astro/issues/6613
- https://github.com/withastro/astro/pull/6566

Also added tests for `@import` in todo that I'll work on in a later PR.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
New tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. tests only.