### PR TITLE
fix middleware typing export

### DIFF
--- a/.changeset/new-seals-hear.md
+++ b/.changeset/new-seals-hear.md
@@ -1,5 +1,5 @@
 ---
-'astro': minor
+'astro': patch
 ---
 
 fix middleware typing export for "moduleResolution: node"

--- a/.changeset/new-seals-hear.md
+++ b/.changeset/new-seals-hear.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+fix middleware typing export for "moduleResolution: node"

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -20,6 +20,9 @@
       ],
       "app/*": [
         "./dist/core/app/*"
+      ],
+      "middleware": [
+        "./dist/core/middleware/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
> Closes #7017

## Changes

This PR fixes the middleware's typing export. Read about the problem on #7017.

https://user-images.githubusercontent.com/12464600/236786864-744c4f50-1390-4950-81bc-b8a03828573e.mp4

## Testing

With the fix applied:

1. Open the `examples/middleware`;
2. check the `astro/middleware` import (the type should be there)

## Docs

No docs change is required since this is a functional change.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
