### PR TITLE
Node built-in modules support for Deno adapter

### DIFF
--- a/.changeset/modern-lobsters-sparkle.md
+++ b/.changeset/modern-lobsters-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/deno': minor
+---
+
+The deno adapter now supports npm package that require built-in node modules.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Use Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.26.1
+          deno-version: v1.34.1
 
       - name: Install dependencies
         run: pnpm install

--- a/packages/integrations/deno/src/index.ts
+++ b/packages/integrations/deno/src/index.ts
@@ -21,6 +21,59 @@ const SHIM = `globalThis.process = {
 };`;
 
 const DENO_VERSION = `0.177.0`;
+// REF: https://github.com/denoland/deno/tree/main/ext/node/polyfills
+const COMPATIBLE_NODE_MODULES = [
+	'assert',
+	'assert/strict',
+	'async_hooks',
+	'buffer',
+	'child_process',
+	'cluster',
+	'console',
+	'constants',
+	'crypto',
+	'dgram',
+	'diagnostics_channel',
+	'dns',
+	'events',
+	'fs',
+	'fs/promises',
+	'http',
+	// 'http2',
+	'https',
+	'inspector',
+	'module',
+	'net',
+	'os',
+	'path',
+	'path/posix',
+	'path/win32',
+	'perf_hooks',
+	'process',
+	'punycode',
+	'querystring',
+	'readline',
+	'repl',
+	'stream',
+	'stream/promises',
+	'stream/web',
+	'string_decoder',
+	'sys',
+	'timers',
+	'timers/promises',
+	// 'tls',
+	'trace_events',
+	'tty',
+	'url',
+	'util',
+	'util/types',
+	// 'v8',
+	// 'vm',
+	// 'wasi',
+	// 'webcrypto',
+	'worker_threads',
+	'zlib'
+];
 
 // We shim deno-specific imports so we can run the code in Node
 // to prerender pages. In the final Deno build, this import is
@@ -51,6 +104,17 @@ const denoImportsShimPlugin = {
 	},
 };
 
