### PR TITLE
Show injected custom 404 route in dev

### DIFF
--- a/.changeset/ninety-snails-study.md
+++ b/.changeset/ninety-snails-study.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Support custom 404s added via `injectRoute` or as `src/pages/404.html`

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -35,11 +35,12 @@ interface MatchedRoute {
 	mod: ComponentInstance;
 }
 
-function getCustom404Route({ config }: AstroSettings, manifest: ManifestData) {
-	// For Windows compat, use relative page paths to match the 404 route
-	const relPages = resolvePages(config).href.replace(config.root.href, '');
-	const pattern = new RegExp(`${appendForwardSlash(relPages)}404.(astro|md)`);
-	return manifest.routes.find((r) => r.component.match(pattern));
+function getCustom404Route(
+	{ config }: AstroSettings,
+	manifest: ManifestData
+): RouteData | undefined {
+	const pathname = config.trailingSlash === 'always' ? '/404/' : '/404';
+	return manifest.routes.find((r) => r.pattern.test(pathname));
 }
 
 export async function matchRoute(

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -1,6 +1,6 @@
 import type http from 'http';
 import mime from 'mime';
-import type { AstroSettings, ComponentInstance, ManifestData, RouteData } from '../@types/astro';
+import type { ComponentInstance, ManifestData, RouteData } from '../@types/astro';
 import type {
 	ComponentPreload,
 	DevelopmentEnvironment,
@@ -12,12 +12,10 @@ import { call as callEndpoint } from '../core/endpoint/dev/index.js';
 import { throwIfRedirectNotAllowed } from '../core/endpoint/index.js';
 import { AstroErrorData } from '../core/errors/index.js';
 import { warn } from '../core/logger/core.js';
-import { appendForwardSlash } from '../core/path.js';
 import { preload, renderPage } from '../core/render/dev/index.js';
 import { getParamsAndProps, GetParamsAndPropsError } from '../core/render/index.js';
 import { createRequest } from '../core/request.js';
 import { matchAllRoutes } from '../core/routing/index.js';
-import { resolvePages } from '../core/util.js';
 import { log404 } from './common.js';
 import { handle404Response, writeSSRResult, writeWebResponse } from './response.js';
 
@@ -35,12 +33,9 @@ interface MatchedRoute {
 	mod: ComponentInstance;
 }
 
-function getCustom404Route(
-	{ config }: AstroSettings,
-	manifest: ManifestData
-): RouteData | undefined {
-	const pathname = config.trailingSlash === 'always' ? '/404/' : '/404';
-	return manifest.routes.find((r) => r.pattern.test(pathname));
+function getCustom404Route(manifest: ManifestData): RouteData | undefined {
+	const route404 = /^\/404\/?$/;
+	return manifest.routes.find((r) => route404.test(r.route));
 }
 
 export async function matchRoute(
@@ -98,7 +93,7 @@ export async function matchRoute(
 	}
 
 	log404(logging, pathname);
-	const custom404 = getCustom404Route(settings, manifest);
+	const custom404 = getCustom404Route(manifest);
 
 	if (custom404) {
 		const filePath = new URL(`./${custom404.component}`, settings.config.root);

--- a/packages/astro/test/custom-404-html.test.js
+++ b/packages/astro/test/custom-404-html.test.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Custom 404.html', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/custom-404-html/',
+			site: 'http://example.com',
+		});
+	});
+
+	describe('dev', () => {
+		let devServer;
+		let $;
+
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('renders /', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			$ = cheerio.load(html);
+
+			expect($('h1').text()).to.equal('Home');
+		});
+
+		it('renders 404 for /a', async () => {
+			const html = await fixture.fetch('/a').then((res) => res.text());
+			$ = cheerio.load(html);
+
+			expect($('h1').text()).to.equal('Page not found');
+			expect($('p').text()).to.equal('This 404 is a static HTML file.');
+		});
+	});
+});

