### PR TITLE
Run example check in parallel with 5 at most

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5306,6 +5306,9 @@ importers:
       kleur:
         specifier: ^4.1.4
         version: 4.1.5
+      p-limit:
+        specifier: ^4.0.0
+        version: 4.0.0
       svelte:
         specifier: ^3.48.0
         version: 3.58.0

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,14 +13,15 @@
     "esbuild": "^0.17.12",
     "globby": "^12.2.0",
     "kleur": "^4.1.4",
+    "p-limit": "^4.0.0",
     "svelte": "^3.48.0",
     "tar": "^6.1.11"
   },
   "devDependencies": {
     "@octokit/action": "^3.18.1",
     "del": "^7.0.0",
-    "execa": "^6.1.0",
     "esbuild-plugin-copy": "^2.0.2",
+    "execa": "^6.1.0",
     "tsconfig-resolver": "^3.0.1"
   }
 }


### PR DESCRIPTION
## Changes

The `test:check-examples` command in CI has been flaky recently. Try running only 5 examples at most in parallel instead  of 28, to ease the CPU.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested manually locally.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a.