### PR TITLE
fix: make `Picture` generate valid dev URLs

### DIFF
--- a/.changeset/few-ants-brake.md
+++ b/.changeset/few-ants-brake.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/image": patch
+---
+
+fix: make `Picture` generate valid dev URLs

--- a/packages/integrations/image/src/lib/get-picture.ts
+++ b/packages/integrations/image/src/lib/get-picture.ts
@@ -86,7 +86,6 @@ export async function getPicture(params: GetPictureParams): Promise<GetPictureRe
 				}
 
 				return `${img.src?.replaceAll(' ', encodeURI)} ${width}w`;
-				// return `${encodeURI(img.src ?? '')} ${width}w`;
 			})
 		);
 

--- a/packages/integrations/image/src/lib/get-picture.ts
+++ b/packages/integrations/image/src/lib/get-picture.ts
@@ -85,7 +85,8 @@ export async function getPicture(params: GetPictureParams): Promise<GetPictureRe
 					image = img;
 				}
 
-				return `${encodeURI(img.src ?? '')} ${width}w`;
+				return `${img.src?.replaceAll(' ', encodeURI)} ${width}w`;
+				// return `${encodeURI(img.src ?? '')} ${width}w`;
 			})
 		);
 

--- a/packages/integrations/image/test/picture-ssg.test.js
+++ b/packages/integrations/image/test/picture-ssg.test.js
@@ -195,6 +195,16 @@ describe('SSG pictures with subpath - dev', function () {
 			const src = image.attr('src');
 			const [route, params] = src.split('?');
 
+			for (const srcset of picture.children('source').map((_, source) => source.attribs['srcset'])) {
+				for (const pictureSrc of srcset.split(',')) {
+					const pictureParams = pictureSrc.split('?')[1];
+
+					const expected = new URLSearchParams(params).get('href');
+					const actual = new URLSearchParams(pictureParams).get('href').replace(/\s+\d+w$/, '');
+					expect(expected).to.equal(actual);
+				}
+			}
+
 			expect(route).to.equal(url);
 
 			const searchParams = new URLSearchParams(params);

--- a/packages/integrations/image/test/picture-ssr-build.test.js
+++ b/packages/integrations/image/test/picture-ssr-build.test.js
@@ -223,6 +223,16 @@ describe('SSR pictures with subpath - build', function () {
 			const src = image.attr('src');
 			const [route, params] = src.split('?');
 
+			for (const srcset of picture.children('source').map((_, source) => source.attribs['srcset'])) {
+				for (const pictureSrc of srcset.split(',')) {
+					const pictureParams = pictureSrc.split('?')[1];
+
+					const expected = new URLSearchParams(params).get('href');
+					const actual = new URLSearchParams(pictureParams).get('href').replace(/\s+\d+w$/, '');
+					expect(expected).to.equal(actual);
+				}
+			}
+
 			expect(route).to.equal(url);
 
 			const searchParams = new URLSearchParams(params);

--- a/packages/integrations/image/test/picture-ssr-dev.test.js
+++ b/packages/integrations/image/test/picture-ssr-dev.test.js
@@ -12,6 +12,7 @@ const toAstroImage = (relpath) =>
 describe('SSR pictures - dev', function () {
 	let fixture;
 	let devServer;
+	/** @type {import('cheerio').CheerioAPI} */
 	let $;
 
 	before(async () => {
@@ -126,6 +127,16 @@ describe('SSR pictures - dev', function () {
 
 			const src = image.attr('src');
 			const [route, params] = src.split('?');
+
+			for (const srcset of picture.children('source').map((_, source) => source.attribs['srcset'])) {
+				for (const pictureSrc of srcset.split(',')) {
+					const pictureParams = pictureSrc.split('?')[1];
+
+					const expected = new URLSearchParams(params).get('href');
+					const actual = new URLSearchParams(pictureParams).get('href').replace(/\s+\d+w$/, '');
+					expect(expected).to.equal(actual);
+				}
+			}
 
 			expect(route).to.equal(url);
 

--- a/packages/integrations/image/test/picture-ssr-dev.test.js
+++ b/packages/integrations/image/test/picture-ssr-dev.test.js
@@ -12,7 +12,6 @@ const toAstroImage = (relpath) =>
 describe('SSR pictures - dev', function () {
 	let fixture;
 	let devServer;
-	/** @type {import('cheerio').CheerioAPI} */
 	let $;
 
 	before(async () => {


### PR DESCRIPTION
## Changes

- Fixes #7481
  - `encodeURI`ing the whole `src` has unwanted side effects other than the original purpose.
  - Encoding only ` `(space characters) seems to be the only way to make sure there are no side effects.
  - See #7340 for the original/wanted change.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

- Added some assertions to the unit tests.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

- Fixed bug in `Picture` and `getPicture` that generates invalid dev URLs.
