### PR TITLE
Remove undici dep

### DIFF
--- a/.changeset/violet-peaches-invent.md
+++ b/.changeset/violet-peaches-invent.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/telemetry': patch
+---
+
+Remove undici dependency

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -211,7 +211,6 @@
     "rollup": "^3.25.1",
     "sass": "^1.63.4",
     "srcset-parse": "^1.1.0",
-    "undici": "^5.22.1",
     "unified": "^10.1.2"
   },
   "engines": {

--- a/packages/astro/test/ssr-api-route.test.js
+++ b/packages/astro/test/ssr-api-route.test.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import net from 'node:net';
-import { File, FormData } from 'undici';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -20,7 +20,6 @@ import { sync } from '../dist/core/sync/index.js';
 process.env.ASTRO_TELEMETRY_DISABLED = true;
 
 /**
- * @typedef {import('undici').Response} Response
  * @typedef {import('../src/core/dev/dev').DedvServer} DevServer
  * @typedef {import('../src/@types/astro').AstroInlineConfig & { root?: string | URL }} AstroInlineConfig
  * @typedef {import('../src/core/preview/index').PreviewServer} PreviewServer

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -48,7 +48,6 @@
     "chai": "^4.3.7",
     "cheerio": "1.0.0-rc.12",
     "mocha": "^9.2.2",
-    "node-mocks-http": "^1.12.2",
-    "undici": "^5.22.1"
+    "node-mocks-http": "^1.12.2"
   }
 }

--- a/packages/integrations/node/src/response-iterator.ts
+++ b/packages/integrations/node/src/response-iterator.ts
@@ -6,7 +6,6 @@
 
 import type { ReadableStreamDefaultReadResult } from 'node:stream/web';
 import { Readable as NodeReadableStream } from 'stream';
-import type { Response as NodeResponse } from 'undici';
 
 interface NodeStreamIterator<T> {
 	next(): Promise<IteratorResult<T, boolean | undefined>>;
@@ -35,8 +34,8 @@ function isBuffer(value: any): value is Buffer {
 	);
 }
 
-function isNodeResponse(value: any): value is NodeResponse {
-	return !!(value as NodeResponse).body;
+function isNodeResponse(value: any): value is Response {
+	return !!(value as Response).body;
 }
 
 function isReadableStream(value: any): value is ReadableStream<any> {
@@ -202,7 +201,7 @@ function asyncIterator<T>(source: AsyncIterableIterator<T>): AsyncIterableIterat
 }
 
 export function responseIterator<T>(
-	response: Response | NodeResponse | Buffer
+	response: Response | Buffer
 ): AsyncIterableIterator<T> {
 	let body: unknown = response;
 

--- a/packages/integrations/node/test/prerender-404.test.js
+++ b/packages/integrations/node/test/prerender-404.test.js
@@ -2,7 +2,6 @@ import nodejs from '../dist/index.js';
 import { loadFixture } from './test-utils.js';
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
-import { fetch } from 'undici';
 
 /**
  * @typedef {import('../../../astro/test/test-utils').Fixture} Fixture

--- a/packages/integrations/node/test/prerender.test.js
+++ b/packages/integrations/node/test/prerender.test.js
@@ -2,7 +2,6 @@ import nodejs from '../dist/index.js';
 import { loadFixture } from './test-utils.js';
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
-import { fetch } from 'undici';
 
 /**
  * @typedef {import('../../../astro/test/test-utils').Fixture} Fixture

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -35,7 +35,6 @@
     "dset": "^3.1.2",
     "is-docker": "^3.0.0",
     "is-wsl": "^2.2.0",
-    "undici": "^5.22.1",
     "which-pm-runs": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/telemetry/src/post.ts
+++ b/packages/telemetry/src/post.ts
@@ -1,5 +1,3 @@
-import { fetch } from 'undici';
-
 const ASTRO_TELEMETRY_ENDPOINT = `https://telemetry.astro.build/api/v1/record`;
 
 export function post(body: Record<string, any>): Promise<any> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -759,9 +759,6 @@ importers:
       srcset-parse:
         specifier: ^1.1.0
         version: 1.1.0
-      undici:
-        specifier: ^5.22.1
-        version: 5.22.1
       unified:
         specifier: ^10.1.2
         version: 10.1.2
@@ -4545,9 +4542,6 @@ importers:
       node-mocks-http:
         specifier: ^1.12.2
         version: 1.12.2
-      undici:
-        specifier: ^5.22.1
-        version: 5.22.1
 
   packages/integrations/node/test/fixtures/api-route:
     dependencies:
@@ -5202,9 +5196,6 @@ importers:
       is-wsl:
         specifier: ^2.2.0
         version: 2.2.0
-      undici:
-        specifier: ^5.22.1
-        version: 5.22.1
       which-pm-runs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -9906,6 +9897,7 @@ packages:
     engines: {node: '>=10.16.0'}
     dependencies:
       streamsearch: 1.1.0
+    dev: true
 
   /bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -16462,6 +16454,7 @@ packages:
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+    dev: true
 
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -17166,12 +17159,6 @@ packages:
     dependencies:
       busboy: 1.6.0
     dev: true
-
-  /undici@5.22.1:
-    resolution: {integrity: sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==}
-    engines: {node: '>=14.0'}
-    dependencies:
-      busboy: 1.6.0
 
   /unherit@3.0.1:
     resolution: {integrity: sha512-akOOQ/Yln8a2sgcLj4U0Jmx0R5jpIg2IUyRrWOzmEbjBtGzBdHtSeFKgoEcoH4KYIG/Pb8GQ/BwtYm0GCq1Sqg==}


### PR DESCRIPTION
## Changes

Remove `undici` dependency as Node.js 18 now includes it ootb.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass. I also ran the astro, node integration, and telemetry tests locally.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. internal change.