### PR TITLE
config: remove ~/assets alias

### DIFF
--- a/.changeset/clever-bats-breathe.md
+++ b/.changeset/clever-bats-breathe.md
@@ -1,5 +1,5 @@
 ---
-'astro': patch
+'astro': major
 ---
 
 This import alias is no longer included by default with astro:assets. If you were using this alias with experimental assets, you must convert them to relative file paths, or create your own [import aliases](https://docs.astro.build/en/guides/aliases/).

--- a/.changeset/clever-bats-breathe.md
+++ b/.changeset/clever-bats-breathe.md
@@ -4,10 +4,10 @@
 
 This import alias is no longer included by default with astro:assets. If you were using this alias with experimental assets, you must convert them to relative file paths, or create your own [import aliases](https://docs.astro.build/en/guides/aliases/).
 
-```astro
+```diff
 ---
 // src/pages/posts/post-1.astro
-import rocket from '~/assets/rocket.png'
-import rocket from '../../assets/rocket.png';
+- import rocket from '~/assets/rocket.png'
++ import rocket from '../../assets/rocket.png';
 ---
 ```

--- a/.changeset/clever-bats-breathe.md
+++ b/.changeset/clever-bats-breathe.md
@@ -1,0 +1,13 @@
+---
+'astro': patch
+---
+
+This import alias is no longer included by default with astro:assets. If you were using this alias with experimental assets, you must convert them to relative file paths, or create your own [import aliases](https://docs.astro.build/en/guides/aliases/).
+
+```astro
+---
+// src/pages/posts/post-1.astro
+import rocket from '~/assets/rocket.png'
+import rocket from '../../assets/rocket.png';
+---
+```

--- a/packages/astro/src/assets/types.ts
+++ b/packages/astro/src/assets/types.ts
@@ -90,7 +90,7 @@ export type LocalImageProps<T> = ImageSharedProps<T> & {
 	 *
 	 * **Example**:
 	 * ```js
-	 * import myImage from "~/assets/my_image.png";
+	 * import myImage from "../assets/my_image.png";
 	 * ```
 	 * And then refer to the image, like so:
 	 * ```astro

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -1,5 +1,4 @@
 import MagicString from 'magic-string';
-import { fileURLToPath } from 'node:url';
 import type * as vite from 'vite';
 import { normalizePath } from 'vite';
 import type { AstroPluginOptions, ImageTransform } from '../@types/astro';
@@ -31,18 +30,6 @@ export default function assets({
 		// Expose the components and different utilities from `astro:assets` and handle serving images from `/_image` in dev
 		{
 			name: 'astro:assets',
-			config() {
-				return {
-					resolve: {
-						alias: [
-							{
-								find: /^~\/assets\/(.+)$/,
-								replacement: fileURLToPath(new URL('./assets/$1', settings.config.srcDir)),
-							},
-						],
-					},
-				};
-			},
 			async resolveId(id) {
 				if (id === VIRTUAL_SERVICE_ID) {
 					return await this.resolve(settings.config.image.service.entrypoint);

--- a/packages/astro/test/fixtures/content-collection-references/src/content/banners/welcome.json
+++ b/packages/astro/test/fixtures/content-collection-references/src/content/banners/welcome.json
@@ -1,4 +1,4 @@
 {
   "alt": "Futuristic landscape with chrome buildings and blue skies",
-  "src": "~/assets/the-future.jpg"
+  "src": "../../assets/the-future.jpg"
 }

--- a/packages/astro/test/fixtures/core-image-base/src/content/blog/one.md
+++ b/packages/astro/test/fixtures/core-image-base/src/content/blog/one.md
@@ -1,6 +1,6 @@
 ---
 title: One
-image: ~/assets/penguin2.jpg
+image: ../../assets/penguin2.jpg
 cover:
   image: ../../assets/penguin1.jpg
 ---

--- a/packages/astro/test/fixtures/core-image-base/tsconfig.json
+++ b/packages/astro/test/fixtures/core-image-base/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/assets/*": ["src/assets/*"]
+    },
+  }
+}

--- a/packages/astro/test/fixtures/core-image-ssg/tsconfig.json
+++ b/packages/astro/test/fixtures/core-image-ssg/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/assets/*": ["src/assets/*"]
+    },
+  }
+}

--- a/packages/astro/test/fixtures/core-image/src/content/blog/one.md
+++ b/packages/astro/test/fixtures/core-image/src/content/blog/one.md
@@ -1,11 +1,11 @@
 ---
 title: One
-image: ~/assets/penguin2.jpg
+image: ../../assets/penguin2.jpg
 cover:
   image: ../../assets/penguin1.jpg
 arrayOfImages:
-  - ~/assets/penguin2.jpg
-  - ~/assets/penguin1.jpg
+  - ../../assets/penguin2.jpg
+  - ../../assets/penguin1.jpg
 refinedImage: ../../assets/penguin1.jpg
 ---
 

--- a/packages/astro/test/fixtures/core-image/tsconfig.json
+++ b/packages/astro/test/fixtures/core-image/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/assets/*": ["src/assets/*"]
+    },
+  }
+}

--- a/packages/astro/tsconfigs/base.json
+++ b/packages/astro/tsconfigs/base.json
@@ -23,11 +23,6 @@
     "esModuleInterop": true,
     // Skip typechecking libraries and .d.ts files
     "skipLibCheck": true,
-    // Add alias for assets folder for easy reference to assets
-    "baseUrl": ".",
-    "paths": {
-      "~/assets/*": ["src/assets/*"]
-    },
     // Allow JavaScript files to be imported
     "allowJs": true
   }

--- a/packages/integrations/markdoc/test/fixtures/image-assets/tsconfig.json
+++ b/packages/integrations/markdoc/test/fixtures/image-assets/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/assets/*": ["src/assets/*"]
+    },
+  }
+}

--- a/packages/integrations/mdx/test/fixtures/mdx-images/tsconfig.json
+++ b/packages/integrations/mdx/test/fixtures/mdx-images/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/assets/*": ["src/assets/*"]
+    },
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18252,21 +18252,25 @@ packages:
   file:packages/astro/test/fixtures/css-assets/packages/font-awesome:
     resolution: {directory: packages/astro/test/fixtures/css-assets/packages/font-awesome, type: directory}
     name: '@test/astro-font-awesome-package'
+    version: 0.0.1
     dev: false
 
   file:packages/astro/test/fixtures/multiple-renderers/renderers/one:
     resolution: {directory: packages/astro/test/fixtures/multiple-renderers/renderers/one, type: directory}
     name: '@test/astro-renderer-one'
+    version: 1.0.0
     dev: false
 
   file:packages/astro/test/fixtures/multiple-renderers/renderers/two:
     resolution: {directory: packages/astro/test/fixtures/multiple-renderers/renderers/two, type: directory}
     name: '@test/astro-renderer-two'
+    version: 1.0.0
     dev: false
 
   file:packages/astro/test/fixtures/solid-component/deps/solid-jsx-component:
     resolution: {directory: packages/astro/test/fixtures/solid-component/deps/solid-jsx-component, type: directory}
     name: '@test/solid-jsx-component'
+    version: 0.0.0
     dependencies:
       solid-js: 1.7.6
     dev: false


### PR DESCRIPTION
## Changes

What the title says, the alias didn't work properly in the editor because of how TypeScript works and it was a bit awkward to have now that `src/assets` isn't necessarily as special as it used to be. We'll revisit this in the future in a dedicated "should we have cool aliases?" RFC potentially. But for 3.0, no built-in aliases. Of course people can still define them themselves if they desire to.

## Testing

Kept the tests for aliases since it's good to test for people who configure them, but added the alias manually to those tests

## Docs

Already covered by Sarah's current work on the v3 page for assets