### PR TITLE
fix(hoisted scripts): consider script's dependents

### DIFF
--- a/.changeset/perfect-oranges-tease.md
+++ b/.changeset/perfect-oranges-tease.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed an issue where scripts that weren't safe to inline were inlined.


### PR DESCRIPTION
## Changes
Fixes #7116
The hoisted scripts plugin seems to have been written with the assumption that each chunk is more-or-less an independent chunk of code. This assumption breaks as Vite creates shared chunks when multiple pages use the same scripts. We already consider that a script may import other scripts, but not that it may be imported by others. This leads to a case where we inline a hoisted script and delete it from the bundle while other scripts have a reference to it.

## Testing
The bug only manifests in large websites where Vite can deduplicate hoisted scripts by creating shared chunks from them. Not sure how to go about making a fixture for this.

## Docs
Not affected.
