### PR TITLE
Add new internal `resolveConfig` API

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1309,6 +1309,9 @@ export interface AstroConfig extends z.output<typeof AstroConfigSchema> {
 	// TypeScript still confirms zod validation matches this type.
 	integrations: AstroIntegration[];
 }
+export interface AstroInlineConfig extends AstroUserConfig {
+	configFile?: string | false;
+}
 
 export type ContentEntryModule = {
 	id: string;

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -9,7 +9,7 @@ import preferredPM from 'preferred-pm';
 import prompts from 'prompts';
 import { fileURLToPath, pathToFileURL } from 'url';
 import type yargs from 'yargs-parser';
-import { loadTSConfig, resolveConfigPath } from '../../core/config/index.js';
+import { loadTSConfig, resolveConfigPath, resolveRoot } from '../../core/config/index.js';
 import {
 	defaultTSConfig,
 	presets,
@@ -133,7 +133,8 @@ export async function add(names: string[], { flags, logging }: AddOptions) {
 	const integrationNames = names.map((name) => (ALIASES.has(name) ? ALIASES.get(name)! : name));
 	const integrations = await validateIntegrations(integrationNames);
 	let installResult = await tryToInstallIntegrations({ integrations, cwd, flags, logging });
-	const root = pathToFileURL(cwd ? path.resolve(cwd) : process.cwd());
+	const rootPath = resolveRoot(cwd);
+	const root = pathToFileURL(rootPath);
 	// Append forward slash to compute relative paths
 	root.href = appendForwardSlash(root.href);
 
@@ -199,7 +200,11 @@ export async function add(names: string[], { flags, logging }: AddOptions) {
 		}
 	}
 
-	const rawConfigPath = await resolveConfigPath({ cwd, flags, fs: fsMod });
+	const rawConfigPath = await resolveConfigPath({
+		root: rootPath,
+		configFile: flags.config,
+		fs: fsMod,
+	});
 	let configURL = rawConfigPath ? pathToFileURL(rawConfigPath) : undefined;
 
 	if (configURL) {

--- a/packages/astro/src/cli/dev/index.ts
+++ b/packages/astro/src/cli/dev/index.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import type yargs from 'yargs-parser';
-import { resolveConfigPath, resolveFlags } from '../../core/config/index.js';
+import { resolveConfigPath, resolveFlags, resolveRoot } from '../../core/config/index.js';
 import devServer from '../../core/dev/index.js';
 import { info, type LogOptions } from '../../core/logger/core.js';
 import { handleConfigError, loadSettings } from '../load-settings.js';
@@ -14,9 +14,11 @@ export async function dev({ flags, logging }: DevOptions) {
 	const settings = await loadSettings({ cmd: 'dev', flags, logging });
 	if (!settings) return;
 
-	const root = flags.root;
+	const root = resolveRoot(flags.root);
 	const configFlag = resolveFlags(flags).config;
-	const configFlagPath = configFlag ? await resolveConfigPath({ cwd: root, flags, fs }) : undefined;
+	const configFlagPath = configFlag
+		? await resolveConfigPath({ root, configFile: configFlag, fs })
+		: undefined;
 
 	return await devServer(settings, {
 		configFlag,

--- a/packages/astro/src/cli/load-settings.ts
+++ b/packages/astro/src/cli/load-settings.ts
@@ -3,12 +3,18 @@ import fs from 'fs';
 import * as colors from 'kleur/colors';
 import type { Arguments as Flags } from 'yargs-parser';
 import { ZodError } from 'zod';
-import { createSettings, openConfig, resolveConfigPath } from '../core/config/index.js';
+import {
+	createSettings,
+	openConfig,
+	resolveConfigPath,
+	resolveRoot,
+} from '../core/config/index.js';
 import { collectErrorMetadata } from '../core/errors/dev/index.js';
 import { error, type LogOptions } from '../core/logger/core.js';
 import { formatConfigErrorMessage, formatErrorMessage } from '../core/messages.js';
 import * as event from '../events/index.js';
 import { eventConfigError, telemetry } from '../events/index.js';
+import type { AstroInlineConfig } from '../@types/astro.js';
 
 interface LoadSettingsOptions {
 	cmd: string;
@@ -35,7 +41,8 @@ export async function handleConfigError(
 	e: any,
 	{ cmd, cwd, flags, logging }: { cmd: string; cwd?: string; flags?: Flags; logging: LogOptions }
 ) {
-	const path = await resolveConfigPath({ cwd, flags, fs });
+	const root = resolveRoot(cwd);
+	const path = await resolveConfigPath({ root, configFile: flags?.config, fs });
 	error(logging, 'astro', `Unable to load ${path ? colors.bold(path) : 'your Astro config'}\n`);
 	if (e instanceof ZodError) {
 		console.error(formatConfigErrorMessage(e) + '\n');
@@ -43,4 +50,27 @@ export async function handleConfigError(
 	} else if (e instanceof Error) {
 		console.error(formatErrorMessage(collectErrorMetadata(e)) + '\n');
 	}
+}
+
+export function flagsToAstroInlineConfig(flags: Flags): AstroInlineConfig {
+	return {
+		configFile: typeof flags.config === 'string' ? flags.config : undefined,
+		root: typeof flags.root === 'string' ? flags.root : undefined,
+		site: typeof flags.site === 'string' ? flags.site : undefined,
+		base: typeof flags.base === 'string' ? flags.base : undefined,
+		markdown: {
+			drafts: typeof flags.drafts === 'boolean' ? flags.drafts : undefined,
+		},
+		server: {
+			port: typeof flags.port === 'number' ? flags.port : undefined,
+			host:
+				typeof flags.host === 'string' || typeof flags.host === 'boolean' ? flags.host : undefined,
+			open: typeof flags.open === 'boolean' ? flags.open : undefined,
+		},
+		experimental: {
+			assets: typeof flags.experimentalAssets === 'boolean' ? flags.experimentalAssets : undefined,
+			redirects:
+				typeof flags.experimentalRedirects === 'boolean' ? flags.experimentalRedirects : undefined,
+		},
+	};
 }

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -1,5 +1,5 @@
 import type { Arguments as Flags } from 'yargs-parser';
-import type { AstroConfig, AstroUserConfig, CLIFlags } from '../../@types/astro';
+import type { AstroConfig, AstroUserConfig, CLIFlags, AstroInlineConfig } from '../../@types/astro';
 
 import fs from 'fs';
 import * as colors from 'kleur/colors';
@@ -10,7 +10,7 @@ import { mergeConfig } from './merge.js';
 import { createRelativeSchema } from './schema.js';
 import { loadConfigWithVite } from './vite-load.js';
 
-export const LEGACY_ASTRO_CONFIG_KEYS = new Set([
+const LEGACY_ASTRO_CONFIG_KEYS = new Set([
 	'projectRoot',
 	'src',
 	'pages',
@@ -23,11 +23,7 @@ export const LEGACY_ASTRO_CONFIG_KEYS = new Set([
 ]);
 
 /** Turn raw config values into normalized values */
-export async function validateConfig(
-	userConfig: any,
-	root: string,
-	cmd: string
-): Promise<AstroConfig> {
+async function validateConfig(userConfig: any, root: string, cmd: string): Promise<AstroConfig> {
 	const fileProtocolRoot = pathToFileURL(root + path.sep);
 	// Manual deprecation checks
 	/* eslint-disable no-console */
@@ -88,6 +84,8 @@ export async function validateConfig(
 }
 
 /** Convert the generic "yargs" flag object into our own, custom TypeScript object. */
+// NOTE: This function will be removed in a later PR. Use `flagsToAstroInlineConfig` instead.
+// All CLI related flow should be located in the `packages/astro/src/cli` directory.
 export function resolveFlags(flags: Partial<Flags>): CLIFlags {
 	return {
 		root: typeof flags.root === 'string' ? flags.root : undefined,
@@ -157,8 +155,8 @@ interface LoadConfigOptions {
 }
 
 interface ResolveConfigPathOptions {
-	cwd?: string;
-	flags?: Flags;
+	root: string;
+	configFile?: string;
 	fs: typeof fs;
 }
 
@@ -166,73 +164,65 @@ interface ResolveConfigPathOptions {
  * Resolve the file URL of the user's `astro.config.js|cjs|mjs|ts` file
  */
 export async function resolveConfigPath(
-	configOptions: ResolveConfigPathOptions
+	options: ResolveConfigPathOptions
 ): Promise<string | undefined> {
-	const root = resolveRoot(configOptions.cwd);
-	const flags = resolveFlags(configOptions.flags || {});
-
 	let userConfigPath: string | undefined;
-	if (flags?.config) {
-		userConfigPath = /^\.*\//.test(flags.config) ? flags.config : `./${flags.config}`;
-		userConfigPath = fileURLToPath(new URL(userConfigPath, `file://${root}/`));
-		if (!configOptions.fs.existsSync(userConfigPath)) {
+	if (options.configFile) {
+		userConfigPath = path.join(options.root, options.configFile);
+		if (!options.fs.existsSync(userConfigPath)) {
 			throw new AstroError({
 				...AstroErrorData.ConfigNotFound,
-				message: AstroErrorData.ConfigNotFound.message(flags.config),
+				message: AstroErrorData.ConfigNotFound.message(options.configFile),
 			});
 		}
 	} else {
-		userConfigPath = await search(configOptions.fs, root);
+		userConfigPath = await search(options.fs, options.root);
 	}
 
 	return userConfigPath;
 }
 
-interface OpenConfigResult {
-	userConfig: AstroUserConfig;
-	astroConfig: AstroConfig;
-	flags: CLIFlags;
-	root: string;
-}
-
 /** Load a configuration file, returning both the userConfig and astroConfig */
-export async function openConfig(configOptions: LoadConfigOptions): Promise<OpenConfigResult> {
+// NOTE: This function will be removed in a later PR. Use `resolveConfig` instead.
+export async function openConfig(configOptions: LoadConfigOptions): Promise<ResolveConfigResult> {
 	const root = resolveRoot(configOptions.cwd);
 	const flags = resolveFlags(configOptions.flags || {});
 
-	const userConfig = await loadConfig(configOptions, root);
-	const astroConfig = await resolveConfig(userConfig, root, flags, configOptions.cmd);
+	const userConfig = await loadConfig(root, flags.config, configOptions.fsMod);
+	const astroConfig = await resolveConfigLegacy(userConfig, root, flags, configOptions.cmd);
 
 	return {
-		astroConfig,
 		userConfig,
-		flags,
-		root,
+		astroConfig,
 	};
 }
 
 async function loadConfig(
-	configOptions: LoadConfigOptions,
-	root: string
+	root: string,
+	configFile?: string | false,
+	fsMod = fs
 ): Promise<Record<string, any>> {
-	const fsMod = configOptions.fsMod ?? fs;
+	if (configFile === false) return {};
+
 	const configPath = await resolveConfigPath({
-		cwd: configOptions.cwd,
-		flags: configOptions.flags,
+		root,
+		configFile,
 		fs: fsMod,
 	});
 	if (!configPath) return {};
 
 	// Create a vite server to load the config
 	return await loadConfigWithVite({
+		root,
 		configPath,
 		fs: fsMod,
-		root,
 	});
 }
 
 /** Attempt to resolve an Astro configuration object. Normalize, validate, and return. */
-export async function resolveConfig(
+// NOTE: This function will be removed in a later PR. Renamed with "Legacy" suffix to make way
+// for the new `resolveConfig` API.
+async function resolveConfigLegacy(
 	userConfig: AstroUserConfig,
 	root: string,
 	flags: CLIFlags = {},
@@ -248,5 +238,25 @@ export function createDefaultDevConfig(
 	userConfig: AstroUserConfig = {},
 	root: string = process.cwd()
 ) {
-	return resolveConfig(userConfig, root, undefined, 'dev');
+	return resolveConfigLegacy(userConfig, root, undefined, 'dev');
+}
+
+interface ResolveConfigResult {
+	userConfig: AstroUserConfig;
+	astroConfig: AstroConfig;
+}
+
+// NOTE: This is the new API to load an Astro config. Use this instead of the other functions!
+export async function resolveConfig(
+	inlineConfig: AstroInlineConfig,
+	command: string,
+	fsMod = fs
+): Promise<ResolveConfigResult> {
+	const root = resolveRoot(inlineConfig.root);
+
+	const userConfig = await loadConfig(root, inlineConfig.configFile, fsMod);
+	const mergedConfig = mergeConfig(userConfig, inlineConfig);
+	const astroConfig = await validateConfig(mergedConfig, root, command);
+
+	return { userConfig, astroConfig };
 }

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -23,7 +23,7 @@ const LEGACY_ASTRO_CONFIG_KEYS = new Set([
 ]);
 
 /** Turn raw config values into normalized values */
-async function validateConfig(userConfig: any, root: string, cmd: string): Promise<AstroConfig> {
+export async function validateConfig(userConfig: any, root: string, cmd: string): Promise<AstroConfig> {
 	const fileProtocolRoot = pathToFileURL(root + path.sep);
 	// Manual deprecation checks
 	/* eslint-disable no-console */

--- a/packages/astro/src/core/config/index.ts
+++ b/packages/astro/src/core/config/index.ts
@@ -2,9 +2,9 @@ export {
 	createDefaultDevConfig,
 	openConfig,
 	resolveConfigPath,
+	resolveConfig,
 	resolveFlags,
 	resolveRoot,
-	validateConfig,
 } from './config.js';
 export { mergeConfig } from './merge.js';
 export type { AstroConfigSchema } from './schema';

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { z } from 'zod';
 import stripAnsi from 'strip-ansi';
 import { formatConfigErrorMessage } from '../../../dist/core/messages.js';
-import { validateConfig } from '../../../dist/core/config/index.js';
+import { validateConfig } from '../../../dist/core/config/config.js';
 
 describe('Config Validation', () => {
 	it('empty user config is valid', async () => {


### PR DESCRIPTION
## Changes

**Note: This merges into the `js-api` branch while I work on these step-by-step**

- Add new `resolveConfig` API. Does the same thing as `openConfig`, but duplicating to easier migrate step-by-step.
- Add `AstroInlineConfig` type. Ideally this will be the config type the `dev` / `build` JS API will accept. ("inline" borrowed from Vite)
- Refactor `resolveConfigPath` to not accept the raw `flags`. Easier to divide between JS and CLI code.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. internal refactor.