### PR TITLE
Fix React dev mode using a base

### DIFF
--- a/.changeset/cold-knives-peel.md
+++ b/.changeset/cold-knives-peel.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': patch
+---
+
+Fix React dev mode using a base

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -45,7 +45,6 @@
     "dev": "astro-scripts dev \"src/**/*.ts\""
   },
   "dependencies": {
-    "@astrojs/internal-helpers": "0.2.0",
     "@vitejs/plugin-react": "^4.0.4",
     "ultrahtml": "^1.3.0"
   },

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -1,4 +1,3 @@
-import { appendForwardSlash } from '@astrojs/internal-helpers/path';
 import react, { type Options as ViteReactPluginOptions } from '@vitejs/plugin-react';
 import type { AstroIntegration } from 'astro';
 import { version as ReactVersion } from 'react-dom';
@@ -94,7 +93,7 @@ export default function ({
 	return {
 		name: '@astrojs/react',
 		hooks: {
-			'astro:config:setup': ({ config, command, addRenderer, updateConfig, injectScript }) => {
+			'astro:config:setup': ({ command, addRenderer, updateConfig, injectScript }) => {
 				addRenderer(getRenderer());
 				updateConfig({
 					vite: getViteConfiguration({ include, exclude, experimentalReactChildren }),
@@ -102,7 +101,7 @@ export default function ({
 				if (command === 'dev') {
 					const preamble = FAST_REFRESH_PREAMBLE.replace(
 						`__BASE__`,
-						appendForwardSlash(config.base)
+						'/'
 					);
 					injectScript('before-hydration', preamble);
 				}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4514,9 +4514,6 @@ importers:
 
   packages/integrations/react:
     dependencies:
-      '@astrojs/internal-helpers':
-        specifier: 0.2.0
-        version: link:../../internal-helpers
       '@vitejs/plugin-react':
         specifier: ^4.0.4
         version: 4.0.4(vite@4.4.9)


### PR DESCRIPTION
## Changes

- React Refresh is the module `@react-refresh`. Previously we were loading it as `/basepathname/@react-refresh`. Instead packages need to be loaded from the absolute root, regardless of whether a base is used or not.
- Fixes https://github.com/withastro/astro/issues/8352

## Testing

- Tested in a demo project.
- Can't be tested in our integration tests due to it requiring the browser loading the module.

## Docs

N/A, bug fix