### PR TITLE
ci: don't run workflow for `ISSUE_TEMPLATE`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
     paths-ignore:
       - ".vscode/**"
       - "**/*.md"
+      - ".github/ISSUE_TEMPLATE/**"
 
 # Automatically cancel older in-progress jobs on the same branch
 concurrency:


### PR DESCRIPTION
## Changes

Adds `.github/ISSUE_TEMPLATE` to the list of paths to ignore.

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
