### PR TITLE
chore: use `z.coerce.date()` to pass input through `new Date(input)`.

### DIFF
--- a/.changeset/breezy-sloths-attend.md
+++ b/.changeset/breezy-sloths-attend.md
@@ -1,5 +1,0 @@
----
-'astro': patch
----
-
-Use zod's `z.coerce.date()` to pass input through `new Date(input)`.

--- a/.changeset/breezy-sloths-attend.md
+++ b/.changeset/breezy-sloths-attend.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Use zod's `z.coerce.date()` to pass input through `new Date(input)`.

--- a/examples/blog/src/content/config.ts
+++ b/examples/blog/src/content/config.ts
@@ -6,14 +6,8 @@ const blog = defineCollection({
 		title: z.string(),
 		description: z.string(),
 		// Transform string to Date object
-		pubDate: z
-			.string()
-			.or(z.date())
-			.transform((val) => new Date(val)),
-		updatedDate: z
-			.string()
-			.optional()
-			.transform((str) => (str ? new Date(str) : undefined)),
+		pubDate: z.coerce.date(),
+		updatedDate: z.coerce.date().optional(),
 		heroImage: z.string().optional(),
 	}),
 });

--- a/packages/astro/test/fixtures/content-ssr-integration/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-ssr-integration/src/content/config.ts
@@ -4,11 +4,8 @@ const blog = defineCollection({
 	schema: z.object({
 		title: z.string(),
 		description: z.string(),
-		pubDate: z.string().transform((str) => new Date(str)),
-		updatedDate: z
-			.string()
-			.optional()
-			.transform((str) => (str ? new Date(str) : undefined)),
+		pubDate: z.coerce.date(),
+		updatedDate: z.coerce.date().optional(),
 		heroImage: z.string().optional(),
 	}),
 });

--- a/packages/astro/test/fixtures/content-static-paths-integration/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-static-paths-integration/src/content/config.ts
@@ -4,11 +4,8 @@ const blog = defineCollection({
 	schema: z.object({
 		title: z.string(),
 		description: z.string(),
-		pubDate: z.string().transform((str) => new Date(str)),
-		updatedDate: z
-			.string()
-			.optional()
-			.transform((str) => (str ? new Date(str) : undefined)),
+		pubDate: z.coerce.date(),
+		updatedDate: z.coerce.date().optional(),
 		heroImage: z.string().optional(),
 	}),
 });


### PR DESCRIPTION
This is my first contribution to Astro, please be gentle!

## Changes

- Using `z.coerce.date()` is shorter and simpler.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Shouldn't change behaviour.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

Shouldn't change behaviour.
