### PR TITLE
Fix parsing image assets from a Markdown line along with other markup

### DIFF
--- a/.changeset/five-phones-notice.md
+++ b/.changeset/five-phones-notice.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix parsing image assets from a Markdown line along with other markup.

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -147,7 +147,7 @@ export default function markdown({ settings, logging }: AstroPluginOptions): Plu
 
 				function updateImageReferences(html) {
 					return html.replaceAll(
-						/__ASTRO_IMAGE_=\"(.+)\"/gm,
+						/__ASTRO_IMAGE_="([^"]+)"/gm,
 						(full, imagePath) => spreadAttributes({src: images[imagePath].src, ...images[imagePath].attributes})
 					);
 				}


### PR DESCRIPTION
## Changes

Every regex that tries to match a substring with .* or .+ is guaranteed to be wrong.  In this case, it was giving incorrect matches straddling multiple quoted attributes:

    <img __ASTRO_IMAGE_="../assets/image.png"> and <a href="link">link</a>
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Fixes #7741.

## Testing

Tested with the test case in #7741.

## Docs

This is a pure bugfix that doesn’t need documentation.