### PR TITLE
Support Bun in create-astro

### DIFF
--- a/packages/create-astro/README.md
+++ b/packages/create-astro/README.md
@@ -14,6 +14,12 @@ npm create astro@latest
 yarn create astro
 ```
 
+**With Bun:**
+
+```bash
+bunx create-astro
+```
+
 `create-astro` automatically runs in _interactive_ mode, but you can also specify your project name and template with command line arguments.
 
 ```bash
@@ -25,6 +31,9 @@ npm create astro@latest my-astro-project -- --template minimal
 
 # yarn
 yarn create astro my-astro-project --template minimal
+
+# bun
+bunx create-astro my-astro-project --template minimal
 ```
 
 [Check out the full list][examples] of example templates, available on GitHub.

--- a/packages/create-astro/src/actions/next-steps.ts
+++ b/packages/create-astro/src/actions/next-steps.ts
@@ -5,7 +5,12 @@ import { nextSteps, say } from '../messages.js';
 
 export async function next(ctx: Pick<Context, 'cwd' | 'pkgManager' | 'skipHouston'>) {
 	let projectDir = path.relative(process.cwd(), ctx.cwd);
-	const devCmd = ctx.pkgManager === 'npm' ? 'npm run dev' : `${ctx.pkgManager} dev`;
+	const devCmd =
+		ctx.pkgManager === 'npm'
+			? 'npm run dev'
+			: ctx.pkgManager === 'bun'
+			? 'bun run dev'
+			: `${ctx.pkgManager} dev`;
 	await nextSteps({ projectDir, devCmd });
 
 	if (!ctx.skipHouston) {


### PR DESCRIPTION
## Changes

Better support for Bun users when using `create-astro`.

- Prints the correct command for starting dev server (`bun run dev`)
- Add `bunx create-astro` to readme 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I didn't see tests for `pnpm` or `yarn`. Bun sets `npm_config_user_agent` like Yarn/pnpm, and `which-pm-runs` detects this as expected. Here's a sample run showing everything working with Bun:

```sh
npm_config_user_agent=bun/1.0 node create-astro.mjs 

╭─────╮  Houston:
│ ◠ ◡ ◠  Let's build something great!
╰─────╯

 astro   v2.10.1 Launch sequence initiated.

   dir   Where should we create your new project?
         ./growing-gamma

  tmpl   How would you like to start your new project?
         Include sample files
      ✔  Template copied

  deps   Install dependencies?
         Yes
      ✔  Dependencies installed

    ts   Do you plan to write TypeScript?
         Yes

   use   How strict should TypeScript be?
         Strict
      ✔  TypeScript customized

   git   Initialize a new git repository?
         No
      ◼  Sounds good! You can always run git init manually.

  next   Liftoff confirmed. Explore your project!

         Enter your project directory using cd ./growing-gamma 
         Run bun run dev to start the dev server. CTRL+C to stop.
         Add frameworks like react or tailwind using astro add.

         Stuck? Join us at https://astro.build/chat

╭─────╮  Houston:
│ ◠ ◡ ◠  Good luck out there, astronaut! 🚀
╰─────╯
``` 

## Docs

Sister documentation PR: https://github.com/withastro/docs/pull/4052

