### PR TITLE
Refactor MDX components exports handling

### DIFF
--- a/.changeset/loud-candles-admire.md
+++ b/.changeset/loud-candles-admire.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Handle `components` exports handling itself

--- a/.changeset/young-roses-teach.md
+++ b/.changeset/young-roses-teach.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+Remove MDX special `components` export handling

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -59,12 +59,7 @@ async function renderPage({ mod, renderContext, env, cookies }: RenderPage) {
 		locals: renderContext.locals ?? {},
 	});
 
-	// Support `export const components` for `MDX` pages
-	if (typeof (mod as any).components === 'object') {
-		Object.assign(renderContext.props, { components: (mod as any).components });
-	}
-
-	let response = await runtimeRenderPage(
+	const response = await runtimeRenderPage(
 		result,
 		Component,
 		renderContext.props,

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -171,11 +171,14 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 										code += `\nexport const file = ${JSON.stringify(fileId)};`;
 									}
 									if (!moduleExports.find(({ n }) => n === 'Content')) {
+										// If have `export const components`, pass that as props to `Content` as fallback
+										const hasComponents = moduleExports.find(({ n }) => n === 'components');
+
 										// Make `Content` the default export so we can wrap `MDXContent` and pass in `Fragment`
 										code = code.replace('export default MDXContent;', '');
 										code += `\nexport const Content = (props = {}) => MDXContent({
 											...props,
-											components: { Fragment, ...props.components },
+											components: { Fragment${hasComponents ? ', ...components' : ''}, ...props.components },
 										});
 										export default Content;`;
 									}


### PR DESCRIPTION
## Changes

Move `export const components` [MDX feature](https://docs.astro.build/en/guides/markdown-content/#assigning-custom-components-to-html-elements) handling from Astro core to MDX integration.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing Astro and MDX tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. Should be transparent when upgraded to latest. Will note in the migration guide issue as so.