### PR TITLE
fix: settings requiring service to be set when settings domains or remotePatterns

### DIFF
--- a/.changeset/many-impalas-sit.md
+++ b/.changeset/many-impalas-sit.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `image.service` requiring to be set manually when `image.domains` or `image.remotePatterns` was assigned a value

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -185,11 +185,13 @@ export const AstroConfigSchema = z.object({
 		.object({
 			service: z
 				.object({
-					entrypoint: z.union([
-						z.literal('astro/assets/services/sharp'),
-						z.literal('astro/assets/services/squoosh'),
-						z.string(),
-					]),
+					entrypoint: z
+						.union([
+							z.literal('astro/assets/services/sharp'),
+							z.literal('astro/assets/services/squoosh'),
+							z.string(),
+						])
+						.default(ASTRO_CONFIG_DEFAULTS.image.service.entrypoint),
 					config: z.record(z.any()).default({}),
 				})
 				.default(ASTRO_CONFIG_DEFAULTS.image.service),

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -29,6 +29,9 @@ const ASTRO_CONFIG_DEFAULTS = {
 		split: false,
 		excludeMiddleware: false,
 	},
+	image: {
+		service: { entrypoint: 'astro/assets/services/sharp', config: {} },
+	},
 	compressHTML: true,
 	server: {
 		host: false,
@@ -180,14 +183,16 @@ export const AstroConfigSchema = z.object({
 		.default(ASTRO_CONFIG_DEFAULTS.redirects),
 	image: z
 		.object({
-			service: z.object({
-				entrypoint: z.union([
-					z.literal('astro/assets/services/sharp'),
-					z.literal('astro/assets/services/squoosh'),
-					z.string(),
-				]),
-				config: z.record(z.any()).default({}),
-			}),
+			service: z
+				.object({
+					entrypoint: z.union([
+						z.literal('astro/assets/services/sharp'),
+						z.literal('astro/assets/services/squoosh'),
+						z.string(),
+					]),
+					config: z.record(z.any()).default({}),
+				})
+				.default(ASTRO_CONFIG_DEFAULTS.image.service),
 			domains: z.array(z.string()).default([]),
 			remotePatterns: z
 				.array(
@@ -213,9 +218,7 @@ export const AstroConfigSchema = z.object({
 				)
 				.default([]),
 		})
-		.default({
-			service: { entrypoint: 'astro/assets/services/sharp', config: {} },
-		}),
+		.default(ASTRO_CONFIG_DEFAULTS.image),
 	markdown: z
 		.object({
 			drafts: z.boolean().default(false),


### PR DESCRIPTION
## Changes

The schema accepted if `image` wasn't set at all, but didn't set a default value to `image.service` if `image` did exists but was missing the service. This fixes that

## Testing

Tested manually

## Docs

N/A
