### PR TITLE
Typo fixed in `node.mdx`

### DIFF
--- a/packages/integrations/node/README.md
+++ b/packages/integrations/node/README.md
@@ -136,7 +136,7 @@ app.use((req, res, next) => {
   };
 
   ssrHandler(req, res, next, locals);
-);
+});
 
 app.listen(8080);
 ```


### PR DESCRIPTION
## Changes

- What does this change?
Typo fixed in `node.mdx`

## Testing

A typo has been fixed, no test is needed.

## Docs

Typo fixed in `node.mdx`
