### PR TITLE
Track added links/styles/scripts to prevent duplicates

### DIFF
--- a/.changeset/yellow-olives-sing.md
+++ b/.changeset/yellow-olives-sing.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes head propagation regression

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2033,6 +2033,8 @@ export interface SSRMetadata {
 	headInTree: boolean;
 	extraHead: string[];
 	propagators: Map<AstroComponentFactory, AstroComponentInstance>;
+	// Used to key track of unique content; links and script tags
+	contentKeys: Set<string>;
 }
 
 /* Preview server stuff */

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -6,7 +6,7 @@ import {
 	createComponent,
 	createHeadAndContent,
 	renderComponent,
-	renderScriptElement,
+	renderUniqueScriptElement,
 	renderTemplate,
 	renderUniqueStylesheet,
 	unescapeHTML,
@@ -303,7 +303,7 @@ async function render({
 						.join('');
 				}
 				if (Array.isArray(collectedScripts)) {
-					scripts = collectedScripts.map((script: any) => renderScriptElement(script)).join('');
+					scripts = collectedScripts.map((script: any) => renderUniqueScriptElement(result, script)).join('');
 				}
 
 				let props = baseProps;

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -258,6 +258,7 @@ export function createResult(args: CreateResultArgs): SSRResult {
 			headInTree: false,
 			extraHead: [],
 			propagators: new Map(),
+			contentKeys: new Set(),
 		},
 	};
 

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -28,6 +28,7 @@ export {
 	renderTemplate,
 	renderToString,
 	renderUniqueStylesheet,
+	renderUniqueScriptElement,
 	voidElementNames,
 } from './render/index.js';
 export type {

--- a/packages/astro/src/runtime/server/render/astro/render.ts
+++ b/packages/astro/src/runtime/server/render/astro/render.ts
@@ -161,7 +161,6 @@ async function bufferHeadContent(result: SSRResult) {
 		const returnValue = await value.init(result);
 		if (isHeadAndContent(returnValue)) {
 			result._metadata.extraHead.push(returnValue.head);
-			console.log("PUSHING", returnValue.head)
 		}
 	}
 }

--- a/packages/astro/src/runtime/server/render/astro/render.ts
+++ b/packages/astro/src/runtime/server/render/astro/render.ts
@@ -71,6 +71,10 @@ export async function renderToReadableStream(
 	// If the Astro component returns a Response on init, return that response
 	if (templateResult instanceof Response) return templateResult;
 
+	if (isPage) {
+		await bufferHeadContent(result);
+	}
+
 	let renderedFirstPageChunk = false;
 
 	return new ReadableStream({
@@ -143,4 +147,21 @@ async function callComponentAsTemplateResultOrResponse(
 	}
 
 	return isHeadAndContent(factoryResult) ? factoryResult.content : factoryResult;
+}
+
+// Recursively calls component instances that might have head content
+// to be propagated up.
+async function bufferHeadContent(result: SSRResult) {
+	const iterator = result._metadata.propagators.values();
+	while (true) {
+		const { value, done } = iterator.next();
+		if (done) {
+			break;
+		}
+		const returnValue = await value.init(result);
+		if (isHeadAndContent(returnValue)) {
+			result._metadata.extraHead.push(returnValue.head);
+			console.log("PUSHING", returnValue.head)
+		}
+	}
 }

--- a/packages/astro/src/runtime/server/render/index.ts
+++ b/packages/astro/src/runtime/server/render/index.ts
@@ -6,6 +6,6 @@ export { renderHTMLElement } from './dom.js';
 export { maybeRenderHead, renderHead } from './head.js';
 export { renderPage } from './page.js';
 export { renderSlot, renderSlotToString, type ComponentSlots } from './slot.js';
-export { renderScriptElement, renderUniqueStylesheet } from './tags.js';
+export { renderScriptElement, renderUniqueScriptElement, renderUniqueStylesheet } from './tags.js';
 export type { RenderInstruction } from './types';
 export { addAttribute, defineScriptVars, voidElementNames } from './util.js';

--- a/packages/astro/src/runtime/server/render/tags.ts
+++ b/packages/astro/src/runtime/server/render/tags.ts
@@ -9,14 +9,43 @@ export function renderScriptElement({ props, children }: SSRElement) {
 	});
 }
 
+export function renderUniqueScriptElement(result: SSRResult, { props, children }: SSRElement) {
+	if(Array.from(result.scripts).some(s => {
+		if(s.props.type === props.type && s.props.src === props.src) {
+			return true;
+		}
+		if(!props.src && s.children === children) return true;
+	})) return '';
+	const key = `script-${props.type}-${props.src}-${children}`;
+	if(checkOrAddContentKey(result, key)) return '';
+	return renderScriptElement({ props, children });
+
+}
+
 export function renderUniqueStylesheet(result: SSRResult, sheet: StylesheetAsset) {
 	if (sheet.type === 'external') {
-		if (Array.from(result.styles).some((s) => s.props.href === sheet.src)) return '';
-		return renderElement('link', { props: { rel: 'stylesheet', href: sheet.src }, children: '' });
+		if (Array.from(result.links).some((s) => s.props.href === sheet.src)) return '';
+		const key = 'script-external-' + sheet.src;
+		if(checkOrAddContentKey(result, key)) return '';
+		return renderElement('link', {
+			props: {
+				rel: 'stylesheet',
+				href: sheet.src
+			},
+			children: ''
+		});
 	}
 
 	if (sheet.type === 'inline') {
 		if (Array.from(result.styles).some((s) => s.children.includes(sheet.content))) return '';
+		const key = `script-inline-` + sheet.content;
+		if(checkOrAddContentKey(result, key)) return '';
 		return renderElement('style', { props: { type: 'text/css' }, children: sheet.content });
 	}
+}
+
+function checkOrAddContentKey(result: SSRResult, key: string): boolean {
+	if(result._metadata.contentKeys.has(key)) return true;
+	result._metadata.contentKeys.add(key);
+	return false;
 }

--- a/packages/astro/src/runtime/server/render/tags.ts
+++ b/packages/astro/src/runtime/server/render/tags.ts
@@ -24,8 +24,8 @@ export function renderUniqueScriptElement(result: SSRResult, { props, children }
 
 export function renderUniqueStylesheet(result: SSRResult, sheet: StylesheetAsset) {
 	if (sheet.type === 'external') {
-		if (Array.from(result.links).some((s) => s.props.href === sheet.src)) return '';
-		const key = 'script-external-' + sheet.src;
+		if (Array.from(result.styles).some((s) => s.props.href === sheet.src)) return '';
+		const key = 'link-external-' + sheet.src;
 		if(checkOrAddContentKey(result, key)) return '';
 		return renderElement('link', {
 			props: {
@@ -38,7 +38,7 @@ export function renderUniqueStylesheet(result: SSRResult, sheet: StylesheetAsset
 
 	if (sheet.type === 'inline') {
 		if (Array.from(result.styles).some((s) => s.children.includes(sheet.content))) return '';
-		const key = `script-inline-` + sheet.content;
+		const key = `link-inline-` + sheet.content;
 		if(checkOrAddContentKey(result, key)) return '';
 		return renderElement('style', { props: { type: 'text/css' }, children: sheet.content });
 	}


### PR DESCRIPTION
## Changes

- https://github.com/withastro/astro/commit/80e3d4d3d0f7719d8eae5435bba3805503057511#diff-3b2bb624348e4447bb08d85298dfd18bbd849514839f175cf0ccbc1de04c2a33 introduced a regression where head content was not propagated.
- It turns out not to be a small thing, but unique style/script rendering was working by mistake perhaps. 
- Uses string keys during rendering to tell if we've rendered a script/style/link or not. And only render when we have.

## Testing

- packages/integrations/mdx/test/css-head-mdx.test.js was failing but now should pass.

## Docs

N/A, bug fix