### PR TITLE
fix(@astrojs/vercel): include astro feature map and adapter features to the static adapter

### DIFF
--- a/.changeset/beige-walls-grow.md
+++ b/.changeset/beige-walls-grow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Add astro feature map and adapter features to the static adapter. This will remove the warning emitted by Astro.

--- a/packages/integrations/vercel/src/static/adapter.ts
+++ b/packages/integrations/vercel/src/static/adapter.ts
@@ -9,7 +9,23 @@ import { getRedirects } from '../lib/redirects.js';
 const PACKAGE_NAME = '@astrojs/vercel/static';
 
 function getAdapter(): AstroAdapter {
-	return { name: PACKAGE_NAME };
+	return {
+		name: PACKAGE_NAME,
+		supportedAstroFeatures: {
+			assets: {
+				supportKind: 'stable',
+				isSquooshCompatible: true,
+				isSharpCompatible: true,
+			},
+			staticOutput: 'stable',
+			serverOutput: 'unsupported',
+			hybridOutput: 'unsupported',
+		},
+		adapterFeatures: {
+			edgeMiddleware: false,
+			functionPerRoute: false,
+		},
+	};
 }
 
 export interface VercelStaticConfig {


### PR DESCRIPTION
## Changes

This PR adds the astro feature map and adapter features to Astro. This will remove the warnings emitted by Astro.

## Testing

I'll do a preview release to check if the warnings are gone.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
