### PR TITLE
fix(ssr): correctly call the middleware when rendering error pages

### DIFF
--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -26,7 +26,6 @@ import {
 import { matchRoute } from '../routing/match.js';
 import type { RouteInfo } from './types';
 import { EndpointNotFoundError, SSRRoutePipeline } from './ssrPipeline.js';
-import { wait } from '../../../test/fixtures/streaming/src/wait';
 export { deserializeManifest } from './common.js';
 
 const clientLocalsSymbol = Symbol.for('astro.locals');

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -49,6 +49,7 @@ export type SSRManifest = {
 	componentMetadata: SSRResult['componentMetadata'];
 	pageModule?: SinglePageBuiltModule;
 	pageMap?: Map<ComponentPath, ImportComponentInstance>;
+	middlewareEntryPoint: string | undefined;
 };
 
 export type SerializedSSRManifest = Omit<

--- a/packages/astro/src/core/build/buildPipeline.ts
+++ b/packages/astro/src/core/build/buildPipeline.ts
@@ -77,6 +77,13 @@ export class BuildPipeline extends Pipeline {
 		return this.#manifest;
 	}
 
+	async retrieveMiddlewareFunction() {
+		if (this.#internals.middlewareEntryPoint) {
+			const middleware = await import(this.#internals.middlewareEntryPoint.toString());
+			this.setMiddlewareFunction(middleware.onRequest);
+		}
+	}
+
 	/**
 	 * The SSR build emits two important files:
 	 * - dist/server/manifest.mjs

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -9,7 +9,6 @@ import type {
 	ComponentInstance,
 	GetStaticPathsItem,
 	ImageTransform,
-	MiddlewareEndpointHandler,
 	RouteData,
 	RouteType,
 	SSRError,
@@ -138,6 +137,7 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 		);
 	}
 	const buildPipeline = new BuildPipeline(opts, internals, manifest);
+	await buildPipeline.retrieveMiddlewareFunction();
 	const outFolder = ssr
 		? opts.settings.config.build.server
 		: getOutDirWithinCwd(opts.settings.config.outDir);
@@ -248,10 +248,6 @@ async function generatePage(
 		.reduce(mergeInlineCss, []);
 
 	const pageModulePromise = ssrEntry.page;
-	const onRequest = ssrEntry.onRequest;
-	if (onRequest) {
-		pipeline.setMiddlewareFunction(onRequest as MiddlewareEndpointHandler);
-	}
 
 	if (!pageModulePromise) {
 		throw new Error(
@@ -612,5 +608,8 @@ export function createBuildManifest(
 			? new URL(settings.config.base, settings.config.site).toString()
 			: settings.config.site,
 		componentMetadata: internals.componentMetadata,
+		middlewareEntryPoint: internals.middlewareEntryPoint
+			? internals.middlewareEntryPoint.toString()
+			: undefined,
 	};
 }

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -237,6 +237,10 @@ function buildManifest(
 		// Set this to an empty string so that the runtime knows not to try and load this.
 		entryModules[BEFORE_HYDRATION_SCRIPT_ID] = '';
 	}
+	const isEdgeMiddleware =
+		// TODO: remove in Astro 4.0
+		settings.config.build.excludeMiddleware ||
+		settings.adapter?.adapterFeatures?.edgeMiddleware;
 
 	const ssrManifest: SerializedSSRManifest = {
 		adapterName: opts.settings.adapter?.name ?? '',
@@ -250,7 +254,7 @@ function buildManifest(
 		clientDirectives: Array.from(settings.clientDirectives),
 		entryModules,
 		assets: staticFiles.map(prefixAssetPath),
-		middlewareEntryPoint: internals.middlewareEntryPoint?.toString() ?? undefined,
+		middlewareEntryPoint: !isEdgeMiddleware ? internals.middlewareEntryPoint?.toString() : undefined,
 	};
 
 	return ssrManifest;

--- a/packages/astro/src/core/build/plugins/plugin-middleware.ts
+++ b/packages/astro/src/core/build/plugins/plugin-middleware.ts
@@ -4,6 +4,7 @@ import { addRollupInput } from '../add-rollup-input.js';
 import type { BuildInternals } from '../internal';
 import type { AstroBuildPlugin } from '../plugin';
 import type { StaticBuildOptions } from '../types';
+import { getOutputDirectory } from '../../../prerender/utils.js';
 
 export const MIDDLEWARE_MODULE_ID = '@astro-middleware';
 
@@ -56,8 +57,13 @@ export function vitePluginMiddleware(
 				if (chunk.type === 'asset') {
 					continue;
 				}
-				if (chunk.fileName === 'middleware.mjs' && opts.settings.config.build.excludeMiddleware) {
-					internals.middlewareEntryPoint = new URL(chunkName, opts.settings.config.build.server);
+				const shouldInclude =
+					// TODO: remove in Astro 4.0
+					!opts.settings.config.build.excludeMiddleware &&
+					!opts.settings.adapter?.adapterFeatures?.edgeMiddleware;
+				if (chunk.fileName === 'middleware.mjs' && shouldInclude) {
+					const outputDirectory = getOutputDirectory(opts.settings.config);
+					internals.middlewareEntryPoint = new URL(chunkName, outputDirectory);
 				}
 			}
 		},

--- a/packages/astro/src/core/build/plugins/plugin-middleware.ts
+++ b/packages/astro/src/core/build/plugins/plugin-middleware.ts
@@ -57,11 +57,7 @@ export function vitePluginMiddleware(
 				if (chunk.type === 'asset') {
 					continue;
 				}
-				const shouldInclude =
-					// TODO: remove in Astro 4.0
-					!opts.settings.config.build.excludeMiddleware &&
-					!opts.settings.adapter?.adapterFeatures?.edgeMiddleware;
-				if (chunk.fileName === 'middleware.mjs' && shouldInclude) {
+				if (chunk.fileName === 'middleware.mjs') {
 					const outputDirectory = getOutputDirectory(opts.settings.config);
 					internals.middlewareEntryPoint = new URL(chunkName, outputDirectory);
 				}

--- a/packages/astro/src/core/build/types.ts
+++ b/packages/astro/src/core/build/types.ts
@@ -4,7 +4,6 @@ import type {
 	AstroSettings,
 	ComponentInstance,
 	ManifestData,
-	MiddlewareHandler,
 	RouteData,
 	RuntimeMode,
 	SSRLoadedRenderer,

--- a/packages/astro/src/core/build/types.ts
+++ b/packages/astro/src/core/build/types.ts
@@ -52,7 +52,6 @@ export interface SinglePageBuiltModule {
 	/**
 	 * The `onRequest` hook exported by the middleware
 	 */
-	onRequest?: MiddlewareHandler<unknown>;
 	renderers: SSRLoadedRenderer[];
 }
 

--- a/packages/astro/src/core/redirects/component.ts
+++ b/packages/astro/src/core/redirects/component.ts
@@ -12,6 +12,5 @@ export const RedirectComponentInstance: ComponentInstance = {
 
 export const RedirectSinglePageBuiltModule: SinglePageBuiltModule = {
 	page: () => Promise.resolve(RedirectComponentInstance),
-	onRequest: (ctx, next) => next(),
 	renderers: [],
 };

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -99,5 +99,6 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 			? new URL(settings.config.base, settings.config.site).toString()
 			: settings.config.site,
 		componentMetadata: new Map(),
+		middlewareEntryPoint: undefined,
 	};
 }

