### PR TITLE
Move all CLI commands to their subfolders

### DIFF
--- a/packages/astro/src/cli/build/index.ts
+++ b/packages/astro/src/cli/build/index.ts
@@ -1,0 +1,21 @@
+import type yargs from 'yargs-parser';
+import _build from '../../core/build/index.js';
+import type { LogOptions } from '../../core/logger/core.js';
+import { loadSettings } from '../load-settings.js';
+
+interface BuildOptions {
+	flags: yargs.Arguments;
+	logging: LogOptions;
+}
+
+export async function build({ flags, logging }: BuildOptions) {
+	const settings = await loadSettings({ cmd: 'build', flags, logging });
+	if (!settings) return;
+
+	await _build(settings, {
+		flags,
+		logging,
+		teardownCompiler: true,
+		mode: flags.mode,
+	});
+}

--- a/packages/astro/src/cli/check/index.ts
+++ b/packages/astro/src/cli/check/index.ts
@@ -17,6 +17,7 @@ import type { LogOptions } from '../../core/logger/core.js';
 import { debug, info } from '../../core/logger/core.js';
 import { printHelp } from '../../core/messages.js';
 import type { ProcessExit, SyncOptions } from '../../core/sync';
+import { loadSettings } from '../load-settings.js';
 import { printDiagnostic } from './print.js';
 
 type DiagnosticResult = {
@@ -74,15 +75,11 @@ const ASTRO_GLOB_PATTERN = '**/*.astro';
  *
  * Every time an astro files is modified, content collections are also generated.
  *
- * @param {AstroSettings} settings
  * @param {CheckPayload} options Options passed {@link AstroChecker}
  * @param {Flags} options.flags Flags coming from the CLI
  * @param {LogOptions} options.logging Logging options
  */
-export async function check(
-	settings: AstroSettings,
-	{ logging, flags }: CheckPayload
-): Promise<AstroChecker | undefined> {
+export async function check({ logging, flags }: CheckPayload): Promise<AstroChecker | undefined> {
 	if (flags.help || flags.h) {
 		printHelp({
 			commandName: 'astro check',
@@ -97,6 +94,10 @@ export async function check(
 		});
 		return;
 	}
+
+	const settings = await loadSettings({ cmd: 'check', flags, logging });
+	if (!settings) return;
+
 	const checkFlags = parseFlags(flags);
 	if (checkFlags.watch) {
 		info(logging, 'check', 'Checking files in watch mode');

--- a/packages/astro/src/cli/dev/index.ts
+++ b/packages/astro/src/cli/dev/index.ts
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import type yargs from 'yargs-parser';
+import devServer from '../../core/dev/index.js';
+import { resolveConfigPath, resolveFlags } from '../../core/config/index.js';
+import { info, type LogOptions } from '../../core/logger/core.js';
+import { handleConfigError, loadSettings } from '../load-settings.js';
+
+interface DevOptions {
+	flags: yargs.Arguments;
+	logging: LogOptions;
+}
+
+export async function dev({ flags, logging }: DevOptions) {
+	const settings = await loadSettings({ cmd: 'dev', flags, logging });
+	if (!settings) return;
+
+	const root = flags.root;
+	const configFlag = resolveFlags(flags).config;
+	const configFlagPath = configFlag ? await resolveConfigPath({ cwd: root, flags, fs }) : undefined;
+
+	await devServer(settings, {
+		configFlag,
+		configFlagPath,
+		flags,
+		logging,
+		handleConfigError(e) {
+			handleConfigError(e, { cmd: 'dev', cwd: root, flags, logging });
+			info(logging, 'astro', 'Continuing with previous valid configuration\n');
+		},
+	});
+}

--- a/packages/astro/src/cli/dev/index.ts
+++ b/packages/astro/src/cli/dev/index.ts
@@ -18,7 +18,7 @@ export async function dev({ flags, logging }: DevOptions) {
 	const configFlag = resolveFlags(flags).config;
 	const configFlagPath = configFlag ? await resolveConfigPath({ cwd: root, flags, fs }) : undefined;
 
-	await devServer(settings, {
+	return await devServer(settings, {
 		configFlag,
 		configFlagPath,
 		flags,

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -161,6 +161,14 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 			await build({ flags, logging });
 			return;
 		}
+		case 'preview': {
+			const { preview } = await import('./preview/index.js');
+			const server = await preview({ flags, logging });
+			if (server) {
+				return await server.closed(); // keep alive until the server is closed
+			}
+			return;
+		}
 
 		case 'check': {
 			const { check } = await import('./check/index.js');
@@ -189,19 +197,6 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 
 			const result = await syncCli(settings, { logging, fs, flags });
 			return process.exit(result);
-		}
-
-		case 'preview': {
-			const { default: preview } = await import('../core/preview/index.js');
-
-			const settings = await loadSettings({ cmd, flags, logging });
-			if (!settings) return;
-
-			const server = await preview(settings, { logging, flags });
-			if (server) {
-				return await server.closed(); // keep alive until the server is closed
-			}
-			return;
 		}
 	}
 

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -152,26 +152,8 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 			return;
 		}
 		case 'dev': {
-			const { default: devServer } = await import('../core/dev/index.js');
-
-			const settings = await loadSettings({ cmd, flags, logging });
-			if (!settings) return;
-
-			const configFlag = resolveFlags(flags).config;
-			const configFlagPath = configFlag
-				? await resolveConfigPath({ cwd: root, flags, fs })
-				: undefined;
-
-			await devServer(settings, {
-				configFlag,
-				configFlagPath,
-				flags,
-				logging,
-				handleConfigError(e) {
-					handleConfigError(e, { cmd, cwd: root, flags, logging });
-					info(logging, 'astro', 'Continuing with previous valid configuration\n');
-				},
-			});
+			const { dev } = await import('./dev/index.js');
+			await dev({ flags, logging });
 			return await new Promise(() => {}); // lives forever
 		}
 

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -156,19 +156,10 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 			await dev({ flags, logging });
 			return await new Promise(() => {}); // lives forever
 		}
-
 		case 'build': {
-			const { default: build } = await import('../core/build/index.js');
-
-			const settings = await loadSettings({ cmd, flags, logging });
-			if (!settings) return;
-
-			return await build(settings, {
-				flags,
-				logging,
-				teardownCompiler: true,
-				mode: flags.mode,
-			});
+			const { build } = await import('./build/index.js');
+			await build({ flags, logging });
+			return;
 		}
 
 		case 'check': {

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -183,15 +183,10 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 				}
 			}
 		}
-
 		case 'sync': {
-			const { syncCli } = await import('../core/sync/index.js');
-
-			const settings = await loadSettings({ cmd, flags, logging });
-			if (!settings) return;
-
-			const result = await syncCli(settings, { logging, fs, flags });
-			return process.exit(result);
+			const { sync } = await import('./sync/index.js');
+			const exitCode = await sync({ flags, logging });
+			return process.exit(exitCode);
 		}
 	}
 

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -169,15 +169,10 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 			}
 			return;
 		}
-
 		case 'check': {
 			const { check } = await import('./check/index.js');
-
-			const settings = await loadSettings({ cmd, flags, logging });
-			if (!settings) return;
-
 			// We create a server to start doing our operations
-			const checkServer = await check(settings, { flags, logging });
+			const checkServer = await check({ flags, logging });
 			if (checkServer) {
 				if (checkServer.isWatchMode) {
 					await checkServer.watch();

--- a/packages/astro/src/cli/load-settings.ts
+++ b/packages/astro/src/cli/load-settings.ts
@@ -1,0 +1,46 @@
+/* eslint-disable no-console */
+import fs from 'fs';
+import * as colors from 'kleur/colors';
+import type { Arguments as Flags } from 'yargs-parser';
+import { ZodError } from 'zod';
+import { createSettings, openConfig, resolveConfigPath } from '../core/config/index.js';
+import { collectErrorMetadata } from '../core/errors/dev/index.js';
+import { error, type LogOptions } from '../core/logger/core.js';
+import { formatConfigErrorMessage, formatErrorMessage } from '../core/messages.js';
+import * as event from '../events/index.js';
+import { eventConfigError, telemetry } from '../events/index.js';
+
+interface LoadSettingsOptions {
+	cmd: string;
+	flags: Flags;
+	logging: LogOptions;
+}
+
+export async function loadSettings({ cmd, flags, logging }: LoadSettingsOptions) {
+	const root = flags.root;
+	const { astroConfig: initialAstroConfig, userConfig: initialUserConfig } = await openConfig({
+		cwd: root,
+		flags,
+		cmd,
+	}).catch(async (e) => {
+		await handleConfigError(e, { cmd, cwd: root, flags, logging });
+		return {} as any;
+	});
+	if (!initialAstroConfig) return;
+	telemetry.record(event.eventCliSession(cmd, initialUserConfig, flags));
+	return createSettings(initialAstroConfig, root);
+}
+
+export async function handleConfigError(
+	e: any,
+	{ cmd, cwd, flags, logging }: { cmd: string; cwd?: string; flags?: Flags; logging: LogOptions }
+) {
+	const path = await resolveConfigPath({ cwd, flags, fs });
+	error(logging, 'astro', `Unable to load ${path ? colors.bold(path) : 'your Astro config'}\n`);
+	if (e instanceof ZodError) {
+		console.error(formatConfigErrorMessage(e) + '\n');
+		telemetry.record(eventConfigError({ cmd, err: e, isFatal: true }));
+	} else if (e instanceof Error) {
+		console.error(formatErrorMessage(collectErrorMetadata(e)) + '\n');
+	}
+}

--- a/packages/astro/src/cli/preview/index.ts
+++ b/packages/astro/src/cli/preview/index.ts
@@ -1,0 +1,16 @@
+import type yargs from 'yargs-parser';
+import type { LogOptions } from '../../core/logger/core.js';
+import previewServer from '../../core/preview/index.js';
+import { loadSettings } from '../load-settings.js';
+
+interface PreviewOptions {
+	flags: yargs.Arguments;
+	logging: LogOptions;
+}
+
+export async function preview({ flags, logging }: PreviewOptions) {
+	const settings = await loadSettings({ cmd: 'preview', flags, logging });
+	if (!settings) return;
+
+	return await previewServer(settings, { flags, logging });
+}

--- a/packages/astro/src/cli/sync/index.ts
+++ b/packages/astro/src/cli/sync/index.ts
@@ -1,0 +1,18 @@
+import fs from 'fs';
+import type yargs from 'yargs-parser';
+import type { LogOptions } from '../../core/logger/core.js';
+import { syncCli } from '../../core/sync/index.js';
+import { loadSettings } from '../load-settings.js';
+
+interface SyncOptions {
+	flags: yargs.Arguments;
+	logging: LogOptions;
+}
+
+export async function sync({ flags, logging }: SyncOptions) {
+	const settings = await loadSettings({ cmd: 'sync', flags, logging });
+	if (!settings) return;
+
+	const exitCode = await syncCli(settings, { logging, fs, flags });
+	return exitCode;
+}


### PR DESCRIPTION
## Changes

- Move the `dev`, `build`, `preview`, `sync` commands to their own folder
- Move loading `settings` to each command itself

---

This currently creates more code, but only a stop point for now to make further refactoring easier. Each command can now start the actual work with only the `flags` and `logging` params.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested manually. This should also improve startup perf a little. Will run the benchmark

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. internal refactor.