### PR TITLE
feat: connect vercel edge middleware to astro

### DIFF
--- a/.changeset/brown-shrimps-hug.md
+++ b/.changeset/brown-shrimps-hug.md
@@ -1,0 +1,11 @@
+---
+'astro': minor
+---
+
+Astro now exposes a utility called `trySerializeLocals` via `astro/middleware` module.
+
+This utility can be used by adapters to validate their `locals` before being sent 
+to the Astro middleware.
+
+This function will throw a runtime error if the value passed is not serializable, so
+consumers will need to handle that error.

--- a/.changeset/good-pigs-fetch.md
+++ b/.changeset/good-pigs-fetch.md
@@ -2,4 +2,5 @@
 '@astrojs/vercel': minor
 ---
 
+We are almost there (funny text to kick off the preview release)
 

--- a/packages/astro/src/core/middleware/index.ts
+++ b/packages/astro/src/core/middleware/index.ts
@@ -32,5 +32,76 @@ function createContext({ request, params }: CreateContext) {
 	});
 }
 
+/**
+ * Checks whether the passed `value` is serializable.
+ *
+ * A serializable value contains plain values. For example, `Proxy`, `Set`, `Map`, functions, etc.
+ * are not accepted because they can't be serialized.
+ */
+function isLocalsSerializable(value: unknown): boolean {
+	let type = typeof value;
+	let plainObject = true;
+	if (type === 'object' && isPlainObject(value)) {
+		for (const [, nestedValue] of Object.entries(value)) {
+			if (!isLocalsSerializable(nestedValue)) {
+				plainObject = false;
+				break;
+			}
+		}
+	} else {
+		plainObject = false;
+	}
+	let result =
+		value === null ||
+		type === 'string' ||
+		type === 'number' ||
+		type === 'boolean' ||
+		Array.isArray(value) ||
+		plainObject;
+
+	return result;
+}
+
+/**
+ *
+ * From [redux-toolkit](https://github.com/reduxjs/redux-toolkit/blob/master/packages/toolkit/src/isPlainObject.ts)
+ *
+ * Returns true if the passed value is "plain" object, i.e. an object whose
+ * prototype is the root `Object.prototype`. This includes objects created
+ * using object literals, but not for instance for class instances.
+ */
+function isPlainObject(value: unknown): value is object {
+	if (typeof value !== 'object' || value === null) return false;
+
+	let proto = Object.getPrototypeOf(value);
+	if (proto === null) return true;
+
+	let baseProto = proto;
+	while (Object.getPrototypeOf(baseProto) !== null) {
+		baseProto = Object.getPrototypeOf(baseProto);
+	}
+
+	return proto === baseProto;
+}
+
+/**
+ * It attempts to serialize `value` and return it as a string.
+ *
+ * ## Errors
+ *  If the `value` is not serializable if the function will throw a runtime error.
+ *
+ * Something is **not serializable** when it contains properties/values like functions, `Map`, `Set`, `Date`,
+ * and other types that can't be made a string.
+ *
+ * @param value
+ */
+function trySerializeLocals(value: unknown) {
+	if (isLocalsSerializable(value)) {
+		return JSON.stringify(value);
+	} else {
+		throw new Error("The passed value can't be serialized.");
+	}
+}
+
 // NOTE: this export must export only the functions that will be exposed to user-land as officials APIs
-export { sequence, defineMiddleware, createContext };
+export { sequence, defineMiddleware, createContext, trySerializeLocals };

