### PR TITLE
feat(blog): add Disqus integration by default

### DIFF
--- a/examples/blog/src/components/Disqus.astro
+++ b/examples/blog/src/components/Disqus.astro
@@ -1,0 +1,18 @@
+---
+const { shortname, identifier, url, title } = Astro.props;
+---
+<div id="disqus_thread"></div>
+<script define:vars={{ shortname, identifier, url, title }}>
+  var disqus_config = function () {
+    this.page.url = url;
+    this.page.identifier = identifier;
+    this.page.title = title;
+  };
+  (function() {
+    var d = document, s = d.createElement('script');
+    s.src = 'https://' + shortname + '.disqus.com/embed.js';
+    s.setAttribute('data-timestamp', new Date().toString());
+    (d.head || d.body).appendChild(s);
+  })();
+</script>
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>

--- a/examples/blog/src/consts.ts
+++ b/examples/blog/src/consts.ts
@@ -3,3 +3,5 @@
 
 export const SITE_TITLE = 'Astro Blog';
 export const SITE_DESCRIPTION = 'Welcome to my website!';
+
+export const DISQUS_SHORTNAME = '';

--- a/examples/blog/src/layouts/BlogPost.astro
+++ b/examples/blog/src/layouts/BlogPost.astro
@@ -3,11 +3,14 @@ import type { CollectionEntry } from 'astro:content';
 import BaseHead from '../components/BaseHead.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import Disqus from '../components/Disqus.astro';
 import FormattedDate from '../components/FormattedDate.astro';
+import { DISQUS_SHORTNAME } from '../consts';
 
 type Props = CollectionEntry<'blog'>['data'];
 
 const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
+const slug = Astro.params.slug;
 ---
 
 <html lang="en">
@@ -77,6 +80,7 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 						<hr />
 					</div>
 					<slot />
+                    {DISQUS_SHORTNAME && <Disqus shortname={DISQUS_SHORTNAME} identifier={slug} url={Astro.url.href} title={title} />}
 				</div>
 			</article>
 		</main>


### PR DESCRIPTION
## Changes

Add Disqus integration to blog template.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
