### PR TITLE
refactor: move page rendering in one single function

### DIFF
--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -2,25 +2,18 @@ import mime from 'mime';
 import type {
 	EndpointHandler,
 	ManifestData,
-	MiddlewareResponseHandler,
 	RouteData,
 	SSRElement,
 	SSRManifest,
 } from '../../@types/astro';
 import type { SinglePageBuiltModule } from '../build/types';
 import { attachToResponse, getSetCookiesFromResponse } from '../cookies/index.js';
-import { callEndpoint, createAPIContext } from '../endpoint/index.js';
+import { callEndpoint } from '../endpoint/index.js';
 import { consoleLogDestination } from '../logger/console.js';
 import { error, type LogOptions } from '../logger/core.js';
-import { callMiddleware } from '../middleware/callMiddleware.js';
 import { prependForwardSlash, removeTrailingForwardSlash } from '../path.js';
 import { RedirectSinglePageBuiltModule } from '../redirects/index.js';
-import {
-	createEnvironment,
-	createRenderContext,
-	renderPage,
-	type Environment,
-} from '../render/index.js';
+import { createEnvironment, createRenderContext, type Environment } from '../render/index.js';
 import { RouteCache } from '../render/route-cache.js';
 import {
 	createAssetLink,
@@ -29,6 +22,7 @@ import {
 } from '../render/ssr-element.js';
 import { matchRoute } from '../routing/match.js';
 import type { RouteInfo } from './types';
+import { tryRenderPage } from '../render/index.js';
 export { deserializeManifest } from './common.js';
 
 const clientLocalsSymbol = Symbol.for('astro.locals');
@@ -256,36 +250,8 @@ export class App {
 				env: this.#env,
 			});
 
-			const apiContext = createAPIContext({
-				request: renderContext.request,
-				params: renderContext.params,
-				props: renderContext.props,
-				site: this.#env.site,
-				adapterName: this.#env.adapterName,
-			});
-			let response;
-			if (page.onRequest) {
-				response = await callMiddleware<Response>(
-					this.#env.logging,
-					page.onRequest as MiddlewareResponseHandler,
-					apiContext,
-					() => {
-						return renderPage({
-							mod,
-							renderContext,
-							env: this.#env,
-							cookies: apiContext.cookies,
-						});
-					}
-				);
-			} else {
-				response = await renderPage({
-					mod,
-					renderContext,
-					env: this.#env,
-					cookies: apiContext.cookies,
-				});
-			}
+			const response = await tryRenderPage(renderContext, this.#env, mod, page.onRequest);
+
 			Reflect.set(request, responseSentSymbol, true);
 			return response;
 		} catch (err: any) {

--- a/packages/astro/src/core/render/index.ts
+++ b/packages/astro/src/core/render/index.ts
@@ -1,6 +1,6 @@
 export { createRenderContext } from './context.js';
 export type { RenderContext } from './context.js';
-export { renderPage } from './core.js';
+export { tryRenderPage } from './core.js';
 export type { Environment } from './environment';
 export { createEnvironment } from './environment.js';
 export { getParamsAndProps } from './params-and-props.js';

--- a/packages/astro/test/units/render/head.test.js
+++ b/packages/astro/test/units/render/head.test.js
@@ -9,7 +9,7 @@ import {
 	renderHead,
 	Fragment,
 } from '../../../dist/runtime/server/index.js';
-import { createRenderContext, renderPage } from '../../../dist/core/render/index.js';
+import { createRenderContext, tryRenderPage } from '../../../dist/core/render/index.js';
 import { createBasicEnvironment } from '../test-utils.js';
 import * as cheerio from 'cheerio';
 
@@ -96,13 +96,7 @@ describe('core/render', () => {
 				env,
 			});
 
-			const response = await renderPage({
-				mod: PageModule,
-				renderContext: ctx,
-				env,
-				params: ctx.params,
-				props: ctx.props,
-			});
+			const response = await tryRenderPage(ctx, env, PageModule);
 
 			const html = await response.text();
 			const $ = cheerio.load(html);
@@ -182,13 +176,7 @@ describe('core/render', () => {
 				mod: PageModule,
 			});
 
-			const response = await renderPage({
-				mod: PageModule,
-				renderContext: ctx,
-				env,
-				params: ctx.params,
-				props: ctx.props,
-			});
+			const response = await tryRenderPage(ctx, env, PageModule);
 			const html = await response.text();
 			const $ = cheerio.load(html);
 
@@ -234,13 +222,7 @@ describe('core/render', () => {
 				mod: PageModule,
 			});
 
-			const response = await renderPage({
-				mod: PageModule,
-				renderContext: ctx,
-				env,
-				params: ctx.params,
-				props: ctx.props,
-			});
+			const response = await tryRenderPage(ctx, env, PageModule);
 			const html = await response.text();
 			const $ = cheerio.load(html);
 

--- a/packages/astro/test/units/render/jsx.test.js
+++ b/packages/astro/test/units/render/jsx.test.js
@@ -6,7 +6,11 @@ import {
 	renderSlot,
 } from '../../../dist/runtime/server/index.js';
 import { jsx } from '../../../dist/jsx-runtime/index.js';
-import { createRenderContext, renderPage, loadRenderer } from '../../../dist/core/render/index.js';
+import {
+	createRenderContext,
+	tryRenderPage,
+	loadRenderer,
+} from '../../../dist/core/render/index.js';
 import { createAstroJSXComponent, renderer as jsxRenderer } from '../../../dist/jsx/index.js';
 import { createBasicEnvironment } from '../test-utils.js';
 
@@ -46,11 +50,7 @@ describe('core/render', () => {
 				mod,
 			});
 
-			const response = await renderPage({
-				mod,
-				renderContext: ctx,
-				env,
-			});
+			const response = await tryRenderPage(ctx, env, mod);
 
 			expect(response.status).to.equal(200);
 
@@ -94,11 +94,7 @@ describe('core/render', () => {
 				env,
 				mod,
 			});
-			const response = await renderPage({
-				mod,
-				renderContext: ctx,
-				env,
-			});
+			const response = await tryRenderPage(ctx, env, mod);
 
 			expect(response.status).to.equal(200);
 
@@ -124,11 +120,7 @@ describe('core/render', () => {
 				mod,
 			});
 
-			const response = await renderPage({
-				mod,
-				renderContext: ctx,
-				env,
-			});
+			const response = await tryRenderPage(ctx, env, mod);
 
 			try {
 				await response.text();


### PR DESCRIPTION
## Changes

Refactor.

I moved the rendering of the page inside a unique function. I called `tryRenderPage` to make it more clear that that's an operation that could throw an error. In fact, there's a place where we handle the thrown error.

## Testing

I updated the unit tests. Current CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
