### PR TITLE
Generate unique ids within each React island

### DIFF
--- a/.changeset/happy-ears-call.md
+++ b/.changeset/happy-ears-call.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': patch
+---
+
+Prevent ID collisions in React.useId

--- a/packages/astro/test/fixtures/react-component/src/components/WithId.jsx
+++ b/packages/astro/test/fixtures/react-component/src/components/WithId.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+export default function () {
+	const id = React.useId();
+  return <p className='react-use-id' id={id}>{id}</p>;
+}

--- a/packages/astro/test/fixtures/react-component/src/pages/index.astro
+++ b/packages/astro/test/fixtures/react-component/src/pages/index.astro
@@ -8,6 +8,7 @@ import Pure from '../components/Pure.jsx';
 import TypeScriptComponent from '../components/TypeScriptComponent';
 import CloneElement from '../components/CloneElement';
 import WithChildren from '../components/WithChildren';
+import WithId from '../components/WithId';
 
 const someProps = {
   text: 'Hello world!',
@@ -34,5 +35,7 @@ const someProps = {
 		<CloneElement />
 		<WithChildren client:load>test</WithChildren>
 		<WithChildren client:load children="test" />
+		<WithId client:idle />
+		<WithId client:idle />
   </body>
 </html>

--- a/packages/astro/test/react-component.test.js
+++ b/packages/astro/test/react-component.test.js
@@ -42,16 +42,21 @@ describe('React Components', () => {
 			expect($('#pure')).to.have.lengthOf(1);
 
 			// test 8: Check number of islands
-			expect($('astro-island[uid]')).to.have.lengthOf(7);
+			expect($('astro-island[uid]')).to.have.lengthOf(9);
 
 			// test 9: Check island deduplication
 			const uniqueRootUIDs = new Set($('astro-island').map((i, el) => $(el).attr('uid')));
-			expect(uniqueRootUIDs.size).to.equal(6);
+			expect(uniqueRootUIDs.size).to.equal(8);
 
 			// test 10: Should properly render children passed as props
 			const islandsWithChildren = $('.with-children');
 			expect(islandsWithChildren).to.have.lengthOf(2);
 			expect($(islandsWithChildren[0]).html()).to.equal($(islandsWithChildren[1]).html());
+
+			// test 11: Should generate unique React.useId per island
+			const islandsWithId = $('.react-use-id');
+			expect(islandsWithId).to.have.lengthOf(2);
+			expect($(islandsWithId[0]).attr('id')).to.not.equal($(islandsWithId[1]).attr('id'))
 		});
 
 		it('Can load Vue', async () => {

--- a/packages/integrations/react/client.js
+++ b/packages/integrations/react/client.js
@@ -13,6 +13,9 @@ function isAlreadyHydrated(element) {
 export default (element) =>
 	(Component, props, { default: children, ...slotted }, { client }) => {
 		if (!element.hasAttribute('ssr')) return;
+		const renderOptions = {
+			identifierPrefix: element.getAttribute('prefix')
+		}
 		for (const [key, value] of Object.entries(slotted)) {
 			props[key] = createElement(StaticHtml, { value, name: key });
 		}
@@ -28,10 +31,10 @@ export default (element) =>
 		}
 		if (client === 'only') {
 			return startTransition(() => {
-				createRoot(element).render(componentEl);
+				createRoot(element, renderOptions).render(componentEl);
 			});
 		}
 		return startTransition(() => {
-			hydrateRoot(element, componentEl);
+			hydrateRoot(element, componentEl, renderOptions);
 		});
 	};

--- a/packages/integrations/react/context.js
+++ b/packages/integrations/react/context.js
@@ -1,0 +1,24 @@
+const contexts = new WeakMap();
+
+const ID_PREFIX = 'r';
+
+function getContext(rendererContextResult) {
+	if (contexts.has(rendererContextResult)) {
+		return contexts.get(rendererContextResult);
+	}
+	const ctx = {
+		currentIndex: 0,
+		get id() {
+			return ID_PREFIX + this.currentIndex.toString();
+		},
+	};
+	contexts.set(rendererContextResult, ctx);
+	return ctx;
+}
+
+export function incrementId(rendererContextResult) {
+	const ctx = getContext(rendererContextResult)
+	const id = ctx.id;
+	ctx.currentIndex++;
+	return id;
+}


### PR DESCRIPTION
Resolves https://github.com/withastro/astro/issues/6849

React's useId hook generates unique IDs by incrementing down the component tree. When multiple react roots are on a single page, these IDs can collide. React provides an option, `identifierPrefix` to prefix ids per root.

Using preact adapters context solution, increment an ID per component rendered on a request, preventing collisions. 

## Changes

- Ensures each react island can generate unique ids without collisions, improve accessibility
- follows the context pattern used by preact-adapter to increment id per component
- incremental id is added to astro-island element attributes, named `prefix`
- id is passed to react server rendering methods directly as `identifierPrefix` option
- id is read from attributes client side, and passed as options to createRoot/hydrateRoot as `indetifierPrefix`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

- tested via local linking to validate results
- test case added to react test suite to validate that two ids generated in separate islands are unique.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
Unsure if documentation is needed; shouldn't change anything for users - something that didn't work properly will now work as intended.

/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
