### PR TITLE
Fix image format error

### DIFF
--- a/.changeset/happy-guests-repeat.md
+++ b/.changeset/happy-guests-repeat.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/image': patch
+---
+
+Improve error message for transforming unsupported formats

--- a/.changeset/spicy-numbers-shave.md
+++ b/.changeset/spicy-numbers-shave.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve error message for transforming unsupported formats

--- a/packages/astro/src/assets/services/squoosh.ts
+++ b/packages/astro/src/assets/services/squoosh.ts
@@ -95,12 +95,22 @@ const service: LocalImageService = {
 			}
 		}
 
-		const data = await processBuffer(inputBuffer, operations, format, quality);
+		try {
+			const data = await processBuffer(inputBuffer, operations, format, quality);
 
-		return {
-			data: Buffer.from(data),
-			format: format,
-		};
+			return {
+				data: Buffer.from(data),
+				format: format,
+			};
+		} catch (err) {
+			const message = err && typeof err === "object" && "message" in err ? err.message : err;
+			// Edge-case for unsupported formats, as Squoosh's error message is not very helpful
+			if (message === "Buffer has an unsupported format") {
+				throw new Error(`${transform.src} has an unsupported format to be transformed by @astrojs/image`);
+			}
+
+			throw err;
+		}
 	},
 };
 


### PR DESCRIPTION
## Changes

When trying to run `getImage` or `<Image>` (either from `astro:assets` or `@astrojs/image`), I get the following error:

```shell
 error   "Buffer has an unsupported format"
  Hint:
    To get as much information as possible from your errors, make sure to throw Error objects instead of `string`. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error for more information.
  File:
    C:\Users\crutchcorn\git\Unicorn\unicorn-utterances\node_modules\astro\dist\core\errors\utils.js:66:19
  Code:
    65 |   } else {
    > 66 |     const error = new Error(JSON.stringify(err));
         |                   ^
      67 |     error.hint = `To get as much information as possible from your errors, make sure to throw Error objects instead of \`${typeof err}\`. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error for more information.`;
      68 |     return error;
      69 |   }
  Stacktrace:
Error: "Buffer has an unsupported format"
    at createSafeError (file:///C:/Users/crutchcorn/git/Unicorn/unicorn-utterances/node_modules/astro/dist/core/errors/utils.js:66:19)
    at throwAndExit (file:///C:/Users/crutchcorn/git/Unicorn/unicorn-utterances/node_modules/astro/dist/cli/throw-and-exit.js:13:50)
    at cli (file:///C:/Users/crutchcorn/git/Unicorn/unicorn-utterances/node_modules/astro/dist/cli/index.js:158:11)
```

However, my transform of an SVG was part of a much larger changeset on a large-scale codebase. To debug this issue, I had to jump through many hoops to find the offending files/transforms.

This PR, per convos with @Princesseuh, fixes this error message to more highly indicate the source of the error.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

This code was tested against my application that had this error.

No tests were added as I didn't see a method for doing so for a failure state in `@astrojs/image` and no tests scaffolding was done in `astro` for this feature-set as far as I saw.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

AFAIK, we shouldn't need docs on this change, as this is an error state that's not intentionally supported.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
