### PR TITLE
Add `edge-light` and `worker` to vercel edge bundling

### DIFF
--- a/.changeset/pretty-planets-wink.md
+++ b/.changeset/pretty-planets-wink.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': minor
+---
+
+Add `edge-light` and `worker` import condition for worker bundling

--- a/packages/integrations/vercel/src/edge/adapter.ts
+++ b/packages/integrations/vercel/src/edge/adapter.ts
@@ -119,6 +119,8 @@ export default function vercelEdge({
 				await esbuild.build({
 					target: 'es2020',
 					platform: 'browser',
+					// https://runtime-keys.proposal.wintercg.org/#edge-light
+					conditions: ['edge-light', 'worker', 'browser'],
 					entryPoints: [entryPath],
 					outfile: entryPath,
 					allowOverwrite: true,


### PR DESCRIPTION
## Changes

Part of the fix for https://github.com/withastro/astro/issues/6989

Similar to https://github.com/withastro/astro/pull/7092, add `edge-light` and `worker` when bundling with esbuild for vercel edge so it bundles the right solid-js entry

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested with the repro at https://github.com/withastro/astro/issues/6989, making sure solid-js is bundled correctly in `.vercel/output/functions/entry.mjs`

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.