### PR TITLE
feat(@astrojs/netlify): add `build.split` support

### DIFF
--- a/.changeset/happy-frogs-appear.md
+++ b/.changeset/happy-frogs-appear.md
@@ -1,0 +1,20 @@
+---
+'@astrojs/netlify': minor
+---
+
+The Netlify adapter builds to a single function by default. Astro 2.9 added support for splitting your build into separate entry points per page. If you use this configuration the Vercel adapter will generate a separate function for each page. This can help reduce the size of each function so they are only bundling code used on that page.
+
+
+  ```js
+  // astro.config.mjs
+  import { defineConfig } from 'astro/config';
+  import netlify from '@astrojs/netlify/functions';
+
+  export default defineConfig({
+    output: 'server',
+    adapter: netlify(),
+    build: {
+      split: true,
+    },
+  });
+  ```

--- a/.changeset/happy-frogs-appear.md
+++ b/.changeset/happy-frogs-appear.md
@@ -2,7 +2,7 @@
 '@astrojs/netlify': minor
 ---
 
-The Netlify adapter builds to a single function by default. Astro 2.9 added support for splitting your build into separate entry points per page. If you use this configuration the Vercel adapter will generate a separate function for each page. This can help reduce the size of each function so they are only bundling code used on that page.
+The Netlify adapter builds to a single function by default. Astro 2.9 added support for splitting your build into separate entry points per page. If you use this configuration, the Netlify adapter will generate a separate function for each page. This can help reduce the size of each function so they are only bundling code used on that page.
 
 
   ```js

--- a/.changeset/happy-frogs-appear.md
+++ b/.changeset/happy-frogs-appear.md
@@ -2,7 +2,7 @@
 '@astrojs/netlify': minor
 ---
 
-The Netlify adapter builds to a single function by default. Astro 2.9 added support for splitting your build into separate entry points per page. If you use this configuration, the Netlify adapter will generate a separate function for each page. This can help reduce the size of each function so they are only bundling code used on that page.
+The Netlify adapter builds to a single function by default. Astro 2.7 added support for splitting your build into separate entry points per page. If you use this configuration, the Netlify adapter will generate a separate function for each page. This can help reduce the size of each function so they are only bundling code used on that page.
 
 
   ```js

--- a/.changeset/nasty-geckos-know.md
+++ b/.changeset/nasty-geckos-know.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/underscore-redirects': minor
+---
+
+Refactor how the routes are passed.

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -264,10 +264,14 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						}
 					}
 
