### PR TITLE
Fix/markdoc assets

### DIFF
--- a/.changeset/smart-hairs-lick.md
+++ b/.changeset/smart-hairs-lick.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/markdoc': patch
+'astro': patch
+---
+
+Fix Markdoc integration not being able to import `emitESMImage` from Astro

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -52,6 +52,7 @@
     "./components": "./components/index.ts",
     "./components/*": "./components/*",
     "./assets": "./dist/assets/index.js",
+    "./assets/utils": "./dist/assets/utils/index.js",
     "./assets/image-endpoint": "./dist/assets/image-endpoint.js",
     "./assets/services/sharp": "./dist/assets/services/sharp.js",
     "./assets/services/squoosh": "./dist/assets/services/squoosh.js",

--- a/packages/astro/src/assets/utils/index.ts
+++ b/packages/astro/src/assets/utils/index.ts
@@ -1,0 +1,1 @@
+export { emitESMImage } from './emitAsset.js';

--- a/packages/integrations/markdoc/src/content-entry-type.ts
+++ b/packages/integrations/markdoc/src/content-entry-type.ts
@@ -6,9 +6,9 @@ import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import type { ErrorPayload as ViteErrorPayload } from 'vite';
 import type { ComponentConfig } from './config.js';
-import { isComponentConfig, isValidUrl, MarkdocError, prependForwardSlash } from './utils.js';
-// @ts-expect-error Cannot find module 'astro/assets' or its corresponding type declarations.
-import { emitESMImage } from 'astro/assets';
+import { MarkdocError, isComponentConfig, isValidUrl, prependForwardSlash } from './utils.js';
+// @ts-expect-error Cannot get the types here without `moduleResolution: 'nodenext'`
+import { emitESMImage } from 'astro/assets/utils';
 import path from 'node:path';
 import type * as rollup from 'rollup';
 import type { MarkdocConfigResult } from './load-config.js';


### PR DESCRIPTION
## Changes

A previous PR removed `emitESMImage` from `astro/assets/index.js` to fix Vercel Edge support, however, the Markdoc integration imported that. We didn't catch it for two reasons:

- Due to `moduleResolution: 'node'` not being able to get the types properly, there's a `@ts-expect-error` there, so type checking didn't fail
- For CI performance reason, we don't run the CI of every single integration on all core changes, so the tests fails weren't caught

Fix https://github.com/withastro/astro/issues/7705

## Testing

Tests should pass!

## Docs

N/A
