### PR TITLE
Skip cloudflare CLI tests if fail to start

### DIFF
--- a/packages/integrations/cloudflare/test/basics.test.js
+++ b/packages/integrations/cloudflare/test/basics.test.js
@@ -8,14 +8,18 @@ describe('Basic app', () => {
 	/** @type {import('./test-utils').WranglerCLI} */
 	let cli;
 
-	before(async () => {
+	before(async function () {
 		fixture = await loadFixture({
 			root: './fixtures/basics/',
 		});
 		await fixture.build();
 
 		cli = await runCLI('./fixtures/basics/', { silent: true, port: 8789 });
-		await cli.ready;
+		await cli.ready.catch((e) => {
+			console.log(e);
+			// if fail to start, skip for now as it's very flaky
+			this.skip();
+		});
 	});
 
 	after(async () => {

--- a/packages/integrations/cloudflare/test/cf.test.js
+++ b/packages/integrations/cloudflare/test/cf.test.js
@@ -9,7 +9,7 @@ describe('Cf metadata and caches', () => {
 	/** @type {import('./test-utils').WranglerCLI} */
 	let cli;
 
-	before(async () => {
+	before(async function () {
 		fixture = await loadFixture({
 			root: './fixtures/cf/',
 			output: 'server',
@@ -17,8 +17,12 @@ describe('Cf metadata and caches', () => {
 		});
 		await fixture.build();
 
-		cli = await runCLI('./fixtures/cf/', { silent: false, port: 8788 });
-		await cli.ready;
+		cli = await runCLI('./fixtures/cf/', { silent: true, port: 8786 });
+		await cli.ready.catch((e) => {
+			console.log(e);
+			// if fail to start, skip for now as it's very flaky
+			this.skip();
+		});
 	});
 
 	after(async () => {

--- a/packages/integrations/cloudflare/test/cf.test.js
+++ b/packages/integrations/cloudflare/test/cf.test.js
@@ -30,7 +30,7 @@ describe('Cf metadata and caches', () => {
 	});
 
 	it('Load cf and caches API', async () => {
-		let res = await fetch(`http://127.0.0.1:8788/`);
+		let res = await fetch(`http://127.0.0.1:8786/`);
 		expect(res.status).to.equal(200);
 		let html = await res.text();
 		let $ = cheerio.load(html);

--- a/packages/integrations/cloudflare/test/runtime.test.js
+++ b/packages/integrations/cloudflare/test/runtime.test.js
@@ -9,7 +9,7 @@ describe('Runtime Locals', () => {
 	/** @type {import('./test-utils.js').WranglerCLI} */
 	let cli;
 
-	before(async () => {
+	before(async function () {
 		fixture = await loadFixture({
 			root: './fixtures/runtime/',
 			output: 'server',
@@ -18,7 +18,11 @@ describe('Runtime Locals', () => {
 		await fixture.build();
 
 		cli = await runCLI('./fixtures/runtime/', { silent: true, port: 8793 });
-		await cli.ready;
+		await cli.ready.catch((e) => {
+			console.log(e);
+			// if fail to start, skip for now as it's very flaky
+			this.skip();
+		});
 	});
 
 	after(async () => {

--- a/packages/integrations/cloudflare/test/with-solid-js.test.js
+++ b/packages/integrations/cloudflare/test/with-solid-js.test.js
@@ -8,14 +8,18 @@ describe('With SolidJS', () => {
 	/** @type {import('./test-utils').WranglerCLI} */
 	let cli;
 
-	before(async () => {
+	before(async function () {
 		fixture = await loadFixture({
 			root: './fixtures/with-solid-js/',
 		});
 		await fixture.build();
 
 		cli = await runCLI('./fixtures/with-solid-js/', { silent: true, port: 8790 });
-		await cli.ready;
+		await cli.ready.catch((e) => {
+			console.log(e);
+			// if fail to start, skip for now as it's very flaky
+			this.skip();
+		});
 	});
 
 	after(async () => {


### PR DESCRIPTION
## Changes

cc @Princesseuh

I tried to use retries, but Mocha doesn't support it in the `before` hook. Implementing retries manually is also tricky, so I went with this PR instead - Try to run the test as usual, but if startup fails, skip the test suite.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Ran the cloudflare tests locally. I've not seen it fail locally though.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a.