### PR TITLE
Fix: add `headings` to `.mdoc` render type

### DIFF
--- a/.changeset/plenty-cows-act.md
+++ b/.changeset/plenty-cows-act.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': patch
+---
+
+Fix: add `headings` to Markdoc `render()` return type.

--- a/packages/integrations/markdoc/template/content-module-types.d.ts
+++ b/packages/integrations/markdoc/template/content-module-types.d.ts
@@ -2,6 +2,7 @@ declare module 'astro:content' {
 	interface Render {
 		'.mdoc': Promise<{
 			Content(props: Record<string, any>): import('astro').MarkdownInstance<{}>['Content'];
+			headings: import('astro').MarkdownHeading[];
 		}>;
 	}
 }


### PR DESCRIPTION
## Changes

- Add `headings` to return type for `render()`

## Testing

N/A - types

## Docs

N/A