### PR TITLE
CI: handle `needs` labels properly

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -10,23 +10,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: remove triage
-        if: |
-            ${{ contains(github.event.label.description, '(priority)') && contains(github.event.issue.labels.*.name, 'needs: triage') }}
+        if: contains(github.event.label.description, '(priority)') && contains(github.event.issue.labels.*.name, 'needs triage')
         uses: actions-cool/issues-helper@v3
         with:
           actions: "remove-labels"
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
-          labels: "needs: triage"
+          labels: "needs triage"
 
       - name: needs repro
         if: |
-            ${{ github.event.label.name == 'needs: repro' }}
+            ${{ github.event.label.name == 'needs repro' }}
         uses: actions-cool/issues-helper@v3
         with:
           actions: "create-comment, remove-labels"
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
           body: |
-            Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://astro.new). Issues marked with `needs: repro` will be closed if they have no activity within 3 days.
-          labels: "needs: triage"
+            Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://astro.new). Issues marked with `needs repro` will be closed if they have no activity within 3 days.
+          labels: "needs triage"

--- a/.github/workflows/issue-needs-repro.yml
+++ b/.github/workflows/issue-needs-repro.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           actions: "close-issues"
           token: ${{ secrets.GITHUB_TOKEN }}
-          labels: "needs: repro"
+          labels: "needs repro"
           inactive-day: 3

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -19,5 +19,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ["needs: triage"]
+              labels: ["needs triage"]
             })


### PR DESCRIPTION
## Changes

- Removes `:` from `needs` labels because GitHub's YAML parser treats them as an object, even within a string. 😭

```
YAML: 1
Nate: 0
```


## Testing

Nope

## Docs

Nah