### PR TITLE
Ensure `injectRoute` works during build

### DIFF
--- a/.changeset/red-bikes-return.md
+++ b/.changeset/red-bikes-return.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Ensure injectRoute is properly handled in `build` as well as `dev`

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -123,7 +123,7 @@ export async function createVite(
 			htmlVitePlugin(),
 			jsxVitePlugin({ settings, logging }),
 			astroPostprocessVitePlugin(),
-			mode === 'dev' && astroIntegrationsContainerPlugin({ settings, logging }),
+			astroIntegrationsContainerPlugin({ settings, logging }),
 			astroScriptsPageSSRPlugin({ settings }),
 			astroHeadPlugin(),
 			astroScannerPlugin({ settings, logging }),

--- a/packages/astro/src/vite-plugin-integrations-container/index.ts
+++ b/packages/astro/src/vite-plugin-integrations-container/index.ts
@@ -17,9 +17,11 @@ export default function astroIntegrationsContainerPlugin({
 	return {
 		name: 'astro:integration-container',
 		configureServer(server) {
+			if (server.config.isProduction) return;
 			runHookServerSetup({ config: settings.config, server, logging });
 		},
 		async buildStart() {
+			if (settings.injectedRoutes.length === settings.resolvedInjectedRoutes.length) return;
 			// Ensure the injectedRoutes are all resolved to their final paths through Rollup
 			settings.resolvedInjectedRoutes = await Promise.all(
 				settings.injectedRoutes.map((route) => resolveEntryPoint.call(this, route))


### PR DESCRIPTION
## Changes

- In https://github.com/withastro/astro/pull/7943, we missed the fact that the integrations container plugin was only applied during `dev`
- This updates the logic to ensure the integrations container plugin can always run
- Adds guard to only run `server:setup` hooks during `dev`
- Adds guard to only run `resolveInjectedRoutes` during server build (otherwise, `buildStart` runs twice)

## Testing

Tested manually because monorepo

## Docs

N/A