### PR TITLE
Fix style crawling logic for CSS HMR

### DIFF
--- a/.changeset/red-turtles-drum.md
+++ b/.changeset/red-turtles-drum.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix style crawling logic for CSS HMR

--- a/packages/astro/src/core/module-loader/loader.ts
+++ b/packages/astro/src/core/module-loader/loader.ts
@@ -48,6 +48,7 @@ export interface ModuleNode {
 	} | null;
 	ssrError: Error | null;
 	importedModules: Set<ModuleNode>;
+	importers: Set<ModuleNode>
 }
 
 export interface ModuleInfo {

--- a/packages/astro/test/units/dev/styles.test.js
+++ b/packages/astro/test/units/dev/styles.test.js
@@ -29,13 +29,16 @@ describe('Crawling graph for CSS', () => {
 					{
 						id: aboutId,
 						url: aboutId,
+						importers: new Set(),
 					},
 					{
 						id: indexId + '?astro&style.css',
 						url: indexId + '?astro&style.css',
+						importers: new Set([{ id: indexId }]),
 						ssrModule: {},
 					},
 				],
+				importers: new Set(),
 				ssrTransformResult: {
 					deps: [indexId + '?astro&style.css'],
 				},
@@ -46,9 +49,11 @@ describe('Crawling graph for CSS', () => {
 					{
 						id: aboutId + '?astro&style.css',
 						url: aboutId + '?astro&style.css',
+						importers: new Set([{ id: aboutId }]),
 						ssrModule: {},
 					},
 				],
+				importers: new Set(),
 				ssrTransformResult: {
 					deps: [aboutId + '?astro&style.css'],
 				},


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/7529

Used the not-so-performant technique initially used in the first commit of https://github.com/withastro/astro/pull/7381 to fix the issue for now.

The issue seems to be that UnoCSS is invalidating the Astro files at https://github.com/unocss/unocss/blob/757b7f18b060f32387689545c878aea1e63203b4/packages/vite/src/modes/global/dev.ts#L59. This breaks our expectations where they are already loaded and exist as `ssrTransformResult`. The invalidation clears out `ssrTransformResult`, causing the issue.

A fix I intially thought is to force `loader.import()` on all modules while we're traversing the graph to counteract UnoCSS, but that feels more non-performant than the initial PR idea, so I went with the initial PR idea instead.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass. Also tested the repro locally. Unfortunately time is a bit tight for me now to add a real test with unocss.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a.
