### PR TITLE
Prevent ViewTransition script from being added by mistake

### DIFF
--- a/.changeset/swift-taxis-sing.md
+++ b/.changeset/swift-taxis-sing.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent ViewTransition script from being added by mistake

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - "1-legacy"
+      - "2-legacy"
       - next
 
 defaults:

--- a/packages/astro/components/index.ts
+++ b/packages/astro/components/index.ts
@@ -1,3 +1,2 @@
 export { default as Code } from './Code.astro';
 export { default as Debug } from './Debug.astro';
-export { default as ViewTransitions } from './ViewTransitions.astro';

--- a/packages/astro/test/code-component.test.js
+++ b/packages/astro/test/code-component.test.js
@@ -23,4 +23,11 @@ describe('Code component', () => {
 		let $ = cheerio.load(html);
 		expect($('pre').attr('is:raw')).to.equal(undefined);
 	});
+
+	// ViewTransitions bug
+	it('No script should be added to the page', async () => {
+		let html = await fixture.readFile('/index.html');
+		let $ = cheerio.load(html);
+		expect($('script')).to.have.a.lengthOf(0);
+	});
 });


### PR DESCRIPTION
## Changes

- Removes `ViewTransitions` from `astro/components`.
- This was added very early (before the first release I think), but we now say to import from `astro:transitions`.
- Having this as part of astro/components brings its script if you are just using, for example, `<Code />`.

## Testing

- Added a test to the Code component test

## Docs

Bug fix.