### PR TITLE
Add MDX optimize option

### DIFF
--- a/.changeset/dirty-singers-enjoy.md
+++ b/.changeset/dirty-singers-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Add `optimize` option for faster builds and rendering

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -83,6 +83,7 @@ You can configure how your MDX is rendered with the following options:
 - [Options inherited from Markdown config](#options-inherited-from-markdown-config)
 - [`extendMarkdownConfig`](#extendmarkdownconfig)
 - [`recmaPlugins`](#recmaplugins)
+- [`optimize`](#optimize)
 
 ### Options inherited from Markdown config
 
@@ -185,9 +186,34 @@ We suggest [using AST Explorer](https://astexplorer.net/) to play with estree ou
 
 ### `optimize`
 
-Whether to optimize the MDX output for faster builds and rendering. An internal rehype plugin will be injected last to transform static parts of the `hast` into [`set:html` properties](https://docs.astro.build/en/reference/directives-reference/#sethtml). As this modifies the intermediate `estree` and leaves some generated HTML to be un-escaped, the option is disabled by default.
+- **Type:** `boolean | { customComponentNames?: string[] }`
 
-As the optimizer works within individual MDX files, if you're [passing custom components to an imported MDX content](https://docs.astro.build/en/guides/markdown-content/#custom-components-with-imported-mdx), you'll need to configure `customComponentNames` to prevent the optimizer from handling the custom components:
+This is an optional configuration setting to optimize the MDX output for faster builds and rendering via an internal rehype plugin. This may be useful if you have many MDX content and notice slow builds. However, this option may generate some unescaped HTML, so make sure your site's interactive parts still work correctly after enabling it.
+
+This is disabled by default. To enable MDX optimization, add the following to your MDX integration configuration:
+
+__`astro.config.mjs`__
+
+```js
+import { defineConfig } from 'astro/config';
+import mdx from '@astrojs/mdx';
+
+export default defineConfig({
+  integrations: [
+    mdx({
+      optimize: true,
+    })
+  ]
+});
+```
+
+### `customComponentNames`
+
+- **Type:** `string[]`
+
+An optional property of `optimize` to prevent the MDX optimizer from handling any [custom components passed to imported MDX content](https://docs.astro.build/en/guides/markdown-content/#custom-components-with-imported-mdx).
+
+You will need to exclude these components from optimization as the optimizer eagerly converts content into a static string, which will break custom components that needs to be dynamically rendered. For example, with the below configuration, the MDX output should be `<Heading>...</Heading>` instead of `"<h1>...</h1>"`.
 
 ```astro
 ---
@@ -197,6 +223,10 @@ import Heading from '../Heading.astro';
 
 <Content components={{...components, h1: Heading }} />
 ```
+
+Note that if you use `export const components = { ... }` in your MDX file to configure custom components, you don't need to manually configure this option as the optimizer will automatically detect them.
+
+To configure this option, specify an array of HTML element names that are custom components:
 
 __`astro.config.mjs`__
 
@@ -215,9 +245,6 @@ export default defineConfig({
   ]
 });
 ```
-
-> **Note**
-> If you're using `export const components = { ... }` in your MDX file, the optimizer will automatically detect and add them to `customComponentNames` so you don't have to manually configure it.
 
 ## Examples
 

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -188,7 +188,7 @@ We suggest [using AST Explorer](https://astexplorer.net/) to play with estree ou
 
 - **Type:** `boolean | { customComponentNames?: string[] }`
 
-This is an optional configuration setting to optimize the MDX output for faster builds and rendering via an internal rehype plugin. This may be useful if you have many MDX content and notice slow builds. However, this option may generate some unescaped HTML, so make sure your site's interactive parts still work correctly after enabling it.
+This is an optional configuration setting to optimize the MDX output for faster builds and rendering via an internal rehype plugin. This may be useful if you have many MDX files and notice slow builds. However, this option may generate some unescaped HTML, so make sure your site's interactive parts still work correctly after enabling it.
 
 This is disabled by default. To enable MDX optimization, add the following to your MDX integration configuration:
 
@@ -211,9 +211,11 @@ export default defineConfig({
 
 - **Type:** `string[]`
 
-An optional property of `optimize` to prevent the MDX optimizer from handling any [custom components passed to imported MDX content](https://docs.astro.build/en/guides/markdown-content/#custom-components-with-imported-mdx).
+An optional property of `optimize` to prevent the MDX optimizer from handling any [custom components passed to imported MDX content via the components prop](https://docs.astro.build/en/guides/markdown-content/#custom-components-with-imported-mdx).
 
-You will need to exclude these components from optimization as the optimizer eagerly converts content into a static string, which will break custom components that needs to be dynamically rendered. For example, with the below configuration, the MDX output should be `<Heading>...</Heading>` instead of `"<h1>...</h1>"`.
+You will need to exclude these components from optimization as the optimizer eagerly converts content into a static string, which will break custom components that needs to be dynamically rendered. 
+
+For example, the intended MDX output of the following is `<Heading>...</Heading>` in place of every `"<h1>...</h1>"`:
 
 ```astro
 ---
@@ -224,9 +226,7 @@ import Heading from '../Heading.astro';
 <Content components={{...components, h1: Heading }} />
 ```
 
-Note that if you use `export const components = { ... }` in your MDX file to configure custom components, you don't need to manually configure this option as the optimizer will automatically detect them.
-
-To configure this option, specify an array of HTML element names that are custom components:
+To configure optimization for this using the `customComponentNames` property, specify an array of HTML element names that should be treated as custom components:
 
 __`astro.config.mjs`__
 
@@ -239,12 +239,15 @@ export default defineConfig({
     mdx({
       optimize: {
         // Prevent the optimizer from handling `h1` elements
+        // These will be treated as custom components
         customComponentNames: ['h1'],
       },
     })
   ]
 });
 ```
+
+Note that if your MDX file [configures custom components using `export const components = { ... }`](https://docs.astro.build/en/guides/markdown-content/#assigning-custom-components-to-html-elements), then you do not need to manually configure this option. The optimizer will automatically detect them.
 
 ## Examples
 

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -183,6 +183,42 @@ These are plugins that modify the output [estree](https://github.com/estree/estr
 
 We suggest [using AST Explorer](https://astexplorer.net/) to play with estree outputs, and trying [`estree-util-visit`](https://unifiedjs.com/explore/package/estree-util-visit/) for searching across JavaScript nodes.
 
+### `optimize`
+
+Whether to optimize the MDX output for faster builds and rendering. An internal rehype plugin will be injected last to transform static parts of the `hast` into [`set:html` properties](https://docs.astro.build/en/reference/directives-reference/#sethtml). As this modifies the intermediate `estree` and leaves some generated HTML to be un-escaped, the option is disabled by default.
+
+As the optimizer works within individual MDX files, if you're [passing custom components to an imported MDX content](https://docs.astro.build/en/guides/markdown-content/#custom-components-with-imported-mdx), you'll need to configure `customComponentNames` to prevent the optimizer from handling the custom components:
+
+```astro
+---
+import { Content, components } from '../content.mdx';
+import Heading from '../Heading.astro';
+---
+
+<Content components={{...components, h1: Heading }} />
+```
+
+__`astro.config.mjs`__
+
+```js
+import { defineConfig } from 'astro/config';
+import mdx from '@astrojs/mdx';
+
+export default defineConfig({
+  integrations: [
+    mdx({
+      optimize: {
+        // Prevent the optimizer from handling `h1` elements
+        customComponentNames: ['h1'],
+      },
+    })
+  ]
+});
+```
+
+> **Note**
+> If you're using `export const components = { ... }` in your MDX file, the optimizer will automatically detect and add them to `customComponentNames` so you don't have to manually configure it.
+
 ## Examples
 
 *   The [Astro MDX starter template](https://github.com/withastro/astro/tree/latest/examples/with-mdx) shows how to use MDX files in your Astro project.

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -207,7 +207,7 @@ export default defineConfig({
 });
 ```
 
-### `customComponentNames`
+#### `customComponentNames`
 
 - **Type:** `string[]`
 

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -43,6 +43,7 @@
     "estree-util-visit": "^1.2.0",
     "github-slugger": "^1.4.0",
     "gray-matter": "^4.0.3",
+    "hast-util-to-html": "^8.0.4",
     "kleur": "^4.1.4",
     "rehype-raw": "^6.1.1",
     "remark-frontmatter": "^4.0.1",

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -12,6 +12,7 @@ import { SourceMapGenerator } from 'source-map';
 import { VFile } from 'vfile';
 import type { Plugin as VitePlugin } from 'vite';
 import { getRehypePlugins, getRemarkPlugins, recmaInjectImportMetaEnvPlugin } from './plugins.js';
+import type { OptimizeOptions } from './rehype-optimize-static.js';
 import { getFileInfo, ignoreStringPlugins, parseFrontmatter } from './utils.js';
 
 export type MdxOptions = Omit<typeof markdownConfigDefaults, 'remarkPlugins' | 'rehypePlugins'> & {
@@ -22,6 +23,7 @@ export type MdxOptions = Omit<typeof markdownConfigDefaults, 'remarkPlugins' | '
 	remarkPlugins: PluggableList;
 	rehypePlugins: PluggableList;
 	remarkRehype: RemarkRehypeOptions;
+	optimize: boolean | OptimizeOptions;
 };
 
 type SetupHookParams = HookParameters<'astro:config:setup'> & {
@@ -195,6 +197,7 @@ function markdownConfigToMdxOptions(markdownConfig: typeof markdownConfigDefault
 		remarkPlugins: ignoreStringPlugins(markdownConfig.remarkPlugins),
 		rehypePlugins: ignoreStringPlugins(markdownConfig.rehypePlugins),
 		remarkRehype: (markdownConfig.remarkRehype as any) ?? {},
+		optimize: false,
 	};
 }
 
@@ -215,6 +218,7 @@ function applyDefaultOptions({
 		remarkPlugins: options.remarkPlugins ?? defaults.remarkPlugins,
 		rehypePlugins: options.rehypePlugins ?? defaults.rehypePlugins,
 		shikiConfig: options.shikiConfig ?? defaults.shikiConfig,
+		optimize: options.optimize ?? defaults.optimize,
 	};
 }
 

--- a/packages/integrations/mdx/src/plugins.ts
+++ b/packages/integrations/mdx/src/plugins.ts
@@ -16,6 +16,7 @@ import type { VFile } from 'vfile';
 import type { MdxOptions } from './index.js';
 import { rehypeInjectHeadingsExport } from './rehype-collect-headings.js';
 import rehypeMetaString from './rehype-meta-string.js';
+import { rehypeOptimizeStatic } from './rehype-optimize-static.js';
 import { remarkImageToComponent } from './remark-images-to-component.js';
 import remarkPrism from './remark-prism.js';
 import remarkShiki from './remark-shiki.js';
@@ -145,6 +146,12 @@ export function getRehypePlugins(mdxOptions: MdxOptions): MdxRollupPluginOptions
 		// computed from `astro.data.frontmatter` in VFile data
 		rehypeApplyFrontmatterExport,
 	];
+
+	if (mdxOptions.optimize) {
+		const options = mdxOptions.optimize === true ? undefined : mdxOptions.optimize;
+		rehypePlugins.push([rehypeOptimizeStatic, options]);
+	}
+
 	return rehypePlugins;
 }
 

--- a/packages/integrations/mdx/src/plugins.ts
+++ b/packages/integrations/mdx/src/plugins.ts
@@ -148,6 +148,7 @@ export function getRehypePlugins(mdxOptions: MdxOptions): MdxRollupPluginOptions
 	];
 
 	if (mdxOptions.optimize) {
+		// Convert user `optimize` option to compatible `rehypeOptimizeStatic` option
 		const options = mdxOptions.optimize === true ? undefined : mdxOptions.optimize;
 		rehypePlugins.push([rehypeOptimizeStatic, options]);
 	}

--- a/packages/integrations/mdx/src/rehype-optimize-static.ts
+++ b/packages/integrations/mdx/src/rehype-optimize-static.ts
@@ -1,0 +1,97 @@
+import { visit } from 'estree-util-visit';
+import { toHtml } from 'hast-util-to-html';
+
+// accessing untyped hast and mdx types
+type Node = any;
+
+export interface OptimizeOptions {
+	customComponentNames?: string[];
+}
+
+const exportConstComponentsRe = /export\s+const\s+components\s*=/;
+
+/**
+ * For MDX only, collapse static subtrees of the hast into `set:html`. Subtrees
+ * do not include any MDX elements.
+ *
+ * This optimization reduces the JS output as more content are represented as a
+ * string instead, which also reduces the AST size that Rollup holds in memory.
+ */
+export function rehypeOptimizeStatic(options?: OptimizeOptions) {
+	return (tree: any) => {
+		// Read `export const components` to make sure the components are not optimized.
+		const customComponentNames = new Set<string>(options?.customComponentNames);
+		for (const child of tree.children) {
+			if (child.type === 'mdxjsEsm' && exportConstComponentsRe.test(child.value)) {
+				const objectPropertyNodes = child.data.estree.body[0]?.declarations?.[0]?.init?.properties;
+				if (objectPropertyNodes) {
+					for (const objectPropertyNode of objectPropertyNodes) {
+						const componentName = objectPropertyNode.key?.name ?? objectPropertyNode.key?.value;
+						if (componentName) {
+							customComponentNames.add(componentName);
+						}
+					}
+				}
+			}
+		}
+
+		// All possible elements that could be the root of a subtree
+		const allPossibleElements = new Set<Node>();
+		// The current collapsible element stack while traversing the tree
+		const elementStack: Node[] = [];
+
+		visit(tree, {
+			enter(node) {
+				// @ts-expect-error read tagName naively
+				const isCustomComponent = node.tagName && customComponentNames.has(node.tagName);
+				// For nodes that can't be optimized, eliminate all elements in the
+				// `elementStack` from the `allPossibleElements` set.
+				if (node.type.startsWith('mdx') || isCustomComponent) {
+					for (const el of elementStack) {
+						allPossibleElements.delete(el);
+					}
+					// Micro-optimization: While this destroys the meaning of an element
+					// stack for this node, things will still work but we won't repeatedly
+					// run the above for other nodes anymore. If this is confusing, you can
+					// comment out the code below when reading.
+					elementStack.length = 0;
+				}
+				// For possible subtree root nodes, record them
+				if (node.type === 'element' || node.type === 'mdxJsxFlowElement') {
+					elementStack.push(node);
+					allPossibleElements.add(node);
+				}
+			},
+			leave(node, _, __, parents) {
+				// Similar as above, but pop the `elementStack`
+				if (node.type === 'element' || node.type === 'mdxJsxFlowElement') {
+					elementStack.pop();
+					// Many possible elements could be part of a subtree, in order to find
+					// the root, we check the parent of the element we're popping. If the
+					// parent exists in `allPossibleElements`, then we're definitely not
+					// the root, so remove ourselves. This will work retroactively as we
+					// climb back up the tree.
+					const parent = parents[parents.length - 1];
+					if (allPossibleElements.has(parent)) {
+						allPossibleElements.delete(node);
+					}
+				}
+			},
+		});
+
+		// For all possible subtree roots, collapse them into `set:html` and
+		// strip of their children
+		for (const el of allPossibleElements) {
+			if (el.type === 'mdxJsxFlowElement') {
+				el.attributes.push({
+					type: 'mdxJsxAttribute',
+					name: 'set:html',
+					value: toHtml(el.children),
+				});
+			} else {
+				el.properties['set:html'] = toHtml(el.children);
+			}
+			el.children = [];
+		}
+	};
+}

--- a/packages/integrations/mdx/test/fixtures/mdx-optimize/astro.config.mjs
+++ b/packages/integrations/mdx/test/fixtures/mdx-optimize/astro.config.mjs
@@ -1,0 +1,9 @@
+import mdx from '@astrojs/mdx';
+
+export default {
+	integrations: [mdx({
+		optimize: {
+			customComponentNames: ['strong']
+		}
+	})]
+}

--- a/packages/integrations/mdx/test/fixtures/mdx-optimize/package.json
+++ b/packages/integrations/mdx/test/fixtures/mdx-optimize/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/mdx-optimize",
+  "private": true,
+  "dependencies": {
+    "@astrojs/mdx": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/mdx/test/fixtures/mdx-optimize/src/components/Blockquote.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-optimize/src/components/Blockquote.astro
@@ -1,0 +1,3 @@
+<blockquote {...Astro.props} class="custom-blockquote">
+  <slot />
+</blockquote>

--- a/packages/integrations/mdx/test/fixtures/mdx-optimize/src/components/Strong.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-optimize/src/components/Strong.astro
@@ -1,0 +1,3 @@
+<strong {...Astro.props} class="custom-strong">
+  <slot />
+</strong>

--- a/packages/integrations/mdx/test/fixtures/mdx-optimize/src/pages/_imported.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-optimize/src/pages/_imported.mdx
@@ -1,0 +1,3 @@
+I once heard a very **inspirational** quote:
+
+> I like pancakes

--- a/packages/integrations/mdx/test/fixtures/mdx-optimize/src/pages/import.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-optimize/src/pages/import.astro
@@ -1,0 +1,15 @@
+---
+import { Content, components } from './index.mdx'
+import Strong from '../components/Strong.astro'
+---
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Import MDX component</title>
+  </head>
+  <body>
+    <h1>Astro page</h1>
+    <Content components={{ ...components, strong: Strong }} />
+  </body>
+</html>

--- a/packages/integrations/mdx/test/fixtures/mdx-optimize/src/pages/index.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-optimize/src/pages/index.mdx
@@ -1,0 +1,15 @@
+import Blockquote from '../components/Blockquote.astro'
+
+export const components = {
+  blockquote: Blockquote
+}
+
+# MDX page
+
+I once heard a very inspirational quote:
+
+> I like pancakes
+
+```js
+const pancakes = 'yummy'
+```

--- a/packages/integrations/mdx/test/mdx-optimize.test.js
+++ b/packages/integrations/mdx/test/mdx-optimize.test.js
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+import { parseHTML } from 'linkedom';
+import { loadFixture } from '../../../astro/test/test-utils.js';
+
+const FIXTURE_ROOT = new URL('./fixtures/mdx-optimize/', import.meta.url);
+
+describe('MDX optimize', () => {
+	let fixture;
+	before(async () => {
+		fixture = await loadFixture({
+			root: FIXTURE_ROOT,
+		});
+		await fixture.build();
+	});
+
+	it('renders an MDX page fine', async () => {
+		const html = await fixture.readFile('/index.html');
+		const { document } = parseHTML(html);
+
+		expect(document.querySelector('h1').textContent).include('MDX page');
+		expect(document.querySelector('p').textContent).include(
+			'I once heard a very inspirational quote:'
+		);
+
+		const blockquote = document.querySelector('blockquote.custom-blockquote');
+		expect(blockquote).to.not.be.null;
+		expect(blockquote.textContent).to.include('I like pancakes');
+
+		const code = document.querySelector('pre.astro-code');
+		expect(code).to.not.be.null;
+		expect(code.textContent).to.include(`const pancakes = 'yummy'`);
+	});
+
+	it('renders an Astro page that imports MDX fine', async () => {
+		const html = await fixture.readFile('/import/index.html');
+		const { document } = parseHTML(html);
+
+		expect(document.querySelector('h1').textContent).include('Astro page');
+		expect(document.querySelector('p').textContent).include(
+			'I once heard a very inspirational quote:'
+		);
+
+		const blockquote = document.querySelector('blockquote.custom-blockquote');
+		expect(blockquote).to.not.be.null;
+		expect(blockquote.textContent).to.include('I like pancakes');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4140,6 +4140,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      hast-util-to-html:
+        specifier: ^8.0.4
+        version: 8.0.4
       kleur:
         specifier: ^4.1.4
         version: 4.1.5
@@ -4312,6 +4315,15 @@ importers:
       react-dom:
         specifier: ^18.1.0
         version: 18.2.0(react@18.2.0)
+
+  packages/integrations/mdx/test/fixtures/mdx-optimize:
+    dependencies:
+      '@astrojs/mdx':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
 
   packages/integrations/mdx/test/fixtures/mdx-page:
     dependencies:


### PR DESCRIPTION
## Changes

Add `optimize` option for `@astrojs/mdx` to optimize the MDX output for faster builds and rendering.

Most of the rehype code is copied from https://github.com/withastro/docs/blob/6b6f629e2241dce12dd4763124d00eeb223aa1f4/plugins/rehype-optimize-static.ts, but:
- Removed special heading handling as this rehype plugin will always run last
- Add custom components handling (`export const components` and from a config option)

## Testing

Added tests to `@astrojs/mdx`. Also manually tested with Astro docs.

## Docs

Added docs for the new option in the `@astrojs/mdx` README.

/cc @withastro/maintainers-docs for feedback!


