### PR TITLE
Disable Vite optimizer for sync and config loading

### DIFF
--- a/.changeset/shiny-roses-tap.md
+++ b/.changeset/shiny-roses-tap.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Disable Vite optimizer for sync and config loading. Improve first page load time for warm server startup.

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -11,7 +11,7 @@ export interface ViteLoader {
 async function createViteLoader(root: string, fs: typeof fsType): Promise<ViteLoader> {
 	const viteServer = await vite.createServer({
 		server: { middlewareMode: true, hmr: false },
-		optimizeDeps: { entries: [] },
+		optimizeDeps: { disabled: true },
 		clearScreen: false,
 		appType: 'custom',
 		ssr: {

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -66,7 +66,7 @@ export async function sync(
 		await createVite(
 			{
 				server: { middlewareMode: true, hmr: false },
-				optimizeDeps: { entries: [] },
+				optimizeDeps: { disabled: true },
 				ssr: { external: [] },
 				logLevel: 'silent',
 			},


### PR DESCRIPTION
## Changes

Disable the optimizer with `optimizeDeps.disabled` so that the optimize metadata is not overwritten


### Explanation

In the astro docs repo, what's happening is that:

1. Load `astro.config.ts` with Vite server, sees `./node_modules/.vite/deps/_metadata.json`, but hash mismatched so remove the file.
2. Start Astro dev server, which sees that there's no `./node_modules/.vite/deps/_metadata.json`.

This causes the Astro dev server startup to always re-optimize on step 2, which makes startup slow. This PR prevents step 1 from happening.

### Result

This removes 200ms of scanning and 600ms of prebundling for the Astro docs repo for warm startups.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Manual testing in astro docs repo

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.