### PR TITLE
Update template deps to latest

### DIFF
--- a/examples/basics/package.json
+++ b/examples/basics/package.json
@@ -11,6 +11,6 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2"
+    "astro": "^2.4.1"
   }
 }

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -11,9 +11,9 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2",
-    "@astrojs/mdx": "^0.19.0",
-    "@astrojs/rss": "^2.4.0",
-    "@astrojs/sitemap": "^1.2.2"
+    "@astrojs/mdx": "^0.19.1",
+    "@astrojs/rss": "^2.4.1",
+    "@astrojs/sitemap": "^1.3.0",
+    "astro": "^2.4.1"
   }
 }

--- a/examples/component/package.json
+++ b/examples/component/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {},
   "devDependencies": {
-    "astro": "^2.3.2"
+    "astro": "^2.4.1"
   },
   "peerDependencies": {
     "astro": "^2.0.0-beta.0"

--- a/examples/deno/package.json
+++ b/examples/deno/package.json
@@ -10,7 +10,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2"
+    "astro": "^2.4.1"
   },
   "devDependencies": {
     "@astrojs/deno": "^4.1.0"

--- a/examples/docs/package.json
+++ b/examples/docs/package.json
@@ -11,18 +11,18 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2",
-    "preact": "^10.7.3",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
-    "@astrojs/react": "^2.1.1",
+    "@algolia/client-search": "^4.17.0",
     "@astrojs/preact": "^2.1.0",
-    "@algolia/client-search": "^4.13.1",
-    "@docsearch/css": "^3.1.0",
-    "@docsearch/react": "^3.1.0",
-    "@types/react": "^17.0.45",
-    "@types/node": "^18.0.0",
-    "@types/react-dom": "^18.0.0"
+    "@astrojs/react": "^2.1.3",
+    "@docsearch/css": "^3.3.4",
+    "@docsearch/react": "^3.3.4",
+    "@types/node": "^18.16.3",
+    "@types/react": "^18.2.5",
+    "@types/react-dom": "^18.2.3",
+    "astro": "^2.4.1",
+    "preact": "^10.13.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "html-escaper": "^3.0.3"

--- a/examples/framework-alpine/package.json
+++ b/examples/framework-alpine/package.json
@@ -11,9 +11,9 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2",
-    "alpinejs": "^3.10.2",
     "@astrojs/alpinejs": "^0.2.1",
-    "@types/alpinejs": "^3.7.0"
+    "@types/alpinejs": "^3.7.1",
+    "alpinejs": "^3.12.0",
+    "astro": "^2.4.1"
   }
 }

--- a/examples/framework-lit/package.json
+++ b/examples/framework-lit/package.json
@@ -11,9 +11,9 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2",
-    "lit": "^2.7.0",
     "@astrojs/lit": "^2.0.1",
-    "@webcomponents/template-shadowroot": "^0.2.1"
+    "@webcomponents/template-shadowroot": "^0.2.1",
+    "astro": "^2.4.1",
+    "lit": "^2.7.4"
   }
 }

--- a/examples/framework-multiple/package.json
+++ b/examples/framework-multiple/package.json
@@ -11,17 +11,17 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2",
-    "preact": "^10.7.3",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
-    "solid-js": "^1.4.3",
-    "svelte": "^3.48.0",
-    "vue": "^3.2.37",
     "@astrojs/preact": "^2.1.0",
-    "@astrojs/react": "^2.1.1",
-    "@astrojs/solid-js": "^2.1.0",
-    "@astrojs/svelte": "^2.1.0",
-    "@astrojs/vue": "^2.1.1"
+    "@astrojs/react": "^2.1.3",
+    "@astrojs/solid-js": "^2.1.1",
+    "@astrojs/svelte": "^2.1.1",
+    "@astrojs/vue": "^2.1.1",
+    "astro": "^2.4.1",
+    "preact": "^10.13.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "solid-js": "^1.7.4",
+    "svelte": "^3.58.0",
+    "vue": "^3.2.47"
   }
 }

--- a/examples/framework-preact/package.json
+++ b/examples/framework-preact/package.json
@@ -11,9 +11,9 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2",
-    "preact": "^10.7.3",
     "@astrojs/preact": "^2.1.0",
-    "@preact/signals": "^1.1.0"
+    "@preact/signals": "^1.1.3",
+    "astro": "^2.4.1",
+    "preact": "^10.13.2"
   }
 }

--- a/examples/framework-react/package.json
+++ b/examples/framework-react/package.json
@@ -11,11 +11,11 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
-    "@astrojs/react": "^2.1.1",
-    "@types/react": "^18.0.10",
-    "@types/react-dom": "^18.0.5"
+    "@astrojs/react": "^2.1.3",
+    "@types/react": "^18.2.5",
+    "@types/react-dom": "^18.2.3",
+    "astro": "^2.4.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/examples/framework-solid/package.json
+++ b/examples/framework-solid/package.json
@@ -11,8 +11,8 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2",
-    "solid-js": "^1.4.3",
-    "@astrojs/solid-js": "^2.1.0"
+    "@astrojs/solid-js": "^2.1.1",
+    "astro": "^2.4.1",
+    "solid-js": "^1.7.4"
   }
 }

--- a/examples/framework-svelte/package.json
+++ b/examples/framework-svelte/package.json
@@ -11,8 +11,8 @@
     "astro": "astro"
   },
   "dependencies": {
-    "svelte": "^3.48.0",
-    "@astrojs/svelte": "^2.1.0",
-    "astro": "^2.3.2"
+    "@astrojs/svelte": "^2.1.1",
+    "astro": "^2.4.1",
+    "svelte": "^3.58.0"
   }
 }

--- a/examples/framework-vue/package.json
+++ b/examples/framework-vue/package.json
@@ -11,8 +11,8 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2",
-    "vue": "^3.2.37",
-    "@astrojs/vue": "^2.1.1"
+    "@astrojs/vue": "^2.1.1",
+    "astro": "^2.4.1",
+    "vue": "^3.2.47"
   }
 }

--- a/examples/hackernews/package.json
+++ b/examples/hackernews/package.json
@@ -11,7 +11,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/node": "^5.1.1",
-    "astro": "^2.3.2"
+    "@astrojs/node": "^5.1.2",
+    "astro": "^2.4.1"
   }
 }

--- a/examples/integration/package.json
+++ b/examples/integration/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {},
   "devDependencies": {
-    "astro": "^2.3.2"
+    "astro": "^2.4.1"
   },
   "peerDependencies": {
     "astro": "^2.0.0-beta.0"

--- a/examples/middleware/package.json
+++ b/examples/middleware/package.json
@@ -12,12 +12,8 @@
     "server": "node dist/server/entry.mjs"
   },
   "dependencies": {
-    "@astrojs/node": "workspace:*",
-    "astro": "workspace:*",
-    "concurrently": "^7.6.0",
-    "html-minifier": "^4.0.0",
-    "svelte": "^3.58.0",
-    "unocss": "^0.15.6",
-    "vite-imagetools": "^4.0.19"
+    "@astrojs/node": "^5.1.2",
+    "astro": "^2.4.1",
+    "html-minifier": "^4.0.0"
   }
 }

--- a/examples/middleware/package.json
+++ b/examples/middleware/package.json
@@ -12,12 +12,12 @@
     "server": "node dist/server/entry.mjs"
   },
   "dependencies": {
-    "astro": "workspace:*",
-    "svelte": "^3.48.0",
     "@astrojs/node": "workspace:*",
-    "concurrently": "^7.2.1",
+    "astro": "workspace:*",
+    "concurrently": "^7.6.0",
+    "html-minifier": "^4.0.0",
+    "svelte": "^3.58.0",
     "unocss": "^0.15.6",
-    "vite-imagetools": "^4.0.4",
-    "html-minifier": "^4.0.0"
+    "vite-imagetools": "^4.0.19"
   }
 }

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -11,6 +11,6 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2"
+    "astro": "^2.4.1"
   }
 }

--- a/examples/non-html-pages/package.json
+++ b/examples/non-html-pages/package.json
@@ -11,6 +11,6 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2"
+    "astro": "^2.4.1"
   }
 }

--- a/examples/portfolio/package.json
+++ b/examples/portfolio/package.json
@@ -11,6 +11,6 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2"
+    "astro": "^2.4.1"
   }
 }

--- a/examples/ssr/package.json
+++ b/examples/ssr/package.json
@@ -15,9 +15,6 @@
     "@astrojs/node": "^5.1.2",
     "@astrojs/svelte": "^2.1.1",
     "astro": "^2.4.1",
-    "concurrently": "^7.6.0",
-    "svelte": "^3.58.0",
-    "unocss": "^0.15.6",
-    "vite-imagetools": "^4.0.19"
+    "svelte": "^3.58.0"
   }
 }

--- a/examples/ssr/package.json
+++ b/examples/ssr/package.json
@@ -12,12 +12,12 @@
     "server": "node dist/server/entry.mjs"
   },
   "dependencies": {
-    "astro": "^2.3.2",
-    "svelte": "^3.48.0",
-    "@astrojs/svelte": "^2.1.0",
-    "@astrojs/node": "^5.1.1",
-    "concurrently": "^7.2.1",
+    "@astrojs/node": "^5.1.2",
+    "@astrojs/svelte": "^2.1.1",
+    "astro": "^2.4.1",
+    "concurrently": "^7.6.0",
+    "svelte": "^3.58.0",
     "unocss": "^0.15.6",
-    "vite-imagetools": "^4.0.4"
+    "vite-imagetools": "^4.0.19"
   }
 }

--- a/examples/with-markdoc/package.json
+++ b/examples/with-markdoc/package.json
@@ -11,8 +11,8 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/markdoc": "^0.1.1",
-    "astro": "^2.3.2",
+    "@astrojs/markdoc": "^0.1.2",
+    "astro": "^2.4.1",
     "kleur": "^4.1.5"
   }
 }

--- a/examples/with-markdown-plugins/package.json
+++ b/examples/with-markdown-plugins/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@astrojs/markdown-remark": "^2.2.0",
     "astro": "^2.4.1",
-    "hast-util-select": "5.0.1",
+    "hast-util-select": "^5.0.5",
     "rehype-autolink-headings": "^6.1.1",
     "rehype-slug": "^5.1.0",
     "rehype-toc": "^3.0.2",

--- a/examples/with-markdown-plugins/package.json
+++ b/examples/with-markdown-plugins/package.json
@@ -11,11 +11,11 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2",
-    "@astrojs/markdown-remark": "^2.1.4",
+    "@astrojs/markdown-remark": "^2.2.0",
+    "astro": "^2.4.1",
     "hast-util-select": "5.0.1",
     "rehype-autolink-headings": "^6.1.1",
-    "rehype-slug": "^5.0.1",
+    "rehype-slug": "^5.1.0",
     "rehype-toc": "^3.0.2",
     "remark-code-titles": "^0.1.2"
   }

--- a/examples/with-markdown-shiki/package.json
+++ b/examples/with-markdown-shiki/package.json
@@ -11,6 +11,6 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2"
+    "astro": "^2.4.1"
   }
 }

--- a/examples/with-mdx/package.json
+++ b/examples/with-mdx/package.json
@@ -11,9 +11,9 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2",
-    "preact": "^10.6.5",
+    "@astrojs/mdx": "^0.19.1",
     "@astrojs/preact": "^2.1.0",
-    "@astrojs/mdx": "^0.19.0"
+    "astro": "^2.4.1",
+    "preact": "^10.13.2"
   }
 }

--- a/examples/with-nanostores/package.json
+++ b/examples/with-nanostores/package.json
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@astrojs/preact": "^2.1.0",
-    "@nanostores/preact": "^0.1.3",
+    "@nanostores/preact": "^0.4.1",
     "astro": "^2.4.1",
-    "nanostores": "^0.5.13",
+    "nanostores": "^0.8.1",
     "preact": "^10.13.2"
   }
 }

--- a/examples/with-nanostores/package.json
+++ b/examples/with-nanostores/package.json
@@ -11,10 +11,10 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2",
-    "preact": "^10.7.3",
     "@astrojs/preact": "^2.1.0",
-    "nanostores": "^0.5.12",
-    "@nanostores/preact": "^0.1.3"
+    "@nanostores/preact": "^0.1.3",
+    "astro": "^2.4.1",
+    "nanostores": "^0.5.13",
+    "preact": "^10.13.2"
   }
 }

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -11,12 +11,12 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/mdx": "^0.19.0",
-    "@astrojs/tailwind": "^3.1.1",
-    "@types/canvas-confetti": "^1.4.3",
-    "astro": "^2.3.2",
+    "@astrojs/mdx": "^0.19.1",
+    "@astrojs/tailwind": "^3.1.2",
+    "@types/canvas-confetti": "^1.6.0",
+    "astro": "^2.4.1",
     "autoprefixer": "^10.4.14",
-    "canvas-confetti": "^1.5.1",
+    "canvas-confetti": "^1.6.0",
     "postcss": "^8.4.23",
     "tailwindcss": "^3.3.2"
   }

--- a/examples/with-vite-plugin-pwa/package.json
+++ b/examples/with-vite-plugin-pwa/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "astro": "^2.4.1",
-    "vite-plugin-pwa": "0.11.11",
+    "vite-plugin-pwa": "0.14.7",
     "workbox-window": "^6.5.4"
   }
 }

--- a/examples/with-vite-plugin-pwa/package.json
+++ b/examples/with-vite-plugin-pwa/package.json
@@ -11,8 +11,8 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2",
+    "astro": "^2.4.1",
     "vite-plugin-pwa": "0.11.11",
-    "workbox-window": "^6.5.3"
+    "workbox-window": "^6.5.4"
   }
 }

--- a/examples/with-vitest/package.json
+++ b/examples/with-vitest/package.json
@@ -12,7 +12,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "astro": "^2.3.2",
+    "astro": "^2.4.1",
     "vitest": "^0.20.3"
   }
 }

--- a/examples/with-vitest/package.json
+++ b/examples/with-vitest/package.json
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "astro": "^2.4.1",
-    "vitest": "^0.20.3"
+    "vitest": "^0.31.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,34 +128,34 @@ importers:
   examples/basics:
     dependencies:
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
 
   examples/blog:
     dependencies:
       '@astrojs/mdx':
-        specifier: ^0.19.0
+        specifier: ^0.19.1
         version: link:../../packages/integrations/mdx
       '@astrojs/rss':
-        specifier: ^2.4.0
+        specifier: ^2.4.1
         version: link:../../packages/astro-rss
       '@astrojs/sitemap':
-        specifier: ^1.2.2
+        specifier: ^1.3.0
         version: link:../../packages/integrations/sitemap
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
 
   examples/component:
     devDependencies:
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
 
   examples/deno:
     dependencies:
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
     devDependencies:
       '@astrojs/deno':
@@ -165,40 +165,40 @@ importers:
   examples/docs:
     dependencies:
       '@algolia/client-search':
-        specifier: ^4.13.1
-        version: 4.13.1
+        specifier: ^4.17.0
+        version: 4.17.0
       '@astrojs/preact':
         specifier: ^2.1.0
         version: link:../../packages/integrations/preact
       '@astrojs/react':
-        specifier: ^2.1.1
+        specifier: ^2.1.3
         version: link:../../packages/integrations/react
       '@docsearch/css':
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^3.3.4
+        version: 3.3.4
       '@docsearch/react':
