### PR TITLE
chore: bump pnpm requirement 8.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node": ">=16.12.0",
     "pnpm": ">=8.2.0"
   },
-  "packageManager": "pnpm@8.2.0",
+  "packageManager": "pnpm@8.6.0",
   "pnpm": {
     "packageExtensions": {
       "svelte2tsx": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
 
 overrides:
   tsconfig-resolver>type-fest: 3.0.0


### PR DESCRIPTION
## Changes

- pnpm introduced a new lockfile version in 8.6.0. This is the first release bumping the package lock to a new version, 6.1 ([see release notes](https://github.com/pnpm/pnpm/releases/tag/v8.6.0))
- bump `packageManager` to >=8.6.0
- recreate lockfile

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
