### PR TITLE
Fix redirects map object-form value validation

### DIFF
--- a/.changeset/eleven-eyes-jog.md
+++ b/.changeset/eleven-eyes-jog.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix redirects map object-form value validation

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -149,7 +149,12 @@ export const AstroConfigSchema = z.object({
 			.optional()
 			.default({})
 	),
-	redirects: z.record(z.string(), z.string()).default(ASTRO_CONFIG_DEFAULTS.redirects),
+	redirects: z
+		.record(
+			z.string(),
+			z.union([z.string(), z.object({ status: z.number(), destination: z.string() })])
+		)
+		.default(ASTRO_CONFIG_DEFAULTS.redirects),
 	image: z
 		.object({
 			service: z.object({

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -152,7 +152,21 @@ export const AstroConfigSchema = z.object({
 	redirects: z
 		.record(
 			z.string(),
-			z.union([z.string(), z.object({ status: z.number(), destination: z.string() })])
+			z.union([
+				z.string(),
+				z.object({
+					status: z.union([
+						z.literal(300),
+						z.literal(301),
+						z.literal(302),
+						z.literal(303),
+						z.literal(304),
+						z.literal(307),
+						z.literal(308),
+					]),
+					destination: z.string(),
+				}),
+			])
 		)
 		.default(ASTRO_CONFIG_DEFAULTS.redirects),
 	image: z


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/7322

Extend `redirects` config validation to pass configs like:
```js
	redirects: {
		'/': {
			status: 302,
			destination: '/home',
		},
	},
```

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested manually for now. I'm planning to add config validation tests in the `js-api` branch and PR so we catch this in the future.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.