+const denoRenameNodeModulesPlugin = {
+	name: '@astrojs/esbuild-rename-node-modules',
+	setup(build: esbuild.PluginBuild) {
+		const filter = new RegExp(COMPATIBLE_NODE_MODULES.map(mod => `(^${mod}$)`).join('|'))
+		build.onResolve(
+			{ filter },
+			args => ({ path: 'node:' + args.path, external: true })
+		)
+	},
+};
+
 export default function createIntegration(args?: Options): AstroIntegration {
 	let _buildConfig: BuildConfig;
 	let _vite: any;
@@ -78,7 +142,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					vite.build = vite.build ?? {};
 					vite.build.rollupOptions = vite.build.rollupOptions ?? {};
 					vite.build.rollupOptions.external = vite.build.rollupOptions.external ?? [];
-
+                    
 					const aliases = [{ find: 'react-dom/server', replacement: 'react-dom/server.browser' }];
 
 					if (Array.isArray(vite.resolve.alias)) {
@@ -89,7 +153,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						}
 					}
 					vite.ssr = {
-						noExternal: true,
+						noExternal: COMPATIBLE_NODE_MODULES
 					};
 
 					if (Array.isArray(vite.build.rollupOptions.external)) {
@@ -114,8 +178,8 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					allowOverwrite: true,
 					format: 'esm',
 					bundle: true,
-					external: ['@astrojs/markdown-remark'],
-					plugins: [denoImportsShimPlugin],
+					external: [...COMPATIBLE_NODE_MODULES.map(mod => `node:${mod}`),'@astrojs/markdown-remark'],
+					plugins: [denoImportsShimPlugin, denoRenameNodeModulesPlugin],
 					banner: {
 						js: SHIM,
 					},

--- a/packages/integrations/deno/src/index.ts
+++ b/packages/integrations/deno/src/index.ts
@@ -72,7 +72,7 @@ const COMPATIBLE_NODE_MODULES = [
 	// 'wasi',
 	// 'webcrypto',
 	'worker_threads',
-	'zlib'
+	'zlib',
 ];
 
 // We shim deno-specific imports so we can run the code in Node
@@ -107,11 +107,8 @@ const denoImportsShimPlugin = {
 const denoRenameNodeModulesPlugin = {
 	name: '@astrojs/esbuild-rename-node-modules',
 	setup(build: esbuild.PluginBuild) {
-		const filter = new RegExp(COMPATIBLE_NODE_MODULES.map(mod => `(^${mod}$)`).join('|'))
-		build.onResolve(
-			{ filter },
-			args => ({ path: 'node:' + args.path, external: true })
-		)
+		const filter = new RegExp(COMPATIBLE_NODE_MODULES.map((mod) => `(^${mod}$)`).join('|'));
+		build.onResolve({ filter }, (args) => ({ path: 'node:' + args.path, external: true }));
 	},
 };
 
@@ -142,7 +139,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					vite.build = vite.build ?? {};
 					vite.build.rollupOptions = vite.build.rollupOptions ?? {};
 					vite.build.rollupOptions.external = vite.build.rollupOptions.external ?? [];
-                    
+
 					const aliases = [{ find: 'react-dom/server', replacement: 'react-dom/server.browser' }];
 
 					if (Array.isArray(vite.resolve.alias)) {
@@ -153,7 +150,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						}
 					}
 					vite.ssr = {
-						noExternal: COMPATIBLE_NODE_MODULES
+						noExternal: COMPATIBLE_NODE_MODULES,
 					};
 
 					if (Array.isArray(vite.build.rollupOptions.external)) {
@@ -178,7 +175,10 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					allowOverwrite: true,
 					format: 'esm',
 					bundle: true,
-					external: [...COMPATIBLE_NODE_MODULES.map(mod => `node:${mod}`),'@astrojs/markdown-remark'],
+					external: [
+						...COMPATIBLE_NODE_MODULES.map((mod) => `node:${mod}`),
+						'@astrojs/markdown-remark',
+					],
 					plugins: [denoImportsShimPlugin, denoRenameNodeModulesPlugin],
 					banner: {
 						js: SHIM,

--- a/packages/integrations/deno/test/basics.test.ts
+++ b/packages/integrations/deno/test/basics.test.ts
@@ -103,7 +103,13 @@ Deno.test({
 			const h1 = doc!.querySelector('h1');
 			assertEquals(h1!.innerText, 'test');
 		});
-
+        
+		await t.step('node compatibility', async () => {
+		    const resp = await fetch(new URL('/nodecompat', app.url));
+			assertEquals(resp.status, 200);
+			await resp.text()
+		})
+        
 		app.stop();
 	},
 });

--- a/packages/integrations/deno/test/basics.test.ts
+++ b/packages/integrations/deno/test/basics.test.ts
@@ -103,13 +103,13 @@ Deno.test({
 			const h1 = doc!.querySelector('h1');
 			assertEquals(h1!.innerText, 'test');
 		});
-        
+
 		await t.step('node compatibility', async () => {
-		    const resp = await fetch(new URL('/nodecompat', app.url));
+			const resp = await fetch(new URL('/nodecompat', app.url));
 			assertEquals(resp.status, 200);
-			await resp.text()
-		})
-        
+			await resp.text();
+		});
+
 		app.stop();
 	},
 });

--- a/packages/integrations/deno/test/fixtures/basics/src/pages/nodecompat.astro
+++ b/packages/integrations/deno/test/fixtures/basics/src/pages/nodecompat.astro
@@ -1,0 +1,15 @@
+---
+// unprefixed node built-in module
+import path from 'path'
+
+// prefixed node built-in module
+import os from 'node:os'
+---
+<body>
+<a href={path.posix.basename('/public/myfile.html')}>Go to my file</a>
+<details>
+    <summary>CPU Architecture</summary>
+    <code>{os.arch()}</code>
+</details>
+<p>Everything went fine.</p>
+</body>


### PR DESCRIPTION
## Changes
It seems to be a use case that's receiving more and more interest. Deno can leverage built-in node modules, but it's blocked by an overly restrictive configuration set by the adapter.

## Testing
[nodecompat.astro](https://github.com/withastro/astro/pull/7288/files#diff-cde1d6bd05d7fffc08097404004b322be91bd41493cbbfbc49b961f64e73da2a)

## Docs
Not a user facing change, though a note somewhere could be useful.