### PR TITLE
chore: update bug report to use the `astro info` command

### DIFF
--- a/.github/ISSUE_TEMPLATE/---01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/---01-bug-report.yml
@@ -11,32 +11,12 @@ body:
 
         ✅ I am using the **latest version of Astro** and all plugins.
         ✅ I am using a version of Node that Astro supports (`>=18.14.1`)
-  - type: input
-    id: astro-version
+  - type: textarea
+    id: astro-info
     attributes:
-      label: What version of `astro` are you using?
-      placeholder: 0.0.0
-    validations:
-      required: true
-  - type: input
-    id: ssr-adapter
-    attributes:
-      label: Are you using an SSR adapter? If so, which one?
-      placeholder: None, or Netlify, Vercel, Cloudflare, etc.
-    validations:
-      required: true
-  - type: input
-    id: package-manager
-    attributes:
-      label: What package manager are you using?
-      placeholder: npm, yarn, pnpm
-    validations:
-      required: true
-  - type: input
-    id: os
-    attributes:
-      label: What operating system are you using?
-      placeholder: Mac, Windows, Linux
+      label: Astro info
+      description: Run the command `astro info` and paste its output here. Please review it, in case there are sensitive information you don't want to share.
+      render: block
     validations:
       required: true
   - type: input


### PR DESCRIPTION
## Changes

This PR updates our issue template to request the information using `astro info` instead of requiring the user to fill them manually.

Unfortunately, the only info we need to request manually it the browser.

## Testing

Eventually, when `next` is merged into `main` we should see the result.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
