### PR TITLE
[create-astro] update shell logic

### DIFF
--- a/.changeset/angry-balloons-argue.md
+++ b/.changeset/angry-balloons-argue.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fix install step to avoid unscrutable errors


### PR DESCRIPTION
## Changes

- The timeout logic added in https://github.com/withastro/astro/pull/8077 caused some issues
- This PR refactors `shell` to rely on Node's built-in `timeout` support
- If a `ChildProcess` times out, it will emit the `close` event but the `exitCode` will be `null`.

## Testing

Tested manually because it's spawning a shell

## Docs

N/A, bug fix only