### PR TITLE
Remove nested JSON.stringify from props serialization

### DIFF
--- a/.changeset/great-icons-turn.md
+++ b/.changeset/great-icons-turn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix quadratic quote escaping in nested data in island props

--- a/packages/astro/src/runtime/server/serialize.ts
+++ b/packages/astro/src/runtime/server/serialize.ts
@@ -4,7 +4,7 @@ type ValueOf<T> = T[keyof T];
 
 const PROP_TYPE = {
 	Value: 0,
-	JSON: 1,
+	JSON: 1, // Actually means Array
 	RegExp: 2,
 	Date: 3,
 	Map: 4,
@@ -68,16 +68,10 @@ function convertToSerializedForm(
 			return [PROP_TYPE.RegExp, (value as RegExp).source];
 		}
 		case '[object Map]': {
-			return [
-				PROP_TYPE.Map,
-				JSON.stringify(serializeArray(Array.from(value as Map<any, any>), metadata, parents)),
-			];
+			return [PROP_TYPE.Map, serializeArray(Array.from(value as Map<any, any>), metadata, parents)];
 		}
 		case '[object Set]': {
-			return [
-				PROP_TYPE.Set,
-				JSON.stringify(serializeArray(Array.from(value as Set<any>), metadata, parents)),
-			];
+			return [PROP_TYPE.Set, serializeArray(Array.from(value as Set<any>), metadata, parents)];
 		}
 		case '[object BigInt]': {
 			return [PROP_TYPE.BigInt, (value as bigint).toString()];
@@ -86,16 +80,16 @@ function convertToSerializedForm(
 			return [PROP_TYPE.URL, (value as URL).toString()];
 		}
 		case '[object Array]': {
-			return [PROP_TYPE.JSON, JSON.stringify(serializeArray(value, metadata, parents))];
+			return [PROP_TYPE.JSON, serializeArray(value, metadata, parents)];
 		}
 		case '[object Uint8Array]': {
-			return [PROP_TYPE.Uint8Array, JSON.stringify(Array.from(value as Uint8Array))];
+			return [PROP_TYPE.Uint8Array, Array.from(value as Uint8Array)];
 		}
 		case '[object Uint16Array]': {
-			return [PROP_TYPE.Uint16Array, JSON.stringify(Array.from(value as Uint16Array))];
+			return [PROP_TYPE.Uint16Array, Array.from(value as Uint16Array)];
 		}
 		case '[object Uint32Array]': {
-			return [PROP_TYPE.Uint32Array, JSON.stringify(Array.from(value as Uint32Array))];
+			return [PROP_TYPE.Uint32Array, Array.from(value as Uint32Array)];
 		}
 		default: {
 			if (value !== null && typeof value === 'object') {

--- a/packages/astro/test/serialize.test.js
+++ b/packages/astro/test/serialize.test.js
@@ -34,7 +34,13 @@ describe('serialize', () => {
 	});
 	it('serializes an array', () => {
 		const input = { a: [0] };
-		const output = `{"a":[1,"[[0,0]]"]}`;
+		const output = `{"a":[1,[[0,0]]]}`;
+		expect(serializeProps(input)).to.equal(output);
+	});
+	it('can serialize deeply nested data without quadratic quote escaping', () => {
+		const input = { a: [{ b: [{ c: [{ d: [{ e: [{ f: [{ g: ['leaf'] }] }] }] }] }] }] };
+		const output =
+			'{"a":[1,[[0,{"b":[1,[[0,{"c":[1,[[0,{"d":[1,[[0,{"e":[1,[[0,{"f":[1,[[0,{"g":[1,[[0,"leaf"]]]}]]]}]]]}]]]}]]]}]]]}]]]}';
 		expect(serializeProps(input)).to.equal(output);
 	});
 	it('serializes a regular expression', () => {
@@ -49,12 +55,12 @@ describe('serialize', () => {
 	});
 	it('serializes a Map', () => {
 		const input = { a: new Map([[0, 1]]) };
-		const output = `{"a":[4,"[[1,\\"[[0,0],[0,1]]\\"]]"]}`;
+		const output = `{"a":[4,[[1,[[0,0],[0,1]]]]]}`;
 		expect(serializeProps(input)).to.equal(output);
 	});
 	it('serializes a Set', () => {
 		const input = { a: new Set([0, 1, 2, 3]) };
-		const output = `{"a":[5,"[[0,0],[0,1],[0,2],[0,3]]"]}`;
+		const output = `{"a":[5,[[0,0],[0,1],[0,2],[0,3]]]}`;
 		expect(serializeProps(input)).to.equal(output);
 	});
 	it('serializes a BigInt', () => {
@@ -69,17 +75,17 @@ describe('serialize', () => {
 	});
 	it('serializes a Uint8Array', () => {
 		const input = { a: new Uint8Array([1, 2, 3]) };
-		const output = `{"a":[8,"[1,2,3]"]}`;
+		const output = `{"a":[8,[1,2,3]]}`;
 		expect(serializeProps(input)).to.equal(output);
 	});
 	it('serializes a Uint16Array', () => {
 		const input = { a: new Uint16Array([1, 2, 3]) };
-		const output = `{"a":[9,"[1,2,3]"]}`;
+		const output = `{"a":[9,[1,2,3]]}`;
 		expect(serializeProps(input)).to.equal(output);
 	});
 	it('serializes a Uint32Array', () => {
 		const input = { a: new Uint32Array([1, 2, 3]) };
-		const output = `{"a":[10,"[1,2,3]"]}`;
+		const output = `{"a":[10,[1,2,3]]}`;
 		expect(serializeProps(input)).to.equal(output);
 	});
 	it('cannot serialize a cyclic reference', () => {


### PR DESCRIPTION
## Changes

- Only call `JSON.stringify` once when serializing props for an island
- Match this change when deserializing props for an island
- This fixes a quadratic increase in quote escaping when using nested data, see #7978 

## Testing

I added a test that the kind of nested data from #7978 results in a normal-sized serialized text.

I didn't add more tests in this branch because I'm not comfortable changing the code organization in the project but I committed to another branch how I tested the implementation, basically by adding roundtrip tests to the file `serialize.test.js`. However I had to move the deserialization to the same file as the serialization, which I'm not sure fits the project structure. See https://github.com/daltonmaag/astro/commit/a513407c9c5efb30cd7be70892c8e2c7e677db56

## Docs

I believe this change should be transparent to users so I'm not sure it needs documenting?
