### PR TITLE
Fix pipeline `beforeHydrationScript` handling

### DIFF
--- a/.changeset/hot-colts-call.md
+++ b/.changeset/hot-colts-call.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Properly handle `BEFORE_HYDRATION_SCRIPT` generation, fixing MIME type error on hydration.

--- a/packages/astro/src/core/build/buildPipeline.ts
+++ b/packages/astro/src/core/build/buildPipeline.ts
@@ -36,7 +36,7 @@ export class BuildPipeline extends Pipeline {
 				compressHTML: manifest.compressHTML,
 				async resolve(specifier: string) {
 					const hashedFilePath = manifest.entryModules[specifier];
-					if (typeof hashedFilePath !== 'string') {
+					if (typeof hashedFilePath !== 'string' || hashedFilePath === '') {
 						// If no "astro:scripts/before-hydration.js" script exists in the build,
 						// then we can assume that no before-hydration scripts are needed.
 						if (specifier === BEFORE_HYDRATION_SCRIPT_ID) {


### PR DESCRIPTION
## How to use this PR before it's merged

You can install a preview of this branch by running

```shell
npm install astro@next--fix-mime
```

## Changes

- We had an error in our `beforeHydrationScript` handling introduced by the pipeline refactors.
- Thanks to @BlankParticle for [tracking this issue down](https://github.com/withastro/astro/pull/8088/files/ce393bdaf98c1db0a26f0d363f8be769a806046f#r1313949318) and recording their thoughts.
- Closes #8379, closes #8373, closes #8355, closes #8323. If you see any others with a MIME type error on hydration, this would also fix that.

## Testing

Tested manually, should come back to add a regression test for the pipeline

## Docs

Bug fix only