### PR TITLE
fix(astro:assets): inject /_image endpoint with prerendered=false on serverLikeOutput

### DIFF
--- a/.changeset/honest-flies-care.md
+++ b/.changeset/honest-flies-care.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+fix(astro:assets): inject `/_image` endpoint with prerendered=false on serverLikeOutput
+
+Previously, on hybrid output, images imported on a server-side-rendered page were not rendered and returned a 404 response.

--- a/.changeset/honest-flies-care.md
+++ b/.changeset/honest-flies-care.md
@@ -2,6 +2,4 @@
 'astro': patch
 ---
 
-fix(astro:assets): inject `/_image` endpoint with prerendered=false on serverLikeOutput
-
-Previously, on hybrid output, images imported on a server-side-rendered page were not rendered and returned a 404 response.
+Ensure injected `/_image` endpoint for image optimization is not prerendered on hybrid output.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1238,6 +1238,7 @@ export type InjectedScriptStage = 'before-hydration' | 'head-inline' | 'page' | 
 export interface InjectedRoute {
 	pattern: string;
 	entryPoint: string;
+	prerender?: boolean;
 }
 export interface AstroConfig extends z.output<typeof AstroConfigSchema> {
 	// Public:

--- a/packages/astro/src/core/config/settings.ts
+++ b/packages/astro/src/core/config/settings.ts
@@ -24,7 +24,7 @@ export function createBaseSettings(config: AstroConfig): AstroSettings {
 		adapter: undefined,
 		injectedRoutes:
 			config.experimental.assets && isServerLikeOutput(config)
-				? [{ pattern: '/_image', entryPoint: 'astro/assets/image-endpoint' }]
+				? [{ pattern: '/_image', entryPoint: 'astro/assets/image-endpoint', prerender: false }]
 				: [],
 		pageExtensions: ['.astro', '.html', ...SUPPORTED_MARKDOWN_FILE_EXTENSIONS],
 		contentEntryTypes: [markdownContentEntryType],

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -387,7 +387,7 @@ export function createRouteManifest(
 			comparator(injectedRouteToItem({ config, cwd }, a), injectedRouteToItem({ config, cwd }, b))
 		)
 		.reverse() // prepend to the routes array from lowest to highest priority
-		.forEach(({ pattern: name, entryPoint }) => {
+		.forEach(({ pattern: name, entryPoint, prerender: prerenderInjected }) => {
 			let resolved: string;
 			try {
 				resolved = require.resolve(entryPoint, { paths: [cwd || fileURLToPath(config.root)] });
@@ -440,7 +440,7 @@ export function createRouteManifest(
 				component,
 				generate,
 				pathname: pathname || void 0,
-				prerender,
+				prerender: prerenderInjected ?? prerender,
 			});
 		});
 


### PR DESCRIPTION

Fixes #7415

## Changes

- Add a boolean property to set prerender value when injectingRoutes
- Effectively set `/_image` endpoint with `prerender: false` (was added as a prerendered asset/route before)

## Testing

Again, I would love very much to add a couple of tests around manifest and/or routing settings, but could find relevant test suites so far. Guidance would be much appreciated.

## Docs

No change relevant to user.
