### PR TITLE
Simplify Deno test

### DIFF
--- a/packages/integrations/deno/test/dynamic-import.test.ts
+++ b/packages/integrations/deno/test/dynamic-import.test.ts
@@ -1,16 +1,14 @@
 import { DOMParser } from 'https://deno.land/x/deno_dom@v0.1.35-alpha/deno-dom-wasm.ts';
 import { assert, assertEquals } from 'https://deno.land/std@0.158.0/testing/asserts.ts';
-import { StartServerCallback, runBuildAndStartAppFromSubprocess } from './helpers.ts';
-
-async function startApp(cb: StartServerCallback) {
-	await runBuildAndStartAppFromSubprocess('./fixtures/dynimport/', cb);
-}
+import { runBuildAndStartAppFromSubprocess } from './helpers.ts';
 
 Deno.test({
 	name: 'Dynamic import',
-	async fn() {
-		await startApp(async (baseUrl: URL) => {
-			const resp = await fetch(baseUrl);
+	async fn(t) {
+		const app = await runBuildAndStartAppFromSubprocess('./fixtures/dynimport/');
+
+		await t.step('Works', async () => {
+			const resp = await fetch(app.url);
 			assertEquals(resp.status, 200);
 			const html = await resp.text();
 			assert(html);
@@ -18,5 +16,7 @@ Deno.test({
 			const div = doc!.querySelector('#thing');
 			assert(div, 'div exists');
 		});
+
+		app.stop();
 	},
 });

--- a/packages/integrations/deno/test/helpers.ts
+++ b/packages/integrations/deno/test/helpers.ts
@@ -12,7 +12,6 @@ export const defaultTestPermissions: Deno.PermissionOptions = {
 	env: true,
 };
 
-export declare type StartServerCallback = (url: URL) => Promise<void>;
 declare type ExitCallback = () => void;
 
 export async function runBuild(fixturePath: string) {
@@ -59,31 +58,20 @@ export async function startModFromSubprocess(baseUrl: URL): Promise<ExitCallback
 	return () => proc.close();
 }
 
-export async function runBuildAndStartApp(fixturePath: string, cb: StartServerCallback) {
+export async function runBuildAndStartApp(fixturePath: string) {
 	const url = new URL(fixturePath, dir);
 
 	await runBuild(fixturePath);
 	const stop = await startModFromImport(url);
 
-	try {
-		await cb(defaultURL);
-	} finally {
-		stop();
-	}
+	return { url: defaultURL, stop };
 }
 
-export async function runBuildAndStartAppFromSubprocess(
-	fixturePath: string,
-	cb: StartServerCallback
-) {
+export async function runBuildAndStartAppFromSubprocess(fixturePath: string) {
 	const url = new URL(fixturePath, dir);
 
 	await runBuild(fixturePath);
 	const stop = await startModFromSubprocess(url);
 
-	try {
-		await cb(defaultURL);
-	} finally {
-		stop();
-	}
+	return { url: defaultURL, stop };
 }


### PR DESCRIPTION
## Changes

Instead of spinning up a new Deno server for each individual test, we can share it similar to the describe-it pattern where each `it` test shares the same server.

In Deno, it's called [test-step](https://deno.com/manual@v1.34.1/basics/testing#test-steps), so I've refactored the code with this pattern. Locally It improves Deno test time from ~25s to ~5s.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Ran the test locally.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. test refactor.