### PR TITLE
fix: tsc errors in components

### DIFF
--- a/.changeset/nervous-beans-argue.md
+++ b/.changeset/nervous-beans-argue.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `tsc` errors inside `astro/components/index.ts`

--- a/packages/astro/components/index.ts
+++ b/packages/astro/components/index.ts
@@ -1,2 +1,6 @@
+// The `ts-expect-error` comments here are necessary because we're importing this file inside the `astro:components`
+// virtual module's types, which means that `tsc` will try to resolve these imports. Don't mind the editor errors.
+// @ts-expect-error
 export { default as Code } from './Code.astro';
+// @ts-expect-error
 export { default as Debug } from './Debug.astro';


### PR DESCRIPTION
## Changes

The new `astro:components`'s types in `client.d.ts` meansn that `astro/component/index.ts` gets included in the TypeScript project. This causes errors in `tsc` because that file is not supposed to be really type checked. This PR adds some comments to tell `tsc` that it's ok, really

Fix https://github.com/withastro/astro/issues/8291

## Testing

Tested manually

## Docs

N/A
