### PR TITLE
chore: update dependencies related to changesets

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -8,14 +8,6 @@ module.exports = {
   plugins: ['./node_modules/prettier-plugin-astro'],
   overrides: [
     {
-      // Changesets run Prettier using our configuration, however it uses a very old version of Prettier that does
-      // not support our plugin and it ends up doing more harm than good. As such, we'll disable our plugin for changelogs
-      files: ['CHANGELOG.md'],
-      options: {
-        plugins: [],
-      },
-    },
-    {
       files: ['.*', '*.json', '*.md', '*.toml', '*.yml'],
       options: {
         useTabs: false,

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,4 +1,3 @@
-// Heads up: This file should be renamed to `.cjs`, however if we did that, changesets wouldn't be able to load it
 module.exports = {
   printWidth: 100,
   semi: true,

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
       ]
     },
     "patchedDependencies": {
-      "@changesets/cli@2.23.0": "patches/@changesets__cli@2.23.0.patch"
+      "@changesets/cli@2.26.1": "patches/@changesets__cli@2.26.1.patch"
     }
   },
   "dependencies": {
@@ -71,8 +71,8 @@
     "astro-benchmark": "workspace:*"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "0.4.4",
-    "@changesets/cli": "2.23.0",
+    "@changesets/changelog-github": "0.4.8",
+    "@changesets/cli": "2.26.1",
     "@octokit/action": "^3.18.1",
     "@types/node": "^18.7.21",
     "@typescript-eslint/eslint-plugin": "^5.58.0",

--- a/patches/@changesets__cli@2.26.1.patch
+++ b/patches/@changesets__cli@2.26.1.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/cli.cjs.dev.js b/dist/cli.cjs.dev.js
-index 5511d0c05d3b7472876dcc8410e938ccf612654f..aa75e3982b68e1226ba1877a7f32017e517480f5 100644
+index 73ab02a861b1f5a8e1bf10984340a0a6b1518b15..2309d78fb1ff07428bc76136d9eb4f4d8d6571cc 100644
 --- a/dist/cli.cjs.dev.js
 +++ b/dist/cli.cjs.dev.js
 @@ -279,6 +279,9 @@ async function confirmMajorRelease(pkgJSON) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,9 @@ overrides:
 packageExtensionsChecksum: 01871422d489547c532184effb134b35
 
 patchedDependencies:
-  '@changesets/cli@2.23.0':
-    hash: kcozqtpxuwjzskw6zg5royevn4
-    path: patches/@changesets__cli@2.23.0.patch
+  '@changesets/cli@2.26.1':
+    hash: rpibscpwt2erpjuy2wpxneagme
+    path: patches/@changesets__cli@2.26.1.patch
 
 importers:
 
@@ -22,11 +22,11 @@ importers:
         version: link:benchmark
     devDependencies:
       '@changesets/changelog-github':
-        specifier: 0.4.4
-        version: 0.4.4
+        specifier: 0.4.8
+        version: 0.4.8
       '@changesets/cli':
-        specifier: 2.23.0
-        version: 2.23.0(patch_hash=kcozqtpxuwjzskw6zg5royevn4)
+        specifier: 2.26.1
+        version: 2.26.1(patch_hash=rpibscpwt2erpjuy2wpxneagme)
       '@octokit/action':
         specifier: ^3.18.1
         version: 3.18.1
@@ -6914,8 +6914,8 @@ packages:
       '@changesets/types': 5.2.1
     dev: true
 
-  /@changesets/changelog-github@0.4.4:
-    resolution: {integrity: sha512-htSILqCkyYtTB5/LoVKwx7GCJQGxAiBcYbfUKWiz/QoDARuM01owYtMXhV6/iytJZq/Dqqz3PjMZUNB4MphpbQ==}
+  /@changesets/changelog-github@0.4.8:
+    resolution: {integrity: sha512-jR1DHibkMAb5v/8ym77E4AMNWZKB5NPzw5a5Wtqm1JepAuIF+hrKp2u04NKM14oBZhHglkCfrla9uq8ORnK/dw==}
     dependencies:
       '@changesets/get-github-info': 0.5.2
       '@changesets/types': 5.2.1
@@ -6924,8 +6924,8 @@ packages:
       - encoding
     dev: true
 
-  /@changesets/cli@2.23.0(patch_hash=kcozqtpxuwjzskw6zg5royevn4):
-    resolution: {integrity: sha512-Gi3tMi0Vr6eNd8GX6q73tbOm9XOzGfuLEm4PYVeWG2neg5DlRGNOjYwrFULJ/An3N9MHtHn4r5h1Qvnju9Ijug==}
+  /@changesets/cli@2.26.1(patch_hash=rpibscpwt2erpjuy2wpxneagme):
+    resolution: {integrity: sha512-XnTa+b51vt057fyAudvDKGB0Sh72xutQZNAdXkCqPBKO2zvs2yYZx5hFZj1u9cbtpwM6Sxtcr02/FQJfZOzemQ==}
     hasBin: true
     dependencies:
       '@babel/runtime': 7.21.0
@@ -6936,12 +6936,12 @@ packages:
       '@changesets/errors': 0.1.4
       '@changesets/get-dependents-graph': 1.3.5
       '@changesets/get-release-plan': 3.0.16
-      '@changesets/git': 1.5.0
+      '@changesets/git': 2.0.0
       '@changesets/logger': 0.0.5
       '@changesets/pre': 1.0.14
       '@changesets/read': 0.5.9
       '@changesets/types': 5.2.1
-      '@changesets/write': 0.1.9
+      '@changesets/write': 0.2.3
       '@manypkg/get-packages': 1.1.3
       '@types/is-ci': 3.0.0
       '@types/semver': 6.2.3
@@ -7017,17 +7017,6 @@ packages:
     resolution: {integrity: sha512-SVqwYs5pULYjYT4op21F2pVbcrca4qA/bAA3FmFXKMN7Y+HcO8sbZUTx3TAy2VXulP2FACd1aC7f2nTuqSPbqg==}
     dev: true
 
-  /@changesets/git@1.5.0:
-    resolution: {integrity: sha512-Xo8AT2G7rQJSwV87c8PwMm6BAc98BnufRMsML7m7Iw8Or18WFvFmxqG5aOL5PBvhgq9KrKvaeIBNIymracSuHg==}
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@changesets/errors': 0.1.4
-      '@changesets/types': 5.2.1
-      '@manypkg/get-packages': 1.1.3
-      is-subdir: 1.2.0
-      spawndamnit: 2.0.0
-    dev: true
-
   /@changesets/git@2.0.0:
     resolution: {integrity: sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==}
     dependencies:
@@ -7084,14 +7073,14 @@ packages:
     resolution: {integrity: sha512-myLfHbVOqaq9UtUKqR/nZA/OY7xFjQMdfgfqeZIBK4d0hA6pgxArvdv8M+6NUzzBsjWLOtvApv8YHr4qM+Kpfg==}
     dev: true
 
-  /@changesets/write@0.1.9:
-    resolution: {integrity: sha512-E90ZrsrfJVOOQaP3Mm5Xd7uDwBAqq3z5paVEavTHKA8wxi7NAL8CmjgbGxSFuiP7ubnJA2BuHlrdE4z86voGOg==}
+  /@changesets/write@0.2.3:
+    resolution: {integrity: sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==}
     dependencies:
       '@babel/runtime': 7.21.0
       '@changesets/types': 5.2.1
       fs-extra: 7.0.1
       human-id: 1.0.2
-      prettier: 1.19.1
+      prettier: 2.8.7
     dev: true
 
   /@cloudflare/kv-asset-handler@0.2.0:
@@ -8364,7 +8353,7 @@ packages:
   /@ts-morph/common@0.16.0:
     resolution: {integrity: sha512-SgJpzkTgZKLKqQniCjLaE3c2L2sdL7UShvmTmPBejAKd2OKV/yfMpQ2IWpAuA+VY5wy7PkSUaEObIqEK6afFuw==}
     dependencies:
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       minimatch: 5.1.6
       mkdirp: 1.0.4
       path-browserify: 1.0.1
@@ -12003,7 +11992,7 @@ packages:
       '@types/glob': 7.2.0
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       glob: 7.2.3
       ignore: 5.2.4
       merge2: 1.4.1
@@ -12016,7 +12005,7 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
@@ -12039,7 +12028,7 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
@@ -15174,12 +15163,6 @@ packages:
       prettier: 2.8.7
       sass-formatter: 0.7.6
       synckit: 0.8.5
-    dev: true
-
-  /prettier@1.19.1:
-    resolution: {integrity: sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==}
-    engines: {node: '>=4'}
-    hasBin: true
     dev: true
 
   /prettier@2.8.7:


### PR DESCRIPTION
## Changes

- Update dependencies related to changesets to use the new features mentioned below
- Change prettier config extension to `.cjs`(Now changesets use latest version of prettier See: https://github.com/changesets/changesets/pull/905).
- Remove workaround in prettier config(Same reason above).

## Testing

Only prettier config has changed.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
