### PR TITLE
Fix vercel edge private env vars

### DIFF
--- a/.changeset/blue-moons-cough.md
+++ b/.changeset/blue-moons-cough.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Fix vercel edge private environment variables usage

--- a/packages/integrations/vercel/src/edge/adapter.ts
+++ b/packages/integrations/vercel/src/edge/adapter.ts
@@ -85,6 +85,13 @@ export default function vercelEdge({
 
 					vite.ssr ||= {};
 					vite.ssr.target ||= 'webworker';
+
+					// Vercel edge runtime is a special webworker-ish environment that supports process.env,
+					// but Vite would replace away `process.env` in webworkers, so we set a define here to prevent it
+					vite.define = {
+						'process.env': 'process.env',
+						...vite.define,
+					};
 				}
 			},
 			'astro:build:done': async ({ routes }) => {


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/6713

When building for Vercel edge with `ssr.target: 'webworker'` in Vite, make sure Vite doesn't replace `process.env` as `({})` so they work in Vercel edge runtime on deploy.

cc @matthewp, didn't mean to steal your fix, but i was playing around some things while debugging it and found a fix 😬 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Ran the issue's repro https://github.com/larryhudson/astro-vercel-edge-env-testing and run `MY_ENV_VAR=foo npm run build` to build it.

After that, I open `.vercel/output/functions/render.func/chunks/pages/all.00bba6ec.mjs` to verify that the `MY_ENV_VAR` is correctly preserved as `process.env.MY_ENV_VAR`, not `{}.MY_ENV_VAR`.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.