### PR TITLE
Add 'starlight' as template alias

### DIFF
--- a/.changeset/chilled-insects-melt.md
+++ b/.changeset/chilled-insects-melt.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Add `starlight` template alias

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -68,11 +68,15 @@ const FILES_TO_UPDATE = {
 		}),
 };
 
-export default async function copyTemplate(tmpl: string, ctx: Context) {
-	const ref = ctx.ref || 'latest';
-	const isThirdParty = tmpl.includes('/');
+function getTemplateTarget(template: string, ref: string = 'latest') {
+	const isThirdParty = template.includes('/');
+	if (isThirdParty) return template;
+	if (template === 'starlight') return `withastro/starlight/examples/basics`;
+	return `github:withastro/astro/examples/${template}#${ref}`;
+}
 
-	const templateTarget = isThirdParty ? tmpl : `github:withastro/astro/examples/${tmpl}#${ref}`;
+export default async function copyTemplate(tmpl: string, ctx: Context) {
+	const templateTarget = getTemplateTarget(tmpl, ctx.ref);
 
 	// Copy
 	if (!ctx.dryRun) {

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -68,11 +68,11 @@ const FILES_TO_UPDATE = {
 		}),
 };
 
-function getTemplateTarget(template: string, ref: string = 'latest') {
-	const isThirdParty = template.includes('/');
-	if (isThirdParty) return template;
-	if (template === 'starlight') return `withastro/starlight/examples/basics`;
-	return `github:withastro/astro/examples/${template}#${ref}`;
+function getTemplateTarget(tmpl: string, ref = 'latest') {
+	const isThirdParty = tmpl.includes('/');
+	if (isThirdParty) return tmpl;
+	if (tmpl === 'starlight') return `withastro/starlight/examples/basics`;
+	return `github:withastro/astro/examples/${tmpl}#${ref}`;
 }
 
 export default async function copyTemplate(tmpl: string, ctx: Context) {


### PR DESCRIPTION
## Changes

- Adds a built-in template alias for `starlight`.
- Refactors template logic for readability.
- Once released, can be used like so...

```
pnpm create astro --template starlight
```

## Testing

Manual

## Docs

Will be updating the Starlight docs once this is released!