### PR TITLE
[docs] update to view transitions in config ref

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1259,7 +1259,7 @@ export interface AstroUserConfig {
 		 * @version 2.9.0
 		 * @description
 		 * Enable experimental support for the `<ViewTransitions / >` component. With this enabled
-		 * you can opt-in to  [client-side routing](https://docs.astro.build/en/guides/client-side-routing/) on a per-page basis using this component
+		 * you can opt-in to [view transitions](https://docs.astro.build/en/guides/view-transitions/) on a per-page basis using this component
 		 * and enable animations with the `transition:animate` directive.
 		 *
 		 * ```js


### PR DESCRIPTION
## Changes

Update the description/link for the experimental View Transitions support to go to the newly-renamed page.

## Testing

no tests

## Docs

Only docs! The change has already been made locally in docs as a quick fix, so there is no urgent need to run ci for this correction. This should match what's already in docs, and will ensure the change in the docs repo is not written over.
