### PR TITLE
Parallelize rendering of sibling components to avoid async waterfalls

### DIFF
--- a/.changeset/clever-garlics-relate.md
+++ b/.changeset/clever-garlics-relate.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Render sibling components in parallel

--- a/packages/astro/src/runtime/server/render/astro/render-template.ts
+++ b/packages/astro/src/runtime/server/render/astro/render-template.ts
@@ -3,6 +3,7 @@ import type { RenderInstruction } from '../types';
 import { HTMLBytes, markHTMLString } from '../../escape.js';
 import { isPromise } from '../../util.js';
 import { renderChild } from '../any.js';
+import { EagerAsyncIterableIterator } from '../util.js';
 
 const renderTemplateResultSym = Symbol.for('astro.renderTemplateResult');
 
@@ -35,12 +36,16 @@ export class RenderTemplateResult {
 	async *[Symbol.asyncIterator]() {
 		const { htmlParts, expressions } = this;
 
+		let iterables: Array<AsyncIterable<any>> = [];
+		for (let i = 0; i < htmlParts.length; i++) {
+			iterables.push(new EagerAsyncIterableIterator(renderChild(expressions[i])));
+		}
 		for (let i = 0; i < htmlParts.length; i++) {
 			const html = htmlParts[i];
-			const expression = expressions[i];
+			const iterable = iterables[i];
 
 			yield markHTMLString(html);
-			yield* renderChild(expression);
+			yield* iterable;
 		}
 	}
 }

