### PR TITLE
Publish missing react vnode-children.js file

### DIFF
--- a/.changeset/fresh-shrimps-happen.md
+++ b/.changeset/fresh-shrimps-happen.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/react": patch
+---
+
+Publish missing `vnode-children.js` file

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -36,7 +36,8 @@
     "jsx-runtime.js",
     "server.js",
     "server-v17.js",
-    "static-html.js"
+    "static-html.js",
+    "vnode-children.js"
   ],
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/8135#issuecomment-1690080856

Looks like the fix from https://github.com/withastro/astro/pull/8137 and https://github.com/withastro/astro/pull/8149 got lost when merging to `next`.

Question: Why in #8137 we export `@astrojs/react/vnode-children.js`? It doesn't seem like the export is used and documented.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Didn't test it. The `"files"` change should work.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.