### PR TITLE
[error msg] add hybrid option to a getStaticPaths error message

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -387,7 +387,7 @@ export const GetStaticPathsRequired = {
 		'`getStaticPaths()` function is required for dynamic routes. Make sure that you `export` a `getStaticPaths` function from your dynamic route.',
 	hint: `See https://docs.astro.build/en/core-concepts/routing/#dynamic-routes for more information on dynamic routes.
 
-Alternatively, set \`output: "server"\` in your Astro config file to switch to a non-static server build. This error can also occur if using \`export const prerender = true;\`.
+Alternatively, set \`output: "server"\` or \`output: "hybrid"\` in your Astro config file to switch to a non-static server build. This error can also occur if using \`export const prerender = true;\`.
 See https://docs.astro.build/en/guides/server-side-rendering/ for more information on non-static rendering.`,
 } satisfies ErrorData;
 /**


### PR DESCRIPTION
## Changes

We received a comment that one of our older (pre-hybrid rendering) error messages only suggests switching to `server` as a solution.

This adds the option to set hybrid rendering to the error message:

> Alternatively, set \`output: "server"\` **or \`output: "hybrid"\`** in your Astro config file to switch to a non-static server build. This error can also occur if using \`export const prerender = true;\`.

## Testing

No tests; docs.

## Docs

All docs!