### PR TITLE
Better dynamic route regex error

### DIFF
--- a/.changeset/kind-cycles-smile.md
+++ b/.changeset/kind-cycles-smile.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add readable error message for invalid dynamic routes.

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -347,8 +347,10 @@ function getInvalidRouteSegmentError(
 	staticPath: GetStaticPathsItem
 ): AstroError {
 	const invalidParam = e.message.match(/^Expected "([^"]+)"/)?.[1];
-	let hint: string | undefined = undefined;
-	if (invalidParam) {
+	const received = invalidParam ? staticPath.params[invalidParam] : undefined;
+	let hint: string =
+		'Learn about dynamic routes at https://docs.astro.build/en/core-concepts/routing/#dynamic-routes';
+	if (invalidParam && typeof received === 'string') {
 		const matchingSegment = route.segments.find(
 			(segment) => segment[0]?.content === invalidParam
 		)?.[0];
@@ -363,7 +365,7 @@ function getInvalidRouteSegmentError(
 			? AstroErrorData.InvalidDynamicRoute.message(
 					route.route,
 					JSON.stringify(invalidParam),
-					JSON.stringify(staticPath.params[invalidParam])
+					JSON.stringify(received)
 			  )
 			: `Generated path for ${route.route} is invalid.`,
 		hint,

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -356,7 +356,7 @@ function getInvalidRouteSegmentError(
 		)?.[0];
 		const mightBeMissingSpread = matchingSegment?.dynamic && !matchingSegment?.spread;
 		if (mightBeMissingSpread) {
-			hint = `If the route has multiple slashes, try using a rest parameter: **[...${invalidParam}]**. Learn more at https://docs.astro.build/en/core-concepts/routing/#dynamic-routes`;
+			hint = `If the param contains slashes, try using a rest parameter: **[...${invalidParam}]**. Learn more at https://docs.astro.build/en/core-concepts/routing/#dynamic-routes`;
 		}
 	}
 	return new AstroError({

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -348,7 +348,7 @@ function getInvalidRouteSegmentError(
 ): AstroError {
 	const invalidParam = e.message.match(/^Expected "([^"]+)"/)?.[1];
 	const received = invalidParam ? staticPath.params[invalidParam] : undefined;
-	let hint: string =
+	let hint =
 		'Learn about dynamic routes at https://docs.astro.build/en/core-concepts/routing/#dynamic-routes';
 	if (invalidParam && typeof received === 'string') {
 		const matchingSegment = route.segments.find(

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -760,6 +760,19 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 		title: 'A redirect must be given a location with the `Location` header.',
 		code: 3037,
 	},
+	/**
+	 * @docs
+	 * @see
+	 * - [Dynamic routes](https://docs.astro.build/en/core-concepts/routing/#dynamic-routes)
+	 * @description
+	 * A dynamic route parameter is invalid. This is often caused by a missing [rest parameter](https://docs.astro.build/en/core-concepts/routing/#rest-parameters).
+	 */
+	InvalidDynamicRoute: {
+		title: 'Invalid dynamic route.',
+		code: 3038,
+		message: (route: string, invalidParam: string, received: string) =>
+			`The ${invalidParam} param for route ${route} is invalid. Received **${received}**.`,
+	},
 	// No headings here, that way Vite errors are merged with Astro ones in the docs, which makes more sense to users.
 	// Vite Errors - 4xxx
 	/**

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -765,7 +765,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	 * @see
 	 * - [Dynamic routes](https://docs.astro.build/en/core-concepts/routing/#dynamic-routes)
 	 * @description
-	 * A dynamic route parameter is invalid. This is often caused by a missing [rest parameter](https://docs.astro.build/en/core-concepts/routing/#rest-parameters).
+	 * A dynamic route param is invalid. This is often caused by an `undefined` parameter or a missing [rest parameter](https://docs.astro.build/en/core-concepts/routing/#rest-parameters).
 	 */
 	InvalidDynamicRoute: {
 		title: 'Invalid dynamic route.',


### PR DESCRIPTION
## Changes

- This adds a readable error when a dynamic route fails to validate.

### Before

<img width="517" alt="image" src="https://github.com/withastro/astro/assets/51384119/fb8d618d-d3ac-4a68-a3ca-7fa6cc65f6fd">


### After

<img width="518" alt="image" src="https://github.com/withastro/astro/assets/51384119/56fb779d-fd5f-4f16-9474-74696ea3d8f0">


## Testing

- Manual testing that readable error throws

## Docs

- Add new error code
