### PR TITLE
Move hoisted script analysis optimization as experimental

### DIFF
--- a/.changeset/wild-jobs-tan.md
+++ b/.changeset/wild-jobs-tan.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Move hoisted script analysis optimization behind the `experimental.optimizeHoistedScript` option

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1280,9 +1280,10 @@ export interface AstroUserConfig {
 		 * @default `false`
 		 * @version 2.10.4
 		 * @description
-		 * Enable hoisted script analysis optimization to prevent unused components' script from being included in a page unexpectedly.
+		 * Prevents unused components' scripts from being included in a page unexpectedly.
 		 * The optimization is best-effort and may inversely miss including the used scripts. Make sure to double-check your built pages
 		 * before publishing.
+		 * Enable hoisted script analysis optimization by adding the experimental flag:
 		 *
 		 * ```js
 		 * {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1272,6 +1272,27 @@ export interface AstroUserConfig {
 		 * ```
 		 */
 		viewTransitions?: boolean;
+
+		/**
+		 * @docs
+		 * @name experimental.optimizeHoistedScript
+		 * @type {boolean}
+		 * @default `false`
+		 * @version 2.10.4
+		 * @description
+		 * Enable hoisted script analysis optimization to prevent unused components' script from being included in a page unexpectedly.
+		 * The optimization is best-effort and may inversely miss including the used scripts. Make sure to double-check your built pages
+		 * before publishing.
+		 *
+		 * ```js
+		 * {
+		 * 	experimental: {
+		 *		optimizeHoistedScript: true,
+		 * 	},
+		 * }
+		 * ```
+		 */
+		optimizeHoistedScript?: boolean;
 	};
 
 	// Legacy options to be removed

--- a/packages/astro/src/core/build/plugins/index.ts
+++ b/packages/astro/src/core/build/plugins/index.ts
@@ -16,7 +16,7 @@ import { pluginSSR, pluginSSRSplit } from './plugin-ssr.js';
 export function registerAllPlugins({ internals, options, register }: AstroBuildPluginContainer) {
 	register(pluginComponentEntry(internals));
 	register(pluginAliasResolve(internals));
-	register(pluginAnalyzer(internals));
+	register(pluginAnalyzer(options, internals));
 	register(pluginInternals(internals));
 	register(pluginRenderers(options));
 	register(pluginMiddleware(options, internals));

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -46,6 +46,7 @@ const ASTRO_CONFIG_DEFAULTS = {
 	experimental: {
 		assets: false,
 		viewTransitions: false,
+		optimizeHoistedScript: false
 	},
 } satisfies AstroUserConfig & { server: { open: boolean } };
 
@@ -237,6 +238,7 @@ export const AstroConfigSchema = z.object({
 				.boolean()
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.experimental.viewTransitions),
+				optimizeHoistedScript: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.optimizeHoistedScript),
 		})
 		.passthrough()
 		.refine(

--- a/packages/astro/test/hoisted-imports.test.js
+++ b/packages/astro/test/hoisted-imports.test.js
@@ -8,6 +8,9 @@ describe('Hoisted Imports', () => {
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/hoisted-imports/',
+			experimental: {
+				optimizeHoistedScript: true,
+			},
 		});
 	});
 


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/7744
Supersedes and closes https://github.com/withastro/astro/pull/7997

Move the feature in https://github.com/withastro/astro/pull/7707 behind an experimental flag. And added extra comments to make the analysis easier to follow.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Updated hoisted script test to enable the experimental flags.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Added the jsdocs. cc @withastro/maintainers-docs for feedback!