### PR TITLE
Make prerendering decision based on `PageBuildData` instead of `BuildInternals`

### DIFF
--- a/.changeset/popular-bats-pump.md
+++ b/.changeset/popular-bats-pump.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Changed where various parts of the build pipeline look to decide if a page should be prerendered. They now exclusively consider PageBuildData, allowing integrations to participate in the decision.

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -39,12 +39,7 @@ import { createRequest } from '../request.js';
 import { matchRoute } from '../routing/match.js';
 import { getOutputFilename } from '../util.js';
 import { getOutDirWithinCwd, getOutFile, getOutFolder } from './common.js';
-import {
-	eachPageData,
-	eachPrerenderedPageData,
-	getPageDataByComponent,
-	sortedCSS,
-} from './internal.js';
+import { eachPageData, getPageDataByComponent, sortedCSS } from './internal.js';
 import type { PageBuildData, SingleFileBuiltModule, StaticBuildOptions } from './types';
 import { getTimeStat } from './util.js';
 
@@ -99,8 +94,9 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 	const builtPaths = new Set<string>();
 
 	if (ssr) {
-		for (const pageData of eachPrerenderedPageData(internals)) {
-			await generatePage(opts, internals, pageData, ssrEntry, builtPaths);
+		for (const pageData of eachPageData(internals)) {
+			if (pageData.route.prerender)
+				await generatePage(opts, internals, pageData, ssrEntry, builtPaths);
 		}
 	} else {
 		for (const pageData of eachPageData(internals)) {

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -216,28 +216,12 @@ export function* eachPageData(internals: BuildInternals) {
 }
 
 export function hasPrerenderedPages(internals: BuildInternals) {
-	for (const id of internals.pagesByViteID.keys()) {
-		if (internals.pageOptionsByPage.get(id)?.prerender) {
+	for (const pageData of eachPageData(internals)) {
+		if (pageData.route.prerender) {
 			return true;
 		}
 	}
 	return false;
-}
-
-export function* eachPrerenderedPageData(internals: BuildInternals) {
-	for (const [id, pageData] of internals.pagesByViteID.entries()) {
-		if (internals.pageOptionsByPage.get(id)?.prerender) {
-			yield pageData;
-		}
-	}
-}
-
-export function* eachServerPageData(internals: BuildInternals) {
-	for (const [id, pageData] of internals.pagesByViteID.entries()) {
-		if (!internals.pageOptionsByPage.get(id)?.prerender) {
-			yield pageData;
-		}
-	}
 }
 
 /**

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -13,7 +13,7 @@ import { joinPaths, prependForwardSlash } from '../../path.js';
 import { serializeRouteData } from '../../routing/index.js';
 import { addRollupInput } from '../add-rollup-input.js';
 import { getOutFile, getOutFolder } from '../common.js';
-import { eachPrerenderedPageData, eachServerPageData, sortedCSS } from '../internal.js';
+import { eachPageData, sortedCSS } from '../internal.js';
 import type { AstroBuildPlugin } from '../plugin';
 
 export const virtualModuleId = '@astrojs-ssr-virtual-entry';
@@ -142,7 +142,8 @@ function buildManifest(
 		}
 	};
 
-	for (const pageData of eachPrerenderedPageData(internals)) {
+	for (const pageData of eachPageData(internals)) {
+		if (!pageData.route.prerender) continue;
 		if (!pageData.route.pathname) continue;
 
 		const outFolder = getOutFolder(
@@ -166,7 +167,8 @@ function buildManifest(
 		staticFiles.push(file);
 	}
 
-	for (const pageData of eachServerPageData(internals)) {
+	for (const pageData of eachPageData(internals)) {
+		if (pageData.route.prerender) continue;
 		const scripts: SerializedRouteInfo['scripts'] = [];
 		if (pageData.hoistedScript) {
 			const hoistedValue = pageData.hoistedScript.value;

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url';
 import * as vite from 'vite';
 import {
 	createBuildInternals,
-	eachPrerenderedPageData,
+	eachPageData,
 	type BuildInternals,
 } from '../../core/build/internal.js';
 import { emptyDir, removeEmptyDirs } from '../../core/fs/index.js';
@@ -290,8 +290,9 @@ async function runPostBuildHooks(
  */
 async function cleanStaticOutput(opts: StaticBuildOptions, internals: BuildInternals) {
 	const allStaticFiles = new Set();
-	for (const pageData of eachPrerenderedPageData(internals)) {
-		allStaticFiles.add(internals.pageToBundleMap.get(pageData.moduleSpecifier));
+	for (const pageData of eachPageData(internals)) {
+		if (pageData.route.prerender)
+			allStaticFiles.add(internals.pageToBundleMap.get(pageData.moduleSpecifier));
 	}
 	const ssr = opts.settings.config.output === 'server';
 	const out = ssr ? opts.buildConfig.server : getOutDirWithinCwd(opts.settings.config.outDir);


### PR DESCRIPTION
Integration developers might expect to able to control prerendering behavior by mutating PageBuildData.route.prerender in the `'astro:build:setup'` hook. However, the decision to prerender is currently made by inspecting BuildInternals.

This PR changes where various parts of the build pipeline look to decide if a page should be prerendered. They now exclusively consider PageBuildData, allowing integrations to participate in the decision.