### PR TITLE
`astro:` namespace for middleware and components

### DIFF
--- a/.changeset/neat-mugs-end.md
+++ b/.changeset/neat-mugs-end.md
@@ -1,0 +1,8 @@
+---
+'astro': minor
+---
+
+
+`astro:`namespace aliases for middleware and components
+
+This adds aliases of `astro:middleware` and `astro:components` for the middleware and components modules. This is to make our documentation consistent between are various modules, where some are virtual modules and others are not. Going forward new built-in modules will use this namespace.

--- a/examples/middleware/src/middleware.ts
+++ b/examples/middleware/src/middleware.ts
@@ -1,4 +1,4 @@
-import { defineMiddleware, sequence } from 'astro/middleware';
+import { defineMiddleware, sequence } from 'astro:middleware';
 import htmlMinifier from 'html-minifier';
 
 const limit = 50;

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -119,6 +119,14 @@ declare module 'astro:transitions' {
 	export const ViewTransitions: ViewTransitionsModule['default'];
 }
 
+declare module 'astro:middleware' {
+	export * from 'astro/middleware';
+}
+
+declare module 'astro:components' {
+	export * from 'astro/components';
+}
+
 type MD = import('./dist/@types/astro').MarkdownInstance<Record<string, any>>;
 interface ExportedMarkdownModuleEntities {
 	frontmatter: MD['frontmatter'];

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -120,7 +120,7 @@ declare module 'astro:transitions' {
 }
 
 declare module 'astro:middleware' {
-	export * from 'astro/middleware';
+	export * from 'astro/middleware/namespace';
 }
 
 declare module 'astro:components' {

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -23,6 +23,9 @@
       ],
       "middleware": [
         "./dist/core/middleware/index.d.ts"
+      ],
+      "middleware/namespace": [
+        "./dist/core/middleware/namespace.d.ts"
       ]
     }
   },
@@ -69,6 +72,10 @@
     "./middleware": {
       "types": "./dist/core/middleware/index.d.ts",
       "default": "./dist/core/middleware/index.js"
+    },
+    "./middleware/namespace": {
+      "types": "./dist/core/middleware/namespace.d.ts",
+      "default": "./dist/core/middleware/namespace.js"
     },
     "./transitions": "./dist/transitions/index.js"
   },

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1852,7 +1852,7 @@ export interface APIContext<Props extends Record<string, any> = Record<string, a
 	 *
 	 * ```ts
 	 * // src/middleware.ts
-	 * import {defineMiddleware} from "astro/middleware";
+	 * import {defineMiddleware} from "astro:middleware";
 	 *
 	 * export const onRequest = defineMiddleware((context, next) => {
 	 *   context.locals.greeting = "Hello!";

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -172,7 +172,7 @@ export async function createVite(
 				},
 				{
 					find: 'astro:middleware',
-					replacement: 'astro/middleware',
+					replacement: 'astro/middleware/namespace',
 				},
 				{
 					find: 'astro:components',

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -170,6 +170,14 @@ export async function createVite(
 					find: /^astro$/,
 					replacement: fileURLToPath(new URL('../@types/astro', import.meta.url)),
 				},
+				{
+					find: 'astro:middleware',
+					replacement: 'astro/middleware',
+				},
+				{
+					find: 'astro:components',
+					replacement: 'astro/components',
+				},
 			],
 			conditions: ['astro'],
 			// Astro imports in third-party packages should use the same version as root

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -658,7 +658,7 @@ export const ResponseSentError = {
  *
  * For example:
  * ```ts
