### PR TITLE
[Markdoc] add URL support for absolute component paths

### DIFF
--- a/.changeset/sour-starfishes-behave.md
+++ b/.changeset/sour-starfishes-behave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': patch
+---
+
+Allow component import paths to be passed as URLs to Markdoc tag and node renderers.

--- a/packages/integrations/markdoc/src/config.ts
+++ b/packages/integrations/markdoc/src/config.ts
@@ -9,7 +9,7 @@ import _Markdoc from '@markdoc/markdoc';
 import type { AstroInstance } from 'astro';
 import { heading } from './heading-ids.js';
 
-type Render = AstroInstance['default'] | string;
+type Render = AstroInstance['default'] | URL | string;
 
 export type AstroMarkdocConfig<C extends Record<string, any> = Record<string, any>> = Omit<
 	MarkdocConfig,

--- a/packages/integrations/markdoc/src/config.ts
+++ b/packages/integrations/markdoc/src/config.ts
@@ -9,7 +9,7 @@ import _Markdoc from '@markdoc/markdoc';
 import type { AstroInstance } from 'astro';
 import { heading } from './heading-ids.js';
 
-type Render = AstroInstance['default'] | URL | string;
+export type Render = AstroInstance['default'] | URL | string;
 
 export type AstroMarkdocConfig<C extends Record<string, any> = Record<string, any>> = Omit<
 	MarkdocConfig,

