### PR TITLE
fix(prefetch): distribute `@types` dir

### DIFF
--- a/.changeset/popular-pots-confess.md
+++ b/.changeset/popular-pots-confess.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/prefetch': patch
+---
+
+distribute @types dir

--- a/packages/integrations/prefetch/package.json
+++ b/packages/integrations/prefetch/package.json
@@ -24,7 +24,8 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist"
+    "dist",
+    "@types"
   ],
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",


### PR DESCRIPTION
## Changes

The `@astrojs/prefetch` integration references a file in its dist `*.js` files that is not included in NPM downloads.
Hence, [my builds are failing](https://github.com/DerYeger/jan-mueller/actions/runs/5029812698/jobs/9021789049?pr=169#step:3:78).

This PR updates the `package.json` `files` section to include the required files.

## Testing

I did not test this change in this library, as only the distribution is affected.
Instead, I replicated the change in my affected repository and verified that the fix does work.

## Docs

No changes to the docs are required, IMO.
