### PR TITLE
Prevent accidental CSS inclusion in dev

### DIFF
--- a/.changeset/tiny-lemons-sit.md
+++ b/.changeset/tiny-lemons-sit.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent accidental inclusion of page CSS in dev mode

--- a/packages/astro/src/core/module-loader/loader.ts
+++ b/packages/astro/src/core/module-loader/loader.ts
@@ -44,6 +44,7 @@ export interface ModuleNode {
 	ssrModule: Record<string, any> | null;
 	ssrError: Error | null;
 	importedModules: Set<ModuleNode>;
+	importers: Set<ModuleNode>;
 }
 
 export interface ModuleInfo {

--- a/packages/astro/src/core/module-loader/loader.ts
+++ b/packages/astro/src/core/module-loader/loader.ts
@@ -42,9 +42,11 @@ export interface ModuleNode {
 	id: string | null;
 	url: string;
 	ssrModule: Record<string, any> | null;
+	ssrTransformResult: {
+		deps: string[];
+	} | null;
 	ssrError: Error | null;
 	importedModules: Set<ModuleNode>;
-	importers: Set<ModuleNode>;
 }
 
 export interface ModuleInfo {

--- a/packages/astro/src/core/module-loader/loader.ts
+++ b/packages/astro/src/core/module-loader/loader.ts
@@ -44,6 +44,7 @@ export interface ModuleNode {
 	ssrModule: Record<string, any> | null;
 	ssrTransformResult: {
 		deps?: string[];
+		dynamicDeps?: string[];
 	} | null;
 	ssrError: Error | null;
 	importedModules: Set<ModuleNode>;

--- a/packages/astro/src/core/module-loader/loader.ts
+++ b/packages/astro/src/core/module-loader/loader.ts
@@ -43,7 +43,7 @@ export interface ModuleNode {
 	url: string;
 	ssrModule: Record<string, any> | null;
 	ssrTransformResult: {
-		deps: string[];
+		deps?: string[];
 	} | null;
 	ssrError: Error | null;
 	importedModules: Set<ModuleNode>;

--- a/packages/astro/src/core/render/dev/vite.ts
+++ b/packages/astro/src/core/render/dev/vite.ts
@@ -41,6 +41,7 @@ export async function* crawlGraph(
 			continue;
 		}
 		if (id === entry.id) {
+			const urlDeps = entry.ssrTransformResult?.deps ?? [];
 			scanned.add(id);
 			const entryIsStyle = isCSSRequest(id);
 
@@ -82,7 +83,7 @@ export async function* crawlGraph(
 						}
 					}
 				}
-				if (isImportedBy(id, importedModule) && !isPropagationStoppingPoint) {
+				if (urlDeps.includes(importedModule.url) && !isPropagationStoppingPoint) {
 					importedModules.add(importedModule);
 				}
 			}
@@ -99,15 +100,4 @@ export async function* crawlGraph(
 		yield importedModule;
 		yield* crawlGraph(loader, importedModule.id, false, scanned);
 	}
-}
-
-// Verify true imports. If the child module has the parent as an importers, it's
-// a real import.
-function isImportedBy(parent: string, entry: ModuleNode) {
-	for(const importer of entry.importers) {
-		if(importer.id === parent) {
-			return true;
-		}
-	}
-	return false;
 }

--- a/packages/astro/src/core/render/dev/vite.ts
+++ b/packages/astro/src/core/render/dev/vite.ts
@@ -82,7 +82,7 @@ export async function* crawlGraph(
 						}
 					}
 				}
-				if (!isPropagationStoppingPoint) {
+				if (isImportedBy(id, importedModule) && !isPropagationStoppingPoint) {
 					importedModules.add(importedModule);
 				}
 			}
@@ -99,4 +99,15 @@ export async function* crawlGraph(
 		yield importedModule;
 		yield* crawlGraph(loader, importedModule.id, false, scanned);
 	}