--- a/packages/integrations/markdoc/src/index.ts
+++ b/packages/integrations/markdoc/src/index.ts
@@ -150,10 +150,7 @@ export default function markdocIntegration(legacyConfig?: any): AstroIntegration
 
 						export const Content = createComponent({
 							async factory(result, props) {
-								const config = await getConfig({
-									variables: props,
-								});
-								
+								const config = await getConfig({ variables: props });
 								return renderComponent(
 									result,
 									Renderer.name,

--- a/packages/integrations/markdoc/src/index.ts
+++ b/packages/integrations/markdoc/src/index.ts
@@ -130,12 +130,8 @@ export default function markdocIntegration(legacyConfig?: any): AstroIntegration
 							renderComponent,
 						} from 'astro/runtime/server/index.js';
 						import { Renderer } from '@astrojs/markdoc/components';
-						import { collectHeadings, setupConfig, setupConfigSync, Markdoc } from '@astrojs/markdoc/runtime';
-						import userConfig from ${JSON.stringify(markdocConfigId)};${
-							astroConfig.experimental.assets
-								? `\nimport { experimentalAssetsConfig } from '@astrojs/markdoc/experimental-assets-config';\nuserConfig.nodes = { ...experimentalAssetsConfig.nodes, ...userConfig.nodes };`
-								: ''
-						}
+						import { collectHeadings, Markdoc } from '@astrojs/markdoc/runtime';
+						import { getConfig, getConfigSync } from ${JSON.stringify(markdocConfigId)};
 						const stringifiedAst = ${JSON.stringify(
 							/* Double stringify to encode *as* stringified JSON */ JSON.stringify(ast)
 						)};
@@ -146,8 +142,7 @@ export default function markdocIntegration(legacyConfig?: any): AstroIntegration
 								instead of the Content component. Would remove double-transform and unlock variable resolution in heading slugs. */
 								''
 							}
-							const headingConfig = userConfig.nodes?.heading;
-							const config = setupConfigSync(headingConfig ? { nodes: { heading: headingConfig } } : {});
+							const config = getConfigSync();
 							const ast = Markdoc.Ast.fromJSON(stringifiedAst);
 							const content = Markdoc.transform(ast, config);
 							return collectHeadings(Array.isArray(content) ? content : content.children);
@@ -155,9 +150,8 @@ export default function markdocIntegration(legacyConfig?: any): AstroIntegration
 
 						export const Content = createComponent({
 							async factory(result, props) {
-								const config = await setupConfig({
-									...userConfig,
-									variables: { ...userConfig.variables, ...props },
+								const config = await getConfig({
+									variables: props,
 								});
 								
 								return renderComponent(

--- a/packages/integrations/markdoc/src/runtime.ts
+++ b/packages/integrations/markdoc/src/runtime.ts
@@ -1,4 +1,5 @@
 import type { MarkdownHeading } from '@astrojs/markdown-remark';
+import type { AstroInstance } from 'astro';
 import Markdoc, { type RenderableTreeNode } from '@markdoc/markdoc';
 import type { AstroMarkdocConfig } from './config.js';
 import { setupHeadingConfig } from './heading-ids.js';
@@ -63,6 +64,26 @@ function mergeConfig(configA: AstroMarkdocConfig, configB: AstroMarkdocConfig): 
 			...configA.variables,
 			...configB.variables,
 		},
+	};
+}
+
+export function resolveComponentImports(
+	markdocConfig: AstroMarkdocConfig,
+	tagComponentMap: Record<string, AstroInstance['default']>
+) {
+	const resolvedTags = { ...markdocConfig.tags };
+	for (const [tagName, tagConfig] of Object.entries(resolvedTags)) {
+		if (tagName in tagComponentMap) {
+			resolvedTags[tagName] = {
+				...tagConfig,
+				render: tagComponentMap[tagName],
+			};
+		}
+	}
+	console.log('resolvedTags', resolvedTags);
+	return {
+		...markdocConfig,
+		tags: resolvedTags,
 	};
 }
 

--- a/packages/integrations/markdoc/src/runtime.ts
+++ b/packages/integrations/markdoc/src/runtime.ts
@@ -1,6 +1,6 @@
 import type { MarkdownHeading } from '@astrojs/markdown-remark';
 import type { AstroInstance } from 'astro';
-import Markdoc, { type RenderableTreeNode } from '@markdoc/markdoc';
+import Markdoc, { type NodeType, type RenderableTreeNode } from '@markdoc/markdoc';
 import type { AstroMarkdocConfig } from './config.js';
 import { setupHeadingConfig } from './heading-ids.js';
 
@@ -68,23 +68,19 @@ function mergeConfig(configA: AstroMarkdocConfig, configB: AstroMarkdocConfig): 
 }
 
 export function resolveComponentImports(
-	markdocConfig: AstroMarkdocConfig,
-	tagComponentMap: Record<string, AstroInstance['default']>
+	markdocConfig: Required<Pick<AstroMarkdocConfig, 'tags' | 'nodes'>>,
+	tagComponentMap: Record<string, AstroInstance['default']>,
+	nodeComponentMap: Record<NodeType, AstroInstance['default']>
 ) {
-	const resolvedTags = { ...markdocConfig.tags };
-	for (const [tagName, tagConfig] of Object.entries(resolvedTags)) {
-		if (tagName in tagComponentMap) {
-			resolvedTags[tagName] = {
-				...tagConfig,
-				render: tagComponentMap[tagName],
-			};
-		}
+	for (const [tag, render] of Object.entries(tagComponentMap)) {
+		const config = markdocConfig.tags[tag];
+		if (config) config.render = render;
 	}
-	console.log('resolvedTags', resolvedTags);
-	return {
-		...markdocConfig,
-		tags: resolvedTags,
-	};
+	for (const [node, render] of Object.entries(nodeComponentMap)) {
+		const config = markdocConfig.nodes[node as NodeType];
+		if (config) config.render = render;
+	}
+	return markdocConfig;
 }
 
 /**

--- a/packages/integrations/markdoc/src/runtime.ts
+++ b/packages/integrations/markdoc/src/runtime.ts
@@ -40,7 +40,10 @@ export function setupConfigSync(
 }
 
 /** Merge function from `@markdoc/markdoc` internals */
-function mergeConfig(configA: AstroMarkdocConfig, configB: AstroMarkdocConfig): AstroMarkdocConfig {
+export function mergeConfig(
+	configA: AstroMarkdocConfig,
+	configB: AstroMarkdocConfig
+): AstroMarkdocConfig {
 	return {
 		...configA,
 		...configB,

--- a/packages/integrations/markdoc/src/vite-plugin-config.ts
+++ b/packages/integrations/markdoc/src/vite-plugin-config.ts
@@ -2,8 +2,7 @@ import type { AstroConfig } from 'astro';
 import type { Plugin } from 'vite';
 import type { PluginContext } from 'rollup';
 import { loadMarkdocConfig } from './load-config.js';
-import type { AstroMarkdocConfig } from './config.js';
-import type { Schema } from '@markdoc/markdoc';
+import type { Schema, Config as MarkdocConfig } from '@markdoc/markdoc';
 import type { Render } from './config.js';
 import { setupConfig } from './runtime.js';
 
@@ -58,7 +57,7 @@ export function vitePluginMarkdocConfig({ astroConfig }: { astroConfig: AstroCon
 	};
 }
 
-function getRenderUrlMap(tagsOrNodes: Record<string, Schema<AstroMarkdocConfig, Render>>) {
+function getRenderUrlMap(tagsOrNodes: Record<string, Schema<MarkdocConfig, Render>>) {
 	const renderPathnameMap: Record<string, string> = {};
 	for (const [name, value] of Object.entries(tagsOrNodes)) {
 		if (value.render instanceof URL) {

--- a/packages/integrations/markdoc/src/vite-plugin-config.ts
+++ b/packages/integrations/markdoc/src/vite-plugin-config.ts
@@ -1,0 +1,54 @@
+import type { AstroConfig } from 'astro';
+import type { Plugin } from 'vite';
+import type { PluginContext } from 'rollup';
+import { loadMarkdocConfig } from './load-config.js';
+
+export const markdocConfigId = 'astro:markdoc-config';
+export const resolvedMarkdocConfigId = '\x00' + markdocConfigId;
+
+export function vitePluginMarkdocConfig({ astroConfig }: { astroConfig: AstroConfig }): Plugin {
+	return {
+		name: '@astrojs/markdoc:config',
+		resolveId(this: PluginContext, id: string) {
+			if (id === markdocConfigId) {
+				return resolvedMarkdocConfigId;
+			}
+		},
+		async load(id: string) {
+			if (id !== resolvedMarkdocConfigId) return;
+
+			// TODO: invalidate on change
+			const markdocConfigResult = await loadMarkdocConfig(astroConfig);
+
+			if (!markdocConfigResult) {
+				return `export default {}`;
+			}
+			const { config, fileUrl } = markdocConfigResult;
+			let componentPathnameByTag: Record<string, string> = {};
+			const { tags = {}, nodes = {} /* TODO: nodes */ } = config;
+			for (const [name, value] of Object.entries(tags)) {
+				if (value.render instanceof URL) {
+					componentPathnameByTag[name] = value.render.pathname;
+				}
+			}
+			let stringifiedComponentImports = '';
+			let stringifiedComponentMap = '{';
+			for (const [tag, componentPathname] of Object.entries(componentPathnameByTag)) {
+				stringifiedComponentImports += `import ${tag} from ${JSON.stringify(
+					componentPathname + '?astroPropagatedAssets'
+				)};\n`;
+				stringifiedComponentMap += `${tag},\n`;
+			}
+			stringifiedComponentMap += '}';
+			const code = `import { resolveComponentImports } from '@astrojs/markdoc/runtime';
+										import markdocConfig from ${JSON.stringify(fileUrl.pathname)};
+										${stringifiedComponentImports};
+
+										const tagComponentMap = ${stringifiedComponentMap};
+										export default resolveComponentImports(markdocConfig, tagComponentMap);`;
+
+			console.log('$$$markdoc-config', code);
+			return code;
+		},
+	};
+}


### PR DESCRIPTION
## Changes

Adds support for URLs for the `render` property on Markdoc tags and nodes. This allows npm packages to apply components to your Markdoc config without importing as `.astro` files directly.

This example references an `Aside.astro` component with a relative path:

```ts
function starlightMarkdocConfig() {
  return {
    tags: {
      cta: {
        render: new URL('./components/CallToAction.astro', import.meta.url),
        attributes: {
          variant: { type: String, required: true },
          link: { type: String, required: true },
        },
      }
    }
  }
}
```

This can also be used to import third party config that relies on components using `extends`:

```ts
import { starlightMarkdocConfig } from '@astrojs/starlight';

export default defineMarkdocConfig({
  extends: [starlightMarkdocConfig()],
});
```

## Testing

TODO: update test runners to URL

## Docs

TODO