### PR TITLE
refactor: use only manifest to compute information

### DIFF
--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -37,7 +37,7 @@ export type SSRManifest = {
 	adapterName: string;
 	routes: RouteInfo[];
 	site?: string;
-	base?: string;
+	base: string;
 	compressHTML?: boolean;
 	assetsPrefix?: string;
 	markdown: MarkdownRenderingOptions;

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -525,7 +525,10 @@ async function generatePath(
 		renderers: manifest.renderers,
 		clientDirectives: manifest.clientDirectives,
 		async resolve(specifier: string) {
-			const hashedFilePath = internals.entrySpecifierToBundleMap.get(specifier);
+			if (!(specifier in manifest.entryModules)) {
+				throw new Error(`Unable to resolve [${specifier}]`);
+			}
+			const hashedFilePath = manifest.entryModules[specifier];
 			if (typeof hashedFilePath !== 'string') {
 				// If no "astro:scripts/before-hydration.js" script exists in the build,
 				// then we can assume that no before-hydration scripts are needed.
@@ -661,7 +664,6 @@ export function generateRuntimeManifest(
 ): SSRManifest {
 	return {
 		assets: new Set(),
-		entryModules: {},
 		routes: [],
 		adapterName: '',
 		markdown: settings.config.markdown,
@@ -673,5 +675,6 @@ export function generateRuntimeManifest(
 			? new URL(settings.config.base, settings.config.site).toString()
 			: settings.config.site,
 		componentMetadata: internals.componentMetadata,
+		entryModules: Object.fromEntries(internals.entrySpecifierToBundleMap.entries()),
 	};
 }

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -525,10 +525,8 @@ async function generatePath(
 		renderers: manifest.renderers,
 		clientDirectives: manifest.clientDirectives,
 		async resolve(specifier: string) {
-			if (!(specifier in manifest.entryModules)) {
-				throw new Error(`Unable to resolve [${specifier}]`);
-			}
-			const hashedFilePath = manifest.entryModules[specifier];
+			// NOTE: next PR, borrow logic from build manifest maybe?
+			const hashedFilePath = internals.entrySpecifierToBundleMap.get(specifier);
 			if (typeof hashedFilePath !== 'string') {
 				// If no "astro:scripts/before-hydration.js" script exists in the build,
 				// then we can assume that no before-hydration scripts are needed.
@@ -664,6 +662,7 @@ export function generateRuntimeManifest(
 ): SSRManifest {
 	return {
 		assets: new Set(),
+		entryModules: {},
 		routes: [],
 		adapterName: '',
 		markdown: settings.config.markdown,
@@ -675,6 +674,5 @@ export function generateRuntimeManifest(
 			? new URL(settings.config.base, settings.config.site).toString()
 			: settings.config.site,
 		componentMetadata: internals.componentMetadata,
-		entryModules: Object.fromEntries(internals.entrySpecifierToBundleMap.entries()),
 	};
 }


### PR DESCRIPTION
## Changes

This is the first step towards a unified way to "render a page or an endpoint".

In this PR, I refactored the generation of the page using the `SSRManifest`. The manifest has already ALL the information needed to render a page.

In this PR we create a `SSRManifest` using the settings, the configuration and build internals. 

## Testing

Current CI should pass

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
