### PR TITLE
feat: add progress to asset generation

### DIFF
--- a/.changeset/polite-scissors-invent.md
+++ b/.changeset/polite-scissors-invent.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+---
+
+Added counter to show progress for assets image generation.
+Fixed small unit of measurement error.

--- a/packages/astro/src/assets/build/generate.ts
+++ b/packages/astro/src/assets/build/generate.ts
@@ -155,12 +155,12 @@ export async function generateImage(
 	};
 }
 
-export function getStaticImageList(): Iterable<
-	[string, { path: string; options: ImageTransform }]
+export function getStaticImageList(): Map<
+	string, { path: string; options: ImageTransform }
 > {
 	if (!globalThis?.astroAsset?.staticImages) {
-		return [];
+		return new Map();
 	}
 
-	return globalThis.astroAsset.staticImages?.entries();
+	return globalThis.astroAsset.staticImages;
 }

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -196,12 +196,12 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 		}
 	}
 
-	const staticImageList = Array.from(getStaticImageList())
+	const staticImageList = getStaticImageList()
 
-	if (staticImageList.length) logger.info(null, `\n${bgGreen(black(` generating optimized images `))}`); let count = 0;
-	for (const imageData of staticImageList) {
+	if (staticImageList.size) logger.info(null, `\n${bgGreen(black(` generating optimized images `))}`); let count = 0;
+	for (const imageData of staticImageList.entries()) {
 		count++
-		await generateImage(pipeline, imageData[1].options, imageData[1].path, count, staticImageList.length);
+		await generateImage(pipeline, imageData[1].options, imageData[1].path, count, staticImageList.size);
 	}
 
 	delete globalThis?.astroAsset?.addStaticImage;

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -228,7 +228,7 @@ async function generateImage(pipeline: BuildPipeline, transform: ImageTransform,
 	const timeIncrease = `(+${timeChange})`;
 	const statsText = generationData.cached
 		? `(reused cache entry)`
-		: `(before: ${generationData.weight.before}kb, after: ${generationData.weight.after}kb)`;
+		: `(before: ${generationData.weight.before}kB, after: ${generationData.weight.after}kB)`;
 	const counter = `(${count}/${length})`;
 	logger.info(null, `  ${green('▶')} ${path} ${dim(statsText)} ${dim(timeIncrease)} ${dim(counter)}}`);
 }

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -214,7 +214,7 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 	logger.info(null, dim(`Completed in ${getTimeStat(timer, performance.now())}.\n`));
 }
 
-async function generateImage(pipeline: BuildPipeline, transform: ImageTransform, path: string, count: number, length: number) {
+async function generateImage(pipeline: BuildPipeline, transform: ImageTransform, path: string, count: number, totalCount: number) {
 	const logger = pipeline.getLogger();
 	let timeStart = performance.now();
 	const generationData = await generateImageInternal(pipeline, transform, path);
@@ -229,7 +229,7 @@ async function generateImage(pipeline: BuildPipeline, transform: ImageTransform,
 	const statsText = generationData.cached
 		? `(reused cache entry)`
 		: `(before: ${generationData.weight.before}kB, after: ${generationData.weight.after}kB)`;
-	const counter = `(${count}/${length})`;
+	const counter = `(${count}/${totalCount})`;
 	logger.info(null, `  ${green('▶')} ${path} ${dim(statsText)} ${dim(timeIncrease)} ${dim(counter)}}`);
 }
 


### PR DESCRIPTION
## Changes

Added counter to show progress for assets image generation.
Fixed small unit of measurement error.

## Testing

No tests are necessary, the change is minimal and just to logging.

## Docs

No documentation changes are needed, adds info to logging.
