### PR TITLE
Fix `astro-entry` error on build with multiple JSX frameworks

### DIFF
--- a/.changeset/loud-bears-glow.md
+++ b/.changeset/loud-bears-glow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `astro-entry` error on build with multiple JSX frameworks

--- a/packages/astro/src/core/build/plugins/plugin-component-entry.ts
+++ b/packages/astro/src/core/build/plugins/plugin-component-entry.ts
@@ -2,7 +2,7 @@ import type { Plugin as VitePlugin } from 'vite';
 import type { BuildInternals } from '../internal.js';
 import type { AstroBuildPlugin } from '../plugin.js';
 
-const astroEntryPrefix = '\0astro-entry:';
+export const astroEntryPrefix = '\0astro-entry:';
 
 /**
  * When adding hydrated or client:only components as Rollup inputs, sometimes we're not using all

--- a/packages/astro/src/vite-plugin-jsx/index.ts
+++ b/packages/astro/src/vite-plugin-jsx/index.ts
@@ -13,6 +13,7 @@ import babel from '@babel/core';
 import * as colors from 'kleur/colors';
 import path from 'path';
 import { CONTENT_FLAG, PROPAGATED_ASSET_FLAG } from '../content/index.js';
+import { astroEntryPrefix } from '../core/build/plugins/plugin-component-entry.js';
 import { error } from '../core/logger/core.js';
 import { removeQueryString } from '../core/path.js';
 import { detectImportSource } from './import-source.js';
@@ -139,7 +140,9 @@ export default function jsx({ settings, logging }: AstroPluginJSXOptions): Plugi
 		},
 		async transform(code, id, opts) {
 			const ssr = Boolean(opts?.ssr);
-			if (SPECIAL_QUERY_REGEX.test(id)) {
+			// Skip special queries and astro entries. We skip astro entries here as we know it doesn't contain
+			// JSX code, and also because we can't detect the import source to apply JSX transforms.
+			if (SPECIAL_QUERY_REGEX.test(id) || id.startsWith(astroEntryPrefix)) {
 				return null;
 			}
 			id = removeQueryString(id);


### PR DESCRIPTION
## Changes

Update the internal `vite-plugin-jsx` to ignore transforming for `astro-entry:` virtual files. These virtual files only contain re-exports to enable treeshaking used exports only (added in #6527), so they can be skipped as they don't contain JSX.

But also it's skipped to avoid this confusing (and harmless) error:

```bash
 building client 
10:19:41 PM [renderer] astro-entry:/Users/bjorn/Work/oss/astro/packages/astro/test/fixtures/static-build-frameworks/src/components/PCounter.jsx
Unable to resolve a renderer that handles this file! With more than one renderer enabled, you should include an import or use a pragma comment.
Add import React from 'react' or /* jsxImportSource: react */ to this file.
```

It happens in the `static-build-frameworks` fixture currently. 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass, but I also manually tested `static-build-frameworks` so there's no false errors on build.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.