### PR TITLE
Make build/preview/sync API accept AstroInlineConfig

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1333,6 +1333,7 @@ export interface AstroConfig extends z.output<typeof AstroConfigSchema> {
 }
 export interface AstroInlineConfig extends AstroUserConfig {
 	configFile?: string | false;
+	mode?: RuntimeMode;
 }
 
 export type ContentEntryModule = {

--- a/packages/astro/src/cli/build/index.ts
+++ b/packages/astro/src/cli/build/index.ts
@@ -1,7 +1,8 @@
 import type yargs from 'yargs-parser';
 import _build from '../../core/build/index.js';
 import type { LogOptions } from '../../core/logger/core.js';
-import { loadSettings } from '../load-settings.js';
+import { printHelp } from '../../core/messages.js';
+import { flagsToAstroInlineConfig } from '../load-settings.js';
 
 interface BuildOptions {
 	flags: yargs.Arguments;
@@ -9,13 +10,25 @@ interface BuildOptions {
 }
 
 export async function build({ flags, logging }: BuildOptions) {
-	const settings = await loadSettings({ cmd: 'build', flags, logging });
-	if (!settings) return;
+	if (flags?.help || flags?.h) {
+		printHelp({
+			commandName: 'astro build',
+			usage: '[...flags]',
+			tables: {
+				Flags: [
+					['--drafts', `Include Markdown draft pages in the build.`],
+					['--help (-h)', 'See all available flags.'],
+				],
+			},
+			description: `Builds your site for deployment.`,
+		});
+		return;
+	}
 
-	await _build(settings, {
-		flags,
+	const inlineConfig = flagsToAstroInlineConfig(flags);
+
+	await _build(inlineConfig, {
 		logging,
 		teardownCompiler: true,
-		mode: flags.mode,
 	});
 }

--- a/packages/astro/src/cli/check/index.ts
+++ b/packages/astro/src/cli/check/index.ts
@@ -105,7 +105,7 @@ export async function check({ logging, flags }: CheckPayload): Promise<AstroChec
 		info(logging, 'check', 'Checking files');
 	}
 
-	const { syncCli } = await import('../../core/sync/index.js');
+	const { syncInternal } = await import('../../core/sync/index.js');
 	const root = settings.config.root;
 	const require = createRequire(import.meta.url);
 	const diagnosticChecker = new AstroCheck(
@@ -116,7 +116,7 @@ export async function check({ logging, flags }: CheckPayload): Promise<AstroChec
 	);
 
 	return new AstroChecker({
-		syncCli,
+		syncInternal,
 		settings,
 		fileSystem: fs,
 		logging,
@@ -130,7 +130,7 @@ type CheckerConstructor = {
 
 	isWatchMode: boolean;
 
-	syncCli: (settings: AstroSettings, options: SyncOptions) => Promise<ProcessExit>;
+	syncInternal: (settings: AstroSettings, options: SyncOptions) => Promise<ProcessExit>;
 
 	settings: Readonly<AstroSettings>;
 
@@ -148,7 +148,7 @@ type CheckerConstructor = {
 export class AstroChecker {
 	readonly #diagnosticsChecker: AstroCheck;
 	readonly #shouldWatch: boolean;
-	readonly #syncCli: (settings: AstroSettings, opts: SyncOptions) => Promise<ProcessExit>;
+	readonly #syncInternal: (settings: AstroSettings, opts: SyncOptions) => Promise<ProcessExit>;
 
 	readonly #settings: AstroSettings;
 
@@ -162,14 +162,14 @@ export class AstroChecker {
 	constructor({
 		diagnosticChecker,
 		isWatchMode,
-		syncCli,
+		syncInternal,
 		settings,
 		fileSystem,
 		logging,
 	}: CheckerConstructor) {
 		this.#diagnosticsChecker = diagnosticChecker;
 		this.#shouldWatch = isWatchMode;
-		this.#syncCli = syncCli;
+		this.#syncInternal = syncInternal;
 		this.#logging = logging;
 		this.#settings = settings;
 		this.#fs = fileSystem;
@@ -223,7 +223,7 @@ export class AstroChecker {
 	 * @param openDocuments Whether the operation should open all `.astro` files
 	 */
 	async #checkAllFiles(openDocuments: boolean): Promise<CheckResult> {
-		const processExit = await this.#syncCli(this.#settings, {
+		const processExit = await this.#syncInternal(this.#settings, {
 			logging: this.#logging,
 			fs: this.#fs,
 		});

--- a/packages/astro/src/cli/preview/index.ts
+++ b/packages/astro/src/cli/preview/index.ts
@@ -1,7 +1,9 @@
+import { cyan } from 'kleur/colors';
 import type yargs from 'yargs-parser';
 import type { LogOptions } from '../../core/logger/core.js';
+import { printHelp } from '../../core/messages.js';
 import previewServer from '../../core/preview/index.js';
-import { loadSettings } from '../load-settings.js';
+import { flagsToAstroInlineConfig } from '../load-settings.js';
 
 interface PreviewOptions {
 	flags: yargs.Arguments;
@@ -9,8 +11,24 @@ interface PreviewOptions {
 }
 
 export async function preview({ flags, logging }: PreviewOptions) {
-	const settings = await loadSettings({ cmd: 'preview', flags, logging });
-	if (!settings) return;
+	if (flags?.help || flags?.h) {
+		printHelp({
+			commandName: 'astro preview',
+			usage: '[...flags]',
+			tables: {
+				Flags: [
+					['--open', 'Automatically open the app in the browser on server start'],
+					['--help (-h)', 'See all available flags.'],
+				],
+			},
+			description: `Starts a local server to serve your static dist/ directory. Check ${cyan(
+				'https://docs.astro.build/en/reference/cli-reference/#astro-preview'
+			)} for more information.`,
+		});
+		return;
+	}
 
-	return await previewServer(settings, { flags, logging });
+	const inlineConfig = flagsToAstroInlineConfig(flags);
+
+	return await previewServer(inlineConfig, { logging });
 }

--- a/packages/astro/src/cli/sync/index.ts
+++ b/packages/astro/src/cli/sync/index.ts
@@ -1,8 +1,8 @@
-import fs from 'node:fs';
 import type yargs from 'yargs-parser';
 import type { LogOptions } from '../../core/logger/core.js';
-import { syncCli } from '../../core/sync/index.js';
-import { loadSettings } from '../load-settings.js';
+import { printHelp } from '../../core/messages.js';
+import { sync as _sync } from '../../core/sync/index.js';
+import { flagsToAstroInlineConfig } from '../load-settings.js';
 
 interface SyncOptions {
 	flags: yargs.Arguments;
@@ -10,9 +10,20 @@ interface SyncOptions {
 }
 
 export async function sync({ flags, logging }: SyncOptions) {
-	const settings = await loadSettings({ cmd: 'sync', flags, logging });
-	if (!settings) return;
+	if (flags?.help || flags?.h) {
+		printHelp({
+			commandName: 'astro sync',
+			usage: '[...flags]',
+			tables: {
+				Flags: [['--help (-h)', 'See all available flags.']],
+			},
+			description: `Generates TypeScript types for all Astro modules.`,
+		});
+		return 0;
+	}
 
-	const exitCode = await syncCli(settings, { logging, fs, flags });
+	const inlineConfig = flagsToAstroInlineConfig(flags);
+
+	const exitCode = await _sync(inlineConfig, { logging });
 	return exitCode;
 }

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -103,8 +103,8 @@ class AstroBuilder {
 		);
 		await runHookConfigDone({ settings: this.settings, logging });
 
-		const { sync } = await import('../sync/index.js');
-		const syncRet = await sync(this.settings, { logging, fs });
+		const { syncInternal } = await import('../sync/index.js');
+		const syncRet = await syncInternal(this.settings, { logging, fs });
 		if (syncRet !== 0) {
 			return process.exit(syncRet);
 		}

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -1,40 +1,28 @@
-import { cyan } from 'kleur/colors';
-import { createRequire } from 'module';
-import { pathToFileURL } from 'node:url';
-import type { Arguments } from 'yargs-parser';
-import type { AstroSettings, PreviewModule, PreviewServer } from '../../@types/astro';
+import { createRequire } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import type { AstroInlineConfig, PreviewModule, PreviewServer } from '../../@types/astro';
+import { telemetry } from '../../events/index.js';
+import { eventCliSession } from '../../events/session.js';
 import { runHookConfigDone, runHookConfigSetup } from '../../integrations/index.js';
+import { resolveConfig } from '../config/config.js';
+import { createSettings } from '../config/settings.js';
 import type { LogOptions } from '../logger/core';
-import { printHelp } from '../messages.js';
 import createStaticPreviewServer from './static-preview-server.js';
 import { getResolvedHostForHttpServer } from './util.js';
 
 interface PreviewOptions {
 	logging: LogOptions;
-	flags?: Arguments;
 }
 
 /** The primary dev action */
 export default async function preview(
-	_settings: AstroSettings,
-	{ logging, flags }: PreviewOptions
+	inlineConfig: AstroInlineConfig,
+	{ logging }: PreviewOptions
 ): Promise<PreviewServer | undefined> {
-	if (flags?.help || flags?.h) {
-		printHelp({
-			commandName: 'astro preview',
-			usage: '[...flags]',
-			tables: {
-				Flags: [
-					['--open', 'Automatically open the app in the browser on server start'],
-					['--help (-h)', 'See all available flags.'],
-				],
-			},
-			description: `Starts a local server to serve your static dist/ directory. Check ${cyan(
-				'https://docs.astro.build/en/reference/cli-reference/#astro-preview'
-			)} for more information.`,
-		});
-		return;
-	}
+	const { userConfig, astroConfig } = await resolveConfig(inlineConfig ?? {}, 'preview');
+	telemetry.record(eventCliSession('preview', userConfig));
+
+	const _settings = createSettings(astroConfig, 'dev', fileURLToPath(astroConfig.root));
 
 	const settings = await runHookConfigSetup({
 		settings: _settings,

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -35,13 +35,7 @@ export async function sync(
 	const { userConfig, astroConfig } = await resolveConfig(inlineConfig ?? {}, 'sync');
 	telemetry.record(eventCliSession('sync', userConfig));
 
-	const _settings = createSettings(astroConfig, 'dev', fileURLToPath(astroConfig.root));
-
-	const settings = await runHookConfigSetup({
-		settings: _settings,
-		logging: options.logging,
-		command: 'build',
-	});
+	const settings = createSettings(astroConfig, 'dev', fileURLToPath(astroConfig.root));
 
 	return await syncInternal(settings, options);
 }
@@ -61,9 +55,15 @@ export async function sync(
  * @return {Promise<ProcessExit>}
  */
 export async function syncInternal(
-	settings: AstroSettings,
+	_settings: AstroSettings,
 	{ logging, fs }: SyncOptions
 ): Promise<ProcessExit> {
+	const settings = await runHookConfigSetup({
+		settings: _settings,
+		logging: logging,
+		command: 'build',
+	});
+
 	const timerStart = performance.now();
 	// Needed to load content config
 	const tempViteServer = await createServer(

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -1,48 +1,49 @@
 import { dim } from 'kleur/colors';
-import type fsMod from 'node:fs';
+import fsMod from 'node:fs';
 import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
 import { createServer, type HMRPayload } from 'vite';
-import type { Arguments } from 'yargs-parser';
-import type { AstroSettings } from '../../@types/astro';
+import type { AstroInlineConfig, AstroSettings } from '../../@types/astro';
 import { createContentTypesGenerator } from '../../content/index.js';
 import { globalContentConfigObserver } from '../../content/utils.js';
+import { telemetry } from '../../events/index.js';
+import { eventCliSession } from '../../events/session.js';
 import { runHookConfigSetup } from '../../integrations/index.js';
 import { setUpEnvTs } from '../../vite-plugin-inject-env-ts/index.js';
 import { getTimeStat } from '../build/util.js';
+import { resolveConfig } from '../config/config.js';
+import { createSettings } from '../config/settings.js';
 import { createVite } from '../create-vite.js';
 import { AstroError, AstroErrorData, createSafeError, isAstroError } from '../errors/index.js';
 import { info, type LogOptions } from '../logger/core.js';
-import { printHelp } from '../messages.js';
 
 export type ProcessExit = 0 | 1;
 
 export type SyncOptions = {
 	logging: LogOptions;
-	fs: typeof fsMod;
+	/**
+	 * Only used for testing
+	 * @internal
+	 */
+	fs?: typeof fsMod;
 };
 
-export async function syncCli(
-	settings: AstroSettings,
-	{ logging, fs, flags }: { logging: LogOptions; fs: typeof fsMod; flags?: Arguments }
+export async function sync(
+	inlineConfig: AstroInlineConfig,
+	options: SyncOptions
 ): Promise<ProcessExit> {
-	if (flags?.help || flags?.h) {
-		printHelp({
-			commandName: 'astro sync',
-			usage: '[...flags]',
-			tables: {
-				Flags: [['--help (-h)', 'See all available flags.']],
-			},
-			description: `Generates TypeScript types for all Astro modules.`,
-		});
-		return 0;
-	}
+	const { userConfig, astroConfig } = await resolveConfig(inlineConfig ?? {}, 'sync');
+	telemetry.record(eventCliSession('sync', userConfig));
 
-	const resolvedSettings = await runHookConfigSetup({
-		settings,
-		logging,
+	const _settings = createSettings(astroConfig, 'dev', fileURLToPath(astroConfig.root));
+
+	const settings = await runHookConfigSetup({
+		settings: _settings,
+		logging: options.logging,
 		command: 'build',
 	});
-	return sync(resolvedSettings, { logging, fs });
+
+	return await syncInternal(settings, options);
 }
 
 /**
@@ -50,13 +51,16 @@ export async function syncCli(
  *
  * A non-zero process signal is emitted in case there's an error while generating content collection types.
  *
+ * This should only be used when the callee already has an `AstroSetting`, otherwise use `sync()` instead.
+ * @internal
+ *
  * @param {SyncOptions} options
  * @param {AstroSettings} settings Astro settings
  * @param {typeof fsMod} options.fs The file system
  * @param {LogOptions} options.logging Logging options
  * @return {Promise<ProcessExit>}
  */
-export async function sync(
+export async function syncInternal(
 	settings: AstroSettings,
 	{ logging, fs }: SyncOptions
 ): Promise<ProcessExit> {
@@ -88,7 +92,7 @@ export async function sync(
 		const contentTypesGenerator = await createContentTypesGenerator({
 			contentConfigObserver: globalContentConfigObserver,
 			logging,
-			fs,
+			fs: fs ?? fsMod,
 			settings,
 			viteServer: tempViteServer,
 		});
@@ -124,7 +128,7 @@ export async function sync(
 	}
 
 	info(logging, 'content', `Types generated ${dim(getTimeStat(timerStart, performance.now()))}`);
-	await setUpEnvTs({ settings, logging, fs });
+	await setUpEnvTs({ settings, logging, fs: fs ?? fsMod });
 
 	return 0;
 }

--- a/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
+++ b/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
@@ -1,7 +1,5 @@
 import { expect } from 'chai';
 import { fileURLToPath } from 'node:url';
-import { validateConfig } from '../../../dist/core/config/config.js';
-import { createSettings } from '../../../dist/core/config/index.js';
 import { sync as _sync } from '../../../dist/core/sync/index.js';
 import { createFsWithFallback, defaultLogging } from '../test-utils.js';
 
@@ -9,10 +7,7 @@ const root = new URL('../../fixtures/content-mixed-errors/', import.meta.url);
 const logging = defaultLogging;
 
 async function sync({ fs, config = {} }) {
-	const astroConfig = await validateConfig(config, fileURLToPath(root), 'prod');
-	const settings = createSettings(astroConfig, 'build', fileURLToPath(root));
-
-	return _sync(settings, { logging, fs });
+	return _sync({ ...config, root: fileURLToPath(root) }, { logging, fs });
 }
 
 describe('Content Collections - mixed content errors', () => {


### PR DESCRIPTION
## Changes

**Note: This PR merges into the js-api branch**

- Make `build`/`preview`/`sync` API accept AstroInlineConfig.
- Mostly moving code around without logic change.

The JS API is almost done! This finishes the APIs above besides `check` and `add` as those will be refactored in 3.0. Two more things to clean up in later PRs:

1. Initial config loading error handling can be improved.
2. `logging` can be tucked into `settings` so the user don't have to pass that in.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass. Also tested locally for the commands to all work.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. internal refactor.