### PR TITLE
Add `@message` to `DuplicateContentEntrySlugError`

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1114,6 +1114,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	},
 	/**
 	 * @docs
+	 * @message `COLLECTION_NAME` contains multiple entries with the same slug: `SLUG`. Slugs must be unique.
 	 * @description
 	 * Content collection entries must have unique slugs. Duplicates are often caused by the `slug` frontmatter property.
 	 */


### PR DESCRIPTION
## Changes

- Updates the JSDoc tag for an error.
- Fixes display in docs where our naive parser couldn’t handle the template string in the error’s `message` property. See https://github.com/withastro/docs/pull/3477

## Testing
Existing tests should pass.

## Docs
/cc @withastro/maintainers-docs for feedback! 