### PR TITLE
fix: :adhesive_bandage: update partytown options ts type

### DIFF
--- a/.changeset/curvy-hotels-study.md
+++ b/.changeset/curvy-hotels-study.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/partytown': minor
+---
+
+fix typescript type for partytown options

--- a/.changeset/curvy-hotels-study.md
+++ b/.changeset/curvy-hotels-study.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/partytown': minor
+'@astrojs/partytown': patch
 ---
 
 fix typescript type for partytown options

--- a/packages/integrations/partytown/src/index.ts
+++ b/packages/integrations/partytown/src/index.ts
@@ -9,17 +9,15 @@ import { fileURLToPath } from 'url';
 import sirv from './sirv.js';
 const resolve = createRequire(import.meta.url).resolve;
 
-type PartytownOptions =
-	| {
-			config?: PartytownConfig;
-	  }
-	| undefined;
+type PartytownOptions = {
+	config?: PartytownConfig;
+};
 
 function appendForwardSlash(str: string) {
 	return str.endsWith('/') ? str : str + '/';
 }
 
-export default function createPlugin(options: PartytownOptions): AstroIntegration {
+export default function createPlugin(options?: PartytownOptions): AstroIntegration {
 	let config: AstroConfig;
 	let partytownSnippetHtml: string;
 	const partytownEntrypoint = resolve('@builder.io/partytown/package.json');


### PR DESCRIPTION
## Changes

- Fixes the typescript type for partytown options, no need to pass `undefined` when you don't want to add any config

## Testing

N.A

## Docs

N.A

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
