### PR TITLE
Fix redirect in SSR (Node and dynamic)

### DIFF
--- a/.changeset/green-berries-flow.md
+++ b/.changeset/green-berries-flow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Properly serialize redirect config for SSR

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1962,9 +1962,10 @@ export type RedirectRouteData = RouteData & {
 	redirect: string;
 };
 
-export type SerializedRouteData = Omit<RouteData, 'generate' | 'pattern'> & {
+export type SerializedRouteData = Omit<RouteData, 'generate' | 'pattern' | 'redirectRoute'> & {
 	generate: undefined;
 	pattern: string;
+	redirectRoute: SerializedRouteData | undefined;
 	_meta: {
 		trailingSlash: AstroConfig['trailingSlash'];
 	};

--- a/packages/astro/src/core/routing/manifest/serialization.ts
+++ b/packages/astro/src/core/routing/manifest/serialization.ts
@@ -10,6 +10,7 @@ export function serializeRouteData(
 		...routeData,
 		generate: undefined,
 		pattern: routeData.pattern.source,
+		redirectRoute: routeData.redirectRoute ? serializeRouteData(routeData.redirectRoute, trailingSlash) : undefined,
 		_meta: { trailingSlash },
 	};
 }
@@ -25,5 +26,7 @@ export function deserializeRouteData(rawRouteData: SerializedRouteData): RouteDa
 		pathname: rawRouteData.pathname || undefined,
 		segments: rawRouteData.segments,
 		prerender: rawRouteData.prerender,
+		redirect: rawRouteData.redirect,
+    redirectRoute: rawRouteData.redirectRoute ? deserializeRouteData(rawRouteData.redirectRoute) : undefined,
 	};
 }

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -47,7 +47,7 @@ describe('Astro.redirect', () => {
 				const request = new Request('http://example.com/api/redirect');
 				const response = await app.render(request);
 				expect(response.status).to.equal(301);
-				expect(response.headers.get('Location')).to.equal('/');
+				expect(response.headers.get('Location')).to.equal('/test');
 			});
 
 			it('Uses 308 for non-GET methods', async () => {


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/7832

## Testing

- Test assertion was wrong. It was asserting that the redirect was to `/` which is the fallback if no redirect destination is provided. It should have asserted the location in the config, which is `/test`.

## Docs

N/A, bug fix