### PR TITLE
Don’t post Discord congrats for auto-formatter commits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   congrats:
     name: congratsbot
-    if: ${{ github.repository_owner == 'withastro' }}
+    if: ${{ github.repository_owner == 'withastro' && github.event.head_commit.message != '[ci] format' }}
     uses: withastro/automation/.github/workflows/congratsbot.yml@main
     with:
       EMOJIS: '🎉,🎊,🧑‍🚀,🥳,🙌,🚀,👏,<:houston_golden:1068575433647456447>,<:astrocoin:894990669515489301>,<:astro_pride:1085944201587458169>'


### PR DESCRIPTION
## Changes

Adds a condition to the Discord congrats bot action to not post if the commit message matches the auto-formatter commit message of `[ci] format`.

Should help reduce some unnecessary noise:

<img width="842" alt="image" src="https://github.com/withastro/astro/assets/357379/5b602c95-38cb-4d60-aa77-df43ba0be05a">


## Testing

We do something like this in docs already.

## Docs

N/A.