### PR TITLE
Update README.md

### DIFF
--- a/packages/integrations/netlify/README.md
+++ b/packages/integrations/netlify/README.md
@@ -92,7 +92,7 @@ export default defineConfig({
 
 ### Static sites
 
-For static sites you usually don't need an adapter. However, if you use `redirects` configuration (experimental) in your Astro config, the Netlify adapter can be used to translate this to the proper `_redirects` format.
+For static sites you usually don't need an adapter, and you are able to use Netlify functions without the adapter. However, if you use `redirects` configuration (experimental) in your Astro config, the Netlify adapter can be used to translate this to the proper `_redirects` format.
 
 ```js
 import { defineConfig } from 'astro/config';


### PR DESCRIPTION

## Changes

Add a short note under "Static sites" that you do not need the Netlify adapter to use Netlify functions.

## Testing

No tests. Small docs README text change only.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

This is a small documentation update. I was confused by this when I was learning how to setup Netlify functions with Astro, and discovered I did not need the adapter.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
