### PR TITLE
Chore: remove legacy mdx content collections handler

### DIFF
--- a/.changeset/six-keys-cheat.md
+++ b/.changeset/six-keys-cheat.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Remove legacy handling for MDX content collections. Ensure you are using @astrojs/mdx v0.18 and above.

--- a/.changeset/six-keys-cheat.md
+++ b/.changeset/six-keys-cheat.md
@@ -2,4 +2,4 @@
 'astro': minor
 ---
 
-Remove legacy handling for MDX content collections. Ensure you are using @astrojs/mdx v0.18 and above.
+Remove legacy handling for MDX content collections. Ensure you are using `@astrojs/mdx` v0.18 and above.

--- a/.changeset/six-keys-cheat.md
+++ b/.changeset/six-keys-cheat.md
@@ -2,4 +2,4 @@
 'astro': minor
 ---
 
-Remove legacy handling for MDX content collections. Ensure you are using `@astrojs/mdx` v0.18 and above.
+Remove legacy handling for MDX content collections. Ensure you are using `@astrojs/mdx` v0.18 or above.

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -19,7 +19,6 @@ import { buildClientDirectiveEntrypoint } from '../core/client-directive/index.j
 import { mergeConfig } from '../core/config/config.js';
 import { info, type LogOptions } from '../core/logger/core.js';
 import { isServerLikeOutput } from '../prerender/utils.js';
-import { mdxContentEntryType } from '../vite-plugin-markdown/content-entry-type.js';
 
 async function withTakingALongTimeMsg<T>({
 	name,

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -150,15 +150,6 @@ export async function runHookConfigSetup({
 				logging,
 			});
 
-			// Add MDX content entry type to support older `@astrojs/mdx` versions
-			// TODO: remove in next Astro minor release
-			if (
-				integration.name === '@astrojs/mdx' &&
-				!updatedSettings.contentEntryTypes.find((c) => c.extensions.includes('.mdx'))
-			) {
-				addContentEntryType(mdxContentEntryType);
-			}
-
 			// Add custom client directives to settings, waiting for compiled code by esbuild
 			for (const [name, compiled] of addedClientDirectives) {
 				updatedSettings.clientDirectives.set(name, await compiled);

--- a/packages/astro/src/vite-plugin-markdown/content-entry-type.ts
+++ b/packages/astro/src/vite-plugin-markdown/content-entry-type.ts
@@ -16,32 +16,3 @@ export const markdownContentEntryType: ContentEntryType = {
 	// We need to handle propagation for Markdown because they support layouts which will bring in styles.
 	handlePropagation: true,
 };
-
-/**
- * MDX content type for compatibility with older `@astrojs/mdx` versions
- * TODO: remove in next Astro minor release
- */
-export const mdxContentEntryType: ContentEntryType = {
-	extensions: ['.mdx'],
-	async getEntryInfo({ fileUrl, contents }: { fileUrl: URL; contents: string }) {
-		const parsed = parseFrontmatter(contents, fileURLToPath(fileUrl));
-		return {
-			data: parsed.data,
-			body: parsed.content,
-			slug: parsed.data.slug,
-			rawData: parsed.matter,
-		};
-	},
-	// MDX can import scripts and styles,
-	// so wrap all MDX files with script / style propagation checks
-	handlePropagation: true,
-	contentModuleTypes: `declare module 'astro:content' {
-	interface Render {
-		'.mdx': Promise<{
-			Content: import('astro').MarkdownInstance<{}>['Content'];
-			headings: import('astro').MarkdownHeading[];
-			remarkPluginFrontmatter: Record<string, any>;
-		}>;
-	}
-}`,
-};


### PR DESCRIPTION
## Changes

- Remove content collections mapper for MDX version 0.17.X and below

## Testing

Make sure nothing breaks

## Docs

changelog should suffice!