### PR TITLE
Deprecate simple objects from endpoints

### DIFF
--- a/.changeset/yellow-tips-cover.md
+++ b/.changeset/yellow-tips-cover.md
@@ -1,0 +1,26 @@
+---
+'astro': patch
+---
+
+Deprecate returning simple objects from endpoints. Endpoints should only return a `Response`.
+
+To return a result with a custom encoding not supported by a `Response`, you can use the `ResponseWithEncoding` utility class instead.
+
+Before:
+
+```ts
+export function GET() {
+  return {
+    body: '...',
+    encoding: 'binary',
+  };
+}
+```
+
+After:
+
+```ts
+export function GET({ ResponseWithEncoding }) {
+  return new ResponseWithEncoding('...', undefined, 'binary');
+}
+```

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -23,6 +23,7 @@ import type { LogOptions, LoggerLevel } from '../core/logger/core';
 import type { AstroIntegrationLogger } from '../core/logger/core';
 import type { AstroComponentFactory, AstroComponentInstance } from '../runtime/server';
 import type { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from './../core/constants.js';
+import type { ResponseWithEncoding } from '../core/endpoint/index.js';
 
 export type {
 	MarkdownHeading,
@@ -1963,12 +1964,13 @@ export interface APIContext<Props extends Record<string, any> = Record<string, a
 	 * ```
 	 */
 	locals: App.Locals;
+	ResponseWithEncoding: typeof ResponseWithEncoding;
 }
 
 export type EndpointOutput =
 	| {
 			body: Body;
-			encoding?: Exclude<BufferEncoding, 'binary'>;
+			encoding?: BufferEncoding;
 	  }
 	| {
 			body: Uint8Array;

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -170,7 +170,7 @@ export class App {
 			}
 		}
 
-		if (SSRRoutePipeline.isResponse(response, routeData.type)) {
+		if (routeData.type === 'page' || routeData.type === 'redirect') {
 			if (STATUS_CODES.has(response.status)) {
 				return this.#renderError(request, {
 					response,

--- a/packages/astro/src/core/app/ssrPipeline.ts
+++ b/packages/astro/src/core/app/ssrPipeline.ts
@@ -1,7 +1,4 @@
 import type { Environment } from '../render';
-import type { EndpointCallResult } from '../endpoint/index.js';
-import mime from 'mime';
-import { attachCookiesToResponse } from '../cookies/index.js';
 import { Pipeline } from '../pipeline.js';
 
 /**
@@ -16,39 +13,16 @@ export class EndpointNotFoundError extends Error {
 }
 
 export class SSRRoutePipeline extends Pipeline {
-	#encoder = new TextEncoder();
-
 	constructor(env: Environment) {
 		super(env);
 		this.setEndpointHandler(this.#ssrEndpointHandler);
 	}
 
 	// This function is responsible for handling the result coming from an endpoint.
-	async #ssrEndpointHandler(request: Request, response: EndpointCallResult): Promise<Response> {
-		if (response.type === 'response') {
-			if (response.response.headers.get('X-Astro-Response') === 'Not-Found') {
-				throw new EndpointNotFoundError(response.response);
-			}
-			return response.response;
-		} else {
-			const url = new URL(request.url);
-			const headers = new Headers();
-			const mimeType = mime.getType(url.pathname);
-			if (mimeType) {
-				headers.set('Content-Type', `${mimeType};charset=utf-8`);
-			} else {
-				headers.set('Content-Type', 'text/plain;charset=utf-8');
-			}
-			const bytes =
-				response.encoding !== 'binary' ? this.#encoder.encode(response.body) : response.body;
-			headers.set('Content-Length', bytes.byteLength.toString());
-
-			const newResponse = new Response(bytes, {
-				status: 200,
-				headers,
-			});
-			attachCookiesToResponse(newResponse, response.cookies);
-			return newResponse;
+	async #ssrEndpointHandler(request: Request, response: Response): Promise<Response> {
+		if (response.headers.get('X-Astro-Response') === 'Not-Found') {
+			throw new EndpointNotFoundError(response);
 		}
+		return response
 	}
 }

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -567,20 +567,16 @@ async function generatePath(pathname: string, gopts: GeneratePathOptions, pipeli
 	} else {
 		// If there's no body, do nothing
 		if (!response.body) return;
-		const result = await pipeline.computeBodyAndEncoding(renderContext.route.type, response);
-		body = result.body;
-		encoding = result.encoding;
+		body = Buffer.from(await response.arrayBuffer());
+		encoding = (response.headers.get('X-Astro-Encoding') as BufferEncoding | null) ?? 'utf-8';
 	}
 
 	const outFolder = getOutFolder(pipeline.getConfig(), pathname, pageData.route.type);
 	const outFile = getOutFile(pipeline.getConfig(), outFolder, pathname, pageData.route.type);
 	pageData.route.distURL = outFile;
-	const possibleEncoding = response.headers.get('X-Astro-Encoding');
-	if (possibleEncoding) {
-		encoding = possibleEncoding as BufferEncoding;
-	}
+
 	await fs.promises.mkdir(outFolder, { recursive: true });
-	await fs.promises.writeFile(outFile, body, encoding ?? 'utf-8');
+	await fs.promises.writeFile(outFile, body, encoding);
 }
 
 /**

--- a/packages/astro/src/core/pipeline.ts
+++ b/packages/astro/src/core/pipeline.ts
@@ -1,11 +1,10 @@
 import { type RenderContext, type Environment } from './render/index.js';
-import { type EndpointCallResult, callEndpoint, createAPIContext } from './endpoint/index.js';
+import { callEndpoint, createAPIContext } from './endpoint/index.js';
 import type {
 	MiddlewareHandler,
 	MiddlewareResponseHandler,
 	ComponentInstance,
 	MiddlewareEndpointHandler,
-	RouteType,
 	EndpointHandler,
 } from '../@types/astro';
 import { callMiddleware } from './middleware/callMiddleware.js';
@@ -13,7 +12,7 @@ import { renderPage } from './render/core.js';
 
 type EndpointResultHandler = (
 	originalRequest: Request,
-	result: EndpointCallResult
+	result: Response
 ) => Promise<Response> | Response;
 
 /**
@@ -76,7 +75,7 @@ export class Pipeline {
 			componentInstance,
 			this.#onRequest
 		);
-		if (Pipeline.isEndpointResult(result, renderContext.route.type)) {
+		if (renderContext.route.type === 'endpoint') {
 			if (!this.#endpointHandler) {
 				throw new Error(
 					'You created a pipeline that does not know how to handle the result coming from an endpoint.'
@@ -103,7 +102,7 @@ export class Pipeline {
 		env: Readonly<Environment>,
 		mod: Readonly<ComponentInstance>,
 		onRequest?: MiddlewareHandler<MiddlewareReturnType>
-	): Promise<Response | EndpointCallResult> {
+	): Promise<Response> {
 		const apiContext = createAPIContext({
 			request: renderContext.request,
 			params: renderContext.params,
@@ -150,16 +149,5 @@ export class Pipeline {
 			default:
 				throw new Error(`Couldn't find route of type [${renderContext.route.type}]`);
 		}
-	}
-
-	/**
-	 * Use this function
-	 */
-	static isEndpointResult(result: any, routeType: RouteType): result is EndpointCallResult {
-		return !(result instanceof Response) && routeType === 'endpoint';
-	}
-
-	static isResponse(result: any, routeType: RouteType): result is Response {
-		return result instanceof Response && (routeType === 'page' || routeType === 'redirect');
 	}
 }

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -4,11 +4,10 @@ import type {
 	EndpointHandler,
 	MiddlewareHandler,
 	MiddlewareResponseHandler,
-	RouteType,
 } from '../../@types/astro';
 import { renderPage as runtimeRenderPage } from '../../runtime/server/index.js';
 import { attachCookiesToResponse } from '../cookies/index.js';
