### PR TITLE
Finalize View Transition event names

### DIFF
--- a/.changeset/proud-fans-type.md
+++ b/.changeset/proud-fans-type.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Finalize View Transition event names

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -17,7 +17,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 		index: number;
 		scrollY: number;
 	};
-	type Events = 'astro:pageload' | 'astro:afterswap';
+	type Events = 'astro:page-load' | 'astro:after-swap';
 
 	const persistState = (state: State) => history.replaceState(state, '');
 
@@ -33,7 +33,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 	const transitionEnabledOnThisPage = () =>
 		!!document.querySelector('[name="astro-view-transitions-enabled"]');
 	const triggerEvent = (name: Events) => document.dispatchEvent(new Event(name));
-	const onPageLoad = () => triggerEvent('astro:pageload');
+	const onPageLoad = () => triggerEvent('astro:page-load');
 	const PERSIST_ATTR = 'data-astro-transition-persist';
 
 	const throttle = (cb: (...args: any[]) => any, delay: number) => {
@@ -175,7 +175,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 				persistState(state);
 			}
 
-			triggerEvent('astro:afterswap');
+			triggerEvent('astro:after-swap');
 		};
 
 		// Wait on links to finish, to prevent FOUC

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -17,7 +17,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 		index: number;
 		scrollY: number;
 	};
-	type Events = 'astro:load' | 'astro:beforeload';
+	type Events = 'astro:pageload' | 'astro:afterswap';
 
 	const persistState = (state: State) => history.replaceState(state, '');
 
@@ -33,7 +33,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 	const transitionEnabledOnThisPage = () =>
 		!!document.querySelector('[name="astro-view-transitions-enabled"]');
 	const triggerEvent = (name: Events) => document.dispatchEvent(new Event(name));
-	const onload = () => triggerEvent('astro:load');
+	const onPageLoad = () => triggerEvent('astro:pageload');
 	const PERSIST_ATTR = 'data-astro-transition-persist';
 
 	const throttle = (cb: (...args: any[]) => any, delay: number) => {
@@ -175,7 +175,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 				persistState(state);
 			}
 
-			triggerEvent('astro:beforeload');
+			triggerEvent('astro:afterswap');
 		};
 
 		// Wait on links to finish, to prevent FOUC
@@ -245,7 +245,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 			// document.documentElement.removeAttribute('data-astro-transition');
 			await runScripts();
 			markScriptsExec();
-			onload();
+			onPageLoad();
 		}
 	}
 
@@ -339,7 +339,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 				{ passive: true, capture: true }
 			);
 		});
-		addEventListener('load', onload);
+		addEventListener('load', onPageLoad);
 		// There's not a good way to record scroll position before a back button.
 		// So the way we do it is by listening to scroll and just continuously recording it.
 		addEventListener(

--- a/packages/astro/e2e/fixtures/view-transitions/src/components/DarkMode.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/components/DarkMode.astro
@@ -6,7 +6,7 @@
 	}
 
 	toggle();
-	document.addEventListener('astro:afterswap', () => {
+	document.addEventListener('astro:after-swap', () => {
 		toggle();
 	})
 </script>

--- a/packages/astro/e2e/fixtures/view-transitions/src/components/DarkMode.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/components/DarkMode.astro
@@ -6,7 +6,7 @@
 	}
 
 	toggle();
-	document.addEventListener('astro:beforeload', () => {
+	document.addEventListener('astro:afterswap', () => {
 		toggle();
 	})
 </script>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/two.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/two.astro
@@ -6,7 +6,7 @@ import Layout from '../components/Layout.astro';
 	<article id="twoarticle"></article>
 </Layout>
 <script>
-	document.addEventListener('astro:load', () => {
+	document.addEventListener('astro:page-load', () => {
 		document.getElementById('twoarticle')!.textContent = 'works';
 	}, { once: true });
 </script>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -147,7 +147,7 @@ test.describe('View Transitions', () => {
 		await expect(p, 'imported CSS updated').toHaveCSS('font-size', '24px');
 	});
 
-	test('astro:load event fires when navigating to new page', async ({ page, astro }) => {
+	test('astro:page-load event fires when navigating to new page', async ({ page, astro }) => {
 		// Go to page 1
 		await page.goto(astro.resolveUrl('/one'));
 		const p = page.locator('#one');
@@ -159,14 +159,14 @@ test.describe('View Transitions', () => {
 		await expect(article, 'should have script content').toHaveText('works');
 	});
 
-	test('astro:load event fires when navigating directly to a page', async ({ page, astro }) => {
+	test('astro:page-load event fires when navigating directly to a page', async ({ page, astro }) => {
 		// Go to page 2
 		await page.goto(astro.resolveUrl('/two'));
 		const article = page.locator('#twoarticle');
 		await expect(article, 'should have script content').toHaveText('works');
 	});
 
-	test('astro:afterswap event fires right after the swap', async ({ page, astro }) => {
+	test('astro:after-swap event fires right after the swap', async ({ page, astro }) => {
 		// Go to page 1
 		await page.goto(astro.resolveUrl('/one'));
 		let p = page.locator('#one');

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -166,7 +166,7 @@ test.describe('View Transitions', () => {
 		await expect(article, 'should have script content').toHaveText('works');
 	});
 
-	test('astro:beforeload event fires right before the swap', async ({ page, astro }) => {
+	test('astro:afterswap event fires right after the swap', async ({ page, astro }) => {
 		// Go to page 1
 		await page.goto(astro.resolveUrl('/one'));
 		let p = page.locator('#one');


### PR DESCRIPTION
> Do not merge! This is a draft as we biekshed these names. Will undraft once consensus is reached.

## Changes

- From the RFC: https://github.com/withastro/roadmap/pull/607
- Renames the `astro:load` to `astro:page-load`
   - `astro:load` is already taken.
- Renames `astro:beforeload` to `astro:after-swap`.
   - The event fires immediate after the DOM contents are swapped, so you can update the DOM to prevent FOUC
     - Most common use-case is dark mode.

## Testing

- Test updated

## Docs

- TBD, after the final naming decision is made.

## Points of contention

Based on other discussions from the RFC, I think these are the major points of contention to decide:

1. The `afterswap` name doesn't mention the transition. Some think it should.
2. The names are lowercased without dashes or camelcasing. The reasoning is that this follows the naming convention of built-in events.