### PR TITLE
Fix 404 status code in dev server

### DIFF
--- a/packages/astro/src/vite-plugin-astro-server/request.ts
+++ b/packages/astro/src/vite-plugin-astro-server/request.ts
@@ -2,6 +2,7 @@ import type http from 'node:http';
 import type { ManifestData, SSRManifest } from '../@types/astro';
 import type { DevelopmentEnvironment } from '../core/render/dev/index';
 import type { DevServerController } from './controller';
+import type { MatchedRoute } from './route.js';
 
 import { collectErrorMetadata } from '../core/errors/dev/index.js';
 import { createSafeError } from '../core/errors/index.js';
@@ -77,10 +78,12 @@ export async function handleRequest({
 		async run() {
 			const matchedRoute = await matchRoute(pathname, env, manifestData);
 			const resolvedPathname = matchedRoute?.resolvedPathname ?? pathname;
+			const status = getStatus(matchedRoute);
 			return await handleRoute({
 				matchedRoute,
 				url,
 				pathname: resolvedPathname,
+				status,
 				body,
 				origin,
 				env,
@@ -110,4 +113,11 @@ export async function handleRequest({
 			return err;
 		},
 	});
+}
+
+function getStatus(matchedRoute?: MatchedRoute): number {
+	if (!matchedRoute) return 404;
+	if (matchedRoute.route.route === '/404') return 404;
+	if (matchedRoute.route.route === '/500') return 500;
+	return 200;
 }

--- a/packages/astro/test/custom-404-html.test.js
+++ b/packages/astro/test/custom-404-html.test.js
@@ -32,7 +32,10 @@ describe('Custom 404.html', () => {
 		});
 
 		it('renders 404 for /a', async () => {
-			const html = await fixture.fetch('/a').then((res) => res.text());
+			const res = await fixture.fetch('/a');
+			expect(res.status).to.equal(404);
+
+			const html = await res.text();
 			$ = cheerio.load(html);
 
 			expect($('h1').text()).to.equal('Page not found');

--- a/packages/astro/test/custom-404-injected.test.js
+++ b/packages/astro/test/custom-404-injected.test.js
@@ -32,7 +32,10 @@ describe('Custom 404 with injectRoute', () => {
 		});
 
 		it('renders 404 for /a', async () => {
-			const html = await fixture.fetch('/a').then((res) => res.text());
+			const res = await fixture.fetch('/a');
+			expect(res.status).to.equal(404);
+
+			const html = await res.text();
 			$ = cheerio.load(html);
 
 			expect($('h1').text()).to.equal('Page not found');

--- a/packages/astro/test/custom-404-md.test.js
+++ b/packages/astro/test/custom-404-md.test.js
@@ -31,7 +31,10 @@ describe('Custom 404 Markdown', () => {
 		});
 
 		it('renders 404 for /abc', async () => {
-			const html = await fixture.fetch('/a').then((res) => res.text());
+			const res = await fixture.fetch('/a');
+			expect(res.status).to.equal(404);
+
+			const html = await res.text();
 			$ = cheerio.load(html);
 
 			expect($('h1').text()).to.equal('Page not found');

--- a/packages/astro/test/custom-404-server.test.js
+++ b/packages/astro/test/custom-404-server.test.js
@@ -32,7 +32,10 @@ describe('Custom 404 server', () => {
 		});
 
 		it('renders 404 for /a', async () => {
-			const html = await fixture.fetch('/a').then((res) => res.text());
+			const res = await fixture.fetch('/a');
+			expect(res.status).to.equal(404);
+
+			const html = await res.text();
 			$ = cheerio.load(html);
 
 			expect($('h1').text()).to.equal('Page not found');

--- a/packages/astro/test/custom-404.test.js
+++ b/packages/astro/test/custom-404.test.js
@@ -32,7 +32,10 @@ describe('Custom 404', () => {
 		});
 
 		it('renders 404 for /a', async () => {
-			const html = await fixture.fetch('/a').then((res) => res.text());
+			const res = await fixture.fetch('/a');
+			expect(res.status).to.equal(404);
+
+			const html = await res.text();
 			$ = cheerio.load(html);
 
 			expect($('h1').text()).to.equal('Page not found');


### PR DESCRIPTION
## Changes

- Properly sets the `Response.status` for custom `404` and `500` pages in the dev server
- Resolves #7516 

## Testing

Existing tests were updated to check the status code

## Docs

Bug fix