### PR TITLE
`@astrojs/image`: Add `fetchpriority` to `Picture` types

### DIFF
--- a/.changeset/purple-zebras-allow.md
+++ b/.changeset/purple-zebras-allow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Add `fetchpriority` to allowed `Picture` attributes in `@astrojs/image`

--- a/packages/integrations/image/components/index.ts
+++ b/packages/integrations/image/components/index.ts
@@ -27,7 +27,7 @@ export interface ImageComponentRemoteImageProps extends TransformOptions, ImgHTM
 export interface PictureComponentLocalImageProps
 	extends GlobalHTMLAttributes,
 		Omit<TransformOptions, 'src'>,
-		Pick<ImgHTMLAttributes, 'loading' | 'decoding'> {
+		Pick<ImgHTMLAttributes, 'loading' | 'decoding' | 'fetchpriority'> {
 	src: ImageMetadata | Promise<{ default: ImageMetadata }>;
 	/** Defines an alternative text description of the image. Set to an empty string (alt="") if the image is not a key part of the content (it's decoration or a tracking pixel). */
 	alt: string;
@@ -39,7 +39,7 @@ export interface PictureComponentLocalImageProps
 export interface PictureComponentRemoteImageProps
 	extends GlobalHTMLAttributes,
 		TransformOptions,
-		Pick<ImgHTMLAttributes, 'loading' | 'decoding'> {
+		Pick<ImgHTMLAttributes, 'loading' | 'decoding' | 'fetchpriority'> {
 	src: string;
 	/** Defines an alternative text description of the image. Set to an empty string (alt="") if the image is not a key part of the content (it's decoration or a tracking pixel). */
 	alt: string;


### PR DESCRIPTION
## Changes

- Adds `fetchpriority` to allowed `Picture` attributes

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
