### PR TITLE
Remove comments from base.json

### DIFF
--- a/packages/astro/tsconfigs/base.json
+++ b/packages/astro/tsconfigs/base.json
@@ -1,30 +1,19 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    // Enable top-level await, and other modern ESM features.
     "target": "ESNext",
     "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
     "moduleResolution": "node",
-    // Enable JSON imports.
     "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Astro directly run TypeScript code, no transpilation needed.
     "noEmit": true,
-    // Report an error when importing a file using a casing different from the casing on disk.
     "forceConsistentCasingInFileNames": true,
-    // Properly support importing CJS modules in ESM
     "esModuleInterop": true,
-    // Skip typechecking libraries and .d.ts files
     "skipLibCheck": true,
-    // Add alias for assets folder for easy reference to assets
     "baseUrl": ".",
     "paths": {
       "~/assets/*": ["src/assets/*"]
     },
-    // TypeScript 5.0 changed how `isolatedModules` and `importsNotUsedAsValues` works, deprecating the later
-    // Until the majority of users are on TypeScript 5.0, we'll have to supress those deprecation errors
     "ignoreDeprecations": "5.0"
   }
 }


### PR DESCRIPTION
Remove otherwise helpful JS-style comments causing various linting errors when base.json config is brought into Astro project by "extends" (comments not compatible with .json files)

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing
Deleting comments fixed the lint errors in my local project. No other testing done.
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
I don't think doc updates are needed. I assume this issue was unintentional.
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
