### PR TITLE
Fix examples check hang

### DIFF
--- a/.changeset/gentle-deers-yawn.md
+++ b/.changeset/gentle-deers-yawn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Call `astro sync` once before calling `astro check`

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "astro-benchmark": "workspace:*"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.1.0",
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.1",
     "@types/node": "^18.16.18",

--- a/packages/astro/src/cli/check/index.ts
+++ b/packages/astro/src/cli/check/index.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import type { Arguments } from 'yargs-parser';
 import { error, info } from '../../core/logger/core.js';
-import { createLoggingFromFlags } from '../flags.js';
+import { createLoggingFromFlags, flagsToAstroInlineConfig } from '../flags.js';
 import { getPackage } from '../install-package.js';
 
 export async function check(flags: Arguments) {
@@ -22,6 +22,16 @@ export async function check(flags: Arguments) {
 			'The `@astrojs/check` and `typescript` packages are required for this command to work. Please manually install them into your project and try again.'
 		);
 		return;
+	}
+
+	// Run sync before check to make sure types are generated.
+	// NOTE: In the future, `@astrojs/check` can expose a `before lint` hook so that this works during `astro check --watch` too.
+	// For now, we run this once as usually `astro check --watch` is ran alongside `astro dev` which also calls `astro sync`.
+	const { sync } = await import('../../core/sync/index.js');
+	const inlineConfig = flagsToAstroInlineConfig(flags);
+	const exitCode = await sync(inlineConfig);
+	if (exitCode !== 0) {
+		process.exit(exitCode);
 	}
 
 	const { check: checker, parseArgsAsCheckConfig } = checkPackage;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: workspace:*
         version: link:benchmark
     devDependencies:
+      '@astrojs/check':
+        specifier: ^0.1.0
+        version: 0.1.0(prettier-plugin-astro@0.11.0)(prettier@3.0.1)(typescript@5.1.6)
       '@changesets/changelog-github':
         specifier: ^0.4.8
         version: 0.4.8
@@ -18707,25 +18710,21 @@ packages:
   file:packages/astro/test/fixtures/css-assets/packages/font-awesome:
     resolution: {directory: packages/astro/test/fixtures/css-assets/packages/font-awesome, type: directory}
     name: '@test/astro-font-awesome-package'
-    version: 0.0.1
     dev: false
 
   file:packages/astro/test/fixtures/multiple-renderers/renderers/one:
     resolution: {directory: packages/astro/test/fixtures/multiple-renderers/renderers/one, type: directory}
     name: '@test/astro-renderer-one'
-    version: 1.0.0
     dev: false
 
   file:packages/astro/test/fixtures/multiple-renderers/renderers/two:
     resolution: {directory: packages/astro/test/fixtures/multiple-renderers/renderers/two, type: directory}
     name: '@test/astro-renderer-two'
-    version: 1.0.0
     dev: false
 
   file:packages/astro/test/fixtures/solid-component/deps/solid-jsx-component:
     resolution: {directory: packages/astro/test/fixtures/solid-component/deps/solid-jsx-component, type: directory}
     name: '@test/solid-jsx-component'
-    version: 0.0.0
     dependencies:
       solid-js: 1.7.6
     dev: false


### PR DESCRIPTION
## Changes

The examples check workflow was hanging as `@astrojs/check` wasn't installed for the examples, and it was requesting user input the install it.

This PR fixes it by installing `@astrojs/check` at the monorepo root.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Examples check should pass now.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a