### PR TITLE
Fix some TS compilation errors

### DIFF
--- a/packages/integrations/netlify/test/edge-functions/dynamic-import.test.js
+++ b/packages/integrations/netlify/test/edge-functions/dynamic-import.test.js
@@ -1,9 +1,6 @@
-// @ts-ignore
 import { runBuild, runApp } from './test-utils.ts';
-// @ts-ignore
 import { assertEquals, assert, DOMParser } from './deps.ts';
 
-// @ts-ignore
 Deno.test({
 	name: 'Dynamic imports',
 	async fn() {

--- a/packages/integrations/netlify/test/edge-functions/edge-basic.test.ts
+++ b/packages/integrations/netlify/test/edge-functions/edge-basic.test.ts
@@ -1,9 +1,6 @@
-// @ts-expect-error
 import { runBuild } from './test-utils.ts';
-// @ts-expect-error
 import { assertEquals, assert, DOMParser } from './deps.ts';
 
-// @ts-expect-error
 Deno.env.set('SECRET_STUFF', 'secret');
 
 // @ts-expect-error

--- a/packages/integrations/netlify/test/edge-functions/prerender.test.ts
+++ b/packages/integrations/netlify/test/edge-functions/prerender.test.ts
@@ -1,9 +1,6 @@
-// @ts-expect-error
 import { runBuild } from './test-utils.ts';
-// @ts-expect-error
 import { assertEquals } from './deps.ts';
 
-// @ts-expect-error
 Deno.test({
 	name: 'Prerender',
 	async fn() {

--- a/packages/integrations/netlify/test/edge-functions/root-dynamic.test.ts
+++ b/packages/integrations/netlify/test/edge-functions/root-dynamic.test.ts
@@ -1,9 +1,6 @@
-// @ts-expect-error
 import { runBuild } from './test-utils.ts';
-// @ts-expect-error
 import { assertEquals, assert, DOMParser } from './deps.ts';
 
-// @ts-expect-error
 Deno.test({
 	// TODO: debug why build cannot be found in "await import"
 	ignore: true,

--- a/packages/integrations/netlify/test/edge-functions/test-utils.ts
+++ b/packages/integrations/netlify/test/edge-functions/test-utils.ts
@@ -1,9 +1,7 @@
-// @ts-expect-error
 import { fromFileUrl, readableStreamFromReader } from './deps.ts';
 const dir = new URL('./', import.meta.url);
 
 export async function runBuild(fixturePath: string) {
-	// @ts-expect-error
 	let proc = Deno.run({
 		cmd: ['node', '../../../../../../astro/astro.js', 'build', '--silent'],
 		cwd: fromFileUrl(new URL(fixturePath, dir)),


### PR DESCRIPTION
## Changes

- Remove some `@ts-expect-error` directives that aren't necessary.

Some examples of the error:
![image](https://user-images.githubusercontent.com/71379045/235253512-14ea03c6-007e-4694-b300-98ac1b67bd2a.png)


## Testing

n/a

## Docs

n/a
