### PR TITLE
Add Transloadit to the Gold Sponsors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Astro is generously supported by Netlify, Storyblok, and several other amazing o
 
 [![Astro's sponsors.](https://astro.build/sponsors.png "Astro's sponsors.
 Platinum sponsors: Netlify, storyblok, Vercel, Ship Shape, Google Chrome
-Gold sponsors: ‹div›RIOTS, DEEPGRAM, CloudCannon, Transloadit
+Gold sponsors: ‹div›RIOTS, DEEPGRAM, Transloadit, CloudCannon
 Sponsors: Monogram, Qoddi, Dimension")](https://github.com/sponsors/withastro)
 
   </a>

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Astro is generously supported by Netlify, Storyblok, and several other amazing o
 
 [![Astro's sponsors.](https://astro.build/sponsors.png "Astro's sponsors.
 Platinum sponsors: Netlify, storyblok, Vercel, Ship Shape, Google Chrome
-Gold sponsors: ‹div›RIOTS, DEEPGRAM, CloudCannon
+Gold sponsors: ‹div›RIOTS, DEEPGRAM, CloudCannon, Transloadit
 Sponsors: Monogram, Qoddi, Dimension")](https://github.com/sponsors/withastro)
 
   </a>


### PR DESCRIPTION
This is a sister PR to https://github.com/withastro/astro.build/pull/765.

**Context:** Transloadit is a Gold Sponsor and we'd like to showcase our logo on the Astro GitHub README and on the Astro homepage. The main changes, including the addition of the logo, can be found in the sister PR mentioned above.

## Changes

- Updated the `alt` for the sponsors image in the README.