### PR TITLE
RSS: Fix string validation of pubDate

### DIFF
--- a/.changeset/eleven-hotels-roll.md
+++ b/.changeset/eleven-hotels-roll.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': patch
+---
+
+Fix pubDate schema tranformation

--- a/packages/astro-rss/src/schema.ts
+++ b/packages/astro-rss/src/schema.ts
@@ -2,7 +2,7 @@ import { z } from 'astro/zod';
 
 export const rssSchema = z.object({
 	title: z.string(),
-	pubDate: z.union([z.string(), z.number(), z.date()]).transform((value) => new Date(value)),
+	pubDate: z.union([z.string(), z.number(), z.date()]).transform((value) => new Date(value)).refine((value) => !isNaN(value.getTime())),
 	description: z.string().optional(),
 	customData: z.string().optional(),
 	draft: z.boolean().optional(),

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -1,4 +1,5 @@
 import rss from '../dist/index.js';
+import { rssSchema } from '../dist/schema.js';
 import chai from 'chai';
 import chaiPromises from 'chai-as-promised';
 import chaiXml from 'chai-xml';
@@ -195,4 +196,16 @@ describe('rss', () => {
 
 		chai.expect(body).xml.to.equal(validXmlResult);
 	});
+
+  it('should fail when an invalid date string is provided', async () => {
+    const res = rssSchema.safeParse({
+      title: phpFeedItem.title,
+      pubDate: 'invalid date',
+      description: phpFeedItem.description,
+      link: phpFeedItem.link,
+    })
+
+    chai.expect(res.success).to.be.false;
+    chai.expect(res.error.issues[0].path[0]).to.equal('pubDate');
+  });
 });


### PR DESCRIPTION
## Changes

Fix a bug with `pubDate` validation caused by transforming invalid formatted strings.

## Testing

Manually tested & I've added a test case to check it correctly catches invalid date strings.

## Docs

N/A