### PR TITLE
Handle esbuild 0.18 changes

### DIFF
--- a/.changeset/happy-stingrays-carry.md
+++ b/.changeset/happy-stingrays-carry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Handle esbuild 0.18 changes

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -41,6 +41,8 @@ export async function cachedFullCompilation({
 			tsconfigRaw: {
 				compilerOptions: {
 					// Ensure client:only imports are treeshaken
+					// @ts-expect-error anticipate esbuild 0.18 feature
+					verbatimModuleSyntax: false,
 					importsNotUsedAsValues: 'remove',
 				},
 			},

--- a/packages/astro/src/vite-plugin-jsx/index.ts
+++ b/packages/astro/src/vite-plugin-jsx/index.ts
@@ -160,6 +160,8 @@ export default function jsx({ settings, logging }: AstroPluginJSXOptions): Plugi
 					tsconfigRaw: {
 						compilerOptions: {
 							// Ensure client:only imports are treeshaken
+							// @ts-expect-error anticipate esbuild 0.18 feature
+							verbatimModuleSyntax: false,
 							importsNotUsedAsValues: 'remove',
 						},
 					},


### PR DESCRIPTION
## Changes

Handle upcoming esbuild 0.18 changes that will be introduced by Vite 4.4. More context at https://github.com/vitejs/vite/pull/13525#issuecomment-1596678961 where Astro was failing in `vite-ecosystem-ci`.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Manually linked Vite locally and ran test

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a.