### PR TITLE
fix: typo for the SVGAttributes `widths` to `width`

### DIFF
--- a/.changeset/cold-suits-sell.md
+++ b/.changeset/cold-suits-sell.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+fix: typo for the SVGAttributes `widths` to `width`

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -1269,7 +1269,7 @@ declare namespace astroHTML.JSX {
 		viewTarget?: number | string | undefined | null;
 		visibility?: number | string | undefined | null;
 		'v-mathematical'?: number | string | undefined | null;
-		widths?: number | string | undefined | null;
+		width?: number | string | undefined | null;
 		'word-spacing'?: number | string | undefined | null;
 		'writing-mode'?: number | string | undefined | null;
 		x1?: number | string | undefined | null;


### PR DESCRIPTION
## Changes

- Change the `widths` to `width` in the astro-jsx file for the SVGAttribute as there is no widths attribute but a width attribute.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Looked at the MDNS documentation to make sure.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

docs is the MDNS one
