### PR TITLE
chore: update `@astrojs/language-server`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5134,7 +5134,7 @@ packages:
     peerDependencies:
       typescript: ^5.0.0
     dependencies:
-      '@astrojs/language-server': 2.2.0(prettier-plugin-astro@0.12.0)(prettier@3.0.2)(typescript@5.1.6)
+      '@astrojs/language-server': 2.3.0(prettier-plugin-astro@0.12.0)(prettier@3.0.2)(typescript@5.1.6)
       chokidar: 3.5.3
       fast-glob: 3.3.1
       kleur: 4.1.5
@@ -5165,12 +5165,12 @@ packages:
     resolution: {integrity: sha512-SKVWorXpOHff+OuZCd5kdTc5HxVX7bVXVXYP0jANT4crz7y2PdthUxMnE21iuYt4+Bq3aV5MId4OdgwlJ2/d/Q==}
     dev: false
 
-  /@astrojs/language-server@2.2.0(prettier-plugin-astro@0.12.0)(prettier@3.0.2)(typescript@5.1.6):
-    resolution: {integrity: sha512-zyEumkwcep3pGyMpcEJFEn96jV6pEg3CUtjehnT9KseDFqf+gPYTbw5nwOpN9uXIJ/E5bAxhqpkr3J2LCQHRrg==}
+  /@astrojs/language-server@2.3.0(prettier-plugin-astro@0.12.0)(prettier@3.0.2)(typescript@5.1.6):
+    resolution: {integrity: sha512-NFSzszjR4+f0+fTUCuFKXrLWusJFqWvHMrIzHB0lXUE8dt3Dm1Ok9Emrdj3s3BvlguJz05MV9xSIz1puMvomtQ==}
     hasBin: true
     peerDependencies:
       prettier: ^3.0.0
-      prettier-plugin-astro: ^0.11.0
+      prettier-plugin-astro: '>=0.11.0'
     peerDependenciesMeta:
       prettier:
         optional: true


### PR DESCRIPTION
## Changes

I run `pnpm update @astrojs/language-server` to update the indirect dependency.

## Testing

I locally checked that we don't have the warning anymore

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