- * import {defineMiddleware} from "astro/middleware";
+ * import {defineMiddleware} from "astro:middleware";
  * export const onRequest = defineMiddleware((context, _) => {
  * 	// doesn't return anything or call `next`
  * 	context.locals.someData = false;
@@ -678,7 +678,7 @@ export const MiddlewareNoDataOrNextCalled = {
  *
  * For example:
  * ```ts
- * import {defineMiddleware} from "astro/middleware";
+ * import {defineMiddleware} from "astro:middleware";
  * export const onRequest = defineMiddleware(() => {
  *   return "string"
  * });
@@ -698,7 +698,7 @@ export const MiddlewareNotAResponse = {
  *
  * For example:
  * ```ts
- * import {defineMiddleware} from "astro/middleware";
+ * import {defineMiddleware} from "astro:middleware";
  * export const onRequest = defineMiddleware((context, next) => {
  *   context.locals = 1541;
  *   return next();

--- a/packages/astro/src/core/middleware/namespace.ts
+++ b/packages/astro/src/core/middleware/namespace.ts
@@ -1,0 +1,4 @@
+export {
+	defineMiddleware,
+	sequence,
+} from './index.js';

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/basic.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/basic.astro
@@ -1,5 +1,5 @@
 ---
-import {Code} from 'astro/components';
+import {Code} from 'astro:components';
 ---
 <html>
 <head><title>Code component</title></head>

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/css-theme.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/css-theme.astro
@@ -1,5 +1,5 @@
 ---
-import {Code} from 'astro/components';
+import {Code} from 'astro:components';
 ---
 <html>
 <head><title>Code component</title></head>

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/custom-theme.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/custom-theme.astro
@@ -1,5 +1,5 @@
 ---
-import {Code} from 'astro/components';
+import {Code} from 'astro:components';
 ---
 <html>
 <head><title>Code component</title></head>

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/imported.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/imported.astro
@@ -1,5 +1,5 @@
 ---
-import {Code} from 'astro/components';
+import {Code} from 'astro:components';
 import riGrammar from '../assets/ri.tmLanguage.json'
 import serendipity from '../assets/serendipity-morning.json'
 

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/inline.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/inline.astro
@@ -1,5 +1,5 @@
 ---
-import {Code} from 'astro/components';
+import {Code} from 'astro:components';
 ---
 <html>
 <head><title>Code component</title></head>

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/no-lang.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/no-lang.astro
@@ -1,5 +1,5 @@
 ---
-import {Code} from 'astro/components';
+import {Code} from 'astro:components';
 ---
 <html>
 <head><title>Code component</title></head>

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/wrap-false.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/wrap-false.astro
@@ -1,5 +1,5 @@
 ---
-import {Code} from 'astro/components';
+import {Code} from 'astro:components';
 ---
 <html>
 <head><title>Code component</title></head>

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/wrap-null.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/wrap-null.astro
@@ -1,5 +1,5 @@
 ---
-import {Code} from 'astro/components';
+import {Code} from 'astro:components';
 ---
 <html>
 <head><title>Code component</title></head>

--- a/packages/astro/test/fixtures/astro-component-code/src/pages/wrap-true.astro
+++ b/packages/astro/test/fixtures/astro-component-code/src/pages/wrap-true.astro
@@ -1,5 +1,5 @@
 ---
-import {Code} from 'astro/components';
+import {Code} from 'astro:components';
 ---
 <html>
 <head><title>Code component</title></head>

--- a/packages/astro/test/fixtures/code-component/src/pages/index.astro
+++ b/packages/astro/test/fixtures/code-component/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import { Code } from 'astro/components';
+import { Code } from 'astro:components';
 ---
 <html>
 	<head>

--- a/packages/astro/test/fixtures/middleware-dev/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware-dev/src/middleware.js
@@ -1,4 +1,4 @@
-import { sequence, defineMiddleware } from 'astro/middleware';
+import { sequence, defineMiddleware } from 'astro:middleware';
 
 const first = defineMiddleware(async (context, next) => {
 	if (context.request.url.includes('/lorem')) {

--- a/packages/astro/test/fixtures/middleware-ssg/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware-ssg/src/middleware.js
@@ -1,4 +1,4 @@
-import { sequence, defineMiddleware } from 'astro/middleware';
+import { sequence, defineMiddleware } from 'astro:middleware';
 
 const first = defineMiddleware(async (context, next) => {
 	if (context.request.url.includes('/second')) {

--- a/packages/astro/test/fixtures/ssr-redirect/src/middleware.ts
+++ b/packages/astro/test/fixtures/ssr-redirect/src/middleware.ts
@@ -1,4 +1,4 @@
-import { defineMiddleware } from 'astro/middleware';
+import { defineMiddleware } from 'astro:middleware';
 
 export const onRequest = defineMiddleware(({ request }, next) => {
 	if(new URL(request.url).pathname === '/middleware-redirect/') {

--- a/packages/astro/test/fixtures/static-build-code-component/src/pages/index.astro
+++ b/packages/astro/test/fixtures/static-build-code-component/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import {Code} from 'astro/components';
+import {Code} from 'astro:components';
 ---
 <html>
 <head><title>Testing</title></head>

--- a/packages/astro/test/fixtures/static-build-dir/src/pages/index.astro
+++ b/packages/astro/test/fixtures/static-build-dir/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import {Code} from 'astro/components';
+import {Code} from 'astro:components';
 ---
 <html>
 <head><title>Testing</title></head>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18252,21 +18252,25 @@ packages:
   file:packages/astro/test/fixtures/css-assets/packages/font-awesome:
     resolution: {directory: packages/astro/test/fixtures/css-assets/packages/font-awesome, type: directory}
     name: '@test/astro-font-awesome-package'
+    version: 0.0.1
     dev: false
 
   file:packages/astro/test/fixtures/multiple-renderers/renderers/one:
     resolution: {directory: packages/astro/test/fixtures/multiple-renderers/renderers/one, type: directory}
     name: '@test/astro-renderer-one'
+    version: 1.0.0
     dev: false
 
   file:packages/astro/test/fixtures/multiple-renderers/renderers/two:
     resolution: {directory: packages/astro/test/fixtures/multiple-renderers/renderers/two, type: directory}
     name: '@test/astro-renderer-two'
+    version: 1.0.0
     dev: false
 
   file:packages/astro/test/fixtures/solid-component/deps/solid-jsx-component:
     resolution: {directory: packages/astro/test/fixtures/solid-component/deps/solid-jsx-component, type: directory}
     name: '@test/solid-jsx-component'
+    version: 0.0.0
     dependencies:
       solid-js: 1.7.6
     dev: false


### PR DESCRIPTION
## Changes

- Adds aliases of `astro:middleware` and `astro:components`

## Testing

- All updated to use the aliases

## Docs

- [PR](https://github.com/withastro/docs/pull/4239)