### PR TITLE
Fix changeset version run

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@example/*", "@test/*"],
+  "ignore": ["!(astro|create-astro|@astrojs/*|astro-scripts)"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }

--- a/packages/create-astro/test/fixtures/not-empty/package.json
+++ b/packages/create-astro/test/fixtures/not-empty/package.json
@@ -1,1 +1,1 @@
-{}
+{"name": "@test/create-astro-not-empty"}


### PR DESCRIPTION
## Changes

Changeset is currently failing as I had removed the `package.json` `workspaces` field that it used to use in #6911. I don't think using that field is right, so I've tweak the changeset config, and provide a package name for one fixture to fix it.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested `pnpm changeset version --dry-run` to make sure there's no errors.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. changeset changes.