### PR TITLE
fix(node): delegate preview's not found and error handling to core/app

### DIFF
--- a/.changeset/rude-ducks-exist.md
+++ b/.changeset/rude-ducks-exist.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Fixed an issue where the preview mode handled 404 and 500 routes differently from running app with node directly.

--- a/packages/integrations/node/src/preview.ts
+++ b/packages/integrations/node/src/preview.ts
@@ -38,15 +38,7 @@ const preview: CreatePreviewServer = async function ({
 	}
 
 	const handler: http.RequestListener = (req, res) => {
-		ssrHandler(req, res, (ssrErr: any) => {
-			if (ssrErr) {
-				res.writeHead(500);
-				res.end(ssrErr.toString());
-			} else {
-				res.writeHead(404);
-				res.end();
-			}
-		});
+		ssrHandler(req, res);
 	};
 
 	const baseWithoutTrailingSlash: string = base.endsWith('/')


### PR DESCRIPTION
## Changes
- Closes #8054
- Cause: the preview entrypoint passed a callback to nodeMiddleware, which overrode the recently refactored 404/500 handling.
- Fix: removed the callback to let src/core/app handle 404 and 500.

## Testing
Tested manually

## Docs
Does not affect usage