### PR TITLE
Implement redirects in Cloudflare

### DIFF
--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -38,6 +38,7 @@
     "test": "mocha --exit --timeout 30000 test/"
   },
   "dependencies": {
+    "@astrojs/underscore-redirects": "^0.1.0",
     "esbuild": "^0.17.12",
     "tiny-glob": "^0.2.9"
   },

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -233,8 +233,6 @@ export default function createIntegration(args?: Options): AstroIntegration {
 	};
 }
 
-function saveRedirects(redirects)
-
 function prependForwardSlash(path: string) {
 	return path[0] === '/' ? path : '/' + path;
 }

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -199,7 +199,11 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					}
 
 					const redirectRoutes = routes.filter(r => r.type === 'redirect');
-					const trueRedirects = createRedirectsFromAstroRoutes(_config, redirectRoutes, dir, '');
+					const trueRedirects = createRedirectsFromAstroRoutes({
+						config: _config,
+						routes: redirectRoutes,
+						dir,
+					});
 					if(!trueRedirects.empty()) {
 						await fs.promises.appendFile(
 							new URL('./_redirects', _config.outDir),

--- a/packages/integrations/cloudflare/test/directory.test.js
+++ b/packages/integrations/cloudflare/test/directory.test.js
@@ -11,6 +11,9 @@ describe('mode: "directory"', () => {
 			root: './fixtures/basics/',
 			output: 'server',
 			adapter: cloudflare({ mode: 'directory' }),
+			redirects: {
+				'/old': '/'
+			}
 		});
 		await fixture.build();
 	});
@@ -18,5 +21,17 @@ describe('mode: "directory"', () => {
 	it('generates functions folder inside the project root', async () => {
 		expect(await fixture.pathExists('../functions')).to.be.true;
 		expect(await fixture.pathExists('../functions/[[path]].js')).to.be.true;
+	});
+
+	it('generates a redirects file', async () => {
+		try {
+			let _redirects = await fixture.readFile('/_redirects');
+			let parts = _redirects.split(/\s+/);
+			expect(parts).to.deep.equal([
+				'/old', '/', '301'
+			]);
+		} catch {
+			expect(false).to.equal(true);
+		}
 	});
 });

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@astrojs/webapi": "^2.1.1",
+    "@astrojs/underscore-redirects": "^0.1.0",
     "@netlify/functions": "^1.0.0",
     "esbuild": "^0.15.18"
   },

