### PR TITLE
Prevent Vite watching on Astro config load

### DIFF
--- a/.changeset/orange-lizards-report.md
+++ b/.changeset/orange-lizards-report.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent Vite watching on Astro config load

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -10,7 +10,7 @@ export interface ViteLoader {
 
 async function createViteLoader(root: string, fs: typeof fsType): Promise<ViteLoader> {
 	const viteServer = await vite.createServer({
-		server: { middlewareMode: true, hmr: false },
+		server: { middlewareMode: true, hmr: false, watch: { ignored: ['**'] } },
 		optimizeDeps: { disabled: true },
 		clearScreen: false,
 		appType: 'custom',

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -65,7 +65,7 @@ export async function sync(
 	const tempViteServer = await createServer(
 		await createVite(
 			{
-				server: { middlewareMode: true, hmr: false },
+				server: { middlewareMode: true, hmr: false, watch: { ignored: ['**/*'] } },
 				optimizeDeps: { disabled: true },
 				ssr: { external: [] },
 				logLevel: 'silent',

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -65,7 +65,7 @@ export async function sync(
 	const tempViteServer = await createServer(
 		await createVite(
 			{
-				server: { middlewareMode: true, hmr: false, watch: { ignored: ['**/*'] } },
+				server: { middlewareMode: true, hmr: false, watch: { ignored: ['**'] } },
 				optimizeDeps: { disabled: true },
 				ssr: { external: [] },
 				logLevel: 'silent',


### PR DESCRIPTION
## Changes

From @ematipico's suggestion https://github.com/withastro/astro/issues/7073#issuecomment-1557144748, we could prevent Vite watching when spinning up the Vite dev server.

It looks like the watching is already disabled for content collections / `astro sync` via:

https://github.com/withastro/astro/blob/6112671100122904db78aa9f880dbfe957aa0c24/packages/astro/src/core/create-vite.ts#L155

But I updated the Astro config load flow too as that will benefit from it.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Logged `viteServer.watcher.getWatched()` to verify that directories aren't watched.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. internal improvement.