### PR TITLE
Increase parallel test time tolerance

### DIFF
--- a/packages/astro/test/parallel.js
+++ b/packages/astro/test/parallel.js
@@ -21,15 +21,15 @@ describe('Component parallelization', () => {
 			Number(element.children[0].data)
 		);
 
-		let renderStartWithin = Math.max(...startTimes) - Math.min(...startTimes);
+		const renderStartWithin = Math.max(...startTimes) - Math.min(...startTimes);
 		expect(renderStartWithin).to.be.lessThan(
-			10, // in theory, this should be 0, so 10ms tolerance
+			40, // in theory, this should be 0, but add 40ms tolerance for CI
 			"The components didn't start rendering in parallel"
 		);
 
 		const totalRenderTime = Math.max(...finishTimes) - Math.min(...startTimes);
 		expect(totalRenderTime).to.be.lessThan(
-			60, // max component delay is 40ms
+			80, // max component delay is 40ms, add 40ms tolerance for CI
 			'The total render time was significantly longer than the max component delay'
 		);
 	});


### PR DESCRIPTION
## Changes

Increase parallel test time tolerance. It started to happen more often since #7136.

This isn't a great fix. I was thinking of using the "max render time if serial" value as the number instead, but the number feels a bit too large that could cause uncaught regressions.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Ran the test manually

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a