### PR TITLE
feat: add noop service and make integrations that needs it use it

### DIFF
--- a/.changeset/heavy-walls-arrive.md
+++ b/.changeset/heavy-walls-arrive.md
@@ -1,0 +1,8 @@
+---
+'@astrojs/cloudflare': major
+'@astrojs/netlify': major
+'@astrojs/vercel': major
+'astro': major
+---
+
+When using an adapter that supports neither Squoosh or Sharp, Astro will now automatically use an image service that does not support processing, but still provides the other benefits of `astro:assets` such as enforcing `alt`, no CLS etc to users

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -56,6 +56,7 @@
     "./assets/image-endpoint": "./dist/assets/image-endpoint.js",
     "./assets/services/sharp": "./dist/assets/services/sharp.js",
     "./assets/services/squoosh": "./dist/assets/services/squoosh.js",
+    "./assets/services/noop": "./dist/assets/services/noop.js",
     "./content/runtime": "./dist/content/runtime.js",
     "./content/runtime-assets": "./dist/content/runtime-assets.js",
     "./debug": "./components/Debug.astro",

--- a/packages/astro/src/assets/services/noop.ts
+++ b/packages/astro/src/assets/services/noop.ts
@@ -1,0 +1,17 @@
+import { baseService, type LocalImageService } from './service.js';
+
+// Empty service used for platforms that neither support Squoosh or Sharp.
+const noopService: LocalImageService = {
+	validateOptions: baseService.validateOptions,
+	getURL: baseService.getURL,
+	parseURL: baseService.parseURL,
+	getHTMLAttributes: baseService.getHTMLAttributes,
+	async transform(inputBuffer, transformOptions) {
+		return {
+			data: inputBuffer,
+			format: transformOptions.format,
+		};
+	},
+};
+
+export default noopService;

--- a/packages/astro/src/integrations/astroFeaturesValidation.ts
+++ b/packages/astro/src/integrations/astroFeaturesValidation.ts
@@ -4,8 +4,7 @@ import type {
 	AstroFeatureMap,
 	SupportsKind,
 } from '../@types/astro';
-import { error, type LogOptions, warn } from '../core/logger/core.js';
-import { bold } from 'kleur/colors';
+import { error, warn, type LogOptions } from '../core/logger/core.js';
 
 const STABLE = 'stable';
 const DEPRECATED = 'deprecated';
@@ -140,9 +139,7 @@ function validateAssetsFeature(
 		error(
 			logging,
 			'astro',
-			`The currently selected adapter \`${adapterName}\` is not compatible with the service "Sharp". ${bold(
-				'Your project will NOT be able to build.'
-			)}`
+			`The currently selected adapter \`${adapterName}\` is not compatible with the image service "Sharp".`
 		);
 		return false;
 	}
@@ -151,9 +148,7 @@ function validateAssetsFeature(
 		error(
 			logging,
 			'astro',
-			`The currently selected adapter \`${adapterName}\` is not compatible with the service "Squoosh". ${bold(
-				'Your project will NOT be able to build.'
-			)}`
+			`The currently selected adapter \`${adapterName}\` is not compatible with the image service "Squoosh".`
 		);
 		return false;
 	}

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -18,7 +18,7 @@ import type { SerializedSSRManifest } from '../core/app/types';
 import type { PageBuildData } from '../core/build/types';
 import { buildClientDirectiveEntrypoint } from '../core/client-directive/index.js';
 import { mergeConfig } from '../core/config/index.js';
-import { info, warn, error, type LogOptions, AstroIntegrationLogger } from '../core/logger/core.js';
+import { AstroIntegrationLogger, error, info, warn, type LogOptions } from '../core/logger/core.js';
 import { isServerLikeOutput } from '../prerender/utils.js';
 import { validateSupportedFeatures } from './astroFeaturesValidation.js';
 
@@ -220,6 +220,17 @@ export async function runHookConfigDone({
 										`The adapter ${adapter.name} doesn't support the feature ${featureName}. Your project won't be built. You should not use it.`
 									);
 								}
+							}
+							if (!validationResult.assets) {
+								info(
+									logging,
+									'astro',
+									`The selected adapter ${adapter.name} does not support Sharp or Squoosh as image services. To ensure your project still build, image processing has been disabled.`
+								);
+								settings.config.image.service = {
+									entrypoint: 'astro/assets/services/noop',
+									config: {},
+								};
 							}
 						}
 						settings.adapter = adapter;

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -225,7 +225,7 @@ export async function runHookConfigDone({
 								info(
 									logging,
 									'astro',
-									`The selected adapter ${adapter.name} does not support Sharp or Squoosh as image services. To ensure your project still build, image processing has been disabled.`
+									`The selected adapter ${adapter.name} does not support Sharp or Squoosh for image processing. To ensure your project is still able to build, image processing has been disabled.`
 								);
 								settings.config.image.service = {
 									entrypoint: 'astro/assets/services/noop',


### PR DESCRIPTION
## Changes

For Cloudflare, Deno, Vercel Edge and Netlify Edge, who don't support Squoosh or Sharp, we instead provide an image service that does nothing

## Testing

Tested manually

## Docs

This shouldn't affect user behaviour from `experimental.assets`, as previously well, it didn't work. Happy to document this though if @withastro/maintainers-docs feels it's necessary!
