### PR TITLE
Fix failed server restart calling integration hooks twice

### DIFF
--- a/.changeset/metal-chairs-beam.md
+++ b/.changeset/metal-chairs-beam.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent integration hooks re-trigger if server restart on config change, but the config failed to load

--- a/.changeset/metal-chairs-beam.md
+++ b/.changeset/metal-chairs-beam.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Prevent integration hooks re-trigger if server restart on config change, but the config failed to load
+Prevent integration hooks from re-triggering if the server restarts on config change, but the config fails to load.

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -120,7 +120,3 @@ export async function startContainer({
 
 	return devServerAddressInfo;
 }
-
-export function isStarted(container: Container): boolean {
-	return !!container.viteServer.httpServer?.listening;
-}

--- a/packages/astro/src/core/dev/index.ts
+++ b/packages/astro/src/core/dev/index.ts
@@ -1,3 +1,3 @@
-export { createContainer, isStarted, startContainer } from './container.js';
+export { createContainer, startContainer } from './container.js';
 export { default } from './dev.js';
 export { createContainerWithAutomaticRestart } from './restart.js';

--- a/packages/astro/test/units/dev/restart.test.js
+++ b/packages/astro/test/units/dev/restart.test.js
@@ -4,12 +4,15 @@ import { fileURLToPath } from 'node:url';
 
 import {
 	createContainerWithAutomaticRestart,
-	isStarted,
 	startContainer,
 } from '../../../dist/core/dev/index.js';
 import { createFs, createRequestAndResponse, triggerFSEvent } from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
+
+function isStarted(container) {
+	return !!container.viteServer.httpServer?.listening;
+}
 
 describe('dev container restarts', () => {
 	it('Surfaces config errors on restarts', async () => {


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/7827

When restarting the server and config load fail, don't re-create the server. Re-use the existing (already running) server instead.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested manually. Tried adding a test, but it seems like config loading is borked. It shouldn't have based it's root on `fixtures/alias` because it always reads that fixture's astro config.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.