### PR TITLE
Fix content render imports flow

### DIFF
--- a/.changeset/shy-games-punch.md
+++ b/.changeset/shy-games-punch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix content render imports flow

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -119,7 +119,7 @@ export function astroContentImportPlugin({
 	if (settings.contentEntryTypes.some((t) => t.getRenderModule)) {
 		plugins.push({
 			name: 'astro:content-render-imports',
-			async load(viteId) {
+			async transform(_, viteId) {
 				const contentRenderer = getContentRendererByViteId(viteId, settings);
 				if (!contentRenderer) return;
 


### PR DESCRIPTION
## Changes

In the `astro:content-render-imports` plugin, it calls `getContentEntryModuleFromCache` in the `load` hook, but the cache is only set in `astro:content-imports`'s [`transform` hook](https://github.com/withastro/astro/blob/923dc6311682ca8183232d51df9fb38ef988fb7d/packages/astro/src/content/vite-plugin-content-imports.ts#L68-L74).

This causes this error to happen in tests sometimes. I'm not sure how it used to work before 😅 

```
[astro:content-render-imports] Could not load /Users/bjorn/Work/oss/astro/packages/integrations/markdoc/test/fixtures/entry-prop/src/content/blog/entry.mdoc (imported by test/fixtures/entry-prop/src/content/blog/entry.mdoc?astroPropagatedAssets=true): Unable to render "/Users/bjorn/Work/oss/astro/packages/integrations/markdoc/test/fixtures/entry-prop/src/content/blog/entry.mdoc". Did you import this module directly without using a content collection query?
```

This seems to be caused by #6817 which changes the `load` to `transform`.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.