### PR TITLE
Improve content collection error message for empty folders

### DIFF
--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -509,9 +509,9 @@ function warnNonexistentCollections({
 			warn(
 				logging,
 				'content',
-				`${JSON.stringify(
+				`The ${JSON.stringify(
 					configuredCollection
-				)} is not a collection. Check your content config for typos.`
+				)} collection does not have an associated folder in your \`content\` directory. Make sure the folder exists, or check your content config for typos.`
 			);
 		}
 	}

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -103,11 +103,11 @@ export async function createContentTypesGenerator({
 			},
 			onlyFiles: false,
 			objectMode: true,
-			ignore: ['config.ts'],
 		});
 
 		for (const entry of globResult) {
 			const entryURL = new URL(entry.path, contentPaths.contentDir);
+			if (entryURL.href.startsWith(contentPaths.config.url.href)) continue;
 			if (entry.dirent.isFile()) {
 				events.push({
 					type: { name: 'add', entry: entryURL },


### PR DESCRIPTION
## Changes

This PR does two things:
- Enhanced the error message to be more clear that it means there's no folder for a collection, and recommend the user to  either create the folder or check their config
- Fix empty folders not being added to the list of collections at start, they'll now be added the same way they would've had they'd been added post launch

Fix https://github.com/withastro/astro/issues/6785

## Testing

Tested manually

## Docs

cc @withastro/maintainers-docs for feedback on the error message
