### PR TITLE
feat: allow more type of props to be parsed in the scanner

### DIFF
--- a/packages/astro/src/core/build/types.ts
+++ b/packages/astro/src/core/build/types.ts
@@ -21,13 +21,14 @@ export type StylesheetAsset =
 	| { type: 'external'; src: string };
 
 export interface PageBuildData {
-	component: ComponentPath;
-	route: RouteData;
-	moduleSpecifier: string;
-	propagatedStyles: Map<string, Set<StylesheetAsset>>;
-	propagatedScripts: Map<string, Set<string>>;
-	hoistedScript: { type: 'inline' | 'external'; value: string } | undefined;
-	styles: Array<{ depth: number; order: number; sheet: StylesheetAsset }>;
+  component: ComponentPath
+  route: RouteData
+  moduleSpecifier: string
+  propagatedStyles: Map<string, Set<StylesheetAsset>>
+  propagatedScripts: Map<string, Set<string>>
+  hoistedScript: { type: 'inline' | 'external'; value: string } | undefined
+  styles: Array<{ depth: number; order: number; sheet: StylesheetAsset }>
+  tag: string
 }
 export type AllPagesData = Record<ComponentPath, PageBuildData>;
 

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -390,6 +390,26 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 	 * @docs
 	 * @message
 	 * **Example error messages:**<br/>
