### PR TITLE
Fix: Hyphens breaking Markdoc tags

### DIFF
--- a/.changeset/witty-pandas-behave.md
+++ b/.changeset/witty-pandas-behave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': patch
+---
+
+Fix hyphens in Markdoc tag names causing build failures

--- a/packages/integrations/markdoc/src/content-entry-type.ts
+++ b/packages/integrations/markdoc/src/content-entry-type.ts
@@ -225,14 +225,19 @@ function getStringifiedImports(
 	let stringifiedComponentImports = '';
 	for (const [key, config] of Object.entries(componentConfigMap)) {
 		const importName = config.namedExport
-			? `{ ${config.namedExport} as ${componentNamePrefix + key} }`
-			: componentNamePrefix + key;
+			? `{ ${config.namedExport} as ${componentNamePrefix + toImportName(key)} }`
+			: componentNamePrefix + toImportName(key);
 		const resolvedPath =
 			config.type === 'local' ? new URL(config.path, root).pathname : config.path;
 
 		stringifiedComponentImports += `import ${importName} from ${JSON.stringify(resolvedPath)};\n`;
 	}
 	return stringifiedComponentImports;
+}
+
+function toImportName(unsafeName: string) {
+	// TODO: more checks that name is a safe JS variable name
+	return unsafeName.replace('-', '_');
 }
 
 /**
@@ -247,7 +252,9 @@ function getStringifiedMap(
 ) {
 	let stringifiedComponentMap = '{';
 	for (const key in componentConfigMap) {
-		stringifiedComponentMap += `${key}: ${componentNamePrefix + key},\n`;
+		stringifiedComponentMap += `${JSON.stringify(key)}: ${
+			componentNamePrefix + toImportName(key)
+		},\n`;
 	}
 	stringifiedComponentMap += '}';
 	return stringifiedComponentMap;

--- a/packages/integrations/markdoc/test/fixtures/render-with-components/markdoc.config.ts
+++ b/packages/integrations/markdoc/test/fixtures/render-with-components/markdoc.config.ts
@@ -11,7 +11,7 @@ export default defineMarkdocConfig({
 		},
 	},
 	tags: {
-		mq: {
+		'marquee-element': {
 			render: component('./src/components/CustomMarquee.astro'),
 			attributes: {
 				direction: {

--- a/packages/integrations/markdoc/test/fixtures/render-with-components/src/content/blog/with-components.mdoc
+++ b/packages/integrations/markdoc/test/fixtures/render-with-components/src/content/blog/with-components.mdoc
@@ -6,9 +6,9 @@ title: Post with components
 
 This uses a custom marquee component with a shortcode:
 
-{% mq direction="right" %}
+{% marquee-element direction="right" %}
 I'm a marquee too!
-{% /mq %}
+{% /marquee-element %}
 
 And a code component for code blocks:
 


### PR DESCRIPTION
## Changes

- Resolves #7595

## Testing

- Add tagname with hyphen to test suite

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
