### PR TITLE
fix: correct URL for entry points

### DIFF
--- a/.changeset/brave-waves-battle.md
+++ b/.changeset/brave-waves-battle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix the URL that belongs to `entryPoints` in the hook `astro:build:ssr`. The paths were created with the wrong output directory.

--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -35,9 +35,8 @@
     },
   });
   ```
-- [#7220](https://github.com/withastro/astro/pull/7220) [`459b5bd05`](https://github.com/withastro/astro/commit/459b5bd05f562238f7250520efe3cf0fa156bb45) Thanks [@ematipico](https://github.com/ematipico)! - Shipped a new SSR build configuration mode: `split`.
 
-  The Astro hook `astro:build:ssr` now receives a new option in their payload, called `entryPoints`.
+- [#7220](https://github.com/withastro/astro/pull/7220) [`459b5bd05`](https://github.com/withastro/astro/commit/459b5bd05f562238f7250520efe3cf0fa156bb45) Thanks [@ematipico](https://github.com/ematipico)! - The Astro hook `astro:build:ssr` now receives a new option in their payload, called `entryPoints`.
 
   `entryPoints` is defined as a `Map<RouteData, URL>`, where `RouteData` represents the information of a Astro route and `URL` is the path to the physical file emitted at the end of the build.
 

--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -35,6 +35,24 @@
     },
   });
   ```
