### PR TITLE
Add changeset for internal helper package

### DIFF
--- a/.changeset/big-tips-whisper.md
+++ b/.changeset/big-tips-whisper.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/internal-helpers': patch
+---
+
+Trigger re-release to fix `collapseDuplicateSlashes` export


### PR DESCRIPTION
## Changes

The `@astrojs/internal-helper` beta code is borked as it doesn't contain the code from v0.1. Likely caused by releasing beta, then main perhaps.

fix https://github.com/withastro/astro/issues/8052

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
n/a. only changeset.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. only changeset.