### PR TITLE
feat: implement partial build

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -883,6 +883,26 @@ export interface AstroUserConfig {
 		 * Please see your [SSR adapter's documentation](/en/guides/integrations-guide/#official-integrations) for using `edgeMiddleware` to define whether or not any SSR middleware code will be bundled when built.
 		 */
 		excludeMiddleware?: boolean;
+
+		/**
+		 * @docs
+		 * @name build.filterPage
+		 * @type {(pagePath: string) => boolean}
+		 * @default `undefined`
+		 * @version 2.10.0
+		 * @description
+		 * When defined, will be called for every single page to be generated (before generation) and gives opportunity to skip the generation of the page (based on user defined criterias)
+		 *
+		 * ```js
+		 * {
+		 *   build: {
+		 *     // will exclude all /dev/ from being generated
+		 *     filterPage: (pagePath) => !pagePath.startsWith('/dev/')
+		 *   }
+		 * }
+		 * ```
+		 */
+		filterPage?: (pagePath: string) => boolean;
 	};
 
 	/**

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -891,9 +891,10 @@ export interface AstroUserConfig {
 		 * @default `undefined`
 		 * @version 2.10.0
 		 * @description
-* Defines a function that will check which pages should be filtered out from the build while returning `false`.
-*
-* When defined, its function will be called for every single page about to be generated and gives the opportunity to skip the page. The criteria defined by the user based on `pageURL`, while returning `false`, will exclude any generated pages from the static build (including prerendered pages).
+		 *
+		 * Defines a function that will check which pages should be filtered out from the build while returning `false`.
+		 *
+		 * When defined, its function will be called for every single page about to be generated and gives the opportunity to skip the page. The criteria defined by the user based on `pageURL`, while returning `false`, will exclude any generated pages from the static build (including prerendered pages).
 		 *
 		 * ```js
 		 * {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -887,22 +887,22 @@ export interface AstroUserConfig {
 		/**
 		 * @docs
 		 * @name build.filterPage
-		 * @type {(pagePath: string) => boolean}
+		 * @type {(pageURL: string) => boolean}
 		 * @default `undefined`
 		 * @version 2.10.0
 		 * @description
-		 * When defined, will be called for every single page to be generated (before generation) and gives opportunity to skip the generation of the page (based on user defined criterias)
+		 * When defined, will be called for every single page about to be generated and gives opportunity to skip the page. When returning `false`, the page matching the finale `pageURL` will be excluded from the static build.
 		 *
 		 * ```js
 		 * {
 		 *   build: {
-		 *     // will exclude all /dev/ from being generated
-		 *     filterPage: (pagePath) => !pagePath.startsWith('/dev/')
+		 *     // will exclude all /dev/* pages from being generated
+		 *     filterPage: (pageURL) => !pageURL.startsWith('/dev/')
 		 *   }
 		 * }
 		 * ```
 		 */
-		filterPage?: (pagePath: string) => boolean;
+		filterPage?: (pageURL: string) => boolean;
 	};
 
 	/**

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -891,7 +891,9 @@ export interface AstroUserConfig {
 		 * @default `undefined`
 		 * @version 2.10.0
 		 * @description
-		 * When defined, will be called for every single page about to be generated and gives opportunity to skip the page. When returning `false`, the page matching the finale `pageURL` will be excluded from the static build.
+* Defines a function that will check which pages should be filtered out from the build while returning `false`.
+*
+* When defined, its function will be called for every single page about to be generated and gives the opportunity to skip the page. The criteria defined by the user based on `pageURL`, while returning `false`, will exclude any generated pages from the static build (including prerendered pages).
 		 *
 		 * ```js
 		 * {

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -165,7 +165,13 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 					// forcing to use undefined, so we fail in an expected way if the module is not even there.
 					const ssrEntry = ssrEntryPage?.pageModule;
 					if (ssrEntry) {
-						await generatePage(pageData, ssrEntry, builtPaths, pipeline);
+						await generatePage(
+							pageData,
+							ssrEntry,
+							builtPaths,
+							pipeline,
+							opts.settings.config.build.filterPage
+						);
 					} else {
 						throw new Error(
 							`Unable to find the manifest for the module ${ssrEntryURLPage.toString()}. This is unexpected and likely a bug in Astro, please report.`
@@ -232,7 +238,8 @@ async function generatePage(
 	pageData: PageBuildData,
 	ssrEntry: SinglePageBuiltModule,
 	builtPaths: Set<string>,
-	pipeline: BuildPipeline
+	pipeline: BuildPipeline,
+	pathFilter?: (path: string) => boolean
 ) {
 	let timeStart = performance.now();
 	const logger = pipeline.getLogger();
@@ -285,6 +292,7 @@ async function generatePage(
 	let prevTimeEnd = timeStart;
 	for (let i = 0; i < paths.length; i++) {
 		const path = paths[i];
+		if (pathFilter && !pathFilter(path)) continue;
 		await generatePath(path, generationOptions, pipeline);
 		const timeEnd = performance.now();
 		const timeChange = getTimeStat(prevTimeEnd, timeEnd);

--- a/packages/astro/src/core/build/page-data.ts
+++ b/packages/astro/src/core/build/page-data.ts
@@ -37,7 +37,9 @@ export async function collectPagesData(
 	for (const route of manifest.routes) {
 		// static route:
 		if (route.pathname) {
-			if (!opts.settings.config.build.filterPage(route.pathname)) continue;
+			if (route.prerender && !opts.settings.config.build.filterPage(route.pathname)) {
+				continue;
+			}
 
 			const routeCollectionLogTimeout = setInterval(() => {
 				opts.logger.info(

--- a/packages/astro/src/core/build/page-data.ts
+++ b/packages/astro/src/core/build/page-data.ts
@@ -37,6 +37,8 @@ export async function collectPagesData(
 	for (const route of manifest.routes) {
 		// static route:
 		if (route.pathname) {
+			if (!opts.settings.config.build.filterPage(route.pathname)) continue;
+
 			const routeCollectionLogTimeout = setInterval(() => {
 				opts.logger.info(
 					'build',

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -28,6 +28,7 @@ const ASTRO_CONFIG_DEFAULTS = {
 		inlineStylesheets: 'auto',
 		split: false,
 		excludeMiddleware: false,
+		filterPage: () => true,
 	},
 	compressHTML: true,
 	server: {
@@ -136,6 +137,10 @@ export const AstroConfigSchema = z.object({
 				.boolean()
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.build.excludeMiddleware),
+			filterPage: z
+				.function()
+				.optional()
+				.default(() => true),
 		})
 		.optional()
 		.default({}),
@@ -348,6 +353,10 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 					.boolean()
 					.optional()
 					.default(ASTRO_CONFIG_DEFAULTS.build.excludeMiddleware),
+				filterPage: z
+					.function()
+					.optional()
+					.default(() => true),
 			})
 			.optional()
 			.default({}),

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -140,7 +140,7 @@ export const AstroConfigSchema = z.object({
 			filterPage: z
 				.function()
 				.optional()
-				.default(() => true),
+				.default(() => () => true),
 		})
 		.optional()
 		.default({}),
@@ -356,7 +356,7 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 				filterPage: z
 					.function()
 					.optional()
-					.default(() => true),
+					.default(() => () => true),
 			})
 			.optional()
 			.default({}),


### PR DESCRIPTION
## Changes

1. added `astroConfig.build.filterPage` option
2. used this option at `collectPagesData` stage to allow skipping pages without dynamic params in it
3. used this option at `getPathsForRoute` stage to allow skipping pages with dynamic params in it

## Goal

The feature gives a way for users to skip the generation of some pages from their astro config. It's a quick win to allow static generation to do _partial_ generation easily.

The feature proposes to filter all pages (_before_ **and** _after_ expansion from `getStaticPaths`). It has to be done so that a user could filter and master 100% the content which is statically built.

**This feature is intended for pages enrolled for prerendering only, since we aim to target only the pages generated at build time.** (not for SSR)


## Common usecases

1. It is possible to prefix routes with `_` which would disable them but it is currently not possible to have routes available only in dev mode (which are excluded from build), but with this we can do:

```ts
{
  build: {
    filterPage: (pageURL) => pageURL.startsWith('/dev/')
  }
}
```

2. For people using Astro as an SSG/hybrid, we can use this feature for regenerating static content from a 3rd party CMS easily:

```ts
{
  build: {
    filterPage: (pageURL) => {
      const regexps = process.env.LIST_OF_EXPR_OF_UPDATED_PAGES_FROM_CMS
        .split(',')
        .map(expr => new RegExp(expr))
    
      return !!regexps.find(regexp => regexp.test(pageURL))
    }
  }
}
```

## Testing

I've tested this manually:

1. cloned astro on my machine
4. built astro from root
5. `cd packages/astro` && `yarn link`
6. in my test project: `yarn link astro`
7. implemented by change, compiled again astro
8. added `filterPage` function in my astro user config

I tried:

1. `filterPage: (pagePath) => false` → no pages built at all
2. `filterPage: (pagePath) => true` → default, no effect
3. `filterPage: (pagePath) => !pagePath.startsWith('/dev/')` → my dev pages weren't built


## Docs

/cc @withastro/maintainers-docs for feedback!
