### PR TITLE
Add URL to RSSOptions.site type

### DIFF
--- a/.changeset/new-otters-sell.md
+++ b/.changeset/new-otters-sell.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': patch
+---
+
+Add URL to RSSOptions.site type

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -16,7 +16,7 @@ export type RSSOptions = {
 	 * We recommend using the [endpoint context object](https://docs.astro.build/en/reference/api-reference/#contextsite),
 	 * which includes the `site` configured in your project's `astro.config.*`
 	 */
-	site: z.infer<typeof rssOptionsValidator>['site'];
+	site: z.infer<typeof rssOptionsValidator>['site'] | URL;
 	/** List of RSS feed items to render. */
 	items: RSSFeedItem[] | GlobResult;
 	/** Specify arbitrary metadata on opening <xml> tag */


### PR DESCRIPTION
## Changes

- This PR adds the URL type to `RSSOptions.site`
- `site` was only of type `string` before and lead to TS errors
- Closes #7951 
- Ran `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

- Did manual testing in TS Playground to check for the best option (wanted to use zod instead of URL directly, but did not really work)
- Existing tests still run as expected

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
- No changes in the docs necessary
