### PR TITLE
fix(deno): add start to options and extract to new file (close #8221)

### DIFF
--- a/.changeset/olive-moles-tan.md
+++ b/.changeset/olive-moles-tan.md
@@ -2,4 +2,4 @@
 '@astrojs/deno': patch
 ---
 
-Fix Options types to include start. Types are extracted to a new file to avoid duplication.
+TypeScript users now get better suggestions when configuring the Deno adapter.

--- a/.changeset/olive-moles-tan.md
+++ b/.changeset/olive-moles-tan.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/deno': patch
+---
+
+Fix Options types to include start. Types are extracted to a new file to avoid duplication.

--- a/packages/integrations/deno/src/index.ts
+++ b/packages/integrations/deno/src/index.ts
@@ -3,17 +3,7 @@ import esbuild from 'esbuild';
 import * as fs from 'node:fs';
 import * as npath from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-interface BuildConfig {
-	server: URL;
-	serverEntry: string;
-	assets: string;
-}
-
-interface Options {
-	port?: number;
-	hostname?: string;
-}
+import type { BuildConfig, Options } from './types';
 
 const SHIM = `globalThis.process = {
 	argv: [],

--- a/packages/integrations/deno/src/server.ts
+++ b/packages/integrations/deno/src/server.ts
@@ -1,15 +1,10 @@
 // Normal Imports
 import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
+import type { Options } from './types';
 
 // @ts-expect-error
 import { fromFileUrl, serveFile, Server } from '@astrojs/deno/__deno_imports.js';
-
-interface Options {
-	port?: number;
-	hostname?: string;
-	start?: boolean;
-}
 
 let _server: Server | undefined = undefined;
 let _startPromise: Promise<void> | undefined = undefined;

--- a/packages/integrations/deno/src/types.ts
+++ b/packages/integrations/deno/src/types.ts
@@ -1,0 +1,11 @@
+export interface Options {
+	port?: number;
+	hostname?: string;
+	start?: boolean;
+}
+
+export interface BuildConfig {
+	server: URL;
+	serverEntry: string;
+	assets: string;
+}


### PR DESCRIPTION
## Changes

- Adds `start` to the `Options` type of the deno adapter
- Extract types to a dedicated file
- Closes #8221

## Testing

Not tested

## Docs

No docs updated
