### PR TITLE
Properly generating local images with string src

### DIFF
--- a/.changeset/witty-cooks-exercise.md
+++ b/.changeset/witty-cooks-exercise.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `astro:assets` to properly transforming local images with string src

--- a/packages/astro/src/assets/build/generate.ts
+++ b/packages/astro/src/assets/build/generate.ts
@@ -54,7 +54,7 @@ export async function generateImage(
 	}
 
 	const isESMImported = isESMImportedImage(options.src);
-	const isLocalImage = isESMImported || !isRemotePath(options.src);
+	const isLocalImage = isESMImported || !isRemotePath((options.src as string));
 
 	const finalFileURL = new URL('.' + filepath, clientRoot);
 	const finalFolderURL = new URL('./', finalFileURL);

--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -36,7 +36,7 @@ export function isRemoteAllowed(
 		remotePatterns = [],
 	}: Partial<Pick<AstroConfig['image'], 'domains' | 'remotePatterns'>>
 ): boolean {
-	if (!isRemotePath(src)) return false;
+	if (!isRemotePath(src)) return true;
 
 	const url = new URL(src);
 	return (


### PR DESCRIPTION
With Astro 3.x (`astro:assets`) `getImage({ src: '/img/something.png', width, height })` is being ignored.

## Changes

This makes `getImage()` and `<Image>` work again (generates the transformed images) with src string as local path.
Also fixes https://github.com/withastro/astro/issues/5699

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

TBH I've tested it only in a non-minimal context porting my customized <Picture> component to Astro v3 (assets), sorry 😬 
I've tested `build` without the change and and no image was generated, after the changes all expected images was generated as usually done with Astro v2 and `@astrojs/images`.

If you think it's importante for this change, I can try to create a minimal reproduction later. Or you can just pick the idea, close the PR and commit a fix yourself with the desired tests, if you prefer.

## Docs

> No docs changes...

Love Astro btw , hoping to use in production really soon ❤️ 