+}
+
+// Verify true imports. If the child module has the parent as an importers, it's
+// a real import.
+function isImportedBy(parent: string, entry: ModuleNode) {
+	for(const importer of entry.importers) {
+		if(importer.id === parent) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/packages/astro/src/core/render/dev/vite.ts
+++ b/packages/astro/src/core/render/dev/vite.ts
@@ -41,7 +41,7 @@ export async function* crawlGraph(
 			continue;
 		}
 		if (id === entry.id) {
-			const urlDeps = entry.ssrTransformResult?.deps ?? [];
+			const urlDeps = getDepsFromEntry(entry);
 			scanned.add(id);
 			const entryIsStyle = isCSSRequest(id);
 
@@ -100,4 +100,12 @@ export async function* crawlGraph(
 		yield importedModule;
 		yield* crawlGraph(loader, importedModule.id, false, scanned);
 	}
+}
+
+function getDepsFromEntry(entry: ModuleNode) {
+	let deps = entry.ssrTransformResult?.deps ?? [];
+	if(entry.ssrTransformResult?.dynamicDeps) {
+		return deps.concat(entry.ssrTransformResult.dynamicDeps);
+	}
+	return deps;
 }

--- a/packages/astro/src/core/render/dev/vite.ts
+++ b/packages/astro/src/core/render/dev/vite.ts
@@ -104,7 +104,7 @@ export async function* crawlGraph(
 
 // Virtual modules URL should start with /@id/ but do not
 function urlId(url: string) {
-	if(url[0] !== '/') {
+	if (url.startsWith('astro:scripts')) {
 		return '/@id/' + url;
 	}
 	return url;

--- a/packages/astro/src/core/render/dev/vite.ts
+++ b/packages/astro/src/core/render/dev/vite.ts
@@ -83,7 +83,7 @@ export async function* crawlGraph(
 						}
 					}
 				}
-				if (urlDeps.includes(importedModule.url) && !isPropagationStoppingPoint) {
+				if (urlDeps.includes(urlId(importedModule.url)) && !isPropagationStoppingPoint) {
 					importedModules.add(importedModule);
 				}
 			}
@@ -100,6 +100,14 @@ export async function* crawlGraph(
 		yield importedModule;
 		yield* crawlGraph(loader, importedModule.id, false, scanned);
 	}
+}
+
+// Virtual modules URL should start with /@id/ but do not
+function urlId(url: string) {
+	if(url[0] !== '/') {
+		return '/@id/' + url;
+	}
+	return url;
 }
 
 function getDepsFromEntry(entry: ModuleNode) {

--- a/packages/astro/test/units/dev/styles.test.js
+++ b/packages/astro/test/units/dev/styles.test.js
@@ -29,24 +29,26 @@ describe('Crawling graph for CSS', () => {
 				id: indexId,
 				importedModules: [{
 					id: aboutId,
-					importers: []
+					url: aboutId,
 				}, {
 					id: indexId + '?astro&style.css',
 					url: indexId + '?astro&style.css',
-					importers: [{ id: indexId }],
 					ssrModule: {}
 				}],
-				importers: []
+				ssrTransformResult: {
+					deps: [indexId + '?astro&style.css']
+				}
 			},
 			{
 				id: aboutId,
 				importedModules: [{
 					id: aboutId + '?astro&style.css',
 					url: aboutId + '?astro&style.css',
-					importers: [{ id: aboutId }],
 					ssrModule: {}
 				}],
-				importers: []
+				ssrTransformResult: {
+					deps: [aboutId + '?astro&style.css']
+				}
 			}
 		]);
 	})

--- a/packages/astro/test/units/dev/styles.test.js
+++ b/packages/astro/test/units/dev/styles.test.js
@@ -1,0 +1,60 @@
+import { expect } from 'chai';
+import { fileURLToPath } from 'url';
+
+import {
+	getStylesForURL
+} from '../../../dist/core/render/dev/css.js';
+
+const root = new URL('../../fixtures/alias/', import.meta.url);
+
+class TestLoader {
+	constructor(modules) {
+		this.modules = new Map(modules.map(m => [m.id, m]))
+	}
+	getModuleById(id) {
+		return this.modules.get(id);
+	}
+	getModulesByFile(id) {
+		return this.modules.has(id) ? [this.modules.get(id)] : [];
+	}
+}
+
+describe('Crawling graph for CSS', () => {
+	let loader;
+	before(() => {
+		const indexId = fileURLToPath(new URL('./src/pages/index.astro', root));
+		const aboutId = fileURLToPath(new URL('./src/pages/about.astro', root));
+		loader = new TestLoader([
+			{
+				id: indexId,
+				importedModules: [{
+					id: aboutId,
+					importers: []
+				}, {
+					id: indexId + '?astro&style.css',
+					url: indexId + '?astro&style.css',
+					importers: [{ id: indexId }],
+					ssrModule: {}
+				}],
+				importers: []
+			},
+			{
+				id: aboutId,
+				importedModules: [{
+					id: aboutId + '?astro&style.css',
+					url: aboutId + '?astro&style.css',
+					importers: [{ id: aboutId }],
+					ssrModule: {}
+				}],
+				importers: []
+			}
+		]);
+	})
+
+	it('importedModules is checked against the child\'s importers', async () => {
+		// In dev mode, HMR modules tracked are added to importedModules. We use `importers`
+		// to verify that they are true importers.
+		const res = await getStylesForURL(new URL('./src/pages/index.astro', root), loader, 'development')
+		expect(res.urls.size).to.equal(1);
+	})
+})

--- a/packages/astro/test/units/dev/styles.test.js
+++ b/packages/astro/test/units/dev/styles.test.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url';
 import {
 	getStylesForURL
 } from '../../../dist/core/render/dev/css.js';
+import { viteID } from '../../../dist/core/util.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
@@ -22,8 +23,8 @@ class TestLoader {
 describe('Crawling graph for CSS', () => {
 	let loader;
 	before(() => {
-		const indexId = fileURLToPath(new URL('./src/pages/index.astro', root));
-		const aboutId = fileURLToPath(new URL('./src/pages/about.astro', root));
+		const indexId = viteID(new URL('./src/pages/index.astro', root));
+		const aboutId = viteID(new URL('./src/pages/about.astro', root));
 		loader = new TestLoader([
 			{
 				id: indexId,


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/7097
- We can't trust `importedModules` to be true imports. It includes stuff tracked for HMR.
- Using `importers` to verify that an import is an import.
- This is slower, O(n), but necessary. A dev-only issue.

## Testing

- Added a new unit test

## Docs

N/A