### PR TITLE
fix(assets): Add missing type for imageConfig export

### DIFF
--- a/.changeset/many-ears-drum.md
+++ b/.changeset/many-ears-drum.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix missing type for `imageConfig` export from `astro:assets`

--- a/packages/astro/client-base.d.ts
+++ b/packages/astro/client-base.d.ts
@@ -53,6 +53,7 @@ declare module 'astro:assets' {
 				| import('./dist/assets/types.js').UnresolvedImageTransform
 		) => Promise<import('./dist/assets/types.js').GetImageResult>;
 		getConfiguredImageService: typeof import('./dist/assets/index.js').getConfiguredImageService;
+		imageConfig: import('./dist/@types/astro').AstroConfig['image'];
 		Image: typeof import('./components/Image.astro').default;
 	};
 
@@ -69,7 +70,7 @@ declare module 'astro:assets' {
 	export type RemoteImageProps = Simplify<
 		import('./dist/assets/types.js').RemoteImageProps<ImgAttributes>
 	>;
-	export const { getImage, getConfiguredImageService, Image }: AstroAssets;
+	export const { getImage, getConfiguredImageService, imageConfig, Image }: AstroAssets;
 }
 
 declare module 'astro:transitions' {


### PR DESCRIPTION
## Changes

What the title says, once again having to manually update the type bit me

## Testing

Tested manually

## Docs

N/A, bug fix
