### PR TITLE
Fix: catch and report config errors from `handleConfigError`

### DIFF
--- a/.changeset/large-keys-peel.md
+++ b/.changeset/large-keys-peel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix Zod errors getting flagged as configuration errors


### PR DESCRIPTION
## Changes

- Remove `instanceof ZodError` catch-all from our error logger. This could unintentionally grab _any_ Zod error (not just config errors), causing confusion for user-built Zod code.
- Move telemetry and error formatting to `handleConfigError()`. This function seems to catch all config errors before hitting the base `process.exit` already.

## Testing

Manual testing

## Docs

N/A