### PR TITLE
remove extra "ago" in hackernews example

### DIFF
--- a/examples/hackernews/src/components/Comment.astro
+++ b/examples/hackernews/src/components/Comment.astro
@@ -14,7 +14,7 @@ const { comment } = Astro.props;
 <li>
 	<div class="by">
 		<a href={`/users/${comment.user}`}>{comment.user}</a>{' '}
-		{comment.time_ago} ago
+		{comment.time_ago}
 	</div>
 	<div class="text" set:html={comment.content} />
 	<Show when={comment.comments.length}>

--- a/examples/hackernews/src/pages/stories/[id].astro
+++ b/examples/hackernews/src/pages/stories/[id].astro
@@ -25,7 +25,7 @@ const story = (await fetchAPI(`item/${id}`)) as IStory;
 				<a href={`/users/${story.user}`}>
 					{story.user}
 				</a>
-				{story.time_ago} ago
+				&nbsp;{story.time_ago}
 			</p>
 		</header>
 		<main>


### PR DESCRIPTION
## Changes

- Remove extra "ago" in Hackernews example

## Testing

| Before                                                                                                                      | After                                                                                                                       |
|-----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
| <img width="404" alt="image" src="https://github.com/withastro/astro/assets/46791833/02e9b130-94f8-4a98-ae45-ac913801862d"> | <img width="505" alt="image" src="https://github.com/withastro/astro/assets/46791833/d50ff15b-a3b6-4ccc-b065-cf0872474c74"> |
| <img width="439" alt="image" src="https://github.com/withastro/astro/assets/46791833/6f6ee640-a457-48d6-95ac-9a177463831e"> | <img width="491" alt="image" src="https://github.com/withastro/astro/assets/46791833/64165d52-4eb7-43b7-aaaa-21dc0a30dea9"> |





<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A