-        specifier: ^3.1.0
-        version: 3.1.0(@types/react@17.0.45)(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^3.3.4
+        version: 3.3.4(@algolia/client-search@4.17.0)(@types/react@17.0.58)(react-dom@18.2.0)(react@18.2.0)
       '@types/node':
-        specifier: ^18.0.0
-        version: 18.7.21
+        specifier: ^18.16.3
+        version: 18.16.3
       '@types/react':
-        specifier: ^17.0.45
-        version: 17.0.45
+        specifier: ^17.0.58
+        version: 17.0.58
       '@types/react-dom':
-        specifier: ^18.0.0
-        version: 18.0.6
+        specifier: ^18.2.3
+        version: 18.2.3
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       preact:
-        specifier: ^10.7.3
+        specifier: ^10.13.2
         version: 10.13.2
       react:
-        specifier: ^18.1.0
+        specifier: ^18.2.0
         version: 18.2.0
       react-dom:
-        specifier: ^18.1.0
+        specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
     devDependencies:
       html-escaper:
@@ -211,13 +211,13 @@ importers:
         specifier: ^0.2.1
         version: link:../../packages/integrations/alpinejs
       '@types/alpinejs':
-        specifier: ^3.7.0
-        version: 3.7.0
+        specifier: ^3.7.1
+        version: 3.7.1
       alpinejs:
-        specifier: ^3.10.2
-        version: 3.10.2
+        specifier: ^3.12.0
+        version: 3.12.0
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
 
   examples/framework-lit:
@@ -229,11 +229,11 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       lit:
-        specifier: ^2.7.0
-        version: 2.7.0
+        specifier: ^2.7.4
+        version: 2.7.4
 
   examples/framework-multiple:
     dependencies:
@@ -241,38 +241,38 @@ importers:
         specifier: ^2.1.0
         version: link:../../packages/integrations/preact
       '@astrojs/react':
-        specifier: ^2.1.1
+        specifier: ^2.1.3
         version: link:../../packages/integrations/react
       '@astrojs/solid-js':
-        specifier: ^2.1.0
+        specifier: ^2.1.1
         version: link:../../packages/integrations/solid
       '@astrojs/svelte':
-        specifier: ^2.1.0
+        specifier: ^2.1.1
         version: link:../../packages/integrations/svelte
       '@astrojs/vue':
         specifier: ^2.1.1
         version: link:../../packages/integrations/vue
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       preact:
-        specifier: ^10.7.3
+        specifier: ^10.13.2
         version: 10.13.2
       react:
-        specifier: ^18.1.0
+        specifier: ^18.2.0
         version: 18.2.0
       react-dom:
-        specifier: ^18.1.0
+        specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       solid-js:
-        specifier: ^1.4.3
-        version: 1.5.6
+        specifier: ^1.7.4
+        version: 1.7.4
       svelte:
-        specifier: ^3.48.0
+        specifier: ^3.58.0
         version: 3.58.0
       vue:
-        specifier: ^3.2.37
-        version: 3.2.40
+        specifier: ^3.2.47
+        version: 3.2.47
 
   examples/framework-preact:
     dependencies:
@@ -280,58 +280,58 @@ importers:
         specifier: ^2.1.0
         version: link:../../packages/integrations/preact
       '@preact/signals':
-        specifier: ^1.1.0
-        version: 1.1.1(preact@10.13.2)
+        specifier: ^1.1.3
+        version: 1.1.3(preact@10.13.2)
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       preact:
-        specifier: ^10.7.3
+        specifier: ^10.13.2
         version: 10.13.2
 
   examples/framework-react:
     dependencies:
       '@astrojs/react':
-        specifier: ^2.1.1
+        specifier: ^2.1.3
         version: link:../../packages/integrations/react
       '@types/react':
-        specifier: ^18.0.10
-        version: 18.0.21
+        specifier: ^18.2.5
+        version: 18.2.5
       '@types/react-dom':
-        specifier: ^18.0.5
-        version: 18.0.6
+        specifier: ^18.2.3
+        version: 18.2.3
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       react:
-        specifier: ^18.1.0
+        specifier: ^18.2.0
         version: 18.2.0
       react-dom:
-        specifier: ^18.1.0
+        specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
 
   examples/framework-solid:
     dependencies:
       '@astrojs/solid-js':
-        specifier: ^2.1.0
+        specifier: ^2.1.1
         version: link:../../packages/integrations/solid
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       solid-js:
-        specifier: ^1.4.3
-        version: 1.5.6
+        specifier: ^1.7.4
+        version: 1.7.4
 
   examples/framework-svelte:
     dependencies:
       '@astrojs/svelte':
-        specifier: ^2.1.0
+        specifier: ^2.1.1
         version: link:../../packages/integrations/svelte
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       svelte:
-        specifier: ^3.48.0
+        specifier: ^3.58.0
         version: 3.58.0
 
   examples/framework-vue:
@@ -340,25 +340,25 @@ importers:
         specifier: ^2.1.1
         version: link:../../packages/integrations/vue
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       vue:
-        specifier: ^3.2.37
-        version: 3.2.40
+        specifier: ^3.2.47
+        version: 3.2.47
 
   examples/hackernews:
     dependencies:
       '@astrojs/node':
-        specifier: ^5.1.1
+        specifier: ^5.1.2
         version: link:../../packages/integrations/node
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
 
   examples/integration:
     devDependencies:
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
 
   examples/middleware:
@@ -370,70 +370,70 @@ importers:
         specifier: workspace:*
         version: link:../../packages/astro
       concurrently:
-        specifier: ^7.2.1
-        version: 7.2.1
+        specifier: ^7.6.0
+        version: 7.6.0
       html-minifier:
         specifier: ^4.0.0
         version: 4.0.0
       svelte:
-        specifier: ^3.48.0
+        specifier: ^3.58.0
         version: 3.58.0
       unocss:
         specifier: ^0.15.6
         version: 0.15.6
       vite-imagetools:
-        specifier: ^4.0.4
-        version: 4.0.4
+        specifier: ^4.0.19
+        version: 4.0.19
 
   examples/minimal:
     dependencies:
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
 
   examples/non-html-pages:
     dependencies:
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
 
   examples/portfolio:
     dependencies:
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
 
   examples/ssr:
     dependencies:
       '@astrojs/node':
-        specifier: ^5.1.1
+        specifier: ^5.1.2
         version: link:../../packages/integrations/node
       '@astrojs/svelte':
-        specifier: ^2.1.0
+        specifier: ^2.1.1
         version: link:../../packages/integrations/svelte
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       concurrently:
-        specifier: ^7.2.1
-        version: 7.2.1
+        specifier: ^7.6.0
+        version: 7.6.0
       svelte:
-        specifier: ^3.48.0
+        specifier: ^3.58.0
         version: 3.58.0
       unocss:
         specifier: ^0.15.6
         version: 0.15.6
       vite-imagetools:
-        specifier: ^4.0.4
-        version: 4.0.4
+        specifier: ^4.0.19
+        version: 4.0.19
 
   examples/with-markdoc:
     dependencies:
       '@astrojs/markdoc':
-        specifier: ^0.1.1
+        specifier: ^0.1.2
         version: link:../../packages/integrations/markdoc
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       kleur:
         specifier: ^4.1.5
@@ -442,10 +442,10 @@ importers:
   examples/with-markdown-plugins:
     dependencies:
       '@astrojs/markdown-remark':
-        specifier: ^2.1.4
+        specifier: ^2.2.0
         version: link:../../packages/markdown/remark
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       hast-util-select:
         specifier: 5.0.1
@@ -454,8 +454,8 @@ importers:
         specifier: ^6.1.1
         version: 6.1.1
       rehype-slug:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.1.0
+        version: 5.1.0
       rehype-toc:
         specifier: ^3.0.2
         version: 3.0.2
@@ -466,22 +466,22 @@ importers:
   examples/with-markdown-shiki:
     dependencies:
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
 
   examples/with-mdx:
     dependencies:
       '@astrojs/mdx':
-        specifier: ^0.19.0
+        specifier: ^0.19.1
         version: link:../../packages/integrations/mdx
       '@astrojs/preact':
         specifier: ^2.1.0
         version: link:../../packages/integrations/preact
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       preact:
-        specifier: ^10.6.5
+        specifier: ^10.13.2
         version: 10.13.2
 
   examples/with-nanostores:
@@ -491,37 +491,37 @@ importers:
         version: link:../../packages/integrations/preact
       '@nanostores/preact':
         specifier: ^0.1.3
-        version: 0.1.3(nanostores@0.5.12)(preact@10.13.2)
+        version: 0.1.3(nanostores@0.5.13)(preact@10.13.2)
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       nanostores:
-        specifier: ^0.5.12
-        version: 0.5.12
+        specifier: ^0.5.13
+        version: 0.5.13
       preact:
-        specifier: ^10.7.3
+        specifier: ^10.13.2
         version: 10.13.2
 
   examples/with-tailwindcss:
     dependencies:
       '@astrojs/mdx':
-        specifier: ^0.19.0
+        specifier: ^0.19.1
         version: link:../../packages/integrations/mdx
       '@astrojs/tailwind':
-        specifier: ^3.1.1
+        specifier: ^3.1.2
         version: link:../../packages/integrations/tailwind
       '@types/canvas-confetti':
-        specifier: ^1.4.3
-        version: 1.4.3
+        specifier: ^1.6.0
+        version: 1.6.0
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       autoprefixer:
         specifier: ^10.4.14
         version: 10.4.14(postcss@8.4.23)
       canvas-confetti:
-        specifier: ^1.5.1
-        version: 1.5.1
+        specifier: ^1.6.0
+        version: 1.6.0
       postcss:
         specifier: ^8.4.23
         version: 8.4.23
@@ -532,19 +532,19 @@ importers:
   examples/with-vite-plugin-pwa:
     dependencies:
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       vite-plugin-pwa:
         specifier: 0.11.11
-        version: 0.11.11(workbox-window@6.5.3)
+        version: 0.11.11(workbox-window@6.5.4)
       workbox-window:
-        specifier: ^6.5.3
-        version: 6.5.3
+        specifier: ^6.5.4
+        version: 6.5.4
 
   examples/with-vitest:
     dependencies:
       astro:
-        specifier: ^2.3.2
+        specifier: ^2.4.1
         version: link:../../packages/astro
       vitest:
         specifier: ^0.20.3
@@ -5163,24 +5163,31 @@ importers:
 
 packages:
 
-  /@algolia/autocomplete-core@1.6.3:
-    resolution: {integrity: sha512-dqQqRt01fX3YuVFrkceHsoCnzX0bLhrrg8itJI1NM68KjrPYQPYsE+kY8EZTCM4y8VDnhqJErR73xe/ZsV+qAA==}
+  /@algolia/autocomplete-core@1.8.2:
+    resolution: {integrity: sha512-mTeshsyFhAqw/ebqNsQpMtbnjr+qVOSKXArEj4K0d7sqc8It1XD0gkASwecm9mF/jlOQ4Z9RNg1HbdA8JPdRwQ==}
     dependencies:
-      '@algolia/autocomplete-shared': 1.6.3
+      '@algolia/autocomplete-shared': 1.8.2
     dev: false
 
-  /@algolia/autocomplete-shared@1.6.3:
-    resolution: {integrity: sha512-UV46bnkTztyADFaETfzFC5ryIdGVb2zpAoYgu0tfcuYWjhg1KbLXveFffZIrGVoboqmAk1b+jMrl6iCja1i3lg==}
+  /@algolia/autocomplete-preset-algolia@1.8.2(@algolia/client-search@4.17.0)(algoliasearch@4.17.0):
+    resolution: {integrity: sha512-J0oTx4me6ZM9kIKPuL3lyU3aB8DEvpVvR6xWmHVROx5rOYJGQcZsdG4ozxwcOyiiu3qxMkIbzntnV1S1VWD8yA==}
+    peerDependencies:
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+    dependencies:
+      '@algolia/autocomplete-shared': 1.8.2
+      '@algolia/client-search': 4.17.0
+      algoliasearch: 4.17.0
+    dev: false
+
+  /@algolia/autocomplete-shared@1.8.2:
+    resolution: {integrity: sha512-b6Z/X4MczChMcfhk6kfRmBzPgjoPzuS9KGR4AFsiLulLNRAAqhP+xZTKtMnZGhLuc61I20d5WqlId02AZvcO6g==}
     dev: false
 
   /@algolia/cache-browser-local-storage@4.17.0:
     resolution: {integrity: sha512-myRSRZDIMYB8uCkO+lb40YKiYHi0fjpWRtJpR/dgkaiBlSD0plRyB6lLOh1XIfmMcSeBOqDE7y9m8xZMrXYfyQ==}
     dependencies:
       '@algolia/cache-common': 4.17.0
-    dev: false
-
-  /@algolia/cache-common@4.13.1:
-    resolution: {integrity: sha512-7Vaf6IM4L0Jkl3sYXbwK+2beQOgVJ0mKFbz/4qSxKd1iy2Sp77uTAazcX+Dlexekg1fqGUOSO7HS4Sx47ZJmjA==}
     dev: false
 
   /@algolia/cache-common@4.17.0:
@@ -5210,13 +5217,6 @@ packages:
       '@algolia/transporter': 4.17.0
     dev: false
 
-  /@algolia/client-common@4.13.1:
-    resolution: {integrity: sha512-LcDoUE0Zz3YwfXJL6lJ2OMY2soClbjrrAKB6auYVMNJcoKZZ2cbhQoFR24AYoxnGUYBER/8B+9sTBj5bj/Gqbg==}
-    dependencies:
-      '@algolia/requester-common': 4.13.1
-      '@algolia/transporter': 4.13.1
-    dev: false
-
   /@algolia/client-common@4.17.0:
     resolution: {integrity: sha512-jHMks0ZFicf8nRDn6ma8DNNsdwGgP/NKiAAL9z6rS7CymJ7L0+QqTJl3rYxRW7TmBhsUH40wqzmrG6aMIN/DrQ==}
     dependencies:
@@ -5232,24 +5232,12 @@ packages:
       '@algolia/transporter': 4.17.0
     dev: false
 
-  /@algolia/client-search@4.13.1:
-    resolution: {integrity: sha512-YQKYA83MNRz3FgTNM+4eRYbSmHi0WWpo019s5SeYcL3HUan/i5R09VO9dk3evELDFJYciiydSjbsmhBzbpPP2A==}
-    dependencies:
-      '@algolia/client-common': 4.13.1
-      '@algolia/requester-common': 4.13.1
-      '@algolia/transporter': 4.13.1
-    dev: false
-
   /@algolia/client-search@4.17.0:
     resolution: {integrity: sha512-x4P2wKrrRIXszT8gb7eWsMHNNHAJs0wE7/uqbufm4tZenAp+hwU/hq5KVsY50v+PfwM0LcDwwn/1DroujsTFoA==}
     dependencies:
       '@algolia/client-common': 4.17.0
       '@algolia/requester-common': 4.17.0
       '@algolia/transporter': 4.17.0
-    dev: false
-
-  /@algolia/logger-common@4.13.1:
-    resolution: {integrity: sha512-L6slbL/OyZaAXNtS/1A8SAbOJeEXD5JcZeDCPYDqSTYScfHu+2ePRTDMgUTY4gQ7HsYZ39N1LujOd8WBTmM2Aw==}
     dev: false
 
   /@algolia/logger-common@4.17.0:
@@ -5268,10 +5256,6 @@ packages:
       '@algolia/requester-common': 4.17.0
     dev: false
 
-  /@algolia/requester-common@4.13.1:
-    resolution: {integrity: sha512-eGVf0ID84apfFEuXsaoSgIxbU3oFsIbz4XiotU3VS8qGCJAaLVUC5BUJEkiFENZIhon7hIB4d0RI13HY4RSA+w==}
-    dev: false
-
   /@algolia/requester-common@4.17.0:
     resolution: {integrity: sha512-XJjmWFEUlHu0ijvcHBoixuXfEoiRUdyzQM6YwTuB8usJNIgShua8ouFlRWF8iCeag0vZZiUm4S2WCVBPkdxFgg==}
     dev: false
@@ -5280,14 +5264,6 @@ packages:
     resolution: {integrity: sha512-bpb/wDA1aC6WxxM8v7TsFspB7yBN3nqCGs2H1OADolQR/hiAIjAxusbuMxVbRFOdaUvAIqioIIkWvZdpYNIn8w==}
     dependencies:
       '@algolia/requester-common': 4.17.0
-    dev: false
-
-  /@algolia/transporter@4.13.1:
-    resolution: {integrity: sha512-pICnNQN7TtrcYJqqPEXByV8rJ8ZRU2hCiIKLTLRyNpghtQG3VAFk6fVtdzlNfdUGZcehSKGarPIZEHlQXnKjgw==}
-    dependencies:
-      '@algolia/cache-common': 4.13.1
-      '@algolia/logger-common': 4.13.1
-      '@algolia/requester-common': 4.13.1
     dev: false
 
   /@algolia/transporter@4.17.0:
@@ -5554,29 +5530,6 @@ packages:
       semver: 6.3.0
     dev: false
 
-  /@babel/helper-create-class-features-plugin@7.21.8(@babel/core@7.18.2):
-    resolution: {integrity: sha512-+THiN8MqiH2AczyuZrnrKL6cAxFRRQDKW9h1YkBvbgKmAm6mwiacig1qT73DHIWMGo40GRnsEfN3LA+E6NtmSw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-    dependencies:
-      '@babel/core': 7.18.2
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.21.5
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-member-expression-to-functions': 7.21.5
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.21.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/helper-split-export-declaration': 7.18.6
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@babel/helper-create-class-features-plugin@7.21.8(@babel/core@7.21.8):
     resolution: {integrity: sha512-+THiN8MqiH2AczyuZrnrKL6cAxFRRQDKW9h1YkBvbgKmAm6mwiacig1qT73DHIWMGo40GRnsEfN3LA+E6NtmSw==}
     engines: {node: '>=6.9.0'}
@@ -5600,7 +5553,7 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/helper-create-regexp-features-plugin@7.21.8(@babel/core@7.18.2):
+  /@babel/helper-create-regexp-features-plugin@7.21.8(@babel/core@7.21.8):
     resolution: {integrity: sha512-zGuSdedkFtsFHGbexAvNuipg1hbtitDLo2XE8/uf6Y9sOQV1xsYX/2pNbtedp/X0eU1pIt+kGvaqHCowkRbS5g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -5609,13 +5562,13 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.3.2
       semver: 6.3.0
     dev: false
 
-  /@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.18.2):
+  /@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.21.8):
     resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
     peerDependencies:
       '@babel/core': ^7.4.0-0
@@ -5623,8 +5576,8 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.18.2)
+      '@babel/core': 7.21.8
+      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
       debug: 4.3.4
       lodash.debounce: 4.0.8
