### PR TITLE
Update `tsconfig.json` presets for TS 5.0

### DIFF
--- a/.changeset/three-adults-exist.md
+++ b/.changeset/three-adults-exist.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+Update `tsconfig.json` presets with `moduleResolution: 'bundler'` and other new options from TypeScript 5.0. Astro now assumes that you use TypeScript 5.0 (March 2023), or that your editor includes it, ex: VS Code 1.77

--- a/packages/astro/tsconfigs/base.json
+++ b/packages/astro/tsconfigs/base.json
@@ -10,9 +10,13 @@
     "allowImportingTsExtensions": true,
     // Enable JSON imports.
     "resolveJsonModule": true,
+    // Enforce the usage of type-only imports when needed, which helps avoiding bundling issues.
+    "verbatimModuleSyntax": true,
+    // Ensure that each file can be transpiled without relying on other imports.
+    "isolatedModules": true,
     // Astro directly run TypeScript code, no transpilation needed.
     "noEmit": true,
-    // Report an error when importing a file using a casing different from the casing on disk.
+    // Report an error when importing a file using a casing different from another import of the same file.
     "forceConsistentCasingInFileNames": true,
     // Properly support importing CJS modules in ESM
     "esModuleInterop": true,

--- a/packages/astro/tsconfigs/base.json
+++ b/packages/astro/tsconfigs/base.json
@@ -5,11 +5,11 @@
     "target": "ESNext",
     "module": "ESNext",
     // Enable node-style module resolution, for things like npm package imports.
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
+    // Allow importing TypeScript files using their native extension (.ts(x)).
+    "allowImportingTsExtensions": true,
     // Enable JSON imports.
     "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
-    "isolatedModules": true,
     // Astro directly run TypeScript code, no transpilation needed.
     "noEmit": true,
     // Report an error when importing a file using a casing different from the casing on disk.
@@ -23,9 +23,6 @@
     "paths": {
       "~/assets/*": ["src/assets/*"]
     },
-    // TypeScript 5.0 changed how `isolatedModules` and `importsNotUsedAsValues` works, deprecating the later
-    // Until the majority of users are on TypeScript 5.0, we'll have to supress those deprecation errors
-    "ignoreDeprecations": "5.0",
     // Allow JavaScript files to be imported
     "allowJs": true
   }

--- a/packages/astro/tsconfigs/base.json
+++ b/packages/astro/tsconfigs/base.json
@@ -13,6 +13,7 @@
     // Enforce the usage of type-only imports when needed, which helps avoiding bundling issues.
     "verbatimModuleSyntax": true,
     // Ensure that each file can be transpiled without relying on other imports.
+    // This is redundant with the previous option, however it ensures that it's on even if someone disable `verbatimModuleSyntax`
     "isolatedModules": true,
     // Astro directly run TypeScript code, no transpilation needed.
     "noEmit": true,

--- a/packages/astro/tsconfigs/strict.json
+++ b/packages/astro/tsconfigs/strict.json
@@ -2,8 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./base.json",
   "compilerOptions": {
-    "strict": true,
-    // Enforce the usage of type-only imports when needed, which helps avoiding bundling issues.
-    "verbatimModuleSyntax": true
+    // Enable strict mode. This enables a few options at a time, see https://www.typescriptlang.org/tsconfig#strict for a list.
+    "strict": true
   }
 }

--- a/packages/astro/tsconfigs/strict.json
+++ b/packages/astro/tsconfigs/strict.json
@@ -3,7 +3,7 @@
   "extends": "./base.json",
   "compilerOptions": {
     "strict": true,
-    // Error when a value import is only used as a type.
-    "importsNotUsedAsValues": "error"
+    // Enforce the usage of type-only imports when needed, which helps avoiding bundling issues.
+    "verbatimModuleSyntax": true
   }
 }


### PR DESCRIPTION
## Changes

TypeScript has this annoying behaviour where if you use an unknown compiler option, it'll.. completely refuse to do anything. I feel like they could've just added a warning instead, but whatever. This PR adds cool new options like `verbatimModuleSyntax` and updates it to use `moduleResolution: 'bundler'`, unlocking supports for the `exports` field. It's neat

## Testing

Tested manually

## Docs

N/A, we don't document this
