### PR TITLE
Tweak adapter config CHANGELOG

### DIFF
--- a/.changeset/fair-emus-divide.md
+++ b/.changeset/fair-emus-divide.md
@@ -8,7 +8,7 @@ The `build.split` and `build.excludeMiddleware` configuration options are deprec
 If your config includes the `build.excludeMiddleware` option, replace it with `edgeMiddleware` in your adapter options:
 
 ```diff
-import {defineConfig} from "astro/config";
+import { defineConfig } from "astro/config";
 import netlify from "@astrojs/netlify/functions";
 
 export default defineConfig({
@@ -24,7 +24,7 @@ export default defineConfig({
 If your config includes the `build.split` option, replace it with `functionPerRoute` in your adapter options:
 
 ```diff
-import {defineConfig} from "astro/config";
+import { defineConfig } from "astro/config";
 import netlify from "@astrojs/netlify/functions";
 
 export default defineConfig({

--- a/.changeset/fair-emus-divide.md
+++ b/.changeset/fair-emus-divide.md
@@ -3,37 +3,37 @@
 '@astrojs/netlify': minor
 ---
 
-The configuration `build.split` and `build.excludeMiddleware` are deprecated.
+The `build.split` and `build.excludeMiddleware` configuration options are deprecated and have been replaced by options in the adapter config.
 
-Configuration that were inside the astro configuration, are now moved inside the adapter:
+If your config includes the `build.excludeMiddleware` option, replace it with `edgeMiddleware` in your adapter options:
 
 ```diff
 import {defineConfig} from "astro/config";
 import netlify from "@astrojs/netlify/functions";
 
 export default defineConfig({
--    build: {
+     build: {
 -        excludeMiddleware: true
--    },
--    adapter: netlify()
-+    adapter: netlify({
+     },
+     adapter: netlify({
 +        edgeMiddleware: true
-+    })
-})
+     }),
+});
 ```
 
+If your config includes the `build.split` option, replace it with `functionPerRoute` in your adapter options:
+
 ```diff
 import {defineConfig} from "astro/config";
 import netlify from "@astrojs/netlify/functions";
 
 export default defineConfig({
--    build: {
+     build: {
 -        split: true
--    },
--    adapter: netlify()
-+    adapter: netlify({
+     },
+     adapter: netlify({
 +        functionPerRoute: true
-+    })
-})
+     }),
+});
 ```
 

--- a/.changeset/tricky-candles-suffer.md
+++ b/.changeset/tricky-candles-suffer.md
@@ -3,37 +3,37 @@
 '@astrojs/vercel': minor
 ---
 
-The configuration `build.split` and `build.excludeMiddleware` are deprecated.
+The `build.split` and `build.excludeMiddleware` configuration options are deprecated and have been replaced by options in the adapter config.
 
-Configuration that were inside the astro configuration, are now moved inside the adapter:
+If your config includes the `build.excludeMiddleware` option, replace it with `edgeMiddleware` in your adapter options:
 
 ```diff
-import {defineConfig} from "astro/config";
+import { defineConfig } from "astro/config";
 import vercel from "@astrojs/vercel/serverless";
 
 export default defineConfig({
--    build: {
+     build: {
 -        excludeMiddleware: true
--    },
--    adapter: vercel()
-+    adapter: vercel({
+     },
+     adapter: vercel({
 +        edgeMiddleware: true
-+    })
-})
+     }),
+});
 ```
 
+If your config includes the `build.split` option, replace it with `functionPerRoute` in your adapter options:
+
 ```diff
-import {defineConfig} from "astro/config";
+import { defineConfig } from "astro/config";
 import vercel from "@astrojs/vercel/serverless";
 
 export default defineConfig({
--    build: {
+     build: {
 -        split: true
--    },
--    adapter: vercel()
-+    adapter: vercel({
+     },
+     adapter: vercel({
 +        functionPerRoute: true
-+    })
-})
+     }),
+});
 ```
 


### PR DESCRIPTION
## Changes

Reworks the CHANGELOG for recent changes to the adapter/build config API. Now looks like this:

The `build.split` and `build.excludeMiddleware` configuration options are deprecated and have been replaced by options in the adapter config.

If your config includes the `build.excludeMiddleware` option, replace it with `edgeMiddleware` in your adapter options:

```diff
import {defineConfig} from "astro/config";
import netlify from "@astrojs/netlify/functions";

export default defineConfig({
     build: {
-        excludeMiddleware: true
     },
     adapter: netlify({
+        edgeMiddleware: true
     }),
});
```

If your config includes the `build.split` option, replace it with `functionPerRoute` in your adapter options:

```diff
import {defineConfig} from "astro/config";
import netlify from "@astrojs/netlify/functions";

export default defineConfig({
     build: {
-        split: true
     },
     adapter: netlify({
+        functionPerRoute: true
     }),
});
```


## Testing

n/a

## Docs

/cc @withastro/maintainers-docs for feedback!