### PR TITLE
fix(prefetch): Fix the inclusion of `@types/network-information`

### DIFF
--- a/.changeset/brown-goats-serve.md
+++ b/.changeset/brown-goats-serve.md
@@ -3,4 +3,4 @@
 '@astrojs/prefetch': patch
 ---
 
-Include the `@types` directory in the published `"files"`.
+Fix the inclusion of `@types/network-information`.

--- a/.changeset/brown-goats-serve.md
+++ b/.changeset/brown-goats-serve.md
@@ -1,6 +1,6 @@
-
 ---
 '@astrojs/prefetch': patch
 ---
 
 Fix the inclusion of `@types/network-information`.
+

--- a/.changeset/brown-goats-serve.md
+++ b/.changeset/brown-goats-serve.md
@@ -1,0 +1,6 @@
+
+---
+'@astrojs/prefetch': patch
+---
+
+Include the `@types` directory in the published `"files"`.

--- a/packages/integrations/prefetch/package.json
+++ b/packages/integrations/prefetch/package.json
@@ -24,8 +24,7 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist",
-    "@types"
+    "dist"
   ],
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",

--- a/packages/integrations/prefetch/package.json
+++ b/packages/integrations/prefetch/package.json
@@ -24,7 +24,8 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist"
+    "dist",
+    "@types"
   ],
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",

--- a/packages/integrations/prefetch/src/client.ts
+++ b/packages/integrations/prefetch/src/client.ts
@@ -1,5 +1,5 @@
+/// <reference types="../@types/network-information.d.ts" />
 import throttles from 'throttles';
-import '../@types/network-information.d.ts';
 import requestIdleCallback from './requestIdleCallback.js';
 
 const events = ['mouseenter', 'touchstart', 'focus'];


### PR DESCRIPTION
## Changes

https://github.com/withastro/astro/pull/7104 added the `"files"` field to all packages to limit the files that are published to npm. The `@astro/prefetch` package only includes the `dist` folder, however, the code tries to import from the `@types` folder, causing the following error:

```
Could not resolve "../@types/network-information.d.ts" from "node_modules/@astrojs/prefetch/dist/client.js"
```

~I added the `@types` folder to the `"files"` field to fix it.~

I changed the import to a triple-slash directive as [suggested](https://github.com/withastro/astro/pull/7123#issuecomment-1554172407) by @bluwy.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I did not test the change as it seems straightforward.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This fixes an expected behavior, so an update to the docs doesn't seem necessary.
