### PR TITLE
fix: reinsert attribute to specify direction of ViewTransition

### DIFF
--- a/.changeset/wet-foxes-sleep.md
+++ b/.changeset/wet-foxes-sleep.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix: reinsert attribute to specify direction of ViewTransition (forward / back)

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -101,9 +101,8 @@ const { fallback = 'animate' } = Astro.props as Props;
 
 	const parser = new DOMParser();
 
-	async function updateDOM(dir: Direction, html: string, state?: State, fallback?: Fallback) {
+	async function updateDOM(html: string, state?: State, fallback?: Fallback) {
 		const doc = parser.parseFromString(html, 'text/html');
-		doc.documentElement.dataset.astroTransition = dir;
 
 		// Check for a head element that should persist, either because it has the data
 		// attribute or is a link el.
@@ -233,15 +232,17 @@ const { fallback = 'animate' } = Astro.props as Props;
 			location.href = href;
 			return;
 		}
+		document.documentElement.dataset.astroTransition = dir;
 		if (supportsViewTransitions) {
-			finished = document.startViewTransition(() => updateDOM(dir, html, state)).finished;
+			finished = document.startViewTransition(() => updateDOM(html, state)).finished;
 		} else {
-			finished = updateDOM(dir, html, state, getFallback());
+			finished = updateDOM(html, state, getFallback());
 		}
 		try {
 			await finished;
 		} finally {
-			document.documentElement.removeAttribute('data-astro-transition');
+			// skip this for the moment as it tends to stop fallback animations
+			// document.documentElement.removeAttribute('data-astro-transition');
 			await runScripts();
 			markScriptsExec();
 			onload();
@@ -291,8 +292,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 				transitionEnabledOnThisPage()
 			) {
 				ev.preventDefault();
-				navigate('forward', link.href, { index: currentHistoryIndex, scrollY: 0 });
-				currentHistoryIndex++;
+				navigate('forward', link.href, { index: ++currentHistoryIndex, scrollY: 0 });
 				const newState: State = { index: currentHistoryIndex, scrollY };
 				persistState({ index: currentHistoryIndex - 1, scrollY });
 				history.pushState(newState, '', link.href);


### PR DESCRIPTION


## Changes

`astroTransition = dir` is now set for the current document.
The removal of the attribute from the DOM is put on hold for now, since the removal seems to prevent fallback animations.
Plus: fix for an of-by-one bug I introduced in a previous commit that prevented the correct detection of direction ;-)

## Testing

Manual tests only

## Docs

n/a bug fix

