### PR TITLE
fix wrong platform build for Cloudflare SSR.

### DIFF
--- a/.changeset/lovely-roses-fix.md
+++ b/.changeset/lovely-roses-fix.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+fix wrong platform build for Cloudflare SSR.

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -112,7 +112,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					// NOTE: AFAIK, esbuild keeps the order of the entryPoints array
 					const { outputFiles } = await esbuild.build({
 						target: 'es2020',
-						platform: 'browser',
+						platform: 'node',
 						conditions: ['workerd', 'worker', 'browser'],
 						entryPoints: entryPaths,
 						outdir: outputDir,
@@ -158,7 +158,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 
 					await esbuild.build({
 						target: 'es2020',
-						platform: 'browser',
+						platform: 'node',
 						conditions: ['workerd', 'worker', 'browser'],
 						entryPoints: [entryPath],
 						outfile: buildPath,


### PR DESCRIPTION
## Changes

- fix wrong platform build for Cloudflare SSR. Resolve: https://github.com/withastro/astro/issues/7664
- Change config of esbuild.build() with is platform = "node"

## Testing
No test for this function.

## Docs

This is fix bug. It unnecessary to update Doc.
