### PR TITLE
Fix race condition when performing swap for fallback

### DIFF
--- a/.changeset/cold-maps-report.md
+++ b/.changeset/cold-maps-report.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix race condition when performing swap for fallback

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -168,13 +168,18 @@ const { fallback = 'animate' } = Astro.props as Props;
 
 			// Trigger the animations
 			document.documentElement.dataset.astroTransitionFallback = 'old';
-			doc.documentElement.dataset.astroTransitionFallback = 'new';
+			const fallbackSwap = () => {
+				removeEventListener('animationend', fallbackSwap);
+				clearTimeout(timeout);
+				swap();
+				document.documentElement.dataset.astroTransitionFallback = 'new';
+			};
 			// If there are any animations, want for the animationend event.
-			addEventListener('animationend', swap, { once: true });
+			addEventListener('animationend', fallbackSwap, { once: true });
 			// If there are no animations, go ahead and swap on next tick
 			// This is necessary because we do not know if there are animations.
 			// The setTimeout is a fallback in case there are none.
-			setTimeout(() => !isAnimating && swap());
+			var timeout = setTimeout(() => !isAnimating && fallbackSwap());
 		} else {
 			swap();
 		}

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -179,7 +179,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 			// If there are no animations, go ahead and swap on next tick
 			// This is necessary because we do not know if there are animations.
 			// The setTimeout is a fallback in case there are none.
-			var timeout = setTimeout(() => !isAnimating && fallbackSwap());
+			let timeout = setTimeout(() => !isAnimating && fallbackSwap());
 		} else {
 			swap();
 		}


### PR DESCRIPTION
## Changes

- In fallback mode for the router we need to wait for animations (if there are any) and also setTimeout (in case there are none). This causes a race condition that can case swap() to be called twice.
- Fix is to remove the event listener and the timeout whenever the first wins.

## Testing

- Tested manually. Maybe we should think about adding Firefox as a test runner some how.

## Docs

Bug fix