### PR TITLE
Fix injectRoute for SSR

### DIFF
--- a/.changeset/friendly-garlics-chew.md
+++ b/.changeset/friendly-garlics-chew.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix routes created by `injectRoute` for SSR

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -151,34 +151,29 @@ function buildManifest(
 		}
 	};
 
-	for (const pageData of eachPageData(internals)) {
-		if (!pageData.route.prerender) continue;
-		if (!pageData.route.pathname) continue;
+	for (const route of opts.manifest.routes) {
+		if (!route.prerender) continue;
+		if (!route.pathname) continue;
 
-		const outFolder = getOutFolder(
-			opts.settings.config,
-			pageData.route.pathname!,
-			pageData.route.type
-		);
-		const outFile = getOutFile(
-			opts.settings.config,
-			outFolder,
-			pageData.route.pathname!,
-			pageData.route.type
-		);
+		const outFolder = getOutFolder(opts.settings.config, route.pathname!, route.type);
+		const outFile = getOutFile(opts.settings.config, outFolder, route.pathname!, route.type);
 		const file = outFile.toString().replace(opts.settings.config.build.client.toString(), '');
 		routes.push({
 			file,
 			links: [],
 			scripts: [],
 			styles: [],
-			routeData: serializeRouteData(pageData.route, settings.config.trailingSlash),
+			routeData: serializeRouteData(route, settings.config.trailingSlash),
 		});
 		staticFiles.push(file);
 	}
 
-	for (const pageData of eachPageData(internals)) {
-		if (pageData.route.prerender) continue;
+	for (const route of opts.manifest.routes) {
+		const pageData = internals.pagesByComponent.get(route.component);
+		if (route.prerender) continue;
+		if (!pageData) {
+			continue;
+		}
 		const scripts: SerializedRouteInfo['scripts'] = [];
 		if (pageData.hoistedScript) {
 			const hoistedValue = pageData.hoistedScript.value;
@@ -217,7 +212,7 @@ function buildManifest(
 					.map(({ stage, content }) => ({ stage, children: content })),
 			],
 			styles,
-			routeData: serializeRouteData(pageData.route, settings.config.trailingSlash),
+			routeData: serializeRouteData(route, settings.config.trailingSlash),
 		});
 	}
 

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -170,10 +170,7 @@ function buildManifest(
 
 	for (const route of opts.manifest.routes) {
 		const pageData = internals.pagesByComponent.get(route.component);
-		if (route.prerender) continue;
-		if (!pageData) {
-			continue;
-		}
+		if (route.prerender || !pageData) continue;
 		const scripts: SerializedRouteInfo['scripts'] = [];
 		if (pageData.hoistedScript) {
 			const hoistedValue = pageData.hoistedScript.value;

--- a/packages/astro/test/ssr-dynamic.test.js
+++ b/packages/astro/test/ssr-dynamic.test.js
@@ -11,6 +11,19 @@ describe('Dynamic pages in SSR', () => {
 		fixture = await loadFixture({
 			root: './fixtures/ssr-dynamic/',
 			output: 'server',
+			integrations: [
+				{
+					name: 'inject-routes',
+					hooks: {
+						'astro:config:setup': ({ injectRoute }) => {
+							injectRoute({
+								pattern: '/path-alias/[id]',
+								entryPoint: './src/pages/api/products/[id].js',
+							});
+						},
+					},
+				},
+			],
 			adapter: testAdapter(),
 		});
 		await fixture.build();
@@ -52,6 +65,11 @@ describe('Dynamic pages in SSR', () => {
 
 	it('Dynamic API routes work', async () => {
 		const json = await fetchJSON('/api/products/33');
+		expect(json.id).to.equal('33');
+	});
+
+	it('Injected route work', async () => {
+		const json = await fetchJSON('/path-alias/33');
 		expect(json.id).to.equal('33');
 	});
 


### PR DESCRIPTION
Use manifest routes for SSR app manifest instead of page components to enable injected routes with SSR.

I don't know whether this is the right way to handle it, but it seemed logical to me looking at the data structures.

## Changes

- Before, routes created by `injectRoute` didn't work for SSR. Now the injected manifest reuses the routes form the manifest, which also included injected routes.

## Testing

One test added to the `ssr-dynamic` suite

## Docs

Docs shouldn't be affected