### PR TITLE
Fix: Heading ID CI flakiness

### DIFF
--- a/.changeset/eleven-tables-speak.md
+++ b/.changeset/eleven-tables-speak.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': patch
+---
+
+Fix inconsistent Markdoc heading IDs for documents with the same headings.

--- a/packages/integrations/markdoc/src/index.ts
+++ b/packages/integrations/markdoc/src/index.ts
@@ -10,7 +10,7 @@ import { emitESMImage } from 'astro/assets';
 import { bold, red, yellow } from 'kleur/colors';
 import type * as rollup from 'rollup';
 import { loadMarkdocConfig, type MarkdocConfigResult } from './load-config.js';
-import { applyDefaultConfig } from './runtime.js';
+import { setupConfig } from './runtime.js';
 
 type SetupHookParams = HookParameters<'astro:config:setup'> & {
 	// `contentEntryType` is not a public API
@@ -52,7 +52,7 @@ export default function markdocIntegration(legacyConfig?: any): AstroIntegration
 					async getRenderModule({ entry, viteId }) {
 						const ast = Markdoc.parse(entry.body);
 						const pluginContext = this;
-						const markdocConfig = applyDefaultConfig(userMarkdocConfig, entry);
+						const markdocConfig = setupConfig(userMarkdocConfig, entry);
 
 						const validationErrors = Markdoc.validate(ast, markdocConfig).filter((e) => {
 							return (
@@ -90,7 +90,7 @@ export default function markdocIntegration(legacyConfig?: any): AstroIntegration
 
 						const res = `import { jsx as h } from 'astro/jsx-runtime';
 						import { Renderer } from '@astrojs/markdoc/components';
-						import { collectHeadings, applyDefaultConfig, Markdoc, headingSlugger } from '@astrojs/markdoc/runtime';
+						import { collectHeadings, setupConfig, Markdoc } from '@astrojs/markdoc/runtime';
 import * as entry from ${JSON.stringify(viteId + '?astroContentCollectionEntry')};
 ${
 	markdocConfigResult
@@ -113,16 +113,14 @@ export function getHeadings() {
 		instead of the Content component. Would remove double-transform and unlock variable resolution in heading slugs. */
 		''
 	}
-	headingSlugger.reset();
 	const headingConfig = userConfig.nodes?.heading;
-	const config = applyDefaultConfig(headingConfig ? { nodes: { heading: headingConfig } } : {}, entry);
+	const config = setupConfig(headingConfig ? { nodes: { heading: headingConfig } } : {}, entry);
 	const ast = Markdoc.Ast.fromJSON(stringifiedAst);
 	const content = Markdoc.transform(ast, config);
 	return collectHeadings(Array.isArray(content) ? content : content.children);
 }
 export async function Content (props) {
-	headingSlugger.reset();
-	const config = applyDefaultConfig({
+	const config = setupConfig({
 		...userConfig,
 		variables: { ...userConfig.variables, ...props },
 	}, entry);

--- a/packages/integrations/markdoc/src/nodes/index.ts
+++ b/packages/integrations/markdoc/src/nodes/index.ts
@@ -1,4 +1,4 @@
 import { heading } from './heading.js';
-export { headingSlugger } from './heading.js';
+export { setupHeadingConfig } from './heading.js';
 
 export const nodes = { heading };

--- a/packages/integrations/markdoc/test/fixtures/headings-custom/src/content/docs/headings-stale-cache-check.mdoc
+++ b/packages/integrations/markdoc/test/fixtures/headings-custom/src/content/docs/headings-stale-cache-check.mdoc
@@ -1,0 +1,13 @@
+Our heading ID generator can have a stale cache for duplicates. Let's check for those!
+
+# Level 1 heading
+
+## Level **2 heading**
+
+### Level _3 heading_
+
+#### Level [4 heading](/with-a-link)
+
+##### Level 5 heading with override {% #id-override %}
+
+###### Level 6 heading

--- a/packages/integrations/markdoc/test/fixtures/headings-custom/src/pages/[slug].astro
+++ b/packages/integrations/markdoc/test/fixtures/headings-custom/src/pages/[slug].astro
@@ -1,8 +1,14 @@
 ---
-import { getEntryBySlug } from "astro:content";
+import { getCollection, CollectionEntry } from "astro:content";
 
-const post = await getEntryBySlug('docs', 'headings');
-const { Content, headings } = await post.render();
+export async function getStaticPaths() {
+	const docs = await getCollection('docs');
+	return docs.map(doc => ({ params: { slug: doc.slug }, props: doc }));
+}
+
+type Props = CollectionEntry<'docs'>;
+
+const { Content, headings } = await Astro.props.render();
 ---
 
 <!DOCTYPE html>

--- a/packages/integrations/markdoc/test/fixtures/headings/src/content/docs/headings-stale-cache-check.mdoc
+++ b/packages/integrations/markdoc/test/fixtures/headings/src/content/docs/headings-stale-cache-check.mdoc
@@ -1,0 +1,13 @@
+Our heading ID generator can have a stale cache for duplicates. Let's check for those!
+
+# Level 1 heading
+
+## Level **2 heading**
+
+### Level _3 heading_
+
+#### Level [4 heading](/with-a-link)
+
+##### Level 5 heading with override {% #id-override %}
+
+###### Level 6 heading

--- a/packages/integrations/markdoc/test/fixtures/headings/src/pages/[slug].astro
+++ b/packages/integrations/markdoc/test/fixtures/headings/src/pages/[slug].astro
@@ -1,8 +1,14 @@
 ---
-import { getEntryBySlug } from "astro:content";
+import { getCollection, CollectionEntry } from "astro:content";
 
-const post = await getEntryBySlug('docs', 'headings');
-const { Content, headings } = await post.render();
+export async function getStaticPaths() {
+	const docs = await getCollection('docs');
+	return docs.map(doc => ({ params: { slug: doc.slug }, props: doc }));
+}
+
+type Props = CollectionEntry<'docs'>;
+
+const { Content, headings } = await Astro.props.render();
 ---
 
 <!DOCTYPE html>

--- a/packages/integrations/markdoc/test/headings.test.js
+++ b/packages/integrations/markdoc/test/headings.test.js
@@ -27,7 +27,15 @@ describe('Markdoc - Headings', () => {
 		});
 
 		it('applies IDs to headings', async () => {
-			const res = await fixture.fetch('/');
+			const res = await fixture.fetch('/headings');
+			const html = await res.text();
+			const { document } = parseHTML(html);
+
+			idTest(document);
+		});
+
+		it('generates the same IDs for other documents with the same headings', async () => {
+			const res = await fixture.fetch('/headings-stale-cache-check');
 			const html = await res.text();
 			const { document } = parseHTML(html);
 
@@ -35,7 +43,7 @@ describe('Markdoc - Headings', () => {
 		});
 
 		it('generates a TOC with correct info', async () => {
-			const res = await fixture.fetch('/');
+			const res = await fixture.fetch('/headings');
 			const html = await res.text();
 			const { document } = parseHTML(html);
 
@@ -49,14 +57,21 @@ describe('Markdoc - Headings', () => {
 		});
 
 		it('applies IDs to headings', async () => {
-			const html = await fixture.readFile('/index.html');
+			const html = await fixture.readFile('/headings/index.html');
+			const { document } = parseHTML(html);
+
+			idTest(document);
+		});
+
+		it('generates the same IDs for other documents with the same headings', async () => {
+			const html = await fixture.readFile('/headings-stale-cache-check/index.html');
 			const { document } = parseHTML(html);
 
 			idTest(document);
 		});
 
 		it('generates a TOC with correct info', async () => {
-			const html = await fixture.readFile('/index.html');
+			const html = await fixture.readFile('/headings/index.html');
 			const { document } = parseHTML(html);
 
 			tocTest(document);
@@ -83,7 +98,15 @@ describe('Markdoc - Headings with custom Astro renderer', () => {
 		});
 
 		it('applies IDs to headings', async () => {
-			const res = await fixture.fetch('/');
+			const res = await fixture.fetch('/headings');
+			const html = await res.text();
+			const { document } = parseHTML(html);
+
+			idTest(document);
+		});
+
+		it('generates the same IDs for other documents with the same headings', async () => {
+			const res = await fixture.fetch('/headings-stale-cache-check');
 			const html = await res.text();
 			const { document } = parseHTML(html);
 
@@ -91,7 +114,7 @@ describe('Markdoc - Headings with custom Astro renderer', () => {
 		});
 
 		it('generates a TOC with correct info', async () => {
-			const res = await fixture.fetch('/');
+			const res = await fixture.fetch('/headings');
 			const html = await res.text();
 			const { document } = parseHTML(html);
 
@@ -99,7 +122,7 @@ describe('Markdoc - Headings with custom Astro renderer', () => {
 		});
 
 		it('renders Astro component for each heading', async () => {
-			const res = await fixture.fetch('/');
+			const res = await fixture.fetch('/headings');
 			const html = await res.text();
 			const { document } = parseHTML(html);
 
@@ -113,21 +136,28 @@ describe('Markdoc - Headings with custom Astro renderer', () => {
 		});
 
 		it('applies IDs to headings', async () => {
-			const html = await fixture.readFile('/index.html');
+			const html = await fixture.readFile('/headings/index.html');
+			const { document } = parseHTML(html);
+
+			idTest(document);
+		});
+
+		it('generates the same IDs for other documents with the same headings', async () => {
+			const html = await fixture.readFile('/headings-stale-cache-check/index.html');
 			const { document } = parseHTML(html);
 
 			idTest(document);
 		});
 
 		it('generates a TOC with correct info', async () => {
-			const html = await fixture.readFile('/index.html');
+			const html = await fixture.readFile('/headings/index.html');
 			const { document } = parseHTML(html);
 
 			tocTest(document);
 		});
 
 		it('renders Astro component for each heading', async () => {
-			const html = await fixture.readFile('/index.html');
+			const html = await fixture.readFile('/headings/index.html');
 			const { document } = parseHTML(html);
 
 			astroComponentTest(document);


### PR DESCRIPTION
## Changes

- Switch from a global `headingSlugger` to a context variable scoped to the config. Adding arbitrary variables to the Markdoc config _was_ endorced by the Stripe team, who uses a `services` pattern for context. We've used `ctx` here.
- Rename `applyDefaultConfig()` to `setupConfig()`. Better captures why this function should be run for each file's transform, and the fact that it sets up context

## Testing

Add test for heading cache leaks for documents with the same heading IDs

## Docs

N/A