### PR TITLE
Prevent ViewTransition script from being added by mistake (#8268)

### DIFF
--- a/.changeset/swift-taxis-sing.md
+++ b/.changeset/swift-taxis-sing.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent ViewTransition script from being added by mistake

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - "1-legacy"
+      - "2-legacy"
       - next
 
 defaults:

--- a/packages/astro/components/index.ts
+++ b/packages/astro/components/index.ts
@@ -1,3 +1,2 @@
 export { default as Code } from './Code.astro';
 export { default as Debug } from './Debug.astro';
-export { default as ViewTransitions } from './ViewTransitions.astro';

--- a/packages/astro/test/code-component.test.js
+++ b/packages/astro/test/code-component.test.js
@@ -23,4 +23,11 @@ describe('Code component', () => {
 		let $ = cheerio.load(html);
 		expect($('pre').attr('is:raw')).to.equal(undefined);
 	});
+
+	// ViewTransitions bug
+	it('No script should be added to the page', async () => {
+		let html = await fixture.readFile('/index.html');
+		let $ = cheerio.load(html);
+		expect($('script')).to.have.a.lengthOf(0);
+	});
 });


### PR DESCRIPTION
## Changes

- Cherry-picks from the patch that went into `2-legacy`
