### PR TITLE
Fix `build.excludeMiddleware` default type docs

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -854,7 +854,7 @@ export interface AstroUserConfig {
 		 * @docs
 		 * @name build.excludeMiddleware
 		 * @type {boolean}
-		 * @default {false}
+		 * @default `false`
 		 * @version 2.8.0
 		 * @description
 		 * Defines whether or not any SSR middleware code will be bundled when built.


### PR DESCRIPTION
## Changes

The default value should be enclosed by backticks, rather than curly braces to avoid a rendering issue in docs.

![image](https://github.com/withastro/astro/assets/61414485/00f5d1e4-b5e5-457d-a2da-06272a0e6884)


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

It's all about the docs
