### PR TITLE
Fix prerender getStaticPaths flaky test

### DIFF
--- a/packages/astro/test/ssr-prerender-get-static-paths.test.js
+++ b/packages/astro/test/ssr-prerender-get-static-paths.test.js
@@ -59,7 +59,11 @@ describe('Prerender', () => {
 				await devServer.stop();
 			});
 
-			it('only calls prerender getStaticPaths once', async () => {
+			it('only calls prerender getStaticPaths once', async function () {
+				// Sometimes this fail in CI as the chokidar watcher triggers an update and invalidates the route cache,
+				// causing getStaticPaths to be called twice. Workaround this with 2 retries for now.
+				this.retries(2);
+
 				let res = await fixture.fetch('/blog/a');
 				expect(res.status).to.equal(200);
 


### PR DESCRIPTION
## Changes

Apply the same retry logic from 

https://github.com/withastro/astro/blob/83e9ba36134de357e7bfccf6860690793b9eb749/packages/astro/test/astro-get-static-paths.test.js#L57-L60

but for **prerender** getStaticPaths

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a.