### PR TITLE
Refactor endpoint response object handling

### DIFF
--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -8,7 +8,6 @@ import type {
 	AstroSettings,
 	ComponentInstance,
 	EndpointHandler,
-	EndpointOutput,
 	GetStaticPathsItem,
 	ImageTransform,
 	MiddlewareHandler,
@@ -556,18 +555,13 @@ async function generatePath(
 	if (pageData.route.type === 'endpoint') {
 		const endpointHandler = mod as unknown as EndpointHandler;
 
-		const result = await callEndpoint(
-			endpointHandler,
-			env,
-			renderContext,
-			onRequest as MiddlewareHandler<Response | EndpointOutput>
-		);
+		const result = await callEndpoint(endpointHandler, env, renderContext, onRequest, true);
 
-		if (result.type === 'response') {
-			throwIfRedirectNotAllowed(result.response, opts.settings.config);
+		if (result instanceof Response) {
+			throwIfRedirectNotAllowed(result, opts.settings.config);
 			// If there's no body, do nothing
-			if (!result.response.body) return;
-			const ab = await result.response.arrayBuffer();
+			if (!result.body) return;
+			const ab = await result.arrayBuffer();
 			body = new Uint8Array(ab);
 		} else {
 			body = result.body;


### PR DESCRIPTION
## Changes

- Make `callEndpoint` return a response directly, even converting simple object form to a response so we don't duplicate work.
- For SSG build, we still need to return the object form. `callEndpoint` now accepts an extra `returnObjectFormIfAvailable` param to return that. Mostly for compat as we _might_ remove object form support in Astro 3.0

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. internal refactor.