### PR TITLE
Export createTransitionScope from the runtime

### DIFF
--- a/.changeset/metal-owls-juggle.md
+++ b/.changeset/metal-owls-juggle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Export createTransitionScope for the runtime

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -36,7 +36,7 @@ export type {
 	ComponentSlots,
 	RenderInstruction,
 } from './render/index.js';
-export { renderTransition } from './transition.js';
+export { renderTransition, createTransitionScope } from './transition.js';
 
 import { markHTMLString } from './escape.js';
 import { addAttribute, Renderer } from './render/index.js';


### PR DESCRIPTION
## Changes

- Exports `createTransitionScope` from the runtime. This is used if you don't provide a `transition:animate` or `transition:name` on the element.

## Testing

- Just tested locally, hot fix noticed in the demo when you remove `transition:name`.

## Docs

N/A, bug fix