-import { callEndpoint, createAPIContext, type EndpointCallResult } from '../endpoint/index.js';
+import { callEndpoint, createAPIContext } from '../endpoint/index.js';
 import { callMiddleware } from '../middleware/callMiddleware.js';
 import { redirectRouteGenerate, redirectRouteStatus, routeIsRedirect } from '../redirects/index.js';
 import type { RenderContext } from './context.js';
@@ -92,7 +91,7 @@ export async function tryRenderRoute<MiddlewareReturnType = Response>(
 	env: Readonly<Environment>,
 	mod: Readonly<ComponentInstance>,
 	onRequest?: MiddlewareHandler<MiddlewareReturnType>
-): Promise<Response | EndpointCallResult> {
+): Promise<Response> {
 	const apiContext = createAPIContext({
 		request: renderContext.request,
 		params: renderContext.params,
@@ -139,12 +138,4 @@ export async function tryRenderRoute<MiddlewareReturnType = Response>(
 		default:
 			throw new Error(`Couldn't find route of type [${renderContext.route.type}]`);
 	}
-}
-
-export function isEndpointResult(result: any, routeType: RouteType): result is EndpointCallResult {
-	return !(result instanceof Response) && routeType === 'endpoint';
-}
-
-export function isResponse(result: any, routeType: RouteType): result is Response {
-	return result instanceof Response && (routeType === 'page' || routeType === 'redirect');
 }

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -216,7 +216,6 @@ export async function handleRoute({
 	if (onRequest) {
 		pipeline.setMiddlewareFunction(onRequest);
 	}
-	pipeline.setCurrentMatchedRoute(route);
 
 	let response = await pipeline.renderRoute(renderContext, mod);
 	if (response.status === 404) {

--- a/packages/astro/test/fixtures/non-html-pages/src/pages/about-object.json.ts
+++ b/packages/astro/test/fixtures/non-html-pages/src/pages/about-object.json.ts
@@ -1,0 +1,12 @@
+// NOTE: test deprecated object form
+// Returns the file body for this non-HTML file.
+// The content type is based off of the extension in the filename,
+// in this case: about.json.
+export async function GET() {
+	return {
+		body: JSON.stringify({
+			name: 'Astro',
+			url: 'https://astro.build/',
+		}),
+	};
+}

--- a/packages/astro/test/fixtures/non-html-pages/src/pages/about.json.ts
+++ b/packages/astro/test/fixtures/non-html-pages/src/pages/about.json.ts
@@ -1,11 +1,12 @@
 // Returns the file body for this non-HTML file.
-// The content type is based off of the extension in the filename,
-// in this case: about.json.
 export async function GET() {
-	return {
-		body: JSON.stringify({
-			name: 'Astro',
-			url: 'https://astro.build/',
-		}),
-	};
+	const data = JSON.stringify({
+		name: 'Astro',
+		url: 'https://astro.build/',
+	})
+	return new Response(data, {
+		headers: {
+			'Content-Type': 'application/json'
+		}
+	})
 }

--- a/packages/astro/test/fixtures/non-html-pages/src/pages/placeholder-object.png.ts
+++ b/packages/astro/test/fixtures/non-html-pages/src/pages/placeholder-object.png.ts
@@ -2,12 +2,16 @@ import { promises as fs } from 'node:fs';
 
 import type { APIRoute } from 'astro';
 
-export const GET: APIRoute = async function get({ ResponseWithEncoding }) {
+// NOTE: test deprecated object form
+export const GET: APIRoute = async function get() {
 	try {
 		// Image is in the public domain. Sourced from
 		// https://en.wikipedia.org/wiki/File:Portrait_placeholder.png
 		const buffer = await fs.readFile('./test/fixtures/non-html-pages/src/images/placeholder.png');
-		return new ResponseWithEncoding(buffer.toString('binary'), undefined, 'binary')
+		return {
+			body: buffer.toString('binary'),
+			encoding: 'binary',
+		} as const;
 	} catch (error: unknown) {
 		throw new Error(`Something went wrong in placeholder.png route!: ${error as string}`);
 	}

--- a/packages/astro/test/fixtures/ssr-api-route/src/pages/binary.js
+++ b/packages/astro/test/fixtures/ssr-api-route/src/pages/binary.js
@@ -1,9 +1,7 @@
 import fs from 'node:fs';
 
 export function GET() {
-	return {
-		body: 'ok'
-	};
+	return new Response('ok')
 }
 
 export async function post({ request }) {

--- a/packages/astro/test/fixtures/ssr-api-route/src/pages/food-object.json.js
+++ b/packages/astro/test/fixtures/ssr-api-route/src/pages/food-object.json.js
@@ -1,0 +1,10 @@
+// NOTE: test deprecated object form
+export function GET() {
+	return {
+		body: JSON.stringify([
+			{ name: 'lettuce' },
+			{ name: 'broccoli' },
+			{ name: 'pizza' }
+		])
+	};
+}

--- a/packages/astro/test/fixtures/ssr-api-route/src/pages/food.json.js
+++ b/packages/astro/test/fixtures/ssr-api-route/src/pages/food.json.js
@@ -1,12 +1,12 @@
 
 export function GET() {
-	return {
-		body: JSON.stringify([
+	return new Response(
+		JSON.stringify([
 			{ name: 'lettuce' },
 			{ name: 'broccoli' },
 			{ name: 'pizza' }
 		])
-	};
+	)
 }
 
 export async function POST({ params, request }) {

--- a/packages/astro/test/non-html-pages.test.js
+++ b/packages/astro/test/non-html-pages.test.js
@@ -15,11 +15,34 @@ describe('Non-HTML Pages', () => {
 			expect(json).to.have.property('name', 'Astro');
 			expect(json).to.have.property('url', 'https://astro.build/');
 		});
+
+		it('should match contents (deprecated object form)', async () => {
+			const json = JSON.parse(await fixture.readFile('/about-object.json'));
+			expect(json).to.have.property('name', 'Astro');
+			expect(json).to.have.property('url', 'https://astro.build/');
+		});
 	});
 
 	describe('png', () => {
 		it('should not have had its encoding mangled', async () => {
 			const buffer = await fixture.readFile('/placeholder.png', 'base64');
+
+			// Sanity check the first byte
+			const hex = Buffer.from(buffer, 'base64').toString('hex');
+			const firstHexByte = hex.slice(0, 2);
+			// If we accidentally utf8 encode the png, the first byte (in hex) will be 'c2'
+			expect(firstHexByte).to.not.equal('c2');
+			// and if correctly encoded in binary, it should be '89'
+			expect(firstHexByte).to.equal('89');
+
+			// Make sure the whole buffer (in base64) matches this snapshot
+			expect(buffer).to.equal(
+				'iVBORw0KGgoAAAANSUhEUgAAAGQAAACWCAYAAAAouC1GAAAD10lEQVR4Xu3ZbW4iMRCE4c1RuP+ZEEfZFZHIAgHGH9Xtsv3m94yx6qHaM+HrfD7//cOfTQJfgNhYfG8EEC8PQMw8AAHELQGz/XCGAGKWgNl2aAggZgmYbYeGAGKWgNl2aAggZgmYbYeGAGKWgNl2aAggZgmYbYeGAGKWgNl2aAggZgmYbYeGAGKWgNl2aAggZgmYbYeGAGKWgNl2aAggZgmYbWe6hpxOp6oIL5dL1fWjL54CpBbhXagz4FiDqCCegZxhLEGiIGaAsQPJwrjhuLXFBiQbwrUtFiCjMZzaMhzEBcMFZSiIG4YDyjAQV4zRKENA3DFGoqSDzIIxCgWQgn9eZb6rpILM1o57qyyUNJCZMTLHFyAFI2s5kBXakYWS0hBAymsYDrISRkZLACn/8j5cGfXUFQqyYjuiWwJIY0Out0W0JAxk5XZEtgQQGtKRgOGt6rEV0pAdxlXU2AKks3U0pDPAiNuVKDREIGQNstP5EXGOyBsCSF/lAOnL7/tuRpYgRPUSKhQaIpIBRBSkahlAVEmK1gFEFKRqGUuQHR951e8i0kMdkP6+SUGu29kVxXJkAUJD+hMQrUBDREGqlgFElaRgHRXGdSsc6oAIEjBbgoYAUpfAbu8i1g3Z7V1EiRFyqANSN02er5Y/Zd0+YJexNUVDdmmJGiNsZAHSPrbCRtYOKFM1ZHWQCIzQkbX64Q5I+1iW3xmFkdKQFUcXIPLvePuCkRhpDVmpJcuArIASjZHakNmfujIwAKk4SpYFmXF0ZWEMachsoysTYyjIDE3JxhgO4owyAsMCxBFlFIYNiBPKSAxAnh57R2PYgLj9/j4SJvQXw5L3LjeM+z2PgBkG4gzx/EXKhEkHmQliRFvSQGaFyEZJAVkB4wYTPb7CQVbCyEAJA1kRImN8hYCsjhHZFDnILhhRKICUvL0eXKM86KUgu7Uj4kyRgeyMoRxfEhAw/neld3x1g4Dx+4DpQQFEcKi/WqIVpQuEdrzXTAcB47haLSjNDQHkGOR6RS1KEwgYZRgtj8PVIGDUYdS2BJD6fJvuKB1dVSC0o8ni56YSFED6Mq66WwpCO6qyf3vxEUpxQwAxAgFDg1HyGFzUEECMQMDQYhy15LAhgBiBgBGD8ent/WNDAIkDeYcCSGzmH1d/9U7yFoR25Eg9owCSk3vxmzsgM4AwrnKV7sfWy4YAAkhuAmaf9rEhtCNfC5D8zA8/8Yby6wyhIYfZhVwASEis7Yu+BKEd7YH23glIb4IB919RHs4QGhKQcsWSgFSElXEpIBkpV3zGAwjjqiK5oEsBCQq2Z9l/4WuAC09sfQEAAAAASUVORK5CYII='
+			);
+		});
+
+		it('should not have had its encoding mangled (deprecated object form)', async () => {
+			const buffer = await fixture.readFile('/placeholder-object.png', 'base64');
 
 			// Sanity check the first byte
 			const hex = Buffer.from(buffer, 'base64').toString('hex');

--- a/packages/astro/test/ssr-api-route.test.js
+++ b/packages/astro/test/ssr-api-route.test.js
@@ -29,6 +29,15 @@ describe('API routes in SSR', () => {
 		const request = new Request('http://example.com/food.json');
 		const response = await app.render(request);
 		expect(response.status).to.equal(200);
+		const body = await response.json();
+		expect(body.length).to.equal(3);
+	});
+
+	it('Can load the API route too (deprecated object form)', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		const request = new Request('http://example.com/food-object.json');
+		const response = await app.render(request);
+		expect(response.status).to.equal(200);
 		expect(response.headers.get('Content-Type')).to.equal('application/json;charset=utf-8');
 		expect(response.headers.get('Content-Length')).to.not.be.empty;
 		const body = await response.json();
@@ -87,8 +96,8 @@ describe('API routes in SSR', () => {
 			expect(res.status).to.equal(200);
 		});
 
-		it('Infer content type with charset for { body } shorthand', async () => {
-			const response = await fixture.fetch('/food.json', {
+		it('Infer content type with charset for { body } shorthand (deprecated object form)', async () => {
+			const response = await fixture.fetch('/food-object.json', {
 				method: 'GET',
 			});
 			expect(response.headers.get('Content-Type')).to.equal('application/json;charset=utf-8');


### PR DESCRIPTION
## Changes

- Deprecate returning simple objects from endpoints
- Refactor endpoint handling to within `callEndpoint`. This makes the `#endpointHandler` convention in Pipeline not used much (only `ssrPipeline` has a special case) cc @ematipico
- NOTE: much of the refactor was a port from https://github.com/withastro/astro/pull/7588

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added test for `ResponseWithEncoding`, and tests for previous object form so they still work, until they're removed.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Added changeset. Any mention of the object form in docs might need to be removed.
/cc @withastro/maintainers-docs for feedback!