### PR TITLE
Handle callGetStaticPaths TODO

### DIFF
--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -307,7 +307,8 @@ async function getPathsForRoute(
 		const route = pageData.route;
 		const result = await callGetStaticPaths({
 			mod,
-			route: pageData.route,
+			route,
+			routeCache: opts.routeCache,
 			isValidate: false,
 			logging: opts.logging,
 			ssr: isServerLikeOutput(opts.settings.config),
@@ -326,9 +327,6 @@ async function getPathsForRoute(
 				debug('build', `├── ${colors.bold(colors.red('✗'))} ${route.component}`);
 				throw err;
 			});
-
-		// Save the route cache so it doesn't get called again
-		opts.routeCache.set(route, result);
 
 		paths = result.staticPaths
 			.map((staticPath) => {

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -305,30 +305,27 @@ async function getPathsForRoute(
 		builtPaths.add(pageData.route.pathname);
 	} else {
 		const route = pageData.route;
-		const result = await callGetStaticPaths({
+		const staticPaths = await callGetStaticPaths({
 			mod,
 			route,
 			routeCache: opts.routeCache,
 			isValidate: false,
 			logging: opts.logging,
 			ssr: isServerLikeOutput(opts.settings.config),
-		})
-			.then((_result) => {
-				const label = _result.staticPaths.length === 1 ? 'page' : 'pages';
-				debug(
-					'build',
-					`├── ${colors.bold(colors.green('✔'))} ${route.component} → ${colors.magenta(
-						`[${_result.staticPaths.length} ${label}]`
-					)}`
-				);
-				return _result;
-			})
-			.catch((err) => {
-				debug('build', `├── ${colors.bold(colors.red('✗'))} ${route.component}`);
-				throw err;
-			});
+		}).catch((err) => {
+			debug('build', `├── ${colors.bold(colors.red('✗'))} ${route.component}`);
+			throw err;
+		});
 
-		paths = result.staticPaths
+		const label = staticPaths.length === 1 ? 'page' : 'pages';
+		debug(
+			'build',
+			`├── ${colors.bold(colors.green('✔'))} ${route.component} → ${colors.magenta(
+				`[${staticPaths.length} ${label}]`
+			)}`
+		);
+
+		paths = staticPaths
 			.map((staticPath) => {
 				try {
 					return route.generate(staticPath.params);

--- a/packages/astro/src/core/render/params-and-props.ts
+++ b/packages/astro/src/core/render/params-and-props.ts
@@ -29,7 +29,7 @@ export async function getParamsAndProps(opts: GetParamsAndPropsOptions): Promise
 
 	// During build, the route cache should already be populated.
 	// During development, the route cache is filled on-demand and may be empty.
-	const routeCacheEntry = await callGetStaticPaths({
+	const staticPaths = await callGetStaticPaths({
 		mod,
 		route,
 		routeCache,
@@ -38,7 +38,7 @@ export async function getParamsAndProps(opts: GetParamsAndPropsOptions): Promise
 		ssr,
 	});
 
-	const matchedStaticPath = findPathItemByKey(routeCacheEntry.staticPaths, params, route);
+	const matchedStaticPath = findPathItemByKey(staticPaths, params, route);
 	if (!matchedStaticPath && (ssr ? route.prerender : true)) {
 		throw new AstroError({
 			...AstroErrorData.NoMatchingStaticPathFound,

--- a/packages/astro/src/core/render/params-and-props.ts
+++ b/packages/astro/src/core/render/params-and-props.ts
@@ -27,15 +27,16 @@ export async function getParamsAndProps(opts: GetParamsAndPropsOptions): Promise
 
 	validatePrerenderEndpointCollision(route, mod, params);
 
-	let routeCacheEntry = routeCache.get(route);
 	// During build, the route cache should already be populated.
 	// During development, the route cache is filled on-demand and may be empty.
-	// TODO(fks): Can we refactor getParamsAndProps() to receive routeCacheEntry
-	// as a prop, and not do a live lookup/populate inside this lower function call.
-	if (!routeCacheEntry) {
-		routeCacheEntry = await callGetStaticPaths({ mod, route, isValidate: true, logging, ssr });
-		routeCache.set(route, routeCacheEntry);
-	}
+	const routeCacheEntry = await callGetStaticPaths({
+		mod,
+		route,
+		routeCache,
+		isValidate: true,
+		logging,
+		ssr,
+	});
 
 	const matchedStaticPath = findPathItemByKey(routeCacheEntry.staticPaths, params, route);
 	if (!matchedStaticPath && (ssr ? route.prerender : true)) {

--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -30,15 +30,19 @@ export async function callGetStaticPaths({
 	isValidate,
 	logging,
 	ssr,
-}: CallGetStaticPathsOptions): Promise<RouteCacheEntry> {
+}: CallGetStaticPathsOptions): Promise<GetStaticPathsResultKeyed> {
 	const cached = routeCache.get(route);
-	if (cached) return cached;
+	if (cached?.staticPaths) return cached.staticPaths;
 
 	validateDynamicRouteModule(mod, { ssr, logging, route });
+
 	// No static paths in SSR mode. Return an empty RouteCacheEntry.
 	if (ssr && !route.prerender) {
-		return { staticPaths: Object.assign([], { keyed: new Map() }) };
+		const entry: GetStaticPathsResultKeyed = Object.assign([], { keyed: new Map() });
+		routeCache.set(route, { ...cached, staticPaths: entry });
+		return entry;
 	}
+
 	// Add a check here to make TypeScript happy.
 	// This is already checked in validateDynamicRouteModule().
 	if (!mod.getStaticPaths) {
@@ -71,12 +75,11 @@ export async function callGetStaticPaths({
 		keyedStaticPaths.keyed.set(paramsKey, sp);
 	}
 
-	const entry: RouteCacheEntry = { staticPaths: keyedStaticPaths };
-	routeCache.set(route, entry);
-	return entry;
+	routeCache.set(route, { ...cached, staticPaths: keyedStaticPaths });
+	return keyedStaticPaths;
 }
 
-export interface RouteCacheEntry {
+interface RouteCacheEntry {
 	staticPaths: GetStaticPathsResultKeyed;
 }
 
@@ -104,7 +107,7 @@ export class RouteCache {
 		// NOTE: This shouldn't be called on an already-cached component.
 		// Warn here so that an unexpected double-call of getStaticPaths()
 		// isn't invisible and developer can track down the issue.
-		if (this.mode === 'production' && this.cache[route.component]) {
+		if (this.mode === 'production' && this.cache[route.component]?.staticPaths) {
 			warn(
 				this.logging,
 				'routeCache',


### PR DESCRIPTION
## Changes

Handle a TODO for `callGetStaticPaths`. Let the function handle the caching itself instead of the consumers.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a