### PR TITLE
refactor: create virtual module for middleware

### DIFF
--- a/.changeset/good-frogs-report.md
+++ b/.changeset/good-frogs-report.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Emit middleware as an entrypoint during build

--- a/packages/astro/src/core/build/plugins/index.ts
+++ b/packages/astro/src/core/build/plugins/index.ts
@@ -10,12 +10,14 @@ import { pluginInternals } from './plugin-internals.js';
 import { pluginPages } from './plugin-pages.js';
 import { pluginPrerender } from './plugin-prerender.js';
 import { pluginSSR } from './plugin-ssr.js';
+import { pluginMiddleware } from './plugin-middleware.js';
 
 export function registerAllPlugins({ internals, options, register }: AstroBuildPluginContainer) {
 	register(pluginComponentEntry(internals));
 	register(pluginAliasResolve(internals));
 	register(pluginAnalyzer(internals));
 	register(pluginInternals(internals));
+	register(pluginMiddleware(options, internals));
 	register(pluginPages(options, internals));
 	register(pluginCSS(options, internals));
 	register(astroHeadBuildPlugin(options, internals));

--- a/packages/astro/src/core/build/plugins/plugin-middleware.ts
+++ b/packages/astro/src/core/build/plugins/plugin-middleware.ts
@@ -1,0 +1,63 @@
+import type { Plugin as VitePlugin } from 'vite';
+import { MIDDLEWARE_PATH_SEGMENT_NAME } from '../../constants.js';
+import { addRollupInput } from '../add-rollup-input.js';
+import type { BuildInternals } from '../internal.js';
+import type { AstroBuildPlugin } from '../plugin';
+import type { StaticBuildOptions } from '../types';
+
+export const MIDDLEWARE_MODULE_ID = '@astro-middleware';
+export const RESOLVED_MIDDLEWARE_MODULE_ID = '\0@astro-middleware';
+
+let inputs: Set<string> = new Set();
+export function vitePluginMiddleware(
+	opts: StaticBuildOptions,
+	_internals: BuildInternals
+): VitePlugin {
+	return {
+		name: '@astro/plugin-middleware',
+		options(options) {
+			if (opts.settings.config.experimental.middleware) {
+				return addRollupInput(options, [MIDDLEWARE_MODULE_ID]);
+			}
+		},
+
+		resolveId(id) {
+			if (id === MIDDLEWARE_MODULE_ID && opts.settings.config.experimental.middleware) {
+				return RESOLVED_MIDDLEWARE_MODULE_ID;
+			}
+		},
+
+		async load(id) {
+			if (id === RESOLVED_MIDDLEWARE_MODULE_ID && opts.settings.config.experimental.middleware) {
+				const imports: string[] = [];
+				const exports: string[] = [];
+				let middlewareId = await this.resolve(
+					`${opts.settings.config.srcDir.pathname}/${MIDDLEWARE_PATH_SEGMENT_NAME}`
+				);
+				if (middlewareId) {
+					imports.push(`import { onRequest } from "${middlewareId.id}"`);
+					exports.push(`export { onRequest }`);
+				}
+				const result = [imports.join('\n'), exports.join('\n')];
+
+				return result.join('\n');
+			}
+		},
+	};
+}
+
+export function pluginMiddleware(
+	opts: StaticBuildOptions,
+	internals: BuildInternals
+): AstroBuildPlugin {
+	return {
+		build: 'ssr',
+		hooks: {
+			'build:before': () => {
+				return {
+					vitePlugin: vitePluginMiddleware(opts, internals),
+				};
+			},
+		},
+	};
+}

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -27,6 +27,7 @@ import { createPluginContainer, type AstroBuildPluginContainer } from './plugin.
 import { registerAllPlugins } from './plugins/index.js';
 import type { PageBuildData, StaticBuildOptions } from './types';
 import { getTimeStat } from './util.js';
+import { RESOLVED_MIDDLEWARE_MODULE_ID } from './plugins/plugin-middleware.js';
 
 export async function viteBuild(opts: StaticBuildOptions) {
 	const { allPages, settings } = opts;
@@ -172,6 +173,8 @@ async function ssrBuild(
 					entryFileNames(chunkInfo) {
 						if (chunkInfo.facadeModuleId === resolvedPagesVirtualModuleId) {
 							return opts.buildConfig.serverEntry;
+						} else if (chunkInfo.facadeModuleId === RESOLVED_MIDDLEWARE_MODULE_ID) {
+							return 'middleware.mjs';
 						} else {
 							return '[name].mjs';
 						}


### PR DESCRIPTION
## Changes

This PR creates a new `vite` plugin for the middleware. This plugin is in charge of creating a new virtual module that yields the code of the middleware.

This is an internal change and the current behaviour should stay the same.

This plugin is going to be helpful in the near future for:
- integrations that want to pull the code of the Astro middleware in their middleware pipeline
- a future refactor of how Astro pages will be compiled 

## Testing

Current tests should pass.

I tested locally if the middleware still works in a pet project of mine.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
