### PR TITLE
fix(data collections): normalize file paths for DataEntry.id

### DIFF
--- a/.changeset/twenty-mirrors-remember.md
+++ b/.changeset/twenty-mirrors-remember.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed an issue where data entries' id included backslashes instead of forward slashes on Windows.

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -209,7 +209,7 @@ export function getDataEntryId({
 	collection,
 }: Pick<ContentPaths, 'contentDir'> & { entry: URL; collection: string }): string {
 	const relativePath = getRelativeEntryPath(entry, collection, contentDir);
-	const withoutFileExt = relativePath.replace(new RegExp(path.extname(relativePath) + '$'), '');
+	const withoutFileExt = normalizePath(relativePath).replace(new RegExp(path.extname(relativePath) + '$'), '');
 
 	return withoutFileExt;
 }


### PR DESCRIPTION
## Changes
- Closes #8134
- Normalize id's for data entries same as content entries are.

## Testing
Quick fix, tested manually.

## Docs
Does not affect usage