### PR TITLE
Speed up docs smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
         run: pnpm run build
 
       - name: Remove docs translations except for English and Korean
-        run: find ./smoke/docs/src/content/docs ! -name 'en' ! -name 'ko' -type d -depth 1 -exec rm -rf {} +
+        run: find smoke/docs/src/content/docs ! -name 'en' ! -name 'ko' -type d -depth 1 -exec rm -rf {} +
 
       - name: Test
         run: pnpm run test:smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,9 @@ jobs:
       - name: Build Packages
         run: pnpm run build
 
+      - name: Remove docs translations except for English and Korean
+        run: find ./smoke/docs/src/content/docs ! -name 'en' ! -name 'ko' -type d -depth 1 -exec rm -rf {} +
+
       - name: Test
         run: pnpm run test:smoke
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
         run: pnpm run build
 
       - name: Remove docs translations except for English and Korean
-        run: find smoke/docs/src/content/docs ! -name 'en' ! -name 'ko' -type d -depth 1 -exec rm -rf {} +
+        run: find smoke/docs/src/content/docs ! -name 'en' ! -name 'ko' -type d -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 
       - name: Test
         run: pnpm run test:smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,4 +242,5 @@ jobs:
       - name: Test
         run: pnpm run test:smoke
         env:
-          SKIP_OG: 1
+          SKIP_OG: true
+          PUBLIC_TWO_LANG: true


### PR DESCRIPTION
## Changes

Uses a new `PUBLIC_TWO_LANG` field from https://github.com/withastro/docs/pull/3102 to speed up docs smoke tests. It will only generates pages for two languages to build faster, as mostly the content varies and not the functionality.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing smoke tests should pass and be faster.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a