### PR TITLE
Fix the path to type definitions in ImportMeta

### DIFF
--- a/.changeset/clever-dingos-end.md
+++ b/.changeset/clever-dingos-end.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fix the path to type definitions in ImportMeta
+
+Vite no longer expose `vite/types/importGlob` and `vite/types/importGlob`

--- a/packages/astro/import-meta.d.ts
+++ b/packages/astro/import-meta.d.ts
@@ -13,11 +13,11 @@ interface ImportMeta {
 
 	readonly env: ImportMetaEnv;
 
-	glob: import('vite/types/importGlob').ImportGlobFunction;
+	glob: import('vite').ImportGlobFunction;
 	/**
 	 * @deprecated Use `import.meta.glob('*', { eager: true })` instead
 	 */
-	globEager: import('vite/types/importGlob').ImportGlobEagerFunction;
+	globEager: import('vite').ImportGlobEagerFunction;
 }
 
 interface ImportMetaEnv {


### PR DESCRIPTION
## Changes

Fixed the path for type definitions for `import.meta.glob` and `import.meta.globEager`. This is because Vite no longer exposes `vite/types/importGlob` and `vite/types/importGlob`, and it needs to be imported from `vite` instead.

## Testing

Verified the type definitions for `import.meta.glob` and `import.meta.globEager` in files that import `import-meta.d.ts`.

## Docs

No additional documentation is required to detail the implementation.