-					const redirectRoutes = routes.filter((r) => r.type === 'redirect');
+					const redirectRoutes: [RouteData, string][] = routes
+						.filter((r) => r.type === 'redirect')
+						.map((r) => {
+							return [r, ''];
+						});
 					const trueRedirects = createRedirectsFromAstroRoutes({
 						config: _config,
-						routeToDynamicTargetMap: redirectRoutes,
+						routeToDynamicTargetMap: new Map(Array.from(redirectRoutes)),
 						dir,
 					});
 					if (!trueRedirects.empty()) {

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -267,7 +267,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					const redirectRoutes = routes.filter((r) => r.type === 'redirect');
 					const trueRedirects = createRedirectsFromAstroRoutes({
 						config: _config,
-						routes: redirectRoutes,
+						routeToDynamicTargetMap: redirectRoutes,
 						dir,
 					});
 					if (!trueRedirects.empty()) {

--- a/packages/integrations/netlify/README.md
+++ b/packages/integrations/netlify/README.md
@@ -72,6 +72,24 @@ export default defineConfig({
 });
 ```
 
+### Per-page functions
+
+The Netlify adapter builds to a single function by default. Astro 2.9 added support for splitting your build into separate entry points per page. If you use this configuration the Vercel adapter will generate a separate function for each page. This can help reduce the size of each function so they are only bundling code used on that page.
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import netlify from '@astrojs/netlify/functions';
+
+export default defineConfig({
+  output: 'server',
+  adapter: netlify(),
+  build: {
+    split: true,
+  },
+});
+```
+
 ### Static sites
 
 For static sites you usually don't need an adapter. However, if you use `redirects` configuration (experimental) in your Astro config, the Netlify adapter can be used to translate this to the proper `_redirects` format.

--- a/packages/integrations/netlify/README.md
+++ b/packages/integrations/netlify/README.md
@@ -74,7 +74,7 @@ export default defineConfig({
 
 ### Per-page functions
 
-The Netlify adapter builds to a single function by default. Astro 2.9 added support for splitting your build into separate entry points per page. If you use this configuration the Vercel adapter will generate a separate function for each page. This can help reduce the size of each function so they are only bundling code used on that page.
+The Netlify adapter builds to a single function by default. Astro 2.9 added support for splitting your build into separate entry points per page. If you use this configuration, the Netlify adapter will generate a separate function for each page. This can help reduce the size of each function so they are only bundling code used on that page.
 
 ```js
 // astro.config.mjs

--- a/packages/integrations/netlify/README.md
+++ b/packages/integrations/netlify/README.md
@@ -74,7 +74,7 @@ export default defineConfig({
 
 ### Per-page functions
 
-The Netlify adapter builds to a single function by default. Astro 2.9 added support for splitting your build into separate entry points per page. If you use this configuration, the Netlify adapter will generate a separate function for each page. This can help reduce the size of each function so they are only bundling code used on that page.
+The Netlify adapter builds to a single function by default. Astro 2.7 added support for splitting your build into separate entry points per page. If you use this configuration, the Netlify adapter will generate a separate function for each page. This can help reduce the size of each function so they are only bundling code used on that page.
 
 ```js
 // astro.config.mjs

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -54,7 +54,8 @@
     "chai": "^4.3.7",
     "cheerio": "1.0.0-rc.12",
     "mocha": "^9.2.2",
-    "vite": "^4.3.9"
+    "vite": "^4.3.9",
+    "chai-jest-snapshot": "^2.0.0"
   },
   "astro": {
     "external": true

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -32,7 +32,7 @@
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test-fn": "mocha --exit --timeout 20000 test/functions/",
+    "test-fn": "mocha --exit --timeout 20000 --file \"./test/setup.js\" test/functions/",
     "test-edge": "deno test --allow-run --allow-read --allow-net --allow-env ./test/edge-functions/",
     "test": "npm run test-fn"
   },

--- a/packages/integrations/netlify/src/integration-edge-functions.ts
+++ b/packages/integrations/netlify/src/integration-edge-functions.ts
@@ -166,7 +166,12 @@ export function netlifyEdgeFunctions({ dist }: NetlifyEdgeFunctionsOptions = {})
 			'astro:build:done': async ({ routes, dir }) => {
 				await bundleServerEntry(_buildConfig, _vite);
 				await createEdgeManifest(routes, entryFile, _config.root);
-				await createRedirects(_config, routes, dir, entryFile, 'edge-functions');
+				const dynamicTarget = `/.netlify/edge-functions/${entryFile}`;
+				const map: [RouteData, string][] = routes.map((route) => {
+					return [route, dynamicTarget];
+				});
+				const routeToDynamicTargetMap = new Map(Array.from(map));
+				await createRedirects(_config, routeToDynamicTargetMap, dir);
 			},
 		},
 	};

--- a/packages/integrations/netlify/src/integration-functions.ts
+++ b/packages/integrations/netlify/src/integration-functions.ts
@@ -65,10 +65,12 @@ function netlifyFunctions({
 					const routeToDynamicTargetMap = new Map();
 					for (const [route, entryFile] of _entryPoints) {
 						const wholeFileUrl = fileURLToPath(entryFile);
+
 						const extension = extname(wholeFileUrl);
 						const relative = wholeFileUrl
-							.slice(fileURLToPath(_config.build.server).length)
-							.replace(extension, '');
+							.replace(fileURLToPath(_config.build.server), '')
+							.replace(extension, '')
+							.replaceAll('\\', '/');
 						const dynamicTarget = `/.netlify/${kind}/${relative}`;
 
 						routeToDynamicTargetMap.set(route, dynamicTarget);

--- a/packages/integrations/netlify/src/integration-functions.ts
+++ b/packages/integrations/netlify/src/integration-functions.ts
@@ -1,6 +1,8 @@
-import type { AstroAdapter, AstroConfig, AstroIntegration } from 'astro';
+import type { AstroAdapter, AstroConfig, AstroIntegration, RouteData } from 'astro';
 import type { Args } from './netlify-functions.js';
 import { createRedirects } from './shared.js';
+import { fileURLToPath } from 'node:url';
+import { extname } from 'node:path';
 
 export function getAdapter(args: Args = {}): AstroAdapter {
 	return {
@@ -23,7 +25,8 @@ function netlifyFunctions({
 	binaryMediaTypes,
 }: NetlifyFunctionsOptions = {}): AstroIntegration {
 	let _config: AstroConfig;
-	let entryFile: string;
+	let _entryPoints: Map<RouteData, URL>;
+	let ssrEntryFile: string;
 	return {
 		name: '@astrojs/netlify',
 		hooks: {
@@ -37,10 +40,13 @@ function netlifyFunctions({
 					},
 				});
 			},
+			'astro:build:ssr': ({ entryPoints }) => {
+				_entryPoints = entryPoints;
+			},
 			'astro:config:done': ({ config, setAdapter }) => {
 				setAdapter(getAdapter({ binaryMediaTypes, builders }));
 				_config = config;
-				entryFile = config.build.serverEntry.replace(/\.m?js/, '');
+				ssrEntryFile = config.build.serverEntry.replace(/\.m?js/, '');
 
 				if (config.output === 'static') {
 					console.warn(
@@ -53,7 +59,30 @@ function netlifyFunctions({
 			},
 			'astro:build:done': async ({ routes, dir }) => {
 				const type = builders ? 'builders' : 'functions';
-				await createRedirects(_config, routes, dir, entryFile, type);
+				const kind = type ?? 'functions';
+
+				if (_entryPoints.size) {
+					const routeToDynamicTargetMap = new Map();
+					for (const [route, entryFile] of _entryPoints) {
+						const wholeFileUrl = fileURLToPath(entryFile);
+						const extension = extname(wholeFileUrl);
+						const relative = wholeFileUrl
+							.slice(fileURLToPath(_config.build.server).length)
+							.replace(extension, '');
+						const dynamicTarget = `/.netlify/${kind}/${relative}`;
+
+						routeToDynamicTargetMap.set(route, dynamicTarget);
+					}
+					await createRedirects(_config, routeToDynamicTargetMap, dir);
+				} else {
+					const dynamicTarget = `/.netlify/${kind}/${ssrEntryFile}`;
+					const map: [RouteData, string][] = routes.map((route) => {
+						return [route, dynamicTarget];
+					});
+					const routeToDynamicTargetMap = new Map(Array.from(map));
+
+					await createRedirects(_config, routeToDynamicTargetMap, dir);
+				}
 			},
 		},
 	};

--- a/packages/integrations/netlify/src/integration-static.ts
+++ b/packages/integrations/netlify/src/integration-static.ts
@@ -1,4 +1,4 @@
-import type { AstroIntegration } from 'astro';
+import type { AstroIntegration, RouteData } from 'astro';
 import { createRedirects } from './shared.js';
 
 export function netlifyStatic(): AstroIntegration {
@@ -18,7 +18,12 @@ export function netlifyStatic(): AstroIntegration {
 				_config = config;
 			},
 			'astro:build:done': async ({ dir, routes }) => {
-				await createRedirects(_config, routes, dir, '', 'static');
+				const mappedRoutes: [RouteData, string][] = routes.map((route) => [
+					route,
+					`/.netlify/static/`,
+				]);
+				const routesToDynamicTargetMap = new Map(Array.from(mappedRoutes));
+				await createRedirects(_config, routesToDynamicTargetMap, dir);
 			},
 		},
 	};

--- a/packages/integrations/netlify/src/shared.ts
+++ b/packages/integrations/netlify/src/shared.ts
@@ -4,20 +4,15 @@ import fs from 'node:fs';
 
 export async function createRedirects(
 	config: AstroConfig,
-	routes: RouteData[],
-	dir: URL,
-	entryFile: string,
-	type: 'functions' | 'edge-functions' | 'builders' | 'static'
+	routeToDynamicTargetMap: Map<RouteData, string>,
+	dir: URL
 ) {
-	const kind = type ?? 'functions';
-	const dynamicTarget = `/.netlify/${kind}/${entryFile}`;
 	const _redirectsURL = new URL('./_redirects', dir);
 
 	const _redirects = createRedirectsFromAstroRoutes({
 		config,
-		routes,
+		routeToDynamicTargetMap,
 		dir,
-		dynamicTarget,
 	});
 	const content = _redirects.print();
 

--- a/packages/integrations/netlify/test/functions/fixtures/prerender/src/pages/index.astro
+++ b/packages/integrations/netlify/test/functions/fixtures/prerender/src/pages/index.astro
@@ -1,0 +1,8 @@
+<html>
+<head>
+    <title>Blog</title>
+</head>
+<body>
+<h1>Blog</h1>
+</body>
+</html>

--- a/packages/integrations/netlify/test/functions/fixtures/prerender/src/pages/index.astro
+++ b/packages/integrations/netlify/test/functions/fixtures/prerender/src/pages/index.astro
@@ -1,8 +1,0 @@
-<html>
-<head>
-	<title>Testing</title>
-</head>
-<body>
-	<h1>testing</h1>
-</body>
-</html>

--- a/packages/integrations/netlify/test/functions/fixtures/split-support/src/pages/blog.astro
+++ b/packages/integrations/netlify/test/functions/fixtures/split-support/src/pages/blog.astro
@@ -1,0 +1,8 @@
+<html>
+<head>
+    <title>Testing</title>
+</head>
+<body>
+<h1>testing</h1>
+</body>
+</html>

--- a/packages/integrations/netlify/test/functions/fixtures/split-support/src/pages/index.astro
+++ b/packages/integrations/netlify/test/functions/fixtures/split-support/src/pages/index.astro
@@ -1,0 +1,8 @@
+<html>
+<head>
+    <title>Blog</title>
+</head>
+<body>
+<h1>Blog</h1>
+</body>
+</html>

--- a/packages/integrations/netlify/test/functions/redirects.test.js
+++ b/packages/integrations/netlify/test/functions/redirects.test.js
@@ -1,17 +1,10 @@
-import { expect, use } from 'chai';
+import { expect } from 'chai';
 import { loadFixture, testIntegration } from './test-utils.js';
 import netlifyAdapter from '../../dist/index.js';
-import chaiJestSnapshot from 'chai-jest-snapshot';
-
-use(chaiJestSnapshot);
 
 describe('SSG - Redirects', () => {
 	/** @type {import('../../../astro/test/test-utils').Fixture} */
 	let fixture;
-
-	beforeEach(function () {
-		chaiJestSnapshot.configureUsingMochaContext(this);
-	});
 
 	before(async () => {
 		fixture = await loadFixture({

--- a/packages/integrations/netlify/test/functions/redirects.test.js
+++ b/packages/integrations/netlify/test/functions/redirects.test.js
@@ -1,10 +1,17 @@
-import { expect } from 'chai';
+import { expect, use } from 'chai';
 import { loadFixture, testIntegration } from './test-utils.js';
 import netlifyAdapter from '../../dist/index.js';
+import chaiJestSnapshot from 'chai-jest-snapshot';
+
+use(chaiJestSnapshot);
 
 describe('SSG - Redirects', () => {
 	/** @type {import('../../../astro/test/test-utils').Fixture} */
 	let fixture;
+
+	beforeEach(function () {
+		chaiJestSnapshot.configureUsingMochaContext(this);
+	});
 
 	before(async () => {
 		fixture = await loadFixture({
@@ -46,5 +53,6 @@ describe('SSG - Redirects', () => {
 			'/.netlify/functions/entry',
 			'200',
 		]);
+		expect(redirects).to.matchSnapshot();
 	});
 });

--- a/packages/integrations/netlify/test/functions/redirects.test.js.snap
+++ b/packages/integrations/netlify/test/functions/redirects.test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SSG - Redirects Creates a redirects file 1`] = `
+"/other              /                            301
+/nope               /.netlify/functions/entry    200
+/                   /.netlify/functions/entry    200
+/team/articles/*    /.netlify/functions/entry    200"
+`;

--- a/packages/integrations/netlify/test/functions/split-support.test.js
+++ b/packages/integrations/netlify/test/functions/split-support.test.js
@@ -44,11 +44,9 @@ describe('Split support', () => {
 
 	describe('Should create multiple functions', () => {
 		it('for index page', async () => {
-			const entryURL = new URL(
-				'./fixtures/split-support/.netlify/functions-internal/src/pages/entry.index.astro.mjs',
-				import.meta.url
+			const { handler } = await import(
+				'./fixtures/split-support/.netlify/functions-internal/src/pages/entry.index.astro.mjs'
 			);
-			const { handler } = await import(entryURL);
 			const resp = await handler({
 				httpMethod: 'POST',
 				headers: {},
@@ -59,12 +57,9 @@ describe('Split support', () => {
 			expect(resp.statusCode).to.equal(200);
 		});
 		it('for blog page', async () => {
-			const entryURL = new URL(
-				'./fixtures/split-support/.netlify/functions-internal/src/pages/entry.blog.astro.mjs',
-				import.meta.url
+			const { handler } = await import(
+				'./fixtures/split-support/.netlify/functions-internal/src/pages/entry.blog.astro.mjs'
 			);
-
-			const { handler } = await import(entryURL);
 			const resp = await handler({
 				httpMethod: 'POST',
 				headers: {},

--- a/packages/integrations/netlify/test/functions/split-support.test.js
+++ b/packages/integrations/netlify/test/functions/split-support.test.js
@@ -1,0 +1,71 @@
+import { expect } from 'chai';
+import netlifyAdapter from '../../dist/index.js';
+import { loadFixture, testIntegration } from './test-utils.js';
+
+describe('Split support', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/split-support/', import.meta.url).toString(),
+			output: 'server',
+			adapter: netlifyAdapter({
+				dist: new URL('./fixtures/split-support/dist/', import.meta.url),
+			}),
+			site: `http://example.com`,
+			integrations: [testIntegration()],
+			build: {
+				split: true,
+			},
+		});
+		await fixture.build();
+	});
+
+	it('outputs a correct redirect file', async () => {
+		const redir = await fixture.readFile('/_redirects');
+		const blogRouteIndex = redir.indexOf(
+			'/blog    /.netlify/functions/src/pages/entry.blog.astro     200'
+		);
+		const baseRouteIndex = redir.indexOf(
+			'/        /.netlify/functions/src/pages/entry.index.astro    200'
+		);
+
+		expect(baseRouteIndex).to.not.be.equal(-1);
+		expect(blogRouteIndex).to.not.be.equal(-1);
+	});
+
+	describe('Should create multiple functions', () => {
+		it('for index page', async () => {
+			const entryURL = new URL(
+				'./fixtures/split-support/.netlify/functions-internal/src/pages/entry.index.astro.mjs',
+				import.meta.url
+			);
+			const { handler } = await import(entryURL);
+			const resp = await handler({
+				httpMethod: 'POST',
+				headers: {},
+				rawUrl: 'http://example.com/',
+				body: '{}',
+				isBase64Encoded: false,
+			});
+			expect(resp.statusCode).to.equal(200);
+		});
+		it('for blog page', async () => {
+			const entryURL = new URL(
+				'./fixtures/split-support/.netlify/functions-internal/src/pages/entry.blog.astro.mjs',
+				import.meta.url
+			);
+
+			const { handler } = await import(entryURL);
+			const resp = await handler({
+				httpMethod: 'POST',
+				headers: {},
+				rawUrl: 'http://example.com/blog',
+				body: '{}',
+				isBase64Encoded: false,
+			});
+			expect(resp.statusCode).to.equal(200);
+		});
+	});
+});

--- a/packages/integrations/netlify/test/functions/split-support.test.js
+++ b/packages/integrations/netlify/test/functions/split-support.test.js
@@ -1,16 +1,10 @@
-import { expect, use } from 'chai';
+import { expect } from 'chai';
 import netlifyAdapter from '../../dist/index.js';
 import { loadFixture, testIntegration } from './test-utils.js';
-import chaiJestSnapshot from 'chai-jest-snapshot';
-
-use(chaiJestSnapshot);
 
 describe('Split support', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
-	beforeEach(function () {
-		chaiJestSnapshot.configureUsingMochaContext(this);
-	});
 
 	before(async () => {
 		fixture = await loadFixture({
@@ -44,15 +38,18 @@ describe('Split support', () => {
 
 	describe('Should create multiple functions', () => {
 		it('for index page', async () => {
-			const { handler } = await import(
-				'./fixtures/split-support/.netlify/functions-internal/src/pages/entry.index.astro.mjs'
+			const entryURL = new URL(
+				'./fixtures/split-support/.netlify/functions-internal/src/pages/entry.index.astro.mjs',
+				import.meta.url
 			);
+			console.debug(entryURL);
+			console.debug(entryURL.toString());
+			const { handler } = await import(entryURL);
 			const resp = await handler({
 				httpMethod: 'POST',
 				headers: {},
 				rawUrl: 'http://example.com/',
 				body: '{}',
-				isBase64Encoded: false,
 			});
 			expect(resp.statusCode).to.equal(200);
 		});
@@ -65,7 +62,6 @@ describe('Split support', () => {
 				headers: {},
 				rawUrl: 'http://example.com/blog',
 				body: '{}',
-				isBase64Encoded: false,
 			});
 			expect(resp.statusCode).to.equal(200);
 		});

--- a/packages/integrations/netlify/test/functions/split-support.test.js
+++ b/packages/integrations/netlify/test/functions/split-support.test.js
@@ -1,10 +1,16 @@
-import { expect } from 'chai';
+import { expect, use } from 'chai';
 import netlifyAdapter from '../../dist/index.js';
 import { loadFixture, testIntegration } from './test-utils.js';
+import chaiJestSnapshot from 'chai-jest-snapshot';
+
+use(chaiJestSnapshot);
 
 describe('Split support', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
+	beforeEach(function () {
+		chaiJestSnapshot.configureUsingMochaContext(this);
+	});
 
 	before(async () => {
 		fixture = await loadFixture({
@@ -33,6 +39,7 @@ describe('Split support', () => {
 
 		expect(baseRouteIndex).to.not.be.equal(-1);
 		expect(blogRouteIndex).to.not.be.equal(-1);
+		expect(redir).to.matchSnapshot();
 	});
 
 	describe('Should create multiple functions', () => {

--- a/packages/integrations/netlify/test/functions/split-support.test.js.snap
+++ b/packages/integrations/netlify/test/functions/split-support.test.js.snap
@@ -1,0 +1,6 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Split support outputs a correct redirect file 1`] = `
+"/blog    /.netlify/functions/src/pages/entry.blog.astro     200
+/        /.netlify/functions/src/pages/entry.index.astro    200"
+`;

--- a/packages/integrations/netlify/test/functions/split-support.test.js.snap
+++ b/packages/integrations/netlify/test/functions/split-support.test.js.snap
@@ -1,6 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Split support outputs a correct redirect file 1`] = `
-"/blog    /.netlify/functions/src/pages/entry.blog.astro     200
-/        /.netlify/functions/src/pages/entry.index.astro    200"
-`;

--- a/packages/integrations/netlify/test/functions/test-utils.js
+++ b/packages/integrations/netlify/test/functions/test-utils.js
@@ -7,7 +7,7 @@ export * from '../../../../astro/test/test-utils.js';
  *
  * @returns {import('../../../../astro/dist/types/@types/astro').AstroIntegration}
  */
-export function testIntegration() {
+export function testIntegration({ setEntryPoints } = {}) {
 	return {
 		name: '@astrojs/netlify/test-integration',
 		hooks: {
@@ -23,6 +23,11 @@ export function testIntegration() {
 						},
 					},
 				});
+			},
+			'astro:build:ssr': ({ entryPoints }) => {
+				if (entryPoints.size) {
+					setEntryPoints(entryPoints);
+				}
 			},
 		},
 	};

--- a/packages/integrations/netlify/test/setup.js
+++ b/packages/integrations/netlify/test/setup.js
@@ -1,0 +1,12 @@
+import { use } from 'chai';
+import chaiJestSnapshot from 'chai-jest-snapshot';
+
+use(chaiJestSnapshot);
+
+before(function () {
+	chaiJestSnapshot.resetSnapshotRegistry();
+});
+
+beforeEach(function () {
+	chaiJestSnapshot.configureUsingMochaContext(this);
+});

--- a/packages/underscore-redirects/src/astro.ts
+++ b/packages/underscore-redirects/src/astro.ts
@@ -13,9 +13,11 @@ function getRedirectStatus(route: RouteData): ValidRedirectStatus {
 
 interface CreateRedirectsFromAstroRoutesParams {
 	config: Pick<AstroConfig, 'build' | 'output'>;
-	routes: RouteData[];
+	/**
+	 * Maps a `RouteData` to a dynamic target
+	 */
+	routeToDynamicTargetMap: Map<RouteData, string>;
 	dir: URL;
-	dynamicTarget?: string;
 }
 
 /**
@@ -23,18 +25,17 @@ interface CreateRedirectsFromAstroRoutesParams {
  */
 export function createRedirectsFromAstroRoutes({
 	config,
-	routes,
+	routeToDynamicTargetMap,
 	dir,
-	dynamicTarget = '',
 }: CreateRedirectsFromAstroRoutesParams) {
 	const output = config.output;
 	const _redirects = new Redirects();
 
-	for (const route of routes) {
+	for (const [route, dynamicTarget = ''] of routeToDynamicTargetMap) {
 		// A route with a `pathname` is as static route.
 		if (route.pathname) {
 			if (route.redirect) {
-				// A redirect route without dynamic parts. Get the redirect status
+				// A redirect route without dynami§c parts. Get the redirect status
 				// from the user if provided.
 				_redirects.add({
 					dynamic: false,

--- a/packages/underscore-redirects/test/astro.test.js
+++ b/packages/underscore-redirects/test/astro.test.js
@@ -8,16 +8,22 @@ describe('Astro', () => {
 	};
 
 	it('Creates a Redirects object from routes', () => {
-		const routes = [
-			{ pathname: '/', distURL: new URL('./index.html', import.meta.url), segments: [] },
-			{ pathname: '/one', distURL: new URL('./one/index.html', import.meta.url), segments: [] },
-		];
-		const dynamicTarget = './.adapter/dist/entry.mjs';
+		const routeToDynamicTargetMap = new Map(
+			Array.from([
+				[
+					{ pathname: '/', distURL: new URL('./index.html', import.meta.url), segments: [] },
+					'./.adapter/dist/entry.mjs',
+				],
+				[
+					{ pathname: '/one', distURL: new URL('./one/index.html', import.meta.url), segments: [] },
+					'./.adapter/dist/entry.mjs',
+				],
+			])
+		);
 		const _redirects = createRedirectsFromAstroRoutes({
 			config: serverConfig,
-			routes,
+			routeToDynamicTargetMap,
 			dir: new URL(import.meta.url),
-			dynamicTarget,
 		});
 
 		expect(_redirects.definitions).to.have.a.lengthOf(2);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4431,6 +4431,9 @@ importers:
       chai:
         specifier: ^4.3.7
         version: 4.3.7
+      chai-jest-snapshot:
+        specifier: ^2.0.0
+        version: 2.0.0(chai@4.3.7)
       cheerio:
         specifier: 1.0.0-rc.12
         version: 1.0.0-rc.12


### PR DESCRIPTION
## Changes

This PR adds `build.split` support for the `@astrojs/netlify` adapter.  

List of changes:
- changed `@astrojs/underscore-redirects` payload to accept a `Map` instead of an array of routes and a dynamic target. This logically makes more sense compared to the previous logic, because a route is mapped to a dynamic target (even though we could have duplicates);
- the changes to `@astrojs/underscore-redirects` allowed me to create redirects correctly using `RouteData` -> `URL` entry point
- I added snapshot testing for netlify redirects, so we can **actually see** the emitted file in PRs and make sure it's correct

## Testing

Added new test cases

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Updated the `README.md` and added a changeset. It's a copy-paste from the Vercel one.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
