### PR TITLE
Ensure `chunkFileNames` do not include invalid characters

### DIFF
--- a/.changeset/eighty-laws-brake.md
+++ b/.changeset/eighty-laws-brake.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Update `chunkFileNames` to avoid emitting invalid characters

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -172,7 +172,20 @@ async function ssrBuild(
 					format: 'esm',
 					// Server chunks can't go in the assets (_astro) folder
 					// We need to keep these separate
-					chunkFileNames: `chunks/[name].[hash].mjs`,
+					chunkFileNames(chunkInfo) {
+						const { name } = chunkInfo;
+						// Sometimes chunks have the `@_@astro` suffix. Remove it!
+						if (name.includes(ASTRO_PAGE_EXTENSION_POST_PATTERN)) {
+							const [sanitizedName] = name.split(ASTRO_PAGE_EXTENSION_POST_PATTERN);
+							return `chunks/${sanitizedName}.[hash].mjs`
+						}
+						// Injected routes include "pages/[name].[ext]" already. Clean those up!
+						if (name.startsWith('pages/')) {
+							const sanitizedName = name.split('.')[0];
+							return `chunks/${sanitizedName}.[hash].mjs`
+						}
+						return `chunks/[name].[hash].mjs`
+					},
 					assetFileNames: `${settings.config.build.assets}/[name].[hash][extname]`,
 					...viteConfig.build?.rollupOptions?.output,
 					entryFileNames(chunkInfo) {

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -177,16 +177,16 @@ async function ssrBuild(
 						// Sometimes chunks have the `@_@astro` suffix. Remove it!
 						if (name.includes(ASTRO_PAGE_EXTENSION_POST_PATTERN)) {
 							const [sanitizedName] = name.split(ASTRO_PAGE_EXTENSION_POST_PATTERN);
-							return `chunks/${sanitizedName}.[hash].mjs`
+							return `chunks/${sanitizedName}_[hash].mjs`
 						}
 						// Injected routes include "pages/[name].[ext]" already. Clean those up!
 						if (name.startsWith('pages/')) {
 							const sanitizedName = name.split('.')[0];
-							return `chunks/${sanitizedName}.[hash].mjs`
+							return `chunks/${sanitizedName}_[hash].mjs`
 						}
-						return `chunks/[name].[hash].mjs`
+						return `chunks/[name]_[hash].mjs`
 					},
-					assetFileNames: `${settings.config.build.assets}/[name].[hash][extname]`,
+					assetFileNames: `${settings.config.build.assets}/[name]_[hash][extname]`,
 					...viteConfig.build?.rollupOptions?.output,
 					entryFileNames(chunkInfo) {
 						if (chunkInfo.facadeModuleId?.startsWith(ASTRO_PAGE_RESOLVED_MODULE_ID)) {
@@ -202,7 +202,7 @@ async function ssrBuild(
 						} else if (chunkInfo.facadeModuleId === RESOLVED_RENDERERS_MODULE_ID) {
 							return 'renderers.mjs';
 						} else if (chunkInfo.facadeModuleId === RESOLVED_SSR_MANIFEST_VIRTUAL_MODULE_ID) {
-							return 'manifest.[hash].mjs';
+							return 'manifest_[hash].mjs';
 						} else {
 							return '[name].mjs';
 						}
@@ -270,9 +270,9 @@ async function clientBuild(
 				input: Array.from(input),
 				output: {
 					format: 'esm',
-					entryFileNames: `${settings.config.build.assets}/[name].[hash].js`,
-					chunkFileNames: `${settings.config.build.assets}/[name].[hash].js`,
-					assetFileNames: `${settings.config.build.assets}/[name].[hash][extname]`,
+					entryFileNames: `${settings.config.build.assets}/[name]_[hash].js`,
+					chunkFileNames: `${settings.config.build.assets}/[name]_[hash].js`,
+					assetFileNames: `${settings.config.build.assets}/[name]_[hash][extname]`,
 					...viteConfig.build?.rollupOptions?.output,
 				},
 				preserveEntrySignatures: 'exports-only',

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -186,7 +186,7 @@ async function ssrBuild(
 						}
 						return `chunks/[name]_[hash].mjs`
 					},
-					assetFileNames: `${settings.config.build.assets}/[name]_[hash][extname]`,
+					assetFileNames: `${settings.config.build.assets}/[name].[hash][extname]`,
 					...viteConfig.build?.rollupOptions?.output,
 					entryFileNames(chunkInfo) {
 						if (chunkInfo.facadeModuleId?.startsWith(ASTRO_PAGE_RESOLVED_MODULE_ID)) {

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -172,9 +172,10 @@ async function ssrBuild(
 					format: 'esm',
 					// Server chunks can't go in the assets (_astro) folder
 					// We need to keep these separate
-					chunkFileNames(chunkInfo) {
+					chunkFileNames: (chunkInfo) {
 						const { name } = chunkInfo;
-						// Sometimes chunks have the `@_@astro` suffix. Remove it!
+						// Sometimes chunks have the `@_@astro` suffix due to SSR logic. Remove it!
+						// TODO: refactor our build logic to avoid this
 						if (name.includes(ASTRO_PAGE_EXTENSION_POST_PATTERN)) {
 							const [sanitizedName] = name.split(ASTRO_PAGE_EXTENSION_POST_PATTERN);
 							return `chunks/${sanitizedName}_[hash].mjs`
@@ -270,9 +271,9 @@ async function clientBuild(
 				input: Array.from(input),
 				output: {
 					format: 'esm',
-					entryFileNames: `${settings.config.build.assets}/[name]_[hash].js`,
-					chunkFileNames: `${settings.config.build.assets}/[name]_[hash].js`,
-					assetFileNames: `${settings.config.build.assets}/[name]_[hash][extname]`,
+					entryFileNames: `${settings.config.build.assets}/[name].[hash].js`,
+					chunkFileNames: `${settings.config.build.assets}/[name].[hash].js`,
+					assetFileNames: `${settings.config.build.assets}/[name].[hash][extname]`,
 					...viteConfig.build?.rollupOptions?.output,
 				},
 				preserveEntrySignatures: 'exports-only',

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -172,7 +172,7 @@ async function ssrBuild(
 					format: 'esm',
 					// Server chunks can't go in the assets (_astro) folder
 					// We need to keep these separate
-					chunkFileNames: (chunkInfo) {
+					chunkFileNames(chunkInfo) {
 						const { name } = chunkInfo;
 						// Sometimes chunks have the `@_@astro` suffix due to SSR logic. Remove it!
 						// TODO: refactor our build logic to avoid this

--- a/packages/astro/test/sourcemap.test.js
+++ b/packages/astro/test/sourcemap.test.js
@@ -11,7 +11,7 @@ describe('Sourcemap', async () => {
 
 	it('Builds sourcemap', async () => {
 		const dir = await fixture.readdir('./_astro');
-		const counterMap = dir.find((file) => file.match(/^Counter\.\w+\.js\.map$/));
+		const counterMap = dir.find((file) => file.match(/^Counter_\w+\.js\.map$/));
 		expect(counterMap).to.be.ok;
 	});
 

--- a/packages/astro/test/sourcemap.test.js
+++ b/packages/astro/test/sourcemap.test.js
@@ -11,7 +11,7 @@ describe('Sourcemap', async () => {
 
 	it('Builds sourcemap', async () => {
 		const dir = await fixture.readdir('./_astro');
-		const counterMap = dir.find((file) => file.match(/^Counter_\w+\.js\.map$/));
+		const counterMap = dir.find((file) => file.match(/^Counter\.\w+\.js\.map$/));
 		expect(counterMap).to.be.ok;
 	});
 


### PR DESCRIPTION
## Changes

- We were getting reports of the `@astrojs/netlify` adapter being totally broken for `server` and `hybrid` deployments.
- Turns out Astro would sometimes emit chunks with invalid characters `@_@` which Netlify choked on
- The fix is to ensure `chunkFileNames` sanitizes the filename first
- Also changes our chunk asset filenames from something like `dist/server/chunks/index@_@astro.[hash].[ext]` to something like `dist/server/chunks/index_hash.[ext]`
- Notable change is `[name].[hash].[ext]` to `[name]_[hash].[ext]`
- Changeset added!

## Testing

Tested manually with community reproductions. It works!

## Docs

Bug fix only, will alert folks!