### PR TITLE
Make APIRoute generic like APIContext

### DIFF
--- a/.changeset/grumpy-readers-draw.md
+++ b/.changeset/grumpy-readers-draw.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Add `Prop` generic for `APIRoute` type

--- a/.changeset/grumpy-readers-draw.md
+++ b/.changeset/grumpy-readers-draw.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Add `Prop` generic for `APIRoute` type
+Add `Props` generic for `APIRoute` type

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1772,8 +1772,8 @@ export interface EndpointOutput {
 	encoding?: BufferEncoding;
 }
 
-export type APIRoute = (
-	context: APIContext
+export type APIRoute<Props extends Record<string, any> = Record<string, any>> = (
+	context: APIContext<Props>
 ) => EndpointOutput | Response | Promise<EndpointOutput | Response>;
 
 export interface EndpointHandler {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1765,8 +1765,6 @@ export interface APIContext<Props extends Record<string, any> = Record<string, a
 	locals: App.Locals;
 }
 
-export type Props = Record<string, unknown>;
-
 export interface EndpointOutput {
 	body: Body;
 	encoding?: BufferEncoding;
@@ -1779,6 +1777,8 @@ export type APIRoute<Props extends Record<string, any> = Record<string, any>> = 
 export interface EndpointHandler {
 	[method: string]: APIRoute | ((params: Params, request: Request) => EndpointOutput | Response);
 }
+
+export type Props = Record<string, unknown>;
 
 export interface AstroRenderer {
 	/** Name of the renderer. */

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1772,8 +1772,8 @@ export interface EndpointOutput {
 	encoding?: BufferEncoding;
 }
 
-export type APIRoute<Props extends Record<string, any> = Record<string, any>> = (
-	context: APIContext<Props>
+export type APIRoute<RouteProps extends Props = Props> = (
+	context: APIContext<RouteProps>
 ) => EndpointOutput | Response | Promise<EndpointOutput | Response>;
 
 export interface EndpointHandler {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1772,8 +1772,8 @@ export interface EndpointOutput {
 	encoding?: BufferEncoding;
 }
 
-export type APIRoute<RouteProps extends Props = Props> = (
-	context: APIContext<RouteProps>
+export type APIRoute<Props extends Record<string, any> = Record<string, any>> = (
+	context: APIContext<Props>
 ) => EndpointOutput | Response | Promise<EndpointOutput | Response>;
 
 export interface EndpointHandler {


### PR DESCRIPTION
## Changes

`APIContext` is generic so that `props` can be typed, but `APIRoute`, which composes `APIContext`, is not likewise generic. This PR changes that.

## Testing

No tests, just a backwards-compatible change to a type.

## Docs

No docs added, it was intuitive to me to expect `APIRoute` to be generic and I was rather surprised that it wasn't already.
