### PR TITLE
Fix weird periods in `NoMatchingRenderer` error

### DIFF
--- a/.changeset/ninety-sheep-knock.md
+++ b/.changeset/ninety-sheep-knock.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix formatting in the `NoMatchingRenderer` error message.

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -167,10 +167,10 @@ export const AstroErrorData = {
 
 ${
 	validRenderersCount > 0
-		? `There ${plural ? 'are.' : 'is.'} ${validRenderersCount} renderer${
-				plural ? 's.' : ''
+		? `There ${plural ? 'are' : 'is'} ${validRenderersCount} renderer${
+				plural ? 's' : ''
 		  } configured in your \`astro.config.mjs\` file,
-but ${plural ? 'none were.' : 'it was not.'} able to server-side render \`${componentName}\`.`
+but ${plural ? 'none were' : 'it was not'} able to server-side render \`${componentName}\`.`
 		: `No valid renderer was found ${
 				componentExtension
 					? `for the \`.${componentExtension}\` file extension.`


### PR DESCRIPTION
## Changes

- Quick fix for some over enthusiastic punctuation in an error message.

## Testing

No testing.

## Docs

Typo change only
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
