### PR TITLE
Remove unused getParamsAndProps call

### DIFF
--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -157,17 +157,6 @@ export async function handleRoute(
 		if (value) res.setHeader(name, value);
 	}
 
-	// attempt to get static paths
-	// if this fails, we have a bad URL match!
-	const paramsAndPropsRes = await getParamsAndProps({
-		mod,
-		route,
-		routeCache: env.routeCache,
-		pathname: pathname,
-		logging,
-		ssr: isServerLikeOutput(config),
-	});
-
 	const options: SSROptions = {
 		env,
 		filePath,


### PR DESCRIPTION
## Changes

Remove unused code since #4087

In that PR, it's moving the call of `getParamsAndProps` from `handleRoute` to `matchRoute`, which is now here: 

https://github.com/withastro/astro/blob/bca45bebe62e07fd7187e18f4982a3f28910093f/packages/astro/src/vite-plugin-astro-server/route.ts#L51-L60

`matchRoute` is already called before `handleRoute` at here:

https://github.com/withastro/astro/blob/bca45bebe62e07fd7187e18f4982a3f28910093f/packages/astro/src/vite-plugin-astro-server/request.ts#L68-L70

https://github.com/withastro/astro/blob/bca45bebe62e07fd7187e18f4982a3f28910093f/packages/astro/src/vite-plugin-astro-server/route.ts#L178-L179

So the second `getParamsAndProps` call isn't needed and it's removed in this PR.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing test should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a.