### PR TITLE
Use head repository name for docgen in smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
         run: cd smoke/docs && pnpm docgen && pnpm docgen:errors && pnpm docgen:integrations
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE_REPO: ${{ github.event.repository.full_name }}
+          SOURCE_REPO: ${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
           SOURCE_BRANCH: ${{ github.head_ref || github.ref_name }}
 
       - name: Test

--- a/packages/integrations/alpinejs/README.md
+++ b/packages/integrations/alpinejs/README.md
@@ -1,5 +1,7 @@
 # @astrojs/alpinejs
 
+<!-- TODO: Remove this comment (which will break MDX anyway -->
+
 This **[Astro integration][astro-integration]** adds [Alpine.js](https://alpinejs.dev/) to your project so that you can use Alpine.js anywhere on your page.
 
 - <strong>[Installation](#installation)</strong>

--- a/packages/integrations/alpinejs/README.md
+++ b/packages/integrations/alpinejs/README.md
@@ -1,7 +1,5 @@
 # @astrojs/alpinejs
 
-<!-- TODO: Remove this comment (which will break MDX anyway -->
-
 This **[Astro integration][astro-integration]** adds [Alpine.js](https://alpinejs.dev/) to your project so that you can use Alpine.js anywhere on your page.
 
 - <strong>[Installation](#installation)</strong>


### PR DESCRIPTION
## Changes

- Uses the head repository’s name as the source repository for documentation generation when running in a PR from a fork (hopefully 😅)
- Making this PR from a personal Astro fork to test this works — hopefully these changes also work for PRs not coming from a fork.

## Testing

Added a docs change, which successfully ran docgen to test and then reverted.

## Docs

CI bug fix, n/a.