--- a/packages/astro/test/fixtures/middleware-dev/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware-dev/src/middleware.js
@@ -18,18 +18,20 @@ const first = defineMiddleware(async (context, next) => {
 		return new Response(JSON.stringify(object), {
 			headers: response.headers,
 		});
-	} else if(context.url.pathname === '/clone') {
+	} else if (context.url.pathname === '/clone') {
 		const response = await next();
 		const newResponse = response.clone();
 		const /** @type {string} */ html = await newResponse.text();
 		const newhtml = html.replace('<h1>testing</h1>', '<h1>it works</h1>');
 		return new Response(newhtml, { status: 200, headers: response.headers });
 	} else {
-		if(context.url.pathname === '/') {
+		if (context.url.pathname === '/') {
 			context.cookies.set('foo', 'bar');
 		}
 
-		context.locals.name = 'bar';
+		context.locals = {
+			name: 'bar',
+		};
 	}
 	return await next();
 });

--- a/packages/astro/test/fixtures/middleware-dev/src/pages/404.astro
+++ b/packages/astro/test/fixtures/middleware-dev/src/pages/404.astro
@@ -1,0 +1,6 @@
+---
+const name = Astro.locals.name;
+---
+
+<title>Error</title>
+<p>{name}</p>

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -237,6 +237,16 @@ describe('Middleware API in PROD mode, SSR', () => {
 			throw e;
 		}
 	});
