### PR TITLE
Prevent animations with prefers-reduced-motion

### DIFF
--- a/.changeset/poor-cameras-tell.md
+++ b/.changeset/poor-cameras-tell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent animations when prefers-reduced-motion

--- a/packages/astro/components/viewtransitions.css
+++ b/packages/astro/components/viewtransitions.css
@@ -49,4 +49,8 @@
   ::view-transition-new(*) {
     animation: none !important;
   }
+
+	[data-astro-transition-fallback] {
+		animation: none !important;
+	}
 }

--- a/packages/astro/components/viewtransitions.css
+++ b/packages/astro/components/viewtransitions.css
@@ -42,3 +42,11 @@
 		transform: translateX(-100%);
 	}
 }
+
+@media (prefers-reduced-motion) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
+}

--- a/packages/astro/components/viewtransitions.css
+++ b/packages/astro/components/viewtransitions.css
@@ -50,7 +50,7 @@
     animation: none !important;
   }
 
-	[data-astro-transition-fallback] {
+	[data-astro-transition-scope] {
 		animation: none !important;
 	}
 }


### PR DESCRIPTION
## Changes

- Adds `prefers-reduced-motion` that eliminates the animations.
- This is a "hammer" and maybe goes further than it should. But I'd rather go to extreme measures and then pull back later.

## Testing

N/A

## Docs

N/A