### PR TITLE
Add timeout for check CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,6 +23,7 @@ jobs:
   check:
     name: astro check
     runs-on: ubuntu-latest
+    timeout-minutes: 7
     steps:
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
## Changes

Make sure they don't run forever. Some are hanging currently.

Set to 7min as that's the max I've seen. Usually they float around 5min.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
