### PR TITLE
Fixes Response not being cloneable by middleware

### DIFF
--- a/.changeset/tasty-beans-give.md
+++ b/.changeset/tasty-beans-give.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow our Response wrapper to be cloneable

--- a/packages/astro/src/runtime/server/response.ts
+++ b/packages/astro/src/runtime/server/response.ts
@@ -52,6 +52,14 @@ function createResponseClass() {
 			}
 			return super.arrayBuffer();
 		}
+
+		clone() {
+			return new StreamingCompatibleResponse!(this.#body, {
+				status: this.status,
+				statusText: this.statusText,
+				headers: this.headers
+			});
+		}
 	};
 
 	return StreamingCompatibleResponse;

--- a/packages/astro/test/fixtures/middleware-dev/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware-dev/src/middleware.js
@@ -18,6 +18,12 @@ const first = defineMiddleware(async (context, next) => {
 		return new Response(JSON.stringify(object), {
 			headers: response.headers,
 		});
+	} else if(context.url.pathname === '/clone') {
+		const response = await next();
+		const newResponse = response.clone();
+		const /** @type {string} */ html = await newResponse.text();
+		const newhtml = html.replace('<h1>testing</h1>', '<h1>it works</h1>');
+		return new Response(newhtml, { status: 200, headers: response.headers });
 	} else {
 		if(context.url.pathname === '/') {
 			context.cookies.set('foo', 'bar');

--- a/packages/astro/test/fixtures/middleware-dev/src/pages/clone.astro
+++ b/packages/astro/test/fixtures/middleware-dev/src/pages/clone.astro
@@ -1,0 +1,12 @@
+---
+
+---
+
+<html>
+<head>
+	<title>Testing</title>
+</head>
+<body>
+	<h1>testing</h1>
+</body>
+</html>

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -73,6 +73,12 @@ describe('Middleware in DEV mode', () => {
 		let res = await fixture.fetch('/');
 		expect(res.headers.get('set-cookie')).to.equal('foo=bar');
 	});
+
+	it('should be able to clone the response', async () => {
+		let res = await fixture.fetch('/clone');
+		let html = await res.text();
+		expect(html).to.contain('<h1>it works</h1>');
+	});
 });
 
 describe('Middleware in PROD mode, SSG', () => {


### PR DESCRIPTION
## Changes

- Implements `clone()` in our response wrapper.
- We should probably investigate removing this in 3.0.
- Fixes https://github.com/withastro/astro/issues/7602

## Testing

- Updated middleware test with this test case.

## Docs

N/A