### PR TITLE
Bump pnpm to 8.6.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ We welcome contributions of any size and skill level. As an open source project,
 
 ```shell
 node: "^>=16.12.0"
-pnpm: "^8.2.0"
+pnpm: "^8.6.2"
 # otherwise, your build will fail
 ```
 

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   ],
   "engines": {
     "node": ">=16.12.0",
-    "pnpm": ">=8.2.0"
+    "pnpm": ">=8.6.2"
   },
-  "packageManager": "pnpm@8.6.0",
+  "packageManager": "pnpm@8.6.2",
   "pnpm": {
     "packageExtensions": {
       "svelte2tsx": {


### PR DESCRIPTION
## Changes

The lockfile is constantly alternating between v6.0 and v6.1 because pnpm messes with it between pnpm v8.6.2 and v8.6.1 😦 This PR bumps it to latest to fix this altogether.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
n/a

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
m/a