### PR TITLE
fix(astrojs/cloudflare): SSR split file renaming misses ts endpoints

### DIFF
--- a/.changeset/shiny-parrots-clap.md
+++ b/.changeset/shiny-parrots-clap.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+fix bug where asset redirects caused Cloudflare error

--- a/.changeset/sweet-bats-clap.md
+++ b/.changeset/sweet-bats-clap.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+fix bug where `.ts` files are not renamed to `.js

--- a/.changeset/sweet-bats-clap.md
+++ b/.changeset/sweet-bats-clap.md
@@ -2,4 +2,4 @@
 '@astrojs/cloudflare': patch
 ---
 
-fix bug where `.ts` files are not renamed to `.js
+fix bug where `.ts` files are not renamed to `.js`

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -133,12 +133,14 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						})
 					)
 
+					console.log(outputFiles)
+
 					// loop through all new bundled files and write them to the functions folder
 					for (const outputFile of outputFiles) {
 
 						// split the path into an array
 						const path = outputFile.split('/');
-
+						console.log(path)
 						// replace dynamic path with [path]
 						const pathWithDynamics = path.map((segment) => segment.replace(/(\_)(\w+)(\_)/g, (_, __, prop) => {
 							return `[${prop}]`;
@@ -166,7 +168,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 
 						const oldFileUrl = new URL(`$astro/${outputFile}`, outputUrl);
 						const newFileUrl = new URL(finalPath, functionsUrl);
-
+						console.log(oldFileUrl, newFileUrl)
 						await fs.promises.rename(oldFileUrl, newFileUrl);
 					}
 				} else {

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -3,6 +3,7 @@ import type { AstroAdapter, AstroConfig, AstroIntegration, RouteData } from 'ast
 import esbuild from 'esbuild';
 import * as fs from 'fs';
 import * as os from 'os';
+import { sep } from 'path';
 import glob from 'tiny-glob';
 import { fileURLToPath, pathToFileURL } from 'url';
 
@@ -133,14 +134,12 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						})
 					)
 
