### PR TITLE
Remove pre-shiki v0.14 theme names

### DIFF
--- a/.changeset/spicy-icons-live.md
+++ b/.changeset/spicy-icons-live.md
@@ -1,0 +1,14 @@
+---
+'@astrojs/markdoc': minor
+'@astrojs/mdx': minor
+'@astrojs/markdown-remark': major
+'astro': major
+---
+
+Remove pre-shiki v0.14 theme names for compatibility. Please rename to the new theme names to migrate:
+
+- `material-darker` -> `material-theme-darker`
+- `material-default` -> `material-theme`
+- `material-lighter` -> `material-theme-lighter`
+- `material-ocean` -> `material-theme-ocean`
+- `material-palenight` -> `material-theme-palenight`

--- a/packages/astro/components/shiki-themes.js
+++ b/packages/astro/components/shiki-themes.js
@@ -34,10 +34,4 @@ export const themes = {
 	'solarized-light': () => import('shiki/themes/solarized-light.json').then(mod => mod.default),
 	'vitesse-dark': () => import('shiki/themes/vitesse-dark.json').then(mod => mod.default),
 	'vitesse-light': () => import('shiki/themes/vitesse-light.json').then(mod => mod.default),
-	// old theme names for compat
-	'material-darker': () => import('shiki/themes/material-theme-darker').then(mod => mod.default),
-	'material-default': () => import('shiki/themes/material-theme').then(mod => mod.default),
-	'material-lighter': () => import('shiki/themes/material-theme-lighter').then(mod => mod.default),
-	'material-ocean': () => import('shiki/themes/material-theme-ocean').then(mod => mod.default),
-	'material-palenight': () => import('shiki/themes/material-theme-palenight').then(mod => mod.default),
 };

--- a/packages/astro/scripts/shiki-gen-themes.mjs
+++ b/packages/astro/scripts/shiki-gen-themes.mjs
@@ -8,15 +8,6 @@ const themeImports = dir.map((f) => {
 	return [f.slice(0, f.indexOf('.json')), toThemeImport(f)];
 });
 
-// Map of old theme names to new names to preserve compatibility when we upgrade shiki
-const compatThemes = {
-	'material-darker': 'material-theme-darker',
-	'material-default': 'material-theme',
-	'material-lighter': 'material-theme-lighter',
-	'material-ocean': 'material-theme-ocean',
-	'material-palenight': 'material-theme-palenight',
-};
-
 let code = `\
 /**
  * This file is prebuilt from packages/astro/scripts/shiki-gen-themes.mjs
@@ -28,10 +19,6 @@ export const themes = {`;
 
 for (const [key, imp] of themeImports) {
 	code += `\n\t'${key}': () => ${imp},`;
-}
-code += `\n\t// old theme names for compat`;
-for (const oldName in compatThemes) {
-	code += `\n\t'${oldName}': () => ${toThemeImport(compatThemes[oldName])},`;
 }
 code += '\n};';
 

--- a/packages/integrations/markdoc/src/extensions/shiki.ts
+++ b/packages/integrations/markdoc/src/extensions/shiki.ts
@@ -5,25 +5,6 @@ import type * as shikiTypes from 'shiki';
 import { getHighlighter } from 'shiki';
 import type { AstroMarkdocConfig } from '../config.js';
 
-// Map of old theme names to new names to preserve compatibility when we upgrade shiki
-const compatThemes: Record<string, string> = {
-	'material-darker': 'material-theme-darker',
-	'material-default': 'material-theme',
-	'material-lighter': 'material-theme-lighter',
-	'material-ocean': 'material-theme-ocean',
-	'material-palenight': 'material-theme-palenight',
-};
-
-const normalizeTheme = (theme: string | shikiTypes.IShikiTheme) => {
-	if (typeof theme === 'string') {
-		return compatThemes[theme] || theme;
-	} else if (compatThemes[theme.name]) {
-		return { ...theme, name: compatThemes[theme.name] };
-	} else {
-		return theme;
-	}
-};
-
 const ASTRO_COLOR_REPLACEMENTS = {
 	'#000001': 'var(--astro-code-color-text)',
 	'#000002': 'var(--astro-code-color-background)',
@@ -53,8 +34,6 @@ export default async function shiki({
 	theme = 'github-dark',
 	wrap = false,
 }: ShikiConfig = {}): Promise<AstroMarkdocConfig> {
-	theme = normalizeTheme(theme);
-
 	const cacheID: string = typeof theme === 'string' ? theme : theme.name;
 	if (!highlighterCache.has(cacheID)) {
 		highlighterCache.set(

--- a/packages/integrations/mdx/src/remark-shiki.ts
+++ b/packages/integrations/mdx/src/remark-shiki.ts
@@ -10,27 +10,7 @@ import { visit } from 'unist-util-visit';
  */
 const highlighterCacheAsync = new Map<string, Promise<shiki.Highlighter>>();
 
-// Map of old theme names to new names to preserve compatibility when we upgrade shiki
-const compatThemes: Record<string, string> = {
-	'material-darker': 'material-theme-darker',
-	'material-default': 'material-theme',
-	'material-lighter': 'material-theme-lighter',
-	'material-ocean': 'material-theme-ocean',
-	'material-palenight': 'material-theme-palenight',
-};
-
-const normalizeTheme = (theme: string | shiki.IShikiTheme) => {
-	if (typeof theme === 'string') {
-		return compatThemes[theme] || theme;
-	} else if (compatThemes[theme.name]) {
-		return { ...theme, name: compatThemes[theme.name] };
-	} else {
-		return theme;
-	}
-};
-
 const remarkShiki = async ({ langs = [], theme = 'github-dark', wrap = false }: ShikiConfig) => {
-	theme = normalizeTheme(theme);
 	const cacheID: string = typeof theme === 'string' ? theme : theme.name;
 	let highlighterAsync = highlighterCacheAsync.get(cacheID);
 	if (!highlighterAsync) {

--- a/packages/markdown/remark/src/remark-shiki.ts
+++ b/packages/markdown/remark/src/remark-shiki.ts
@@ -10,30 +10,10 @@ import type { ShikiConfig } from './types.js';
  */
 const highlighterCacheAsync = new Map<string, Promise<shiki.Highlighter>>();
 
-// Map of old theme names to new names to preserve compatibility when we upgrade shiki
-const compatThemes: Record<string, string> = {
-	'material-darker': 'material-theme-darker',
-	'material-default': 'material-theme',
-	'material-lighter': 'material-theme-lighter',
-	'material-ocean': 'material-theme-ocean',
-	'material-palenight': 'material-theme-palenight',
-};
-
-const normalizeTheme = (theme: string | shiki.IShikiTheme) => {
-	if (typeof theme === 'string') {
-		return compatThemes[theme] || theme;
-	} else if (compatThemes[theme.name]) {
-		return { ...theme, name: compatThemes[theme.name] };
-	} else {
-		return theme;
-	}
-};
-
 const remarkShiki = async (
 	{ langs = [], theme = 'github-dark', wrap = false }: ShikiConfig,
 	scopedClassName?: string | null
 ) => {
-	theme = normalizeTheme(theme);
 	const cacheID: string = typeof theme === 'string' ? theme : theme.name;
 	let highlighterAsync = highlighterCacheAsync.get(cacheID);
 	if (!highlighterAsync) {


### PR DESCRIPTION
## Changes

Some theme names in pre-shiki v0.14 were preserved for backwards compatibility, which was introduced in https://github.com/withastro/astro/pull/6932.

This PR removes this compatibility. Users should rename to the new names instead.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing tests should pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
New changeset.