### PR TITLE
Update prefetch README filename styling

### DIFF
--- a/.changeset/ten-buckets-rush.md
+++ b/.changeset/ten-buckets-rush.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/prefetch": patch
+---
+
+Update prefetch README filename syntax

--- a/packages/integrations/prefetch/README.md
+++ b/packages/integrations/prefetch/README.md
@@ -86,9 +86,8 @@ export default defineConfig({
 
 By default, the prefetch script also searches the page for any links that include a `rel="prefetch-intent"` attribute, ex: `<a rel="prefetch-intent" />`. This behavior can be changed in your `astro.config.*` file to use a custom query selector when finding prefetch-intent links.
 
-**`astro.config.mjs`**
-
 ```js
+// astro.config.mjs
 import { defineConfig } from 'astro/config';
 import prefetch from '@astrojs/prefetch';
 


### PR DESCRIPTION
## Changes

Now that we're using `expressive-code` under the hood in Astro Docs, the filename as paragraph syntax isn't supported anymore, which means we have to resort to the comment syntax instead.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
/cc @withastro/maintainers-docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
