### PR TITLE
Fix smoke test markdoc CI

### DIFF
--- a/examples/with-markdoc/package.json
+++ b/examples/with-markdoc/package.json
@@ -11,7 +11,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/markdoc": "^0.1.2",
+    "@astrojs/markdoc": "^0.2.0",
     "astro": "^2.4.1",
     "kleur": "^4.1.5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,8 +409,8 @@ importers:
   examples/with-markdoc:
     dependencies:
       '@astrojs/markdoc':
-        specifier: ^0.1.2
-        version: 0.1.2(astro@packages+astro)
+        specifier: ^0.2.0
+        version: link:../../packages/integrations/markdoc
       astro:
         specifier: ^2.4.1
         version: link:../../packages/astro
@@ -5519,23 +5519,6 @@ packages:
       vscode-languageserver-textdocument: 1.0.8
       vscode-languageserver-types: 3.17.3
       vscode-uri: 3.0.7
-    dev: false
-
-  /@astrojs/markdoc@0.1.2(astro@packages+astro):
-    resolution: {integrity: sha512-pOHMGQ/az9UOw+3X21cViPlZBwtxYXZpF8bv9pBQquVJGsfrBv4VZhdJkiXkwp2sq+SXa/Bxk02EXhevUVogCQ==}
-    engines: {node: '>=16.12.0'}
-    peerDependencies:
-      astro: '*'
-    dependencies:
-      '@markdoc/markdoc': 0.2.2
-      astro: link:packages/astro
-      esbuild: 0.17.18
-      gray-matter: 4.0.3
-      kleur: 4.1.5
-      zod: 3.20.6
-    transitivePeerDependencies:
-      - '@types/react'
-      - react
     dev: false
 
   /@babel/code-frame@7.21.4:


### PR DESCRIPTION
## Changes

The markdoc example uses `@astrojs/markdoc` v0.1, but requires v0.2 to work. Looks like pnpm only uses the workspace package if the semver matches, so I made it to match to work.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Ran build locally for with-markdoc example

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a