### PR TITLE
Filter out astro from `peerDependencies` in `astro add`

### DIFF
--- a/.changeset/rude-balloons-sniff.md
+++ b/.changeset/rude-balloons-sniff.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Filter out `astro` from integration peer dependencies when running `astro add`

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -756,7 +756,8 @@ export async function validateIntegrations(integrations: string[]): Promise<Inte
 					const meta = pkgJson['peerDependenciesMeta'] || {};
 					for (const peer in pkgJson['peerDependencies']) {
 						const optional = meta[peer]?.optional || false;
-						if (!optional) {
+						const isAstro = peer === 'astro';
+						if (!optional && !isAstro) {
 							dependencies.push([peer, pkgJson['peerDependencies'][peer]]);
 						}
 					}


### PR DESCRIPTION
## Changes

A while back we started adding `astro` as a peer dependency to integrations. This means it shows up when running `astro add`. For example:

```
> astro "add" "svelte"

✔ Resolving packages...

  Astro will run the following command:
  If you skip this step, you can always run it yourself later

 ╭──────────────────────────────────────────────────────╮
 │ pnpm add @astrojs/svelte astro@^2.7.1 svelte@^4.0.0  │
 ╰──────────────────────────────────────────────────────╯
```

This PR filters out `astro` from the peer dependencies so we don’t offer to reinstall it.

## Testing

Tested in a local project with `pnpm patch`.

## Docs

Not required.
