### PR TITLE
Improve undici fetch failed errors in tests

### DIFF
--- a/packages/astro/test/astro-get-static-paths.test.js
+++ b/packages/astro/test/astro-get-static-paths.test.js
@@ -3,11 +3,11 @@ import { loadFixture } from './test-utils.js';
 import * as cheerio from 'cheerio';
 
 describe('getStaticPaths - build calls', () => {
-	before(async () => {
-		// reset the flag used by [...calledTwiceTest].astro between each test
-		globalThis.isCalledOnce = false;
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
 
-		const fixture = await loadFixture({
+	before(async () => {
+		fixture = await loadFixture({
 			root: './fixtures/astro-get-static-paths/',
 			site: 'https://mysite.dev/',
 			base: '/blog',
@@ -15,9 +15,21 @@ describe('getStaticPaths - build calls', () => {
 		await fixture.build();
 	});
 
+	afterEach(() => {
+		// reset the flag used by [...calledTwiceTest].astro between each test
+		globalThis.isCalledOnce = false;
+	});
+
 	it('is only called once during build', () => {
 		// useless expect; if build() throws in setup then this test fails
 		expect(true).to.equal(true);
+	});
+
+	it('Astro.url sets the current pathname', async () => {
+		const html = await fixture.readFile('/food/tacos/index.html');
+		const $ = cheerio.load(html);
+
+		expect($('#url').text()).to.equal('/blog/food/tacos/');
 	});
 });
 
@@ -26,11 +38,16 @@ describe('getStaticPaths - dev calls', () => {
 	let devServer;
 
 	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/astro-get-static-paths/',
+			site: 'https://mysite.dev/',
+		});
+		devServer = await fixture.startDevServer();
+	});
+
+	afterEach(() => {
 		// reset the flag used by [...calledTwiceTest].astro between each test
 		globalThis.isCalledOnce = false;
-
-		fixture = await loadFixture({ root: './fixtures/astro-get-static-paths/' });
-		devServer = await fixture.startDevServer();
 	});
 
 	after(async () => {
@@ -47,95 +64,46 @@ describe('getStaticPaths - dev calls', () => {
 		res = await fixture.fetch('/c');
 		expect(res.status).to.equal(200);
 	});
-});
 
-describe('getStaticPaths - 404 behavior', () => {
-	let fixture;
-	let devServer;
-
-	before(async () => {
-		// reset the flag used by [...calledTwiceTest].astro between each test
-		globalThis.isCalledOnce = false;
-
-		fixture = await loadFixture({ root: './fixtures/astro-get-static-paths/' });
-		devServer = await fixture.startDevServer();
-	});
-
-	after(async () => {
-		devServer.stop();
-	});
-
-	it('resolves 200 on matching static path - named params', async () => {
-		const res = await fixture.fetch('/pizza/provolone-sausage');
-		expect(res.status).to.equal(200);
-	});
-
-	it('resolves 404 on pattern match without static path - named params', async () => {
-		const res = await fixture.fetch('/pizza/provolone-pineapple');
-		expect(res.status).to.equal(404);
-	});
-
-	it('resolves 200 on matching static path - rest params', async () => {
-		const res = await fixture.fetch('/pizza/grimaldis/new-york');
-		expect(res.status).to.equal(200);
-	});
-
-	it('resolves 404 on pattern match without static path - rest params', async () => {
-		const res = await fixture.fetch('/pizza/pizza-hut');
-		expect(res.status).to.equal(404);
-	});
-});
-
-describe('getStaticPaths - route params type validation', () => {
-	let fixture, devServer;
-
-	before(async () => {
-		// reset the flag used by [...calledTwiceTest].astro between each test
-		globalThis.isCalledOnce = false;
-
-		fixture = await loadFixture({ root: './fixtures/astro-get-static-paths/' });
-		devServer = await fixture.startDevServer();
-	});
-
-	after(async () => {
-		await devServer.stop();
-	});
-
-	it('resolves 200 on nested array parameters', async () => {
-		const res = await fixture.fetch('/nested-arrays/slug1');
-		expect(res.status).to.equal(200);
-	});
-
-	it('resolves 200 on matching static path - string params', async () => {
-		// route provided with { params: { year: "2022", slug: "post-2" }}
-		const res = await fixture.fetch('/blog/2022/post-1');
-		expect(res.status).to.equal(200);
-	});
-
-	it('resolves 200 on matching static path - numeric params', async () => {
-		// route provided with { params: { year: 2022, slug: "post-2" }}
-		const res = await fixture.fetch('/blog/2022/post-2');
-		expect(res.status).to.equal(200);
-	});
-});
-
-describe('getStaticPaths - numeric route params', () => {
-	let fixture;
-	let devServer;
-
-	before(async () => {
-		// reset the flag used by [...calledTwiceTest].astro between each test
-		globalThis.isCalledOnce = false;
-
-		fixture = await loadFixture({
-			root: './fixtures/astro-get-static-paths/',
-			site: 'https://mysite.dev/',
+	describe('404 behavior', () => {
+		it('resolves 200 on matching static path - named params', async () => {
+			const res = await fixture.fetch('/pizza/provolone-sausage');
+			expect(res.status).to.equal(200);
 		});
-		devServer = await fixture.startDevServer();
+
+		it('resolves 404 on pattern match without static path - named params', async () => {
+			const res = await fixture.fetch('/pizza/provolone-pineapple');
+			expect(res.status).to.equal(404);
+		});
+
+		it('resolves 200 on matching static path - rest params', async () => {
+			const res = await fixture.fetch('/pizza/grimaldis/new-york');
+			expect(res.status).to.equal(200);
+		});
+
+		it('resolves 404 on pattern match without static path - rest params', async () => {
+			const res = await fixture.fetch('/pizza/pizza-hut');
+			expect(res.status).to.equal(404);
+		});
 	});
 
-	after(async () => {
-		await devServer.stop();
+	describe('route params type validation', () => {
+		it('resolves 200 on nested array parameters', async () => {
+			const res = await fixture.fetch('/nested-arrays/slug1');
+			expect(res.status).to.equal(200);
+		});
+
+		it('resolves 200 on matching static path - string params', async () => {
+			// route provided with { params: { year: "2022", slug: "post-2" }}
+			const res = await fixture.fetch('/blog/2022/post-1');
+			expect(res.status).to.equal(200);
+		});
+
+		it('resolves 200 on matching static path - numeric params', async () => {
+			// route provided with { params: { year: 2022, slug: "post-2" }}
+			const res = await fixture.fetch('/blog/2022/post-2');
+			expect(res.status).to.equal(200);
+		});
 	});
 
 	it('resolves 200 on matching static paths', async () => {
@@ -153,27 +121,5 @@ describe('getStaticPaths - numeric route params', () => {
 				`doesn't trim the /${page} route param`
 			);
 		}
-	});
-});
-
-describe('getStaticPaths - Astro.url', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
-	before(async () => {
-		// reset the flag used by [...calledTwiceTest].astro between each test
-		globalThis.isCalledOnce = false;
-
-		fixture = await loadFixture({
-			root: './fixtures/astro-get-static-paths/',
-			site: 'https://mysite.dev/',
-		});
-		await fixture.build();
-	});
-
-	it('Sets the current pathname', async () => {
-		const html = await fixture.readFile('/food/tacos/index.html');
-		const $ = cheerio.load(html);
-
-		expect($('#url').text()).to.equal('/food/tacos/');
 	});
 });

--- a/packages/astro/test/ssr-prerender-get-static-paths.test.js
+++ b/packages/astro/test/ssr-prerender-get-static-paths.test.js
@@ -3,11 +3,11 @@ import { loadFixture } from './test-utils.js';
 import * as cheerio from 'cheerio';
 
 describe('prerender getStaticPaths - build calls', () => {
-	before(async () => {
-		// reset the flag used by [...calledTwiceTest].astro between each test
-		globalThis.isCalledOnce = false;
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
 
-		const fixture = await loadFixture({
+	before(async () => {
+		fixture = await loadFixture({
 			root: './fixtures/ssr-prerender-get-static-paths/',
 			site: 'https://mysite.dev/',
 			base: '/blog',
@@ -15,9 +15,22 @@ describe('prerender getStaticPaths - build calls', () => {
 		await fixture.build();
 	});
 
+	afterEach(() => {
+		// reset the flag used by [...calledTwiceTest].astro between each test
+		globalThis.isCalledOnce = false;
+	});
+
 	it('is only called once during build', () => {
 		// useless expect; if build() throws in setup then this test fails
 		expect(true).to.equal(true);
+	});
+
+	it('Astro.url sets the current pathname', async () => {
+		const html = await fixture.readFile('/food/tacos/index.html');
+		const $ = cheerio.load(html);
+
+		expect($('#props').text()).to.equal('10');
+		expect($('#url').text()).to.equal('/blog/food/tacos/');
 	});
 });
 
@@ -26,11 +39,17 @@ describe('prerender getStaticPaths - dev calls', () => {
 	let devServer;
 
 	before(async () => {
+		globalThis.isCalledOnce = false;
+		fixture = await loadFixture({
+			root: './fixtures/ssr-prerender-get-static-paths/',
+			site: 'https://mysite.dev/',
+		});
+		devServer = await fixture.startDevServer();
+	});
+
+	afterEach(() => {
 		// reset the flag used by [...calledTwiceTest].astro between each test
 		globalThis.isCalledOnce = false;
-
-		fixture = await loadFixture({ root: './fixtures/ssr-prerender-get-static-paths/' });
-		devServer = await fixture.startDevServer();
 	});
 
 	after(async () => {
@@ -47,99 +66,50 @@ describe('prerender getStaticPaths - dev calls', () => {
 		res = await fixture.fetch('/c');
 		expect(res.status).to.equal(200);
 	});
-});
 
-describe('prerender getStaticPaths - 404 behavior', () => {
-	let fixture;
-	let devServer;
-
-	before(async () => {
-		// reset the flag used by [...calledTwiceTest].astro between each test
-		globalThis.isCalledOnce = false;
-
-		fixture = await loadFixture({ root: './fixtures/ssr-prerender-get-static-paths/' });
-		devServer = await fixture.startDevServer();
-	});
-
-	after(async () => {
-		devServer.stop();
-	});
-
-	it('resolves 200 on matching static path - named params', async () => {
-		const res = await fixture.fetch('/pizza/provolone-sausage');
-		expect(res.status).to.equal(200);
-	});
-
-	it('resolves 404 on pattern match without static path - named params', async () => {
-		const res = await fixture.fetch('/pizza/provolone-pineapple');
-		const html = await res.text();
-		expect(res.status).to.equal(404);
-		expect(html).to.match(/404/);
-	});
-
-	it('resolves 200 on matching static path - rest params', async () => {
-		const res = await fixture.fetch('/pizza/grimaldis/new-york');
-		expect(res.status).to.equal(200);
-	});
-
-	it('resolves 404 on pattern match without static path - rest params', async () => {
-		const res = await fixture.fetch('/pizza/pizza-hut');
-		const html = await res.text();
-		expect(res.status).to.equal(404);
-		expect(html).to.match(/404/);
-	});
-});
-
-describe('prerender getStaticPaths - route params type validation', () => {
-	let fixture, devServer;
-
-	before(async () => {
-		// reset the flag used by [...calledTwiceTest].astro between each test
-		globalThis.isCalledOnce = false;
-
-		fixture = await loadFixture({ root: './fixtures/ssr-prerender-get-static-paths/' });
-		devServer = await fixture.startDevServer();
-	});
-
-	after(async () => {
-		await devServer.stop();
-	});
-
-	it('resolves 200 on nested array parameters', async () => {
-		const res = await fixture.fetch('/nested-arrays/slug1');
-		expect(res.status).to.equal(200);
-	});
-
-	it('resolves 200 on matching static path - string params', async () => {
-		// route provided with { params: { year: "2022", slug: "post-2" }}
-		const res = await fixture.fetch('/blog/2022/post-1');
-		expect(res.status).to.equal(200);
-	});
-
-	it('resolves 200 on matching static path - numeric params', async () => {
-		// route provided with { params: { year: 2022, slug: "post-2" }}
-		const res = await fixture.fetch('/blog/2022/post-2');
-		expect(res.status).to.equal(200);
-	});
-});
-
-describe('prerender getStaticPaths - numeric route params', () => {
-	let fixture;
-	let devServer;
-
-	before(async () => {
-		// reset the flag used by [...calledTwiceTest].astro between each test
-		globalThis.isCalledOnce = false;
-
-		fixture = await loadFixture({
-			root: './fixtures/ssr-prerender-get-static-paths/',
-			site: 'https://mysite.dev/',
+	describe('404 behavior', () => {
+		it('resolves 200 on matching static path - named params', async () => {
+			const res = await fixture.fetch('/pizza/provolone-sausage');
+			expect(res.status).to.equal(200);
 		});
-		devServer = await fixture.startDevServer();
+
+		it('resolves 404 on pattern match without static path - named params', async () => {
+			const res = await fixture.fetch('/pizza/provolone-pineapple');
+			const html = await res.text();
+			expect(res.status).to.equal(404);
+			expect(html).to.match(/404/);
+		});
+
+		it('resolves 200 on matching static path - rest params', async () => {
+			const res = await fixture.fetch('/pizza/grimaldis/new-york');
+			expect(res.status).to.equal(200);
+		});
+
+		it('resolves 404 on pattern match without static path - rest params', async () => {
+			const res = await fixture.fetch('/pizza/pizza-hut');
+			const html = await res.text();
+			expect(res.status).to.equal(404);
+			expect(html).to.match(/404/);
+		});
 	});
 
-	after(async () => {
-		await devServer.stop();
+	describe('route params type validation', () => {
+		it('resolves 200 on nested array parameters', async () => {
+			const res = await fixture.fetch('/nested-arrays/slug1');
+			expect(res.status).to.equal(200);
+		});
+
+		it('resolves 200 on matching static path - string params', async () => {
+			// route provided with { params: { year: "2022", slug: "post-2" }}
+			const res = await fixture.fetch('/blog/2022/post-1');
+			expect(res.status).to.equal(200);
+		});
+
+		it('resolves 200 on matching static path - numeric params', async () => {
+			// route provided with { params: { year: 2022, slug: "post-2" }}
+			const res = await fixture.fetch('/blog/2022/post-2');
+			expect(res.status).to.equal(200);
+		});
 	});
 
 	it('resolves 200 on matching static paths', async () => {
@@ -157,49 +127,5 @@ describe('prerender getStaticPaths - numeric route params', () => {
 				`doesn't trim the /${page} route param`
 			);
 		}
-	});
-});
-
-describe('prerender getStaticPaths - Astro.url', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
-	before(async () => {
-		// reset the flag used by [...calledTwiceTest].astro between each test
-		globalThis.isCalledOnce = false;
-
-		fixture = await loadFixture({
-			root: './fixtures/ssr-prerender-get-static-paths/',
-			site: 'https://mysite.dev/',
-		});
-		await fixture.build();
-	});
-
-	it('Sets the current pathname', async () => {
-		const html = await fixture.readFile('/food/tacos/index.html');
-		const $ = cheerio.load(html);
-
-		expect($('#url').text()).to.equal('/food/tacos/');
-	});
-});
-
-describe('prerender getStaticPaths - props', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
-	before(async () => {
-		// reset the flag used by [...calledTwiceTest].astro between each test
-		globalThis.isCalledOnce = false;
-
-		fixture = await loadFixture({
-			root: './fixtures/ssr-prerender-get-static-paths/',
-			site: 'https://mysite.dev/',
-		});
-		await fixture.build();
-	});
-
-	it('Sets the current pathname', async () => {
-		const html = await fixture.readFile('/food/tacos/index.html');
-		const $ = cheerio.load(html);
-
-		expect($('#props').text()).to.equal('10');
 	});
 });

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -195,6 +195,7 @@ export async function loadFixture(inlineConfig) {
 				// undici throws a vague error when it fails, so we log the url here to easily debug it
 				if (err.message?.includes('fetch failed')) {
 					console.error(`[astro test] failed to fetch ${resolvedUrl}`);
+					console.error(err);
 				}
 				throw err;
 			}

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -187,7 +187,18 @@ export async function loadFixture(inlineConfig) {
 		},
 		config,
 		resolveUrl,
-		fetch: (url, init) => fetch(resolveUrl(url), init),
+		fetch: async (url, init) => {
+			const resolvedUrl = resolveUrl(url);
+			try {
+				return await fetch(resolvedUrl, init);
+			} catch (err) {
+				// undici throws a vague error when it fails, so we log the url here to easily debug it
+				if (err.message.includes('fetch failed')) {
+					console.error(`[astro test] failed to fetch ${resolvedUrl}`);
+				}
+				throw err;
+			}
+		},
 		preview: async (opts = {}) => {
 			process.env.NODE_ENV = 'production';
 			const previewServer = await preview(settings, {

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -193,7 +193,7 @@ export async function loadFixture(inlineConfig) {
 				return await fetch(resolvedUrl, init);
 			} catch (err) {
 				// undici throws a vague error when it fails, so we log the url here to easily debug it
-				if (err.message.includes('fetch failed')) {
+				if (err.message?.includes('fetch failed')) {
 					console.error(`[astro test] failed to fetch ${resolvedUrl}`);
 				}
 				throw err;


### PR DESCRIPTION
## Changes

Sometimes undici fails with `fetch failed` without any other hints, this PR adds the URL that might have caused the fail, which I'm guessing it's the issue here.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Shouldn't break existing tests.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a