### PR TITLE
Remove `@mdx-js/rollup` dependency

### DIFF
--- a/.changeset/spotty-glasses-return.md
+++ b/.changeset/spotty-glasses-return.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Remove `@mdx-js/rollup` dependency

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -37,7 +37,6 @@
     "@astrojs/markdown-remark": "^2.2.1",
     "@astrojs/prism": "^2.1.2",
     "@mdx-js/mdx": "^2.3.0",
-    "@mdx-js/rollup": "^2.3.0",
     "acorn": "^8.8.0",
     "es-module-lexer": "^1.1.1",
     "estree-util-visit": "^1.2.0",

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -1,8 +1,7 @@
 import { markdownConfigDefaults } from '@astrojs/markdown-remark';
 import { toRemarkInitializeAstroData } from '@astrojs/markdown-remark/dist/internal.js';
-import { compile as mdxCompile } from '@mdx-js/mdx';
+import { compile as mdxCompile, type CompileOptions } from '@mdx-js/mdx';
 import type { PluggableList } from '@mdx-js/mdx/lib/core.js';
-import mdxPlugin, { type Options as MdxRollupPluginOptions } from '@mdx-js/rollup';
 import type { AstroIntegration, ContentEntryType, HookParameters } from 'astro';
 import { parse as parseESM } from 'es-module-lexer';
 import fs from 'node:fs/promises';
@@ -67,7 +66,7 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 					),
 				});
 
-				const mdxPluginOpts: MdxRollupPluginOptions = {
+				const mdxPluginOpts: CompileOptions = {
 					remarkPlugins: await getRemarkPlugins(mdxOptions, config),
 					rehypePlugins: getRehypePlugins(mdxOptions),
 					recmaPlugins: mdxOptions.recmaPlugins,
@@ -87,8 +86,8 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 					vite: {
 						plugins: [
 							{
+								name: '@mdx-js/rollup',
 								enforce: 'pre',
-								...mdxPlugin(mdxPluginOpts),
 								configResolved(resolved) {
 									importMetaEnv = { ...importMetaEnv, ...resolved.env };
 								},

--- a/packages/integrations/mdx/src/plugins.ts
+++ b/packages/integrations/mdx/src/plugins.ts
@@ -5,7 +5,6 @@ import {
 } from '@astrojs/markdown-remark/dist/internal.js';
 import { nodeTypes } from '@mdx-js/mdx';
 import type { PluggableList } from '@mdx-js/mdx/lib/core.js';
-import type { Options as MdxRollupPluginOptions } from '@mdx-js/rollup';
 import type { AstroConfig } from 'astro';
 import type { Literal, MemberExpression } from 'estree';
 import { visit as estreeVisit } from 'estree-util-visit';
@@ -99,7 +98,7 @@ export function rehypeApplyFrontmatterExport() {
 export async function getRemarkPlugins(
 	mdxOptions: MdxOptions,
 	config: AstroConfig
-): Promise<MdxRollupPluginOptions['remarkPlugins']> {
+): Promise<PluggableList> {
 	let remarkPlugins: PluggableList = [
 		...(config.experimental.assets ? [remarkCollectImages, remarkImageToComponent] : []),
 	];
@@ -128,7 +127,7 @@ export async function getRemarkPlugins(
 	return remarkPlugins;
 }
 
-export function getRehypePlugins(mdxOptions: MdxOptions): MdxRollupPluginOptions['rehypePlugins'] {
+export function getRehypePlugins(mdxOptions: MdxOptions): PluggableList {
 	let rehypePlugins: PluggableList = [
 		// ensure `data.meta` is preserved in `properties.metastring` for rehype syntax highlighters
 		rehypeMetaString,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4125,9 +4125,6 @@ importers:
       '@mdx-js/mdx':
         specifier: ^2.3.0
         version: 2.3.0
-      '@mdx-js/rollup':
-        specifier: ^2.3.0
-        version: 2.3.0
       acorn:
         specifier: ^8.8.0
         version: 8.8.2
@@ -8084,22 +8081,6 @@ packages:
       unist-util-position-from-estree: 1.1.2
       unist-util-stringify-position: 3.0.3
       unist-util-visit: 4.1.0
-      vfile: 5.3.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@mdx-js/rollup@2.3.0:
-    resolution: {integrity: sha512-wLvRfJS/M4UmdqTd+WoaySEE7q4BIejYf1xAHXYvtT1du/1Tl/z2450Gg2+Hu7fh05KwRRiehiTP9Yc/Dtn0fA==}
-    peerDependencies:
-      rollup: '>=2'
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@mdx-js/mdx': 2.3.0
-      '@rollup/pluginutils': 5.0.2(rollup@3.20.1)
-      source-map: 0.7.4
       vfile: 5.3.2
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/7176

Remove `@mdx-js/rollup` dep for `@astrojs/mdx` because we're not really using the Rollup plugin entirely. In it's[ source code](https://github.com/mdx-js/mdx/blob/30e4a5d5d561db0b14ec60467ce44d7e3bf27884/packages/rollup/lib/index.js#L44-L45), there's the `name` and `transform` field, and we're replacing it with our own `transform` field: 

https://github.com/withastro/astro/blob/f43300f1bdf80671c66678ea4596b5a0abfde05d/packages/integrations/mdx/src/index.ts#L94-L96

That leaves the `name` being used only, and we can simplify it by copying over the name and remove the dependency.

## Testing

Existing test should pass.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. internal refactoring.