### PR TITLE
fix: declare namespace so client-base.d.ts stays an ambient definition

### DIFF
--- a/.changeset/giant-planes-try.md
+++ b/.changeset/giant-planes-try.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix types from `astro/client` not working properly due to `client-base.d.ts` being an non-ambient declaration file

--- a/packages/astro/client-base.d.ts
+++ b/packages/astro/client-base.d.ts
@@ -389,7 +389,7 @@ declare module '*?inline' {
 }
 
 // eslint-disable-next-line  @typescript-eslint/no-namespace
-export namespace App {
+declare namespace App {
 	// eslint-disable-next-line  @typescript-eslint/no-empty-interface
 	export interface Locals {}
 }

--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import { basename, join } from 'node:path/posix';
 import type { StaticBuildOptions } from '../core/build/types.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
+import { warn } from '../core/logger/core.js';
 import { prependForwardSlash } from '../core/path.js';
 import { isLocalService, type ImageService, type LocalImageService } from './services/service.js';
 import type { GetImageResult, ImageMetadata, ImageTransform } from './types.js';
@@ -103,9 +104,10 @@ export async function generateImage(
 	try {
 		await fs.promises.mkdir(assetsCacheDir, { recursive: true });
 	} catch (err) {
-		console.error(
-			'An error was encountered while creating the cache directory. Proceeding without caching. Error: ',
-			err
+		warn(
+			buildOpts.logging,
+			'astro:assets',
+			`An error was encountered while creating the cache directory. Proceeding without caching. Error: ${err}`
 		);
 		useCache = false;
 	}
@@ -160,9 +162,10 @@ export async function generateImage(
 			await fs.promises.writeFile(cachedFileURL, resultData.data);
 			await fs.promises.copyFile(cachedFileURL, finalFileURL);
 		} catch (e) {
-			console.error(
-				`There was an error creating the cache entry for ${filepath}. Attempting to write directly to output directory. Error: `,
-				e
+			warn(
+				buildOpts.logging,
+				'astro:assets',
+				`An error was encountered while creating the cache directory. Proceeding without caching. Error: ${e}`
 			);
 			await fs.promises.writeFile(finalFileURL, resultData.data);
 		}


### PR DESCRIPTION
## Changes

In declaration files, you can't export a namespace, you need to declare it. Otherwise the file isn't considered an ambient declaration anymore and you can't refer to it with a triple slash

Fix https://github.com/withastro/astro/issues/7003

## Testing

Tested manually

## Docs

N/A
