### PR TITLE
Document SSG format and trailingSlash consistency

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -699,7 +699,7 @@ export interface AstroUserConfig {
 		 *
 		 * This means that when you create relative URLs using `new URL('./relative', Astro.url)`, you will get consistent behavior between dev and build.
 		 * 
-		 * To further align the trailing slash behaviour in dev, you can restrict the `trailingSlash` option to `'always'` or `'never'` to prevent inconsistencies:
+		 * To prevent inconsistencies with trailing slash behaviour in dev, you can restrict the [`trailingSlash` option](#trailingslash) to `'always'` or `'never'` depending on your build format:
 		 * - `directory` - Set `trailingSlash: 'always'`
 		 * - `file` - Set `trailingSlash: 'never'`
 		 */

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -698,6 +698,10 @@ export interface AstroUserConfig {
 		 * - `file` - The `Astro.url.pathname` will include `.html`; ie `/foo.html`.
 		 *
 		 * This means that when you create relative URLs using `new URL('./relative', Astro.url)`, you will get consistent behavior between dev and build.
+		 * 
+		 * To further align the trailing slash behaviour in dev, you can restrict the `trailingSlash` option to `'always'` or `'never'` to prevent inconsistencies:
+		 * - `directory` - Set `trailingSlash: 'always'`
+		 * - `file` - Set `trailingSlash: 'never'`
 		 */
 		format?: 'file' | 'directory';
 		/**


### PR DESCRIPTION
## Changes

close https://github.com/withastro/astro/issues/5630

It is documented how `build.format` affects `Astro.url`. This PR further explains how to prevent inconsistencies in dev by updating `trailingSlash` so it aligns with how `build.format` affects `Astro.url`.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
n/a.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->

updates the jsdoc for `build.format`
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
