### PR TITLE
fix(vercel): Fix typo in README 🤦‍♀️

### DIFF
--- a/.changeset/plenty-geese-fold.md
+++ b/.changeset/plenty-geese-fold.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Fix `imagesConfig` being wrongly spelt as `imageConfig` in the README

--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -108,7 +108,7 @@ export default defineConfig({
 });
 ```
 
-### imageConfig
+### imagesConfig
 
 **Type:** `VercelImageConfig`<br>
 **Available for:** Edge, Serverless, Static
@@ -124,7 +124,7 @@ import vercel from '@astrojs/vercel/static';
 export default defineConfig({
   output: 'server',
   adapter: vercel({
-    imageConfig: {
+    imagesConfig: {
       sizes: [320, 640, 1280]
     }
   })


### PR DESCRIPTION
## Changes

Property is called `imagesConfig`, matching Vercel's config file. Not `imageConfig`. In truth, it should probably just be named `images` anyway, but that'd be breaking now, shucks.

Fix https://github.com/withastro/astro/issues/7152

## Testing

N/A

## Docs

N/A