@@ -5703,7 +5656,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.18.2):
+  /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.21.8):
     resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -5712,7 +5665,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.21.5
       '@babel/helper-wrap-function': 7.20.5
@@ -5816,7 +5769,7 @@ packages:
       '@babel/types': 7.18.4
     dev: false
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -5825,11 +5778,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.20.7(@babel/core@7.18.2):
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.20.7(@babel/core@7.21.8):
     resolution: {integrity: sha512-sbr9+wNE5aXMBBFBICk01tt7sBf2Oc9ikRFEcem/ZORup9IMUdNhW7/wVLEbbtlWOsEubJet46mHAL2C8+2jKQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -5838,13 +5791,13 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.18.2)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.21.8)
     dev: false
 
-  /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.18.2):
+  /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.21.8):
     resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -5853,16 +5806,16 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-environment-visitor': 7.21.5
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.18.2)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.18.2)
+      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.21.8)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.21.8)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -5871,14 +5824,14 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
-      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.18.2)
+      '@babel/core': 7.21.8
+      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-class-static-block@7.21.0(@babel/core@7.18.2):
+  /@babel/plugin-proposal-class-static-block@7.21.0(@babel/core@7.21.8):
     resolution: {integrity: sha512-XP5G9MWNUskFuP30IfFSEFB0Z6HzLIUcjYM4bYOPHXl7eiJ9HFv8tWj6TXTN5QODiEhDZAeI4hLok2iHFFV4hw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -5887,15 +5840,15 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
-      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.18.2)
+      '@babel/core': 7.21.8
+      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.18.2)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.21.8)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-dynamic-import@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-proposal-dynamic-import@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -5904,12 +5857,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.18.2)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.21.8)
     dev: false
 
-  /@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.18.2):
+  /@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.21.8):
     resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -5918,12 +5871,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.18.2)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.21.8)
     dev: false
 
-  /@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -5932,12 +5885,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.18.2)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.21.8)
     dev: false
 
-  /@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.18.2):
+  /@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.21.8):
     resolution: {integrity: sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -5946,12 +5899,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.18.2)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.21.8)
     dev: false
 
-  /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -5960,12 +5913,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.18.2)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.21.8)
     dev: false
 
-  /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -5974,12 +5927,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.18.2)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.21.8)
     dev: false
 
-  /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.18.2):
+  /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.21.8):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -5989,14 +5942,14 @@ packages:
         optional: true
     dependencies:
       '@babel/compat-data': 7.21.7
-      '@babel/core': 7.18.2
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.18.2)
+      '@babel/core': 7.21.8
+      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.18.2)
-      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.18.2)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.8)
+      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.21.8)
     dev: false
 
-  /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6005,12 +5958,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.18.2)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.21.8)
     dev: false
 
-  /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.18.2):
+  /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.21.8):
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6019,13 +5972,13 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.18.2)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.8)
     dev: false
 
-  /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6034,14 +5987,14 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
-      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.18.2)
+      '@babel/core': 7.21.8
+      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-private-property-in-object@7.21.0(@babel/core@7.18.2):
+  /@babel/plugin-proposal-private-property-in-object@7.21.0(@babel/core@7.21.8):
     resolution: {integrity: sha512-ha4zfehbJjc5MmXBlHec1igel5TJXXLDDRbuJ4+XT2TJcyD9/V1919BA8gMvsdHcNMBy4WBUBiRb3nw/EQUtBw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6050,16 +6003,16 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.18.2)
+      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.18.2)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.21.8)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -6068,12 +6021,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
-      '@babel/helper-create-regexp-features-plugin': 7.21.8(@babel/core@7.18.2)
+      '@babel/core': 7.21.8
+      '@babel/helper-create-regexp-features-plugin': 7.21.8(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.18.2):
+  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.21.8):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6081,11 +6034,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.18.2):
+  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.21.8):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6093,11 +6046,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.18.2):
+  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6106,11 +6059,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.18.2):
+  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.21.8):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6118,11 +6071,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.18.2):
+  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.21.8):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6130,11 +6083,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-import-assertions@7.20.0(@babel/core@7.18.2):
+  /@babel/plugin-syntax-import-assertions@7.20.0(@babel/core@7.21.8):
     resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6143,11 +6096,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.18.2):
+  /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.21.8):
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6155,11 +6108,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.18.2):
+  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.21.8):
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6167,7 +6120,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
@@ -6197,7 +6150,7 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.18.2):
+  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.21.8):
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6205,11 +6158,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.18.2):
+  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.21.8):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6217,11 +6170,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.18.2):
+  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.21.8):
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6229,11 +6182,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.18.2):
+  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.21.8):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6241,11 +6194,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.18.2):
+  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.21.8):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6253,11 +6206,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.18.2):
+  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.21.8):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6265,11 +6218,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.18.2):
+  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6278,11 +6231,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.18.2):
+  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6291,7 +6244,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
@@ -6308,7 +6261,7 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-arrow-functions@7.21.5(@babel/core@7.18.2):
+  /@babel/plugin-transform-arrow-functions@7.21.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-wb1mhwGOCaXHDTcsRYMKF9e5bbMgqwxtqa2Y1ifH96dXJPwbuLX9qHy3clhrxVqgMz7nyNXs8VkxdH8UBcjKqA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6317,11 +6270,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-async-to-generator@7.20.7(@babel/core@7.18.2):
+  /@babel/plugin-transform-async-to-generator@7.20.7(@babel/core@7.21.8):
     resolution: {integrity: sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6330,15 +6283,15 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-module-imports': 7.21.4
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.18.2)
+      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.21.8)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6347,11 +6300,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.18.2):
+  /@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.21.8):
     resolution: {integrity: sha512-Mdrbunoh9SxwFZapeHVrwFmri16+oYotcZysSzhNIVDwIAb1UV+kvnxULSYq9J3/q5MDG+4X6w8QVgD1zhBXNQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6360,11 +6313,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-classes@7.21.0(@babel/core@7.18.2):
+  /@babel/plugin-transform-classes@7.21.0(@babel/core@7.21.8):
     resolution: {integrity: sha512-RZhbYTCEUAe6ntPehC4hlslPWosNHDox+vAs4On/mCLRLfoDVHf6hVEd7kuxr1RnHwJmxFfUM3cZiZRmPxJPXQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6373,9 +6326,9 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.18.2)
+      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.8)
       '@babel/helper-environment-visitor': 7.21.5
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-optimise-call-expression': 7.18.6
@@ -6387,7 +6340,7 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-computed-properties@7.21.5(@babel/core@7.18.2):
+  /@babel/plugin-transform-computed-properties@7.21.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-TR653Ki3pAwxBxUe8srfF3e4Pe3FTA46uaNHYyQwIoM4oWKSoOZiDNyHJ0oIoDIUPSRQbQG7jzgVBX3FPVne1Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6396,12 +6349,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/template': 7.20.7
     dev: false
 
-  /@babel/plugin-transform-destructuring@7.21.3(@babel/core@7.18.2):
+  /@babel/plugin-transform-destructuring@7.21.3(@babel/core@7.21.8):
     resolution: {integrity: sha512-bp6hwMFzuiE4HqYEyoGJ/V2LeIWn+hLVKc4pnj++E5XQptwhtcGmSayM029d/j2X1bPKGTlsyPwAubuU22KhMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6410,11 +6363,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6423,12 +6376,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
-      '@babel/helper-create-regexp-features-plugin': 7.21.8(@babel/core@7.18.2)
+      '@babel/core': 7.21.8
+      '@babel/helper-create-regexp-features-plugin': 7.21.8(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-duplicate-keys@7.18.9(@babel/core@7.18.2):
+  /@babel/plugin-transform-duplicate-keys@7.18.9(@babel/core@7.21.8):
     resolution: {integrity: sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6437,11 +6390,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6450,12 +6403,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.21.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-for-of@7.21.5(@babel/core@7.18.2):
+  /@babel/plugin-transform-for-of@7.21.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-nYWpjKW/7j/I/mZkGVgHJXh4bA1sfdFnJoOXwJuj4m3Q2EraO/8ZyrkCau9P5tbHQk01RMSt6KYLCsW7730SXQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6464,11 +6417,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.18.2):
+  /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.21.8):
     resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6477,13 +6430,13 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.18.2)
+      '@babel/core': 7.21.8
+      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.8)
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-literals@7.18.9(@babel/core@7.18.2):
+  /@babel/plugin-transform-literals@7.18.9(@babel/core@7.21.8):
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6492,11 +6445,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6505,11 +6458,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-modules-amd@7.20.11(@babel/core@7.18.2):
+  /@babel/plugin-transform-modules-amd@7.20.11(@babel/core@7.21.8):
     resolution: {integrity: sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6518,14 +6471,14 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-module-transforms': 7.21.5
       '@babel/helper-plugin-utils': 7.21.5
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-modules-commonjs@7.21.5(@babel/core@7.18.2):
+  /@babel/plugin-transform-modules-commonjs@7.21.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-OVryBEgKUbtqMoB7eG2rs6UFexJi6Zj6FDXx+esBLPTCxCNxAY9o+8Di7IsUGJ+AVhp5ncK0fxWUBd0/1gPhrQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6534,7 +6487,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-module-transforms': 7.21.5
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-simple-access': 7.21.5
@@ -6542,7 +6495,7 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-modules-systemjs@7.20.11(@babel/core@7.18.2):
+  /@babel/plugin-transform-modules-systemjs@7.20.11(@babel/core@7.21.8):
     resolution: {integrity: sha512-vVu5g9BPQKSFEmvt2TA4Da5N+QVS66EX21d8uoOihC+OCpUoGvzVsXeqFdtAEfVa5BILAeFt+U7yVmLbQnAJmw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6551,7 +6504,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-module-transforms': 7.21.5
       '@babel/helper-plugin-utils': 7.21.5
@@ -6560,7 +6513,7 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6569,14 +6522,14 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-module-transforms': 7.21.5
       '@babel/helper-plugin-utils': 7.21.5
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-named-capturing-groups-regex@7.20.5(@babel/core@7.18.2):
+  /@babel/plugin-transform-named-capturing-groups-regex@7.20.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-mOW4tTzi5iTLnw+78iEq3gr8Aoq4WNRGpmSlrogqaiCBoR1HFhpU4JkpQFOHfeYx3ReVIFWOQJS4aZBRvuZ6mA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6585,12 +6538,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
-      '@babel/helper-create-regexp-features-plugin': 7.21.8(@babel/core@7.18.2)
+      '@babel/core': 7.21.8
+      '@babel/helper-create-regexp-features-plugin': 7.21.8(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-new-target@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-transform-new-target@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6599,11 +6552,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6612,14 +6565,14 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-replace-supers': 7.21.5
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-parameters@7.21.3(@babel/core@7.18.2):
+  /@babel/plugin-transform-parameters@7.21.3(@babel/core@7.21.8):
     resolution: {integrity: sha512-Wxc+TvppQG9xWFYatvCGPvZ6+SIUxQ2ZdiBP+PHYMIjnPXD+uThCshaz4NZOnODAtBjjcVQQ/3OKs9LW28purQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6628,11 +6581,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6641,7 +6594,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
@@ -6662,7 +6615,7 @@ packages:
       '@babel/types': 7.18.4
     dev: false
 
-  /@babel/plugin-transform-regenerator@7.21.5(@babel/core@7.18.2):
+  /@babel/plugin-transform-regenerator@7.21.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-ZoYBKDb6LyMi5yCsByQ5jmXsHAQDDYeexT1Szvlmui+lADvfSecr5Dxd/PkrTC3pAD182Fcju1VQkB4oCp9M+w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6671,12 +6624,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
       regenerator-transform: 0.15.1
     dev: false
 
-  /@babel/plugin-transform-reserved-words@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-transform-reserved-words@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6685,11 +6638,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6698,11 +6651,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-spread@7.20.7(@babel/core@7.18.2):
+  /@babel/plugin-transform-spread@7.20.7(@babel/core@7.21.8):
     resolution: {integrity: sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6711,12 +6664,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
     dev: false
 
-  /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6725,11 +6678,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.18.2):
+  /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.21.8):
     resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6738,11 +6691,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-typeof-symbol@7.18.9(@babel/core@7.18.2):
+  /@babel/plugin-transform-typeof-symbol@7.18.9(@babel/core@7.21.8):
     resolution: {integrity: sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6751,7 +6704,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
@@ -6773,7 +6726,7 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-unicode-escapes@7.21.5(@babel/core@7.18.2):
+  /@babel/plugin-transform-unicode-escapes@7.21.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-LYm/gTOwZqsYohlvFUe/8Tujz75LqqVC2w+2qPHLR+WyWHGCZPN1KBpJCJn+4Bk4gOkQy/IXKIge6az5MqwlOg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6782,11 +6735,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.18.2):
+  /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6795,12 +6748,12 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
-      '@babel/helper-create-regexp-features-plugin': 7.21.8(@babel/core@7.18.2)
+      '@babel/core': 7.21.8
+      '@babel/helper-create-regexp-features-plugin': 7.21.8(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
     dev: false
 
-  /@babel/preset-env@7.21.5(@babel/core@7.18.2):
+  /@babel/preset-env@7.21.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-wH00QnTTldTbf/IefEVyChtRdw5RJvODT/Vb4Vcxq1AZvtXj6T0YeX0cAcXhI6/BdGuiP3GcNIL4OQbI2DVNxg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
@@ -6810,87 +6763,87 @@ packages:
         optional: true
     dependencies:
       '@babel/compat-data': 7.21.7
-      '@babel/core': 7.18.2
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.18.2)
+      '@babel/core': 7.21.8
+      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-validator-option': 7.21.0
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.20.7(@babel/core@7.18.2)
-      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.18.2)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-proposal-class-static-block': 7.21.0(@babel/core@7.18.2)
-      '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.18.2)
-      '@babel/plugin-proposal-json-strings': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7(@babel/core@7.18.2)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.18.2)
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.18.2)
-      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0(@babel/core@7.18.2)
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.18.2)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.18.2)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.18.2)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.18.2)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.18.2)
-      '@babel/plugin-syntax-import-assertions': 7.20.0(@babel/core@7.18.2)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.18.2)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.18.2)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.18.2)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.18.2)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.18.2)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.18.2)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.18.2)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.18.2)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.18.2)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.18.2)
-      '@babel/plugin-transform-arrow-functions': 7.21.5(@babel/core@7.18.2)
-      '@babel/plugin-transform-async-to-generator': 7.20.7(@babel/core@7.18.2)
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.18.2)
-      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.18.2)
-      '@babel/plugin-transform-computed-properties': 7.21.5(@babel/core@7.18.2)
-      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.18.2)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-transform-duplicate-keys': 7.18.9(@babel/core@7.18.2)
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-transform-for-of': 7.21.5(@babel/core@7.18.2)
-      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.18.2)
-      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.18.2)
-      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.18.2)
-      '@babel/plugin-transform-modules-commonjs': 7.21.5(@babel/core@7.18.2)
-      '@babel/plugin-transform-modules-systemjs': 7.20.11(@babel/core@7.18.2)
-      '@babel/plugin-transform-modules-umd': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5(@babel/core@7.18.2)
-      '@babel/plugin-transform-new-target': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.18.2)
-      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-transform-regenerator': 7.21.5(@babel/core@7.18.2)
-      '@babel/plugin-transform-reserved-words': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.18.2)
-      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.18.2)
-      '@babel/plugin-transform-typeof-symbol': 7.18.9(@babel/core@7.18.2)
-      '@babel/plugin-transform-unicode-escapes': 7.21.5(@babel/core@7.18.2)
-      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.18.2)
-      '@babel/preset-modules': 0.1.5(@babel/core@7.18.2)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.20.7(@babel/core@7.21.8)
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.21.8)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-proposal-class-static-block': 7.21.0(@babel/core@7.21.8)
+      '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.21.8)
+      '@babel/plugin-proposal-json-strings': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7(@babel/core@7.21.8)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.21.8)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.21.8)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0(@babel/core@7.21.8)
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.21.8)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.21.8)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.21.8)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.21.8)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.21.8)
+      '@babel/plugin-syntax-import-assertions': 7.20.0(@babel/core@7.21.8)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.21.8)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.21.8)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.21.8)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.21.8)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.21.8)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.8)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.21.8)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.8)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.21.8)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-arrow-functions': 7.21.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-async-to-generator': 7.20.7(@babel/core@7.21.8)
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.21.8)
+      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.21.8)
+      '@babel/plugin-transform-computed-properties': 7.21.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.21.8)
+      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-duplicate-keys': 7.18.9(@babel/core@7.21.8)
+      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-for-of': 7.21.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.21.8)
+      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.21.8)
+      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.21.8)
+      '@babel/plugin-transform-modules-commonjs': 7.21.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-modules-systemjs': 7.20.11(@babel/core@7.21.8)
+      '@babel/plugin-transform-modules-umd': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-new-target': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.21.8)
+      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-regenerator': 7.21.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-reserved-words': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.21.8)
+      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.21.8)
+      '@babel/plugin-transform-typeof-symbol': 7.18.9(@babel/core@7.21.8)
+      '@babel/plugin-transform-unicode-escapes': 7.21.5(@babel/core@7.21.8)
+      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.21.8)
+      '@babel/preset-modules': 0.1.5(@babel/core@7.21.8)
       '@babel/types': 7.21.5
