### PR TITLE
Fix streaming Astro components

### DIFF
--- a/.changeset/new-ants-speak.md
+++ b/.changeset/new-ants-speak.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix streaming Astro components

--- a/packages/astro/test/streaming.test.js
+++ b/packages/astro/test/streaming.test.js
@@ -48,7 +48,7 @@ describe('Streaming', () => {
 				let chunk = decoder.decode(bytes);
 				chunks.push(chunk);
 			}
-			expect(chunks.length).to.equal(2);
+			expect(chunks.length).to.equal(3);
 		});
 	});
 


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/7886

Instead of awaiting the entire Astro component before rendering, which blocks streaming, don't await it. Instead keep the chunks in a buffer and await on `render()` instead.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Edited a test that I edited before in #7782 thinking it was a mistake. It wasn't!

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.