### PR TITLE
[docs] Markdoc README problematic aside notation

### DIFF
--- a/packages/integrations/markdoc/README.md
+++ b/packages/integrations/markdoc/README.md
@@ -425,9 +425,7 @@ export default defineConfig({
 ```
 
 > **Warning**
-> When `allowHTML` is enabled, HTML markup inside Markdoc documents will be rendered as actual HTML elements (including `<script>`), making attack vectors like XSS possible.
->
-> Ensure that any HTML markup comes from trusted sources.
+> When `allowHTML` is enabled, HTML markup inside Markdoc documents will be rendered as actual HTML elements (including `<script>`), making attack vectors like XSS possible. Ensure that any HTML markup comes from trusted sources.
 
 ## Examples
 


### PR DESCRIPTION
## Changes

This takes yet another stab at making an aside using GitHub notation that imports properly into Docs.

## Testing

This tested my patience.

## Docs

Only docs!
