### PR TITLE
[docs] remove experimental from image configs

### DIFF
--- a/.changeset/hot-timers-wink.md
+++ b/.changeset/hot-timers-wink.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Remove "experimental" text from the image config options, for docs and editor etc. text displayed.

--- a/.changeset/hot-timers-wink.md
+++ b/.changeset/hot-timers-wink.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+'astro': patch
 ---
 
 Remove "experimental" text from the image config options, for docs and editor etc. text displayed.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -975,7 +975,7 @@ export interface AstroUserConfig {
 	image?: {
 		/**
 		 * @docs
-		 * @name image.service (Experimental)
+		 * @name image.service
 		 * @type {{entrypoint: 'astro/assets/services/sharp' | 'astro/assets/services/squoosh' | string, config: Record<string, any>}}
 		 * @default `{entrypoint: 'astro/assets/services/sharp', config?: {}}`
 		 * @version 2.1.0
@@ -999,7 +999,7 @@ export interface AstroUserConfig {
 
 		/**
 		 * @docs
-		 * @name image.domains (Experimental)
+		 * @name image.domains
 		 * @type {string[]}
 		 * @default `{domains: []}`
 		 * @version 2.10.10
@@ -1022,7 +1022,7 @@ export interface AstroUserConfig {
 
 		/**
 		 * @docs
-		 * @name image.remotePatterns (Experimental)
+		 * @name image.remotePatterns
 		 * @type {RemotePattern[]}
 		 * @default `{remotePatterns: []}`
 		 * @version 2.10.10

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1006,7 +1006,7 @@ export interface AstroUserConfig {
 		 * @description
 		 * Defines a list of permitted image source domains for local image optimization. No other remote images will be optimized by Astro.
 		 *
-		 * This option requires an array of individual domain names as strings. Wildcards are not permitted. Instead, use [`image.remotePatterns`](#imageremotepatterns-experimental) to define a list of allowed source URL patterns.
+		 * This option requires an array of individual domain names as strings. Wildcards are not permitted. Instead, use [`image.remotePatterns`](#imageremotepatterns) to define a list of allowed source URL patterns.
 		 *
 		 * ```js
 		 * // astro.config.mjs


### PR DESCRIPTION
## Changes

removes "experimental" from the image service configs

## Testing

no testing, docs.

## Docs

only docs!