### PR TITLE
Content collections: ignored underscore directories in file glob

### DIFF
--- a/.changeset/rotten-pens-destroy.md
+++ b/.changeset/rotten-pens-destroy.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix: ignore `.json` files within content collection directories starting with an `_` underscore.

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -44,14 +44,21 @@ export function astroContentVirtualModPlugin({
 		)
 		.replace('@@CONTENT_DIR@@', relContentDir)
 		.replace(
-			'@@CONTENT_ENTRY_GLOB_PATH@@',
-			// [!_] = ignore files starting with "_"
-			`${relContentDir}**/[!_]*${getExtGlob(contentEntryExts)}`
+			"'@@CONTENT_ENTRY_GLOB_PATH@@'",
+			JSON.stringify(globWithUnderscoresIgnored(relContentDir, contentEntryExts))
 		)
-		.replace('@@DATA_ENTRY_GLOB_PATH@@', `${relContentDir}**/[!_]*${getExtGlob(dataEntryExts)}`)
 		.replace(
-			'@@RENDER_ENTRY_GLOB_PATH@@',
-			`${relContentDir}**/*${getExtGlob(/** Note: data collections excluded */ contentEntryExts)}`
+			"'@@DATA_ENTRY_GLOB_PATH@@'",
+			JSON.stringify(globWithUnderscoresIgnored(relContentDir, dataEntryExts))
+		)
+		.replace(
+			"'@@RENDER_ENTRY_GLOB_PATH@@'",
+			JSON.stringify(
+				globWithUnderscoresIgnored(
+					relContentDir,
+					/** Note: data collections excluded */ contentEntryExts
+				)
+			)
 		);
 
 	const astroContentVirtualModuleId = '\0' + VIRTUAL_MODULE_ID;
@@ -189,3 +196,8 @@ const UnexpectedLookupMapError = new AstroError({
 	...AstroErrorData.UnknownContentCollectionError,
 	message: `Unexpected error while parsing content entry IDs and slugs.`,
 });
+
+function globWithUnderscoresIgnored(relContentDir: string, exts: string[]): string[] {
+	const extGlob = getExtGlob(exts);
+	return [`${relContentDir}/**/*${extGlob}`, `!**/_*/**${extGlob}`, `!**/_*${extGlob}`];
+}


### PR DESCRIPTION
## Changes

- Resolves #7154 
- Ignore underscore directories (nested and top-level) in collection file globs. Only ignored `_underscore-files` in the previous patch.

## Testing

- Manual testing

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
