### PR TITLE
Added support for a `maxWidth` property in assets

### DIFF
--- a/packages/astro/src/assets/services/service.ts
+++ b/packages/astro/src/assets/services/service.ts
@@ -108,7 +108,7 @@ export type BaseServiceTransform = {
  *
  */
 export const baseService: Omit<LocalImageService, 'transform'> = {
-	validateOptions(options) {
+	validateOptions(options, serviceConfig) {
 		// `src` is missing or is `undefined`.
 		if (!options.src || (typeof options.src !== 'string' && typeof options.src !== 'object')) {
 			throw new AstroError({
@@ -164,6 +164,14 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 		// In the future, hopefully we can replace this with `avif`, alas, Edge. See https://caniuse.com/avif
 		if (!options.format) {
 			options.format = 'webp';
+		}
+
+		const { width, height } = options.src;
+
+		if (serviceConfig.maxWidth && width > serviceConfig.maxWidth) {
+			const aspectRatio = width / height;
+			options.width = serviceConfig.maxWidth;
+			options.height = Math.floor(serviceConfig.maxWidth / aspectRatio);
 		}
 
 		return options;


### PR DESCRIPTION
## Changes

This updates the base service in Assets to support a `maxWidth` parameter. With this, all images over a certain width would be resized. 

### Why? 

I got used to this with Gatsby, and if the user puts a giant 6000x6000 image it would never get sent to the browser at that size.

Usage:
```
// astro.config.mjs
image: {
    service: {
      entrypoint: 'astro/assets/services/sharp',
      config: {
        maxWidth: 590,
      },
    },
  },
```

## Testing

Locally using a project. I'm happy to add a test.

## Docs

It will need to be added to the docs, if accepted. I'm not sure if it should be in the API docs or just the Assets docs.

/cc @withastro/maintainers-docs for feedback
