### PR TITLE
Fix `partytown` README

### DIFF
--- a/.changeset/wise-jars-trade.md
+++ b/.changeset/wise-jars-trade.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/partytown': patch
+---
+
+Fixed a code example that was wrongly closed

--- a/packages/integrations/partytown/README.md
+++ b/packages/integrations/partytown/README.md
@@ -100,7 +100,7 @@ export default defineConfig({
   integrations: [partytown({
     // Example: Disable debug mode.
     config: { debug: false },
-  
+  })]
 })
 ```
 


### PR DESCRIPTION
## Changes

Fixed a code example that was wrongly closed in `partytown` readme.

* BEFORE:

```js
export default defineConfig({
  integrations: [partytown({
    // Example: Disable debug mode.
    config: { debug: false },

})
```

* AFTER:

```js
export default defineConfig({
  integrations: [partytown({
    // Example: Disable debug mode.
    config: { debug: false },
  })]
})
```

## Testing

As only one block of code has been closed, no tests are required.

## Docs

Within the partytown README there was a block that was not closed correctly, the example has been closed and corrected.

/cc @withastro/maintainers-docs for feedback!

