### PR TITLE
Move createBasicEnvironment as test-util

### DIFF
--- a/packages/astro/src/core/render/environment.ts
+++ b/packages/astro/src/core/render/environment.ts
@@ -1,8 +1,7 @@
 import type { MarkdownRenderingOptions } from '@astrojs/markdown-remark';
 import type { RuntimeMode, SSRLoadedRenderer } from '../../@types/astro';
-import { getDefaultClientDirectives } from '../client-directive/default.js';
 import type { LogOptions } from '../logger/core.js';
-import { RouteCache } from './route-cache.js';
+import type { RouteCache } from './route-cache.js';
 
 /**
  * An environment represents the static parts of rendering that do not change
@@ -41,28 +40,4 @@ export type CreateEnvironmentArgs = Environment;
 
 export function createEnvironment(options: CreateEnvironmentArgs): Environment {
 	return options;
-}
-
-export type CreateBasicEnvironmentArgs = Partial<Environment> & {
-	logging: CreateEnvironmentArgs['logging'];
-};
-
-/**
- * Only used in tests
- */
-export function createBasicEnvironment(options: CreateBasicEnvironmentArgs): Environment {
-	const mode = options.mode ?? 'development';
-	return createEnvironment({
-		...options,
-		markdown: {
-			...(options.markdown ?? {}),
-		},
-		mode,
-		renderers: options.renderers ?? [],
-		clientDirectives: getDefaultClientDirectives(),
-		resolve: options.resolve ?? ((s: string) => Promise.resolve(s)),
-		routeCache: new RouteCache(options.logging, mode),
-		ssr: options.ssr ?? true,
-		streaming: options.streaming ?? true,
-	});
 }

--- a/packages/astro/src/core/render/index.ts
+++ b/packages/astro/src/core/render/index.ts
@@ -2,6 +2,6 @@ export { createRenderContext } from './context.js';
 export type { RenderContext } from './context.js';
 export { renderPage } from './core.js';
 export type { Environment } from './environment';
-export { createBasicEnvironment, createEnvironment } from './environment.js';
+export { createEnvironment } from './environment.js';
 export { getParamsAndProps } from './params-and-props.js';
 export { loadRenderer, loadRenderers } from './renderer.js';

--- a/packages/astro/test/units/config/config-server.test.js
+++ b/packages/astro/test/units/config/config-server.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { fileURLToPath } from 'url';
-import { defaultLogging as logging } from '../../test-utils.js';
+import { defaultLogging } from '../test-utils.js';
 import { openConfig } from '../../../dist/core/config/index.js';
 
 const cwd = fileURLToPath(new URL('../../fixtures/config-host/', import.meta.url));
@@ -11,7 +11,7 @@ describe('config.server', () => {
 			cwd: flags.root || cwd,
 			flags,
 			cmd: 'dev',
-			logging,
+			logging: defaultLogging,
 		});
 	}
 

--- a/packages/astro/test/units/config/format.test.js
+++ b/packages/astro/test/units/config/format.test.js
@@ -2,8 +2,7 @@ import { expect } from 'chai';
 
 import { runInContainer } from '../../../dist/core/dev/index.js';
 import { openConfig, createSettings } from '../../../dist/core/config/index.js';
-import { createFs } from '../test-utils.js';
-import { defaultLogging } from '../../test-utils.js';
+import { createFs, defaultLogging } from '../test-utils.js';
 
 const root = new URL('../../fixtures/tailwindcss-ts/', import.meta.url);
 

--- a/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
+++ b/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
@@ -3,8 +3,7 @@ import { fileURLToPath } from 'url';
 import { validateConfig } from '../../../dist/core/config/config.js';
 import { createSettings } from '../../../dist/core/config/index.js';
 import { sync as _sync } from '../../../dist/core/sync/index.js';
-import { defaultLogging } from '../../test-utils.js';
-import { createFsWithFallback } from '../test-utils.js';
+import { createFsWithFallback, defaultLogging } from '../test-utils.js';
 
 const root = new URL('../../fixtures/content-mixed-errors/', import.meta.url);
 const logging = defaultLogging;

--- a/packages/astro/test/units/dev/collections-renderentry.test.js
+++ b/packages/astro/test/units/dev/collections-renderentry.test.js
@@ -1,15 +1,15 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
+import os from 'os';
 
 import { runInContainer } from '../../../dist/core/dev/index.js';
 import { createFsWithFallback, createRequestAndResponse } from '../test-utils.js';
