### PR TITLE
Temporarily pin Node 20 version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         OS: [ubuntu-latest]
-        NODE_VERSION: [18, 20]
+        NODE_VERSION: [18, 20.5.1]
         include:
           - os: macos-latest
             NODE_VERSION: 18


### PR DESCRIPTION
## Changes

- Node 20 is currently broken, pinning our tests to the last working version to unblock PRs.
