### PR TITLE
Raise error for duplicate content entry slugs

### DIFF
--- a/.changeset/yellow-icons-attack.md
+++ b/.changeset/yellow-icons-attack.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Raise error when multiple content collection entries have the same slug

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -166,6 +166,19 @@ export async function getStringifiedLookupMap({
 						fileUrl: pathToFileURL(filePath),
 						contentEntryType,
 					});
+					if (lookupMap[collection]?.entries?.[slug]) {
+						throw new AstroError({
+							code: 99999,
+							title: 'Duplicate content entry slug',
+							message: `Multiple content entries in **${collection}** with slug ${JSON.stringify(
+								slug
+							)}. Slugs must be unique.`,
+							hint:
+								slug !== generatedSlug
+									? `Check the \`slug\` frontmatter property in **${id}**.`
+									: undefined,
+						});
+					}
 					lookupMap[collection] = {
 						type: 'content',
 						entries: {

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -169,8 +169,6 @@ export async function getStringifiedLookupMap({
 					if (lookupMap[collection]?.entries?.[slug]) {
 						throw new AstroError({
 							...AstroErrorData.DuplicateContentEntrySlugError,
-							code: 99999,
-							title: 'Duplicate content entry slug',
 							message: AstroErrorData.DuplicateContentEntrySlugError.message(collection, slug),
 							hint:
 								slug !== generatedSlug

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -168,11 +168,10 @@ export async function getStringifiedLookupMap({
 					});
 					if (lookupMap[collection]?.entries?.[slug]) {
 						throw new AstroError({
+							...AstroErrorData.DuplicateContentEntrySlugError,
 							code: 99999,
 							title: 'Duplicate content entry slug',
-							message: `Multiple content entries in **${collection}** with slug ${JSON.stringify(
-								slug
-							)}. Slugs must be unique.`,
+							message: AstroErrorData.DuplicateContentEntrySlugError.message(collection, slug),
 							hint:
 								slug !== generatedSlug
 									? `Check the \`slug\` frontmatter property in **${id}**.`

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1112,6 +1112,18 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 		},
 		hint: 'Ensure your data entry is an object with valid JSON (for `.json` entries) or YAML (for `.yaml` entries).',
 	},
+	/**
+	 * @docs
+	 * @description
+	 * Content collection entries must have unique slugs. Duplicates are often caused by the `slug` frontmatter property.
+	 */
+	DuplicateContentEntrySlugError: {
+		title: 'Duplicate content entry slug.',
+		code: 9008,
+		message: (collection: string, slug: string) => {
+			return `**${collection}** contains multiple entries with the same slug: \`${slug}\`. Slugs must be unique.`;
+		},
+	},
 
 	// Generic catch-all - Only use this in extreme cases, like if there was a cosmic ray bit flip
 	UnknownError: {


### PR DESCRIPTION
## Changes

- Resolves #7133 - this issue discovered that you can create duplicate content entry slugs with the `slug` frontmatter property. This silently maps multiple entries to the same identifier, breaking `getEntryBySlug()` and our internal rendering logic.
- **Raise an error** when this is detected. There may be good reasons to allow multiple entries with the same slug. But today, this is difficult to support in a non-breaking way. 
<img width="1175" alt="image" src="https://github.com/withastro/astro/assets/51384119/a303265d-3dea-45f4-b8e6-509de610251f">


## Testing

Manually test that error is readable

## Docs

New AstroErrorsData entry