### PR TITLE
Remove deepmerge-ts for simpler implementation

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -137,7 +137,6 @@
     "common-ancestor-path": "^1.0.1",
     "cookie": "^0.5.0",
     "debug": "^4.3.4",
-    "deepmerge-ts": "^4.3.0",
     "devalue": "^4.3.2",
     "diff": "^5.1.0",
     "es-module-lexer": "^1.3.0",

--- a/packages/astro/src/core/config/tsconfig.ts
+++ b/packages/astro/src/core/config/tsconfig.ts
@@ -1,4 +1,3 @@
-import { deepmerge } from 'deepmerge-ts';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import * as tsr from 'tsconfig-resolver';
@@ -96,5 +95,28 @@ export function updateTSConfigForFramework(
 		return target;
 	}
 
-	return deepmerge(target, presets.get(framework)!);
+	return deepMergeObjects(target, presets.get(framework)!);
+}
+
+// Simple deep merge implementation that merges objects and strings
+function deepMergeObjects<T extends Record<string, any>>(a: T, b: T): T {
+	const merged: T = { ...a };
+
+	for (const key in b) {
+		const value = b[key];
+
+		if (a[key] == null) {
+			merged[key] = value;
+			continue;
+		}
+
+		if (typeof a[key] === 'object' && typeof value === 'object') {
+			merged[key] = deepMergeObjects(a[key], value);
+			continue;
+		}
+
+		merged[key] = value;
+	}
+
+	return merged;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -548,9 +548,6 @@ importers:
       debug:
         specifier: ^4.3.4
         version: 4.3.4
-      deepmerge-ts:
-        specifier: ^4.3.0
-        version: 4.3.0
       devalue:
         specifier: ^4.3.2
         version: 4.3.2
@@ -10808,11 +10805,6 @@ packages:
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
-
-  /deepmerge-ts@4.3.0:
-    resolution: {integrity: sha512-if3ZYdkD2dClhnXR5reKtG98cwyaRT1NeugQoAPTTfsOpV9kqyeiBF9Qa5RHjemb3KzD5ulqygv6ED3t5j9eJw==}
-    engines: {node: '>=12.4.0'}
-    dev: false
 
   /deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}


### PR DESCRIPTION
## Changes

Implement a simpler merge function (based on Astro's mergeConfig utility but simplified) to prevent needing to use a dep.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested with a project running `astro add preact`, `astro add solid-js`, etc. Making sure the `tsconfig.json` updates still work.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. internal change.