### PR TITLE
Add changeset & docs for next `@astrojs/netlify` release

### DIFF
--- a/.changeset/great-days-judge.md
+++ b/.changeset/great-days-judge.md
@@ -1,0 +1,8 @@
+---
+'@astrojs/netlify': minor
+---
+
+When a project uses the new `build.excludeMiddleware` Astro config option, the `@astrojs/netlify/functions` adapter will bundle your middleware to run in a [Netlify Edge Function](https://docs.netlify.com/edge-functions/overview/).
+
+See the [Netlify adapter documentation](https://docs.astro.build/en/guides/integrations-guide/netlify/#run-middleware-in-edge-functions) for more details.
+

--- a/packages/integrations/netlify/README.md
+++ b/packages/integrations/netlify/README.md
@@ -98,7 +98,7 @@ Netlify Edge Functions provide a [context object](https://docs.netlify.com/edge-
 
 To expose values from this context to your site, create a `netlify-edge-middleware.ts` (or `.js`) file in your project’s [source directory](https://docs.astro.build/en/reference/configuration-reference/#srcdir). This file must export a function that returns the data to add to [Astro’s `locals` object](https://docs.astro.build/en/guides/middleware/#locals), which is available in middleware and Astro routes.
 
-In this example, `visitorCountry` and `hasEdgeMiddleware` would both be added to the Astro’s `locals` object:
+In this example, `visitorCountry` and `hasEdgeMiddleware` would both be added to Astro’s `locals` object:
 
 ```ts
 // src/netlify-edge-middleware.ts

--- a/packages/integrations/netlify/README.md
+++ b/packages/integrations/netlify/README.md
@@ -57,7 +57,7 @@ If you prefer to install the adapter manually instead, complete the following tw
 
 ### Edge Functions
 
-Netlify has two serverless platforms, Netlify Functions and [Netlify's experimental Edge Functions](https://docs.netlify.com/netlify-labs/experimental-features/edge-functions/#app). With Edge Functions your code is distributed closer to your users, lowering latency.
+Netlify has two serverless platforms, [Netlify Functions](https://docs.netlify.com/functions/overview/) and [Netlify Edge Functions](https://docs.netlify.com/edge-functions/overview/). With Edge Functions your code is distributed closer to your users, lowering latency.
 
 To deploy with Edge Functions, use `netlify/edge-functions` in the Astro config file instead of `netlify/functions`.
 
@@ -71,6 +71,56 @@ export default defineConfig({
   adapter: netlify(),
 });
 ```
+
+### Run middleware in Edge Functions
+
+When deploying to Netlify Functions, you can choose to use an Edge Function to run your Astro middleware.
+
+To enable this, set the `build.excludeMiddleware` Astro config option to `true`:
+
+```js ins={9}
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import netlify from '@astrojs/netlify/functions';
+
+export default defineConfig({
+  output: 'server',
+  adapter: netlify(),
+  build: {
+    excludeMiddleware: true,
+  },
+});
+```
+
+#### Pass edge context to your site
+
+Netlify Edge Functions provide a [context object](https://docs.netlify.com/edge-functions/api/#netlify-specific-context-object) including metadata about the request, such as a user’s IP, geolocation data, and cookies.
+
+To expose values from this context to your site, create a `netlify-edge-middleware.ts` (or `.js`) file in your project’s [source directory](https://docs.astro.build/en/reference/configuration-reference/#srcdir). This file must export a function that returns the data to add to [Astro’s `locals` object](https://docs.astro.build/en/guides/middleware/#locals), which is available in middleware and Astro routes.
+
+In this example, `visitorCountry` and `hasEdgeMiddleware` would both be added to the Astro’s `locals` object:
+
+```ts
+// src/netlify-edge-middleware.ts
+import type { Context } from 'https://edge.netlify.com';
+
+export default function ({ request, context }: { request: Request; context: Context }) {
+  // Return serializable data to add to Astro.locals
+  return {
+    visitorCountry: context.geo.country.name,
+    hasEdgeMiddleware: true,
+  };
+}
+```
+
+> **Note**
+> Netlify Edge Functions run in [a Deno environment](https://docs.netlify.com/edge-functions/api/#runtime-environment), so import statements in this file must use Deno’s URL syntax.
+
+`netlify-edge-middleware.ts` must provide a function as its default export. This function:
+
+- must return a JSON-serializable object, which cannot include types like `Map`, `function`, `Set`, etc.
+- will always run first, before any other middleware and routes.
+- cannot return a response or redirect.
 
 ### Per-page functions
 


### PR DESCRIPTION
## Changes

- Follow-up PR to #7698
- Adds docs and changeset for #7632, which we removed to avoid releasing before docs were polished.

Would love @ematipico to make sure none of what I wrote is lies 😀 

## Testing
N/A — docs only.

## Docs

/cc @withastro/maintainers-docs