### PR TITLE
Fix: remove odd `/1/` check on RSS canonicals

### DIFF
--- a/.changeset/flat-peas-wave.md
+++ b/.changeset/flat-peas-wave.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/rss": patch
+---
+
+Fix: remove accidental stripping of trailing `/1/` on canonical URLs

--- a/packages/astro-rss/src/util.ts
+++ b/packages/astro-rss/src/util.ts
@@ -8,7 +8,6 @@ export function createCanonicalURL(
 	base?: string
 ): URL {
 	let pathname = url.replace(/\/index.html$/, ''); // index.html is not canonical
-	pathname = pathname.replace(/\/1\/?$/, ''); // neither is a trailing /1/ (impl. detail of collections)
 	if (trailingSlash === false) {
 		// remove the trailing slash
 		pathname = pathname.replace(/(\/+)?$/, '');


### PR DESCRIPTION
## Changes

- Remove `/1/` regex on RSS canonical URLs. This is legacy code ported from the _old_ RSS package from 2021, and doesn't make sense with our `import.meta.glob` and content collection handlers.

## Testing

N/A

## Docs

N/A