### PR TITLE
Fix missing async/await in vite-plugin-integrations-container on astro:server:setup hook

### DIFF
--- a/packages/astro/src/vite-plugin-integrations-container/index.ts
+++ b/packages/astro/src/vite-plugin-integrations-container/index.ts
@@ -16,9 +16,9 @@ export default function astroIntegrationsContainerPlugin({
 }): VitePlugin {
 	return {
 		name: 'astro:integration-container',
-		configureServer(server) {
+		async configureServer(server) {
 			if (server.config.isProduction) return;
-			runHookServerSetup({ config: settings.config, server, logging });
+			await runHookServerSetup({ config: settings.config, server, logging });
 		},
 		async buildStart() {
 			if (settings.injectedRoutes.length === settings.resolvedInjectedRoutes.length) return;

--- a/packages/astro/test/fixtures/integration-server-setup/integration.js
+++ b/packages/astro/test/fixtures/integration-server-setup/integration.js
@@ -1,8 +1,12 @@
+import { setTimeout } from "node:timers/promises";
+
 export default function() {
 	return {
 		name: '@astrojs/test-integration',
 		hooks: {
-			'astro:server:setup': ({ server }) => {
+			'astro:server:setup': async ({ server }) => {
+				// Ensure that `async` is respected
+				await setTimeout(100);
 				server.middlewares.use(
 					function middleware(req, res, next) {
 						res.setHeader('x-middleware', 'true');


### PR DESCRIPTION
## Changes

Closes #8097

Add async/await into configureServer so that integrations with an async astro:server:setup hook can function correctly.

## Testing

I edited the built file directly in my target app before creating this patch, and it worked for me in that scenario.  I don't yet know how to create a proper test case around this.  Please see discussion in #8097 

## Docs

No documentation change; the docs already have this hook defined to return a Promise<Void>, this change just fixes the code so it honors that.
