### PR TITLE
[docs] escape style tags for config reference

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1060,8 +1060,8 @@ export interface AstroUserConfig {
 		 * @type {('always' | 'auto' | 'never')}
 		 * @default `never`
 		 * @description
-		 * Control whether styles are sent to the browser in a separate css file or inlined into <style> tags. Choose from the following options:
-		 *  - `'always'` - all styles are inlined into <style> tags
+		 * Control whether styles are sent to the browser in a separate css file or inlined into `<style>` tags. Choose from the following options:
+		 *  - `'always'` - all styles are inlined into `<style>` tags
 		 *  - `'auto'` - only stylesheets smaller than `ViteConfig.build.assetsInlineLimit` (default: 4kb) are inlined. Otherwise, styles are sent in external stylesheets.
 		 *  - `'never'` - all styles are sent in external stylesheets
 		 *


### PR DESCRIPTION
## Changes

Escapes `<style>` tags in the `experimental.inlineStylesheets` text

## Testing

This was painfully tested.  :sweat_smile: I've made the change in docs source to get it working immediately.

## Docs

This will make its way into docs.
