### PR TITLE
View Transitions: use history.scrollRestoration="manual"

### DIFF
--- a/.changeset/twenty-crabs-fry.md
+++ b/.changeset/twenty-crabs-fry.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+View Transitions: use history.scrollRestoration="manual"

--- a/.changeset/twenty-crabs-fry.md
+++ b/.changeset/twenty-crabs-fry.md
@@ -1,5 +1,5 @@
 ---
-'astro': minor
+'astro': patch
 ---
 
-View Transitions: use history.scrollRestoration="manual"
+Fixes scroll behavior when using View Transitions by enabling `manual` scroll restoration

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -35,12 +35,6 @@ const { fallback = 'animate' } = Astro.props as Props;
 		persistState({ index: currentHistoryIndex, scrollY: 0 });
 	}
 
-	// With the default "auto", the browser will jump to the old scroll position
-	// before the ViewTransition is complete.
-	if (history.scrollRestoration) {
-		history.scrollRestoration = "manual";
-	}
-
 	const throttle = (cb: (...args: any[]) => any, delay: number) => {
 		let wait = false;
 		// During the waiting time additional events are lost.
@@ -361,7 +355,16 @@ const { fallback = 'animate' } = Astro.props as Props;
 			// Just ignore stateless entries.
 			// The browser will handle navigation fine without our help
 			if (ev.state === null) {
+				if (history.scrollRestoration) {
+					history.scrollRestoration = "auto";
+				}
 				return;
+			}
+
+			// With the default "auto", the browser will jump to the old scroll position
+			// before the ViewTransition is complete.
+			if (history.scrollRestoration) {
+				history.scrollRestoration = "manual";
 			}
 
 			const state: State | undefined = history.state;

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -35,6 +35,12 @@ const { fallback = 'animate' } = Astro.props as Props;
 		persistState({ index: currentHistoryIndex, scrollY: 0 });
 	}
 
+	// With the default "auto", the browser will jump to the old scroll position
+	// before the ViewTransition is complete.
+	if (history.scrollRestoration) {
+		history.scrollRestoration = "manual";
+	}
+
 	const throttle = (cb: (...args: any[]) => any, delay: number) => {
 		let wait = false;
 		// During the waiting time additional events are lost.


### PR DESCRIPTION
## Changes

- When using the morph animation, there is a scroll position jump when navigating back / forward through history.
- This is because the browser is restoring the old scroll position before the DOM is swapped.
- This PR simply changes `history.scrollRestoration = "manual";` to tell the browser we'll take care of the scroll position ourselves.

## Testing

- Create a morph animation with `transition:name`
- Navigate back / forwards in history at various scroll positions and see the smooth animation

## Docs

- No doc updated needed, this was a bug.