### PR TITLE
Update `setTimeout()` to `queueMicrotask()`

### DIFF
--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -149,10 +149,10 @@ export function bufferIterators<T>(iterators: AsyncIterable<T>[]): AsyncIterable
 	const eagerIterators = iterators.map((it) => new EagerAsyncIterableIterator(it));
 	// once the execution of the next for loop is suspended due to an async component,
 	// this timeout triggers and we start buffering the other iterators
-	setTimeout(() => {
+	queueMicrotask(() => {
 		// buffer all iterators that haven't started yet
 		eagerIterators.forEach((it) => !it.isStarted() && it.buffer());
-	}, 0);
+	});
 	return eagerIterators;
 }
 


### PR DESCRIPTION
## Changes

Replaces the instance of `setTimeout()` in the runtime to use `queueMicrotask()`, to resolve limitations on Cloudflare Workers.

Solves https://github.com/withastro/astro/issues/7460.

## Testing

No tests were added per https://github.com/withastro/astro/issues/7460#issuecomment-1606954052.

## Docs

No changes in documentation is required, no user-facing changes nor different behaviour is expected.
