### PR TITLE
Configure redoc to be noExternal

### DIFF
--- a/.changeset/many-fans-reply.md
+++ b/.changeset/many-fans-reply.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/react": patch
+---
+
+Automatically configure redoc

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -66,6 +66,7 @@ function getViteConfiguration() {
 				'@mui/material',
 				'@mui/base',
 				'@babel/runtime',
+				'redoc',
 				'use-immer',
 			],
 		},


### PR DESCRIPTION
## Changes

- Automatically set `noExternal` configuration for redoc, a popular React package
- Closes https://github.com/withastro/astro/issues/6656

## Testing

Just in stackblitz.

https://stackblitz.com/edit/github-dubfdg?file=package.json,astro.config.mjs,src%2Fpages%2Findex.astro,node_modules%2Fastro%2Fdist%2F%40types%2Fastro.d.ts,node_modules%2Fvite%2Fdist%2Fnode%2Findex.d.ts&on=stackblitz

## Docs

No