### PR TITLE
refactor: use SSR manifest in dev

### DIFF
--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -42,27 +42,26 @@ export interface MatchOptions {
 export class App {
 	/**
 	 * The current environment of the application
-	 * @protected
 	 */
-	protected env: Environment;
+	#env: Environment;
 	#manifest: SSRManifest;
-	protected manifestData: ManifestData;
+	#manifestData: ManifestData;
 	#routeDataToRouteInfo: Map<RouteData, RouteInfo>;
-	protected encoder = new TextEncoder();
-	protected logging: LogOptions = {
+	#encoder = new TextEncoder();
+	#logging: LogOptions = {
 		dest: consoleLogDestination,
 		level: 'info',
 	};
-	protected baseWithoutTrailingSlash: string;
+	#baseWithoutTrailingSlash: string;
 
 	constructor(manifest: SSRManifest, streaming = true) {
 		this.#manifest = manifest;
-		this.manifestData = {
+		this.#manifestData = {
 			routes: manifest.routes.map((route) => route.routeData),
 		};
 		this.#routeDataToRouteInfo = new Map(manifest.routes.map((route) => [route.routeData, route]));
-		this.baseWithoutTrailingSlash = removeTrailingForwardSlash(this.#manifest.base);
-		this.env = this.#createEnvironment(streaming);
+		this.#baseWithoutTrailingSlash = removeTrailingForwardSlash(this.#manifest.base);
+		this.#env = this.#createEnvironment(streaming);
 	}
 
 	set setManifest(newManifest: SSRManifest) {
@@ -78,7 +77,7 @@ export class App {
 	#createEnvironment(streaming = false) {
 		return createEnvironment({
 			adapterName: this.#manifest.adapterName,
-			logging: this.logging,
+			logging: this.#logging,
 			markdown: this.#manifest.markdown,
 			mode: 'production',
 			compressHTML: this.#manifest.compressHTML,
@@ -99,7 +98,7 @@ export class App {
 					}
 				}
 			},
-			routeCache: new RouteCache(this.logging),
+			routeCache: new RouteCache(this.#logging),
 			site: this.#manifest.site,
 			ssr: true,
 			streaming,
@@ -107,11 +106,11 @@ export class App {
 	}
 
 	set setManifestData(newManifestData: ManifestData) {
-		this.manifestData = newManifestData;
+		this.#manifestData = newManifestData;
 	}
 	removeBase(pathname: string) {
 		if (pathname.startsWith(this.#manifest.base)) {
-			return pathname.slice(this.baseWithoutTrailingSlash.length + 1);
+			return pathname.slice(this.#baseWithoutTrailingSlash.length + 1);
 		}
 		return pathname;
 	}
@@ -122,13 +121,13 @@ export class App {
 			return undefined;
 		}
 		let pathname = prependForwardSlash(this.removeBase(url.pathname));
-		let routeData = matchRoute(pathname, this.manifestData);
+		let routeData = matchRoute(pathname, this.#manifestData);
 
 		if (routeData) {
 			if (routeData.prerender) return undefined;
 			return routeData;
 		} else if (matchNotFound) {
-			const notFoundRouteData = matchRoute('/404', this.manifestData);
+			const notFoundRouteData = matchRoute('/404', this.#manifestData);
 			if (notFoundRouteData?.prerender) return undefined;
 			return notFoundRouteData;
 		} else {
@@ -165,7 +164,7 @@ export class App {
 
 			// If there was a known error code, try sending the according page (e.g. 404.astro / 500.astro).
 			if (response.status === 500 || response.status === 404) {
-				const errorRouteData = matchRoute('/' + response.status, this.manifestData);
+				const errorRouteData = matchRoute('/' + response.status, this.#manifestData);
 				if (errorRouteData && errorRouteData.route !== routeData.route) {
 					mod = await this.#getModuleForRoute(errorRouteData);
 					try {
@@ -254,27 +253,27 @@ export class App {
 				route: routeData,
 				status,
 				mod,
-				env: this.env,
+				env: this.#env,
 			});
 
 			const apiContext = createAPIContext({
 				request: renderContext.request,
 				params: renderContext.params,
 				props: renderContext.props,
-				site: this.env.site,
-				adapterName: this.env.adapterName,
+				site: this.#env.site,
+				adapterName: this.#env.adapterName,
 			});
 			let response;
 			if (page.onRequest) {
 				response = await callMiddleware<Response>(
-					this.env.logging,
+					this.#env.logging,
 					page.onRequest as MiddlewareResponseHandler,
 					apiContext,
 					() => {
 						return renderPage({
 							mod,
 							renderContext,
-							env: this.env,
+							env: this.#env,
 							cookies: apiContext.cookies,
 						});
 					}
@@ -283,14 +282,14 @@ export class App {
 				response = await renderPage({
 					mod,
 					renderContext,
-					env: this.env,
+					env: this.#env,
 					cookies: apiContext.cookies,
 				});
 			}
 			Reflect.set(request, responseSentSymbol, true);
 			return response;
 		} catch (err: any) {
-			error(this.logging, 'ssr', err.stack || err.message || String(err));
+			error(this.#logging, 'ssr', err.stack || err.message || String(err));
 			return new Response(null, {
 				status: 500,
 				statusText: 'Internal server error',
@@ -314,11 +313,11 @@ export class App {
 			pathname,
 			route: routeData,
 			status,
-			env: this.env,
+			env: this.#env,
 			mod: handler as any,
 		});
 
-		const result = await callEndpoint(handler, this.env, ctx, page.onRequest);
+		const result = await callEndpoint(handler, this.#env, ctx, page.onRequest);
 
 		if (result.type === 'response') {
 			if (result.response.headers.get('X-Astro-Response') === 'Not-Found') {
@@ -338,7 +337,7 @@ export class App {
 			} else {
 				headers.set('Content-Type', 'text/plain;charset=utf-8');
 			}
-			const bytes = this.encoder.encode(body);
+			const bytes = this.#encoder.encode(body);
 			headers.set('Content-Length', bytes.byteLength.toString());
 
 			const response = new Response(bytes, {

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -163,27 +163,27 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 					}
 				} else {
 					const ssrEntry = ssrEntryPage as SinglePageBuiltModule;
-					const manifest = generateRuntimeManifest(opts.settings, internals, ssrEntry.renderers);
+					const manifest = createBuildManifest(opts.settings, internals, ssrEntry.renderers);
 					await generatePage(opts, internals, pageData, ssrEntry, builtPaths, manifest);
 				}
 			}
 		}
 		for (const pageData of eachRedirectPageData(internals)) {
 			const entry = await getEntryForRedirectRoute(pageData.route, internals, outFolder);
-			const manifest = generateRuntimeManifest(opts.settings, internals, entry.renderers);
+			const manifest = createBuildManifest(opts.settings, internals, entry.renderers);
 			await generatePage(opts, internals, pageData, entry, builtPaths, manifest);
 		}
 	} else {
 		for (const [pageData, filePath] of eachPageDataFromEntryPoint(internals)) {
 			const ssrEntryURLPage = createEntryURL(filePath, outFolder);
 			const entry: SinglePageBuiltModule = await import(ssrEntryURLPage.toString());
-			const manifest = generateRuntimeManifest(opts.settings, internals, entry.renderers);
+			const manifest = createBuildManifest(opts.settings, internals, entry.renderers);
 
 			await generatePage(opts, internals, pageData, entry, builtPaths, manifest);
 		}
 		for (const pageData of eachRedirectPageData(internals)) {
 			const entry = await getEntryForRedirectRoute(pageData.route, internals, outFolder);
-			const manifest = generateRuntimeManifest(opts.settings, internals, entry.renderers);
+			const manifest = createBuildManifest(opts.settings, internals, entry.renderers);
 			await generatePage(opts, internals, pageData, entry, builtPaths, manifest);
 		}
 	}
@@ -521,8 +521,7 @@ async function generatePath(
 		clientDirectives: manifest.clientDirectives,
 		compressHTML: manifest.compressHTML,
 		async resolve(specifier: string) {
-			// NOTE: next PR, borrow logic from build manifest maybe?
-			const hashedFilePath = internals.entrySpecifierToBundleMap.get(specifier);
+			const hashedFilePath = manifest.entryModules[specifier];
 			if (typeof hashedFilePath !== 'string') {
 				// If no "astro:scripts/before-hydration.js" script exists in the build,
 				// then we can assume that no before-hydration scripts are needed.
@@ -647,14 +646,14 @@ async function generatePath(
  * @param settings
  * @param renderers
  */
-export function generateRuntimeManifest(
+export function createBuildManifest(
 	settings: AstroSettings,
 	internals: BuildInternals,
 	renderers: SSRLoadedRenderer[]
 ): SSRManifest {
 	return {
 		assets: new Set(),
-		entryModules: {},
+		entryModules: Object.fromEntries(internals.entrySpecifierToBundleMap.entries()),
 		routes: [],
 		adapterName: '',
 		markdown: settings.config.markdown,

--- a/packages/astro/src/core/render/dev/environment.ts
+++ b/packages/astro/src/core/render/dev/environment.ts
@@ -1,9 +1,8 @@
-import type { AstroSettings, RuntimeMode } from '../../../@types/astro';
+import type { AstroSettings, RuntimeMode, SSRManifest } from '../../../@types/astro';
 import { isServerLikeOutput } from '../../../prerender/utils.js';
 import type { LogOptions } from '../../logger/core.js';
 import type { ModuleLoader } from '../../module-loader/index';
 import type { Environment } from '../index';
-
 import { createEnvironment } from '../index.js';
 import { RouteCache } from '../route-cache.js';
 import { createResolve } from './resolve.js';
@@ -14,23 +13,24 @@ export type DevelopmentEnvironment = Environment & {
 };
 
 export function createDevelopmentEnvironment(
+	manifest: SSRManifest,
 	settings: AstroSettings,
 	logging: LogOptions,
 	loader: ModuleLoader
 ): DevelopmentEnvironment {
 	const mode: RuntimeMode = 'development';
 	let env = createEnvironment({
-		adapterName: settings.adapter?.name,
+		adapterName: manifest.adapterName,
 		logging,
-		markdown: settings.config.markdown,
+		markdown: manifest.markdown,
 		mode,
 		// This will be overridden in the dev server
 		renderers: [],
-		clientDirectives: settings.clientDirectives,
+		clientDirectives: manifest.clientDirectives,
 		compressHTML: settings.config.compressHTML,
 		resolve: createResolve(loader, settings.config.root),
 		routeCache: new RouteCache(logging, mode),
-		site: settings.config.site,
+		site: manifest.site,
 		ssr: isServerLikeOutput(settings.config),
 		streaming: true,
 	});

--- a/packages/astro/src/core/render/dev/environment.ts
+++ b/packages/astro/src/core/render/dev/environment.ts
@@ -27,7 +27,7 @@ export function createDevelopmentEnvironment(
 		// This will be overridden in the dev server
 		renderers: [],
 		clientDirectives: manifest.clientDirectives,
-		compressHTML: settings.config.compressHTML,
+		compressHTML: manifest.compressHTML,
 		resolve: createResolve(loader, settings.config.root),
 		routeCache: new RouteCache(logging, mode),
 		site: manifest.site,

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -26,7 +26,7 @@ export default function createVitePluginAstroServer({
 		name: 'astro:server',
 		configureServer(viteServer) {
 			const loader = createViteLoader(viteServer);
-			const manifest = generateDevelopmentManifest(settings);
+			const manifest = createDevelopmentManifest(settings);
 			const env = createDevelopmentEnvironment(manifest, settings, logging, loader);
 			let manifestData: ManifestData = createRouteManifest({ settings, fsMod }, logging);
 			const controller = createController({ loader });
@@ -86,7 +86,7 @@ export default function createVitePluginAstroServer({
  * @param settings
  * @param renderers
  */
-export function generateDevelopmentManifest(settings: AstroSettings): SSRManifest {
+export function createDevelopmentManifest(settings: AstroSettings): SSRManifest {
 	return {
 		compressHTML: settings.config.compressHTML,
 		assets: new Set(),

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -1,6 +1,5 @@
 import type * as vite from 'vite';
 import type { AstroSettings, ManifestData } from '../@types/astro';
-
 import type fs from 'fs';
 import { patchOverlay } from '../core/errors/overlay.js';
 import type { LogOptions } from '../core/logger/core.js';
@@ -10,6 +9,7 @@ import { createRouteManifest } from '../core/routing/index.js';
 import { baseMiddleware } from './base.js';
 import { createController } from './controller.js';
 import { handleRequest } from './request.js';
+import type { SSRManifest } from '../@types/astro';
 
 export interface AstroPluginOptions {
 	settings: AstroSettings;
@@ -26,15 +26,16 @@ export default function createVitePluginAstroServer({
 		name: 'astro:server',
 		configureServer(viteServer) {
 			const loader = createViteLoader(viteServer);
-			let env = createDevelopmentEnvironment(settings, logging, loader);
-			let manifest: ManifestData = createRouteManifest({ settings, fsMod }, logging);
-			const serverController = createController({ loader });
+			const manifest = generateDevelopmentManifest(settings);
+			const env = createDevelopmentEnvironment(manifest, settings, logging, loader);
+			let manifestData: ManifestData = createRouteManifest({ settings, fsMod }, logging);
+			const controller = createController({ loader });
 
 			/** rebuild the route cache + manifest, as needed. */
 			function rebuildManifest(needsManifestRebuild: boolean) {
 				env.routeCache.clearAll();
 				if (needsManifestRebuild) {
-					manifest = createRouteManifest({ settings }, logging);
+					manifestData = createRouteManifest({ settings }, logging);
 				}
 			}
 			// Rebuild route manifest on file change, if needed.
@@ -51,13 +52,20 @@ export default function createVitePluginAstroServer({
 					});
 				}
 				// Note that this function has a name so other middleware can find it.
-				viteServer.middlewares.use(async function astroDevHandler(req, res) {
-					if (req.url === undefined || !req.method) {
-						res.writeHead(500, 'Incomplete request');
-						res.end();
+				viteServer.middlewares.use(async function astroDevHandler(request, response) {
+					if (request.url === undefined || !request.method) {
+						response.writeHead(500, 'Incomplete request');
+						response.end();
 						return;
 					}
-					handleRequest(env, manifest, serverController, req, res);
+					handleRequest({
+						env,
+						manifestData,
+						controller,
+						incomingRequest: request,
+						incomingResponse: response,
+						manifest,
+					});
 				});
 			};
 		},
@@ -68,5 +76,31 @@ export default function createVitePluginAstroServer({
 			// Replace the Vite overlay with ours
 			return patchOverlay(code);
 		},
+	};
+}
+
+/**
+ * It creates a `SSRManifest` from the `AstroSettings`.
+ *
+ * Renderers needs to be pulled out from the page module emitted during the build.
+ * @param settings
+ * @param renderers
+ */
+export function generateDevelopmentManifest(settings: AstroSettings): SSRManifest {
+	return {
+		compressHTML: settings.config.compressHTML,
+		assets: new Set(),
+		entryModules: {},
+		routes: [],
+		adapterName: '',
+		markdown: settings.config.markdown,
+		clientDirectives: settings.clientDirectives,
+		renderers: [],
+		base: settings.config.base,
+		assetsPrefix: settings.config.build.assetsPrefix,
+		site: settings.config.site
+			? new URL(settings.config.base, settings.config.site).toString()
+			: settings.config.site,
+		componentMetadata: new Map(),
 	};
 }

--- a/packages/astro/src/vite-plugin-astro-server/request.ts
+++ b/packages/astro/src/vite-plugin-astro-server/request.ts
@@ -1,5 +1,5 @@
 import type http from 'http';
-import type { ManifestData } from '../@types/astro';
+import type { ManifestData, SSRManifest } from '../@types/astro';
 import type { DevelopmentEnvironment } from '../core/render/dev/index';
 import type { DevServerController } from './controller';
 
@@ -14,22 +14,32 @@ import { runWithErrorHandling } from './controller.js';
 import { handle500Response } from './response.js';
 import { handleRoute, matchRoute } from './route.js';
 
+type HandleRequest = {
+	env: DevelopmentEnvironment;
+	manifestData: ManifestData;
+	controller: DevServerController;
+	incomingRequest: http.IncomingMessage;
+	incomingResponse: http.ServerResponse;
+	manifest: SSRManifest;
+};
+
 /** The main logic to route dev server requests to pages in Astro. */
-export async function handleRequest(
-	env: DevelopmentEnvironment,
-	manifest: ManifestData,
-	controller: DevServerController,
-	req: http.IncomingMessage,
-	res: http.ServerResponse
-) {
+export async function handleRequest({
+	env,
+	manifestData,
+	controller,
+	incomingRequest,
+	incomingResponse,
+	manifest,
+}: HandleRequest) {
 	const { settings, loader: moduleLoader } = env;
 	const { config } = settings;
-	const origin = `${moduleLoader.isHttps() ? 'https' : 'http'}://${req.headers.host}`;
+	const origin = `${moduleLoader.isHttps() ? 'https' : 'http'}://${incomingRequest.headers.host}`;
 	const buildingToSSR = isServerLikeOutput(config);
 
-	const url = new URL(origin + req.url);
+	const url = new URL(origin + incomingRequest.url);
 	let pathname: string;
-	if (config.trailingSlash === 'never' && !req.url) {
+	if (config.trailingSlash === 'never' && !incomingRequest.url) {
 		pathname = '';
 	} else {
 		pathname = decodeURI(url.pathname);
@@ -50,13 +60,13 @@ export async function handleRequest(
 	}
 
 	let body: ArrayBuffer | undefined = undefined;
-	if (!(req.method === 'GET' || req.method === 'HEAD')) {
+	if (!(incomingRequest.method === 'GET' || incomingRequest.method === 'HEAD')) {
 		let bytes: Uint8Array[] = [];
 		await new Promise((resolve) => {
-			req.on('data', (part) => {
+			incomingRequest.on('data', (part) => {
 				bytes.push(part);
 			});
-			req.on('end', resolve);
+			incomingRequest.on('end', resolve);
 		});
 		body = Buffer.concat(bytes);
 	}
@@ -65,19 +75,20 @@ export async function handleRequest(
 		controller,
 		pathname,
 		async run() {
-			const matchedRoute = await matchRoute(pathname, env, manifest);
+			const matchedRoute = await matchRoute(pathname, env, manifestData);
 			const resolvedPathname = matchedRoute?.resolvedPathname ?? pathname;
-			return await handleRoute(
+			return await handleRoute({
 				matchedRoute,
 				url,
-				resolvedPathname,
+				pathname: resolvedPathname,
 				body,
 				origin,
 				env,
+				manifestData,
+				incomingRequest: incomingRequest,
+				incomingResponse: incomingResponse,
 				manifest,
-				req,
-				res
-			);
+			});
 		},
 		onError(_err) {
 			const err = createSafeError(_err);
@@ -94,7 +105,7 @@ export async function handleRequest(
 			telemetry.record(eventError({ cmd: 'dev', err: errorWithMetadata, isFatal: false }));
 
 			error(env.logging, null, msg.formatErrorMessage(errorWithMetadata));
-			handle500Response(moduleLoader, res, errorWithMetadata);
+			handle500Response(moduleLoader, incomingResponse, errorWithMetadata);
 
 			return err;
 		},

--- a/packages/astro/test/units/routing/route-matching.test.js
+++ b/packages/astro/test/units/routing/route-matching.test.js
@@ -9,6 +9,7 @@ import { createContainer } from '../../../dist/core/dev/container.js';
 import * as cheerio from 'cheerio';
 import testAdapter from '../../test-adapter.js';
 import { getSortedPreloadedMatches } from '../../../dist/prerender/routing.js';
+import { createDevelopmentManifest } from '../../../dist/vite-plugin-astro-server/plugin.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 const fileSystem = {
@@ -120,7 +121,7 @@ const fileSystem = {
 
 describe('Route matching', () => {
 	let env;
-	let manifest;
+	let manifestData;
 	let container;
 	let settings;
 
@@ -138,8 +139,9 @@ describe('Route matching', () => {
 		settings = container.settings;
 
 		const loader = createViteLoader(container.viteServer);
-		env = createDevelopmentEnvironment(container.settings, defaultLogging, loader);
-		manifest = createRouteManifest(
+		const manifest = createDevelopmentManifest(container.settings);
+		env = createDevelopmentEnvironment(manifest, container.settings, defaultLogging, loader);
+		manifestData = createRouteManifest(
 			{
 				cwd: fileURLToPath(root),
 				settings,
@@ -155,7 +157,7 @@ describe('Route matching', () => {
 
 	describe('Matched routes', () => {
 		it('should be sorted correctly', async () => {
-			const matches = matchAllRoutes('/try-matching-a-route', manifest);
+			const matches = matchAllRoutes('/try-matching-a-route', manifestData);
 			const preloadedMatches = await getSortedPreloadedMatches({ env, matches, settings });
 			const sortedRouteNames = preloadedMatches.map((match) => match.route.route);
 
@@ -169,7 +171,7 @@ describe('Route matching', () => {
 			]);
 		});
 		it('nested should be sorted correctly', async () => {
-			const matches = matchAllRoutes('/nested/try-matching-a-route', manifest);
+			const matches = matchAllRoutes('/nested/try-matching-a-route', manifestData);
 			const preloadedMatches = await getSortedPreloadedMatches({ env, matches, settings });
 			const sortedRouteNames = preloadedMatches.map((match) => match.route.route);
 

--- a/packages/astro/test/units/vite-plugin-astro-server/request.test.js
+++ b/packages/astro/test/units/vite-plugin-astro-server/request.test.js
@@ -44,7 +44,7 @@ describe('vite-plugin-astro-server', () => {
 				},
 				'/'
 			);
-			const manifest = createRouteManifest(
+			const manifestData = createRouteManifest(
 				{
 					fsMod: fs,
 					settings: env.settings,
@@ -53,7 +53,13 @@ describe('vite-plugin-astro-server', () => {
 			);
 
 			try {
-				await handleRequest(env, manifest, controller, req, res);
+				await handleRequest({
+					env,
+					manifestData,
+					controller,
+					incomingRequest: req,
+					incomingResponse: res,
+				});
 			} catch (err) {
 				expect(err.message).to.be.undefined();
 			}


### PR DESCRIPTION
## Changes

There isn't a great change in logic. In this PR we create an `SSRManifest` in dev mode, which we pass down until the `handleRoute`.

This should "normalize" the code across dev, SSG and SSR. I also changed a bit the `App` class to prepare some methods that will be needed in the near future.

## Testing

Current CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
