### PR TITLE
fix: move service functions from astro/assets to astro/config so it can be imported

### DIFF
--- a/.changeset/mean-houses-exist.md
+++ b/.changeset/mean-houses-exist.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Move sharpImageService and squooshImageService functions to `astro/config` so they can be imported

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -1,6 +1,7 @@
 type ViteUserConfig = import('vite').UserConfig;
 type ViteUserConfigFn = import('vite').UserConfigFn;
 type AstroUserConfig = import('./dist/@types/astro.js').AstroUserConfig;
+type ImageServiceConfig = import('./dist/@types/astro.js').ImageServiceConfig;
 
 /**
  * See the full Astro Configuration API Documentation
@@ -12,3 +13,14 @@ export function defineConfig(config: AstroUserConfig): AstroUserConfig;
  * Use Astro to generate a fully resolved Vite config
  */
 export function getViteConfig(config: ViteUserConfig): ViteUserConfigFn;
+
+/**
+ * Return the configuration needed to use the Sharp-based image service
+ * See: https://docs.astro.build/en/guides/assets/#using-sharp
+ */
+export function sharpImageService(): ImageServiceConfig;
+
+/**
+ * Return the configuration needed to use the Squoosh-based image service
+ */
+export function squooshImageService(): ImageServiceConfig;

--- a/packages/astro/config.mjs
+++ b/packages/astro/config.mjs
@@ -1,1 +1,15 @@
 export { defineConfig, getViteConfig } from './dist/config/index.js';
+
+export function sharpImageService() {
+	return {
+		entrypoint: 'astro/assets/services/sharp',
+		config: {},
+	};
+}
+
+export function squooshImageService() {
+	return {
+		entrypoint: 'astro/assets/services/squoosh',
+		config: {},
+	};
+}

--- a/packages/astro/src/assets/index.ts
+++ b/packages/astro/src/assets/index.ts
@@ -1,21 +1,5 @@
-import type { ImageServiceConfig } from '../@types/astro.js';
-
 export { getConfiguredImageService, getImage } from './internal.js';
 export { baseService, isLocalService } from './services/service.js';
 export { type LocalImageProps, type RemoteImageProps } from './types.js';
 export { emitESMImage } from './utils/emitAsset.js';
 export { imageMetadata } from './utils/metadata.js';
-
-export function sharpImageService(): ImageServiceConfig {
-	return {
-		entrypoint: 'astro/assets/services/sharp',
-		config: {},
-	};
-}
-
-export function squooshImageService(): ImageServiceConfig {
-	return {
-		entrypoint: 'astro/assets/services/squoosh',
-		config: {},
-	};
-}


### PR DESCRIPTION
## Changes

The service functions were available from `astro/assets`, but it's not intended that people import things from there, as it's an internal file first and foremost. This PR moves the utilities methods to `astro/config`, so they can be imported easily in the same breath as the other utility methods.

## Testing

Tested manually

## Docs

https://github.com/withastro/docs/pull/3174