-					console.log(outputFiles)
-
 					// loop through all new bundled files and write them to the functions folder
 					for (const outputFile of outputFiles) {
 
 						// split the path into an array
-						const path = outputFile.split('/');
-						console.log(path)
+						const path = outputFile.split(sep);
+
 						// replace dynamic path with [path]
 						const pathWithDynamics = path.map((segment) => segment.replace(/(\_)(\w+)(\_)/g, (_, __, prop) => {
 							return `[${prop}]`;
@@ -168,7 +167,6 @@ export default function createIntegration(args?: Options): AstroIntegration {
 
 						const oldFileUrl = new URL(`$astro/${outputFile}`, outputUrl);
 						const newFileUrl = new URL(finalPath, functionsUrl);
-						console.log(oldFileUrl, newFileUrl)
 						await fs.promises.rename(oldFileUrl, newFileUrl);
 					}
 				} else {

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -3,7 +3,6 @@ import type { AstroAdapter, AstroConfig, AstroIntegration, RouteData } from 'ast
 import esbuild from 'esbuild';
 import * as fs from 'fs';
 import * as os from 'os';
-import { dirname } from 'path';
 import glob from 'tiny-glob';
 import { fileURLToPath, pathToFileURL } from 'url';
 
@@ -141,12 +140,12 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						const path = outputFile.split('/');
 
 						// replace dynamic path with [path]
-						const pathWithDynamics = path.map((segment) => segment.replace(/(\_)(\w+)(\_)/g, (_, __, prop, ___) => {
+						const pathWithDynamics = path.map((segment) => segment.replace(/(\_)(\w+)(\_)/g, (_, __, prop) => {
 							return `[${prop}]`;
 						}));
 
 						// replace nested dynamic path with [[path]]
-						const pathWithNestedDynamics = pathWithDynamics.map((segment) => segment.replace(/(\_\-\-\-)(\w+)(\_)/g, (_, __, prop, ___) => {
+						const pathWithNestedDynamics = pathWithDynamics.map((segment) => segment.replace(/(\_\-\-\-)(\w+)(\_)/g, (_, __, prop) => {
 							return `[[${prop}]]`;
 						}))
 

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -107,10 +107,10 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					const entryPointsRouteData = [..._entryPoints.keys()];
 					const entryPointsURL = [..._entryPoints.values()];
 					const entryPaths = entryPointsURL.map((entry) => fileURLToPath(entry));
-					const outputDir = fileURLToPath(new URL('.astro', _buildConfig.server));
+					const outputUrl = new URL('$astro', _buildConfig.server)
+					const outputDir = fileURLToPath(outputUrl);
 
-					// NOTE: AFAIK, esbuild keeps the order of the entryPoints array
-					const { outputFiles } = await esbuild.build({
+					await esbuild.build({
 						target: 'es2020',
 						platform: 'browser',
 						conditions: ['workerd', 'worker', 'browser'],
@@ -126,29 +126,52 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						logOverride: {
 							'ignored-bare-import': 'silent',
 						},
-						write: false,
 					});
 
-					// loop through all bundled files and write them to the functions folder
-					for (const [index, outputFile] of outputFiles.entries()) {
-						// we need to make sure the filename in the functions folder
-						// matches to cloudflares routing capabilities (see their docs)
-						// IN: src/pages/[language]/files/[...path].astro
-						// OUT: [language]/files/[[path]].js
-						const fileName = entryPointsRouteData[index].component
-							.replace('src/pages/', '')
-							.replace('.astro', '.js')
-							.replace('.ts', '.js')
-							.replace(/(\[\.\.\.)(\w+)(\])/g, (_match, _p1, p2, _p3) => {
-								return `[[${p2}]]`;
-							});
+					const outputFiles: Array<string> = (
+						await glob(`**/*`, {
+							cwd: outputDir,
+							filesOnly: true,
+						})
+					)
 
-						const fileUrl = new URL(fileName, functionsUrl);
-						const newFileDir = dirname(fileURLToPath(fileUrl));
-						if (!fs.existsSync(newFileDir)) {
-							fs.mkdirSync(newFileDir, { recursive: true });
-						}
-						await fs.promises.writeFile(fileUrl, outputFile.contents);
+					console.log(outputFiles)
+
+					// loop through all new bundled files and write them to the functions folder
+					for (const outputFile of outputFiles) {
+
+						// split the path into an array
+						const path = outputFile.split('/');
+
+						// replace dynamic path with [path]
+						const pathWithDynamics = path.map((segment) => segment.replace(/(\_)(\w+)(\_)/g, (_, __, prop, ___) => {
+							return `[${prop}]`;
+						}));
+
+						// replace nested dynamic path with [[path]]
+						const pathWithNestedDynamics = pathWithDynamics.map((segment) => segment.replace(/(\_\-\-\-)(\w+)(\_)/g, (_, __, prop, ___) => {
+							return `[[${prop}]]`;
+						}))
+
+						// remove original file extension
+						const pathReversed = pathWithNestedDynamics.reverse();
+						pathReversed[0] = pathReversed[0]
+							.replace('entry.', '')
+							.replace(/(.*)\.(\w+)\.(\w+)$/g, (_, fileName, oldExt, newExt) => {
+								return `${fileName}.${newExt}`;
+							})
+
+						const finalSegments = pathReversed.reverse();
+						const finalDirPath = finalSegments.slice(0, -1).join('/');
+						const finalPath = finalSegments.join('/');
+
+						const newDirUrl = new URL(finalDirPath, functionsUrl);
+						await fs.promises.mkdir(newDirUrl, { recursive: true })
+
+						const oldFileUrl = new URL(`$astro/${outputFile}`, outputUrl);
+						const newFileUrl = new URL(finalPath, functionsUrl);
+
+						await fs.promises.rename(oldFileUrl, newFileUrl);
 					}
 				} else {
 					const entryPath = fileURLToPath(new URL(_buildConfig.serverEntry, _buildConfig.server));

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -205,8 +205,8 @@ export default function createIntegration(args?: Options): AstroIntegration {
 				}
 
 				// // // throw the server folder in the bin
-				// const serverUrl = new URL(_buildConfig.server);
-				// await fs.promises.rm(serverUrl, { recursive: true, force: true });
+				const serverUrl = new URL(_buildConfig.server);
+				await fs.promises.rm(serverUrl, { recursive: true, force: true });
 
 				// move cloudflare specific files to the root
 				const cloudflareSpecialFiles = ['_headers', '_redirects', '_routes.json'];

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -104,7 +104,6 @@ export default function createIntegration(args?: Options): AstroIntegration {
 				}
 
 				if (isModeDirectory && _buildConfig.split) {
-					const entryPointsRouteData = [..._entryPoints.keys()];
 					const entryPointsURL = [..._entryPoints.values()];
 					const entryPaths = entryPointsURL.map((entry) => fileURLToPath(entry));
 					const outputUrl = new URL('$astro', _buildConfig.server)
@@ -134,8 +133,6 @@ export default function createIntegration(args?: Options): AstroIntegration {
 							filesOnly: true,
 						})
 					)
-
-					console.log(outputFiles)
 
 					// loop through all new bundled files and write them to the functions folder
 					for (const outputFile of outputFiles) {

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -21,15 +21,15 @@ interface BuildConfig {
 export function getAdapter(isModeDirectory: boolean): AstroAdapter {
 	return isModeDirectory
 		? {
-				name: '@astrojs/cloudflare',
-				serverEntrypoint: '@astrojs/cloudflare/server.directory.js',
-				exports: ['onRequest', 'manifest'],
-		  }
+			name: '@astrojs/cloudflare',
+			serverEntrypoint: '@astrojs/cloudflare/server.directory.js',
+			exports: ['onRequest', 'manifest'],
+		}
 		: {
-				name: '@astrojs/cloudflare',
-				serverEntrypoint: '@astrojs/cloudflare/server.advanced.js',
-				exports: ['default'],
-		  };
+			name: '@astrojs/cloudflare',
+			serverEntrypoint: '@astrojs/cloudflare/server.advanced.js',
+			exports: ['default'],
+		};
 }
 
 const SHIM = `globalThis.process = {
@@ -138,7 +138,8 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						const fileName = entryPointsRouteData[index].component
 							.replace('src/pages/', '')
 							.replace('.astro', '.js')
-							.replace(/(\[\.\.\.)(\w+)(\])/g, (_match, _p1, p2) => {
+							.replace('.ts', '.js')
+							.replace(/(\[\.\.\.)(\w+)(\])/g, (_match, _p1, p2, _p3) => {
 								return `[[${p2}]]`;
 							});
 
@@ -184,8 +185,8 @@ export default function createIntegration(args?: Options): AstroIntegration {
 				}
 
 				// // // throw the server folder in the bin
-				const serverUrl = new URL(_buildConfig.server);
-				await fs.promises.rm(serverUrl, { recursive: true, force: true });
+				// const serverUrl = new URL(_buildConfig.server);
+				// await fs.promises.rm(serverUrl, { recursive: true, force: true });
 
 				// move cloudflare specific files to the root
 				const cloudflareSpecialFiles = ['_headers', '_redirects', '_routes.json'];

--- a/packages/integrations/cloudflare/src/server.directory.ts
+++ b/packages/integrations/cloudflare/src/server.directory.ts
@@ -24,7 +24,13 @@ export function createExports(manifest: SSRManifest) {
 		const { pathname } = new URL(request.url);
 		// static assets fallback, in case default _routes.json is not used
 		if (manifest.assets.has(pathname)) {
-			return next(request);
+			// we need this so the page does not error
+			// https://developers.cloudflare.com/pages/platform/functions/advanced-mode/#set-up-a-function
+			return (runtimeEnv.env as unknown & {
+				ASSETS: {
+					fetch: typeof fetch;
+				};
+			}).ASSETS.fetch(request);
 		}
 
 		let routeData = app.match(request, { matchNotFound: true });

--- a/packages/integrations/cloudflare/src/util.ts
+++ b/packages/integrations/cloudflare/src/util.ts
@@ -9,9 +9,9 @@ export function getProcessEnvProxy() {
 				console.warn(
 					// NOTE: \0 prevents Vite replacement
 					`Unable to access \`import.meta\0.env.${prop.toString()}\` on initialization ` +
-						`as the Cloudflare platform only provides the environment variables per request. ` +
-						`Please move the environment variable access inside a function ` +
-						`that's only called after a request has been received.`
+					`as the Cloudflare platform only provides the environment variables per request. ` +
+					`Please move the environment variable access inside a function ` +
+					`that's only called after a request has been received.`
 				);
 			},
 		}

--- a/packages/integrations/cloudflare/src/util.ts
+++ b/packages/integrations/cloudflare/src/util.ts
@@ -9,9 +9,9 @@ export function getProcessEnvProxy() {
 				console.warn(
 					// NOTE: \0 prevents Vite replacement
 					`Unable to access \`import.meta\0.env.${prop.toString()}\` on initialization ` +
-					`as the Cloudflare platform only provides the environment variables per request. ` +
-					`Please move the environment variable access inside a function ` +
-					`that's only called after a request has been received.`
+						`as the Cloudflare platform only provides the environment variables per request. ` +
+						`Please move the environment variable access inside a function ` +
+						`that's only called after a request has been received.`
 				);
 			},
 		}

--- a/packages/integrations/cloudflare/test/directory-split.test.js
+++ b/packages/integrations/cloudflare/test/directory-split.test.js
@@ -37,6 +37,8 @@ describe('Cloudflare SSR split', () => {
 		expect(await fixture.pathExists('../functions/files/[[path]].js')).to.be.true;
 		expect(await fixture.pathExists('../functions/[language]/files/[[path]].js')).to.be.true;
 		expect(await fixture.pathExists('../functions/trpc/[trpc].js')).to.be.true;
+		expect(await fixture.pathExists('../functions/javascript.js')).to.be.true;
+		expect(await fixture.pathExists('../functions/test.json.js')).to.be.true;
 	});
 
 	it('generates pre-rendered files', async () => {

--- a/packages/integrations/cloudflare/test/directory-split.test.js
+++ b/packages/integrations/cloudflare/test/directory-split.test.js
@@ -36,6 +36,7 @@ describe('Cloudflare SSR split', () => {
 		expect(await fixture.pathExists('../functions/[person]/[car].js')).to.be.true;
 		expect(await fixture.pathExists('../functions/files/[[path]].js')).to.be.true;
 		expect(await fixture.pathExists('../functions/[language]/files/[[path]].js')).to.be.true;
+		expect(await fixture.pathExists('../functions/trpc/[trpc].js')).to.be.true;
 	});
 
 	it('generates pre-rendered files', async () => {

--- a/packages/integrations/cloudflare/test/fixtures/split/src/pages/trpc/[trpc].ts
+++ b/packages/integrations/cloudflare/test/fixtures/split/src/pages/trpc/[trpc].ts
@@ -1,7 +1,0 @@
-export const prerender = false
-
-import type { APIRoute } from 'astro'
-
-export const all: APIRoute = (opts) => {
-	return ""
-}

--- a/packages/integrations/cloudflare/test/fixtures/split/src/pages/trpc/[trpc].ts
+++ b/packages/integrations/cloudflare/test/fixtures/split/src/pages/trpc/[trpc].ts
@@ -1,0 +1,7 @@
+export const prerender = false
+
+import type { APIRoute } from 'astro'
+
+export const all: APIRoute = (opts) => {
+	return ""
+}


### PR DESCRIPTION
## Changes

- fixed an bug, where `ts` endpoint files are not renamed to .js after bundle step
## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
- updated test suite
- manually

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
