### PR TITLE
Use more permissive type for `defineCollection` schema option

### DIFF
--- a/.changeset/unlucky-cougars-heal.md
+++ b/.changeset/unlucky-cougars-heal.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Make typing of `defineCollection` more permissive to support advanced union and intersection types

--- a/packages/astro/content-types.template.d.ts
+++ b/packages/astro/content-types.template.d.ts
@@ -53,12 +53,9 @@ declare module 'astro:content' {
 
 	type BaseSchemaWithoutEffects =
 		| import('astro/zod').AnyZodObject
-		| import('astro/zod').ZodUnion<import('astro/zod').AnyZodObject[]>
+		| import('astro/zod').ZodUnion<[BaseSchemaWithoutEffects, ...BaseSchemaWithoutEffects[]]>
 		| import('astro/zod').ZodDiscriminatedUnion<string, import('astro/zod').AnyZodObject[]>
-		| import('astro/zod').ZodIntersection<
-				import('astro/zod').AnyZodObject,
-				import('astro/zod').AnyZodObject
-		  >;
+		| import('astro/zod').ZodIntersection<BaseSchemaWithoutEffects, BaseSchemaWithoutEffects>;
 
 	type BaseSchema =
 		| BaseSchemaWithoutEffects


### PR DESCRIPTION
## Changes

- Makes the type for the `schema` option in `defineCollection` more permissive to match what we actually support internally.
- The current stricter type allows only the following, i.e. objects, unions of objects, or an intersection of objects:
  - `z.object({...})`
  - `z.union([z.object({...}), z.object({...}), ...])`
  - `z.object({...}).and(z.object({...})`
  - `z.discriminatedUnion('type', [z.object({...}), z.object({...})])`
- By making the type recursive, it also allows cases such as unions of unions, intersection of an object with an object union etc. If a user provides one of these types today, the code runs as expected, but `tsc` and editor tooling will complain about a type error.
- The base type is still only for objects, so this doesn’t expand the type to unsupported shapes like arrays or string literals etc. it just allows different permutations of unions and intersections of objects.

## Testing

- Patched `astro` in a project and used more complex schema — no type error was shown.
- Existing tests should pass.

## Docs

I don’t think this needs additional docs — basically just updates the type to better match the current behaviour.
