### PR TITLE
Improve stress test benchmark

### DIFF
--- a/benchmark/bench/_util.js
+++ b/benchmark/bench/_util.js
@@ -1,6 +1,9 @@
-import { createRequire } from 'module';
+import { createRequire } from 'node:module';
+import path from 'node:path';
 
-export const astroBin = createRequire(import.meta.url).resolve('astro');
+const astroPkgPath = createRequire(import.meta.url).resolve('astro/package.json');
+
+export const astroBin = path.resolve(astroPkgPath, '../astro.js');
 
 /** @typedef {{ avg: number, stdev: number, max: number }} Stat */
 

--- a/benchmark/make-project/server-stress-default.js
+++ b/benchmark/make-project/server-stress-default.js
@@ -7,11 +7,13 @@ import { loremIpsum } from './_util.js';
 export async function run(projectDir) {
 	await fs.rm(projectDir, { recursive: true, force: true });
 	await fs.mkdir(new URL('./src/pages', projectDir), { recursive: true });
+	await fs.mkdir(new URL('./src/components', projectDir), { recursive: true });
 
 	await fs.writeFile(
 		new URL('./src/pages/index.astro', projectDir),
 		`\
 ---
+import Paragraph from '../components/Paragraph.astro'
 const content = "${loremIpsum}"
 ---
 
@@ -25,10 +27,19 @@ const content = "${loremIpsum}"
 	<body>
 		<h1>Astro</h1>
 		<div>
-			${Array.from({ length: 60 }).map(() => '<p>{content}</p>')}
+			${Array.from({ length: 100 }).map(() => '<p>{content}</p>').join('\n')}
+		</div>
+		<div>
+			${Array.from({ length: 50 }).map((_, i) => '<Paragraph num={' + i + '} str={content} />').join('\n')}
 		</div>
 	</body>
 </html>`,
+		'utf-8'
+	);
+
+	await fs.writeFile(
+		new URL('./src/components/Paragraph.astro', projectDir),
+		`<div>{Astro.props.num} {Astro.props.str}</div>`,
 		'utf-8'
 	);
 


### PR DESCRIPTION
## Changes

Improve stress test benchmark to also render other Astro components.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Ran `pnpm astro-benchmark server-stress` locally.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. benchmark changes only.