### PR TITLE
Split support in the Vercel Serverless adapter

### DIFF
--- a/.changeset/tricky-snails-poke.md
+++ b/.changeset/tricky-snails-poke.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': minor
+---
+
+Split support in Serverless

--- a/.changeset/tricky-snails-poke.md
+++ b/.changeset/tricky-snails-poke.md
@@ -2,4 +2,20 @@
 '@astrojs/vercel': minor
 ---
 
-Split support in Serverless
+Split support in Vercel Serverless
+
+The Vercel adapter builds to a single function by default. Astro 2.7 added support for splitting your build into separate entry points per page. If you use this configuration the Vercel adapter will generate a separate function for each page. This can help reduce the size of each function so they are only bundling code used on that page.
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import vercel from '@astrojs/vercel/serverless';
+
+export default defineConfig({
+  output: 'server',
+  adapter: vercel(),
+  build: {
+    split: true
+  }
+});
+```

--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -215,6 +215,24 @@ export default defineConfig({
 });
 ```
 
+### Per-page functions
+
+The Vercel adapter builds to a single function by default. Astro 2.7 added support for splitting your build into separate entry points per page. If you use this configuration the Vercel adapter will generate a separate function for each page. This can help reduce the size of each function so they are only bundling code used on that page.
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import vercel from '@astrojs/vercel/serverless';
+
+export default defineConfig({
+  output: 'server',
+  adapter: vercel(),
+  build: {
+    split: true
+  }
+});
+```
+
 ### Vercel Middleware
 
 You can use Vercel middleware to intercept a request and redirect before sending a response. Vercel middleware can run for Edge, SSR, and Static deployments. You don't need to install `@vercel/edge` to write middleware, but you do need to install it to use features such as geolocation. For more information see [Vercel’s middleware documentation](https://vercel.com/docs/concepts/functions/edge-middleware).

--- a/packages/integrations/vercel/src/lib/fs.ts
+++ b/packages/integrations/vercel/src/lib/fs.ts
@@ -4,7 +4,7 @@ import nodePath from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 export async function writeJson<T>(path: PathLike, data: T) {
-	await fs.writeFile(path, JSON.stringify(data), { encoding: 'utf-8' });
+	await fs.writeFile(path, JSON.stringify(data, null, '\t'), { encoding: 'utf-8' });
 }
 
 export async function removeDir(dir: PathLike) {

--- a/packages/integrations/vercel/test/fixtures/basic/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/basic/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+import vercel from '@astrojs/vercel/serverless';
+
+export default defineConfig({
+	adapter: vercel()
+});

--- a/packages/integrations/vercel/test/fixtures/basic/package.json
+++ b/packages/integrations/vercel/test/fixtures/basic/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/astro-vercel-basic",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/vercel": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/vercel/test/fixtures/basic/src/pages/one.astro
+++ b/packages/integrations/vercel/test/fixtures/basic/src/pages/one.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>One</title>
+	</head>
+	<body>
+		<h1>One</h1>
+	</body>
+</html>

--- a/packages/integrations/vercel/test/fixtures/basic/src/pages/two.astro
+++ b/packages/integrations/vercel/test/fixtures/basic/src/pages/two.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>Two</title>
+	</head>
+	<body>
+		<h1>Two</h1>
+	</body>
+</html>

--- a/packages/integrations/vercel/test/split.test.js
+++ b/packages/integrations/vercel/test/split.test.js
@@ -16,7 +16,8 @@ describe('build: split', () => {
 		await fixture.build();
 	});
 
-	it('works', async () => {
-		console.log('hi')
+	it('creates separate functions for each page', async () => {
+		const files = await fixture.readdir('../.vercel/output/functions/')
+		expect(files.length).to.equal(2);
 	});
 });

--- a/packages/integrations/vercel/test/split.test.js
+++ b/packages/integrations/vercel/test/split.test.js
@@ -1,0 +1,22 @@
+import { loadFixture } from './test-utils.js';
+import { expect } from 'chai';
+
+describe('build: split', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/basic/',
+			output: 'server',
+			build: {
+				split: true,
+			}
+		});
+		await fixture.build();
+	});
+
+	it('works', async () => {
+		console.log('hi')
+	});
+});

--- a/packages/integrations/vercel/test/split.test.js
+++ b/packages/integrations/vercel/test/split.test.js
@@ -20,4 +20,10 @@ describe('build: split', () => {
 		const files = await fixture.readdir('../.vercel/output/functions/')
 		expect(files.length).to.equal(2);
 	});
+
+	it('creates the route definitions in the config.json', async () => {
+		const json = await fixture.readFile('../.vercel/output/config.json');
+		const config = JSON.parse(json);
+		expect(config.routes).to.have.a.lengthOf(3);
+	})
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4902,6 +4902,15 @@ importers:
         specifier: ^9.2.2
         version: 9.2.2
 
+  packages/integrations/vercel/test/fixtures/basic:
+    dependencies:
+      '@astrojs/vercel':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/vercel/test/fixtures/image:
     dependencies:
       '@astrojs/vercel':


### PR DESCRIPTION
## Changes

- This adds support for `build.split: true` in the Vercel adapter. Similar to cloudflare, a new function folder is created for each one.

## Testing

Manually testing.

## Docs

TBD