### PR TITLE
Optimize JSX and MDX plugins

### DIFF
--- a/.changeset/young-queens-attend.md
+++ b/.changeset/young-queens-attend.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/mdx': minor
+'astro': patch
+---
+
+Optimize Astro JSX and MDX plugins

--- a/packages/astro/src/vite-plugin-jsx/index.ts
+++ b/packages/astro/src/vite-plugin-jsx/index.ts
@@ -190,8 +190,20 @@ export default function jsx({ settings, logging }: AstroPluginJSXOptions): Plugi
 			const { mode } = viteConfig;
 			// Shortcut: only use Astro renderer for MD and MDX files
 			if (id.endsWith('.mdx')) {
+				const { code: jsxCode } = await transformWithEsbuild(code, id, {
+					loader: getEsbuildLoader(id),
+					jsx: 'preserve',
+					sourcemap: 'inline',
+					tsconfigRaw: {
+						compilerOptions: {
+							// Ensure client:only imports are treeshaken
+							// TODO: investigate if this can be shaken manually instead of through esbuild
+							importsNotUsedAsValues: 'remove',
+						},
+					},
+				});
 				return transformJSX({
-					code,
+					code: jsxCode,
 					id,
 					renderer: astroJSXRenderer,
 					mode,

--- a/packages/astro/src/vite-plugin-jsx/tag.ts
+++ b/packages/astro/src/vite-plugin-jsx/tag.ts
@@ -9,13 +9,11 @@ import * as t from '@babel/types';
  * This plugin crawls each export in the file and "tags" each export with a given `rendererName`.
  * This allows us to automatically match a component to a renderer and skip the usual `check()` calls.
  */
-export default async function tagExportsWithRenderer({
+export default function tagExportsWithRenderer({
 	rendererName,
-	root,
 }: {
 	rendererName: string;
-	root: URL;
-}): Promise<PluginObj> {
+}): PluginObj {
 	return {
 		visitor: {
 			Program: {

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -94,12 +94,8 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 								},
 								// Override transform to alter code before MDX compilation
 								// ex. inject layouts
-								async transform(_, id) {
+								async transform(code, id) {
 									if (!id.endsWith('mdx')) return;
-
-									// Read code from file manually to prevent Vite from parsing `import.meta.env` expressions
-									const { fileId } = getFileInfo(id, config);
-									const code = await fs.readFile(fileId, 'utf-8');
 
 									const { data: frontmatter, content: pageContent } = parseFrontmatter(code, id);
 									const compiled = await mdxCompile(new VFile({ value: pageContent, path: id }), {


### PR DESCRIPTION
## Changes

Optimize how we handle JSX and MDX.

- Remove `@astrojs/mdx` manual fs read in favour of skipping content files in `vite-plugin-env` instead.
- Cache renderers' `jsxTransformOptions`
- Prevent Vite from double transforming JSX/TSX with esbuild

Added a todo to
- Remove esbuild transform for MDX files (I'm not sure how to do that yet but feels doable)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