+	 * InvalidStaticExport: A static export has been detected, but its value cannot be statically analyzed.
+	 * @description
+	 * Some static feature only supports a subset of valid JavaScript — be sure to use exactly `export const {var} = {value}` so that our compiler can detect this directive at build time. Variables, `let`, and `var` declarations are not supported.
+	 */
+	InvalidStaticExport: {
+		title: 'Invalid static export.',
+		message: (prefix: string, suffix: string, isHydridOuput: boolean) => {
+			const defaultExpectedValue = isHydridOuput ? 'false' : 'true';
+			let msg = `A static export has been detected, but its value cannot be statically analyzed.`;
+			if (prefix !== 'const') msg += `\nExpected \`const\` declaration but got \`${prefix}\`.`;
+			if (suffix !== 'true')
+				msg += `\nExpected \`${defaultExpectedValue}\` value but got \`${suffix}\`.`;
+			return msg;
+		},
+		hint: 'Mutable values declared at runtime are not supported. Please make sure to use exactly `export const`.',
+	},
+	/**
+	 * @docs
+	 * @message
+	 * **Example error messages:**<br/>
 	 * InvalidPrerenderExport: A `prerender` export has been detected, but its value cannot be statically analyzed.
 	 * @description
 	 * The `prerender` feature only supports a subset of valid JavaScript — be sure to use exactly `export const prerender = true` so that our compiler can detect this directive at build time. Variables, `let`, and `var` declarations are not supported.

--- a/packages/astro/src/vite-plugin-astro/types.ts
+++ b/packages/astro/src/vite-plugin-astro/types.ts
@@ -2,7 +2,8 @@ import type { TransformResult } from '@astrojs/compiler';
 import type { PropagationHint } from '../@types/astro';
 
 export interface PageOptions {
-	prerender?: boolean;
+  prerender?: boolean
+  tag?: string
 }
 
 export interface PluginMetadata {

--- a/packages/astro/src/vite-plugin-scanner/scan.ts
+++ b/packages/astro/src/vite-plugin-scanner/scan.ts
@@ -1,74 +1,51 @@
 import * as eslexer from 'es-module-lexer';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import type { PageOptions } from '../vite-plugin-astro/types.js';
+import { ScanStrategy, STRATEGIES } from './strategies';
 
-const BOOLEAN_EXPORTS = new Set(['prerender']);
+const KNOWN_EXPORTS = new Map<string, ScanStrategy>(
+  Object.entries({
+    prerender: 'boolean',
+    tag: 'string',
+  })
+)
 
 // Quick scan to determine if code includes recognized export
 // False positives are not a problem, so be forgiving!
 function includesExport(code: string) {
-	for (const name of BOOLEAN_EXPORTS) {
-		if (code.includes(name)) return true;
-	}
-	return false;
+  for (const name of KNOWN_EXPORTS.keys()) {
+    if (code.includes(name)) return true
+  }
+  return false
 }
 
-// Support quoted values to allow statically known `import.meta.env` variables to be used
-function isQuoted(value: string) {
-	return (value[0] === '"' || value[0] === "'") && value[value.length - 1] === value[0];
-}
+let didInit = false
 
-function isTruthy(value: string) {
-	if (isQuoted(value)) {
-		value = value.slice(1, -1);
-	}
-	return value === 'true' || value === '1';
-}
+export async function scan(
+  code: string,
+  id: string,
+  isHybridOutput = false
+): Promise<PageOptions> {
+  if (!includesExport(code)) return {}
+  if (!didInit) {
+    await eslexer.init
+    didInit = true
+  }
 
-function isFalsy(value: string) {
-	if (isQuoted(value)) {
-		value = value.slice(1, -1);
-	}
-	return value === 'false' || value === '0';
-}
+  const [, exports] = eslexer.parse(code, id)
+  let pageOptions: PageOptions = {}
+  for (const _export of exports) {
+    const { n: name, le: endOfLocalName } = _export
+    // mark that a `prerender` export was found
+    if (KNOWN_EXPORTS.has(name)) {
+      const strategy = KNOWN_EXPORTS.get(name)
 
-let didInit = false;
-
-export async function scan(code: string, id: string, isHybridOutput = false): Promise<PageOptions> {
-	if (!includesExport(code)) return {};
-	if (!didInit) {
-		await eslexer.init;
-		didInit = true;
-	}
-
-	const [, exports] = eslexer.parse(code, id);
-	let pageOptions: PageOptions = {};
-	for (const _export of exports) {
-		const { n: name, le: endOfLocalName } = _export;
-		// mark that a `prerender` export was found
-		if (BOOLEAN_EXPORTS.has(name)) {
-			// For a given export, check the value of the local declaration
-			// Basically extract the `const` from the statement `export const prerender = true`
-			const prefix = code
-				.slice(0, endOfLocalName)
-				.split('export')
-				.pop()!
-				.trim()
-				.replace('prerender', '')
-				.trim();
-			// For a given export, check the value of the first non-whitespace token.
-			// Basically extract the `true` from the statement `export const prerender = true`
-			const suffix = code.slice(endOfLocalName).trim().replace(/\=/, '').trim().split(/[;\n]/)[0];
-			if (prefix !== 'const' || !(isTruthy(suffix) || isFalsy(suffix))) {
-				throw new AstroError({
-					...AstroErrorData.InvalidPrerenderExport,
-					message: AstroErrorData.InvalidPrerenderExport.message(prefix, suffix, isHybridOutput),
-					location: { file: id },
-				});
-			} else {
-				pageOptions[name as keyof PageOptions] = isTruthy(suffix);
-			}
-		}
-	}
-	return pageOptions;
+      pageOptions[name as keyof PageOptions] = STRATEGIES[strategy]({
+        code,
+        name,
+        endOfLocalName,
+      })
+    }
+  }
+  return pageOptions
 }

--- a/packages/astro/src/vite-plugin-scanner/strategies/booleanStrategy.ts
+++ b/packages/astro/src/vite-plugin-scanner/strategies/booleanStrategy.ts
@@ -1,0 +1,58 @@
+import { AstroError, AstroErrorData } from '../../core/errors/index.js';
+
+import type { ScanStrategyHandler } from './types'
+
+// Support quoted values to allow statically known `import.meta.env` variables to be used
+function isQuoted(value: string) {
+	return (value[0] === '"' || value[0] === "'") && value[value.length - 1] === value[0];
+}
+
+function isTruthy(value: string) {
+	if (isQuoted(value)) {
+		value = value.slice(1, -1);
+	}
+	return value === 'true' || value === '1';
+}
+
+function isFalsy(value: string) {
+	if (isQuoted(value)) {
+		value = value.slice(1, -1);
+	}
+	return value === 'false' || value === '0';
+}
+export const booleanStrategyHandler: ScanStrategyHandler<boolean> = ({
+  code,
+  name,
+  endOfLocalName,
+}) => {
+  // For a given export, check the value of the local declaration
+  // Basically extract the `const` from the statement `export const prerender = true`
+  const prefix = code
+    .slice(0, endOfLocalName)
+    .split('export')
+    .pop()!
+    .trim()
+    .replace(name, '')
+    .trim()
+  // For a given export, check the value of the first non-whitespace token.
+  // Basically extract the `true` from the statement `export const prerender = true`
+  const suffix = code
+    .slice(endOfLocalName)
+    .trim()
+    .replace(/\=/, '')
+    .trim()
+    .split(/[;\n]/)[0]
+  if (prefix !== 'const' || !(isTruthy(suffix) || isFalsy(suffix))) {
+    throw new AstroError({
+      ...AstroErrorData.InvalidPrerenderExport,
+      message: AstroErrorData.InvalidPrerenderExport.message(
+        prefix,
+        suffix,
+        isHybridOutput
+      ),
+      location: { file: id },
+    })
+  }
+
+  return isTruthy(suffix)
+}

--- a/packages/astro/src/vite-plugin-scanner/strategies/index.ts
+++ b/packages/astro/src/vite-plugin-scanner/strategies/index.ts
@@ -1,0 +1,9 @@
+import { booleanStrategyHandler } from './booleanStrategy'
+import { stringStrategyHandler } from './stringStrategy'
+
+export * from './types'
+
+export const STRATEGIES = {
+  boolean: booleanStrategyHandler,
+  string: stringStrategyHandler,
+} as const

--- a/packages/astro/src/vite-plugin-scanner/strategies/stringStrategy.ts
+++ b/packages/astro/src/vite-plugin-scanner/strategies/stringStrategy.ts
@@ -1,0 +1,23 @@
+export const stringStrategyHandler: StrategyHandler<string> = ({
+  code,
+  name,
+  endOfLocalName,
+}) => {
+  const expr = `^export\\sconst\\s${name}\\s?=\\s?['"\`](.*)['"\`]`
+  const regExp = new RegExp(expr, 'gm')
+  const [_, match] = regExp.exec(code)
+
+  if (!match?.length) {
+    throw new AstroError({
+      ...AstroErrorData.InvalidStaticExport,
+      message: AstroErrorData.InvalidStaticExport.message(
+        prefix,
+        suffix,
+        isHybridOutput
+      ),
+      location: { file: id },
+    })
+  }
+
+  return match
+}

--- a/packages/astro/src/vite-plugin-scanner/strategies/types.ts
+++ b/packages/astro/src/vite-plugin-scanner/strategies/types.ts
@@ -1,0 +1,8 @@
+export type ScanStrategy = 'boolean' | 'string'
+
+export type ScanStrategyHandler<T> = (params: {
+  code: string
+  name: string
+  endOfLocalName: string
+  isHybridOutput?: boolean
+}) => T


### PR DESCRIPTION
## Changes

- What does this change?

It widen the range of the `vite-astro-scanner` plugin to allow parsing of more properties, and of type `string`.

This is mainly for plugin/integrations authors. There are many behaviors that could be made if we could let users expose some "route based props" which could be later picked up in integrations.

On the side, i'd like to bring another approach to this using recma instead of regular expression and split of strings which may break easily.

## Testing, Docs

The goal of this PR is to have an open discussion, not necessarily to be merged. I'm happy to add tests/docs if this can be merged as-is.
