### PR TITLE
Lazily initialize ResponseWithEncoding

### DIFF
--- a/.changeset/grumpy-years-remember.md
+++ b/.changeset/grumpy-years-remember.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix, lazily initialize ResponseWithEncoding

--- a/packages/astro/e2e/fixtures/view-transitions/src/components/Video.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/components/Video.astro
@@ -1,3 +1,3 @@
-<video controls="" autoplay="" name="media" transition:persist transition:name="video">
+<video controls="" autoplay="" name="media" transition:persist transition:name="video" autoplay>
 	<source src="https://ia804502.us.archive.org/33/items/GoldenGa1939_3/GoldenGa1939_3_512kb.mp4" type="video/mp4">
 </video>

--- a/packages/astro/e2e/fixtures/view-transitions/src/components/Video.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/components/Video.astro
@@ -1,3 +1,6 @@
+---
+import vid from '../videos/golden-gate.mp4';
+---
 <video controls="" autoplay="" name="media" transition:persist transition:name="video">
-	<source src="https://ia804502.us.archive.org/33/items/GoldenGa1939_3/GoldenGa1939_3_512kb.mp4" type="video/mp4">
+	<source src={vid} type="video/mp4">
 </video>

--- a/packages/astro/e2e/fixtures/view-transitions/src/components/Video.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/components/Video.astro
@@ -1,6 +1,3 @@
----
-import vid from '../videos/golden-gate.mp4';
----
 <video controls="" autoplay="" name="media" transition:persist transition:name="video">
-	<source src={vid} type="video/mp4">
+	<source src="https://ia804502.us.archive.org/33/items/GoldenGa1939_3/GoldenGa1939_3_512kb.mp4" type="video/mp4">
 </video>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/video-one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/video-one.astro
@@ -8,11 +8,16 @@ import Video from '../components/Video.astro';
 	<Video />
 	<script is:inline>
 		const vid = document.querySelector('video');
-		
-		vid.addEventListener('canplay', () => {
+		if(vid.readyState > 2) {
 			// Jump to the 1 minute mark
 			vid.currentTime = 60;
 			vid.dataset.ready = '';
-		}, { once: true });
+		} else {
+			vid.addEventListener('canplay', () => {
+				// Jump to the 1 minute mark
+				vid.currentTime = 60;
+				vid.dataset.ready = '';
+			}, { once: true });
+		}
 	</script>
 </Layout>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/video-one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/video-one.astro
@@ -6,10 +6,10 @@ import Video from '../components/Video.astro';
 	<p id="video-one">Page 1</p>
 	<a id="click-two" href="/video-two">go to 2</a>
 	<Video />
-	<script>
+	<script is:inline>
 		const vid = document.querySelector('video');
 		
