### PR TITLE
CollectionEntry type improvement 

### DIFF
--- a/packages/astro/content-types.template.d.ts
+++ b/packages/astro/content-types.template.d.ts
@@ -10,7 +10,9 @@ declare module 'astro:content' {
 
 declare module 'astro:content' {
 	export { z } from 'astro/zod';
-	export type CollectionEntry<C extends keyof AnyEntryMap> = AnyEntryMap[C][keyof AnyEntryMap[C]];
+	
+	type Flatten<T> = T extends { [K: string]: infer U } ? U : never;
+	export type CollectionEntry<C extends keyof AnyEntryMap> = Flatten<AnyEntryMap[C]>;
 
 	// TODO: Remove this when having this fallback is no longer relevant. 2.3? 3.0? - erika, 2023-04-04
 	/**


### PR DESCRIPTION
Provides more useful information when hovering variables typed with CollectionEntry<"collectionName"> 

* Does not change the functionality of existing code

* Flatten<AnyEntryMap[C]> is the same as AnyEntryMap[C][keyof AnyEntryMap[C]]

* Both will produce a union of all note entry types within the "collectionName" key

## Changes

- What does this change?

The CollectionEntry type which is a part of astro:content module that is autogenerated in .astro/types.d.ts

- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
Made this change locally and tried it with VSCode having made sure the types were updated with both astro build and npm run dev. Tried it with multiple collections, of different shapes. 
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->

No, it will only improve IDE experience.

<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This nuance typescript experience isn't currently documented, more of something a user would stumble upon, but it is somewhat expected behavior to have a useful hover for a typed variable. 
