### PR TITLE
[docs] fix note syntax in Netlify README

### DIFF
--- a/packages/integrations/netlify/README.md
+++ b/packages/integrations/netlify/README.md
@@ -96,7 +96,8 @@ export default defineConfig({
 
 Once you run `astro build` there will be a `dist/_redirects` file. Netlify will use that to properly route pages in production.
 
-> __Note__, you can still include a `public/_redirects` file for manual redirects. Any redirects you specify in the redirects config are appended to the end of your own.
+> **Note**
+> You can still include a `public/_redirects` file for manual redirects. Any redirects you specify in the redirects config are appended to the end of your own.
 
 ## Usage
 


### PR DESCRIPTION
## Changes

Changes the note syntax in the Netlify README so that the note renders properly in Docs.

## Testing

No tests. Docs.

## Docs

Will end up properly in docs.
