### PR TITLE
chore: fix incorrect default type

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -830,7 +830,7 @@ export interface AstroUserConfig {
 		 * @docs
 		 * @name build.split
 		 * @type {boolean}
-		 * @default {false}
+		 * @default `false`
 		 * @version 2.7.0
 		 * @description
 		 * Defines how the SSR code should be bundled when built.


### PR DESCRIPTION
## Changes

Fix the docs

It doesn't appear https://docs.astro.build/en/reference/configuration-reference/#buildsplit

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs


N/A
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
