### PR TITLE
Fix Astro components parent-child render order

### DIFF
--- a/.changeset/mean-snakes-play.md
+++ b/.changeset/mean-snakes-play.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix Astro components parent-child render order

--- a/packages/astro/src/runtime/server/render/any.ts
+++ b/packages/astro/src/runtime/server/render/any.ts
@@ -12,14 +12,13 @@ export async function renderChild(destination: RenderDestination, child: any) {
 		destination.write(child);
 	} else if (Array.isArray(child)) {
 		// Render all children eagerly and in parallel
-		const childPromises = child.map((c) => {
+		const childRenders = child.map((c) => {
 			return renderToBufferDestination((bufferDestination) => {
 				return renderChild(bufferDestination, c);
 			});
 		});
-		for (const childPromise of childPromises) {
-			const { renderToFinalDestination } = await childPromise;
-			renderToFinalDestination(destination);
+		for (const childRender of childRenders) {
+			await childRender.renderToFinalDestination(destination);
 		}
 	} else if (typeof child === 'function') {
 		// Special: If a child is a function, call it automatically.

--- a/packages/astro/src/runtime/server/render/any.ts
+++ b/packages/astro/src/runtime/server/render/any.ts
@@ -2,6 +2,7 @@ import { escapeHTML, isHTMLString, markHTMLString } from '../escape.js';
 import { isAstroComponentInstance, isRenderTemplateResult } from './astro/index.js';
 import { isRenderInstance, type RenderDestination } from './common.js';
 import { SlotString } from './slot.js';
+import { renderToBufferDestination } from './util.js';
 
 export async function renderChild(destination: RenderDestination, child: any) {
 	child = await child;
@@ -10,8 +11,15 @@ export async function renderChild(destination: RenderDestination, child: any) {
 	} else if (isHTMLString(child)) {
 		destination.write(child);
 	} else if (Array.isArray(child)) {
-		for (const c of child) {
-			await renderChild(destination, c);
+		// Render all children eagerly and in parallel
+		const childPromises = child.map((c) => {
+			return renderToBufferDestination((bufferDestination) => {
+				return renderChild(bufferDestination, c);
+			});
+		});
+		for (const childPromise of childPromises) {
+			const { renderToFinalDestination } = await childPromise;
+			renderToFinalDestination(destination);
 		}
 	} else if (typeof child === 'function') {
 		// Special: If a child is a function, call it automatically.

--- a/packages/astro/src/runtime/server/render/astro/render-template.ts
+++ b/packages/astro/src/runtime/server/render/astro/render-template.ts
@@ -34,7 +34,7 @@ export class RenderTemplateResult {
 
 	async render(destination: RenderDestination) {
 		// Render all expressions eagerly and in parallel
-		const expPromises = this.expressions.map((exp) => {
+		const expRenders = this.expressions.map((exp) => {
 			return renderToBufferDestination((bufferDestination) => {
 				// Skip render if falsy, except the number 0
 				if (exp || exp === 0) {
@@ -45,12 +45,11 @@ export class RenderTemplateResult {
 
 		for (let i = 0; i < this.htmlParts.length; i++) {
 			const html = this.htmlParts[i];
-			const expPromise = expPromises[i];
+			const expRender = expRenders[i];
 
 			destination.write(markHTMLString(html));
-			if (expPromise) {
-				const { renderToFinalDestination } = await expPromise;
-				await renderToFinalDestination(destination);
+			if (expRender) {
+				await expRender.renderToFinalDestination(destination);
 			}
 		}
 	}

--- a/packages/astro/src/runtime/server/render/astro/render-template.ts
+++ b/packages/astro/src/runtime/server/render/astro/render-template.ts
@@ -2,6 +2,7 @@ import { markHTMLString } from '../../escape.js';
 import { isPromise } from '../../util.js';
 import { renderChild } from '../any.js';
 import type { RenderDestination } from '../common.js';
+import { renderToBufferDestination } from '../util.js';
 
 const renderTemplateResultSym = Symbol.for('astro.renderTemplateResult');
 
@@ -32,14 +33,24 @@ export class RenderTemplateResult {
 	}
 
 	async render(destination: RenderDestination) {
+		// Render all expressions eagerly and in parallel
+		const expPromises = this.expressions.map((exp) => {
+			return renderToBufferDestination((bufferDestination) => {
+				// Skip render if falsy, except the number 0
+				if (exp || exp === 0) {
+					return renderChild(bufferDestination, exp);
+				}
+			});
+		});
+
 		for (let i = 0; i < this.htmlParts.length; i++) {
 			const html = this.htmlParts[i];
-			const exp = this.expressions[i];
+			const expPromise = expPromises[i];
 
 			destination.write(markHTMLString(html));
-			// Skip render if falsy, except the number 0
-			if (exp || exp === 0) {
-				await renderChild(destination, exp);
+			if (expPromise) {
+				const { renderToFinalDestination } = await expPromise;
+				await renderToFinalDestination(destination);
 			}
 		}
 	}

--- a/packages/astro/src/runtime/server/render/common.ts
+++ b/packages/astro/src/runtime/server/render/common.ts
@@ -37,8 +37,10 @@ export interface RenderDestination {
 }
 
 export interface RenderInstance {
-	render(destination: RenderDestination): Promise<void> | void;
+	render: RenderFunction;
 }
+
+export type RenderFunction = (destination: RenderDestination) => Promise<void> | void;
 
 export const Fragment = Symbol.for('astro:fragment');
 export const Renderer = Symbol.for('astro:renderer');

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -419,13 +419,12 @@ function renderAstroComponent(
 	props: Record<string | number, any>,
 	slots: any = {}
 ): RenderInstance {
+	const instance = createAstroComponentInstance(result, displayName, Component, props, slots);
 	return {
 		async render(destination) {
-			// NOTE: Creating an Astro instance will also invoke its slots recursively for head propagation.
-			// If an Astro component is used as a slot, it will also call this function, so make sure any side-effectful
-			// behaviour is kept within this `render` function, otherwise if it's outside, the side-effect will
-			// be called reversed / bottom-up in the slots tree.
-			const instance = createAstroComponentInstance(result, displayName, Component, props, slots);
+			// NOTE: This render call can't be pre-invoked outside of this function as it'll also initialize the slots
+			// recursively, which causes each Astro components in the tree to be called bottom-up, and is incorrect.
+			// The slots are initialized eagerly for head propagation.
 			await instance.render(destination);
 		},
 	};

--- a/packages/astro/test/astro-basic.test.js
+++ b/packages/astro/test/astro-basic.test.js
@@ -102,6 +102,12 @@ describe('Astro basics', () => {
 			// will have already erred by now, but add test anyway
 			expect(await fixture.readFile('/special-“characters” -in-file/index.html')).to.be.ok;
 		});
+
+		it('renders the components top-down', async () => {
+			const html = await fixture.readFile('/order/index.html');
+			const $ = cheerio.load(html);
+			expect($('#rendered-order').text()).to.eq('Rendered order: A, B')
+		})
 	});
 
 	it('Supports void elements whose name is a string (#2062)', async () => {

--- a/packages/astro/test/fixtures/astro-basic/src/components/OrderA.astro
+++ b/packages/astro/test/fixtures/astro-basic/src/components/OrderA.astro
@@ -1,0 +1,7 @@
+---
+globalThis.__ASTRO_TEST_ORDER__ ??= []
+globalThis.__ASTRO_TEST_ORDER__.push('A')
+---
+
+<p>A</p>
+<slot />

--- a/packages/astro/test/fixtures/astro-basic/src/components/OrderB.astro
+++ b/packages/astro/test/fixtures/astro-basic/src/components/OrderB.astro
@@ -1,0 +1,7 @@
+---
+globalThis.__ASTRO_TEST_ORDER__ ??= []
+globalThis.__ASTRO_TEST_ORDER__.push('B')
+---
+
+<p>B</p>
+<slot />

--- a/packages/astro/test/fixtures/astro-basic/src/components/OrderLast.astro
+++ b/packages/astro/test/fixtures/astro-basic/src/components/OrderLast.astro
@@ -1,0 +1,1 @@
+<p id="rendered-order">Rendered order: {() => (globalThis.__ASTRO_TEST_ORDER__ ?? []).join(', ')}</p>

--- a/packages/astro/test/fixtures/astro-basic/src/pages/order.astro
+++ b/packages/astro/test/fixtures/astro-basic/src/pages/order.astro
@@ -1,0 +1,13 @@
+---
+import OrderA from "../components/OrderA.astro";
+import OrderB from "../components/OrderB.astro";
+import OrderLast from "../components/OrderLast.astro";
+
+globalThis.__ASTRO_TEST_ORDER__ = [];
+---
+
+<OrderA>
+  <OrderB>
+    <OrderLast />
+  </OrderB>
+</OrderA>


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/8059

Previously, the `renderComponent` API will kick off the render directly, however I didn't notice that component slots are inited eagerly (for head propagation) and it kicked off the rendering of slots eagerly (not good).

This PR reverts to the previous technique where the parent will render each child in parallel manually instead. It renders all the child into a buffer first, then flush it out when it's its turn to render.

NOTE: While the benchmark shows that this is faster, it's because I removed the `bufferChunks.length = 0` optimization which seems to do more harm than good for perf. If I ported that, the perf is actually slightly lower because things are less in parallel.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added a new test

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.
