### PR TITLE
Move `logging` option to `logLevel` inline config option

### DIFF
--- a/packages/astro/e2e/errors.test.js
+++ b/packages/astro/e2e/errors.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { getErrorOverlayContent, silentLogging, testFactory } from './test-utils.js';
+import { getErrorOverlayContent, testFactory } from './test-utils.js';
 
 const test = testFactory({
 	root: './fixtures/errors/',
@@ -12,10 +12,7 @@ const test = testFactory({
 let devServer;
 
 test.beforeAll(async ({ astro }) => {
-	devServer = await astro.startDevServer({
-		// Only test the error overlay, don't print to console
-		logging: silentLogging,
-	});
+	devServer = await astro.startDevServer();
 });
 
 test.afterAll(async ({ astro }) => {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -19,7 +19,7 @@ import type { PageBuildData } from '../core/build/types';
 import type { AstroConfigSchema } from '../core/config';
 import type { AstroTimer } from '../core/config/timer';
 import type { AstroCookies } from '../core/cookies';
-import type { LogOptions } from '../core/logger/core';
+import type { LogOptions, LoggerLevel } from '../core/logger/core';
 import type { AstroComponentFactory, AstroComponentInstance } from '../runtime/server';
 import type { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from './../core/constants.js';
 export type {
@@ -1331,9 +1331,15 @@ export interface AstroConfig extends z.output<typeof AstroConfigSchema> {
 	// TypeScript still confirms zod validation matches this type.
 	integrations: AstroIntegration[];
 }
-export interface AstroInlineConfig extends AstroUserConfig {
+export interface AstroInlineConfig extends AstroUserConfig, AstroInlineOnlyConfig {}
+export interface AstroInlineOnlyConfig {
 	configFile?: string | false;
 	mode?: RuntimeMode;
+	logLevel?: LoggerLevel;
+	/**
+	 * @internal for testing only
+	 */
+	logging?: LogOptions;
 }
 
 export type ContentEntryModule = {

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -26,9 +26,9 @@ import { eventCliSession, telemetry } from '../../events/index.js';
 import { generate, parse, t, visit } from './babel.js';
 import { ensureImport } from './imports.js';
 import { wrapDefaultExport } from './wrapper.js';
+import { createLoggingFromFlags } from '../flags.js';
 
 interface AddOptions {
-	logging: LogOptions;
 	flags: yargs.Arguments;
 }
 
@@ -86,7 +86,7 @@ async function getRegistry(): Promise<string> {
 	}
 }
 
-export async function add(names: string[], { flags, logging }: AddOptions) {
+export async function add(names: string[], { flags }: AddOptions) {
 	telemetry.record(eventCliSession('add'));
 	applyPolyfill();
 	if (flags.help || names.length === 0) {
@@ -130,6 +130,7 @@ export async function add(names: string[], { flags, logging }: AddOptions) {
 
 	// Some packages might have a common alias! We normalize those here.
 	const cwd = flags.root;
+	const logging = createLoggingFromFlags(flags);
 	const integrationNames = names.map((name) => (ALIASES.has(name) ? ALIASES.get(name)! : name));
 	const integrations = await validateIntegrations(integrationNames);
 	let installResult = await tryToInstallIntegrations({ integrations, cwd, flags, logging });

--- a/packages/astro/src/cli/build/index.ts
+++ b/packages/astro/src/cli/build/index.ts
@@ -1,6 +1,5 @@
 import type yargs from 'yargs-parser';
 import _build from '../../core/build/index.js';
-import type { LogOptions } from '../../core/logger/core.js';
 import { printHelp } from '../../core/messages.js';
 import { flagsToAstroInlineConfig } from '../flags.js';
 

--- a/packages/astro/src/cli/build/index.ts
+++ b/packages/astro/src/cli/build/index.ts
@@ -6,10 +6,9 @@ import { flagsToAstroInlineConfig } from '../flags.js';
 
 interface BuildOptions {
 	flags: yargs.Arguments;
-	logging: LogOptions;
 }
 
-export async function build({ flags, logging }: BuildOptions) {
+export async function build({ flags }: BuildOptions) {
 	if (flags?.help || flags?.h) {
 		printHelp({
 			commandName: 'astro build',
@@ -28,7 +27,6 @@ export async function build({ flags, logging }: BuildOptions) {
 	const inlineConfig = flagsToAstroInlineConfig(flags);
 
 	await _build(inlineConfig, {
-		logging,
 		teardownCompiler: true,
 	});
 }

--- a/packages/astro/src/cli/dev/index.ts
+++ b/packages/astro/src/cli/dev/index.ts
@@ -1,16 +1,14 @@
 import { cyan } from 'kleur/colors';
 import type yargs from 'yargs-parser';
 import devServer from '../../core/dev/index.js';
-import type { LogOptions } from '../../core/logger/core.js';
 import { printHelp } from '../../core/messages.js';
 import { flagsToAstroInlineConfig } from '../flags.js';
 
 interface DevOptions {
 	flags: yargs.Arguments;
-	logging: LogOptions;
 }
 
-export async function dev({ flags, logging }: DevOptions) {
+export async function dev({ flags }: DevOptions) {
 	if (flags.help || flags.h) {
 		printHelp({
 			commandName: 'astro dev',
@@ -33,5 +31,5 @@ export async function dev({ flags, logging }: DevOptions) {
 
 	const inlineConfig = flagsToAstroInlineConfig(flags);
 
-	return await devServer(inlineConfig, { logging });
+	return await devServer(inlineConfig);
 }

--- a/packages/astro/src/cli/flags.ts
+++ b/packages/astro/src/cli/flags.ts
@@ -1,9 +1,16 @@
 import type { Arguments as Flags } from 'yargs-parser';
 import type { AstroInlineConfig } from '../@types/astro.js';
+import type { LogOptions } from '../core/logger/core.js';
+import { nodeLogDestination } from '../core/logger/node.js';
 
 export function flagsToAstroInlineConfig(flags: Flags): AstroInlineConfig {
 	return {
+		// Inline-only configs
 		configFile: typeof flags.config === 'string' ? flags.config : undefined,
+		mode: typeof flags.mode === 'string' ? (flags.mode as AstroInlineConfig['mode']) : undefined,
+		logLevel: flags.verbose ? 'debug' : flags.silent ? 'silent' : undefined,
+
+		// Astro user configs
 		root: typeof flags.root === 'string' ? flags.root : undefined,
 		site: typeof flags.site === 'string' ? flags.site : undefined,
 		base: typeof flags.base === 'string' ? flags.base : undefined,
@@ -20,4 +27,23 @@ export function flagsToAstroInlineConfig(flags: Flags): AstroInlineConfig {
 			assets: typeof flags.experimentalAssets === 'boolean' ? flags.experimentalAssets : undefined,
 		},
 	};
+}
+
+/**
+ * The `logging` is usually created from an `AstroInlineConfig`, but some flows like `add`
+ * doesn't read the AstroConfig directly, so we create a `logging` object from the CLI flags instead.
+ */
+export function createLoggingFromFlags(flags: Flags): LogOptions {
+	const logging: LogOptions = {
+		dest: nodeLogDestination,
+		level: 'info',
+	};
+
+	if (flags.verbose) {
+		logging.level = 'debug';
+	} else if (flags.silent) {
+		logging.level = 'silent';
+	}
+
+	return logging;
 }

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -2,7 +2,6 @@
 import * as colors from 'kleur/colors';
 import yargs from 'yargs-parser';
 import { ASTRO_VERSION } from '../core/constants.js';
-import type { LogOptions } from '../core/logger/core.js';
 
 type CLICommand =
 	| 'help'
@@ -112,16 +111,10 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 		}
 	}
 
-	const { enableVerboseLogging, nodeLogDestination } = await import('../core/logger/node.js');
-	const logging: LogOptions = {
-		dest: nodeLogDestination,
-		level: 'info',
-	};
+	// In verbose/debug mode, we log the debug logs asap before any potential errors could appear
 	if (flags.verbose) {
-		logging.level = 'debug';
+		const { enableVerboseLogging } = await import('../core/logger/node.js');
 		enableVerboseLogging();
-	} else if (flags.silent) {
-		logging.level = 'silent';
 	}
 
 	// Start with a default NODE_ENV so Vite doesn't set an incorrect default when loading the Astro config
@@ -135,12 +128,12 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 		case 'add': {
 			const { add } = await import('./add/index.js');
 			const packages = flags._.slice(3) as string[];
-			await add(packages, { flags, logging });
+			await add(packages, { flags });
 			return;
 		}
 		case 'dev': {
 			const { dev } = await import('./dev/index.js');
-			const server = await dev({ flags, logging });
+			const server = await dev({ flags });
 			if (server) {
 				return await new Promise(() => {}); // lives forever
 			}
@@ -148,12 +141,12 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 		}
 		case 'build': {
 			const { build } = await import('./build/index.js');
-			await build({ flags, logging });
+			await build({ flags });
 			return;
 		}
 		case 'preview': {
 			const { preview } = await import('./preview/index.js');
-			const server = await preview({ flags, logging });
+			const server = await preview({ flags });
 			if (server) {
 				return await server.closed(); // keep alive until the server is closed
 			}
@@ -162,7 +155,7 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 		case 'check': {
 			const { check } = await import('./check/index.js');
 			// We create a server to start doing our operations
-			const checkServer = await check({ flags, logging });
+			const checkServer = await check({ flags });
 			if (checkServer) {
 				if (checkServer.isWatchMode) {
 					await checkServer.watch();
@@ -176,7 +169,7 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 		}
 		case 'sync': {
 			const { sync } = await import('./sync/index.js');
-			const exitCode = await sync({ flags, logging });
+			const exitCode = await sync({ flags });
 			return process.exit(exitCode);
 		}
 	}

--- a/packages/astro/src/cli/preview/index.ts
+++ b/packages/astro/src/cli/preview/index.ts
@@ -1,16 +1,14 @@
 import { cyan } from 'kleur/colors';
 import type yargs from 'yargs-parser';
-import type { LogOptions } from '../../core/logger/core.js';
 import { printHelp } from '../../core/messages.js';
 import previewServer from '../../core/preview/index.js';
 import { flagsToAstroInlineConfig } from '../flags.js';
 
 interface PreviewOptions {
 	flags: yargs.Arguments;
-	logging: LogOptions;
 }
 
-export async function preview({ flags, logging }: PreviewOptions) {
+export async function preview({ flags }: PreviewOptions) {
 	if (flags?.help || flags?.h) {
 		printHelp({
 			commandName: 'astro preview',
@@ -30,5 +28,5 @@ export async function preview({ flags, logging }: PreviewOptions) {
 
 	const inlineConfig = flagsToAstroInlineConfig(flags);
 
-	return await previewServer(inlineConfig, { logging });
+	return await previewServer(inlineConfig);
 }

--- a/packages/astro/src/cli/sync/index.ts
+++ b/packages/astro/src/cli/sync/index.ts
@@ -1,15 +1,13 @@
 import type yargs from 'yargs-parser';
-import type { LogOptions } from '../../core/logger/core.js';
 import { printHelp } from '../../core/messages.js';
 import { sync as _sync } from '../../core/sync/index.js';
 import { flagsToAstroInlineConfig } from '../flags.js';
 
 interface SyncOptions {
 	flags: yargs.Arguments;
-	logging: LogOptions;
 }
 
-export async function sync({ flags, logging }: SyncOptions) {
+export async function sync({ flags }: SyncOptions) {
 	if (flags?.help || flags?.h) {
 		printHelp({
 			commandName: 'astro sync',
@@ -24,6 +22,6 @@ export async function sync({ flags, logging }: SyncOptions) {
 
 	const inlineConfig = flagsToAstroInlineConfig(flags);
 
-	const exitCode = await _sync(inlineConfig, { logging });
+	const exitCode = await _sync(inlineConfig);
 	return exitCode;
 }

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -1,5 +1,11 @@
 import type { Arguments as Flags } from 'yargs-parser';
-import type { AstroConfig, AstroInlineConfig, AstroUserConfig, CLIFlags } from '../../@types/astro';
+import type {
+	AstroConfig,
+	AstroInlineConfig,
+	AstroInlineOnlyConfig,
+	AstroUserConfig,
+	CLIFlags,
+} from '../../@types/astro';
 
 import * as colors from 'kleur/colors';
 import fs from 'node:fs';
@@ -205,6 +211,21 @@ async function loadConfig(
 	}
 }
 
+function splitInlineConfig(inlineConfig: AstroInlineConfig): {
+	inlineUserConfig: AstroUserConfig;
+	inlineOnlyConfig: AstroInlineOnlyConfig;
+} {
+	const { configFile, mode, logLevel, ...inlineUserConfig } = inlineConfig;
+	return {
+		inlineUserConfig,
+		inlineOnlyConfig: {
+			configFile,
+			mode,
+			logLevel,
+		},
+	};
+}
+
 interface ResolveConfigResult {
 	userConfig: AstroUserConfig;
 	astroConfig: AstroConfig;
@@ -216,9 +237,10 @@ export async function resolveConfig(
 	fsMod = fs
 ): Promise<ResolveConfigResult> {
 	const root = resolveRoot(inlineConfig.root);
+	const { inlineUserConfig, inlineOnlyConfig } = splitInlineConfig(inlineConfig);
 
-	const userConfig = await loadConfig(root, inlineConfig.configFile, fsMod);
-	const mergedConfig = mergeConfig(userConfig, inlineConfig);
+	const userConfig = await loadConfig(root, inlineOnlyConfig.configFile, fsMod);
+	const mergedConfig = mergeConfig(userConfig, inlineUserConfig);
 	const astroConfig = await validateConfig(mergedConfig, root, command);
 
 	return { userConfig, astroConfig };

--- a/packages/astro/src/core/config/index.ts
+++ b/packages/astro/src/core/config/index.ts
@@ -1,4 +1,5 @@
 export { resolveConfig, resolveConfigPath, resolveFlags, resolveRoot } from './config.js';
+export { createNodeLogging } from './logging.js';
 export { mergeConfig } from './merge.js';
 export type { AstroConfigSchema } from './schema';
 export { createSettings } from './settings.js';

--- a/packages/astro/src/core/config/logging.ts
+++ b/packages/astro/src/core/config/logging.ts
@@ -1,0 +1,13 @@
+import type { AstroInlineConfig } from '../../@types/astro.js';
+import type { LogOptions } from '../logger/core.js';
+import { nodeLogDestination } from '../logger/node.js';
+
+export function createNodeLogging(inlineConfig: AstroInlineConfig): LogOptions {
+	// For internal testing, the inline config can pass the raw `logging` object directly
+	if (inlineConfig.logging) return inlineConfig.logging;
+
+	return {
+		dest: nodeLogDestination,
+		level: inlineConfig.logLevel ?? 'info',
+	};
+}

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -7,7 +7,7 @@ import { createNodeLogging, createSettings, resolveConfig } from '../config/inde
 import { collectErrorMetadata } from '../errors/dev/utils.js';
 import { isAstroConfigZodError } from '../errors/errors.js';
 import { createSafeError } from '../errors/index.js';
-import { error as logError, info, type LogOptions } from '../logger/core.js';
+import { error as logError, info } from '../logger/core.js';
 import { formatErrorMessage } from '../messages.js';
 import type { Container } from './container';
 import { createContainer, isStarted, startContainer } from './container.js';

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 import * as vite from 'vite';
 import type { AstroInlineConfig, AstroSettings } from '../../@types/astro';
 import { eventCliSession, telemetry } from '../../events/index.js';
-import { createSettings, resolveConfig } from '../config/index.js';
+import { createNodeLogging, createSettings, resolveConfig } from '../config/index.js';
 import { collectErrorMetadata } from '../errors/dev/utils.js';
 import { isAstroConfigZodError } from '../errors/errors.js';
 import { createSafeError } from '../errors/index.js';
@@ -102,7 +102,6 @@ export async function restartContainer(
 
 export interface CreateContainerWithAutomaticRestart {
 	inlineConfig?: AstroInlineConfig;
-	logging: LogOptions;
 	fs: typeof nodeFs;
 }
 
@@ -113,9 +112,9 @@ interface Restart {
 
 export async function createContainerWithAutomaticRestart({
 	inlineConfig,
-	logging,
 	fs,
 }: CreateContainerWithAutomaticRestart): Promise<Restart> {
+	const logging = createNodeLogging(inlineConfig ?? {});
 	const { userConfig, astroConfig } = await resolveConfig(inlineConfig ?? {}, 'dev', fs);
 	telemetry.record(eventCliSession('dev', userConfig));
 

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -6,19 +6,15 @@ import { eventCliSession } from '../../events/session.js';
 import { runHookConfigDone, runHookConfigSetup } from '../../integrations/index.js';
 import { resolveConfig } from '../config/config.js';
 import { createSettings } from '../config/settings.js';
-import type { LogOptions } from '../logger/core';
 import createStaticPreviewServer from './static-preview-server.js';
 import { getResolvedHostForHttpServer } from './util.js';
-
-interface PreviewOptions {
-	logging: LogOptions;
-}
+import { createNodeLogging } from '../config/logging.js';
 
 /** The primary dev action */
 export default async function preview(
-	inlineConfig: AstroInlineConfig,
-	{ logging }: PreviewOptions
+	inlineConfig: AstroInlineConfig
 ): Promise<PreviewServer | undefined> {
+	const logging = createNodeLogging(inlineConfig);
 	const { userConfig, astroConfig } = await resolveConfig(inlineConfig ?? {}, 'preview');
 	telemetry.record(eventCliSession('preview', userConfig));
 

--- a/packages/astro/test/astro-sync.test.js
+++ b/packages/astro/test/astro-sync.test.js
@@ -19,7 +19,7 @@ describe('astro sync', () => {
 				},
 			},
 		};
-		await fixture.sync({ fs: fsMock });
+		await fixture.sync({}, { fs: fsMock });
 
 		const expectedTypesFile = new URL('.astro/types.d.ts', fixture.config.root).href;
 		expect(writtenFiles).to.haveOwnProperty(expectedTypesFile);
@@ -55,7 +55,7 @@ describe('astro sync', () => {
 				},
 			},
 		};
-		await fixture.sync({ fs: fsMock });
+		await fixture.sync({}, { fs: fsMock });
 
 		expect(writtenFiles, 'Did not try to update env.d.ts file.').to.haveOwnProperty(typesEnvPath);
 		expect(writtenFiles[typesEnvPath]).to.include(`/// <reference path="../.astro/types.d.ts" />`);
@@ -79,7 +79,7 @@ describe('astro sync', () => {
 				},
 			},
 		};
-		await fixture.sync({ fs: fsMock });
+		await fixture.sync({}, { fs: fsMock });
 
 		expect(writtenFiles, 'Did not try to write env.d.ts file.').to.haveOwnProperty(typesEnvPath);
 		expect(writtenFiles[typesEnvPath]).to.include(`/// <reference types="astro/client" />`);

--- a/packages/astro/test/client-address.test.js
+++ b/packages/astro/test/client-address.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { loadFixture, silentLogging } from './test-utils.js';
+import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
 import * as cheerio from 'cheerio';
 
@@ -108,8 +108,7 @@ describe('Astro.clientAddress', () => {
 			let devServer;
 
 			before(async () => {
-				// We expect an error, so silence the output
-				devServer = await fixture.startDevServer({ logging: silentLogging });
+				devServer = await fixture.startDevServer();
 			});
 
 			after(async () => {

--- a/packages/astro/test/dev-routing.test.js
+++ b/packages/astro/test/dev-routing.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { loadFixture, silentLogging } from './test-utils.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Development Routing', () => {
 	describe('No site config', () => {
@@ -10,9 +10,7 @@ describe('Development Routing', () => {
 
 		before(async () => {
 			fixture = await loadFixture({ root: './fixtures/without-site-config/' });
-			devServer = await fixture.startDevServer({
-				logging: silentLogging,
-			});
+			devServer = await fixture.startDevServer();
 		});
 
 		after(async () => {

--- a/packages/astro/test/dynamic-endpoint-collision.test.js
+++ b/packages/astro/test/dynamic-endpoint-collision.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { load as cheerioLoad } from 'cheerio';
-import { loadFixture, silentLogging } from './test-utils.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Dynamic endpoint collision', () => {
 	describe('build', () => {
@@ -31,9 +31,7 @@ describe('Dynamic endpoint collision', () => {
 				root: './fixtures/dynamic-endpoint-collision/',
 			});
 
-			devServer = await fixture.startDevServer({
-				logging: silentLogging,
-			});
+			devServer = await fixture.startDevServer();
 		});
 
 		after(async () => {

--- a/packages/astro/test/error-bad-js.test.js
+++ b/packages/astro/test/error-bad-js.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { loadFixture, silentLogging } from './test-utils.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Errors in JavaScript', () => {
 	/** @type {import('./test-utils').Fixture} */
@@ -15,9 +15,7 @@ describe('Errors in JavaScript', () => {
 				logLevel: 'silent',
 			},
 		});
-		devServer = await fixture.startDevServer({
-			logging: silentLogging,
-		});
+		devServer = await fixture.startDevServer();
 	});
 
 	after(async () => {

--- a/packages/astro/test/error-non-error.test.js
+++ b/packages/astro/test/error-non-error.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { loadFixture, silentLogging } from './test-utils.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Can handle errors that are not instanceof Error', () => {
 	/** @type {import('./test-utils').Fixture} */
@@ -12,9 +12,7 @@ describe('Can handle errors that are not instanceof Error', () => {
 		fixture = await loadFixture({
 			root: './fixtures/error-non-error',
 		});
-		devServer = await fixture.startDevServer({
-			logging: silentLogging,
-		});
+		devServer = await fixture.startDevServer();
 	});
 
 	after(async () => {

--- a/packages/astro/test/react-component.test.js
+++ b/packages/astro/test/react-component.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { load as cheerioLoad } from 'cheerio';
-import { isWindows, loadFixture, silentLogging } from './test-utils.js';
+import { isWindows, loadFixture } from './test-utils.js';
 
 let fixture;
 
@@ -108,9 +108,7 @@ describe('React Components', () => {
 		let devServer;
 
 		before(async () => {
-			devServer = await fixture.startDevServer({
-				logging: silentLogging,
-			});
+			devServer = await fixture.startDevServer();
 		});
 
 		after(async () => {

--- a/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
+++ b/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
@@ -1,13 +1,12 @@
 import { expect } from 'chai';
 import { fileURLToPath } from 'node:url';
 import { sync as _sync } from '../../../dist/core/sync/index.js';
-import { createFsWithFallback, defaultLogging } from '../test-utils.js';
+import { createFsWithFallback } from '../test-utils.js';
 
 const root = new URL('../../fixtures/content-mixed-errors/', import.meta.url);
-const logging = defaultLogging;
 
 async function sync({ fs, config = {} }) {
-	return _sync({ ...config, root: fileURLToPath(root) }, { logging, fs });
+	return _sync({ ...config, root: fileURLToPath(root), logLevel: 'silent' }, { fs });
 }
 
 describe('Content Collections - mixed content errors', () => {

--- a/packages/astro/test/units/dev/hydration.test.js
+++ b/packages/astro/test/units/dev/hydration.test.js
@@ -1,11 +1,6 @@
 import { expect } from 'chai';
 import { fileURLToPath } from 'node:url';
-import {
-	createFs,
-	createRequestAndResponse,
-	runInContainer,
-	silentLogging,
-} from '../test-utils.js';
+import { createFs, createRequestAndResponse, runInContainer } from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
@@ -36,8 +31,8 @@ describe('hydration', () => {
 				fs,
 				inlineConfig: {
 					root: fileURLToPath(root),
+					logLevel: 'silent',
 				},
-				logging: silentLogging,
 			},
 			async (container) => {
 				const { req, res, done } = createRequestAndResponse({

--- a/packages/astro/test/units/dev/restart.test.js
+++ b/packages/astro/test/units/dev/restart.test.js
@@ -7,12 +7,7 @@ import {
 	isStarted,
 	startContainer,
 } from '../../../dist/core/dev/index.js';
-import {
-	createFs,
-	createRequestAndResponse,
-	defaultLogging,
-	triggerFSEvent,
-} from '../test-utils.js';
+import { createFs, createRequestAndResponse, triggerFSEvent } from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
@@ -37,8 +32,7 @@ describe('dev container restarts', () => {
 
 		const restart = await createContainerWithAutomaticRestart({
 			fs,
-			inlineConfig: { root: fileURLToPath(root) },
-			logging: defaultLogging,
+			inlineConfig: { root: fileURLToPath(root), logLevel: 'silent' },
 		});
 
 		try {
@@ -102,8 +96,7 @@ describe('dev container restarts', () => {
 
 		const restart = await createContainerWithAutomaticRestart({
 			fs,
-			inlineConfig: { root: fileURLToPath(root) },
-			logging: defaultLogging,
+			inlineConfig: { root: fileURLToPath(root), logLevel: 'silent' },
 		});
 		await startContainer(restart.container);
 		expect(isStarted(restart.container)).to.equal(true);
@@ -132,8 +125,7 @@ describe('dev container restarts', () => {
 
 		const restart = await createContainerWithAutomaticRestart({
 			fs,
-			inlineConfig: { root: fileURLToPath(root) },
-			logging: defaultLogging,
+			inlineConfig: { root: fileURLToPath(root), logLevel: 'silent' },
 		});
 		await startContainer(restart.container);
 		expect(isStarted(restart.container)).to.equal(true);
@@ -160,8 +152,7 @@ describe('dev container restarts', () => {
 
 		const restart = await createContainerWithAutomaticRestart({
 			fs,
-			inlineConfig: { root: fileURLToPath(root) },
-			logging: defaultLogging,
+			inlineConfig: { root: fileURLToPath(root), logLevel: 'silent' },
 		});
 		await startContainer(restart.container);
 		expect(isStarted(restart.container)).to.equal(true);
@@ -186,8 +177,7 @@ describe('dev container restarts', () => {
 
 		const restart = await createContainerWithAutomaticRestart({
 			fs,
-			inlineConfig: { root: fileURLToPath(root) },
-			logging: defaultLogging,
+			inlineConfig: { root: fileURLToPath(root), logLevel: 'silent' },
 		});
 		await startContainer(restart.container);
 		expect(isStarted(restart.container)).to.equal(true);

--- a/packages/astro/test/units/render/components.test.js
+++ b/packages/astro/test/units/render/components.test.js
@@ -2,12 +2,7 @@ import { expect } from 'chai';
 import * as cheerio from 'cheerio';
 import { fileURLToPath } from 'node:url';
 import svelte from '../../../../integrations/svelte/dist/index.js';
-import {
-	createFs,
-	createRequestAndResponse,
-	runInContainer,
-	silentLogging,
-} from '../test-utils.js';
+import { createFs, createRequestAndResponse, runInContainer } from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 
@@ -35,9 +30,9 @@ describe('core/render components', () => {
 		await runInContainer(
 			{
 				fs,
-				logging: silentLogging,
 				inlineConfig: {
 					root: fileURLToPath(root),
+					logLevel: 'silent',
 					integrations: [svelte()],
 				},
 			},


### PR DESCRIPTION
## Changes

**NOTE: this merges into the js-api branch**

- Changes `dev({ root: '...' }, { logging: { ... } })` to `dev({ root: '...', logLevel: '...' })`
- Similar changes for `build`, `preview`, and `sync`
- However, you can still do `dev({ logging: { ... } })`. I added `logging` as an internal option because some tests passes a custom `logging` to collect logs.

NOTE: After this is merged, I think we can merge `js-api` into `main`, then decide if we want to expose the JS API as a feature since the changes so far are mostly refactors.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass. Also tested the commands manually.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. Internal change as JS API is not exposed yet.