### PR TITLE
fix: better error when Sharp can't be resolved (ex: pnpm)

### DIFF
--- a/.changeset/cyan-carrots-stare.md
+++ b/.changeset/cyan-carrots-stare.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Update error message when Sharp couldn't be found (tends to happen on pnpm notably)

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -24,3 +24,10 @@ export function sharpImageService(): ImageServiceConfig;
  * Return the configuration needed to use the Squoosh-based image service
  */
 export function squooshImageService(): ImageServiceConfig;
+
+/**
+ * Return the configuration needed to use the passthrough image service. This image services does not perform
+ * any image transformations, and is mainly useful when your platform does not support other image services, or you are
+ * not using Astro's built-in image processing.
+ */
+export function passthroughImageService(): ImageServiceConfig;

--- a/packages/astro/config.mjs
+++ b/packages/astro/config.mjs
@@ -13,3 +13,10 @@ export function squooshImageService() {
 		config: {},
 	};
 }
+
+export function passthroughImageService() {
+	return {
+		entrypoint: 'astro/assets/services/noop',
+		config: {},
+	};
+}

--- a/packages/astro/src/assets/services/sharp.ts
+++ b/packages/astro/src/assets/services/sharp.ts
@@ -1,4 +1,5 @@
 import type { FormatEnum } from 'sharp';
+import { AstroError, AstroErrorData } from '../../core/errors/index.js';
 import type { ImageOutputFormat, ImageQualityPreset } from '../types.js';
 import {
 	baseService,
@@ -21,7 +22,7 @@ async function loadSharp() {
 	try {
 		sharpImport = (await import('sharp')).default;
 	} catch (e) {
-		throw new Error('Could not find Sharp. Please install Sharp manually into your project.');
+		throw new AstroError(AstroErrorData.MissingSharp);
 	}
 
 	return sharpImport;

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -794,11 +794,13 @@ export const InvalidDynamicRoute = {
 /**
  * @docs
  * @see
- * - [Images](https://docs.astro.build/en/guides/images/)
+ * - [Default Image Service](https://docs.astro.build/en/guides/images/#default-image-service)
+ * - [Image Component](https://docs.astro.build/en/guides/images/#image--astroassets)
+ * - [Image Services API](https://docs.astro.build/en/reference/image-service-reference/)
  * @description
- * When using a [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) like pnpm, Sharp must be installed manually into your project in order to use image processing.
+ * Sharp is the default image service used for `astro:assets`. When using a [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) like pnpm, Sharp must be installed manually into your project in order to use image processing.
  *
- * If you are not using image processing, you can use a passthrough image service that does no processing, like such:
+ * If you are not using `astro:assets` for image processing, and do not wish to install Sharp, you can configure the following passthrough image service that does no processing:
  *
  * ```js
  * import { defineConfig, passthroughImageService } from "astro/config";
@@ -813,7 +815,7 @@ export const MissingSharp = {
 	name: 'MissingSharp',
 	title: 'Could not find Sharp.',
 	message: 'Could not find Sharp. Please install Sharp (`sharp`) manually into your project.',
-	hint: "See Sharp's installation instructions for more information: https://sharp.pixelplumbing.com/install. If you are not using image processing, you may want to use the passthrough image service instead, see https://docs.astro.build/en/reference/errors/missing-sharp for more information.",
+	hint: "See Sharp's installation instructions for more information: https://sharp.pixelplumbing.com/install. If you are not relying on `astro:assets` to optimize, transform, or process any images, you can configure a passthrough image service instead of installing Sharp. See https://docs.astro.build/en/reference/errors/missing-sharp for more information.",
 };
 // No headings here, that way Vite errors are merged with Astro ones in the docs, which makes more sense to users.
 // Vite Errors - 4xxx

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -791,6 +791,30 @@ export const InvalidDynamicRoute = {
 	message: (route: string, invalidParam: string, received: string) =>
 		`The ${invalidParam} param for route ${route} is invalid. Received **${received}**.`,
 } satisfies ErrorData;
+/**
+ * @docs
+ * @see
+ * - [Images](https://docs.astro.build/en/guides/images/)
+ * @description
+ * When using a [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) like pnpm, Sharp must be installed manually into your project in order to use image processing.
+ *
+ * If you are not using image processing, you can use a passthrough image service that does no processing, like such:
+ *
+ * ```js
+ * import { defineConfig, passthroughImageService } from "astro/config";
+ * export default defineConfig({
+ *  image: {
+ *    service: passthroughImageService(),
+ *  },
+ * });
+ * ```
+ */
+export const MissingSharp = {
+	name: 'MissingSharp',
+	title: 'Could not find Sharp.',
+	message: 'Could not find Sharp. Please install Sharp (`sharp`) manually into your project.',
+	hint: "See Sharp's installation instructions for more information: https://sharp.pixelplumbing.com/install. If you are not using image processing, you may want to use the passthrough image service instead, see https://docs.astro.build/en/reference/errors/missing-sharp for more information.",
+};
 // No headings here, that way Vite errors are merged with Astro ones in the docs, which makes more sense to users.
 // Vite Errors - 4xxx
 /**


### PR DESCRIPTION
## Changes

Unfortunately, due to bundling, packaging, JavaScript, etc nonsense, on pnpm Sharp fails to be found. There's no proper way to fix this that wouldn't be: risky and/or unreliable. Trust me, I tried putting `sharp` in every single Vite config I found.

So, I did the next best thing: I upgraded the error message with every bit of info I could. I also added the passthrough / noop image service to the config so it's easier to use for SSR users who don't want to install Sharp into their projects. In the future, a more optimal solution for SSR would be a way to disable the endpoint, but that also requires either rethinking how we do images in Markdown, or at least a way to disable image processing in Markdown, it's a bit complex.

Fix https://github.com/withastro/astro/issues/7966

## Testing

Tested manually

## Docs

/cc @withastro/maintainers-docs for feedback on the error message and description
