### PR TITLE
fix(types): Fix getImage type requesting for a second parameter

### DIFF
--- a/.changeset/nice-jars-breathe.md
+++ b/.changeset/nice-jars-breathe.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix getImage type

--- a/packages/astro/client-base.d.ts
+++ b/packages/astro/client-base.d.ts
@@ -3,6 +3,23 @@
 declare module 'astro:assets' {
 	// Exporting things one by one is a bit cumbersome, not sure if there's a better way - erika, 2023-02-03
 	type AstroAssets = {
+		// getImage's type here is different from the internal function since the Vite module implicitly pass the service config
+		/**
+		 * Get an optimized image and the necessary attributes to render it.
+		 *
+		 * **Example**
+		 * ```astro
+		 * ---
+		 * import { getImage } from 'astro:assets';
+		 * import originalImage from '../assets/image.png';
+		 *
+		 * const optimizedImage = await getImage({src: originalImage, width: 1280 });
+		 * ---
+		 * <img src={optimizedImage.src} {...optimizedImage.attributes} />
+		 * ```
+		 *
+		 * This is functionally equivalent to using the `<Image />` component, as the component calls this function internally.
+		 */
 		getImage: (
 			options: import('./dist/assets/types.js').ImageTransform
 		) => Promise<import('./dist/assets/types.js').GetImageResult>;

--- a/packages/astro/client-base.d.ts
+++ b/packages/astro/client-base.d.ts
@@ -3,7 +3,9 @@
 declare module 'astro:assets' {
 	// Exporting things one by one is a bit cumbersome, not sure if there's a better way - erika, 2023-02-03
 	type AstroAssets = {
-		getImage: typeof import('./dist/assets/index.js').getImage;
+		getImage: (
+			options: import('./dist/assets/types.js').ImageTransform
+		) => Promise<import('./dist/assets/types.js').GetImageResult>;
 		getConfiguredImageService: typeof import('./dist/assets/index.js').getConfiguredImageService;
 		Image: typeof import('./components/Image.astro').default;
 	};

--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -29,22 +29,6 @@ export async function getConfiguredImageService(): Promise<ImageService> {
 	return globalThis.astroAsset.imageService;
 }
 
-/**
- * Get an optimized image and the necessary attributes to render it.
- *
- * **Example**
- * ```astro
- * ---
- * import { getImage } from 'astro:assets';
- * import originalImage from '../assets/image.png';
- *
- * const optimizedImage = await getImage({src: originalImage, width: 1280 });
- * ---
- * <img src={optimizedImage.src} {...optimizedImage.attributes} />
- * ```
- *
- * This is functionally equivalent to using the `<Image />` component, as the component calls this function internally.
- */
 export async function getImage(
 	options: ImageTransform,
 	serviceConfig: Record<string, any>


### PR DESCRIPTION
## Changes

`getImage` type was pointing to the internal function, which takes two parameters. But we expose a wrapper in our vite virtual module that does not require it, so we need a separate definition

## Testing

Tested manually

## Docs

N/A
