### PR TITLE
Allow custom `const x = boolean` exports to be read from plugins

### DIFF
--- a/.changeset/brown-tips-drop.md
+++ b/.changeset/brown-tips-drop.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Plugins can now access a page's boolean exports on RouteData['customOptions']

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2108,6 +2108,7 @@ export interface RouteData {
 	segments: RoutePart[][];
 	type: RouteType;
 	prerender: boolean;
+	customOptions: Record<string, boolean>;
 	redirect?: RedirectConfig;
 	redirectRoute?: RouteData;
 }

--- a/packages/astro/src/core/build/plugins/plugin-prerender.ts
+++ b/packages/astro/src/core/build/plugins/plugin-prerender.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import type { Plugin as VitePlugin } from 'vite';
-import { getPrerenderMetadata } from '../../../prerender/metadata.js';
+import { getPageOptionsMetadata } from '../../../prerender/metadata.js';
 import type { BuildInternals } from '../internal.js';
 import type { AstroBuildPlugin } from '../plugin.js';
 import type { StaticBuildOptions } from '../types';
@@ -19,9 +19,12 @@ function vitePluginPrerender(opts: StaticBuildOptions, internals: BuildInternals
 					}
 					const pageInfo = internals.pagesByViteID.get(id);
 					if (pageInfo) {
+						const pageOptions = getPageOptionsMetadata(meta.getModuleInfo(id));
+						pageInfo.route.customOptions = pageOptions?.custom ?? {};
+
 						// prerendered pages should be split into their own chunk
 						// Important: this can't be in the `pages/` directory!
-						if (getPrerenderMetadata(meta.getModuleInfo(id))) {
+						if (pageOptions?.prerender) {
 							pageInfo.route.prerender = true;
 							return 'prerender';
 						}

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -345,6 +345,7 @@ export function createRouteManifest(
 					generate,
 					pathname: pathname || undefined,
 					prerender,
+					customOptions: {},
 				});
 			}
 		});
@@ -421,6 +422,7 @@ export function createRouteManifest(
 				generate,
 				pathname: pathname || void 0,
 				prerender: prerenderInjected ?? prerender,
+				customOptions: {},
 			});
 		});
 
@@ -458,6 +460,7 @@ export function createRouteManifest(
 			generate,
 			pathname: pathname || void 0,
 			prerender: false,
+			customOptions: {},
 			redirect: to,
 			redirectRoute: routes.find((r) => r.route === to),
 		};

--- a/packages/astro/src/core/routing/manifest/serialization.ts
+++ b/packages/astro/src/core/routing/manifest/serialization.ts
@@ -28,6 +28,7 @@ export function deserializeRouteData(rawRouteData: SerializedRouteData): RouteDa
 		pathname: rawRouteData.pathname || undefined,
 		segments: rawRouteData.segments,
 		prerender: rawRouteData.prerender,
+		customOptions: rawRouteData.customOptions,
 		redirect: rawRouteData.redirect,
 		redirectRoute: rawRouteData.redirectRoute
 			? deserializeRouteData(rawRouteData.redirectRoute)

--- a/packages/astro/src/prerender/metadata.ts
+++ b/packages/astro/src/prerender/metadata.ts
@@ -1,5 +1,6 @@
 import type { ModuleInfo, ModuleLoader } from '../core/module-loader';
 import { viteID } from '../core/util.js';
