### PR TITLE
Remove deprecated APIs

### DIFF
--- a/.changeset/happy-penguins-hug.md
+++ b/.changeset/happy-penguins-hug.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+Remove deprecated config option types, deprecated script/style attributes, and deprecated `image` export from `astro:content`

--- a/packages/astro/content-types.template.d.ts
+++ b/packages/astro/content-types.template.d.ts
@@ -14,25 +14,6 @@ declare module 'astro:content' {
 	type Flatten<T> = T extends { [K: string]: infer U } ? U : never;
 	export type CollectionEntry<C extends keyof AnyEntryMap> = Flatten<AnyEntryMap[C]>;
 
-	// TODO: Remove this when having this fallback is no longer relevant. 2.3? 3.0? - erika, 2023-04-04
-	/**
-	 * @deprecated
-	 * `astro:content` no longer provide `image()`.
-	 *
-	 * Please use it through `schema`, like such:
-	 * ```ts
-	 * import { defineCollection, z } from "astro:content";
-	 *
-	 * defineCollection({
-	 *   schema: ({ image }) =>
-	 *     z.object({
-	 *       image: image(),
-	 *     }),
-	 * });
-	 * ```
-	 */
-	export const image: never;
-
 	// This needs to be in sync with ImageMetadata
 	export type ImageFunction = () => import('astro/zod').ZodObject<{
 		src: import('astro/zod').ZodString;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -104,15 +104,11 @@ export interface AstroDefineVarsAttribute {
 }
 
 export interface AstroStyleAttributes {
-	/** @deprecated Use `is:global` instead */
-	global?: boolean;
 	'is:global'?: boolean;
 	'is:inline'?: boolean;
 }
 
 export interface AstroScriptAttributes {
-	/** @deprecated Hoist is now the default behavior */
-	hoist?: boolean;
 	'is:inline'?: boolean;
 }
 
@@ -1342,29 +1338,6 @@ export interface AstroUserConfig {
 		 */
 		optimizeHoistedScript?: boolean;
 	};
-
-	// Legacy options to be removed
-
-	/** @deprecated - Use "integrations" instead. Run Astro to learn more about migrating. */
-	renderers?: never;
-	/** @deprecated `projectRoot` has been renamed to `root` */
-	projectRoot?: never;
-	/** @deprecated `src` has been renamed to `srcDir` */
-	src?: never;
-	/** @deprecated `pages` has been removed. It is no longer configurable. */
-	pages?: never;
-	/** @deprecated `public` has been renamed to `publicDir` */
-	public?: never;
-	/** @deprecated `dist` has been renamed to `outDir` */
-	dist?: never;
-	/** @deprecated `styleOptions` has been renamed to `style` */
-	styleOptions?: never;
-	/** @deprecated `markdownOptions` has been renamed to `markdown` */
-	markdownOptions?: never;
-	/** @deprecated `buildOptions` has been renamed to `build` */
-	buildOptions?: never;
-	/** @deprecated `devOptions` has been renamed to `server` */
-	devOptions?: never;
 }
 
 // NOTE(fks): We choose to keep our hand-generated AstroUserConfig interface so that

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -20,73 +20,12 @@ import { mergeConfig } from './merge.js';
 import { createRelativeSchema } from './schema.js';
 import { loadConfigWithVite } from './vite-load.js';
 
-const LEGACY_ASTRO_CONFIG_KEYS = new Set([
-	'projectRoot',
-	'src',
-	'pages',
-	'public',
-	'dist',
-	'styleOptions',
-	'markdownOptions',
-	'buildOptions',
-	'devOptions',
-]);
-
 /** Turn raw config values into normalized values */
 export async function validateConfig(
 	userConfig: any,
 	root: string,
 	cmd: string
 ): Promise<AstroConfig> {
-	// Manual deprecation checks
-	/* eslint-disable no-console */
-	if (userConfig.hasOwnProperty('renderers')) {
-		console.error('Astro "renderers" are now "integrations"!');
-		console.error('Update your configuration and install new dependencies:');
-		try {
-			const rendererKeywords = userConfig.renderers.map((r: string) =>
-				r.replace('@astrojs/renderer-', '')
-			);
-			const rendererImports = rendererKeywords
-				.map((r: string) => `  import ${r} from '@astrojs/${r === 'solid' ? 'solid-js' : r}';`)
-				.join('\n');
-			const rendererIntegrations = rendererKeywords.map((r: string) => `    ${r}(),`).join('\n');
-			console.error('');
-			console.error(colors.dim('  // astro.config.js'));
-			if (rendererImports.length > 0) {
-				console.error(colors.green(rendererImports));
-			}
-			console.error('');
-			console.error(colors.dim('  // ...'));
-			if (rendererIntegrations.length > 0) {
-				console.error(colors.green('  integrations: ['));
-				console.error(colors.green(rendererIntegrations));
-				console.error(colors.green('  ],'));
-			} else {
-				console.error(colors.green('  integrations: [],'));
-			}
-			console.error('');
-		} catch (err) {
-			// We tried, better to just exit.
-		}
-		process.exit(1);
-	}
-
-	let legacyConfigKey: string | undefined;
-	for (const key of Object.keys(userConfig)) {
-		if (LEGACY_ASTRO_CONFIG_KEYS.has(key)) {
-			legacyConfigKey = key;
-			break;
-		}
-	}
-	if (legacyConfigKey) {
-		throw new AstroError({
-			...AstroErrorData.ConfigLegacyKey,
-			message: AstroErrorData.ConfigLegacyKey.message(legacyConfigKey),
-		});
-	}
-	/* eslint-enable no-console */
-
 	const AstroConfigRelativeSchema = createRelativeSchema(cmd, root);
 
 	// First-Pass Validation


### PR DESCRIPTION
## Changes

Remove:

- Deprecated config option types and its validation
- Deprecated script/style attributes - `global` and `hoist`
- Deprecated `image` export from `astro:content` - The deprecated implementation was also removed early on at https://github.com/withastro/astro/pull/6850/files#diff-75fd7a1222f3a8c9d21456acdff9e21849148f3cab76e7a13f6a9f6e26b2370eL14-L19



## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Existing test should pass

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a