### PR TITLE
feat: adapter features, deprecate astro configs

### DIFF
--- a/.changeset/fair-emus-divide.md
+++ b/.changeset/fair-emus-divide.md
@@ -1,0 +1,39 @@
+---
+'astro': major
+'@astrojs/netlify': minor
+---
+
+The configuration `build.split` and `build.excludeMiddleware` are deprecated.
+
+Configuration that were inside the astro configuration, are now moved inside the adapter:
+
+```diff
+import {defineConfig} from "astro/config";
+import netlify from "@astrojs/netlify/functions";
+
+export default defineConfig({
+-    build: {
+-        excludeMiddleware: true
+-    },
+-    adapter: netlify()
++    adapter: netlify({
++        edgeMiddleware: true
++    })
+})
+```
+
+```diff
+import {defineConfig} from "astro/config";
+import vercel from "@astrojs/vercel/serverless";
+
+export default defineConfig({
+-    build: {
+-        split: true
+-    },
+-    adapter: netlify()
++    adapter: netlify({
++        functionPerRoute: true
++    })
+})
+```
+

--- a/.changeset/fair-emus-divide.md
+++ b/.changeset/fair-emus-divide.md
@@ -24,7 +24,7 @@ export default defineConfig({
 
 ```diff
 import {defineConfig} from "astro/config";
-import vercel from "@astrojs/vercel/serverless";
+import netlify from "@astrojs/netlify/functions";
 
 export default defineConfig({
 -    build: {

--- a/.changeset/tricky-candles-suffer.md
+++ b/.changeset/tricky-candles-suffer.md
@@ -1,0 +1,39 @@
+---
+'astro': major
+'@astrojs/vercel': minor
+---
+
+The configuration `build.split` and `build.excludeMiddleware` are deprecated.
+
+Configuration that were inside the astro configuration, are now moved inside the adapter:
+
+```diff
+import {defineConfig} from "astro/config";
+import vercel from "@astrojs/vercel/serverless";
+
+export default defineConfig({
+-    build: {
+-        excludeMiddleware: true
+-    },
+-    adapter: vercel()
++    adapter: vercel({
++        edgeMiddleware: true
++    })
+})
+```
+
+```diff
+import {defineConfig} from "astro/config";
+import vercel from "@astrojs/vercel/serverless";
+
+export default defineConfig({
+-    build: {
+-        split: true
+-    },
+-    adapter: vercel()
++    adapter: vercel({
++        functionPerRoute: true
++    })
+})
+```
+

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1400,6 +1400,17 @@ export interface DataEntryType {
 
 export type GetDataEntryInfoReturnType = { data: Record<string, unknown>; rawData?: string };
 
+export interface AstroAdapterFeatures {
+	/**
+	 * Creates and edge function that will communiate with the Astro middleware
+	 */
+	edgeMiddleware: boolean;
+	/**
+	 * SSR only. Each route becomes its own function/file.
+	 */
+	functionPerRoute: boolean;
+}
+
 export interface AstroSettings {
 	config: AstroConfig;
 	adapter: AstroAdapter | undefined;
@@ -1664,6 +1675,7 @@ export interface AstroAdapter {
 	previewEntrypoint?: string;
 	exports?: string[];
 	args?: any;
+	adapterFeatures?: AstroAdapterFeatures;
 }
 
 type Body = string;

--- a/packages/astro/src/core/build/plugins/plugin-pages.ts
+++ b/packages/astro/src/core/build/plugins/plugin-pages.ts
@@ -74,7 +74,11 @@ function vitePluginPages(opts: StaticBuildOptions, internals: BuildInternals): V
 						exports.push(`export { renderers };`);
 
 						// The middleware should not be imported by the pages
-						if (!opts.settings.config.build.excludeMiddleware) {
+						if (
+							// TODO: remover in Astro 4.0
+							!opts.settings.config.build.excludeMiddleware ||
+							opts.settings.adapter?.adapterFeatures?.edgeMiddleware === true
+						) {
 							const middlewareModule = await this.resolve(MIDDLEWARE_MODULE_ID);
 							if (middlewareModule) {
 								imports.push(`import { onRequest } from "${middlewareModule.id}";`);

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -124,7 +124,15 @@ export const AstroConfigSchema = z.object({
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.build.inlineStylesheets),
 
+			/**
+			 * @deprecated
+			 * Use the adapter feature instead
+			 */
 			split: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.build.split),
+			/**
+			 * @deprecated
+			 * Use the adapter feature instead
+			 */
 			excludeMiddleware: z
 				.boolean()
 				.optional()

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -4,6 +4,7 @@ import type { AddressInfo } from 'node:net';
 import { fileURLToPath } from 'node:url';
 import type { InlineConfig, ViteDevServer } from 'vite';
 import type {
+	AstroAdapter,
 	AstroConfig,
 	AstroIntegration,
 	AstroRenderer,
@@ -408,5 +409,21 @@ export async function runHookBuildDone({ config, pages, routes, logging }: RunHo
 				logging,
 			});
 		}
+	}
+}
+
+export function isFunctionPerRouteEnabled(adapter: AstroAdapter | undefined): boolean {
+	if (adapter?.adapterFeatures?.functionPerRoute === true) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+export function isEdgeMiddlewareEnabled(adapter: AstroAdapter | undefined): boolean {
+	if (adapter?.adapterFeatures?.edgeMiddleware === true) {
+		return true;
+	} else {
+		return false;
 	}
 }

--- a/packages/integrations/netlify/src/integration-functions.ts
+++ b/packages/integrations/netlify/src/integration-functions.ts
@@ -8,12 +8,16 @@ import { createRedirects } from './shared.js';
 export const NETLIFY_EDGE_MIDDLEWARE_FILE = 'netlify-edge-middleware';
 export const ASTRO_LOCALS_HEADER = 'x-astro-locals';
 
-export function getAdapter(args: Args = {}): AstroAdapter {
+export function getAdapter({ functionPerRoute, edgeMiddleware, ...args }: Args): AstroAdapter {
 	return {
 		name: '@astrojs/netlify/functions',
 		serverEntrypoint: '@astrojs/netlify/netlify-functions.js',
 		exports: ['handler'],
 		args,
+		adapterFeatures: {
+			functionPerRoute,
+			edgeMiddleware,
+		},
 	};
 }
 
@@ -21,12 +25,16 @@ interface NetlifyFunctionsOptions {
 	dist?: URL;
 	builders?: boolean;
 	binaryMediaTypes?: string[];
+	edgeMiddleware?: boolean;
+	functionPerRoute?: boolean;
 }
 
 function netlifyFunctions({
 	dist,
 	builders,
 	binaryMediaTypes,
+	functionPerRoute = false,
+	edgeMiddleware = false,
 }: NetlifyFunctionsOptions = {}): AstroIntegration {
 	let _config: AstroConfig;
 	let _entryPoints: Map<RouteData, URL>;
@@ -53,7 +61,7 @@ function netlifyFunctions({
 				_entryPoints = entryPoints;
 			},
 			'astro:config:done': ({ config, setAdapter }) => {
-				setAdapter(getAdapter({ binaryMediaTypes, builders }));
+				setAdapter(getAdapter({ binaryMediaTypes, builders, functionPerRoute, edgeMiddleware }));
 				_config = config;
 				ssrEntryFile = config.build.serverEntry.replace(/\.m?js/, '');
 

--- a/packages/integrations/netlify/src/netlify-functions.ts
+++ b/packages/integrations/netlify/src/netlify-functions.ts
@@ -9,6 +9,8 @@ applyPolyfills();
 export interface Args {
 	builders?: boolean;
 	binaryMediaTypes?: string[];
+	edgeMiddleware: boolean;
+	functionPerRoute: boolean;
 }
 
 function parseContentType(header?: string) {

--- a/packages/integrations/netlify/test/functions/edge-middleware.test.js
+++ b/packages/integrations/netlify/test/functions/edge-middleware.test.js
@@ -10,6 +10,7 @@ describe('Middleware', () => {
 			output: 'server',
 			adapter: netlifyAdapter({
 				dist: new URL('./fixtures/middleware-with-handler-file/dist/', import.meta.url),
+				edgeMiddleware: true,
 			}),
 			site: `http://example.com`,
 			integrations: [testIntegration()],

--- a/packages/integrations/netlify/test/functions/split-support.test.js
+++ b/packages/integrations/netlify/test/functions/split-support.test.js
@@ -13,6 +13,7 @@ describe('Split support', () => {
 			output: 'server',
 			adapter: netlifyAdapter({
 				dist: new URL('./fixtures/split-support/dist/', import.meta.url),
+				functionPerRoute: true,
 			}),
 			site: `http://example.com`,
 			integrations: [
@@ -22,9 +23,6 @@ describe('Split support', () => {
 					},
 				}),
 			],
-			build: {
-				split: true,
-			},
 		});
 		await fixture.build();
 	});

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -29,11 +29,21 @@ const SUPPORTED_NODE_VERSIONS: Record<
 	18: { status: 'current' },
 };
 
