### PR TITLE
fix(prefetch): adds '@types' folder to 'files' in package.json

### DIFF
--- a/.changeset/cyan-eels-fold.md
+++ b/.changeset/cyan-eels-fold.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/prefetch': patch
+---
+
+adds the types folder in the distributed package

--- a/packages/integrations/prefetch/package.json
+++ b/packages/integrations/prefetch/package.json
@@ -24,7 +24,8 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist"
+    "dist",
+    "@types"
   ],
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",


### PR DESCRIPTION
## Changes

This PR adds the @types folder to the files of the distributed package. Otherwise the current package give the following error:

```bash
11:24:19 [content] Watching src/content/ for changes
11:24:20 [content] Types generated
11:24:20 [astro] update /.astro/types.d.ts
✘ [ERROR] Could not resolve "../@types/network-information.d.ts"

    node_modules/@astrojs/prefetch/dist/client.js:2:7:
      2 │ import "../@types/network-information.d.ts";
        ╵        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

11:24:28 [vite] error while updating dependencies:
Error: Build failed with 1 error:
node_modules/@astrojs/prefetch/dist/client.js:2:7: ERROR: Could not resolve "../@types/network-information.d.ts"
    at failureErrorWithLog (/Users/simba/Projects/cpts/website/node_modules/esbuild/lib/main.js:1636:15)
    at /Users/simba/Projects/cpts/website/node_modules/esbuild/lib/main.js:1048:25
    at /Users/simba/Projects/cpts/website/node_modules/esbuild/lib/main.js:1512:9
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

## Testing

The change only concerns the distributed package.

## Docs

The change only concerns the distributed package.
