### PR TITLE
Fallback to default `npm` registry if config command fails

### DIFF
--- a/.changeset/fair-trees-jump.md
+++ b/.changeset/fair-trees-jump.md
@@ -1,0 +1,6 @@
+---
+'create-astro': patch
+'astro': patch
+---
+
+Default registry logic to fallback to NPM if registry command fails (sorry, Bun users!)

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -79,8 +79,12 @@ const OFFICIAL_ADAPTER_TO_IMPORT_MAP: Record<string, string> = {
 // A copy of this function also exists in the create-astro package
 async function getRegistry(): Promise<string> {
 	const packageManager = (await preferredPM(process.cwd()))?.name || 'npm';
-	const { stdout } = await execa(packageManager, ['config', 'get', 'registry']);
-	return stdout || 'https://registry.npmjs.org';
+	try {
+		const { stdout } = await execa(packageManager, ['config', 'get', 'registry']);
+		return stdout || 'https://registry.npmjs.org';
+	} catch (e) {
+		return 'https://registry.npmjs.org';
+	}
 }
 
 export default async function add(names: string[], { cwd, flags, logging, telemetry }: AddOptions) {

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -13,8 +13,12 @@ import detectPackageManager from 'which-pm-runs';
 // A copy of this function also exists in the astro package
 async function getRegistry(): Promise<string> {
 	const packageManager = detectPackageManager()?.name || 'npm';
-	const { stdout } = await execa(packageManager, ['config', 'get', 'registry']);
-	return stdout || 'https://registry.npmjs.org';
+	try {
+		const { stdout } = await execa(packageManager, ['config', 'get', 'registry']);
+		return stdout || 'https://registry.npmjs.org';
+	} catch (e) {
+		return 'https://registry.npmjs.org';
+	}
 }
 
 let stdout = process.stdout;


### PR DESCRIPTION
## Changes

- Resolves #7471.
- Falls back `create-astro` and `astro add` registry commands to default NPM registry
- Fixes issues for Bun users 👍🏻 

## Testing

Tested manually, we don't have Bun in CI

## Docs

N/A, bug fix only