### PR TITLE
Fix sitemap filter

### DIFF
--- a/.changeset/eight-planes-drop.md
+++ b/.changeset/eight-planes-drop.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/sitemap': patch
+---
+
+Fix sitemap does not filter pages

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -118,6 +118,8 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 						return urls;
 					}, []);
 
+					pageUrls = Array.from(new Set([...pageUrls, ...routeUrls, ...(customPages ?? [])]));
+
 					try {
 						if (filter) {
 							pageUrls = pageUrls.filter(filter);
@@ -126,8 +128,6 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 						logger.error(`Error filtering pages\n${(err as any).toString()}`);
 						return;
 					}
-
-					pageUrls = Array.from(new Set([...pageUrls, ...routeUrls, ...(customPages ?? [])]));
 
 					if (pageUrls.length === 0) {
 						logger.warn(`No pages found!\n\`${OUTFILE}\` not created.`);

--- a/packages/integrations/sitemap/test/filter.test.js
+++ b/packages/integrations/sitemap/test/filter.test.js
@@ -1,0 +1,46 @@
+import { loadFixture, readXML } from './test-utils.js';
+import { expect } from 'chai';
+import { sitemap } from './fixtures/static/deps.mjs';
+
+describe('Filter support', () => {
+	/** @type {import('./test-utils.js').Fixture} */
+	let fixture;
+
+	describe('Static', () => {
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/static/',
+        integrations: [sitemap({
+          filter: (page) => page !== 'http://example.com/two/'
+        })],
+			});
+			await fixture.build();
+		});
+
+		it('Just one page is added', async () => {
+			const data = await readXML(fixture.readFile('/sitemap-0.xml'));
+			const urls = data.urlset.url;
+			expect(urls.length).to.equal(1);
+		});
+	});
+
+	describe('SSR', () => {
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/ssr/',
+        integrations: [sitemap({
+          filter: (page) => page !== 'http://example.com/two/'
+        })],
+			});
+			await fixture.build();
+		});
+
+		it('Just one page is added', async () => {
+			const data = await readXML(fixture.readFile('/client/sitemap-0.xml'));
+			const urls = data.urlset.url;
+			expect(urls.length).to.equal(1);
+		});
+	});
+
+});
+

--- a/packages/integrations/sitemap/test/fixtures/static/deps.mjs
+++ b/packages/integrations/sitemap/test/fixtures/static/deps.mjs
@@ -1,0 +1,1 @@
+export { default as sitemap } from '@astrojs/sitemap';


### PR DESCRIPTION
Fixes #7256

- Change the position of `pageUrls` value attribution.

## Testing

- Added two test cases using `filter`, one for Static and the other for SSR pages.

## Docs

n/a
