### PR TITLE
add: config error if `outDir` is inside `publicDir`

### DIFF
--- a/.changeset/brown-numbers-prove.md
+++ b/.changeset/brown-numbers-prove.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Displays a new config error if `outDir` is placed within `publicDir`.

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -410,6 +410,8 @@ A future version of Astro will stop using the site pathname when producing <link
 		}
 
 		return config;
+	}).refine((obj) => !obj.outDir.toString().startsWith(obj.publicDir.toString()), {
+		message: '`outDir` must not be placed inside `publicDir` to prevent an infinite loop. Please adjust the directory configuration and try again'
 	});
 
 	return AstroConfigRelativeSchema;

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -68,4 +68,10 @@ describe('Config Validation', () => {
 		).catch((err) => err);
 		expect(configError).to.be.not.instanceOf(Error);
 	});
+	it('Error when outDir is placed within publicDir', async () => {
+		const configError = await validateConfig({ outDir: './public/dist' }, process.cwd()).catch((err) => err);
+		expect(configError instanceof z.ZodError).to.equal(true);
+		expect(configError.errors[0].message).to.equal('`outDir` must not be placed inside `publicDir` to prevent an infinite loop. \
+Please adjust the directory configuration and try again')
+	});
 });


### PR DESCRIPTION
## Changes

fixes #6904

![image](https://github.com/withastro/astro/assets/71379045/b6a6c9d4-4203-4468-b8b1-329aec47e1d7)

I thought that creating a ZodError in schema would be better than throwing a new error so it works for both ssr and ssg and we just need to change one file. What do you think?

And is this message ok?

## Testing

New test expecting an error message.

## Docs

n/a