+- [#7220](https://github.com/withastro/astro/pull/7220) [`459b5bd05`](https://github.com/withastro/astro/commit/459b5bd05f562238f7250520efe3cf0fa156bb45) Thanks [@ematipico](https://github.com/ematipico)! - Shipped a new SSR build configuration mode: `split`.
+
+  The Astro hook `astro:build:ssr` now receives a new option in their payload, called `entryPoints`.
+
+  `entryPoints` is defined as a `Map<RouteData, URL>`, where `RouteData` represents the information of a Astro route and `URL` is the path to the physical file emitted at the end of the build.
+
+  ```ts
+  export function integration(): AstroIntegration {
+      return {
+          name: "my-integration",
+          hooks: { 
+              "astro:build:ssr": ({ entryPoints }) => {
+                  // do something with `entryPoints`
+              }
+          }
+      }
+  } 
+  ```
 
 ### Patch Changes
 

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -111,21 +111,6 @@ export interface CLIFlags {
 	experimentalRedirects?: boolean;
 }
 
-export interface BuildConfig {
-	/**
-	 * @deprecated Use config.build.client instead.
-	 */
-	client: URL;
-	/**
-	 * @deprecated Use config.build.server instead.
-	 */
-	server: URL;
-	/**
-	 * @deprecated Use config.build.serverEntry instead.
-	 */
-	serverEntry: string;
-}
-
 /**
  * Astro global available in all contexts in .astro files
  *

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -133,8 +133,9 @@ export function chunkIsPage(
 export async function generatePages(opts: StaticBuildOptions, internals: BuildInternals) {
 	const timer = performance.now();
 	const ssr = isServerLikeOutput(opts.settings.config);
-	const serverEntry = opts.buildConfig.serverEntry;
-	const outFolder = ssr ? opts.buildConfig.server : getOutDirWithinCwd(opts.settings.config.outDir);
+	const outFolder = ssr
+		? opts.settings.config.build.server
+		: getOutDirWithinCwd(opts.settings.config.outDir);
 
 	if (ssr && !hasPrerenderedPages(internals)) return;
 
@@ -180,7 +181,6 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 
 	await runHookBuildGenerated({
 		config: opts.settings.config,
-		buildConfig: opts.buildConfig,
 		logging: opts.logging,
 	});
 

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -1,11 +1,5 @@
 import type { AstroTelemetry } from '@astrojs/telemetry';
-import type {
-	AstroConfig,
-	AstroSettings,
-	BuildConfig,
-	ManifestData,
-	RuntimeMode,
-} from '../../@types/astro';
+import type { AstroConfig, AstroSettings, ManifestData, RuntimeMode } from '../../@types/astro';
 
 import fs from 'fs';
 import * as colors from 'kleur/colors';
@@ -123,11 +117,6 @@ class AstroBuilder {
 
 	/** Run the build logic. build() is marked private because usage should go through ".run()" */
 	private async build({ viteConfig }: { viteConfig: vite.InlineConfig }) {
-		const buildConfig: BuildConfig = {
-			client: this.settings.config.build.client,
-			server: this.settings.config.build.server,
-			serverEntry: this.settings.config.build.serverEntry,
-		};
 		await runHookBuildStart({ config: this.settings.config, logging: this.logging });
 		this.validateConfig();
 
@@ -168,7 +157,6 @@ class AstroBuilder {
 			routeCache: this.routeCache,
 			teardownCompiler: this.teardownCompiler,
 			viteConfig,
-			buildConfig,
 		};
 
 		const { internals } = await viteBuild(opts);
@@ -188,7 +176,6 @@ class AstroBuilder {
 		// You're done! Time to clean up.
 		await runHookBuildDone({
 			config: this.settings.config,
-			buildConfig,
 			pages: pageNames,
 			routes: Object.values(allPages).map((pd) => pd.route),
 			logging: this.logging,

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -382,7 +382,7 @@ function storeEntryPoint(
 	const componentPath = getPathFromVirtualModulePageName(RESOLVED_SPLIT_MODULE_ID, moduleKey);
 	for (const [page, pageData] of Object.entries(options.allPages)) {
 		if (componentPath == page) {
-			const publicPath = fileURLToPath(options.settings.config.outDir);
+			const publicPath = fileURLToPath(options.settings.config.build.server);
 			internals.entryPoints.set(pageData.route, pathToFileURL(join(publicPath, fileName)));
 		}
 	}

--- a/packages/astro/src/core/build/types.ts
+++ b/packages/astro/src/core/build/types.ts
@@ -2,7 +2,6 @@ import type { default as vite, InlineConfig } from 'vite';
 import type {
 	AstroConfig,
 	AstroSettings,
-	BuildConfig,
 	ComponentInstance,
 	ManifestData,
 	MiddlewareHandler,
@@ -36,7 +35,6 @@ export type AllPagesData = Record<ComponentPath, PageBuildData>;
 export interface StaticBuildOptions {
 	allPages: AllPagesData;
 	settings: AstroSettings;
-	buildConfig: BuildConfig;
 	logging: LogOptions;
 	manifest: ManifestData;
 	mode: RuntimeMode;

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -7,7 +7,6 @@ import type {
 	AstroConfig,
 	AstroRenderer,
 	AstroSettings,
-	BuildConfig,
 	ContentEntryType,
 	DataEntryType,
 	HookParameters,
@@ -323,14 +322,12 @@ export async function runHookBuildSsr({
 
 export async function runHookBuildGenerated({
 	config,
-	buildConfig,
 	logging,
 }: {
 	config: AstroConfig;
-	buildConfig: BuildConfig;
 	logging: LogOptions;
 }) {
-	const dir = isServerLikeOutput(config) ? buildConfig.client : config.outDir;
+	const dir = isServerLikeOutput(config) ? config.build.client : config.outDir;
 
 	for (const integration of config.integrations) {
 		if (integration?.hooks?.['astro:build:generated']) {
@@ -345,18 +342,16 @@ export async function runHookBuildGenerated({
 
 export async function runHookBuildDone({
 	config,
-	buildConfig,
 	pages,
 	routes,
 	logging,
 }: {
 	config: AstroConfig;
-	buildConfig: BuildConfig;
 	pages: string[];
 	routes: RouteData[];
 	logging: LogOptions;
 }) {
-	const dir = isServerLikeOutput(config) ? buildConfig.client : config.outDir;
+	const dir = isServerLikeOutput(config) ? config.build.client : config.outDir;
 	await fs.promises.mkdir(dir, { recursive: true });
 
 	for (const integration of config.integrations) {

--- a/packages/astro/test/ssr-split-manifest.test.js
+++ b/packages/astro/test/ssr-split-manifest.test.js
@@ -41,7 +41,7 @@ describe('astro:ssr-manifest, split', () => {
 	it('should give access to entry points that exists on file system', async () => {
 		// number of the pages inside src/
 		expect(entryPoints.size).to.equal(4);
-		for (const fileUrl in entryPoints.values()) {
+		for (const fileUrl of entryPoints.values()) {
 			let filePath = fileURLToPath(fileUrl);
 			expect(existsSync(filePath)).to.be.true;
 		}


### PR DESCRIPTION
## Changes

There were two issues:
- the test case was using `for..in` instead of `for..of`, because of that, the test was running but the for loop wasn't executed. Fixing that showed the issue and it was failing;
- fixed the path of `entryPoints`, which now uses the correct `build.server` URL
- we forgot to document the introduction of `entryPoints` in a changeset; we can't create a new changeset now because the feature is already released. I changed `CHANGELOG.md`. Once accepted, I will change the text of https://github.com/withastro/astro/releases/tag/astro%402.7.0

## Testing

Fixed the current test case

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
