### PR TITLE
[Content collections] Fast `getEntryBySlug()` lookup

### DIFF
--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -14,6 +14,7 @@ import {
 
 type GlobResult = Record<string, () => Promise<any>>;
 type CollectionToEntryMap = Record<string, GlobResult>;
+type GetEntryImport = (collection: string, lookupId: string) => () => Promise<any>;
 
 export function createCollectionToGlobResultMap({
 	globResult,
@@ -28,9 +29,8 @@ export function createCollectionToGlobResultMap({
 		const segments = keyRelativeToContentDir.split('/');
 		if (segments.length <= 1) continue;
 		const collection = segments[0];
-		const entryId = segments.slice(1).join('/');
 		collectionToGlobResultMap[collection] ??= {};
-		collectionToGlobResultMap[collection][entryId] = globResult[key];
+		collectionToGlobResultMap[collection][key] = globResult[key];
 	}
 	return collectionToGlobResultMap;
 }
@@ -38,10 +38,10 @@ export function createCollectionToGlobResultMap({
 const cacheEntriesByCollection = new Map<string, any[]>();
 export function createGetCollection({
 	collectionToEntryMap,
-	collectionToRenderEntryMap,
+	getRenderEntryImport,
 }: {
 	collectionToEntryMap: CollectionToEntryMap;
-	collectionToRenderEntryMap: CollectionToEntryMap;
+	getRenderEntryImport: GetEntryImport;
 }) {
 	return async function getCollection(collection: string, filter?: (entry: any) => unknown) {
 		const lazyImports = Object.values(collectionToEntryMap[collection] ?? {});
@@ -64,7 +64,7 @@ export function createGetCollection({
 							return render({
 								collection: entry.collection,
 								id: entry.id,
-								collectionToRenderEntryMap,
+								renderEntryImport: await getRenderEntryImport(collection, entry.slug),
 							});
 						},
 					};
@@ -82,10 +82,10 @@ export function createGetCollection({
 
 export function createGetEntryBySlug({
 	getCollection,
-	collectionToRenderEntryMap,
+	getRenderEntryImport,
 }: {
 	getCollection: ReturnType<typeof createGetCollection>;
-	collectionToRenderEntryMap: CollectionToEntryMap;
+	getRenderEntryImport: GetEntryImport;
 }) {
 	return async function getEntryBySlug(collection: string, slug: string) {
 		// This is not an optimized lookup. Should look into an O(1) implementation
@@ -114,7 +114,7 @@ export function createGetEntryBySlug({
 				return render({
 					collection: entry.collection,
 					id: entry.id,
-					collectionToRenderEntryMap,
+					renderEntryImport: await getRenderEntryImport(collection, entry.slug),
 				});
 			},
 		};
@@ -124,21 +124,20 @@ export function createGetEntryBySlug({
 async function render({
 	collection,
 	id,
-	collectionToRenderEntryMap,
+	renderEntryImport,
 }: {
 	collection: string;
 	id: string;
-	collectionToRenderEntryMap: CollectionToEntryMap;
+	renderEntryImport?: ReturnType<GetEntryImport>;
 }) {
 	const UnexpectedRenderError = new AstroError({
 		...AstroErrorData.UnknownContentCollectionError,
 		message: `Unexpected error while rendering ${String(collection)} → ${String(id)}.`,
 	});
 
-	const lazyImport = collectionToRenderEntryMap[collection]?.[id];
-	if (typeof lazyImport !== 'function') throw UnexpectedRenderError;
+	if (typeof renderEntryImport !== 'function') throw UnexpectedRenderError;
 
-	const baseMod = await lazyImport();
+	const baseMod = await renderEntryImport();
 	if (baseMod == null || typeof baseMod !== 'object') throw UnexpectedRenderError;
 
 	const { collectedStyles, collectedLinks, collectedScripts, getMod } = baseMod;

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -81,29 +81,18 @@ export function createGetCollection({
 }
 
 export function createGetEntryBySlug({
-	getCollection,
+	getEntryImport,
 	getRenderEntryImport,
 }: {
-	getCollection: ReturnType<typeof createGetCollection>;
+	getEntryImport: GetEntryImport;
 	getRenderEntryImport: GetEntryImport;
 }) {
 	return async function getEntryBySlug(collection: string, slug: string) {
-		// This is not an optimized lookup. Should look into an O(1) implementation
-		// as it's probably that people will have very large collections.
-		const entries = await getCollection(collection);
-		let candidate: (typeof entries)[number] | undefined = undefined;
-		for (let entry of entries) {
-			if (entry.slug === slug) {
-				candidate = entry;
-				break;
-			}
-		}
+		const entryImport = await getEntryImport(collection, slug);
+		if (typeof entryImport !== 'function') return undefined;
 
-		if (typeof candidate === 'undefined') {
-			return undefined;
-		}
+		const entry = await entryImport();
 
-		const entry = candidate;
 		return {
 			id: entry.id,
 			slug: entry.slug,
@@ -114,7 +103,7 @@ export function createGetEntryBySlug({
 				return render({
 					collection: entry.collection,
 					id: entry.id,
-					renderEntryImport: await getRenderEntryImport(collection, entry.slug),
+					renderEntryImport: await getRenderEntryImport(collection, slug),
 				});
 			},
 		};

--- a/packages/astro/src/content/template/virtual-mod.mjs
+++ b/packages/astro/src/content/template/virtual-mod.mjs
@@ -52,6 +52,6 @@ export const getCollection = createGetCollection({
 });
 
 export const getEntryBySlug = createGetEntryBySlug({
-	getCollection,
+	getEntryImport: createGlobLookup(collectionToEntryMap),
 	getRenderEntryImport: createGlobLookup(collectionToRenderEntryMap),
 });

--- a/packages/astro/src/content/template/virtual-mod.mjs
+++ b/packages/astro/src/content/template/virtual-mod.mjs
@@ -28,6 +28,16 @@ const collectionToEntryMap = createCollectionToGlobResultMap({
 	contentDir,
 });
 
+function createGlobLookup(entryGlob) {
+	return async (collection, lookupId) => {
+		const { default: lookupMap } = await import('@@LOOKUP_MAP_PATH@@');
+		const filePath = lookupMap[collection]?.[lookupId];
+
+		if (!filePath) return undefined;
+		return entryGlob[collection][filePath];
+	};
+}
+
 const renderEntryGlob = import.meta.glob('@@RENDER_ENTRY_GLOB_PATH@@', {
 	query: { astroPropagatedAssets: true },
 });
@@ -38,10 +48,10 @@ const collectionToRenderEntryMap = createCollectionToGlobResultMap({
 
 export const getCollection = createGetCollection({
 	collectionToEntryMap,
-	collectionToRenderEntryMap,
+	getRenderEntryImport: createGlobLookup(collectionToRenderEntryMap),
 });
 
 export const getEntryBySlug = createGetEntryBySlug({
 	getCollection,
-	collectionToRenderEntryMap,
+	getRenderEntryImport: createGlobLookup(collectionToRenderEntryMap),
 });

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -22,6 +22,7 @@ import {
 	type ContentObservable,
 	type ContentPaths,
 	type EntryInfo,
+	updateLookupMaps,
 } from './utils.js';
 
 type ChokidarEvent = 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir';
@@ -277,6 +278,12 @@ export async function createContentTypesGenerator({
 				typeTemplateContent,
 				contentConfig: observable.status === 'loaded' ? observable.config : undefined,
 				contentEntryTypes: settings.contentEntryTypes,
+			});
+			await updateLookupMaps({
+				contentEntryExts,
+				contentPaths,
+				root: settings.config.root,
+				fs,
 			});
 			if (observable.status === 'loaded' && ['info', 'warn'].includes(logLevel)) {
 				warnNonexistentCollections({

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -19,6 +19,7 @@ import {
 	globalContentConfigObserver,
 	NoCollectionError,
 	type ContentConfig,
+	getContentEntryConfigByExtMap,
 } from './utils.js';
 
 function isContentFlagImport(viteId: string) {
@@ -55,12 +56,7 @@ export function astroContentImportPlugin({
 	const contentPaths = getContentPaths(settings.config, fs);
 	const contentEntryExts = getContentEntryExts(settings);
 
-	const contentEntryExtToParser: Map<string, ContentEntryType> = new Map();
-	for (const entryType of settings.contentEntryTypes) {
-		for (const ext of entryType.extensions) {
-			contentEntryExtToParser.set(ext, entryType);
-		}
-	}
+	const contentEntryConfigByExt = getContentEntryConfigByExtMap(settings);
 
 	const plugins: Plugin[] = [
 		{
@@ -196,7 +192,7 @@ export function astroContentImportPlugin({
 		const contentConfig = await getContentConfigFromGlobal();
 		const rawContents = await fs.promises.readFile(fileId, 'utf-8');
 		const fileExt = extname(fileId);
-		if (!contentEntryExtToParser.has(fileExt)) {
+		if (!contentEntryConfigByExt.has(fileExt)) {
 			throw new AstroError({
 				...AstroErrorData.UnknownContentCollectionError,
 				message: `No parser found for content entry ${JSON.stringify(
@@ -204,13 +200,13 @@ export function astroContentImportPlugin({
 				)}. Did you apply an integration for this file type?`,
 			});
 		}
-		const contentEntryParser = contentEntryExtToParser.get(fileExt)!;
+		const contentEntryConfig = contentEntryConfigByExt.get(fileExt)!;
 		const {
 			rawData,
 			body,
-			slug: unvalidatedSlug,
+			slug: frontmatterSlug,
 			data: unvalidatedData,
-		} = await contentEntryParser.getEntryInfo({
+		} = await contentEntryConfig.getEntryInfo({
 			fileUrl: pathToFileURL(fileId),
 			contents: rawContents,
 		});
@@ -225,7 +221,12 @@ export function astroContentImportPlugin({
 		const _internal = { filePath: fileId, rawData: rawData };
 		// TODO: move slug calculation to the start of the build
 		// to generate a performant lookup map for `getEntryBySlug`
-		const slug = getEntrySlug({ id, collection, slug: generatedSlug, unvalidatedSlug });
+		const slug = getEntrySlug({
+			id,
+			collection,
+			generatedSlug,
+			frontmatterSlug,
+		});
 
 		const collectionConfig = contentConfig?.collections[collection];
 		let data = collectionConfig

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -1,11 +1,9 @@
 import fsMod from 'node:fs';
-import * as path from 'node:path';
 import type { Plugin } from 'vite';
-import { normalizePath } from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
-import { appendForwardSlash, prependForwardSlash } from '../core/path.js';
 import { VIRTUAL_MODULE_ID } from './consts.js';
-import { getContentEntryExts, getContentPaths } from './utils.js';
+import { getContentEntryExts, getContentPaths, getExtGlob } from './utils.js';
+import { rootRelativePath } from '../core/util.js';
 
 interface AstroContentVirtualModPluginParams {
 	settings: AstroSettings;
@@ -15,13 +13,7 @@ export function astroContentVirtualModPlugin({
 	settings,
 }: AstroContentVirtualModPluginParams): Plugin {
 	const contentPaths = getContentPaths(settings.config);
-	const relContentDir = normalizePath(
-		appendForwardSlash(
-			prependForwardSlash(
-				path.relative(settings.config.root.pathname, contentPaths.contentDir.pathname)
-			)
-		)
-	);
+	const relContentDir = rootRelativePath(settings.config.root, contentPaths.contentDir);
 	const contentEntryExts = getContentEntryExts(settings);
 
 	const extGlob =
@@ -32,6 +24,7 @@ export function astroContentVirtualModPlugin({
 	const entryGlob = `${relContentDir}**/*${extGlob}`;
 	const virtualModContents = fsMod
 		.readFileSync(contentPaths.virtualModTemplate, 'utf-8')
+		.replace('@@LOOKUP_MAP_PATH@@', new URL('lookup-map.json', contentPaths.cacheDir).pathname)
 		.replace('@@CONTENT_DIR@@', relContentDir)
 		.replace('@@ENTRY_GLOB_PATH@@', entryGlob)
 		.replace('@@RENDER_ENTRY_GLOB_PATH@@', entryGlob);

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -151,18 +151,15 @@ export function relativeToSrcDir(config: AstroConfig, idOrUrl: URL | string) {
 	return id.slice(slash(fileURLToPath(config.srcDir)).length);
 }
 
-export function rootRelativePath(root: URL, idOrUrl: URL | string) {
+export function rootRelativePath(root: URL, idOrUrl: URL | string, prependSlash = true) {
 	let id: string;
 	if (typeof idOrUrl !== 'string') {
 		id = unwrapId(viteID(idOrUrl));
 	} else {
 		id = idOrUrl;
 	}
-	const normalizedRoot = normalizePath(fileURLToPath(root));
-	if (id.startsWith(normalizedRoot)) {
-		id = id.slice(normalizedRoot.length);
-	}
-	return prependForwardSlash(id);
+	id = id.slice(normalizePath(fileURLToPath(root)).length);
+	return prependSlash ? prependForwardSlash(id) : id;
 }
 
 export function emoji(char: string, fallback: string) {


### PR DESCRIPTION
## Changes

- Generate a `.astro/lookup-map.json`. This maps collection entry slugs to their local file path for glob imports.
- Update `getEntryBySlug()` to look up entries from this lookup map, instead of filtering across the entire collection.

## Testing

N/A - check that `getEntryBySlug()` tests still pass

## Docs

N/A