### PR TITLE
Fix: Markdoc v0.4.0 docs

### DIFF
--- a/.changeset/sharp-ducks-walk.md
+++ b/.changeset/sharp-ducks-walk.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': patch
+---
+
+Add a documentation link to the configuration error hint for those migration pre-v0.4.0 config to the latest version.

--- a/packages/integrations/markdoc/README.md
+++ b/packages/integrations/markdoc/README.md
@@ -136,6 +136,31 @@ Use tags like this fancy "aside" to add some _flair_ to your docs.
 {% /aside %}
 ```
 
+### Use Astro components from npm packages and TypeScript files
+
+You may need to use Astro components from TypeScript or JavaScript files with named imports. This is common when using npm packages and design systems.
+
+You can pass the import name as the second argument to the `component()` function like so:
+
+```js
+// markdoc.config.mjs
+import { defineMarkdocConfig, component } from '@astrojs/markdoc/config';
+
+export default defineMarkdocConfig({
+  tags: {
+    tabs: {
+      render: component('@astrojs/starlight/components', 'Tabs'),
+    },
+  },
+});
+```
+
+This generates the following import statement internally:
+
+```ts
+import { Tabs } from '@astrojs/starlight/components';
+```
+
 ### Custom headings
 
 `@astrojs/markdoc` automatically adds anchor links to your headings, and [generates a list of `headings` via the content collections API](https://docs.astro.build/en/guides/content-collections/#rendering-content-to-html). To further customize how headings are rendered, you can apply an Astro component [as a Markdoc node][markdoc-nodes].

--- a/packages/integrations/markdoc/README.md
+++ b/packages/integrations/markdoc/README.md
@@ -140,7 +140,7 @@ Use tags like this fancy "aside" to add some _flair_ to your docs.
 
 You may need to use Astro components from TypeScript or JavaScript files with named imports. This is common when using npm packages and design systems.
 
-You can pass the import name as the second argument to the `component()` function like so:
+You can pass the import name as the second argument to the `component()` function:
 
 ```js
 // markdoc.config.mjs

--- a/packages/integrations/markdoc/README.md
+++ b/packages/integrations/markdoc/README.md
@@ -138,7 +138,7 @@ Use tags like this fancy "aside" to add some _flair_ to your docs.
 
 ### Use Astro components from npm packages and TypeScript files
 
-You may need to use Astro components from TypeScript or JavaScript files with named imports. This is common when using npm packages and design systems.
+You may need to use Astro components exposed as named exports from TypeScript or JavaScript files. This is common when using npm packages and design systems.
 
 You can pass the import name as the second argument to the `component()` function:
 

--- a/packages/integrations/markdoc/src/load-config.ts
+++ b/packages/integrations/markdoc/src/load-config.ts
@@ -77,7 +77,7 @@ async function bundleConfigFile({
 						// This swallows the `hint` and blows up the stacktrace.
 						markdocError = new MarkdocError({
 							message: '`.astro` files are no longer supported in the Markdoc config.',
-							hint: 'Use the `component()` utility to specify a component path instead.',
+							hint: 'Use the `component()` utility to specify a component path instead. See https://docs.astro.build/en/guides/integrations-guide/markdoc/',
 						});
 						return {
 							// Stub with an unused default export.


### PR DESCRIPTION
## Changes

- Add note on named exports to README
- Add link to docs from error hint

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
