### PR TITLE
Fix scroll position in view transition (#7882)

### DIFF
--- a/.changeset/witty-bikes-relate.md
+++ b/.changeset/witty-bikes-relate.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix for #7882 by setting state in page navigation (view transitions)

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -187,7 +187,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 				transitionEnabledOnThisPage()
 			) {
 				ev.preventDefault();
-				navigate('forward', link.href);
+				navigate('forward', link.href, { index:currentHistoryIndex, scrollY:0 });
 				currentHistoryIndex++;
 				const newState: State = { index: currentHistoryIndex, scrollY };
 				persistState({ index: currentHistoryIndex - 1, scrollY });


### PR DESCRIPTION
## Changes

Fixes #7882

When the click handler navigates to a page, it now resets the current scroll position to zero.
Otherwise, the new page might be shown half way scrolled down, depending on the scroll position of the previous page. 

## Testing

Manual test: Linked the fixed module into a local copy of https://stackblitz.com/edit/github-fmqrqm?file=src%2Fpages%2Fother-page.astro

## Docs
