### PR TITLE
[Cloudflare integration] Expose cf metadata and Cloudflare caches API

### DIFF
--- a/.changeset/angry-socks-sell.md
+++ b/.changeset/angry-socks-sell.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': minor
+---
+
+Expose cf metadata and Cloudflare Worker Cache API through `caches` in runtime.

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@astrojs/underscore-redirects": "^0.1.0",
+    "@cloudflare/workers-types": "^4.20230518.0",
     "esbuild": "^0.17.12",
     "tiny-glob": "^0.2.9"
   },

--- a/packages/integrations/cloudflare/src/runtime.ts
+++ b/packages/integrations/cloudflare/src/runtime.ts
@@ -1,8 +1,12 @@
+import type { Cache, CacheStorage, IncomingRequestCfProperties } from '@cloudflare/workers-types';
+
 export type WorkerRuntime<T = unknown> = {
 	name: 'cloudflare';
 	env: T;
 	waitUntil(promise: Promise<any>): void;
 	passThroughOnException(): void;
+	caches?: CacheStorage & { default: Cache };
+	cf?: IncomingRequestCfProperties;
 };
 
 export type PagesRuntime<T = unknown, U = unknown> = {
@@ -13,6 +17,8 @@ export type PagesRuntime<T = unknown, U = unknown> = {
 	data: U;
 	waitUntil(promise: Promise<any>): void;
 	next(request: Request): void;
+	caches?: CacheStorage & { default: Cache };
+	cf?: IncomingRequestCfProperties;
 };
 
 export function getRuntime<T = unknown, U = unknown>(

--- a/packages/integrations/cloudflare/src/server.advanced.ts
+++ b/packages/integrations/cloudflare/src/server.advanced.ts
@@ -1,7 +1,7 @@
 import type { SSRManifest } from 'astro';
+import type { Request } from '@cloudflare/workers-types';
 import { App } from 'astro/app';
 import { getProcessEnvProxy, isNode } from './util.js';
-import type { Request } from '@cloudflare/workers-types';
 
 if (!isNode) {
 	process.env = getProcessEnvProxy();

--- a/packages/integrations/cloudflare/src/server.advanced.ts
+++ b/packages/integrations/cloudflare/src/server.advanced.ts
@@ -1,6 +1,7 @@
 import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
 import { getProcessEnvProxy, isNode } from './util.js';
+import type { Request } from '@cloudflare/workers-types';
 
 if (!isNode) {
 	process.env = getProcessEnvProxy();
@@ -31,7 +32,13 @@ export function createExports(manifest: SSRManifest) {
 				Symbol.for('astro.clientAddress'),
 				request.headers.get('cf-connecting-ip')
 			);
-			Reflect.set(request, Symbol.for('runtime'), { env, name: 'cloudflare', ...context });
+			Reflect.set(request, Symbol.for('runtime'), {
+				env,
+				name: 'cloudflare',
+				caches,
+				cf: request.cf,
+				...context,
+			});
 			let response = await app.render(request, routeData);
 
 			if (app.setCookieHeaders) {

--- a/packages/integrations/cloudflare/src/server.advanced.ts
+++ b/packages/integrations/cloudflare/src/server.advanced.ts
@@ -1,5 +1,5 @@
 import type { SSRManifest } from 'astro';
-import type { Request } from '@cloudflare/workers-types';
+import type { Request as CFRequest } from '@cloudflare/workers-types';
 import { App } from 'astro/app';
 import { getProcessEnvProxy, isNode } from './util.js';
 
@@ -15,7 +15,7 @@ type Env = {
 export function createExports(manifest: SSRManifest) {
 	const app = new App(manifest);
 
-	const fetch = async (request: Request, env: Env, context: any) => {
+	const fetch = async (request: Request & CFRequest, env: Env, context: any) => {
 		process.env = env as any;
 
 		const { pathname } = new URL(request.url);

--- a/packages/integrations/cloudflare/src/server.directory.ts
+++ b/packages/integrations/cloudflare/src/server.directory.ts
@@ -1,7 +1,7 @@
 import type { SSRManifest } from 'astro';
+import type { Request } from '@cloudflare/workers-types';
 import { App } from 'astro/app';
 import { getProcessEnvProxy, isNode } from './util.js';
-import type { Request } from '@cloudflare/workers-types';
 
 if (!isNode) {
 	process.env = getProcessEnvProxy();

--- a/packages/integrations/cloudflare/src/server.directory.ts
+++ b/packages/integrations/cloudflare/src/server.directory.ts
@@ -1,5 +1,5 @@
 import type { SSRManifest } from 'astro';
-import type { Request } from '@cloudflare/workers-types';
+import type { Request as CFRequest } from '@cloudflare/workers-types';
 import { App } from 'astro/app';
 import { getProcessEnvProxy, isNode } from './util.js';
 
@@ -15,7 +15,7 @@ export function createExports(manifest: SSRManifest) {
 		next,
 		...runtimeEnv
 	}: {
-		request: Request;
+		request: Request & CFRequest;
 		next: (request: Request) => void;
 	} & Record<string, unknown>) => {
 		process.env = runtimeEnv.env as any;

--- a/packages/integrations/cloudflare/src/server.directory.ts
+++ b/packages/integrations/cloudflare/src/server.directory.ts
@@ -1,6 +1,7 @@
 import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
 import { getProcessEnvProxy, isNode } from './util.js';
+import type { Request } from '@cloudflare/workers-types';
 
 if (!isNode) {
 	process.env = getProcessEnvProxy();
@@ -36,6 +37,8 @@ export function createExports(manifest: SSRManifest) {
 				...runtimeEnv,
 				name: 'cloudflare',
 				next,
+				caches,
+				cf: request.cf,
 			});
 			let response = await app.render(request, routeData);
 

--- a/packages/integrations/cloudflare/test/cf.js
+++ b/packages/integrations/cloudflare/test/cf.js
@@ -1,0 +1,35 @@
+import { loadFixture, runCLI } from './test-utils.js';
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+import cloudflare from '../dist/index.js';
+
+describe('Cf metadata and caches', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/cf/',
+			output: 'server',
+			adapter: cloudflare(),
+		});
+		await fixture.build();
+	});
+
+	it('Load cf and caches API', async () => {
+		const { ready, stop } = runCLI('./fixtures/cf/', { silent: false, port: 8788 });
+
+		try {
+			await ready;
+			let res = await fetch(`http://localhost:8788/`);
+			expect(res.status).to.equal(200);
+			let html = await res.text();
+			let $ = cheerio.load(html);
+			// console.log($('#cf').text(), html);
+			expect($('#cf').text()).to.contain('city');
+			expect($('#hasCache').text()).to.equal('true');
+		} finally {
+			stop();
+		}
+	});
+});

--- a/packages/integrations/cloudflare/test/fixtures/cf/astro.config.mjs
+++ b/packages/integrations/cloudflare/test/fixtures/cf/astro.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'astro/config';
+import cloudflare from '@astrojs/cloudflare';
+
+
+export default defineConfig({
+	adapter: cloudflare(),
+	output: 'server',
+});

--- a/packages/integrations/cloudflare/test/fixtures/cf/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/cf/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/astro-cloudflare-basics",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/cloudflare": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/cloudflare/test/fixtures/cf/package.json
+++ b/packages/integrations/cloudflare/test/fixtures/cf/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/astro-cloudflare-basics",
+  "name": "@test/astro-cloudflare-cf",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/packages/integrations/cloudflare/test/fixtures/cf/src/pages/index.astro
+++ b/packages/integrations/cloudflare/test/fixtures/cf/src/pages/index.astro
@@ -1,0 +1,14 @@
+---
+import { getRuntime } from '@astrojs/cloudflare/runtime';
+const runtime = getRuntime(Astro.request);
+---
+<html>
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<h1>Testing</h1>
+		<div id="cf">{JSON.stringify(runtime.cf)}</div>
+		<div id="hasCache">{!!runtime.caches}</div>
+	</body>
+</html>

--- a/packages/integrations/cloudflare/test/test-utils.js
+++ b/packages/integrations/cloudflare/test/test-utils.js
@@ -19,9 +19,9 @@ const wranglerPath = fileURLToPath(
 	new URL('../node_modules/wrangler/bin/wrangler.js', import.meta.url)
 );
 
-export function runCLI(basePath, { silent }) {
+export function runCLI(basePath, { silent, port = 8787 }) {
 	const script = fileURLToPath(new URL(`${basePath}/dist/_worker.js`, import.meta.url));
-	const p = spawn('node', [wranglerPath, 'dev', '-l', script]);
+	const p = spawn('node', [wranglerPath, 'dev', '-l', script, '--port', port]);
 
 	p.stderr.setEncoding('utf-8');
 	p.stdout.setEncoding('utf-8');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3589,6 +3589,9 @@ importers:
       '@astrojs/underscore-redirects':
         specifier: ^0.1.0
         version: link:../../underscore-redirects
+      '@cloudflare/workers-types':
+        specifier: ^4.20230518.0
+        version: 4.20230518.0
       esbuild:
         specifier: ^0.17.12
         version: 0.17.12
@@ -7225,6 +7228,10 @@ packages:
     dependencies:
       mime: 3.0.0
     dev: true
+
+  /@cloudflare/workers-types@4.20230518.0:
+    resolution: {integrity: sha512-A0w1V+5SUawGaaPRlhFhSC/SCDT9oQG8TMoWOKFLA4qbqagELqEAFD4KySBIkeVOvCBLT1DZSYBMCxbXddl0kw==}
+    dev: false
 
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,4 @@
-lockfileVersion: '6.1'
-
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false
+lockfileVersion: '6.0'
 
 overrides:
   tsconfig-resolver>type-fest: 3.0.0
@@ -3622,6 +3618,15 @@ importers:
         version: 2.0.23
 
   packages/integrations/cloudflare/test/fixtures/basics:
+    dependencies:
+      '@astrojs/cloudflare':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
+  packages/integrations/cloudflare/test/fixtures/cf:
     dependencies:
       '@astrojs/cloudflare':
         specifier: workspace:*
@@ -18400,3 +18405,7 @@ packages:
     dependencies:
       solid-js: 1.7.4
     dev: false
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Changes
This pull request expose the Cloudflare `caches` API and cf object (request metadata provided by Cloudflare's edge) to the runtime object.


## Example
Cloudflare add some usefull informations about the request such as geolocation properties see [the docs](https://developers.cloudflare.com/workers/runtime-apis/request#incomingrequestcfproperties)

``` ts
const runtime = getRuntime(Astro.request);
const visitor_country  = runtime.cf?.country;
```

The Cloudflare cache API can now be used.

``` ts
const runtime = getRuntime(Astro.request);
const cachedObject = await runtime.caches?.default.match(Astro.request);
```
