### PR TITLE
fix: Installs underneath a path containing leading underscores

### DIFF
--- a/.changeset/flat-papayas-invite.md
+++ b/.changeset/flat-papayas-invite.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow astro to be installed underneath a folder with leading slashes

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -21,6 +21,7 @@ import {
 	type ContentLookupMap,
 	type ContentPaths,
 } from './utils.js';
+import { appendForwardSlash } from '../core/path.js';
 
 interface AstroContentVirtualModPluginParams {
 	settings: AstroSettings;
@@ -209,5 +210,6 @@ const UnexpectedLookupMapError = new AstroError({
 
 function globWithUnderscoresIgnored(relContentDir: string, exts: string[]): string[] {
 	const extGlob = getExtGlob(exts);
-	return [`${relContentDir}/**/*${extGlob}`, `!**/_*/**${extGlob}`, `!**/_*${extGlob}`];
+	const contentDir = appendForwardSlash(relContentDir.trim());
+	return [`${contentDir}**/*${extGlob}`, `!${contentDir}_*/**${extGlob}`, `!${contentDir}_*${extGlob}`];
 }

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -210,6 +210,6 @@ const UnexpectedLookupMapError = new AstroError({
 
 function globWithUnderscoresIgnored(relContentDir: string, exts: string[]): string[] {
 	const extGlob = getExtGlob(exts);
-	const contentDir = appendForwardSlash(relContentDir.trim());
+	const contentDir = appendForwardSlash(relContentDir);
 	return [`${contentDir}**/*${extGlob}`, `!${contentDir}_*/**${extGlob}`, `!${contentDir}_*${extGlob}`];
 }


### PR DESCRIPTION
Fixes #7406 


Makes it possible to run astro underneath a path that contains leading underscores, like e.g. `/_my/path/to/site/`.

## Changes

- Make the glob patterns in the `astroContentVirtualModPlugin` relative to the content directory

## Testing

I really don't know how I should test this using a written test. Tested it manually instead.

Still, out of curiosity I ran `pnpm run test`. There were a few tests that were failing for me, regardless of the proposed change from this PR.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This is a bugfix, no docs needed I guess
