### PR TITLE
Update rss package to return a response

### DIFF
--- a/.changeset/honest-houses-deny.md
+++ b/.changeset/honest-houses-deny.md
@@ -1,0 +1,25 @@
+---
+'@astrojs/rss': major
+---
+
+Update the `rss()` default export to return a `Response` instead of a simple object, which is deprecated in Astro 3.0.
+
+You can also import `getRssString()` to get the RSS string directly and use it to return your own Response:
+
+```ts
+// src/pages/rss.xml.js
+import { getRssString } from '@astrojs/rss';
+
+export async function get(context) {
+  const rssString = await getRssString({
+    title: 'Buzz’s Blog',
+    ...
+  });
+
+  return new Response(rssString, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  });
+}
+```

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -370,7 +370,27 @@ export async function get(context) {
 }
 ```
 
----
+## `getRssString()`
+
+As `rss()` returns a `Response`, you can also use `getRssString()` to get the RSS string directly and use it in your own response:
+
+```ts "getRssString"
+// src/pages/rss.xml.js
+import { getRssString } from '@astrojs/rss';
+
+export async function get(context) {
+  const rssString = await getRssString({
+    title: 'Buzz’s Blog',
+    ...
+  });
+
+  return new Response(rssString, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  });
+}
+```
 
 For more on building with Astro, [visit the Astro docs][astro-rss].
 

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -98,12 +98,18 @@ const rssOptionsValidator = z.object({
 	trailingSlash: z.boolean().default(true),
 });
 
-export default async function getRSS(rssOptions: RSSOptions) {
-	const validatedRssOptions = await validateRssOptions(rssOptions);
+export default async function getRssResponse(rssOptions: RSSOptions): Promise<Response> {
+	const rssString = await getRssString(rssOptions);
+	return new Response(rssString, {
+		headers: {
+			'Content-Type': 'application/xml',
+		},
+	});
+}
 
-	return {
-		body: await generateRSS(validatedRssOptions),
-	};
+export async function getRssString(rssOptions: RSSOptions): Promise<string> {
+	const validatedRssOptions = await validateRssOptions(rssOptions);
+	return await generateRSS(validatedRssOptions);
 }
 
 async function validateRssOptions(rssOptions: RSSOptions) {


### PR DESCRIPTION
## Changes

**Breaking change for RC!**

Thanks @fflaten for spotting this at https://github.com/withastro/docs/issues/4296#issuecomment-1688567901, the `rss` integration is currently returning a simple object for the endpoint which is deprecated.

This PR changes it to a `Response`, and export a new `getRssString` utility to get the string directly if needed.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested `blog` example app manually.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->

Updated the README. It looks like we don't document what `rss()` returned before, so for most users, this change should be transparent. The main docs change is for the new `getRssString` utility.
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
