### PR TITLE
Cloudflare workerd - Static file compatibility

### DIFF
--- a/.changeset/empty-months-pump.md
+++ b/.changeset/empty-months-pump.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': minor
+---
+
+Updating the static asset fallback handling, to rewrite the headers. This shouldn't affect cloudflare pages deployments as static file handling shouldn't hit fallback, but this does add compatibility with cloudflare's workerd, the open source worker runtime, as by default files are sent as `application/octet-stream` https://github.com/cloudflare/workerd/blob/main/src/workerd/server/workerd.capnp#LL665C29-L665C53

--- a/.changeset/empty-months-pump.md
+++ b/.changeset/empty-months-pump.md
@@ -2,4 +2,4 @@
 '@astrojs/cloudflare': minor
 ---
 
-Updating the static asset fallback handling, to rewrite the headers. This shouldn't affect cloudflare pages deployments as static file handling shouldn't hit fallback, but this does add compatibility with cloudflare's workerd, the open source worker runtime, as by default files are sent as `application/octet-stream` https://github.com/cloudflare/workerd/blob/main/src/workerd/server/workerd.capnp#LL665C29-L665C53
+Fix the static asset fallback handling to rewrite the headers. This shouldn't affect Cloudflare pages deployments as static file handling shouldn't hit fallback, but this does add compatibility with Cloudflare's workerd, the open source worker runtime, as by default files are sent as `application/octet-stream` https://github.com/cloudflare/workerd/blob/main/src/workerd/server/workerd.capnp#LL665C29-L665C53

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -39,20 +39,21 @@
   },
   "dependencies": {
     "esbuild": "^0.17.12",
-    "tiny-glob": "^0.2.9",
-    "mime": "^3.0.0"
+    "mime": "^3.0.0",
+    "tiny-glob": "^0.2.9"
   },
   "peerDependencies": {
     "astro": "workspace:^2.4.5"
   },
   "devDependencies": {
+    "@types/mime": "^2.0.3",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "chai": "^4.3.6",
     "cheerio": "^1.0.0-rc.11",
     "mocha": "^9.2.2",
     "slash": "^4.0.0",
-    "wrangler": "^2.0.23",
-    "@types/mime": "^2.0.3"
+    "workerd": "^1.20230512.0",
+    "wrangler": "^2.0.23"
   }
 }

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -39,7 +39,8 @@
   },
   "dependencies": {
     "esbuild": "^0.17.12",
-    "tiny-glob": "^0.2.9"
+    "tiny-glob": "^0.2.9",
+    "mime": "^3.0.0"
   },
   "peerDependencies": {
     "astro": "workspace:^2.4.5"
@@ -51,6 +52,7 @@
     "cheerio": "^1.0.0-rc.11",
     "mocha": "^9.2.2",
     "slash": "^4.0.0",
-    "wrangler": "^2.0.23"
+    "wrangler": "^2.0.23",
+    "@types/mime": "^2.0.3"
   }
 }

--- a/packages/integrations/cloudflare/test/fixtures/workerd/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/workerd/astro.config.mjs
@@ -1,0 +1,12 @@
+import { defineConfig } from 'astro/config';
+import cloudflare from '@astrojs/cloudflare';
+
+export default defineConfig({
+	adapter: cloudflare(),
+	output: 'server',
+	vite: {
+		build: {
+			minify: false,
+		},
+	},
+});

--- a/packages/integrations/cloudflare/test/fixtures/workerd/config.capnp
+++ b/packages/integrations/cloudflare/test/fixtures/workerd/config.capnp
@@ -1,0 +1,28 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const config :Workerd.Config = (
+  services = [
+    (name = "main", worker = .mainWorker),
+    (name = "site-files", disk = ()) #For testing because of relative dirs this must be specified with --directory-path <service-name>=<path>
+  ],
+
+  sockets = [
+    # Serve HTTP on port 8080.
+
+    ( name = "http",
+      address = "*:8080",
+      http = (),
+      service = "main"
+    ),
+  ]
+);
+
+const mainWorker :Workerd.Worker = (
+  modules = [
+    (name = "main", esModule = embed "./dist/_worker.js")
+  ],
+  compatibilityDate = "2023-02-28",
+  bindings = [
+    (name = "ASSETS", service = "site-files"),
+  ]
+);

