### PR TITLE
Update dependencies to remove peer dep warnings

### DIFF
--- a/.changeset/wise-steaks-wash.md
+++ b/.changeset/wise-steaks-wash.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/tailwind': patch
+'@astrojs/svelte': patch
+---
+
+Update dependencies

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -15,9 +15,9 @@
     "@astrojs/tailwind": "^3.1.1",
     "@types/canvas-confetti": "^1.4.3",
     "astro": "^2.3.2",
-    "autoprefixer": "^10.4.7",
+    "autoprefixer": "^10.4.14",
     "canvas-confetti": "^1.5.1",
-    "postcss": "^8.4.14",
-    "tailwindcss": "^3.0.24"
+    "postcss": "^8.4.23",
+    "tailwindcss": "^3.3.2"
   }
 }

--- a/packages/astro/e2e/fixtures/tailwindcss/package.json
+++ b/packages/astro/e2e/fixtures/tailwindcss/package.json
@@ -5,8 +5,8 @@
   "dependencies": {
     "@astrojs/tailwind": "workspace:*",
     "astro": "workspace:*",
-    "autoprefixer": "^10.4.7",
-    "postcss": "^8.4.14",
-    "tailwindcss": "^3.0.24"
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.23",
+    "tailwindcss": "^3.3.2"
   }
 }

--- a/packages/astro/test/fixtures/postcss/package.json
+++ b/packages/astro/test/fixtures/postcss/package.json
@@ -7,8 +7,8 @@
     "@astrojs/svelte": "workspace:*",
     "@astrojs/vue": "workspace:*",
     "astro": "workspace:*",
-    "autoprefixer": "^10.4.7",
-    "postcss": "^8.4.14",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.23",
     "solid-js": "^1.5.6",
     "svelte": "^3.48.0",
     "vue": "^3.2.39"

--- a/packages/astro/test/fixtures/tailwindcss-ts/package.json
+++ b/packages/astro/test/fixtures/tailwindcss-ts/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@astrojs/tailwind": "workspace:*",
     "astro": "workspace:*",
-    "tailwindcss": "^3.2.4",
-    "postcss": ">=8.3.3 <9.0.0"
+    "tailwindcss": "^3.3.2",
+    "postcss": "^8.4.23"
   }
 }

--- a/packages/astro/test/fixtures/tailwindcss/package.json
+++ b/packages/astro/test/fixtures/tailwindcss/package.json
@@ -6,8 +6,8 @@
     "@astrojs/tailwind": "workspace:*",
     "@astrojs/mdx": "workspace:*",
     "astro": "workspace:*",