-      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.18.2)
-      babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.18.2)
-      babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.18.2)
+      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.21.8)
+      babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.21.8)
+      babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.21.8)
       core-js-compat: 3.30.1
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/preset-modules@0.1.5(@babel/core@7.18.2):
+  /@babel/preset-modules@0.1.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6898,11 +6851,11 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.18.2)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.18.2)
-      '@babel/types': 7.18.4
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.21.8)
+      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.21.8)
+      '@babel/types': 7.21.5
       esutils: 2.0.3
     dev: false
 
@@ -7343,12 +7296,12 @@ packages:
       which: 2.0.2
     dev: true
 
-  /@docsearch/css@3.1.0:
-    resolution: {integrity: sha512-bh5IskwkkodbvC0FzSg1AxMykfDl95hebEKwxNoq4e5QaGzOXSBgW8+jnMFZ7JU4sTBiB04vZWoUSzNrPboLZA==}
+  /@docsearch/css@3.3.4:
+    resolution: {integrity: sha512-vDwCDoVXDgopw/hvr0zEADew2wWaGP8Qq0Bxhgii1Ewz2t4fQeyJwIRN/mWADeLFYPVkpz8TpEbxya/i6Tm0WA==}
     dev: false
 
-  /@docsearch/react@3.1.0(@types/react@17.0.45)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-bjB6ExnZzf++5B7Tfoi6UXgNwoUnNOfZ1NyvnvPhWgCMy5V/biAtLL4o7owmZSYdAKeFSvZ5Lxm0is4su/dBWg==}
+  /@docsearch/react@3.3.4(@algolia/client-search@4.17.0)(@types/react@17.0.58)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-aeOf1WC5zMzBEi2SI6WWznOmIo9rnpN4p7a3zHXxowVciqlI4HsZGtOR9nFOufLeolv7HibwLlaM0oyUqJxasw==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
       react: '>= 16.8.0 < 19.0.0'
@@ -7361,12 +7314,15 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@algolia/autocomplete-core': 1.6.3
-      '@docsearch/css': 3.1.0
-      '@types/react': 17.0.45
+      '@algolia/autocomplete-core': 1.8.2
+      '@algolia/autocomplete-preset-algolia': 1.8.2(@algolia/client-search@4.17.0)(algoliasearch@4.17.0)
+      '@docsearch/css': 3.3.4
+      '@types/react': 17.0.58
       algoliasearch: 4.17.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@algolia/client-search'
     dev: false
 
   /@emmetio/abbreviation@2.3.2:
@@ -8023,14 +7979,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@nanostores/preact@0.1.3(nanostores@0.5.12)(preact@10.13.2):
+  /@nanostores/preact@0.1.3(nanostores@0.5.13)(preact@10.13.2):
     resolution: {integrity: sha512-uiX1ned0LrzASot+sPUjyJzr8Js3pX075omazgsSdLf0zPp4ss8xwTiuNh5FSKigTSQEVqZFiS+W8CnHIrX62A==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     peerDependencies:
       nanostores: ^0.5.2
       preact: '>=10.0.0'
     dependencies:
-      nanostores: 0.5.12
+      nanostores: 0.5.13
       preact: 10.13.2
     dev: false
 
@@ -8220,7 +8176,7 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
     dependencies:
-      '@types/node': 18.7.21
+      '@types/node': 18.16.3
       playwright-core: 1.29.2
     dev: true
 
@@ -8234,6 +8190,15 @@ packages:
 
   /@preact/signals@1.1.1(preact@10.13.2):
     resolution: {integrity: sha512-I1DhYo2d1t9qDkEq1jYDVTQdBGmo4NlqatNEtulsS/87kVdwhZluP6TTDS4/5sc2h86TlBF6UA6LO+tDpIt/Gw==}
+    peerDependencies:
+      preact: 10.x
+    dependencies:
+      '@preact/signals-core': 1.3.0
+      preact: 10.13.2
+    dev: false
+
+  /@preact/signals@1.1.3(preact@10.13.2):
+    resolution: {integrity: sha512-N09DuAVvc90bBZVRwD+aFhtGyHAmJLhS3IFoawO/bYJRcil4k83nBOchpCEoS0s5+BXBpahgp0Mjf+IOqP57Og==}
     peerDependencies:
       preact: 10.x
     dependencies:
@@ -8261,7 +8226,7 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@rollup/plugin-babel@5.3.1(@babel/core@7.18.2)(rollup@2.79.1):
+  /@rollup/plugin-babel@5.3.1(@babel/core@7.21.8)(rollup@2.79.1):
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -8276,7 +8241,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
+      '@babel/core': 7.21.8
       '@babel/helper-module-imports': 7.21.4
       '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
       rollup: 2.79.1
@@ -8394,7 +8359,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.1
       estree-walker: 2.0.2
       picomatch: 2.3.1
     dev: false
@@ -8463,8 +8428,8 @@ packages:
       '@types/estree': 1.0.0
     dev: false
 
-  /@types/alpinejs@3.7.0:
-    resolution: {integrity: sha512-iMvJwgJHYFUlMOixKF68BmMQZbnxVA/erh1blbfhY8Z6u6oleEJViz8bye58roLOp8jyBNOsXtobyq7zR/7A2g==}
+  /@types/alpinejs@3.7.1:
+    resolution: {integrity: sha512-gzwyuHXH/meGQQhurMGWlZgMQxe18lMOoSPd7X6CvGoDelHte9EsU7SpTIoRu8yYir0tbHDeaSMdX9LeQz/QtA==}
     dependencies:
       '@vue/reactivity': 3.2.47
     dev: false
@@ -8499,11 +8464,11 @@ packages:
   /@types/better-sqlite3@7.6.4:
     resolution: {integrity: sha512-dzrRZCYPXIXfSR1/surNbJ/grU3scTaygS0OMzjlGf71i9sc2fGyHPXXiXmEvNIoE0cGwsanEFMVJxPXmco9Eg==}
     dependencies:
-      '@types/node': 18.7.21
+      '@types/node': 18.16.3
     dev: true
 
-  /@types/canvas-confetti@1.4.3:
-    resolution: {integrity: sha512-UwFPTsW1ZwVyo/ETp4hPSikSD7yl2V42E3VWBF5P/0+DHO4iajyceWv7hfNdZ2AX5tkZnuViiBWOqyCPohU2FQ==}
+  /@types/canvas-confetti@1.6.0:
+    resolution: {integrity: sha512-Yq6rIccwcco0TLD5SMUrIM7Fk7Fe/C0jmNRxJJCLtAF6gebDkPuUjK5EHedxecm69Pi/aA+It39Ux4OHmFhjRw==}
     dev: false
 
   /@types/chai-as-promised@7.1.5:
@@ -8515,11 +8480,16 @@ packages:
   /@types/chai-subset@1.3.3:
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
     dependencies:
-      '@types/chai': 4.3.3
+      '@types/chai': 4.3.5
     dev: false
 
   /@types/chai@4.3.3:
     resolution: {integrity: sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==}
+    dev: true
+
+  /@types/chai@4.3.5:
+    resolution: {integrity: sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==}
+    dev: false
 
   /@types/common-ancestor-path@1.0.0:
     resolution: {integrity: sha512-RuLE14U0ewtlGo81hOjQtzXl3RsVlTkbHqfpsbl9V1hIhAxF30L5ru1Q6C1x7L7d7zs434HbMBeFrdd7fWVQ2Q==}
@@ -8528,7 +8498,7 @@ packages:
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 18.7.21
+      '@types/node': 18.16.3
     dev: true
 
   /@types/cookie@0.5.1:
@@ -8563,6 +8533,10 @@ packages:
   /@types/estree@1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
 
+  /@types/estree@1.0.1:
+    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
+    dev: false
+
   /@types/extend@3.0.1:
     resolution: {integrity: sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw==}
     dev: true
@@ -8570,7 +8544,7 @@ packages:
   /@types/fs-extra@8.1.2:
     resolution: {integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==}
     dependencies:
-      '@types/node': 18.7.21
+      '@types/node': 18.16.3
     dev: true
 
   /@types/github-slugger@1.3.0:
@@ -8581,14 +8555,14 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.7.21
+      '@types/node': 18.16.3
     dev: true
 
   /@types/glob@8.1.0:
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.7.21
+      '@types/node': 18.16.3
     dev: true
 
   /@types/hast@2.3.4:
@@ -8688,7 +8662,6 @@ packages:
 
   /@types/node@14.18.21:
     resolution: {integrity: sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q==}
-    dev: true
 
   /@types/node@16.18.25:
     resolution: {integrity: sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==}
@@ -8697,6 +8670,9 @@ packages:
   /@types/node@17.0.45:
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
     dev: false
+
+  /@types/node@18.16.3:
+    resolution: {integrity: sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==}
 
   /@types/node@18.7.21:
     resolution: {integrity: sha512-rLFzK5bhM0YPyCoTC8bolBjMk7bwnZ8qeZUBslBfjZQou2ssJdWslx9CZ8DGM+Dx7QXQiiTVZ/6QO6kwtHkZCA==}
@@ -8720,7 +8696,7 @@ packages:
   /@types/prompts@2.0.14:
     resolution: {integrity: sha512-HZBd99fKxRWpYCErtm2/yxUZv6/PBI9J7N4TNFffl5JbrYMHBwF25DjQGTW3b3jmXq+9P6/8fCIb2ee57BFfYA==}
     dependencies:
-      '@types/node': 18.7.21
+      '@types/node': 18.16.3
     dev: true
 
   /@types/prop-types@15.7.5:
@@ -8738,12 +8714,27 @@ packages:
       '@types/react': 18.0.21
     dev: false
 
+  /@types/react-dom@18.2.3:
+    resolution: {integrity: sha512-hxXEXWxFJXbY0LMj/T69mznqOZJXNtQMqVxIiirVAZnnpeYiD4zt+lPsgcr/cfWg2VLsxZ1y26vigG03prYB+Q==}
+    dependencies:
+      '@types/react': 17.0.58
+    dev: false
+
   /@types/react@17.0.45:
     resolution: {integrity: sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.3
       csstype: 3.1.2
+    dev: true
+
+  /@types/react@17.0.58:
+    resolution: {integrity: sha512-c1GzVY97P0fGxwGxhYq989j4XwlcHQoto6wQISOC2v6wm3h0PORRWJFHlkRjfGsiG3y1609WdQ+J+tKxvrEd6A==}
+    dependencies:
+      '@types/prop-types': 15.7.5
+      '@types/scheduler': 0.16.3
+      csstype: 3.1.2
+    dev: false
 
   /@types/react@18.0.21:
     resolution: {integrity: sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==}
@@ -8753,10 +8744,18 @@ packages:
       csstype: 3.1.2
     dev: false
 
+  /@types/react@18.2.5:
+    resolution: {integrity: sha512-RuoMedzJ5AOh23Dvws13LU9jpZHIc/k90AgmK7CecAYeWmSr3553L4u5rk4sWAPBuQosfT7HmTfG4Rg5o4nGEA==}
+    dependencies:
+      '@types/prop-types': 15.7.5
+      '@types/scheduler': 0.16.3
+      csstype: 3.1.2
+    dev: false
+
   /@types/resolve@1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 18.7.21
+      '@types/node': 14.18.21
 
   /@types/resolve@1.20.2:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -8765,13 +8764,13 @@ packages:
     resolution: {integrity: sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==}
     dependencies:
       '@types/glob': 8.1.0
-      '@types/node': 18.7.21
+      '@types/node': 18.16.3
     dev: true
 
   /@types/sax@1.2.4:
     resolution: {integrity: sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==}
     dependencies:
-      '@types/node': 18.7.21
+      '@types/node': 17.0.45
     dev: false
 
   /@types/scheduler@0.16.3:
@@ -8789,19 +8788,19 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 18.7.21
+      '@types/node': 18.16.3
     dev: true
 
   /@types/server-destroy@1.0.1:
     resolution: {integrity: sha512-77QGr7waZbE0Y0uF+G+uH3H3SmhyA78Jf2r5r7QSrpg0U3kSXduWpGjzP9PvPLR/KCy+kHjjpnugRHsYTnHopg==}
     dependencies:
-      '@types/node': 18.7.21
+      '@types/node': 18.16.3
     dev: true
 
   /@types/set-cookie-parser@2.4.2:
     resolution: {integrity: sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==}
     dependencies:
-      '@types/node': 18.7.21
+      '@types/node': 18.16.3
     dev: true
 
   /@types/stack-trace@0.0.29:
@@ -9012,7 +9011,7 @@ packages:
       chokidar: 3.5.3
       colorette: 2.0.20
       consola: 2.15.3
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       pathe: 0.2.0
     dev: false
 
@@ -9204,6 +9203,15 @@ packages:
       estree-walker: 2.0.2
       source-map: 0.6.1
 
+  /@vue/compiler-core@3.2.47:
+    resolution: {integrity: sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==}
+    dependencies:
+      '@babel/parser': 7.21.8
+      '@vue/shared': 3.2.47
+      estree-walker: 2.0.2
+      source-map: 0.6.1
+    dev: false
+
   /@vue/compiler-dom@3.2.39:
     resolution: {integrity: sha512-HMFI25Be1C8vLEEv1hgEO1dWwG9QQ8LTTPmCkblVJY/O3OvWx6r1+zsox5mKPMGvqYEZa6l8j+xgOfUspgo7hw==}
     dependencies:
@@ -9216,6 +9224,13 @@ packages:
     dependencies:
       '@vue/compiler-core': 3.2.40
       '@vue/shared': 3.2.40
+
+  /@vue/compiler-dom@3.2.47:
+    resolution: {integrity: sha512-dBBnEHEPoftUiS03a4ggEig74J2YBZ2UIeyfpcRM2tavgMWo4bsEfgCGsu+uJIL/vax9S+JztH8NmQerUo7shQ==}
+    dependencies:
+      '@vue/compiler-core': 3.2.47
+      '@vue/shared': 3.2.47
+    dev: false
 
   /@vue/compiler-sfc@3.2.39:
     resolution: {integrity: sha512-fqAQgFs1/BxTUZkd0Vakn3teKUt//J3c420BgnYgEOoVdTwYpBTSXCMJ88GOBCylmUBbtquGPli9tVs7LzsWIA==}
@@ -9246,6 +9261,21 @@ packages:
       postcss: 8.4.23
       source-map: 0.6.1
 
+  /@vue/compiler-sfc@3.2.47:
+    resolution: {integrity: sha512-rog05W+2IFfxjMcFw10tM9+f7i/+FFpZJJ5XHX72NP9eC2uRD+42M3pYcQqDXVYoj74kHMSEdQ/WmCjt8JFksQ==}
+    dependencies:
+      '@babel/parser': 7.21.8
+      '@vue/compiler-core': 3.2.47
+      '@vue/compiler-dom': 3.2.47
+      '@vue/compiler-ssr': 3.2.47
+      '@vue/reactivity-transform': 3.2.47
+      '@vue/shared': 3.2.47
+      estree-walker: 2.0.2
+      magic-string: 0.25.9
+      postcss: 8.4.23
+      source-map: 0.6.1
+    dev: false
+
   /@vue/compiler-ssr@3.2.39:
     resolution: {integrity: sha512-EoGCJ6lincKOZGW+0Ky4WOKsSmqL7hp1ZYgen8M7u/mlvvEQUaO9tKKOy7K43M9U2aA3tPv0TuYYQFrEbK2eFQ==}
     dependencies:
@@ -9258,6 +9288,13 @@ packages:
     dependencies:
       '@vue/compiler-dom': 3.2.40
       '@vue/shared': 3.2.40
+
+  /@vue/compiler-ssr@3.2.47:
+    resolution: {integrity: sha512-wVXC+gszhulcMD8wpxMsqSOpvDZ6xKXSVWkf50Guf/S+28hTAXPDYRTbLQ3EDkOP5Xz/+SY37YiwDquKbJOgZw==}
+    dependencies:
+      '@vue/compiler-dom': 3.2.47
+      '@vue/shared': 3.2.47
+    dev: false
 
   /@vue/reactivity-transform@3.2.39:
     resolution: {integrity: sha512-HGuWu864zStiWs9wBC6JYOP1E00UjMdDWIG5W+FpUx28hV3uz9ODOKVNm/vdOy/Pvzg8+OcANxAVC85WFBbl3A==}
@@ -9277,6 +9314,16 @@ packages:
       '@vue/shared': 3.2.40
       estree-walker: 2.0.2
       magic-string: 0.25.9
+
+  /@vue/reactivity-transform@3.2.47:
+    resolution: {integrity: sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==}
+    dependencies:
+      '@babel/parser': 7.21.8
+      '@vue/compiler-core': 3.2.47
+      '@vue/shared': 3.2.47
+      estree-walker: 2.0.2
+      magic-string: 0.25.9
+    dev: false
 
   /@vue/reactivity@3.1.5:
     resolution: {integrity: sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==}
@@ -9301,12 +9348,27 @@ packages:
       '@vue/reactivity': 3.2.40
       '@vue/shared': 3.2.40
 
+  /@vue/runtime-core@3.2.47:
+    resolution: {integrity: sha512-RZxbLQIRB/K0ev0K9FXhNbBzT32H9iRtYbaXb0ZIz2usLms/D55dJR2t6cIEUn6vyhS3ALNvNthI+Q95C+NOpA==}
+    dependencies:
+      '@vue/reactivity': 3.2.47
+      '@vue/shared': 3.2.47
+    dev: false
+
   /@vue/runtime-dom@3.2.40:
     resolution: {integrity: sha512-AO2HMQ+0s2+MCec8hXAhxMgWhFhOPJ/CyRXnmTJ6XIOnJFLrH5Iq3TNwvVcODGR295jy77I6dWPj+wvFoSYaww==}
     dependencies:
       '@vue/runtime-core': 3.2.40
       '@vue/shared': 3.2.40
       csstype: 2.6.21
+
+  /@vue/runtime-dom@3.2.47:
+    resolution: {integrity: sha512-ArXrFTjS6TsDei4qwNvgrdmHtD930KgSKGhS5M+j8QxXrDJYLqYw4RRcDy1bz1m1wMmb6j+zGLifdVHtkXA7gA==}
+    dependencies:
+      '@vue/runtime-core': 3.2.47
+      '@vue/shared': 3.2.47
+      csstype: 2.6.21
+    dev: false
 
   /@vue/server-renderer@3.2.40(vue@3.2.40):
     resolution: {integrity: sha512-gtUcpRwrXOJPJ4qyBpU3EyxQa4EkV8I4f8VrDePcGCPe4O/hd0BPS7v9OgjIQob6Ap8VDz9G+mGTKazE45/95w==}
@@ -9316,6 +9378,16 @@ packages:
       '@vue/compiler-ssr': 3.2.40
       '@vue/shared': 3.2.40
       vue: 3.2.40
+
+  /@vue/server-renderer@3.2.47(vue@3.2.47):
+    resolution: {integrity: sha512-dN9gc1i8EvmP9RCzvneONXsKfBRgqFeFZLurmHOveL7oH6HiFXJw5OGu294n1nHc/HMgTy6LulU/tv5/A7f/LA==}
+    peerDependencies:
+      vue: 3.2.47
+    dependencies:
+      '@vue/compiler-ssr': 3.2.47
+      '@vue/shared': 3.2.47
+      vue: 3.2.47
+    dev: false
 
   /@vue/shared@3.1.5:
     resolution: {integrity: sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==}
@@ -9440,8 +9512,8 @@ packages:
       '@algolia/transporter': 4.17.0
     dev: false
 
-  /alpinejs@3.10.2:
-    resolution: {integrity: sha512-P6DTX78J94FgsskS3eS23s26hfb0NWQZUidBnkUK7fId1x64/kLm5E79lL3HNItUmHDCKOHvfP8EAcuCVab89w==}
+  /alpinejs@3.12.0:
+    resolution: {integrity: sha512-YENcRBA9dlwR8PsZNFMTHbmdlTNwd1BkCeivPvOzzCKHas6AfwNRsDK9UEFmE5dXTMEZjnnpCTxV8vkdpWiOCw==}
     dependencies:
       '@vue/reactivity': 3.1.5
     dev: false
@@ -9686,7 +9758,7 @@ packages:
       resolve: 1.22.2
     dev: false
 
-  /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.18.2):
+  /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.21.8):
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -9695,14 +9767,14 @@ packages:
         optional: true
     dependencies:
       '@babel/compat-data': 7.21.7
-      '@babel/core': 7.18.2
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.18.2)
+      '@babel/core': 7.21.8
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.8)
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.18.2):
+  /babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.21.8):
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -9710,14 +9782,14 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.18.2)
+      '@babel/core': 7.21.8
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.8)
       core-js-compat: 3.30.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.18.2):
