### PR TITLE
Bugfix #7070 Middleware not working with endpoints

### DIFF
--- a/.changeset/short-lies-heal.md
+++ b/.changeset/short-lies-heal.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+#7070 - middleware defering endpoint rendering until next() is called

--- a/examples/middleware/src/env.d.ts
+++ b/examples/middleware/src/env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="astro/client" />
 declare namespace App {
 	interface Locals {
+    foo?: string;
 		user: {
 			name: string;
 			surname: string;

--- a/examples/middleware/src/middleware.ts
+++ b/examples/middleware/src/middleware.ts
@@ -8,6 +8,11 @@ const loginInfo = {
 	currentTime: undefined,
 };
 
+export const first = defineMiddleware(async (context, next) => {
+  context.locals.foo = 'bar';
+	return await next();
+});
+
 export const minifier = defineMiddleware(async (context, next) => {
 	const response = await next();
 	// check if the response is returning some HTML
@@ -53,17 +58,17 @@ const validation = defineMiddleware(async (context, next) => {
 	} else if (context.request.url.endsWith('/api/login')) {
 		const response = await next();
 		// the login endpoint will return to us a JSON with username and password
-		const data = await response.json();
-		// we naively check if username and password are equals to some string
-		if (data.username === 'astro' && data.password === 'astro') {
-			// we store the token somewhere outside of locals because the `locals` object is attached to the request
-			// and when doing a redirect, we lose that information
-			loginInfo.token = 'loggedIn';
-			loginInfo.currentTime = new Date().getTime();
-			return context.redirect('/admin');
-		}
+    const data = await response.json();
+    // we naively check if username and password are equals to some string
+    if (data.username === 'astro' && data.password === 'astro') {
+      // we store the token somewhere outside of locals because the `locals` object is attached to the request
+      // and when doing a redirect, we lose that information
+      loginInfo.token = 'loggedIn';
+      loginInfo.currentTime = new Date().getTime();
+      return context.redirect('/admin');
+    }
 	}
 	return next();
 });
 
-export const onRequest = sequence(validation, minifier);
+export const onRequest = sequence(first, validation, minifier);

--- a/examples/middleware/src/pages/hello-endpointoutput-json.json.js
+++ b/examples/middleware/src/pages/hello-endpointoutput-json.json.js
@@ -1,0 +1,6 @@
+
+export function get(context) {
+  return {
+    body: `{ "hello": "world: ${context.locals?.name ?? 'null'}" }`
+  };
+}

--- a/examples/middleware/src/pages/hello-endpointoutput.js
+++ b/examples/middleware/src/pages/hello-endpointoutput.js
@@ -1,0 +1,6 @@
+
+export function get(context) {
+  return {
+    body: `hello world: ${context.locals?.foo ?? "null"}`
+  };
+}

--- a/examples/middleware/src/pages/hello-response.js
+++ b/examples/middleware/src/pages/hello-response.js
@@ -1,0 +1,4 @@
+
+export function get(context) {
+  return new Response(`hello world: ${context.locals?.foo ?? "null"}`, { status: 200 });
+}

--- a/packages/astro/src/core/middleware/callMiddleware.ts
+++ b/packages/astro/src/core/middleware/callMiddleware.ts
@@ -36,65 +36,65 @@ import { AstroError, AstroErrorData } from '../errors/index.js';
  * @param responseFunction A callback function that should return a promise with the response
  */
 export async function callMiddleware<R>(
-  onRequest: MiddlewareHandler<R>,
-  apiContext: APIContext,
-  responseFunction: () => Promise<R>
+	onRequest: MiddlewareHandler<R>,
+	apiContext: APIContext,
+	responseFunction: () => Promise<R>
 ): Promise<Response | R> {
-  let resolveResolve: any;
-  new Promise((resolve) => {
-    resolveResolve = resolve;
-  });
+	let resolveResolve: any;
+	new Promise((resolve) => {
+		resolveResolve = resolve;
+	});
 
-  let nextCalled = false;
-  let responseFunctionPromise: Promise<R> | undefined = undefined;
-  const next: MiddlewareNext<R> = async () => {
-    nextCalled = true;
-    responseFunctionPromise = responseFunction();
-    return responseFunctionPromise;
-  };
+	let nextCalled = false;
+	let responseFunctionPromise: Promise<R> | undefined = undefined;
+	const next: MiddlewareNext<R> = async () => {
+		nextCalled = true;
+		responseFunctionPromise = responseFunction();
+		return responseFunctionPromise;
+	};
 
-  let middlewarePromise = onRequest(apiContext, next);
+	let middlewarePromise = onRequest(apiContext, next);
 
-  return await Promise.resolve(middlewarePromise).then(async (value) => {
-    // first we check if `next` was called
-    if (nextCalled) {
-      /**
-       * Then we check if a value is returned. If so, we need to return the value returned by the
-       * middleware.
-       * e.g.
-       * ```js
-       * 	const response = await next();
-       * 	const new Response(null, { status: 500, headers: response.headers });
-       * ```
-       */
-      if (typeof value !== 'undefined') {
-        if (value instanceof Response === false) {
-          throw new AstroError(AstroErrorData.MiddlewareNotAResponse);
-        }
-        return value as R;
-      } else {
-        /**
-         * Here we handle the case where `next` was called and returned nothing.
-         */
-        if (responseFunctionPromise) {
-          return responseFunctionPromise;
-        } else {
-          throw new AstroError(AstroErrorData.MiddlewareNotAResponse);
-        }
-      }
-    } else if (typeof value === 'undefined') {
-      /**
-       * There might be cases where `next` isn't called and the middleware **must** return
-       * something.
-       *
-       * If not thing is returned, then we raise an Astro error.
-       */
-      throw new AstroError(AstroErrorData.MiddlewareNoDataOrNextCalled);
-    } else if (value instanceof Response === false) {
-      throw new AstroError(AstroErrorData.MiddlewareNotAResponse);
-    } else {
-      // Middleware did not call resolve and returned a value
-      return value as R;
-    }
-  });
+	return await Promise.resolve(middlewarePromise).then(async (value) => {
+		// first we check if `next` was called
+		if (nextCalled) {
+			/**
+			 * Then we check if a value is returned. If so, we need to return the value returned by the
+			 * middleware.
+			 * e.g.
+			 * ```js
+			 * 	const response = await next();
+			 * 	const new Response(null, { status: 500, headers: response.headers });
+			 * ```
+			 */
+			if (typeof value !== 'undefined') {
+				if (value instanceof Response === false) {
+					throw new AstroError(AstroErrorData.MiddlewareNotAResponse);
+				}
+				return value as R;
+			} else {
+				/**
+				 * Here we handle the case where `next` was called and returned nothing.
+				 */
+				if (responseFunctionPromise) {
+					return responseFunctionPromise;
+				} else {
+					throw new AstroError(AstroErrorData.MiddlewareNotAResponse);
+				}
+			}
+		} else if (typeof value === 'undefined') {
+			/**
+			 * There might be cases where `next` isn't called and the middleware **must** return
+			 * something.
+			 *
+			 * If not thing is returned, then we raise an Astro error.
+			 */
+			throw new AstroError(AstroErrorData.MiddlewareNoDataOrNextCalled);
+		} else if (value instanceof Response === false) {
+			throw new AstroError(AstroErrorData.MiddlewareNotAResponse);
+		} else {
+			// Middleware did not call resolve and returned a value
+			return value as R;
+		}
+	});
 }

--- a/packages/astro/test/fixtures/middleware-dev/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware-dev/src/middleware.js
@@ -1,5 +1,14 @@
 import { sequence, defineMiddleware } from 'astro/middleware';
 
+const interceptEndpoint = defineMiddleware(async (context, next) => {
+	if (context.request.url.includes('/hello-never')) {
+    return new Response('intercepted', {
+			status: 200,
+		});
+	}
+	return await next();
+});
+
 const first = defineMiddleware(async (context, next) => {
 	if (context.request.url.includes('/lorem')) {
 		context.locals.name = 'ipsum';
@@ -37,4 +46,4 @@ const third = defineMiddleware(async (context, next) => {
 	return next();
 });
 
-export const onRequest = sequence(first, second, third);
+export const onRequest = sequence(interceptEndpoint, first, second, third);

--- a/packages/astro/test/fixtures/middleware-dev/src/pages/hello-endpointoutput-json.json.js
+++ b/packages/astro/test/fixtures/middleware-dev/src/pages/hello-endpointoutput-json.json.js
@@ -1,0 +1,6 @@
+
+export function get(context) {
+  return {
+    body: `{ "hello": "world: ${context.locals?.name ?? 'null'}" }`
+  };
+}

--- a/packages/astro/test/fixtures/middleware-dev/src/pages/hello-endpointoutput-text.js
+++ b/packages/astro/test/fixtures/middleware-dev/src/pages/hello-endpointoutput-text.js
@@ -1,0 +1,6 @@
+
+export function get(context) {
+  return {
+    body: `hello world: ${context.locals?.name ?? "null"}`
+  };
+}

--- a/packages/astro/test/fixtures/middleware-dev/src/pages/hello-never.js
+++ b/packages/astro/test/fixtures/middleware-dev/src/pages/hello-never.js
@@ -1,0 +1,5 @@
+
+export function get(context) {
+  console.error("** this should never run **");
+  throw new Error("this should never run, middleware should return before this function get a chance to execute");
+}

--- a/packages/astro/test/fixtures/middleware-dev/src/pages/hello-response.js
+++ b/packages/astro/test/fixtures/middleware-dev/src/pages/hello-response.js
@@ -1,0 +1,4 @@
+
+export function get(context) {
+  return new Response(`hello world: ${context.locals?.name ?? "null"}`, { status: 200 });
+}

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -117,6 +117,46 @@ describe('Middleware API in PROD mode, SSR', () => {
 		await fixture.build();
 	});
 
+	it('middleware should intercept and never run api endpoint', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		const request = new Request('http://example.com/hello-never');
+		const response = await app.render(request);
+		const text = await response.text();
+    expect(response.status).to.equal(200);
+    expect(text).to.equal("intercepted");
+	});
+
+	it('middleware should get api endpoint result (Response)', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		const request = new Request('http://example.com/hello-response');
+		const response = await app.render(request);
+		const text = await response.text();
+    expect(response.status).to.equal(200);
+    expect(text).to.equal("hello world: bar");
+	});
+
+	it('middleware should get api endpoint result (EndpointOutput default encoding)', async () => {
+    // endpoint returns a 'simple' result with a derived encoding of text/plain from the default encoding behavior
+		const app = await fixture.loadTestAdapterApp();
+		const request = new Request('http://example.com/hello-endpointoutput-text');
+		const response = await app.render(request);
+		const text = await response.text();
+    expect(response.status).to.equal(200);
+    expect(response.headers.get("content-type")).to.equal("text/plain;charset=utf-8");
+    expect(text).to.equal("hello world: bar");
+	});
+
+	it('middleware should get api endpoint result (EndpointOutput derived encoding)', async () => {
+    // endpoint returns a 'simple' result with a derived encoding of application/json based on the path extension
+		const app = await fixture.loadTestAdapterApp();
+		const request = new Request('http://example.com/hello-endpointoutput-json.json');
+		const response = await app.render(request);
+		const text = await response.text();
+    expect(response.status).to.equal(200);
+    expect(response.headers.get("content-type")).to.equal("application/json;charset=utf-8");
+    expect(text).to.equal('{ "hello": "world: bar" }');
+	});
+
 	it('should render locals data', async () => {
 		const app = await fixture.loadTestAdapterApp();
 		const request = new Request('http://example.com/');


### PR DESCRIPTION
## Changes

* when middleware is used with endpoints, defer execution of `renderEndpoint` until the middleware invokes `next()` (making it properly chainable, like it is for pages)
* standalone type definitions for endpoint return types so that the types can be reused for a few purposes
* abstract conversion of endpoint "simple" return type into a Response into a reusable function
* modify endpoint middleware `next()` implementation, which invokes `renderEndpoint`, to convert any simple result into a Response and log a warning. This is necessary because middleware handlers are typed to only support receiving a `Response` instance from the result of `next()`.
* add unit test coverage
* expand the @examples/middleware to show usage with endpoint scenarios

I looked into changing middleware handlers to all needing to handle `Response | EndpointOutput`, but that was a deep rabbit hole that would have potentially breaking changes for any existing middleware handler code out in the wild.

So, instead, to make middleware "just work" for all use cases, in a sane way people would expect (which is that middleware should *ALWAYS* run, so you can trust it for things like auth/session checks, etc), I added an automatic conversion from any endpoint "simple" result into a `Response` immediately after it's resolved via `next()` using the same process that `App.callEndpoint` used, abstracting that functionality into a common utility function.

## Testing

Unit tests were added which cover:

* middleware + endpoint with `Response` result
* middleware + endpoint where middleware intercepts and returns a `Response` directly, never invoking `next()` (thus the API endpoint is never executed)
* middleware + endpoint with "simple" result using `text/plain;charset=utf-8` encoding
* middleware + endpoint with "simple" result using `application/json;charset=utf-8` encoding derived from path extension

## Docs

/cc @withastro/maintainers-docs for feedback!
