### PR TITLE
Add types for `import.meta.env.ASSETS_PREFIX` and `import.meta.env.SITE`

### DIFF
--- a/.changeset/hungry-lobsters-happen.md
+++ b/.changeset/hungry-lobsters-happen.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add types for `import.meta.env.ASSETS_PREFIX` and `import.meta.env.SITE`

--- a/packages/astro/client-base.d.ts
+++ b/packages/astro/client-base.d.ts
@@ -1,5 +1,32 @@
 /// <reference path="./import-meta.d.ts" />
 
+// eslint-disable-next-line  @typescript-eslint/no-namespace
+declare namespace App {
+	// eslint-disable-next-line  @typescript-eslint/no-empty-interface
+	export interface Locals {}
+}
+
+interface ImportMetaEnv {
+	/**
+	 * The prefix for Astro-generated asset links if the build.assetsPrefix config option is set. This can be used to create asset links not handled by Astro.
+	 */
+	readonly ASSETS_PREFIX: string;
+	/**
+	 * This is set to the site option specified in your project’s Astro config file.
+	 */
+	readonly SITE: string;
+}
+
+interface ImportMeta {
+	/**
+	 * Astro and Vite expose environment variables through `import.meta.env`. For a complete list of the environment variables available, see the two references below.
+	 *
+	 * - [Astro reference](https://docs.astro.build/en/guides/environment-variables/#default-environment-variables)
+	 * - [Vite reference](https://vitejs.dev/guide/env-and-mode.html#env-variables)
+	 */
+	readonly env: ImportMetaEnv;
+}
+
 declare module 'astro:assets' {
 	// Exporting things one by one is a bit cumbersome, not sure if there's a better way - erika, 2023-02-03
 	type AstroAssets = {
@@ -386,10 +413,4 @@ declare module '*?url' {
 declare module '*?inline' {
 	const src: string;
 	export default src;
-}
-
-// eslint-disable-next-line  @typescript-eslint/no-namespace
-declare namespace App {
-	// eslint-disable-next-line  @typescript-eslint/no-empty-interface
-	export interface Locals {}
 }

--- a/packages/astro/client-image.d.ts
+++ b/packages/astro/client-image.d.ts
@@ -2,7 +2,7 @@
 
 // TODO: Merge this file with `client-base.d.ts` in 3.0, when the `astro:assets` feature isn't under a flag anymore.
 
-type InputFormat = import('./dist/assets/types.js').InputFormat;
+type InputFormat = import('./dist/assets/types.js').ImageInputFormat;
 
 interface ImageMetadata {
 	src: string;

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -21,10 +21,6 @@ declare module '*.svg' {
 	const src: string;
 	export default src;
 }
-declare module '*.ico' {
-	const src: string;
-	export default src;
-}
 declare module '*.webp' {
 	const src: string;
 	export default src;

--- a/packages/astro/import-meta.d.ts
+++ b/packages/astro/import-meta.d.ts
@@ -1,17 +1,10 @@
-// File vendored from Vite itself, as a workaround to https://github.com/vitejs/vite/pull/9827 until Vite 4 comes out
+// File vendored from Vite itself, as a workaround to https://github.com/vitejs/vite/issues/13309 until Vite 5 comes out
 
 // This file is an augmentation to the built-in ImportMeta interface
 // Thus cannot contain any top-level imports
 // <https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation>
 
 /* eslint-disable @typescript-eslint/consistent-type-imports */
-
-// Duplicate of import('../src/node/importGlob').GlobOptions in order to
-// avoid breaking the production client type. Because this file is referenced
-// in vite/client.d.ts and in production src/node/importGlob.ts doesn't exist.
-interface GlobOptions {
-	as?: string;
-}
 
 interface ImportMeta {
 	url: string;


### PR DESCRIPTION
## Changes

Added types and documentation for the two base env vars that Astro provide. This PR also includes some minimal type fixes that slipped in in previous update, nothing too major

## Testing

Tested manually

## Docs

cc @withastro/maintainers-docs for feedback on the JSDocs
