### PR TITLE
add warn message when using unsupported file types in pages/

### DIFF
--- a/.changeset/hip-bottles-hide.md
+++ b/.changeset/hip-bottles-hide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Added warning message when using unsupported file extensions in pages/

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -227,6 +227,8 @@ export function createRouteManifest(
 	const validEndpointExtensions: Set<string> = new Set(['.js', '.ts']);
 	const localFs = fsMod ?? nodeFs;
 
+	const foundInvalidFileExtensions: Set<string> = new Set();
+
 	function walk(
 		fs: typeof nodeFs,
 		dir: string,
@@ -250,6 +252,11 @@ export function createRouteManifest(
 			}
 			// filter out "foo.astro_tmp" files, etc
 			if (!isDir && !validPageExtensions.has(ext) && !validEndpointExtensions.has(ext)) {
+				if (!foundInvalidFileExtensions.has(ext)) {
+					foundInvalidFileExtensions.add(ext);
+					warn(logging, 'astro', `Invalid file extension for Pages: ${ext}`);
+				}
+
 				return;
 			}
 			const segment = isDir ? basename : name;


### PR DESCRIPTION
## Changes

- add warning message when files with unsupported extensions are used in pages/
<img width="341" alt="console output" src="https://user-images.githubusercontent.com/20999486/232190927-6a3712f8-c2b2-46b9-bbe6-cc615ba93d0e.png">

<details><summary>Motivation</summary>
<p>
Occasionally, I messed up the file extensions and wondered why the page is not found. Especially since Vite just shows "updated file xyz", I think this warning message might be useful to the user
</p>
</details> 

## Testing

Tested with the projects from `examples/`, unit testing logging does not really make sense

## Docs

Docs are not needed since this feature serves as a way to alert the user that something is wrong. Docs are already clear on which file extensions are allowed
