### PR TITLE
Fixes withastro/astro#7793 astro add cli pass down arguments to install cmd 

### DIFF
--- a/.changeset/soft-colts-heal.md
+++ b/.changeset/soft-colts-heal.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+pass down `astro add` cli arguments to package manager

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -641,13 +641,22 @@ async function tryToInstallIntegrations({
 }): Promise<UpdateResult> {
 	const installCommand = await getInstallIntegrationsCommand({ integrations, cwd });
 
+	const inheritedFlags = Object.entries(flags)
+		.map(([flag, value]) => {
+			if (flag == '_') return;
+
+			return [`-${flag}`, value.toString()];
+		})
+		.filter(Boolean)
+		.flat();
+
 	if (installCommand === null) {
 		return UpdateResult.none;
 	} else {
 		const coloredOutput = `${bold(installCommand.pm)} ${installCommand.command}${[
 			'',
 			...installCommand.flags,
-		].join(' ')} ${cyan(installCommand.dependencies.join(' '))}`;
+		].join(' ')} ${cyan(installCommand.dependencies.join(' '))} ${inheritedFlags.join(' ')}`;
 		const message = `\n${boxen(coloredOutput, {
 			margin: 0.5,
 			padding: 0.5,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18666,7 +18666,6 @@ packages:
     resolution: {directory: packages/astro, type: directory}
     id: file:packages/astro
     name: astro
-    version: 2.9.2
     engines: {node: '>=16.12.0', npm: '>=6.14.0'}
     hasBin: true
     peerDependencies:
@@ -18775,7 +18774,6 @@ packages:
     resolution: {directory: packages/integrations/netlify, type: directory}
     id: file:packages/integrations/netlify
     name: '@astrojs/netlify'
-    version: 2.5.0
     peerDependencies:
       astro: '*'
     dependencies:
@@ -18790,7 +18788,6 @@ packages:
     resolution: {directory: packages/integrations/vercel, type: directory}
     id: file:packages/integrations/vercel
     name: '@astrojs/vercel'
-    version: 3.7.4
     peerDependencies:
       astro: '*'
     dependencies:


### PR DESCRIPTION
## Changes

- get arguments from the `astro add` cli
- pass them down to the actual package manager

## Testing

I tested it locally, running `astro add astro-compress -D` ran `pnpm add astro-compress -D true`

## Docs

I think it should be in the docs

/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
