### PR TITLE
Uppercase endpoint examples in adapter READMEs

### DIFF
--- a/.changeset/quiet-sheep-refuse.md
+++ b/.changeset/quiet-sheep-refuse.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/cloudflare': patch
+'@astrojs/netlify': patch
+---
+
+Update README

--- a/packages/integrations/cloudflare/README.md
+++ b/packages/integrations/cloudflare/README.md
@@ -99,7 +99,7 @@ From an endpoint:
 
 ```js
 // src/pages/api/someFile.js
-export function get(context) {
+export function GET(context) {
   const runtime = context.locals.runtime;
 
   return new Response('Some body');

--- a/packages/integrations/netlify/README.md
+++ b/packages/integrations/netlify/README.md
@@ -243,7 +243,7 @@ We check for common mime types for audio, image, and video files. To include spe
 
 import fs from 'node:fs';
 
-export function get() {
+export function GET() {
   const buffer = fs.readFileSync('../image.jpg');
 
   // Return the buffer directly, @astrojs/netlify will base64 encode the body


### PR DESCRIPTION
## Changes

- Updates two adapter README examples to use `GET()` instead of `get()`

## Testing

- n/a

## Docs
- Spotted this in https://github.com/withastro/docs/pull/4467
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