-import { isWindows } from '../../test-utils.js';
 import mdx from '../../../../integrations/mdx/dist/index.js';
 import { attachContentServerListeners } from '../../../dist/content/server-listeners.js';
 
 const root = new URL('../../fixtures/content/', import.meta.url);
 
-const describe = isWindows ? global.describe.skip : global.describe;
+const describe = os.platform() === 'win32' ? global.describe.skip : global.describe;
 
 async function runInContainerWithContentListeners(params, callback) {
 	return await runInContainer(params, async (container) => {

--- a/packages/astro/test/units/dev/hydration.test.js
+++ b/packages/astro/test/units/dev/hydration.test.js
@@ -1,9 +1,8 @@
 import { expect } from 'chai';
 
 import { runInContainer } from '../../../dist/core/dev/index.js';
-import { createFs, createRequestAndResponse } from '../test-utils.js';
+import { createFs, createRequestAndResponse, silentLogging } from '../test-utils.js';
 import svelte from '../../../../integrations/svelte/dist/index.js';
-import { defaultLogging } from '../../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
@@ -33,11 +32,7 @@ describe('dev container', () => {
 			{
 				fs,
 				root,
-				logging: {
-					...defaultLogging,
-					// Error is expected in this test
-					level: 'silent',
-				},
+				logging: silentLogging,
 				userConfig: {
 					integrations: [svelte()],
 				},

--- a/packages/astro/test/units/dev/restart.test.js
+++ b/packages/astro/test/units/dev/restart.test.js
@@ -7,9 +7,13 @@ import {
 	isStarted,
 	startContainer,
 } from '../../../dist/core/dev/index.js';
-import { createFs, createRequestAndResponse, triggerFSEvent } from '../test-utils.js';
+import {
+	createFs,
+	createRequestAndResponse,
+	defaultLogging,
+	triggerFSEvent,
+} from '../test-utils.js';
 import { createSettings, openConfig } from '../../../dist/core/config/index.js';
-import { defaultLogging } from '../../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 

--- a/packages/astro/test/units/render/components.test.js
+++ b/packages/astro/test/units/render/components.test.js
@@ -2,9 +2,8 @@ import { expect } from 'chai';
 import * as cheerio from 'cheerio';
 
 import { runInContainer } from '../../../dist/core/dev/index.js';
-import { createFs, createRequestAndResponse } from '../test-utils.js';
+import { createFs, createRequestAndResponse, silentLogging } from '../test-utils.js';
 import svelte from '../../../../integrations/svelte/dist/index.js';
-import { defaultLogging } from '../../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
@@ -33,11 +32,7 @@ describe('core/render components', () => {
 			{
 				fs,
 				root,
-				logging: {
-					...defaultLogging,
-					// Error is expected in this test
-					level: 'silent',
-				},
+				logging: silentLogging,
 				userConfig: {
 					integrations: [svelte()],
 				},

--- a/packages/astro/test/units/render/head.test.js
+++ b/packages/astro/test/units/render/head.test.js
@@ -9,12 +9,9 @@ import {
 	renderHead,
 	Fragment,
 } from '../../../dist/runtime/server/index.js';
-import {
-	createBasicEnvironment,
-	createRenderContext,
-	renderPage,
-} from '../../../dist/core/render/index.js';
+import { createRenderContext, renderPage } from '../../../dist/core/render/index.js';
 import { defaultLogging as logging } from '../../test-utils.js';
+import { createBasicEnvironment } from '../test-utils.js';
 import * as cheerio from 'cheerio';
 
 const createAstroModule = (AstroComponent) => ({ default: AstroComponent });

--- a/packages/astro/test/units/render/head.test.js
+++ b/packages/astro/test/units/render/head.test.js
@@ -10,7 +10,6 @@ import {
 	Fragment,
 } from '../../../dist/runtime/server/index.js';
 import { createRenderContext, renderPage } from '../../../dist/core/render/index.js';
-import { defaultLogging as logging } from '../../test-utils.js';
 import { createBasicEnvironment } from '../test-utils.js';
 import * as cheerio from 'cheerio';
 
@@ -20,10 +19,7 @@ describe('core/render', () => {
 	describe('Injected head contents', () => {
 		let env;
 		before(async () => {
-			env = createBasicEnvironment({
-				logging,
-				renderers: [],
-			});
+			env = createBasicEnvironment();
 		});
 
 		it('Multi-level layouts and head injection, with explicit head', async () => {

--- a/packages/astro/test/units/render/jsx.test.js
+++ b/packages/astro/test/units/render/jsx.test.js
@@ -6,14 +6,8 @@ import {
 	renderSlot,
 } from '../../../dist/runtime/server/index.js';
 import { jsx } from '../../../dist/jsx-runtime/index.js';
-import {
-	createBasicEnvironment,
-	createRenderContext,
-	renderPage,
-	loadRenderer,
-} from '../../../dist/core/render/index.js';
+import { createRenderContext, renderPage, loadRenderer } from '../../../dist/core/render/index.js';
 import { createAstroJSXComponent, renderer as jsxRenderer } from '../../../dist/jsx/index.js';
-import { defaultLogging as logging } from '../../test-utils.js';
 import { createBasicEnvironment } from '../test-utils.js';
 
 const createAstroModule = (AstroComponent) => ({ default: AstroComponent });
@@ -24,7 +18,6 @@ describe('core/render', () => {
 		let env;
 		before(async () => {
 			env = createBasicEnvironment({
-				logging,
 				renderers: [await loadJSXRenderer()],
 			});
 		});

--- a/packages/astro/test/units/render/jsx.test.js
+++ b/packages/astro/test/units/render/jsx.test.js
@@ -14,6 +14,7 @@ import {
 } from '../../../dist/core/render/index.js';
 import { createAstroJSXComponent, renderer as jsxRenderer } from '../../../dist/jsx/index.js';
 import { defaultLogging as logging } from '../../test-utils.js';
+import { createBasicEnvironment } from '../test-utils.js';
 
 const createAstroModule = (AstroComponent) => ({ default: AstroComponent });
 const loadJSXRenderer = () => loadRenderer(jsxRenderer, { import: (s) => import(s) });

--- a/packages/astro/test/units/routing/route-matching.test.js
+++ b/packages/astro/test/units/routing/route-matching.test.js
@@ -1,8 +1,7 @@
 // @ts-check
-import { createFs, createRequestAndResponse } from '../test-utils.js';
+import { createFs, createRequestAndResponse, defaultLogging } from '../test-utils.js';
 import { createRouteManifest, matchAllRoutes } from '../../../dist/core/routing/index.js';
 import { fileURLToPath } from 'url';
-import { defaultLogging } from '../../test-utils.js';
 import { createViteLoader } from '../../../dist/core/module-loader/vite.js';
 import { createDevelopmentEnvironment } from '../../../dist/core/render/dev/environment.js';
 import { expect } from 'chai';

--- a/packages/astro/test/units/test-utils.js
+++ b/packages/astro/test/units/test-utils.js
@@ -5,6 +5,9 @@ import realFS from 'node:fs';
 import npath from 'path';
 import { fileURLToPath } from 'url';
 import { unixify } from './correct-path.js';
+import { getDefaultClientDirectives } from '../../dist/core/client-directive/index.js';
+import { createEnvironment } from '../../dist/core/render/index.js';
+import { RouteCache } from '../../dist/core/render/route-cache.js';
 
 class VirtualVolume extends Volume {
 	#root = '';
@@ -151,3 +154,24 @@ export function buffersToString(buffers) {
 
 // A convenience method for creating an astro module from a component
 export const createAstroModule = (AstroComponent) => ({ default: AstroComponent });
+
+/**
+ * @param {Partial<import('../../src/core/render/environment.js').CreateEnvironmentArgs>} options
+ * @returns {import('../../src/core/render/environment.js').Environment}
+ */
+export function createBasicEnvironment(options) {
+	const mode = options.mode ?? 'development';
+	return createEnvironment({
+		...options,
+		markdown: {
+			...(options.markdown ?? {}),
+		},
+		mode,
+		renderers: options.renderers ?? [],
+		clientDirectives: getDefaultClientDirectives(),
+		resolve: options.resolve ?? ((s) => Promise.resolve(s)),
+		routeCache: new RouteCache(options.logging, mode),
+		ssr: options.ssr ?? true,
+		streaming: options.streaming ?? true,
+	});
+}

--- a/packages/astro/test/units/test-utils.js
+++ b/packages/astro/test/units/test-utils.js
@@ -8,6 +8,19 @@ import { unixify } from './correct-path.js';
 import { getDefaultClientDirectives } from '../../dist/core/client-directive/index.js';
 import { createEnvironment } from '../../dist/core/render/index.js';
 import { RouteCache } from '../../dist/core/render/route-cache.js';
+import { nodeLogDestination } from '../../dist/core/logger/node.js';
+
+/** @type {import('../../src/core/logger/core').LogOptions} */
+export const defaultLogging = {
+	dest: nodeLogDestination,
+	level: 'error',
+};
+
+/** @type {import('../../src/core/logger/core').LogOptions} */
+export const silentLogging = {
+	dest: nodeLogDestination,
+	level: 'error',
+};
 
 class VirtualVolume extends Volume {
 	#root = '';
@@ -159,7 +172,7 @@ export const createAstroModule = (AstroComponent) => ({ default: AstroComponent 
  * @param {Partial<import('../../src/core/render/environment.js').CreateEnvironmentArgs>} options
  * @returns {import('../../src/core/render/environment.js').Environment}
  */
-export function createBasicEnvironment(options) {
+export function createBasicEnvironment(options = {}) {
 	const mode = options.mode ?? 'development';
 	return createEnvironment({
 		...options,
@@ -171,6 +184,7 @@ export function createBasicEnvironment(options) {
 		clientDirectives: getDefaultClientDirectives(),
 		resolve: options.resolve ?? ((s) => Promise.resolve(s)),
 		routeCache: new RouteCache(options.logging, mode),
+		logging: options.logging ?? defaultLogging,
 		ssr: options.ssr ?? true,
 		streaming: options.streaming ?? true,
 	});

--- a/packages/astro/test/units/vite-plugin-astro-server/request.test.js
+++ b/packages/astro/test/units/vite-plugin-astro-server/request.test.js
@@ -2,12 +2,16 @@ import { expect } from 'chai';
 
 import { createDefaultDevSettings } from '../../../dist/core/config/index.js';
 import { createLoader } from '../../../dist/core/module-loader/index.js';
-import { createBasicEnvironment } from '../../../dist/core/render/index.js';
 import { createRouteManifest } from '../../../dist/core/routing/index.js';
 import { createComponent, render } from '../../../dist/runtime/server/index.js';
 import { createController, handleRequest } from '../../../dist/vite-plugin-astro-server/index.js';
 import { defaultLogging as logging } from '../../test-utils.js';
-import { createAstroModule, createFs, createRequestAndResponse } from '../test-utils.js';
+import {
+	createAstroModule,
+	createBasicEnvironment,
+	createFs,
+	createRequestAndResponse,
+} from '../test-utils.js';
 
 async function createDevEnvironment(overrides = {}) {
 	const env = createBasicEnvironment({

--- a/packages/astro/test/units/vite-plugin-astro-server/request.test.js
+++ b/packages/astro/test/units/vite-plugin-astro-server/request.test.js
@@ -5,19 +5,16 @@ import { createLoader } from '../../../dist/core/module-loader/index.js';
 import { createRouteManifest } from '../../../dist/core/routing/index.js';
 import { createComponent, render } from '../../../dist/runtime/server/index.js';
 import { createController, handleRequest } from '../../../dist/vite-plugin-astro-server/index.js';
-import { defaultLogging as logging } from '../../test-utils.js';
 import {
 	createAstroModule,
 	createBasicEnvironment,
 	createFs,
 	createRequestAndResponse,
+	defaultLogging,
 } from '../test-utils.js';
 
 async function createDevEnvironment(overrides = {}) {
-	const env = createBasicEnvironment({
-		logging,
-		renderers: [],
-	});
+	const env = createBasicEnvironment();
 	env.settings = await createDefaultDevSettings({}, '/');
 	env.settings.renderers = [];
 	env.loader = createLoader();
@@ -52,7 +49,7 @@ describe('vite-plugin-astro-server', () => {
 					fsMod: fs,
 					settings: env.settings,
 				},
-				logging
+				defaultLogging
 			);
 
 			try {


### PR DESCRIPTION
## Changes

- Move `createBasicEnvironment` as test-util
- Prevent importing integration test-utils in unit tests

This make sure that our source code doesn't include test-related implementation, and that unit tests only imports it's unit test-utils. The integration test-utils are much heftier on load, so this should help with unit tests startup slightly.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a