### PR TITLE
chore: update prettier to `3.0`

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -6,7 +6,7 @@ module.exports = {
   tabWidth: 2,
   trailingComma: 'es5',
   useTabs: true,
-  plugins: ['./node_modules/prettier-plugin-astro/dist/index.js'],
+  plugins: ['prettier-plugin-astro'],
   overrides: [
     {
       files: ['.*', '*.json', '*.md', '*.toml', '*.yml'],

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -6,7 +6,7 @@ module.exports = {
   tabWidth: 2,
   trailingComma: 'es5',
   useTabs: true,
-  plugins: ['./node_modules/prettier-plugin-astro'],
+  plugins: ['./node_modules/prettier-plugin-astro/dist/index.js'],
   overrides: [
     {
       files: ['.*', '*.json', '*.md', '*.toml', '*.yml'],

--- a/examples/blog/src/content/blog/markdown-style-guide.md
+++ b/examples/blog/src/content/blog/markdown-style-guide.md
@@ -58,7 +58,7 @@ The blockquote element represents content that is quoted from another source, op
 ## Code Blocks
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "turbo run dev --concurrency=40 --parallel --filter=astro --filter=create-astro --filter=\"@astrojs/*\" --filter=\"@benchmark/*\"",
     "format": "pnpm run format:code",
     "format:ci": "pnpm run format:imports && pnpm run format:code",
-    "format:code": "prettier -w . --cache --plugin-search-dir=.",
+    "format:code": "prettier -w . --cache",
     "format:imports": "organize-imports-cli ./packages/*/tsconfig.json ./packages/*/*/tsconfig.json",
     "test": "turbo run test --concurrency=1 --filter=astro --filter=create-astro --filter=\"@astrojs/*\"",
     "test:match": "cd packages/astro && pnpm run test:match",

--- a/package.json
+++ b/package.json
@@ -88,8 +88,8 @@
     "eslint-plugin-prettier": "^4.2.1",
     "only-allow": "^1.1.1",
     "organize-imports-cli": "^0.10.0",
-    "prettier": "^2.8.8",
-    "prettier-plugin-astro": "^0.10.0",
+    "prettier": "^3.0.1",
+    "prettier-plugin-astro": "^0.11.0",
     "tiny-glob": "^0.2.9",
     "turbo": "^1.10.3",
     "typescript": "~5.1.6"

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -9,7 +9,7 @@
  * Adapted from React’s TypeScript definition from DefinitelyTyped.
  * @see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts
  */
-declare namespace astroHTML.JSX {
+namespace astroHTML.JSX {
 	export type Child = Node | Node[] | string | number | boolean | null | undefined | unknown;
 	export type Children = Child | Child[];
 

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -9,7 +9,9 @@
  * Adapted from React’s TypeScript definition from DefinitelyTyped.
  * @see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts
  */
-namespace astroHTML.JSX {
+// BUG! Prettier 3.0 removes `declare`: https://github.com/prettier/prettier/issues/15207
+// prettier-ignore
+declare namespace astroHTML.JSX {
 	export type Child = Node | Node[] | string | number | boolean | null | undefined | unknown;
 	export type Children = Child | Child[];
 

--- a/packages/astro/content-types.template.d.ts
+++ b/packages/astro/content-types.template.d.ts
@@ -44,7 +44,7 @@ declare module 'astro:content' {
 				import('astro/zod').ZodLiteral<'tiff'>,
 				import('astro/zod').ZodLiteral<'webp'>,
 				import('astro/zod').ZodLiteral<'gif'>,
-				import('astro/zod').ZodLiteral<'svg'>
+				import('astro/zod').ZodLiteral<'svg'>,
 			]
 		>;
 	}>;
@@ -87,7 +87,7 @@ declare module 'astro:content' {
 
 	export function getEntryBySlug<
 		C extends keyof ContentEntryMap,
-		E extends ValidContentEntrySlug<C> | (string & {})
+		E extends ValidContentEntrySlug<C> | (string & {}),
 	>(
 		collection: C,
 		// Note that this has to accept a regular string too, for SSR
@@ -112,7 +112,7 @@ declare module 'astro:content' {
 
 	export function getEntry<
 		C extends keyof ContentEntryMap,
-		E extends ValidContentEntrySlug<C> | (string & {})
+		E extends ValidContentEntrySlug<C> | (string & {}),
 	>(entry: {
 		collection: C;
 		slug: E;
@@ -121,7 +121,7 @@ declare module 'astro:content' {
 		: Promise<CollectionEntry<C> | undefined>;
 	export function getEntry<
 		C extends keyof DataEntryMap,
-		E extends keyof DataEntryMap[C] | (string & {})
+		E extends keyof DataEntryMap[C] | (string & {}),
 	>(entry: {
 		collection: C;
 		id: E;
@@ -130,7 +130,7 @@ declare module 'astro:content' {
 		: Promise<CollectionEntry<C> | undefined>;
 	export function getEntry<
 		C extends keyof ContentEntryMap,
-		E extends ValidContentEntrySlug<C> | (string & {})
+		E extends ValidContentEntrySlug<C> | (string & {}),
 	>(
 		collection: C,
 		slug: E
@@ -139,7 +139,7 @@ declare module 'astro:content' {
 		: Promise<CollectionEntry<C> | undefined>;
 	export function getEntry<
 		C extends keyof DataEntryMap,
-		E extends keyof DataEntryMap[C] | (string & {})
+		E extends keyof DataEntryMap[C] | (string & {}),
 	>(
 		collection: C,
 		id: E

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1916,7 +1916,7 @@ export interface SSRLoadedRenderer extends AstroRenderer {
 
 export type HookParameters<
 	Hook extends keyof AstroIntegration['hooks'],
-	Fn = AstroIntegration['hooks'][Hook]
+	Fn = AstroIntegration['hooks'][Hook],
 > = Fn extends (...args: any) => any ? Parameters<Fn>[0] : never;
 
 export interface AstroIntegration {

--- a/packages/astro/src/vite-plugin-head/index.ts
+++ b/packages/astro/src/vite-plugin-head/index.ts
@@ -16,7 +16,7 @@ export default function configHeadVitePlugin(): vite.Plugin {
 
 	function propagateMetadata<
 		P extends keyof PluginMetadata['astro'],
-		V extends PluginMetadata['astro'][P]
+		V extends PluginMetadata['astro'][P],
 	>(
 		this: { getModuleInfo(id: string): ModuleInfo | null },
 		id: string,

--- a/packages/integrations/image/README.md
+++ b/packages/integrations/image/README.md
@@ -130,14 +130,14 @@ import heroImage from '../assets/hero.png';
 // optimized image, keeping the original width, height, and image format
 <Image src={heroImage} alt="descriptive text" />
 
-// specify multiple sizes for responsive images or art direction
+ // specify multiple sizes for responsive images or art direction
 <Picture
   src={heroImage}
   widths={[200, 400, 800]}
   sizes="(max-width: 800px) 100vw, 800px"
   alt="descriptive text"
 />
----
+ ---
 ```
 
 The included image transformers support resizing images and encoding them to different image formats. Third-party image services will be able to add support for custom transformations as well (ex: `blur`, `filter`, `rotate`, etc).
@@ -566,16 +566,16 @@ import heroImage from '../assets/hero.png';
 // optimized image, keeping the original width, height, and image format
 <Image src={heroImage} alt="descriptive text" />
 
-// height will be recalculated to match the original aspect ratio
+ // height will be recalculated to match the original aspect ratio
 <Image src={heroImage} width={300} alt="descriptive text" />
 
-// cropping to a specific width and height
+ // cropping to a specific width and height
 <Image src={heroImage} width={300} height={600} alt="descriptive text" />
 
-// cropping to a specific aspect ratio and converting to an avif format
+ // cropping to a specific aspect ratio and converting to an avif format
 <Image src={heroImage} width={300} aspectRatio="16:9" format="avif" alt="descriptive text" />
 
-// image imports can also be inlined directly
+ // image imports can also be inlined directly
 <Image src={import('../assets/hero.png')} alt="descriptive text" />
 ```
 
@@ -612,7 +612,7 @@ const imageUrl = 'https://astro.build/assets/press/full-logo-dark.png';
 // cropping to a specific width and height
 <Image src={imageUrl} width={750} height={250} format="avif" alt="descriptive text" />
 
-// height will be recalculated to match the aspect ratio
+ // height will be recalculated to match the aspect ratio
 <Image src={imageUrl} width={750} aspectRatio={16 / 9} format="avif" alt="descriptive text" />
 ```
 
@@ -641,7 +641,7 @@ const imageUrl =
   alt="descriptive text"
 />
 
-// Remote image (aspect ratio is required)
+ // Remote image (aspect ratio is required)
 <Picture
   src={imageUrl}
   widths={[200, 400, 800]}
@@ -650,7 +650,7 @@ const imageUrl =
   alt="descriptive text"
 />
 
-// Inlined imports are supported
+ // Inlined imports are supported
 <Picture
   src={import('../assets/hero.png')}
   widths={[200, 400, 800]}

--- a/packages/integrations/image/src/build/ssg.ts
+++ b/packages/integrations/image/src/build/ssg.ts
@@ -127,7 +127,7 @@ export async function ssgBuild({
 
 	async function processStaticImage([src, transformsMap]: [
 		string,
-		Map<string, TransformOptions>
+		Map<string, TransformOptions>,
 	]): Promise<void> {
 		let inputFile: string | undefined = undefined;
 		let inputBuffer: Buffer | undefined = undefined;

--- a/packages/integrations/node/src/response-iterator.ts
+++ b/packages/integrations/node/src/response-iterator.ts
@@ -200,9 +200,7 @@ function asyncIterator<T>(source: AsyncIterableIterator<T>): AsyncIterableIterat
 	};
 }
 
-export function responseIterator<T>(
-	response: Response | Buffer
-): AsyncIterableIterator<T> {
+export function responseIterator<T>(response: Response | Buffer): AsyncIterableIterator<T> {
 	let body: unknown = response;
 
 	if (isNodeResponse(response)) body = response.body;

--- a/packages/integrations/node/src/response-iterator.ts
+++ b/packages/integrations/node/src/response-iterator.ts
@@ -120,7 +120,7 @@ function nodeStreamIterator<T>(stream: NodeReadableStream): AsyncIterableIterato
 				| IteratorResult<T, boolean | undefined>
 				| PromiseLike<IteratorResult<T, boolean | undefined>>
 		) => void,
-		(reason?: any) => void
+		(reason?: any) => void,
 	][] = [];
 
 	function onData(chunk: any) {

--- a/packages/integrations/node/src/types.ts
+++ b/packages/integrations/node/src/types.ts
@@ -21,7 +21,7 @@ export type RequestHandlerParams = [
 	req: IncomingMessage,
 	res: ServerResponse,
 	next?: (err?: unknown) => void,
-	locals?: object
+	locals?: object,
 ];
 
 export type ErrorHandlerParams = [unknown, ...RequestHandlerParams];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 2.6.0
       eslint-plugin-prettier:
         specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.43.0)(prettier@2.8.8)
+        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.43.0)(prettier@3.0.1)
       only-allow:
         specifier: ^1.1.1
         version: 1.1.1
@@ -55,11 +55,11 @@ importers:
         specifier: ^0.10.0
         version: 0.10.0
       prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^3.0.1
+        version: 3.0.1
       prettier-plugin-astro:
-        specifier: ^0.10.0
-        version: 0.10.0
+        specifier: ^0.11.0
+        version: 0.11.0
       tiny-glob:
         specifier: ^0.2.9
         version: 0.2.9
@@ -650,7 +650,7 @@ importers:
     devDependencies:
       '@astrojs/check':
         specifier: ^0.1.0
-        version: 0.1.0(prettier-plugin-astro@0.10.0)(prettier@2.8.8)(typescript@5.1.6)
+        version: 0.1.0(prettier-plugin-astro@0.11.0)(prettier@3.0.1)(typescript@5.1.6)
       '@playwright/test':
         specifier: ^1.29.2
         version: 1.29.2
@@ -5360,13 +5360,13 @@ packages:
       lite-youtube-embed: 0.2.0
     dev: false
 
-  /@astrojs/check@0.1.0(prettier-plugin-astro@0.10.0)(prettier@2.8.8)(typescript@5.1.6):
+  /@astrojs/check@0.1.0(prettier-plugin-astro@0.11.0)(prettier@3.0.1)(typescript@5.1.6):
     resolution: {integrity: sha512-tgjq+Vehgv0dwdsRlT4ai3QgT3etn8W5C4E4dvQ0Xe9ccwjKdMTWmpty5exfBtHLLAAOvwe5/OkYQsQ9OyKoVw==}
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
     dependencies:
-      '@astrojs/language-server': 2.2.0(prettier-plugin-astro@0.10.0)(prettier@2.8.8)(typescript@5.1.6)
+      '@astrojs/language-server': 2.2.0(prettier-plugin-astro@0.11.0)(prettier@3.0.1)(typescript@5.1.6)
       chokidar: 3.5.3
       fast-glob: 3.3.1
       kleur: 4.1.5
@@ -5420,7 +5420,7 @@ packages:
       vscode-uri: 3.0.7
     dev: false
 
-  /@astrojs/language-server@2.2.0(prettier-plugin-astro@0.10.0)(prettier@2.8.8)(typescript@5.1.6):
+  /@astrojs/language-server@2.2.0(prettier-plugin-astro@0.11.0)(prettier@3.0.1)(typescript@5.1.6):
     resolution: {integrity: sha512-zyEumkwcep3pGyMpcEJFEn96jV6pEg3CUtjehnT9KseDFqf+gPYTbw5nwOpN9uXIJ/E5bAxhqpkr3J2LCQHRrg==}
     hasBin: true
     peerDependencies:
@@ -5442,12 +5442,12 @@ packages:
       '@volar/typescript': 1.10.0
       fast-glob: 3.3.1
       muggle-string: 0.3.1
-      prettier: 2.8.8
-      prettier-plugin-astro: 0.10.0
+      prettier: 3.0.1
+      prettier-plugin-astro: 0.11.0
       volar-service-css: 0.0.11(@volar/language-service@1.10.0)
       volar-service-emmet: 0.0.11(@volar/language-service@1.10.0)
       volar-service-html: 0.0.11(@volar/language-service@1.10.0)
-      volar-service-prettier: 0.0.11(@volar/language-service@1.10.0)(prettier@2.8.8)
+      volar-service-prettier: 0.0.11(@volar/language-service@1.10.0)(prettier@3.0.1)
       volar-service-typescript: 0.0.11(@volar/language-service@1.10.0)(@volar/typescript@1.10.0)
       volar-service-typescript-twoslash-queries: 0.0.11(@volar/language-service@1.10.0)
       vscode-html-languageservice: 5.0.6
@@ -11646,7 +11646,7 @@ packages:
     engines: {node: '>=4.0.0'}
     dev: true
 
-  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@8.43.0)(prettier@2.8.8):
+  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@8.43.0)(prettier@3.0.1):
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -11659,7 +11659,7 @@ packages:
     dependencies:
       eslint: 8.43.0
       eslint-config-prettier: 8.8.0(eslint@8.43.0)
-      prettier: 2.8.8
+      prettier: 3.0.1
       prettier-linter-helpers: 1.0.0
     dev: true
 
@@ -15600,12 +15600,12 @@ packages:
       fast-diff: 1.2.0
     dev: true
 
-  /prettier-plugin-astro@0.10.0:
-    resolution: {integrity: sha512-dPzop0gKZyVGpTDQmfy+e7FKXC9JT3mlpfYA2diOVz+Ui+QR1U4G/s+OesKl2Hib2JJOtAYJs/l+ovgT0ljlFA==}
+  /prettier-plugin-astro@0.11.0:
+    resolution: {integrity: sha512-rl2hJ4Kty/aEfGjk3i4JS+bpng9MjgvwqLRNzeb9NqYhqKoWNwOR39cIJXFjU1vR3zYOPnwWNRMelKb0orunYA==}
     engines: {node: ^14.15.0 || >=16.0.0, pnpm: '>=7.14.0'}
     dependencies:
       '@astrojs/compiler': 1.8.1
-      prettier: 2.8.8
+      prettier: 3.0.1
       sass-formatter: 0.7.6
     dev: true
 
@@ -15623,6 +15623,12 @@ packages:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  /prettier@3.0.1:
+    resolution: {integrity: sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
 
   /pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
@@ -18029,7 +18035,7 @@ packages:
       vscode-uri: 3.0.7
     dev: true
 
-  /volar-service-prettier@0.0.11(@volar/language-service@1.10.0)(prettier@2.8.8):
+  /volar-service-prettier@0.0.11(@volar/language-service@1.10.0)(prettier@3.0.1):
     resolution: {integrity: sha512-A4vEU5BUitNNAySb+t/fCjEoL01uYUkoe/Fe5UxR3JJbdgr2nTeXb5IlW90/1vzmnTKZznadJV4i1SoAf2CRbg==}
     peerDependencies:
       '@volar/language-service': ~1.10.0
@@ -18041,7 +18047,7 @@ packages:
         optional: true
     dependencies:
       '@volar/language-service': 1.10.0
-      prettier: 2.8.8
+      prettier: 3.0.1
     dev: true
 
   /volar-service-typescript-twoslash-queries@0.0.11(@volar/language-service@1.10.0):


### PR DESCRIPTION
## Changes

It updates prettier to `3.0`

## Testing

I run locally the script that formats the code, and it works as expected.

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
