### PR TITLE
fix: cloudflare waitUntil not working as inteded with getRuntime

### DIFF
--- a/.changeset/clever-apes-shop.md
+++ b/.changeset/clever-apes-shop.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/cloudflare': minor
+'@astrojs/cloudflare': patch
 ---
 
 Fixed issue with cloudflare runtime `waitUntil` not working as intended.

--- a/.changeset/clever-apes-shop.md
+++ b/.changeset/clever-apes-shop.md
@@ -2,5 +2,5 @@
 '@astrojs/cloudflare': minor
 ---
 
-Fixed issue with runtime wait until not working as intended.
+Fixed issue with cloudflare runtime `waitUntil` not working as intended.
 

--- a/.changeset/clever-apes-shop.md
+++ b/.changeset/clever-apes-shop.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/cloudflare': minor
+---
+
+Fixed issue with runtime wait until not working as intended.
+

--- a/packages/integrations/cloudflare/src/server.advanced.ts
+++ b/packages/integrations/cloudflare/src/server.advanced.ts
@@ -1,4 +1,4 @@
-import type { Request as CFRequest } from '@cloudflare/workers-types';
+import type { Request as CFRequest, ExecutionContext } from '@cloudflare/workers-types';
 import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
 import { getProcessEnvProxy, isNode } from './util.js';
@@ -15,7 +15,7 @@ type Env = {
 export function createExports(manifest: SSRManifest) {
 	const app = new App(manifest);
 
-	const fetch = async (request: Request & CFRequest, env: Env, context: any) => {
+	const fetch = async (request: Request & CFRequest, env: Env, context: ExecutionContext) => {
 		process.env = env as any;
 
 		const { pathname } = new URL(request.url);
@@ -38,6 +38,9 @@ export function createExports(manifest: SSRManifest) {
 				caches,
 				cf: request.cf,
 				...context,
+				waitUntil: (promise: Promise<any>) => {
+					context.waitUntil(promise);
+				},
 			});
 			let response = await app.render(request, routeData);
 

--- a/packages/integrations/cloudflare/src/server.directory.ts
+++ b/packages/integrations/cloudflare/src/server.directory.ts
@@ -1,4 +1,4 @@
-import type { Request as CFRequest } from '@cloudflare/workers-types';
+import type { Request as CFRequest, EventContext } from '@cloudflare/workers-types';
 import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
 import { getProcessEnvProxy, isNode } from './util.js';
@@ -17,6 +17,7 @@ export function createExports(manifest: SSRManifest) {
 	}: {
 		request: Request & CFRequest;
 		next: (request: Request) => void;
+		waitUntil: (promise: Promise<any>) => void;
 	} & Record<string, unknown>) => {
 		process.env = runtimeEnv.env as any;
 
@@ -35,6 +36,9 @@ export function createExports(manifest: SSRManifest) {
 			);
 			Reflect.set(request, Symbol.for('runtime'), {
 				...runtimeEnv,
+				waitUntil: (promise: Promise<any>) => {
+					runtimeEnv.waitUntil(promise);
+				},
 				name: 'cloudflare',
 				next,
 				caches,

--- a/packages/integrations/cloudflare/src/server.directory.ts
+++ b/packages/integrations/cloudflare/src/server.directory.ts
@@ -17,7 +17,7 @@ export function createExports(manifest: SSRManifest) {
 	}: {
 		request: Request & CFRequest;
 		next: (request: Request) => void;
-		waitUntil: (promise: Promise<any>) => void;
+		waitUntil: EventContext<unknown, any, unknown>['waitUntil'];
 	} & Record<string, unknown>) => {
 		process.env = runtimeEnv.env as any;
 


### PR DESCRIPTION
## Changes

### What does this change?

- The cloudflare context was spread. This did not work and waitUntil was not passed on as intended.
( This might also be an issue for other context runtime functions )
- Wait until has to be "proxied" through a function, passing the reference alone will trigger illegal invocations.

## Testing

Tested on our own environment.
Has been tested on our `advanced` mode website.
I cannot speak for `directory` mode, but I assume the problem is the same.

## Docs

No need to update docs,  `waitUntil` should now work as intended.


### Comments

I did not bother to mock waitUntil since we already have a mock In our project.

Its up to the Astro team to decide from this point on. But you could do something like what we do:

```typescript
    waitUntil: (promise: Promise<any>) => {
      if (runtime?.waitUntil) {
        runtime.waitUntil(promise);
      } else {
        Promise.resolve(promise).catch((error) => {
          console.error(error);
          // noop
        });
      }
    },
```



<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
