### PR TITLE
fix: astro island urls missing assetsPrefix in SSR mode

### DIFF
--- a/.changeset/large-pens-rhyme.md
+++ b/.changeset/large-pens-rhyme.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Fixes bug with assetsPrefix not being prepended to component-url and renderer-url in astro islands when using SSR mode.

--- a/.changeset/large-pens-rhyme.md
+++ b/.changeset/large-pens-rhyme.md
@@ -1,5 +1,5 @@
 ---
-'astro': minor
+'astro': patch
 ---
 
 Fixes bug with assetsPrefix not being prepended to component-url and renderer-url in astro islands when using SSR mode.

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -21,6 +21,7 @@ import {
 } from '../render/index.js';
 import { RouteCache } from '../render/route-cache.js';
 import {
+	createAssetLink,
 	createLinkStylesheetElementSet,
 	createModuleScriptElement,
 } from '../render/ssr-element.js';
@@ -71,7 +72,11 @@ export class App {
 						return bundlePath;
 					}
 					default: {
-						return prependForwardSlash(joinPaths(manifest.base, bundlePath));
+						return createAssetLink(
+							bundlePath,
+							manifest.base,
+							manifest.assetsPrefix
+						);
 					}
 				}
 			},

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -31,6 +31,7 @@ export interface SSRManifest {
 	routes: RouteInfo[];
 	site?: string;
 	base?: string;
+	assetsPrefix?: string;
 	markdown: MarkdownRenderingOptions;
 	pageMap: Map<ComponentPath, ComponentInstance>;
 	renderers: SSRLoadedRenderer[];

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -212,6 +212,7 @@ function buildManifest(
 		routes,
 		site: settings.config.site,
 		base: settings.config.base,
+		assetsPrefix: settings.config.build.assetsPrefix,
 		markdown: settings.config.markdown,
 		pageMap: null as any,
 		componentMetadata: Array.from(internals.componentMetadata),

--- a/packages/astro/test/astro-assets-prefix.test.js
+++ b/packages/astro/test/astro-assets-prefix.test.js
@@ -98,6 +98,17 @@ describe('Assets Prefix - Server', () => {
 		expect(imgAsset.attr('src')).to.match(assetsPrefixRegex);
 	});
 
+	it('react component astro-island should import from assetsPrefix', async () => {
+		const request = new Request('http://example.com/custom-base/');
+		const response = await app.render(request);
+		expect(response.status).to.equal(200);
+		const html = await response.text();
+		const $ = cheerio.load(html);
+		const island = $('astro-island');
+		expect(island.attr('component-url')).to.match(assetsPrefixRegex);
+		expect(island.attr('renderer-url')).to.match(assetsPrefixRegex);
+	});
+
 	it('markdown image src start with assetsPrefix', async () => {
 		const request = new Request('http://example.com/custom-base/markdown/');
 		const response = await app.render(request);


### PR DESCRIPTION
## Changes

- Fixes #6852
- In SSR mode, `assetsPrefix` is not being prepended to component-url and renderer-url.

## Testing

We added a test to `astro/test/astro-assets-prefix.test.js`.

```js
it('react component astro-island should import from assetsPrefix', async () => {
	const request = new Request('http://example.com/custom-base/');
	const response = await app.render(request);
	expect(response.status).to.equal(200);
	const html = await response.text();
	const $ = cheerio.load(html);
	const island = $('astro-island');
	expect(island.attr('component-url')).to.match(assetsPrefixRegex);
	expect(island.attr('renderer-url')).to.match(assetsPrefixRegex);
});
```

A similar test case already existed for the SSG case, but not for SSR. I just copied and adapted the test case for SSR. When the test case was added for SSR, it was failing until we implemented the fix.

## Docs

This change should not really affect the user's behavior since it is a bug fix.
