### PR TITLE
feat(ViewTransitions): use `scrollend` instead of `scroll` where supported

### DIFF
--- a/.changeset/long-chefs-jump.md
+++ b/.changeset/long-chefs-jump.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+The scrollend mechanism is a better way to record the scroll position compared to throttling, so we now use it whenever a browser supports it.

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -341,9 +341,9 @@ const { fallback = 'animate' } = Astro.props as Props;
 		});
 		addEventListener('load', onload);
 		// There's not a good way to record scroll position before a back button.
-		// So the way we do it is by listening to scroll and just continuously recording it.
+		// So the way we do it is by listening to scrollend if supported, and if not continuously record the scroll position.
     const updateState = () => {
-			// only updste history entries that are managed by us
+			// only update history entries that are managed by us
 			// leave other entries alone and do not accidently add state.
 			if (history.state) {
 				persistState({ ...history.state, scrollY });

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -342,16 +342,14 @@ const { fallback = 'animate' } = Astro.props as Props;
 		addEventListener('load', onload);
 		// There's not a good way to record scroll position before a back button.
 		// So the way we do it is by listening to scroll and just continuously recording it.
-		addEventListener(
-			'scroll',
-			throttle(() => {
-				// only updste history entries that are managed by us
-				// leave other entries alone and do not accidently add state.
-				if (history.state) {
-					persistState({ ...history.state, scrollY });
-				}
-			}, 300),
-			{ passive: true }
-		);
+    const updateState = () => {
+			// only updste history entries that are managed by us
+			// leave other entries alone and do not accidently add state.
+			if (history.state) {
+				persistState({ ...history.state, scrollY });
+			}
+		}
+		if ('onscrollend' in window) addEventListener('scrollend', updateState);
+		else addEventListener('scroll', throttle(updateState, 300));
 	}
 </script>


### PR DESCRIPTION
## Changes

The [scrollend](https://developer.chrome.com/blog/scrollend-a-new-javascript-event/#event-details) mechanism seems like a better way to record the scroll position compared to throttling, so we could use it whenever a browser supports it.

Additionally, I've removed the `{passive}` flag from the `scroll` event, as it does nothing ([source](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener?retiredLocale=de#improving_scrolling_performance_with_passive_listeners:~:text=You%20don%27t%20need%20to%20worry%20about%20the%20value%20of%20passive%20for%20the%20basic%20scroll%20event.%20Since%20it%20can%27t%20be%20canceled%2C%20event%20listeners%20can%27t%20block%20page%20rendering%20anyway.)).

- [x] TODO: run `pnpm exec changeset`

## Testing

I've tested it locally, but maybe I'm missing out how you are testing changes to this component.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

Open question: Does it make sense to document we're using `scrollend` in modern browsers? Personally, I don't think so (implementation details), but maybe it's interesting for some techy folks.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
