### PR TITLE
Fix CI lint command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,27 +53,8 @@ jobs:
       - name: Build (ignoring failures)
         run: pnpm run build || true
 
-      # Lint autofix cannot run on forks, so just skip those! See https://github.com/wearerequired/lint-action/issues/13
-      - name: Lint (External)
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != github.repository_owner }}
-        run: pnpm run lint
-
-      # Otherwise, run lint autofixer
       - name: Lint
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}
-        uses: wearerequired/lint-action@v2.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          eslint: true
-          eslint_extensions: js,ts,cts,mts,cjs,mjs
-          prettier: false
-          auto_fix: false
-          git_name: fredkbot
-          git_email: fred+astrobot@astro.build
-          commit_message: "chore(lint): ${linter} fix"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          neutral_check_on_warning: true
+        run: pnpm run lint
 
       # Checks that the formatter runs successfully on all files
       # In the future, we may have this fail PRs on unformatted code


### PR DESCRIPTION
## Changes

The CI lint workflow is failing. I think it's because of the recent eslint change (#7425), the third-party action doesn't handle well with the breaking changes.

Anyways the third-party action doesn't seem to be needed since we had disable `auto_fix`, and the auto commit feature never really ran. Instead we can run our own `pnpm run lint` command to have the same & simpler effect.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
The lint CI should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a