### PR TITLE
Export JS API

### DIFF
--- a/.changeset/many-pears-explode.md
+++ b/.changeset/many-pears-explode.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+Export `dev`, `build`, `preview`, and `sync` APIs from `astro`. This replaces the previous entrypoint code which runs the Astro CLI programmatically.

--- a/packages/astro/index.d.ts
+++ b/packages/astro/index.d.ts
@@ -1,0 +1,2 @@
+export * from './dist/@types/astro.js'
+export * from './dist/core/index.js'

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://astro.build",
-  "types": "./dist/@types/astro.d.ts",
+  "types": "./index.d.ts",
   "typesVersions": {
     "*": {
       "app": [
@@ -28,8 +28,8 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/@types/astro.d.ts",
-      "default": "./astro.js"
+      "types": "./index.d.ts",
+      "default": "./dist/core/index.js"
     },
     "./env": "./env.d.ts",
     "./types": "./types.d.ts",
@@ -86,6 +86,7 @@
     "tsconfigs",
     "dist",
     "astro.js",
+    "index.d.ts",
     "config.d.ts",
     "config.mjs",
     "zod.d.ts",

--- a/packages/astro/src/cli/build/index.ts
+++ b/packages/astro/src/cli/build/index.ts
@@ -25,7 +25,5 @@ export async function build({ flags }: BuildOptions) {
 
 	const inlineConfig = flagsToAstroInlineConfig(flags);
 
-	await _build(inlineConfig, {
-		teardownCompiler: true,
-	});
+	await _build(inlineConfig);
 }

--- a/packages/astro/src/cli/sync/index.ts
+++ b/packages/astro/src/cli/sync/index.ts
@@ -1,6 +1,6 @@
 import type yargs from 'yargs-parser';
 import { printHelp } from '../../core/messages.js';
-import { sync as _sync } from '../../core/sync/index.js';
+import _sync from '../../core/sync/index.js';
 import { flagsToAstroInlineConfig } from '../flags.js';
 
 interface SyncOptions {

--- a/packages/astro/src/core/README.md
+++ b/packages/astro/src/core/README.md
@@ -1,5 +1,7 @@
 # `core/`
 
-Code that executes within the top-level Node context. Contains the main Astro logic for the `build` and `dev` commands, and also manages the Vite server and SSR.
+Code that executes within the top-level Node context. Contains the main Astro logic for the `build`, `dev`, `preview`, and `sync` commands, and also manages the Vite server and SSR.
+
+The `core/index.ts` file is the main entrypoint for the `astro` package.
 
 [See CONTRIBUTING.md](../../../../CONTRIBUTING.md) for a code overview.

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -18,7 +18,10 @@ export interface DevServer {
 	stop(): Promise<void>;
 }
 
-/** `astro dev` */
+/**
+ * Runs Astro’s development server. This is a local HTTP server that doesn’t bundle assets.
+ * It uses Hot Module Replacement (HMR) to update your browser as you save changes in your editor.
+ */
 export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevServer> {
 	const devStart = performance.now();
 	await telemetry.record([]);

--- a/packages/astro/src/core/index.ts
+++ b/packages/astro/src/core/index.ts
@@ -1,0 +1,6 @@
+// This is the main entrypoint when importing the `astro` package.
+
+export { default as build } from './build/index.js';
+export { default as dev } from './dev/index.js';
+export { default as preview } from './preview/index.js';
+export { default as sync } from './sync/index.js';

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -10,10 +10,11 @@ import { createSettings } from '../config/settings.js';
 import createStaticPreviewServer from './static-preview-server.js';
 import { getResolvedHostForHttpServer } from './util.js';
 
-/** The primary dev action */
-export default async function preview(
-	inlineConfig: AstroInlineConfig
-): Promise<PreviewServer | undefined> {
+/**
+ * Starts a local server to serve your static dist/ directory. This command is useful for previewing
+ * your build locally, before deploying it. It is not designed to be run in production.
+ */
+export default async function preview(inlineConfig: AstroInlineConfig): Promise<PreviewServer> {
 	const logging = createNodeLogging(inlineConfig);
 	const { userConfig, astroConfig } = await resolveConfig(inlineConfig ?? {}, 'preview');
 	telemetry.record(eventCliSession('preview', userConfig));

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -22,8 +22,7 @@ export type ProcessExit = 0 | 1;
 
 export type SyncOptions = {
 	/**
-	 * Only used for testing
-	 * @internal
+	 * @internal only used for testing
 	 */
 	fs?: typeof fsMod;
 };
@@ -32,10 +31,11 @@ export type SyncInternalOptions = SyncOptions & {
 	logging: LogOptions;
 };
 
-export async function sync(
-	inlineConfig: AstroInlineConfig,
-	options?: SyncOptions
-): Promise<ProcessExit> {
+/**
+ * Generates TypeScript types for all Astro modules. This sets up a `src/env.d.ts` file for type inferencing,
+ * and defines the `astro:content` module for the Content Collections API.
+ */
+export default async function sync(inlineConfig: AstroInlineConfig): Promise<ProcessExit> {
 	const logging = createNodeLogging(inlineConfig);
 	const { userConfig, astroConfig } = await resolveConfig(inlineConfig ?? {}, 'sync');
 	telemetry.record(eventCliSession('sync', userConfig));
@@ -48,7 +48,11 @@ export async function sync(
 		command: 'build',
 	});
 
-	return await syncInternal(settings, { logging, fs: options?.fs });
+	// Use this hack to prevent the sync options being public API
+	// eslint-disable-next-line prefer-rest-params
+	const internalOptions = arguments[1] as SyncOptions | undefined;
+
+	return await syncInternal(settings, { ...internalOptions, logging });
 }
 
 /**

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -6,15 +6,12 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import stripAnsi from 'strip-ansi';
 import { check } from '../dist/cli/check/index.js';
-import build from '../dist/core/build/index.js';
+import { dev, build, preview, sync } from '../dist/core/index.js';
 import { RESOLVED_SPLIT_MODULE_ID } from '../dist/core/build/plugins/plugin-ssr.js';
 import { getVirtualModulePageNameFromPath } from '../dist/core/build/plugins/util.js';
 import { makeSplitEntryPointFileName } from '../dist/core/build/static-build.js';
 import { mergeConfig, resolveConfig } from '../dist/core/config/index.js';
-import dev from '../dist/core/dev/index.js';
 import { nodeLogDestination } from '../dist/core/logger/node.js';
-import preview from '../dist/core/preview/index.js';
-import { sync } from '../dist/core/sync/index.js';
 
 // Disable telemetry when running tests
 process.env.ASTRO_TELEMETRY_DISABLED = true;
@@ -149,7 +146,7 @@ export async function loadFixture(inlineConfig) {
 	return {
 		build: async (extraInlineConfig = {}) => {
 			process.env.NODE_ENV = 'production';
-			return build(mergeConfig(inlineConfig, extraInlineConfig));
+			return build(mergeConfig(inlineConfig, extraInlineConfig), { teardownCompiler: false });
 		},
 		sync: async (extraInlineConfig = {}, opts) => {
 			return sync(mergeConfig(inlineConfig, extraInlineConfig), opts);

--- a/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
+++ b/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { fileURLToPath } from 'node:url';
-import { sync as _sync } from '../../../dist/core/sync/index.js';
+import _sync from '../../../dist/core/sync/index.js';
 import { createFsWithFallback } from '../test-utils.js';
 
 const root = new URL('../../fixtures/content-mixed-errors/', import.meta.url);

--- a/packages/astro/tsconfig.json
+++ b/packages/astro/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src", "index.d.ts"],
+  "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
     "declarationDir": "./dist",


### PR DESCRIPTION
## Changes

Export `dev`, `build`, `preview`, and `sync` JavaScript APIs.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests updated to use the entrypoint to test it.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->

I copied each APIs jsdoc from the [CLI reference docs](https://docs.astro.build/en/reference/cli-reference/#astro-dev) because I ~~am lazy~~ wanted to keep it consistent with what we have now.

We'll likely need a dedicated page for it as we add more APIs in the future (e.g. there was discussion to move `defineConfig` to the main entrypoint), but it could be weird to have two places referring to similar info?

Appreciate some feedback on this, cc @withastro/maintainers-docs!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
