### PR TITLE
feat: remove support for old API routes syntax

### DIFF
--- a/.changeset/mighty-dancers-lay.md
+++ b/.changeset/mighty-dancers-lay.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+Removed support for old syntax of the API routes.

--- a/packages/astro/src/runtime/server/endpoint.ts
+++ b/packages/astro/src/runtime/server/endpoint.ts
@@ -45,7 +45,7 @@ export async function renderEndpoint(
 	ssr: boolean,
 	logging: LogOptions
 ) {
-	const { request, params } = context;
+	const { request } = context;
 
 	const chosenMethod = request.method?.toUpperCase();
 	const handler = getHandlerFromModule(mod, chosenMethod, logging);
@@ -68,35 +68,10 @@ ${chosenMethod} requests are not available when building a static site. Update y
 		return response;
 	}
 
-	// TODO: Remove support for old API in Astro 3.0
-	if (handler.length > 1) {
-		// eslint-disable-next-line no-console
-		console.warn(`
-API routes with 2 arguments have been deprecated. Instead they take a single argument in the form of:
-
-export function get({ params, request }) {
-	//...
-}
-
-Update your code to remove this warning.`);
-	}
-
 	const proxy = new Proxy(context, {
 		get(target, prop) {
 			if (prop in target) {
 				return Reflect.get(target, prop);
-			} else if (prop in params) {
-				// TODO: Remove support for old API in Astro 3.0
-				// eslint-disable-next-line no-console
-				console.warn(`
-API routes no longer pass params as the first argument. Instead an object containing a params property is provided in the form of:
-
-export function get({ params }) {
-	// ...
-}
-
-Update your code to remove this warning.`);
-				return Reflect.get(params, prop);
 			} else {
 				return undefined;
 			}


### PR DESCRIPTION
## Changes

As per the title, this PR removes the code that was handling the old API syntax - which I don't know because I don't have enough knowledge 😆 

## Testing

I run the tests locally, and it seems we don't have old syntax, so the current CI should pass.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
question for @withastro/maintainers-docs: do we have pages that still have the old syntax?

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
