### PR TITLE
fix broken partytown GitHub link

### DIFF
--- a/packages/integrations/partytown/README.md
+++ b/packages/integrations/partytown/README.md
@@ -130,7 +130,7 @@ export default defineConfig({
 
 ## Examples
 
-- [Browse projects with Astro Partytown on GitHub](https://github.com/search?q=%22@astrojs/partytown%22+filename:package.json&type=Code) for more examples!
+- [Browse projects with Astro Partytown on GitHub](https://github.com/search?q=%22%40astrojs%2Fpartytown%22+path%3A**%2Fpackage.json&type=code) for more examples!
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Changes

- Fix broken GitHub link
- closes https://github.com/withastro/docs/issues/4038

## Testing

Manually tested

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Update docs with correct GitHub link

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
