### PR TITLE
fix: MDX errors not having stack trace and a confusing name

### DIFF
--- a/.changeset/olive-deers-switch.md
+++ b/.changeset/olive-deers-switch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Fix errors not having a stacktrace

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -153,7 +153,14 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 										};
 									} catch (e: any) {
 										const err: SSRError = e;
+
+										// For some reason MDX puts the error location in the error's name, not very useful for us.
+										err.name = 'MDXError';
 										err.loc = { file: fileId, line: e.line, column: e.column };
+
+										// For another some reason, MDX doesn't include a stack trace. Weird
+										Error.captureStackTrace(err);
+
 										throw err;
 									}
 								},


### PR DESCRIPTION
## Changes

What the title says, errors in MDX are very weird. The position in the error name is very creative, but not very useful for us

## Testing

Tested manually

## Docs

N/A
