### PR TITLE
Fix vercel redirects with trailingSlash always

### DIFF
--- a/.changeset/nervous-paws-knock.md
+++ b/.changeset/nervous-paws-knock.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Fix redirects for root page when using `trailingSlash: "always"`

--- a/packages/integrations/vercel/src/lib/redirects.ts
+++ b/packages/integrations/vercel/src/lib/redirects.ts
@@ -87,7 +87,7 @@ export function getRedirects(routes: RouteData[], config: AstroConfig): VercelRo
 				headers: { Location: getRedirectLocation(route, config) },
 				status: getRedirectStatus(route),
 			});
-		} else if (route.type === 'page') {
+		} else if (route.type === 'page' && route.route !== '/') {
 			if (config.trailingSlash === 'always') {
 				redirects.push({
 					src: config.base + getMatchPattern(route.segments),

--- a/packages/integrations/vercel/test/redirects.test.js
+++ b/packages/integrations/vercel/test/redirects.test.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Redirects', () => {
@@ -18,6 +17,7 @@ describe('Redirects', () => {
 				},
 				'/blog/[...slug]': '/team/articles/[...slug]',
 			},
+			trailingSlash: 'always',
 			experimental: {
 				redirects: true,
 			},
@@ -55,5 +55,18 @@ describe('Redirects', () => {
 		expect(blogRoute).to.not.be.undefined;
 		expect(blogRoute.headers.Location.startsWith('/team/articles')).to.equal(true);
 		expect(blogRoute.status).to.equal(301);
+	});
+
+	it('define trailingSlash redirect for sub pages', async () => {
+		const config = await getConfig();
+
+		const subpathRoute = config.routes.find((r) => r.src === '/\\/subpage');
+		expect(subpathRoute).to.not.be.undefined;
+		expect(subpathRoute.headers.Location).to.equal('/subpage/');
+	});
+
+	it('does not define trailingSlash redirect for root page', async () => {
+		const config = await getConfig();
+		expect(config.routes.find((r) => r.src === '/')).to.be.undefined;
 	});
 });


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/7444

It was generating redirects from `/` to `//`, which was causing infinite redirects. I've removed creating redirects for the root page, which should fix this.

I don't see `@astrojs/underscore-redirects` creating redirects based on `trailingSlash` so they might be unaffected.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added test in vercel

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.