### PR TITLE
Prevent View Transition fallback from waiting on looping animations

### DIFF
--- a/.changeset/late-foxes-juggle.md
+++ b/.changeset/late-foxes-juggle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent View Transition fallback from waiting on looping animations

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -98,6 +98,17 @@ const { fallback = 'animate' } = Astro.props as Props;
 		return wait;
 	}
 
+	function isInfinite(animation: Animation) {
+		const effect = animation.effect;
+		if(
+			!effect ||
+			!(effect instanceof KeyframeEffect) ||
+			!effect.target
+		) return false;
+    const style = window.getComputedStyle(effect.target, effect.pseudoElement);
+    return style.animationIterationCount === "infinite";
+}
+
 	const parser = new DOMParser();
 
 	async function updateDOM(html: string, state?: State, fallback?: Fallback) {
@@ -223,7 +234,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 			// Trigger the animations
 			const currentAnimations = document.getAnimations();
 			document.documentElement.dataset.astroTransitionFallback = 'old';
-			const newAnimations = document.getAnimations().filter(a => !currentAnimations.includes(a));
+			const newAnimations = document.getAnimations().filter(a => !currentAnimations.includes(a) && !isInfinite(a));
 			const finished = Promise.all(newAnimations.map(a => a.finished));
 			const fallbackSwap = () => {
 				swap();

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -221,8 +221,10 @@ const { fallback = 'animate' } = Astro.props as Props;
 
 		if (fallback === 'animate') {
 			// Trigger the animations
+			const currentAnimations = document.getAnimations();
 			document.documentElement.dataset.astroTransitionFallback = 'old';
-			const finished = Promise.all(document.getAnimations().map(a => a.finished));
+			const newAnimations = document.getAnimations().filter(a => !currentAnimations.includes(a));
+			const finished = Promise.all(newAnimations.map(a => a.finished));
 			const fallbackSwap = () => {
 				swap();
 				document.documentElement.dataset.astroTransitionFallback = 'new';


### PR DESCRIPTION
## Changes

- Fixes an issue some have reported where navigation does not complete in Safari.
- Before trigger animations, get a list of animations that currently exist. Then trigger the animation and filter out the existing animations. What you're left with should be animations that are part of the view transition.


## Testing

https://github.com/withastro/astro/assets/361671/a3d87c05-d1b5-468d-850e-eb6c8e23d42f

## Docs

N/A, bug fix