### PR TITLE
fix: exclude redirects when running `functionPerRoute`

### DIFF
--- a/.changeset/gorgeous-dogs-speak.md
+++ b/.changeset/gorgeous-dogs-speak.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Exclude redirects from split entry points

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -148,7 +148,10 @@ function vitePluginSSRSplit(
 			if (options.settings.config.build.split || functionPerRouteEnabled) {
 				const inputs = new Set<string>();
 
-				for (const path of Object.keys(options.allPages)) {
+				for (const [path, pageData] of Object.entries(options.allPages)) {
+					if (routeIsRedirect(pageData.route)) {
+						continue;
+					}
 					inputs.add(getVirtualModulePageNameFromPath(SPLIT_MODULE_ID, path));
 				}
 

--- a/packages/astro/test/fixtures/ssr-split-manifest/astro.config.mjs
+++ b/packages/astro/test/fixtures/ssr-split-manifest/astro.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from 'astro/config';
 export default defineConfig({
-    build: {
-        split: true
-    },
-    output: "server"
+    output: "server",
+    redirects: {
+        "/redirect": "/"
+    }
 })

--- a/packages/astro/test/fixtures/ssr-split-manifest/src/pages/index.astro
+++ b/packages/astro/test/fixtures/ssr-split-manifest/src/pages/index.astro
@@ -11,7 +11,7 @@ import { manifest } from 'astro:ssr-manifest';
 		</style>
 	</head>
 	<body>
-		<h1>Testing</h1>
+		<h1>Testing index</h1>
 		<div id="assets" set:html={JSON.stringify([...manifest.assets])}></div>
 	</body>
 </html>


### PR DESCRIPTION
## Changes

Closes PLT-864
Closes https://github.com/withastro/astro/issues/8315

## Testing

Created a new test, and verified that failed.
Applied the fix and verified that build works and the test passes.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
