### PR TITLE
[markdoc README] note re: article tag

### DIFF
--- a/packages/integrations/markdoc/README.md
+++ b/packages/integrations/markdoc/README.md
@@ -90,6 +90,8 @@ const { Content } = await entry.render();
 <!--Render Markdoc contents with the Content component-->
 <Content />
 ```
+> **Note**
+> The `<Content />` component renders your Markdown content within `<article></article>`. This may affect CSS and styling of your content.
 
 📚 See the [Astro Content Collection docs][astro-content-collections] for more information.
 


### PR DESCRIPTION

## Changes

Trying to clean up a docs issue ( https://github.com/withastro/docs/issues/2904 ), and I think something like this will do it!

- adds a note re: how Markdoc wraps content in `<article></article>` because this can affect styling issues.

## Testing

- no tests, docs

## Docs

- updates README with a note.
