### PR TITLE
Add missing code language in Cloudflare README

### DIFF
--- a/.changeset/tidy-singers-thank.md
+++ b/.changeset/tidy-singers-thank.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/cloudflare": patch
+---
+
+Fix missing code language in Cloudflare README

--- a/packages/integrations/cloudflare/README.md
+++ b/packages/integrations/cloudflare/README.md
@@ -117,7 +117,7 @@ You can also check our [Astro Integration Documentation][astro-integration] for 
 
 Currently, errors during running your application in Wrangler are not very useful, due to the minification of your code. For better debugging, you can add `vite.build.minify = false` setting to your `astro.config.js`
 
-```
+```js
 export default defineConfig({
 	adapter: cloudflare(),
 	output: 'server',


### PR DESCRIPTION
## Changes

This adds the missing `js` language to a code block that was causing issues in the docs integration page.
See: https://github.com/withastro/docs/pull/3105

## Testing

No tests!

## Docs

It's all about docs.
