### PR TITLE
[Markdoc] Validation and debugging improvements

### DIFF
--- a/packages/integrations/markdoc/README.md
+++ b/packages/integrations/markdoc/README.md
@@ -143,28 +143,26 @@ Use tags like this fancy "aside" to add some *flair* to your docs.
 
 #### Render Markdoc nodes / HTML elements as Astro components
 
-You may also want to map standard HTML elements like headings and paragraphs to components. For this, you can configure a custom [Markdoc node][markdoc-nodes]. This example overrides Markdoc's `heading` node to render a `Heading` component, passing the built-in `level` attribute as a prop:
+You may also want to map standard HTML elements like headings and paragraphs to components. For this, you can configure a custom [Markdoc node][markdoc-nodes]. This example overrides Markdoc's `heading` node to render a `Heading` component, and passes through Markdoc's default attributes for headings via the `Markdoc` object. This is exposed by the `@astrojs/markdoc/config` module and contains all properties from [the `@markdoc/markdoc` package](https://github.com/markdoc/markdoc).
 
 ```js
 // markdoc.config.mjs
-import { defineMarkdocConfig } from '@astrojs/markdoc/config';
+import { defineMarkdocConfig, Markdoc } from '@astrojs/markdoc/config';
 import Heading from './src/components/Heading.astro';
 
 export default defineMarkdocConfig({
   nodes: {
     heading: {
       render: Heading,
-      attributes: {
-        // Pass the attributes from Markdoc's default heading node
-        // as component props.
-        level: { type: String },
-      }
+      attributes: Markdoc.nodes.heading.attributes,
     },
   },
 })
 ```
 
-Now, all Markdown headings will render with the `Heading.astro` component. This example uses a level 3 heading, automatically passing `level: 3` as the component prop:
+Now, all Markdown headings will render with the `Heading.astro` component, and pass these `attributes` as component props. For headings, Markdoc provides a `level` attribute containing the numeric heading level.
+
+This example uses a level 3 heading, automatically passing `level: 3` as the component prop:
 
 ```md
 ### I'm a level 3 heading!

--- a/packages/integrations/markdoc/src/config.ts
+++ b/packages/integrations/markdoc/src/config.ts
@@ -1,4 +1,5 @@
 import type { ConfigType as MarkdocConfig } from '@markdoc/markdoc';
+export { default as Markdoc } from '@markdoc/markdoc';
 
 export function defineMarkdocConfig(config: MarkdocConfig): MarkdocConfig {
 	return config;

--- a/packages/integrations/markdoc/src/load-config.ts
+++ b/packages/integrations/markdoc/src/load-config.ts
@@ -11,7 +11,14 @@ const SUPPORTED_MARKDOC_CONFIG_FILES = [
 	'markdoc.config.ts',
 ];
 
-export async function loadMarkdocConfig(astroConfig: Pick<AstroConfig, 'root'>) {
+export type MarkdocConfigResult = {
+	config: MarkdocConfig;
+	fileUrl: URL;
+};
+
+export async function loadMarkdocConfig(
+	astroConfig: Pick<AstroConfig, 'root'>
+): Promise<MarkdocConfigResult | undefined> {
 	let markdocConfigUrl: URL | undefined;
 	for (const filename of SUPPORTED_MARKDOC_CONFIG_FILES) {
 		const filePath = new URL(filename, astroConfig.root);


### PR DESCRIPTION
## Changes

- Resolves #6865 
- Improve Markdoc validation error messages:
  - Log full Markdoc error instead of _just_ an error id.
  - Pass file path for a file preview.
  - Pass the first error line number for better debugging.
- Expose `Markdoc` global from `@astrojs/markdoc/config`. This makes spreading existing nodes simpler.
- Log warning to restart dev server on config changes.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Update `nodes` reference to recommend the `Markdoc` global and better explain component props.