-		vid.addEventListener('canplaythrough', () => {
+		vid.addEventListener('canplay', () => {
 			// Jump to the 1 minute mark
 			vid.currentTime = 60;
 			vid.dataset.ready = '';

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/video-one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/video-one.astro
@@ -6,18 +6,4 @@ import Video from '../components/Video.astro';
 	<p id="video-one">Page 1</p>
 	<a id="click-two" href="/video-two">go to 2</a>
 	<Video />
-	<script is:inline>
-		const vid = document.querySelector('video');
-		if(vid.readyState > 2) {
-			// Jump to the 1 minute mark
-			vid.currentTime = 60;
-			vid.dataset.ready = '';
-		} else {
-			vid.addEventListener('canplay', () => {
-				// Jump to the 1 minute mark
-				vid.currentTime = 60;
-				vid.dataset.ready = '';
-			}, { once: true });
-		}
-	</script>
 </Layout>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/video-one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/video-one.astro
@@ -8,7 +8,8 @@ import Video from '../components/Video.astro';
 	<Video />
 	<script>
 		const vid = document.querySelector('video');
-		vid.addEventListener('canplay', () => {
+		
+		vid.addEventListener('canplaythrough', () => {
 			// Jump to the 1 minute mark
 			vid.currentTime = 60;
 			vid.dataset.ready = '';

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -300,6 +300,9 @@ test.describe('View Transitions', () => {
 	test('<video> can persist using transition:persist', async ({ page, astro }) => {
 		page.on("console", (message) => {
 			console.log(message.type(), message.text())
+		});
+		page.on('pageerror', err => {
+			console.log("PAGE ERROR", err)
 		})
 
 		const getTime = () => document.querySelector('video').currentTime;

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -298,6 +298,10 @@ test.describe('View Transitions', () => {
 	});
 
 	test('<video> can persist using transition:persist', async ({ page, astro }) => {
+		page.on("console", (message) => {
+			console.log(message.type(), message.text())
+		})
+
 		const getTime = () => document.querySelector('video').currentTime;
 
 		// Go to page 1

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -298,18 +298,11 @@ test.describe('View Transitions', () => {
 	});
 
 	test('<video> can persist using transition:persist', async ({ page, astro }) => {
-		page.on("console", (message) => {
-			console.log(message.type(), message.text())
-		});
-		page.on('pageerror', err => {
-			console.log("PAGE ERROR", err)
-		})
-
 		const getTime = () => document.querySelector('video').currentTime;
 
 		// Go to page 1
 		await page.goto(astro.resolveUrl('/video-one'));
-		const vid = page.locator('video[data-ready]');
+		const vid = page.locator('video');
 		await expect(vid).toBeVisible();
 		const firstTime = await page.evaluate(getTime);
 

--- a/packages/astro/src/core/endpoint/index.ts
+++ b/packages/astro/src/core/endpoint/index.ts
@@ -95,7 +95,6 @@ type ResponseParameters = ConstructorParameters<typeof Response>;
 export let ResponseWithEncoding: ReturnType<typeof initResponseWithEncoding>;
 // TODO Remove this after StackBlitz supports Node 18.
 let initResponseWithEncoding = () => {
-	// eslint-disable-next-line @typescript-eslint/no-shadow
 	class LocalResponseWithEncoding extends Response {
 		constructor(body: ResponseParameters[0], init: ResponseParameters[1], encoding?: BufferEncoding) {
 			// If a body string is given, try to encode it to preserve the behaviour as simple objects.

--- a/packages/astro/src/core/endpoint/index.ts
+++ b/packages/astro/src/core/endpoint/index.ts
@@ -92,10 +92,10 @@ export function createAPIContext({
 
 type ResponseParameters = ConstructorParameters<typeof Response>;
 
-let ResponseWithEncoding: ReturnType<typeof initResponseWithEncoding>;
+export let ResponseWithEncoding: ReturnType<typeof initResponseWithEncoding>;
 let initResponseWithEncoding = () => {
 	// eslint-disable-next-line @typescript-eslint/no-shadow
-	class ResponseWithEncoding extends Response {
+	class LocalResponseWithEncoding extends Response {
 		constructor(body: ResponseParameters[0], init: ResponseParameters[1], encoding?: BufferEncoding) {
 			// If a body string is given, try to encode it to preserve the behaviour as simple objects.
 			// We don't do the full handling as simple objects so users can control how headers are set instead.
@@ -118,10 +118,13 @@ let initResponseWithEncoding = () => {
 		}
 	}
 
+	// Set the module scoped variable.
+	ResponseWithEncoding = LocalResponseWithEncoding;
+
 	// Turn this into a noop.
 	initResponseWithEncoding = (() => {}) as any;
 
-	return ResponseWithEncoding;
+	return LocalResponseWithEncoding;
 }
 
 export async function callEndpoint<MiddlewareResult = Response | EndpointOutput>(

--- a/packages/astro/src/core/endpoint/index.ts
+++ b/packages/astro/src/core/endpoint/index.ts
@@ -39,6 +39,7 @@ export function createAPIContext({
 	props,
 	adapterName,
 }: CreateAPIContext): APIContext {
+	initResponseWithEncoding();
 	const context = {
 		cookies: new AstroCookies(request),
 		request,
@@ -91,27 +92,36 @@ export function createAPIContext({
 
 type ResponseParameters = ConstructorParameters<typeof Response>;
 
-export class ResponseWithEncoding extends Response {
-	constructor(body: ResponseParameters[0], init: ResponseParameters[1], encoding?: BufferEncoding) {
-		// If a body string is given, try to encode it to preserve the behaviour as simple objects.
-		// We don't do the full handling as simple objects so users can control how headers are set instead.
-		if (typeof body === 'string') {
-			// In NodeJS, we can use Buffer.from which supports all BufferEncoding
-			if (typeof Buffer !== 'undefined' && Buffer.from) {
-				body = Buffer.from(body, encoding);
+let ResponseWithEncoding: ReturnType<typeof initResponseWithEncoding>;
+let initResponseWithEncoding = () => {
+	// eslint-disable-next-line @typescript-eslint/no-shadow
+	class ResponseWithEncoding extends Response {
+		constructor(body: ResponseParameters[0], init: ResponseParameters[1], encoding?: BufferEncoding) {
+			// If a body string is given, try to encode it to preserve the behaviour as simple objects.
+			// We don't do the full handling as simple objects so users can control how headers are set instead.
+			if (typeof body === 'string') {
+				// In NodeJS, we can use Buffer.from which supports all BufferEncoding
+				if (typeof Buffer !== 'undefined' && Buffer.from) {
+					body = Buffer.from(body, encoding);
+				}
+				// In non-NodeJS, use the web-standard TextEncoder for utf-8 strings
+				else if (encoding == null || encoding === 'utf8' || encoding === 'utf-8') {
+					body = encoder.encode(body);
+				}
 			}
-			// In non-NodeJS, use the web-standard TextEncoder for utf-8 strings
-			else if (encoding == null || encoding === 'utf8' || encoding === 'utf-8') {
-				body = encoder.encode(body);
+	
+			super(body, init);
+	
+			if (encoding) {
+				this.headers.set('X-Astro-Encoding', encoding);
 			}
-		}
-
-		super(body, init);
-
-		if (encoding) {
-			this.headers.set('X-Astro-Encoding', encoding);
 		}
 	}
+
+	// Turn this into a noop.
+	initResponseWithEncoding = (() => {}) as any;
+
+	return ResponseWithEncoding;
 }
 
 export async function callEndpoint<MiddlewareResult = Response | EndpointOutput>(

--- a/packages/astro/src/core/endpoint/index.ts
+++ b/packages/astro/src/core/endpoint/index.ts
@@ -93,6 +93,7 @@ export function createAPIContext({
 type ResponseParameters = ConstructorParameters<typeof Response>;
 
 export let ResponseWithEncoding: ReturnType<typeof initResponseWithEncoding>;
+// TODO Remove this after StackBlitz supports Node 18.
 let initResponseWithEncoding = () => {
 	// eslint-disable-next-line @typescript-eslint/no-shadow
 	class LocalResponseWithEncoding extends Response {


### PR DESCRIPTION
## Changes

- Due to StackBlitz not yet supporting Node 18, we cannot extend `Response` until the polyfills have ran.

## Testing

Just manually, this only affects stackblitz.

## Docs

N/A, bug fix