### PR TITLE
fix(astro): strongly type Astro.self

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -216,7 +216,7 @@ export interface AstroGlobal<Props extends Record<string, any> = Record<string, 
 	 *
 	 * [Astro reference](https://docs.astro.build/en/guides/api-reference/#astroself)
 	 */
-	self: AstroComponentFactory;
+	self: AstroComponentFactory<any, AstroSharedContext<Props>['props']>;
 	/** Utility functions for modifying an Astro component’s slotted children
 	 *
 	 * [Astro reference](https://docs.astro.build/en/reference/api-reference/#astroslots)

--- a/packages/astro/src/runtime/server/render/astro/factory.ts
+++ b/packages/astro/src/runtime/server/render/astro/factory.ts
@@ -5,8 +5,8 @@ import type { RenderTemplateResult } from './render-template';
 export type AstroFactoryReturnValue = RenderTemplateResult | Response | HeadAndContent;
 
 // The callback passed to to $$createComponent
-export interface AstroComponentFactory {
-	(result: any, props: any, slots: any): AstroFactoryReturnValue;
+export interface AstroComponentFactory<TResult = any, TProps = any, TSlots = any> {
+	(result: TResult, props: TProps, slots: TSlots): AstroFactoryReturnValue;
 	isAstroComponentFactory?: boolean;
 	moduleId?: string | undefined;
 	propagation?: PropagationHint;


### PR DESCRIPTION
## Changes

Basically trying to strongly type `Astro.self` so we can get completions in the language tools.

This is the safest non-breaking way I could think of doing it, since `AstroComponentFactory` should work as it did before if you don't specify any type parameters.

I'm not entirely sure how `AstroComponentFactory` ends up working in TSX (in the type system) since it doesn't look like the shape of a JSX element. so this may also be the completely wrong solution. either way, if someone could explain that gap in my knowledge, that'd be super helpful

## Testing

Couldn't find any existing tests for the types package. If there are some, i'm happy to add to them.

## Docs

N/A since the behaviour should remain the same
