### PR TITLE
Fix telemetry reporting for integrations that return an array

### DIFF
--- a/.changeset/witty-roses-relate.md
+++ b/.changeset/witty-roses-relate.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix telemetry reporting for integrations that return an array

--- a/packages/astro/src/events/session.ts
+++ b/packages/astro/src/events/session.ts
@@ -83,7 +83,10 @@ export function eventCliSession(
 					) ?? []),
 				] as string[],
 				adapter: userConfig?.adapter?.name ?? null,
-				integrations: (userConfig?.integrations ?? []).filter(Boolean).map((i: any) => i?.name),
+				integrations: (userConfig?.integrations ?? [])
+					.filter(Boolean)
+					.flat()
+					.map((i: any) => i?.name),
 				trailingSlash: userConfig?.trailingSlash,
 				build: userConfig?.build
 					? {


### PR DESCRIPTION
## Changes

- We report integration names to telemetry, but currently miss integrations if they return `AstroIntegration[]` (which we support for bundling multiple integrations in one).
- This PR updatest the event logic to first flatten the integrations array before mapping over it to find names.

## Testing

Existing tests should pass.

## Docs

No docs needed, bug fix only.