### PR TITLE
Fixed `AstroUserConfig`'s redirect type definition

### DIFF
--- a/.changeset/proud-vans-approve.md
+++ b/.changeset/proud-vans-approve.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed `RedirectConfig` type definition

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1839,12 +1839,14 @@ export interface RoutePart {
 	spread: boolean;
 }
 
-type RedirectConfig =
+type RedirectConfig = Record<
+	string,
 	| string
 	| {
 			status: ValidRedirectStatus;
 			destination: string;
-	  };
+	  }
+>;
 
 export interface RouteData {
 	route: string;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -455,7 +455,7 @@ export interface AstroUserConfig {
 	/**
 	 * @docs
 	 * @name redirects (Experimental)
-	 * @type {RedirectConfig}
+	 * @type {Record<string, RedirectConfig>}
 	 * @default `{}`
 	 * @version 2.6.0
 	 * @description Specify a mapping of redirects where the key is the route to match
@@ -495,7 +495,7 @@ export interface AstroUserConfig {
 	 * }
 	 * ```
 	 */
-	redirects?: RedirectConfig;
+	redirects?: Record<string, RedirectConfig>;
 
 	/**
 	 * @docs
@@ -1839,14 +1839,12 @@ export interface RoutePart {
 	spread: boolean;
 }
 
-type RedirectConfig = Record<
-	string,
+type RedirectConfig =
 	| string
 	| {
 			status: ValidRedirectStatus;
 			destination: string;
-	  }
->;
+	  };
 
 export interface RouteData {
 	route: string;


### PR DESCRIPTION
## Changes

- Changed `config.redirects` from `RedirectConfig` to `Record<string, RedirectConfig>` (fix #7365)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
No testing is needed for this minor type definition, I think.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
No docs were added as the code now follows the docs.
