### PR TITLE
fix: `EndpointOutput` type with encoding `'binary'`

### DIFF
--- a/.changeset/funny-glasses-bathe.md
+++ b/.changeset/funny-glasses-bathe.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed `EndpointOutput` types with `{ encoding: 'binary' }`

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1823,10 +1823,15 @@ export interface APIContext<Props extends Record<string, any> = Record<string, a
 	locals: App.Locals;
 }
 
-export interface EndpointOutput {
-	body: Body;
-	encoding?: BufferEncoding;
-}
+export type EndpointOutput =
+	| {
+			body: Body;
+			encoding?: Exclude<BufferEncoding, 'binary'>;
+	  }
+	| {
+			body: Uint8Array;
+			encoding: 'binary';
+	  };
 
 export type APIRoute<Props extends Record<string, any> = Record<string, any>> = (
 	context: APIContext<Props>

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -195,7 +195,6 @@ export class App {
 				}
 				return response.response;
 			} else {
-				const body = response.body;
 				const headers = new Headers();
 				const mimeType = mime.getType(url.pathname);
 				if (mimeType) {
@@ -203,7 +202,8 @@ export class App {
 				} else {
 					headers.set('Content-Type', 'text/plain;charset=utf-8');
 				}
-				const bytes = this.#encoder.encode(body);
+				const bytes =
+					response.encoding !== 'binary' ? this.#encoder.encode(response.body) : response.body;
 				headers.set('Content-Length', bytes.byteLength.toString());
 
 				const newResponse = new Response(bytes, {

--- a/packages/astro/src/core/endpoint/index.ts
+++ b/packages/astro/src/core/endpoint/index.ts
@@ -18,12 +18,10 @@ const clientAddressSymbol = Symbol.for('astro.clientAddress');
 const clientLocalsSymbol = Symbol.for('astro.locals');
 
 export type EndpointCallResult =
-	| {
+	| (EndpointOutput & {
 			type: 'simple';
-			body: string;
-			encoding?: BufferEncoding;
 			cookies: AstroCookies;
-	  }
+	  })
 	| {
 			type: 'response';
 			response: Response;
@@ -153,9 +151,8 @@ export async function callEndpoint<MiddlewareResult = Response | EndpointOutput>
 	}
 
 	return {
+		...response,
 		type: 'simple',
-		body: response.body,
-		encoding: response.encoding,
 		cookies: context.cookies,
 	};
 }

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -246,12 +246,15 @@ export async function handleRoute({
 			if (computedMimeType) {
 				contentType = computedMimeType;
 			}
-			const response = new Response(Buffer.from(result.body, result.encoding), {
-				status: 200,
-				headers: {
-					'Content-Type': `${contentType};charset=utf-8`,
-				},
-			});
+			const response = new Response(
+				result.encoding !== 'binary' ? Buffer.from(result.body, result.encoding) : result.body,
+				{
+					status: 200,
+					headers: {
+						'Content-Type': `${contentType};charset=utf-8`,
+					},
+				}
+			);
 			attachToResponse(response, result.cookies);
 			await writeWebResponse(incomingResponse, response);
 		}


### PR DESCRIPTION
## Changes

Fixes `EndpointOutput` type.

```ts
// Before
const output: EndpointOutput = {
  body: someBuffer, // Error! "Should be a string"
  encoding: 'binary',
}

// After
const output: EndpointOutput = {
  body: someBuffer, // Ok!
  encoding: 'binary',
}
```

## Testing

Just types updates

## Docs

Docs already describe the desired behavior