### PR TITLE
Fix absolute path handling for config validation in windows

### DIFF
--- a/.changeset/loud-hairs-tell.md
+++ b/.changeset/loud-hairs-tell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix absolute path handling when passing `root`, `srcDir`, `publicDir`, `outDir`, `cacheDir`, `build.client`, and `build.server` configs in Windows

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -4,7 +4,7 @@ import type { AstroConfig, AstroUserConfig, CLIFlags } from '../../@types/astro'
 import * as colors from 'kleur/colors';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 import { mergeConfig } from './merge.js';
 import { createRelativeSchema } from './schema.js';

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -28,7 +28,6 @@ export async function validateConfig(
 	root: string,
 	cmd: string
 ): Promise<AstroConfig> {
-	const fileProtocolRoot = pathToFileURL(root + path.sep);
 	// Manual deprecation checks
 	/* eslint-disable no-console */
 	if (userConfig.hasOwnProperty('renderers')) {
@@ -78,7 +77,7 @@ export async function validateConfig(
 	}
 	/* eslint-enable no-console */
 
-	const AstroConfigRelativeSchema = createRelativeSchema(cmd, fileProtocolRoot);
+	const AstroConfigRelativeSchema = createRelativeSchema(cmd, root);
 
 	// First-Pass Validation
 	const result = await AstroConfigRelativeSchema.parseAsync(userConfig);

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -4,6 +4,8 @@ import type { ILanguageRegistration, IThemeRegistration, Theme } from 'shiki';
 import type { AstroUserConfig, ViteUserConfig } from '../../@types/astro';
 
 import type { OutgoingHttpHeaders } from 'node:http';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { BUNDLED_THEMES } from 'shiki';
 import { z } from 'zod';
 import { appendForwardSlash, prependForwardSlash, trimSlashes } from '../path.js';
@@ -237,31 +239,31 @@ export const AstroConfigSchema = z.object({
 	legacy: z.object({}).optional().default({}),
 });
 
-export function createRelativeSchema(cmd: string, fileProtocolRoot: URL) {
+export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 	// We need to extend the global schema to add transforms that are relative to root.
 	// This is type checked against the global schema to make sure we still match.
 	const AstroConfigRelativeSchema = AstroConfigSchema.extend({
 		root: z
 			.string()
 			.default(ASTRO_CONFIG_DEFAULTS.root)
-			.transform((val) => new URL(appendForwardSlash(val), fileProtocolRoot)),
+			.transform((val) => resolveDirAsUrl(val, fileProtocolRoot)),
 		srcDir: z
 			.string()
 			.default(ASTRO_CONFIG_DEFAULTS.srcDir)
-			.transform((val) => new URL(appendForwardSlash(val), fileProtocolRoot)),
+			.transform((val) => resolveDirAsUrl(val, fileProtocolRoot)),
 		compressHTML: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.compressHTML),
 		publicDir: z
 			.string()
 			.default(ASTRO_CONFIG_DEFAULTS.publicDir)
-			.transform((val) => new URL(appendForwardSlash(val), fileProtocolRoot)),
+			.transform((val) => resolveDirAsUrl(val, fileProtocolRoot)),
 		outDir: z
 			.string()
 			.default(ASTRO_CONFIG_DEFAULTS.outDir)
-			.transform((val) => new URL(appendForwardSlash(val), fileProtocolRoot)),
+			.transform((val) => resolveDirAsUrl(val, fileProtocolRoot)),
 		cacheDir: z
 			.string()
 			.default(ASTRO_CONFIG_DEFAULTS.cacheDir)
-			.transform((val) => new URL(appendForwardSlash(val), fileProtocolRoot)),
+			.transform((val) => resolveDirAsUrl(val, fileProtocolRoot)),
 		build: z
 			.object({
 				format: z
@@ -272,12 +274,12 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: URL) {
 					.string()
 					.optional()
 					.default(ASTRO_CONFIG_DEFAULTS.build.client)
-					.transform((val) => new URL(val, fileProtocolRoot)),
+					.transform((val) => resolveDirAsUrl(val, fileProtocolRoot)),
 				server: z
 					.string()
 					.optional()
 					.default(ASTRO_CONFIG_DEFAULTS.build.server)
-					.transform((val) => new URL(val, fileProtocolRoot)),
+					.transform((val) => resolveDirAsUrl(val, fileProtocolRoot)),
 				assets: z.string().optional().default(ASTRO_CONFIG_DEFAULTS.build.assets),
 				assetsPrefix: z.string().optional(),
 				serverEntry: z.string().optional().default(ASTRO_CONFIG_DEFAULTS.build.serverEntry),
@@ -356,4 +358,12 @@ A future version of Astro will stop using the site pathname when producing <link
 	});
 
 	return AstroConfigRelativeSchema;
+}
+
+function resolveDirAsUrl(dir: string, root: string) {
+	let resolvedDir = path.resolve(root, dir);
+	if (!resolvedDir.endsWith(path.sep)) {
+		resolvedDir += path.sep;
+	}
+	return pathToFileURL(resolvedDir);
 }


### PR DESCRIPTION
## Changes

Fix passing absolute paths to `root`, `srcDir`, `publicDir`, `outDir`, `cacheDir`, `build.client`, and `build.server` on Windows. We currently have code like this:

https://github.com/withastro/astro/blob/b3b9fc52b33ae8d9bd3f205758051814a1ed4add/packages/astro/src/core/config/schema.ts#L251

And they fail on Windows because `val` looks like `C:\\User\\bob`. The `C:` looks like a protocol when passed to `new URL` and that creates an invalid final URL. Switching to `path.resolve` fixes this for now.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested in https://github.com/withastro/astro/pull/7682 where I passed the absolute `root` path in tests, and it failed. The [fa32ff0](https://github.com/withastro/astro/pull/7682/commits/fa32ff029c68272f57b4299501f6f083152daed2) commit there fixes it, which I ported it to here to `main` first.

Besides that, no actual tests here yet, but CI should continue to pass.

Also thanks `@hippotastic` for testing that this works.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
The docs for `srcDir`, `publicDir`, `outDir`, and `cacheDir` mentioned that they accept absolute paths. `root`, `build.client`, and `build.server` don't exactly mention it, but it would be nice if they work still for consistency.