### PR TITLE
View Transitions: do not animate same page navigation, but animate hash links to different pages

### DIFF
--- a/.changeset/tender-tips-kneel.md
+++ b/.changeset/tender-tips-kneel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+View transitions: Links with hash marks are now supported if they lead to a different page

--- a/.changeset/tender-tips-kneel.md
+++ b/.changeset/tender-tips-kneel.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-View transitions: Links with hash marks are now supported if they lead to a different page
+Links with hash marks now trigger view transitions if they lead to a different page. Links to the same page do not trigger view transitions.

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -224,12 +224,6 @@ const { fallback = 'animate' } = Astro.props as Props;
 		document.head.append(link);
 	}
 
-	function isSamePage(location, link) {
-		const linkURL = new URL(link.href, location.href);
-		linkURL.hash = location.hash;
-		return linkURL.href.replace(/#$/, '') === location.href.replace(/#$/, '');
-	}
-
 	if (supportsViewTransitions || getFallback() !== 'none') {
 		document.addEventListener('click', (ev) => {
 			let link = ev.target;
@@ -245,7 +239,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 				link.href &&
 				(!link.target || link.target === '_self') &&
 				link.origin === location.origin &&
-				!isSamePage(location, link) &&
+				location.pathname !== link.pathname &&
 				ev.button === 0 && // left clicks only
 				!ev.metaKey && // new tab (mac)
 				!ev.ctrlKey && // new tab (windows)

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -132,6 +132,10 @@ const { fallback = 'animate' } = Astro.props as Props;
 				}
 			}
 
+			if (state?.scrollY === 0 && location.hash) {
+				const id = decodeURIComponent(location.hash.slice(1));
+				state.scrollY = document.getElementById(id)?.offsetTop || 0;
+			}
 			if (state?.scrollY != null) {
 				scrollTo(0, state.scrollY);
 			}
@@ -220,6 +224,12 @@ const { fallback = 'animate' } = Astro.props as Props;
 		document.head.append(link);
 	}
 
+	function samePage(location, link) {
+		const linkURL = new URL(link.href, location.href);
+		linkURL.hash = location.hash;
+		return linkURL.href === location.href;
+	}
+
 	if (supportsViewTransitions || getFallback() !== 'none') {
 		document.addEventListener('click', (ev) => {
 			let link = ev.target;
@@ -235,7 +245,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 				link.href &&
 				(!link.target || link.target === '_self') &&
 				link.origin === location.origin &&
-				!link.hash &&
+				!(link.hash && samePage(location, link)) &&
 				ev.button === 0 && // left clicks only
 				!ev.metaKey && // new tab (mac)
 				!ev.ctrlKey && // new tab (windows)

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -245,7 +245,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 				link.href &&
 				(!link.target || link.target === '_self') &&
 				link.origin === location.origin &&
-				!(link.hash && samePage(location, link)) &&
+				!samePage(location, link) &&
 				ev.button === 0 && // left clicks only
 				!ev.metaKey && // new tab (mac)
 				!ev.ctrlKey && // new tab (windows)

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -224,10 +224,10 @@ const { fallback = 'animate' } = Astro.props as Props;
 		document.head.append(link);
 	}
 
-	function samePage(location, link) {
+	function isSamePage(location, link) {
 		const linkURL = new URL(link.href, location.href);
 		linkURL.hash = location.hash;
-		return linkURL.href === location.href;
+		return linkURL.href.replace(/#$/, '') === location.href.replace(/#$/, '');
 	}
 
 	if (supportsViewTransitions || getFallback() !== 'none') {
@@ -245,7 +245,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 				link.href &&
 				(!link.target || link.target === '_self') &&
 				link.origin === location.origin &&
-				!samePage(location, link) &&
+				!isSamePage(location, link) &&
 				ev.button === 0 && // left clicks only
 				!ev.metaKey && // new tab (mac)
 				!ev.ctrlKey && // new tab (windows)


### PR DESCRIPTION
## Changes

- Formerly, links with a hash mark did not start view transitions. Now they will, if they lead to a different page.
- Formerly, links to the same page (without hashes) did start view transitions. Now they don't.  

## Testing

Tested with the examples from #7849 and #7882

## Docs

No doc updates required.
Fixes unexpected behavior