### PR TITLE
Remove weird changeset symbols

### DIFF
--- a/.changeset/fluffy-timers-remain.md
+++ b/.changeset/fluffy-timers-remain.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fix `astro:assets` not respecting EXIF rotation
+Fix `astro:assets` not respecting EXIF rotation

--- a/.changeset/tasty-bags-accept.md
+++ b/.changeset/tasty-bags-accept.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Add support for using `.svg` files with `astro:assets`'s base services. The SVGs will NOT be processed and will be return as-is, however, proper attributes, alt enforcement etc will all work correctly.
+Add support for using `.svg` files with `astro:assets`'s base services. The SVGs will NOT be processed and will be return as-is, however, proper attributes, alt enforcement etc will all work correctly.


### PR DESCRIPTION
## Changes

The release PR changelog currently have weird symbols so this removes them 😄 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
n/a

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a