### PR TITLE
fix: Removed extra double quotes from computed style in shiki code component

### DIFF
--- a/.changeset/tall-owls-act.md
+++ b/.changeset/tall-owls-act.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Removed extra double quotes from computed style in shiki code component

--- a/.changeset/tall-owls-act.md
+++ b/.changeset/tall-owls-act.md
@@ -1,5 +1,5 @@
 ---
-'astro': minor
+'astro': patch
 ---
 
 Removed extra double quotes from computed style in shiki code component

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -74,9 +74,9 @@ const html = renderToHtml(tokens, {
 			// Handle code wrapping
 			// if wrap=null, do nothing.
 			if (wrap === false) {
-				style += '; overflow-x: auto;"';
+				style += '; overflow-x: auto;';
 			} else if (wrap === true) {
-				style += '; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word;"';
+				style += '; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word;';
 			}
 			return `<${tag} class="${className}" style="${style}" tabindex="0">${children}</${tag}>`;
 		},


### PR DESCRIPTION
## Changes

Removed an invalid extra double quote that is added to the shiki wrapper component called Code.

## Testing

Sorry, I don't have the time to learn how to properly create unit tests for this within your ecosystem.  Sorry if this is unacceptable.  The test I would add I guess would be whether the style attribute is properly formed without the extra double quote.  I am not sure how to do that.

## Docs

I would assume no document changes should be needed for this.  It currently creates malformed html, but at least Chrome still renders properly even with the malformed HTML.  This should not affect the functionality other than possibly make stricter browsers (if they exist) work properly.