### PR TITLE
Add ability to remove assets originals

### DIFF
--- a/.changeset/thirty-geckos-bathe.md
+++ b/.changeset/thirty-geckos-bathe.md
@@ -1,5 +1,5 @@
 ---
-'astro': patch
+'astro': minor
 ---
 
 Add ability to remove assets originals

--- a/.changeset/thirty-geckos-bathe.md
+++ b/.changeset/thirty-geckos-bathe.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add ability to remove assets originals

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -793,6 +793,24 @@ export interface AstroUserConfig {
 		assetsPrefix?: string;
 		/**
 		 * @docs
+		 * @name build.assetsRemoveOriginals
+		 * @type {boolean}
+		 * @default `false`
+		 * @version 3.0.6
+		 * @description
+		 * Specifies necessity for removing assets originals.
+		 *
+		 * ```js
+		 * {
+		 *   build: {
+		 *     assetsRemoveOriginals: true
+		 *   }
+		 * }
+		 * ```
+		 */
+		assetsRemoveOriginals?: boolean;
+		/**
+		 * @docs
 		 * @name build.serverEntry
 		 * @type {string}
 		 * @default `'entry.mjs'`

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -793,24 +793,6 @@ export interface AstroUserConfig {
 		assetsPrefix?: string;
 		/**
 		 * @docs
-		 * @name build.assetsRemoveOriginals
-		 * @type {boolean}
-		 * @default `false`
-		 * @version 3.0.6
-		 * @description
-		 * Specifies necessity for removing assets originals.
-		 *
-		 * ```js
-		 * {
-		 *   build: {
-		 *     assetsRemoveOriginals: true
-		 *   }
-		 * }
-		 * ```
-		 */
-		assetsRemoveOriginals?: boolean;
-		/**
-		 * @docs
 		 * @name build.serverEntry
 		 * @type {string}
 		 * @default `'entry.mjs'`
@@ -1076,6 +1058,26 @@ export interface AstroUserConfig {
 
 		 */
 		remotePatterns?: Partial<RemotePattern>[];
+		/**
+		 * @docs
+		 * @name image.removeOriginals
+		 * @type {boolean}
+		 * @default `false`
+		 * @version 3.1.0
+		 * @description
+		 * Specifies if original files for optimized assets should be removed from the final build in SSG.
+		 * Note that this option is **potentially unsafe**, as we cannot reliably tell if your website uses the original files outside of the optimization pipeline.
+		 * With this option enabled, **ALL** original files won't be included in the final output.
+		 *
+		 * ```js
+		 * {
+		 *   image: {
+		 *     removeOriginals: true
+		 *   }
+		 * }
+		 * ```
+		 */
+		removeOriginals?: boolean;
 	};
 
 	/**

--- a/packages/astro/src/assets/build/generate.ts
+++ b/packages/astro/src/assets/build/generate.ts
@@ -29,6 +29,7 @@ export async function generateImage(
 ): Promise<GenerationData | undefined> {
 	const config = pipeline.getConfig();
 	const logger = pipeline.getLogger();
+	const ssr = isServerLikeOutput(config);
 	let useCache = true;
 	const assetsCacheDir = new URL('assets/', config.cacheDir);
 
@@ -44,7 +45,7 @@ export async function generateImage(
 	}
 
 	let serverRoot: URL, clientRoot: URL;
-	if (isServerLikeOutput(config)) {
+	if (ssr) {
 		serverRoot = config.build.server;
 		clientRoot = config.build.client;
 	} else {
@@ -62,7 +63,7 @@ export async function generateImage(
 		? (options.src as ImageMetadata).src
 		: (options.src as string);
 
-	if (config.build.assetsRemoveOriginals) {
+	if (!ssr && config.image.removeOriginals) {
 		const originalFileURL = new URL('.' + originalImagePath, clientRoot);
 		try {
 			await fs.promises.unlink(originalFileURL);

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -9,7 +9,6 @@ import type {
 	AstroSettings,
 	ComponentInstance,
 	GetStaticPathsItem,
-	ImageMetadata,
 	ImageTransform,
 	MiddlewareEndpointHandler,
 	RouteData,

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -23,6 +23,7 @@ const ASTRO_CONFIG_DEFAULTS = {
 		client: './dist/client/',
 		server: './dist/server/',
 		assets: '_astro',
+		assetsRemoveOriginals: false,
 		serverEntry: 'entry.mjs',
 		redirects: true,
 		inlineStylesheets: 'auto',
@@ -119,6 +120,7 @@ export const AstroConfigSchema = z.object({
 				.transform((val) => new URL(val)),
 			assets: z.string().optional().default(ASTRO_CONFIG_DEFAULTS.build.assets),
 			assetsPrefix: z.string().optional(),
+			assetsRemoveOriginals: z.boolean().default(ASTRO_CONFIG_DEFAULTS.build.assetsRemoveOriginals),
 			serverEntry: z.string().optional().default(ASTRO_CONFIG_DEFAULTS.build.serverEntry),
 			redirects: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.build.redirects),
 			inlineStylesheets: z
@@ -341,6 +343,7 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 					.transform((val) => resolveDirAsUrl(val, fileProtocolRoot)),
 				assets: z.string().optional().default(ASTRO_CONFIG_DEFAULTS.build.assets),
 				assetsPrefix: z.string().optional(),
+			assetsRemoveOriginals: z.boolean().default(ASTRO_CONFIG_DEFAULTS.build.assetsRemoveOriginals),
 				serverEntry: z.string().optional().default(ASTRO_CONFIG_DEFAULTS.build.serverEntry),
 				redirects: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.build.redirects),
 				inlineStylesheets: z

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -23,7 +23,6 @@ const ASTRO_CONFIG_DEFAULTS = {
 		client: './dist/client/',
 		server: './dist/server/',
 		assets: '_astro',
-		assetsRemoveOriginals: false,
 		serverEntry: 'entry.mjs',
 		redirects: true,
 		inlineStylesheets: 'auto',
@@ -32,6 +31,7 @@ const ASTRO_CONFIG_DEFAULTS = {
 	},
 	image: {
 		service: { entrypoint: 'astro/assets/services/sharp', config: {} },
+		removeOriginals: false,
 	},
 	compressHTML: true,
 	server: {
@@ -120,7 +120,6 @@ export const AstroConfigSchema = z.object({
 				.transform((val) => new URL(val)),
 			assets: z.string().optional().default(ASTRO_CONFIG_DEFAULTS.build.assets),
 			assetsPrefix: z.string().optional(),
-			assetsRemoveOriginals: z.boolean().default(ASTRO_CONFIG_DEFAULTS.build.assetsRemoveOriginals),
 			serverEntry: z.string().optional().default(ASTRO_CONFIG_DEFAULTS.build.serverEntry),
 			redirects: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.build.redirects),
 			inlineStylesheets: z
@@ -221,6 +220,7 @@ export const AstroConfigSchema = z.object({
 					})
 				)
 				.default([]),
+			removeOriginals: z.boolean().default(ASTRO_CONFIG_DEFAULTS.image.removeOriginals),
 		})
 		.default(ASTRO_CONFIG_DEFAULTS.image),
 	markdown: z
@@ -343,7 +343,6 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 					.transform((val) => resolveDirAsUrl(val, fileProtocolRoot)),
 				assets: z.string().optional().default(ASTRO_CONFIG_DEFAULTS.build.assets),
 				assetsPrefix: z.string().optional(),
-			assetsRemoveOriginals: z.boolean().default(ASTRO_CONFIG_DEFAULTS.build.assetsRemoveOriginals),
 				serverEntry: z.string().optional().default(ASTRO_CONFIG_DEFAULTS.build.serverEntry),
 				redirects: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.build.redirects),
 				inlineStylesheets: z


### PR DESCRIPTION
## Changes

- Related to #8143
- Setting `image.removeOriginals: true` will remove original images from `dist/_astro` folder

Without `image.removeOriginals`:

```
❯ erd -H -y inverted dist/_astro
  1.7 MiB _astro
260.0 KiB ├─ settings_40fps_2.731da867.jpg
256.0 KiB ├─ settings_30fps_1.629c7257.jpg
160.0 KiB ├─ settings_30fps_1.629c7257_20zUBg.webp
160.0 KiB ├─ settings_40fps_2.731da867_ZhzHjC.webp
152.0 KiB ├─ settings_30fps_2.97c4dee7.jpg
128.0 KiB ├─ settings_graphics_2.bd8cfba5.jpg
128.0 KiB ├─ settings_40fps_1.f27d3847.jpg
124.0 KiB ├─ settings_graphics_1.9412e5b9.jpg
100.0 KiB ├─ settings_video.e331578c.jpg
 72.0 KiB ├─ settings_30fps_2.97c4dee7_Z2blIQe.webp
 60.0 KiB ├─ settings_graphics_2.bd8cfba5_8VVIW.webp
 56.0 KiB ├─ settings_40fps_1.f27d3847_XiBlO.webp
 56.0 KiB ├─ settings_graphics_1.9412e5b9_25cKaG.webp
 44.0 KiB └─ settings_video.e331578c_ZuGlht.webp

14 files
```

With `image.removeOriginals: true`:

```
608.0 KiB _astro
160.0 KiB ├─ settings_30fps_1.629c7257_20zUBg.webp
160.0 KiB ├─ settings_40fps_2.731da867_ZhzHjC.webp
 72.0 KiB ├─ settings_30fps_2.97c4dee7_Z2blIQe.webp
 60.0 KiB ├─ settings_graphics_2.bd8cfba5_8VVIW.webp
 56.0 KiB ├─ settings_40fps_1.f27d3847_XiBlO.webp
 56.0 KiB ├─ settings_graphics_1.9412e5b9_25cKaG.webp
 44.0 KiB └─ settings_video.e331578c_ZuGlht.webp

7 files
```

## Testing

Don't know how exactly test this feature 🥲

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