--- a/packages/astro/src/runtime/server/render/astro/render-template.ts
+++ b/packages/astro/src/runtime/server/render/astro/render-template.ts
@@ -41,8 +41,10 @@ export class RenderTemplateResult {
 		for (let i = 0; i < htmlParts.length; i++) {
 			iterables.push(new EagerAsyncIterableIterator(renderChild(expressions[i])));
 		}
-		// once the execution is interrupted, we start buffering the other iterators
+		// once the execution of the next for loop is suspended due to an async component,
+		// this timeout triggers and we start buffering the other iterators
 		setTimeout(() => {
+			// buffer all iterators that haven't started yet
 			iterables.forEach((it) => !it.isStarted() && it.buffer());
 		}, 0);
 		for (let i = 0; i < htmlParts.length; i++) {

--- a/packages/astro/src/runtime/server/render/astro/render-template.ts
+++ b/packages/astro/src/runtime/server/render/astro/render-template.ts
@@ -36,10 +36,15 @@ export class RenderTemplateResult {
 	async *[Symbol.asyncIterator]() {
 		const { htmlParts, expressions } = this;
 
-		let iterables: Array<AsyncIterable<any>> = [];
+		let iterables: Array<EagerAsyncIterableIterator> = [];
+		// all async iterators start running in non-buffered mode to avoid useless caching
 		for (let i = 0; i < htmlParts.length; i++) {
 			iterables.push(new EagerAsyncIterableIterator(renderChild(expressions[i])));
 		}
+		// once the execution is interrupted, we start buffering the other iterators
+		setTimeout(() => {
+			iterables.forEach((it) => !it.isStarted() && it.buffer());
+		}, 0);
 		for (let i = 0; i < htmlParts.length; i++) {
 			const html = htmlParts[i];
 			const iterable = iterables[i];

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -157,6 +157,10 @@ export async function renderPage(
 										}
 									}
 								}
+
+								// `chunk` might be a Response that contains a redirect,
+								// that was rendered eagerly and therefore bypassed the early check
+								// whether headers can still be modified. In that case, throw an error
 								if (chunk instanceof Response) {
 									throw new AstroError({
 										...AstroErrorData.ResponseSentError,

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -157,6 +157,11 @@ export async function renderPage(
 										}
 									}
 								}
+								if (chunk instanceof Response) {
+									throw new AstroError({
+										...AstroErrorData.ResponseSentError,
+									});
+								}
 
 								const bytes = chunkToByteArray(result, chunk);
 								controller.enqueue(bytes);

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -158,10 +158,12 @@ export class EagerAsyncIterableIterator {
 
 	/**
 	 * Starts to eagerly fetch the inner iterator and cache the results.
-	 * Note: This might not be called, once next() has been called once, e.g. the iterator is started
+	 * Note: This might not be called after next() has been called once, e.g. the iterator is started
 	 */
 	async buffer() {
 		if (this.#gen) {
+			// If this called as part of rendering, please open a bug report.
+			// Any call to buffer() should verify that the iterator isn't running
 			throw new Error('Cannot not switch from non-buffer to buffer mode');
 		}
 		this.#isBuffering = true;
@@ -195,6 +197,8 @@ export class EagerAsyncIterableIterator {
 			return this.#queue.shift()!;
 		}
 		await this.#next;
+		// the previous statement will either put an element in the queue or throw,
+		// so we can safely assume we have something now
 		return this.#queue.shift()!;
 	}
 

--- a/packages/astro/test/fixtures/parallel/package.json
+++ b/packages/astro/test/fixtures/parallel/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@test/parallel-components",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "astro build",
+    "dev": "astro dev"
+  },
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/parallel/src/components/Delayed.astro
+++ b/packages/astro/test/fixtures/parallel/src/components/Delayed.astro
@@ -1,0 +1,11 @@
+---
+const { ms } = Astro.props
+const start = new Date().valueOf();
+await new Promise(res => setTimeout(res, ms));
+const finished = new Date().valueOf();
+---
+<section>
+	<h1>{ms}ms Delayed</h1>
+	<span class="start">{ start }</span>
+	<span class="finished">{ finished }</span>
+</section>

--- a/packages/astro/test/fixtures/parallel/src/pages/index.astro
+++ b/packages/astro/test/fixtures/parallel/src/pages/index.astro
@@ -1,0 +1,8 @@
+---
+import Delayed from '../components/Delayed.astro'
+---
+
+<Delayed ms={30} />
+<Delayed ms={20} />
+<Delayed ms={40} />
+<Delayed ms={10} />

--- a/packages/astro/test/fixtures/streaming/src/pages/slot.astro
+++ b/packages/astro/test/fixtures/streaming/src/pages/slot.astro
@@ -15,7 +15,7 @@ import Wait from '../components/Wait.astro';
 				<p>Section content</p>
 			</Wait>
 			<h2>Next section</h2>
-			<Wait ms={50}>
+			<Wait ms={60}>
 				<p>Section content</p>
 			</Wait>
 			<p>Paragraph 3</p>

--- a/packages/astro/test/parallel.js
+++ b/packages/astro/test/parallel.js
@@ -19,6 +19,6 @@ describe('Component parallelization', () => {
 		let firstStart = Number($('.start').first().text());
 		let lastStart = Number($('.start').last().text());
 		let timeTook = lastStart - firstStart;
-		expect(timeTook).to.be.lessThan(50, 'the components in the list were kicked off more-or-less at the same time.');
+		expect(timeTook).to.be.lessThan(50, "The components didn't render in parallel");
 	});
 });

--- a/packages/astro/test/parallel.js
+++ b/packages/astro/test/parallel.js
@@ -16,9 +16,21 @@ describe('Component parallelization', () => {
 		let html = await fixture.readFile('/index.html');
 		let $ = cheerio.load(html);
 
-		let firstStart = Number($('.start').first().text());
-		let lastStart = Number($('.start').last().text());
-		let timeTook = lastStart - firstStart;
-		expect(timeTook).to.be.lessThan(50, "The components didn't render in parallel");
+		const startTimes = Array.from($('.start')).map((element) => Number(element.children[0].data));
+		const finishTimes = Array.from($('.finished')).map((element) =>
+			Number(element.children[0].data)
+		);
+
+		let renderStartWithin = Math.max(...startTimes) - Math.min(...startTimes);
+		expect(renderStartWithin).to.be.lessThan(
+			10, // in theory, this should be 0, so 10ms tolerance
+			"The components didn't start rendering in parallel"
+		);
+
+		const totalRenderTime = Math.max(...finishTimes) - Math.min(...startTimes);
+		expect(totalRenderTime).to.be.lessThan(
+			60, // max component delay is 40ms
+			'The total render time was significantly longer than the max component delay'
+		);
 	});
 });

--- a/packages/astro/test/parallel.js
+++ b/packages/astro/test/parallel.js
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Component parallelization', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/parallel/',
+		});
+		await fixture.build();
+	});
+
+	it('renders fast', async () => {
+		let html = await fixture.readFile('/index.html');
+		let $ = cheerio.load(html);
+
+		let firstStart = Number($('.start').first().text());
+		let lastStart = Number($('.start').last().text());
+		let timeTook = lastStart - firstStart;
+		expect(timeTook).to.be.lessThan(50, 'the components in the list were kicked off more-or-less at the same time.');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2832,6 +2832,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/parallel:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/postcss:
     dependencies:
       '@astrojs/solid-js':


### PR DESCRIPTION
## Changes

This changes the rendering behavior of Astro components to render child components in parallel.
In cases where multiple components in different subtrees fetch data, this data fetching can be done in parallel and will improve loading times in those scenarios.

## Testing

A test is added to confirm the parallel execution of the artificial delays. Also, an existing test (number of stream chunks) had to be changed, because the parallel execution lead to 2 chunks instead of the expected 3.

## Docs

Docs & changeset will be added as this is just a draft