### PR TITLE
feat: :art: export rss feeditem type

### DIFF
--- a/.changeset/lemon-flies-smoke.md
+++ b/.changeset/lemon-flies-smoke.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': patch
+---
+
+exposes RSSFeedItem type

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -32,7 +32,7 @@ export type RSSOptions = {
 	trailingSlash?: z.infer<typeof rssOptionsValidator>['trailingSlash'];
 };
 
-type RSSFeedItem = {
+export type RSSFeedItem = {
 	/** Link to item */
 	link: string;
 	/** Full content of the item. Should be valid HTML */


### PR DESCRIPTION
## Changes

Exposes `RSSFeedItem` type. This will be helpful when we are processing multiple items and want to typecast is correctly before passing it to `rss({}: RSSOptions)` 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Nothing to test specifically since this does not change any core logic

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Not sure if we need to mention this in docs that we are exposing the type, since I did not find anything about existing exported types as well like `RSSOptions` 🤔 
