### PR TITLE
feat: add `entryPoints` to astro:build:done

### DIFF
--- a/.changeset/chilled-wolves-jog.md
+++ b/.changeset/chilled-wolves-jog.md
@@ -1,0 +1,23 @@
+---
+'astro': minor
+---
+
+The hook `astro:build:done` now accepts a new property called `entryPoints`.
+
+`entryPoints` is defined as `Map<RouteData, URL>`. The key difference between this
+property and the one provided in the hook `astro:build:done`, is that these
+URLs map the physical files **before** they are moved in the server destination
+folder.
+
+```js
+export function itegration(): AstroIntegration {
+    return {
+        name: "my-integration",
+        hooks: {
+            "astor:build:ssr": ({ entryPoints }) => {
+                // do something with entry points
+            }
+        }
+    }
+}
+```

--- a/.changeset/silly-trains-occur.md
+++ b/.changeset/silly-trains-occur.md
@@ -1,0 +1,23 @@
+---
+'astro': minor
+---
+
+The hook `astro:build:done` now accepts a new property called `entryPoints`.
+
+`entryPoints` is defined as `Map<RouteData, URL>`. The key difference between this 
+property and the one provided in the hook `astro:build:ssr`, is that these
+URLs map the physical files **after** they are moved in the server destination
+folder.
+
+```js
+export function itegration(): AstroIntegration {
+    return {
+        name: "my-integration",
+        hooks: {
+            "astor:build:done": ({ entryPoints }) => {
+                // do something with entry points
+            }
+        }
+    }
+}
+```

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1854,6 +1854,8 @@ export interface AstroIntegration {
 			/**
 			 * This maps a {@link RouteData} to an {@link URL}, this URL represents
 			 * the physical file you should import.
+			 *
+			 * These files point to URLs **before** they are moved in the `build.server` folder.
 			 */
 			entryPoints: Map<RouteData, URL>;
 		}) => void | Promise<void>;
@@ -1869,6 +1871,13 @@ export interface AstroIntegration {
 			pages: { pathname: string }[];
 			dir: URL;
 			routes: RouteData[];
+			/**
+			 * This maps a {@link RouteData} to an {@link URL}, this URL represents
+			 * the physical file you should import.
+			 *
+			 * These files point to URLs **after** they are moved in the `build.server` folder.
+			 */
+			entryPoints: Map<RouteData, URL>;
 		}) => void | Promise<void>;
 	};
 }

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -29,7 +29,7 @@ import { staticBuild, viteBuild } from './static-build.js';
 import type { StaticBuildOptions } from './types.js';
 import { getTimeStat } from './util.js';
 import { isServerLikeOutput } from '../../prerender/utils.js';
-import { fileURLToPath, pathToFileURL } from 'url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { join } from 'node:path';
 
 export interface BuildOptions {
@@ -197,11 +197,10 @@ class AstroBuilder {
 				const relativeFilePath = fileURLToPath(filePath).slice(
 					fileURLToPath(this.settings.config.outDir).length
 				);
+
 				movedEntryPoints.set(
 					route,
-					pathToFileURL(
-						join(outDir, fileURLToPath(opts.settings.config.build.server), relativeFilePath)
-					)
+					pathToFileURL(join(fileURLToPath(opts.settings.config.build.server), relativeFilePath))
 				);
 			}
 		}

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -343,19 +343,22 @@ export async function runHookBuildGenerated({
 	}
 }
 
+type RunHookBuildDone = {
+	config: AstroConfig;
+	buildConfig: BuildConfig;
+	pages: string[];
+	routes: RouteData[];
+	logging: LogOptions;
+	entryPoints: Map<RouteData, URL>;
+};
 export async function runHookBuildDone({
 	config,
 	buildConfig,
 	pages,
 	routes,
 	logging,
-}: {
-	config: AstroConfig;
-	buildConfig: BuildConfig;
-	pages: string[];
-	routes: RouteData[];
-	logging: LogOptions;
-}) {
+	entryPoints,
+}: RunHookBuildDone) {
 	const dir = isServerLikeOutput(config) ? buildConfig.client : config.outDir;
 	await fs.promises.mkdir(dir, { recursive: true });
 
@@ -367,6 +370,7 @@ export async function runHookBuildDone({
 					pages: pages.map((p) => ({ pathname: p })),
 					dir,
 					routes,
+					entryPoints,
 				}),
 				logging,
 			});

--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -1,11 +1,19 @@
 import { viteID } from '../dist/core/util.js';
 
 /**
+ * @typedef {(hookName: string, entryPoints: Map<RouteData, URL>) => undefined} SetEntryPoints
+ */
+
+/**
  *
+ * @param provideAddress
+ * @param extendAdapter
+ * @param {SetEntryPoints} setEntryPoints
+ * @param setRoutes
  * @returns {import('../src/@types/astro').AstroIntegration}
  */
 export default function (
-	{ provideAddress = true, extendAdapter, setEntryPoints = undefined, setRoutes = undefined } = {
+	{ provideAddress = true, extendAdapter, setEntryPoints, setRoutes } = {
 		provideAddress: true,
 	}
 ) {
@@ -76,12 +84,15 @@ export default function (
 			},
 			'astro:build:ssr': ({ entryPoints }) => {
 				if (setEntryPoints) {
-					setEntryPoints(entryPoints);
+					setEntryPoints('astro:build:ssr', entryPoints);
 				}
 			},
-			'astro:build:done': ({ routes }) => {
+			'astro:build:done': ({ routes, entryPoints }) => {
 				if (setRoutes) {
 					setRoutes(routes);
+				}
+				if (setEntryPoints) {
+					setEntryPoints('astro:build:done', entryPoints);
 				}
 			},
 		},


### PR DESCRIPTION
## Changes

This exposes `entryPoints` to the hook `astro:build:done`.

I noticed that I forgot to officially track the `entryPoints` we added to `astro:build:ssr`, so I added a changeset just for that, that's why there are two changesets.

## Testing

Changed a bit the test adapter, and added a test case.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
