### PR TITLE
fix: no asset plugin w/ img is imported with query

### DIFF
--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -14,9 +14,6 @@ import { hashTransform, propsToFilename } from './utils/transformToPath.js';
 
 const resolvedVirtualModuleId = '\0' + VIRTUAL_MODULE_ID;
 
-const rawRE = /(?:\?|&)raw(?:&|$)/;
-const urlRE = /(\?|&)url(?:&|$)/;
-
 export default function assets({
 	settings,
 	mode,
@@ -119,8 +116,9 @@ export default function assets({
 				resolvedConfig = viteConfig;
 			},
 			async load(id) {
-				// If our import has the `?raw` or `?url` Vite query params, we'll let Vite handle it
-				if (rawRE.test(id) || urlRE.test(id)) {
+				// If our import has any query params, we'll let Vite handle it
+				// See https://github.com/withastro/astro/issues/8333
+				if (id.includes('?')) {
 					return;
 				}
 


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
