### PR TITLE
feat(astro/MDX): Add `disableImageOptimization` to disable `Image` astro:assets auto-injection

### DIFF
--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -252,7 +252,7 @@ function applyDefaultOptions({
 		rehypePlugins: options.rehypePlugins ?? defaults.rehypePlugins,
 		shikiConfig: options.shikiConfig ?? defaults.shikiConfig,
 		optimize: options.optimize ?? defaults.optimize,
-		disableImageOptimization: option.disableImageOptimization ?? defaults.disableImageOptimization,
+		disableImageOptimization: options.disableImageOptimization ?? defaults.disableImageOptimization,
 	};
 }
 

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -24,6 +24,7 @@ export type MdxOptions = Omit<typeof markdownConfigDefaults, 'remarkPlugins' | '
 	rehypePlugins: PluggableList;
 	remarkRehype: RemarkRehypeOptions;
 	optimize: boolean | OptimizeOptions;
+	disableImageOptimization: boolean;
 };
 
 type SetupHookParams = HookParameters<'astro:config:setup'> & {
@@ -229,6 +230,7 @@ function markdownConfigToMdxOptions(markdownConfig: typeof markdownConfigDefault
 		rehypePlugins: ignoreStringPlugins(markdownConfig.rehypePlugins),
 		remarkRehype: (markdownConfig.remarkRehype as any) ?? {},
 		optimize: false,
+		disableImageOptimization: false,
 	};
 }
 
@@ -250,6 +252,7 @@ function applyDefaultOptions({
 		rehypePlugins: options.rehypePlugins ?? defaults.rehypePlugins,
 		shikiConfig: options.shikiConfig ?? defaults.shikiConfig,
 		optimize: options.optimize ?? defaults.optimize,
+		disableImageOptimization: option.disableImageOptimization ?? defaults.disableImageOptimization,
 	};
 }
 

--- a/packages/integrations/mdx/src/plugins.ts
+++ b/packages/integrations/mdx/src/plugins.ts
@@ -96,7 +96,7 @@ export function rehypeApplyFrontmatterExport() {
 }
 
 export async function getRemarkPlugins(mdxOptions: MdxOptions): Promise<PluggableList> {
-	let remarkPlugins: PluggableList = [...(MdxOptions.disableImageOptimization ? [] : [remarkCollectImages, remarkImageToComponent])];
+	let remarkPlugins: PluggableList = [...(mdxOptions.disableImageOptimization ? [] : [remarkCollectImages, remarkImageToComponent])];
 
 	if (!isPerformanceBenchmark) {
 		if (mdxOptions.gfm) {

--- a/packages/integrations/mdx/src/plugins.ts
+++ b/packages/integrations/mdx/src/plugins.ts
@@ -96,7 +96,7 @@ export function rehypeApplyFrontmatterExport() {
 }
 
 export async function getRemarkPlugins(mdxOptions: MdxOptions): Promise<PluggableList> {
-	let remarkPlugins: PluggableList = [remarkCollectImages, remarkImageToComponent];
+	let remarkPlugins: PluggableList = [...(MdxOptions.disableImageOptimization ? [] : [remarkCollectImages, remarkImageToComponent])];
 
 	if (!isPerformanceBenchmark) {
 		if (mdxOptions.gfm) {


### PR DESCRIPTION
## Changes

Closes #7223 with a workaround which would allow to create custom components for `img` tags


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Didn't test as I'm doing this via GitHub Web edit files. Also, this PR can be interpreted as RFC from Astro/MDX dev/maintainers 

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

Docs should include `disableImageOptimization` as an option for MDX integration that would change how `img` are handled.
