### PR TITLE
Support redirects in Netlify SSR configuration

### DIFF
--- a/packages/integrations/netlify/src/integration-static.ts
+++ b/packages/integrations/netlify/src/integration-static.ts
@@ -10,16 +10,6 @@ export function netlifyStatic(): AstroIntegration {
 			'astro:config:done': ({ config }) => {
 				_config = config;
 			},
-			// 'astro:config:setup': ({ config, updateConfig }) => {
-			// 	const outDir = dist ?? new URL('./dist/', config.root);
-			// 	updateConfig({
-			// 		outDir,
-			// 		build: {
-			// 			client: outDir,
-			// 			server: new URL('./.netlify/functions-internal/', config.root),
-			// 		},
-			// 	});
-			// },
 			'astro:build:done': async ({ dir, routes }) => {
 				await createRedirects(_config, routes, dir, '', 'static');
 			}

--- a/packages/integrations/netlify/src/shared.ts
+++ b/packages/integrations/netlify/src/shared.ts
@@ -23,16 +23,18 @@ export async function createRedirects(
 
 	for (const route of routes) {
 		if (route.pathname) {
-			if( kind === 'static') {
-				if(route.redirect) {
-					definitions.push({
-						dynamic: false,
-						input: route.pathname,
-						target: route.redirect,
-						status: 301,
-						weight: 1
-					});
-				}
+			if(route.redirect) {
+				definitions.push({
+					dynamic: false,
+					input: route.pathname,
+					target: route.redirect,
+					status: 301,
+					weight: 1
+				});
+				continue;
+			}
+
+			if(kind === 'static') {
 				continue;
 			}
 			else if (route.distURL) {
@@ -80,7 +82,7 @@ export async function createRedirects(
 					})
 					.join('/');
 
-			if(kind === 'static') {
+			//if(kind === 'static') {
 				if(route.redirect) {
 					definitions.push({
 						dynamic: true,
@@ -89,8 +91,11 @@ export async function createRedirects(
 						status: 301,
 						weight: 1
 					});
+					continue;
 				}
-				continue;
+
+			if(kind === 'static') {
+				continue;	
 			}
 			else if (route.distURL) {
 				const target =

--- a/packages/integrations/netlify/test/functions/redirects.test.js
+++ b/packages/integrations/netlify/test/functions/redirects.test.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import { load as cheerioLoad } from 'cheerio';
+import { loadFixture, testIntegration } from './test-utils.js';
+import netlifyAdapter from '../../dist/index.js';
+import { fileURLToPath } from 'url';
+
+describe('SSG - Redirects', () => {
+	/** @type {import('../../../astro/test/test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('../static/fixtures/redirects/', import.meta.url).toString(),
+			output: 'server',
+			adapter: netlifyAdapter({
+				dist: new URL('../static/fixtures/redirects/dist/', import.meta.url),
+			}),
+			site: `http://example.com`,
+			integrations: [testIntegration()],
+			redirects: {
+				'/other': '/'
+			}
+		});
+		await fixture.build();
+	});
+
+	it('Creates a redirects file', async () => {
+		let redirects = await fixture.readFile('/_redirects');
+		let parts = redirects.split(/\s+/);
+		expect(parts).to.deep.equal([
+			'/other', '/', '301',
+			'/', '/.netlify/functions/entry', '200',
+
+			// This uses the dynamic Astro.redirect, so we don't know that it's a redirect
+			// until runtime. This is correct!
+			'/nope', '/.netlify/functions/entry', '200'
+		]);
+	});
+});


### PR DESCRIPTION
## Changes

- Adds support for the `redirects` config to Netlify adapters (Edge and Serverless).
- Creates (or updates) the `_redirects` config file.

## Testing

- Test case added

## Docs

N/A