### PR TITLE
fix: missing imageConfig type in astro:assets

### DIFF
--- a/.changeset/hip-cats-jump.md
+++ b/.changeset/hip-cats-jump.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix missing type for `imageConfig` export from `astro:assets`

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -52,6 +52,7 @@ declare module 'astro:assets' {
 				| import('./dist/assets/types.js').ImageTransform
 				| import('./dist/assets/types.js').UnresolvedImageTransform
 		) => Promise<import('./dist/assets/types.js').GetImageResult>;
+		imageConfig: import('./dist/@types/astro').AstroConfig['image'];
 		getConfiguredImageService: typeof import('./dist/assets/index.js').getConfiguredImageService;
 		Image: typeof import('./components/Image.astro').default;
 	};
@@ -69,7 +70,7 @@ declare module 'astro:assets' {
 	export type RemoteImageProps = Simplify<
 		import('./dist/assets/types.js').RemoteImageProps<ImgAttributes>
 	>;
-	export const { getImage, getConfiguredImageService, Image }: AstroAssets;
+	export const { getImage, getConfiguredImageService, imageConfig, Image }: AstroAssets;
 }
 
 type InputFormat = import('./dist/assets/types.js').ImageInputFormat;


### PR DESCRIPTION
## Changes

Not sure how that happened, but we lost https://github.com/withastro/astro/pull/8171 in the rebasing process. This PR just brings it back

## Testing

Tested manually

## Docs

N/A
