### PR TITLE
Document inlineStylesheets available astro version

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1082,6 +1082,7 @@ export interface AstroUserConfig {
 		 * @name experimental.inlineStylesheets
 		 * @type {('always' | 'auto' | 'never')}
 		 * @default `never`
+		 * @version 2.4.0
 		 * @description
 		 * Control whether styles are sent to the browser in a separate css file or inlined into `<style>` tags. Choose from the following options:
 		 *  - `'always'` - all styles are inlined into `<style>` tags


### PR DESCRIPTION
## Changes

Tiny change so https://docs.astro.build/en/reference/configuration-reference/#experimentalinlinestylesheets to show which Astro version is required for that experimental feature.

Feature changelog:

https://github.com/withastro/astro/blob/edd30d18d105247ffa4d78a5351632e87af05d6f/packages/astro/CHANGELOG.md#L41-L47

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
n/a

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
 /cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
