### PR TITLE
fix: typo alpine -> alpinejs

### DIFF
--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -105,7 +105,7 @@ export async function add(names: string[], { flags, logging }: AddOptions) {
 					['svelte', 'astro add svelte'],
 					['solid-js', 'astro add solid-js'],
 					['lit', 'astro add lit'],
-					['alpine', 'astro add alpine'],
+					['alpinejs', 'astro add alpinejs'],
 				],
 				'SSR Adapters': [
 					['netlify', 'astro add netlify'],


### PR DESCRIPTION
## Changes

- Fixed typo from ` alpine ` -> `alpinejs `. Which is real pkg name

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
