### PR TITLE
Ensure unique workspace name

### DIFF
--- a/packages/astro/e2e/fixtures/astro-envs/package.json
+++ b/packages/astro/e2e/fixtures/astro-envs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/astro-envs",
+  "name": "@e2e/astro-envs",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/e2e/fixtures/preact-compat-component/package.json
+++ b/packages/astro/e2e/fixtures/preact-compat-component/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@e2e/preact-component",
+  "name": "@e2e/preact-compat-component",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/e2e/fixtures/vue-component/package.json
+++ b/packages/astro/e2e/fixtures/vue-component/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/vue-component",
+  "name": "@e2e/vue-component",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/content-collections-with-config-mjs/package.json
+++ b/packages/astro/test/fixtures/content-collections-with-config-mjs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/content-with-spaces-in-folder-name",
+  "name": "@test/content-collections-with-config-mjs",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/core-image-base/package.json
+++ b/packages/astro/test/fixtures/core-image-base/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/core-image-ssg",
+  "name": "@test/core-image-base",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/core-image-errors/package.json
+++ b/packages/astro/test/fixtures/core-image-errors/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/core-image",
+  "name": "@test/core-image-errors",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/css-assets/package.json
+++ b/packages/astro/test/fixtures/css-assets/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/astro-sitemap-rss",
+  "name": "@test/css-assets",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/css-order-dynamic-import/package.json
+++ b/packages/astro/test/fixtures/css-order-dynamic-import/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/css-order-import",
+  "name": "@test/css-order-dynamic-import",
   "dependencies": {
     "astro": "workspace:*"
   }

--- a/packages/astro/test/fixtures/error-build-location/package.json
+++ b/packages/astro/test/fixtures/error-build-location/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/error-non-error",
+  "name": "@test/error-build-location",
   "version": "0.0.1",
   "private": true,
   "scripts": {

--- a/packages/astro/test/fixtures/root-srcdir-css/package.json
+++ b/packages/astro/test/fixtures/root-srcdir-css/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/remote-css",
+  "name": "@test/root-srcdir-css",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/static-build-ssr/package.json
+++ b/packages/astro/test/fixtures/static-build-ssr/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/static-build",
+  "name": "@test/static-build-ssr",
   "version": "0.0.0",
   "dependencies": {
     "@astrojs/node": "workspace:*",

--- a/packages/integrations/image/test/fixtures/rotation/package.json
+++ b/packages/integrations/image/test/fixtures/rotation/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/basic-image",
+  "name": "@test/rotation",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/integrations/image/test/fixtures/squoosh-service/package.json
+++ b/packages/integrations/image/test/fixtures/squoosh-service/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/basic-image",
+  "name": "@test/squoosh-service",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/integrations/node/test/fixtures/prerender/package.json
+++ b/packages/integrations/node/test/fixtures/prerender/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/nodejs-encoded",
+  "name": "@test/nodejs-prerender",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/integrations/prefetch/test/fixtures/style-prefetch/package.json
+++ b/packages/integrations/prefetch/test/fixtures/style-prefetch/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/astro-prefetch",
+  "name": "@test/astro-style-prefetch",
   "version": "0.0.0",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Changes

A small chore to ensure workspace packages have a unique name. This is required when I upgrade turbo, but for some reason turbo also scans gitignored packages (e.g. build output), and those build output have empty names causing https://github.com/vercel/turbo/issues/3340

So I stick with the old turbo version for now, but thought it would be good to do this cleanup.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. cleanup.