### PR TITLE
[docs] deprecate build.split and build.excludeMiddleware in config ref

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -859,22 +859,12 @@ export interface AstroUserConfig {
 		 * @name build.split
 		 * @type {boolean}
 		 * @default `false`
-		 * @version 2.7.0
+		 * @deprecated since version 3.0
 		 * @description
-		 * Defines how the SSR code should be bundled when built.
+		 * The build config option `build.split` has been replaced by the adapter configuration option `functionPerRoute`. 
 		 *
-		 * When `split` is `true`, Astro will emit a file for each page.
-		 * Each file emitted will render only one page. The pages will be emitted
-		 * inside a `dist/pages/` directory, and the emitted files will keep the same file paths
-		 * of the `src/pages` directory.
-		 *
-		 * ```js
-		 * {
-		 *   build: {
-		 *     split: true
-		 *   }
-		 * }
-		 * ```
+		 * Please see your [SSR adapter's documentation](/en/guides/integrations-guide/#official-integrations) for using `functionPerRoute` to define how your SSR code is bundled.
+		 * 
 		 */
 		split?: boolean;
 
@@ -883,19 +873,11 @@ export interface AstroUserConfig {
 		 * @name build.excludeMiddleware
 		 * @type {boolean}
 		 * @default `false`
-		 * @version 2.8.0
+		 * @deprecated since version 3.0
 		 * @description
-		 * Defines whether or not any SSR middleware code will be bundled when built.
+		 * The build config option `build.excludeMiddleware` has been replaced by the adapter configuration option `edgeMiddleware`. 
 		 *
-		 * When enabled, middleware code is not bundled and imported by all pages during the build. To instead execute and import middleware code manually, set `build.excludeMiddleware: true`:
-		 *
-		 * ```js
-		 * {
-		 *   build: {
-		 *     excludeMiddleware: true
-		 *   }
-		 * }
-		 * ```
+		 * Please see your [SSR adapter's documentation](/en/guides/integrations-guide/#official-integrations) for using `edgeMiddleware` to define whether or not any SSR middleware code will be bundled when built.
 		 */
 		excludeMiddleware?: boolean;
 	};

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -861,7 +861,7 @@ export interface AstroUserConfig {
 		 * @default `false`
 		 * @deprecated since version 3.0
 		 * @description
-		 * The build config option `build.split` has been replaced by the adapter configuration option `functionPerRoute`. 
+		 * The build config option `build.split` has been replaced by the adapter configuration option [`functionPerRoute`](/en/reference/adapter-reference/#functionperroute). 
 		 *
 		 * Please see your [SSR adapter's documentation](/en/guides/integrations-guide/#official-integrations) for using `functionPerRoute` to define how your SSR code is bundled.
 		 * 
@@ -875,7 +875,7 @@ export interface AstroUserConfig {
 		 * @default `false`
 		 * @deprecated since version 3.0
 		 * @description
-		 * The build config option `build.excludeMiddleware` has been replaced by the adapter configuration option `edgeMiddleware`. 
+		 * The build config option `build.excludeMiddleware` has been replaced by the adapter configuration option [`edgeMiddleware`](/en/reference/adapter-reference/#edgemiddleware). 
 		 *
 		 * Please see your [SSR adapter's documentation](/en/guides/integrations-guide/#official-integrations) for using `edgeMiddleware` to define whether or not any SSR middleware code will be bundled when built.
 		 */


### PR DESCRIPTION
…ference

## Changes

Updates the configuration reference docs for the two build options being deprecated in favour of new adaptor config options.

- removes `@version` (is that the right thing to do?) and adds the `@deprecated` tag
- provides a short description that mentions the adaptor config that replaces it, links to the adapter reference page, and also links to our list of SSR adapter guides and suggests reading those for docs on the new config options.

## Testing

No tests, and you must absolutely vet this syntax!

## Docs

It's all docs!
