### PR TITLE
feat: change `compressHTML` default value to `true`

### DIFF
--- a/.changeset/unlucky-ravens-type.md
+++ b/.changeset/unlucky-ravens-type.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+The property `compressHTML` is now `true` by default.

--- a/.changeset/unlucky-ravens-type.md
+++ b/.changeset/unlucky-ravens-type.md
@@ -2,4 +2,13 @@
 'astro': major
 ---
 
-The property `compressHTML` is now `true` by default.
+The property `compressHTML` is now `true` by default. Setting this value to `true` is no longer required.
+
+If you do not want to minify your HTML output, you must set this value to `false` in `astro.config.mjs`.
+
+```diff
+import {defineConfig} from "astro/config";
+export default defineConfig({
++  compressHTML: false
+})
+```

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -29,7 +29,7 @@ const ASTRO_CONFIG_DEFAULTS = {
 		split: false,
 		excludeMiddleware: false,
 	},
-	compressHTML: false,
+	compressHTML: true,
 	server: {
 		host: false,
 		port: 4321,

--- a/packages/astro/test/ssr-manifest.test.js
+++ b/packages/astro/test/ssr-manifest.test.js
@@ -11,7 +11,6 @@ describe('astro:ssr-manifest', () => {
 		fixture = await loadFixture({
 			root: './fixtures/ssr-manifest/',
 			output: 'server',
-			compressHTML: true,
 			adapter: testAdapter(),
 		});
 		await fixture.build();


### PR DESCRIPTION
## Changes

Changes the default value of `compressHTML` to `true`.

## Testing

I updated some tests to reflect the new default.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
