### PR TITLE
Fix warning syntax in Vercel integration README

### DIFF
--- a/.changeset/wet-schools-clap.md
+++ b/.changeset/wet-schools-clap.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vercel": patch
+---
+
+Fix warning syntax in README

--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -175,7 +175,8 @@ You can use Vercel middleware to intercept a request and redirect before sending
     ```
 1. While developing locally, you can run `vercel dev` to run middleware. In production, Vercel will handle this for you.
 
-:::caution[Trying to rewrite?] Currently rewriting a request with middleware only works for static files. :::
+> **Warning**
+> **Trying to rewrite?** Currently rewriting a request with middleware only works for static files.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Changes

Fixes syntax used for a caution in the Vercel integration README. This was added using the docs syntax of `:::caution` which doesn’t work on GH/npm. We can use GH’s syntax instead though as we use a remark plugin to convert that to our syntax in docs.

## Testing

Docs only.

## Docs

Docs fix!
/cc @withastro/maintainers-docs for feedback!