-function getAdapter(): AstroAdapter {
+function getAdapter({
+	edgeMiddleware,
+	functionPerRoute,
+}: {
+	edgeMiddleware: boolean;
+	functionPerRoute: boolean;
+}): AstroAdapter {
 	return {
 		name: PACKAGE_NAME,
 		serverEntrypoint: `${PACKAGE_NAME}/entrypoint`,
 		exports: ['default'],
+		adapterFeatures: {
+			edgeMiddleware,
+			functionPerRoute,
+		},
 	};
 }
 
@@ -43,6 +53,8 @@ export interface VercelServerlessConfig {
 	analytics?: boolean;
 	imageService?: boolean;
 	imagesConfig?: VercelImageConfig;
+	edgeMiddleware?: boolean;
+	functionPerRoute?: boolean;
 }
 
 export default function vercelServerless({
@@ -51,6 +63,8 @@ export default function vercelServerless({
 	analytics,
 	imageService,
 	imagesConfig,
+	functionPerRoute = false,
+	edgeMiddleware = false,
 }: VercelServerlessConfig = {}): AstroIntegration {
 	let _config: AstroConfig;
 	let buildTempFolder: URL;
@@ -112,7 +126,7 @@ export default function vercelServerless({
 			},
 			'astro:config:done': ({ setAdapter, config }) => {
 				throwIfAssetsNotEnabled(config, imageService);
-				setAdapter(getAdapter());
+				setAdapter(getAdapter({ functionPerRoute, edgeMiddleware }));
 				_config = config;
 				buildTempFolder = config.build.server;
 				serverEntry = config.build.serverEntry;

--- a/packages/integrations/vercel/test/fixtures/functionPerRoute/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/functionPerRoute/astro.config.mjs
@@ -4,5 +4,6 @@ import vercel from '@astrojs/vercel/serverless';
 export default defineConfig({
 	adapter: vercel({
 		functionPerRoute: true
-	})
+	}),
+	output: "server"
 });

--- a/packages/integrations/vercel/test/fixtures/functionPerRoute/package.json
+++ b/packages/integrations/vercel/test/fixtures/functionPerRoute/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/astro-vercel-function-per-route",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/vercel": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/vercel/test/fixtures/functionPerRoute/src/pages/one.astro
+++ b/packages/integrations/vercel/test/fixtures/functionPerRoute/src/pages/one.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>One</title>
+	</head>
+	<body>
+		<h1>One</h1>
+	</body>
+</html>

--- a/packages/integrations/vercel/test/fixtures/functionPerRoute/src/pages/two.astro
+++ b/packages/integrations/vercel/test/fixtures/functionPerRoute/src/pages/two.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>Two</title>
+	</head>
+	<body>
+		<h1>Two</h1>
+	</body>
+</html>

--- a/packages/integrations/vercel/test/fixtures/middleware-with-edge-file/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/middleware-with-edge-file/astro.config.mjs
@@ -2,9 +2,8 @@ import {defineConfig} from "astro/config";
 import vercel from "@astrojs/vercel/serverless";
 
 export default defineConfig({
-    adapter: vercel(),
-    build: {
-        excludeMiddleware: true
-    },
+    adapter: vercel({
+        edgeMiddleware: true
+    }),
     output: 'server'
 });

--- a/packages/integrations/vercel/test/fixtures/middleware-without-edge-file/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/middleware-without-edge-file/astro.config.mjs
@@ -2,9 +2,8 @@ import {defineConfig} from "astro/config";
 import vercel from "@astrojs/vercel/serverless";
 
 export default defineConfig({
-    adapter: vercel(),
-    build: {
-        excludeMiddleware: true
-    },
+    adapter: vercel({
+        edgeMiddleware: true
+    }),
     output: 'server'
 });

--- a/packages/integrations/vercel/test/split.test.js
+++ b/packages/integrations/vercel/test/split.test.js
@@ -7,11 +7,8 @@ describe('build: split', () => {
 
 	before(async () => {
 		fixture = await loadFixture({
-			root: './fixtures/basic/',
+			root: './fixtures/functionPerRoute/',
 			output: 'server',
-			build: {
-				split: true,
-			},
 		});
 		await fixture.build();
 	});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4961,6 +4961,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/vercel/test/fixtures/functionPerRoute:
+    dependencies:
+      '@astrojs/vercel':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/vercel/test/fixtures/image:
     dependencies:
       '@astrojs/vercel':


### PR DESCRIPTION
## Changes

This PR deprecates `build.split` and `build.excludeMiddleware`.

After an internal discussion, we realised that these two config values should not live inside Astro, because they are only usable only with an adapter that can understand it

Because of that, we introduced the concept of `adapterFeatures`. These features are toggles that signal Astro to change the output of the build, and then the adapter needs to do something with those. 

## Testing

I updated the current test to use the new configuration. The tests should pass.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
