### PR TITLE
Make Astro.cookies.get(key) return undefined

### DIFF
--- a/.changeset/twenty-cheetahs-deny.md
+++ b/.changeset/twenty-cheetahs-deny.md
@@ -1,0 +1,17 @@
+---
+'astro': major
+---
+
+Astro.cookies.get(key) returns undefined if cookie doesn't exist
+
+With this change, Astro.cookies.get(key) no longer always returns a `AstroCookie` object. Instead it now returns `undefined` if the cookie does not exist.
+
+You should update your code if you assume that all calls to `get()` return a value. When using with `has()` you still need to assert the value, like so:
+
+```astro
+---
+if(Astro.cookies.has(id)) {
+  const id = Astro.cookies.get(id)!;
+}
+---
+```

--- a/packages/astro/test/units/cookies/delete.test.js
+++ b/packages/astro/test/units/cookies/delete.test.js
@@ -30,7 +30,7 @@ describe('astro/src/core/cookies', () => {
 			expect(cookies.get('foo').value).to.equal('bar');
 
 			cookies.delete('foo');
-			expect(cookies.get('foo').value).to.equal(undefined);
+			expect(cookies.get('foo')).to.equal(undefined);
 		});
 
 		it('calling cookies.has() after returns false', () => {

--- a/packages/astro/test/units/cookies/get.test.js
+++ b/packages/astro/test/units/cookies/get.test.js
@@ -16,6 +16,13 @@ describe('astro/src/core/cookies', () => {
 			expect(cookies.get('foo').value).to.equal('bar');
 		});
 
+		it('Returns undefined is the value doesn\'t exist', () => {
+			const req = new Request('http://example.com/');
+			let cookies = new AstroCookies(req);
+			let cookie = cookies.get('foo');
+			expect(cookie).to.equal(undefined);
+		});
+
 		describe('.json()', () => {
 			it('returns a JavaScript object', () => {
 				const req = new Request('http://example.com/', {
@@ -28,13 +35,6 @@ describe('astro/src/core/cookies', () => {
 				const json = cookies.get('foo').json();
 				expect(json).to.be.an('object');
 				expect(json.key).to.equal('value');
-			});
-
-			it('throws if the value is undefined', () => {
-				const req = new Request('http://example.com/');
-				let cookies = new AstroCookies(req);
-				let cookie = cookies.get('foo');
-				expect(() => cookie.json()).to.throw('Cannot convert undefined to an object.');
 			});
 		});
 


### PR DESCRIPTION
## Changes

- Astro.cookies.get(key) now returns `undefined` if the cookie isn't present.
- This is a breaking change, as previously you needed to use `has()` to check for existence.

## Testing

- Test updated

## Docs

- TBD