### PR TITLE
fix(@astrojs/vercel): slowness and symbolic link

### DIFF
--- a/.changeset/proud-forks-rescue.md
+++ b/.changeset/proud-forks-rescue.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/vercel': patch
+---
+
+- Cache result during bundling, to speed up the process of multiple functions;
+- Avoid creating multiple symbolic links of the dependencies when building the project with `funcitonPerRoute` enabled;

--- a/packages/integrations/vercel/src/lib/nft.ts
+++ b/packages/integrations/vercel/src/lib/nft.ts
@@ -1,19 +1,28 @@
 import { relative as relativePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { relative } from 'node:path';
 import { copyFilesToFunction } from './fs.js';
+import type { AstroIntegrationLogger } from 'astro';
 
-export async function copyDependenciesToFunction({
-	entry,
-	outDir,
-	includeFiles,
-	excludeFiles,
-}: {
-	entry: URL;
-	outDir: URL;
-	includeFiles: URL[];
-	excludeFiles: URL[];
-}): Promise<{ handler: string }> {
+export async function copyDependenciesToFunction(
+	{
+		entry,
+		outDir,
+		includeFiles,
+		excludeFiles,
+		logger,
+	}: {
+		entry: URL;
+		outDir: URL;
+		includeFiles: URL[];
+		excludeFiles: URL[];
+		logger: AstroIntegrationLogger;
+	},
+	// we want to pass the caching by reference, and not by value
+	cache: object
+): Promise<{ handler: string }> {
 	const entryPath = fileURLToPath(entry);
+	logger.info(`Bundling function ${relative(fileURLToPath(outDir), entryPath)}`);
 
 	// Get root of folder of the system (like C:\ on Windows or / on Linux)
 	let base = entry;
@@ -31,6 +40,7 @@ export async function copyDependenciesToFunction({
 		// If you have a route of /dev this appears in source and NFT will try to
 		// scan your local /dev :8
 		ignore: ['/dev/**'],
+		cache,
 	});
 
 	for (const error of result.warnings) {


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/8312

This PR addresses two issues:
- **slowness of the build**: our adapter, when bundling a function, needs to carry over the dependencies that are inlined. Unfortunately, some package managers rely on symbolic links, and we need to trace them. This means that most of the time, the base path to start looking for files is the root folder (`/` or `C:\`). On big projects (monorepos), this could cause a lot of overhead. Fortunately, `@vercel/nft` allows us to pass a `cache` object to reuse when bundling the functions. **The first function to bundle will always be slow**, but the next ones are way faster. 
- **symbolic link issues**: I suppose this is specific to `pnpm`. Essentially, our adapter carries over the symbolic link of our inlined (external, not bundled) dependencies. After the first run, we have the source of the symbolic link in the `pnpm` store, so we don't need to create a new one again. Hopefully, this should fix the issue. 


## Testing

Create a preview release and ask users to try it, and make sure to check if the deployed function works.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
