### PR TITLE
fix: build fail upon have 'process.env' in *.md file.

### DIFF
--- a/.changeset/pink-ghosts-end.md
+++ b/.changeset/pink-ghosts-end.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix: build fail upon have 'process.env' in \*.md file.

--- a/packages/astro/src/vite-plugin-utils/index.ts
+++ b/packages/astro/src/vite-plugin-utils/index.ts
@@ -14,7 +14,9 @@ import { viteID } from '../core/util.js';
  * in our JS representation of modules like Markdown
  */
 export function escapeViteEnvReferences(code: string) {
-	return code.replace(/import\.meta\.env/g, 'import\\u002Emeta.env');
+	return code
+		.replace(/import\.meta\.env/g, 'import\\u002Emeta.env')
+		.replace(/process\.env/g, 'process\\u002Eenv');
 }
 
 export function getFileInfo(id: string, config: AstroConfig) {


### PR DESCRIPTION
## Changes

- Resolve: #7149 
- Replace "process.env" into "process\\u002Eenv"

## Testing

No test for this function.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

This is fix bug. It unnecessary to update Doc

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
