### PR TITLE
Fix `renderToFinalDestination` handling

### DIFF
--- a/.changeset/tame-fans-happen.md
+++ b/.changeset/tame-fans-happen.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix issue where `renderToFinalDestination` would throw in internal Astro code

--- a/packages/astro/src/runtime/server/render/any.ts
+++ b/packages/astro/src/runtime/server/render/any.ts
@@ -18,6 +18,7 @@ export async function renderChild(destination: RenderDestination, child: any) {
 			});
 		});
 		for (const childRender of childRenders) {
+			if (!childRender) continue;
 			await childRender.renderToFinalDestination(destination);
 		}
 	} else if (typeof child === 'function') {


### PR DESCRIPTION
## Changes

- Closes #8434
- Properly handles children that return `undefined`
- Seems to happen with Markdown content mainly? Not sure why.

## Testing

Manually tested with user reproduction

## Docs

Bug fix only