### PR TITLE
Fix CSS deduping and missing chunks

### DIFF
--- a/.changeset/eighty-gifts-cheer.md
+++ b/.changeset/eighty-gifts-cheer.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix CSS deduping and missing chunks

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -14,7 +14,7 @@ export interface BuildInternals {
 	 * components are the entrypoint instead. This map is used as a cache from the SSR
 	 * build so the client can pick up the same information and use the same chunk ids.
 	 */
-	cssModuleToChunkId: Map<string, string>;
+	cssModuleToChunkIdMap: Map<string, string>;
 
 	// A mapping of hoisted script ids back to the exact hoisted scripts it references
 	hoistedScriptIdToHoistedMap: Map<string, Set<string>>;
@@ -95,7 +95,7 @@ export function createBuildInternals(): BuildInternals {
 	const hoistedScriptIdToPagesMap = new Map<string, Set<string>>();
 
 	return {
-		cssModuleToChunkId: new Map(),
+		cssModuleToChunkIdMap: new Map(),
 		hoistedScriptIdToHoistedMap,
 		hoistedScriptIdToPagesMap,
 		entrySpecifierToBundleMap: new Map<string, string>(),

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -8,11 +8,6 @@ import type { PageBuildData, StylesheetAsset, ViteID } from './types';
 
 export interface BuildInternals {
 	/**
-	 * The module ids of all CSS chunks, used to deduplicate CSS assets between
-	 * SSR build and client build in vite-plugin-css.
-	 */
-	cssChunkModuleIds: Set<string>;
-	/**
 	 * Each CSS module is named with a chunk id derived from the Astro pages they
 	 * are used in by default. It's easy to crawl this relation in the SSR build as
 	 * the Astro pages are the entrypoint, but not for the client build as hydratable
@@ -100,7 +95,6 @@ export function createBuildInternals(): BuildInternals {
 	const hoistedScriptIdToPagesMap = new Map<string, Set<string>>();
 
 	return {
-		cssChunkModuleIds: new Set(),
 		cssModuleToChunkId: new Map(),
 		hoistedScriptIdToHoistedMap,
 		hoistedScriptIdToPagesMap,

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -12,6 +12,14 @@ export interface BuildInternals {
 	 * SSR build and client build in vite-plugin-css.
 	 */
 	cssChunkModuleIds: Set<string>;
+	/**
+	 * Each CSS module is named with a chunk id derived from the Astro pages they
+	 * are used in by default. It's easy to crawl this relation in the SSR build as
+	 * the Astro pages are the entrypoint, but not for the client build as hydratable
+	 * components are the entrypoint instead. This map is used as a cache from the SSR
+	 * build so the client can pick up the same information and use the same chunk ids.
+	 */
+	cssModuleToChunkId: Map<string, string>;
 
 	// A mapping of hoisted script ids back to the exact hoisted scripts it references
 	hoistedScriptIdToHoistedMap: Map<string, Set<string>>;
@@ -93,6 +101,7 @@ export function createBuildInternals(): BuildInternals {
 
 	return {
 		cssChunkModuleIds: new Set(),
+		cssModuleToChunkId: new Map(),
 		hoistedScriptIdToHoistedMap,
 		hoistedScriptIdToPagesMap,
 		entrySpecifierToBundleMap: new Map<string, string>(),

--- a/packages/astro/src/core/build/plugins/plugin-css.ts
+++ b/packages/astro/src/core/build/plugins/plugin-css.ts
@@ -113,27 +113,6 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 				// Skip if the chunk has no CSS, we want to handle CSS chunks only
 				if (meta.importedCss.size < 1) continue;
 
-				// In the SSR build, keep track of all CSS chunks' modules as the client build may
-				// duplicate them, e.g. for `client:load` components that render in SSR and client
-				// for hydation.
-				if (options.target === 'server') {
-					for (const id of Object.keys(chunk.modules)) {
-						internals.cssChunkModuleIds.add(id);
-					}
-				}
-
-				// In the client build, we bail if the chunk is a duplicated CSS chunk tracked from
-				// above. We remove all the importedCss to prevent emitting the CSS asset.
-				if (options.target === 'client') {
-					if (Object.keys(chunk.modules).every((id) => internals.cssChunkModuleIds.has(id))) {
-						for (const importedCssImport of meta.importedCss) {
-							delete bundle[importedCssImport];
-							meta.importedCss.delete(importedCssImport);
-						}
-						return;
-					}
-				}
-
 				// For the client build, client:only styles need to be mapped
 				// over to their page. For this chunk, determine if it's a child of a
 				// client:only component and if so, add its CSS to the page it belongs to.

--- a/packages/astro/src/core/build/plugins/plugin-css.ts
+++ b/packages/astro/src/core/build/plugins/plugin-css.ts
@@ -64,15 +64,6 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 	const cssBuildPlugin: VitePlugin = {
 		name: 'astro:rollup-plugin-build-css',
 
-		transform(_, id) {
-			// In the SSR build, styles that are bundled are tracked in `internals.cssChunkModuleIds`.
-			// In the client build, if we're also bundling the same style, return an empty string to
-			// deduplicate the final CSS output.
-			if (options.target === 'client' && internals.cssChunkModuleIds.has(id)) {
-				return '';
-			}
-		},
-
 		outputOptions(outputOptions) {
 			// Skip in client builds as its module graph doesn't have reference to Astro pages
 			// to be able to chunk based on it's related top-level pages.
@@ -119,6 +110,18 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 				if (options.target === 'server') {
 					for (const id of Object.keys(chunk.modules)) {
 						internals.cssChunkModuleIds.add(id);
+					}
+				}
+
+				// In the client build, we bail if the chunk is a duplicated CSS chunk tracked from
+				// above. We remove all the importedCss to prevent emitting the CSS asset.
+				if (options.target === 'client') {
+					if (Object.keys(chunk.modules).every((id) => internals.cssChunkModuleIds.has(id))) {
+						for (const importedCssImport of meta.importedCss) {
+							delete bundle[importedCssImport];
+							meta.importedCss.delete(importedCssImport);
+						}
+						return;
 					}
 				}
 

--- a/packages/astro/test/0-css.test.js
+++ b/packages/astro/test/0-css.test.js
@@ -265,6 +265,21 @@ describe('CSS', function () {
 					new RegExp(`.svelte-scss.${scopedClass}[^{]*{font-family:ComicSansMS`)
 				);
 			});
+
+			it('client:only and SSR in two pages, both should have styles', async () => {
+				const onlyHtml = await fixture.readFile('/client-only-and-ssr/only/index.html');
+				const $onlyHtml = cheerio.load(onlyHtml);
+				const onlyHtmlCssHref = $onlyHtml('link[rel=stylesheet][href^=/_astro/]').attr('href');
+				const onlyHtmlCss = await fixture.readFile(onlyHtmlCssHref.replace(/^\/?/, '/'));
+
+				const ssrHtml = await fixture.readFile('/client-only-and-ssr/ssr/index.html');
+				const $ssrHtml = cheerio.load(ssrHtml);
+				const ssrHtmlCssHref = $ssrHtml('link[rel=stylesheet][href^=/_astro/]').attr('href');
+				const ssrHtmlCss = await fixture.readFile(ssrHtmlCssHref.replace(/^\/?/, '/'));
+
+				expect(onlyHtmlCss).to.include('.svelte-only-and-ssr');
+				expect(ssrHtmlCss).to.include('.svelte-only-and-ssr');
+			});
 		});
 
 		describe('Vite features', () => {

--- a/packages/astro/test/fixtures/0-css/src/pages/client-only-and-ssr/_components/SvelteOnlyAndSsr.svelte
+++ b/packages/astro/test/fixtures/0-css/src/pages/client-only-and-ssr/_components/SvelteOnlyAndSsr.svelte
@@ -1,0 +1,11 @@
+<!-- This file will be used as client:only and SSR on two different pages -->
+
+<div class="svelte-only-and-ssr">
+	Svelte only and SSR
+</div>
+
+<style>
+	.svelte-only-and-ssr {
+		background-color: green;
+	}
+</style>

--- a/packages/astro/test/fixtures/0-css/src/pages/client-only-and-ssr/only.astro
+++ b/packages/astro/test/fixtures/0-css/src/pages/client-only-and-ssr/only.astro
@@ -1,0 +1,7 @@
+---
+import SvelteOnlyAndSsr from './_components/SvelteOnlyAndSsr.svelte'
+---
+
+<div>
+  <SvelteOnlyAndSsr client:only />
+</div>

--- a/packages/astro/test/fixtures/0-css/src/pages/client-only-and-ssr/ssr.astro
+++ b/packages/astro/test/fixtures/0-css/src/pages/client-only-and-ssr/ssr.astro
@@ -1,0 +1,7 @@
+---
+import SvelteOnlyAndSsr from './_components/SvelteOnlyAndSsr.svelte'
+---
+
+<div>
+  <SvelteOnlyAndSsr />
+</div>


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/6931
May also fix this issue: https://github.com/withastro/astro/issues/7124 (cc @PxlBuzzard appreciate if you can test this after it's released)

> Preface: "CSS module" here means the CSS rollup module, not [CSS modules](https://github.com/css-modules/css-modules)

The previous CSS deduping flow was incorrect, as it assumed a CSS module found in a SSR build applies to all pages, which isn't the case most of the time. This regression was introduced in #6582

I've fixed this by implementing a more correct CSS deduping strategy, that is to make sure SSR and client builds' generated CSS chunk ids are always derived the same way. That way the chunk name and content are always the same when written to fs.

I've put more in-code comments on how it works and why.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added test from #6931. Made sure all other tests passed.

I'm also trying a new way to create the test, moving the new fixture code in `0-css/src/pages/client-only-and-ssr/` only. This way each new test we add are only new folders in `pages/`


## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.