--- a/packages/integrations/cloudflare/test/fixtures/workerd/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/workerd/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/astro-cloudflare-workerd",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/cloudflare": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/cloudflare/test/fixtures/workerd/public/static.svg
+++ b/packages/integrations/cloudflare/test/fixtures/workerd/public/static.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- License: PD. Made by mapbox: https://github.com/mapbox/maki -->
+<svg width="800px" height="800px" viewBox="0 0 60 15" version="1.1" id="playground" xmlns="http://www.w3.org/2000/svg">
+  <text>I'm Static</text>
+</svg>

--- a/packages/integrations/cloudflare/test/fixtures/workerd/src/pages/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/workerd/src/pages/index.astro
@@ -1,0 +1,13 @@
+---
+console.log('This is SSR');
+---
+
+<html lang="en">
+	<head>
+		<title>Astro</title>
+	</head>
+	<body>
+		<h1>Testing</h1>
+		<img src="/static.svg" />
+	</body>
+</html>

--- a/packages/integrations/cloudflare/test/test-utils.js
+++ b/packages/integrations/cloudflare/test/test-utils.js
@@ -74,8 +74,7 @@ export function runWorkerd(basePath, { silent }) {
 	const p = spawn(workerdPath, ['serve', configPath, '--verbose', '--directory-path', `site-files=${distPath}`]);
 	p.stderr.setEncoding('utf-8');
 	p.stdout.setEncoding('utf-8');
-	const pwd = process.cwd();
-	console.log(pwd);
+
 	const timeout = 10000;
 
 	const ready = new Promise(async (resolve, reject) => {
@@ -88,7 +87,7 @@ export function runWorkerd(basePath, { silent }) {
 			if (!silent) {
 				// eslint-disable-next-line
 				console.error(data);
-				reject(data)
+				reject(new Error(data));
 			}
 		});
 

--- a/packages/integrations/cloudflare/test/workerd.test.js
+++ b/packages/integrations/cloudflare/test/workerd.test.js
@@ -13,7 +13,7 @@ describe('workerd static file', () => {
 	});
 
 	it('can render', async () => {
-		const { ready, stop } = runWorkerd('./fixtures/workerd', { silent: false });
+		const { ready, stop } = runWorkerd('./fixtures/workerd', { silent: true });
 
 		try {
 			await ready;

--- a/packages/integrations/cloudflare/test/workerd.test.js
+++ b/packages/integrations/cloudflare/test/workerd.test.js
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+import { loadFixture, runWorkerd } from './test-utils.js';
+import * as cheerio from 'cheerio';
+
+describe('workerd static file', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/workerd/',
+		});
+		await fixture.build();
+	});
+
+	it('can render', async () => {
+		const { ready, stop } = runWorkerd('./fixtures/workerd', { silent: false });
+
+		try {
+			await ready;
+
+			let res = await fetch(`http://localhost:8080/`);
+			expect(res.status).to.equal(200);
+			let html = await res.text();
+			let $ = cheerio.load(html);
+			expect($('h1').text()).to.equal('Testing');
+			expect($('img').attr('src')).to.equal('/static.svg');
+
+			res = await fetch(`http://localhost:8080/static.svg`);
+			expect(res.status).to.equal(200);
+			let svg = await res.text();
+			$ = cheerio.load(svg);
+			expect($('text').text()).to.equal("I'm Static");
+
+		} finally {
+			stop();
+		}
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3621,10 +3621,16 @@ importers:
       esbuild:
         specifier: ^0.17.12
         version: 0.17.12
+      mime:
+        specifier: ^3.0.0
+        version: 3.0.0
       tiny-glob:
         specifier: ^0.2.9
         version: 0.2.9
     devDependencies:
+      '@types/mime':
+        specifier: ^2.0.3
+        version: 2.0.3
       astro:
         specifier: workspace:*
         version: link:../../astro

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3649,6 +3649,9 @@ importers:
       slash:
         specifier: ^4.0.0
         version: 4.0.0
+      workerd:
+        specifier: ^1.20230512.0
+        version: 1.20230512.0
       wrangler:
         specifier: ^2.0.23
         version: 2.0.23
@@ -3694,6 +3697,15 @@ importers:
       solid-js:
         specifier: '*'
         version: 1.7.4
+
+  packages/integrations/cloudflare/test/fixtures/workerd:
+    dependencies:
+      '@astrojs/cloudflare':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
 
   packages/integrations/deno:
     dependencies:
@@ -7282,6 +7294,51 @@ packages:
     dependencies:
       mime: 3.0.0
     dev: true
+
+  /@cloudflare/workerd-darwin-64@1.20230512.0:
+    resolution: {integrity: sha512-V80DswMTu0hiVue5BmjlC0cVufXLKk0KbkesbJ0IywHiuGk0f9uEOgwwL91ioOhPu+3Ss/ka5BNxwPXDxKkG3g==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@cloudflare/workerd-darwin-arm64@1.20230512.0:
+    resolution: {integrity: sha512-HojEqgtCW8FCRQq/ENPsBVv1YoxJVp2kDrC27D7xfwOa2+LCmxh55c2cckxZuGTNAsBIqk6lczq4yQx9xcfSdg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@cloudflare/workerd-linux-64@1.20230512.0:
+    resolution: {integrity: sha512-zhu61wFAyjbO+MtiQjcKDv+HUXYnW3GhGCKW8xKUsCktaXKr/l2Vp/t3VFzF+M8CuFMML5xmE/1gopHB9pIUcA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@cloudflare/workerd-linux-arm64@1.20230512.0:
+    resolution: {integrity: sha512-LvW/DFz35ISnkgagE6qra1CyFmak5sPJcOZ01fovtHIQdwtgUrU5Q+mTAoDZy+8yQnVIM8HCXJxe5gKxM9hnxQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@cloudflare/workerd-windows-64@1.20230512.0:
+    resolution: {integrity: sha512-OgRmn5FjroPSha/2JgcM8AQg5NpTig8TqDXgdM61Y/7DCCCEuOuMsZSqU1IrYkPU7gtOFvZSQZLgFA4XxbePbA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -18191,6 +18248,19 @@ packages:
       '@types/trusted-types': 2.0.3
       workbox-core: 6.5.4
     dev: false
+
+  /workerd@1.20230512.0:
+    resolution: {integrity: sha512-rueIsVxLTVlqWyaSVHlDKFZRLkDAMmUhxiKXE+guMR3fauwPPsuzs/VKWUqX2sqR2UKF+1JxrUtH9OvaIqoHhA==}
+    engines: {node: '>=16'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20230512.0
+      '@cloudflare/workerd-darwin-arm64': 1.20230512.0
+      '@cloudflare/workerd-linux-64': 1.20230512.0
+      '@cloudflare/workerd-linux-arm64': 1.20230512.0
+      '@cloudflare/workerd-windows-64': 1.20230512.0
+    dev: true
 
   /workerpool@6.2.0:
     resolution: {integrity: sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==}


### PR DESCRIPTION
## Changes

- What does this change?

Cloudflare workerd is the runtime that Cloudflare Workers and subsequently Pages runs on. `_worker.js` that is output by the astro cloudflare integration runs readily on workerd with little setup needed, with the only caveat being that static files aren't handled correctly. This is because by default workerd returns a `application/octet-stream` content type for all files. I've added some basic handling to re-wrap the file in a new content type. 

## Testing

Running `npx workerd serve config.capnp` with the following config.capnp:
```
using Workerd = import "/workerd/workerd.capnp";

const config :Workerd.Config = (
  services = [
    (name = "main", worker = .mainWorker),
    (name = "site-files", disk = "./astro/dist")
  ],

  sockets = [
    # Serve HTTP on port 8080.
    ( name = "http",
      address = "*:8080",
      http = (),
      service = "main"
    ),
  ]
);

const mainWorker :Workerd.Worker = (
  modules = [
    (name = "main", esModule = embed "./astro/dist/_worker.js")
  ],
  compatibilityDate = "2023-02-28",
  bindings = [
    (name = "ASSETS", service = "site-files"),
  ]
);
```

### EDIT: Adding tests

Created workerd test that runs astro with a static file using workerd.
- Checks that astro serves correctly with h1 element
- Checks for a string in a statically served SVG. 

## Docs

No docs needed to be added, this probably doesn't make a difference for services running on Cloudflare Pages, as they use the _routes.json file and don't fallback to serving static files. 

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
