### PR TITLE
Simplify telemetry Vite version detection

### DIFF
--- a/.changeset/brave-candles-invent.md
+++ b/.changeset/brave-candles-invent.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Simplify telemetry Vite version detection

--- a/packages/astro/src/events/index.ts
+++ b/packages/astro/src/events/index.ts
@@ -1,19 +1,10 @@
 import { AstroTelemetry } from '@astrojs/telemetry';
-import { createRequire } from 'module';
+import { version as viteVersion } from 'vite';
 import { ASTRO_VERSION } from '../core/constants.js';
-const require = createRequire(import.meta.url);
-
-function getViteVersion() {
-	try {
-		const { version } = require('vite/package.json');
-		return version;
-	} catch (e) {}
-	return undefined;
-}
 
 export const telemetry = new AstroTelemetry({
 	astroVersion: ASTRO_VERSION,
-	viteVersion: getViteVersion(),
+	viteVersion,
 });
 
 export * from './error.js';


### PR DESCRIPTION
## Changes

Vite exports the `version` variable which we can use, instead of reading `package.json` manually.

Stumbled on this while checking out Astro's codebase.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested manually in example project. Vite exports `version` since Vite 4 (Astro v2)

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a