### PR TITLE
Remove invalid code block language tag in sitemap README

### DIFF
--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -91,7 +91,8 @@ After verifying that the sitemaps are built, you can add them to your site's `<h
 </head>
 ```
 
-```txt ins={4} title="public/robots.txt"
+<!-- prettier-ignore -->
+``` ins={4} title="public/robots.txt"
 User-agent: *
 Allow: /
 


### PR DESCRIPTION
## Changes

- Removes use of `txt` as a language tag in a code block, which is [not valid](https://github.com/shikijs/shiki/blob/main/docs/languages.md#all-languages) and causes error logging in docs.
- Had to use a `<!-- prettier-ignore -->` comment because otherwise Prettier tries to remove the whitespace between the opening backticks and the metadata docs uses for insertion highlighting and filename.
- No changeset because in non-docs contexts this change is essentially invisible.

## Testing

Docs-only, n/a.

## Docs

/cc @withastro/maintainers-docs for feedback!