### PR TITLE
Execute scripts on page navigation (view transitions)

### DIFF
--- a/.changeset/sharp-seas-smile.md
+++ b/.changeset/sharp-seas-smile.md
@@ -2,11 +2,11 @@
 'astro': patch
 ---
 
-Execute scripts when navigating to a new page
+Execute scripts when navigating to a new page.
 
-When navigating to an new page with client-side navigation, scripts are executed (and re-executed). This makes it so that any new scripts on the incoming page are run and DOM can be updated.
+When navigating to an new page with client-side navigation, scripts are executed (and re-executed) so that any new scripts on the incoming page are run and the DOM can be updated.
 
-Module scripts won't re-execute because they never do. To support cases where you want to modify the DOM this also adds a `astro:load` event that you can listen to:
+However, `type=module` scripts never re-execute in Astro, and will not do so in client-side routing. To support cases where you want to modify the DOM, a new `astro:load` event listener been added:
 
 ```js
 document.addEventListener('astro:load', () => {

--- a/.changeset/sharp-seas-smile.md
+++ b/.changeset/sharp-seas-smile.md
@@ -1,0 +1,15 @@
+---
+'astro': patch
+---
+
+Execute scripts when navigating to a new page
+
+When navigating to an new page with client-side navigation, scripts are executed (and re-executed). This makes it so that any new scripts on the incoming page are run and DOM can be updated.
+
+Module scripts won't re-execute because they never do. To support cases where you want to modify the DOM this also adds a `astro:load` event that you can listen to:
+
+```js
+document.addEventListener('astro:load', () => {
+  updateTheDOMSomehow();
+});
+```

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -25,6 +25,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 	const supportsViewTransitions = !!document.startViewTransition;
 	const transitionEnabledOnThisPage = () =>
 		!!document.querySelector('[name="astro-view-transitions-enabled"]');
+	const onload = () => document.dispatchEvent(new Event('astro:load'));
 
 	async function getHTML(href: string) {
 		const res = await fetch(href);
@@ -38,6 +39,23 @@ const { fallback = 'animate' } = Astro.props as Props;
 			return el.getAttribute('content') as Fallback;
 		}
 		return 'animate';
+	}
+
+	function runScripts() {
+		let wait = Promise.resolve();
+		for(const script of Array.from(document.scripts)) {
+			const s = document.createElement('script');
+			s.innerHTML = script.innerHTML;
+			for(const attr of script.attributes) {
+				if(attr.name === 'src') {
+					const p = new Promise(r => {s.onload = r});
+					wait = wait.then(() => p as any);
+				}
+				s.setAttribute(attr.name, attr.value);
+			}
+			script.replaceWith(s);
+		}
+		return wait;
 	}
 
 	const parser = new DOMParser();
@@ -95,6 +113,8 @@ const { fallback = 'animate' } = Astro.props as Props;
 			await finished;
 		} finally {
 			document.documentElement.removeAttribute('data-astro-transition');
+			await runScripts();
+			onload();
 		}
 	}
 
@@ -171,5 +191,6 @@ const { fallback = 'animate' } = Astro.props as Props;
 				{ passive: true, capture: true }
 			);
 		});
+		addEventListener('load', onload)
 	}
 </script>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/two.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/two.astro
@@ -3,4 +3,10 @@ import Layout from '../components/Layout.astro';
 ---
 <Layout link="/two.css">
 	<p id="two">Page 2</p>
+	<article id="twoarticle"></article>
 </Layout>
+<script>
+	document.addEventListener('astro:load', () => {
+		document.getElementById('twoarticle')!.textContent = 'works';
+	}, { once: true });
+</script>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -128,10 +128,6 @@ test.describe('View Transitions', () => {
 	});
 
 	test('Stylesheets in the head are waited on', async ({ page, astro }) => {
-		page.addListener('console', (data) => {
-			console.log(data);
-		});
-
 		// Go to page 1
 		await page.goto(astro.resolveUrl('/one'));
 		let p = page.locator('#one');
@@ -142,5 +138,24 @@ test.describe('View Transitions', () => {
 		p = page.locator('#two');
 		await expect(p, 'should have content').toHaveText('Page 2');
 		await expect(p, 'imported CSS updated').toHaveCSS('font-size', '24px');
+	});
+
+	test('astro:load event fires when navigating to new page', async ({ page, astro }) => {
+		// Go to page 1
+		await page.goto(astro.resolveUrl('/one'));
+		const p = page.locator('#one');
+		await expect(p, 'should have content').toHaveText('Page 1');
+
+		// go to page 2
+		await page.click('#click-two');
+		const article = page.locator('#twoarticle');
+		await expect(article, 'should have script content').toHaveText('works');
+	});
+
+	test('astro:load event fires when navigating directly to a page', async ({ page, astro }) => {
+		// Go to page 1
+		await page.goto(astro.resolveUrl('/two'));
+		const article = page.locator('#twoarticle');
+		await expect(article, 'should have script content').toHaveText('works');
 	});
 });


### PR DESCRIPTION
## Changes

- DOMParser creates scripts that are non executable, event after inserting into the page.
- This makes it so that scripts are always executed. If they have already run we reinsert them. That means for inline classic scripts those will re-run. Module scripts will not.
- This approach was chosen mostly because it's the last amount of code. It also aligns with what Swup does it.
- Adds the `astro:load` even that you can listen to if you need to rerun something on page navigation.
- Fixes https://github.com/withastro/astro/issues/7765

## Testing

- Test added to verify the `astro:load` event fire on forward navigation.
- Test added to verify `astro:load` fires on direct page navigation (MPA).

## Docs

- https://github.com/withastro/docs/pull/3810