--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -208,9 +208,9 @@ export default defineConfig({
 });
 ```
 
-### Vercel Middleware
+### Vercel Edge Middleware
 
-You can use Vercel middleware to intercept a request and redirect before sending a response. Vercel middleware can run for Edge, SSR, and Static deployments. You don't need to install `@vercel/edge` to write middleware, but you do need to install it to use features such as geolocation. For more information see [Vercel’s middleware documentation](https://vercel.com/docs/concepts/functions/edge-middleware).
+You can use Vercel edge middleware to intercept a request and redirect before sending a response. Vercel middleware can run for Edge, SSR, and Static deployments. You don't need to install `@vercel/edge` to write middleware, but you do need to install it to use features such as geolocation. For more information see [Vercel’s middleware documentation](https://vercel.com/docs/concepts/functions/edge-middleware).
 
 1. Add a `middleware.js` file to the root of your project:
 

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@types/set-cookie-parser": "^2.4.2",
+    "@vercel/edge": "^0.3.4",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "chai": "^4.3.7",

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -67,6 +67,7 @@
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "chai": "^4.3.7",
+    "chai-jest-snapshot": "^2.0.0",
     "cheerio": "1.0.0-rc.12",
     "mocha": "^9.2.2",
     "rollup": "^3.20.1"

--- a/packages/integrations/vercel/src/lib/nft.ts
+++ b/packages/integrations/vercel/src/lib/nft.ts
@@ -1,4 +1,3 @@
-import { nodeFileTrace } from '@vercel/nft';
 import { relative as relativePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { copyFilesToFunction } from './fs.js';

--- a/packages/integrations/vercel/src/lib/nft.ts
+++ b/packages/integrations/vercel/src/lib/nft.ts
@@ -1,7 +1,6 @@
 import { nodeFileTrace } from '@vercel/nft';
 import { relative as relativePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
-
 import { copyFilesToFunction } from './fs.js';
 
 export async function copyDependenciesToFunction({
@@ -23,6 +22,7 @@ export async function copyDependenciesToFunction({
 		base = new URL('../', base);
 	}
 
+	const { nodeFileTrace } = await import('@vercel/nft');
 	const result = await nodeFileTrace([entryPath], {
 		base: fileURLToPath(base),
 	});

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -14,8 +14,12 @@ import { copyDependenciesToFunction } from '../lib/nft.js';
 import { getRedirects } from '../lib/redirects.js';
 import { generateEdgeMiddleware } from './middleware.js';
 import { fileURLToPath } from 'node:url';
+// import type { VercelRequest } from '@vercel/node';
 
 const PACKAGE_NAME = '@astrojs/vercel/serverless';
+export const ASTRO_LOCALS_HEADER = 'x-astro-locals';
+
+export type CreateLocals = ({ request }: { request: Request }) => object;
 
 function getAdapter(): AstroAdapter {
 	return {
@@ -31,6 +35,7 @@ export interface VercelServerlessConfig {
 	analytics?: boolean;
 	imageService?: boolean;
 	imagesConfig?: VercelImageConfig;
+	createLocals?: CreateLocals;
 }
 
 export default function vercelServerless({
@@ -39,6 +44,7 @@ export default function vercelServerless({
 	analytics,
 	imageService,
 	imagesConfig,
+	createLocals,
 }: VercelServerlessConfig = {}): AstroIntegration {
 	let _config: AstroConfig;
 	let buildTempFolder: URL;
@@ -88,7 +94,11 @@ export default function vercelServerless({
 			'astro:build:ssr': async ({ middlewareEntryPoint }) => {
 				if (middlewareEntryPoint) {
 					const outPath = fileURLToPath(buildTempFolder);
-					const bundledMiddlewarePath = await generateEdgeMiddleware(middlewareEntryPoint, outPath);
+					const bundledMiddlewarePath = await generateEdgeMiddleware(
+						middlewareEntryPoint,
+						outPath,
+						createLocals
+					);
 					// let's tell the adapter that we need to save this file
 					filesToInclude.push(bundledMiddlewarePath);
 				}

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -18,6 +18,7 @@ import type { RequestContext } from '@vercel/edge';
 
 const PACKAGE_NAME = '@astrojs/vercel/serverless';
 export const ASTRO_LOCALS_HEADER = 'x-astro-locals';
+export const VERCEL_EDGE_MIDDLEWARE_FILE = 'vercel-edge-middleware';
 
 export type CreateLocals = ({
 	request,
@@ -100,10 +101,14 @@ export default function vercelServerless({
 			'astro:build:ssr': async ({ middlewareEntryPoint }) => {
 				if (middlewareEntryPoint) {
 					const outPath = fileURLToPath(buildTempFolder);
+					const vercelEdgeMiddlewareHandlerPath = new URL(
+						VERCEL_EDGE_MIDDLEWARE_FILE,
+						_config.srcDir
+					);
 					const bundledMiddlewarePath = await generateEdgeMiddleware(
 						middlewareEntryPoint,
 						outPath,
-						createLocals
+						vercelEdgeMiddlewareHandlerPath
 					);
 					// let's tell the adapter that we need to save this file
 					filesToInclude.push(bundledMiddlewarePath);

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -14,12 +14,18 @@ import { copyDependenciesToFunction } from '../lib/nft.js';
 import { getRedirects } from '../lib/redirects.js';
 import { generateEdgeMiddleware } from './middleware.js';
 import { fileURLToPath } from 'node:url';
-// import type { VercelRequest } from '@vercel/node';
+import type { RequestContext } from '@vercel/edge';
 
 const PACKAGE_NAME = '@astrojs/vercel/serverless';
 export const ASTRO_LOCALS_HEADER = 'x-astro-locals';
 
-export type CreateLocals = ({ request }: { request: Request }) => object;
+export type CreateLocals = ({
+	request,
+	context,
+}: {
+	request: Request;
+	context: RequestContext;
+}) => object;
 
 function getAdapter(): AstroAdapter {
 	return {

--- a/packages/integrations/vercel/src/serverless/entrypoint.ts
+++ b/packages/integrations/vercel/src/serverless/entrypoint.ts
@@ -4,6 +4,7 @@ import { App } from 'astro/app';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import { getRequest, setResponse } from './request-transform';
+import { ASTRO_LOCALS_HEADER } from './adapter';
 
 polyfill(globalThis, {
 	exclude: 'window document',
@@ -28,7 +29,14 @@ export const createExports = (manifest: SSRManifest) => {
 			return res.end('Not found');
 		}
 
-		await setResponse(app, res, await app.render(request, routeData));
+		let locals = {};
+		if (request.headers.has(ASTRO_LOCALS_HEADER)) {
+			let localsAsString = request.headers.get(ASTRO_LOCALS_HEADER);
+			if (localsAsString) {
+				locals = JSON.parse(localsAsString);
+			}
+		}
+		await setResponse(app, res, await app.render(request, routeData, locals));
 	};
 
 	return { default: handler };

--- a/packages/integrations/vercel/src/serverless/middleware.ts
+++ b/packages/integrations/vercel/src/serverless/middleware.ts
@@ -1,5 +1,4 @@
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import esbuild from 'esbuild';
 import { join } from 'node:path';
 import { ASTRO_LOCALS_HEADER, type CreateLocals } from './adapter.js';
 
@@ -25,6 +24,7 @@ export async function generateEdgeMiddleware(
 	const code = edgeMiddlewareTemplate(entryPointPathURLAsString, saveLocals);
 	// https://vercel.com/docs/concepts/functions/edge-middleware#create-edge-middleware
 	const bundledFilePath = join(outPath, 'middleware.mjs');
+	const esbuild = await import('esbuild');
 	await esbuild.build({
 		stdin: {
 			contents: code,

--- a/packages/integrations/vercel/src/serverless/middleware.ts
+++ b/packages/integrations/vercel/src/serverless/middleware.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import esbuild from 'esbuild';
 import { join } from 'node:path';
-import { writeFile } from '../lib/fs.js';
+import { ASTRO_LOCALS_HEADER, type CreateLocals } from './adapter.js';
 
 /**
  * It generates the Vercel Edge Middleware file.
@@ -16,12 +16,13 @@ import { writeFile } from '../lib/fs.js';
  */
 export async function generateEdgeMiddleware(
 	astroMiddlewareEntryPointPath: URL,
-	outPath: string
+	outPath: string,
+	saveLocals?: CreateLocals
 ): Promise<URL> {
 	const entryPointPathURLAsString = JSON.stringify(
 		fileURLToPath(astroMiddlewareEntryPointPath).replace(/\\/g, '/')
 	);
-	const code = edgeMiddlewareTemplate(entryPointPathURLAsString);
+	const code = edgeMiddlewareTemplate(entryPointPathURLAsString, saveLocals);
 	// https://vercel.com/docs/concepts/functions/edge-middleware#create-edge-middleware
 	const bundledFilePath = join(outPath, 'middleware.mjs');
 	await esbuild.build({
@@ -34,7 +35,6 @@ export async function generateEdgeMiddleware(
 		// https://runtime-keys.proposal.wintercg.org/#edge-light
 		conditions: ['edge-light', 'worker', 'browser'],
 		external: ['astro/middleware'],
-		// entryPoints: [middlewareEdgePath],
 		outfile: bundledFilePath,
 		allowOverwrite: true,
 		format: 'esm',
@@ -44,18 +44,26 @@ export async function generateEdgeMiddleware(
 	return pathToFileURL(bundledFilePath);
 }
 
-function edgeMiddlewareTemplate(middlewarePath: string) {
+function edgeMiddlewareTemplate(middlewarePath: string, createLocals?: CreateLocals) {
+	const localsFn = createLocals ? `(${createLocals})({request})` : '(() => {})({request})';
 	return `
 import { onRequest } from ${middlewarePath};
