### PR TITLE
Fix double prepended forward slash in certain cases

### DIFF
--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -14,7 +14,7 @@ import { call as callEndpoint, createAPIContext } from '../endpoint/index.js';
 import { consoleLogDestination } from '../logger/console.js';
 import { error, type LogOptions } from '../logger/core.js';
 import { callMiddleware } from '../middleware/callMiddleware.js';
-import { removeTrailingForwardSlash } from '../path.js';
+import { prependForwardSlash, removeTrailingForwardSlash } from '../path.js';
 import {
 	createEnvironment,
 	createRenderContext,
@@ -101,7 +101,7 @@ export class App {
 		if (this.#manifest.assets.has(url.pathname)) {
 			return undefined;
 		}
-		let pathname = '/' + this.removeBase(url.pathname);
+		let pathname = prependForwardSlash(this.removeBase(url.pathname));
 		let routeData = matchRoute(pathname, this.#manifestData);
 
 		if (routeData) {


### PR DESCRIPTION
## Changes

Fix a regression where pathname of pages would be prepended with two forward slashes.
I assume this PR https://github.com/withastro/astro/pull/7076 broke some assumptions that we had on the pathname (that it would never have a leading forward slash?).

## Testing

Added back the previous tests (without a base)

## Docs

N/A bug fix