### PR TITLE
chore: resolve ShellCheck 2086 diagnostic in gitpod setup script

### DIFF
--- a/.gitpod/gitpod-setup.sh
+++ b/.gitpod/gitpod-setup.sh
@@ -17,7 +17,7 @@ fi
 # Wait for VSCode to be ready (port 23000)
 gp ports await 23000 > /dev/null 2>&1
 
-echo "Loading example project:" $EXAMPLE_PROJECT
+echo "Loading example project: $EXAMPLE_PROJECT"
 
 # Go to the requested example project
 cd "$GITPOD_REPO_ROOT"/examples/"$EXAMPLE_PROJECT" || exit


### PR DESCRIPTION
## Changes

This resolves [ShellCheck 2086](https://www.shellcheck.net/wiki/SC2086) to prevent potential globbing and word splitting issues in the `gitpod-setup.sh` script.

## Testing

No tests were added because it just moved a quotation mark in a script's `echo` command.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

No documentation is required because it is one-character change to a tooling script.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
