### PR TITLE
Support Bun by adjusting how `@babel/plugin-transform-react-jsx` is imported.

### DIFF
--- a/.changeset/quick-actors-sing.md
+++ b/.changeset/quick-actors-sing.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/preact': patch
+'astro': patch
+---
+
+Support Bun by adjusting how `@babel/plugin-transform-react-jsx` is imported.

--- a/packages/astro/src/jsx/renderer.ts
+++ b/packages/astro/src/jsx/renderer.ts
@@ -3,10 +3,9 @@ const renderer = {
 	serverEntrypoint: 'astro/jsx/server.js',
 	jsxImportSource: 'astro',
 	jsxTransformOptions: async () => {
-		const {
-			default: { default: jsx },
-			// @ts-expect-error
-		} = await import('@babel/plugin-transform-react-jsx');
+		// @ts-expect-error types not found
+		const plugin = await import('@babel/plugin-transform-react-jsx');
+		const jsx = plugin.default?.default ?? plugin.default;
 		const { default: astroJSX } = await import('./babel.js');
 		return {
 			plugins: [

--- a/packages/integrations/preact/src/index.ts
+++ b/packages/integrations/preact/src/index.ts
@@ -7,10 +7,9 @@ function getRenderer(development: boolean): AstroRenderer {
 		serverEntrypoint: '@astrojs/preact/server.js',
 		jsxImportSource: 'preact',
 		jsxTransformOptions: async () => {
-			const {
-				default: { default: jsx },
-				// @ts-expect-error types not found
-			} = await import('@babel/plugin-transform-react-jsx');
+			// @ts-expect-error types not found
+			const plugin = await import('@babel/plugin-transform-react-jsx');
+			const jsx = plugin.default?.default ?? plugin.default;
 			return {
 				plugins: [jsx({}, { runtime: 'automatic', importSource: 'preact' })],
 			};
@@ -25,10 +24,9 @@ function getCompatRenderer(development: boolean): AstroRenderer {
 		serverEntrypoint: '@astrojs/preact/server.js',
 		jsxImportSource: 'react',
 		jsxTransformOptions: async () => {
-			const {
-				default: { default: jsx },
-				// @ts-expect-error types not found
-			} = await import('@babel/plugin-transform-react-jsx');
+			// @ts-expect-error types not found
+			const plugin = await import('@babel/plugin-transform-react-jsx');
+			const jsx = plugin.default?.default ?? plugin.default;
 			return {
 				plugins: [
 					jsx({}, { runtime: 'automatic', importSource: 'preact/compat' }),


### PR DESCRIPTION
## Changes

This brings Astro a step closer to running on Bun by working around an existing workaround done when loading `@babel/plugin-transform-react-jsx`.

In Bun and some other tooling, `import`ing a CommonJS module that has `module.exports.__esModule` will tell the module loader/bundler to set `module.exports.default` as the ESM default export, where without this annotation the default export will be set to `module.exports`. Node does not do this transformation, which turns transpiled-to-cjs modules like `@babel/plugin-transform-react-jsx` into `{ default: { default: Function } }`, where in bun this loads as originally intended like `{ default: Function }`

This PR fixes the three places astro uses `.default.default` and ensures it handles the case where it may be just `.default`.

Our tracking issue for Astro as a whole is https://github.com/oven-sh/bun/issues/3746. This PR doesn't fully close that yet, as there are some remaining stability issues in Bun (random segfaults) when using larger projects.

## Testing

I have been manually testing this on the astro.build docs locally on macos with node.js v20.5.0 and a development build of bun.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

This is an internal change to the codebase and has no user-facing side effects. Maybe I should've added a comment for future code readers to understand why checking both `.default.default` and `.default` is necessary.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
