### PR TITLE
chore: update Deno server import path

### DIFF
--- a/packages/integrations/deno/README.md
+++ b/packages/integrations/deno/README.md
@@ -81,7 +81,7 @@ npm run preview
 After [performing a build](https://docs.astro.build/en/guides/deploy/#building-your-site-locally) there will be a `dist/server/entry.mjs` module. You can start a server by importing this module in your Deno app:
 
 ```js
-import './dist/entry.mjs';
+import './dist/server/entry.mjs';
 ```
 
 See the `start` option below for how you can have more control over starting the Astro server.
@@ -129,7 +129,7 @@ If you disable this, you need to write your own Deno web server. Import and call
 
 ```ts
 import { serve } from 'https://deno.land/std@0.167.0/http/server.ts';
-import { handle } from './dist/entry.mjs';
+import { handle } from './dist/server/entry.mjs';
 
 serve((req: Request) => {
   // Check the request, maybe do static file handling here.


### PR DESCRIPTION
## Changes

- updates wrong import of `dist/entry.mjs` to `dist/server/entry.mjs`

## Testing

only docs change

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Closes https://github.com/withastro/docs/issues/4040

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
