### PR TITLE
nit: export props has been unnecessary.. forever

### DIFF
--- a/examples/basics/src/components/Card.astro
+++ b/examples/basics/src/components/Card.astro
@@ -1,5 +1,5 @@
 ---
-export interface Props {
+interface Props {
 	title: string;
 	body: string;
 	href: string;

--- a/examples/basics/src/layouts/Layout.astro
+++ b/examples/basics/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-export interface Props {
+interface Props {
 	title: string;
 }
 

--- a/examples/blog/src/components/BaseHead.astro
+++ b/examples/blog/src/components/BaseHead.astro
@@ -3,7 +3,7 @@
 // all pages through the use of the <BaseHead /> component.
 import '../styles/global.css';
 
-export interface Props {
+interface Props {
 	title: string;
 	description: string;
 	image?: string;

--- a/examples/blog/src/components/FormattedDate.astro
+++ b/examples/blog/src/components/FormattedDate.astro
@@ -1,5 +1,5 @@
 ---
-export interface Props {
+interface Props {
 	date: Date;
 }
 

--- a/examples/component/src/MyComponent.astro
+++ b/examples/component/src/MyComponent.astro
@@ -1,6 +1,6 @@
 ---
 // Write your component code in this file!
-export interface Props {
+interface Props {
 	prefix?: string;
 }
 ---

--- a/examples/deno/src/components/Layout.astro
+++ b/examples/deno/src/components/Layout.astro
@@ -1,5 +1,5 @@
 ---
-export interface Props {
+interface Props {
 	title: string;
 }
 

--- a/examples/framework-alpine/src/components/Counter.astro
+++ b/examples/framework-alpine/src/components/Counter.astro
@@ -2,7 +2,7 @@
 // Full Astro Component Syntax:
 // https://docs.astro.build/core-concepts/astro-components/
 
-export interface Props {
+interface Props {
 	initialCount?: number;
 }
 

--- a/examples/hackernews/src/components/Comment.astro
+++ b/examples/hackernews/src/components/Comment.astro
@@ -1,10 +1,10 @@
 ---
+import type { IComment } from '../types.js';
 import For from './For.astro';
 import Show from './Show.astro';
 import Toggle from './Toggle.astro';
-import type { IComment } from '../types.js';
 
-export interface Props {
+interface Props {
 	comment: IComment;
 }
 

--- a/examples/hackernews/src/components/For.astro
+++ b/examples/hackernews/src/components/For.astro
@@ -1,7 +1,7 @@
 ---
 import Show from './Show.astro';
 
-export interface Props<T> {
+interface Props<T> {
 	each: Iterable<T>;
 }
 

--- a/examples/hackernews/src/components/Show.astro
+++ b/examples/hackernews/src/components/Show.astro
@@ -1,5 +1,5 @@
 ---
-export interface Props<T> {
+interface Props<T> {
 	when: T | number | boolean | undefined | null;
 }
 

--- a/examples/hackernews/src/components/Story.astro
+++ b/examples/hackernews/src/components/Story.astro
@@ -1,8 +1,8 @@
 ---
-import Show from './Show.astro';
 import type { IStory } from '../types.js';
+import Show from './Show.astro';
 
-export interface Props {
+interface Props {
 	story: IStory;
 }
 

--- a/examples/hackernews/src/components/Toggle.astro
+++ b/examples/hackernews/src/components/Toggle.astro
@@ -1,5 +1,5 @@
 ---
-export interface Props {
+interface Props {
 	open?: boolean;
 }
 

--- a/examples/middleware/src/components/Card.astro
+++ b/examples/middleware/src/components/Card.astro
@@ -1,5 +1,5 @@
 ---
-export interface Props {
+interface Props {
 	title: string;
 	body: string;
 	href: string;

--- a/examples/middleware/src/layouts/Layout.astro
+++ b/examples/middleware/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-export interface Props {
+interface Props {
 	title: string;
 }
 

--- a/examples/portfolio/src/components/Icon.astro
+++ b/examples/portfolio/src/components/Icon.astro
@@ -2,7 +2,7 @@
 import type { HTMLAttributes } from 'astro/types';
 import { iconPaths } from './IconPaths';
 
-export interface Props {
+interface Props {
 	icon: keyof typeof iconPaths;
 	color?: string;
 	gradient?: boolean;

--- a/examples/with-markdoc/src/components/Aside.astro
+++ b/examples/with-markdoc/src/components/Aside.astro
@@ -2,7 +2,7 @@
 // Inspired by the `Aside` component from docs.astro.build
 // https://github.com/withastro/docs/blob/main/src/components/Aside.astro
 
-export interface Props {
+interface Props {
 	type?: 'note' | 'tip' | 'caution' | 'danger';
 	title?: string;
 }

--- a/examples/with-markdoc/src/layouts/Layout.astro
+++ b/examples/with-markdoc/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-export interface Props {
+interface Props {
 	title: string;
 }
 

--- a/examples/with-nanostores/src/layouts/Layout.astro
+++ b/examples/with-nanostores/src/layouts/Layout.astro
@@ -1,8 +1,8 @@
 ---
-import CartFlyoutToggle from '../components/CartFlyoutToggle';
 import CartFlyout from '../components/CartFlyout';
+import CartFlyoutToggle from '../components/CartFlyoutToggle';
 
-export interface Props {
+interface Props {
 	title: string;
 }
 
@@ -34,7 +34,7 @@ const { title } = Astro.props;
 	:root {
 		--font-family: system-ui, sans-serif;
 		--font-size-base: clamp(1rem, 0.34vw + 0.91rem, 1.19rem);
-		--font-size-lg: clamp(1.2rem, 0.7vw + 1.2rem, 1.5rem); 
+		--font-size-lg: clamp(1.2rem, 0.7vw + 1.2rem, 1.5rem);
 		--font-size-xl: clamp(2.0rem, 1.75vw + 1.35rem, 2.75rem);
 
 		--color-text: hsl(12, 5%, 4%);

--- a/packages/astro-prism/Prism.astro
+++ b/packages/astro-prism/Prism.astro
@@ -1,7 +1,7 @@
 ---
 import { runHighlighterWithAstro } from './dist/highlighter';
 
-export interface Props {
+interface Props {
 	class?: string;
 	lang?: string;
 	code: string;

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -3,7 +3,7 @@ import type * as shiki from 'shiki';
 import { renderToHtml } from 'shiki';
 import { getHighlighter } from './Shiki.js';
 
-export interface Props {
+interface Props {
 	/** The code to highlight. Required. */
 	code: string;
 	/**

--- a/packages/astro/performance/fixtures/utils/Aside.astro
+++ b/packages/astro/performance/fixtures/utils/Aside.astro
@@ -2,7 +2,7 @@
 // Inspired by the `Aside` component from docs.astro.build
 // https://github.com/withastro/docs/blob/main/src/components/Aside.astro
 
-export interface Props {
+interface Props {
 	type?: 'note' | 'tip' | 'caution' | 'danger';
 	title?: string;
 }

--- a/packages/astro/test/fixtures/content-ssr-integration/src/components/HeaderLink.astro
+++ b/packages/astro/test/fixtures/content-ssr-integration/src/components/HeaderLink.astro
@@ -1,5 +1,5 @@
 ---
-export interface Props extends astroHTML.JSX.AnchorHTMLAttributes {}
+interface Props extends astroHTML.JSX.AnchorHTMLAttributes {}
 
 const { href, class: className, ...props } = Astro.props;
 

--- a/packages/astro/test/fixtures/content-static-paths-integration/src/components/HeaderLink.astro
+++ b/packages/astro/test/fixtures/content-static-paths-integration/src/components/HeaderLink.astro
@@ -1,5 +1,5 @@
 ---
-export interface Props extends astroHTML.JSX.AnchorHTMLAttributes {}
+interface Props extends astroHTML.JSX.AnchorHTMLAttributes {}
 
 const { href, class: className, ...props } = Astro.props;
 

--- a/packages/astro/test/fixtures/css-import-as-inline/src/layouts/Layout.astro
+++ b/packages/astro/test/fixtures/css-import-as-inline/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-export interface Props {
+interface Props {
 	title: string;
 }
 

--- a/packages/astro/test/fixtures/css-inline-stylesheets/always/src/layouts/Layout.astro
+++ b/packages/astro/test/fixtures/css-inline-stylesheets/always/src/layouts/Layout.astro
@@ -1,8 +1,8 @@
 ---
-import '../imported.css';
 import Button from '../components/Button.astro';
+import '../imported.css';
 
-export interface Props {
+interface Props {
 	title: string;
 }
 

--- a/packages/astro/test/fixtures/css-inline-stylesheets/auto/src/layouts/Layout.astro
+++ b/packages/astro/test/fixtures/css-inline-stylesheets/auto/src/layouts/Layout.astro
@@ -1,8 +1,8 @@
 ---
-import '../imported.css';
 import Button from '../components/Button.astro';
+import '../imported.css';
 
-export interface Props {
+interface Props {
 	title: string;
 }
 

--- a/packages/astro/test/fixtures/css-inline-stylesheets/never/src/layouts/Layout.astro
+++ b/packages/astro/test/fixtures/css-inline-stylesheets/never/src/layouts/Layout.astro
@@ -1,8 +1,8 @@
 ---
-import '../imported.css';
 import Button from '../components/Button.astro';
+import '../imported.css';
 
-export interface Props {
+interface Props {
 	title: string;
 }
 

--- a/packages/astro/test/fixtures/head-injection/src/components/SlotsRender.astro
+++ b/packages/astro/test/fixtures/head-injection/src/components/SlotsRender.astro
@@ -1,5 +1,5 @@
 ---
-export interface Props {
+interface Props {
   title: string;
   subtitle: string;
   content?: string;

--- a/packages/astro/test/fixtures/unused-slot/src/components/Card.astro
+++ b/packages/astro/test/fixtures/unused-slot/src/components/Card.astro
@@ -1,5 +1,5 @@
 ---
-export interface Props {
+interface Props {
     title: string,
     body: string,
     href: string,

--- a/packages/integrations/markdoc/test/fixtures/propagated-assets/src/components/Aside.astro
+++ b/packages/integrations/markdoc/test/fixtures/propagated-assets/src/components/Aside.astro
@@ -2,7 +2,7 @@
 // Inspired by the `Aside` component from docs.astro.build
 // https://github.com/withastro/docs/blob/main/src/components/Aside.astro
 
-export interface Props {
+interface Props {
 	type?: 'note' | 'tip' | 'caution' | 'danger';
 	title?: string;
 }

--- a/packages/integrations/mdx/test/fixtures/css-head-mdx/src/layouts/ContentLayout.astro
+++ b/packages/integrations/mdx/test/fixtures/css-head-mdx/src/layouts/ContentLayout.astro
@@ -1,6 +1,6 @@
 ---
 import BaseHead from "../components/BaseHead.astro";
-export interface Props {
+interface Props {
 	title: string;
 }
 

--- a/packages/markdown/component/Markdown.astro
+++ b/packages/markdown/component/Markdown.astro
@@ -1,5 +1,5 @@
 ---
-export interface Props {
+interface Props {
 	content?: string;
 }
 


### PR DESCRIPTION
## Changes

People always get confused by `export interface Props` since the `export` has never, ever, been needed. This removes it from every public-facing files in the repo

## Testing

N/A

## Docs

N/A
