### PR TITLE
Fix `astro:build:setup` hook `updateConfig` utility

### DIFF
--- a/.changeset/cyan-vans-clap.md
+++ b/.changeset/cyan-vans-clap.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `astro:build:setup` hook `updateConfig` utility

--- a/.changeset/cyan-vans-clap.md
+++ b/.changeset/cyan-vans-clap.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fix `astro:build:setup` hook `updateConfig` utility
+Fix `astro:build:setup` hook `updateConfig` utility, where the configuration wasn't correctly updated when the hook was fired.

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -201,7 +201,7 @@ async function ssrBuild(
 		base: settings.config.base,
 	};
 
-	await runHookBuildSetup({
+	const updatedViteBuildConfig = await runHookBuildSetup({
 		config: settings.config,
 		pages: internals.pagesByComponent,
 		vite: viteBuildConfig,
@@ -209,7 +209,7 @@ async function ssrBuild(
 		logging: opts.logging,
 	});
 
-	return await vite.build(viteBuildConfig);
+	return await vite.build(updatedViteBuildConfig);
 }
 
 async function clientBuild(

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -286,7 +286,9 @@ export async function runHookBuildSetup({
 	pages: Map<string, PageBuildData>;
 	target: 'server' | 'client';
 	logging: LogOptions;
-}) {
+}): Promise<InlineConfig> {
+	let updatedConfig = vite;
+
 	for (const integration of config.integrations) {
 		if (integration?.hooks?.['astro:build:setup']) {
 			await withTakingALongTimeMsg({
@@ -296,13 +298,15 @@ export async function runHookBuildSetup({
 					pages,
 					target,
 					updateConfig: (newConfig) => {
-						mergeConfig(vite, newConfig);
+						updatedConfig = mergeConfig(updatedConfig, newConfig);
 					},
 				}),
 				logging,
 			});
 		}
 	}
+
+	return updatedConfig;
 }
 
 export async function runHookBuildSsr({

--- a/packages/astro/test/units/integrations/api.test.js
+++ b/packages/astro/test/units/integrations/api.test.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import { runHookBuildSetup } from '../../../dist/integrations/index.js';
+
+describe('Integration API', () => {
+	it('runHookBuildSetup should work', async () => {
+		const updatedViteConfig = await runHookBuildSetup({
+			config: {
+				integrations: [
+					{
+						name: 'test',
+						hooks: {
+							'astro:build:setup'({ updateConfig }) {
+								updateConfig({
+									define: {
+										foo: 'bar',
+									},
+								});
+							},
+						},
+					},
+				],
+			},
+			vite: {},
+			logging: {},
+			pages: new Map(),
+			target: 'server',
+		});
+		expect(updatedViteConfig).to.haveOwnProperty('define');
+	});
+});


### PR DESCRIPTION
## Changes

While working on some fixes today, I noticed `astro:build:setup` hook's `updateConfig` util doesn't actually update the config.

In contrary, the `astro:config:setup` hook's `updateConfig` util does actually update the astro config. So the above seems like a bug to me, which is fixed here.


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added unit test.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Looks like it's not documented 🤔 https://docs.astro.build/en/reference/integrations-reference/#astrobuildsetup. The feature is added in https://github.com/withastro/astro/pull/3392