### PR TITLE
Ensure sitemap excludes nested error pages

### DIFF
--- a/.changeset/fuzzy-toes-float.md
+++ b/.changeset/fuzzy-toes-float.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/sitemap': patch
+---
+
+Ensure nested 404 and 500 pages are always excluded

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -49,7 +49,15 @@ function formatConfigErrorMessage(err: ZodError) {
 
 const PKG_NAME = '@astrojs/sitemap';
 const OUTFILE = 'sitemap-index.xml';
-const STATUS_CODE_PAGES = new Set(['/404', '/500']);
+const STATUS_CODE_PAGES = new Set(['404', '500']);
+
+function isStatusCodePage(pathname: string): boolean {
+	if (pathname.endsWith('/')) {
+		pathname = pathname.slice(0, -1);
+	}
+	const end = pathname.split('/').pop() ?? '';
+	return STATUS_CODE_PAGES.has(end);
+}
 
 const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 	let config: AstroConfig;
@@ -87,7 +95,7 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 					}
 
 					let pageUrls = pages
-						.filter((p) => !STATUS_CODE_PAGES.has('/' + p.pathname.slice(0, -1)))
+						.filter((p) => !isStatusCodePage(p.pathname))
 						.map((p) => {
 							if (p.pathname !== '' && !finalSiteUrl.pathname.endsWith('/'))
 								finalSiteUrl.pathname += '/';
@@ -103,7 +111,7 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 						 * Dynamic URLs have entries with `undefined` pathnames
 						 */
 						if (r.pathname) {
-							if (STATUS_CODE_PAGES.has(r.pathname)) return urls;
+							if (isStatusCodePage(r.pathname ?? r.route)) return urls;
 							/**
 							 * remove the initial slash from relative pathname
 							 * because `finalSiteUrl` always has trailing slash

--- a/packages/integrations/sitemap/test/fixtures/static/src/pages/de/404.astro
+++ b/packages/integrations/sitemap/test/fixtures/static/src/pages/de/404.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>404</title>
+	</head>
+	<body>
+		<h1>404</h1>
+	</body>
+</html>

--- a/packages/integrations/sitemap/test/staticPaths.test.js
+++ b/packages/integrations/sitemap/test/staticPaths.test.js
@@ -26,6 +26,10 @@ describe('getStaticPaths support', () => {
 		expect(urls).to.not.include('http://example.com/404/');
 	});
 
+	it('does not include nested 404 pages', () => {
+		expect(urls).to.not.include('http://example.com/de/404/');
+	});
+
 	it('includes numerical pages', () => {
 		expect(urls).to.include('http://example.com/123/');
 	});


### PR DESCRIPTION
## Changes

- There was a regression introduced in https://github.com/withastro/astro/pull/7655
- This PR fixes the regression, so that nested `[...slug]/404` and `[...slug]/500` pages are excluded as well
- Changeset added

## Testing

Test updated to include nested 404 page

## Docs

N/A, bug fix only