### PR TITLE
fix: detect `mdx` files using full extension

### DIFF
--- a/.changeset/lazy-zebras-invent.md
+++ b/.changeset/lazy-zebras-invent.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/mdx': patch
+'astro': patch
+---
+
+Detect `mdx` files using their full extension

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -306,7 +306,7 @@ async function render({
 
 			let props = baseProps;
 			// Auto-apply MDX components export
-			if (id.endsWith('mdx')) {
+			if (id.endsWith('.mdx')) {
 				props = {
 					components: mod.components ?? {},
 					...baseProps,

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -95,7 +95,7 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 								// Override transform to alter code before MDX compilation
 								// ex. inject layouts
 								async transform(_, id) {
-									if (!id.endsWith('mdx')) return;
+									if (!id.endsWith('.mdx')) return;
 
 									// Read code from file manually to prevent Vite from parsing `import.meta.env` expressions
 									const { fileId } = getFileInfo(id, config);


### PR DESCRIPTION
## Changes

Changes how we detect `mdx` files using the full extension: `.mdx`

## Testing

Current CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
