### PR TITLE
Refactor HTML Meta and DOCTYPE Declarations

### DIFF
--- a/examples/basics/src/layouts/Layout.astro
+++ b/examples/basics/src/layouts/Layout.astro
@@ -6,15 +6,14 @@ interface Props {
 const { title } = Astro.props;
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
-		<meta name="description" content="Astro description">
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
 		<title>{title}</title>
+		<meta name="description" content="Astro description">
 	</head>
 	<body>
 		<slot />

--- a/examples/blog/src/components/BaseHead.astro
+++ b/examples/blog/src/components/BaseHead.astro
@@ -9,14 +9,12 @@ interface Props {
 	image?: string;
 }
 
-const canonicalURL = new URL(Astro.url.pathname, Astro.site);
-
 const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 ---
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="viewport" content="width=device-width" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <meta name="generator" content={Astro.generator} />
 
@@ -25,23 +23,16 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <link rel="preload" href="/fonts/atkinson-bold.woff" as="font" type="font/woff" crossorigin />
 
 <!-- Canonical URL -->
-<link rel="canonical" href={canonicalURL} />
+<link rel="canonical" href={Astro.url} />
 
 <!-- Primary Meta Tags -->
 <title>{title}</title>
-<meta name="title" content={title} />
 <meta name="description" content={description} />
 
-<!-- Open Graph / Facebook -->
+<!-- Open Graph / Facebook / Twitter -->
 <meta property="og:type" content="website" />
 <meta property="og:url" content={Astro.url} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
 <meta property="og:image" content={new URL(image, Astro.url)} />
-
-<!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:url" content={Astro.url} />
-<meta property="twitter:title" content={title} />
-<meta property="twitter:description" content={description} />
-<meta property="twitter:image" content={new URL(image, Astro.url)} />

--- a/examples/blog/src/content/blog/markdown-style-guide.md
+++ b/examples/blog/src/content/blog/markdown-style-guide.md
@@ -99,7 +99,7 @@ we can use 3 backticks ``` in new line and write snippet and close with 3 backti
 
 ````markdown
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -115,7 +115,7 @@ we can use 3 backticks ``` in new line and write snippet and close with 3 backti
 Output
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/examples/blog/src/layouts/BlogPost.astro
+++ b/examples/blog/src/layouts/BlogPost.astro
@@ -11,7 +11,7 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 ---
 
 <html lang="en">
-	<head>
+	<head prefix="og: https://ogp.me/ns#">
 		<BaseHead title={title} description={description} />
 		<style>
 			main {

--- a/examples/blog/src/pages/blog/index.astro
+++ b/examples/blog/src/pages/blog/index.astro
@@ -11,7 +11,6 @@ const posts = (await getCollection('blog')).sort(
 );
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 	<head>
 		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />

--- a/examples/blog/src/pages/index.astro
+++ b/examples/blog/src/pages/index.astro
@@ -5,9 +5,8 @@ import Footer from '../components/Footer.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 ---
 
-<!DOCTYPE html>
 <html lang="en">
-	<head>
+	<head prefix="og: https://ogp.me/ns#">
 		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
 	</head>
 	<body>

--- a/examples/deno/src/components/Layout.astro
+++ b/examples/deno/src/components/Layout.astro
@@ -6,10 +6,9 @@ interface Props {
 const { title } = Astro.props as Props;
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<title>{title}</title>

--- a/examples/framework-lit/src/pages/index.astro
+++ b/examples/framework-lit/src/pages/index.astro
@@ -7,7 +7,6 @@ import { MyCounter } from '../components/my-counter.js';
 // https://docs.astro.build/core-concepts/astro-components/
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />

--- a/examples/hackernews/src/layouts/Layout.astro
+++ b/examples/hackernews/src/layouts/Layout.astro
@@ -6,7 +6,7 @@ import Nav from '../components/Nav.astro';
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro - Hacker News</title>
 		<meta name="description" content="Hacker News Clone built with Astro" />

--- a/examples/middleware/src/layouts/Layout.astro
+++ b/examples/middleware/src/layouts/Layout.astro
@@ -6,10 +6,9 @@ interface Props {
 const { title } = Astro.props;
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />

--- a/examples/portfolio/src/components/MainHead.astro
+++ b/examples/portfolio/src/components/MainHead.astro
@@ -12,11 +12,11 @@ const {
 } = Astro.props;
 ---
 
-<meta charset="UTF-8" />
-<meta name="description" property="og:description" content={description} />
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width" />
 <meta name="generator" content={Astro.generator} />
 <title>{title}</title>
+<meta name="description" content={description} />
 
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/examples/with-markdoc/src/layouts/Layout.astro
+++ b/examples/with-markdoc/src/layouts/Layout.astro
@@ -6,10 +6,9 @@ interface Props {
 const { title } = Astro.props;
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />

--- a/examples/with-nanostores/src/layouts/Layout.astro
+++ b/examples/with-nanostores/src/layouts/Layout.astro
@@ -9,10 +9,9 @@ interface Props {
 const { title } = Astro.props;
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
 	<meta name="generator" content={Astro.generator} />
 	<link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/packages/astro/e2e/fixtures/nested-styles/src/components/partials/Layout/index.astro
+++ b/packages/astro/e2e/fixtures/nested-styles/src/components/partials/Layout/index.astro
@@ -6,8 +6,7 @@ import '../../../styles/global.css'
 <html>
 	<head>
 		<meta charset="utf-8" />
-		<meta http-equiv="x-ua-compatible" content="ie=edge" />
-		<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no" />
+		<meta name="viewport" content="width=device-width" />
 	</head>
 	<body>
 		<Header />

--- a/packages/astro/e2e/fixtures/tailwindcss/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/tailwindcss/src/pages/index.astro
@@ -6,7 +6,7 @@ import Complex from '../components/Complex.astro';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 		<title>Astro + TailwindCSS</title>
 	</head>

--- a/packages/astro/performance/fixtures/utils/RenderContent.astro
+++ b/packages/astro/performance/fixtures/utils/RenderContent.astro
@@ -7,12 +7,10 @@ type Props = {
 const { posts, renderer: ContentRenderer } = Astro.props;
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Md render test</title>
 </head>
 <body>

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -555,7 +555,7 @@ async function generatePath(pathname: string, gopts: GeneratePathOptions, pipeli
 		// A short delay causes Google to interpret the redirect as temporary.
 		// https://developers.google.com/search/docs/crawling-indexing/301-redirects#metarefresh
 		const delay = response.status === 302 ? 2 : 0;
-		body = `<!doctype html>
+		body = `<!DOCTYPE html>
 <title>Redirecting to: ${location}</title>
 <meta http-equiv="refresh" content="${delay};url=${location}">
 <meta name="robots" content="noindex">

--- a/packages/astro/src/runtime/server/render/astro/render.ts
+++ b/packages/astro/src/runtime/server/render/astro/render.ts
@@ -33,7 +33,7 @@ export async function renderToString(
 			// Automatic doctype insertion for pages
 			if (isPage && !renderedFirstPageChunk) {
 				renderedFirstPageChunk = true;
-				if (!/<!doctype html/i.test(String(chunk))) {
+				if (!/<!DOCTYPE html/i.test(String(chunk))) {
 					const doctype = result.compressHTML ? '<!DOCTYPE html>' : '<!DOCTYPE html>\n';
 					str += doctype;
 				}
@@ -84,7 +84,7 @@ export async function renderToReadableStream(
 					// Automatic doctype insertion for pages
 					if (isPage && !renderedFirstPageChunk) {
 						renderedFirstPageChunk = true;
-						if (!/<!doctype html/i.test(String(chunk))) {
+						if (!/<!DOCTYPE html/i.test(String(chunk))) {
 							const doctype = result.compressHTML ? '<!DOCTYPE html>' : '<!DOCTYPE html>\n';
 							controller.enqueue(encoder.encode(doctype));
 						}

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -500,7 +500,7 @@ export async function renderComponentToString(
 				// Automatic doctype and head insertion for pages
 				if (isPage && !renderedFirstPageChunk) {
 					renderedFirstPageChunk = true;
-					if (!/<!doctype html/i.test(String(chunk))) {
+					if (!/<!DOCTYPE html/i.test(String(chunk))) {
 						const doctype = result.compressHTML ? '<!DOCTYPE html>' : '<!DOCTYPE html>\n';
 						str += doctype + head;
 					}

--- a/packages/astro/src/template/4xx.ts
+++ b/packages/astro/src/template/4xx.ts
@@ -21,10 +21,10 @@ export default function template({
 	tabTitle,
 	body,
 }: ErrorTemplateOptions): string {
-	return `<!doctype html>
+	return `<!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8">
+		<meta charset="utf-8">
 		<title>${tabTitle}</title>
 		<style>
 			:root {

--- a/packages/astro/test/fixtures/0-css/src/pages/index.astro
+++ b/packages/astro/test/fixtures/0-css/src/pages/index.astro
@@ -28,7 +28,7 @@ import raw from '../styles/raw.css?raw'
 
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="utf-8" />
     <style lang="scss">
       .wrapper {
         margin-left: auto;

--- a/packages/astro/test/fixtures/astro-basic/src/layouts/base.astro
+++ b/packages/astro/test/fixtures/astro-basic/src/layouts/base.astro
@@ -2,7 +2,6 @@
 const { content } = Astro.props;
 ---
 
-<!doctype html>
 <html lang="en">
 <head>
   <title>{content.title}</title>

--- a/packages/astro/test/fixtures/astro-check-errors/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-check-errors/src/pages/index.astro
@@ -4,9 +4,8 @@
 
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Document</title>
 </head>
 <body>

--- a/packages/astro/test/fixtures/astro-check-no-errors/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-check-no-errors/src/pages/index.astro
@@ -1,8 +1,7 @@
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Document</title>
 </head>
 <body>

--- a/packages/astro/test/fixtures/astro-doctype/src/layouts/WithDoctype.astro
+++ b/packages/astro/test/fixtures/astro-doctype/src/layouts/WithDoctype.astro
@@ -1,7 +1,7 @@
 ---
 import Meta from '../components/Meta.astro';
 ---
-<!doctype html>
+
 <html lang="en">
   <head>
     <title>My App</title>

--- a/packages/astro/test/fixtures/astro-doctype/src/pages/capital.astro
+++ b/packages/astro/test/fixtures/astro-doctype/src/pages/capital.astro
@@ -2,7 +2,6 @@
 let title = 'My Site';
 ---
 
-<!DOCTYPE html>
 <html lang="en">
   <head><title>{title}</title></head>
   <body><h1>Hello world</h1></body>

--- a/packages/astro/test/fixtures/astro-doctype/src/pages/provided.astro
+++ b/packages/astro/test/fixtures/astro-doctype/src/pages/provided.astro
@@ -2,7 +2,6 @@
 let title = 'My Site';
 ---
 
-<!doctype html>
 <html lang="en">
   <head><title>{title}</title></head>
   <body><h1>Hello world</h1></body>

--- a/packages/astro/test/fixtures/astro-head/src/components/Head.astro
+++ b/packages/astro/test/fixtures/astro-head/src/components/Head.astro
@@ -4,7 +4,7 @@ const { title } = Astro.props;
 ---
 
 <head>
-  <meta charset="UTF-8">
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   <title>{title}</title>

--- a/packages/astro/test/fixtures/astro-head/src/pages/head-own-component.astro
+++ b/packages/astro/test/fixtures/astro-head/src/pages/head-own-component.astro
@@ -3,7 +3,6 @@
 import Head from "../components/Head.astro";
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 <Head title="title"/>
 <body>

--- a/packages/astro/test/fixtures/astro-markdown/src/layouts/Base.astro
+++ b/packages/astro/test/fixtures/astro-markdown/src/layouts/Base.astro
@@ -14,15 +14,11 @@ const {
 } = Astro.props;
 ---
 
-<!DOCTYPE html>
 <html lang="en">
-
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 </head>
-
 <body>
 	<p data-content-title>{content.title}</p>
 	<p data-frontmatter-title>{frontmatter.title}</p>

--- a/packages/astro/test/fixtures/css-import-as-inline/src/layouts/Layout.astro
+++ b/packages/astro/test/fixtures/css-import-as-inline/src/layouts/Layout.astro
@@ -6,10 +6,9 @@ interface Props {
 const { title } = Astro.props;
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />

--- a/packages/astro/test/fixtures/css-inline-stylesheets/src/layouts/Layout.astro
+++ b/packages/astro/test/fixtures/css-inline-stylesheets/src/layouts/Layout.astro
@@ -9,10 +9,9 @@ interface Props {
 const { title } = Astro.props;
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />

--- a/packages/astro/test/fixtures/css-no-code-split/src/pages/index.astro
+++ b/packages/astro/test/fixtures/css-no-code-split/src/pages/index.astro
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="utf-8" />
   </head>
   <body>
     <h1>css no code split</h1>

--- a/packages/astro/test/fixtures/css-order-layout/src/components/MainHead.astro
+++ b/packages/astro/test/fixtures/css-order-layout/src/components/MainHead.astro
@@ -2,4 +2,4 @@
 import "../styles/global.css";
 ---
 
-<meta charset="UTF-8" />
+<meta charset="utf-8" />

--- a/packages/astro/test/fixtures/head-injection/src/components/Layout.astro
+++ b/packages/astro/test/fixtures/head-injection/src/components/Layout.astro
@@ -1,7 +1,7 @@
 ---
 const title = 'My Title';
 ---
-<!DOCTYPE html>
+
 <html lang="en" class="dark">
   <head>
     <title set:html={title}></title>

--- a/packages/astro/test/fixtures/head-injection/src/components/SlotRenderLayout.astro
+++ b/packages/astro/test/fixtures/head-injection/src/components/SlotRenderLayout.astro
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
   <head> </head>
   <body>

--- a/packages/astro/test/fixtures/static-build/src/components/MainHead.astro
+++ b/packages/astro/test/fixtures/static-build/src/components/MainHead.astro
@@ -3,9 +3,9 @@ import '../styles/main.scss';
 const { title = 'Static Build', description = 'This is a demo of the static build' } = Astro.props;
 ---
 
-<meta charset="UTF-8" />
-<meta name="description" property="og:description" content={description} />
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width" />
 <title>{title}</title>
+<meta name="description" content={description} />
 
 <link rel="icon" type="image/x-icon" href="/favicon.ico" />

--- a/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
+++ b/packages/astro/test/fixtures/tailwindcss/src/pages/index.astro
@@ -6,7 +6,7 @@ import Complex from '../components/Complex.astro';
 
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
+		<meta charset="utf-8" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 		<title>Astro + TailwindCSS</title>
 	</head>

--- a/packages/integrations/markdoc/test/fixtures/headings-custom/src/pages/[slug].astro
+++ b/packages/integrations/markdoc/test/fixtures/headings-custom/src/pages/[slug].astro
@@ -11,12 +11,10 @@ type Props = CollectionEntry<'docs'>;
 const { Content, headings } = await Astro.props.render();
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Content</title>
 </head>
 <body>

--- a/packages/integrations/markdoc/test/fixtures/headings/src/pages/[slug].astro
+++ b/packages/integrations/markdoc/test/fixtures/headings/src/pages/[slug].astro
@@ -11,12 +11,10 @@ type Props = CollectionEntry<'docs'>;
 const { Content, headings } = await Astro.props.render();
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Content</title>
 </head>
 <body>

--- a/packages/integrations/markdoc/test/fixtures/propagated-assets/src/pages/[slug].astro
+++ b/packages/integrations/markdoc/test/fixtures/propagated-assets/src/pages/[slug].astro
@@ -12,12 +12,10 @@ export async function getStaticPaths() {
 const { Content } = await Astro.props.render();
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>{Astro.props.data.title}</title>
 </head>
 <body>

--- a/packages/integrations/markdoc/test/fixtures/render-html/src/pages/[slug].astro
+++ b/packages/integrations/markdoc/test/fixtures/render-html/src/pages/[slug].astro
@@ -15,12 +15,10 @@ export async function getStaticPaths() {
 
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Content</title>
 </head>
 <body>

--- a/packages/integrations/markdoc/test/fixtures/render-null/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-null/src/pages/index.astro
@@ -5,12 +5,10 @@ const post = await getEntryBySlug('blog', 'render-null');
 const { Content } = await post.render();
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Content</title>
 </head>
 <body>

--- a/packages/integrations/markdoc/test/fixtures/render-simple/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-simple/src/pages/index.astro
@@ -5,12 +5,10 @@ const post = await getEntryBySlug('blog', 'simple');
 const { Content } = await post.render();
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Content</title>
 </head>
 <body>

--- a/packages/integrations/markdoc/test/fixtures/render-with-components/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-components/src/pages/index.astro
@@ -5,12 +5,10 @@ const post = await getEntryBySlug('blog', 'with-components');
 const { Content } = await post.render();
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Content</title>
 </head>
 <body>

--- a/packages/integrations/markdoc/test/fixtures/render-with-config/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-config/src/pages/index.astro
@@ -5,12 +5,10 @@ const post = await getEntryBySlug('blog', 'with-config');
 const { Content } = await post.render();
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 	<title>Content</title>
 </head>
 <body>

--- a/packages/integrations/mdx/test/fixtures/css-head-mdx/src/components/BaseHead.astro
+++ b/packages/integrations/mdx/test/fixtures/css-head-mdx/src/components/BaseHead.astro
@@ -1,7 +1,7 @@
 ---
 const { title } = Astro.props;
 ---
-<meta charset="UTF-8" />
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <meta name="generator" content={Astro.generator} />

--- a/packages/integrations/mdx/test/fixtures/css-head-mdx/src/layouts/ContentLayout.astro
+++ b/packages/integrations/mdx/test/fixtures/css-head-mdx/src/layouts/ContentLayout.astro
@@ -7,7 +7,6 @@ interface Props {
 const { title } = Astro.props;
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 	<head>
 		<BaseHead title={title} />

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/layouts/Base.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/layouts/Base.astro
@@ -3,12 +3,10 @@ const defaults = { title: 'Frontmatter not passed to layout!' }
 const { frontmatter = defaults, content = defaults } = Astro.props;
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
   <title>{frontmatter.title}</title>
 </head>
 <body>

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter/src/layouts/Base.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter/src/layouts/Base.astro
@@ -12,15 +12,11 @@ const {
 } = Astro.props;
 ---
 
-<!DOCTYPE html>
 <html lang="en">
-
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 </head>
-
 <body>
 	<p data-content-title>{content.title}</p>
 	<p data-frontmatter-title>{frontmatter.title}</p>

--- a/packages/integrations/mdx/test/fixtures/mdx-optimize/src/pages/import.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-optimize/src/pages/import.astro
@@ -3,7 +3,6 @@ import { Content, components } from './index.mdx'
 import Strong from '../components/Strong.astro'
 ---
 
-<!DOCTYPE html>
 <html>
   <head>
     <title>Import MDX component</title>

--- a/packages/integrations/node/test/fixtures/node-middleware/src/pages/404.astro
+++ b/packages/integrations/node/test/fixtures/node-middleware/src/pages/404.astro
@@ -1,12 +1,10 @@
 ---
 ---
 
-<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
   <title>404</title>
 </head>
 <body>Page does not exist</body>

--- a/packages/integrations/prefetch/test/fixtures/style-prefetch/src/pages/index.astro
+++ b/packages/integrations/prefetch/test/fixtures/style-prefetch/src/pages/index.astro
@@ -3,9 +3,8 @@
 
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
     <title>Home</title>
 </head>
 <body>

--- a/packages/integrations/prefetch/test/fixtures/style-prefetch/src/pages/style1.astro
+++ b/packages/integrations/prefetch/test/fixtures/style-prefetch/src/pages/style1.astro
@@ -3,9 +3,8 @@
 
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
     <title>Style1</title>
     <link rel="stylesheet" href="/main.css">
 </head>

--- a/packages/integrations/prefetch/test/fixtures/style-prefetch/src/pages/style2.astro
+++ b/packages/integrations/prefetch/test/fixtures/style-prefetch/src/pages/style2.astro
@@ -3,9 +3,8 @@
 
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
     <title>Style2</title>
     <link rel="stylesheet" href="/main.css">
 </head>


### PR DESCRIPTION
## Changes

- Removed unnecessary `<!DOCTYPE html>` from `.astro` files for improved efficiency.
- Standardized naming conventions by changing `<!doctype html>` to `<!DOCTYPE html>`.
- Ensured consistent character encoding by changing `<meta charset="UTF-8">` to `<meta charset="utf-8">`.
- Removed the `<meta http-equiv="X-UA-Compatible">` tag, no longer needed for modern browsers.
- Simplified viewport meta tags by setting `<meta name="viewport" content="width=device-width">`.
- Replaced Twitter Card tags (`twitter:url`, `twitter:title`, `twitter:description`, `twitter:image`) with Open Graph (`og:*`) tags for better compatibility and added `prefix="og: http://ogp.me/ns#"` support packages.

References:
- https://death-to-ie11.com/
- https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag
- https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started##twitter-cards-and-open-graph

## Testing

This change was tested by thoroughly reviewing the modified code to ensure correctness and by running relevant test cases. It has undergone manual testing on various browsers and devices to verify compatibility.

## Docs

No need for docs change, it's a basic change and has no relationship with the documentation.