+  /babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.21.8):
     resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -9725,8 +9797,8 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.2
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.18.2)
+      '@babel/core': 7.21.8
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.8)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -9964,8 +10036,8 @@ packages:
   /caniuse-lite@1.0.30001482:
     resolution: {integrity: sha512-F1ZInsg53cegyjroxLNW9DmrEQ1SuGRTO1QlpA0o2/6OpQ0gFeDRoq1yFmnr8Sakn9qwwt9DmbxHB6w167OSuQ==}
 
-  /canvas-confetti@1.5.1:
-    resolution: {integrity: sha512-Ncz+oZJP6OvY7ti4E1slxVlyAV/3g7H7oQtcCDXgwGgARxPnwYY9PW5Oe+I8uvspYNtuHviAdgA0LfcKFWJfpg==}
+  /canvas-confetti@1.6.0:
+    resolution: {integrity: sha512-ej+w/m8Jzpv9Z7W7uJZer14Ke8P2ogsjg4ZMGIuq4iqUOqY2Jq8BNW42iGmNfRwREaaEfFIczLuZZiEVSYNHAA==}
     dev: false
 
   /ccount@2.0.1:
@@ -10001,6 +10073,19 @@ packages:
       loupe: 2.3.6
       pathval: 1.1.1
       type-detect: 4.0.8
+
+  /chai@4.3.7:
+    resolution: {integrity: sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==}
+    engines: {node: '>=4'}
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.2
+      deep-eql: 4.1.3
+      get-func-name: 2.0.0
+      loupe: 2.3.6
+      pathval: 1.1.1
+      type-detect: 4.0.8
+    dev: false
 
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -10260,15 +10345,15 @@ packages:
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  /concurrently@7.2.1:
-    resolution: {integrity: sha512-7cab/QyqipqghrVr9qZmoWbidu0nHsmxrpNqQ7r/67vfl1DWJElexehQnTH1p+87tDkihaAjM79xTZyBQh7HLw==}
+  /concurrently@7.6.0:
+    resolution: {integrity: sha512-BKtRgvcJGeZ4XttiDiNcFiRlxoAeZOseqUvyYRUp/Vtd+9p1ULmeoSqGsDA+2ivdeDFpqrJvGvmI+StKfKl5hw==}
     engines: {node: ^12.20.0 || ^14.13.0 || >=16.0.0}
     hasBin: true
     dependencies:
       chalk: 4.1.2
       date-fns: 2.30.0
       lodash: 4.17.21
-      rxjs: 6.6.7
+      rxjs: 7.8.1
       shell-quote: 1.8.1
       spawn-command: 0.0.2-1
       supports-color: 8.1.1
@@ -10571,6 +10656,13 @@ packages:
     engines: {node: '>=0.12'}
     dependencies:
       type-detect: 4.0.8
+
+  /deep-eql@4.1.3:
+    resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
+    engines: {node: '>=6'}
+    dependencies:
+      type-detect: 4.0.8
+    dev: false
 
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -12341,7 +12433,7 @@ packages:
       nth-check: 2.1.1
       property-information: 6.2.0
       space-separated-tokens: 2.0.2
-      unist-util-visit: 4.1.0
+      unist-util-visit: 4.1.2
       zwitch: 2.0.4
     dev: false
 
@@ -12987,7 +13079,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.7.21
+      '@types/node': 18.16.3
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: false
@@ -13204,6 +13296,14 @@ packages:
       lit-element: 3.3.2
       lit-html: 2.7.3
 
+  /lit@2.7.4:
+    resolution: {integrity: sha512-cgD7xrZoYr21mbrkZIuIrj98YTMw/snJPg52deWVV4A8icLyNHI3bF70xsJeAgwTuiq5Kkd+ZR8gybSJDCPB7g==}
+    dependencies:
+      '@lit/reactive-element': 1.6.1
+      lit-element: 3.3.2
+      lit-html: 2.7.3
+    dev: false
+
   /lite-vimeo-embed@0.1.0:
     resolution: {integrity: sha512-XFzPdv4NaWlyaM9WpBaS5CIUkf+laIRZEXQGsBb2ZdDWkuMmnzfAZ5nriYv3a3MVx5tEEetGN0sNaUhAVRXr1g==}
     dev: false
@@ -13365,13 +13465,6 @@ packages:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
-
-  /magic-string@0.26.7:
-    resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
-    engines: {node: '>=12'}
-    dependencies:
-      sourcemap-codec: 1.4.8
-    dev: false
 
   /magic-string@0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
@@ -14207,6 +14300,11 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
+  /mrmime@1.0.1:
+    resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
+    engines: {node: '>=10'}
+    dev: false
+
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
     dev: false
