### PR TITLE
[docs] Markdoc README syntax fixes

### DIFF
--- a/packages/integrations/markdoc/README.md
+++ b/packages/integrations/markdoc/README.md
@@ -424,11 +424,10 @@ export default defineConfig({
 });
 ```
 
-:::caution
-When `allowHTML` is enabled, HTML markup inside Markdoc documents will be rendered as actual HTML elements (including `<script>`), making attack vectors like XSS possible.
-
-Ensure that any HTML markup comes from trusted sources.
-:::
+> **Caution**
+> When `allowHTML` is enabled, HTML markup inside Markdoc documents will be rendered as actual HTML elements (including `<script>`), making attack vectors like XSS possible.
+>
+> Ensure that any HTML markup comes from trusted sources.
 
 ## Examples
 

--- a/packages/integrations/markdoc/README.md
+++ b/packages/integrations/markdoc/README.md
@@ -405,18 +405,13 @@ This can now be accessed as `$frontmatter` in your Markdoc.
 
 The Astro Markdoc integration handles configuring Markdoc options and capabilities that are not available through the `markdoc.config.js` file.
 
-### allowHTML
+### `allowHTML`
 
 Enables writing HTML markup alongside Markdoc tags and nodes.
 
 By default, Markdoc will not recognize HTML markup as semantic content.
 
 To achieve a more Markdown-like experience, where HTML elements can be included alongside your content, set `allowHTML:true` as a `markdoc` integration option. This will enable HTML parsing in Markdoc markup.
-
-> **Warning**
-> When `allowHTML` is enabled, HTML markup inside Markdoc documents will be rendered as actual HTML elements (including `<script>`), making attack vectors like XSS possible.
->
-> Ensure that any HTML markup comes from trusted sources.
 
 ```js {7} "allowHTML: true"
 // astro.config.mjs
@@ -428,6 +423,12 @@ export default defineConfig({
   integrations: [markdoc({ allowHTML: true })],
 });
 ```
+
+:::caution
+When `allowHTML` is enabled, HTML markup inside Markdoc documents will be rendered as actual HTML elements (including `<script>`), making attack vectors like XSS possible.
+
+Ensure that any HTML markup comes from trusted sources.
+:::
 
 ## Examples
 


### PR DESCRIPTION
## Changes

Fixes wonky rendering in docs because of the `:::caution` syntax. 

Replaces with a GitHub caution. Also moves the caution below so it's not between code sample and its explanation.

## Testing

No tests

## Docs

Only Docs!
