### PR TITLE
Mark #7314 changeset as major

### DIFF
--- a/.changeset/sour-turtles-tap.md
+++ b/.changeset/sour-turtles-tap.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/svelte': patch
+'@astrojs/svelte': major
 ---
 
 Update to svelte2tsx 0.6.15 and vite-plugin-svelte 2.4.1


### PR DESCRIPTION
## Changes

#7314 changes the peer dep ranges which is a breaking change, marking it as `major` from `patch` (https://github.com/withastro/astro/pull/7314#issuecomment-1579600612)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
n/a

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a