### PR TITLE
only update our own history entries during back navigation through VT

### DIFF
--- a/.changeset/small-nails-try.md
+++ b/.changeset/small-nails-try.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+On back navigation only animate view transitions that were animated going forward.

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -306,10 +306,11 @@ const { fallback = 'animate' } = Astro.props as Props;
 				return;
 			}
 
-			// hash change creates no state.
+			// History entries without state are created by the browser (e.g. for hash links)
+			// Our view transition entries always have state.
+			// Just ignore stateless entries.
+			// The browser will handle navigation fine without our help
 			if (ev.state === null) {
-				persistState({ index: currentHistoryIndex, scrollY });
-				ev.preventDefault();
 				return;
 			}
 
@@ -344,6 +345,8 @@ const { fallback = 'animate' } = Astro.props as Props;
 		addEventListener(
 			'scroll',
 			throttle(() => {
+				// only updste history entries that are managed by us
+				// leave other entries alone and do not accidently add state.
 				if (history.state) {
 					persistState({ ...history.state, scrollY });
 				}


### PR DESCRIPTION
## Changes

When the popState handler sees a entry without state, leave that alone.

The original code updated the entry and thereby introduced state.
A entry with state is viewed as an view transition entry.
Thus when navigating back, the transition gut animated 
even though it wasn't when we walked forward in the first place

## Testing

only manual tests

## Docs

n/a. Bug fix.
