### PR TITLE
Vercel: exclude `@vercel/nft` automatically

### DIFF
--- a/.changeset/pretty-hats-smash.md
+++ b/.changeset/pretty-hats-smash.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Fix critical build regression. `@vercel/nft` is excluded from the bundle automatically.

--- a/packages/integrations/vercel/src/edge/adapter.ts
+++ b/packages/integrations/vercel/src/edge/adapter.ts
@@ -66,6 +66,9 @@ export default function vercelEdge({
 					},
 					vite: {
 						define: viteDefine,
+						ssr: {
+							external: ['@vercel/nft']
+						}
 					},
 					...getImageConfig(imageService, imagesConfig, command),
 				});

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -94,6 +94,9 @@ export default function vercelServerless({
 					},
 					vite: {
 						define: viteDefine,
+						ssr: {
+							external: ['@vercel/nft']
+						}
 					},
 					...getImageConfig(imageService, imagesConfig, command),
 				});


### PR DESCRIPTION
## Changes

- Fix #7654 regression
- Excludes `@vercel/nft` from the bundle automatically

## Testing

Tested manually. It works!

## Docs

N/A, bug fix only