### PR TITLE
fix: update examples to use the new API of cookies 

### DIFF
--- a/examples/ssr/src/pages/cart.astro
+++ b/examples/ssr/src/pages/cart.astro
@@ -3,7 +3,7 @@ import Header from '../components/Header.astro';
 import Container from '../components/Container.astro';
 import { getCart } from '../api';
 
-if (!Astro.cookies.get('user-id').value) {
+if (!Astro.cookies.get('user-id')) {
 	return Astro.redirect('/');
 }
 

--- a/packages/astro/test/fixtures/astro-cookies/src/pages/early-return.astro
+++ b/packages/astro/test/fixtures/astro-cookies/src/pages/early-return.astro
@@ -1,5 +1,5 @@
 ---
-const mode = Astro.cookies.get('prefs').json().mode;
+const mode = Astro.cookies.get('prefs')!.json().mode;
 
 Astro.cookies.set('prefs', {
 	mode: mode === 'light' ? 'dark' : 'light'

--- a/packages/astro/test/fixtures/astro-cookies/src/pages/get-json.astro
+++ b/packages/astro/test/fixtures/astro-cookies/src/pages/get-json.astro
@@ -1,5 +1,5 @@
 ---
-const cookie = Astro.cookies.get('prefs');
+const cookie = Astro.cookies.get('prefs')!;
 const prefs = cookie.json();
 ---
 <html>


### PR DESCRIPTION
## Changes

`AstroCookies.get` can return `undefined` now.

## Testing

The CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
