### PR TITLE
Implement redirect priority

### DIFF
--- a/packages/astro/test/units/routing/manifest.test.js
+++ b/packages/astro/test/units/routing/manifest.test.js
@@ -31,4 +31,32 @@ describe('routing - createRouteManifest', () => {
 		expect(pattern.test('')).to.equal(true);
 		expect(pattern.test('/')).to.equal(false);
 	});
+
+	it('redirects are sorted alongside the filesystem routes', async () => {
+		const fs = createFs(
+			{
+				'/src/pages/index.astro': `<h1>test</h1>`,
+				'/src/pages/blog/contributing.astro': `<h1>test</h1>`,
+			},
+			root
+		);
+		const settings = await createDefaultDevSettings(
+			{
+				base: '/search',
+				trailingSlash: 'never',
+				redirects: {
+					'/blog/[...slug]': '/'
+				}
+			},
+			root
+		);
+		const manifest = createRouteManifest({
+			cwd: fileURLToPath(root),
+			settings,
+			fsMod: fs,
+		});
+		
+		expect(manifest.routes[1].route).to.equal('/blog/contributing');
+		expect(manifest.routes[2].route).to.equal('/blog/[...slug]');
+	})
 });


### PR DESCRIPTION
## Changes

- This updates the code to use the same priority as with file-system routes. So if there is a spread redirect route and a static FS route, the FS route is prioritized. 

## Testing

- Manifest unit tests.

## Docs

N/A