### PR TITLE
Better support in detecting Bun

### DIFF
--- a/.changeset/early-owls-attend.md
+++ b/.changeset/early-owls-attend.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': patch
+---
+
+Fix missing package file regression

--- a/.changeset/rude-ducks-exist.md
+++ b/.changeset/rude-ducks-exist.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Fixed an issue where the preview mode handled 404 and 500 routes differently from running app with node directly.

--- a/.changeset/twenty-mirrors-remember.md
+++ b/.changeset/twenty-mirrors-remember.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed an issue where data entries' id included backslashes instead of forward slashes on Windows.

--- a/.changeset/yellow-terms-taste.md
+++ b/.changeset/yellow-terms-taste.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Update `astro add` command to detect `bun`

--- a/examples/basics/package.json
+++ b/examples/basics/package.json
@@ -11,6 +11,6 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.10.12"
+    "astro": "^2.10.11"
   }
 }

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -14,6 +14,6 @@
     "@astrojs/mdx": "^0.19.7",
     "@astrojs/rss": "^2.4.4",
     "@astrojs/sitemap": "^2.0.2",
-    "astro": "^2.10.12"
+    "astro": "^2.10.11"
   }
 }

--- a/examples/component/package.json
+++ b/examples/component/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {},
   "devDependencies": {
-    "astro": "^2.10.12"
+    "astro": "^2.10.11"
   },
   "peerDependencies": {
     "astro": "^2.0.0-beta.0"

--- a/examples/deno/package.json
+++ b/examples/deno/package.json
@@ -10,7 +10,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.10.12"
+    "astro": "^2.10.11"
   },
   "devDependencies": {
     "@astrojs/deno": "^4.3.0"

--- a/examples/framework-alpine/package.json
+++ b/examples/framework-alpine/package.json
@@ -14,6 +14,6 @@
     "@astrojs/alpinejs": "^0.2.2",
     "@types/alpinejs": "^3.7.1",
     "alpinejs": "^3.12.2",
-    "astro": "^2.10.12"
+    "astro": "^2.10.11"
   }
 }

--- a/examples/framework-lit/package.json
+++ b/examples/framework-lit/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@astrojs/lit": "^2.1.1",
     "@webcomponents/template-shadowroot": "^0.2.1",
-    "astro": "^2.10.12",
+    "astro": "^2.10.11",
     "lit": "^2.7.5"
   }
 }

--- a/examples/framework-multiple/package.json
+++ b/examples/framework-multiple/package.json
@@ -12,11 +12,11 @@
   },
   "dependencies": {
     "@astrojs/preact": "^2.2.2",
-    "@astrojs/react": "^2.3.2",
+    "@astrojs/react": "^2.3.1",
     "@astrojs/solid-js": "^2.2.1",
     "@astrojs/svelte": "^3.1.1",
     "@astrojs/vue": "^2.2.1",
-    "astro": "^2.10.12",
+    "astro": "^2.10.11",
     "preact": "^10.15.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/examples/framework-preact/package.json
+++ b/examples/framework-preact/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@astrojs/preact": "^2.2.2",
     "@preact/signals": "^1.1.3",
-    "astro": "^2.10.12",
+    "astro": "^2.10.11",
     "preact": "^10.15.1"
   }
 }

--- a/examples/framework-react/package.json
+++ b/examples/framework-react/package.json
@@ -11,10 +11,10 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/react": "^2.3.2",
+    "@astrojs/react": "^2.3.1",
     "@types/react": "^18.2.13",
     "@types/react-dom": "^18.2.6",
-    "astro": "^2.10.12",
+    "astro": "^2.10.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/examples/framework-solid/package.json
+++ b/examples/framework-solid/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@astrojs/solid-js": "^2.2.1",
-    "astro": "^2.10.12",
+    "astro": "^2.10.11",
     "solid-js": "^1.7.6"
   }
 }

--- a/examples/framework-svelte/package.json
+++ b/examples/framework-svelte/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@astrojs/svelte": "^3.1.1",
-    "astro": "^2.10.12",
+    "astro": "^2.10.11",
     "svelte": "^3.59.1"
   }
 }

--- a/examples/framework-vue/package.json
+++ b/examples/framework-vue/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@astrojs/vue": "^2.2.1",
-    "astro": "^2.10.12",
+    "astro": "^2.10.11",
     "vue": "^3.3.4"
   }
 }

--- a/examples/hackernews/package.json
+++ b/examples/hackernews/package.json
@@ -11,7 +11,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/node": "^5.3.5",
-    "astro": "^2.10.12"
+    "@astrojs/node": "^5.3.4",
+    "astro": "^2.10.11"
   }
 }

