### PR TITLE
Update Action labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,37 +1,37 @@
 # See https://github.com/actions/labeler
 
-example:
+'pkg: example':
 - examples/**/*
 
 '🚨 action':
 - .github/workflows/**
 
-core:
+'pkg: astro':
 - packages/astro/**
 
-create-astro:
+'pkg: create-astro':
 - packages/create-astro/**
 
-markdown:
+'feat: markdown':
 - packages/markdown/**
 
-integration:
+'pkg: integration':
 - packages/integrations/**
 
-framework-lit:
+'pkg: lit':
 - packages/integrations/lit/**
 
-framework-preact:
+'pkg: preact':
 - packages/integrations/preact/**
 
-framework-react:
+'pkg: react':
 - packages/integrations/react/**
 
-framework-solid:
+'pkg: solid':
 - packages/integrations/solid/**
 
-framework-svelte:
+'pkg: svelte':
 - packages/integrations/svelte/**
 
-framework-vue:
+'pkg: vue':
 - packages/integrations/vue/**

--- a/.github/workflows/check-merge.yml
+++ b/.github/workflows/check-merge.yml
@@ -69,7 +69,7 @@ jobs:
               issue_number: process.env.issue_number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ['semver minor']
+              labels: ['semver: minor']
             });
 
       - name: Change PR Status

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -1,0 +1,32 @@
+name: Issue Labeled
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  reply-labeled:
+    if: github.repository == 'withastro/astro'
+    runs-on: ubuntu-latest
+    steps:
+      - name: remove triage
+        if: |
+            ${{ contains(github.event.label.description, '(priority)') && contains(github.event.issue.labels.*.name, 'needs: triage') }}
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "remove-labels"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: "needs: triage"
+
+      - name: needs repro
+        if: |
+            ${{ github.event.label.name == 'needs: repro' }}
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "create-comment, remove-labels"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://astro.new). Issues marked with `needs: repro` will be closed if they have no activity within 3 days.
+          labels: "needs: triage"

--- a/.github/workflows/issue-needs-repro.yml
+++ b/.github/workflows/issue-needs-repro.yml
@@ -1,0 +1,18 @@
+name: Close Issues (needs repro)
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    if: github.repository == 'withastro/astro'
+    runs-on: ubuntu-latest
+    steps:
+      - name: needs repro
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "close-issues"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "needs: repro"
+          inactive-day: 3

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -1,0 +1,23 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    if: github.repository == 'withastro/astro'
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["needs: triage"]
+            })


### PR DESCRIPTION
## Changes

- Updates GitHub Action labels to match cleaned up labels in this repro
- Adds some workflows inspired by [Vite](https://github.com/vitejs/vite/tree/main/.github/workflows) to automatically add `needs: triage` label and remove when issue has been triaged.
- Adds a workflow to close `needs: repro` issues after 3 days of inactivity

## Testing

We'll do it live

## Docs

N/A