### PR TITLE
Update error message for custom slugs in collection

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1044,7 +1044,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	 * @see
 	 * - [The reserved entry `slug` field](https://docs.astro.build/en/guides/content-collections/)
 	 * @description
-	 * A content collection schema should not contain the `slug` field. This is reserved by Astro for generating entry slugs. Remove the `slug` field from your schema, or choose a different name.
+	 * A content collection schema should not contain the `slug` field. Remove `slug` from your schema in order to use custom slugs in your frontmatter.
 	 */
 	ContentSchemaContainsSlugError: {
 		title: 'Content Schema should not contain `slug`.',


### PR DESCRIPTION
## Changes

If you had a field called `slug` in a frontmatter in a Content Collection, you would get the following error message:

```
A content collection schema should not contain slug since it is reserved for slug generation. Remove this from your podcasts collection schema.
```

I understood it like the name `slug` was not allowed _at all_. But it _is_ allowed and can be used in frontmatter to override and get a custom slug.

So I asked @sarah11918 and she proposed a better error message.

## Testing

No testing, just a string change.

## Docs

Should not need a doc update since the beginning of the error message stays the same so the docs can keep referencing it.