-import { createAPIContext } from 'astro/middleware';
-export default function middleware(request) {
+import { createContext, trySerializeLocals } from 'astro/middleware';
+export default async function middleware(request) {
 	const url = new URL(request.url);
-	const next = async () => {
-		const response = await fetch(url);
+	const ctx = createContext({ 
+		request,
+		params: {}
+	});
+	const next = async () => {	
+		ctx.locals = ${localsFn};
+		const response = await fetch(url, {
+			headers: {
+				${JSON.stringify(ASTRO_LOCALS_HEADER)}: trySerializeLocals(ctx.locals)
+			}
+		});
 		return response;
 	};
-
-	const ctx = createAPIContext(request);
 
 	return onRequest(ctx, next);
 }`;

--- a/packages/integrations/vercel/src/serverless/middleware.ts
+++ b/packages/integrations/vercel/src/serverless/middleware.ts
@@ -45,11 +45,13 @@ export async function generateEdgeMiddleware(
 }
 
 function edgeMiddlewareTemplate(middlewarePath: string, createLocals?: CreateLocals) {
-	const localsFn = createLocals ? `(${createLocals})({request})` : '(() => {})({request})';
+	const localsFn = createLocals
+		? `(${createLocals})({ request, context })`
+		: '(() => undefined)({ request, context })';
 	return `
 import { onRequest } from ${middlewarePath};
 import { createContext, trySerializeLocals } from 'astro/middleware';
-export default async function middleware(request) {
+export default async function middleware(request, context) {
 	const url = new URL(request.url);
 	const ctx = createContext({ 
 		request,

--- a/packages/integrations/vercel/test/edge-middleware.test.js
+++ b/packages/integrations/vercel/test/edge-middleware.test.js
@@ -1,11 +1,19 @@
 import { loadFixture } from './test-utils.js';
-import { expect } from 'chai';
+import { expect, use } from 'chai';
+import chaiJestSnapshot from 'chai-jest-snapshot';
+
+use(chaiJestSnapshot);
 
 describe('Serverless prerender', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
 
+	beforeEach(function () {
+		chaiJestSnapshot.configureUsingMochaContext(this);
+	});
+
 	before(async () => {
+		chaiJestSnapshot.resetSnapshotRegistry();
 		fixture = await loadFixture({
 			root: './fixtures/middleware/',
 			build: {
@@ -16,11 +24,10 @@ describe('Serverless prerender', () => {
 
 	it('build successfully the middleware edge file', async () => {
 		await fixture.build();
-		expect(
-			await fixture.readFile(
-				// this is abysmal...
-				'../.vercel/output/functions/render.func/packages/integrations/vercel/test/fixtures/middleware/dist/middleware.mjs'
-			)
-		).to.be.ok;
-	});
+		const contents = await fixture.readFile(
+			// this is abysmal...
+			'../.vercel/output/functions/render.func/packages/integrations/vercel/test/fixtures/middleware/dist/middleware.mjs'
+		);
+		expect(contents).to.matchSnapshot();
+	}).timeout(5000);
 });

--- a/packages/integrations/vercel/test/edge-middleware.test.js
+++ b/packages/integrations/vercel/test/edge-middleware.test.js
@@ -16,9 +16,6 @@ describe('Serverless prerender', () => {
 		chaiJestSnapshot.resetSnapshotRegistry();
 		fixture = await loadFixture({
 			root: './fixtures/middleware/',
-			build: {
-				excludeMiddleware: true,
-			},
 		});
 	});
 

--- a/packages/integrations/vercel/test/edge-middleware.test.js
+++ b/packages/integrations/vercel/test/edge-middleware.test.js
@@ -29,5 +29,5 @@ describe('Serverless prerender', () => {
 			'../.vercel/output/functions/render.func/packages/integrations/vercel/test/fixtures/middleware/dist/middleware.mjs'
 		);
 		expect(contents).to.matchSnapshot();
-	}).timeout(5000);
+	});
 });

--- a/packages/integrations/vercel/test/edge-middleware.test.js.snap
+++ b/packages/integrations/vercel/test/edge-middleware.test.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Serverless prerender build successfully the middleware edge file 1`] = `
+"// test/fixtures/middleware/dist/middleware2.mjs
+var onRequest = async (context, next) => {
+  const response = await next();
+  return response;
+};
+
+// <stdin>
+import { createContext, trySerializeLocals } from \\"astro/middleware\\";
+async function middleware(request) {
+  const url = new URL(request.url);
+  const ctx = createContext({
+    request,
+    params: {}
+  });
+  const next = async () => {
+    ctx.locals = (({ request: request2 }) => {
+      console.log(request2);
+      return {
+        \\"foo\\": \\"bar\\"
+      };
+    })({ request });
+    const response = await fetch(url, {
+      headers: {
+        \\"x-astro-locals\\": trySerializeLocals(ctx.locals)
+      }
+    });
+    return response;
+  };
+  return onRequest(ctx, next);
+}
+export {
+  middleware as default
+};
+"
+`;

--- a/packages/integrations/vercel/test/edge-middleware.test.js.snap
+++ b/packages/integrations/vercel/test/edge-middleware.test.js.snap
@@ -1,7 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Serverless prerender build successfully the middleware edge file 1`] = `
-"// test/fixtures/middleware/dist/middleware2.mjs
+"// test/fixtures/middleware/src/vercel-edge-middleware.js
+function vercel_edge_middleware_default({ request, context }) {
+  return {
+    title: \\"Hello world\\"
+  };
+}
+
+// test/fixtures/middleware/dist/middleware2.mjs
 var onRequest = async (context, next) => {
   const response = await next();
   return response;
@@ -15,13 +22,8 @@ async function middleware(request, context) {
     request,
     params: {}
   });
+  ctx.locals = vercel_edge_middleware_default({ request, context });
   const next = async () => {
-    ctx.locals = (({ request: request2 }) => {
-      console.log(request2);
-      return {
-        \\"foo\\": \\"bar\\"
-      };
-    })({ request, context });
     const response = await fetch(url, {
       headers: {
         \\"x-astro-locals\\": trySerializeLocals(ctx.locals)

--- a/packages/integrations/vercel/test/edge-middleware.test.js.snap
+++ b/packages/integrations/vercel/test/edge-middleware.test.js.snap
@@ -9,7 +9,7 @@ var onRequest = async (context, next) => {
 
 // <stdin>
 import { createContext, trySerializeLocals } from \\"astro/middleware\\";
-async function middleware(request) {
+async function middleware(request, context) {
   const url = new URL(request.url);
   const ctx = createContext({
     request,
@@ -21,7 +21,7 @@ async function middleware(request) {
       return {
         \\"foo\\": \\"bar\\"
       };
-    })({ request });
+    })({ request, context });
     const response = await fetch(url, {
       headers: {
         \\"x-astro-locals\\": trySerializeLocals(ctx.locals)

--- a/packages/integrations/vercel/test/fixtures/middleware/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/middleware/astro.config.mjs
@@ -2,6 +2,12 @@ import {defineConfig} from "astro/config";
 import vercel from "@astrojs/vercel/serverless";
 
 export default defineConfig({
-    adapter: vercel(),
+    adapter: vercel({
+        createLocals: ({request}) => {
+            console.log(request);
+            return {
+                "foo": "bar"
+            }
+        }}),
     output: 'server'
 });

--- a/packages/integrations/vercel/test/fixtures/middleware/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/middleware/astro.config.mjs
@@ -9,5 +9,8 @@ export default defineConfig({
                 "foo": "bar"
             }
         }}),
+    build: {
+        excludeMiddleware: true
+    },
     output: 'server'
 });

--- a/packages/integrations/vercel/test/fixtures/middleware/src/vercel-edge-middleware.js
+++ b/packages/integrations/vercel/test/fixtures/middleware/src/vercel-edge-middleware.js
@@ -1,0 +1,5 @@
+export default function ({ request, context }) {
+	return {
+		title: 'Hello world',
+	};
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4889,6 +4889,9 @@ importers:
       '@types/set-cookie-parser':
         specifier: ^2.4.2
         version: 2.4.2
+      '@vercel/edge':
+        specifier: ^0.3.4
+        version: 0.3.4
       astro:
         specifier: workspace:*
         version: link:../../astro
@@ -9013,6 +9016,10 @@ packages:
       react:
         optional: true
     dev: false
+
+  /@vercel/edge@0.3.4:
+    resolution: {integrity: sha512-dFU+yAUDQRwpuRGxRDlEO1LMq0y1LGsBgkyryQWe4w15/Fy2/lCnpvdIoAhHl3QvIGAxCLHzwRHsqfLRdpxgJQ==}
+    dev: true
 
   /@vercel/nft@0.22.6:
     resolution: {integrity: sha512-gTsFnnT4mGxodr4AUlW3/urY+8JKKB452LwF3m477RFUJTAaDmcz2JqFuInzvdybYIeyIv1sSONEJxsxnbQ5JQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4898,6 +4898,9 @@ importers:
       chai:
         specifier: ^4.3.7
         version: 4.3.7
+      chai-jest-snapshot:
+        specifier: ^2.0.0
+        version: 2.0.0(chai@4.3.7)
       cheerio:
         specifier: 1.0.0-rc.12
         version: 1.0.0-rc.12
@@ -9351,6 +9354,11 @@ packages:
       type-fest: 1.4.0
     dev: false
 
+  /ansi-regex@3.0.1:
+    resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==}
+    engines: {node: '>=4'}
+    dev: true
+
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -9876,6 +9884,16 @@ packages:
     dependencies:
       chai: 4.3.7
       check-error: 1.0.2
+    dev: true
+
+  /chai-jest-snapshot@2.0.0(chai@4.3.7):
+    resolution: {integrity: sha512-u8jZZjw/0G1t5A8wDfH6K7DAVfMg3g0dsw9wKQURNUyrZX96VojHNrFMmLirq1m0kOvC5icgL/Qh/fu1MZyvUw==}
+    peerDependencies:
+      chai: '>=1.9.0'
+    dependencies:
+      chai: 4.3.7
+      jest-snapshot: 21.2.1
+      lodash.values: 4.3.0
     dev: true
 
   /chai-xml@0.4.1(chai@4.3.7):
@@ -10583,6 +10601,11 @@ packages:
 
   /didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  /diff@3.5.0:
+    resolution: {integrity: sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==}
+    engines: {node: '>=0.3.1'}
+    dev: true
 
   /diff@5.0.0:
     resolution: {integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==}
@@ -12824,6 +12847,38 @@ packages:
       minimatch: 3.1.2
     dev: false
 
+  /jest-diff@21.2.1:
+    resolution: {integrity: sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==}
+    dependencies:
+      chalk: 2.4.2
+      diff: 3.5.0
+      jest-get-type: 21.2.0
+      pretty-format: 21.2.1
+    dev: true
+
+  /jest-get-type@21.2.0:
+    resolution: {integrity: sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==}
+    dev: true
+
+  /jest-matcher-utils@21.2.1:
+    resolution: {integrity: sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==}
+    dependencies:
+      chalk: 2.4.2
+      jest-get-type: 21.2.0
+      pretty-format: 21.2.1
+    dev: true
+
+  /jest-snapshot@21.2.1:
+    resolution: {integrity: sha512-bpaeBnDpdqaRTzN8tWg0DqOTo2DvD3StOemxn67CUd1p1Po+BUpvePAp44jdJ7Pxcjfg+42o4NHw1SxdCA2rvg==}
+    dependencies:
+      chalk: 2.4.2
+      jest-diff: 21.2.1
+      jest-matcher-utils: 21.2.1
+      mkdirp: 0.5.6
+      natural-compare: 1.4.0
+      pretty-format: 21.2.1
+    dev: true
+
   /jest-worker@26.6.2:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
@@ -13119,6 +13174,10 @@ packages:
 
   /lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+    dev: true
+
+  /lodash.values@4.3.0:
+    resolution: {integrity: sha512-r0RwvdCv8id9TUblb/O7rYPwVy6lerCbcawrfdo9iC/1t1wsNMJknO79WNBgwkH0hIeJ08jmvvESbFpNb4jH0Q==}
     dev: true
 
   /lodash@4.17.21:
@@ -14003,6 +14062,13 @@ packages:
 
   /mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  /mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.8
+    dev: true
 
   /mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
@@ -15197,6 +15263,13 @@ packages:
     resolution: {integrity: sha512-Rk753HI8f4uivXi4ZCIYdhmG1V+WKzvRMg/X+M42a6t7D07RcmopXJMDNk6N++7Bl75URRGsb40ruvg7Hcp2wQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
     dev: false
+
+  /pretty-format@21.2.1:
+    resolution: {integrity: sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==}
+    dependencies:
+      ansi-regex: 3.0.1
+      ansi-styles: 3.2.1
+    dev: true
 
   /pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}


### PR DESCRIPTION
## Changes

This PR connects the Vercel Edge Middleware to the Astro middleware:
- created a new API called `trySerializeLocals` to serialise the `locals`. This is important because these `locals` will travel via headers, and we need to keep them when they are transferred from the vercel middleware to the Astro middleware;
- ~created a new API inside the `@astrojs/vercel` adapter, this API is called `createLocals` and allows users to initialize their `locals` with anything they want. The function accepts an object that contains `request` and `context`. You can check [Vercel documentation](https://vercel.com/docs/concepts/functions/edge-middleware/middleware-api#edge-middleware-signature);~ As per @bluwy suggestion, the new API is actually a new key file called `vercel-edge-middleware`, it receives an object with `request` and `context` and `esbuild` will bundle the file.
- updated the adapter to pass `locals` to `app.render`. These `locals` are extracted from the headers of the request;

## Testing

I plan to create a preview release, create a new project and deploy it on Vercel.

Also, I added a snapshot test for the generated middleware. The reason is that it's very difficult to see how's the code generated, especially for reviewers. Please let me know how do feel about it; I am happy to remove it.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A Later when I know the APIs are stable and settled among the team members.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