--- a/examples/integration/package.json
+++ b/examples/integration/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {},
   "devDependencies": {
-    "astro": "^2.10.12"
+    "astro": "^2.10.11"
   },
   "peerDependencies": {
     "astro": "^2.0.0-beta.0"

--- a/examples/middleware/package.json
+++ b/examples/middleware/package.json
@@ -12,8 +12,8 @@
     "server": "node dist/server/entry.mjs"
   },
   "dependencies": {
-    "@astrojs/node": "^5.3.5",
-    "astro": "^2.10.12",
+    "@astrojs/node": "^5.3.4",
+    "astro": "^2.10.11",
     "html-minifier": "^4.0.0"
   }
 }

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -11,6 +11,6 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.10.12"
+    "astro": "^2.10.11"
   }
 }

--- a/examples/non-html-pages/package.json
+++ b/examples/non-html-pages/package.json
@@ -11,6 +11,6 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.10.12"
+    "astro": "^2.10.11"
   }
 }

--- a/examples/portfolio/package.json
+++ b/examples/portfolio/package.json
@@ -11,6 +11,6 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.10.12"
+    "astro": "^2.10.11"
   }
 }

--- a/examples/ssr/package.json
+++ b/examples/ssr/package.json
@@ -12,9 +12,9 @@
     "server": "node dist/server/entry.mjs"
   },
   "dependencies": {
-    "@astrojs/node": "^5.3.5",
+    "@astrojs/node": "^5.3.4",
     "@astrojs/svelte": "^3.1.1",
-    "astro": "^2.10.12",
+    "astro": "^2.10.11",
     "svelte": "^3.59.1"
   }
 }

--- a/examples/with-markdoc/package.json
+++ b/examples/with-markdoc/package.json
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@astrojs/markdoc": "^0.4.4",
-    "astro": "^2.10.12"
+    "astro": "^2.10.11"
   }
 }

--- a/examples/with-markdown-plugins/package.json
+++ b/examples/with-markdown-plugins/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^2.2.1",
-    "astro": "^2.10.12",
+    "astro": "^2.10.11",
     "hast-util-select": "^5.0.5",
     "rehype-autolink-headings": "^6.1.1",
     "rehype-slug": "^5.1.0",

--- a/examples/with-markdown-shiki/package.json
+++ b/examples/with-markdown-shiki/package.json
@@ -11,6 +11,6 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.10.12"
+    "astro": "^2.10.11"
   }
 }

--- a/examples/with-mdx/package.json
+++ b/examples/with-mdx/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@astrojs/mdx": "^0.19.7",
     "@astrojs/preact": "^2.2.2",
-    "astro": "^2.10.12",
+    "astro": "^2.10.11",
     "preact": "^10.15.1"
   }
 }

--- a/examples/with-nanostores/package.json
+++ b/examples/with-nanostores/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@astrojs/preact": "^2.2.2",
     "@nanostores/preact": "^0.4.1",
-    "astro": "^2.10.12",
+    "astro": "^2.10.11",
     "nanostores": "^0.8.1",
     "preact": "^10.15.1"
   }

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@astrojs/tailwind": "^4.0.0",
     "@types/canvas-confetti": "^1.6.0",
-    "astro": "^2.10.12",
+    "astro": "^2.10.11",
     "autoprefixer": "^10.4.14",
     "canvas-confetti": "^1.6.0",
     "postcss": "^8.4.24",

--- a/examples/with-vite-plugin-pwa/package.json
+++ b/examples/with-vite-plugin-pwa/package.json
@@ -11,7 +11,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.10.12",
+    "astro": "^2.10.11",
     "vite-plugin-pwa": "0.14.7",
     "workbox-window": "^6.6.0"
   }

--- a/examples/with-vitest/package.json
+++ b/examples/with-vitest/package.json
@@ -12,7 +12,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "astro": "^2.10.12",
+    "astro": "^2.10.11",
     "vitest": "^0.31.4"
   }
 }

--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -1,11 +1,5 @@
 # astro
 
