### PR TITLE
Remove error message for using Markdown component

### DIFF
--- a/.changeset/modern-turkeys-shop.md
+++ b/.changeset/modern-turkeys-shop.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-component': patch
+---
+
+Fix Markdown component error message false positive

--- a/packages/markdown/component/Markdown.astro
+++ b/packages/markdown/component/Markdown.astro
@@ -3,13 +3,6 @@ export interface Props {
 	content?: string;
 }
 
-// NOTE(fks): We are most likely moving this component out of Astro core
-// in a few weeks. Checking the name like this is a bit of a hack, but we
-// intentionally don't want to add an SSR flag for others to read from, just yet.
-if (Astro.redirect.name !== '_onlyAvailableInSSR') {
-	console.error(`\x1B[31mThe <Markdown> component is not available in SSR. See https://github.com/withastro/rfcs/discussions/179 for more info.\x1B[39m`);
-}
-
 const dedent = (str: string) => {
 	const _str = str.split('\n').filter(s => s.trimStart().length > 0);
 	if (_str.length === 0) {
@@ -24,6 +17,7 @@ const dedent = (str: string) => {
 
 // Internal props that should not be part of the external interface.
 interface InternalProps extends Props {
+	class: string;
 	$scope: string;
 }
 


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/7335
- Previously, this error message relied on the function name of Astro.redirects. That function name changed which broke the error message.
- Think we should just remove this error (which doesn't actually stop you from building). Because:
  - There's no way for an Astro component to know that the app is running in SSG or SSR mode.
  - We don't want to add one, especially not to accommodate this feature.
  - Very few people are still using this component.

## Testing

Did not

## Docs

N/A, bug fix