### PR TITLE
fix: add astro-static-slot to the list of inert tags in astro css

### DIFF
--- a/.changeset/static-slot-css.md
+++ b/.changeset/static-slot-css.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+fix: add astro-static-slot to the list of inert tags in astro css

--- a/.changeset/static-slot-css.md
+++ b/.changeset/static-slot-css.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+'astro': patch
 ---
 
 fix: add astro-static-slot to the list of inert tags in astro css

--- a/packages/astro/src/runtime/server/scripts.ts
+++ b/packages/astro/src/runtime/server/scripts.ts
@@ -1,7 +1,7 @@
 import type { SSRResult } from '../../@types/astro';
 import islandScript from './astro-island.prebuilt.js';
 
-const ISLAND_STYLES = `<style>astro-island,astro-slot{display:contents}</style>`;
+const ISLAND_STYLES = `<style>astro-island,astro-slot,astro-static-slot{display:contents}</style>`;
 
 export function determineIfNeedsHydrationScript(result: SSRResult): boolean {
 	if (result._metadata.hasHydrationScript) {


### PR DESCRIPTION
## Changes

In a recent version of Astro we introduced the `<astro-static-slot>` element. Prior to this only `<astro-slot>` and `<astro-island>`. 

When we have this kind of code, we expect the slot to not have an effect ad the div and the image to be on the same line.

```html
<div style="display: flex;">
  <astro-static-slot>
    <img src="test.jpg" />
    <div>Button Content</div>
  </astro-static-slot>
</div>
```

## Testing

It's a simple bug fix, could be tested if browser rendering had apis.

## Docs

Bug fix

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
