### PR TITLE
Fix prefetch test fail

### DIFF
--- a/packages/integrations/prefetch/test/custom-selectors.test.js
+++ b/packages/integrations/prefetch/test/custom-selectors.test.js
@@ -10,6 +10,8 @@ const customIntentSelector = [
 ];
 
 const test = testFactory({
+	// pass custom prefetch configuration
+	configFile: false,
 	root: './fixtures/basic-prefetch/',
 	integrations: [
 		prefetch({


### PR DESCRIPTION
## Changes

Failing in main as the new config setup initializes the prefetch integration twice. Set `configFile: false` to disable one of it from `astro.config.mjs`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested manually

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
