### PR TITLE
Fix 8083

### DIFF
--- a/.changeset/popular-planes-cover.md
+++ b/.changeset/popular-planes-cover.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+ViewTransition: bug fix for lost scroll position in browser history

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -38,12 +38,21 @@ const { fallback = 'animate' } = Astro.props as Props;
 
 	const throttle = (cb: (...args: any[]) => any, delay: number) => {
 		let wait = false;
+		// During the waiting time additional events are lost.
+		// So repeat the callback at the end if we have swallowed events.
+		let onceMore = false;
 		return (...args: any[]) => {
-			if (wait) return;
-
+			if (wait) {
+				onceMore = true;
+				return;
+			}
 			cb(...args);
 			wait = true;
 			setTimeout(() => {
+				if (onceMore) {
+					onceMore = false;
+					cb(...args);
+				}
 				wait = false;
 			}, delay);
 		};

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -163,6 +163,8 @@ const { fallback = 'animate' } = Astro.props as Props;
 			}
 			if (state?.scrollY != null) {
 				scrollTo(0, state.scrollY);
+				// Overwrite erroneous updates by the scroll handler during transition
+				persistState(state);
 			}
 
 			triggerEvent('astro:beforeload');


### PR DESCRIPTION
## Changes

Closes #8083

During the transition, the scroll handler might record wrong intermediate offsets in the browser history.
Solution: at the end of the navigation the state is updated with the actual position.

Plus: scroll handler lost trailing events in throttling. 
Run callback once more at the end of the waiting period to compensate for lost events

## Testing

only manual tests

## Docs

n/a. bug fix