-    "autoprefixer": "^10.4.7",
-    "postcss": "^8.4.14",
-    "tailwindcss": "^3.0.24"
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.23",
+    "tailwindcss": "^3.3.2"
   }
 }

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -33,7 +33,7 @@
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {
-    "@sveltejs/vite-plugin-svelte": "^2.0.2",
+    "@sveltejs/vite-plugin-svelte": "^2.1.1",
     "svelte2tsx": "^0.5.11"
   },
   "devDependencies": {

--- a/packages/integrations/tailwind/package.json
+++ b/packages/integrations/tailwind/package.json
@@ -28,15 +28,15 @@
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {
-    "@proload/core": "^0.3.2",
-    "autoprefixer": "^10.4.7",
-    "postcss": "^8.4.14",
+    "@proload/core": "^0.3.3",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.23",
     "postcss-load-config": "^4.0.1"
   },
   "devDependencies": {
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
-    "tailwindcss": "^3.0.24",
+    "tailwindcss": "^3.3.2",
     "vite": "^4.3.1"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -493,17 +493,17 @@ importers:
         specifier: ^2.3.2
         version: link:../../packages/astro
       autoprefixer:
-        specifier: ^10.4.7
-        version: 10.4.7(postcss@8.4.14)
+        specifier: ^10.4.14
+        version: 10.4.14(postcss@8.4.23)
       canvas-confetti:
         specifier: ^1.5.1
         version: 1.5.1
       postcss:
-        specifier: ^8.4.14
-        version: 8.4.14
+        specifier: ^8.4.23
+        version: 8.4.23
       tailwindcss:
-        specifier: ^3.0.24
-        version: 3.2.4(postcss@8.4.14)
+        specifier: ^3.3.2
+        version: 3.3.2
 
   examples/with-vite-plugin-pwa:
     dependencies:
@@ -1471,14 +1471,14 @@ importers:
         specifier: workspace:*
         version: link:../../..
       autoprefixer:
-        specifier: ^10.4.7
-        version: 10.4.7(postcss@8.4.14)
+        specifier: ^10.4.14
+        version: 10.4.14(postcss@8.4.23)
       postcss:
-        specifier: ^8.4.14
-        version: 8.4.14
+        specifier: ^8.4.23
+        version: 8.4.23
       tailwindcss:
-        specifier: ^3.0.24
-        version: 3.2.4(postcss@8.4.14)
+        specifier: ^3.3.2
+        version: 3.3.2
 
   packages/astro/e2e/fixtures/ts-resolution:
     dependencies:
@@ -2784,11 +2784,11 @@ importers:
         specifier: workspace:*
         version: link:../../..
       autoprefixer:
-        specifier: ^10.4.7
-        version: 10.4.7(postcss@8.4.14)
+        specifier: ^10.4.14
+        version: 10.4.14(postcss@8.4.23)
       postcss:
-        specifier: ^8.4.14
-        version: 8.4.14
+        specifier: ^8.4.23
+        version: 8.4.23
       solid-js:
         specifier: ^1.5.6
         version: 1.5.6
@@ -2801,7 +2801,7 @@ importers:
     devDependencies:
       postcss-preset-env:
         specifier: ^7.7.1
-        version: 7.7.1(postcss@8.4.14)
+        version: 7.7.1(postcss@8.4.23)
 
   packages/astro/test/fixtures/preact-compat-component:
     dependencies:
@@ -3316,14 +3316,14 @@ importers:
         specifier: workspace:*
         version: link:../../..
       autoprefixer:
-        specifier: ^10.4.7
-        version: 10.4.7(postcss@8.4.14)
+        specifier: ^10.4.14
+        version: 10.4.14(postcss@8.4.23)
       postcss:
-        specifier: ^8.4.14
-        version: 8.4.14
+        specifier: ^8.4.23
+        version: 8.4.23
       tailwindcss:
-        specifier: ^3.0.24
-        version: 3.2.4(postcss@8.4.14)
+        specifier: ^3.3.2
+        version: 3.3.2
 
   packages/astro/test/fixtures/tailwindcss-ts:
     dependencies:
@@ -3334,11 +3334,11 @@ importers:
         specifier: workspace:*
         version: link:../../..
       postcss:
-        specifier: '>=8.3.3 <9.0.0'
-        version: 8.4.14
+        specifier: ^8.4.23
+        version: 8.4.23
       tailwindcss:
-        specifier: ^3.2.4
-        version: 3.2.4(postcss@8.4.14)
+        specifier: ^3.3.2
+        version: 3.3.2
 
   packages/astro/test/fixtures/third-party-astro:
     dependencies:
@@ -4531,8 +4531,8 @@ importers:
   packages/integrations/svelte:
     dependencies:
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^2.0.2
-        version: 2.0.2(svelte@3.54.0)(vite@4.3.1)
+        specifier: ^2.1.1
+        version: 2.1.1(svelte@3.54.0)(vite@4.3.1)
       svelte2tsx:
         specifier: ^0.5.11
         version: 0.5.11(svelte@3.54.0)(typescript@5.0.2)
@@ -4553,17 +4553,17 @@ importers:
   packages/integrations/tailwind:
     dependencies:
       '@proload/core':
-        specifier: ^0.3.2
-        version: 0.3.2
+        specifier: ^0.3.3
+        version: 0.3.3
       autoprefixer:
-        specifier: ^10.4.7
-        version: 10.4.7(postcss@8.4.14)
+        specifier: ^10.4.14
+        version: 10.4.14(postcss@8.4.23)
       postcss:
-        specifier: ^8.4.14
-        version: 8.4.14
+        specifier: ^8.4.23
+        version: 8.4.23
       postcss-load-config:
         specifier: ^4.0.1
-        version: 4.0.1(postcss@8.4.14)
+        version: 4.0.1(postcss@8.4.23)
     devDependencies:
       astro:
         specifier: workspace:*
@@ -4572,8 +4572,8 @@ importers:
         specifier: workspace:*
         version: link:../../../scripts
       tailwindcss:
-        specifier: ^3.0.24
-        version: 3.2.4(postcss@8.4.14)
+        specifier: ^3.3.2
+        version: 3.3.2
       vite:
         specifier: ^4.3.1
         version: 4.3.1(@types/node@18.7.21)(sass@1.52.2)
@@ -5198,6 +5198,10 @@ packages:
       '@algolia/logger-common': 4.17.0
       '@algolia/requester-common': 4.17.0
     dev: false
+
+  /@alloc/quick-lru@5.2.0:
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   /@altano/tiny-async-pool@1.0.2:
     resolution: {integrity: sha512-qQzaI0TBUPdpjZ3qo5b2ziQY9MSNpbziH2ZrE5lvtUZL+kn9GwVuVJwoOubaoNkeDB+rqEefnpu1k+oMpOCYiw==}
@@ -7090,128 +7094,128 @@ packages:
     dev: false
     optional: true
 
-  /@csstools/postcss-cascade-layers@1.1.1(postcss@8.4.14):
+  /@csstools/postcss-cascade-layers@1.1.1(postcss@8.4.23):
     resolution: {integrity: sha512-+KdYrpKC5TgomQr2DlZF4lDEpHcoxnj5IGddYYfBWJAKfj1JtuHUIqMa+E1pJJ+z3kvDViWMqyqPlG4Ja7amQA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
       '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.11)
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-selector-parser: 6.0.11
     dev: true
 
-  /@csstools/postcss-color-function@1.1.1(postcss@8.4.14):
+  /@csstools/postcss-color-function@1.1.1(postcss@8.4.23):
     resolution: {integrity: sha512-Bc0f62WmHdtRDjf5f3e2STwRAl89N2CLb+9iAwzrv4L2hncrbDwnQD9PCq0gtAt7pOI2leIV08HIBUd4jxD8cw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.14)
-      postcss: 8.4.14
+      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.23)
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-font-format-keywords@1.0.1(postcss@8.4.14):
+  /@csstools/postcss-font-format-keywords@1.0.1(postcss@8.4.23):
     resolution: {integrity: sha512-ZgrlzuUAjXIOc2JueK0X5sZDjCtgimVp/O5CEqTcs5ShWBa6smhWYbS0x5cVc/+rycTDbjjzoP0KTDnUneZGOg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-hwb-function@1.0.2(postcss@8.4.14):
+  /@csstools/postcss-hwb-function@1.0.2(postcss@8.4.23):
     resolution: {integrity: sha512-YHdEru4o3Rsbjmu6vHy4UKOXZD+Rn2zmkAmLRfPet6+Jz4Ojw8cbWxe1n42VaXQhD3CQUXXTooIy8OkVbUcL+w==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-ic-unit@1.0.1(postcss@8.4.14):
+  /@csstools/postcss-ic-unit@1.0.1(postcss@8.4.23):
     resolution: {integrity: sha512-Ot1rcwRAaRHNKC9tAqoqNZhjdYBzKk1POgWfhN4uCOE47ebGcLRqXjKkApVDpjifL6u2/55ekkpnFcp+s/OZUw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.14)
-      postcss: 8.4.14
+      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.23)
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-is-pseudo-class@2.0.7(postcss@8.4.14):
+  /@csstools/postcss-is-pseudo-class@2.0.7(postcss@8.4.23):
     resolution: {integrity: sha512-7JPeVVZHd+jxYdULl87lvjgvWldYu+Bc62s9vD/ED6/QTGjy0jy0US/f6BG53sVMTBJ1lzKZFpYmofBN9eaRiA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
       '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.11)
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-selector-parser: 6.0.11
     dev: true
 
-  /@csstools/postcss-normalize-display-values@1.0.1(postcss@8.4.14):
+  /@csstools/postcss-normalize-display-values@1.0.1(postcss@8.4.23):
     resolution: {integrity: sha512-jcOanIbv55OFKQ3sYeFD/T0Ti7AMXc9nM1hZWu8m/2722gOTxFg7xYu4RDLJLeZmPUVQlGzo4jhzvTUq3x4ZUw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-oklab-function@1.1.1(postcss@8.4.14):
+  /@csstools/postcss-oklab-function@1.1.1(postcss@8.4.23):
     resolution: {integrity: sha512-nJpJgsdA3dA9y5pgyb/UfEzE7W5Ka7u0CX0/HIMVBNWzWemdcTH3XwANECU6anWv/ao4vVNLTMxhiPNZsTK6iA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.14)
-      postcss: 8.4.14
+      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.23)
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-progressive-custom-properties@1.3.0(postcss@8.4.14):
+  /@csstools/postcss-progressive-custom-properties@1.3.0(postcss@8.4.23):
     resolution: {integrity: sha512-ASA9W1aIy5ygskZYuWams4BzafD12ULvSypmaLJT2jvQ8G0M3I8PRQhC0h7mG0Z3LI05+agZjqSR9+K9yaQQjA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.3
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-stepped-value-functions@1.0.1(postcss@8.4.14):
+  /@csstools/postcss-stepped-value-functions@1.0.1(postcss@8.4.23):
     resolution: {integrity: sha512-dz0LNoo3ijpTOQqEJLY8nyaapl6umbmDcgj4AD0lgVQ572b2eqA1iGZYTTWhrcrHztWDDRAX2DGYyw2VBjvCvQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-trigonometric-functions@1.0.2(postcss@8.4.14):
+  /@csstools/postcss-trigonometric-functions@1.0.2(postcss@8.4.23):
     resolution: {integrity: sha512-woKaLO///4bb+zZC2s80l+7cm07M7268MsyG3M0ActXXEFi6SuhvriQYcb58iiKGbjwwIU7n45iRLEHypB47Og==}
     engines: {node: ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-unset-value@1.0.2(postcss@8.4.14):
+  /@csstools/postcss-unset-value@1.0.2(postcss@8.4.23):
     resolution: {integrity: sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
     dev: true
 
   /@csstools/selector-specificity@2.2.0(postcss-selector-parser@6.0.11):
@@ -7581,17 +7585,14 @@ packages:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.18
-    dev: false
 
   /@jridgewell/resolve-uri@3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
     engines: {node: '>=6.0.0'}
-    dev: false
 
   /@jridgewell/set-array@1.1.2:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
-    dev: false
 
   /@jridgewell/source-map@0.3.3:
     resolution: {integrity: sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==}
@@ -7602,7 +7603,6 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
-    dev: false
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
@@ -7612,7 +7612,6 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
-    dev: false
 
   /@jsdevtools/rehype-toc@3.0.2:
     resolution: {integrity: sha512-n5JEf16Wr4mdkRMZ8wMP/wN9/sHmTjRPbouXjJH371mZ2LEGDl72t8tEsMRNFerQN/QJtivOxqK1frdGa4QK5Q==}
@@ -8137,8 +8136,8 @@ packages:
       preact: 10.11.0
     dev: false
 
-  /@proload/core@0.3.2:
-    resolution: {integrity: sha512-4ga4HpS0ieVYWVMS+F62W++6SNACBu0lkw8snw3tEdH6AeqZu8i8262n3I81jWAWXVcg3sMfhb+kBexrfGrTUQ==}
+  /@proload/core@0.3.3:
+    resolution: {integrity: sha512-7dAFWsIK84C90AMl24+N/ProHKm4iw0akcnoKjRvbfHifJZBLhaDsDus1QJmhG12lXj4e/uB/8mB/0aduCW+NQ==}
     dependencies:
       deepmerge: 4.3.1
       escalade: 3.1.1
@@ -8312,8 +8311,8 @@ packages:
       string.prototype.matchall: 4.0.8
     dev: false
 
-  /@sveltejs/vite-plugin-svelte@2.0.2(svelte@3.54.0)(vite@4.3.1):
-    resolution: {integrity: sha512-xCEan0/NNpQuL0l5aS42FjwQ6wwskdxC3pW1OeFtEKNZwRg7Evro9lac9HesGP6TdFsTv2xMes5ASQVKbCacxg==}
+  /@sveltejs/vite-plugin-svelte@2.1.1(svelte@3.54.0)(vite@4.3.1):
+    resolution: {integrity: sha512-7YeBDt4us0FiIMNsVXxyaP4Hwyn2/v9x3oqStkHU3ZdIc5O22pGwUwH33wUqYo+7Itdmo8zxJ45Qvfm3H7UUjQ==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
       svelte: ^3.54.0
@@ -8325,7 +8324,7 @@ packages:
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
-      magic-string: 0.27.0
+      magic-string: 0.30.0
       svelte: 3.54.0
       svelte-hmr: 0.15.1(svelte@3.54.0)
       vite: 4.3.1(@types/node@18.7.21)(sass@1.52.2)
@@ -8347,7 +8346,7 @@ packages:
   /@ts-morph/common@0.16.0:
     resolution: {integrity: sha512-SgJpzkTgZKLKqQniCjLaE3c2L2sdL7UShvmTmPBejAKd2OKV/yfMpQ2IWpAuA+VY5wy7PkSUaEObIqEK6afFuw==}
     dependencies:
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       minimatch: 5.1.6
       mkdirp: 1.0.4
       path-browserify: 1.0.1
@@ -9136,7 +9135,7 @@ packages:
       '@vue/shared': 3.2.39
       estree-walker: 2.0.2
       magic-string: 0.25.9
-      postcss: 8.4.14
+      postcss: 8.4.23
       source-map: 0.6.1
     dev: false
 
@@ -9151,7 +9150,7 @@ packages:
       '@vue/shared': 3.2.40
       estree-walker: 2.0.2
       magic-string: 0.25.9
-      postcss: 8.4.14
+      postcss: 8.4.23
       source-map: 0.6.1
 
   /@vue/compiler-ssr@3.2.39:
@@ -9274,16 +9273,10 @@ packages:
     dependencies:
       acorn: 8.8.1
 
-  /acorn-node@1.8.2:
-    resolution: {integrity: sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==}
-    dependencies:
-      acorn: 7.4.1
-      acorn-walk: 7.2.0
-      xtend: 4.0.2
-
   /acorn-walk@7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
     engines: {node: '>=0.4.0'}
+    dev: true
 
   /acorn-walk@8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
@@ -9294,6 +9287,7 @@ packages:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+    dev: true
 
   /acorn@8.8.1:
     resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
@@ -9404,6 +9398,9 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
     dev: false
+
+  /any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
   /anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -9549,8 +9546,8 @@ packages:
       timestring: 6.0.0
     dev: false
 
-  /autoprefixer@10.4.7(postcss@8.4.14):
-    resolution: {integrity: sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==}
+  /autoprefixer@10.4.14(postcss@8.4.23):
+    resolution: {integrity: sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
@@ -9561,7 +9558,7 @@ packages:
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.0.0
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
 
   /available-typed-arrays@1.0.5:
@@ -10111,6 +10108,10 @@ packages:
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  /commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
   /commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
@@ -10236,36 +10237,36 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /css-blank-pseudo@3.0.3(postcss@8.4.14):
+  /css-blank-pseudo@3.0.3(postcss@8.4.23):
     resolution: {integrity: sha512-VS90XWtsHGqoM0t4KpH053c4ehxZ2E6HtGI7x68YFV0pTo/QmkV/YFA+NnlvK8guxZVNWGQhVNJGC39Q8XF4OQ==}
     engines: {node: ^12 || ^14 || >=16}
     hasBin: true
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-selector-parser: 6.0.11
     dev: true
 
-  /css-has-pseudo@3.0.4(postcss@8.4.14):
+  /css-has-pseudo@3.0.4(postcss@8.4.23):
     resolution: {integrity: sha512-Vse0xpR1K9MNlp2j5w1pgWIJtm1a8qS0JwS9goFYcImjlHEmywP9VUF05aGBXzGpDJF86QXk4L0ypBmwPhGArw==}
     engines: {node: ^12 || ^14 || >=16}
     hasBin: true
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-selector-parser: 6.0.11
     dev: true
 
-  /css-prefers-color-scheme@6.0.3(postcss@8.4.14):
+  /css-prefers-color-scheme@6.0.3(postcss@8.4.23):
     resolution: {integrity: sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==}
     engines: {node: ^12 || ^14 || >=16}
     hasBin: true
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
     dev: true
 
   /css-select@5.1.0:
@@ -10476,9 +10477,6 @@ packages:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
 
-  /defined@1.0.1:
-    resolution: {integrity: sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==}
-
   /defu@5.0.1:
     resolution: {integrity: sha512-EPS1carKg+dkEVy3qNTqIdp2qV7mUP08nIsupfwQpz++slCVRw7qbQyWvSTig+kFPwz2XXp5/kIIkH+CwrJKkQ==}
     dev: false
@@ -10549,15 +10547,6 @@ packages:
   /detect-libc@2.0.1:
     resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==}
     engines: {node: '>=8'}
-
-  /detective@5.2.1:
-    resolution: {integrity: sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==}
-    engines: {node: '>=0.8.0'}
-    hasBin: true
-    dependencies:
-      acorn-node: 1.8.2
-      defined: 1.0.1
-      minimist: 1.2.8
 
   /devalue@4.2.0:
     resolution: {integrity: sha512-mbjoAaCL2qogBKgeFxFPOXAUsZchircF+B/79LD4sHH0+NHfYm8gZpQrskKDn5gENGt35+5OI1GUF7hLVnkPDw==}
@@ -11922,6 +11911,16 @@ packages:
     dependencies:
       is-glob: 4.0.3
 
+  /glob@7.1.6:
+    resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
   /glob@7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
     dependencies:
@@ -11981,7 +11980,7 @@ packages:
       '@types/glob': 7.2.0
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       glob: 7.2.3
       ignore: 5.2.4
       merge2: 1.4.1
@@ -11994,7 +11993,7 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
@@ -12817,7 +12816,6 @@ packages:
   /jiti@1.18.2:
     resolution: {integrity: sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==}
     hasBin: true
-    dev: false
 
   /js-sdsl@4.4.0:
     resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
@@ -12997,7 +12995,6 @@ packages:
 
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-    dev: true
 
   /linkedom@0.14.17:
     resolution: {integrity: sha512-PD6GQKvZ4s6Ai4/WkpyHc8MhiZdCz4hWmMOWJk+MO3/kl1QvPUbo4nQWS9+VHO7lRBk1ucIa9ONS9qzCUcBAmQ==}
@@ -13198,6 +13195,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  /magic-string@0.30.0:
+    resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: false
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -14037,6 +14041,13 @@ packages:
     hasBin: true
     dev: true
 
+  /mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
   /nanoid@3.3.1:
     resolution: {integrity: sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -14245,7 +14256,6 @@ packages:
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
@@ -14627,6 +14637,10 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  /pirates@4.0.5:
+    resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
+    engines: {node: '>= 6'}
+
   /pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
@@ -14659,220 +14673,204 @@ packages:
     resolution: {integrity: sha512-Hz/WvSNt5+7x+Rq1Cn6DetJOZxKtLDehJ1mLCYge6ju4QvSF/PHvRgy94e1SKJVI96AJTcqEdNwkkaAFad+TXQ==}
     dev: false
 
-  /postcss-attribute-case-insensitive@5.0.2(postcss@8.4.14):
+  /postcss-attribute-case-insensitive@5.0.2(postcss@8.4.23):
     resolution: {integrity: sha512-XIidXV8fDr0kKt28vqki84fRK8VW8eTuIa4PChv2MqKuT6C9UjmSKzen6KaWhWEoYvwxFCa7n/tC1SZ3tyq4SQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-selector-parser: 6.0.11
     dev: true
 
-  /postcss-clamp@4.1.0(postcss@8.4.14):
+  /postcss-clamp@4.1.0(postcss@8.4.23):
     resolution: {integrity: sha512-ry4b1Llo/9zz+PKC+030KUnPITTJAHeOwjfAyyB60eT0AorGLdzp52s31OsPRHRf8NchkgFoG2y6fCfn1IV1Ow==}
     engines: {node: '>=7.6.0'}
     peerDependencies:
       postcss: ^8.4.6
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-color-functional-notation@4.2.4(postcss@8.4.14):
+  /postcss-color-functional-notation@4.2.4(postcss@8.4.23):
     resolution: {integrity: sha512-2yrTAUZUab9s6CpxkxC4rVgFEVaR6/2Pipvi6qcgvnYiVqZcbDHEoBDhrXzyb7Efh2CCfHQNtcqWcIruDTIUeg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-color-hex-alpha@8.0.4(postcss@8.4.14):
+  /postcss-color-hex-alpha@8.0.4(postcss@8.4.23):
     resolution: {integrity: sha512-nLo2DCRC9eE4w2JmuKgVA3fGL3d01kGq752pVALF68qpGLmx2Qrk91QTKkdUqqp45T1K1XV8IhQpcu1hoAQflQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-color-rebeccapurple@7.1.1(postcss@8.4.14):
+  /postcss-color-rebeccapurple@7.1.1(postcss@8.4.23):
     resolution: {integrity: sha512-pGxkuVEInwLHgkNxUc4sdg4g3py7zUeCQ9sMfwyHAT+Ezk8a4OaaVZ8lIY5+oNqA/BXXgLyXv0+5wHP68R79hg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-custom-media@8.0.2(postcss@8.4.14):
+  /postcss-custom-media@8.0.2(postcss@8.4.23):
     resolution: {integrity: sha512-7yi25vDAoHAkbhAzX9dHx2yc6ntS4jQvejrNcC+csQJAXjj15e7VcWfMgLqBNAbOvqi5uIa9huOVwdHbf+sKqg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.3
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-custom-properties@12.1.11(postcss@8.4.14):
+  /postcss-custom-properties@12.1.11(postcss@8.4.23):
     resolution: {integrity: sha512-0IDJYhgU8xDv1KY6+VgUwuQkVtmYzRwu+dMjnmdMafXYv86SWqfxkc7qdDvWS38vsjaEtv8e0vGOUQrAiMBLpQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-custom-selectors@6.0.3(postcss@8.4.14):
+  /postcss-custom-selectors@6.0.3(postcss@8.4.23):
     resolution: {integrity: sha512-fgVkmyiWDwmD3JbpCmB45SvvlCD6z9CG6Ie6Iere22W5aHea6oWa7EM2bpnv2Fj3I94L3VbtvX9KqwSi5aFzSg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.3
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-selector-parser: 6.0.11
     dev: true
 
-  /postcss-dir-pseudo-class@6.0.5(postcss@8.4.14):
+  /postcss-dir-pseudo-class@6.0.5(postcss@8.4.23):
     resolution: {integrity: sha512-eqn4m70P031PF7ZQIvSgy9RSJ5uI2171O/OO/zcRNYpJbvaeKFUlar1aJ7rmgiQtbm0FSPsRewjpdS0Oew7MPA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-selector-parser: 6.0.11
     dev: true
 
-  /postcss-double-position-gradients@3.1.2(postcss@8.4.14):
+  /postcss-double-position-gradients@3.1.2(postcss@8.4.23):
     resolution: {integrity: sha512-GX+FuE/uBR6eskOK+4vkXgT6pDkexLokPaz/AbJna9s5Kzp/yl488pKPjhy0obB475ovfT1Wv8ho7U/cHNaRgQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.14)
-      postcss: 8.4.14
+      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.23)
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-env-function@4.0.6(postcss@8.4.14):
+  /postcss-env-function@4.0.6(postcss@8.4.23):
     resolution: {integrity: sha512-kpA6FsLra+NqcFnL81TnsU+Z7orGtDTxcOhl6pwXeEq1yFPpRMkCDpHhrz8CFQDr/Wfm0jLiNQ1OsGGPjlqPwA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-focus-visible@6.0.4(postcss@8.4.14):
+  /postcss-focus-visible@6.0.4(postcss@8.4.23):
     resolution: {integrity: sha512-QcKuUU/dgNsstIK6HELFRT5Y3lbrMLEOwG+A4s5cA+fx3A3y/JTq3X9LaOj3OC3ALH0XqyrgQIgey/MIZ8Wczw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-selector-parser: 6.0.11
     dev: true
 
-  /postcss-focus-within@5.0.4(postcss@8.4.14):
+  /postcss-focus-within@5.0.4(postcss@8.4.23):
     resolution: {integrity: sha512-vvjDN++C0mu8jz4af5d52CB184ogg/sSxAFS+oUJQq2SuCe7T5U2iIsVJtsCp2d6R4j0jr5+q3rPkBVZkXD9fQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-selector-parser: 6.0.11
     dev: true
 
-  /postcss-font-variant@5.0.0(postcss@8.4.14):
+  /postcss-font-variant@5.0.0(postcss@8.4.23):
     resolution: {integrity: sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
     dev: true
 
-  /postcss-gap-properties@3.0.5(postcss@8.4.14):
+  /postcss-gap-properties@3.0.5(postcss@8.4.23):
     resolution: {integrity: sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
     dev: true
 
-  /postcss-image-set-function@4.0.7(postcss@8.4.14):
+  /postcss-image-set-function@4.0.7(postcss@8.4.23):
     resolution: {integrity: sha512-9T2r9rsvYzm5ndsBE8WgtrMlIT7VbtTfE7b3BQnudUqnBcBo7L758oc+o+pdj/dUV0l5wjwSdjeOH2DZtfv8qw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-import@14.1.0(postcss@8.4.14):
-    resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
-    engines: {node: '>=10.0.0'}
+  /postcss-import@15.1.0(postcss@8.4.23):
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.2
 
-  /postcss-initial@4.0.1(postcss@8.4.14):
+  /postcss-initial@4.0.1(postcss@8.4.23):
     resolution: {integrity: sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
     dev: true
 
-  /postcss-js@4.0.1(postcss@8.4.14):
+  /postcss-js@4.0.1(postcss@8.4.23):
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
       postcss: ^8.4.21
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.14
+      postcss: 8.4.23
 
-  /postcss-lab-function@4.2.1(postcss@8.4.14):
+  /postcss-lab-function@4.2.1(postcss@8.4.23):
     resolution: {integrity: sha512-xuXll4isR03CrQsmxyz92LJB2xX9n+pZJ5jE9JgcnmsCammLyKdlzrBin+25dy6wIjfhJpKBAN80gsTlCgRk2w==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.14)
-      postcss: 8.4.14
+      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.23)
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-load-config@3.1.4(postcss@8.4.14):
-    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
-    engines: {node: '>= 10'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 2.1.0
-      postcss: 8.4.14
-      yaml: 1.10.2
-
-  /postcss-load-config@4.0.1(postcss@8.4.14):
+  /postcss-load-config@4.0.1(postcss@8.4.23):
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -14885,166 +14883,165 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.1.0
-      postcss: 8.4.14
+      postcss: 8.4.23
       yaml: 2.2.1
-    dev: false
 
-  /postcss-logical@5.0.4(postcss@8.4.14):
+  /postcss-logical@5.0.4(postcss@8.4.23):
     resolution: {integrity: sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
     dev: true
 
-  /postcss-media-minmax@5.0.0(postcss@8.4.14):
+  /postcss-media-minmax@5.0.0(postcss@8.4.23):
     resolution: {integrity: sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
     dev: true
 
-  /postcss-nested@6.0.0(postcss@8.4.14):
-    resolution: {integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==}
+  /postcss-nested@6.0.1(postcss@8.4.23):
+    resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-selector-parser: 6.0.11
 
-  /postcss-nesting@10.2.0(postcss@8.4.14):
+  /postcss-nesting@10.2.0(postcss@8.4.23):
     resolution: {integrity: sha512-EwMkYchxiDiKUhlJGzWsD9b2zvq/r2SSubcRrgP+jujMXFzqvANLt16lJANC+5uZ6hjI7lpRmI6O8JIl+8l1KA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
       '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.11)
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-selector-parser: 6.0.11
     dev: true
 
-  /postcss-opacity-percentage@1.1.3(postcss@8.4.14):
+  /postcss-opacity-percentage@1.1.3(postcss@8.4.23):
     resolution: {integrity: sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
     dev: true
 
-  /postcss-overflow-shorthand@3.0.4(postcss@8.4.14):
+  /postcss-overflow-shorthand@3.0.4(postcss@8.4.23):
     resolution: {integrity: sha512-otYl/ylHK8Y9bcBnPLo3foYFLL6a6Ak+3EQBPOTR7luMYCOsiVTUk1iLvNf6tVPNGXcoL9Hoz37kpfriRIFb4A==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-page-break@3.0.4(postcss@8.4.14):
+  /postcss-page-break@3.0.4(postcss@8.4.23):
     resolution: {integrity: sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==}
     peerDependencies:
       postcss: ^8
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
     dev: true
 
-  /postcss-place@7.0.5(postcss@8.4.14):
+  /postcss-place@7.0.5(postcss@8.4.23):
     resolution: {integrity: sha512-wR8igaZROA6Z4pv0d+bvVrvGY4GVHihBCBQieXFY3kuSuMyOmEnnfFzHl/tQuqHZkfkIVBEbDvYcFfHmpSet9g==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-preset-env@7.7.1(postcss@8.4.14):
+  /postcss-preset-env@7.7.1(postcss@8.4.23):
     resolution: {integrity: sha512-1sx6+Nl1wMVJzaYLVaz4OAR6JodIN/Z1upmVqLwSPCLT6XyxrEoePgNMHPH08kseLe3z06i9Vfkt/32BYEKDeA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      '@csstools/postcss-cascade-layers': 1.1.1(postcss@8.4.14)
-      '@csstools/postcss-color-function': 1.1.1(postcss@8.4.14)
-      '@csstools/postcss-font-format-keywords': 1.0.1(postcss@8.4.14)
-      '@csstools/postcss-hwb-function': 1.0.2(postcss@8.4.14)
-      '@csstools/postcss-ic-unit': 1.0.1(postcss@8.4.14)
-      '@csstools/postcss-is-pseudo-class': 2.0.7(postcss@8.4.14)
-      '@csstools/postcss-normalize-display-values': 1.0.1(postcss@8.4.14)
-      '@csstools/postcss-oklab-function': 1.1.1(postcss@8.4.14)
-      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.14)
-      '@csstools/postcss-stepped-value-functions': 1.0.1(postcss@8.4.14)
-      '@csstools/postcss-trigonometric-functions': 1.0.2(postcss@8.4.14)
-      '@csstools/postcss-unset-value': 1.0.2(postcss@8.4.14)
-      autoprefixer: 10.4.7(postcss@8.4.14)
+      '@csstools/postcss-cascade-layers': 1.1.1(postcss@8.4.23)
+      '@csstools/postcss-color-function': 1.1.1(postcss@8.4.23)
+      '@csstools/postcss-font-format-keywords': 1.0.1(postcss@8.4.23)
+      '@csstools/postcss-hwb-function': 1.0.2(postcss@8.4.23)
+      '@csstools/postcss-ic-unit': 1.0.1(postcss@8.4.23)
+      '@csstools/postcss-is-pseudo-class': 2.0.7(postcss@8.4.23)
+      '@csstools/postcss-normalize-display-values': 1.0.1(postcss@8.4.23)
+      '@csstools/postcss-oklab-function': 1.1.1(postcss@8.4.23)
+      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.23)
+      '@csstools/postcss-stepped-value-functions': 1.0.1(postcss@8.4.23)
+      '@csstools/postcss-trigonometric-functions': 1.0.2(postcss@8.4.23)
+      '@csstools/postcss-unset-value': 1.0.2(postcss@8.4.23)
+      autoprefixer: 10.4.14(postcss@8.4.23)
       browserslist: 4.21.5
-      css-blank-pseudo: 3.0.3(postcss@8.4.14)
-      css-has-pseudo: 3.0.4(postcss@8.4.14)
-      css-prefers-color-scheme: 6.0.3(postcss@8.4.14)
+      css-blank-pseudo: 3.0.3(postcss@8.4.23)
+      css-has-pseudo: 3.0.4(postcss@8.4.23)
+      css-prefers-color-scheme: 6.0.3(postcss@8.4.23)
       cssdb: 6.6.3
-      postcss: 8.4.14
-      postcss-attribute-case-insensitive: 5.0.2(postcss@8.4.14)
-      postcss-clamp: 4.1.0(postcss@8.4.14)
-      postcss-color-functional-notation: 4.2.4(postcss@8.4.14)
-      postcss-color-hex-alpha: 8.0.4(postcss@8.4.14)
-      postcss-color-rebeccapurple: 7.1.1(postcss@8.4.14)
-      postcss-custom-media: 8.0.2(postcss@8.4.14)
-      postcss-custom-properties: 12.1.11(postcss@8.4.14)
-      postcss-custom-selectors: 6.0.3(postcss@8.4.14)
-      postcss-dir-pseudo-class: 6.0.5(postcss@8.4.14)
-      postcss-double-position-gradients: 3.1.2(postcss@8.4.14)
-      postcss-env-function: 4.0.6(postcss@8.4.14)
-      postcss-focus-visible: 6.0.4(postcss@8.4.14)
-      postcss-focus-within: 5.0.4(postcss@8.4.14)
-      postcss-font-variant: 5.0.0(postcss@8.4.14)
-      postcss-gap-properties: 3.0.5(postcss@8.4.14)
-      postcss-image-set-function: 4.0.7(postcss@8.4.14)
-      postcss-initial: 4.0.1(postcss@8.4.14)
-      postcss-lab-function: 4.2.1(postcss@8.4.14)
-      postcss-logical: 5.0.4(postcss@8.4.14)
-      postcss-media-minmax: 5.0.0(postcss@8.4.14)
-      postcss-nesting: 10.2.0(postcss@8.4.14)
-      postcss-opacity-percentage: 1.1.3(postcss@8.4.14)
-      postcss-overflow-shorthand: 3.0.4(postcss@8.4.14)
-      postcss-page-break: 3.0.4(postcss@8.4.14)
-      postcss-place: 7.0.5(postcss@8.4.14)
-      postcss-pseudo-class-any-link: 7.1.6(postcss@8.4.14)
-      postcss-replace-overflow-wrap: 4.0.0(postcss@8.4.14)
-      postcss-selector-not: 6.0.1(postcss@8.4.14)
+      postcss: 8.4.23
+      postcss-attribute-case-insensitive: 5.0.2(postcss@8.4.23)
+      postcss-clamp: 4.1.0(postcss@8.4.23)
+      postcss-color-functional-notation: 4.2.4(postcss@8.4.23)
+      postcss-color-hex-alpha: 8.0.4(postcss@8.4.23)
+      postcss-color-rebeccapurple: 7.1.1(postcss@8.4.23)
+      postcss-custom-media: 8.0.2(postcss@8.4.23)
+      postcss-custom-properties: 12.1.11(postcss@8.4.23)
+      postcss-custom-selectors: 6.0.3(postcss@8.4.23)
+      postcss-dir-pseudo-class: 6.0.5(postcss@8.4.23)
+      postcss-double-position-gradients: 3.1.2(postcss@8.4.23)
+      postcss-env-function: 4.0.6(postcss@8.4.23)
+      postcss-focus-visible: 6.0.4(postcss@8.4.23)
+      postcss-focus-within: 5.0.4(postcss@8.4.23)
+      postcss-font-variant: 5.0.0(postcss@8.4.23)
+      postcss-gap-properties: 3.0.5(postcss@8.4.23)
+      postcss-image-set-function: 4.0.7(postcss@8.4.23)
+      postcss-initial: 4.0.1(postcss@8.4.23)
+      postcss-lab-function: 4.2.1(postcss@8.4.23)
+      postcss-logical: 5.0.4(postcss@8.4.23)
+      postcss-media-minmax: 5.0.0(postcss@8.4.23)
+      postcss-nesting: 10.2.0(postcss@8.4.23)
+      postcss-opacity-percentage: 1.1.3(postcss@8.4.23)
+      postcss-overflow-shorthand: 3.0.4(postcss@8.4.23)
+      postcss-page-break: 3.0.4(postcss@8.4.23)
+      postcss-place: 7.0.5(postcss@8.4.23)
+      postcss-pseudo-class-any-link: 7.1.6(postcss@8.4.23)
+      postcss-replace-overflow-wrap: 4.0.0(postcss@8.4.23)
+      postcss-selector-not: 6.0.1(postcss@8.4.23)
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-pseudo-class-any-link@7.1.6(postcss@8.4.14):
+  /postcss-pseudo-class-any-link@7.1.6(postcss@8.4.23):
     resolution: {integrity: sha512-9sCtZkO6f/5ML9WcTLcIyV1yz9D1rf0tWc+ulKcvV30s0iZKS/ONyETvoWsr6vnrmW+X+KmuK3gV/w5EWnT37w==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-selector-parser: 6.0.11
     dev: true
 
-  /postcss-replace-overflow-wrap@4.0.0(postcss@8.4.14):
+  /postcss-replace-overflow-wrap@4.0.0(postcss@8.4.23):
     resolution: {integrity: sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==}
     peerDependencies:
       postcss: ^8.0.3
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
     dev: true
 
-  /postcss-selector-not@6.0.1(postcss@8.4.14):
+  /postcss-selector-not@6.0.1(postcss@8.4.23):
     resolution: {integrity: sha512-1i9affjAe9xu/y9uqWH+tD4r6/hDaXJruk8xn2x1vzxC2U3J3LKO3zJW4CyxlNhA56pADJ/djpEwpH1RClI2rQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.14
+      postcss: 8.4.23
       postcss-selector-parser: 6.0.11
     dev: true
 
@@ -15058,16 +15055,8 @@ packages:
   /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  /postcss@8.4.14:
-    resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.6
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
-
-  /postcss@8.4.21:
-    resolution: {integrity: sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==}
+  /postcss@8.4.23:
+    resolution: {integrity: sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.6
@@ -15249,10 +15238,6 @@ packages:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
     engines: {node: '>=8'}
     dev: true
-
-  /quick-lru@5.1.1:
-    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
-    engines: {node: '>=10'}
 
   /randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -16360,6 +16345,19 @@ packages:
       minimist: 1.2.8
     dev: false
 
+  /sucrase@3.32.0:
+    resolution: {integrity: sha512-ydQOU34rpSyj2TGyz4D2p8rbktIOZ8QY9s+DGLvFU1i5pWJE8vkpruCjGCMHsdXwnD7JDcS+noSwM/a7zyNFDQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.3
+      commander: 4.1.1
+      glob: 7.1.6
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.5
+      ts-interface-checker: 0.1.13
+
   /suf-log@2.5.3:
     resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
     dependencies:
@@ -16441,36 +16439,34 @@ packages:
       '@pkgr/utils': 2.3.1
       tslib: 2.5.0
 
-  /tailwindcss@3.2.4(postcss@8.4.14):
-    resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
-    engines: {node: '>=12.13.0'}
+  /tailwindcss@3.3.2:
+    resolution: {integrity: sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==}
+    engines: {node: '>=14.0.0'}
     hasBin: true
-    peerDependencies:
-      postcss: ^8.0.9
     dependencies:
+      '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
       chokidar: 3.5.3
-      color-name: 1.1.4
-      detective: 5.2.1
       didyoumean: 1.2.2
       dlv: 1.1.3
       fast-glob: 3.2.12
       glob-parent: 6.0.2
       is-glob: 4.0.3
+      jiti: 1.18.2
       lilconfig: 2.1.0
       micromatch: 4.0.5
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.0.0
-      postcss: 8.4.14
-      postcss-import: 14.1.0(postcss@8.4.14)
-      postcss-js: 4.0.1(postcss@8.4.14)
-      postcss-load-config: 3.1.4(postcss@8.4.14)
-      postcss-nested: 6.0.0(postcss@8.4.14)
+      postcss: 8.4.23
+      postcss-import: 15.1.0(postcss@8.4.23)
+      postcss-js: 4.0.1(postcss@8.4.23)
+      postcss-load-config: 4.0.1(postcss@8.4.23)
+      postcss-nested: 6.0.1(postcss@8.4.23)
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
-      quick-lru: 5.1.1
       resolve: 1.22.2
+      sucrase: 3.32.0
     transitivePeerDependencies:
       - ts-node
 
@@ -16555,6 +16551,17 @@ packages:
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
+
+  /thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+    dependencies:
+      thenify: 3.3.1
+
+  /thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+    dependencies:
+      any-promise: 1.3.0
 
   /throttles@1.0.1:
     resolution: {integrity: sha512-fab7Xg+zELr9KOv4fkaBoe/b3L0GMGLd0IBSCn16GoE/Qx6/OfCr1eGNyEcDU2pUA79qQfZ8kPQWlRuok4YwTw==}
@@ -16649,6 +16656,9 @@ packages:
 
   /trough@2.1.0:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
+
+  /ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   /ts-morph@15.1.0:
     resolution: {integrity: sha512-RBsGE2sDzUXFTnv8Ba22QfeuKbgvAGJFuTN7HfmIRUkgT/NaVLfDM/8OFm2NlFkGlWEXdpW5OaFIp1jvqdDuOg==}
@@ -17222,7 +17232,7 @@ packages:
     dependencies:
       '@types/node': 18.7.21
       esbuild: 0.15.18
-      postcss: 8.4.21
+      postcss: 8.4.23
       resolve: 1.22.2
       rollup: 2.79.1
     optionalDependencies:
@@ -17256,7 +17266,7 @@ packages:
     dependencies:
       '@types/node': 18.7.21
       esbuild: 0.17.12
-      postcss: 8.4.21
+      postcss: 8.4.23
       rollup: 3.20.6
       sass: 1.52.2
     optionalDependencies:
@@ -17826,10 +17836,6 @@ packages:
     resolution: {integrity: sha512-xl/50/Cf32VsGq/1R8jJE5ajH1yMCQkpmoS10QbFZWl2Oor4H0Me64Pu2yxvsRWK3m6soJbmGfzSR7BYmDcWAA==}
     dev: true
 
-  /xtend@4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
-
   /xxhash-wasm@1.0.2:
     resolution: {integrity: sha512-ibF0Or+FivM9lNrg+HGJfVX8WJqgo+kCLDc4vx6xMeTce7Aj+DLttKbxxRR/gNLSAelRc1omAPlJ77N/Jem07A==}
     dev: true
@@ -17852,14 +17858,9 @@ packages:
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
-  /yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
-    engines: {node: '>= 6'}
-
   /yaml@2.2.1:
     resolution: {integrity: sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==}
     engines: {node: '>= 14'}
-    dev: false
 
   /yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}


### PR DESCRIPTION
## Changes

- Update dependencies to prevent the postcss peer dep warnings on install.
- Also update the `@sveltejs/vite-plugin-svelte` dep as that removes the stats log clutter in the CI logs

There's one remaining peer dep warning though:

```
 WARN  Issues with peer dependencies found
packages/integrations/svelte
└─┬ svelte2tsx 0.5.11
  └── ✕ unmet peer typescript@^4.1.2: found 5.0.2
```

We need to upgrade to svelte2tsx v6 to fix it, but that bumps the peer dep of `svelte` to 3.55.0. Our svelte peer dep is 3.54.0. So we'd need to cut a major if we want to fix it, which doesn't seem worth it for now.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. deps update