### PR TITLE
Clarify SSR limitations of sitemaps of dynamic routes

### DIFF
--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -19,6 +19,9 @@ A sitemap file is recommended for large multi-page sites. If you don't use a sit
 
 With Astro Sitemap, you don't have to worry about creating this file: build your Astro site how you normally would, and the Astro Sitemap integration will crawl your routes and create the sitemap file.
 
+> **Note**
+> [Dynamic routes](https://docs.astro.build/en/core-concepts/routing/#dynamic-routes) like `[...slug]` or `src/pages/[lang]/[version]/info.astro` will generate sitemap entries for the pages those routes render, _provided that they are rendered statically_ (i.e., using `getStaticPaths()`. But because of the nature of [Astro's SSR mode](https://docs.astro.build/en/guides/server-side-rendering/), any dynamic routes that are server-rendered (via Astro's server or hybrid modes) do not output a static array of pages, so they will _not_ generate corresponding sitemap entries.
+
 ## Installation
 
 ### Quick Install


### PR DESCRIPTION
While this README doesn't distinguish between SSR mode and static mode (and SSR mode was recently made available for the sitemaps integration), there is one important difference: Dynamic routes that are server-rendered can't be used to create sitemap entries. As far as I can tell, anyway, based on experimentation and on [this comment](https://github.com/withastro/astro/pull/6534#issuecomment-1467906589)

This note makes that clear.

## Changes

Adds a note clarifying that dynamic routes can only generate sitemaps when their pages are statically generated.

## Testing

- set up a default install
- enabled SSR mode
- tried two versions of dynamic routes:
    - one from [this example](https://docs.astro.build/en/core-concepts/routing/#modifying-the-slug-example-for-ssr)
    - another that renders pages from a content collection of pages.
- sitemap failed to render

## Docs

/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
