### PR TITLE
chore: add warnings  to console for deprecated options

### DIFF
--- a/.changeset/proud-trains-wonder.md
+++ b/.changeset/proud-trains-wonder.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add useful warning when deprecated options are still used.

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -242,6 +242,10 @@ class AstroBuilder {
 					'The option `build.split` won\'t take effect, because `output` is not `"server"` or `"hybrid"`.'
 				);
 			}
+			this.logger.warn(
+				'configuration',
+				'The option `build.split` is deprecated. Use the adapter options.'
+			);
 		}
 		if (config.build.excludeMiddleware === true) {
 			if (config.output === 'static') {
@@ -250,14 +254,10 @@ class AstroBuilder {
 					'The option `build.excludeMiddleware` won\'t take effect, because `output` is not `"server"` or `"hybrid"`.'
 				);
 			}
-		}
-
-		if (config.build.split === true) {
-			if (config.output !== 'server') {
-				throw new Error(
-					'The option `build.split` can only be used when `output` is set to `"server"`.'
-				);
-			}
+			this.logger.warn(
+				'configuration',
+				'The option `build.excludeMiddleware` is deprecated. Use the adapter options.'
+			);
 		}
 	}
 


### PR DESCRIPTION
## Changes

This PR adds some useful warnings in case the user uses deprecated options.

## Testing

Tested locally 
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
<img width="941" alt="Screenshot 2023-08-30 at 13 06 06" src="https://github.com/withastro/astro/assets/602478/5222f49a-16f8-4a1f-8c64-128941b8ce8c">

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
