### PR TITLE
fix(assets): Fix endpoint not being injected when an integration would enable `experimental.assets`

### DIFF
--- a/.changeset/neat-balloons-doubt.md
+++ b/.changeset/neat-balloons-doubt.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `astro:assets` endpoint not working in dev and SSR if `experimental.assets` was enabled by an integration (such as Starlight)

--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -1,6 +1,17 @@
+import type { AstroSettings } from '../@types/astro.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { isLocalService, type ImageService } from './services/service.js';
 import type { GetImageResult, ImageMetadata, ImageTransform } from './types.js';
+
+export function injectImageEndpoint(settings: AstroSettings) {
+	settings.injectedRoutes.push({
+		pattern: '/_image',
+		entryPoint: 'astro/assets/image-endpoint',
+		prerender: false,
+	});
+
+	return settings;
+}
 
 export function isESMImportedImage(src: ImageMetadata | string): src is ImageMetadata {
 	return typeof src === 'object';

--- a/packages/astro/src/cli/load-settings.ts
+++ b/packages/astro/src/cli/load-settings.ts
@@ -27,10 +27,9 @@ export async function loadSettings({ cmd, flags, logging }: LoadSettingsOptions)
 		return {} as any;
 	});
 
-	const mode = cmd === 'build' ? 'build' : 'dev';
 	if (!initialAstroConfig) return;
 	telemetry.record(event.eventCliSession(cmd, initialUserConfig, flags));
