### PR TITLE
Fix: changed inline-style to regular selector

### DIFF
--- a/examples/portfolio/src/components/Nav.astro
+++ b/examples/portfolio/src/components/Nav.astro
@@ -36,7 +36,7 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 			</template>
 		</menu-button>
 	</div>
-	<noscript class="menu-noscript">
+	<noscript>
 		<ul class="nav-items">
 			{
 				textLinks.map(({ label, href }) => (
@@ -60,7 +60,7 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 			}
 		</ul>
 	</noscript>
-	<noscript style="menu-content">
+	<noscript>
 		<div class="menu-footer">
 			<div class="socials">
 				{

--- a/examples/portfolio/src/components/Nav.astro
+++ b/examples/portfolio/src/components/Nav.astro
@@ -60,7 +60,7 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 			}
 		</ul>
 	</noscript>
-	<noscript style="menu-contents">
+	<noscript style="menu-content">
 		<div class="menu-footer">
 			<div class="socials">
 				{

--- a/examples/portfolio/src/components/Nav.astro
+++ b/examples/portfolio/src/components/Nav.astro
@@ -60,7 +60,7 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 			}
 		</ul>
 	</noscript>
-	<noscript style="display: contents;">
+	<noscript style="menu-contents">
 		<div class="menu-footer">
 			<div class="socials">
 				{


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/astro/issues/8161
- Replaced the inline-style to a regular selector, for some reason it was breaking the template. 

### Before:
<img width="1473" alt="image" src="https://github.com/withastro/astro/assets/85648028/08100cc0-25bc-4eaf-b8bb-6ad8d60ba0d0">

### After:
<img width="1465" alt="image" src="https://github.com/withastro/astro/assets/85648028/69e21df9-4ba8-4ec0-91a5-9c88a57ab7f0">
