### PR TITLE
Add trailing newlines to create-astro generated package.json and tsconfig.json

### DIFF
--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -60,7 +60,7 @@ const FILES_TO_UPDATE = {
 					Object.assign(JSON.parse(value), Object.assign(overrides, { private: undefined })),
 					null,
 					indent
-				),
+				) + '\n',
 				'utf-8'
 			);
 		}),

--- a/packages/create-astro/src/actions/typescript.ts
+++ b/packages/create-astro/src/actions/typescript.ts
@@ -81,7 +81,7 @@ export async function setupTypeScript(value: string, { cwd }: { cwd: string }) {
 				extends: `astro/tsconfigs/${value}`,
 			});
 
-			fs.writeFileSync(templateTSConfigPath, JSON.stringify(result, null, 2));
+			fs.writeFileSync(templateTSConfigPath, JSON.stringify(result, null, 2) + '\n');
 		} else {
 			throw new Error(
 				"There was an error applying the requested TypeScript settings. This could be because the template's tsconfig.json is malformed"
@@ -92,7 +92,7 @@ export async function setupTypeScript(value: string, { cwd }: { cwd: string }) {
 			// If the template doesn't have a tsconfig.json, let's add one instead
 			fs.writeFileSync(
 				templateTSConfigPath,
-				JSON.stringify({ extends: `astro/tsconfigs/${value}` }, null, 2)
+				JSON.stringify({ extends: `astro/tsconfigs/${value}` }, null, 2) + '\n'
 			);
 		}
 	}


### PR DESCRIPTION
## Changes

- Add a tailing newline to `package.json` generated from `create-astro`
- Add a trailing newline to `tsconfig.json` generated from `create-astro`

## Testing

Did not directly test in `create-astro` package.

## Docs

No changes to docs needed.
