### PR TITLE
nit: use `node:` prefix everywhere

### DIFF
--- a/.github/scripts/bundle-size.mjs
+++ b/.github/scripts/bundle-size.mjs
@@ -1,5 +1,5 @@
 import { build } from 'esbuild';
-import { existsSync } from 'fs';
+import { existsSync } from 'node:fs';
 
 const CLIENT_RUNTIME_PATH = 'packages/astro/src/runtime/client/';
 
@@ -27,13 +27,13 @@ export default async function checkBundleSize({ github, context }) {
 		return file.filename.startsWith(CLIENT_RUNTIME_PATH) && file.status !== 'removed'
 	});
 	if (clientRuntimeFiles.length === 0) return;
-	
+
 	const table = [
 		'| File | Old Size | New Size | Change |',
 		'| ---- | -------- | -------- | ------ |',
 	];
 	const output = await bundle(clientRuntimeFiles);
-	
+
 	for (let [filename, { oldSize, newSize, sourceFile }] of Object.entries(output)) {
 		filename = ['idle', 'load', 'media', 'only', 'visible'].includes(filename) ? `client:${filename}` : filename;
 		const prefix = (newSize - oldSize) === 0 ? '' : (newSize - oldSize) > 0 ? '+ ' : '- ';
@@ -60,7 +60,7 @@ ${table.join('\n')}`,
 }
 
 async function bundle(files) {
-	
+
 	const { metafile } = await build({
 		entryPoints: [...files.map(({ filename }) => filename), ...files.map(({ filename }) => `main/${filename}`).filter(f => existsSync(f))],
 		bundle: true,

--- a/benchmark/bench/cli-startup.js
+++ b/benchmark/bench/cli-startup.js
@@ -1,4 +1,4 @@
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { execaCommand } from 'execa';
 import { markdownTable } from 'markdown-table';
 import { astroBin, calculateStat } from './_util.js';

--- a/benchmark/bench/memory.js
+++ b/benchmark/bench/memory.js
@@ -1,7 +1,7 @@
-import fs from 'fs/promises';
-import { fileURLToPath } from 'node:url';
 import { execaCommand } from 'execa';
 import { markdownTable } from 'markdown-table';
+import fs from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import { astroBin } from './_util.js';
 
 /** @typedef {Record<string, import('../../packages/astro/src/core/config/timer').Stat>} AstroTimerStat */

--- a/benchmark/bench/memory.js
+++ b/benchmark/bench/memory.js
@@ -1,5 +1,5 @@
 import fs from 'fs/promises';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { execaCommand } from 'execa';
 import { markdownTable } from 'markdown-table';
 import { astroBin } from './_util.js';

--- a/benchmark/bench/render.js
+++ b/benchmark/bench/render.js
@@ -1,6 +1,6 @@
 import { execaCommand } from 'execa';
-import fs from 'fs/promises';
 import { markdownTable } from 'markdown-table';
+import fs from 'node:fs/promises';
 import http from 'node:http';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/benchmark/bench/render.js
+++ b/benchmark/bench/render.js
@@ -1,12 +1,12 @@
-import fs from 'fs/promises';
-import http from 'http';
-import path from 'path';
-import { fileURLToPath } from 'url';
 import { execaCommand } from 'execa';
-import { waitUntilBusy } from 'port-authority';
+import fs from 'fs/promises';
 import { markdownTable } from 'markdown-table';
-import { renderFiles } from '../make-project/render-default.js';
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { waitUntilBusy } from 'port-authority';
 import { calculateStat } from '../make-project/_util.js';
+import { renderFiles } from '../make-project/render-default.js';
 import { astroBin } from './_util.js';
 
 const port = 4322;

--- a/benchmark/bench/server-stress.js
+++ b/benchmark/bench/server-stress.js
@@ -1,9 +1,9 @@
-import fs from 'fs/promises';
-import { fileURLToPath } from 'node:url';
 import autocannon from 'autocannon';
 import { execaCommand } from 'execa';
-import { waitUntilBusy } from 'port-authority';
 import { markdownTable } from 'markdown-table';
+import fs from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { waitUntilBusy } from 'port-authority';
 import pb from 'pretty-bytes';
 import { astroBin } from './_util.js';
 

--- a/benchmark/bench/server-stress.js
+++ b/benchmark/bench/server-stress.js
@@ -1,5 +1,5 @@
 import fs from 'fs/promises';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import autocannon from 'autocannon';
 import { execaCommand } from 'execa';
 import { waitUntilBusy } from 'port-authority';

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,6 +1,6 @@
 import fs from 'fs/promises';
-import path from 'path';
-import { pathToFileURL } from 'url';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import mri from 'mri';
 
 const args = mri(process.argv.slice(2));

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,7 +1,7 @@
-import fs from 'fs/promises';
+import mri from 'mri';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import mri from 'mri';
 
 const args = mri(process.argv.slice(2));
 

--- a/benchmark/make-project/memory-default.js
+++ b/benchmark/make-project/memory-default.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 import { loremIpsum } from './_util.js';
 
 /**

--- a/benchmark/make-project/render-default.js
+++ b/benchmark/make-project/render-default.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 import { loremIpsumHtml, loremIpsumMd } from './_util.js';
 
 // Map of files to be generated and tested for rendering.

--- a/benchmark/make-project/server-stress-default.js
+++ b/benchmark/make-project/server-stress-default.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 import { loremIpsum } from './_util.js';
 
 /**

--- a/benchmark/packages/timer/src/preview.ts
+++ b/benchmark/packages/timer/src/preview.ts
@@ -1,5 +1,5 @@
 import type { CreatePreviewServer } from 'astro';
-import { createServer } from 'http';
+import { createServer } from 'node:http';
 import enableDestroy from 'server-destroy';
 
 const preview: CreatePreviewServer = async function ({ serverEntrypoint, host, port }) {

--- a/benchmark/packages/timer/src/server.ts
+++ b/benchmark/packages/timer/src/server.ts
@@ -1,7 +1,7 @@
 import { polyfill } from '@astrojs/webapi';
 import type { SSRManifest } from 'astro';
 import { NodeApp } from 'astro/app/node';
-import type { IncomingMessage, ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 
 polyfill(globalThis, {
 	exclude: 'window document',

--- a/packages/astro/e2e/fixtures/custom-client-directives/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/custom-client-directives/astro.config.mjs
@@ -1,6 +1,6 @@
 import { defineConfig } from 'astro/config';
 import react from "@astrojs/react";
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   integrations: [astroClientClickDirective(), astroClientPasswordDirective(), react()],

--- a/packages/astro/e2e/fixtures/tailwindcss/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/tailwindcss/astro.config.mjs
@@ -1,6 +1,6 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/tailwindcss/tailwind.config.js
+++ b/packages/astro/e2e/fixtures/tailwindcss/tailwind.config.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 
 module.exports = {
 	content: [path.join(__dirname, 'src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}')],

--- a/packages/astro/e2e/test-utils.js
+++ b/packages/astro/e2e/test-utils.js
@@ -1,6 +1,6 @@
-import fs from 'fs/promises';
+import { expect, test as testBase } from '@playwright/test';
+import fs from 'node:fs/promises';
 import path from 'node:path';
-import { test as testBase, expect } from '@playwright/test';
 import { loadFixture as baseLoadFixture } from '../test/test-utils.js';
 
 export const isWindows = process.platform === 'win32';

--- a/packages/astro/e2e/test-utils.js
+++ b/packages/astro/e2e/test-utils.js
@@ -1,5 +1,5 @@
 import fs from 'fs/promises';
-import path from 'path';
+import path from 'node:path';
 import { test as testBase, expect } from '@playwright/test';
 import { loadFixture as baseLoadFixture } from '../test/test-utils.js';
 

--- a/packages/astro/performance/content-benchmark.mjs
+++ b/packages/astro/performance/content-benchmark.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { loadFixture } from '../test/test-utils.js';
 import { generatePosts } from './scripts/generate-posts.mjs';
 import yargs from 'yargs-parser';

--- a/packages/astro/performance/scripts/generate-posts.mjs
+++ b/packages/astro/performance/scripts/generate-posts.mjs
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const NUM_POSTS = 10;
 const POSTS_DIR = './src/content/posts.generated';

--- a/packages/astro/scripts/shiki-gen-languages.mjs
+++ b/packages/astro/scripts/shiki-gen-languages.mjs
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 const dir = await fs.promises.readdir('packages/astro/node_modules/shiki/languages/');
 

--- a/packages/astro/scripts/shiki-gen-themes.mjs
+++ b/packages/astro/scripts/shiki-gen-themes.mjs
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 const dir = await fs.promises.readdir('packages/astro/node_modules/shiki/themes/');
 

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -8,8 +8,8 @@ import type {
 	ShikiConfig,
 } from '@astrojs/markdown-remark';
 import type * as babel from '@babel/core';
-import type { OutgoingHttpHeaders } from 'http';
-import type { AddressInfo } from 'net';
+import type { OutgoingHttpHeaders } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import type * as rollup from 'rollup';
 import type { TsConfigJson } from 'tsconfig-resolver';
 import type * as vite from 'vite';

--- a/packages/astro/src/assets/services/vendor/squoosh/avif/avif_node_dec.ts
+++ b/packages/astro/src/assets/services/vendor/squoosh/avif/avif_node_dec.ts
@@ -41,13 +41,13 @@ var Module = (function () {
     var nodePath
     if (ENVIRONMENT_IS_NODE) {
       if (ENVIRONMENT_IS_WORKER) {
-        scriptDirectory = require('path').dirname(scriptDirectory) + '/'
+        scriptDirectory = require('node:path').dirname(scriptDirectory) + '/'
       } else {
         scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
-        if (!nodeFS) nodeFS = require('fs')
-        if (!nodePath) nodePath = require('path')
+        if (!nodeFS) nodeFS = require('node:fs')
+        if (!nodePath) nodePath = require('node:path')
         filename = nodePath['normalize'](filename)
         return nodeFS['readFileSync'](filename, binary ? null : 'utf8')
       }

--- a/packages/astro/src/assets/services/vendor/squoosh/avif/avif_node_enc.ts
+++ b/packages/astro/src/assets/services/vendor/squoosh/avif/avif_node_enc.ts
@@ -41,13 +41,13 @@ var Module = (function () {
     var nodePath
     if (ENVIRONMENT_IS_NODE) {
       if (ENVIRONMENT_IS_WORKER) {
-        scriptDirectory = require('path').dirname(scriptDirectory) + '/'
+        scriptDirectory = require('node:path').dirname(scriptDirectory) + '/'
       } else {
         scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
-        if (!nodeFS) nodeFS = require('fs')
-        if (!nodePath) nodePath = require('path')
+        if (!nodeFS) nodeFS = require('node:fs')
+        if (!nodePath) nodePath = require('node:path')
         filename = nodePath['normalize'](filename)
         return nodeFS['readFileSync'](filename, binary ? null : 'utf8')
       }

--- a/packages/astro/src/assets/services/vendor/squoosh/image-pool.ts
+++ b/packages/astro/src/assets/services/vendor/squoosh/image-pool.ts
@@ -1,6 +1,6 @@
+import { cpus } from 'node:os';
+import { fileURLToPath } from 'node:url';
 import { isMainThread } from 'node:worker_threads';
-import { cpus } from 'os';
-import { fileURLToPath } from 'url';
 import type { ImageOutputFormat } from '../../../types.js';
 import { getModuleURL } from './emscripten-utils.js';
 import type { Operation } from './image.js';

--- a/packages/astro/src/assets/services/vendor/squoosh/mozjpeg/mozjpeg_node_dec.ts
+++ b/packages/astro/src/assets/services/vendor/squoosh/mozjpeg/mozjpeg_node_dec.ts
@@ -41,13 +41,13 @@ var Module = (function () {
     var nodePath
     if (ENVIRONMENT_IS_NODE) {
       if (ENVIRONMENT_IS_WORKER) {
-        scriptDirectory = require('path').dirname(scriptDirectory) + '/'
+        scriptDirectory = require('node:path').dirname(scriptDirectory) + '/'
       } else {
         scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
-        if (!nodeFS) nodeFS = require('fs')
-        if (!nodePath) nodePath = require('path')
+        if (!nodeFS) nodeFS = require('node:fs')
+        if (!nodePath) nodePath = require('node:path')
         filename = nodePath['normalize'](filename)
         return nodeFS['readFileSync'](filename, binary ? null : 'utf8')
       }

--- a/packages/astro/src/assets/services/vendor/squoosh/mozjpeg/mozjpeg_node_enc.ts
+++ b/packages/astro/src/assets/services/vendor/squoosh/mozjpeg/mozjpeg_node_enc.ts
@@ -41,13 +41,13 @@ var Module = (function () {
     var nodePath
     if (ENVIRONMENT_IS_NODE) {
       if (ENVIRONMENT_IS_WORKER) {
-        scriptDirectory = require('path').dirname(scriptDirectory) + '/'
+        scriptDirectory = require('node:path').dirname(scriptDirectory) + '/'
       } else {
         scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
-        if (!nodeFS) nodeFS = require('fs')
-        if (!nodePath) nodePath = require('path')
+        if (!nodeFS) nodeFS = require('node:fs')
+        if (!nodePath) nodePath = require('node:path')
         filename = nodePath['normalize'](filename)
         return nodeFS['readFileSync'](filename, binary ? null : 'utf8')
       }

--- a/packages/astro/src/assets/services/vendor/squoosh/webp/webp_node_dec.ts
+++ b/packages/astro/src/assets/services/vendor/squoosh/webp/webp_node_dec.ts
@@ -41,13 +41,13 @@ var Module = (function () {
     var nodePath
     if (ENVIRONMENT_IS_NODE) {
       if (ENVIRONMENT_IS_WORKER) {
-        scriptDirectory = require('path').dirname(scriptDirectory) + '/'
+        scriptDirectory = require('node:path').dirname(scriptDirectory) + '/'
       } else {
         scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
-        if (!nodeFS) nodeFS = require('fs')
-        if (!nodePath) nodePath = require('path')
+        if (!nodeFS) nodeFS = require('node:fs')
+        if (!nodePath) nodePath = require('node:path')
         filename = nodePath['normalize'](filename)
         return nodeFS['readFileSync'](filename, binary ? null : 'utf8')
       }

--- a/packages/astro/src/assets/services/vendor/squoosh/webp/webp_node_enc.ts
+++ b/packages/astro/src/assets/services/vendor/squoosh/webp/webp_node_enc.ts
@@ -41,13 +41,13 @@ var Module = (function () {
     var nodePath
     if (ENVIRONMENT_IS_NODE) {
       if (ENVIRONMENT_IS_WORKER) {
-        scriptDirectory = require('path').dirname(scriptDirectory) + '/'
+        scriptDirectory = require('node:path').dirname(scriptDirectory) + '/'
       } else {
         scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
-        if (!nodeFS) nodeFS = require('fs')
-        if (!nodePath) nodePath = require('path')
+        if (!nodeFS) nodeFS = require('node:fs')
+        if (!nodePath) nodePath = require('node:path')
         filename = nodePath['normalize'](filename)
         return nodeFS['readFileSync'](filename, binary ? null : 'utf8')
       }

--- a/packages/astro/src/assets/utils/transformToPath.ts
+++ b/packages/astro/src/assets/utils/transformToPath.ts
@@ -1,4 +1,4 @@
-import { basename, extname } from 'path';
+import { basename, extname } from 'node:path';
 import { removeQueryString } from '../../core/path.js';
 import { shorthash } from '../../runtime/server/shorthash.js';
 import { isESMImportedImage } from '../internal.js';

--- a/packages/astro/src/assets/vendor/image-size/index.ts
+++ b/packages/astro/src/assets/vendor/image-size/index.ts
@@ -1,5 +1,5 @@
-import * as fs from "fs";
-import * as path from "path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import Queue from "../queue/queue.js";
 import { detector } from "./detector.js";
 import { typeHandlers, type imageType } from "./types.js";

--- a/packages/astro/src/assets/vendor/image-size/types/tiff.ts
+++ b/packages/astro/src/assets/vendor/image-size/types/tiff.ts
@@ -1,6 +1,6 @@
 // based on http://www.compix.com/fileformattif.htm
 // TO-DO: support big-endian as well
-import * as fs from 'fs'
+import * as fs from 'node:fs'
 import { readUInt } from '../readUInt.js'
 import type { IImage } from './interface'
 

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -1,13 +1,13 @@
 import boxen from 'boxen';
 import { diffWords } from 'diff';
 import { execa } from 'execa';
-import fsMod, { existsSync, promises as fs } from 'fs';
 import { bold, cyan, dim, green, magenta, red, yellow } from 'kleur/colors';
+import fsMod, { existsSync, promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import ora from 'ora';
-import path from 'path';
 import preferredPM from 'preferred-pm';
 import prompts from 'prompts';
-import { fileURLToPath, pathToFileURL } from 'url';
 import type yargs from 'yargs-parser';
 import { loadTSConfig, resolveConfigPath } from '../../core/config/index.js';
 import {

--- a/packages/astro/src/cli/check/index.ts
+++ b/packages/astro/src/cli/check/index.ts
@@ -5,12 +5,12 @@ import {
 } from '@astrojs/language-server';
 import type { FSWatcher } from 'chokidar';
 import glob from 'fast-glob';
-import fs from 'fs';
 import { bold, dim, red, yellow } from 'kleur/colors';
 import { createRequire } from 'module';
+import fs from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import ora from 'ora';
-import { fileURLToPath, pathToFileURL } from 'url';
 import type { Arguments as Flags } from 'yargs-parser';
 import type { AstroSettings } from '../../@types/astro';
 import type { LogOptions } from '../../core/logger/core.js';

--- a/packages/astro/src/cli/check/print.ts
+++ b/packages/astro/src/cli/check/print.ts
@@ -12,7 +12,7 @@ import {
 	yellow,
 } from 'kleur/colors';
 import stringWidth from 'string-width';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 export function printDiagnostic(filePath: string, text: string, diag: Diagnostic): string {
 	let result = [];

--- a/packages/astro/src/cli/dev/index.ts
+++ b/packages/astro/src/cli/dev/index.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 import type yargs from 'yargs-parser';
 import { resolveConfigPath, resolveFlags } from '../../core/config/index.js';
 import devServer from '../../core/dev/index.js';

--- a/packages/astro/src/cli/load-settings.ts
+++ b/packages/astro/src/cli/load-settings.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
-import fs from 'fs';
 import * as colors from 'kleur/colors';
+import fs from 'node:fs';
 import type { Arguments as Flags } from 'yargs-parser';
 import { ZodError } from 'zod';
 import { createSettings, openConfig, resolveConfigPath } from '../core/config/index.js';

--- a/packages/astro/src/cli/sync/index.ts
+++ b/packages/astro/src/cli/sync/index.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 import type yargs from 'yargs-parser';
 import type { LogOptions } from '../../core/logger/core.js';
 import { syncCli } from '../../core/sync/index.js';

--- a/packages/astro/src/config/index.ts
+++ b/packages/astro/src/config/index.ts
@@ -22,7 +22,7 @@ export function getViteConfig(inlineConfig: UserConfig) {
 			{ runHookConfigSetup, runHookConfigDone },
 			{ astroContentListenPlugin },
 		] = await Promise.all([
-			import('fs'),
+			import('node:fs'),
 			import('vite'),
 			import('../core/logger/node.js'),
 			import('../core/config/index.js'),

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -2,7 +2,7 @@ import * as devalue from 'devalue';
 import type fsMod from 'node:fs';
 import { extname } from 'node:path';
 import type { PluginContext } from 'rollup';
-import { pathToFileURL } from 'url';
+import { pathToFileURL } from 'node:url';
 import type { Plugin } from 'vite';
 import type {
 	AstroConfig,

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -1,9 +1,9 @@
 import type { RouteData } from '../../@types/astro';
 import type { SerializedSSRManifest, SSRManifest } from './types';
 
-import * as fs from 'fs';
-import { IncomingMessage } from 'http';
-import { TLSSocket } from 'tls';
+import * as fs from 'node:fs';
+import { IncomingMessage } from 'node:http';
+import { TLSSocket } from 'node:tls';
 import { deserializeManifest } from './common.js';
 import { App, type MatchOptions } from './index.js';
 

--- a/packages/astro/src/core/build/common.ts
+++ b/packages/astro/src/core/build/common.ts
@@ -1,5 +1,5 @@
-import npath from 'path';
-import { fileURLToPath, pathToFileURL } from 'url';
+import npath from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { AstroConfig, RouteType } from '../../@types/astro';
 import { appendForwardSlash } from '../../core/path.js';
 

--- a/packages/astro/src/core/build/css-asset-name.ts
+++ b/packages/astro/src/core/build/css-asset-name.ts
@@ -1,7 +1,7 @@
 import type { GetModuleInfo } from 'rollup';
 
-import crypto from 'crypto';
-import npath from 'path';
+import crypto from 'node:crypto';
+import npath from 'node:path';
 import type { AstroSettings } from '../../@types/astro';
 import { viteID } from '../util.js';
 import { getTopLevelPages } from './graph.js';

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -1,8 +1,8 @@
-import fs from 'fs';
 import * as colors from 'kleur/colors';
 import { bgGreen, black, cyan, dim, green, magenta } from 'kleur/colors';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import type { OutputAsset, OutputChunk } from 'rollup';
-import { fileURLToPath } from 'url';
 import type {
 	AstroConfig,
 	AstroSettings,
@@ -41,8 +41,8 @@ import { callEndpoint, throwIfRedirectNotAllowed } from '../endpoint/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 import { debug, info } from '../logger/core.js';
 import {
-	getRedirectLocationOrThrow,
 	RedirectSinglePageBuiltModule,
+	getRedirectLocationOrThrow,
 	routeIsRedirect,
 } from '../redirects/index.js';
 import { createEnvironment, createRenderContext, tryRenderPage } from '../render/index.js';

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -1,6 +1,6 @@
 import * as colors from 'kleur/colors';
 import fs from 'node:fs';
-import { performance } from 'perf_hooks';
+import { performance } from 'node:perf_hooks';
 import type * as vite from 'vite';
 import type yargs from 'yargs-parser';
 import type { AstroConfig, AstroSettings, ManifestData, RuntimeMode } from '../../@types/astro';

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
 import * as colors from 'kleur/colors';
+import fs from 'node:fs';
 import { performance } from 'perf_hooks';
 import type * as vite from 'vite';
 import type yargs from 'yargs-parser';

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -1,11 +1,10 @@
 import { teardown } from '@astrojs/compiler';
 import * as eslexer from 'es-module-lexer';
 import glob from 'fast-glob';
-import fs from 'fs';
 import { bgGreen, bgMagenta, black, dim } from 'kleur/colors';
-import { extname } from 'node:path';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import path, { extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import * as vite from 'vite';
 import type { RouteData } from '../../@types/astro';
 import {

--- a/packages/astro/src/core/compile/compile.ts
+++ b/packages/astro/src/core/compile/compile.ts
@@ -3,7 +3,7 @@ import type { ResolvedConfig } from 'vite';
 import type { AstroConfig } from '../../@types/astro';
 
 import { transform } from '@astrojs/compiler';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { normalizePath } from 'vite';
 import { AggregateError, AstroError, CompilerError } from '../errors/errors.js';
 import { AstroErrorData } from '../errors/index.js';

--- a/packages/astro/src/core/compile/style.ts
+++ b/packages/astro/src/core/compile/style.ts
@@ -1,5 +1,5 @@
 import type { TransformOptions } from '@astrojs/compiler';
-import fs from 'fs';
+import fs from 'node:fs';
 import { preprocessCSS, type ResolvedConfig } from 'vite';
 import { AstroErrorData, CSSError, positionAt } from '../errors/index.js';
 

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -1,10 +1,10 @@
 import type { Arguments as Flags } from 'yargs-parser';
 import type { AstroConfig, AstroUserConfig, CLIFlags } from '../../@types/astro';
 
-import fs from 'fs';
 import * as colors from 'kleur/colors';
-import path from 'path';
-import { fileURLToPath, pathToFileURL } from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 import { mergeConfig } from './merge.js';
 import { createRelativeSchema } from './schema.js';

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -3,7 +3,7 @@ import { markdownConfigDefaults } from '@astrojs/markdown-remark';
 import type { ILanguageRegistration, IThemeRegistration, Theme } from 'shiki';
 import type { AstroUserConfig, ViteUserConfig } from '../../@types/astro';
 
-import type { OutgoingHttpHeaders } from 'http';
+import type { OutgoingHttpHeaders } from 'node:http';
 import { BUNDLED_THEMES } from 'shiki';
 import { z } from 'zod';
 import { appendForwardSlash, prependForwardSlash, trimSlashes } from '../path.js';

--- a/packages/astro/src/core/config/settings.ts
+++ b/packages/astro/src/core/config/settings.ts
@@ -1,6 +1,6 @@
 import yaml from 'js-yaml';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { AstroConfig, AstroSettings, AstroUserConfig } from '../../@types/astro';
 import { getContentPaths } from '../../content/index.js';
 import jsxRenderer from '../../jsx/renderer.js';

--- a/packages/astro/src/core/config/timer.ts
+++ b/packages/astro/src/core/config/timer.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 // Type used by `bench-memory.js`
 export interface Stat {

--- a/packages/astro/src/core/config/tsconfig.ts
+++ b/packages/astro/src/core/config/tsconfig.ts
@@ -1,6 +1,6 @@
 import { deepmerge } from 'deepmerge-ts';
-import { existsSync } from 'fs';
-import { join } from 'path';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import * as tsr from 'tsconfig-resolver';
 
 export const defaultTSConfig: tsr.TsConfigJson = { extends: 'astro/tsconfigs/base' };

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -1,5 +1,5 @@
-import type fsType from 'fs';
-import { pathToFileURL } from 'url';
+import type fsType from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import { createServer, type ViteDevServer } from 'vite';
 import loadFallbackPlugin from '../../vite-plugin-load-fallback/index.js';
 import { debug } from '../logger/core.js';

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -1,8 +1,8 @@
 import type { AstroSettings } from '../@types/astro';
 import type { LogOptions } from './logger/core';
 
-import nodeFs from 'fs';
-import { fileURLToPath } from 'url';
+import nodeFs from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import * as vite from 'vite';
 import { crawlFrameworkPkgs } from 'vitefu';
 import astroAssetsPlugin from '../assets/vite-plugin-assets.js';

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -1,8 +1,8 @@
-import type * as http from 'http';
-import type { AddressInfo } from 'net';
+import type * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
 import type { AstroSettings, AstroUserConfig } from '../../@types/astro';
 
-import nodeFs from 'fs';
+import nodeFs from 'node:fs';
 import * as vite from 'vite';
 import {
 	runHookConfigDone,

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -1,6 +1,6 @@
-import type http from 'http';
 import { cyan } from 'kleur/colors';
-import type { AddressInfo } from 'net';
+import type http from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { performance } from 'perf_hooks';
 import type * as vite from 'vite';
 import type yargs from 'yargs-parser';

--- a/packages/astro/src/core/errors/dev/vite.ts
+++ b/packages/astro/src/core/errors/dev/vite.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
+import * as fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { getHighlighter } from 'shiki';
-import { fileURLToPath } from 'url';
 import type { ErrorPayload } from 'vite';
 import type { ModuleLoader } from '../../module-loader/index.js';
 import { AstroErrorData } from '../errors-data.js';

--- a/packages/astro/src/core/fs/index.ts
+++ b/packages/astro/src/core/fs/index.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { appendForwardSlash } from '../path.js';
 
 const isWindows = process.platform === 'win32';
@@ -63,7 +63,7 @@ export function emptyDir(_dir: URL, skip?: Set<string>): void {
  * Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
 copyright notice and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR

--- a/packages/astro/src/core/logger/node.ts
+++ b/packages/astro/src/core/logger/node.ts
@@ -1,7 +1,7 @@
 import debugPackage from 'debug';
 import { bold, cyan, dim, red, reset, yellow } from 'kleur/colors';
-import * as readline from 'readline';
-import { Writable } from 'stream';
+import * as readline from 'node:readline';
+import { Writable } from 'node:stream';
 import stringWidth from 'string-width';
 import { dateTimeFormat, error, info, warn } from './core.js';
 

--- a/packages/astro/src/core/module-loader/loader.ts
+++ b/packages/astro/src/core/module-loader/loader.ts
@@ -1,5 +1,5 @@
-import { EventEmitter } from 'events';
-import type * as fs from 'fs';
+import { EventEmitter } from 'node:events';
+import type * as fs from 'node:fs';
 import type { TypedEventEmitter } from '../../@types/typed-emitter';
 
 // This is a generic interface for a module loader. In the astro cli this is

--- a/packages/astro/src/core/module-loader/vite.ts
+++ b/packages/astro/src/core/module-loader/vite.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 import type * as vite from 'vite';
 import type { ModuleLoader, ModuleLoaderEventEmitter } from './loader';
 

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -1,6 +1,6 @@
 import { cyan } from 'kleur/colors';
 import { createRequire } from 'module';
-import { pathToFileURL } from 'url';
+import { pathToFileURL } from 'node:url';
 import type { Arguments } from 'yargs-parser';
 import type { AstroSettings, PreviewModule, PreviewServer } from '../../@types/astro';
 import { runHookConfigDone, runHookConfigSetup } from '../../integrations/index.js';

--- a/packages/astro/src/core/preview/static-preview-server.ts
+++ b/packages/astro/src/core/preview/static-preview-server.ts
@@ -1,7 +1,7 @@
-import type http from 'http';
+import type http from 'node:http';
+import { fileURLToPath } from 'node:url';
 import { performance } from 'perf_hooks';
 import enableDestroy from 'server-destroy';
-import { fileURLToPath } from 'url';
 import { preview, type PreviewServer as VitePreviewServer } from 'vite';
 import type { AstroSettings } from '../../@types/astro';
 import type { LogOptions } from '../logger/core';

--- a/packages/astro/src/core/preview/vite-plugin-astro-preview.ts
+++ b/packages/astro/src/core/preview/vite-plugin-astro-preview.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import type { Plugin } from 'vite';
 import type { AstroSettings } from '../../@types/astro.js';
 import { notFoundTemplate, subpathNotUsedTemplate } from '../../template/4xx.js';

--- a/packages/astro/src/core/render/dev/vite.ts
+++ b/packages/astro/src/core/render/dev/vite.ts
@@ -1,6 +1,6 @@
 import type { ModuleLoader, ModuleNode } from '../../module-loader/index';
 
-import npath from 'path';
+import npath from 'node:path';
 import { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from '../../constants.js';
 import { unwrapId } from '../../util.js';
 import { isCSSRequest } from './util.js';

--- a/packages/astro/src/core/request.ts
+++ b/packages/astro/src/core/request.ts
@@ -1,4 +1,4 @@
-import type { IncomingHttpHeaders } from 'http';
+import type { IncomingHttpHeaders } from 'node:http';
 import type { LogOptions } from './logger/core';
 import { warn } from './logger/core.js';
 

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -8,10 +8,10 @@ import type {
 } from '../../../@types/astro';
 import type { LogOptions } from '../../logger/core';
 
-import nodeFs from 'fs';
 import { createRequire } from 'module';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import nodeFs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { getPrerenderDefault } from '../../../prerender/utils.js';
 import { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from '../../constants.js';
 import { warn } from '../../logger/core.js';

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { normalizePath } from 'vite';
 import type { AstroConfig, AstroSettings, RouteType } from '../@types/astro';
 import { isServerLikeOutput } from '../prerender/utils.js';

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -1,6 +1,6 @@
 import { bold } from 'kleur/colors';
-import type { AddressInfo } from 'net';
 import fs from 'node:fs';
+import type { AddressInfo } from 'node:net';
 import { fileURLToPath } from 'node:url';
 import type { InlineConfig, ViteDevServer } from 'vite';
 import type {

--- a/packages/astro/src/vite-plugin-astro-server/base.ts
+++ b/packages/astro/src/vite-plugin-astro-server/base.ts
@@ -1,7 +1,7 @@
 import type * as vite from 'vite';
 import type { AstroSettings } from '../@types/astro';
 
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { warn, type LogOptions } from '../core/logger/core.js';
 import notFoundTemplate, { subpathNotUsedTemplate } from '../template/4xx.js';
 import { log404 } from './common.js';

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -1,4 +1,4 @@
-import type fs from 'fs';
+import type fs from 'node:fs';
 import type * as vite from 'vite';
 import type { AstroSettings, ManifestData, SSRManifest } from '../@types/astro';
 import { patchOverlay } from '../core/errors/overlay.js';

--- a/packages/astro/src/vite-plugin-astro-server/request.ts
+++ b/packages/astro/src/vite-plugin-astro-server/request.ts
@@ -1,4 +1,4 @@
-import type http from 'http';
+import type http from 'node:http';
 import type { ManifestData, SSRManifest } from '../@types/astro';
 import type { DevelopmentEnvironment } from '../core/render/dev/index';
 import type { DevServerController } from './controller';

--- a/packages/astro/src/vite-plugin-astro-server/response.ts
+++ b/packages/astro/src/vite-plugin-astro-server/response.ts
@@ -1,4 +1,4 @@
-import type http from 'http';
+import type http from 'node:http';
 import type { ErrorWithMetadata } from '../core/errors/index.js';
 import type { ModuleLoader } from '../core/module-loader/index';
 

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -1,5 +1,5 @@
-import type http from 'http';
 import mime from 'mime';
+import type http from 'node:http';
 import type { ComponentInstance, ManifestData, RouteData, SSRManifest } from '../@types/astro';
 import { attachToResponse } from '../core/cookies/index.js';
 import { call as callEndpoint } from '../core/endpoint/dev/index.js';

--- a/packages/astro/src/vite-plugin-config-alias/index.ts
+++ b/packages/astro/src/vite-plugin-config-alias/index.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { normalizePath, type Plugin as VitePlugin, type ResolvedConfig } from 'vite';
 import type { AstroSettings } from '../@types/astro';
 

--- a/packages/astro/src/vite-plugin-env/index.ts
+++ b/packages/astro/src/vite-plugin-env/index.ts
@@ -1,5 +1,5 @@
 import MagicString from 'magic-string';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import type * as vite from 'vite';
 import { loadEnv } from 'vite';
 import type { AstroConfig, AstroSettings } from '../@types/astro';

--- a/packages/astro/src/vite-plugin-jsx/index.ts
+++ b/packages/astro/src/vite-plugin-jsx/index.ts
@@ -11,7 +11,7 @@ import type { PluginMetadata } from '../vite-plugin-astro/types';
 
 import babel from '@babel/core';
 import * as colors from 'kleur/colors';
-import path from 'path';
+import path from 'node:path';
 import { CONTENT_FLAG, PROPAGATED_ASSET_FLAG } from '../content/index.js';
 import { astroEntryPrefix } from '../core/build/plugins/plugin-component-entry.js';
 import { error } from '../core/logger/core.js';

--- a/packages/astro/src/vite-plugin-load-fallback/index.ts
+++ b/packages/astro/src/vite-plugin-load-fallback/index.ts
@@ -1,5 +1,5 @@
-import nodeFs from 'fs';
-import npath from 'path';
+import nodeFs from 'node:fs';
+import npath from 'node:path';
 import type * as vite from 'vite';
 import { slash } from '../core/path.js';
 
@@ -15,7 +15,7 @@ export default function loadFallbackPlugin({
 	root,
 }: LoadFallbackPluginParams): vite.Plugin[] | false {
 	// Only add this plugin if a custom fs implementation is provided.
-	// Also check for `fs.default` because `import * as fs from 'fs'` will
+	// Also check for `fs.default` because `import * as fs from 'node:fs'` will
 	// export as so, which only it's `.default` would === `nodeFs`.
 	// @ts-expect-error check default
 	if (!fs || fs === nodeFs || fs.default === nodeFs) {

--- a/packages/astro/src/vite-plugin-utils/index.ts
+++ b/packages/astro/src/vite-plugin-utils/index.ts
@@ -1,5 +1,5 @@
 import ancestor from 'common-ancestor-path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import type { AstroConfig } from '../@types/astro';
 import {
 	appendExtension,

--- a/packages/astro/test/debug-component.test.js
+++ b/packages/astro/test/debug-component.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
+import os from 'node:os';
 import { loadFixture } from './test-utils.js';
-import os from 'os';
 
 // TODO: fix these tests on macOS
 const isMacOS = os.platform() === 'darwin';

--- a/packages/astro/test/dont-delete-root.test.js
+++ b/packages/astro/test/dont-delete-root.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
+import * as fs from 'node:fs';
 import { loadFixture } from './test-utils.js';
-import * as fs from 'fs';
 
 describe('outDir set to project root', async () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/fixtures/astro-scripts/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-scripts/astro.config.mjs
@@ -1,6 +1,6 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
 	integrations: [

--- a/packages/astro/test/fixtures/middleware-tailwind/astro.config.mjs
+++ b/packages/astro/test/fixtures/middleware-tailwind/astro.config.mjs
@@ -1,6 +1,6 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/tailwindcss-ts/astro.config.ts
+++ b/packages/astro/test/fixtures/tailwindcss-ts/astro.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/tailwindcss/astro.config.mjs
+++ b/packages/astro/test/fixtures/tailwindcss/astro.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
 import mdx from '@astrojs/mdx';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/tailwindcss/tailwind.config.js
+++ b/packages/astro/test/fixtures/tailwindcss/tailwind.config.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 
 module.exports = {
 	content: [path.join(__dirname, 'src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}')],

--- a/packages/astro/test/route-manifest.test.js
+++ b/packages/astro/test/route-manifest.test.js
@@ -1,6 +1,6 @@
 // TODO: unskip this test
 // import { expect } from 'chai';
-// import { fileURLToPath } from 'url';
+// import { fileURLToPath } from 'node:url';
 // import { createRouteManifest } from '../dist/core/routing/index.js';
 // import { validateConfig } from '../dist/core/config.js';
 

--- a/packages/astro/test/ssr-api-route.test.js
+++ b/packages/astro/test/ssr-api-route.test.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
+import net from 'node:net';
 import { File, FormData } from 'undici';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
-import net from 'net';
 
 describe('API routes in SSR', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -29,7 +29,7 @@ export default function (
 									if (id === '@my-ssr') {
 										return `
 											import { App } from 'astro/app';
-											import fs from 'fs';
+											import fs from 'node:fs';
 
 											class MyApp extends App {
 												#manifest = null;
@@ -50,12 +50,12 @@ export default function (
 													return super.render(request, routeData, locals);
 												}
 											}
-											
+
 											export function createExports(manifest) {
 												return {
 													manifest,
 													createApp: (streaming) => new MyApp(manifest, streaming)
-													
+
 												};
 											}
 										`;

--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -29,7 +29,7 @@ export default function (
 									if (id === '@my-ssr') {
 										return `
 											import { App } from 'astro/app';
-											import fs from 'node:fs';
+											import fs from 'fs';
 
 											class MyApp extends App {
 												#manifest = null;

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -1,21 +1,21 @@
 import { polyfill } from '@astrojs/webapi';
 import { execa } from 'execa';
 import fastGlob from 'fast-glob';
-import fs from 'fs';
-import os from 'os';
+import fs from 'node:fs';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
 import stripAnsi from 'strip-ansi';
-import { fileURLToPath } from 'url';
-import { sync } from '../dist/core/sync/index.js';
+import { check } from '../dist/cli/check/index.js';
 import build from '../dist/core/build/index.js';
+import { RESOLVED_SPLIT_MODULE_ID } from '../dist/core/build/plugins/plugin-ssr.js';
+import { getVirtualModulePageNameFromPath } from '../dist/core/build/plugins/util.js';
+import { makeSplitEntryPointFileName } from '../dist/core/build/static-build.js';
 import { openConfig } from '../dist/core/config/config.js';
 import { createSettings } from '../dist/core/config/index.js';
 import dev from '../dist/core/dev/index.js';
 import { nodeLogDestination } from '../dist/core/logger/node.js';
 import preview from '../dist/core/preview/index.js';
-import { check } from '../dist/cli/check/index.js';
-import { getVirtualModulePageNameFromPath } from '../dist/core/build/plugins/util.js';
-import { RESOLVED_SPLIT_MODULE_ID } from '../dist/core/build/plugins/plugin-ssr.js';
-import { makeSplitEntryPointFileName } from '../dist/core/build/static-build.js';
+import { sync } from '../dist/core/sync/index.js';
 
 // polyfill WebAPIs to globalThis for Node v12, Node v14, and Node v16
 polyfill(globalThis, {

--- a/packages/astro/test/units/compile/invalid-css.test.js
+++ b/packages/astro/test/units/compile/invalid-css.test.js
@@ -2,7 +2,7 @@ import { resolveConfig } from 'vite';
 import { expect } from 'chai';
 import { cachedCompilation } from '../../../dist/core/compile/index.js';
 import { AggregateError } from '../../../dist/core/errors/index.js';
-import { pathToFileURL } from 'url';
+import { pathToFileURL } from 'node:url';
 
 describe('astro/src/core/compile', () => {
 	describe('Invalid CSS', () => {

--- a/packages/astro/test/units/config/config-server.test.js
+++ b/packages/astro/test/units/config/config-server.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { defaultLogging } from '../test-utils.js';
 import { openConfig } from '../../../dist/core/config/index.js';
 

--- a/packages/astro/test/units/config/config-tsconfig.test.js
+++ b/packages/astro/test/units/config/config-tsconfig.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { loadTSConfig, updateTSConfigForFramework } from '../../../dist/core/config/index.js';
-import * as path from 'path';
+import * as path from 'node:path';
 import * as tsr from 'tsconfig-resolver';
 
 const cwd = fileURLToPath(new URL('../../fixtures/tsconfig-handling/', import.meta.url));

--- a/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
+++ b/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { validateConfig } from '../../../dist/core/config/config.js';
 import { createSettings } from '../../../dist/core/config/index.js';
 import { sync as _sync } from '../../../dist/core/sync/index.js';

--- a/packages/astro/test/units/dev/collections-renderentry.test.js
+++ b/packages/astro/test/units/dev/collections-renderentry.test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
-import os from 'os';
+import os from 'node:os';
 
-import { runInContainer } from '../../../dist/core/dev/index.js';
-import { createFsWithFallback, createRequestAndResponse } from '../test-utils.js';
 import mdx from '../../../../integrations/mdx/dist/index.js';
 import { attachContentServerListeners } from '../../../dist/content/server-listeners.js';
+import { runInContainer } from '../../../dist/core/dev/index.js';
+import { createFsWithFallback, createRequestAndResponse } from '../test-utils.js';
 
 const root = new URL('../../fixtures/content/', import.meta.url);
 

--- a/packages/astro/test/units/dev/restart.test.js
+++ b/packages/astro/test/units/dev/restart.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 import {
 	createContainerWithAutomaticRestart,
@@ -30,7 +30,7 @@ describe('dev container restarts', () => {
 				</html>
 			`,
 				'/astro.config.mjs': `
-				
+
 				`,
 			},
 			root

--- a/packages/astro/test/units/routing/manifest.test.js
+++ b/packages/astro/test/units/routing/manifest.test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { createFs } from '../test-utils.js';
 import { createRouteManifest } from '../../../dist/core/routing/manifest/create.js';
 import { createDefaultDevSettings } from '../../../dist/core/config/index.js';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { defaultLogging } from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);

--- a/packages/astro/test/units/routing/route-matching.test.js
+++ b/packages/astro/test/units/routing/route-matching.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { createFs, createRequestAndResponse, defaultLogging } from '../test-utils.js';
 import { createRouteManifest, matchAllRoutes } from '../../../dist/core/routing/index.js';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { createViteLoader } from '../../../dist/core/module-loader/vite.js';
 import { createDevelopmentEnvironment } from '../../../dist/core/render/dev/environment.js';
 import { expect } from 'chai';

--- a/packages/astro/test/units/test-utils.js
+++ b/packages/astro/test/units/test-utils.js
@@ -1,14 +1,14 @@
-import { EventEmitter } from 'events';
 import { Volume } from 'memfs';
 import httpMocks from 'node-mocks-http';
+import { EventEmitter } from 'node:events';
 import realFS from 'node:fs';
-import npath from 'path';
-import { fileURLToPath } from 'url';
-import { unixify } from './correct-path.js';
+import npath from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { getDefaultClientDirectives } from '../../dist/core/client-directive/index.js';
+import { nodeLogDestination } from '../../dist/core/logger/node.js';
 import { createEnvironment } from '../../dist/core/render/index.js';
 import { RouteCache } from '../../dist/core/render/route-cache.js';
-import { nodeLogDestination } from '../../dist/core/logger/node.js';
+import { unixify } from './correct-path.js';
 
 /** @type {import('../../src/core/logger/core').LogOptions} */
 export const defaultLogging = {
@@ -99,7 +99,7 @@ export function createFsWithFallback(json, root) {
 /**
  *
  * @param {import('../../src/core/dev/container').Container} container
- * @param {typeof import('fs')} fs
+ * @param {typeof import('node:fs')} fs
  * @param {string} shortPath
  * @param {'change'} eventType
  */

--- a/packages/astro/test/units/vite-plugin-astro/compile.test.js
+++ b/packages/astro/test/units/vite-plugin-astro/compile.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { resolveConfig } from 'vite';
 import { cachedFullCompilation } from '../../../dist/vite-plugin-astro/compile.js';
 import { init, parse } from 'es-module-lexer';
-import { pathToFileURL } from 'url';
+import { pathToFileURL } from 'node:url';
 
 const viteConfig = await resolveConfig({ configFile: false }, 'serve');
 

--- a/packages/create-astro/test/git.test.js
+++ b/packages/create-astro/test/git.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
-import fs from 'fs';
 import { execa } from 'execa';
+import fs from 'node:fs';
 
 import { git } from '../dist/index.js';
 import { setup } from './utils.js';

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -1,11 +1,11 @@
 import { createRedirectsFromAstroRoutes } from '@astrojs/underscore-redirects';
 import type { AstroAdapter, AstroConfig, AstroIntegration, RouteData } from 'astro';
 import esbuild from 'esbuild';
-import * as fs from 'fs';
-import * as os from 'os';
-import { sep } from 'path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { sep } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import glob from 'tiny-glob';
-import { fileURLToPath, pathToFileURL } from 'url';
 
 type Options = {
 	mode: 'directory' | 'advanced';

--- a/packages/integrations/cloudflare/test/test-utils.js
+++ b/packages/integrations/cloudflare/test/test-utils.js
@@ -1,6 +1,6 @@
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { loadFixture as baseLoadFixture } from '../../../astro/test/test-utils.js';
-import { spawn } from 'child_process';
-import { fileURLToPath } from 'url';
 
 export { fixLineEndings } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/deno/src/index.ts
+++ b/packages/integrations/deno/src/index.ts
@@ -1,8 +1,8 @@
 import type { AstroAdapter, AstroIntegration } from 'astro';
 import esbuild from 'esbuild';
-import * as fs from 'fs';
-import * as npath from 'path';
-import { fileURLToPath } from 'url';
+import * as fs from 'node:fs';
+import * as npath from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 interface BuildConfig {
 	server: URL;

--- a/packages/integrations/deno/test/fixtures/basics/src/pages/nodecompat.astro
+++ b/packages/integrations/deno/test/fixtures/basics/src/pages/nodecompat.astro
@@ -1,6 +1,6 @@
 ---
 // unprefixed node built-in module
-import path from 'path'
+import path from 'node:path'
 
 // prefixed node built-in module
 import os from 'node:os'

--- a/packages/integrations/image/src/vendor/squoosh/avif/avif_node_dec.ts
+++ b/packages/integrations/image/src/vendor/squoosh/avif/avif_node_dec.ts
@@ -41,13 +41,13 @@ var Module = (function () {
     var nodePath
     if (ENVIRONMENT_IS_NODE) {
       if (ENVIRONMENT_IS_WORKER) {
-        scriptDirectory = require('path').dirname(scriptDirectory) + '/'
+        scriptDirectory = require('node:path').dirname(scriptDirectory) + '/'
       } else {
         scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
-        if (!nodeFS) nodeFS = require('fs')
-        if (!nodePath) nodePath = require('path')
+        if (!nodeFS) nodeFS = require('node:fs')
+        if (!nodePath) nodePath = require('node:path')
         filename = nodePath['normalize'](filename)
         return nodeFS['readFileSync'](filename, binary ? null : 'utf8')
       }

--- a/packages/integrations/image/src/vendor/squoosh/avif/avif_node_enc.ts
+++ b/packages/integrations/image/src/vendor/squoosh/avif/avif_node_enc.ts
@@ -41,13 +41,13 @@ var Module = (function () {
     var nodePath
     if (ENVIRONMENT_IS_NODE) {
       if (ENVIRONMENT_IS_WORKER) {
-        scriptDirectory = require('path').dirname(scriptDirectory) + '/'
+        scriptDirectory = require('node:path').dirname(scriptDirectory) + '/'
       } else {
         scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
-        if (!nodeFS) nodeFS = require('fs')
-        if (!nodePath) nodePath = require('path')
+        if (!nodeFS) nodeFS = require('node:fs')
+        if (!nodePath) nodePath = require('node:path')
         filename = nodePath['normalize'](filename)
         return nodeFS['readFileSync'](filename, binary ? null : 'utf8')
       }

--- a/packages/integrations/image/src/vendor/squoosh/image-pool.ts
+++ b/packages/integrations/image/src/vendor/squoosh/image-pool.ts
@@ -1,6 +1,6 @@
+import { cpus } from 'node:os';
+import { fileURLToPath } from 'node:url';
 import { isMainThread } from 'node:worker_threads';
-import { cpus } from 'os';
-import { fileURLToPath } from 'url';
 import type { OutputFormat } from '../../loaders/index.js';
 import execOnce from '../../utils/execOnce.js';
 import WorkerPool from '../../utils/workerPool.js';

--- a/packages/integrations/image/src/vendor/squoosh/mozjpeg/mozjpeg_node_dec.ts
+++ b/packages/integrations/image/src/vendor/squoosh/mozjpeg/mozjpeg_node_dec.ts
@@ -41,13 +41,13 @@ var Module = (function () {
     var nodePath
     if (ENVIRONMENT_IS_NODE) {
       if (ENVIRONMENT_IS_WORKER) {
-        scriptDirectory = require('path').dirname(scriptDirectory) + '/'
+        scriptDirectory = require('node:path').dirname(scriptDirectory) + '/'
       } else {
         scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
-        if (!nodeFS) nodeFS = require('fs')
-        if (!nodePath) nodePath = require('path')
+        if (!nodeFS) nodeFS = require('node:fs')
+        if (!nodePath) nodePath = require('node:path')
         filename = nodePath['normalize'](filename)
         return nodeFS['readFileSync'](filename, binary ? null : 'utf8')
       }

--- a/packages/integrations/image/src/vendor/squoosh/mozjpeg/mozjpeg_node_enc.ts
+++ b/packages/integrations/image/src/vendor/squoosh/mozjpeg/mozjpeg_node_enc.ts
@@ -41,13 +41,13 @@ var Module = (function () {
     var nodePath
     if (ENVIRONMENT_IS_NODE) {
       if (ENVIRONMENT_IS_WORKER) {
-        scriptDirectory = require('path').dirname(scriptDirectory) + '/'
+        scriptDirectory = require('node:path').dirname(scriptDirectory) + '/'
       } else {
         scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
-        if (!nodeFS) nodeFS = require('fs')
-        if (!nodePath) nodePath = require('path')
+        if (!nodeFS) nodeFS = require('node:fs')
+        if (!nodePath) nodePath = require('node:path')
         filename = nodePath['normalize'](filename)
         return nodeFS['readFileSync'](filename, binary ? null : 'utf8')
       }

--- a/packages/integrations/image/src/vendor/squoosh/webp/webp_node_dec.ts
+++ b/packages/integrations/image/src/vendor/squoosh/webp/webp_node_dec.ts
@@ -41,13 +41,13 @@ var Module = (function () {
     var nodePath
     if (ENVIRONMENT_IS_NODE) {
       if (ENVIRONMENT_IS_WORKER) {
-        scriptDirectory = require('path').dirname(scriptDirectory) + '/'
+        scriptDirectory = require('node:path').dirname(scriptDirectory) + '/'
       } else {
         scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
-        if (!nodeFS) nodeFS = require('fs')
-        if (!nodePath) nodePath = require('path')
+        if (!nodeFS) nodeFS = require('node:fs')
+        if (!nodePath) nodePath = require('node:path')
         filename = nodePath['normalize'](filename)
         return nodeFS['readFileSync'](filename, binary ? null : 'utf8')
       }

--- a/packages/integrations/image/src/vendor/squoosh/webp/webp_node_enc.ts
+++ b/packages/integrations/image/src/vendor/squoosh/webp/webp_node_enc.ts
@@ -41,13 +41,13 @@ var Module = (function () {
     var nodePath
     if (ENVIRONMENT_IS_NODE) {
       if (ENVIRONMENT_IS_WORKER) {
-        scriptDirectory = require('path').dirname(scriptDirectory) + '/'
+        scriptDirectory = require('node:path').dirname(scriptDirectory) + '/'
       } else {
         scriptDirectory = dirname(getModuleURL(import.meta.url)) + '/'
       }
       read_ = function shell_read(filename, binary) {
-        if (!nodeFS) nodeFS = require('fs')
-        if (!nodePath) nodePath = require('path')
+        if (!nodeFS) nodeFS = require('node:fs')
+        if (!nodePath) nodePath = require('node:path')
         filename = nodePath['normalize'](filename)
         return nodeFS['readFileSync'](filename, binary ? null : 'utf8')
       }

--- a/packages/integrations/image/test/background-color-image-ssg.test.js
+++ b/packages/integrations/image/test/background-color-image-ssg.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
 import sharp from 'sharp';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { loadFixture } from './test-utils.js';
 
 describe('SSG image with background - dev', function () {

--- a/packages/integrations/image/test/fixtures/background-color-image/server/server.mjs
+++ b/packages/integrations/image/test/fixtures/background-color-image/server/server.mjs
@@ -1,6 +1,6 @@
-import { createServer } from 'http';
-import fs from 'fs';
 import mime from 'mime';
+import fs from 'node:fs';
+import { createServer } from 'node:http';
 import { handler as ssrHandler } from '../dist/server/entry.mjs';
 
 const clientRoot = new URL('../dist/client/', import.meta.url);

--- a/packages/integrations/image/test/fixtures/basic-image/server/server.mjs
+++ b/packages/integrations/image/test/fixtures/basic-image/server/server.mjs
@@ -1,6 +1,6 @@
-import { createServer } from 'http';
-import fs from 'fs';
 import mime from 'mime';
+import fs from 'node:fs';
+import { createServer } from 'node:http';
 import { handler as ssrHandler } from '../dist/server/entry.mjs';
 
 const clientRoot = new URL('../dist/client/', import.meta.url);

--- a/packages/integrations/image/test/fixtures/basic-picture/server/server.mjs
+++ b/packages/integrations/image/test/fixtures/basic-picture/server/server.mjs
@@ -1,6 +1,6 @@
-import { createServer } from 'http';
-import fs from 'fs';
 import mime from 'mime';
+import fs from 'node:fs';
+import { createServer } from 'node:http';
 import { handler as ssrHandler } from '../dist/server/entry.mjs';
 
 const clientRoot = new URL('../dist/client/', import.meta.url);

--- a/packages/integrations/image/test/fixtures/no-alt-text-image/server/server.mjs
+++ b/packages/integrations/image/test/fixtures/no-alt-text-image/server/server.mjs
@@ -1,6 +1,6 @@
-import { createServer } from 'http';
-import fs from 'fs';
 import mime from 'mime';
+import fs from 'node:fs';
+import { createServer } from 'node:http';
 import { handler as ssrHandler } from '../dist/server/entry.mjs';
 
 const clientRoot = new URL('../dist/client/', import.meta.url);

--- a/packages/integrations/image/test/fixtures/no-alt-text-picture/server/server.mjs
+++ b/packages/integrations/image/test/fixtures/no-alt-text-picture/server/server.mjs
@@ -1,6 +1,6 @@
-import { createServer } from 'http';
-import fs from 'fs';
 import mime from 'mime';
+import fs from 'node:fs';
+import { createServer } from 'node:http';
 import { handler as ssrHandler } from '../dist/server/entry.mjs';
 
 const clientRoot = new URL('../dist/client/', import.meta.url);

--- a/packages/integrations/image/test/fixtures/rotation/server/server.mjs
+++ b/packages/integrations/image/test/fixtures/rotation/server/server.mjs
@@ -1,6 +1,6 @@
-import { createServer } from 'http';
-import fs from 'fs';
 import mime from 'mime';
+import fs from 'node:fs';
+import { createServer } from 'node:http';
 import { handler as ssrHandler } from '../dist/server/entry.mjs';
 
 const clientRoot = new URL('../dist/client/', import.meta.url);

--- a/packages/integrations/image/test/fixtures/squoosh-service/server/server.mjs
+++ b/packages/integrations/image/test/fixtures/squoosh-service/server/server.mjs
@@ -1,6 +1,6 @@
-import { createServer } from 'http';
-import fs from 'fs';
 import mime from 'mime';
+import fs from 'node:fs';
+import { createServer } from 'node:http';
 import { handler as ssrHandler } from '../dist/server/entry.mjs';
 
 const clientRoot = new URL('../dist/client/', import.meta.url);

--- a/packages/integrations/image/test/fixtures/with-mdx/server/server.mjs
+++ b/packages/integrations/image/test/fixtures/with-mdx/server/server.mjs
@@ -1,6 +1,6 @@
-import { createServer } from 'http';
-import fs from 'fs';
 import mime from 'mime';
+import fs from 'node:fs';
+import { createServer } from 'node:http';
 import { handler as ssrHandler } from '../dist/server/entry.mjs';
 
 const clientRoot = new URL('../dist/client/', import.meta.url);

--- a/packages/integrations/image/test/image-ssg.test.js
+++ b/packages/integrations/image/test/image-ssg.test.js
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
 import sizeOf from 'image-size';
-import fs from 'fs/promises';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import fs from 'node:fs/promises';
 import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { loadFixture } from './test-utils.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));

--- a/packages/integrations/image/test/picture-ssg.test.js
+++ b/packages/integrations/image/test/picture-ssg.test.js
@@ -1,12 +1,11 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
-import fs from 'fs';
 import sizeOf from 'image-size';
-import path from 'path';
+import fs from 'node:fs';
+import path, { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { join } from 'node:path';
-import { loadFixture } from './test-utils.js';
 import srcsetParse from 'srcset-parse';
+import { loadFixture } from './test-utils.js';
 
 const matchSrcset = srcsetParse.default;
 

--- a/packages/integrations/image/test/rotation.test.js
+++ b/packages/integrations/image/test/rotation.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
 import sizeOf from 'image-size';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { loadFixture } from './test-utils.js';
 
 let fixture;

--- a/packages/integrations/image/test/with-mdx.test.js
+++ b/packages/integrations/image/test/with-mdx.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
 import sizeOf from 'image-size';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { loadFixture } from './test-utils.js';
 
 describe('Images in MDX - build', function () {

--- a/packages/integrations/netlify/src/shared.ts
+++ b/packages/integrations/netlify/src/shared.ts
@@ -2,8 +2,8 @@ import { createRedirectsFromAstroRoutes } from '@astrojs/underscore-redirects';
 import type { AstroConfig, RouteData } from 'astro';
 import esbuild from 'esbuild';
 import fs from 'node:fs';
-import npath from 'path';
-import { fileURLToPath } from 'url';
+import npath from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const DENO_SHIM = `globalThis.process = {
 	argv: [],

--- a/packages/integrations/netlify/test/functions/test-utils.js
+++ b/packages/integrations/netlify/test/functions/test-utils.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 export * from '../../../../astro/test/test-utils.js';
 

--- a/packages/integrations/netlify/test/static/test-utils.js
+++ b/packages/integrations/netlify/test/static/test-utils.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 export * from '../../../../astro/test/test-utils.js';
 

--- a/packages/integrations/node/README.md
+++ b/packages/integrations/node/README.md
@@ -108,7 +108,7 @@ Or, with Fastify (>4):
 import Fastify from 'fastify';
 import fastifyMiddie from '@fastify/middie';
 import fastifyStatic from '@fastify/static';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { handler as ssrHandler } from './dist/server/entry.mjs';
 
 const app = Fastify({ logger: true });

--- a/packages/integrations/node/src/createOutgoingHttpHeaders.ts
+++ b/packages/integrations/node/src/createOutgoingHttpHeaders.ts
@@ -1,4 +1,4 @@
-import type { OutgoingHttpHeaders } from 'http';
+import type { OutgoingHttpHeaders } from 'node:http';
 
 /**
  * Takes in a nullable WebAPI Headers object and produces a NodeJS OutgoingHttpHeaders object suitable for usage

--- a/packages/integrations/node/src/http-server.ts
+++ b/packages/integrations/node/src/http-server.ts
@@ -1,9 +1,9 @@
-import fs from 'fs';
-import http from 'http';
 import https from 'https';
+import fs from 'node:fs';
+import http from 'node:http';
+import { fileURLToPath } from 'node:url';
 import send from 'send';
 import enableDestroy from 'server-destroy';
-import { fileURLToPath } from 'url';
 
 interface CreateServerOptions {
 	client: URL;

--- a/packages/integrations/node/src/nodeMiddleware.ts
+++ b/packages/integrations/node/src/nodeMiddleware.ts
@@ -1,5 +1,5 @@
 import type { NodeApp } from 'astro/app/node';
-import type { IncomingMessage, ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Readable } from 'stream';
 import { createOutgoingHttpHeaders } from './createOutgoingHttpHeaders';
 import { responseIterator } from './response-iterator';

--- a/packages/integrations/node/src/preview.ts
+++ b/packages/integrations/node/src/preview.ts
@@ -1,6 +1,6 @@
 import type { CreatePreviewServer } from 'astro';
-import type http from 'http';
-import { fileURLToPath } from 'url';
+import type http from 'node:http';
+import { fileURLToPath } from 'node:url';
 import { createServer } from './http-server.js';
 import type { createExports } from './server';
 

--- a/packages/integrations/node/src/standalone.ts
+++ b/packages/integrations/node/src/standalone.ts
@@ -1,7 +1,7 @@
 import type { NodeApp } from 'astro/app/node';
 import https from 'https';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { createServer } from './http-server.js';
 import middleware from './nodeMiddleware.js';
 import type { Options } from './types';

--- a/packages/integrations/node/test/test-utils.js
+++ b/packages/integrations/node/test/test-utils.js
@@ -1,5 +1,5 @@
-import { EventEmitter } from 'events';
 import httpMocks from 'node-mocks-http';
+import { EventEmitter } from 'node:events';
 import { loadFixture as baseLoadFixture } from '../../../astro/test/test-utils.js';
 
 /**

--- a/packages/integrations/node/test/url-protocol.test.js
+++ b/packages/integrations/node/test/url-protocol.test.js
@@ -1,7 +1,7 @@
-import { TLSSocket } from 'tls';
-import nodejs from '../dist/index.js';
-import { loadFixture, createRequestAndResponse } from './test-utils.js';
 import { expect } from 'chai';
+import { TLSSocket } from 'node:tls';
+import nodejs from '../dist/index.js';
+import { createRequestAndResponse, loadFixture } from './test-utils.js';
 
 describe('URL protocol', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/integrations/partytown/src/index.ts
+++ b/packages/integrations/partytown/src/index.ts
@@ -2,10 +2,10 @@ import type { PartytownConfig } from '@builder.io/partytown/integration';
 import { partytownSnippet } from '@builder.io/partytown/integration';
 import { copyLibFiles, libDirPath } from '@builder.io/partytown/utils';
 import type { AstroIntegration } from 'astro';
-import * as fs from 'fs';
 import { createRequire } from 'module';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import * as fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import sirv from './sirv.js';
 const resolve = createRequire(import.meta.url).resolve;
 

--- a/packages/integrations/partytown/src/sirv.ts
+++ b/packages/integrations/partytown/src/sirv.ts
@@ -30,12 +30,12 @@
  * THE SOFTWARE.
  */
 
-import * as fs from 'fs';
-import { join, normalize, resolve } from 'path';
+import * as fs from 'node:fs';
+import { join, normalize, resolve } from 'node:path';
 // import { totalist } from 'totalist/sync';
 // import { parse } from '@polka/url';
 import { lookup } from 'mrmime';
-import { URL } from 'url';
+import { URL } from 'node:url';
 
 const noop = () => {};
 

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -5,7 +5,7 @@ import {
 	type LinkItem as LinkItemBase,
 	type SitemapItemLoose,
 } from 'sitemap';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { ZodError } from 'zod';
 
 import { generateSitemap } from './generate-sitemap.js';

--- a/packages/integrations/solid/src/dependencies.ts
+++ b/packages/integrations/solid/src/dependencies.ts
@@ -1,5 +1,5 @@
 import type { AstroConfig } from 'astro';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { crawlFrameworkPkgs } from 'vitefu';
 
 export async function getSolidPkgsConfig(isBuild: boolean, astroConfig: AstroConfig) {

--- a/packages/integrations/svelte/src/index.ts
+++ b/packages/integrations/svelte/src/index.ts
@@ -1,7 +1,7 @@
 import type { Options } from '@sveltejs/vite-plugin-svelte';
 import { svelte, vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import type { AstroIntegration, AstroRenderer } from 'astro';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import type { UserConfig } from 'vite';
 
 function getRenderer(): AstroRenderer {

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -3,7 +3,7 @@ import type { AstroAdapter, AstroConfig, AstroIntegration, RouteData } from 'ast
 import glob from 'fast-glob';
 import { basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { pathToFileURL } from 'url';
+import { pathToFileURL } from 'node:url';
 import {
 	defaultImageConfig,
 	getImageConfig,

--- a/packages/integrations/vercel/src/serverless/middleware.ts
+++ b/packages/integrations/vercel/src/serverless/middleware.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { ASTRO_LOCALS_HEADER } from './adapter.js';
@@ -62,12 +62,12 @@ import { onRequest } from ${middlewarePath};
 import { createContext, trySerializeLocals } from 'astro/middleware';
 export default async function middleware(request, context) {
 	const url = new URL(request.url);
-	const ctx = createContext({ 
+	const ctx = createContext({
 		request,
 		params: {}
 	});
 	ctx.locals = ${handlerTemplateCall};
-	const next = async () => {	
+	const next = async () => {
 		const response = await fetch(url, {
 			headers: {
 				${JSON.stringify(ASTRO_LOCALS_HEADER)}: trySerializeLocals(ctx.locals)

--- a/packages/markdown/remark/src/load-plugins.ts
+++ b/packages/markdown/remark/src/load-plugins.ts
@@ -1,7 +1,7 @@
 import { resolve as importMetaResolve } from 'import-meta-resolve';
-import path from 'path';
+import path from 'node:path';
 import type * as unified from 'unified';
-import { pathToFileURL } from 'url';
+import { pathToFileURL } from 'node:url';
 
 const cwdUrlStr = pathToFileURL(path.join(process.cwd(), 'package.json')).toString();
 

--- a/packages/telemetry/src/project-info.ts
+++ b/packages/telemetry/src/project-info.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execSync } from 'node:child_process';
 import type { BinaryLike } from 'node:crypto';
 import { createHash } from 'node:crypto';
 import detectPackageManager from 'which-pm-runs';

--- a/scripts/cmd/build.js
+++ b/scripts/cmd/build.js
@@ -1,8 +1,8 @@
 import { deleteAsync } from 'del';
 import esbuild from 'esbuild';
 import { copy } from 'esbuild-plugin-copy';
-import { promises as fs } from 'fs';
 import { dim, green, red, yellow } from 'kleur/colors';
+import { promises as fs } from 'node:fs';
 import glob from 'tiny-glob';
 import svelte from '../utils/svelte-plugin.js';
 import prebuild from './prebuild.js';

--- a/scripts/cmd/copy.js
+++ b/scripts/cmd/copy.js
@@ -1,7 +1,7 @@
-import { promises as fs, readFileSync } from 'fs';
-import { posix } from 'path';
 import arg from 'arg';
 import { globby as glob } from 'globby';
+import { promises as fs, readFileSync } from 'node:fs';
+import { posix } from 'node:path';
 import tar from 'tar';
 
 const { resolve, dirname, sep, join } = posix;

--- a/scripts/cmd/prebuild.js
+++ b/scripts/cmd/prebuild.js
@@ -1,9 +1,9 @@
 import esbuild from 'esbuild';
 import { red } from 'kleur/colors';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import glob from 'tiny-glob';
-import fs from 'fs';
-import path from 'path';
-import { pathToFileURL, fileURLToPath } from 'url';
 
 function escapeTemplateLiterals(str) {
 	return str.replace(/\`/g, '\\`').replace(/\$\{/g, '\\${');

--- a/scripts/smoke/check.js
+++ b/scripts/smoke/check.js
@@ -1,8 +1,8 @@
 // @ts-check
 
-import { spawn } from 'child_process';
-import { readdirSync, readFileSync, writeFileSync } from 'fs';
-import * as path from 'path';
+import { spawn } from 'node:child_process';
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
 import pLimit from 'p-limit';
 import { tsconfigResolverSync } from 'tsconfig-resolver';
 

--- a/scripts/stats/index.js
+++ b/scripts/stats/index.js
@@ -1,7 +1,6 @@
 // @ts-check
 import { Octokit } from '@octokit/action';
-import { execSync } from 'child_process';
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 
 const octokit = new Octokit();
 const owner = 'snowpackjs';

--- a/scripts/utils/svelte-plugin.js
+++ b/scripts/utils/svelte-plugin.js
@@ -1,7 +1,7 @@
 // @ts-nocheck
+import { promises as fs } from 'node:fs';
+import { dirname, isAbsolute, join, relative } from 'node:path';
 import { compile } from 'svelte/compiler';
-import { relative, isAbsolute, join, dirname } from 'path';
-import { promises as fs } from 'fs';
 
 const convertMessage = ({ message, start, end, filename, frame }) => ({
 	text: message,


### PR DESCRIPTION
## Changes

As we head into a future of multiple runtimes, climate change, AI taking over etc. we might want to run Astro on other runtimes. The `node:` prefix allows tools to identify Node deps more easily. It's also useful for us, because we sometimes use Node deps where we shouldn't and the prefix makes it easier to see at a glance where Node is hiding

## Testing

Tests should all pass!

## Docs

N/A
