### PR TITLE
Added `readImageFile` helper in astro:assets

### DIFF
--- a/packages/astro/client-base.d.ts
+++ b/packages/astro/client-base.d.ts
@@ -52,6 +52,9 @@ declare module 'astro:assets' {
 		) => Promise<import('./dist/assets/types.js').GetImageResult>;
 		getConfiguredImageService: typeof import('./dist/assets/index.js').getConfiguredImageService;
 		Image: typeof import('./components/Image.astro').default;
+		readImageFile: (
+			src: import('./dist/assets/types.js').ImageMetadata
+		) => Promise<Buffer>;
 	};
 
 	type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
@@ -67,7 +70,7 @@ declare module 'astro:assets' {
 	export type RemoteImageProps = Simplify<
 		import('./dist/assets/types.js').RemoteImageProps<ImgAttributes>
 	>;
-	export const { getImage, getConfiguredImageService, Image }: AstroAssets;
+	export const { getImage, getConfiguredImageService, Image, readImageFile }: AstroAssets;
 }
 
 type MD = import('./dist/@types/astro').MarkdownInstance<Record<string, any>>;

--- a/packages/astro/src/assets/index.ts
+++ b/packages/astro/src/assets/index.ts
@@ -1,4 +1,4 @@
-export { getConfiguredImageService, getImage } from './internal.js';
+export { getConfiguredImageService, getImage, readImageFile } from './internal.js';
 export { baseService, isLocalService } from './services/service.js';
 export { type LocalImageProps, type RemoteImageProps } from './types.js';
 export { emitESMImage } from './utils/emitAsset.js';

--- a/packages/astro/src/assets/types.ts
+++ b/packages/astro/src/assets/types.ts
@@ -10,6 +10,7 @@ export type ImageOutputFormat = (typeof VALID_OUTPUT_FORMATS)[number] | (string 
 declare global {
 	// eslint-disable-next-line no-var
 	var astroAsset: {
+		emittedAssets?: Map<string, URL>;
 		imageService?: ImageService;
 		addStaticImage?: ((options: ImageTransform) => string) | undefined;
 		staticImages?: Map<string, { path: string; options: ImageTransform }>;

--- a/packages/astro/src/assets/utils/emitAsset.ts
+++ b/packages/astro/src/assets/utils/emitAsset.ts
@@ -32,6 +32,11 @@ export async function emitESMImage(
 		});
 
 		meta.src = `__ASTRO_ASSET_IMAGE__${handle}__`;
+
+		// Store magic string in map for later use
+		if (!globalThis.astroAsset) globalThis.astroAsset = {};
+		if (!globalThis.astroAsset.emittedAssets) globalThis.astroAsset.emittedAssets = new Map<string, URL>();
+		globalThis.astroAsset.emittedAssets.set(meta.src, url);
 	} else {
 		// Pass the original file information through query params so we don't have to load the file twice
 		url.searchParams.append('origWidth', meta.width.toString());
@@ -42,6 +47,14 @@ export async function emitESMImage(
 	}
 
 	return meta;
+}
+
+export function assetMagicStringToFileURL(magicString: string): URL | undefined {
+	if(!globalThis.astroAsset?.emittedAssets) {
+		return undefined;
+	}
+
+	return globalThis.astroAsset.emittedAssets.get(magicString);
 }
 
 function fileURLToNormalizedPath(filePath: URL): string {

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -21,6 +21,7 @@ import { emitESMImage } from './utils/emitAsset.js';
 import { imageMetadata } from './utils/metadata.js';
 import { getOrigQueryParams } from './utils/queryParams.js';
 import { hashTransform, propsToFilename } from './utils/transformToPath.js';
+import { isServerLikeOutput } from '../prerender/utils.js';
 
 const resolvedVirtualModuleId = '\0' + VIRTUAL_MODULE_ID;
 
@@ -88,11 +89,14 @@ export default function assets({
 				if (id === resolvedVirtualModuleId) {
 					return `
 					export { getConfiguredImageService, isLocalService } from "astro/assets";
-					import { getImage as getImageInternal } from "astro/assets";
+					import { getImage as getImageInternal, readImageFile as readImageFileInternal } from "astro/assets";
 					export { default as Image } from "astro/components/Image.astro";
 
 					export const imageServiceConfig = ${JSON.stringify(settings.config.image.service.config)};
 					export const getImage = async (options) => await getImageInternal(options, imageServiceConfig);
+
+					const serverRootURL = ${JSON.stringify(isServerLikeOutput(settings.config) ? settings.config.build.server : settings.config.outDir)};
+					export const readImageFile = async(src) => await readImageFileInternal(src, serverRootURL);
 				`;
 				}
 			},


### PR DESCRIPTION
## Changes

- Added `readImageFile(src: ImageMetadata)` helper in `astro:assets`. Returns a `Buffer` of the imported file when passed an `ImageMetadata`.
- Handles the following cases:
  - `readImageFile()` is called before client is generated, while magic strings (`__ASTRO_ASSET_IMAGE__[hash]__`) are still in use.
  - `readImageFile()` is called during building pages, after magic strings are replaced with the final relative urls (`/_astro/file.ext`).
  - `readImageFile()` is called using the dev server, while `.src` returns URLs in the format of `/@fs/<path>` (on Windows and POSIX)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
This change was tested in a private project of mine where I'm hitting all the use cases described above. I did not adjust any test fixtures to test if `readImageFile()` returns a proper buffer.

However, I could modify the `astro-assets` and `astro-assets-prefix` fixtures to add an attribute to the `img` derived from the content of the buffer (a hash, maybe?).

## Docs

The assets page document will need to be updated to add information about this new method; what use cases it can accomplish (generate small placeholder images on the fly using `plaiceholder`, or maybe reading EXIF information from the source images for a portfolio website).

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback! 
/cc @Princesseuh This is related to [our discussion on the official Discord](https://discord.com/channels/830184174198718474/1123600493848047670)

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