--- a/packages/integrations/netlify/src/shared.ts
+++ b/packages/integrations/netlify/src/shared.ts
@@ -13,7 +13,9 @@ export async function createRedirects(
 	const dynamicTarget = `/.netlify/${kind}/${entryFile}`;
 	const _redirectsURL = new URL('./_redirects', dir);
 
-	const _redirects = createRedirectsFromAstroRoutes(config, routes, dir, dynamicTarget);
+	const _redirects = createRedirectsFromAstroRoutes({
+		config, routes, dir, dynamicTarget
+	});
 	const content = _redirects.print();
 
 	// Always use appendFile() because the redirects file could already exist,

--- a/packages/integrations/netlify/src/shared.ts
+++ b/packages/integrations/netlify/src/shared.ts
@@ -1,20 +1,6 @@
-import type { AstroConfig, RouteData, ValidRedirectStatus } from 'astro';
-import fs from 'fs';
-
-export type RedirectDefinition = {
-	dynamic: boolean;
-	input: string;
-	target: string;
-	weight: 0 | 1;
-	status: 200 | 404 | ValidRedirectStatus;
-};
-
-function getRedirectStatus(route: RouteData): ValidRedirectStatus {
-	if(typeof route.redirect === 'object') {
-		return route.redirect.status;
-	}
-	return 301;
-}
+import type { AstroConfig, RouteData } from 'astro';
+import { createRedirectsFromAstroRoutes } from '@astrojs/underscore-redirects';
+import fs from 'node:fs';
 
 export async function createRedirects(
 	config: AstroConfig,
@@ -23,151 +9,15 @@ export async function createRedirects(
 	entryFile: string,
 	type: 'functions' | 'edge-functions' | 'builders' | 'static'
 ) {
-	const _redirectsURL = new URL('./_redirects', dir);
 	const kind = type ?? 'functions';
+	const dynamicTarget = `/.netlify/${kind}/${entryFile}`;
+	const _redirectsURL = new URL('./_redirects', dir);
 
-	const definitions: RedirectDefinition[] = [];
-
-	for (const route of routes) {
-		if (route.pathname) {
-			if(route.redirect) {
-				definitions.push({
-					dynamic: false,
-					input: route.pathname,
-					target: typeof route.redirect === 'object' ? route.redirect.destination : route.redirect,
-					status: getRedirectStatus(route),
-					weight: 1
-				});
-				continue;
-			}
-
-			if(kind === 'static') {
-				continue;
-			}
-			else if (route.distURL) {
-				definitions.push({
-					dynamic: false,
-					input: route.pathname,
-					target: prependForwardSlash(route.distURL.toString().replace(dir.toString(), '')),
-					status: 200,
-					weight: 1,
-				});
-			} else {
-				definitions.push({
-					dynamic: false,
-					input: route.pathname,
-					target: `/.netlify/${kind}/${entryFile}`,
-					status: 200,
-					weight: 1,
-				});
-
-				if (route.route === '/404') {
-					definitions.push({
-						dynamic: true,
-						input: '/*',
-						target: `/.netlify/${kind}/${entryFile}`,
-						status: 404,
-						weight: 0,
-					});
-				}
-			}
-		} else {
-			const pattern = generateDynamicPattern(route);
-
-			if (route.distURL) {
-				const targetRoute = route.redirectRoute ?? route;
-				const targetPattern = generateDynamicPattern(targetRoute);
-				const target =
-					`${targetPattern}` + (config.build.format === 'directory' ? '/index.html' : '.html');
-				definitions.push({
-					dynamic: true,
-					input: pattern,
-					target,
-					status: route.type === 'redirect' ? 301 : 200,
-					weight: 1,
-				});
-			} else {
-				definitions.push({
-					dynamic: true,
-					input: pattern,
-					target: `/.netlify/${kind}/${entryFile}`,
-					status: 200,
-					weight: 1,
-				});
-			}
-		}
-	}
-
-	let _redirects = prettify(definitions);
+	const _redirects = createRedirectsFromAstroRoutes(config, routes, dir, dynamicTarget);
+	const content = _redirects.print();
 
 	// Always use appendFile() because the redirects file could already exist,
 	// e.g. due to a `/public/_redirects` file that got copied to the output dir.
 	// If the file does not exist yet, appendFile() automatically creates it.
-	await fs.promises.appendFile(_redirectsURL, _redirects, 'utf-8');
-}
-
-function generateDynamicPattern(route: RouteData) {
-	const pattern =
-		'/' +
-		route.segments
-			.map(([part]) => {
-				//(part.dynamic ? '*' : part.content)
-				if (part.dynamic) {
-					if (part.spread) {
-						return '*';
-					} else {
-						return ':' + part.content;
-					}
-				} else {
-					return part.content;
-				}
-			})
-			.join('/');
-	return pattern;
-}
-
-function prettify(definitions: RedirectDefinition[]) {
-	let minInputLength = 4,
-		minTargetLength = 4;
-	definitions.sort((a, b) => {
-		// Find the longest input, so we can format things nicely
-		if (a.input.length > minInputLength) {
-			minInputLength = a.input.length;
-		}
-		if (b.input.length > minInputLength) {
-			minInputLength = b.input.length;
-		}
-
-		// Same for the target
-		if (a.target.length > minTargetLength) {
-			minTargetLength = a.target.length;
-		}
-		if (b.target.length > minTargetLength) {
-			minTargetLength = b.target.length;
-		}
-
-		// Sort dynamic routes on top
-		return b.weight - a.weight;
-	});
-
-	let _redirects = '';
-	// Loop over the definitions
-	definitions.forEach((defn, i) => {
-		// Figure out the number of spaces to add. We want at least 4 spaces
-		// after the input. This ensure that all targets line up together.
-		let inputSpaces = minInputLength - defn.input.length + 4;
-		let targetSpaces = minTargetLength - defn.target.length + 4;
-		_redirects +=
-			(i === 0 ? '' : '\n') +
-			defn.input +
-			' '.repeat(inputSpaces) +
-			defn.target +
-			' '.repeat(Math.abs(targetSpaces)) +
-			defn.status;
-	});
-	return _redirects;
-}
-
-function prependForwardSlash(str: string) {
-	return str[0] === '/' ? str : '/' + str;
+	await fs.promises.appendFile(_redirectsURL, content, 'utf-8');
 }

--- a/packages/integrations/netlify/test/functions/dynamic-route.test.js
+++ b/packages/integrations/netlify/test/functions/dynamic-route.test.js
@@ -26,6 +26,7 @@ describe('Dynamic pages', () => {
 
 	it('Prerendered routes are also included using placeholder syntax', async () => {
 		const redir = await fixture.readFile('/_redirects');
+		console.log(redir)
 		expect(redir).to.include('/pets/:cat       /pets/:cat/index.html        200');
 		expect(redir).to.include('/pets/:dog       /pets/:dog/index.html        200');
 		expect(redir).to.include('/pets            /.netlify/functions/entry    200');

--- a/packages/integrations/netlify/test/functions/dynamic-route.test.js
+++ b/packages/integrations/netlify/test/functions/dynamic-route.test.js
@@ -26,7 +26,6 @@ describe('Dynamic pages', () => {
 
 	it('Prerendered routes are also included using placeholder syntax', async () => {
 		const redir = await fixture.readFile('/_redirects');
-		console.log(redir)
 		expect(redir).to.include('/pets/:cat       /pets/:cat/index.html        200');
 		expect(redir).to.include('/pets/:dog       /pets/:dog/index.html        200');
 		expect(redir).to.include('/pets            /.netlify/functions/entry    200');

--- a/packages/integrations/netlify/test/functions/redirects.test.js
+++ b/packages/integrations/netlify/test/functions/redirects.test.js
@@ -28,12 +28,11 @@ describe('SSG - Redirects', () => {
 		let redirects = await fixture.readFile('/_redirects');
 		let parts = redirects.split(/\s+/);
 		expect(parts).to.deep.equal([
-			'/other', '/', '301',
-			'/', '/.netlify/functions/entry', '200',
-
 			// This uses the dynamic Astro.redirect, so we don't know that it's a redirect
 			// until runtime. This is correct!
 			'/nope', '/.netlify/functions/entry', '200',
+			'/', '/.netlify/functions/entry', '200',
+			'/other', '/', '301',
 
 			// A real route
 			'/team/articles/*', '/.netlify/functions/entry', '200',

--- a/packages/integrations/netlify/test/static/redirects.test.js
+++ b/packages/integrations/netlify/test/static/redirects.test.js
@@ -27,6 +27,7 @@ describe('SSG - Redirects', () => {
 
 	it('Creates a redirects file', async () => {
 		let redirects = await fixture.readFile('/_redirects');
+		console.log(redirects)
 		let parts = redirects.split(/\s+/);
 		expect(parts).to.deep.equal([
 			'/nope', '/', '301',

--- a/packages/integrations/netlify/test/static/redirects.test.js
+++ b/packages/integrations/netlify/test/static/redirects.test.js
@@ -29,11 +29,11 @@ describe('SSG - Redirects', () => {
 		let redirects = await fixture.readFile('/_redirects');
 		let parts = redirects.split(/\s+/);
 		expect(parts).to.deep.equal([
-			'/blog/*', '/team/articles/*/index.html', '301',
-			'/two', '/', '302',
-			'/other', '/', '301',
 			'/nope', '/', '301',
-			'/team/articles/*', '/team/articles/*/index.html', '200'
+			'/other', '/', '301',
+			'/two', '/', '302',
+			'/team/articles/*', '/team/articles/*/index.html', '200',
+			'/blog/*', '/team/articles/*/index.html', '301',
 		]);
 	});
 });

--- a/packages/underscore-redirects/package.json
+++ b/packages/underscore-redirects/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@astrojs/underscore-redirects",
+  "description": "Utilities to generate _redirects files in Astro projects",
+  "version": "0.1.0",
+  "type": "module",
+  "author": "withastro",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/withastro/astro.git",
+    "directory": "packages/underscore-redirects"
+  },
+  "bugs": "https://github.com/withastro/astro/issues",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prepublish": "pnpm build",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc -p tsconfig.json",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
+    "postbuild": "astro-scripts copy \"src/**/*.js\"",
+    "dev": "astro-scripts dev \"src/**/*.ts\"",
+    "test": "mocha --exit --timeout 20000"
+  },
+  "devDependencies": {
+    "astro": "workspace:*",
+    "astro-scripts": "workspace:*",
+    "@types/chai": "^4.3.1",
+    "@types/mocha": "^9.1.1",
+    "chai": "^4.3.6",
+    "mocha": "^9.2.2"
+  },
+  "keywords": [
+    "astro",
+    "astro-component"
+  ]
+}

--- a/packages/underscore-redirects/package.json
+++ b/packages/underscore-redirects/package.json
@@ -12,6 +12,7 @@
   },
   "bugs": "https://github.com/withastro/astro/issues",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js"
   },

--- a/packages/underscore-redirects/readme.md
+++ b/packages/underscore-redirects/readme.md
@@ -1,0 +1,3 @@
+# @astrojs/underscore-redirects
+
+These are internal helpers used by core Astro packages. This package does not follow semver and should not be used externally.

--- a/packages/underscore-redirects/src/astro.ts
+++ b/packages/underscore-redirects/src/astro.ts
@@ -1,0 +1,122 @@
+import type { AstroConfig, RouteData, ValidRedirectStatus } from 'astro';
+import { Redirects } from './redirects.js';
+import { join as pathJoin } from 'node:path';
+
+
+function getRedirectStatus(route: RouteData): ValidRedirectStatus {
+	if(typeof route.redirect === 'object') {
+		return route.redirect.status;
+	}
+	return 301;
+}
+
+export function createRedirectsFromAstroRoutes(
+	config: Pick<AstroConfig, 'output' | 'build'>,
+	routes: RouteData[],
+	dir: URL,
+	dynamicTargetValue: string
+) {
+	const output = config.output;
+	const _redirects = new Redirects();
+
+	for (const route of routes) {
+		if (route.pathname) {
+			if(route.redirect) {
+				_redirects.add({
+					dynamic: false,
+					input: route.pathname,
+					target: typeof route.redirect === 'object' ? route.redirect.destination : route.redirect,
+					status: getRedirectStatus(route),
+					weight: 2
+				});
+				continue;
+			}
+
+			if(output === 'static') {
+				continue;
+			}
+
+			else if (route.distURL) {
+				_redirects.add({
+					dynamic: false,
+					input: route.pathname,
+					target: prependForwardSlash(route.distURL.toString().replace(dir.toString(), '')),
+					status: 200,
+					weight: 2,
+				});
+			} else {
+				_redirects.add({
+					dynamic: false,
+					input: route.pathname,
+					target: dynamicTargetValue,
+					status: 200,
+					weight: 2,
+				});
+
+				if (route.route === '/404') {
+					_redirects.add({
+						dynamic: true,
+						input: '/*',
+						target: dynamicTargetValue,
+						status: 404,
+						weight: 0,
+					});
+				}
+			}
+		} else {
+			const pattern = generateDynamicPattern(route);
+
+			if (route.distURL) {
+				const targetRoute = route.redirectRoute ?? route;
+				const targetPattern = generateDynamicPattern(targetRoute);
+				let target = targetPattern;
+				if(config.build.format === 'directory') {
+					target = pathJoin(target, 'index.html');
+				} else {
+					target += '.html';
+				}
+				_redirects.add({
+					dynamic: true,
+					input: pattern,
+					target,
+					status: route.type === 'redirect' ? 301 : 200,
+					weight: 1,
+				});
+			} else {
+				_redirects.add({
+					dynamic: true,
+					input: pattern,
+					target: dynamicTargetValue,
+					status: 200,
+					weight: 1,
+				});
+			}
+		}
+	}
+
+	return _redirects;
+}
+
+function generateDynamicPattern(route: RouteData) {
+	const pattern =
+		'/' +
+		route.segments
+			.map(([part]) => {
+				//(part.dynamic ? '*' : part.content)
+				if (part.dynamic) {
+					if (part.spread) {
+						return '*';
+					} else {
+						return ':' + part.content;
+					}
+				} else {
+					return part.content;
+				}
+			})
+			.join('/');
+	return pattern;
+}
+
+function prependForwardSlash(str: string) {
+	return str[0] === '/' ? str : '/' + str;
+}

--- a/packages/underscore-redirects/src/astro.ts
+++ b/packages/underscore-redirects/src/astro.ts
@@ -1,7 +1,8 @@
 import type { AstroConfig, RouteData, ValidRedirectStatus } from 'astro';
 import { Redirects } from './redirects.js';
-import { join as pathJoin } from 'node:path';
+import { posix } from 'node:path';
 
+const pathJoin = posix.join;
 
 function getRedirectStatus(route: RouteData): ValidRedirectStatus {
 	if(typeof route.redirect === 'object') {

--- a/packages/underscore-redirects/src/index.ts
+++ b/packages/underscore-redirects/src/index.ts
@@ -1,0 +1,8 @@
+export {
+	Redirects,
+	type RedirectDefinition
+} from './redirects.js';
+
+export {
+	createRedirectsFromAstroRoutes
+} from './astro.js';

--- a/packages/underscore-redirects/src/print.ts
+++ b/packages/underscore-redirects/src/print.ts
@@ -1,0 +1,26 @@
+import type { RedirectDefinition } from './redirects';
+
+export function print(
+	definitions: RedirectDefinition[],
+	minInputLength: number,
+	minTargetLength: number
+) {
+	let _redirects = '';
+
+	// Loop over the definitions
+	definitions.forEach((defn, i) => {
+		// Figure out the number of spaces to add. We want at least 4 spaces
+		// after the input. This ensure that all targets line up together.
+		let inputSpaces = minInputLength - defn.input.length + 4;
+		let targetSpaces = minTargetLength - defn.target.length + 4;
+		_redirects +=
+			(i === 0 ? '' : '\n') +
+			defn.input +
+			' '.repeat(inputSpaces) +
+			defn.target +
+			' '.repeat(Math.abs(targetSpaces)) +
+			defn.status;
+	});
+
+	return _redirects;
+}

--- a/packages/underscore-redirects/src/print.ts
+++ b/packages/underscore-redirects/src/print.ts
@@ -1,5 +1,14 @@
 import type { RedirectDefinition } from './redirects';
 
+/**
+ * Pretty print a list of definitions into the output format. Keeps
+ * things readable for humans. Ex:
+ * /nope               /                              301
+ * /other              /                              301
+ * /two                /                              302
+ * /team/articles/*    /team/articles/*\/index.html    200
+ * /blog/*             /team/articles/*\/index.html    301
+ */
 export function print(
 	definitions: RedirectDefinition[],
 	minInputLength: number,
@@ -8,19 +17,20 @@ export function print(
 	let _redirects = '';
 
 	// Loop over the definitions
-	definitions.forEach((defn, i) => {
+	for(let i = 0; i < definitions.length; i++) {
+		let definition = definitions[i];
 		// Figure out the number of spaces to add. We want at least 4 spaces
 		// after the input. This ensure that all targets line up together.
-		let inputSpaces = minInputLength - defn.input.length + 4;
-		let targetSpaces = minTargetLength - defn.target.length + 4;
+		let inputSpaces = minInputLength - definition.input.length + 4;
+		let targetSpaces = minTargetLength - definition.target.length + 4;
 		_redirects +=
 			(i === 0 ? '' : '\n') +
-			defn.input +
+			definition.input +
 			' '.repeat(inputSpaces) +
-			defn.target +
+			definition.target +
 			' '.repeat(Math.abs(targetSpaces)) +
-			defn.status;
-	});
+			definition.status;
+	}
 
 	return _redirects;
 }

--- a/packages/underscore-redirects/src/redirects.ts
+++ b/packages/underscore-redirects/src/redirects.ts
@@ -1,0 +1,61 @@
+import { print } from './print.js';
+
+export type RedirectDefinition = {
+	dynamic: boolean;
+	input: string;
+	target: string;
+	weight: 0 | 1 | 2;
+	status: number;
+};
+
+export class Redirects {
+	public definitions: RedirectDefinition[] = [];
+	public minInputLength = 4;
+	public minTargetLength = 4;
+
+	add(defn: RedirectDefinition) {
+		// Find the longest input, so we can format things nicely
+		if (defn.input.length > this.minInputLength) {
+			this.minInputLength = defn.input.length;
+		}
+		// Same for the target
+		if (defn.target.length > this.minTargetLength) {
+			this.minTargetLength = defn.target.length;
+		}
+
+		binaryInsert(this.definitions, defn, (a, b) => {
+			return a.weight > b.weight;
+		});
+	}
+
+	print(): string {
+		return print(this.definitions, this.minInputLength, this.minTargetLength);
+	}
+
+	empty(): boolean {
+		return this.definitions.length === 0;
+	}
+}
+
+function binaryInsert<T>(sorted: T[], item: T, comparator: (a: T, b: T) => boolean) {
+  if(sorted.length === 0) {
+    sorted.push(item);
+    return 0;
+  }
+  let low = 0, high = sorted.length - 1, mid = 0;
+  while (low <= high) {
+    mid = low + (high - low >> 1);
+    if(comparator(sorted[mid], item)) {
+      low = mid + 1;
+    } else {
+      high = mid -1;
+    }
+  }
+
+  if(comparator(sorted[mid], item)) {
+    mid++;
+  }
+
+  sorted.splice(mid, 0, item);
+  return mid;
+}

--- a/packages/underscore-redirects/src/redirects.ts
+++ b/packages/underscore-redirects/src/redirects.ts
@@ -4,7 +4,10 @@ export type RedirectDefinition = {
 	dynamic: boolean;
 	input: string;
 	target: string;
-	weight: 0 | 1 | 2;
+	// Allows specifying a weight to the definition.
+	// This allows insertion of definitions out of order but having
+	// a priority once inserted.
+	weight: number;
 	status: number;
 };
 
@@ -13,17 +16,22 @@ export class Redirects {
 	public minInputLength = 4;
 	public minTargetLength = 4;
 
-	add(defn: RedirectDefinition) {
+	/**
+	 * Adds a new definition by inserting it into the list of definitions
+	 * prioritized by the given weight. This keeps higher priority definitions
+	 * At the top of the list once printed.
+	 */
+	add(definition: RedirectDefinition) {
 		// Find the longest input, so we can format things nicely
-		if (defn.input.length > this.minInputLength) {
-			this.minInputLength = defn.input.length;
+		if (definition.input.length > this.minInputLength) {
+			this.minInputLength = definition.input.length;
 		}
 		// Same for the target
-		if (defn.target.length > this.minTargetLength) {
-			this.minTargetLength = defn.target.length;
+		if (definition.target.length > this.minTargetLength) {
+			this.minTargetLength = definition.target.length;
 		}
 
-		binaryInsert(this.definitions, defn, (a, b) => {
+		binaryInsert(this.definitions, definition, (a, b) => {
 			return a.weight > b.weight;
 		});
 	}

--- a/packages/underscore-redirects/test/astro.test.js
+++ b/packages/underscore-redirects/test/astro.test.js
@@ -1,0 +1,21 @@
+import { createRedirectsFromAstroRoutes } from '../dist/index.js';
+import { expect } from 'chai';
+
+describe('Astro', () => {
+	const serverConfig = {
+		output: 'server',
+		build: { format: 'directory' }
+	};
+
+	it('Creates a Redirects object from routes', () => {
+		const routes = [
+			{ pathname: '/', distURL: new URL('./index.html', import.meta.url), segments: [] },
+			{ pathname: '/one', distURL: new URL('./one/index.html', import.meta.url), segments: [] }
+		];
+		const dynamicTarget = './.adapter/dist/entry.mjs';
+		const _redirects = createRedirectsFromAstroRoutes(serverConfig, routes,
+			new URL(import.meta.url), dynamicTarget);
+
+		expect(_redirects.definitions).to.have.a.lengthOf(2);
+	});
+});

--- a/packages/underscore-redirects/test/astro.test.js
+++ b/packages/underscore-redirects/test/astro.test.js
@@ -13,8 +13,12 @@ describe('Astro', () => {
 			{ pathname: '/one', distURL: new URL('./one/index.html', import.meta.url), segments: [] }
 		];
 		const dynamicTarget = './.adapter/dist/entry.mjs';
-		const _redirects = createRedirectsFromAstroRoutes(serverConfig, routes,
-			new URL(import.meta.url), dynamicTarget);
+		const _redirects = createRedirectsFromAstroRoutes({
+			config: serverConfig,
+			routes,
+			dir: new URL(import.meta.url),
+			dynamicTarget
+		});
 
 		expect(_redirects.definitions).to.have.a.lengthOf(2);
 	});

--- a/packages/underscore-redirects/test/print.test.js
+++ b/packages/underscore-redirects/test/print.test.js
@@ -1,0 +1,28 @@
+import { Redirects } from '../dist/index.js';
+import { expect } from 'chai';
+
+describe('Printing', () => {
+	it('Formats long lines in a pretty way', () => {
+		const _redirects = new Redirects();
+		_redirects.add({
+			dynamic: false,
+			input: '/a',
+			target: '/b',
+			weight: 0,
+			status: 200
+		});
+		_redirects.add({
+			dynamic: false,
+			input: '/some-pretty-long-input-line',
+			target: '/b',
+			weight: 0,
+			status: 200
+		});
+		let out = _redirects.print();
+		
+		let [lineOne, lineTwo] = out.split('\n');
+
+		expect(lineOne.indexOf('/b')).to.equal(lineTwo.indexOf('/b'), 'destinations lined up');
+		expect(lineOne.indexOf('200')).to.equal(lineTwo.indexOf('200'), 'statuses lined up');
+	});
+});

--- a/packages/underscore-redirects/test/print.test.js
+++ b/packages/underscore-redirects/test/print.test.js
@@ -25,4 +25,20 @@ describe('Printing', () => {
 		expect(lineOne.indexOf('/b')).to.equal(lineTwo.indexOf('/b'), 'destinations lined up');
 		expect(lineOne.indexOf('200')).to.equal(lineTwo.indexOf('200'), 'statuses lined up');
 	});
+
+	it('Properly prints dynamic routes', () => {
+		const _redirects = new Redirects();
+		_redirects.add({
+			dynamic: true,
+			input: '/pets/:cat',
+			target: '/pets/:cat/index.html',
+			status: 200,
+			weight: 1
+		});
+		let out = _redirects.print();
+		let parts = out.split(/\s+/);
+		expect(parts).to.deep.equal([
+			'/pets/:cat', '/pets/:cat/index.html', '200',
+		])
+	});
 });

--- a/packages/underscore-redirects/test/weight.test.js
+++ b/packages/underscore-redirects/test/weight.test.js
@@ -1,0 +1,32 @@
+import { Redirects } from '../dist/index.js';
+import { expect } from 'chai';
+
+describe('Weight', () => {
+	it('Puts higher weighted definitions on top', () => {
+		const _redirects = new Redirects();
+		_redirects.add({
+			dynamic: false,
+			input: '/a',
+			target: '/b',
+			weight: 0,
+			status: 200
+		});
+		_redirects.add({
+			dynamic: false,
+			input: '/c',
+			target: '/d',
+			weight: 0,
+			status: 200
+		});
+		_redirects.add({
+			dynamic: false,
+			input: '/e',
+			target: '/f',
+			weight: 1,
+			status: 200
+		});
+		const firstDefn = _redirects.definitions[0];
+		expect(firstDefn.weight).to.equal(1);
+		expect(firstDefn.input).to.equal('/e');
+	});
+});

--- a/packages/underscore-redirects/tsconfig.json
+++ b/packages/underscore-redirects/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "allowJs": true,
+    "target": "ES2021",
+    "module": "ES2022",
+    "outDir": "./dist"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3630,6 +3630,9 @@ importers:
 
   packages/integrations/cloudflare:
     dependencies:
+      '@astrojs/underscore-redirects':
+        specifier: ^0.1.0
+        version: link:../../underscore-redirects
       esbuild:
         specifier: ^0.17.12
         version: 0.17.12
@@ -4363,6 +4366,9 @@ importers:
 
   packages/integrations/netlify:
     dependencies:
+      '@astrojs/underscore-redirects':
+        specifier: ^0.1.0
+        version: link:../../underscore-redirects
       '@astrojs/webapi':
         specifier: ^2.1.1
         version: link:../../webapi
@@ -5212,6 +5218,27 @@ importers:
       '@types/which-pm-runs':
         specifier: ^1.0.0
         version: 1.0.0
+      astro-scripts:
+        specifier: workspace:*
+        version: link:../../scripts
+      chai:
+        specifier: ^4.3.6
+        version: 4.3.6
+      mocha:
+        specifier: ^9.2.2
+        version: 9.2.2
+
+  packages/underscore-redirects:
+    devDependencies:
+      '@types/chai':
+        specifier: ^4.3.1
+        version: 4.3.3
+      '@types/mocha':
+        specifier: ^9.1.1
+        version: 9.1.1
+      astro:
+        specifier: workspace:*
+        version: link:../astro
       astro-scripts:
         specifier: workspace:*
         version: link:../../scripts
@@ -8802,11 +8829,12 @@ packages:
   /@types/chai-subset@1.3.3:
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
     dependencies:
-      '@types/chai': 4.3.3
+      '@types/chai': 4.3.5
     dev: false
 
   /@types/chai@4.3.3:
     resolution: {integrity: sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==}
+    dev: true
 
   /@types/chai@4.3.5:
     resolution: {integrity: sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==}


### PR DESCRIPTION
## Changes

- Adds a new package `@astrojs/underscore-redirects` which is used to build the `_redirects` format, shared by Netlify and Cloudflare, from Astro route definitions.

## Testing

- Unit tests in new package
- Integration test with Cloudflare

## Docs

N/A, documented as part of release.