### PR TITLE
chore: update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/---01-bug-report.yml
@@ -56,8 +56,8 @@ body:
   - type: textarea
     id: bug-expectation
     attributes:
-      label: What's the expected result
-      description: Describe what you expected to happen.
+      label: What's the expected result?
+      description: Describe what you expect to happen.
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/---01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/---01-bug-report.yml
@@ -53,6 +53,13 @@ body:
       description: A clear and concise description of what the bug is.
     validations:
       required: true
+  - type: textarea
+    id: bug-expectation
+    attributes:
+      label: What's the expected result
+      description: Describe what you expected to happen.
+    validations:
+      required: true
   - type: input
     id: bug-reproduction
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://github.com/withastro/docs
     about: File an issue or make an improvement to the docs website.
   - name: 💡 Ideas for New Features, Improvements and RFCs
-    url: https://github.com/withastro/rfcs/discussions
+    url: https://github.com/withastro/roadmap/discussions
     about: Propose and discuss future improvements to Astro
   - name: 👾 Chat
     url: https://astro.build/chat


### PR DESCRIPTION
## Changes

- update the bug report template by adding a new section called "What's the expected result", where the reporter should tell us what they expect. This is useful, because also the expectations are a form of feedback and dicussion
- fix the `config.yml`, the link to the discussions was pointing to the old repo (even though there's a redirect in place)


## Testing

N/A
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
