### PR TITLE
fix: caching not working for `astro:assets`

### DIFF
--- a/.changeset/empty-rings-bow.md
+++ b/.changeset/empty-rings-bow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes remote assets caching logic to not use expired assets

--- a/packages/astro/src/assets/build/generate.ts
+++ b/packages/astro/src/assets/build/generate.ts
@@ -75,7 +75,7 @@ export async function generateImage(
 			const JSONData = JSON.parse(readFileSync(cachedFileURL, 'utf-8')) as RemoteCacheEntry;
 
 			// If the cache entry is not expired, use it
-			if (JSONData.expires < Date.now()) {
+			if (JSONData.expires > Date.now()) {
 				await fs.promises.writeFile(finalFileURL, Buffer.from(JSONData.data, 'base64'));
 
 				return {


### PR DESCRIPTION
## Changes

It reverses the check for remote images in `astro:assets`, `JSONData.expires` should be higher than `Date.now()`, not lower.

## Testing

No new tests, but tested locally by changing the sign.

## Docs

Actually makes what the docs say should happen.