+
+	it('should correctly call the middleware function for 404', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		const request = new Request('http://example.com/funky-url');
+		const routeData = app.match(request, { matchNotFound: true });
+		const response = await app.render(request, routeData);
+		const text = await response.text();
+		expect(text.includes('Error')).to.be.true;
+		expect(text.includes('bar')).to.be.true;
+	});
 });
 
 describe('Middleware with tailwind', () => {

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -211,6 +211,16 @@ describe('Middleware API in PROD mode, SSR', () => {
 		expect(text.includes('REDACTED')).to.be.true;
 	});
 
+	it('should correctly call the middleware function for 404', async () => {
+		const app = await fixture.loadTestAdapterApp();
+		const request = new Request('http://example.com/funky-url');
+		const routeData = app.match(request, { matchNotFound: true });
+		const response = await app.render(request, routeData);
+		const text = await response.text();
+		expect(text.includes('Error')).to.be.true;
+		expect(text.includes('bar')).to.be.true;
+	});
+	
 	it('the integration should receive the path to the middleware', async () => {
 		fixture = await loadFixture({
 			root: './fixtures/middleware-dev/',
@@ -236,15 +246,6 @@ describe('Middleware API in PROD mode, SSR', () => {
 		}
 	});
 
-	it('should correctly call the middleware function for 404', async () => {
-		const app = await fixture.loadTestAdapterApp();
-		const request = new Request('http://example.com/funky-url');
-		const routeData = app.match(request, { matchNotFound: true });
-		const response = await app.render(request, routeData);
-		const text = await response.text();
-		expect(text.includes('Error')).to.be.true;
-		expect(text.includes('bar')).to.be.true;
-	});
 });
 
 describe('Middleware with tailwind', () => {

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -219,10 +219,8 @@ describe('Middleware API in PROD mode, SSR', () => {
 				excludeMiddleware: true,
 			},
 			adapter: testAdapter({
-				setEntryPoints(entryPointsOrMiddleware) {
-					if (entryPointsOrMiddleware instanceof URL) {
-						middlewarePath = entryPointsOrMiddleware;
-					}
+				setMiddlewareEntryPoint(entryPointsOrMiddleware) {
+					middlewarePath = entryPointsOrMiddleware;
 				},
 			}),
 		});

--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -5,7 +5,13 @@ import { viteID } from '../dist/core/util.js';
  * @returns {import('../src/@types/astro').AstroIntegration}
  */
 export default function (
-	{ provideAddress = true, extendAdapter, setEntryPoints = undefined, setRoutes = undefined } = {
+	{
+		provideAddress = true,
+		extendAdapter,
+		setEntryPoints = undefined,
+		setMiddlewareEntryPoint = undefined,
+		setRoutes = undefined,
+	} = {
 		provideAddress: true,
 	}
 ) {
@@ -86,7 +92,9 @@ export default function (
 			'astro:build:ssr': ({ entryPoints, middlewareEntryPoint }) => {
 				if (setEntryPoints) {
 					setEntryPoints(entryPoints);
-					setEntryPoints(middlewareEntryPoint);
+				}
+				if (setMiddlewareEntryPoint) {
+					setMiddlewareEntryPoint(middlewareEntryPoint);
 				}
 			},
 			'astro:build:done': ({ routes }) => {


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/8154

This fix goes into `next` because it requires some infrastructure that we have there but not in `main`.

This PR removes the `onRequest` function from the "ComponentInstance", instead we move its resolution inside the pipeline. The middleware now becomes 100% detached from a page/route. 

This change fits perfectly because the SSR build already creates a `middleware.mjs` file, and we already save the `middlewareEntryPoint` file.

## Testing

I created a new test case.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
