### PR TITLE
Prevent bundling sharp

### DIFF
--- a/.changeset/spicy-stingrays-cheer.md
+++ b/.changeset/spicy-stingrays-cheer.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent bundling sharp as it errors in runtime

--- a/packages/astro/src/core/build/plugins/plugin-internals.ts
+++ b/packages/astro/src/core/build/plugins/plugin-internals.ts
@@ -1,4 +1,4 @@
-import type { UserConfig, Plugin as VitePlugin } from 'vite';
+import type { Plugin as VitePlugin } from 'vite';
 import type { BuildInternals } from '../internal.js';
 import type { AstroBuildPlugin } from '../plugin';
 import { normalizeEntryId } from './plugin-component-entry.js';
@@ -8,19 +8,20 @@ export function vitePluginInternals(input: Set<string>, internals: BuildInternal
 		name: '@astro/plugin-build-internals',
 
 		config(config, options) {
-			const extra: Partial<UserConfig> = {};
-			const noExternal = [],
-				external = [];
 			if (options.command === 'build' && config.build?.ssr) {
-				noExternal.push('astro');
-				external.push('shiki');
+				return {
+					ssr: {
+						// Always bundle Astro runtime when building for SSR
+						noExternal: ['astro'],
+						// Except for these packages as they're not bundle-friendly. Users with strict package installations
+						// need to manually install these themselves if they use the related features.
+						external: [
+							'shiki', // For syntax highlighting
+							'sharp', // For sharp image service
+						],
+					},
+				};
 			}
-
-			extra.ssr = {
-				external,
-				noExternal,
-			};
-			return extra;
 		},
 
 		async generateBundle(_options, bundle) {


### PR DESCRIPTION
## Changes

`sharp` can't be bundled and it fails in runtime if so. It's bundled by default with pnpm unless the user installs `sharp` themselves.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
I'm updating some dependencies and it causes the Vercel test to OOM, this fixes it.

I also tested this with the `ssr` example app and it still works.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.