### PR TITLE
Fix routing behavior when getStaticPaths params include hyphens

### DIFF
--- a/.changeset/stupid-trains-move.md
+++ b/.changeset/stupid-trains-move.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix route matching behavior when `getStaticPaths` result includes hyphenated params

--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -71,7 +71,7 @@ export async function callGetStaticPaths({
 	keyedStaticPaths.keyed = new Map<string, GetStaticPathsItem>();
 
 	for (const sp of keyedStaticPaths) {
-		const paramsKey = stringifyParams(sp.params, route.component);
+		const paramsKey = stringifyParams(sp.params, route);
 		keyedStaticPaths.keyed.set(paramsKey, sp);
 	}
 
@@ -127,7 +127,7 @@ export function findPathItemByKey(
 	params: Params,
 	route: RouteData
 ) {
-	const paramsKey = stringifyParams(params, route.component);
+	const paramsKey = stringifyParams(params, route);
 	const matchedStaticPath = staticPaths.keyed.get(paramsKey);
 	if (matchedStaticPath) {
 		return matchedStaticPath;

--- a/packages/astro/src/core/routing/params.ts
+++ b/packages/astro/src/core/routing/params.ts
@@ -1,4 +1,4 @@
-import type { GetStaticPathsItem, Params } from '../../@types/astro';
+import type { GetStaticPathsItem, RouteData, Params } from '../../@types/astro';
 import { validateGetStaticPathsParameter } from './validation.js';
 
 /**
@@ -27,15 +27,14 @@ export function getParams(array: string[]) {
  * values and create a stringified key for the route
  * that can be used to match request routes
  */
-export function stringifyParams(params: GetStaticPathsItem['params'], routeComponent: string) {
+export function stringifyParams(params: GetStaticPathsItem['params'], route: RouteData) {
 	// validate parameter values then stringify each value
 	const validatedParams = Object.entries(params).reduce((acc, next) => {
-		validateGetStaticPathsParameter(next, routeComponent);
+		validateGetStaticPathsParameter(next, route.component);
 		const [key, value] = next;
 		acc[key] = value?.toString();
 		return acc;
 	}, {} as Params);
 
-	// Always sort keys before stringifying to make sure objects match regardless of parameter ordering
-	return JSON.stringify(validatedParams, Object.keys(params).sort());
+	return JSON.stringify(route.generate(validatedParams))
 }

--- a/packages/astro/test/astro-get-static-paths.test.js
+++ b/packages/astro/test/astro-get-static-paths.test.js
@@ -126,4 +126,9 @@ describe('getStaticPaths - dev calls', () => {
 			);
 		}
 	});
+
+	it('properly handles hyphenation in getStaticPaths', async () => {
+		const res = await fixture.fetch('/pizza/parmesan-and-olives');
+		expect(res.status).to.equal(200);
+	});
 });

--- a/packages/astro/test/fixtures/astro-get-static-paths/src/pages/pizza/[cheese]-[topping].astro
+++ b/packages/astro/test/fixtures/astro-get-static-paths/src/pages/pizza/[cheese]-[topping].astro
@@ -4,6 +4,9 @@ export function getStaticPaths() {
 		params: { cheese: 'mozzarella', topping: 'pepperoni' },
 	}, {
 		params: { cheese: 'provolone', topping: 'sausage' },
+  },  {
+		// fix(#7265): hyphenated behavior
+		params: { cheese: 'parmesan-and', topping: 'olives' },
   }]
 }
 const { cheese, topping } = Astro.params


### PR DESCRIPTION
## Changes

- Our `getStaticPaths` implementation includes a keyed object
- When we generate the `RouteManifest`, the generated `route.pattern` doesn't _always_ match the generated routes due to hyphenization.
- Rather than updating the `route.pattern` logic to account for hyphens, the correct fix is to update our `getStaticPaths.keyed` implementation to only store the final, generated pathname of the route. This removes any mismatched `keys <=> data` relationship. Hyphens are no longer relevant!
- This is way more common than it might seem for anyone that has `/route/[a]-[b]`
- Resolved #7265

## Testing

Test added, existing tests should pass

## Docs

Bug fix only