### PR TITLE
Add error message if `Astro.glob` is called outside

### DIFF
--- a/.changeset/moody-coats-develop.md
+++ b/.changeset/moody-coats-develop.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add error message if `Astro.glob` is called outside of an Astro file

--- a/packages/astro/src/runtime/server/astro-global.ts
+++ b/packages/astro/src/runtime/server/astro-global.ts
@@ -4,6 +4,11 @@ import { ASTRO_VERSION } from '../../core/constants.js';
 /** Create the Astro.glob() runtime function. */
 function createAstroGlobFn() {
 	const globHandler = (importMetaGlobResult: Record<string, any>, globValue: () => any) => {
+		if (typeof importMetaGlobResult === 'string') {
+			throw new Error(
+				'Astro.glob() does not work outside of an Astro file. Use `import.meta.glob()` instead.'
+			);
+		}
 		let allEntries = [...Object.values(importMetaGlobResult)];
 		if (allEntries.length === 0) {
 			throw new Error(`Astro.glob(${JSON.stringify(globValue())}) - no matches found.`);

--- a/packages/astro/test/units/runtime/astro-global.test.js
+++ b/packages/astro/test/units/runtime/astro-global.test.js
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import { createAstro } from '../../../dist/runtime/server/index.js';
+
+describe('astro global', () => {
+	it('Glob should error if passed incorrect value', async () => {
+		const Astro = createAstro(undefined);
+		expect(() => {
+			Astro.glob('./**/*.md');
+		}).to.throw(
+			'Astro.glob() does not work outside of an Astro file. Use `import.meta.glob()` instead.'
+		);
+	});
+});


### PR DESCRIPTION
## Changes

Fixes https://github.com/withastro/astro/issues/5552

`Astro.glob` only works in .astro files. Error if otherwise.

I did a really quick fix for this one. Should we use the `AstroError` class here?

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added a unit test.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
There's an existing docs for this at https://docs.astro.build/en/reference/api-reference/#astroglob