--- a/packages/astro/test/custom-404-injected.test.js
+++ b/packages/astro/test/custom-404-injected.test.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Custom 404 with injectRoute', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/custom-404-injected/',
+			site: 'http://example.com',
+		});
+	});
+
+	describe('dev', () => {
+		let devServer;
+		let $;
+
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('renders /', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			$ = cheerio.load(html);
+
+			expect($('h1').text()).to.equal('Home');
+		});
+
+		it('renders 404 for /a', async () => {
+			const html = await fixture.fetch('/a').then((res) => res.text());
+			$ = cheerio.load(html);
+
+			expect($('h1').text()).to.equal('Page not found');
+			expect($('p').text()).to.equal('/a');
+		});
+	});
+});

--- a/packages/astro/test/fixtures/custom-404-html/astro.config.mjs
+++ b/packages/astro/test/fixtures/custom-404-html/astro.config.mjs
@@ -1,0 +1,4 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({});

--- a/packages/astro/test/fixtures/custom-404-html/package.json
+++ b/packages/astro/test/fixtures/custom-404-html/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/custom-404",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/custom-404-html/package.json
+++ b/packages/astro/test/fixtures/custom-404-html/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/custom-404",
+  "name": "@test/custom-404-html",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/astro/test/fixtures/custom-404-html/src/pages/404.html
+++ b/packages/astro/test/fixtures/custom-404-html/src/pages/404.html
@@ -1,0 +1,9 @@
+<html lang="en">
+<head>
+  <title>Not Found - Custom 404</title>
+</head>
+<body>
+  <h1>Page not found</h1>
+	<p>This 404 is a static HTML file.</p>
+</body>
+</html>

--- a/packages/astro/test/fixtures/custom-404-html/src/pages/index.astro
+++ b/packages/astro/test/fixtures/custom-404-html/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+---
+
+<html lang="en">
+<head>
+  <title>Custom 404</title>
+</head>
+<body>
+  <h1>Home</h1>
+</body>
+</html>

--- a/packages/astro/test/fixtures/custom-404-injected/astro.config.mjs
+++ b/packages/astro/test/fixtures/custom-404-injected/astro.config.mjs
@@ -1,0 +1,18 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+  integrations: [
+    {
+      name: '404-integration',
+      hooks: {
+        'astro:config:setup': ({ injectRoute }) => {
+          injectRoute({
+            pattern: '404',
+            entryPoint: '/src/404.astro',
+          });
+        },
+      },
+    },
+  ],
+});

--- a/packages/astro/test/fixtures/custom-404-injected/astro.config.mjs
+++ b/packages/astro/test/fixtures/custom-404-injected/astro.config.mjs
@@ -9,7 +9,7 @@ export default defineConfig({
         'astro:config:setup': ({ injectRoute }) => {
           injectRoute({
             pattern: '404',
-            entryPoint: '/src/404.astro',
+            entryPoint: 'src/404.astro',
           });
         },
       },

--- a/packages/astro/test/fixtures/custom-404-injected/package.json
+++ b/packages/astro/test/fixtures/custom-404-injected/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/custom-404-injected",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/custom-404-injected/src/404.astro
+++ b/packages/astro/test/fixtures/custom-404-injected/src/404.astro
@@ -1,0 +1,13 @@
+---
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+---
+
+<html lang="en">
+<head>
+  <title>Not Found - Custom 404</title>
+</head>
+<body>
+  <h1>Page not found</h1>
+	<p>{canonicalURL.pathname}</p>
+</body>
+</html>

--- a/packages/astro/test/fixtures/custom-404-injected/src/pages/index.astro
+++ b/packages/astro/test/fixtures/custom-404-injected/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+---
+
+<html lang="en">
+<head>
+  <title>Custom 404</title>
+</head>
+<body>
+  <h1>Home</h1>
+</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2438,6 +2438,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/custom-404-injected:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/custom-404-md:
     dependencies:
       astro:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2438,6 +2438,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/custom-404-html:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/custom-404-injected:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

- Fixes #6937
- Updates `getCustom404Route` logic to find 404s added via `injectRoute`
- As a side effect, also adds support for `src/pages/404.html`, which we don’t have currently.

## Testing

Added a fixture + test like we have for the current custom 404 strategies and also a dev server unit test.

I also applied the same changes in a patch inside a monorepo project to test the logic when the injected route comes from a separate package.

## Docs

Bug fix, no docs needed.