### PR TITLE
fix: update lit example to properly ignore error

### DIFF
--- a/examples/framework-lit/src/pages/index.astro
+++ b/examples/framework-lit/src/pages/index.astro
@@ -21,12 +21,15 @@ import { MyCounter } from '../components/my-counter.js';
 		<Lorem />
 
 		{
-			/**
-			 * Our VS Code extension does not currently properly typecheck attributes on Lit components
-			 * As such, the following code will result in a TypeScript error inside the editor, nonetheless, it works in Astro!
-			 */
+			(
+				/**
+				 * Our editor tooling does not currently properly typecheck attributes on imported Lit components. As such, without a
+				 * pragma directive telling TypeScript to ignore the error, the line below will result in an error in the editor.
+				 * Nonetheless, this code works in Astro itself!
+				 */
+				// @ts-expect-error
+				<CalcAdd num={0} />
+			)
 		}
-		{/** @ts-expect-error */}
-		<CalcAdd num={0} />
 	</body>
 </html>


### PR DESCRIPTION
## Changes

Due to an upstream issue in the compiler (https://github.com/withastro/compiler/issues/784), the TS pragma doesn't appear on the correct line in the generated TSX, so the comment didn't work. This PR updates the example with a temporary workaround in the meantime

## Testing

Tested manually

## Docs

N/A
