### PR TITLE
Content collections - fix `.json` collection errors

### DIFF
--- a/.changeset/olive-rabbits-rhyme.md
+++ b/.changeset/olive-rabbits-rhyme.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix content collection build errors for empty collections or underscore files of type `.json`.

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -425,11 +425,11 @@ async function writeContentFiles({
 					...AstroErrorData.ContentCollectionTypeMismatchError,
 					message: AstroErrorData.ContentCollectionTypeMismatchError.message(
 						collectionKey,
-						collectionType,
+						collection.type,
 						collectionConfig.type
 					),
 					hint:
-						collectionType === 'data'
+						collection.type === 'data'
 							? "Try adding `type: 'data'` to your collection config."
 							: undefined,
 					location: { file: '' /** required for error overlay `ws` messages */ },

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -414,18 +414,23 @@ async function writeContentFiles({
 	for (const collectionKey of Object.keys(collectionEntryMap).sort()) {
 		const collectionConfig = contentConfig?.collections[JSON.parse(collectionKey)];
 		const collection = collectionEntryMap[collectionKey];
-		if (collectionConfig?.type && collection.type !== collectionConfig.type) {
+		const collectionType = collectionConfig?.type ?? collection.type;
+		if (
+			collectionConfig?.type &&
+			collectionType !== 'unknown' &&
+			collectionType !== collectionConfig.type
+		) {
 			viteServer.ws.send({
 				type: 'error',
 				err: new AstroError({
 					...AstroErrorData.ContentCollectionTypeMismatchError,
 					message: AstroErrorData.ContentCollectionTypeMismatchError.message(
 						collectionKey,
-						collection.type,
+						collectionType,
 						collectionConfig.type
 					),
 					hint:
-						collection.type === 'data'
+						collectionType === 'data'
 							? "Try adding `type: 'data'` to your collection config."
 							: undefined,
 					location: { file: '' /** required for error overlay `ws` messages */ },
@@ -433,7 +438,7 @@ async function writeContentFiles({
 			});
 			return;
 		}
-		switch (collection.type) {
+		switch (collectionType) {
 			case 'content':
 				contentTypesStr += `${collectionKey}: {\n`;
 				for (const entryKey of Object.keys(collection.entries).sort()) {

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -43,8 +43,11 @@ export function astroContentVirtualModPlugin({
 			new URL('reference-map.json', contentPaths.cacheDir).pathname
 		)
 		.replace('@@CONTENT_DIR@@', relContentDir)
-		.replace('@@CONTENT_ENTRY_GLOB_PATH@@', `${relContentDir}**/*${getExtGlob(contentEntryExts)}`)
-		.replace('@@DATA_ENTRY_GLOB_PATH@@', `${relContentDir}**/*${getExtGlob(dataEntryExts)}`)
+		.replace(
+			'@@CONTENT_ENTRY_GLOB_PATH@@',
+			`${relContentDir}**/[!_]*${getExtGlob(contentEntryExts)}`
+		)
+		.replace('@@DATA_ENTRY_GLOB_PATH@@', `${relContentDir}**/[!_]*${getExtGlob(dataEntryExts)}`)
 		.replace(
 			'@@RENDER_ENTRY_GLOB_PATH@@',
 			`${relContentDir}**/*${getExtGlob(/** Note: data collections excluded */ contentEntryExts)}`

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -45,6 +45,7 @@ export function astroContentVirtualModPlugin({
 		.replace('@@CONTENT_DIR@@', relContentDir)
 		.replace(
 			'@@CONTENT_ENTRY_GLOB_PATH@@',
+			// [!_] = ignore files starting with "_"
 			`${relContentDir}**/[!_]*${getExtGlob(contentEntryExts)}`
 		)
 		.replace('@@DATA_ENTRY_GLOB_PATH@@', `${relContentDir}**/[!_]*${getExtGlob(dataEntryExts)}`)

--- a/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
+++ b/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
@@ -119,4 +119,32 @@ title: Post
 			expect(e.hint).to.include("Try adding `type: 'data'`");
 		}
 	});
+
+	it('does not raise error for empty collection with config', async () => {
+		const fs = createFsWithFallback(
+			{
+				// Add placeholder to ensure directory exists
+				'/src/content/i18n/_placeholder.txt': 'Need content here',
+				'/src/content/config.ts': `
+					import { z, defineCollection } from 'astro:content';
+					
+					const i18n = defineCollection({
+						type: 'data',
+						schema: z.object({
+							greeting: z.string(),
+						}),
+					});
+							
+					export const collections = { i18n };`,
+			},
+			root
+		);
+
+		try {
+			const res = await sync({ fs });
+			expect(res).to.equal(0);
+		} catch (e) {
+			expect.fail(0, 1, `Did not expect sync to throw: ${e.message}`);
+		}
+	});
 });


### PR DESCRIPTION
## Changes

- Resolves #7154 
- Avoid raising errors when collection type is `unknown` (can't be inferred by files in the directory)
- Respect `_` in content glob imports

## Testing

- Add test for errors on empty collections

## Docs

N/A