### PR TITLE
Fix markdown page HMR

### DIFF
--- a/.changeset/twelve-cars-tell.md
+++ b/.changeset/twelve-cars-tell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix markdown page HMR

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -107,7 +107,7 @@ export default function markdown({ settings, logger }: AstroPluginOptions): Plug
 				}
 
 				const code = escapeViteEnvReferences(`
-				import { unescapeHTML, spreadAttributes, createComponent, render, renderComponent } from ${JSON.stringify(
+				import { unescapeHTML, spreadAttributes, createComponent, render, renderComponent, maybeRenderHead } from ${JSON.stringify(
 					astroServerRuntimeModulePath
 				)};
 				import { AstroError, AstroErrorData } from ${JSON.stringify(astroErrorModulePath)};
@@ -180,10 +180,9 @@ export default function markdown({ settings, logger }: AstroPluginOptions): Plug
 							}, {
 								'default': () => render\`\${unescapeHTML(html)}\`
 							})}\`;`
-							: `render\`\${unescapeHTML(html)}\`;`
+							: `render\`\${maybeRenderHead(result)}\${unescapeHTML(html)}\`;`
 					}
 				});
-				Content[Symbol.for('astro.needsHeadRendering')] = ${layout ? 'false' : 'true'};
 				export default Content;
 				`);
 

--- a/packages/astro/test/astro-pages.test.js
+++ b/packages/astro/test/astro-pages.test.js
@@ -49,5 +49,10 @@ describe('Pages', () => {
 
 			expect($('#testing').length).to.be.greaterThan(0);
 		});
+
+		it('should have Vite client in dev', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			expect(html).to.include('/@vite/client', 'Markdown page does not have Vite client for HMR');
+		});
 	});
 });


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/8378

The [JSX refactor PR](https://github.com/withastro/astro/pull/7924) updated vite-plugin-markdown so it returns an Astro component instance. When rendering Astro components, head is not rendered by default unless it calls `renderHead` or `maybeRenderHead`, which it doesn't.

This PR adds it to preserve the previous behaviour, and to fix the HMR issue.

Before the PR, markdown pages return non-Astro components and it has automatic head rendering, denoted by the `astro.needsHeadRendering` symbol. So it worked before.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added a new test to ensure to Vite script is added.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.