### PR TITLE
Refactor dev CLI flow

### DIFF
--- a/packages/astro/src/cli/dev/index.ts
+++ b/packages/astro/src/cli/dev/index.ts
@@ -1,9 +1,10 @@
-import fs from 'node:fs';
+import { cyan } from 'kleur/colors';
 import type yargs from 'yargs-parser';
-import { resolveConfigPath, resolveFlags, resolveRoot } from '../../core/config/index.js';
+import { resolveRoot } from '../../core/config/index.js';
 import devServer from '../../core/dev/index.js';
 import { info, type LogOptions } from '../../core/logger/core.js';
-import { handleConfigError, loadSettings } from '../load-settings.js';
+import { printHelp } from '../../core/messages.js';
+import { flagsToAstroInlineConfig, handleConfigError } from '../load-settings.js';
 
 interface DevOptions {
 	flags: yargs.Arguments;
@@ -11,21 +12,32 @@ interface DevOptions {
 }
 
 export async function dev({ flags, logging }: DevOptions) {
-	const settings = await loadSettings({ cmd: 'dev', flags, logging });
-	if (!settings) return;
+	if (flags.help || flags.h) {
+		printHelp({
+			commandName: 'astro dev',
+			usage: '[...flags]',
+			tables: {
+				Flags: [
+					['--port', `Specify which port to run on. Defaults to 3000.`],
+					['--host', `Listen on all addresses, including LAN and public addresses.`],
+					['--host <custom-address>', `Expose on a network IP address at <custom-address>`],
+					['--open', 'Automatically open the app in the browser on server start'],
+					['--help (-h)', 'See all available flags.'],
+				],
+			},
+			description: `Check ${cyan(
+				'https://docs.astro.build/en/reference/cli-reference/#astro-dev'
+			)} for more information.`,
+		});
+		return;
+	}
 
-	const root = resolveRoot(flags.root);
-	const configFlag = resolveFlags(flags).config;
-	const configFlagPath = configFlag
-		? await resolveConfigPath({ root, configFile: configFlag, fs })
-		: undefined;
+	const inlineConfig = flagsToAstroInlineConfig(flags);
 
-	return await devServer(settings, {
-		configFlag,
-		configFlagPath,
-		flags,
+	return await devServer(inlineConfig, {
 		logging,
 		handleConfigError(e) {
+			const root = resolveRoot(flags.root);
 			handleConfigError(e, { cmd: 'dev', cwd: root, flags, logging });
 			info(logging, 'astro', 'Continuing with previous valid configuration\n');
 		},

--- a/packages/astro/src/core/config/index.ts
+++ b/packages/astro/src/core/config/index.ts
@@ -1,12 +1,5 @@
-export {
-	createDefaultDevConfig,
-	openConfig,
-	resolveConfig,
-	resolveConfigPath,
-	resolveFlags,
-	resolveRoot,
-} from './config.js';
+export { resolveConfig, resolveConfigPath, resolveFlags, resolveRoot } from './config.js';
 export { mergeConfig } from './merge.js';
 export type { AstroConfigSchema } from './schema';
-export { createDefaultDevSettings, createSettings } from './settings.js';
+export { createSettings } from './settings.js';
 export { loadTSConfig, updateTSConfigForFramework } from './tsconfig.js';

--- a/packages/astro/src/core/config/settings.ts
+++ b/packages/astro/src/core/config/settings.ts
@@ -1,7 +1,7 @@
 import yaml from 'js-yaml';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import type { AstroConfig, AstroSettings, AstroUserConfig } from '../../@types/astro';
+import type { AstroConfig, AstroSettings } from '../../@types/astro';
 import { getContentPaths } from '../../content/index.js';
 import jsxRenderer from '../../jsx/renderer.js';
 import { isServerLikeOutput } from '../../prerender/utils.js';
@@ -10,7 +10,6 @@ import { getDefaultClientDirectives } from '../client-directive/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 import { formatYAMLException, isYAMLException } from '../errors/utils.js';
 import { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from './../constants.js';
-import { createDefaultDevConfig } from './config.js';
 import { AstroTimer } from './timer.js';
 import { loadTSConfig } from './tsconfig.js';
 
@@ -126,15 +125,4 @@ export function createSettings(
 	settings.tsConfigPath = tsconfig?.path;
 	settings.watchFiles = watchFiles;
 	return settings;
-}
-
-export async function createDefaultDevSettings(
-	userConfig: AstroUserConfig = {},
-	root?: string | URL
-): Promise<AstroSettings> {
-	if (root && typeof root !== 'string') {
-		root = fileURLToPath(root);
-	}
-	const config = await createDefaultDevConfig(userConfig, root);
-	return createBaseSettings(config, 'dev');
 }

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -1,6 +1,6 @@
 import type * as http from 'node:http';
 import type { AddressInfo } from 'node:net';
-import type { AstroSettings, AstroUserConfig } from '../../@types/astro';
+import type { AstroInlineConfig, AstroSettings } from '../../@types/astro';
 
 import nodeFs from 'node:fs';
 import * as vite from 'vite';
@@ -10,52 +10,36 @@ import {
 	runHookServerDone,
 	runHookServerStart,
 } from '../../integrations/index.js';
-import { createDefaultDevSettings, resolveRoot } from '../config/index.js';
 import { createVite } from '../create-vite.js';
 import type { LogOptions } from '../logger/core.js';
-import { nodeLogDestination } from '../logger/node.js';
-import { appendForwardSlash } from '../path.js';
 import { apply as applyPolyfill } from '../polyfill.js';
-
-const defaultLogging: LogOptions = {
-	dest: nodeLogDestination,
-	level: 'error',
-};
 
 export interface Container {
 	fs: typeof nodeFs;
 	logging: LogOptions;
 	settings: AstroSettings;
-	viteConfig: vite.InlineConfig;
 	viteServer: vite.ViteDevServer;
-	resolvedRoot: string;
-	configFlag: string | undefined;
-	configFlagPath: string | undefined;
+	inlineConfig: AstroInlineConfig;
 	restartInFlight: boolean; // gross
 	handle: (req: http.IncomingMessage, res: http.ServerResponse) => void;
 	close: () => Promise<void>;
 }
 
 export interface CreateContainerParams {
+	logging: LogOptions;
+	settings: AstroSettings;
+	inlineConfig?: AstroInlineConfig;
 	isRestart?: boolean;
-	logging?: LogOptions;
-	userConfig?: AstroUserConfig;
-	settings?: AstroSettings;
 	fs?: typeof nodeFs;
-	root?: string | URL;
-	// The string passed to --config and the resolved path
-	configFlag?: string;
-	configFlagPath?: string;
 }
 
-export async function createContainer(params: CreateContainerParams = {}): Promise<Container> {
-	let {
-		isRestart = false,
-		logging = defaultLogging,
-		settings = await createDefaultDevSettings(params.userConfig, params.root),
-		fs = nodeFs,
-	} = params;
-
+export async function createContainer({
+	isRestart = false,
+	logging,
+	inlineConfig,
+	settings,
+	fs = nodeFs,
+}: CreateContainerParams): Promise<Container> {
 	// Initialize
 	applyPolyfill();
 	settings = await runHookConfigSetup({
@@ -86,14 +70,11 @@ export async function createContainer(params: CreateContainerParams = {}): Promi
 	const viteServer = await vite.createServer(viteConfig);
 
 	const container: Container = {
-		configFlag: params.configFlag,
-		configFlagPath: params.configFlagPath,
+		inlineConfig: inlineConfig ?? {},
 		fs,
 		logging,
-		resolvedRoot: appendForwardSlash(resolveRoot(params.root)),
 		restartInFlight: false,
 		settings,
-		viteConfig,
 		viteServer,
 		handle(req, res) {
 			viteServer.middlewares.handle(req, res, Function.prototype);
@@ -134,19 +115,4 @@ export async function startContainer({
 
 export function isStarted(container: Container): boolean {
 	return !!container.viteServer.httpServer?.listening;
-}
-
-/**
- * Only used in tests
- */
-export async function runInContainer(
-	params: CreateContainerParams,
-	callback: (container: Container) => Promise<void> | void
-) {
-	const container = await createContainer(params);
-	try {
-		await callback(container);
-	} finally {
-		await container.close();
-	}
 }

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -1,25 +1,19 @@
-import { cyan } from 'kleur/colors';
+import fs from 'node:fs';
 import type http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { performance } from 'perf_hooks';
 import type * as vite from 'vite';
-import type yargs from 'yargs-parser';
-import type { AstroSettings } from '../../@types/astro';
+import type { AstroInlineConfig } from '../../@types/astro';
 import { attachContentServerListeners } from '../../content/index.js';
 import { telemetry } from '../../events/index.js';
 import { info, warn, type LogOptions } from '../logger/core.js';
 import * as msg from '../messages.js';
-import { printHelp } from '../messages.js';
 import { startContainer } from './container.js';
 import { createContainerWithAutomaticRestart } from './restart.js';
 
 export interface DevOptions {
-	configFlag: string | undefined;
-	configFlagPath: string | undefined;
-	flags?: yargs.Arguments;
 	logging: LogOptions;
 	handleConfigError: (error: Error) => void;
-	isRestart?: boolean;
 }
 
 export interface DevServer {
@@ -31,44 +25,20 @@ export interface DevServer {
 
 /** `astro dev` */
 export default async function dev(
-	settings: AstroSettings,
+	inlineConfig: AstroInlineConfig,
 	options: DevOptions
-): Promise<DevServer | undefined> {
-	if (options.flags?.help || options.flags?.h) {
-		printHelp({
-			commandName: 'astro dev',
-			usage: '[...flags]',
-			tables: {
-				Flags: [
-					['--port', `Specify which port to run on. Defaults to 3000.`],
-					['--host', `Listen on all addresses, including LAN and public addresses.`],
-					['--host <custom-address>', `Expose on a network IP address at <custom-address>`],
-					['--open', 'Automatically open the app in the browser on server start'],
-					['--help (-h)', 'See all available flags.'],
-				],
-			},
-			description: `Check ${cyan(
-				'https://docs.astro.build/en/reference/cli-reference/#astro-dev'
-			)} for more information.`,
-		});
-		return;
-	}
-
+): Promise<DevServer> {
 	const devStart = performance.now();
 	await telemetry.record([]);
 
 	// Create a container which sets up the Vite server.
 	const restart = await createContainerWithAutomaticRestart({
-		flags: options.flags ?? {},
+		inlineConfig,
+		logging: options.logging,
+		fs,
 		handleConfigError: options.handleConfigError,
 		// eslint-disable-next-line no-console
 		beforeRestart: () => console.clear(),
-		params: {
-			settings,
-			root: options.flags?.root,
-			logging: options.logging,
-			isRestart: options.isRestart,
-		},
 	});
 
 	// Start listening to the port
@@ -80,9 +50,8 @@ export default async function dev(
 		msg.serverStart({
 			startupTime: performance.now() - devStart,
 			resolvedUrls: restart.container.viteServer.resolvedUrls || { local: [], network: [] },
-			host: settings.config.server.host,
-			base: settings.config.base,
-			isRestart: options.isRestart,
+			host: restart.container.settings.config.server.host,
+			base: restart.container.settings.config.base,
 		})
 	);
 
@@ -90,7 +59,7 @@ export default async function dev(
 	if (currentVersion.includes('-')) {
 		warn(options.logging, null, msg.prerelease({ currentVersion }));
 	}
-	if (restart.container.viteConfig.server?.fs?.strict === false) {
+	if (restart.container.viteServer.config.server?.fs?.strict === false) {
 		warn(options.logging, null, msg.fsStrictWarning());
 	}
 

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -1,3 +1,3 @@
-export { createContainer, isStarted, runInContainer, startContainer } from './container.js';
+export { createContainer, isStarted, startContainer } from './container.js';
 export { default } from './dev.js';
 export { createContainerWithAutomaticRestart } from './restart.js';

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -177,7 +177,7 @@ export async function loadFixture(inlineConfig) {
 		},
 		startDevServer: async (opts = {}) => {
 			process.env.NODE_ENV = 'development';
-			devServer = await dev(await getSettings('dev'), { logging, ...opts });
+			devServer = await dev({ ...inlineConfig, root }, { logging, ...opts });
 			config.server.host = parseAddressToHost(devServer.address.address); // update host
 			config.server.port = devServer.address.port; // update port
 			return devServer;

--- a/packages/astro/test/units/config/format.test.js
+++ b/packages/astro/test/units/config/format.test.js
@@ -1,9 +1,6 @@
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { expect } from 'chai';
-
-import { runInContainer } from '../../../dist/core/dev/index.js';
-import { resolveConfig, createSettings } from '../../../dist/core/config/index.js';
-import { createFs } from '../test-utils.js';
+import { createFs, runInContainer } from '../test-utils.js';
 
 const root = new URL('../../fixtures/tailwindcss-ts/', import.meta.url);
 
@@ -21,10 +18,7 @@ describe('Astro config formats', () => {
 			root
 		);
 
-		const { astroConfig } = await resolveConfig({ root: fileURLToPath(root) }, 'dev', fs);
-		const settings = createSettings(astroConfig, 'dev');
-
-		await runInContainer({ fs, root, settings }, () => {
+		await runInContainer({ fs, inlineConfig: { root: fileURLToPath(root) } }, () => {
 			expect(true).to.equal(
 				true,
 				'We were able to get into the container which means the config loaded.'

--- a/packages/astro/test/units/content-collections/frontmatter.test.js
+++ b/packages/astro/test/units/content-collections/frontmatter.test.js
@@ -2,9 +2,8 @@ import { fileURLToPath } from 'node:url';
 import nodeFS from 'node:fs';
 import path from 'node:path';
 
-import { runInContainer } from '../../../dist/core/dev/index.js';
 import { attachContentServerListeners } from '../../../dist/content/index.js';
-import { createFs, triggerFSEvent } from '../test-utils.js';
+import { createFs, runInContainer, triggerFSEvent } from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
@@ -53,7 +52,7 @@ describe('frontmatter', () => {
 			root
 		);
 
-		await runInContainer({ fs, root }, async (container) => {
+		await runInContainer({ fs, inlineConfig: { root: fileURLToPath(root) } }, async (container) => {
 			await attachContentServerListeners(container);
 
 			fs.writeFileFromRootSync(

--- a/packages/astro/test/units/dev/base.test.js
+++ b/packages/astro/test/units/dev/base.test.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
-
-import { runInContainer } from '../../../dist/core/dev/index.js';
-import { createFs, createRequestAndResponse } from '../test-utils.js';
+import { fileURLToPath } from 'node:url';
+import { createFs, createRequestAndResponse, runInContainer } from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
@@ -19,8 +18,8 @@ describe('base configuration', () => {
 				await runInContainer(
 					{
 						fs,
-						root,
-						userConfig: {
+						inlineConfig: {
+							root: fileURLToPath(root),
 							base: '/docs',
 							trailingSlash: 'never',
 						},
@@ -48,8 +47,8 @@ describe('base configuration', () => {
 				await runInContainer(
 					{
 						fs,
-						root,
-						userConfig: {
+						inlineConfig: {
+							root: fileURLToPath(root),
 							base: '/docs',
 							trailingSlash: 'never',
 						},
@@ -79,8 +78,8 @@ describe('base configuration', () => {
 				await runInContainer(
 					{
 						fs,
-						root,
-						userConfig: {
+						inlineConfig: {
+							root: fileURLToPath(root),
 							base: '/docs',
 							trailingSlash: 'never',
 						},
@@ -108,8 +107,8 @@ describe('base configuration', () => {
 				await runInContainer(
 					{
 						fs,
-						root,
-						userConfig: {
+						inlineConfig: {
+							root: fileURLToPath(root),
 							base: '/docs',
 							trailingSlash: 'never',
 						},

--- a/packages/astro/test/units/dev/collections-renderentry.test.js
+++ b/packages/astro/test/units/dev/collections-renderentry.test.js
@@ -1,16 +1,16 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
 import os from 'node:os';
+import { fileURLToPath } from 'node:url';
 
-import mdx from '../../../../integrations/mdx/dist/index.js';
 import { attachContentServerListeners } from '../../../dist/content/server-listeners.js';
-import { runInContainer } from '../../../dist/core/dev/index.js';
-import { createFsWithFallback, createRequestAndResponse } from '../test-utils.js';
+import { createFsWithFallback, createRequestAndResponse, runInContainer } from '../test-utils.js';
 
 const root = new URL('../../fixtures/content/', import.meta.url);
 
 const describe = os.platform() === 'win32' ? global.describe.skip : global.describe;
 
+/** @type {typeof runInContainer} */
 async function runInContainerWithContentListeners(params, callback) {
 	return await runInContainer(params, async (container) => {
 		await attachContentServerListeners(container);
@@ -56,9 +56,8 @@ describe('Content Collections - render()', () => {
 		await runInContainerWithContentListeners(
 			{
 				fs,
-				root,
-				userConfig: {
-					integrations: [mdx()],
+				inlineConfig: {
+					root: fileURLToPath(root),
 					vite: { server: { middlewareMode: true } },
 				},
 			},
@@ -72,6 +71,7 @@ describe('Content Collections - render()', () => {
 				const html = await text();
 
 				const $ = cheerio.load(html);
+				console.log(html);
 				// Rendered the content
 				expect($('ul li')).to.have.a.lengthOf(3);
 
@@ -129,9 +129,8 @@ description: Astro is launching this week!
 		await runInContainerWithContentListeners(
 			{
 				fs,
-				root,
-				userConfig: {
-					integrations: [mdx()],
+				inlineConfig: {
+					root: fileURLToPath(root),
 					vite: { server: { middlewareMode: true } },
 				},
 			},
@@ -200,9 +199,8 @@ description: Astro is launching this week!
 		await runInContainerWithContentListeners(
 			{
 				fs,
-				root,
-				userConfig: {
-					integrations: [mdx()],
+				inlineConfig: {
+					root: fileURLToPath(root),
 					vite: { server: { middlewareMode: true } },
 				},
 			},
@@ -270,9 +268,8 @@ description: Astro is launching this week!
 		await runInContainerWithContentListeners(
 			{
 				fs,
-				root,
-				userConfig: {
-					integrations: [mdx()],
+				inlineConfig: {
+					root: fileURLToPath(root),
 					vite: { server: { middlewareMode: true } },
 				},
 			},

--- a/packages/astro/test/units/dev/collections-renderentry.test.js
+++ b/packages/astro/test/units/dev/collections-renderentry.test.js
@@ -71,7 +71,6 @@ describe('Content Collections - render()', () => {
 				const html = await text();
 
 				const $ = cheerio.load(html);
-				console.log(html);
 				// Rendered the content
 				expect($('ul li')).to.have.a.lengthOf(3);
 

--- a/packages/astro/test/units/dev/dev.test.js
+++ b/packages/astro/test/units/dev/dev.test.js
@@ -1,8 +1,12 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
-
-import { runInContainer } from '../../../dist/core/dev/index.js';
-import { createFs, createRequestAndResponse, triggerFSEvent } from '../test-utils.js';
+import { fileURLToPath } from 'node:url';
+import {
+	createFs,
+	createRequestAndResponse,
+	triggerFSEvent,
+	runInContainer,
+} from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
@@ -25,7 +29,7 @@ describe('dev container', () => {
 			root
 		);
 
-		await runInContainer({ fs, root }, async (container) => {
+		await runInContainer({ fs, inlineConfig: { root: fileURLToPath(root) } }, async (container) => {
 			const { req, res, text } = createRequestAndResponse({
 				method: 'GET',
 				url: '/',
@@ -60,7 +64,7 @@ describe('dev container', () => {
 			root
 		);
 
-		await runInContainer({ fs, root }, async (container) => {
+		await runInContainer({ fs, inlineConfig: { root: fileURLToPath(root) } }, async (container) => {
 			let r = createRequestAndResponse({
 				method: 'GET',
 				url: '/',
@@ -119,8 +123,8 @@ describe('dev container', () => {
 		await runInContainer(
 			{
 				fs,
-				root,
-				userConfig: {
+				inlineConfig: {
+					root: fileURLToPath(root),
 					output: 'server',
 					integrations: [
 						{
@@ -170,8 +174,8 @@ describe('dev container', () => {
 		await runInContainer(
 			{
 				fs,
-				root,
-				userConfig: {
+				inlineConfig: {
+					root: fileURLToPath(root),
 					output: 'server',
 					integrations: [
 						{
@@ -223,8 +227,8 @@ describe('dev container', () => {
 	it('items in public/ are not available from root when using a base', async () => {
 		await runInContainer(
 			{
-				root,
-				userConfig: {
+				inlineConfig: {
+					root: fileURLToPath(root),
 					base: '/sub/',
 				},
 			},
@@ -256,7 +260,7 @@ describe('dev container', () => {
 	});
 
 	it('items in public/ are available from root when not using a base', async () => {
-		await runInContainer({ root }, async (container) => {
+		await runInContainer({ inlineConfig: { root: fileURLToPath(root) } }, async (container) => {
 			// Try the root path
 			let r = createRequestAndResponse({
 				method: 'GET',

--- a/packages/astro/test/units/dev/head-injection.test.js
+++ b/packages/astro/test/units/dev/head-injection.test.js
@@ -1,8 +1,7 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
-
-import { runInContainer } from '../../../dist/core/dev/index.js';
-import { createFs, createRequestAndResponse } from '../test-utils.js';
+import { fileURLToPath } from 'node:url';
+import { createFs, createRequestAndResponse, runInContainer } from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
@@ -65,8 +64,8 @@ describe('head injection', () => {
 		await runInContainer(
 			{
 				fs,
-				root,
-				userConfig: {
+				inlineConfig: {
+					root: fileURLToPath(root),
 					vite: { server: { middlewareMode: true } },
 				},
 			},
@@ -154,8 +153,8 @@ describe('head injection', () => {
 		await runInContainer(
 			{
 				fs,
-				root,
-				userConfig: {
+				inlineConfig: {
+					root: fileURLToPath(root),
 					vite: { server: { middlewareMode: true } },
 				},
 			},

--- a/packages/astro/test/units/dev/hydration.test.js
+++ b/packages/astro/test/units/dev/hydration.test.js
@@ -1,12 +1,15 @@
 import { expect } from 'chai';
-
-import { runInContainer } from '../../../dist/core/dev/index.js';
-import { createFs, createRequestAndResponse, silentLogging } from '../test-utils.js';
-import svelte from '../../../../integrations/svelte/dist/index.js';
+import { fileURLToPath } from 'node:url';
+import {
+	createFs,
+	createRequestAndResponse,
+	runInContainer,
+	silentLogging,
+} from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
-describe('dev container', () => {
+describe('hydration', () => {
 	it('should not crash when reassigning a hydrated component', async () => {
 		const fs = createFs(
 			{
@@ -31,11 +34,10 @@ describe('dev container', () => {
 		await runInContainer(
 			{
 				fs,
-				root,
-				logging: silentLogging,
-				userConfig: {
-					integrations: [svelte()],
+				inlineConfig: {
+					root: fileURLToPath(root),
 				},
+				logging: silentLogging,
 			},
 			async (container) => {
 				const { req, res, done } = createRequestAndResponse({

--- a/packages/astro/test/units/dev/restart.test.js
+++ b/packages/astro/test/units/dev/restart.test.js
@@ -7,8 +7,12 @@ import {
 	isStarted,
 	startContainer,
 } from '../../../dist/core/dev/index.js';
-import { createSettings, resolveConfig } from '../../../dist/core/config/index.js';
-import { createFs, createRequestAndResponse, triggerFSEvent } from '../test-utils.js';
+import {
+	createFs,
+	createRequestAndResponse,
+	defaultLogging,
+	triggerFSEvent,
+} from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
@@ -31,8 +35,10 @@ describe('dev container restarts', () => {
 			root
 		);
 
-		let restart = await createContainerWithAutomaticRestart({
-			params: { fs, root },
+		const restart = await createContainerWithAutomaticRestart({
+			fs,
+			inlineConfig: { root: fileURLToPath(root) },
+			logging: defaultLogging,
 		});
 
 		try {
@@ -94,8 +100,10 @@ describe('dev container restarts', () => {
 			root
 		);
 
-		let restart = await createContainerWithAutomaticRestart({
-			params: { fs, root },
+		const restart = await createContainerWithAutomaticRestart({
+			fs,
+			inlineConfig: { root: fileURLToPath(root) },
+			logging: defaultLogging,
 		});
 		await startContainer(restart.container);
 		expect(isStarted(restart.container)).to.equal(true);
@@ -122,11 +130,10 @@ describe('dev container restarts', () => {
 			troot
 		);
 
-		const { astroConfig } = await resolveConfig({ root: fileURLToPath(troot) }, 'dev');
-		const settings = createSettings(astroConfig, 'dev');
-
-		let restart = await createContainerWithAutomaticRestart({
-			params: { fs, root, settings },
+		const restart = await createContainerWithAutomaticRestart({
+			fs,
+			inlineConfig: { root: fileURLToPath(root) },
+			logging: defaultLogging,
 		});
 		await startContainer(restart.container);
 		expect(isStarted(restart.container)).to.equal(true);
@@ -151,11 +158,10 @@ describe('dev container restarts', () => {
 			root
 		);
 
-		const { astroConfig } = await resolveConfig({ root: fileURLToPath(root) }, 'dev');
-		const settings = createSettings(astroConfig, 'dev', fileURLToPath(root));
-
-		let restart = await createContainerWithAutomaticRestart({
-			params: { fs, root, settings },
+		const restart = await createContainerWithAutomaticRestart({
+			fs,
+			inlineConfig: { root: fileURLToPath(root) },
+			logging: defaultLogging,
 		});
 		await startContainer(restart.container);
 		expect(isStarted(restart.container)).to.equal(true);
@@ -178,11 +184,10 @@ describe('dev container restarts', () => {
 			root
 		);
 
-		const { astroConfig } = await resolveConfig({ root: fileURLToPath(root) }, 'dev');
-		const settings = createSettings(astroConfig, 'dev', fileURLToPath(root));
-
-		let restart = await createContainerWithAutomaticRestart({
-			params: { fs, root, settings },
+		const restart = await createContainerWithAutomaticRestart({
+			fs,
+			inlineConfig: { root: fileURLToPath(root) },
+			logging: defaultLogging,
 		});
 		await startContainer(restart.container);
 		expect(isStarted(restart.container)).to.equal(true);

--- a/packages/astro/test/units/render/components.test.js
+++ b/packages/astro/test/units/render/components.test.js
@@ -1,9 +1,13 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
-
-import { runInContainer } from '../../../dist/core/dev/index.js';
-import { createFs, createRequestAndResponse, silentLogging } from '../test-utils.js';
+import { fileURLToPath } from 'node:url';
 import svelte from '../../../../integrations/svelte/dist/index.js';
+import {
+	createFs,
+	createRequestAndResponse,
+	runInContainer,
+	silentLogging,
+} from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
@@ -31,9 +35,9 @@ describe('core/render components', () => {
 		await runInContainer(
 			{
 				fs,
-				root,
 				logging: silentLogging,
-				userConfig: {
+				inlineConfig: {
+					root: fileURLToPath(root),
 					integrations: [svelte()],
 				},
 			},

--- a/packages/astro/test/units/routing/manifest.test.js
+++ b/packages/astro/test/units/routing/manifest.test.js
@@ -1,10 +1,8 @@
 import { expect } from 'chai';
 
-import { createFs } from '../test-utils.js';
-import { createRouteManifest } from '../../../dist/core/routing/manifest/create.js';
-import { createDefaultDevSettings } from '../../../dist/core/config/index.js';
 import { fileURLToPath } from 'node:url';
-import { defaultLogging } from '../test-utils.js';
+import { createRouteManifest } from '../../../dist/core/routing/manifest/create.js';
+import { createBasicSettings, createFs, defaultLogging } from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
@@ -16,13 +14,11 @@ describe('routing - createRouteManifest', () => {
 			},
 			root
 		);
-		const settings = await createDefaultDevSettings(
-			{
-				base: '/search',
-				trailingSlash: 'never',
-			},
-			root
-		);
+		const settings = await createBasicSettings({
+			root: fileURLToPath(root),
+			base: '/search',
+			trailingSlash: 'never',
+		});
 		const manifest = createRouteManifest({
 			cwd: fileURLToPath(root),
 			settings,
@@ -41,17 +37,15 @@ describe('routing - createRouteManifest', () => {
 			},
 			root
 		);
-		const settings = await createDefaultDevSettings(
-			{
-				base: '/search',
-				trailingSlash: 'never',
-				redirects: {
-					'/blog/[...slug]': '/',
-					'/blog/contributing': '/another',
-				},
+		const settings = await createBasicSettings({
+			root: fileURLToPath(root),
+			base: '/search',
+			trailingSlash: 'never',
+			redirects: {
+				'/blog/[...slug]': '/',
+				'/blog/contributing': '/another',
 			},
-			root
-		);
+		});
 		const manifest = createRouteManifest({
 			cwd: fileURLToPath(root),
 			settings,
@@ -70,15 +64,13 @@ describe('routing - createRouteManifest', () => {
 			},
 			root
 		);
-		const settings = await createDefaultDevSettings(
-			{
-				trailingSlash: 'never',
-				redirects: {
-					'/foo': '/bar',
-				},
+		const settings = await createBasicSettings({
+			root: fileURLToPath(root),
+			trailingSlash: 'never',
+			redirects: {
+				'/foo': '/bar',
 			},
-			root
-		);
+		});
 		const manifest = createRouteManifest(
 			{
 				cwd: fileURLToPath(root),

--- a/packages/astro/test/units/routing/route-matching.test.js
+++ b/packages/astro/test/units/routing/route-matching.test.js
@@ -1,5 +1,9 @@
-// @ts-check
-import { createFs, createRequestAndResponse, defaultLogging } from '../test-utils.js';
+import {
+	createBasicSettings,
+	createFs,
+	createRequestAndResponse,
+	defaultLogging,
+} from '../test-utils.js';
 import { createRouteManifest, matchAllRoutes } from '../../../dist/core/routing/index.js';
 import { fileURLToPath } from 'node:url';
 import { createViteLoader } from '../../../dist/core/module-loader/vite.js';
@@ -127,16 +131,17 @@ describe('Route matching', () => {
 
 	before(async () => {
 		const fs = createFs(fileSystem, root);
+		settings = await createBasicSettings({
+			root: fileURLToPath(root),
+			trailingSlash: 'never',
+			output: 'hybrid',
+			adapter: testAdapter(),
+		});
 		container = await createContainer({
 			fs,
-			root,
-			userConfig: {
-				trailingSlash: 'never',
-				output: 'hybrid',
-				adapter: testAdapter(),
-			},
+			settings,
+			logging: defaultLogging,
 		});
-		settings = container.settings;
 
 		const loader = createViteLoader(container.viteServer);
 		const manifest = createDevelopmentManifest(container.settings);

--- a/packages/astro/test/units/shiki/shiki.test.js
+++ b/packages/astro/test/units/shiki/shiki.test.js
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
+import { fileURLToPath } from 'node:url';
 import { createContainer } from '../../../dist/core/dev/index.js';
 import { createViteLoader } from '../../../dist/core/module-loader/index.js';
+import { createBasicSettings, defaultLogging } from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
@@ -9,7 +11,8 @@ describe('<Code />', () => {
 		let container;
 		let mod;
 		before(async () => {
-			container = await createContainer({ root });
+			const settings = await createBasicSettings({ root: fileURLToPath(root) });
+			container = await createContainer({ settings, logging: defaultLogging });
 			const loader = createViteLoader(container.viteServer);
 			mod = await loader.import('astro/components/Shiki.js');
 		});

--- a/packages/astro/test/units/test-utils.js
+++ b/packages/astro/test/units/test-utils.js
@@ -8,6 +8,9 @@ import { getDefaultClientDirectives } from '../../dist/core/client-directive/ind
 import { nodeLogDestination } from '../../dist/core/logger/node.js';
 import { createEnvironment } from '../../dist/core/render/index.js';
 import { RouteCache } from '../../dist/core/render/route-cache.js';
+import { resolveConfig } from '../../dist/core/config/index.js';
+import { createBaseSettings } from '../../dist/core/config/settings.js';
+import { createContainer } from '../../dist/core/dev/container.js';
 import { unixify } from './correct-path.js';
 
 /** @type {import('../../src/core/logger/core').LogOptions} */
@@ -188,4 +191,43 @@ export function createBasicEnvironment(options = {}) {
 		ssr: options.ssr ?? true,
 		streaming: options.streaming ?? true,
 	});
+}
+
+/**
+ * @param {import('../../src/@types/astro.js').AstroInlineConfig} inlineConfig
+ * @returns {Promise<import('../../src/@types/astro.js').AstroSettings>}
+ */
+export async function createBasicSettings(inlineConfig = {}) {
+	if (!inlineConfig.root) {
+		inlineConfig.root = fileURLToPath(new URL('.', import.meta.url));
+	}
+	const { astroConfig } = await resolveConfig(inlineConfig, 'dev');
+	return createBaseSettings(astroConfig, 'dev');
+}
+
+/**
+ * @typedef {{
+ * 	fs?: typeof realFS,
+ * 	inlineConfig?: import('../../src/@types/astro.js').AstroInlineConfig,
+ *  logging?: import('../../src/core/logger/core').LogOptions,
+ * }} RunInContainerOptions
+ */
+
+/**
+ * @param {RunInContainerOptions} options
+ * @param {(container: import('../../src/core/dev/container.js').Container) => Promise<void> | void} callback
+ */
+export async function runInContainer(options = {}, callback) {
+	const settings = await createBasicSettings(options.inlineConfig ?? {});
+	const container = await createContainer({
+		fs: options?.fs ?? realFS,
+		settings,
+		inlineConfig: options.inlineConfig ?? {},
+		logging: defaultLogging,
+	});
+	try {
+		await callback(container);
+	} finally {
+		await container.close();
+	}
 }

--- a/packages/astro/test/units/vite-plugin-astro-server/request.test.js
+++ b/packages/astro/test/units/vite-plugin-astro-server/request.test.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 
-import { createDefaultDevSettings } from '../../../dist/core/config/index.js';
 import { createLoader } from '../../../dist/core/module-loader/index.js';
 import { createRouteManifest } from '../../../dist/core/routing/index.js';
 import { createComponent, render } from '../../../dist/runtime/server/index.js';
@@ -8,6 +7,7 @@ import { createController, handleRequest } from '../../../dist/vite-plugin-astro
 import {
 	createAstroModule,
 	createBasicEnvironment,
+	createBasicSettings,
 	createFs,
 	createRequestAndResponse,
 	defaultLogging,
@@ -15,7 +15,7 @@ import {
 
 async function createDevEnvironment(overrides = {}) {
 	const env = createBasicEnvironment();
-	env.settings = await createDefaultDevSettings({}, '/');
+	env.settings = await createBasicSettings({ root: '/' });
 	env.settings.renderers = [];
 	env.loader = createLoader();
 	Object.assign(env, overrides);


### PR DESCRIPTION
## Changes

**Note: this merges into the js-api branch**

Refactor the `dev` command CLI flow

1. Remove `openConfig` usage, switch to `resolveConfig` instead
2. Make a somewhat cleaner `dev()` JS API (now accepts `AstroInlineConfig`)
3. Update tests with new signature.

Next will be making the same changes as no2 for all other commands, which should be easier than `dev`.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass. I also tested the dev command locally, especially restarts when editing `astro.config.mjs`.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. internal change for now. will document more when we expose a JS API.