### PR TITLE
fix(examples/blog): Header component is using constant instead of 'title' prop

### DIFF
--- a/examples/blog/src/components/Header.astro
+++ b/examples/blog/src/components/Header.astro
@@ -1,11 +1,16 @@
 ---
 import HeaderLink from './HeaderLink.astro';
-import { SITE_TITLE } from '../consts';
+
+export interface Props {
+	title: string;
+}
+
+const { title } = Astro.props;
 ---
 
 <header>
 	<h2>
-		{SITE_TITLE}
+		{title}
 	</h2>
 	<nav>
 		<HeaderLink href="/">Home</HeaderLink>

--- a/examples/blog/src/layouts/BlogPost.astro
+++ b/examples/blog/src/layouts/BlogPost.astro
@@ -29,7 +29,7 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 	</head>
 
 	<body>
-		<Header />
+		<Header title={title} />
 		<main>
 			<article>
 				{heroImage && <img width={720} height={360} src={heroImage} alt="" />}

--- a/examples/blog/src/pages/blog/index.astro
+++ b/examples/blog/src/pages/blog/index.astro
@@ -34,7 +34,7 @@ const posts = (await getCollection('blog')).sort(
 		</style>
 	</head>
 	<body>
-		<Header />
+		<Header title={SITE_TITLE} />
 		<main>
 			<section>
 				<ul>


### PR DESCRIPTION
## Changes

Use 'title' prop instead of importing constant in Header Component.

## Testing

Tested manually, transparent change.

## Docs

no new docs needed.

