### PR TITLE
Handle noscript tags in head during ViewTransitions

### DIFF
--- a/.changeset/shaggy-cameras-hide.md
+++ b/.changeset/shaggy-cameras-hide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Handle `<noscript>` tags in `<head>` during ViewTransitions

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -125,6 +125,10 @@ const { fallback = 'animate' } = Astro.props as Props;
 		};
 
 		const swap = () => {
+			// noscript tags inside head element are not honored on swap (#7969).
+			// Remove them before swapping.
+			doc.querySelectorAll('head noscript').forEach((el) => el.remove());
+
 			// Swap head
 			for (const el of Array.from(document.head.children)) {
 				const newEl = persistedHeadElement(el);


### PR DESCRIPTION
## Changes

deletes `<noscript>` descendants of the `<head>` element, since they are ignored during view transitions.
Since this is a JavaScript client side router, we can ignore noscript trees completely. 
Solves #7969

## Testing

Manually tested with the Minimal Reproducible Example of #7969

## Docs

n.a. / bug fix