-## 2.10.12
-
-### Patch Changes
-
-- [#8144](https://github.com/withastro/astro/pull/8144) [`04caa99c4`](https://github.com/withastro/astro/commit/04caa99c48ce604ca3b90302ff0df8dcdbeee650) Thanks [@lilnasy](https://github.com/lilnasy)! - Fixed an issue where data entries' id included backslashes instead of forward slashes on Windows.
-
 ## 2.10.11
 
 ### Patch Changes

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -156,7 +156,6 @@
     "ora": "^6.3.1",
     "p-limit": "^4.0.0",
     "path-to-regexp": "^6.2.1",
-    "preferred-pm": "^3.0.3",
     "prompts": "^2.4.2",
     "rehype": "^12.0.1",
     "semver": "^7.5.3",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -127,6 +127,7 @@
     "@babel/plugin-transform-react-jsx": "^7.22.5",
     "@babel/traverse": "^7.22.5",
     "@babel/types": "^7.22.5",
+    "@skarab/detect-package-manager": "^1.0.0",
     "@types/babel__core": "^7.20.1",
     "@types/dom-view-transitions": "^1.0.1",
     "@types/yargs-parser": "^21.0.0",
@@ -169,7 +170,6 @@
     "vfile": "^5.3.7",
     "vite": "^4.4.6",
     "vitefu": "^0.2.4",
-    "which-pm": "^2.0.0",
     "yargs-parser": "^21.1.1",
     "zod": "^3.20.6"
   },

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro",
-  "version": "2.10.12",
+  "version": "2.10.11",
   "description": "Astro is a modern site builder with web best practices, performance, and DX front-of-mind.",
   "type": "module",
   "author": "withastro",

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -6,6 +6,7 @@ import fsMod, { existsSync, promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import ora from 'ora';
+import whichPM from 'which-pm';
 import prompts from 'prompts';
 import type yargs from 'yargs-parser';
 import { loadTSConfig, resolveConfigPath, resolveRoot } from '../../core/config/index.js';
@@ -73,17 +74,27 @@ const OFFICIAL_ADAPTER_TO_IMPORT_MAP: Record<string, string> = {
 
 async function detectPackageManager(cwd = process.cwd()) {
 	if (existsSync(path.join(cwd, 'package-lock.json'))) {
-		return { name: 'npm' };
+		return { name: 'npm', version: '>=5' };
 	}
 	if (existsSync(path.join(cwd, 'yarn.lock'))) {
-		return { name: 'yarn' };
+		return { name: 'yarn', version: '*' };
 	}
 	if (existsSync(path.join(cwd, 'pnpm-lock.yaml'))) {
-		return { name: 'pnpm' };
+		return { name: 'pnpm', version: '>=3' };
 	}
-	if (existsSync(path.join(cwd, 'bun.lock'))) {
-		return { name: 'bun' };
+	if (existsSync(path.join(cwd, 'bun.lockb'))) {
+		return { name: 'bun', version: '*' };
 	}
+
+	// Use whichPM as a fallback if no other lock files are detected
+	const pm = await whichPM(cwd);
+	if (pm) {
+		return {
+			name: pm.name,
+			version: pm.version || '*',
+		};
+	}
+
 	return null;
 }
 

--- a/packages/astro/src/cli/info/index.ts
+++ b/packages/astro/src/cli/info/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import * as colors from 'kleur/colors';
 import { arch, platform } from 'node:os';
-import whichPm from 'which-pm';
+import { detectAgent } from '@skarab/detect-package-manager';
 import type yargs from 'yargs-parser';
 import { resolveConfig } from '../../core/config/index.js';
 import { ASTRO_VERSION } from '../../core/constants.js';
@@ -13,7 +13,7 @@ interface InfoOptions {
 
 export async function printInfo({ flags }: InfoOptions) {
 	const inlineConfig = flagsToAstroInlineConfig(flags);
-	const packageManager = await whichPm(process.cwd());
+	const packageManager = await detectAgent(process.cwd());
 	let adapter = "Couldn't determine.";
 	let integrations = [];
 

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -38,10 +38,10 @@
   },
   "devDependencies": {
     "@types/which-pm-runs": "^1.0.0",
-    "chai": "^4.3.7",
-    "mocha": "^9.2.2",
     "arg": "^5.0.2",
     "astro-scripts": "workspace:*",
+    "chai": "^4.3.7",
+    "mocha": "^9.2.2",
     "strip-ansi": "^7.1.0",
     "strip-json-comments": "^5.0.0"
   },

--- a/packages/create-astro/src/actions/context.ts
+++ b/packages/create-astro/src/actions/context.ts
@@ -9,7 +9,7 @@ export interface Context {
 	help: boolean;
 	prompt: typeof prompt;
 	cwd: string;
-	pkgManager: string;
+	packageManager: string;
 	username: string;
 	version: string;
 	skipHouston: boolean;
@@ -50,7 +50,7 @@ export async function getContext(argv: string[]): Promise<Context> {
 		{ argv, permissive: true }
 	);
 
-	const pkgManager = process.env.BUN_INSTALL
+	const packageManager = process.env.BUN_INSTALL
 		? detectPackageManager()?.name || 'bun'
 		: detectPackageManager()?.name || 'npm';
 
@@ -87,7 +87,7 @@ export async function getContext(argv: string[]): Promise<Context> {
 	const context: Context = {
 		help,
 		prompt,
-		pkgManager,
+		packageManager,
 		username,
 		version,
 		skipHouston,

--- a/packages/create-astro/src/actions/context.ts
+++ b/packages/create-astro/src/actions/context.ts
@@ -50,7 +50,10 @@ export async function getContext(argv: string[]): Promise<Context> {
 		{ argv, permissive: true }
 	);
 
-	const pkgManager = detectPackageManager()?.name ?? 'npm';
+	const pkgManager = process.env.BUN_INSTALL
+		? detectPackageManager()?.name || 'bun'
+		: detectPackageManager()?.name || 'npm';
+
 	const [username, version] = await Promise.all([getName(), getVersion()]);
 	let cwd = flags['_'][0];
 	let {

--- a/packages/create-astro/src/actions/dependencies.ts
+++ b/packages/create-astro/src/actions/dependencies.ts
@@ -6,7 +6,7 @@ import { shell } from '../shell.js';
 import type { Context } from './context';
 
 export async function dependencies(
-	ctx: Pick<Context, 'install' | 'yes' | 'prompt' | 'pkgManager' | 'cwd' | 'dryRun'>
+	ctx: Pick<Context, 'install' | 'yes' | 'prompt' | 'packageManager' | 'cwd' | 'dryRun'>
 ) {
 	let deps = ctx.install ?? ctx.yes;
 	if (deps === undefined) {
@@ -25,15 +25,15 @@ export async function dependencies(
 		await info('--dry-run', `Skipping dependency installation`);
 	} else if (deps) {
 		await spinner({
-			start: `Installing dependencies with ${ctx.pkgManager}...`,
+			start: `Installing dependencies with ${ctx.packageManager}...`,
 			end: 'Dependencies installed',
 			while: () => {
-				return install({ pkgManager: ctx.pkgManager, cwd: ctx.cwd }).catch((e) => {
+				return install({ packageManager: ctx.packageManager, cwd: ctx.cwd }).catch((e) => {
 					error('error', e);
 					error(
 						'error',
 						`Dependencies failed to install, please run ${color.bold(
-							ctx.pkgManager + ' install'
+							ctx.packageManager + ' install'
 						)}  to install them manually after setup.`
 					);
 				});
@@ -47,9 +47,9 @@ export async function dependencies(
 	}
 }
 
-async function install({ pkgManager, cwd }: { pkgManager: string; cwd: string }) {
-	if (pkgManager === 'yarn') await ensureYarnLock({ cwd });
-	return shell(pkgManager, ['install'], { cwd, timeout: 90_000, stdio: 'ignore' });
+async function install({ packageManager, cwd }: { packageManager: string; cwd: string }) {
+	if (packageManager === 'yarn') await ensureYarnLock({ cwd });
+	return shell(packageManager, ['install'], { cwd, timeout: 90_000, stdio: 'ignore' });
 }
 
 async function ensureYarnLock({ cwd }: { cwd: string }) {

--- a/packages/create-astro/src/actions/next-steps.ts
+++ b/packages/create-astro/src/actions/next-steps.ts
@@ -3,14 +3,14 @@ import type { Context } from './context';
 
 import { nextSteps, say } from '../messages.js';
 
-export async function next(ctx: Pick<Context, 'cwd' | 'pkgManager' | 'skipHouston'>) {
+export async function next(ctx: Pick<Context, 'cwd' | 'packageManager' | 'skipHouston'>) {
 	let projectDir = path.relative(process.cwd(), ctx.cwd);
 	const devCmd =
-		ctx.pkgManager === 'npm'
+		ctx.packageManager === 'npm'
 			? 'npm run dev'
-			: ctx.pkgManager === 'bun'
+			: ctx.packageManager === 'bun'
 			? 'bun run dev'
-			: `${ctx.pkgManager} dev`;
+			: `${ctx.packageManager} dev`;
 	await nextSteps({ projectDir, devCmd });
 
 	if (!ctx.skipHouston) {

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -12,11 +12,11 @@ import { shell } from './shell.js';
 //
 // A copy of this function also exists in the astro package
 async function getRegistry(): Promise<string> {
-	const pkgManager = process.env.BUN_INSTALL
+	const packageManager = process.env.BUN_INSTALL
 		? detectPackageManager()?.name || 'bun'
 		: detectPackageManager()?.name || 'npm';
 	try {
-		const { stdout } = await shell(pkgManager, ['config', 'get', 'registry']);
+		const { stdout } = await shell(packageManager, ['config', 'get', 'registry']);
 		return stdout?.trim()?.replace(/\/$/, '') || 'https://registry.npmjs.org';
 	} catch (e) {
 		return 'https://registry.npmjs.org';

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -12,9 +12,11 @@ import { shell } from './shell.js';
 //
 // A copy of this function also exists in the astro package
 async function getRegistry(): Promise<string> {
-	const packageManager = detectPackageManager()?.name || 'npm';
+	const pkgManager = process.env.BUN_INSTALL
+		? detectPackageManager()?.name || 'bun'
+		: detectPackageManager()?.name || 'npm';
 	try {
-		const { stdout } = await shell(packageManager, ['config', 'get', 'registry']);
+		const { stdout } = await shell(pkgManager, ['config', 'get', 'registry']);
 		return stdout?.trim()?.replace(/\/$/, '') || 'https://registry.npmjs.org';
 	} catch (e) {
 		return 'https://registry.npmjs.org';

--- a/packages/create-astro/test/dependencies.test.js
+++ b/packages/create-astro/test/dependencies.test.js
@@ -10,7 +10,7 @@ describe('dependencies', () => {
 		const context = {
 			cwd: '',
 			yes: true,
-			pkgManager: 'npm',
+			packageManager: 'npm',
 			dryRun: true,
 			prompt: () => ({ deps: true }),
 		};
@@ -21,7 +21,7 @@ describe('dependencies', () => {
 	it('prompt yes', async () => {
 		const context = {
 			cwd: '',
-			pkgManager: 'npm',
+			packageManager: 'npm',
 			dryRun: true,
 			prompt: () => ({ deps: true }),
 			install: undefined,
@@ -34,7 +34,7 @@ describe('dependencies', () => {
 	it('prompt no', async () => {
 		const context = {
 			cwd: '',
-			pkgManager: 'npm',
+			packageManager: 'npm',
 			dryRun: true,
 			prompt: () => ({ deps: false }),
 			install: undefined,
@@ -48,7 +48,7 @@ describe('dependencies', () => {
 		const context = {
 			cwd: '',
 			install: true,
-			pkgManager: 'npm',
+			packageManager: 'npm',
 			dryRun: true,
 			prompt: () => ({ deps: false }),
 		};
@@ -61,7 +61,7 @@ describe('dependencies', () => {
 		const context = {
 			cwd: '',
 			install: false,
-			pkgManager: 'npm',
+			packageManager: 'npm',
 			dryRun: true,
 			prompt: () => ({ deps: false }),
 		};

--- a/packages/create-astro/test/next.test.js
+++ b/packages/create-astro/test/next.test.js
@@ -7,14 +7,22 @@ describe('next steps', () => {
 	const fixture = setup();
 
 	it('no arguments', async () => {
-		await next({ skipHouston: false, cwd: './it/fixtures/not-empty', pkgManager: 'npm' });
+		await next({
+			skipHouston: false,
+			cwd: './it/fixtures/not-empty',
+			packageManager: 'npm',
+		});
 		expect(fixture.hasMessage('Liftoff confirmed.')).to.be.true;
 		expect(fixture.hasMessage('npm run dev')).to.be.true;
 		expect(fixture.hasMessage('Good luck out there, astronaut!')).to.be.true;
 	});
 
 	it('--skip-houston', async () => {
-		await next({ skipHouston: true, cwd: './it/fixtures/not-empty', pkgManager: 'npm' });
+		await next({
+			skipHouston: true,
+			cwd: './it/fixtures/not-empty',
+			packageManager: 'npm',
+		});
 		expect(fixture.hasMessage('Good luck out there, astronaut!')).to.be.false;
 	});
 });

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -45,7 +45,7 @@
     "tiny-glob": "^0.2.9"
   },
   "peerDependencies": {
-    "astro": "workspace:^2.10.12"
+    "astro": "workspace:^2.10.11"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/packages/integrations/deno/package.json
+++ b/packages/integrations/deno/package.json
@@ -36,7 +36,7 @@
     "esbuild": "^0.15.18"
   },
   "peerDependencies": {
-    "astro": "workspace:^2.10.12"
+    "astro": "workspace:^2.10.11"
   },
   "devDependencies": {
     "astro": "workspace:*",

--- a/packages/integrations/image/package.json
+++ b/packages/integrations/image/package.json
@@ -63,7 +63,7 @@
     "vite": "^4.4.6"
   },
   "peerDependencies": {
-    "astro": "workspace:^2.10.12",
+    "astro": "workspace:^2.10.11",
     "sharp": ">=0.31.0"
   },
   "peerDependenciesMeta": {

--- a/packages/integrations/markdoc/package.json
+++ b/packages/integrations/markdoc/package.json
@@ -75,7 +75,7 @@
     "zod": "^3.17.3"
   },
   "peerDependencies": {
-    "astro": "workspace:^2.10.12"
+    "astro": "workspace:^2.10.11"
   },
   "devDependencies": {
     "@astrojs/markdown-remark": "^2.2.1",

--- a/packages/integrations/netlify/package.json
+++ b/packages/integrations/netlify/package.json
@@ -45,7 +45,7 @@
     "esbuild": "^0.15.18"
   },
   "peerDependencies": {
-    "astro": "workspace:^2.10.12"
+    "astro": "workspace:^2.10.11"
   },
   "devDependencies": {
     "@netlify/edge-functions": "^2.0.0",

--- a/packages/integrations/node/CHANGELOG.md
+++ b/packages/integrations/node/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @astrojs/node
 
-## 5.3.5
-
-### Patch Changes
-
-- [#8141](https://github.com/withastro/astro/pull/8141) [`4c15c0696`](https://github.com/withastro/astro/commit/4c15c069691ca25efcb9ebb7d9b45605cd136ed3) Thanks [@lilnasy](https://github.com/lilnasy)! - Fixed an issue where the preview mode handled 404 and 500 routes differently from running app with node directly.
-
-- Updated dependencies [[`04caa99c4`](https://github.com/withastro/astro/commit/04caa99c48ce604ca3b90302ff0df8dcdbeee650)]:
-  - astro@2.10.12
-
 ## 5.3.4
 
 ### Patch Changes

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@astrojs/node",
   "description": "Deploy your site to a Node.js server",
-  "version": "5.3.5",
+  "version": "5.3.4",
   "type": "module",
   "types": "./dist/index.d.ts",
   "author": "withastro",
@@ -38,7 +38,7 @@
     "server-destroy": "^1.0.1"
   },
   "peerDependencies": {
-    "astro": "workspace:^2.10.12"
+    "astro": "workspace:^2.10.11"
   },
   "devDependencies": {
     "@types/node": "^18.16.18",

--- a/packages/integrations/react/CHANGELOG.md
+++ b/packages/integrations/react/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @astrojs/react
 
-## 2.3.2
-
-### Patch Changes
-
-- [#8149](https://github.com/withastro/astro/pull/8149) [`531cc3e49`](https://github.com/withastro/astro/commit/531cc3e490bc3bc1b896eeaec05664571df5bb24) Thanks [@matthewp](https://github.com/matthewp)! - Fix missing package file regression
-
 ## 2.3.1
 
 ### Patch Changes

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@astrojs/react",
   "description": "Use React components within Astro",
-  "version": "2.3.2",
+  "version": "2.3.1",
   "type": "module",
   "types": "./dist/index.d.ts",
   "author": "withastro",

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -48,7 +48,7 @@
     "vite": "^4.4.6"
   },
   "peerDependencies": {
-    "astro": "workspace:^2.10.12",
+    "astro": "workspace:^2.10.11",
     "svelte": "^3.55.0 || ^4.0.0"
   },
   "engines": {

--- a/packages/integrations/tailwind/package.json
+++ b/packages/integrations/tailwind/package.json
@@ -43,7 +43,7 @@
     "vite": "^4.4.6"
   },
   "peerDependencies": {
-    "astro": "workspace:^2.10.12",
+    "astro": "workspace:^2.10.11",
     "tailwindcss": "^3.0.24"
   }
 }

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -61,7 +61,7 @@
     "web-vitals": "^3.3.2"
   },
   "peerDependencies": {
-    "astro": "workspace:^2.10.12"
+    "astro": "workspace:^2.10.11"
   },
   "devDependencies": {
     "@types/set-cookie-parser": "^2.4.2",

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -56,7 +56,7 @@
     "vue": "^3.3.4"
   },
   "peerDependencies": {
-    "astro": "workspace:^2.10.12",
+    "astro": "workspace:^2.10.11",
     "vue": "^3.2.30"
   },
   "engines": {

--- a/packages/telemetry/src/project-info.ts
+++ b/packages/telemetry/src/project-info.ts
@@ -106,11 +106,16 @@ function getProjectId(isCI: boolean): Pick<ProjectInfo, 'anonymousProjectId' | '
 
 export function getProjectInfo(isCI: boolean): ProjectInfo {
 	const projectId = getProjectId(isCI);
-	const packageManager = detectPackageManager();
+	const detectedPkgManager = detectPackageManager();
+
+	const packageManager = process.env.BUN_INSTALL
+		? detectedPkgManager?.name || 'bun'
+		: detectedPkgManager?.name || 'npm';
+
 	return {
 		...projectId,
-		packageManager: packageManager?.name,
-		packageManagerVersion: packageManager?.version,
+		packageManager: packageManager,
+		packageManagerVersion: detectedPkgManager?.version,
 	};
 }
 //

--- a/packages/telemetry/src/project-info.ts
+++ b/packages/telemetry/src/project-info.ts
@@ -106,16 +106,16 @@ function getProjectId(isCI: boolean): Pick<ProjectInfo, 'anonymousProjectId' | '
 
 export function getProjectInfo(isCI: boolean): ProjectInfo {
 	const projectId = getProjectId(isCI);
-	const detectedPkgManager = detectPackageManager();
+	const detectedPackageManager = detectPackageManager();
 
 	const packageManager = process.env.BUN_INSTALL
-		? detectedPkgManager?.name || 'bun'
-		: detectedPkgManager?.name || 'npm';
+		? detectedPackageManager?.name || 'bun'
+		: detectedPackageManager?.name || 'npm';
 
 	return {
 		...projectId,
 		packageManager: packageManager,
-		packageManagerVersion: detectedPkgManager?.version,
+		packageManagerVersion: detectedPackageManager?.version,
 	};
 }
 //

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -605,9 +605,6 @@ importers:
       path-to-regexp:
         specifier: ^6.2.1
         version: 6.2.1
-      preferred-pm:
-        specifier: ^3.0.3
-        version: 3.0.3
       prompts:
         specifier: ^2.4.2
         version: 2.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,6 +521,9 @@ importers:
       '@types/babel__core':
         specifier: ^7.20.1
         version: 7.20.1
+				'@skarab/detect-package-manager':
+				specifier: ^1.0.0
+				version: 1.0.0
       '@types/dom-view-transitions':
         specifier: ^1.0.1
         version: 1.0.1
@@ -644,9 +647,6 @@ importers:
       vitefu:
         specifier: ^0.2.4
         version: 0.2.4(vite@4.4.6)
-      which-pm:
-        specifier: ^2.0.0
-        version: 2.0.0
       yargs-parser:
         specifier: ^21.1.1
         version: 21.1.1
@@ -8753,6 +8753,11 @@ packages:
       picomatch: 2.3.1
       rollup: 3.20.1
     dev: false
+
+		/askarab/detect-package-manager@1.0.0:
+		resolution: {integrity: sha512-CuU1x6LgkJIF+H8FCKi j×6DbWVP1Y7kqPk88LS×Ne@ulbe3BZ37qd3Aa×3t5vnFZESLFMcjQd2d1PhdvWNSdQ==}
+		engines: {node: '>=14', ppm: '>=7'}
+		dev: false
 
   /@solidjs/router@0.5.1(solid-js@1.7.6):
     resolution: {integrity: sha512-igyrwUqm/9T26Lb6l7oXwpc4lLUVqbhbN92wOL3NgLoLVmkQlUNTZciuAe+Su8XeJXlrWjl6oxDJDLt+6pws/g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,12 +518,12 @@ importers:
       '@babel/types':
         specifier: ^7.22.5
         version: 7.22.5
+      '@skarab/detect-package-manager':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@types/babel__core':
         specifier: ^7.20.1
         version: 7.20.1
-				'@skarab/detect-package-manager':
-				specifier: ^1.0.0
-				version: 1.0.0
       '@types/dom-view-transitions':
         specifier: ^1.0.1
         version: 1.0.1
@@ -8754,10 +8754,10 @@ packages:
       rollup: 3.20.1
     dev: false
 
-		/askarab/detect-package-manager@1.0.0:
-		resolution: {integrity: sha512-CuU1x6LgkJIF+H8FCKi j×6DbWVP1Y7kqPk88LS×Ne@ulbe3BZ37qd3Aa×3t5vnFZESLFMcjQd2d1PhdvWNSdQ==}
-		engines: {node: '>=14', ppm: '>=7'}
-		dev: false
+  /@skarab/detect-package-manager@1.0.0:
+    resolution: {integrity: sha512-CuU1x6LgkJIF+H8FCnKijx6DbWVP1Y7kqPk88LSxNe0ulbe3BZ37qd3AaX3t5vnFZESLFMcjQd2dlPhdvWNSdQ==}
+    engines: {node: '>=14', pnpm: '>=7'}
+    dev: false
 
   /@solidjs/router@0.5.1(solid-js@1.7.6):
     resolution: {integrity: sha512-igyrwUqm/9T26Lb6l7oXwpc4lLUVqbhbN92wOL3NgLoLVmkQlUNTZciuAe+Su8XeJXlrWjl6oxDJDLt+6pws/g==}
@@ -11962,6 +11962,7 @@ packages:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+    dev: true
 
   /find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -11969,12 +11970,14 @@ packages:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+    dev: true
 
   /find-yarn-workspace-root2@1.2.16:
     resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==}
     dependencies:
       micromatch: 4.0.5
       pkg-dir: 4.2.0
+    dev: true
 
   /flat-cache@3.0.4:
     resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
@@ -13401,6 +13404,7 @@ packages:
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
+    dev: true
 
   /local-pkg@0.4.3:
     resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
@@ -13420,12 +13424,14 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-locate: 4.1.0
+    dev: true
 
   /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
     dependencies:
       p-locate: 5.0.0
+    dev: true
 
   /lodash.chunk@4.2.0:
     resolution: {integrity: sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==}
@@ -14810,6 +14816,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
+    dev: true
 
   /p-limit@4.0.0:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
@@ -14830,12 +14837,14 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-limit: 2.3.0
+    dev: true
 
   /p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
     dependencies:
       p-limit: 3.1.0
+    dev: true
 
   /p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
@@ -15052,6 +15061,7 @@ packages:
   /pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+    dev: true
 
   /pirates@4.0.5:
     resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
@@ -15062,6 +15072,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       find-up: 4.1.0
+    dev: true
 
   /pkg-types@1.0.3:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
@@ -15535,6 +15546,7 @@ packages:
       find-yarn-workspace-root2: 1.2.16
       path-exists: 4.0.0
       which-pm: 2.0.0
+    dev: true
 
   /prelude-ls@1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
@@ -16813,6 +16825,7 @@ packages:
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+    dev: true
 
   /strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
@@ -18103,6 +18116,7 @@ packages:
     dependencies:
       load-yaml-file: 0.2.0
       path-exists: 4.0.0
+    dev: true
 
   /which-typed-array@1.1.9:
     resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
@@ -18540,6 +18554,7 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
 
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
@@ -18568,25 +18583,21 @@ packages:
   file:packages/astro/test/fixtures/css-assets/packages/font-awesome:
     resolution: {directory: packages/astro/test/fixtures/css-assets/packages/font-awesome, type: directory}
     name: '@test/astro-font-awesome-package'
-    version: 0.0.1
     dev: false
 
   file:packages/astro/test/fixtures/multiple-renderers/renderers/one:
     resolution: {directory: packages/astro/test/fixtures/multiple-renderers/renderers/one, type: directory}
     name: '@test/astro-renderer-one'
-    version: 1.0.0
     dev: false
 
   file:packages/astro/test/fixtures/multiple-renderers/renderers/two:
     resolution: {directory: packages/astro/test/fixtures/multiple-renderers/renderers/two, type: directory}
     name: '@test/astro-renderer-two'
-    version: 1.0.0
     dev: false
 
   file:packages/astro/test/fixtures/solid-component/deps/solid-jsx-component:
     resolution: {directory: packages/astro/test/fixtures/solid-component/deps/solid-jsx-component, type: directory}
     name: '@test/solid-jsx-component'
-    version: 0.0.0
     dependencies:
       solid-js: 1.7.6
     dev: false


### PR DESCRIPTION
## Changes

- Prints the correct command for adding an integration when using bun (`bunx astro add`)
- Bun is now detected as a package manager in all cases
- improves upon #7944
- added consistent wording

## Testing

Tested manually. Here's a screenshot.
<img width="963" alt="works" src="https://github.com/withastro/astro/assets/44789941/8a8f1f64-7228-4807-8b5e-c379edd010e1">

## Docs

Sister documentation PR: https://github.com/withastro/docs/pull/4052
https://docs.astro.build/en/recipes/bun/
