### PR TITLE
Fix tsconfig alias baseUrl handling for "." and ".." imports

### DIFF
--- a/.changeset/funny-plums-drum.md
+++ b/.changeset/funny-plums-drum.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix tsconfig alias baseUrl handling for "." and ".." imports

--- a/packages/astro/src/vite-plugin-config-alias/index.ts
+++ b/packages/astro/src/vite-plugin-config-alias/index.ts
@@ -48,7 +48,7 @@ const getConfigAlias = (settings: AstroSettings): Alias[] | null => {
 	// - `baseUrl` changes the way non-relative specifiers are resolved
 	// - if `baseUrl` exists then all non-relative specifiers are resolved relative to it
 	aliases.push({
-		find: /^(?!\.*\/|\w:)(.+)$/,
+		find: /^(?!\.*\/|\.*$|\w:)(.+)$/,
 		replacement: `${[...normalizePath(resolvedBaseUrl)]
 			.map((segment) => (segment === '$' ? '$$' : segment))
 			.join('')}/$1`,

--- a/packages/astro/test/alias-tsconfig.test.js
+++ b/packages/astro/test/alias-tsconfig.test.js
@@ -61,6 +61,7 @@ describe('Aliases with tsconfig.json', () => {
 
 			expect($('#foo').text()).to.equal('foo');
 			expect($('#constants-foo').text()).to.equal('foo');
+			expect($('#constants-index').text()).to.equal('index');
 		});
 
 		it('can load namespace packages with @* paths', async () => {
@@ -107,6 +108,7 @@ describe('Aliases with tsconfig.json', () => {
 
 			expect($('#foo').text()).to.equal('foo');
 			expect($('#constants-foo').text()).to.equal('foo');
+			expect($('#constants-index').text()).to.equal('index');
 		});
 
 		it('can load namespace packages with @* paths', async () => {

--- a/packages/astro/test/fixtures/alias-tsconfig/src/pages/index.astro
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/pages/index.astro
@@ -4,7 +4,7 @@ import Foo from 'src/components/Foo.astro';
 import StyleComp from 'src/components/Style.astro';
 import Alias from '@components/Alias.svelte';
 import { namespace } from '@test/namespace-package'
-import { foo } from 'src/utils/constants';
+import { foo, index } from 'src/utils/constants';
 import '@styles/main.css';
 ---
 <html lang="en">
@@ -21,6 +21,7 @@ import '@styles/main.css';
       <Alias client:load />
       <p id="namespace">{namespace}</p>
       <p id="constants-foo">{foo}</p>
+      <p id="constants-index">{index}</p>
       <p id="style-red">style-red</p>
       <p id="style-blue">style-blue</p>
     </main>

--- a/packages/astro/test/fixtures/alias-tsconfig/src/utils/constants.js
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/utils/constants.js
@@ -1,1 +1,3 @@
+export * from '.'
+
 export const foo = 'foo'

--- a/packages/astro/test/fixtures/alias-tsconfig/src/utils/index.js
+++ b/packages/astro/test/fixtures/alias-tsconfig/src/utils/index.js
@@ -1,0 +1,1 @@
+export const index = 'index'


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/6901

We were aliasing `import "."` and `import ".."` and prepending the `baseUrl` before which shouldn't happen. This PR updates the regex to ignore `.` and `..`.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added a new test using those imports.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.