### PR TITLE
feat: expose middleware URL to integrations

### DIFF
--- a/.changeset/chilly-pants-fix.md
+++ b/.changeset/chilly-pants-fix.md
@@ -11,8 +11,8 @@ function integration(): AstroIntegration {
     return {
         name: "fancy-astro-integration",
         hooks: {
-            'astro:build:done': ({ middlewarePath }) => { 
-                if (middlewarePath) {
+            'astro:build:done': ({ middlewareEntryPoint }) => { 
+                if (middlewareEntryPoint) {
                     // do some operations
                 }
             }
@@ -21,4 +21,4 @@ function integration(): AstroIntegration {
 }
 ```
 
-The `middlewarePath` is only defined if the user has created an Astro middleware.
+The `middlewareEntryPoint` is only defined if the user has created an Astro middleware.

--- a/.changeset/chilly-pants-fix.md
+++ b/.changeset/chilly-pants-fix.md
@@ -1,0 +1,24 @@
+---
+'astro': minor
+---
+
+Astro exposes the middleware file path to the integrations in the hook `astro:build:done`
+
+```ts
+// myIntegration.js
+import type { AstroIntegration } from 'astro';
+function integration(): AstroIntegration {
+    return {
+        name: "fancy-astro-integration",
+        hooks: {
+            'astro:build:done': ({ middlewarePath }) => { 
+                if (middlewarePath) {
+                    // do some operations
+                }
+            }
+        }
+    }
+}
+```
+
+The `middlewarePath` is only defined if the user has created an Astro middleware.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1869,7 +1869,7 @@ export interface AstroIntegration {
 			pages: { pathname: string }[];
 			dir: URL;
 			routes: RouteData[];
-			middlewarePath: URL | undefined;
+			middlewareEntryPoint: URL | undefined;
 		}) => void | Promise<void>;
 	};
 }

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1869,6 +1869,7 @@ export interface AstroIntegration {
 			pages: { pathname: string }[];
 			dir: URL;
 			routes: RouteData[];
+			middlewarePath: URL | undefined;
 		}) => void | Promise<void>;
 	};
 }

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -188,7 +188,7 @@ class AstroBuilder {
 		});
 		debug('build', timerMessage('Additional assets copied', this.timer.assetsStart));
 
-		let newMiddlewareEntryPoint = undefined;
+		let middlewareEntryPoint = undefined;
 		// during the last phase of the build, the emitted code gets copied inside
 		// `dist/server/` folder, so we need to shred the old URL and make a new one again
 		if (internals.middlewareEntryPoint && isServerLikeOutput(this.settings.config)) {
@@ -196,7 +196,7 @@ class AstroBuilder {
 			const middlewareRelativePath = fileURLToPath(internals.middlewareEntryPoint).slice(
 				fileURLToPath(this.settings.config.outDir).length
 			);
-			newMiddlewareEntryPoint = pathToFileURL(join(outDir, 'server', middlewareRelativePath));
+			middlewareEntryPoint = pathToFileURL(join(outDir, 'server', middlewareRelativePath));
 		}
 
 		// You're done! Time to clean up.
@@ -205,7 +205,7 @@ class AstroBuilder {
 			pages: pageNames,
 			routes: Object.values(allPages).map((pd) => pd.route),
 			logging: this.logging,
-			middlewarePath: newMiddlewareEntryPoint,
+			middlewareEntryPoint,
 		});
 
 		if (this.logging.level && levels[this.logging.level] <= levels['info']) {

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -189,6 +189,8 @@ class AstroBuilder {
 		debug('build', timerMessage('Additional assets copied', this.timer.assetsStart));
 
 		let newMiddlewareEntryPoint = undefined;
+		// during the last phase of the build, the emitted code gets copied inside
+		// `dist/server/` folder, so we need to shred the old URL and make a new one again
 		if (internals.middlewareEntryPoint && isServerLikeOutput(this.settings.config)) {
 			const outDir = fileURLToPath(this.settings.config.outDir);
 			const middlewareRelativePath = fileURLToPath(internals.middlewareEntryPoint).slice(

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -188,10 +188,10 @@ class AstroBuilder {
 		// You're done! Time to clean up.
 		await runHookBuildDone({
 			config: this.settings.config,
-			buildConfig,
 			pages: pageNames,
 			routes: Object.values(allPages).map((pd) => pd.route),
 			logging: this.logging,
+			middlewarePath: internals.middlewareEntryPoint,
 		});
 
 		if (this.logging.level && levels[this.logging.level] <= levels['info']) {

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -84,7 +84,6 @@ export interface BuildInternals {
 	entryPoints: Map<RouteData, URL>;
 	ssrSplitEntryChunks: Map<string, Rollup.OutputChunk>;
 	componentMetadata: SSRResult['componentMetadata'];
-
 	middlewareEntryPoint?: URL;
 }
 

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -84,6 +84,8 @@ export interface BuildInternals {
 	entryPoints: Map<RouteData, URL>;
 	ssrSplitEntryChunks: Map<string, Rollup.OutputChunk>;
 	componentMetadata: SSRResult['componentMetadata'];
+
+	middlewareEntryPoint?: URL;
 }
 
 /**

--- a/packages/astro/src/core/build/plugins/plugin-middleware.ts
+++ b/packages/astro/src/core/build/plugins/plugin-middleware.ts
@@ -11,7 +11,7 @@ const EMPTY_MIDDLEWARE = '\0empty-middleware';
 
 export function vitePluginMiddleware(
 	opts: StaticBuildOptions,
-	_internals: BuildInternals
+	internals: BuildInternals
 ): VitePlugin {
 	return {
 		name: '@astro/plugin-middleware',
@@ -39,6 +39,17 @@ export function vitePluginMiddleware(
 		load(id) {
 			if (id === EMPTY_MIDDLEWARE) {
 				return 'export const onRequest = undefined';
+			}
+		},
+
+		writeBundle(_, bundle) {
+			for (const [chunkName, chunk] of Object.entries(bundle)) {
+				if (chunk.type === 'asset') {
+					continue;
+				}
+				if (chunk.fileName === 'middleware.mjs') {
+					internals.middlewareEntryPoint = new URL(chunkName, opts.settings.config.outDir);
+				}
 			}
 		},
 	};

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -348,7 +348,7 @@ type RunHookBuildDone = {
 	pages: string[];
 	routes: RouteData[];
 	logging: LogOptions;
-	middlewarePath: URL | undefined;
+	middlewareEntryPoint: URL | undefined;
 };
 
 export async function runHookBuildDone({
@@ -356,7 +356,7 @@ export async function runHookBuildDone({
 	pages,
 	routes,
 	logging,
-	middlewarePath,
+	middlewareEntryPoint,
 }: RunHookBuildDone) {
 	const dir = isServerLikeOutput(config) ? config.build.client : config.outDir;
 	await fs.promises.mkdir(dir, { recursive: true });
@@ -369,7 +369,7 @@ export async function runHookBuildDone({
 					pages: pages.map((p) => ({ pathname: p })),
 					dir,
 					routes,
-					middlewarePath,
+					middlewareEntryPoint,
 				}),
 				logging,
 			});

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -343,20 +343,22 @@ export async function runHookBuildGenerated({
 	}
 }
 
-export async function runHookBuildDone({
-	config,
-	buildConfig,
-	pages,
-	routes,
-	logging,
-}: {
+type RunHookBuildDone = {
 	config: AstroConfig;
-	buildConfig: BuildConfig;
 	pages: string[];
 	routes: RouteData[];
 	logging: LogOptions;
-}) {
-	const dir = isServerLikeOutput(config) ? buildConfig.client : config.outDir;
+	middlewarePath: URL | undefined;
+};
+
+export async function runHookBuildDone({
+	config,
+	pages,
+	routes,
+	logging,
+	middlewarePath,
+}: RunHookBuildDone) {
+	const dir = isServerLikeOutput(config) ? config.build.client : config.outDir;
 	await fs.promises.mkdir(dir, { recursive: true });
 
 	for (const integration of config.integrations) {
@@ -367,6 +369,7 @@ export async function runHookBuildDone({
 					pages: pages.map((p) => ({ pathname: p })),
 					dir,
 					routes,
+					middlewarePath,
 				}),
 				logging,
 			});

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -215,7 +215,6 @@ describe('Middleware API in PROD mode, SSR', () => {
 		expect(middlewarePath).to.not.be.undefined;
 		try {
 			const path = fileURLToPath(middlewarePath);
-			console.log(path);
 			expect(existsSync(path)).to.be.true;
 			const content = readFileSync(fileURLToPath(middlewarePath), 'utf-8');
 			expect(content.length).to.be.greaterThan(0);

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -2,6 +2,8 @@ import { loadFixture } from './test-utils.js';
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
+import { fileURLToPath } from 'node:url';
+import { readFileSync, existsSync } from 'node:fs';
 
 describe('Middleware in DEV mode', () => {
 	/** @type {import('./test-utils').Fixture} */
@@ -104,12 +106,19 @@ describe('Middleware in PROD mode, SSG', () => {
 describe('Middleware API in PROD mode, SSR', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
+	let middlewarePath;
 
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/middleware-dev/',
 			output: 'server',
-			adapter: testAdapter({}),
+			adapter: testAdapter({
+				setEntryPoints(entryPointsOrMiddleware) {
+					if (entryPointsOrMiddleware instanceof URL) {
+						middlewarePath = entryPointsOrMiddleware;
+					}
+				},
+			}),
 		});
 		await fixture.build();
 	});
@@ -200,6 +209,19 @@ describe('Middleware API in PROD mode, SSR', () => {
 		const response = await app.render(request);
 		const text = await response.text();
 		expect(text.includes('REDACTED')).to.be.true;
+	});
+
+	it('the integration should receive the path to the middleware', async () => {
+		expect(middlewarePath).to.not.be.undefined;
+		try {
+			const path = fileURLToPath(middlewarePath);
+			console.log(path);
+			expect(existsSync(path)).to.be.true;
+			const content = readFileSync(fileURLToPath(middlewarePath), 'utf-8');
+			expect(content.length).to.be.greaterThan(0);
+		} catch (e) {
+			throw e;
+		}
 	});
 });
 

--- a/packages/astro/test/ssr-split-manifest.test.js
+++ b/packages/astro/test/ssr-split-manifest.test.js
@@ -17,7 +17,9 @@ describe('astro:ssr-manifest, split', () => {
 			output: 'server',
 			adapter: testAdapter({
 				setEntryPoints(entries) {
-					entryPoints = entries;
+					if (entries) {
+						entryPoints = entries;
+					}
 				},
 				setRoutes(routes) {
 					currentRoutes = routes;

--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -79,12 +79,12 @@ export default function (
 					setEntryPoints(entryPoints);
 				}
 			},
-			'astro:build:done': ({ routes, middlewarePath }) => {
+			'astro:build:done': ({ routes, middlewareEntryPoint }) => {
 				if (setRoutes) {
 					setRoutes(routes);
 				}
 				if (setEntryPoints) {
-					setEntryPoints(middlewarePath);
+					setEntryPoints(middlewareEntryPoint);
 				}
 			},
 		},

--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -79,9 +79,12 @@ export default function (
 					setEntryPoints(entryPoints);
 				}
 			},
-			'astro:build:done': ({ routes }) => {
+			'astro:build:done': ({ routes, middlewarePath }) => {
 				if (setRoutes) {
 					setRoutes(routes);
+				}
+				if (setEntryPoints) {
+					setEntryPoints(middlewarePath);
 				}
 			},
 		},

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -109,9 +109,6 @@ export default function vercelServerless({
 				// Remove temporary folder
 				await removeDir(buildTempFolder);
 
-				// Write middleware
-				await writeFile(new URL('./middleware.js', functionFolder), generateMiddlewareCode());
-
 				// Enable ESM
 				// https://aws.amazon.com/blogs/compute/using-node-js-es-modules-and-top-level-await-in-aws-lambda/
 				await writeJson(new URL(`./package.json`, functionFolder), {
@@ -148,13 +145,4 @@ function getRuntime() {
 	const version = process.version.slice(1); // 'v16.5.0' --> '16.5.0'
 	const major = version.split('.')[0]; // '16.5.0' --> '16'
 	return `nodejs${major}.x`;
-}
-
-function generateMiddlewareCode() {
-	return `
-import {onRequest} from "somethere";
-export default function middleware(request, context) {
-	return onRequest(request)
-}
-`;
 }

--- a/packages/integrations/vercel/test/edge-middleware.test.js
+++ b/packages/integrations/vercel/test/edge-middleware.test.js
@@ -10,9 +10,4 @@ describe('Serverless prerender', () => {
 			root: './fixtures/middleware/',
 		});
 	});
-
-	it('build successful', async () => {
-		await fixture.build();
-		expect(await fixture.readFile('../.vercel/output/static/index.html')).to.be.ok;
-	});
 });


### PR DESCRIPTION
## Changes

This is another feature towards the support of Vercel Edge Middleware.

This feature exposes the file path of the middleware file emitted during the astro build.



## Testing

I extended the functionality of the test adapter and created a test that makes sure that the file exists and it has content.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

I will document the new payload towards the end of the feature.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
