### PR TITLE
Preserve base slash when trailingSlash ignore

### DIFF
--- a/.changeset/six-grapes-look.md
+++ b/.changeset/six-grapes-look.md
@@ -1,0 +1,15 @@
+---
+'astro': major
+---
+
+The value of `import.meta.env.BASE_URL`, which is derived from the `base` option, will no longer have a trailing slash added by default or when `trailingSlash: "ignore"` is set. The existing behavior of `base` in combination with `trailingSlash: "always"` or `trailingSlash: "never"` is unchanged.
+
+If your `base` already has a trailing slash, no change is needed.
+
+If your `base` does not have a trailing slash, add one to preserve the previous behaviour:
+
+```diff
+// astro.config.mjs
+- base: 'my-base',
++ base: 'my-base/',
+```

--- a/packages/astro/e2e/astro-envs.test.js
+++ b/packages/astro/e2e/astro-envs.test.js
@@ -18,11 +18,11 @@ test.describe('Astro Environment BASE_URL', () => {
 		await page.goto(astro.resolveUrl('/blog/'));
 
 		const astroBaseUrl = page.locator('id=astro-base-url');
-		await expect(astroBaseUrl, 'astroBaseUrl equals to /blog/').toHaveText('/blog/');
+		await expect(astroBaseUrl, 'astroBaseUrl equals to /blog').toHaveText('/blog');
 
 		const clientComponentBaseUrl = page.locator('id=client-component-base-url');
 		await expect(clientComponentBaseUrl, 'clientComponentBaseUrl equals to /blog').toHaveText(
-			'/blog/'
+			'/blog'
 		);
 	});
 });

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -572,12 +572,7 @@ export interface AstroUserConfig {
 	 *
 	 * When using this option, all of your static asset imports and URLs should add the base as a prefix. You can access this value via `import.meta.env.BASE_URL`.
 	 *
-	 * By default, the value of `import.meta.env.BASE_URL` includes a trailing slash. If you have the [`trailingSlash`](https://docs.astro.build/en/reference/configuration-reference/#trailingslash) option set to `'never'`, you will need to add it manually in your static asset imports and URLs.
-	 *
-	 * ```astro
-	 * <a href="/docs/about/">About</a>
-	 * <img src=`${import.meta.env.BASE_URL}image.png`>
-	 * ```
+	 * The value of `import.meta.env.BASE_URL` respects your `trailingSlash` config and will include a trailing slash if you explicitly include one or if `trailingSlash: "always"` is set. If `trailingSlash: "never"` is set, `BASE_URL` will not include a trailing slash, even if `base` includes one.
 	 */
 	base?: string;
 

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -28,6 +28,7 @@ import {
 } from '../../core/build/internal.js';
 import {
 	isRelativePath,
+	joinPaths,
 	prependForwardSlash,
 	removeLeadingForwardSlash,
 	removeTrailingForwardSlash,
@@ -437,11 +438,11 @@ function getUrlForPath(
 		buildPathname = base;
 	} else if (routeType === 'endpoint') {
 		const buildPathRelative = removeLeadingForwardSlash(pathname);
-		buildPathname = base + buildPathRelative;
+		buildPathname = joinPaths(base, buildPathRelative);
 	} else {
 		const buildPathRelative =
 			removeTrailingForwardSlash(removeLeadingForwardSlash(pathname)) + ending;
-		buildPathname = base + buildPathRelative;
+		buildPathname = joinPaths(base, buildPathRelative);
 	}
 	const url = new URL(buildPathname, origin);
 	return url;

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -8,7 +8,7 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { BUNDLED_THEMES } from 'shiki';
 import { z } from 'zod';
-import { appendForwardSlash, prependForwardSlash, trimSlashes } from '../path.js';
+import { appendForwardSlash, prependForwardSlash, removeTrailingForwardSlash } from '../path.js';
 
 const ASTRO_CONFIG_DEFAULTS = {
 	root: '.',
@@ -366,22 +366,14 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 		) {
 			config.build.client = new URL('./dist/client/', config.outDir);
 		}
-		const trimmedBase = trimSlashes(config.base);
 
-		// If there is no base but there is a base for site config, warn.
-		const sitePathname = config.site && new URL(config.site).pathname;
-		if (!trimmedBase.length && sitePathname && sitePathname !== '/') {
-			config.base = sitePathname;
-			/* eslint-disable no-console */
-			console.warn(`The site configuration value includes a pathname of ${sitePathname} but there is no base configuration.
-
-A future version of Astro will stop using the site pathname when producing <link> and <script> tags. Set your site's base with the base configuration.`);
-		}
-
-		if (trimmedBase.length && config.trailingSlash === 'never') {
-			config.base = prependForwardSlash(trimmedBase);
+		// Handle `base` trailing slash based on `trailingSlash` config
+		if (config.trailingSlash === 'never') {
+			config.base = prependForwardSlash(removeTrailingForwardSlash(config.base));
+		} else if (config.trailingSlash === 'always') {
+			config.base = prependForwardSlash(appendForwardSlash(config.base));
 		} else {
-			config.base = prependForwardSlash(appendForwardSlash(trimmedBase));
+			config.base = prependForwardSlash(config.base);
 		}
 
 		return config;

--- a/packages/astro/test/astro-envs.test.js
+++ b/packages/astro/test/astro-envs.test.js
@@ -109,7 +109,7 @@ describe('Environment Variables', () => {
 			expect(res.status).to.equal(200);
 			let indexHtml = await res.text();
 			let $ = cheerio.load(indexHtml);
-			expect($('#base-url').text()).to.equal('/blog/');
+			expect($('#base-url').text()).to.equal('/blog');
 		});
 
 		it('does render destructured builtin SITE env', async () => {
@@ -117,7 +117,7 @@ describe('Environment Variables', () => {
 			expect(res.status).to.equal(200);
 			let indexHtml = await res.text();
 			let $ = cheerio.load(indexHtml);
-			expect($('#base-url').text()).to.equal('/blog/');
+			expect($('#base-url').text()).to.equal('/blog');
 		});
 	});
 });

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -54,10 +54,10 @@ describe('Astro Global', () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('#pathname').text()).to.equal('/blog/');
+			expect($('#pathname').text()).to.equal('/blog');
 			expect($('#searchparams').text()).to.equal('{}');
-			expect($('#child-pathname').text()).to.equal('/blog/');
-			expect($('#nested-child-pathname').text()).to.equal('/blog/');
+			expect($('#child-pathname').text()).to.equal('/blog');
+			expect($('#nested-child-pathname').text()).to.equal('/blog');
 		});
 
 		it('Astro.site', async () => {

--- a/packages/astro/test/dev-routing.test.js
+++ b/packages/astro/test/dev-routing.test.js
@@ -113,9 +113,9 @@ describe('Development Routing', () => {
 			expect(response.status).to.equal(200);
 		});
 
-		it('404 when loading subpath root without trailing slash', async () => {
+		it('200 when loading subpath root without trailing slash', async () => {
 			const response = await fixture.fetch('/blog');
-			expect(response.status).to.equal(404);
+			expect(response.status).to.equal(200);
 		});
 
 		it('200 when loading another page with subpath used', async () => {
@@ -163,9 +163,9 @@ describe('Development Routing', () => {
 			expect(response.status).to.equal(200);
 		});
 
-		it('404 when loading subpath root without trailing slash', async () => {
+		it('200 when loading subpath root without trailing slash', async () => {
 			const response = await fixture.fetch('/blog');
-			expect(response.status).to.equal(404);
+			expect(response.status).to.equal(200);
 		});
 
 		it('200 when loading another page with subpath used', async () => {

--- a/packages/astro/test/preview-routing.test.js
+++ b/packages/astro/test/preview-routing.test.js
@@ -157,9 +157,9 @@ describe('Preview Routing', () => {
 				expect(response.status).to.equal(200);
 			});
 
-			it('404 when loading subpath root without trailing slash', async () => {
+			it('200 when loading subpath root without trailing slash', async () => {
 				const response = await fixture.fetch('/blog');
-				expect(response.status).to.equal(404);
+				expect(response.status).to.equal(200);
 			});
 
 			it('200 when loading another page with subpath used', async () => {
@@ -345,9 +345,9 @@ describe('Preview Routing', () => {
 				expect(response.status).to.equal(200);
 			});
 
-			it('404 when loading subpath root without trailing slash', async () => {
+			it('200 when loading subpath root without trailing slash', async () => {
 				const response = await fixture.fetch('/blog');
-				expect(response.status).to.equal(404);
+				expect(response.status).to.equal(200);
 			});
 
 			it('200 when loading another page with subpath used', async () => {

--- a/packages/astro/test/public-base-404.test.js
+++ b/packages/astro/test/public-base-404.test.js
@@ -44,7 +44,7 @@ describe('Public dev with base', () => {
 		expect(response.status).to.equal(404);
 		const html = await response.text();
 		$ = cheerio.load(html);
-		expect($('a').first().text()).to.equal('/blog/');
+		expect($('a').first().text()).to.equal('/blog');
 	});
 
 	it('default 404 page when loading /none/', async () => {


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/6623

When `trailingSlash` is set to `ignore`, the `import.meta.env.BASE_URL` will have a string that's the same as `config.base` as-is. Unlike `always` where it always adds a trailing slash, and unlike `never` where it'll never have a trailing slash.

Since the issue was created, looks like docs now [document the old, different behaviour](https://docs.astro.build/en/reference/configuration-reference/#base):

> By default, the value of import.meta.env.BASE_URL includes a trailing slash. If you have the [trailingSlash](https://docs.astro.build/en/reference/configuration-reference/#trailingslash) option set to 'never', you will need to add it manually in your static asset imports and URLs.

where `ignore` would work like `always` (Always have a trailing slash). Perhaps we should discuss if this change makes sense?

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Updated some tests to fix the old behaviour, the rest should still pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
Added changelog, and updated docs in `astro.ts`
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
