### PR TITLE
Add shorthand for Starlight templates to `create astro`

### DIFF
--- a/.changeset/dry-pandas-flash.md
+++ b/.changeset/dry-pandas-flash.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Add support for more Starlight templates

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -67,9 +67,14 @@ const FILES_TO_UPDATE = {
 };
 
 function getTemplateTarget(tmpl: string, ref = 'latest') {
+	if (tmpl === 'starlight') tmpl = 'starlight/basics';
+	const starlightMatches = tmpl.match(/^starlight\/(.+)$/);
+	if (starlightMatches) {
+		const [, starter] = starlightMatches;
+		return `withastro/starlight/examples/${starter}`;
+	}
 	const isThirdParty = tmpl.includes('/');
 	if (isThirdParty) return tmpl;
-	if (tmpl === 'starlight') return `withastro/starlight/examples/basics`;
 	return `github:withastro/astro/examples/${tmpl}#${ref}`;
 }
 

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -67,10 +67,8 @@ const FILES_TO_UPDATE = {
 };
 
 function getTemplateTarget(tmpl: string, ref = 'latest') {
-	if (tmpl === 'starlight') tmpl = 'starlight/basics';
-	const starlightMatches = tmpl.match(/^starlight\/(.+)$/);
-	if (starlightMatches) {
-		const [, starter] = starlightMatches;
+	if (tmpl.startsWith('starlight')) {
+		const [_, starter = 'basics'] = tmpl.split('/');
 		return `withastro/starlight/examples/${starter}`;
 	}
 	const isThirdParty = tmpl.includes('/');

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -68,7 +68,7 @@ const FILES_TO_UPDATE = {
 
 function getTemplateTarget(tmpl: string, ref = 'latest') {
 	if (tmpl.startsWith('starlight')) {
-		const [_, starter = 'basics'] = tmpl.split('/');
+		const [, starter = 'basics'] = tmpl.split('/');
 		return `withastro/starlight/examples/${starter}`;
 	}
 	const isThirdParty = tmpl.includes('/');


### PR DESCRIPTION
## Changes

This adds some more special case handling for Starlight starter templates

Currently we hardcode `--template starlight` to `withastro/starlight/examples/basics`.

But https://github.com/withastro/starlight/pull/337 adds a new starter, and it would be nice to shorten the command needed to use it.

```sh
# current syntax
npm create astro@latest -- --template withastro/starlight/examples/tailwind

# with the changes in this PR
npm create astro@latest -- --template starlight/tailwind
```

If we think this is too much special-casing, we can close this.

## Testing

Tested the logic works manually, but not sure if it’s possible to run the local `create-astro`?

## Docs

Will only impact Starlight’s docs, which I’ll update if we merge this.
