### PR TITLE
Refactor passing compressHTML

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1991,6 +1991,7 @@ export interface SSRResult {
 	 * Map of directive name (e.g. `load`) to the directive script code
 	 */
 	clientDirectives: Map<string, string>;
+	compressHTML: boolean;
 	/**
 	 * Only used for logging
 	 */

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -63,6 +63,7 @@ export class App {
 			logging: this.#logging,
 			markdown: manifest.markdown,
 			mode: 'production',
+			compressHTML: manifest.compressHTML,
 			renderers: manifest.renderers,
 			clientDirectives: manifest.clientDirectives,
 			async resolve(specifier: string) {
@@ -204,7 +205,6 @@ export class App {
 		const url = new URL(request.url);
 		const pathname = prependForwardSlash(this.removeBase(url.pathname));
 		const info = this.#routeDataToRouteInfo.get(routeData)!;
-		const isCompressHTML = this.#manifest.compressHTML ?? false;
 		// may be used in the future for handling rel=modulepreload, rel=icon, rel=manifest etc.
 		const links = new Set<never>();
 		const styles = createStylesheetElementSet(info.styles);
@@ -257,7 +257,6 @@ export class App {
 							renderContext,
 							env: this.#env,
 							cookies: apiContext.cookies,
-							isCompressHTML,
 						});
 					}
 				);
@@ -267,7 +266,6 @@ export class App {
 					renderContext,
 					env: this.#env,
 					cookies: apiContext.cookies,
-					isCompressHTML,
 				});
 			}
 			Reflect.set(request, responseSentSymbol, true);

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -38,7 +38,7 @@ export type SSRManifest = {
 	routes: RouteInfo[];
 	site?: string;
 	base: string;
-	compressHTML?: boolean;
+	compressHTML: boolean;
 	assetsPrefix?: string;
 	markdown: MarkdownRenderingOptions;
 	renderers: SSRLoadedRenderer[];

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -519,6 +519,7 @@ async function generatePath(
 		mode: opts.mode,
 		renderers: manifest.renderers,
 		clientDirectives: manifest.clientDirectives,
+		compressHTML: manifest.compressHTML,
 		async resolve(specifier: string) {
 			// NOTE: next PR, borrow logic from build manifest maybe?
 			const hashedFilePath = internals.entrySpecifierToBundleMap.get(specifier);
@@ -594,7 +595,6 @@ async function generatePath(
 							mod,
 							renderContext,
 							env,
-							isCompressHTML: settings.config.compressHTML,
 							cookies: apiContext.cookies,
 						});
 					}
@@ -604,7 +604,6 @@ async function generatePath(
 					mod,
 					renderContext,
 					env,
-					isCompressHTML: settings.config.compressHTML,
 					cookies: apiContext.cookies,
 				});
 			}
