### PR TITLE
Unflag hybrid output

### DIFF
--- a/.changeset/weak-wombats-swim.md
+++ b/.changeset/weak-wombats-swim.md
@@ -1,0 +1,10 @@
+---
+'astro': minor
+'@astrojs/image': minor
+'@astrojs/cloudflare': patch
+'@astrojs/netlify': patch
+'@astrojs/node': patch
+'@astrojs/vercel': patch
+---
+
+Unflags support for `output: 'hybrid'` mode, which enables pre-rendering by default. The additional `experimental.hybridOutput` flag can be safely removed from your configuration.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1141,44 +1141,6 @@ export interface AstroUserConfig {
 		 * ```
 		 */
 		middleware?: boolean;
-
-		/**
-		 * @docs
-		 * @name experimental.hybridOutput
-		 * @type {boolean}
-		 * @default `false`
-		 * @version 2.5.0
-		 * @description
-		 * Enable experimental support for hybrid SSR with pre-rendering enabled by default.
-		 *
-		 * To enable this feature, first set `experimental.hybridOutput` to `true` in your Astro config, and set `output` to `hybrid`.
-		 *
-		 * ```js
-		 * {
-		 *  output: 'hybrid',
-		 * 	experimental: {
-		 *		hybridOutput: true,
-		 * 	},
-		 * }
-		 * ```
-		 * Then add `export const prerender =  false` to any page or endpoint you want to opt-out of pre-rendering.
-		 * ```astro
-		 * ---
-		 * // pages/contact.astro
-		 * export const prerender = false
-		 *
-		 * if (Astro.request.method === 'POST') {
-		 *  // handle form submission
-		 * }
-		 * ---
-		 * <form method="POST">
-		 * 	<input type="text" name="name" />
-		 * 	<input type="email" name="email" />
-		 * 	<button type="submit">Submit</button>
-		 * </form>
-		 * ```
-		 */
-		hybridOutput?: boolean;
 	};
 
 	// Legacy options to be removed

--- a/packages/astro/src/assets/generate.ts
+++ b/packages/astro/src/assets/generate.ts
@@ -3,7 +3,7 @@ import { basename, join } from 'node:path/posix';
 import type { StaticBuildOptions } from '../core/build/types.js';
 import { warn } from '../core/logger/core.js';
 import { prependForwardSlash } from '../core/path.js';
-import { isHybridOutput } from '../prerender/utils.js';
+import { isServerLikeOutput } from '../prerender/utils.js';
 import { getConfiguredImageService, isESMImportedImage } from './internal.js';
 import type { LocalImageService } from './services/service.js';
 import type { ImageTransform } from './types.js';
@@ -47,7 +47,7 @@ export async function generateImage(
 	}
 
 	let serverRoot: URL, clientRoot: URL;
-	if (buildOpts.settings.config.output === 'server' || isHybridOutput(buildOpts.settings.config)) {
+	if (isServerLikeOutput(buildOpts.settings.config)) {
 		serverRoot = buildOpts.settings.config.build.server;
 		clientRoot = buildOpts.settings.config.build.client;
 	} else {

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -31,7 +31,7 @@ import {
 	removeTrailingForwardSlash,
 } from '../../core/path.js';
 import { runHookBuildGenerated } from '../../integrations/index.js';
-import { isHybridOutput } from '../../prerender/utils.js';
+import { isServerLikeOutput } from '../../prerender/utils.js';
 import { BEFORE_HYDRATION_SCRIPT_ID, PAGE_SCRIPT_ID } from '../../vite-plugin-scripts/index.js';
 import { callEndpoint, createAPIContext, throwIfRedirectNotAllowed } from '../endpoint/index.js';
 import { AstroError } from '../errors/index.js';
@@ -94,7 +94,7 @@ export function chunkIsPage(
 
 export async function generatePages(opts: StaticBuildOptions, internals: BuildInternals) {
 	const timer = performance.now();
-	const ssr = opts.settings.config.output === 'server' || isHybridOutput(opts.settings.config); // hybrid mode is essentially SSR with prerender by default
+	const ssr = isServerLikeOutput(opts.settings.config);
 	const serverEntry = opts.buildConfig.serverEntry;
 	const outFolder = ssr ? opts.buildConfig.server : getOutDirWithinCwd(opts.settings.config.outDir);
 
@@ -237,7 +237,7 @@ async function getPathsForRoute(
 			route: pageData.route,
 			isValidate: false,
 			logging: opts.logging,
-			ssr: opts.settings.config.output === 'server' || isHybridOutput(opts.settings.config),
+			ssr: isServerLikeOutput(opts.settings.config),
 		})
 			.then((_result) => {
 				const label = _result.staticPaths.length === 1 ? 'page' : 'pages';
@@ -413,7 +413,7 @@ async function generatePath(
 		}
 	}
 
-	const ssr = settings.config.output === 'server' || isHybridOutput(settings.config);
+	const ssr = isServerLikeOutput(settings.config);
 	const url = getUrlForPath(
 		pathname,
 		opts.settings.config.base,

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'url';
 import type { Plugin as VitePlugin } from 'vite';
 import type { AstroAdapter } from '../../../@types/astro';
 import { runHookBuildSsr } from '../../../integrations/index.js';
-import { isHybridOutput } from '../../../prerender/utils.js';
+import { isServerLikeOutput } from '../../../prerender/utils.js';
 import { BEFORE_HYDRATION_SCRIPT_ID, PAGE_SCRIPT_ID } from '../../../vite-plugin-scripts/index.js';
 import type { SerializedRouteInfo, SerializedSSRManifest } from '../../app/types';
 import { joinPaths, prependForwardSlash } from '../../path.js';
@@ -272,8 +272,7 @@ export function pluginSSR(
 	options: StaticBuildOptions,
 	internals: BuildInternals
 ): AstroBuildPlugin {
-	const ssr =
-		options.settings.config.output === 'server' || isHybridOutput(options.settings.config);
+	const ssr = isServerLikeOutput(options.settings.config);
 	return {
 		build: 'ssr',
 		hooks: {

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -6,7 +6,6 @@ import * as colors from 'kleur/colors';
 import path from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { mergeConfig as mergeViteConfig } from 'vite';
-import { isHybridMalconfigured } from '../../prerender/utils.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 import type { LogOptions } from '../logger/core.js';
 import { arraify, isObject, isURL } from '../util.js';
@@ -223,12 +222,6 @@ export async function openConfig(configOptions: LoadConfigOptions): Promise<Open
 		userConfig = config.value;
 	}
 	const astroConfig = await resolveConfig(userConfig, root, flags, configOptions.cmd);
-
-	if (isHybridMalconfigured(astroConfig)) {
-		throw new Error(
-			`The "output" config option must be set to "hybrid" and "experimental.hybridOutput" must be set to true to use the hybrid output mode. Falling back to "static" output mode.`
-		);
-	}
 
 	return {
 		astroConfig,

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -39,7 +39,6 @@ const ASTRO_CONFIG_DEFAULTS: AstroUserConfig & any = {
 	legacy: {},
 	experimental: {
 		assets: false,
-		hybridOutput: false,
 		customClientDirectives: false,
 		inlineStylesheets: 'never',
 		middleware: false,
@@ -208,7 +207,6 @@ export const AstroConfigSchema = z.object({
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.experimental.inlineStylesheets),
 			middleware: z.oboolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.middleware),
-			hybridOutput: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.hybridOutput),
 		})
 		.passthrough()
 		.refine(

--- a/packages/astro/src/core/config/settings.ts
+++ b/packages/astro/src/core/config/settings.ts
@@ -4,7 +4,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import type { AstroConfig, AstroSettings, AstroUserConfig } from '../../@types/astro';
 import { getContentPaths } from '../../content/index.js';
 import jsxRenderer from '../../jsx/renderer.js';
-import { isHybridOutput } from '../../prerender/utils.js';
+import { isServerLikeOutput } from '../../prerender/utils.js';
 import { markdownContentEntryType } from '../../vite-plugin-markdown/content-entry-type.js';
 import { getDefaultClientDirectives } from '../client-directive/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
@@ -23,7 +23,7 @@ export function createBaseSettings(config: AstroConfig): AstroSettings {
 
 		adapter: undefined,
 		injectedRoutes:
-			config.experimental.assets && (config.output === 'server' || isHybridOutput(config))
+			config.experimental.assets && isServerLikeOutput(config)
 				? [{ pattern: '/_image', entryPoint: 'astro/assets/image-endpoint' }]
 				: [],
 		pageExtensions: ['.astro', '.html', ...SUPPORTED_MARKDOWN_FILE_EXTENSIONS],

--- a/packages/astro/src/core/endpoint/index.ts
+++ b/packages/astro/src/core/endpoint/index.ts
@@ -9,7 +9,7 @@ import type {
 } from '../../@types/astro';
 import type { Environment, RenderContext } from '../render/index';
 
-import { isHybridOutput } from '../../prerender/utils.js';
+import { isServerLikeOutput } from '../../prerender/utils.js';
 import { renderEndpoint } from '../../runtime/server/index.js';
 import { ASTRO_VERSION } from '../constants.js';
 import { AstroCookies, attachToResponse } from '../cookies/index.js';
@@ -161,7 +161,7 @@ function isRedirect(statusCode: number) {
 }
 
 export function throwIfRedirectNotAllowed(response: Response, config: AstroConfig) {
-	if (config.output !== 'server' && !isHybridOutput(config) && isRedirect(response.status)) {
+	if (!isServerLikeOutput(config) && isRedirect(response.status)) {
 		throw new AstroError(AstroErrorData.StaticRedirectNotAvailable);
 	}
 }

--- a/packages/astro/src/core/render/dev/environment.ts
+++ b/packages/astro/src/core/render/dev/environment.ts
@@ -1,5 +1,5 @@
 import type { AstroSettings, RuntimeMode } from '../../../@types/astro';
-import { isHybridOutput } from '../../../prerender/utils.js';
+import { isServerLikeOutput } from '../../../prerender/utils.js';
 import type { LogOptions } from '../../logger/core.js';
 import type { ModuleLoader } from '../../module-loader/index';
 import type { Environment } from '../index';
@@ -30,7 +30,7 @@ export function createDevelopmentEnvironment(
 		resolve: createResolve(loader, settings.config.root),
 		routeCache: new RouteCache(logging, mode),
 		site: settings.config.site,
-		ssr: settings.config.output === 'server' || isHybridOutput(settings.config),
+		ssr: isServerLikeOutput(settings.config),
 		streaming: true,
 		telemetry: Boolean(settings.forceDisableTelemetry),
 	});

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -13,7 +13,7 @@ import { createRequire } from 'module';
 import path from 'path';
 import slash from 'slash';
 import { fileURLToPath } from 'url';
-import { isHybridOutput } from '../../../prerender/utils.js';
+import { getPrerenderDefault } from '../../../prerender/utils.js';
 import { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from '../../constants.js';
 import { warn } from '../../logger/core.js';
 import { removeLeadingForwardSlash } from '../../path.js';
@@ -228,7 +228,7 @@ export function createRouteManifest(
 	]);
 	const validEndpointExtensions: Set<string> = new Set(['.js', '.ts']);
 	const localFs = fsMod ?? nodeFs;
-	const isPrerenderDefault = isHybridOutput(settings.config);
+	const prerender = getPrerenderDefault(settings.config);
 
 	const foundInvalidFileExtensions: Set<string> = new Set();
 
@@ -341,7 +341,7 @@ export function createRouteManifest(
 					component,
 					generate,
 					pathname: pathname || undefined,
-					prerender: isPrerenderDefault,
+					prerender,
 				});
 			}
 		});
@@ -417,7 +417,7 @@ export function createRouteManifest(
 				component,
 				generate,
 				pathname: pathname || void 0,
-				prerender: isPrerenderDefault,
+				prerender,
 			});
 		});
 

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -4,7 +4,7 @@ import slash from 'slash';
 import { fileURLToPath } from 'url';
 import { normalizePath } from 'vite';
 import type { AstroConfig, AstroSettings, RouteType } from '../@types/astro';
-import { isHybridOutput } from '../prerender/utils.js';
+import { isServerLikeOutput } from '../prerender/utils.js';
 import { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from './constants.js';
 import type { ModuleLoader } from './module-loader';
 import { prependForwardSlash, removeTrailingForwardSlash } from './path.js';
@@ -139,9 +139,7 @@ export function isEndpoint(file: URL, settings: AstroSettings): boolean {
 }
 
 export function isModeServerWithNoAdapter(settings: AstroSettings): boolean {
-	return (
-		(settings.config.output === 'server' || isHybridOutput(settings.config)) && !settings.adapter
-	);
+	return isServerLikeOutput(settings.config) && !settings.adapter;
 }
 
 export function relativeToSrcDir(config: AstroConfig, idOrUrl: URL | string) {

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -18,7 +18,7 @@ import type { PageBuildData } from '../core/build/types';
 import { buildClientDirectiveEntrypoint } from '../core/client-directive/index.js';
 import { mergeConfig } from '../core/config/config.js';
 import { info, type LogOptions } from '../core/logger/core.js';
-import { isHybridOutput } from '../prerender/utils.js';
+import { isServerLikeOutput } from '../prerender/utils.js';
 import { mdxContentEntryType } from '../vite-plugin-markdown/content-entry-type.js';
 
 async function withTakingALongTimeMsg<T>({
@@ -339,8 +339,7 @@ export async function runHookBuildGenerated({
 	buildConfig: BuildConfig;
 	logging: LogOptions;
 }) {
-	const dir =
-		config.output === 'server' || isHybridOutput(config) ? buildConfig.client : config.outDir;
+	const dir = isServerLikeOutput(config) ? buildConfig.client : config.outDir;
 
 	for (const integration of config.integrations) {
 		if (integration?.hooks?.['astro:build:generated']) {
@@ -366,8 +365,7 @@ export async function runHookBuildDone({
 	routes: RouteData[];
 	logging: LogOptions;
 }) {
-	const dir =
-		config.output === 'server' || isHybridOutput(config) ? buildConfig.client : config.outDir;
+	const dir = isServerLikeOutput(config) ? buildConfig.client : config.outDir;
 	await fs.promises.mkdir(dir, { recursive: true });
 
 	for (const integration of config.integrations) {

--- a/packages/astro/src/prerender/utils.ts
+++ b/packages/astro/src/prerender/utils.ts
@@ -1,11 +1,9 @@
-// TODO: remove after the experimetal phase when
-
 import type { AstroConfig } from '../@types/astro';
 
-export function isHybridMalconfigured(config: AstroConfig) {
-	return config.experimental.hybridOutput ? config.output !== 'hybrid' : config.output === 'hybrid';
+export function isServerLikeOutput(config: AstroConfig) {
+	return config.output === 'server' || config.output === 'hybrid';
 }
 
-export function isHybridOutput(config: AstroConfig) {
-	return config.experimental.hybridOutput && config.output === 'hybrid';
+export function getPrerenderDefault(config: AstroConfig) {
+	return config.output === 'hybrid';
 }

--- a/packages/astro/src/vite-plugin-astro-server/request.ts
+++ b/packages/astro/src/vite-plugin-astro-server/request.ts
@@ -9,7 +9,7 @@ import { error } from '../core/logger/core.js';
 import * as msg from '../core/messages.js';
 import { removeTrailingForwardSlash } from '../core/path.js';
 import { eventError, telemetry } from '../events/index.js';
-import { isHybridOutput } from '../prerender/utils.js';
+import { isServerLikeOutput } from '../prerender/utils.js';
 import { runWithErrorHandling } from './controller.js';
 import { handle500Response } from './response.js';
 import { handleRoute, matchRoute } from './route.js';
@@ -25,7 +25,7 @@ export async function handleRequest(
 	const { settings, loader: moduleLoader } = env;
 	const { config } = settings;
 	const origin = `${moduleLoader.isHttps() ? 'https' : 'http'}://${req.headers.host}`;
-	const buildingToSSR = config.output === 'server' || isHybridOutput(config);
+	const buildingToSSR = isServerLikeOutput(config);
 
 	const url = new URL(origin + req.url);
 	let pathname: string;

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -17,7 +17,7 @@ import { getParamsAndProps, GetParamsAndPropsError } from '../core/render/index.
 import { createRequest } from '../core/request.js';
 import { matchAllRoutes } from '../core/routing/index.js';
 import { getSortedPreloadedMatches } from '../prerender/routing.js';
-import { isHybridOutput } from '../prerender/utils.js';
+import { isServerLikeOutput } from '../prerender/utils.js';
 import { log404 } from './common.js';
 import { handle404Response, writeSSRResult, writeWebResponse } from './response.js';
 
@@ -59,7 +59,7 @@ export async function matchRoute(
 			routeCache,
 			pathname: pathname,
 			logging,
-			ssr: settings.config.output === 'server' || isHybridOutput(settings.config),
+			ssr: isServerLikeOutput(settings.config),
 		});
 
 		if (paramsAndPropsRes !== GetParamsAndPropsError.NoMatchingStaticPath) {
@@ -132,7 +132,7 @@ export async function handleRoute(
 	const { config } = settings;
 	const filePath: URL | undefined = matchedRoute.filePath;
 	const { route, preloadedComponent, mod } = matchedRoute;
-	const buildingToSSR = config.output === 'server' || isHybridOutput(config);
+	const buildingToSSR = isServerLikeOutput(config);
 
 	// Headers are only available when using SSR.
 	const request = createRequest({
@@ -158,7 +158,7 @@ export async function handleRoute(
 		routeCache: env.routeCache,
 		pathname: pathname,
 		logging,
-		ssr: config.output === 'server' || isHybridOutput(config),
+		ssr: isServerLikeOutput(config),
 	});
 
 	const options: SSROptions = {

--- a/packages/astro/src/vite-plugin-scanner/index.ts
+++ b/packages/astro/src/vite-plugin-scanner/index.ts
@@ -2,7 +2,7 @@ import { normalizePath, type Plugin as VitePlugin } from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
 import { isEndpoint, isPage } from '../core/util.js';
 
-import { isHybridOutput } from '../prerender/utils.js';
+import { getPrerenderDefault } from '../prerender/utils.js';
 import { scan } from './scan.js';
 
 export default function astroScannerPlugin({ settings }: { settings: AstroSettings }): VitePlugin {
@@ -25,11 +25,11 @@ export default function astroScannerPlugin({ settings }: { settings: AstroSettin
 			const fileIsPage = isPage(fileURL, settings);
 			const fileIsEndpoint = isEndpoint(fileURL, settings);
 			if (!(fileIsPage || fileIsEndpoint)) return;
-			const hybridOutput = isHybridOutput(settings.config);
-			const pageOptions = await scan(code, id, hybridOutput);
+			const defaultPrerender = getPrerenderDefault(settings.config);
+			const pageOptions = await scan(code, id, settings.config.output === 'hybrid');
 
 			if (typeof pageOptions.prerender === 'undefined') {
-				pageOptions.prerender = hybridOutput ? true : false;
+				pageOptions.prerender = defaultPrerender;
 			}
 
 			const { meta = {} } = this.getModuleInfo(id) ?? {};

--- a/packages/astro/test/ssr-prerender-get-static-paths.test.js
+++ b/packages/astro/test/ssr-prerender-get-static-paths.test.js
@@ -144,9 +144,6 @@ describe('Prerender', () => {
 					adapter: testAdapter(),
 					base: '/blog',
 					output: 'hybrid',
-					experimental: {
-						hybridOutput: true,
-					},
 					vite: {
 						plugins: [vitePluginRemovePrerenderExport()],
 					},

--- a/packages/astro/test/units/routing/route-matching.test.js
+++ b/packages/astro/test/units/routing/route-matching.test.js
@@ -133,9 +133,6 @@ describe('Route matching', () => {
 			userConfig: {
 				trailingSlash: 'never',
 				output: 'hybrid',
-				experimental: {
-					hybridOutput: true,
-				},
 				adapter: testAdapter(),
 			},
 			disableTelemetry: true,

--- a/packages/integrations/cloudflare/test/prerender.test.js
+++ b/packages/integrations/cloudflare/test/prerender.test.js
@@ -38,9 +38,6 @@ describe('Hybrid rendering', () => {
 		fixture = await loadFixture({
 			root: './fixtures/prerender/',
 			output: 'hybrid',
-			experimental: {
-				hybridOutput: true,
-			},
 		});
 		await fixture.build();
 	});

--- a/packages/integrations/image/src/index.ts
+++ b/packages/integrations/image/src/index.ts
@@ -3,7 +3,7 @@ import { ssgBuild } from './build/ssg.js';
 import type { ImageService, SSRImageService, TransformOptions } from './loaders/index.js';
 import type { LoggerLevel } from './utils/logger.js';
 import { joinPaths, prependForwardSlash, propsToFilename } from './utils/paths.js';
-import { isHybridOutput } from './utils/prerender.js';
+import { isServerLikeOutput } from './utils/prerender.js';
 import { createPlugin } from './vite-plugin-astro-image.js';
 
 export { getImage } from './lib/get-image.js';
@@ -85,7 +85,7 @@ export default function integration(options: IntegrationOptions = {}): AstroInte
 					vite: getViteConfiguration(command === 'dev'),
 				});
 
-				if (command === 'dev' || config.output === 'server' || isHybridOutput(config)) {
+				if (command === 'dev' || isServerLikeOutput(config)) {
 					injectRoute({
 						pattern: ROUTE_PATTERN,
 						entryPoint: '@astrojs/image/endpoint',

--- a/packages/integrations/image/src/utils/prerender.ts
+++ b/packages/integrations/image/src/utils/prerender.ts
@@ -1,5 +1,5 @@
 import type { AstroConfig } from 'astro';
 
-export function isHybridOutput(config: AstroConfig) {
-	return config.experimental.hybridOutput && config.output === 'hybrid';
+export function isServerLikeOutput(config: AstroConfig) {
+	return config.output === 'server' || config.output === 'hybrid';
 }

--- a/packages/integrations/netlify/test/edge-functions/fixtures/prerender/astro.config.mjs
+++ b/packages/integrations/netlify/test/edge-functions/fixtures/prerender/astro.config.mjs
@@ -6,13 +6,6 @@ const isHybridMode = process.env.PRERENDER === "false";
 /** @type {import('astro').AstroConfig} */
 const partialConfig = {
   output: isHybridMode ? "hybrid" : "server",
-  ...(isHybridMode
-    ? ({
-      experimental: {
-        hybridOutput: true,
-      },
-    })
-    : ({})),
 };
 
 export default defineConfig({

--- a/packages/integrations/netlify/test/functions/prerender.test.js
+++ b/packages/integrations/netlify/test/functions/prerender.test.js
@@ -46,9 +46,6 @@ describe('Mixed Hybrid rendering with SSR', () => {
 		fixture = await loadFixture({
 			root: new URL('./fixtures/prerender/', import.meta.url).toString(),
 			output: 'hybrid',
-			experimental: {
-				hybridOutput: true,
-			},
 			adapter: netlifyAdapter({
 				dist: new URL('./fixtures/prerender/dist/', import.meta.url),
 			}),

--- a/packages/integrations/node/test/prerender.test.js
+++ b/packages/integrations/node/test/prerender.test.js
@@ -140,9 +140,6 @@ describe('Hybrid rendering', () => {
 				base: '/some-base',
 				root: './fixtures/prerender/',
 				output: 'hybrid',
-				experimental: {
-					hybridOutput: true,
-				},
 				adapter: nodejs({ mode: 'standalone' }),
 			});
 			await fixture.build();
@@ -199,9 +196,6 @@ describe('Hybrid rendering', () => {
 			fixture = await loadFixture({
 				root: './fixtures/prerender/',
 				output: 'hybrid',
-				experimental: {
-					hybridOutput: true,
-				},
 				adapter: nodejs({ mode: 'standalone' }),
 			});
 			await fixture.build();

--- a/packages/integrations/vercel/src/lib/prerender.ts
+++ b/packages/integrations/vercel/src/lib/prerender.ts
@@ -1,5 +1,5 @@
 import type { AstroConfig } from 'astro';
 
-export function isHybridOutput(config: AstroConfig) {
-	return config.experimental.hybridOutput && config.output === 'hybrid';
+export function isServerLikeOutput(config: AstroConfig) {
+	return config.output === 'server' || config.output === 'hybrid';
 }

--- a/packages/integrations/vercel/src/static/adapter.ts
+++ b/packages/integrations/vercel/src/static/adapter.ts
@@ -8,7 +8,7 @@ import {
 } from '../image/shared.js';
 import { exposeEnv } from '../lib/env.js';
 import { emptyDir, getVercelOutput, writeJson } from '../lib/fs.js';
-import { isHybridOutput } from '../lib/prerender.js';
+import { isServerLikeOutput } from '../lib/prerender.js';
 import { getRedirects } from '../lib/redirects.js';
 
 const PACKAGE_NAME = '@astrojs/vercel/static';
@@ -55,7 +55,7 @@ export default function vercelStatic({
 				setAdapter(getAdapter());
 				_config = config;
 
-				if (config.output === 'server' || isHybridOutput(config)) {
+				if (isServerLikeOutput(config)) {
 					throw new Error(`${PACKAGE_NAME} should be used with output: 'static'`);
 				}
 			},

--- a/packages/integrations/vercel/test/serverless-prerender.test.js
+++ b/packages/integrations/vercel/test/serverless-prerender.test.js
@@ -27,9 +27,6 @@ describe('Serverless hybrid rendering', () => {
 		fixture = await loadFixture({
 			root: './fixtures/serverless-prerender/',
 			output: 'hybrid',
-			experimental: {
-				hybridOutput: true,
-			},
 		});
 	});
 


### PR DESCRIPTION
## Changes

- Accidentally merged #7255 so this adds the code changes back
- Follow-up to https://github.com/withastro/astro/pull/6991
- Stabilizes `output: 'hybrid'` by removing the `experimental.hybridOutput` flag
- Refactors some internal code that checked for `server || hybrid` with a shared utility.

## Testing

Existing tests should pass, `experimental.hybridOutput` flags have been removed from fixtures.

## Docs

Config docs will be automatically updated.
