### PR TITLE
Add location data to MDX compile errors

### DIFF
--- a/.changeset/spotty-glasses-grin.md
+++ b/.changeset/spotty-glasses-grin.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Add location data to MDX compile errors


### PR DESCRIPTION
## Changes

- Exposes MDX’s line/column data for errors in the shape Astro expects them so they get shown to users.
- Closes #8404 

## Testing

Tested with a patch. I guess existing tests should pass.

Do we otherwise test error handling?

## Docs

N/A