### PR TITLE
Build edge/worker runtime with webworker ssr target

### DIFF
--- a/.changeset/quiet-gifts-pay.md
+++ b/.changeset/quiet-gifts-pay.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Add missing esbuild dependency

--- a/.changeset/silver-ties-vanish.md
+++ b/.changeset/silver-ties-vanish.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/cloudflare': patch
+'@astrojs/vercel': patch
+'@astrojs/solid-js': patch
+---
+
+Always build edge/worker runtime with Vite `webworker` SSR target

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -72,8 +72,8 @@ export default function createIntegration(args?: Options): AstroIntegration {
 			},
 			'astro:build:setup': ({ vite, target }) => {
 				if (target === 'server') {
-					vite.resolve = vite.resolve || {};
-					vite.resolve.alias = vite.resolve.alias || {};
+					vite.resolve ||= {};
+					vite.resolve.alias ||= {};
 
 					const aliases = [{ find: 'react-dom/server', replacement: 'react-dom/server.browser' }];
 
@@ -84,8 +84,8 @@ export default function createIntegration(args?: Options): AstroIntegration {
 							(vite.resolve.alias as Record<string, string>)[alias.find] = alias.replacement;
 						}
 					}
-					vite.ssr = vite.ssr || {};
-					vite.ssr.target = vite.ssr.target || 'webworker';
+					vite.ssr ||= {};
+					vite.ssr.target = 'webworker';
 				}
 			},
 			'astro:build:done': async ({ pages }) => {

--- a/packages/integrations/solid/src/index.ts
+++ b/packages/integrations/solid/src/index.ts
@@ -45,7 +45,6 @@ async function getViteConfiguration(isDev: boolean, astroConfig: AstroConfig) {
 			exclude: ['@astrojs/solid-js/server.js', ...solidPkgsConfig.optimizeDeps.exclude],
 		},
 		ssr: {
-			target: 'node',
 			external: ['babel-preset-solid', ...solidPkgsConfig.ssr.external],
 			noExternal: [...solidPkgsConfig.ssr.noExternal],
 		},

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -50,6 +50,7 @@
     "@astrojs/webapi": "^2.1.1",
     "@vercel/analytics": "^0.1.8",
     "@vercel/nft": "^0.22.1",
+    "esbuild": "^0.17.12",
     "fast-glob": "^3.2.11",
     "set-cookie-parser": "^2.5.1",
     "web-vitals": "^3.1.1"

--- a/packages/integrations/vercel/src/edge/adapter.ts
+++ b/packages/integrations/vercel/src/edge/adapter.ts
@@ -101,7 +101,7 @@ export default function vercelEdge({
 					}
 
 					vite.ssr ||= {};
-					vite.ssr.target ||= 'webworker';
+					vite.ssr.target = 'webworker';
 
 					// Vercel edge runtime is a special webworker-ish environment that supports process.env,
 					// but Vite would replace away `process.env` in webworkers, so we set a define here to prevent it

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4698,6 +4698,9 @@ importers:
       '@vercel/nft':
         specifier: ^0.22.1
         version: 0.22.1
+      esbuild:
+        specifier: ^0.17.12
+        version: 0.17.12
       fast-glob:
         specifier: ^3.2.11
         version: 3.2.11


### PR DESCRIPTION
## Changes

Part of the fix for https://github.com/withastro/astro/issues/6989

The solid integration was setting the SSR target to `node`, but in a Cloudflare / Vercel edge setup, it should be `webworker`. This PR fixes that.

Also fixes a missing esbuild dep in `@astrojs/vercel`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Manually tested with the PR repro.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.