### PR TITLE
Prevent React hook call warnings when used with MDX

### DIFF
--- a/.changeset/tame-seas-sort.md
+++ b/.changeset/tame-seas-sort.md
@@ -1,0 +1,9 @@
+---
+'astro': patch
+---
+
+Prevent React hook call warnings when used with MDX
+
+When React and MDX are used in the same project, if the MDX integration is added before React, previously you'd get a warning about hook calls.
+
+This makes it so that the MDX integration's JSX renderer is last in order.

--- a/packages/integrations/mdx/test/fixtures/mdx-plus-react/astro.config.mjs
+++ b/packages/integrations/mdx/test/fixtures/mdx-plus-react/astro.config.mjs
@@ -2,5 +2,5 @@ import mdx from '@astrojs/mdx';
 import react from '@astrojs/react';
 
 export default {
-	integrations: [react(), mdx()]
+	integrations: [mdx(), react()]
 }

--- a/packages/integrations/mdx/test/fixtures/mdx-plus-react/src/components/Component.jsx
+++ b/packages/integrations/mdx/test/fixtures/mdx-plus-react/src/components/Component.jsx
@@ -1,5 +1,8 @@
+import { useState } from "react";
+
 const Component = () => {
-  return <p>Hello world</p>;
+	const [name] = useState('world');
+  return <p>Hello {name}</p>;
 };
 
 export default Component;

--- a/packages/integrations/mdx/test/fixtures/mdx-plus-react/src/pages/post.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-plus-react/src/pages/post.mdx
@@ -1,0 +1,3 @@
+# Testing
+
+This works!

--- a/packages/integrations/mdx/test/mdx-plus-react.test.js
+++ b/packages/integrations/mdx/test/mdx-plus-react.test.js
@@ -2,13 +2,27 @@ import { expect } from 'chai';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
+function hookError() {
+	const error = console.error;
+	const errors = [];
+	console.error = function(...args) {
+		errors.push(args);
+	};
+	return () => { 
+		console.error = error;
+		return errors;
+	};
+}
+
 describe('MDX and React', () => {
 	let fixture;
+	let unhook;
 
 	before(async () => {
 		fixture = await loadFixture({
 			root: new URL('./fixtures/mdx-plus-react/', import.meta.url),
 		});
+		unhook = hookError();
 		await fixture.build();
 	});
 
@@ -19,5 +33,17 @@ describe('MDX and React', () => {
 		const p = document.querySelector('p');
 
 		expect(p.textContent).to.equal('Hello world');
+	});
+
+	it('mdx renders fine', async () => {
+		const html = await fixture.readFile('/post/index.html');
+		const { document } = parseHTML(html);
+		const h = document.querySelector('#testing');
+		expect(h.textContent).to.equal('Testing');
+	});
+
+	it('does not get a invalid hook call warning', () => {
+		const errors = unhook();
+		expect(errors).to.have.a.lengthOf(0);
 	});
 });


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/8317
- Previously when the JSX plugin was added by default it would be added last. When this was moved to being used by the MDX plugin that stopped happening.
- This fixes it by moving it to the end again.

## Testing

- Test added to the mdx integration to check for warnings.

## Docs

N/A, bug fix