### PR TITLE
Prevent building .html files in hybrid mode

### DIFF
--- a/.changeset/ninety-kids-fail.md
+++ b/.changeset/ninety-kids-fail.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Prevent building .html file redirects in hybrid mode

--- a/packages/integrations/netlify/src/integration-functions.ts
+++ b/packages/integrations/netlify/src/integration-functions.ts
@@ -40,6 +40,7 @@ function netlifyFunctions({
 				updateConfig({
 					outDir,
 					build: {
+						redirects: false,
 						client: outDir,
 						server: new URL('./.netlify/functions-internal/', config.root),
 					},

--- a/packages/integrations/netlify/test/functions/fixtures/redirects/src/pages/index.astro
+++ b/packages/integrations/netlify/test/functions/fixtures/redirects/src/pages/index.astro
@@ -1,0 +1,9 @@
+---
+export const prerender = false;
+---
+<html>
+<head><title>Testing</title></head>
+<body>
+	<h1>Testing</h1>
+</body>
+</html>

--- a/packages/integrations/netlify/test/functions/fixtures/redirects/src/pages/nope.astro
+++ b/packages/integrations/netlify/test/functions/fixtures/redirects/src/pages/nope.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/');
+---

--- a/packages/integrations/netlify/test/functions/fixtures/redirects/src/pages/team/articles/[...slug].astro
+++ b/packages/integrations/netlify/test/functions/fixtures/redirects/src/pages/team/articles/[...slug].astro
@@ -1,0 +1,27 @@
+---
+export const prerender = false;
+
+export const getStaticPaths = (async () => {
+  const posts = [
+		{ slug: 'one', data: {draft: false, title: 'One'} },
+		{ slug: 'two', data: {draft: false, title: 'Two'} }
+	];
+  return posts.map((post) => {
+    return {
+      params: { slug: post.slug },
+      props: { draft: post.data.draft, title: post.data.title },
+    };
+  });
+})
+
+const { slug } = Astro.params;
+const { title } = Astro.props;
+---
+<html>
+	<head>
+		<title>{ title }</title>
+	</head>
+	<body>
+		<h1>{ title }</h1>
+	</body>
+</html>

--- a/packages/integrations/netlify/test/functions/redirects.test.js
+++ b/packages/integrations/netlify/test/functions/redirects.test.js
@@ -8,10 +8,10 @@ describe('SSG - Redirects', () => {
 
 	before(async () => {
 		fixture = await loadFixture({
-			root: new URL('../static/fixtures/redirects/', import.meta.url).toString(),
-			output: 'server',
+			root: new URL('../functions/fixtures/redirects/', import.meta.url).toString(),
+			output: 'hybrid',
 			adapter: netlifyAdapter({
-				dist: new URL('../static/fixtures/redirects/dist/', import.meta.url),
+				dist: new URL('../functions/fixtures/redirects/dist/', import.meta.url),
 			}),
 			site: `http://example.com`,
 			integrations: [testIntegration()],
@@ -44,5 +44,14 @@ describe('SSG - Redirects', () => {
 			'200',
 		]);
 		expect(redirects).to.matchSnapshot();
+	});
+
+	it('Does not create .html files', async () => {
+		try {
+			await fixture.readFile('/other/index.html');
+			expect(false).to.equal(true, 'this file should not exist');
+		} catch {
+			expect(true).to.equal(true);
+		}
 	});
 });


### PR DESCRIPTION
## Changes

- In Netlify, do not build .html files because it prioritizes those
- This only is an issue with hybrid mode
- Fixes: https://github.com/withastro/astro/issues/7731

## Testing

- Test case added

## Docs

N/A, bug fix