### PR TITLE
Fix `create-astro` regression

### DIFF
--- a/.changeset/nice-shrimps-search.md
+++ b/.changeset/nice-shrimps-search.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fix create astro regression

--- a/packages/create-astro/src/actions/dependencies.ts
+++ b/packages/create-astro/src/actions/dependencies.ts
@@ -26,15 +26,6 @@ export async function dependencies(
 			start: `Dependencies installing with ${ctx.pkgManager}...`,
 			end: 'Dependencies installed',
 			while: () => {
-				return Promise.reject('Unknown error').catch((e) => {
-					error('error', e);
-					error(
-						'error',
-						`Dependencies failed to install, please run ${color.bold(
-							ctx.pkgManager + ' install'
-						)} to install them manually after setup.`
-					);
-				});
 				return install({ pkgManager: ctx.pkgManager, cwd: ctx.cwd }).catch((e) => {
 					error('error', e);
 					error(


### PR DESCRIPTION
## Changes

Fix a regression on `create-astro` where the dependency installation step always fails

## Testing

Tested manually

## Docs

N/A, bug fix