### PR TITLE
fix: `pnpm` failure on `create-astro`

### DIFF
--- a/.changeset/clever-rings-draw.md
+++ b/.changeset/clever-rings-draw.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fix registry failures using unexpected package managers when running create-astro

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -35,8 +35,7 @@
     "chai": "^4.3.7",
     "execa": "^6.1.0",
     "giget": "1.0.0",
-    "mocha": "^9.2.2",
-    "preferred-pm": "^3.0.3"
+    "mocha": "^9.2.2"
   },
   "devDependencies": {
     "@types/which-pm-runs": "^1.0.0",

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -35,15 +35,15 @@
     "chai": "^4.3.7",
     "execa": "^6.1.0",
     "giget": "1.0.0",
-    "mocha": "^9.2.2"
+    "mocha": "^9.2.2",
+    "which-pm-runs": "^1.1.0"
   },
   "devDependencies": {
     "@types/which-pm-runs": "^1.0.0",
     "arg": "^5.0.2",
     "astro-scripts": "workspace:*",
     "strip-ansi": "^7.1.0",
-    "strip-json-comments": "^5.0.0",
-    "which-pm-runs": "^1.1.0"
+    "strip-json-comments": "^5.0.0"
   },
   "engines": {
     "node": ">=16.12.0"

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -4,15 +4,15 @@ import { align, sleep } from '@astrojs/cli-kit/utils';
 import { execa } from 'execa';
 import { exec } from 'node:child_process';
 import { get } from 'node:https';
-import preferredPM from 'preferred-pm';
 import stripAnsi from 'strip-ansi';
+import detectPackageManager from 'which-pm-runs';
 
 // Users might lack access to the global npm registry, this function
 // checks the user's project type and will return the proper npm registry
 //
 // A copy of this function also exists in the astro package
 async function getRegistry(): Promise<string> {
-	const packageManager = (await preferredPM(process.cwd()))?.name || 'npm';
+	const packageManager = detectPackageManager()?.name || 'npm';
 	const { stdout } = await execa(packageManager, ['config', 'get', 'registry']);
 	return stdout || 'https://registry.npmjs.org';
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3577,9 +3577,6 @@ importers:
       mocha:
         specifier: ^9.2.2
         version: 9.2.2
-      preferred-pm:
-        specifier: ^3.0.3
-        version: 3.0.3
     devDependencies:
       '@types/which-pm-runs':
         specifier: ^1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3577,6 +3577,9 @@ importers:
       mocha:
         specifier: ^9.2.2
         version: 9.2.2
+      which-pm-runs:
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@types/which-pm-runs':
         specifier: ^1.0.0
@@ -3593,9 +3596,6 @@ importers:
       strip-json-comments:
         specifier: ^5.0.0
         version: 5.0.0
-      which-pm-runs:
-        specifier: ^1.1.0
-        version: 1.1.0
 
   packages/create-astro/test/fixtures/not-empty: {}
 


### PR DESCRIPTION
## Changes

- Resolves #7379
- Switch from `preferred-pm` to the `which-pm-runs` package we already use for detecting npm versions during the "install" step (see #7326). Seems `preferred-pm` does a lot of extra work to crawl lock files and `node_modules` to find the package manager. This result can differ from the "install" step, which doesn't seem right.

## Testing

- Manual testing to ensure npm, yarn, and pnpm correctly resolve.

## Docs

N/A