### PR TITLE
config: set proper default config on framework-react example

### DIFF
--- a/examples/framework-react/tsconfig.json
+++ b/examples/framework-react/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "astro/tsconfigs/base"
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
+  }
 }


### PR DESCRIPTION
## Changes

Config has been outdated for the past two years. Luckily, `astro add react` did set the proper config

## Testing

N/A

## Docs

N/A
