### PR TITLE
Fix incorrect format from organize-imports-cli

### DIFF
--- a/packages/integrations/sitemap/src/config-defaults.ts
+++ b/packages/integrations/sitemap/src/config-defaults.ts
@@ -1,3 +1,6 @@
+// organize-imports-ignore there's a bug where it strips out this import
+import type { SitemapOptions } from './index.js';
+
 export const SITEMAP_CONFIG_DEFAULTS = {
 	entryLimit: 45000,
 } satisfies SitemapOptions;


### PR DESCRIPTION
## Changes

CI is currently failing because `organize-imports-cli` is incorrectly stripping out the import in this file for some reason.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Ran `pnpm format:ci` locally

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a