### PR TITLE
Export astro/compiler-runtime and cleanup exports

### DIFF
--- a/.changeset/neat-owls-run.md
+++ b/.changeset/neat-owls-run.md
@@ -1,0 +1,25 @@
+---
+'astro': major
+---
+
+Remove exports for `astro/internal/*` and `astro/runtime/server/*` in favour of `astro/runtime/*`. Add new `astro/compiler-runtime` export for compiler-specific runtime code.
+
+These are exports for Astro's internal API and should not affect your project, but if you do use these entrypoints, you can migrate like below:
+
+```diff
+- import 'astro/internal/index.js';
++ import 'astro/runtime/server/index.js';
+
+- import 'astro/server/index.js';
++ import 'astro/runtime/server/index.js';
+```
+
+```diff
+import { transform } from '@astrojs/compiler';
+
+const result = await transform(source, {
+- internalURL: 'astro/runtime/server/index.js',
++ internalURL: 'astro/compiler-runtime',
+  // ...
+});
+```

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -42,6 +42,8 @@
     "./tsconfigs/*": "./tsconfigs/*.json",
     "./jsx/*": "./dist/jsx/*",
     "./jsx-runtime": "./dist/jsx-runtime/index.js",
+    "./compiler-runtime": "./dist/runtime/compiler/index.js",
+    "./runtime/*": "./dist/runtime/*",
     "./config": {
       "types": "./config.d.ts",
       "default": "./config.mjs"
@@ -60,10 +62,7 @@
     "./content/runtime": "./dist/content/runtime.js",
     "./content/runtime-assets": "./dist/content/runtime-assets.js",
     "./debug": "./components/Debug.astro",
-    "./internal/*": "./dist/runtime/server/*",
     "./package.json": "./package.json",
-    "./runtime/*": "./dist/runtime/*",
-    "./server/*": "./dist/runtime/server/*",
     "./zod": {
       "types": "./zod.d.ts",
       "default": "./zod.mjs"

--- a/packages/astro/src/core/compile/compile.ts
+++ b/packages/astro/src/core/compile/compile.ts
@@ -41,7 +41,7 @@ export async function compile({
 			filename,
 			normalizedFilename: normalizeFilename(filename, astroConfig.root),
 			sourcemap: 'both',
-			internalURL: 'astro/server/index.js',
+			internalURL: 'astro/compiler-runtime',
 			astroGlobalArgs: JSON.stringify(astroConfig.site),
 			scopedStyleStrategy: astroConfig.scopedStyleStrategy,
 			resultScopedSlot: true,

--- a/packages/astro/src/runtime/README.md
+++ b/packages/astro/src/runtime/README.md
@@ -4,5 +4,6 @@ Code that executes within isolated contexts:
 
 - `client/`: executes within the browser. Astro’s client-side partial hydration code lives here, and only browser-compatible code can be used.
 - `server/`: executes inside Vite SSR. Though also a Node context, this is isolated from code in `core/`.
+- `compiler/`: same as `server/`, but only used by the Astro compiler `internalURL` option.
 
 [See CONTRIBUTING.md](../../../../CONTRIBUTING.md) for a code overview.

--- a/packages/astro/src/runtime/compiler/index.ts
+++ b/packages/astro/src/runtime/compiler/index.ts
@@ -1,0 +1,20 @@
+// NOTE: Although this entrypoint is exported, it is internal API and may change at any time.
+
+export {
+	Fragment,
+	render,
+	createAstro,
+	createComponent,
+	renderComponent,
+	renderHead,
+	maybeRenderHead,
+	unescapeHTML,
+	renderSlot,
+	mergeSlots,
+	addAttribute,
+	renderTransition,
+	createTransitionScope,
+	spreadAttributes,
+	defineStyleVars,
+	defineScriptVars,
+} from '../server/index.js';

--- a/packages/astro/src/runtime/server/index.ts
+++ b/packages/astro/src/runtime/server/index.ts
@@ -1,3 +1,5 @@
+// NOTE: Although this entrypoint is exported, it is internal API and may change at any time.
+
 export { createComponent } from './astro-component.js';
 export { createAstro } from './astro-global.js';
 export { renderEndpoint } from './endpoint.js';

--- a/packages/astro/src/vite-plugin-mdx/tag.ts
+++ b/packages/astro/src/vite-plugin-mdx/tag.ts
@@ -18,7 +18,7 @@ export default async function tagExportsWithRenderer({
 	return {
 		visitor: {
 			Program: {
-				// Inject `import { __astro_tag_component__ } from 'astro/server/index.js'`
+				// Inject `import { __astro_tag_component__ } from 'astro/runtime/server/index.js'`
 				enter(path) {
 					path.node.body.splice(
 						0,
@@ -30,7 +30,7 @@ export default async function tagExportsWithRenderer({
 									t.identifier('__astro_tag_component__')
 								),
 							],
-							t.stringLiteral('astro/server/index.js')
+							t.stringLiteral('astro/runtime/server/index.js')
 						)
 					);
 				},


### PR DESCRIPTION
## Changes

(Same as changeset)

Remove exports for `astro/internal/*` and `astro/runtime/server/*` in favour of `astro/runtime/*`. Add new `astro/compiler-runtime` export for compiler-specific runtime code.

Ultimately it would be nice to get rid of `astro/runtime/*` and make it all stricter, but that's longer term.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
We currently don't reference these exports in the docs, which is great since they are internal APIs. The `@astrojs/compiler` README can use an update after 3.0 is released to recommend `astro/compiler-runtime` over `astro/runtime/server/index.js`