### PR TITLE
Fix Astro.params does not contain path parameter from URL with non-English characters

### DIFF
--- a/.changeset/few-cats-beam.md
+++ b/.changeset/few-cats-beam.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix Astro.params does not contain path parameter from URL with non-English characters.

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -32,7 +32,9 @@ export async function getParamsAndProps(
 	let pageProps: Props;
 	if (route && !route.pathname) {
 		if (route.params.length) {
-			const paramsMatch = route.pattern.exec(pathname);
+			// The RegExp pattern expects a decoded string, but the pathname is encoded
+			// when the URL contains non-English characters.
+			const paramsMatch = route.pattern.exec(decodeURIComponent(pathname));
 			if (paramsMatch) {
 				params = getParams(route.params)(paramsMatch);
 

--- a/packages/astro/test/fixtures/ssr-params/src/pages/東西/[category].astro
+++ b/packages/astro/test/fixtures/ssr-params/src/pages/東西/[category].astro
@@ -1,0 +1,12 @@
+---
+const { category } = Astro.params
+---
+<html>
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<h1>Testing</h1>
+		<h2 class="category">{ category }</h2>
+	</body>
+</html>

--- a/packages/astro/test/ssr-params.test.js
+++ b/packages/astro/test/ssr-params.test.js
@@ -26,4 +26,16 @@ describe('Astro.params in SSR', () => {
 		const $ = cheerio.load(html);
 		expect($('.category').text()).to.equal('food');
 	});
+
+	describe('Non-english characters in the URL', () => {
+		it('Params are passed to component', async () => {
+			const app = await fixture.loadTestAdapterApp();
+			const request = new Request('http://example.com/users/houston/東西/food');
+			const response = await app.render(request);
+			expect(response.status).to.equal(200);
+			const html = await response.text();
+			const $ = cheerio.load(html);
+			expect($('.category').text()).to.equal('food');
+		});
+	});
 });


### PR DESCRIPTION
Fixes #6831

- Fixed bug where Astro.params does not contain path parameter when the URL has non-English characters.
- Added related test.

## Changes

I noticed that `route.pattern` expects a decoded string, but the `pathname` is encoded. So I decoded the `pathname` before passing it to the pattern matching.
```js
...
route: {
    route: '/東西/[name]',
    type: 'page',
    pattern: /^\/東西\/([^/]+?)\/?$/, // decoded value
    params: [ 'name' ],
    component: 'src/pages/東西/[name].astro',
    generate: [Function (anonymous)],
    pathname: undefined,
    segments: [ [Array], [Array] ],
    prerender: false
  },
  routeCache: RouteCache {
    cache: {},
    logging: { dest: [Object], level: 'info' },
    mode: 'production'
  },
  pathname: '/%E6%9D%B1%E8%A5%BF/test', // encoded value
...
```

## Testing

- I added a test that reproduces the behavior.

## Docs

n/a