@@ -661,6 +660,7 @@ export function generateRuntimeManifest(
 		adapterName: '',
 		markdown: settings.config.markdown,
 		clientDirectives: settings.clientDirectives,
+		compressHTML: settings.config.compressHTML,
 		renderers,
 		base: settings.config.base,
 		assetsPrefix: settings.config.build.assetsPrefix,

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -10,17 +10,10 @@ export type RenderPage = {
 	mod: ComponentInstance;
 	renderContext: RenderContext;
 	env: Environment;
-	isCompressHTML?: boolean;
 	cookies: AstroCookies;
 };
 
-export async function renderPage({
-	mod,
-	renderContext,
-	env,
-	cookies,
-	isCompressHTML = false,
-}: RenderPage) {
+export async function renderPage({ mod, renderContext, env, cookies }: RenderPage) {
 	if (routeIsRedirect(renderContext.route)) {
 		return new Response(null, {
 			status: redirectRouteStatus(renderContext.route, renderContext.request.method),
@@ -47,6 +40,7 @@ export async function renderPage({
 		resolve: env.resolve,
 		renderers: env.renderers,
 		clientDirectives: env.clientDirectives,
+		compressHTML: env.compressHTML,
 		request: renderContext.request,
 		site: env.site,
 		scripts: renderContext.scripts,
@@ -67,7 +61,6 @@ export async function renderPage({
 		renderContext.props,
 		null,
 		env.streaming,
-		isCompressHTML,
 		renderContext.route
 	);
 

--- a/packages/astro/src/core/render/dev/environment.ts
+++ b/packages/astro/src/core/render/dev/environment.ts
@@ -27,6 +27,7 @@ export function createDevelopmentEnvironment(
 		// This will be overridden in the dev server
 		renderers: [],
 		clientDirectives: settings.clientDirectives,
+		compressHTML: settings.config.compressHTML,
 		resolve: createResolve(loader, settings.config.root),
 		routeCache: new RouteCache(logging, mode),
 		site: settings.config.site,

--- a/packages/astro/src/core/render/environment.ts
+++ b/packages/astro/src/core/render/environment.ts
@@ -21,6 +21,7 @@ export interface Environment {
 	markdown: MarkdownRenderingOptions;
 	/** "development" or "production" */
 	mode: RuntimeMode;
+	compressHTML: boolean;
 	renderers: SSRLoadedRenderer[];
 	clientDirectives: Map<string, string>;
 	resolve: (s: string) => Promise<string>;

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -39,6 +39,7 @@ export interface CreateResultArgs {
 	pathname: string;
 	renderers: SSRLoadedRenderer[];
 	clientDirectives: Map<string, string>;
+	compressHTML: boolean;
 	resolve: (s: string) => Promise<string>;
 	/**
 	 * Used for `Astro.site`
@@ -134,8 +135,7 @@ class Slots {
 let renderMarkdown: any = null;
 
 export function createResult(args: CreateResultArgs): SSRResult {
-	const { markdown, params, pathname, renderers, clientDirectives, request, resolve, locals } =
-		args;
+	const { markdown, params, request, resolve, locals } = args;
 
 	const url = new URL(request.url);
 	const headers = new Headers();
@@ -155,7 +155,6 @@ export function createResult(args: CreateResultArgs): SSRResult {
 
 	// Astro.cookies is defined lazily to avoid the cost on pages that do not use it.
 	let cookies: AstroCookies | undefined = args.cookies;
-	let componentMetadata = args.componentMetadata ?? new Map();
 
 	// Create the result object that will be passed into the render function.
 	// This object starts here as an empty shell (not yet the result) but then
@@ -164,10 +163,11 @@ export function createResult(args: CreateResultArgs): SSRResult {
 		styles: args.styles ?? new Set<SSRElement>(),
 		scripts: args.scripts ?? new Set<SSRElement>(),
 		links: args.links ?? new Set<SSRElement>(),
-		componentMetadata,
-		renderers,
-		clientDirectives,
-		pathname,
+		componentMetadata: args.componentMetadata ?? new Map(),
+		renderers: args.renderers,
+		clientDirectives: args.clientDirectives,
+		compressHTML: args.compressHTML,
+		pathname: args.pathname,
 		cookies,
 		/** This function returns the `Astro` faux-global */
 		createAstro(

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -30,7 +30,6 @@ function nonAstroPageNeedsHeadInjection(pageComponent: NonAstroPageComponent): b
 async function iterableToHTMLBytes(
 	result: SSRResult,
 	iterable: ComponentIterable,
-	isCompressHTML: boolean,
 	onDocTypeInjection?: (parts: HTMLParts) => Promise<void>
 ): Promise<Uint8Array> {
 	const parts = new HTMLParts();
@@ -40,7 +39,7 @@ async function iterableToHTMLBytes(
 			if (i === 0) {
 				i++;
 				if (!/<!doctype html/i.test(String(chunk))) {
-					parts.append(`${isCompressHTML ? '<!DOCTYPE html>' : '<!DOCTYPE html>\n'}`, result);
+					parts.append(`${result.compressHTML ? '<!DOCTYPE html>' : '<!DOCTYPE html>\n'}`, result);
 					if (onDocTypeInjection) {
 						await onDocTypeInjection(parts);
 					}
@@ -74,7 +73,6 @@ export async function renderPage(
 	props: any,
 	children: any,
 	streaming: boolean,
-	isCompressHTML: boolean,
 	route?: RouteData | undefined
 ): Promise<Response> {
 	if (!isAstroComponentFactory(componentFactory)) {
@@ -115,7 +113,7 @@ export async function renderPage(
 		}
 
 		// Accumulate the HTML string and append the head if necessary.
-		const bytes = await iterableToHTMLBytes(result, output, isCompressHTML, async (parts) => {
+		const bytes = await iterableToHTMLBytes(result, output, async (parts) => {
 			parts.append(head, result);
 		});
 
@@ -156,7 +154,7 @@ export async function renderPage(
 										if (!/<!doctype html/i.test(String(chunk))) {
 											controller.enqueue(
 												encoder.encode(
-													`${isCompressHTML ? '<!DOCTYPE html>' : '<!DOCTYPE html>\n'}`
+													`${result.compressHTML ? '<!DOCTYPE html>' : '<!DOCTYPE html>\n'}`
 												)
 											);
 										}
@@ -193,7 +191,7 @@ export async function renderPage(
 				},
 			});
 		} else {
-			body = await iterableToHTMLBytes(result, iterable, isCompressHTML);
+			body = await iterableToHTMLBytes(result, iterable);
 			headers.set('Content-Length', body.byteLength.toString());
 		}
 


### PR DESCRIPTION
## Changes

The `compressHTML` flow is a bit out of place. It's being passed manually to the rendering flow instead of throught `SSRResult` like the other configs. This PR:

- Moves `compressHTML` to `SSRResult`
- Adds `compressHTML` to `Environment` (to be passed to `SSRResult`)
- Make `compressHTML` type in `SSRManifest` non-optional. The value should always exist.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a