### PR TITLE
Shortcuts in `astro dev` like in vite

### DIFF
--- a/.changeset/shiny-hounds-buy.md
+++ b/.changeset/shiny-hounds-buy.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+added shortcuts to `astro dev`

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -12,6 +12,7 @@ import * as msg from '../messages.js';
 import { printHelp } from '../messages.js';
 import { startContainer } from './container.js';
 import { createContainerWithAutomaticRestart } from './restart.js';
+import { listenForShortcuts } from './shortcuts.js';
 
 export interface DevOptions {
 	configFlag: string | undefined;
@@ -96,6 +97,12 @@ export default async function dev(
 	}
 
 	await attachContentServerListeners(restart.container);
+
+	listenForShortcuts({
+		container: restart.container,
+		options,
+		settings,
+	});
 
 	return {
 		address: devServerAddressInfo,

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -98,11 +98,12 @@ export default async function dev(
 
 	await attachContentServerListeners(restart.container);
 
-	listenForShortcuts({
-		container: restart.container,
-		options,
-		settings,
-	});
+	if (process.stdin.isTTY && !process.env.CI)
+		listenForShortcuts({
+			container: restart.container,
+			options,
+			settings,
+		});
 
 	return {
 		address: devServerAddressInfo,

--- a/packages/astro/src/core/dev/shortcuts.ts
+++ b/packages/astro/src/core/dev/shortcuts.ts
@@ -1,0 +1,78 @@
+import type { AstroSettings } from '../../@types/astro';
+import { info } from '../logger/core.js';
+import type { Container } from './container.js';
+import type { DevOptions } from './dev.js';
+import * as msg from '../messages.js';
+import { restartContainer } from './restart.js';
+
+export type Shortcut = {
+	letter: string;
+	description: string;
+	action?: () => void;
+};
+
+export function listenForShortcuts({
+	options,
+	container,
+	settings,
+}: {
+	options: DevOptions;
+	container: Container;
+	settings: AstroSettings;
+}) {
+	const shortcuts = [
+		{
+			letter: 'r',
+			description: 'restart the server',
+			action: () =>
+				restartContainer({
+					container,
+					flags: options.flags ?? {},
+					handleConfigError: options.handleConfigError,
+					logMsg: 'Restarting...',
+				}),
+		},
+		{
+			letter: 'u',
+			description: 'show server url',
+			action: () =>
+				info(
+					options.logging,
+					null,
+					msg.serverUrls({
+						resolvedUrls: container.viteServer.resolvedUrls || { local: [], network: [] },
+						host: settings.config.server.host,
+						base: settings.config.base,
+					})
+				),
+		},
+		{
+			letter: 'o',
+			description: 'open in browser',
+			action: () => container.viteServer.openBrowser(),
+		},
+		{
+			letter: 'h',
+			description: 'show this help',
+			action: () => {
+				info(options.logging, null, msg.printShortcuts(shortcuts));
+			},
+		},
+		{
+			letter: 'q',
+			description: 'quit',
+		},
+	];
+
+	process.stdin.setRawMode(true); // read stdin by character instead of line
+	process.stdin
+		.on('data', (data) => {
+			const char = data.toString();
+			if (['q', '\x03', '\x04'].includes(char))
+				return container.close().finally(() => process.exit(0));
+			const shortcut = shortcuts.find((s) => s.letter === char);
+			if (shortcut) shortcut.action?.();
+		})
+		.setEncoding('utf8')
+		.resume();
+}

--- a/packages/astro/src/core/dev/shortcuts.ts
+++ b/packages/astro/src/core/dev/shortcuts.ts
@@ -20,6 +20,8 @@ export function listenForShortcuts({
 	container: Container;
 	settings: AstroSettings;
 }) {
+	const resolvedUrls = container.viteServer.resolvedUrls || { local: [], network: [] };
+
 	const shortcuts = [
 		{
 			letter: 'r',
@@ -40,7 +42,7 @@ export function listenForShortcuts({
 					options.logging,
 					null,
 					msg.serverUrls({
-						resolvedUrls: container.viteServer.resolvedUrls || { local: [], network: [] },
+						resolvedUrls,
 						host: settings.config.server.host,
 						base: settings.config.base,
 					})

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -19,6 +19,7 @@ import type { ZodError } from 'zod';
 import { renderErrorMarkdown } from './errors/dev/utils.js';
 import { AstroError, CompilerError, type ErrorWithMetadata } from './errors/index.js';
 import { emoji, padMultilineString } from './util.js';
+import type { Shortcut } from './dev/shortcuts.js';
 
 const PREFIX_PADDING = 6;
 
@@ -66,6 +67,27 @@ export function serverStart({
 }): string {
 	// PACKAGE_VERSION is injected at build-time
 	const version = process.env.PACKAGE_VERSION ?? '0.0.0';
+
+	const messages = [
+		`  ${emoji('🚀 ', '')}${bgGreen(black(` astro `))} ${green(`v${version}`)} ${dim(
+			`${isRestart ? 're' : ''}started in ${Math.round(startupTime)}ms`
+		)}`,
+		'  ',
+		serverUrls({ base, host, resolvedUrls }),
+		'  ',
+	];
+	return messages.join('\n');
+}
+
+export function serverUrls({
+	base,
+	host,
+	resolvedUrls,
+}: {
+	resolvedUrls: ResolvedServerUrls;
+	base: string;
+	host: string | boolean;
+}) {
 	const localPrefix = `${dim('┃')} Local    `;
 	const networkPrefix = `${dim('┃')} Network  `;
 	const emptyPrefix = ' '.repeat(11);
@@ -86,19 +108,19 @@ export function serverStart({
 		}
 	}
 
-	const messages = [
-		`${emoji('🚀 ', '')}${bgGreen(black(` astro `))} ${green(`v${version}`)} ${dim(
-			`${isRestart ? 're' : ''}started in ${Math.round(startupTime)}ms`
-		)}`,
-		'',
-		...localUrlMessages,
-		...networkUrlMessages,
-		'',
-	];
+	const messages = [...localUrlMessages, ...networkUrlMessages];
 	return messages
 		.filter((msg) => typeof msg === 'string')
 		.map((msg) => `  ${msg}`)
 		.join('\n');
+}
+
+export function printShortcuts(shortcuts: Shortcut[]) {
+	return `  ${bold('Shortcuts')}\n${shortcuts
+		.map(
+			({ description, letter }) => `  ${dim('press')} ${bold(letter)} ${dim(`to ${description}`)}`
+		)
+		.join('\n')}`;
 }
 
 export function telemetryNotice() {

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -74,6 +74,7 @@ export function serverStart({
 		)}`,
 		'  ',
 		serverUrls({ base, host, resolvedUrls }),
+		`  ${dim('┃ press')} ${bold('h')} ${dim('to show help')}`,
 		'  ',
 	];
 	return messages.join('\n');


### PR DESCRIPTION
## Changes

In vite projects while the dev server is running, I can press `r` in the terminal to restart it, or press `u` to show the server URL again. I was missing this feature in astro. Today I thought, why don't I add it myself.

![2023-04-16_04-57](https://user-images.githubusercontent.com/35634442/232262035-a30d597f-29e8-4592-b090-98e327633dd4.png)


## Testing

not sure how to test this

## Docs

I added an info message when the dev server starts. Don't think any additions to docs are necessary.
