### PR TITLE
fix(@astrojs/vercel): warn user when `functionPerRoute` is `true`

### DIFF
--- a/.changeset/thirty-bees-check.md
+++ b/.changeset/thirty-bees-check.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Add warning when `functionPerRoute` is set to `true`

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -129,7 +129,12 @@ export default function vercelServerless({
 					...getImageConfig(imageService, imagesConfig, command),
 				});
 			},
-			'astro:config:done': ({ setAdapter, config }) => {
+			'astro:config:done': ({ setAdapter, config, logger }) => {
+				if (functionPerRoute === true) {
+					logger.warn(
+						"The Vercel plans might have limits to the number of functions you can create, make sure to check them if you don't want to incur into additional costs."
+					);
+				}
 				setAdapter(getAdapter({ functionPerRoute, edgeMiddleware }));
 				_config = config;
 				buildTempFolder = config.build.server;


### PR DESCRIPTION
## Changes

We log a warning to the user, because the number of functions emitted could exceed the limit of someone's plan.

## Testing

Current tests should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs please check the warning

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
