### PR TITLE
feat: make Sharp the default image service

### DIFF
--- a/.changeset/four-houses-compete.md
+++ b/.changeset/four-houses-compete.md
@@ -1,0 +1,18 @@
+---
+'astro': major
+---
+
+Sharp is now the default image service used for `astro:assets`. If you would prefer to still use Squoosh, you can update your config with the following:
+
+```ts
+import { defineConfig, squooshImageService } from "astro/config";
+
+// https://astro.build/config
+export default defineConfig({
+  image: {
+    service: squooshImageService(),
+  }
+})
+```
+
+However, not only do we recommend using Sharp as it is faster and more reliable, it is also highly likely that the Squoosh service will be removed in a future release.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -153,6 +153,7 @@
     "mime": "^3.0.0",
     "network-information-types": "^0.1.1",
     "ora": "^6.3.1",
+    "sharp": "^0.32.1",
     "p-limit": "^4.0.0",
     "path-to-regexp": "^6.2.1",
     "preferred-pm": "^3.0.3",
@@ -209,18 +210,9 @@
     "remark-code-titles": "^0.1.2",
     "rollup": "^3.25.1",
     "sass": "^1.63.4",
-    "sharp": "^0.32.1",
     "srcset-parse": "^1.1.0",
     "undici": "^5.22.1",
     "unified": "^10.1.2"
-  },
-  "peerDependencies": {
-    "sharp": ">=0.31.0"
-  },
-  "peerDependenciesMeta": {
-    "sharp": {
-      "optional": true
-    }
   },
   "engines": {
     "node": ">=18.14.1",

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -20,9 +20,9 @@ import type { AstroConfigSchema } from '../core/config';
 import type { AstroTimer } from '../core/config/timer';
 import type { AstroCookies } from '../core/cookies';
 import type { LogOptions, LoggerLevel } from '../core/logger/core';
+import { AstroIntegrationLogger } from '../core/logger/core';
 import type { AstroComponentFactory, AstroComponentInstance } from '../runtime/server';
 import type { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from './../core/constants.js';
-import { AstroIntegrationLogger } from '../core/logger/core';
 export type {
 	MarkdownHeading,
 	MarkdownMetadata,
@@ -986,7 +986,7 @@ export interface AstroUserConfig {
 		 * @docs
 		 * @name image.service (Experimental)
 		 * @type {{entrypoint: 'astro/assets/services/sharp' | 'astro/assets/services/squoosh' | string, config: Record<string, any>}}
-		 * @default `{entrypoint: 'astro/assets/services/squoosh', config?: {}}`
+		 * @default `{entrypoint: 'astro/assets/services/sharp', config?: {}}`
 		 * @version 2.1.0
 		 * @description
 		 * Set which image service is used for Astro’s experimental assets support.

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -191,7 +191,7 @@ export const AstroConfigSchema = z.object({
 			}),
 		})
 		.default({
-			service: { entrypoint: 'astro/assets/services/squoosh', config: {} },
+			service: { entrypoint: 'astro/assets/services/sharp', config: {} },
 		}),
 	markdown: z
 		.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -614,6 +614,9 @@ importers:
       server-destroy:
         specifier: ^1.0.1
         version: 1.0.1
+      sharp:
+        specifier: ^0.32.1
+        version: 0.32.1
       shiki:
         specifier: ^0.14.1
         version: 0.14.1
@@ -756,9 +759,6 @@ importers:
       sass:
         specifier: ^1.63.4
         version: 1.63.4
-      sharp:
-        specifier: ^0.32.1
-        version: 0.32.1
       srcset-parse:
         specifier: ^1.1.0
         version: 1.1.0
@@ -18498,11 +18498,6 @@ packages:
     version: 2.9.6
     engines: {node: '>=18.14.1', npm: '>=6.14.0'}
     hasBin: true
-    peerDependencies:
-      sharp: '>=0.31.0'
-    peerDependenciesMeta:
-      sharp:
-        optional: true
     dependencies:
       '@astrojs/compiler': 1.6.3
       '@astrojs/internal-helpers': link:packages/internal-helpers
@@ -18550,6 +18545,7 @@ packages:
       rehype: 12.0.1
       semver: 7.5.4
       server-destroy: 1.0.1
+      sharp: 0.32.1
       shiki: 0.14.1
       string-width: 5.1.2
       strip-ansi: 7.1.0


### PR DESCRIPTION
## Changes

What the title says, the Squoosh service is still available if someone really needs it for now

## Testing

Tests should still pass!

## Docs

https://github.com/withastro/docs/issues/3756#issuecomment-1660190933