+import type { PageOptions } from '../vite-plugin-astro/types';
 
 type GetPrerenderStatusParams = {
 	filePath: URL;
@@ -13,10 +14,10 @@ export function getPrerenderStatus({
 	const fileID = viteID(filePath);
 	const moduleInfo = loader.getModuleInfo(fileID);
 	if (!moduleInfo) return;
-	const prerenderStatus = getPrerenderMetadata(moduleInfo);
-	return prerenderStatus;
+	const pageOptions = getPageOptionsMetadata(moduleInfo);
+	return pageOptions?.prerender;
 }
 
-export function getPrerenderMetadata(moduleInfo: ModuleInfo) {
-	return moduleInfo?.meta?.astro?.pageOptions?.prerender;
+export function getPageOptionsMetadata(moduleInfo: ModuleInfo) {
+	return moduleInfo?.meta?.astro?.pageOptions as PageOptions | undefined;
 }

--- a/packages/astro/src/vite-plugin-astro/types.ts
+++ b/packages/astro/src/vite-plugin-astro/types.ts
@@ -3,6 +3,7 @@ import type { PropagationHint } from '../@types/astro';
 
 export interface PageOptions {
 	prerender?: boolean;
+	custom?: Record<string, boolean>;
 }
 
 export interface PluginMetadata {

--- a/packages/astro/src/vite-plugin-scanner/scan.ts
+++ b/packages/astro/src/vite-plugin-scanner/scan.ts
@@ -10,6 +10,9 @@ type BuiltInExports = Exclude<keyof PageOptions, 'custom'>;
 // Quick scan to determine if code includes recognized export
 // False positives are not a problem, so be forgiving!
 function includesExport(code: string) {
+	for (const name of BOOLEAN_EXPORTS) {
+		if (code.includes(name)) return true;
+	}
 	return code.includes('export const');
 }
 

--- a/packages/astro/src/vite-plugin-scanner/scan.ts
+++ b/packages/astro/src/vite-plugin-scanner/scan.ts
@@ -54,7 +54,7 @@ export async function scan(
 		// For a given export, check the value of the local declaration
 		// Basically extract the `const` from the statement `export const prerender = true`
 		const indexOfExport = code.lastIndexOf('export', startOfLocalName);
-		const prefix = code.slice(indexOfExport + 6, startOfLocalName).trim();
+		const prefix = code.slice(indexOfExport + /* "export".length */ 6, startOfLocalName).trim();
 
 		// `export const name = "value";
 		//                      ^      ^

--- a/packages/astro/test/custom-page-options.test.js
+++ b/packages/astro/test/custom-page-options.test.js
@@ -27,6 +27,7 @@ describe('Public', () => {
 		expect(page.customOptions).to.deep.equal({
 			customTrue: true,
 			customFalse: false,
+			whitespace: true,
 			// customString: 'string',
 			// customString2: 'string2',
 			// customNumber: 123,

--- a/packages/astro/test/custom-page-options.test.js
+++ b/packages/astro/test/custom-page-options.test.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import { loadFixture } from './test-utils.js';
+
+describe('Public', () => {
+	let fixture;
+	let routes;
+
+	const integration = {
+		name: 'test-custom-page-options',
+		hooks: {
+			['astro:build:done']: (options) => {
+				routes = options.routes;
+			},
+		},
+	}
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/custom-page-options/',
+			integrations: [integration],
+		});
+		await fixture.build();
+	});
+
+	it('sets custom options', async () => {
+		const page = routes.find(r => r.pathname === '/');
+		expect(page.customOptions).to.deep.equal({
+			customTrue: true,
+			customFalse: false,
+			// customString: 'string',
+			// customString2: 'string2',
+			// customNumber: 123,
+			// customNumber2: -123.456,
+			// customHexNumber: 0xa,
+			// customOctalNumber: 0o10,
+			// customBinaryNumber: 0b1010,
+		});
+	});
+});

--- a/packages/astro/test/fixtures/custom-page-options/astro.config.mjs
+++ b/packages/astro/test/fixtures/custom-page-options/astro.config.mjs
@@ -1,0 +1,4 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({});

--- a/packages/astro/test/fixtures/custom-page-options/package.json
+++ b/packages/astro/test/fixtures/custom-page-options/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "@test/custom-page-options",
+	"version": "0.0.0",
+	"private": true,
+	"dependencies": {
+		"astro": "workspace:*"
+	}
+}

--- a/packages/astro/test/fixtures/custom-page-options/src/pages/index.astro
+++ b/packages/astro/test/fixtures/custom-page-options/src/pages/index.astro
@@ -1,0 +1,13 @@
+---
+export const prerender = true;
+
+export const customTrue = true;
+export const customFalse = false;
+export const customString = 'string';
+export const customString2 = "string2";
+export const customNumber = 123;
+export const customNumber2 = -123.456;
+export const customHexNumber = 0xa;
+export const customOctalNumber = 0o10;
+export const customBinaryNumber = 0b1010;
+---

--- a/packages/astro/test/fixtures/custom-page-options/src/pages/index.astro
+++ b/packages/astro/test/fixtures/custom-page-options/src/pages/index.astro
@@ -3,6 +3,8 @@ export const prerender = true;
 
 export const customTrue = true;
 export const customFalse = false;
+export const whitespace  	= true  	
+export let invalid = true;
 
 // For later?
 export const customString = 'string';

--- a/packages/astro/test/fixtures/custom-page-options/src/pages/index.astro
+++ b/packages/astro/test/fixtures/custom-page-options/src/pages/index.astro
@@ -3,6 +3,8 @@ export const prerender = true;
 
 export const customTrue = true;
 export const customFalse = false;
+
+// For later?
 export const customString = 'string';
 export const customString2 = "string2";
 export const customNumber = 123;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2536,6 +2536,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/custom-page-options:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/data-collections:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

- Any const boolean exports on a page can now be accessed on `RouteData`. This allows plugins to define custom per-page options.

## Testing

- Adds a new `custom-page-options` test

## Docs

- This should probably be added to plugin docs
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
