### PR TITLE
Fix multiple `create-astro` registry issues

### DIFF
--- a/.changeset/old-seahorses-fold.md
+++ b/.changeset/old-seahorses-fold.md
@@ -3,4 +3,4 @@
 'create-astro': patch
 ---
 
-Update registry logic to handle registry URLs ending with '/'
+Update registry logic, improving edge cases (redirects, UTF-8 sequences, registries ending with '/')

--- a/.changeset/old-seahorses-fold.md
+++ b/.changeset/old-seahorses-fold.md
@@ -2,4 +2,4 @@
 'create-astro': patch
 ---
 
-fix: getVersion Error when registry ends with '/'
+Update registry logic to handle registry URLs ending with '/'

--- a/.changeset/old-seahorses-fold.md
+++ b/.changeset/old-seahorses-fold.md
@@ -1,4 +1,5 @@
 ---
+'astro': patch
 'create-astro': patch
 ---
 

--- a/.changeset/old-seahorses-fold.md
+++ b/.changeset/old-seahorses-fold.md
@@ -1,0 +1,5 @@
+---
+'create-astro': major
+---
+
+fix: getVersion Error when registry ends with '/'

--- a/.changeset/old-seahorses-fold.md
+++ b/.changeset/old-seahorses-fold.md
@@ -1,5 +1,5 @@
 ---
-'create-astro': major
+'create-astro': patch
 ---
 
 fix: getVersion Error when registry ends with '/'

--- a/.changeset/old-seahorses-fold.md
+++ b/.changeset/old-seahorses-fold.md
@@ -3,4 +3,4 @@
 'create-astro': patch
 ---
 
-Update registry logic, improving edge cases (redirects, UTF-8 sequences, registries ending with '/')
+Update registry logic, improving edge cases (http support, redirects, registries ending with '/')

--- a/packages/astro/src/core/add/index.ts
+++ b/packages/astro/src/core/add/index.ts
@@ -79,7 +79,7 @@ async function getRegistry(): Promise<string> {
 	const packageManager = (await preferredPM(process.cwd()))?.name || 'npm';
 	try {
 		const { stdout } = await execa(packageManager, ['config', 'get', 'registry']);
-		return stdout || 'https://registry.npmjs.org';
+		return stdout?.trim()?.replace(/\/$/, '') || 'https://registry.npmjs.org';
 	} catch (e) {
 		return 'https://registry.npmjs.org';
 	}

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -36,6 +36,7 @@
     "execa": "^6.1.0",
     "giget": "1.0.0",
     "mocha": "^9.2.2",
+    "node-fetch-native": "^1.2.0",
     "which-pm-runs": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -81,7 +81,11 @@ let v: string;
 export const getVersion = () =>
 	new Promise<string>(async (resolve) => {
 		if (v) return resolve(v);
-		const registry = await getRegistry();
+		let registry = await getRegistry();
+		// if the registry ends with '/', trim it.
+		if (registry.lastIndexOf('/') === registry.length - 1) {
+			registry = registry.substring(0, registry.length - 1);
+		}
 		get(`${registry}/astro/latest`, (res) => {
 			let body = '';
 			res.on('data', (chunk) => (body += chunk));

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -15,7 +15,7 @@ async function getRegistry(): Promise<string> {
 	const packageManager = detectPackageManager()?.name || 'npm';
 	try {
 		const { stdout } = await execa(packageManager, ['config', 'get', 'registry']);
-		return stdout || 'https://registry.npmjs.org';
+		return stdout?.trim()?.replace(/\/$/, '') || 'https://registry.npmjs.org';
 	} catch (e) {
 		return 'https://registry.npmjs.org';
 	}
@@ -82,10 +82,6 @@ export const getVersion = () =>
 	new Promise<string>(async (resolve) => {
 		if (v) return resolve(v);
 		let registry = await getRegistry();
-		// if the registry ends with '/', trim it.
-		if (registry.lastIndexOf('/') === registry.length - 1) {
-			registry = registry.substring(0, registry.length - 1);
-		}
 		get(`${registry}/astro/latest`, (res) => {
 			let body = '';
 			res.on('data', (chunk) => (body += chunk));

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -3,7 +3,7 @@ import { color, label, say as houston, spinner as load } from '@astrojs/cli-kit'
 import { align, sleep } from '@astrojs/cli-kit/utils';
 import { execa } from 'execa';
 import { exec } from 'node:child_process';
-import { get } from 'node:https';
+import fetch from 'node-fetch-native';
 import stripAnsi from 'strip-ansi';
 import detectPackageManager from 'which-pm-runs';
 
@@ -82,15 +82,9 @@ export const getVersion = () =>
 	new Promise<string>(async (resolve) => {
 		if (v) return resolve(v);
 		let registry = await getRegistry();
-		get(`${registry}/astro/latest`, (res) => {
-			let body = '';
-			res.on('data', (chunk) => (body += chunk));
-			res.on('end', () => {
-				const { version } = JSON.parse(body);
-				v = version;
-				resolve(version);
-			});
-		});
+		const { version } = await fetch(`${registry}/astro/latest`, { redirect: 'follow' }).then(res => res.json());
+		v = version;
+		resolve(version);
 	});
 
 export const log = (message: string) => stdout.write(message + '\n');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3574,6 +3574,9 @@ importers:
       mocha:
         specifier: ^9.2.2
         version: 9.2.2
+      node-fetch-native:
+        specifier: ^1.2.0
+        version: 1.2.0
       which-pm-runs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -11921,7 +11924,7 @@ packages:
       defu: 6.1.2
       https-proxy-agent: 5.0.1
       mri: 1.2.0
-      node-fetch-native: 1.1.1
+      node-fetch-native: 1.2.0
       pathe: 1.1.0
       tar: 6.1.14
     transitivePeerDependencies:
@@ -14162,8 +14165,8 @@ packages:
     engines: {node: '>=10.5.0'}
     dev: false
 
-  /node-fetch-native@1.1.1:
-    resolution: {integrity: sha512-9VvspTSUp2Sxbl+9vbZTlFGq9lHwE8GDVVekxx6YsNd1YH59sb3Ba8v3Y3cD8PkLNcileGGcA21PFjVl0jzDaw==}
+  /node-fetch-native@1.2.0:
+    resolution: {integrity: sha512-5IAMBTl9p6PaAjYCnMv5FmqIF6GcZnawAVnzaCG0rX2aYZJ4CxEkZNtVPuTRug7fL7wyM5BQYTlAzcyMPi6oTQ==}
     dev: false
 
   /node-fetch@2.6.11:


### PR DESCRIPTION
## Changes

- Fixes #7480 (supports http), fixes #7362 (follows redirects + handles trailing `/`)
- In the method "getVersion", before sending request, if the registry ends with "/", trim it.
When I use the registry "https://registry.npmmirror.com/", create-astro will be failed because the request of "getVersion" gets  the 404 error and the error is not be caught.
![create-astro-error](https://github.com/withastro/astro/assets/32624612/0f077c35-b79d-4464-88ec-a9a497118c4e)


## Testing

I add the code and link the local package to global by using ``` pnpm link -g ```, and then I run ```create-astro``` again. I am successfully into creating app.
![image](https://github.com/withastro/astro/assets/32624612/ddeb4b06-1d60-4f3a-8227-f6cc8034ca97)
 

## Docs

Bug fixes only