-	return createSettings(initialAstroConfig, mode, root);
+	return createSettings(initialAstroConfig, root);
 }
 
 export async function handleConfigError(

--- a/packages/astro/src/config/index.ts
+++ b/packages/astro/src/config/index.ts
@@ -35,7 +35,7 @@ export function getViteConfig(inlineConfig: UserConfig) {
 			level: 'info',
 		};
 		const { astroConfig: config } = await openConfig({ cmd });
-		const settings = createSettings(config, cmd, inlineConfig.root);
+		const settings = createSettings(config, inlineConfig.root);
 		await runHookConfigSetup({ settings, command: cmd, logging });
 		const viteConfig = await createVite(
 			{

--- a/packages/astro/src/core/config/settings.ts
+++ b/packages/astro/src/core/config/settings.ts
@@ -4,7 +4,6 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { AstroConfig, AstroSettings, AstroUserConfig } from '../../@types/astro';
 import { getContentPaths } from '../../content/index.js';
 import jsxRenderer from '../../jsx/renderer.js';
-import { isServerLikeOutput } from '../../prerender/utils.js';
 import { markdownContentEntryType } from '../../vite-plugin-markdown/content-entry-type.js';
 import { getDefaultClientDirectives } from '../client-directive/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
@@ -22,10 +21,7 @@ export function createBaseSettings(config: AstroConfig, mode: 'build' | 'dev'): 
 		tsConfigPath: undefined,
 
 		adapter: undefined,
-		injectedRoutes:
-			config.experimental.assets && (isServerLikeOutput(config) || mode === 'dev')
-				? [{ pattern: '/_image', entryPoint: 'astro/assets/image-endpoint', prerender: false }]
-				: [],
+		injectedRoutes: [],
 		pageExtensions: ['.astro', '.html', ...SUPPORTED_MARKDOWN_FILE_EXTENSIONS],
 		contentEntryTypes: [markdownContentEntryType],
 		dataEntryTypes: [

--- a/packages/astro/src/core/config/settings.ts
+++ b/packages/astro/src/core/config/settings.ts
@@ -13,7 +13,7 @@ import { createDefaultDevConfig } from './config.js';
 import { AstroTimer } from './timer.js';
 import { loadTSConfig } from './tsconfig.js';
 
-export function createBaseSettings(config: AstroConfig, mode: 'build' | 'dev'): AstroSettings {
+export function createBaseSettings(config: AstroConfig): AstroSettings {
 	const { contentDir } = getContentPaths(config);
 	return {
 		config,
@@ -104,13 +104,9 @@ export function createBaseSettings(config: AstroConfig, mode: 'build' | 'dev'): 
 	};
 }
 
-export function createSettings(
-	config: AstroConfig,
-	mode: 'build' | 'dev',
-	cwd?: string
-): AstroSettings {
+export function createSettings(config: AstroConfig, cwd?: string): AstroSettings {
 	const tsconfig = loadTSConfig(cwd);
-	const settings = createBaseSettings(config, mode);
+	const settings = createBaseSettings(config);
 
 	const watchFiles = tsconfig?.exists ? [tsconfig.path, ...tsconfig.extendedPaths] : [];
 
@@ -132,5 +128,5 @@ export async function createDefaultDevSettings(
 		root = fileURLToPath(root);
 	}
 	const config = await createDefaultDevConfig(userConfig, root);
-	return createBaseSettings(config, 'dev');
+	return createBaseSettings(config);
 }

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -4,6 +4,7 @@ import type { AstroSettings, AstroUserConfig } from '../../@types/astro';
 
 import nodeFs from 'node:fs';
 import * as vite from 'vite';
+import { injectImageEndpoint } from '../../assets/internal.js';
 import {
 	runHookConfigDone,
 	runHookConfigSetup,
@@ -64,6 +65,13 @@ export async function createContainer(params: CreateContainerParams = {}): Promi
 		logging,
 		isRestart,
 	});
+
+	// HACK: Since we only inject the endpoint if `experimental.assets` is on and it's possible for an integration to
+	// add that flag, we need to only check and inject the endpoint after running the config setup hook.
+	if (settings.config.experimental.assets) {
+		settings = injectImageEndpoint(settings);
+	}
+
 	const { host, headers, open } = settings.config.server;
 
 	// The client entrypoint for renderers. Since these are imported dynamically

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -92,7 +92,7 @@ export async function restartContainer({
 		});
 		info(logging, 'astro', logMsg + '\n');
 		let astroConfig = newConfig.astroConfig;
-		const settings = createSettings(astroConfig, 'dev', resolvedRoot);
+		const settings = createSettings(astroConfig, resolvedRoot);
 		await close();
 		return {
 			container: await createRestartedContainer(container, settings, needsStart),

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -138,8 +138,8 @@ export async function loadFixture(inlineConfig) {
 	 * the `AstroSettings`. This function helps to create a fresh settings object that is used by the
 	 * command functions below to prevent tests from polluting each other.
 	 */
-	const getSettings = async (mode) => {
-		let settings = createSettings(config, mode, fileURLToPath(cwd));
+	const getSettings = async () => {
+		let settings = createSettings(config, fileURLToPath(cwd));
 		if (config.integrations.find((integration) => integration.name === '@astrojs/mdx')) {
 			// Enable default JSX integration. It needs to come first, so unshift rather than push!
 			const { default: jsxRenderer } = await import('astro/jsx/renderer.js');

--- a/packages/astro/test/units/config/format.test.js
+++ b/packages/astro/test/units/config/format.test.js
@@ -27,7 +27,7 @@ describe('Astro config formats', () => {
 			logging: defaultLogging,
 			fsMod: fs,
 		});
-		const settings = createSettings(astroConfig, 'dev');
+		const settings = createSettings(astroConfig);
 
 		await runInContainer({ fs, root, settings }, () => {
 			expect(true).to.equal(

--- a/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
+++ b/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
@@ -10,7 +10,7 @@ const logging = defaultLogging;
 
 async function sync({ fs, config = {} }) {
 	const astroConfig = await validateConfig(config, fileURLToPath(root), 'prod');
-	const settings = createSettings(astroConfig, 'build', fileURLToPath(root));
+	const settings = createSettings(astroConfig, fileURLToPath(root));
 
 	return _sync(settings, { logging, fs });
 }

--- a/packages/astro/test/units/dev/restart.test.js
+++ b/packages/astro/test/units/dev/restart.test.js
@@ -133,7 +133,7 @@ describe('dev container restarts', () => {
 			cmd: 'dev',
 			logging: defaultLogging,
 		});
-		const settings = createSettings(astroConfig, 'dev');
+		const settings = createSettings(astroConfig);
 
 		let restart = await createContainerWithAutomaticRestart({
 			params: { fs, root, settings },
@@ -167,7 +167,7 @@ describe('dev container restarts', () => {
 			cmd: 'dev',
 			logging: defaultLogging,
 		});
-		const settings = createSettings(astroConfig, 'dev', fileURLToPath(root));
+		const settings = createSettings(astroConfig, fileURLToPath(root));
 
 		let restart = await createContainerWithAutomaticRestart({
 			params: { fs, root, settings },
@@ -199,7 +199,7 @@ describe('dev container restarts', () => {
 			cmd: 'dev',
 			logging: defaultLogging,
 		});
-		const settings = createSettings(astroConfig, 'dev', fileURLToPath(root));
+		const settings = createSettings(astroConfig, fileURLToPath(root));
 
 		let restart = await createContainerWithAutomaticRestart({
 			params: { fs, root, settings },


### PR DESCRIPTION
## Changes

What the title says. We'd only check for `experimental.assets` before running the integration's config setup hooks, so we'd miss it if an integration would enable it for the user (such as Starlight

## Testing

Tested manually, we'll be removing this in 3.0 anyway, so

## Docs

N/A
