### PR TITLE
feat: support features for adapters

### DIFF
--- a/.changeset/sharp-elephants-vanish.md
+++ b/.changeset/sharp-elephants-vanish.md
@@ -1,0 +1,17 @@
+---
+'astro': minor
+---
+
+Now you can tell Astro if an adapter supports certain features.
+
+When creating ad adapter, you can specify an object like this:
+
+```js
+// adapter.js
+setAdapter({
+    // ...
+    supportsFeatures: {
+        edgeMiddleware: "Experimental"
+    }
+})
+```

--- a/.changeset/tiny-colts-call.md
+++ b/.changeset/tiny-colts-call.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/cloudflare': patch
+'@astrojs/vercel': patch
+'@astrojs/node': patch
+---
+
+Signal Astro the kind of support for of the new created features

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1638,12 +1638,31 @@ export type PaginateFunction = (data: any[], args?: PaginateOptions) => GetStati
 
 export type Params = Record<string, string | undefined>;
 
+export type SupportsKind = 'Unsupported' | 'Stable' | 'Experimental' | 'Deprecated';
+
+export type AstroAdapterSupportsFeatures = {
+	/**
+	 * Support when `build.split` is enabled.
+	 */
+	buildSplit?: SupportsKind;
+	/**
+	 * Support when `build.ecludeMiddleware` is enabled.
+	 */
+	edgeMiddleware?: SupportsKind;
+};
+
 export interface AstroAdapter {
 	name: string;
 	serverEntrypoint?: string;
 	previewEntrypoint?: string;
 	exports?: string[];
 	args?: any;
+	/**
+	 * List of features supported by an adapter.
+	 *
+	 * If the adapter is not able to handle certain configurations, Astro will throw an error.
+	 */
+	supportsFeatures?: AstroAdapterSupportsFeatures;
 }
 
 type Body = string;

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1073,6 +1073,19 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 
 	/**
 	 * @docs
+	 * @message Feature not supported by the adapter.
+	 * @description
+	 * The adapter doesn't support certain feature enabled via configuration.
+	 */
+	FeatureNotSupportedByAdapter: {
+		title: 'Feature not supported by the adapter.',
+		message: (adapterName: string, featureName: string) => {
+			return `The adapter ${adapterName} doesn't support the feature ${featureName}. Please turn it off.`;
+		},
+	},
+
+	/**
+	 * @docs
 	 * @see
 	 * - [devalue library](https://github.com/rich-harris/devalue)
 	 * @description

--- a/packages/astro/test/featuresSupport.test.js
+++ b/packages/astro/test/featuresSupport.test.js
@@ -1,0 +1,55 @@
+import { loadFixture } from './test-utils.js';
+import { expect } from 'chai';
+import testAdapter from './test-adapter.js';
+
+describe('Adapter', () => {
+	let fixture;
+
+	it("should error if the adapter doesn't support edge middleware", async () => {
+		try {
+			fixture = await loadFixture({
+				root: './fixtures/middleware-dev/',
+				output: 'server',
+				build: {
+					excludeMiddleware: true,
+				},
+				adapter: testAdapter({
+					extendAdapter: {
+						supportsFeatures: {
+							edgeMiddleware: 'Unsupported',
+						},
+					},
+				}),
+			});
+			await fixture.build();
+		} catch (e) {
+			expect(e.toString()).to.contain(
+				"The adapter my-ssr-adapter doesn't support the feature build.excludeMiddleware."
+			);
+		}
+	});
+
+	it("should error if the adapter doesn't support split build", async () => {
+		try {
+			fixture = await loadFixture({
+				root: './fixtures/middleware-dev/',
+				output: 'server',
+				build: {
+					split: true,
+				},
+				adapter: testAdapter({
+					extendAdapter: {
+						supportsFeatures: {
+							buildSplit: 'Unsupported',
+						},
+					},
+				}),
+			});
+			await fixture.build();
+		} catch (e) {
+			expect(e.toString()).to.contain(
+				"The adapter my-ssr-adapter doesn't support the feature build.split."
+			);
+		}
+	});
+});

--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -71,6 +71,10 @@ export default function (
 					name: 'my-ssr-adapter',
 					serverEntrypoint: '@my-ssr',
 					exports: ['manifest', 'createApp'],
+					supportsFeatures: {
+						edgeMiddleware: 'Stable',
+						buildSplit: 'Stable',
+					},
 					...extendAdapter,
 				});
 			},

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -24,11 +24,17 @@ export function getAdapter(isModeDirectory: boolean): AstroAdapter {
 				name: '@astrojs/cloudflare',
 				serverEntrypoint: '@astrojs/cloudflare/server.directory.js',
 				exports: ['onRequest', 'manifest'],
+				supportsFeatures: {
+					buildSplit: 'Experimental',
+				},
 		  }
 		: {
 				name: '@astrojs/cloudflare',
 				serverEntrypoint: '@astrojs/cloudflare/server.advanced.js',
 				exports: ['default'],
+				supportsFeatures: {
+					buildSplit: 'Experimental',
+				},
 		  };
 }
 

--- a/packages/integrations/node/src/index.ts
+++ b/packages/integrations/node/src/index.ts
@@ -8,6 +8,10 @@ export function getAdapter(options: Options): AstroAdapter {
 		previewEntrypoint: '@astrojs/node/preview.js',
 		exports: ['handler', 'startServer'],
 		args: options,
+		supportsFeatures: {
+			edgeMiddleware: 'Stable',
+			buildSplit: 'Stable',
+		},
 	};
 }
 

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -25,6 +25,10 @@ function getAdapter(): AstroAdapter {
 		name: PACKAGE_NAME,
 		serverEntrypoint: `${PACKAGE_NAME}/entrypoint`,
 		exports: ['default'],
+		supportsFeatures: {
+			buildSplit: 'Experimental',
+			edgeMiddleware: 'Experimental',
+		},
 	};
 }
 


### PR DESCRIPTION
## Changes

Recently we added new options to Astro, but these options are only valid if the adapter can support them. From a [discord discussion](https://discord.com/channels/830184174198718474/1120744365350993930/1126129156455927838), we thought that there should be a system where the adapter tells Astro if it's able to support certain features.

Since I am about to add one of these features to the Netlify adapter, I thought adding this system was an excellent chance.

## Testing

Added some test case

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Not now, I will prepare some something in the next PRs.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
