### PR TITLE
Fix `astro:assets` SSR error

### DIFF
--- a/.changeset/green-chefs-build.md
+++ b/.changeset/green-chefs-build.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `astro:assets` SSR error

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -58,6 +58,8 @@ const ONLY_DEV_EXTERNAL = [
 	'shiki',
 	// Imported by `@astrojs/prism` which exposes `<Prism/>` that is processed by Vite
 	'prismjs/components/index.js',
+	// Imported by `astro/assets` -> `packages/astro/src/core/logger/core.ts`
+	'string-width',
 ];
 
 /** Return a common starting point for all Vite actions */


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/7022

`astro:assets` -> `astro/assets` -> `packages/astro/src/core/logger/core.ts` -> `string-width` -> `eastasianwidth` was loaded by Vite's SSR runtime, which only supports ESM. This PR harcodes `string-width` to externalized by Vite in order to not process it as ESM, and instead let node import it.

Ideally this should be fixed by Vite to handle this properly: https://github.com/vitejs/vite/pull/9763

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing test should pass (failing in main CI)

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.