### PR TITLE
feat: feature map for adapters

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1660,12 +1660,55 @@ export type PaginateFunction = (data: any[], args?: PaginateOptions) => GetStati
 
 export type Params = Record<string, string | undefined>;
 
+export type SupportsKind = 'Unsupported' | 'Stable' | 'Experimental' | 'Deprecated';
+
+export type AstroAdapterFeatureMap = {
+	/**
+	 * The adapter is able serve static pages
+	 */
+	staticOutput?: SupportsKind;
+	/**
+	 * The adapter is able to serve pages that are static or rendered via server
+	 */
+	hybridOutput?: SupportsKind;
+	/**
+	 * The adapter is able to serve SSR pages
+	 */
+	serverOutput?: SupportsKind;
+	/**
+	 * Support for emitting a SSR file per page
+	 */
+	functionPerPage?: SupportsKind;
+	/**
+	 * Support when `build.ecludeMiddleware` is enabled.
+	 */
+	edgeMiddleware?: SupportsKind;
+	/**
+	 * The adapter can emit static assets
+	 */
+	assets?: {
+		supportKind?: SupportsKind;
+		/**
+		 * Whether if this adapter deploys files in an enviroment that is Node.js compatible.
+		 *
+		 * The default services used by Astro needs Node.js.
+		 */
+		isNodeCompatible?: boolean;
+	};
+};
+
 export interface AstroAdapter {
 	name: string;
 	serverEntrypoint?: string;
 	previewEntrypoint?: string;
 	exports?: string[];
 	args?: any;
+	/**
+	 * List of features supported by an adapter.
+	 *
+	 * If the adapter is not able to handle certain configurations, Astro will throw an error.
+	 */
+	supportedFeatures?: AstroAdapterFeatureMap;
 }
 
 type Body = string;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1676,14 +1676,6 @@ export type AstroAdapterFeatureMap = {
 	 */
 	serverOutput?: SupportsKind;
 	/**
-	 * Support for emitting a SSR file per page
-	 */
-	functionPerPage?: SupportsKind;
-	/**
-	 * Support when `build.ecludeMiddleware` is enabled.
-	 */
-	edgeMiddleware?: SupportsKind;
-	/**
 	 * The adapter can emit static assets
 	 */
 	assets?: {

--- a/packages/astro/src/assets/generate.ts
+++ b/packages/astro/src/assets/generate.ts
@@ -27,6 +27,11 @@ export async function generateImage(
 	options: ImageTransform,
 	filepath: string
 ): Promise<GenerationData | undefined> {
+	if (typeof buildOpts.settings.config.image === 'undefined') {
+		throw new Error(
+			"Astro hasn't set a default service for `astro:assets`. This is an internal error and you should report it."
+		);
+	}
 	if (!isESMImportedImage(options.src)) {
 		return undefined;
 	}

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -26,6 +26,12 @@ export default function assets({
 	logging,
 	mode,
 }: AstroPluginOptions & { mode: string }): vite.Plugin[] {
+	const imageService = settings.config.image;
+	if (typeof imageService === 'undefined') {
+		throw new Error(
+			"Astro hasn't set a default service for `astro:assets`. This is an internal error and you should report it."
+		);
+	}
 	let resolvedConfig: vite.ResolvedConfig;
 
 	globalThis.astroAsset = {};
@@ -40,7 +46,7 @@ export default function assets({
 	const adapterName = settings.config.adapter?.name;
 	if (
 		['astro/assets/services/sharp', 'astro/assets/services/squoosh'].includes(
-			settings.config.image.service.entrypoint
+			imageService.service.entrypoint
 		) &&
 		adapterName &&
 		UNSUPPORTED_ADAPTERS.has(adapterName)
@@ -72,7 +78,7 @@ export default function assets({
 			},
 			async resolveId(id) {
 				if (id === VIRTUAL_SERVICE_ID) {
-					return await this.resolve(settings.config.image.service.entrypoint);
+					return await this.resolve(imageService.service.entrypoint);
 				}
 				if (id === VIRTUAL_MODULE_ID) {
 					return resolvedVirtualModuleId;
@@ -85,7 +91,7 @@ export default function assets({
 					import { getImage as getImageInternal } from "astro/assets";
 					export { default as Image } from "astro/components/Image.astro";
 
-					export const imageServiceConfig = ${JSON.stringify(settings.config.image.service.config)};
+					export const imageServiceConfig = ${JSON.stringify(imageService.service.config)};
 					export const getImage = async (options) => await getImageInternal(options, imageServiceConfig);
 				`;
 				}
@@ -103,7 +109,7 @@ export default function assets({
 						>();
 					}
 
-					const hash = hashTransform(options, settings.config.image.service.entrypoint);
+					const hash = hashTransform(options, imageService.service.entrypoint);
 
 					let filePath: string;
 					if (globalThis.astroAsset.staticImages.has(hash)) {

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1073,6 +1073,19 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 
 	/**
 	 * @docs
+	 * @message Feature not supported by the adapter.
+	 * @description
+	 * The adapter doesn't support certain feature enabled via configuration.
+	 */
+	FeatureNotSupportedByAdapter: {
+		title: 'Feature not supported by the adapter.',
+		message: (adapterName: string, featureName: string) => {
+			return `The adapter ${adapterName} doesn't support the feature ${featureName}. Please turn it off.`;
+		},
+	},
+
+	/**
+	 * @docs
 	 * @see
 	 * - [devalue library](https://github.com/rich-harris/devalue)
 	 * @description

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -239,9 +239,7 @@ export async function runHookConfigDone({
 const ALL_UNSUPPORTED: Required<AstroAdapterFeatureMap> = {
 	serverOutput: UNSUPPORTED,
 	staticOutput: UNSUPPORTED,
-	edgeMiddleware: UNSUPPORTED,
 	hybridOutput: UNSUPPORTED,
-	functionPerPage: UNSUPPORTED,
 	assets: { supportKind: UNSUPPORTED },
 };
 
@@ -263,29 +261,13 @@ export function validateSupportedFeatures(
 	logging: LogOptions
 ): ValidationResult {
 	const {
-		functionPerPage = UNSUPPORTED,
-		edgeMiddleware = UNSUPPORTED,
 		assets,
 		serverOutput = UNSUPPORTED,
 		staticOutput = UNSUPPORTED,
 		hybridOutput = UNSUPPORTED,
 	} = featureMap;
 	const validationResult: ValidationResult = {};
-	validationResult.functionPerPage = validateSupportKind(
-		functionPerPage,
-		adapterName,
-		logging,
-		'functionPerPage',
-		() => config?.build?.split === true && config?.output === 'server'
-	);
 
-	validationResult.edgeMiddleware = validateSupportKind(
-		edgeMiddleware,
-		adapterName,
-		logging,
-		'edgeMiddleware',
-		() => config?.build?.excludeMiddleware === true
-	);
 	validationResult.staticOutput = validateSupportKind(
 		staticOutput,
 		adapterName,

--- a/packages/astro/test/featuresSupport.test.js
+++ b/packages/astro/test/featuresSupport.test.js
@@ -1,0 +1,55 @@
+import { loadFixture } from './test-utils.js';
+import { expect } from 'chai';
+import testAdapter from './test-adapter.js';
+
+describe('Adapter', () => {
+	let fixture;
+
+	it("should error if the adapter doesn't support edge middleware", async () => {
+		try {
+			fixture = await loadFixture({
+				root: './fixtures/middleware-dev/',
+				output: 'server',
+				build: {
+					excludeMiddleware: true,
+				},
+				adapter: testAdapter({
+					extendAdapter: {
+						supportsFeatures: {
+							edgeMiddleware: 'Unsupported',
+						},
+					},
+				}),
+			});
+			await fixture.build();
+		} catch (e) {
+			expect(e.toString()).to.contain(
+				"The adapter my-ssr-adapter doesn't support the feature build.excludeMiddleware."
+			);
+		}
+	});
+
+	it("should error if the adapter doesn't support split build", async () => {
+		try {
+			fixture = await loadFixture({
+				root: './fixtures/middleware-dev/',
+				output: 'server',
+				build: {
+					split: true,
+				},
+				adapter: testAdapter({
+					extendAdapter: {
+						supportsFeatures: {
+							functionPerPage: 'Unsupported',
+						},
+					},
+				}),
+			});
+			await fixture.build();
+		} catch (e) {
+			expect(e.toString()).to.contain(
+				"The adapter my-ssr-adapter doesn't support the feature build.split."
+			);
+		}
+	});
+});

--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -72,8 +72,6 @@ export default function (
 					serverEntrypoint: '@my-ssr',
 					exports: ['manifest', 'createApp'],
 					supportedFeatures: {
-						edgeMiddleware: 'Stable',
-						functionPerPage: 'Stable',
 						assets: {
 							supportKind: 'Stable',
 							isNodeCompatible: true,

--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -71,6 +71,17 @@ export default function (
 					name: 'my-ssr-adapter',
 					serverEntrypoint: '@my-ssr',
 					exports: ['manifest', 'createApp'],
+					supportedFeatures: {
+						edgeMiddleware: 'Stable',
+						functionPerPage: 'Stable',
+						assets: {
+							supportKind: 'Stable',
+							isNodeCompatible: true,
+						},
+						serverOutput: 'Stable',
+						staticOutput: 'Stable',
+						hybridOutput: 'Stable',
+					},
 					...extendAdapter,
 				});
 			},

--- a/packages/astro/test/units/integrations/api.test.js
+++ b/packages/astro/test/units/integrations/api.test.js
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
 import { runHookBuildSetup } from '../../../dist/integrations/index.js';
+import { validateSupportedFeatures } from '../../../dist/integrations/index.js';
+import { defaultLogging } from '../test-utils.js';
 
 describe('Integration API', () => {
 	it('runHookBuildSetup should work', async () => {
@@ -26,5 +28,198 @@ describe('Integration API', () => {
 			target: 'server',
 		});
 		expect(updatedViteConfig).to.haveOwnProperty('define');
+	});
+});
+
+describe('Integration feature map', function () {
+	it('should support the feature when stable', () => {
+		let result = validateSupportedFeatures(
+			'test',
+			{
+				edgeMiddleware: 'Stable',
+			},
+			{
+				build: {
+					excludeMiddleware: true,
+				},
+			},
+			defaultLogging
+		);
+		expect(result['edgeMiddleware']).to.be.true;
+	});
+
+	it('should not support the feature when not provided', () => {
+		let result = validateSupportedFeatures(
+			'test',
+			undefined,
+			{
+				build: {
+					excludeMiddleware: true,
+				},
+			},
+			defaultLogging
+		);
+		expect(result['edgeMiddleware']).to.be.false;
+	});
+
+	it('should not support the feature when an empty object is provided', () => {
+		let result = validateSupportedFeatures(
+			'test',
+			{},
+			{
+				build: {
+					excludeMiddleware: true,
+				},
+			},
+			defaultLogging
+		);
+		expect(result['edgeMiddleware']).to.be.false;
+	});
+
+	describe('edge middleware feature', function () {
+		it('should be supported with the correct config', () => {
+			let result = validateSupportedFeatures(
+				'test',
+				{
+					edgeMiddleware: 'Stable',
+				},
+				{
+					build: {
+						excludeMiddleware: true,
+					},
+				},
+				defaultLogging
+			);
+			expect(result['edgeMiddleware']).to.be.true;
+		});
+
+		it("should not be valid if the config is correct, but the it's unsupported", () => {
+			let result = validateSupportedFeatures(
+				'test',
+				{
+					edgeMiddleware: 'Unsupported',
+				},
+				{
+					build: {
+						excludeMiddleware: true,
+					},
+				},
+				defaultLogging
+			);
+			expect(result['edgeMiddleware']).to.be.false;
+		});
+	});
+	describe('function per page feature', function () {
+		it('should be supported with the correct config', () => {
+			let result = validateSupportedFeatures(
+				'test',
+				{ functionPerPage: 'Stable' },
+				{
+					build: {
+						split: true,
+					},
+					output: 'server',
+				},
+				defaultLogging
+			);
+			expect(result['functionPerPage']).to.be.true;
+		});
+
+		it("should not be valid if the config is correct, but the it's unsupported", () => {
+			// the output: server is missing
+			let result = validateSupportedFeatures(
+				'test',
+				{
+					functionPerPage: 'Unsupported',
+				},
+				{
+					build: {
+						split: true,
+					},
+					output: 'server',
+				},
+				defaultLogging
+			);
+			expect(result['functionPerPage']).to.be.false;
+		});
+	});
+	describe('static output', function () {
+		it('should be supported with the correct config', () => {
+			let result = validateSupportedFeatures(
+				'test',
+				{ staticOutput: 'Stable' },
+				{
+					output: 'static',
+				},
+				defaultLogging
+			);
+			expect(result['staticOutput']).to.be.true;
+		});
+
+		it("should not be valid if the config is correct, but the it's unsupported", () => {
+			let result = validateSupportedFeatures(
+				'test',
+				{ staticOutput: 'Unsupported' },
+				{
+					output: 'static',
+				},
+				defaultLogging
+			);
+			expect(result['staticOutput']).to.be.false;
+		});
+	});
+	describe('hybrid output', function () {
+		it('should be supported with the correct config', () => {
+			let result = validateSupportedFeatures(
+				'test',
+				{ hybridOutput: 'Stable' },
+				{
+					output: 'hybrid',
+				},
+				defaultLogging
+			);
+			expect(result['hybridOutput']).to.be.true;
+		});
+
+		it("should not be valid if the config is correct, but the it's unsupported", () => {
+			let result = validateSupportedFeatures(
+				'test',
+				{
+					hybridOutput: 'Unsupported',
+				},
+				{
+					output: 'hybrid',
+				},
+				defaultLogging
+			);
+			expect(result['hybridOutput']).to.be.false;
+		});
+	});
+	describe('server output', function () {
+		it('should be supported with the correct config', () => {
+			let result = validateSupportedFeatures(
+				'test',
+				{ serverOutput: 'Stable' },
+				{
+					output: 'server',
+				},
+				defaultLogging
+			);
+			expect(result['serverOutput']).to.be.true;
+		});
+
+		it("should not be valid if the config is correct, but the it's unsupported", () => {
+			let result = validateSupportedFeatures(
+				'test',
+				{
+					serverOutput: 'Unsupported',
+				},
+				{
+					output: 'server',
+				},
+				defaultLogging
+			);
+			expect(result['serverOutput']).to.be.false;
+		});
 	});
 });

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -25,12 +25,13 @@ export function getAdapter(isModeDirectory: boolean): AstroAdapter {
 				serverEntrypoint: '@astrojs/cloudflare/server.directory.js',
 				exports: ['onRequest', 'manifest'],
 				supportedFeatures: {
-					functionPerPage: 'Experimental',
-					edgeMiddleware: 'Unsupported',
 					hybridOutput: 'Stable',
 					staticOutput: 'Unsupported',
 					serverOutput: 'Stable',
-					assets: 'Unsupported',
+					assets: {
+						supportKind: 'Unsupported',
+						isNodeCompatible: false,
+					},
 				},
 		  }
 		: {
@@ -38,12 +39,13 @@ export function getAdapter(isModeDirectory: boolean): AstroAdapter {
 				serverEntrypoint: '@astrojs/cloudflare/server.advanced.js',
 				exports: ['default'],
 				supportedFeatures: {
-					functionPerPage: 'Experimental',
-					edgeMiddleware: 'Unsupported',
 					hybridOutput: 'Stable',
 					staticOutput: 'Unsupported',
 					serverOutput: 'Stable',
-					assets: 'Unsupported',
+					assets: {
+						supportKind: 'Unsupported',
+						isNodeCompatible: false,
+					},
 				},
 		  };
 }

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -24,11 +24,27 @@ export function getAdapter(isModeDirectory: boolean): AstroAdapter {
 				name: '@astrojs/cloudflare',
 				serverEntrypoint: '@astrojs/cloudflare/server.directory.js',
 				exports: ['onRequest', 'manifest'],
+				supportedFeatures: {
+					functionPerPage: 'Experimental',
+					edgeMiddleware: 'Unsupported',
+					hybridOutput: 'Stable',
+					staticOutput: 'Unsupported',
+					serverOutput: 'Stable',
+					assets: 'Unsupported',
+				},
 		  }
 		: {
 				name: '@astrojs/cloudflare',
 				serverEntrypoint: '@astrojs/cloudflare/server.advanced.js',
 				exports: ['default'],
+				supportedFeatures: {
+					functionPerPage: 'Experimental',
+					edgeMiddleware: 'Unsupported',
+					hybridOutput: 'Stable',
+					staticOutput: 'Unsupported',
+					serverOutput: 'Stable',
+					assets: 'Unsupported',
+				},
 		  };
 }
 

--- a/packages/integrations/cloudflare/test/no-output.test.js
+++ b/packages/integrations/cloudflare/test/no-output.test.js
@@ -19,6 +19,6 @@ describe('Missing output config', () => {
 			error = err;
 		}
 		expect(error).to.not.be.equal(undefined);
-		expect(error.message).to.include(`output: "server"`);
+		expect(error.message).to.include(`staticOutput`);
 	});
 });

--- a/packages/integrations/deno/src/index.ts
+++ b/packages/integrations/deno/src/index.ts
@@ -90,12 +90,13 @@ export function getAdapter(args?: Options): AstroAdapter {
 		args: args ?? {},
 		exports: ['stop', 'handle', 'start', 'running'],
 		supportedFeatures: {
-			functionPerPage: 'Unsupported',
-			edgeMiddleware: 'Unsupported',
 			hybridOutput: 'Stable',
 			staticOutput: 'Stable',
 			serverOutput: 'Stable',
-			assets: 'Unsupported',
+			assets: {
+				supportKind: 'Unsupported',
+				isNodeCompatible: false,
+			},
 		},
 	};
 }

--- a/packages/integrations/deno/src/index.ts
+++ b/packages/integrations/deno/src/index.ts
@@ -89,6 +89,14 @@ export function getAdapter(args?: Options): AstroAdapter {
 		serverEntrypoint: '@astrojs/deno/server.js',
 		args: args ?? {},
 		exports: ['stop', 'handle', 'start', 'running'],
+		supportedFeatures: {
+			functionPerPage: 'Unsupported',
+			edgeMiddleware: 'Unsupported',
+			hybridOutput: 'Stable',
+			staticOutput: 'Stable',
+			serverOutput: 'Stable',
+			assets: 'Unsupported',
+		},
 	};
 }
 

--- a/packages/integrations/netlify/src/integration-edge-functions.ts
+++ b/packages/integrations/netlify/src/integration-edge-functions.ts
@@ -11,6 +11,15 @@ export function getAdapter(): AstroAdapter {
 		name: '@astrojs/netlify/edge-functions',
 		serverEntrypoint: '@astrojs/netlify/netlify-edge-functions.js',
 		exports: ['default'],
+		supportedFeatures: {
+			hybridOutput: 'Stable',
+			staticOutput: 'Stable',
+			serverOutput: 'Stable',
+			assets: {
+				supportKind: 'Unsupported',
+				isNodeCompatible: false,
+			},
+		},
 	};
 }
 

--- a/packages/integrations/netlify/src/integration-functions.ts
+++ b/packages/integrations/netlify/src/integration-functions.ts
@@ -14,6 +14,14 @@ export function getAdapter(args: Args = {}): AstroAdapter {
 		serverEntrypoint: '@astrojs/netlify/netlify-functions.js',
 		exports: ['handler'],
 		args,
+		supportedFeatures: {
+			functionPerPage: 'Experimental',
+			edgeMiddleware: 'Experimental',
+			hybridOutput: 'Stable',
+			staticOutput: 'Stable',
+			serverOutput: 'Stable',
+			assets: 'Unsupported',
+		},
 	};
 }
 

--- a/packages/integrations/netlify/src/integration-functions.ts
+++ b/packages/integrations/netlify/src/integration-functions.ts
@@ -15,12 +15,13 @@ export function getAdapter(args: Args = {}): AstroAdapter {
 		exports: ['handler'],
 		args,
 		supportedFeatures: {
-			functionPerPage: 'Experimental',
-			edgeMiddleware: 'Experimental',
 			hybridOutput: 'Stable',
 			staticOutput: 'Stable',
 			serverOutput: 'Stable',
-			assets: 'Unsupported',
+			assets: {
+				supportKind: 'Stable',
+				isNodeCompatible: true,
+			},
 		},
 	};
 }

--- a/packages/integrations/node/src/index.ts
+++ b/packages/integrations/node/src/index.ts
@@ -9,12 +9,13 @@ export function getAdapter(options: Options): AstroAdapter {
 		exports: ['handler', 'startServer'],
 		args: options,
 		supportedFeatures: {
-			functionPerPage: 'Stable',
-			edgeMiddleware: 'Stable',
 			hybridOutput: 'Stable',
 			staticOutput: 'Stable',
 			serverOutput: 'Stable',
-			assets: 'Experimental',
+			assets: {
+				supportKind: 'Stable',
+				isNodeCompatible: true,
+			},
 		},
 	};
 }

--- a/packages/integrations/node/src/index.ts
+++ b/packages/integrations/node/src/index.ts
@@ -8,6 +8,14 @@ export function getAdapter(options: Options): AstroAdapter {
 		previewEntrypoint: '@astrojs/node/preview.js',
 		exports: ['handler', 'startServer'],
 		args: options,
+		supportedFeatures: {
+			functionPerPage: 'Stable',
+			edgeMiddleware: 'Stable',
+			hybridOutput: 'Stable',
+			staticOutput: 'Stable',
+			serverOutput: 'Stable',
+			assets: 'Experimental',
+		},
 	};
 }
 

--- a/packages/integrations/vercel/src/edge/adapter.ts
+++ b/packages/integrations/vercel/src/edge/adapter.ts
@@ -27,6 +27,14 @@ function getAdapter(): AstroAdapter {
 		name: PACKAGE_NAME,
 		serverEntrypoint: `${PACKAGE_NAME}/entrypoint`,
 		exports: ['default'],
+		supportedFeatures: {
+			functionPerPage: 'Unsupported',
+			edgeMiddleware: 'Unsupported',
+			hybridOutput: 'Stable',
+			staticOutput: 'Stable',
+			serverOutput: 'Stable',
+			assets: 'Unsupported',
+		},
 	};
 }
 

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -35,12 +35,13 @@ function getAdapter(): AstroAdapter {
 		serverEntrypoint: `${PACKAGE_NAME}/entrypoint`,
 		exports: ['default'],
 		supportedFeatures: {
-			functionPerPage: 'Experimental',
-			edgeMiddleware: 'Experimental',
 			hybridOutput: 'Stable',
 			staticOutput: 'Stable',
 			serverOutput: 'Stable',
-			assets: 'Stable',
+			assets: {
+				supportKind: 'Unsupported',
+				isNodeCompatible: false,
+			},
 		},
 	};
 }

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -34,6 +34,14 @@ function getAdapter(): AstroAdapter {
 		name: PACKAGE_NAME,
 		serverEntrypoint: `${PACKAGE_NAME}/entrypoint`,
 		exports: ['default'],
+		supportedFeatures: {
+			functionPerPage: 'Experimental',
+			edgeMiddleware: 'Experimental',
+			hybridOutput: 'Stable',
+			staticOutput: 'Stable',
+			serverOutput: 'Stable',
+			assets: 'Stable',
+		},
 	};
 }
 


### PR DESCRIPTION
## Changes

This PR adds a new API that adapters can use when registering one. It's called `supportedFeatures`, and it's a new way to tell Astro if and when an adapter is able to support certain features that are enabled via configuration. 

The adapter can also tell Astro the kind of support:
- stable
- experimental
- unsupported
- deprecated


For now, this new API/object is not mandatory, but it will be in Astro 4.0.

The PR also updates the adapters that we maintain, and it adds the feature map to them.

### About `assets`

There's a small caveat for the assets. Astro assets is a feature that is already turned on by default, meaning that Astro sets already a default service. This means that adapters that **don't support** assets will always get an error, which is inconvenient. I came up with a solution where we set the default **after** the adapter validation, although I don't like the solution very much, and I wonder if there's a better way to handle a case like this.

The assets feature is just an example; we might have the same problem with future features like this. What do you suggest?

## Testing

I added new unit test cases and updated the existing ones.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

I will create the changelog in another PR

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
