### PR TITLE
Fixes an issue where create Astro doesn't respect custom npm registries

### DIFF
--- a/.changeset/thirty-books-smoke.md
+++ b/.changeset/thirty-books-smoke.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Ensure create-astro respects package manager registry configuration

--- a/.changeset/yellow-plants-stare.md
+++ b/.changeset/yellow-plants-stare.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes issue where Astro doesn't respect custom npm registry settings during project creation

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -35,7 +35,8 @@
     "chai": "^4.3.6",
     "execa": "^6.1.0",
     "giget": "1.0.0",
-    "mocha": "^9.2.2"
+    "mocha": "^9.2.2",
+    "preferred-pm": "^3.0.3"
   },
   "devDependencies": {
     "@types/which-pm-runs": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3554,6 +3554,9 @@ importers:
       mocha:
         specifier: ^9.2.2
         version: 9.2.2
+      preferred-pm:
+        specifier: ^3.0.3
+        version: 3.0.3
     devDependencies:
       '@types/which-pm-runs':
         specifier: ^1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,4 @@
-lockfileVersion: '6.1'
-
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false
+lockfileVersion: '6.0'
 
 overrides:
   tsconfig-resolver>type-fest: 3.0.0
@@ -3558,9 +3554,6 @@ importers:
       mocha:
         specifier: ^9.2.2
         version: 9.2.2
-      preferred-pm:
-        specifier: ^3.0.3
-        version: 3.0.3
     devDependencies:
       '@types/which-pm-runs':
         specifier: ^1.0.0
@@ -4393,7 +4386,7 @@ importers:
         version: 9.2.2
       vite:
         specifier: ^4.3.1
-        version: 4.3.1(@types/node@14.18.21)
+        version: 4.3.1(@types/node@18.16.3)(sass@1.52.2)
 
   packages/integrations/netlify/test/edge-functions/fixtures/dynimport:
     dependencies:
@@ -4911,7 +4904,7 @@ importers:
         version: 3.0.0(vite@4.3.1)(vue@3.2.47)
       '@vue/babel-plugin-jsx':
         specifier: ^1.1.1
-        version: 1.1.1
+        version: 1.1.1(@babel/core@7.21.8)
       '@vue/compiler-sfc':
         specifier: ^3.2.39
         version: 3.2.39
@@ -9320,23 +9313,6 @@ packages:
 
   /@vue/babel-helper-vue-transform-on@1.0.2:
     resolution: {integrity: sha512-hz4R8tS5jMn8lDq6iD+yWL6XNB699pGIVLk7WSJnn1dbpjaazsjZQkieJoRX6gW5zpYSCFqQ7jUquPNY65tQYA==}
-    dev: false
-
-  /@vue/babel-plugin-jsx@1.1.1:
-    resolution: {integrity: sha512-j2uVfZjnB5+zkcbc/zsOc0fSNGCMMjaEXP52wdwdIfn0qjFfEYpYZBFKFg+HHnQeJCVrjOeO0YxgaL7DMrym9w==}
-    dependencies:
-      '@babel/helper-module-imports': 7.21.4
-      '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.18.2)
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.18.2
-      '@babel/types': 7.21.5
-      '@vue/babel-helper-vue-transform-on': 1.0.2
-      camelcase: 6.3.0
-      html-tags: 3.3.1
-      svg-tags: 1.0.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
     dev: false
 
   /@vue/babel-plugin-jsx@1.1.1(@babel/core@7.21.8):
@@ -17626,39 +17602,6 @@ packages:
       - '@types/babel__core'
       - supports-color
     dev: false
-
-  /vite@4.3.1(@types/node@14.18.21):
-    resolution: {integrity: sha512-EPmfPLAI79Z/RofuMvkIS0Yr091T2ReUoXQqc5ppBX/sjFRhHKiPPF/R46cTdoci/XgeQpB23diiJxq5w30vdg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 14.18.21
-      esbuild: 0.17.18
-      postcss: 8.4.23
-      rollup: 3.21.8
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
 
   /vite@4.3.1(@types/node@18.16.3)(sass@1.52.2):
     resolution: {integrity: sha512-EPmfPLAI79Z/RofuMvkIS0Yr091T2ReUoXQqc5ppBX/sjFRhHKiPPF/R46cTdoci/XgeQpB23diiJxq5w30vdg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
 
 overrides:
   tsconfig-resolver>type-fest: 3.0.0
@@ -3554,6 +3558,9 @@ importers:
       mocha:
         specifier: ^9.2.2
         version: 9.2.2
+      preferred-pm:
+        specifier: ^3.0.3
+        version: 3.0.3
     devDependencies:
       '@types/which-pm-runs':
         specifier: ^1.0.0
@@ -4386,7 +4393,7 @@ importers:
         version: 9.2.2
       vite:
         specifier: ^4.3.1
-        version: 4.3.1(@types/node@18.16.3)(sass@1.52.2)
+        version: 4.3.1(@types/node@14.18.21)
 
   packages/integrations/netlify/test/edge-functions/fixtures/dynimport:
     dependencies:
@@ -4904,7 +4911,7 @@ importers:
         version: 3.0.0(vite@4.3.1)(vue@3.2.47)
       '@vue/babel-plugin-jsx':
         specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.21.8)
+        version: 1.1.1
       '@vue/compiler-sfc':
         specifier: ^3.2.39
         version: 3.2.39
@@ -9313,6 +9320,23 @@ packages:
 
   /@vue/babel-helper-vue-transform-on@1.0.2:
     resolution: {integrity: sha512-hz4R8tS5jMn8lDq6iD+yWL6XNB699pGIVLk7WSJnn1dbpjaazsjZQkieJoRX6gW5zpYSCFqQ7jUquPNY65tQYA==}
+    dev: false
+
+  /@vue/babel-plugin-jsx@1.1.1:
+    resolution: {integrity: sha512-j2uVfZjnB5+zkcbc/zsOc0fSNGCMMjaEXP52wdwdIfn0qjFfEYpYZBFKFg+HHnQeJCVrjOeO0YxgaL7DMrym9w==}
+    dependencies:
+      '@babel/helper-module-imports': 7.21.4
+      '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.18.2)
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.18.2
+      '@babel/types': 7.21.5
+      '@vue/babel-helper-vue-transform-on': 1.0.2
+      camelcase: 6.3.0
+      html-tags: 3.3.1
+      svg-tags: 1.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
     dev: false
 
   /@vue/babel-plugin-jsx@1.1.1(@babel/core@7.21.8):
@@ -17602,6 +17626,39 @@ packages:
       - '@types/babel__core'
       - supports-color
     dev: false
+
+  /vite@4.3.1(@types/node@14.18.21):
+    resolution: {integrity: sha512-EPmfPLAI79Z/RofuMvkIS0Yr091T2ReUoXQqc5ppBX/sjFRhHKiPPF/R46cTdoci/XgeQpB23diiJxq5w30vdg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 14.18.21
+      esbuild: 0.17.18
+      postcss: 8.4.23
+      rollup: 3.21.8
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
 
   /vite@4.3.1(@types/node@18.16.3)(sass@1.52.2):
     resolution: {integrity: sha512-EPmfPLAI79Z/RofuMvkIS0Yr091T2ReUoXQqc5ppBX/sjFRhHKiPPF/R46cTdoci/XgeQpB23diiJxq5w30vdg==}


### PR DESCRIPTION
## Changes

- Introduced a fix for #7279 by introducing a utility to check the preferred package manager config to find any custom package registry, defaulting to the public npm registry (which is currently in use)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
I'm not sure how to effectively test this fix without affecting the entire build process. Happy to accept suggestions.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
This should enable Astro to behave as expected for users with custom package registries (such as large enterprises who might block the public npm registry for security or efficiency reasons).
