### PR TITLE
feat(tsconfigs): Enable allowJs in base preset

### DIFF
--- a/.changeset/slimy-hotels-agree.md
+++ b/.changeset/slimy-hotels-agree.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Update base `tsconfig.json` template with `allowJs: true` to provide a better relaxed experience for users unfamilliar with TypeScript. `allowJs` is still set to `false` (its default value) when using the `strictest` preset.

--- a/packages/astro/tsconfigs/base.json
+++ b/packages/astro/tsconfigs/base.json
@@ -25,6 +25,8 @@
     },
     // TypeScript 5.0 changed how `isolatedModules` and `importsNotUsedAsValues` works, deprecating the later
     // Until the majority of users are on TypeScript 5.0, we'll have to supress those deprecation errors
-    "ignoreDeprecations": "5.0"
+    "ignoreDeprecations": "5.0",
+    // Allow JavaScript files to be imported
+    "allowJs": true
   }
 }

--- a/packages/astro/tsconfigs/strictest.json
+++ b/packages/astro/tsconfigs/strictest.json
@@ -19,6 +19,8 @@
     // Report an error for unreachable code instead of just a warning.
     "allowUnreachableCode": false,
     // Report an error for unused labels instead of just a warning.
-    "allowUnusedLabels": false
+    "allowUnusedLabels": false,
+    // Disallow JavaScript files from being imported
+    "allowJs": false
   }
 }


### PR DESCRIPTION
## Changes

In our language-server, [we force `allowJs` on](https://github.com/withastro/language-tools/blob/45944dd9f0bd781348cd2fb11ee268015de9c165/packages/language-server/src/plugins/typescript/language-service.ts#L368) (this is still the case in 2.0). This is required because otherwise, you wouldn't get intellisense inside inline scripts (which are virtual `.js` files). Other frameworks (Vue and Svelte) also suffer from this, Svelte forces `allowJs` on for you, [Vue requires you to explicitly set it](https://github.com/withastro/astro/assets/3019731/dbd364e8-2e72-4a6a-9cdd-feee8d12e093).

This kinda made me forgot how `allowJs` works, so this PR adds `allowJs` to our base preset, but still disable it in `strictest`. In Astro, Svelte and Vue files, all the native behaviour will work (so forced on for Astro and Svelte, required to change in Vue) 

This is kinda breaking, in the sense that a project that didn't type check before could type check now when using the `base` or `strict` presets, but in my opinion it was a bug that it wasn't included before. This will overall improve the experience for people not used to TypeScript / who don't know in details how its settings works, as this enable completions and auto imports for `.js(x)` files in their project now.

(alternatively, we could make it so when you choose No to the `Are you writing TypeScript` question it changes to a `jsconfig.json`, which implies `allowJs`, however, `jsconfig.json` is non-standard, not always supported and makes it harder to move to a real `tsconfig.json` for users, so who knows)


## Testing

N/A

## Docs

N/A
