### PR TITLE
feat: cache assets in Vercel adapter

### DIFF
--- a/packages/integrations/vercel/src/edge/adapter.ts
+++ b/packages/integrations/vercel/src/edge/adapter.ts
@@ -151,6 +151,11 @@ export default function vercelEdge({
 					version: 3,
 					routes: [
 						...getRedirects(routes, _config),
+						{
+							src: '^/_astro/(.*)$',
+							headers: { 'cache-control': 'public, max-age=31536000, immutable' },
+							continue: true,
+						},
 						{ handle: 'filesystem' },
 						{ src: '/.*', dest: 'render' },
 					],

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -129,6 +129,11 @@ export default function vercelServerless({
 					version: 3,
 					routes: [
 						...getRedirects(routes, _config),
+						{
+							src: '^/_astro/(.*)$',
+							headers: { 'cache-control': 'public, max-age=31536000, immutable' },
+							continue: true,
+						},
 						{ handle: 'filesystem' },
 						{ src: '/.*', dest: 'render' },
 					],

--- a/packages/integrations/vercel/src/static/adapter.ts
+++ b/packages/integrations/vercel/src/static/adapter.ts
@@ -71,7 +71,15 @@ export default function vercelStatic({
 				// https://vercel.com/docs/build-output-api/v3#build-output-configuration
 				await writeJson(new URL(`./config.json`, getVercelOutput(_config.root)), {
 					version: 3,
-					routes: [...getRedirects(routes, _config), { handle: 'filesystem' }],
+					routes: [
+						...getRedirects(routes, _config),
+						{
+							src: '^/_astro/(.*)$',
+							headers: { 'cache-control': 'public, max-age=31536000, immutable' },
+							continue: true,
+						},
+						{ handle: 'filesystem' },
+					],
 					...(imageService || imagesConfig
 						? { images: imagesConfig ? imagesConfig : defaultImageConfig }
 						: {}),


### PR DESCRIPTION
## Changes

Add cache headers to assets in Vercel adapter's route config, following [Vercel's default config](https://github.com/vercel/vercel/blob/cfea31e6cff33c0a2dd3663025093fd9b8e7f1d8/packages/frameworks/src/frameworks.ts#L276-L280).

This provides better config out of the box and is more consistent with static only builds, which uses Vercel's default config.

## Testing

[Before](https://nikki-q2suzaqdf-kidonng.vercel.app/2023-01-27): assets are not cached

<img width="584" alt="image" src="https://github.com/withastro/astro/assets/44045911/cfb9c07a-6e2e-45a1-8957-393be035b869">

[After](https://nikki-brvcredwz-kidonng.vercel.app/2023-01-27): assets are strongly cached

<img width="585" alt="image" src="https://github.com/withastro/astro/assets/44045911/9be7c938-9e8a-4a3a-83f3-d96ad042329a">

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
