### PR TITLE
Simpify passing endpoint logging option

### DIFF
--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -301,7 +301,7 @@ export class App {
 			mod: handler as any,
 		});
 
-		const result = await callEndpoint(handler, this.#env, ctx, this.#logging, page.onRequest);
+		const result = await callEndpoint(handler, this.#env, ctx, page.onRequest);
 
 		if (result.type === 'response') {
 			if (result.response.headers.get('X-Astro-Response') === 'Not-Found') {

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -559,7 +559,6 @@ async function generatePath(
 			endpointHandler,
 			env,
 			renderContext,
-			logging,
 			onRequest as MiddlewareHandler<Response | EndpointOutput>
 		);
 

--- a/packages/astro/src/core/endpoint/dev/index.ts
+++ b/packages/astro/src/core/endpoint/dev/index.ts
@@ -1,10 +1,9 @@
 import type { EndpointHandler } from '../../../@types/astro';
-import type { LogOptions } from '../../logger/core';
 import type { SSROptions } from '../../render/dev';
 import { createRenderContext } from '../../render/index.js';
 import { callEndpoint } from '../index.js';
 
-export async function call(options: SSROptions, logging: LogOptions) {
+export async function call(options: SSROptions) {
 	const { env, preload, middleware } = options;
 	const endpointHandler = preload as unknown as EndpointHandler;
 
@@ -16,5 +15,5 @@ export async function call(options: SSROptions, logging: LogOptions) {
 		mod: preload,
 	});
 
-	return await callEndpoint(endpointHandler, env, ctx, logging, middleware?.onRequest);
+	return await callEndpoint(endpointHandler, env, ctx, middleware?.onRequest);
 }

--- a/packages/astro/src/core/endpoint/index.ts
+++ b/packages/astro/src/core/endpoint/index.ts
@@ -14,7 +14,7 @@ import { renderEndpoint } from '../../runtime/server/index.js';
 import { ASTRO_VERSION } from '../constants.js';
 import { AstroCookies, attachToResponse } from '../cookies/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
-import { warn, type LogOptions } from '../logger/core.js';
+import { warn } from '../logger/core.js';
 import { callMiddleware } from '../middleware/callMiddleware.js';
 const clientAddressSymbol = Symbol.for('astro.clientAddress');
 const clientLocalsSymbol = Symbol.for('astro.locals');
@@ -104,7 +104,6 @@ export async function callEndpoint<MiddlewareResult = Response | EndpointOutput>
 	mod: EndpointHandler,
 	env: Environment,
 	ctx: RenderContext,
-	logging: LogOptions,
 	onRequest?: MiddlewareHandler<MiddlewareResult> | undefined
 ): Promise<EndpointCallResult> {
 	const context = createAPIContext({
@@ -140,7 +139,7 @@ export async function callEndpoint<MiddlewareResult = Response | EndpointOutput>
 	if (env.ssr && !ctx.route?.prerender) {
 		if (response.hasOwnProperty('headers')) {
 			warn(
-				logging,
+				env.logging,
 				'ssr',
 				'Setting headers is not supported when returning an object. Please return an instance of Response. See https://docs.astro.build/en/core-concepts/endpoints/#server-endpoints-api-routes for more information.'
 			);
@@ -148,7 +147,7 @@ export async function callEndpoint<MiddlewareResult = Response | EndpointOutput>
 
 		if (response.encoding) {
 			warn(
-				logging,
+				env.logging,
 				'ssr',
 				'`encoding` is ignored in SSR. To return a charset other than UTF-8, please return an instance of Response. See https://docs.astro.build/en/core-concepts/endpoints/#server-endpoints-api-routes for more information.'
 			);

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -176,7 +176,7 @@ export async function handleRoute(
 	}
 	// Route successfully matched! Render it.
 	if (route.type === 'endpoint') {
-		const result = await callEndpoint(options, logging);
+		const result = await callEndpoint(options);
 		if (result.type === 'response') {
 			if (result.response.headers.get('X-Astro-Response') === 'Not-Found') {
 				const fourOhFourRoute = await matchRoute('/404', env, manifest);


### PR DESCRIPTION
## Changes

Small refactor to avoid an extra `logging` parameter, because we can use `env.logging` instead.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing test should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a