### PR TITLE
Handle flaky tests

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -107,8 +107,8 @@
     "postbuild": "astro-scripts copy \"src/**/*.astro\" && astro-scripts copy \"src/**/*.wasm\"",
     "test:unit": "mocha --exit --timeout 30000 ./test/units/**/*.test.js",
     "test:unit:match": "mocha --exit --timeout 30000 ./test/units/**/*.test.js -g",
-    "test": "pnpm run test:unit && mocha --exit --timeout 20000 --ignore **/lit-element.test.js && mocha --timeout 20000 **/lit-element.test.js",
-    "test:match": "mocha --timeout 20000 -g",
+    "test": "pnpm run test:unit && mocha --exit --timeout 30000 --ignore **/lit-element.test.js && mocha --timeout 30000 **/lit-element.test.js",
+    "test:match": "mocha --timeout 30000 -g",
     "test:e2e": "playwright test",
     "test:e2e:match": "playwright test -g"
   },

--- a/packages/astro/test/astro-get-static-paths.test.js
+++ b/packages/astro/test/astro-get-static-paths.test.js
@@ -54,7 +54,11 @@ describe('getStaticPaths - dev calls', () => {
 		await devServer.stop();
 	});
 
-	it('only calls getStaticPaths once', async () => {
+	it('only calls getStaticPaths once', async function () {
+		// Sometimes this fail in CI as the chokidar watcher triggers an update and invalidates the route cache,
+		// causing getStaticPaths to be called twice. Workaround this with 2 retries for now.
+		this.retries(2);
+
 		let res = await fixture.fetch('/a');
 		expect(res.status).to.equal(200);
 

--- a/packages/integrations/cloudflare/test/basics.test.js
+++ b/packages/integrations/cloudflare/test/basics.test.js
@@ -5,28 +5,29 @@ import * as cheerio from 'cheerio';
 describe.skip('Basic app', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
+	/** @type {import('./test-utils').WranglerCLI} */
+	let cli;
 
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/basics/',
 		});
 		await fixture.build();
+
+		cli = runCLI('./fixtures/basics/', { silent: true, port: 8789 });
+		await cli.ready;
+	});
+
+	after(async () => {
+		await cli.stop();
 	});
 
 	it('can render', async () => {
-		const { ready, stop } = runCLI('./fixtures/basics/', { silent: true, port: 8789 });
-
-		try {
-			await ready;
-
-			let res = await fetch(`http://localhost:8789/`);
-			expect(res.status).to.equal(200);
-			let html = await res.text();
-			let $ = cheerio.load(html);
-			expect($('h1').text()).to.equal('Testing');
-			expect($('#env').text()).to.equal('secret');
-		} finally {
-			await stop();
-		}
+		let res = await fetch(`http://localhost:8789/`);
+		expect(res.status).to.equal(200);
+		let html = await res.text();
+		let $ = cheerio.load(html);
+		expect($('h1').text()).to.equal('Testing');
+		expect($('#env').text()).to.equal('secret');
 	});
 });

--- a/packages/integrations/cloudflare/test/cf.test.js
+++ b/packages/integrations/cloudflare/test/cf.test.js
@@ -6,6 +6,8 @@ import cloudflare from '../dist/index.js';
 describe('Cf metadata and caches', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
+	/** @type {import('./test-utils').WranglerCLI} */
+	let cli;
 
 	before(async () => {
 		fixture = await loadFixture({
@@ -14,22 +16,22 @@ describe('Cf metadata and caches', () => {
 			adapter: cloudflare(),
 		});
 		await fixture.build();
+
+		cli = runCLI('./fixtures/cf/', { silent: true, port: 8788 });
+		await cli.ready;
+	});
+
+	after(async () => {
+		await cli.stop();
 	});
 
 	it('Load cf and caches API', async () => {
-		const { ready, stop } = runCLI('./fixtures/cf/', { silent: true, port: 8788 });
-
-		try {
-			await ready;
-			let res = await fetch(`http://localhost:8788/`);
-			expect(res.status).to.equal(200);
-			let html = await res.text();
-			let $ = cheerio.load(html);
-			// console.log($('#cf').text(), html);
-			expect($('#cf').text()).to.contain('city');
-			expect($('#hasCache').text()).to.equal('true');
-		} finally {
-			await stop();
-		}
+		let res = await fetch(`http://localhost:8788/`);
+		expect(res.status).to.equal(200);
+		let html = await res.text();
+		let $ = cheerio.load(html);
+		// console.log($('#cf').text(), html);
+		expect($('#cf').text()).to.contain('city');
+		expect($('#hasCache').text()).to.equal('true');
 	});
 });

--- a/packages/integrations/cloudflare/test/test-utils.js
+++ b/packages/integrations/cloudflare/test/test-utils.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url';
 export { fixLineEndings } from '../../../astro/test/test-utils.js';
 
 /**
+ * @typedef {{ ready: Promise<void>, stop: Promise<void> }} WranglerCLI
  * @typedef {import('../../../astro/test/test-utils').Fixture} Fixture
  */
 
@@ -19,6 +20,9 @@ const wranglerPath = fileURLToPath(
 	new URL('../node_modules/wrangler/bin/wrangler.js', import.meta.url)
 );
 
+/**
+ * @returns {WranglerCLI}
+ */
 export function runCLI(basePath, { silent, port = 8787 }) {
 	const script = fileURLToPath(new URL(`${basePath}/dist/_worker.js`, import.meta.url));
 	const p = spawn('node', [wranglerPath, 'dev', '-l', script, '--port', port]);

--- a/packages/integrations/cloudflare/test/with-solid-js.test.js
+++ b/packages/integrations/cloudflare/test/with-solid-js.test.js
@@ -5,27 +5,28 @@ import * as cheerio from 'cheerio';
 describe('With SolidJS', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
+	/** @type {import('./test-utils').WranglerCLI} */
+	let cli;
 
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/with-solid-js/',
 		});
 		await fixture.build();
+
+		cli = runCLI('./fixtures/with-solid-js/', { silent: true, port: 8790 });
+		await cli.ready;
+	});
+
+	after(async () => {
+		await cli.stop();
 	});
 
 	it('renders the solid component', async () => {
-		const { ready, stop } = runCLI('./fixtures/with-solid-js/', { silent: true, port: 8790 });
-
-		try {
-			await ready;
-
-			let res = await fetch(`http://localhost:8790/`);
-			expect(res.status).to.equal(200);
-			let html = await res.text();
-			let $ = cheerio.load(html);
-			expect($('.solid').text()).to.equal('Solid Content');
-		} finally {
-			await stop();
-		}
+		let res = await fetch(`http://localhost:8790/`);
+		expect(res.status).to.equal(200);
+		let html = await res.text();
+		let $ = cheerio.load(html);
+		expect($('.solid').text()).to.equal('Solid Content');
 	});
 });


### PR DESCRIPTION
## Changes

- Update cloudflare tests to prevent test timeout. Move CLI startup and teardown to before/after hook to spread out the timeout limit
  - Handles `"renders the solid component"` and `"Load cf and caches API"` fails
- Set integration test timeout to 30s. Some builds take longer than expected.
  - Handles `"Code component inside static build"` and `"Static build: dir takes the URL path to the output directory"` fails
- Retry getStaticPath test twice
  - Handles `"only calls getStaticPaths once"` fail

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should still pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. internal refactor.