### PR TITLE
Fix: `ts-expect-error` on astro runtime types

### DIFF
--- a/packages/integrations/markdoc/src/runtime.ts
+++ b/packages/integrations/markdoc/src/runtime.ts
@@ -6,6 +6,7 @@ import Markdoc, {
 	type RenderableTreeNode,
 } from '@markdoc/markdoc';
 import type { AstroInstance } from 'astro';
+// @ts-expect-error Cannot find module 'astro/runtime/server/index.js' or its corresponding type declarations.
 import { createComponent, renderComponent } from 'astro/runtime/server/index.js';
 import type { AstroMarkdocConfig } from './config.js';
 import { setupHeadingConfig } from './heading-ids.js';


### PR DESCRIPTION
## Changes

- This module is used by the Markdoc runtime and does not include bundled types (internal export). ts ignore!

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
