### PR TITLE
fix: add back code to update user's env.d.ts with proper types

### DIFF
--- a/.changeset/tasty-dragons-smash.md
+++ b/.changeset/tasty-dragons-smash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Automatically update user's env.d.ts with the proper types to help out migrating away from assets being experimental

--- a/packages/astro/src/vite-plugin-inject-env-ts/index.ts
+++ b/packages/astro/src/vite-plugin-inject-env-ts/index.ts
@@ -50,6 +50,16 @@ export async function setUpEnvTs({
 	if (fs.existsSync(envTsPath)) {
 		let typesEnvContents = await fs.promises.readFile(envTsPath, 'utf-8');
 
+		// TODO: Remove this in 4.0, this code is only to help users migrate away from assets being experimental for a long time
+		if (typesEnvContents.includes('types="astro/client-image"')) {
+			typesEnvContents = typesEnvContents.replace(
+				'types="astro/client-image"',
+				'types="astro/client"'
+			);
+			await fs.promises.writeFile(envTsPath, typesEnvContents, 'utf-8');
+			info(logging, 'assets', `Removed ${bold(envTsPathRelativetoRoot)} types`);
+		}
+
 		if (!fs.existsSync(dotAstroDir))
 			// Add `.astro` types reference if none exists
 			return;


### PR DESCRIPTION
## Changes

#7921 removed this code by accident, but it was intended to stay until 4.0~ to help users who are migrating to 3.0.

## Testing

Copy-pasted back code in

## Docs

N/A
