### PR TITLE
Remove AstroError if content directory is empty

### DIFF
--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -55,9 +55,11 @@ export function createGetCollection({
 		} else if (collection in dataCollectionToEntryMap) {
 			type = 'data';
 		} else {
-			throw new AstroError({
-				...AstroErrorData.CollectionDoesNotExistError,
-				message: AstroErrorData.CollectionDoesNotExistError.message(collection),
+			return zodString().transform((_, ctx) => {
+				ctx.addIssue({
+					code: ZodIssueCode.custom,
+					message: `The collection **${collection}** does not exist. Ensure a collection directory with this name exists.`,
+				});
 			});
 		}
 		const lazyImports = Object.values(

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -230,6 +230,22 @@ describe('Content Collections', () => {
 		});
 	});
 
+	describe('With empty collections directory', () => {
+		it('Handles the empty directory correclty', async () => {
+			const fixture = await loadFixture({
+				root: './fixtures/content-collections-empty-dir/'
+			});
+			let error;
+			try {
+				await fixture.build();
+			} catch (e) {
+				error = e.message;
+			}
+			expect(error).to.be.undefined;
+			// TODO: try to render a page
+		})
+	})
+
 	describe('SSR integration', () => {
 		let app;
 

--- a/packages/astro/test/fixtures/content-collections-empty-dir/package.json
+++ b/packages/astro/test/fixtures/content-collections-empty-dir/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/content-collections-empty-dir",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/content-collections-empty-dir/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections-empty-dir/src/content/config.ts
@@ -1,0 +1,11 @@
+import { z, defineCollection } from 'astro:content';
+
+const blog = defineCollection({
+	schema: z.object({
+		title: z.string(),
+	}),
+});
+
+export const collections = {
+	blog,
+};

--- a/packages/astro/test/fixtures/content-collections-empty-dir/src/pages/index.astro
+++ b/packages/astro/test/fixtures/content-collections-empty-dir/src/pages/index.astro
@@ -1,0 +1,8 @@
+---
+import { getCollection } from 'astro:content'
+
+const blogs =  await getCollection("blogs")
+// console.log(blogs)
+---
+
+<p>This should still render</p>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2360,6 +2360,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/content-collections-empty-dir:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/content-collections-empty-md-file:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

- Remove `AstroError` in `getCollection` if the targeted content directory is empty 
- Warns instead
- Closes #8336 


## Testing

<!-- How was this change tested? -->
Added a new test in the `content-collection.test.js`, currently work in progress 
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Docs are unaffected by this change

## Still Todo
Wanted to wait for some feedback before:
- [ ] Finish tests
- [ ] changeset