@@ -14239,8 +14337,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  /nanostores@0.5.12:
-    resolution: {integrity: sha512-5BccS7nNInTc7Noz2gv19gyx5h5y6m72nj6ZnCTV98GdFdwvcFJf2MMl+7VsX76E1toV1YrLqlDn+R+OF73PVg==}
+  /nanostores@0.5.13:
+    resolution: {integrity: sha512-UxC2eZsCbbcHZ1Z/hwFQ1C4gy8Tkhzskvmu6wOsAhOMAOd72HmVX1Nxs96DSDUcd7V1x0IdRtsl+zAm7rg7slA==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: false
 
@@ -15658,6 +15756,18 @@ packages:
       unified: 10.1.2
       unist-util-visit: 4.1.0
 
+  /rehype-slug@5.1.0:
+    resolution: {integrity: sha512-Gf91dJoXneiorNEnn+Phx97CO7oRMrpi+6r155tTxzGuLtm+QrI4cTwCa9e1rtePdL4i9tSO58PeSS6HWfgsiw==}
+    dependencies:
+      '@types/hast': 2.3.4
+      github-slugger: 2.0.0
+      hast-util-has-property: 2.0.1
+      hast-util-heading-rank: 2.1.1
+      hast-util-to-string: 2.0.0
+      unified: 10.1.2
+      unist-util-visit: 4.1.2
+    dev: false
+
   /rehype-stringify@9.0.3:
     resolution: {integrity: sha512-kWiZ1bgyWlgOxpqD5HnxShKAdXtb2IUljn3hQAhySeak6IOQPPt6DeGnsIh4ixm7yKJWzm8TXFuC/lPfcWHJqw==}
     dependencies:
@@ -15959,11 +16069,10 @@ packages:
     dependencies:
       queue-microtask: 1.2.3
 
-  /rxjs@6.6.7:
-    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
-    engines: {npm: '>=2.0.0'}
+  /rxjs@7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
-      tslib: 1.14.1
+      tslib: 2.5.0
     dev: false
 
   /s.color@0.0.15:
@@ -16094,6 +16203,11 @@ packages:
     dependencies:
       randombytes: 2.1.0
 
+  /seroval@0.5.1:
+    resolution: {integrity: sha512-ZfhQVB59hmIauJG5Ydynupy8KHyr5imGNtdDhbZG68Ufh1Ynkv9KOYOAABf71oVbQxJ8VkWnMHAjEHE7fWkH5g==}
+    engines: {node: '>=10'}
+    dev: false
+
   /server-destroy@1.0.1:
     resolution: {integrity: sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==}
     dev: false
@@ -16116,7 +16230,7 @@ packages:
       detect-libc: 2.0.1
       node-addon-api: 5.1.0
       prebuild-install: 7.1.1
-      semver: 7.3.8
+      semver: 7.5.0
       simple-get: 4.0.1
       tar-fs: 2.1.1
       tunnel-agent: 0.6.0
@@ -16222,7 +16336,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       '@polka/url': 1.0.0-next.21
-      mrmime: 1.0.0
+      mrmime: 1.0.1
       totalist: 1.1.0
     dev: false
 
@@ -16299,6 +16413,13 @@ packages:
     resolution: {integrity: sha512-EA7hjMIEdDUuV6Fk3WUQ2fPx7sRnhjl+3M59zj6Sh+c7c3JF3N1cSViBvX8MYJG9vEBEqKQBZUfKHPe/9JgKvQ==}
     dependencies:
       csstype: 3.1.2
+
+  /solid-js@1.7.4:
+    resolution: {integrity: sha512-hD/bzIpaa7DL/LGRRTLFvejQuxQaoXyH+DBgPputJW7zvFigCewQIoDvbwDR4VHTsa8VsMDPzV8BT0F9OqsS1Q==}
+    dependencies:
+      csstype: 3.1.2
+      seroval: 0.5.1
+    dev: false
 
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
@@ -16901,6 +17022,7 @@ packages:
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: true
 
   /tslib@2.1.0:
     resolution: {integrity: sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==}
@@ -17272,6 +17394,14 @@ packages:
       unist-util-is: 5.2.1
       unist-util-visit-parents: 5.1.3
 
+  /unist-util-visit@4.1.2:
+    resolution: {integrity: sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==}
+    dependencies:
+      '@types/unist': 2.0.6
+      unist-util-is: 5.2.1
+      unist-util-visit-parents: 5.1.3
+    dev: false
+
   /universal-user-agent@6.0.0:
     resolution: {integrity: sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==}
     dev: true
@@ -17410,16 +17540,17 @@ packages:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
 
-  /vite-imagetools@4.0.4:
-    resolution: {integrity: sha512-ik1Sq4ueKYN2iBjxe3g8YxqM9aul2goQ2z8CuTKKxOG3M1nF63SRqialbXMuJVH8aKJ9A2oGhs1sktCAoo9EBg==}
+  /vite-imagetools@4.0.19:
+    resolution: {integrity: sha512-vZaPsjLDgEqZrbj+ZsniRKthmoj4mvVrMOK/FZhRAbrVB4LOsil0BO2Gcq20e/JRlom4DzqtLw1UQUkfcqgCrA==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@rollup/pluginutils': 4.2.1
+      '@rollup/pluginutils': 5.0.2
       imagetools-core: 3.3.1
-      magic-string: 0.26.7
+    transitivePeerDependencies:
+      - rollup
     dev: false
 
-  /vite-plugin-pwa@0.11.11(workbox-window@6.5.3):
+  /vite-plugin-pwa@0.11.11(workbox-window@6.5.4):
     resolution: {integrity: sha512-/nSLS7VfGN5UrL4a1ALGEQAyga/H0hYZjEkwPehiEFW1PM1DTi1A8GkPCsmevKwR6vt10P+5wS1wrvSgwQemzw==}
     peerDependencies:
       vite: ^2.0.0
@@ -17429,17 +17560,17 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       pretty-bytes: 5.6.0
       rollup: 2.79.1
       workbox-build: 6.5.4
-      workbox-window: 6.5.3
+      workbox-window: 6.5.4
     transitivePeerDependencies:
       - '@types/babel__core'
       - supports-color
     dev: false
 
-  /vite@3.2.6(@types/node@18.7.21):
+  /vite@3.2.6(@types/node@18.16.3):
     resolution: {integrity: sha512-nTXTxYVvaQNLoW5BQ8PNNQ3lPia57gzsQU/Khv+JvzKPku8kNZL6NMUR/qwXhMG6E+g1idqEPanomJ+VZgixEg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -17464,7 +17595,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 18.7.21
+      '@types/node': 18.16.3
       esbuild: 0.15.18
       postcss: 8.4.23
       resolve: 1.22.2
@@ -17542,15 +17673,15 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/chai': 4.3.3
+      '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.7.21
-      chai: 4.3.6
+      '@types/node': 18.16.3
+      chai: 4.3.7
       debug: 4.3.4
       local-pkg: 0.4.3
       tinypool: 0.2.4
       tinyspy: 1.1.1
-      vite: 3.2.6(@types/node@18.7.21)
+      vite: 3.2.6(@types/node@18.16.3)
     transitivePeerDependencies:
       - less
       - sass
@@ -17640,6 +17771,16 @@ packages:
       '@vue/runtime-dom': 3.2.40
       '@vue/server-renderer': 3.2.40(vue@3.2.40)
       '@vue/shared': 3.2.40
+
+  /vue@3.2.47:
+    resolution: {integrity: sha512-60188y/9Dc9WVrAZeUVSDxRQOZ+z+y5nO2ts9jWXSTkMvayiWxCWOWtBQoYjLeccfXkiiPZWAHcV+WTPhkqJHQ==}
+    dependencies:
+      '@vue/compiler-dom': 3.2.47
+      '@vue/compiler-sfc': 3.2.47
+      '@vue/runtime-dom': 3.2.47
+      '@vue/server-renderer': 3.2.47(vue@3.2.47)
+      '@vue/shared': 3.2.47
+    dev: false
 
   /w3c-hr-time@1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}
@@ -17821,10 +17962,10 @@ packages:
     engines: {node: '>=10.0.0'}
     dependencies:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.12.0)
-      '@babel/core': 7.18.2
-      '@babel/preset-env': 7.21.5(@babel/core@7.18.2)
+      '@babel/core': 7.21.8
+      '@babel/preset-env': 7.21.5(@babel/core@7.21.8)
       '@babel/runtime': 7.21.5
-      '@rollup/plugin-babel': 5.3.1(@babel/core@7.18.2)(rollup@2.79.1)
+      '@rollup/plugin-babel': 5.3.1(@babel/core@7.21.8)(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 11.2.1(rollup@2.79.1)
       '@rollup/plugin-replace': 2.4.2(rollup@2.79.1)
       '@surma/rollup-plugin-off-main-thread': 2.2.3
@@ -17866,10 +18007,6 @@ packages:
     resolution: {integrity: sha512-DCR9uD0Fqj8oB2TSWQEm1hbFs/85hXXoayVwFKLVuIuxwJaihBsLsp4y7J9bvZbqtPJ1KlCkmYVGQKrBU4KAug==}
     dependencies:
       workbox-core: 6.5.4
-    dev: false
-
-  /workbox-core@6.5.3:
-    resolution: {integrity: sha512-Bb9ey5n/M9x+l3fBTlLpHt9ASTzgSGj6vxni7pY72ilB/Pb3XtN+cZ9yueboVhD5+9cNQrC9n/E1fSrqWsUz7Q==}
     dev: false
 
   /workbox-core@6.5.4:
@@ -17944,13 +18081,6 @@ packages:
 
   /workbox-sw@6.5.4:
     resolution: {integrity: sha512-vo2RQo7DILVRoH5LjGqw3nphavEjK4Qk+FenXeUsknKn14eCNedHOXWbmnvP4ipKhlE35pvJ4yl4YYf6YsJArA==}
-    dev: false
-
-  /workbox-window@6.5.3:
-    resolution: {integrity: sha512-GnJbx1kcKXDtoJBVZs/P7ddP0Yt52NNy4nocjBpYPiRhMqTpJCNrSL+fGHZ/i/oP6p/vhE8II0sA6AZGKGnssw==}
-    dependencies:
-      '@types/trusted-types': 2.0.3
-      workbox-core: 6.5.3
     dev: false
 
   /workbox-window@6.5.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,13 +178,13 @@ importers:
         version: 3.3.4
       '@docsearch/react':
         specifier: ^3.3.4
-        version: 3.3.4(@algolia/client-search@4.17.0)(@types/react@17.0.58)(react-dom@18.2.0)(react@18.2.0)
+        version: 3.3.4(@algolia/client-search@4.17.0)(@types/react@18.2.5)(react-dom@18.2.0)(react@18.2.0)
       '@types/node':
         specifier: ^18.16.3
         version: 18.16.3
       '@types/react':
-        specifier: ^17.0.58
-        version: 17.0.58
+        specifier: ^18.2.5
+        version: 18.2.5
       '@types/react-dom':
         specifier: ^18.2.3
         version: 18.2.3
@@ -364,26 +364,14 @@ importers:
   examples/middleware:
     dependencies:
       '@astrojs/node':
-        specifier: workspace:*
+        specifier: ^5.1.2
         version: link:../../packages/integrations/node
       astro:
-        specifier: workspace:*
+        specifier: ^2.4.1
         version: link:../../packages/astro
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       html-minifier:
         specifier: ^4.0.0
         version: 4.0.0
-      svelte:
-        specifier: ^3.58.0
-        version: 3.58.0
-      unocss:
-        specifier: ^0.15.6
-        version: 0.15.6
-      vite-imagetools:
-        specifier: ^4.0.19
-        version: 4.0.19
 
   examples/minimal:
     dependencies:
@@ -414,18 +402,9 @@ importers:
       astro:
         specifier: ^2.4.1
         version: link:../../packages/astro
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       svelte:
         specifier: ^3.58.0
         version: 3.58.0
-      unocss:
-        specifier: ^0.15.6
-        version: 0.15.6
-      vite-imagetools:
-        specifier: ^4.0.19
-        version: 4.0.19
 
   examples/with-markdoc:
     dependencies:
@@ -448,8 +427,8 @@ importers:
         specifier: ^2.4.1
         version: link:../../packages/astro
       hast-util-select:
-        specifier: 5.0.1
-        version: 5.0.1
+        specifier: ^5.0.5
+        version: 5.0.5
       rehype-autolink-headings:
         specifier: ^6.1.1
         version: 6.1.1
@@ -490,14 +469,14 @@ importers:
         specifier: ^2.1.0
         version: link:../../packages/integrations/preact
       '@nanostores/preact':
-        specifier: ^0.1.3
-        version: 0.1.3(nanostores@0.5.13)(preact@10.13.2)
+        specifier: ^0.4.1
+        version: 0.4.1(nanostores@0.8.1)(preact@10.13.2)
       astro:
         specifier: ^2.4.1
         version: link:../../packages/astro
       nanostores:
-        specifier: ^0.5.13
-        version: 0.5.13
+        specifier: ^0.8.1
+        version: 0.8.1
       preact:
         specifier: ^10.13.2
         version: 10.13.2
@@ -535,8 +514,8 @@ importers:
         specifier: ^2.4.1
         version: link:../../packages/astro
       vite-plugin-pwa:
-        specifier: 0.11.11
-        version: 0.11.11(workbox-window@6.5.4)
+        specifier: 0.14.7
+        version: 0.14.7(workbox-window@6.5.4)
       workbox-window:
         specifier: ^6.5.4
         version: 6.5.4
@@ -547,8 +526,8 @@ importers:
         specifier: ^2.4.1
         version: link:../../packages/astro
       vitest:
-        specifier: ^0.20.3
-        version: 0.20.3
+        specifier: ^0.31.0
+        version: 0.31.0
 
   packages/astro:
     dependencies:
@@ -5290,23 +5269,6 @@ packages:
       '@jridgewell/trace-mapping': 0.3.18
     dev: false
 
-  /@antfu/install-pkg@0.1.1:
-    resolution: {integrity: sha512-LyB/8+bSfa0DFGC06zpCEfs89/XoWZwws5ygEa5D+Xsm3OfI+aXQ86VgVG7Acyef+rSZ5HE7J8rrxzrQeM3PjQ==}
-    dependencies:
-      execa: 5.1.1
-      find-up: 5.0.0
-    dev: false
-
-  /@antfu/utils@0.3.0:
-    resolution: {integrity: sha512-UU8TLr/EoXdg7OjMp0h9oDoIAVr+Z/oW9cpOxQQyrsz6Qzd2ms/1CdWx8fl2OQdFpxGmq5Vc4TwfLHId6nAZjA==}
-    dependencies:
-      '@types/throttle-debounce': 2.1.0
-    dev: false
-
-  /@antfu/utils@0.5.2:
-    resolution: {integrity: sha512-CQkeV+oJxUazwjlHD0/3ZD08QWKuGQkhnrKo3e6ly5pd48VUpXbb77q0xMU4+vc2CkJnDS02Eq/M9ugyX20XZA==}
-    dev: false
-
   /@apideck/better-ajv-errors@0.3.6(ajv@8.12.0):
     resolution: {integrity: sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA==}
     engines: {node: '>=10'}
@@ -7300,7 +7262,7 @@ packages:
     resolution: {integrity: sha512-vDwCDoVXDgopw/hvr0zEADew2wWaGP8Qq0Bxhgii1Ewz2t4fQeyJwIRN/mWADeLFYPVkpz8TpEbxya/i6Tm0WA==}
     dev: false
 
-  /@docsearch/react@3.3.4(@algolia/client-search@4.17.0)(@types/react@17.0.58)(react-dom@18.2.0)(react@18.2.0):
+  /@docsearch/react@3.3.4(@algolia/client-search@4.17.0)(@types/react@18.2.5)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-aeOf1WC5zMzBEi2SI6WWznOmIo9rnpN4p7a3zHXxowVciqlI4HsZGtOR9nFOufLeolv7HibwLlaM0oyUqJxasw==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
@@ -7317,7 +7279,7 @@ packages:
       '@algolia/autocomplete-core': 1.8.2
       '@algolia/autocomplete-preset-algolia': 1.8.2(@algolia/client-search@4.17.0)(algoliasearch@4.17.0)
       '@docsearch/css': 3.3.4
-      '@types/react': 17.0.58
+      '@types/react': 18.2.5
       algoliasearch: 4.17.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -7622,23 +7584,6 @@ packages:
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
     dev: true
 
-  /@iconify/types@1.1.0:
-    resolution: {integrity: sha512-Jh0llaK2LRXQoYsorIH8maClebsnzTcve+7U3rQUSnC11X4jtPnFuyatqFLvMxZ8MLG8dB4zfHsbPfuvxluONw==}
-    dev: false
-
-  /@iconify/utils@1.0.33:
-    resolution: {integrity: sha512-vGeAqo7aGPxOQmGdVoXFUOuyN+0V7Lcrx2EvaiRjxUD1x6Om0Tvq2bdm7E24l2Pz++4S0mWMCVFXe/17EtKImQ==}
-    dependencies:
-      '@antfu/install-pkg': 0.1.1
-      '@antfu/utils': 0.5.2
-      '@iconify/types': 1.1.0
-      debug: 4.3.4
-      kolorist: 1.8.0
-      local-pkg: 0.4.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
@@ -7801,7 +7746,7 @@ packages:
         optional: true
     dependencies:
       '@mdx-js/mdx': 2.3.0
-      '@rollup/pluginutils': 5.0.2
+      '@rollup/pluginutils': 5.0.2(rollup@3.21.4)
       source-map: 0.7.4
       vfile: 5.3.2
     transitivePeerDependencies:
@@ -7979,14 +7924,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@nanostores/preact@0.1.3(nanostores@0.5.13)(preact@10.13.2):
-    resolution: {integrity: sha512-uiX1ned0LrzASot+sPUjyJzr8Js3pX075omazgsSdLf0zPp4ss8xwTiuNh5FSKigTSQEVqZFiS+W8CnHIrX62A==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+  /@nanostores/preact@0.4.1(nanostores@0.8.1)(preact@10.13.2):
+    resolution: {integrity: sha512-a5nUVjoGuPqdMBUINOFbQKPfabD1mVLcuspefmtdKZqhvXeDkw9Vg8S6xINIjfWnu/eZgpA+Hb1Pkl/Sx1l/vw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      nanostores: ^0.5.2
+      nanostores: ^0.8.0
       preact: '>=10.0.0'
     dependencies:
-      nanostores: 0.5.13
+      nanostores: 0.8.1
       preact: 10.13.2
     dev: false
 
@@ -8180,10 +8125,6 @@ packages:
       playwright-core: 1.29.2
     dev: true
 
-  /@polka/url@1.0.0-next.21:
-    resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
-    dev: false
-
   /@preact/signals-core@1.3.0:
     resolution: {integrity: sha512-M+M3ZOtd1dtV/uasyk4SZu1vbfEJ4NeENv0F7F12nijZYedB5wSgbtZcuACyssnTznhF4ctUyrR0dZHuHfyWKA==}
     dev: false
@@ -8310,6 +8251,20 @@ packages:
       rollup: 2.79.1
     dev: false
 
+  /@rollup/plugin-replace@5.0.2(rollup@3.21.4):
+    resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2(rollup@3.21.4)
+      magic-string: 0.27.0
+      rollup: 3.21.4
+    dev: false
+
   /@rollup/plugin-typescript@8.3.2(rollup@2.79.1)(tslib@2.5.0)(typescript@5.0.2):
     resolution: {integrity: sha512-MtgyR5LNHZr3GyN0tM7gNO9D0CS+Y+vflS4v/PHmrX17JCkHUYKvQ5jN5o3cz1YKllM3duXUqu3yOHwMPUxhDg==}
     engines: {node: '>=8.0.0'}
@@ -8342,15 +8297,7 @@ packages:
       picomatch: 2.3.1
       rollup: 2.79.1
 
-  /@rollup/pluginutils@4.2.1:
-    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
-    engines: {node: '>= 8.0.0'}
-    dependencies:
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    dev: false
-
-  /@rollup/pluginutils@5.0.2:
+  /@rollup/pluginutils@5.0.2(rollup@3.21.4):
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -8362,6 +8309,7 @@ packages:
       '@types/estree': 1.0.1
       estree-walker: 2.0.2
       picomatch: 2.3.1
+      rollup: 3.21.4
     dev: false
 
   /@solidjs/router@0.5.0(solid-js@1.5.6):
@@ -8416,7 +8364,7 @@ packages:
   /@ts-morph/common@0.16.0:
     resolution: {integrity: sha512-SgJpzkTgZKLKqQniCjLaE3c2L2sdL7UShvmTmPBejAKd2OKV/yfMpQ2IWpAuA+VY5wy7PkSUaEObIqEK6afFuw==}
     dependencies:
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       minimatch: 5.1.6
       mkdirp: 1.0.4
       path-browserify: 1.0.1
@@ -8705,19 +8653,19 @@ packages:
   /@types/react-dom@17.0.17:
     resolution: {integrity: sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==}
     dependencies:
-      '@types/react': 17.0.45
+      '@types/react': 17.0.58
     dev: true
 
   /@types/react-dom@18.0.6:
     resolution: {integrity: sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==}
     dependencies:
-      '@types/react': 18.0.21
+      '@types/react': 18.2.5
     dev: false
 
   /@types/react-dom@18.2.3:
     resolution: {integrity: sha512-hxXEXWxFJXbY0LMj/T69mznqOZJXNtQMqVxIiirVAZnnpeYiD4zt+lPsgcr/cfWg2VLsxZ1y26vigG03prYB+Q==}
     dependencies:
-      '@types/react': 17.0.58
+      '@types/react': 18.2.5
     dev: false
 
   /@types/react@17.0.45:
@@ -8734,7 +8682,7 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.3
       csstype: 3.1.2
-    dev: false
+    dev: true
 
   /@types/react@18.0.21:
     resolution: {integrity: sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==}
@@ -8814,10 +8762,6 @@ packages:
   /@types/strip-json-comments@0.0.30:
     resolution: {integrity: sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==}
     dev: true
-
-  /@types/throttle-debounce@2.1.0:
-    resolution: {integrity: sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==}
-    dev: false
 
   /@types/trusted-types@2.0.3:
     resolution: {integrity: sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==}
@@ -8999,96 +8943,6 @@ packages:
     resolution: {integrity: sha512-TSVh8CpnwNAsPC5wXcIyh92Bv1gq6E9cNDeeLu7Z4h8V4/qWtXJp7y42qljRkqcpmsve1iozwv1wr+3BNdILCg==}
     dev: true
 
-  /@unocss/cli@0.15.6:
-    resolution: {integrity: sha512-NPgUJklUTS+RzfEZghpTgg+FiZAm3B+AMy5x7nimSCoqwkeSioV/1YBu4eVaO+a1QdNqTKq8LrSM5qyvumrKOw==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dependencies:
-      '@unocss/config': 0.15.6
-      '@unocss/core': 0.15.6
-      '@unocss/preset-uno': 0.15.6
-      cac: 6.7.14
-      chokidar: 3.5.3
-      colorette: 2.0.20
-      consola: 2.15.3
-      fast-glob: 3.2.12
-      pathe: 0.2.0
-    dev: false
-
-  /@unocss/config@0.15.6:
-    resolution: {integrity: sha512-RRDqJpPvSL9d4JuDMkkNzd1wPNb2lyO8/ih5dNjgm19lNqbNNW8LX7yhakr3ctRVJ07j7riOccJMLokoqRSd3A==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@unocss/core': 0.15.6
-      unconfig: 0.2.2
-    dev: false
-
-  /@unocss/core@0.15.6:
-    resolution: {integrity: sha512-rGigqZEnYIhb38ldiRYR4CcsPc8sjAu5TIx04/Ta4OmolmSVYhdV4/MHnFvjqBATsUNl8FcZLmI+Si+qwtxKtg==}
-    dev: false
-
-  /@unocss/inspector@0.15.6:
-    resolution: {integrity: sha512-chEPZiDf9LMv6UN/US7P3Q8WkC5X/4g4ZYJQbu/j1T1u6RWBe809wXmNbcpHA87o62gMweX1VINs2nwdFz3rTw==}
-    dependencies:
-      gzip-size: 6.0.0
-      sirv: 1.0.19
-    dev: false
-
-  /@unocss/preset-attributify@0.15.6:
-    resolution: {integrity: sha512-drXO5EiaWx6B+I+5FzaKR9blnKoKYQ56di0hDgZ3heGfFsCskQ6DwVHYKBjCDozMqwSOjGZBjTLMwALj/MnaqA==}
-    dependencies:
-      '@unocss/core': 0.15.6
-    dev: false
-
-  /@unocss/preset-icons@0.15.6:
-    resolution: {integrity: sha512-o5NWtOu3OKVaWYVieQ1pVmsj7jvWvMgE5TXPKRr3OTRR2u8M5wo+yRX4+m1sVjAtWiUz8e49TpbbsQTM42Lv7A==}
-    dependencies:
-      '@iconify/utils': 1.0.33
-      '@unocss/core': 0.15.6
-      local-pkg: 0.4.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@unocss/preset-mini@0.15.6:
-    resolution: {integrity: sha512-L5yt4kgnEvbYRsESjqel6N1m3AFrqBKYekurPl8s0VBa/Wkm3dq3RVO7qxEdsE2/AW0HxsEIIEKJtqJJEQY6xg==}
-    dependencies:
-      '@unocss/core': 0.15.6
-    dev: false
-
-  /@unocss/preset-uno@0.15.6:
-    resolution: {integrity: sha512-tnp8U6M52W1LPaJphiNyR0UWR7eR29/SICu+u23kGGTlqsLctMWn/DCqq5YiEBrs7MuBARpaK95mYD17D1fAVA==}
-    dependencies:
-      '@unocss/core': 0.15.6
-      '@unocss/preset-mini': 0.15.6
-      '@unocss/preset-wind': 0.15.6
-    dev: false
-
-  /@unocss/preset-wind@0.15.6:
-    resolution: {integrity: sha512-rCGQwuBDoVUUrocmPSguNgxumuichaTBfu9KCjsZv1m5xWn78EHu5igQCnLhIVjyHaakQwwfawQW0pdvzAC1tw==}
-    dependencies:
-      '@unocss/core': 0.15.6
-      '@unocss/preset-mini': 0.15.6
-    dev: false
-
-  /@unocss/reset@0.15.6:
-    resolution: {integrity: sha512-hjOYCrheZCrxWRC2eaTb0S29QnIRjt/KHscbMl4oL0lijOhWJ2BujJxYQ1sDZ47oCo+yBsEF6rqecNZ5puDb3g==}
-    dev: false
-
-  /@unocss/scope@0.15.6:
-    resolution: {integrity: sha512-ygHAxmW+VUSdG30JatnMzL3uQs3j/JinVhLmXkA5/A66xPq3JIwzvzJrGG7ZWUBbwaN5OHncS+5seB7jgjqsQw==}
-    dev: false
-
-  /@unocss/vite@0.15.6:
-    resolution: {integrity: sha512-AQOlqDfVfTbHRKzTU33iazszyG6CC3aL6lQrKhEsi506zgTn/CzqPyiLOEAGFbrQNR7CFeab0aufL/KR0McNpg==}
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      '@unocss/config': 0.15.6
-      '@unocss/core': 0.15.6
-      '@unocss/inspector': 0.15.6
-      '@unocss/scope': 0.15.6
-    dev: false
-
   /@vercel/analytics@0.1.8:
     resolution: {integrity: sha512-PQrOI8BJ9qUiVJuQfnKiJd15eDjDJH9TBKsNeMrtelT4NAk7d9mBVz1CoZkvoFnHQ0OW7Xnqmr1F2nScfAnznQ==}
     peerDependencies:
@@ -9149,6 +9003,45 @@ packages:
     dependencies:
       vite: 4.3.1(@types/node@18.7.21)(sass@1.52.2)
       vue: 3.2.40
+    dev: false
+
+  /@vitest/expect@0.31.0:
+    resolution: {integrity: sha512-Jlm8ZTyp6vMY9iz9Ny9a0BHnCG4fqBa8neCF6Pk/c/6vkUk49Ls6UBlgGAU82QnzzoaUs9E/mUhq/eq9uMOv/g==}
+    dependencies:
+      '@vitest/spy': 0.31.0
+      '@vitest/utils': 0.31.0
+      chai: 4.3.7
+    dev: false
+
+  /@vitest/runner@0.31.0:
+    resolution: {integrity: sha512-H1OE+Ly7JFeBwnpHTrKyCNm/oZgr+16N4qIlzzqSG/YRQDATBYmJb/KUn3GrZaiQQyL7GwpNHVZxSQd6juLCgw==}
+    dependencies:
+      '@vitest/utils': 0.31.0
+      concordance: 5.0.4
+      p-limit: 4.0.0
+      pathe: 1.1.0
+    dev: false
+
+  /@vitest/snapshot@0.31.0:
+    resolution: {integrity: sha512-5dTXhbHnyUMTMOujZPB0wjFjQ6q5x9c8TvAsSPUNKjp1tVU7i9pbqcKPqntyu2oXtmVxKbuHCqrOd+Ft60r4tg==}
+    dependencies:
+      magic-string: 0.30.0
+      pathe: 1.1.0
+      pretty-format: 27.5.1
+    dev: false
+
+  /@vitest/spy@0.31.0:
+    resolution: {integrity: sha512-IzCEQ85RN26GqjQNkYahgVLLkULOxOm5H/t364LG0JYb3Apg0PsYCHLBYGA006+SVRMWhQvHlBBCyuByAMFmkg==}
+    dependencies:
+      tinyspy: 2.1.0
+    dev: false
+
+  /@vitest/utils@0.31.0:
+    resolution: {integrity: sha512-kahaRyLX7GS1urekRXN2752X4gIgOGVX4Wo8eDUGUkTWlGpXzf5ZS6N9RUUS+Re3XEE8nVGqNyxkSxF5HXlGhQ==}
+    dependencies:
+      concordance: 5.0.4
+      loupe: 2.3.6
+      pretty-format: 27.5.1
     dev: false
 
   /@vscode/emmet-helper@2.8.7:
@@ -9446,7 +9339,6 @@ packages:
   /acorn-walk@8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /acorn@7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
@@ -9561,6 +9453,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+
+  /ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+    dev: false
 
   /ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
@@ -9867,6 +9764,10 @@ packages:
   /blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
     dev: true
+
+  /blueimp-md5@2.19.0:
+    resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
+    dev: false
 
   /boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -10255,6 +10156,7 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+    dev: true
 
   /clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -10345,24 +10247,18 @@ packages:
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  /concurrently@7.6.0:
-    resolution: {integrity: sha512-BKtRgvcJGeZ4XttiDiNcFiRlxoAeZOseqUvyYRUp/Vtd+9p1ULmeoSqGsDA+2ivdeDFpqrJvGvmI+StKfKl5hw==}
-    engines: {node: ^12.20.0 || ^14.13.0 || >=16.0.0}
-    hasBin: true
+  /concordance@5.0.4:
+    resolution: {integrity: sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==}
+    engines: {node: '>=10.18.0 <11 || >=12.14.0 <13 || >=14'}
     dependencies:
-      chalk: 4.1.2
-      date-fns: 2.30.0
+      date-time: 3.1.0
+      esutils: 2.0.3
+      fast-diff: 1.2.0
+      js-string-escape: 1.0.1
       lodash: 4.17.21
-      rxjs: 7.8.1
-      shell-quote: 1.8.1
-      spawn-command: 0.0.2-1
-      supports-color: 8.1.1
-      tree-kill: 1.2.2
-      yargs: 17.7.2
-    dev: false
-
-  /consola@2.15.3:
-    resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
+      md5-hex: 3.0.1
+      semver: 7.5.0
+      well-known-symbols: 2.0.0
     dev: false
 
   /console-control-strings@1.1.0:
@@ -10574,11 +10470,11 @@ packages:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
     dev: true
 
-  /date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
+  /date-time@3.1.0:
+    resolution: {integrity: sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==}
+    engines: {node: '>=6'}
     dependencies:
-      '@babel/runtime': 7.21.5
+      time-zone: 1.0.0
     dev: false
 
   /debug@2.6.9:
@@ -10712,10 +10608,6 @@ packages:
     dependencies:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
-
-  /defu@5.0.1:
-    resolution: {integrity: sha512-EPS1carKg+dkEVy3qNTqIdp2qV7mUP08nIsupfwQpz++slCVRw7qbQyWvSTig+kFPwz2XXp5/kIIkH+CwrJKkQ==}
-    dev: false
 
   /defu@6.1.2:
     resolution: {integrity: sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==}
@@ -10866,10 +10758,6 @@ packages:
   /dset@3.1.2:
     resolution: {integrity: sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==}
     engines: {node: '>=4'}
-    dev: false
-
-  /duplexer@0.1.2:
-    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
     dev: false
 
   /eastasianwidth@0.2.0:
@@ -11806,7 +11694,6 @@ packages:
 
   /fast-diff@1.2.0:
     resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
-    dev: true
 
   /fast-glob@3.2.11:
     resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}
@@ -12229,7 +12116,7 @@ packages:
       '@types/glob': 7.2.0
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       glob: 7.2.3
       ignore: 5.2.4
       merge2: 1.4.1
@@ -12242,7 +12129,7 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
@@ -12265,7 +12152,7 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
@@ -12299,13 +12186,6 @@ packages:
   /growl@1.10.5:
     resolution: {integrity: sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==}
     engines: {node: '>=4.x'}
-
-  /gzip-size@6.0.0:
-    resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
-    engines: {node: '>=10'}
-    dependencies:
-      duplexer: 0.1.2
-    dev: false
 
   /hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
@@ -12410,30 +12290,9 @@ packages:
       html-void-elements: 2.0.1
       parse5: 6.0.1
       unist-util-position: 4.0.4
-      unist-util-visit: 4.1.0
+      unist-util-visit: 4.1.2
       vfile: 5.3.2
       web-namespaces: 2.0.1
-      zwitch: 2.0.4
-    dev: false
-
-  /hast-util-select@5.0.1:
-    resolution: {integrity: sha512-cxnImmR/tN/ipvbwGrKtEErmy83K1xWx8Bu7nImiwTOJ7X/fW1X6L1241ux+MYUXDwx8GxrE4LVmXRlEnbQsQA==}
-    dependencies:
-      '@types/hast': 2.3.4
-      '@types/unist': 2.0.6
-      bcp-47-match: 2.0.3
-      comma-separated-tokens: 2.0.3
-      css-selector-parser: 1.4.1
-      direction: 2.0.1
-      hast-util-has-property: 2.0.1
-      hast-util-is-element: 2.1.3
-      hast-util-to-string: 2.0.0
-      hast-util-whitespace: 2.0.1
-      not: 0.1.0
-      nth-check: 2.1.1
-      property-information: 6.2.0
-      space-separated-tokens: 2.0.2
-      unist-util-visit: 4.1.2
       zwitch: 2.0.4
     dev: false
 
@@ -12455,6 +12314,26 @@ packages:
       property-information: 6.2.0
       space-separated-tokens: 2.0.2
       unist-util-visit: 4.1.0
+      zwitch: 2.0.4
+    dev: false
+
+  /hast-util-select@5.0.5:
+    resolution: {integrity: sha512-QQhWMhgTFRhCaQdgTKzZ5g31GLQ9qRb1hZtDPMqQaOhpLBziWcshUS0uCR5IJ0U1jrK/mxg35fmcq+Dp/Cy2Aw==}
+    dependencies:
+      '@types/hast': 2.3.4
+      '@types/unist': 2.0.6
+      bcp-47-match: 2.0.3
+      comma-separated-tokens: 2.0.3
+      css-selector-parser: 1.4.1
+      direction: 2.0.1
+      hast-util-has-property: 2.0.1
+      hast-util-to-string: 2.0.0
+      hast-util-whitespace: 2.0.1
+      not: 0.1.0
+      nth-check: 2.1.1
+      property-information: 6.2.0
+      space-separated-tokens: 2.0.2
+      unist-util-visit: 4.1.2
       zwitch: 2.0.4
     dev: false
 
@@ -12707,13 +12586,6 @@ packages:
     hasBin: true
     dependencies:
       queue: 6.0.2
-    dev: false
-
-  /imagetools-core@3.3.1:
-    resolution: {integrity: sha512-xllF2GDRg0SXCQQRxBAtE6N9dPAttc+ro+QDLnRmVSE5lH5clQxD2Al4XluirXj0T7lIH5VbetFmBLowW6ps+w==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      sharp: 0.31.3
     dev: false
 
   /immutable@4.3.0:
@@ -13092,6 +12964,11 @@ packages:
     resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
     dev: true
 
+  /js-string-escape@1.0.1:
+    resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -13234,10 +13111,6 @@ packages:
   /kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
-
-  /kolorist@1.8.0:
-    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
-    dev: false
 
   /leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -13524,12 +13397,19 @@ packages:
       speech-rule-engine: 4.0.7
     dev: true
 
+  /md5-hex@3.0.1:
+    resolution: {integrity: sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==}
+    engines: {node: '>=8'}
+    dependencies:
+      blueimp-md5: 2.19.0
+    dev: false
+
   /mdast-util-definitions@5.1.2:
     resolution: {integrity: sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==}
     dependencies:
       '@types/mdast': 3.0.10
       '@types/unist': 2.0.6
-      unist-util-visit: 4.1.0
+      unist-util-visit: 4.1.2
 
   /mdast-util-find-and-replace@2.2.2:
     resolution: {integrity: sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==}
@@ -13695,7 +13575,7 @@ packages:
       trim-lines: 3.0.1
       unist-util-generated: 2.0.1
       unist-util-position: 4.0.4
-      unist-util-visit: 4.1.0
+      unist-util-visit: 4.1.2
 
   /mdast-util-to-markdown@1.5.0:
     resolution: {integrity: sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==}
@@ -13706,7 +13586,7 @@ packages:
       mdast-util-phrasing: 3.0.1
       mdast-util-to-string: 3.1.0
       micromark-util-decode-string: 1.0.2
-      unist-util-visit: 4.1.0
+      unist-util-visit: 4.1.2
       zwitch: 2.0.4
 
   /mdast-util-to-string@3.1.0:
@@ -13721,7 +13601,7 @@ packages:
       github-slugger: 2.0.0
       mdast-util-to-string: 3.1.0
       unist-util-is: 5.2.1
-      unist-util-visit: 4.1.0
+      unist-util-visit: 4.1.2
     dev: true
 
   /media-typer@0.3.0:
@@ -14261,6 +14141,15 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  /mlly@1.2.0:
+    resolution: {integrity: sha512-+c7A3CV0KGdKcylsI6khWyts/CYrGTrRVo4R/I7u/cUsy0Conxa6LUhiEzVKIw14lc2L5aiO4+SeVe4TeGRKww==}
+    dependencies:
+      acorn: 8.8.2
+      pathe: 1.1.0
+      pkg-types: 1.0.3
+      ufo: 1.1.2
+    dev: false
+
   /mocha@9.2.2:
     resolution: {integrity: sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==}
     engines: {node: '>= 12.0.0'}
@@ -14300,11 +14189,6 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /mrmime@1.0.1:
-    resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
-    engines: {node: '>=10'}
-    dev: false
-
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
     dev: false
@@ -14337,9 +14221,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  /nanostores@0.5.13:
-    resolution: {integrity: sha512-UxC2eZsCbbcHZ1Z/hwFQ1C4gy8Tkhzskvmu6wOsAhOMAOd72HmVX1Nxs96DSDUcd7V1x0IdRtsl+zAm7rg7slA==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+  /nanostores@0.8.1:
+    resolution: {integrity: sha512-1ZCfQtII2XeFDrtqXL2cdQ/diGrLxzRB3YMyQjn8m7GSGQrJfGST2iuqMpWnS/ZlifhtjgR/SX0Jy6Uij6lRLA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     dev: false
 
   /napi-build-utils@1.0.2:
@@ -14391,10 +14275,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       semver: 7.3.8
-
-  /node-addon-api@5.1.0:
-    resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
-    dev: false
 
   /node-addon-api@6.1.0:
     resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
@@ -14688,6 +14568,13 @@ packages:
     dependencies:
       yocto-queue: 0.1.0
 
+  /p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      yocto-queue: 1.0.0
+    dev: false
+
   /p-locate@3.0.0:
     resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
     engines: {node: '>=6'}
@@ -14886,10 +14773,6 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  /pathe@0.2.0:
-    resolution: {integrity: sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==}
-    dev: false
-
   /pathe@1.1.0:
     resolution: {integrity: sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==}
     dev: false
@@ -14940,6 +14823,14 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       find-up: 4.1.0
+
+  /pkg-types@1.0.3:
+    resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
+    dependencies:
+      jsonc-parser: 3.2.0
+      mlly: 1.2.0
+      pathe: 1.1.0
+    dev: false
 
   /pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
@@ -15437,6 +15328,15 @@ packages:
     engines: {node: ^14.13.1 || >=16.0.0}
     dev: false
 
+  /pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+    dev: false
+
   /pretty-format@3.8.0:
     resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
     dev: false
@@ -15557,6 +15457,10 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+
+  /react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+    dev: false
 
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
@@ -15955,7 +15859,7 @@ packages:
       '@types/nlcst': 1.0.0
       nlcst-to-string: 3.1.1
       unified: 10.1.2
-      unist-util-visit: 4.1.0
+      unist-util-visit: 4.1.2
     dev: false
 
   /retext-stringify@3.1.0:
@@ -16068,12 +15972,6 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
-
-  /rxjs@7.8.1:
-    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
-    dependencies:
-      tslib: 2.5.0
-    dev: false
 
   /s.color@0.0.15:
     resolution: {integrity: sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==}
@@ -16221,21 +16119,6 @@ packages:
   /setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  /sharp@0.31.3:
-    resolution: {integrity: sha512-XcR4+FCLBFKw1bdB+GEhnUNXNXvnt0tDo4WsBsraKymuo/IAuPuCBVAL2wIkUw2r/dwFW5Q5+g66Kwl2dgDFVg==}
-    engines: {node: '>=14.15.0'}
-    requiresBuild: true
-    dependencies:
-      color: 4.2.3
-      detect-libc: 2.0.1
-      node-addon-api: 5.1.0
-      prebuild-install: 7.1.1
-      semver: 7.5.0
-      simple-get: 4.0.1
-      tar-fs: 2.1.1
-      tunnel-agent: 0.6.0
-    dev: false
-
   /sharp@0.32.1:
     resolution: {integrity: sha512-kQTFtj7ldpUqSe8kDxoGLZc1rnMFU0AO2pqbX6pLy3b7Oj8ivJIdoKNwxHVQG2HN6XpHPJqCSM2nsma2gOXvOg==}
     engines: {node: '>=14.15.0'}
@@ -16274,6 +16157,7 @@ packages:
 
   /shell-quote@1.8.1:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
+    dev: true
 
   /shiki-twoslash@3.1.0:
     resolution: {integrity: sha512-uDqrTutOIZzyHbo103GsK7Vvc10saK1XCCivnOQ1NHJzgp3FBilEpftGeVzVSMOJs+JyhI7whkvhXV7kXQ5zCg==}
@@ -16309,6 +16193,10 @@ packages:
       get-intrinsic: 1.2.0
       object-inspect: 1.12.3
 
+  /siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: false
+
   /sigmund@1.0.1:
     resolution: {integrity: sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==}
     dev: true
@@ -16330,15 +16218,6 @@ packages:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
     dependencies:
       is-arrayish: 0.3.2
-
-  /sirv@1.0.19:
-    resolution: {integrity: sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==}
-    engines: {node: '>= 10'}
-    dependencies:
-      '@polka/url': 1.0.0-next.21
-      mrmime: 1.0.1
-      totalist: 1.1.0
-    dev: false
 
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -16454,10 +16333,6 @@ packages:
   /space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
-  /spawn-command@0.0.2-1:
-    resolution: {integrity: sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==}
-    dev: false
-
   /spawndamnit@2.0.0:
     resolution: {integrity: sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==}
     dependencies:
@@ -16507,9 +16382,17 @@ packages:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
     dev: true
 
+  /stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: false
+
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+
+  /std-env@3.3.3:
+    resolution: {integrity: sha512-Rz6yejtVyWnVjC1RFvNmYL10kgjC49EOghxWn0RFqlCHGFpQx+Xe7yW3I4ceK1SGrWIGMjD5Kbue8W/udkbMJg==}
+    dev: false
 
   /stream-transform@2.1.3:
     resolution: {integrity: sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==}
@@ -16663,6 +16546,12 @@ packages:
     resolution: {integrity: sha512-V1LGY4UUo0jgwC+ELQ2BNWfPa17TIuwBLg+j1AA/9RPzKINl1lhxVEu2r+ZTTO8aetIsUzE5Qj6LMSBkoGYKKw==}
     engines: {node: '>=14.16'}
     dev: true
+
+  /strip-literal@1.0.1:
+    resolution: {integrity: sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==}
+    dependencies:
+      acorn: 8.8.2
+    dev: false
 
   /strnum@1.0.5:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
@@ -16898,6 +16787,11 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /time-zone@1.0.0:
+    resolution: {integrity: sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==}
+    engines: {node: '>=4'}
+    dev: false
+
   /timestring@6.0.0:
     resolution: {integrity: sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA==}
     engines: {node: '>=8'}
@@ -16909,13 +16803,17 @@ packages:
       globalyzer: 0.1.0
       globrex: 0.1.2
 
-  /tinypool@0.2.4:
-    resolution: {integrity: sha512-Vs3rhkUH6Qq1t5bqtb816oT+HeJTXfwt2cbPH17sWHIYKTotQIFPk3tf2fgqRrVyMDVOc1EnPgzIxfIulXVzwQ==}
+  /tinybench@2.5.0:
+    resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
+    dev: false
+
+  /tinypool@0.5.0:
+    resolution: {integrity: sha512-paHQtnrlS1QZYKF/GnLoOM/DN9fqaGOFbCbxzAhwniySnzl9Ebk8w73/dd34DAhe/obUbPAOldTyYXQZxnPBPQ==}
     engines: {node: '>=14.0.0'}
     dev: false
 
-  /tinyspy@1.1.1:
-    resolution: {integrity: sha512-UVq5AXt/gQlti7oxoIg5oi/9r0WpF7DGEVwXgqWSMmyN16+e3tl5lIvTaOpJ3TAtu5xFzWccFRM4R5NaWHF+4g==}
+  /tinyspy@2.1.0:
+    resolution: {integrity: sha512-7eORpyqImoOvkQJCSkL0d0mB4NHHIFAy4b1u8PHdDa7SjGS2njzl6/lyGoZLm+eyYEtlUmFGE0rFj66SWxZgQQ==}
     engines: {node: '>=14.0.0'}
     dev: false
 
@@ -16944,11 +16842,6 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  /totalist@1.1.0:
-    resolution: {integrity: sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==}
-    engines: {node: '>=6'}
-    dev: false
-
   /tough-cookie@4.1.2:
     resolution: {integrity: sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==}
     engines: {node: '>=6'}
@@ -16974,11 +16867,6 @@ packages:
     dependencies:
       punycode: 2.3.0
     dev: true
-
-  /tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
-    dev: false
 
   /trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -17202,6 +17090,10 @@ packages:
     engines: {node: '>=12.20'}
     hasBin: true
 
+  /ufo@1.1.2:
+    resolution: {integrity: sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==}
+    dev: false
+
   /uglify-js@3.17.4:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
     engines: {node: '>=0.8.0'}
@@ -17223,14 +17115,6 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
-
-  /unconfig@0.2.2:
-    resolution: {integrity: sha512-JN1MeYJ/POnjBj7NgOJJxPp6+NcD6Nd0hEuK0D89kjm9GvQQUq8HeE2Eb7PZgtu+64mWkDiqeJn1IZoLH7htPg==}
-    dependencies:
-      '@antfu/utils': 0.3.0
-      defu: 5.0.1
-      jiti: 1.18.2
-    dev: false
 
   /undici@5.20.0:
     resolution: {integrity: sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==}
@@ -17334,7 +17218,7 @@ packages:
     resolution: {integrity: sha512-TkBb0HABNmxzAcfLf4qsIbFbaPDvMO6wa3b3j4VcEzFVaw1LBKwnW4/sRJ/atSLSzoIg41JWEdnE7N6DIhGDGQ==}
     dependencies:
       '@types/unist': 2.0.6
-      unist-util-visit: 4.1.0
+      unist-util-visit: 4.1.2
 
   /unist-util-select@4.0.3:
     resolution: {integrity: sha512-1074+K9VyR3NyUz3lgNtHKm7ln+jSZXtLJM4E22uVuoFn88a/Go2pX8dusrt/W+KWH1ncn8jcd8uCQuvXb/fXA==}
@@ -17400,7 +17284,6 @@ packages:
       '@types/unist': 2.0.6
       unist-util-is: 5.2.1
       unist-util-visit-parents: 5.1.3
-    dev: false
 
   /universal-user-agent@6.0.0:
     resolution: {integrity: sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==}
@@ -17419,21 +17302,6 @@ packages:
   /universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
-
-  /unocss@0.15.6:
-    resolution: {integrity: sha512-Cq2CQCA2ISHnNgv2ben1nQP8/3w8O1D5geoK6ZZY8F5wvIvw/mZ9+qcgVx2ZuX5lLZMRP8MG9jL2WW0ocVgjNg==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@unocss/cli': 0.15.6
-      '@unocss/core': 0.15.6
-      '@unocss/preset-attributify': 0.15.6
-      '@unocss/preset-icons': 0.15.6
-      '@unocss/preset-uno': 0.15.6
-      '@unocss/reset': 0.15.6
-      '@unocss/vite': 0.15.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -17540,68 +17408,46 @@ packages:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
 
-  /vite-imagetools@4.0.19:
-    resolution: {integrity: sha512-vZaPsjLDgEqZrbj+ZsniRKthmoj4mvVrMOK/FZhRAbrVB4LOsil0BO2Gcq20e/JRlom4DzqtLw1UQUkfcqgCrA==}
-    engines: {node: '>=12.0.0'}
+  /vite-node@0.31.0(@types/node@18.16.3):
+    resolution: {integrity: sha512-8x1x1LNuPvE2vIvkSB7c1mApX5oqlgsxzHQesYF7l5n1gKrEmrClIiZuOFbFDQcjLsmcWSwwmrWrcGWm9Fxc/g==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2
-      imagetools-core: 3.3.1
+      cac: 6.7.14
+      debug: 4.3.4
+      mlly: 1.2.0
+      pathe: 1.1.0
+      picocolors: 1.0.0
+      vite: 4.3.1(@types/node@18.7.21)(sass@1.52.2)
     transitivePeerDependencies:
-      - rollup
+      - '@types/node'
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
     dev: false
 
-  /vite-plugin-pwa@0.11.11(workbox-window@6.5.4):
-    resolution: {integrity: sha512-/nSLS7VfGN5UrL4a1ALGEQAyga/H0hYZjEkwPehiEFW1PM1DTi1A8GkPCsmevKwR6vt10P+5wS1wrvSgwQemzw==}
+  /vite-plugin-pwa@0.14.7(workbox-window@6.5.4):
+    resolution: {integrity: sha512-dNJaf0fYOWncmjxv9HiSa2xrSjipjff7IkYE5oIUJ2x5HKu3cXgA8LRgzOwTc5MhwyFYRSU0xyN0Phbx3NsQYw==}
     peerDependencies:
-      vite: ^2.0.0
-      workbox-window: ^6.4.0
+      vite: ^3.1.0 || ^4.0.0
+      workbox-window: ^6.5.4
     peerDependenciesMeta:
       vite:
         optional: true
     dependencies:
+      '@rollup/plugin-replace': 5.0.2(rollup@3.21.4)
       debug: 4.3.4
       fast-glob: 3.2.12
-      pretty-bytes: 5.6.0
-      rollup: 2.79.1
+      pretty-bytes: 6.0.0
+      rollup: 3.21.4
       workbox-build: 6.5.4
       workbox-window: 6.5.4
     transitivePeerDependencies:
       - '@types/babel__core'
       - supports-color
-    dev: false
-
-  /vite@3.2.6(@types/node@18.16.3):
-    resolution: {integrity: sha512-nTXTxYVvaQNLoW5BQ8PNNQ3lPia57gzsQU/Khv+JvzKPku8kNZL6NMUR/qwXhMG6E+g1idqEPanomJ+VZgixEg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 18.16.3
-      esbuild: 0.15.18
-      postcss: 8.4.23
-      resolve: 1.22.2
-      rollup: 2.79.1
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: false
 
   /vite@4.3.1(@types/node@18.7.21)(sass@1.52.2):
@@ -17648,17 +17494,19 @@ packages:
       vite: 4.3.1(@types/node@18.7.21)(sass@1.52.2)
     dev: false
 
-  /vitest@0.20.3:
-    resolution: {integrity: sha512-cXMjTbZxBBUUuIF3PUzEGPLJWtIMeURBDXVxckSHpk7xss4JxkiiWh5cnIlfGyfJne2Ii3QpbiRuFL5dMJtljw==}
-    engines: {node: '>=v14.16.0'}
+  /vitest@0.31.0:
+    resolution: {integrity: sha512-JwWJS9p3GU9GxkG7eBSmr4Q4x4bvVBSswaCFf1PBNHiPx00obfhHRJfgHcnI0ffn+NMlIh9QGvG75FlaIBdKGA==}
+    engines: {node: '>=v14.18.0'}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@vitest/browser': '*'
       '@vitest/ui': '*'
-      c8: '*'
       happy-dom: '*'
       jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -17666,22 +17514,42 @@ packages:
         optional: true
       '@vitest/ui':
         optional: true
-      c8:
-        optional: true
       happy-dom:
         optional: true
       jsdom:
+        optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
         optional: true
     dependencies:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
       '@types/node': 18.16.3
+      '@vitest/expect': 0.31.0
+      '@vitest/runner': 0.31.0
+      '@vitest/snapshot': 0.31.0
+      '@vitest/spy': 0.31.0
+      '@vitest/utils': 0.31.0
+      acorn: 8.8.2
+      acorn-walk: 8.2.0
+      cac: 6.7.14
       chai: 4.3.7
+      concordance: 5.0.4
       debug: 4.3.4
       local-pkg: 0.4.3
-      tinypool: 0.2.4
-      tinyspy: 1.1.1
-      vite: 3.2.6(@types/node@18.16.3)
+      magic-string: 0.30.0
+      pathe: 1.1.0
+      picocolors: 1.0.0
+      std-env: 3.3.3
+      strip-literal: 1.0.1
+      tinybench: 2.5.0
+      tinypool: 0.5.0
+      vite: 4.3.1(@types/node@18.7.21)(sass@1.52.2)
+      vite-node: 0.31.0(@types/node@18.16.3)
+      why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
       - sass
@@ -17824,6 +17692,11 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /well-known-symbols@2.0.0:
+    resolution: {integrity: sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==}
+    engines: {node: '>=6'}
+    dev: false
+
   /whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
@@ -17914,6 +17787,15 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+
+  /why-is-node-running@2.2.2:
+    resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+    dev: false
 
   /wicked-good-xpath@1.3.0:
     resolution: {integrity: sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==}
@@ -18245,6 +18127,7 @@ packages:
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+    dev: true
 
   /yargs-unparser@2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
@@ -18295,10 +18178,16 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+    dev: true
 
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  /yocto-queue@1.0.0:
+    resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
+    engines: {node: '>=12.20'}
+    dev: false
 
   /youch@2.2.2:
     resolution: {integrity: sha512-/FaCeG3GkuJwaMR34GHVg0l8jCbafZLHiFowSjqLlqhC6OMyf2tPJBu8UirF7/NI9X/R5ai4QfEKUCOxMAGxZQ==}
@@ -18344,5 +18233,5 @@ packages:
     name: '@test/solid-jsx-component'
     version: 0.0.0
     dependencies:
-      solid-js: 1.5.6
+      solid-js: 1.7.4
     dev: false


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/6998 for now

- First commit updates non-major deps: `pnpm update --filter "@example/*"`
- Second commit update deps with breaking changes: manual with `pnpm outdated --filter "@example/*"`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
I made sure the templates with breaking change deps still works by manually running dev and building + previewing them.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. dep update.