### PR TITLE
fix(@astrojs/cloudflare): unsynced astro asset support flag

### DIFF
--- a/.changeset/strong-papayas-chew.md
+++ b/.changeset/strong-papayas-chew.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Sync Astro Asset support across both modes

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -29,7 +29,7 @@ export function getAdapter(isModeDirectory: boolean): AstroAdapter {
 					staticOutput: 'unsupported',
 					serverOutput: 'stable',
 					assets: {
-						supportKind: 'unsupported',
+						supportKind: 'stable',
 						isSharpCompatible: false,
 						isSquooshCompatible: false,
 					},


### PR DESCRIPTION
## Changes

- Sync astro features setting across both adapter modes
- astro assets is supported, but only `noop`

## Testing

- Not needed

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
- changeset review
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
