### PR TITLE
 Allow fallback animations on html element

### DIFF
--- a/.changeset/strong-needles-accept.md
+++ b/.changeset/strong-needles-accept.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow fallback animations on html element

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -220,23 +220,16 @@ const { fallback = 'animate' } = Astro.props as Props;
 		links.length && (await Promise.all(links));
 
 		if (fallback === 'animate') {
-			let isAnimating = false;
-			addEventListener('animationstart', () => (isAnimating = true), { once: true });
-
 			// Trigger the animations
 			document.documentElement.dataset.astroTransitionFallback = 'old';
+			const finished = Promise.all(document.getAnimations().map(a => a.finished));
 			const fallbackSwap = () => {
-				removeEventListener('animationend', fallbackSwap);
-				clearTimeout(timeout);
-				swap();
 				document.documentElement.dataset.astroTransitionFallback = 'new';
+				swap();
+				
 			};
-			// If there are any animations, want for the animationend event.
-			addEventListener('animationend', fallbackSwap, { once: true });
-			// If there are no animations, go ahead and swap on next tick
-			// This is necessary because we do not know if there are animations.
-			// The setTimeout is a fallback in case there are none.
-			let timeout = setTimeout(() => !isAnimating && fallbackSwap());
+			await finished;
+			fallbackSwap();
 		} else {
 			swap();
 		}

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -224,9 +224,8 @@ const { fallback = 'animate' } = Astro.props as Props;
 			document.documentElement.dataset.astroTransitionFallback = 'old';
 			const finished = Promise.all(document.getAnimations().map(a => a.finished));
 			const fallbackSwap = () => {
-				document.documentElement.dataset.astroTransitionFallback = 'new';
 				swap();
-				
+				document.documentElement.dataset.astroTransitionFallback = 'new';
 			};
 			await finished;
 			fallbackSwap();

--- a/packages/astro/src/runtime/server/transition.ts
+++ b/packages/astro/src/runtime/server/transition.ts
@@ -52,7 +52,8 @@ export function renderTransition(
 			}
 		}
 	} else if (animationName === 'none') {
-		sheet.addAnimationRaw('old', 'animation: none; mix-blend-mode: normal;');
+		sheet.addFallback('old', 'animation: none; mix-blend-mode: normal;');
+		sheet.addModern('old', 'animation: none; opacity: 0; mix-blend-mode: normal;');
 		sheet.addAnimationRaw('new', 'animation: none; mix-blend-mode: normal;');
 	}
 
@@ -88,8 +89,17 @@ class ViewTransitionStyleSheet {
 	}
 
 	addAnimationRaw(image: 'old' | 'new' | 'group', animation: string) {
-		const { scope, name } = this;
+		this.addModern(image, animation);
+		this.addFallback(image, animation);
+	}
+
+	addModern(image: 'old' | 'new' | 'group', animation: string) {
+		const { name } = this;
 		this.addRule('modern', `::view-transition-${image}(${name}) { ${animation} }`);
+	}
+
+	addFallback(image: 'old' | 'new' | 'group', animation: string) {
+		const { scope } = this;
 		this.addRule(
 			'fallback',
 			// Two selectors here, the second in case there is an animation on the root.

--- a/packages/astro/src/runtime/server/transition.ts
+++ b/packages/astro/src/runtime/server/transition.ts
@@ -52,7 +52,7 @@ export function renderTransition(
 			}
 		}
 	} else if (animationName === 'none') {
-		sheet.addAnimationRaw('old', 'animation: none; opacity: 0; mix-blend-mode: normal;');
+		sheet.addAnimationRaw('old', 'animation: none; mix-blend-mode: normal;');
 		sheet.addAnimationRaw('new', 'animation: none; mix-blend-mode: normal;');
 	}
 
@@ -92,7 +92,9 @@ class ViewTransitionStyleSheet {
 		this.addRule('modern', `::view-transition-${image}(${name}) { ${animation} }`);
 		this.addRule(
 			'fallback',
-			`[data-astro-transition-fallback="${image}"] [data-astro-transition-scope="${scope}"] { ${animation} }`
+			// Two selectors here, the second in case there is an animation on the root.
+			`[data-astro-transition-fallback="${image}"] [data-astro-transition-scope="${scope}"],
+			[data-astro-transition-fallback="${image}"][data-astro-transition-scope="${scope}"] { ${animation} }`
 		);
 	}
 
@@ -107,7 +109,8 @@ class ViewTransitionStyleSheet {
 		this.addRule('modern', `${prefix}::view-transition-${image}(${name}) { ${animation} }`);
 		this.addRule(
 			'fallback',
-			`${prefix}[data-astro-transition-fallback="${image}"] [data-astro-transition-scope="${scope}"] { ${animation} }`
+			`${prefix}[data-astro-transition-fallback="${image}"] [data-astro-transition-scope="${scope}"],
+			${prefix}[data-astro-transition-fallback="${image}"][data-astro-transition-scope="${scope}"] { ${animation} }`
 		);
 	}
 }


### PR DESCRIPTION
## Changes

- Allows animations on the `html` element by fixing the selector so it targets both children and the root itself.
- Simplifies the fallback logic. Previous was not working in Safari because `animationstart` did not fire before the setTimeout.
  - Now using https://developer.mozilla.org/en-US/docs/Web/API/Document/getAnimations which *I think* is safe to use. Waits on their `finished` event.
- Removed `opacity: 0` for the `none` animation as that causes the element to be invisible.

## Testing

https://github.com/withastro/astro/assets/361671/3e6575bb-1825-4a38-96c2-9fc5124d6af7

## Docs
N/A