### PR TITLE
fix: document `open` option

### DIFF
--- a/.changeset/sour-teachers-kiss.md
+++ b/.changeset/sour-teachers-kiss.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Correctly type the option `server.open`

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -342,7 +342,7 @@ type ServerConfig = {
 	 * @default `false`
 	 * @version 2.1.8
 	 * @description
-	 * Opens the browser window on startup
+	 * Control whether the dev server should open in your browser window on startup.
 	 */
 	open?: boolean;
 };

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -335,6 +335,16 @@ type ServerConfig = {
 	 * Set custom HTTP response headers to be sent in `astro dev` and `astro preview`.
 	 */
 	headers?: OutgoingHttpHeaders;
+
+	/**
+	 * @name server.open
+	 * @type {boolean}
+	 * @default `false`
+	 * @version 2.1.8
+	 * @description
+	 * Opens the browser window on startup
+	 */
+	open?: boolean;
 };
 
 export interface ViteUserConfig extends vite.UserConfig {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -343,6 +343,12 @@ type ServerConfig = {
 	 * @version 2.1.8
 	 * @description
 	 * Control whether the dev server should open in your browser window on startup.
+	 *
+	 * ```js
+	 * {
+	 *   server: { open: true }
+	 * }
+	 * ```
 	 */
 	open?: boolean;
 };
@@ -884,6 +890,21 @@ export interface AstroUserConfig {
 	 * ```js
 	 * {
 	 *   server: { port: 8080 }
+	 * }
+	 * ```
+	 */
+
+	/**
+	 * @name server.open
+	 * @type {boolean}
+	 * @default `false`
+	 * @version 2.1.8
+	 * @description
+	 * Control whether the dev server should open in your browser window on startup.
+	 *
+	 * ```js
+	 * {
+	 *   server: { open: true }
 	 * }
 	 * ```
 	 */


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/7398

For some reason `server.open` wasn't correctly typed. This fixes it.


## Testing

Manual check

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs



<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
