### PR TITLE
fix: `astro info` command fallback for package manager

### DIFF
--- a/.changeset/orange-mails-marry.md
+++ b/.changeset/orange-mails-marry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add a fallback label if `astro info` command can't determine the package manager used.

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -112,8 +112,9 @@ async function printInfo({
 		}
 	} catch (_e) {}
 	console.log();
+	const packageManagerName = packageManager?.name ?? "Couldn't determine.";
 	printRow('Astro version', `v${ASTRO_VERSION}`);
-	printRow('Package manager', packageManager?.name);
+	printRow('Package manager', packageManagerName);
 	printRow('Platform', platform());
 	printRow('Architecture', arch());
 	printRow('Adapter', adapter);


### PR DESCRIPTION
## Changes

This PR fixes an edge case where `astro info` command can't determine the package manager.

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
