### PR TITLE
Add caching for optimized images

### DIFF
--- a/.changeset/forty-horses-act.md
+++ b/.changeset/forty-horses-act.md
@@ -2,4 +2,4 @@
 'astro': minor
 ---
 
-Generated optimized images are now cached inside the `node_modules/.astro` folder. The cached images will be used to avoid doing extra work and speed up subsequent builds.
+Generated optimized images are now cached inside the `node_modules/.astro/assets` folder. The cached images will be used to avoid doing extra work and speed up subsequent builds.

--- a/.changeset/forty-horses-act.md
+++ b/.changeset/forty-horses-act.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Generated optimized images are now cached inside the `node_modules/.astro` folder. The cached images will be used to avoid doing extra work and speed up subsequent builds.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -431,6 +431,23 @@ export interface AstroUserConfig {
 
 	/**
 	 * @docs
+	 * @name cacheDir
+	 * @type {string}
+	 * @default `"./node_modules/.astro"`
+	 * @description Set the directory used to cache build artifacts to. Files in this directory will be used in subsequent builds to speed up the build time.
+	 *
+	 * The value can be either an absolute file system path or a path relative to the project root.
+	 *
+	 * ```js
+	 * {
+	 *   cacheDir: './my-custom-cache-directory'
+	 * }
+	 * ```
+	 */
+	cacheDir?: string;
+
+	/**
+	 * @docs
 	 * @name site
 	 * @type {string}
 	 * @description

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -434,7 +434,7 @@ export interface AstroUserConfig {
 	 * @name cacheDir
 	 * @type {string}
 	 * @default `"./node_modules/.astro"`
-	 * @description Set the directory used to cache build artifacts to. Files in this directory will be used in subsequent builds to speed up the build time.
+	 * @description Set the directory for caching build artifacts. Files in this directory will be used in subsequent builds to speed up the build time.
 	 *
 	 * The value can be either an absolute file system path or a path relative to the project root.
 	 *

--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -96,8 +96,10 @@ export async function generateImage(
 		return undefined;
 	}
 
+	const assetsCacheDir = new URL('assets/', buildOpts.settings.config.cacheDir);
+
 	// Ensure that the cache directory exists
-	await fs.promises.mkdir(buildOpts.settings.config.cacheDir, { recursive: true });
+	await fs.promises.mkdir(assetsCacheDir, { recursive: true });
 
 	let serverRoot: URL, clientRoot: URL;
 	if (buildOpts.settings.config.output === 'server') {
@@ -107,9 +109,10 @@ export async function generateImage(
 		serverRoot = buildOpts.settings.config.outDir;
 		clientRoot = buildOpts.settings.config.outDir;
 	}
+
 	const finalFileURL = new URL('.' + filepath, clientRoot);
 	const finalFolderURL = new URL('./', finalFileURL);
-	const cachedFileURL = new URL(basename(filepath), buildOpts.settings.config.cacheDir);
+	const cachedFileURL = new URL(basename(filepath), assetsCacheDir);
 
 	try {
 		await fs.promises.copyFile(cachedFileURL, finalFileURL);

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -133,13 +133,10 @@ async function generateImage(opts: StaticBuildOptions, transform: ImageTransform
 	const timeEnd = performance.now();
 	const timeChange = getTimeStat(timeStart, timeEnd);
 	const timeIncrease = `(+${timeChange})`;
-	info(
-		opts.logging,
-		null,
-		`  ${green('▶')} ${path} ${dim(
-			`(before: ${generationData.weight.before}kb, after: ${generationData.weight.after}kb)`
-		)} ${dim(timeIncrease)}`
-	);
+	const statsText = generationData.cached
+		? `(reused cache entry)`
+		: `(before: ${generationData.weight.before}kb, after: ${generationData.weight.after}kb)`;
+	info(opts.logging, null, `  ${green('▶')} ${path} ${dim(statsText)} ${dim(timeIncrease)}`);
 }
 
 async function generatePage(

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -13,6 +13,7 @@ const ASTRO_CONFIG_DEFAULTS: AstroUserConfig & any = {
 	srcDir: './src',
 	publicDir: './public',
 	outDir: './dist',
+	cacheDir: './node_modules/.astro',
 	base: '/',
 	trailingSlash: 'ignore',
 	build: {
@@ -60,6 +61,11 @@ export const AstroConfigSchema = z.object({
 		.string()
 		.optional()
 		.default(ASTRO_CONFIG_DEFAULTS.outDir)
+		.transform((val) => new URL(val)),
+	cacheDir: z
+		.string()
+		.optional()
+		.default(ASTRO_CONFIG_DEFAULTS.cacheDir)
 		.transform((val) => new URL(val)),
 	site: z.string().url().optional(),
 	base: z.string().optional().default(ASTRO_CONFIG_DEFAULTS.base),
@@ -208,6 +214,10 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: URL) {
 		outDir: z
 			.string()
 			.default(ASTRO_CONFIG_DEFAULTS.outDir)
+			.transform((val) => new URL(appendForwardSlash(val), fileProtocolRoot)),
+		cacheDir: z
+			.string()
+			.default(ASTRO_CONFIG_DEFAULTS.cacheDir)
 			.transform((val) => new URL(appendForwardSlash(val), fileProtocolRoot)),
 		build: z
 			.object({

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -1,7 +1,9 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
+import { basename } from 'node:path';
 import { Writable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
+import { removeDir } from '../dist/core/fs/index.js';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
 
@@ -455,6 +457,9 @@ describe('astro:image', () => {
 					assets: true,
 				},
 			});
+			// Remove cache directory
+			removeDir(new URL('./fixtures/core-image-ssg/node_modules/.astro', import.meta.url));
+
 			await fixture.build();
 		});
 
@@ -568,6 +573,39 @@ describe('astro:image', () => {
 			const html = await fixture.readFile('/format/index.html');
 			const $ = cheerio.load(html);
 			expect($('#no-format img').attr('src')).to.not.equal($('#format-avif img').attr('src'));
+		});
+
+		it('has cache entries', async () => {
+			const generatedImages = (await fixture.glob('_astro/**/*.webp')).map((path) =>
+				basename(path)
+			);
+			const cachedImages = (await fixture.glob('../node_modules/.astro/**/*.webp')).map((path) =>
+				basename(path)
+			);
+
+			expect(generatedImages).to.deep.equal(cachedImages);
+		});
+
+		it('uses cache entries ssss', async () => {
+			const logs = [];
+			const logging = {
+				dest: {
+					write(chunk) {
+						logs.push(chunk);
+					},
+				},
+			};
+
+			await fixture.build({ logging });
+			const generatingImageIndex = logs.findIndex((logLine) =>
+				logLine.message.includes('generating optimized images')
+			);
+			const relevantLogs = logs.slice(generatingImageIndex + 1, -1);
+			const isReusingCache = relevantLogs.every((logLine) =>
+				logLine.message.includes('(reused cache entry)')
+			);
+
+			expect(isReusingCache).to.be.true;
 		});
 	});
 

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -579,14 +579,14 @@ describe('astro:image', () => {
 			const generatedImages = (await fixture.glob('_astro/**/*.webp')).map((path) =>
 				basename(path)
 			);
-			const cachedImages = (await fixture.glob('../node_modules/.astro/**/*.webp')).map((path) =>
-				basename(path)
+			const cachedImages = (await fixture.glob('../node_modules/.astro/assets/**/*.webp')).map(
+				(path) => basename(path)
 			);
 
 			expect(generatedImages).to.deep.equal(cachedImages);
 		});
 
-		it('uses cache entries ssss', async () => {
+		it('uses cache entries', async () => {
 			const logs = [];
 			const logging = {
 				dest: {


### PR DESCRIPTION
## Changes

This PR adds a new setting `cacheDir` (default is `./node_modules/.astro` (same as `@astrojs/image`)) that is then used to cache optimized images in order to be able to reuse the build artifacts in subsequent builds.

This should unblock larger website from using `astro:assets`, as the previous implementation wasn't performant enough

## Testing

Added tests

## Docs

N/A
