### PR TITLE
docs: Fix typo in react integration README

### DIFF
--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -113,7 +113,7 @@ import ReactComponent from './ReactComponent';
 </ReactComponent>
 ```
 
-If you are using a library that _expects_ more than one child element element to be passed, for example so that it can slot certain elements in different places, you might find this to be a blocker.
+If you are using a library that _expects_ more than one child element to be passed, for example so that it can slot certain elements in different places, you might find this to be a blocker.
 
 You can set the experimental flag `experimentalReactChildren` to tell Astro to always pass children to React as React vnodes. There is some runtime cost to this, but it can help with compatibility.
 


### PR DESCRIPTION
## Changes

- What does this change?
  - Fix type for react integration
- Before/after screenshots can help as well.
  - N/A
- Don't forget a changeset! `pnpm exec changeset`
  - N/A

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

No tests are needed as this is a doc typo fix PR

## Docs

 No docs are needed as this is a typo change within the react integration doc itself
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
