### PR TITLE
Add newline between HTML elements and <style> tags in example files

### DIFF
--- a/examples/basics/src/components/Card.astro
+++ b/examples/basics/src/components/Card.astro
@@ -19,6 +19,7 @@ const { href, title, body } = Astro.props;
 		</p>
 	</a>
 </li>
+
 <style>
 	.link-card {
 		list-style: none;

--- a/examples/basics/src/layouts/Layout.astro
+++ b/examples/basics/src/layouts/Layout.astro
@@ -20,6 +20,7 @@ const { title } = Astro.props;
 		<slot />
 	</body>
 </html>
+
 <style is:global>
 	:root {
 		--accent: 136, 58, 234;


### PR DESCRIPTION
## Changes

These changes provide more delineation between HTML and CSS in example files. Also matches existing delineation in `index.astro`.

- Add newline between </html> and <style> tags in example `components/Card.astro`
- Add newline between </html> and <style> tags in example `layouts/Layout.astro`

## Testing

No testing performed.

## Docs

No changes to docs needed.