### PR TITLE
Remove false-positive warnings from Vercel's build.

### DIFF
--- a/.changeset/lovely-hornets-sip.md
+++ b/.changeset/lovely-hornets-sip.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/vercel': patch
+---
+
+Remove false-positive warnings from Vercel's build.
+
+Vercel includes warnings when it bundles the already-built output from astro.build. Those warnings are mostly due to `"sideEffects": false` packages that are included in the Vite built output because they are marked as external. Rollup will remove unused imports from these packages but will not remove the actual import, causing the false-positive warning.

--- a/packages/integrations/vercel/src/edge/adapter.ts
+++ b/packages/integrations/vercel/src/edge/adapter.ts
@@ -130,6 +130,9 @@ export default function vercelEdge({
 					format: 'esm',
 					bundle: true,
 					minify: true,
+					logOverride: {
+						'ignored-bare-import': 'silent',
+					},
 				});
 
 				// Copy entry and other server files


### PR DESCRIPTION
## Changes
- Closes #7736 
- This PR removes the false-positive warnings from Vercel's build.

## Testing
- No

## Docs
N/A