### PR TITLE
ci: fix and update check merge workflow

### DIFF
--- a/.github/workflows/check-merge.yml
+++ b/.github/workflows/check-merge.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Get changed files in the .changeset folder
         id: changed-files
-        uses: tj-actions/changed-files@v29
+        uses: tj-actions/changed-files@v35
         if: steps.set-blocks.outputs.blocks == ''
         with:
           files: |
@@ -87,5 +87,5 @@ jobs:
           --url https://api.github.com/repos/${{github.repository}}/pulls/${{github.event.number}}/reviews \
           --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
           --header 'content-type: application/json' \
-          -d '{"event":"REQUEST_CHANGES"}'
+          -d '{"event":"REQUEST_CHANGES", body: ""}'
 


### PR DESCRIPTION
## Changes

The check merge action was still buggy. The request to change the PR status requires a `body` in the request. I want to try to make the body an empty string and see if that works. If it doesn't, we will have to send a body message, which will be annoying because we will see multiple messages from the github bot.

I updated also one of the other actions. They were causing some warnings.

## Testing

Merge and verify manually.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
