### PR TITLE
fix(image): Fix astro:assets from interfering with SSR query params ending with image extensions

### DIFF
--- a/.changeset/young-schools-refuse.md
+++ b/.changeset/young-schools-refuse.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix astro:assets interfering with SSR query params ending with image extensions

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -8,7 +8,12 @@ import type * as vite from 'vite';
 import { normalizePath } from 'vite';
 import type { AstroPluginOptions, ImageTransform } from '../@types/astro';
 import { error } from '../core/logger/core.js';
-import { appendForwardSlash, joinPaths, prependForwardSlash } from '../core/path.js';
+import {
+	appendForwardSlash,
+	joinPaths,
+	prependForwardSlash,
+	removeQueryString,
+} from '../core/path.js';
 import { VIRTUAL_MODULE_ID, VIRTUAL_SERVICE_ID } from './consts.js';
 import { isESMImportedImage } from './internal.js';
 import { isLocalService } from './services/service.js';
@@ -228,7 +233,8 @@ export default function assets({
 				resolvedConfig = viteConfig;
 			},
 			async load(id) {
-				if (/\.(jpeg|jpg|png|tiff|webp|gif|svg)$/.test(id)) {
+				const cleanedUrl = removeQueryString(id);
+				if (/\.(jpeg|jpg|png|tiff|webp|gif|svg)$/.test(cleanedUrl)) {
 					const meta = await emitESMImage(id, this.meta.watchMode, this.emitFile, settings);
 					return `export default ${JSON.stringify(meta)}`;
 				}

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -627,7 +627,7 @@ describe('astro:image', () => {
 			await devServer.stop();
 		});
 
-		it('does not interfere with query params ssssss', async () => {
+		it('does not interfere with query params', async () => {
 			let res = await fixture.fetch('/api?src=image.png');
 			const html = await res.text();
 			expect(html).to.equal('An image: "image.png"');

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -609,6 +609,31 @@ describe('astro:image', () => {
 		});
 	});
 
+	describe('dev ssr', () => {
+		let devServer;
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/core-image-ssr/',
+				output: 'server',
+				adapter: testAdapter(),
+				experimental: {
+					assets: true,
+				},
+			});
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('does not interfere with query params ssssss', async () => {
+			let res = await fixture.fetch('/api?src=image.png');
+			const html = await res.text();
+			expect(html).to.equal('An image: "image.png"');
+		});
+	});
+
 	describe('prod ssr', () => {
 		before(async () => {
 			fixture = await loadFixture({

--- a/packages/astro/test/fixtures/core-image-ssr/src/pages/api.ts
+++ b/packages/astro/test/fixtures/core-image-ssr/src/pages/api.ts
@@ -1,0 +1,11 @@
+import { APIRoute } from "../../../../../src/@types/astro";
+
+export const get = (async ({ params, request }) => {
+	const url = new URL(request.url);
+	console.log(url)
+  const src = url.searchParams.get("src");
+
+	return {
+		body: "An image: " + JSON.stringify(src),
+	};
+}) satisfies APIRoute;


### PR DESCRIPTION
## Changes

Remove the query params before trying to match the request, that way we avoid taking over requests with query params ending in `.png`, ha! I'm unfortunately unsure if there's a better solution at this time for this, as it doesn't necessarily seems to be the most reliable way of only taking over imports we care about, but it works!

Fix https://github.com/withastro/astro/issues/6569

## Testing

Added a test

## Docs

N/A