### PR TITLE
fix(vercel): Don't output an error message for failing to resolve sharp

### DIFF
--- a/.changeset/shy-socks-return.md
+++ b/.changeset/shy-socks-return.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Fix unnecessary warning about Sharp showing while building

--- a/packages/integrations/vercel/src/lib/nft.ts
+++ b/packages/integrations/vercel/src/lib/nft.ts
@@ -49,6 +49,9 @@ export async function copyDependenciesToFunction(
 			// The import(astroRemark) sometimes fails to resolve, but it's not a problem
 			if (module === '@astrojs/') continue;
 
+			// Sharp is always external and won't be able to be resolved, but that's also not a problem
+			if (module === 'sharp') continue;
+
 			if (entryPath === file) {
 				console.warn(
 					`[@astrojs/vercel] The module "${module}" couldn't be resolved. This may not be a problem, but it's worth checking.`


### PR DESCRIPTION
## Changes

What the title says. Sharp is always external, so it'll always output a warning but this is not a problem

## Testing

Tested it manually, it didn't output a warning, sir

## Docs

N/A
