### PR TITLE
Add route information for getStaticPaths warning

### DIFF
--- a/.changeset/swift-lamps-doubt.md
+++ b/.changeset/swift-lamps-doubt.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add route information when warning of `getStaticPaths()` ignored

--- a/packages/astro/src/core/routing/validation.ts
+++ b/packages/astro/src/core/routing/validation.ts
@@ -1,3 +1,4 @@
+import { bold } from 'kleur/colors';
 import type { ComponentInstance, GetStaticPathsResult, RouteData } from '../../@types/astro';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 import type { LogOptions } from '../logger/core';
@@ -32,7 +33,11 @@ export function validateDynamicRouteModule(
 	}
 ) {
 	if (ssr && mod.getStaticPaths && !mod.prerender) {
-		warn(logging, 'getStaticPaths', 'getStaticPaths() is ignored when "output: server" is set.');
+		warn(
+			logging,
+			'getStaticPaths',
+			`getStaticPaths() in ${bold(route.component)} is ignored when "output: server" is set.`
+		);
 	}
 	if ((!ssr || mod.prerender) && !mod.getStaticPaths) {
 		throw new AstroError({


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/7023

Add route information when warning about `getStaticPaths()` ignored for SSR:

```
04:48:51 PM [getStaticPaths] getStaticPaths() in src/pages/[lang]/index.astro is ignored when "output: server" is set.
```

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Manually tested with the issue's repro.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. I don't think we're documenting the warnings currently.