### PR TITLE
Document partytown script block by extensions

### DIFF
--- a/packages/integrations/partytown/README.md
+++ b/packages/integrations/partytown/README.md
@@ -132,6 +132,8 @@ export default defineConfig ({
 
 ## Troubleshooting
 
+- If you're getting a `Failed to fetch` error, make sure you're not using any browser extensions that are blocking the script.
+
 For help, check out the `#support` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
 
 You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.


### PR DESCRIPTION
## Changes

Close https://github.com/withastro/astro/issues/5454

Note that browser extensions could make partytown scripts not working.

I followed the pattern in `@astrojs/image` troubleshooting section: https://docs.astro.build/en/guides/integrations-guide/image/#troubleshooting

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
n/a

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->

Updated the partytown README.

 /cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
