### PR TITLE
Open to configured base path

### DIFF
--- a/.changeset/popular-carrots-sneeze.md
+++ b/.changeset/popular-carrots-sneeze.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Open to configured `base` when `astro dev --open` runs

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -56,7 +56,9 @@ export async function createContainer({
 		settings = injectImageEndpoint(settings);
 	}
 
-	const { host, headers, open } = settings.config.server;
+	const { base, server: { host, headers, open: shouldOpen }} = settings.config;
+	// Open server to the correct path
+	const open = shouldOpen ? base : false;
 
 	// The client entrypoint for renderers. Since these are imported dynamically
 	// we need to tell Vite to preoptimize them.


### PR DESCRIPTION
## Changes

- When running `astro dev --open` or using `astro dev` with `server.open === true` and a set `base` path, this PR makes it so the browser opens to `/[base]`
- Closes #7486

## Testing

Tested manually

## Docs

N/A, bug fix