### PR TITLE
Fix cloudflare runtime env var handling

### DIFF
--- a/.changeset/light-jars-cheat.md
+++ b/.changeset/light-jars-cheat.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Handle inlining non-string boolean environment variables

--- a/.changeset/spicy-pugs-wonder.md
+++ b/.changeset/spicy-pugs-wonder.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fix runtime env var handling

--- a/packages/astro/src/vite-plugin-env/index.ts
+++ b/packages/astro/src/vite-plugin-env/index.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'url';
 import type * as vite from 'vite';
 import { loadEnv } from 'vite';
 import type { AstroConfig, AstroSettings } from '../@types/astro';
+import { string } from 'zod';
 
 interface EnvPluginOptions {
 	settings: AstroSettings;
@@ -31,7 +32,11 @@ function getPrivateEnv(
 		// Ignore public env var
 		if (envPrefixes.every((prefix) => !key.startsWith(prefix))) {
 			if (typeof process.env[key] !== 'undefined') {
-				const value = process.env[key];
+				let value = process.env[key];
+				// Replacements are always strings, so try to convert to strings here first
+				if (typeof value !== 'string') {
+					value = `${value}`;
+				}
 				// Boolean values should be inlined to support `export const prerender`
 				// We already know that these are NOT sensitive values, so inlining is safe
 				if (value === '0' || value === '1' || value === 'true' || value === 'false') {

--- a/packages/astro/src/vite-plugin-env/index.ts
+++ b/packages/astro/src/vite-plugin-env/index.ts
@@ -3,7 +3,6 @@ import { fileURLToPath } from 'url';
 import type * as vite from 'vite';
 import { loadEnv } from 'vite';
 import type { AstroConfig, AstroSettings } from '../@types/astro';
-import { string } from 'zod';
 
 interface EnvPluginOptions {
 	settings: AstroSettings;

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -94,7 +94,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 
 					// Cloudflare env is only available per request. This isn't feasible for code that access env vars
 					// in a global way, so we shim their access as `process.env.*`. We will populate `process.env` later
-					// in it's fetch handler.
+					// in its fetch handler.
 					vite.define = {
 						'process.env': 'process.env',
 						...vite.define,

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -91,6 +91,14 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					}
 					vite.ssr ||= {};
 					vite.ssr.target = 'webworker';
+
+					// Cloudflare env is only available per request. This isn't feasible for code that access env vars
+					// in a global way, so we shim their access as `process.env.*`. We will populate `process.env` later
+					// in it's fetch handler.
+					vite.define = {
+						'process.env': 'process.env',
+						...vite.define,
+					};
 				}
 			},
 			'astro:build:ssr': ({ entryPoints }) => {

--- a/packages/integrations/cloudflare/test/basics.test.js
+++ b/packages/integrations/cloudflare/test/basics.test.js
@@ -2,7 +2,7 @@ import { loadFixture, runCLI } from './test-utils.js';
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
 
-describe.skip('Basic app', () => {
+describe('Basic app', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
 


### PR DESCRIPTION
## Changes

Follow up from https://github.com/withastro/astro/pull/7651#discussion_r1263856991
Fix https://github.com/withastro/astro/issues/7137

Fix cloudflare runtime env var handling. We're using Vite's `ssr.target = 'webworker'` config, and it's converting our `process.env.RUNTIME_VAR` to `({}).RUNTIME_VAR`, causing it to not work.

This also tweaked Astro's env handling for the `PRERENDER` test, as it's indirectly passing with the bug above. Since it was passed a boolean value, I had to update `vite-plugin-env` to handle it too.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Un-skipped a test that revealed this bug.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.