### PR TITLE
fix: double test names

### DIFF
--- a/packages/integrations/sitemap/test/fixtures/ssr/package.json
+++ b/packages/integrations/sitemap/test/fixtures/ssr/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/sitemap-trailing-slash",
+  "name": "@test/sitemap-ssr",
   "version": "0.0.0",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Changes

Build is failing because there are two packages with the same name

## Testing

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
