### PR TITLE
Fix head propagation for MDX components

### DIFF
--- a/.changeset/friendly-bulldogs-flash.md
+++ b/.changeset/friendly-bulldogs-flash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix head propagation for MDX components

--- a/packages/astro/src/runtime/server/render/astro/instance.ts
+++ b/packages/astro/src/runtime/server/render/astro/instance.ts
@@ -37,6 +37,7 @@ export class AstroComponentInstance {
 	}
 
 	async init(result: SSRResult) {
+		if (this.returnValue !== undefined) return this.returnValue;
 		this.returnValue = this.factory(result, this.props, this.slotValues);
 		return this.returnValue;
 	}
@@ -72,7 +73,7 @@ function validateComponentProps(props: any, displayName: string) {
 	}
 }
 
-export async function createAstroComponentInstance(
+export function createAstroComponentInstance(
 	result: SSRResult,
 	displayName: string,
 	factory: AstroComponentFactory,
@@ -81,16 +82,9 @@ export async function createAstroComponentInstance(
 ) {
 	validateComponentProps(props, displayName);
 	const instance = new AstroComponentInstance(result, props, slots, factory);
-
 	if (isAPropagatingComponent(result, factory) && !result._metadata.propagators.has(factory)) {
 		result._metadata.propagators.set(factory, instance);
-		// Call component instances that might have head content to be propagated up.
-		const returnValue = await instance.init(result);
-		if (isHeadAndContent(returnValue)) {
-			result._metadata.extraHead.push(returnValue.head);
-		}
 	}
-
 	return instance;
 }
 

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -420,7 +420,7 @@ async function renderAstroComponent(
 	props: Record<string | number, any>,
 	slots: any = {}
 ): Promise<RenderInstance> {
-	const instance = await createAstroComponentInstance(result, displayName, Component, props, slots);
+	const instance = createAstroComponentInstance(result, displayName, Component, props, slots);
 
 	// Eagerly render the component so they are rendered in parallel
 	const chunks: RenderDestinationChunk[] = [];


### PR DESCRIPTION
## Changes

Revert this part https://github.com/withastro/astro/pull/7782#discussion_r1272460169

Fixes MDX fail (Presumably also [fixes markdoc](https://github.com/withastro/astro/blob/73eb4dfe2f1ed8bceeba6fb57d60c583f61d78b3/packages/integrations/markdoc/components/TreeNode.ts#L94-L102) but it doesn't seem to have tests cover head propagation)

I'm actually not sure how MDX components can get their head propagated, because it involves attaching themselves to `result._metadata.propagators` (which I didn't see any for MDX specifically). But reverting this part for now fix it.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Ran MDX and markdoc test locally. Others tests should also pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.