### PR TITLE
Fix "Cannot read properties of null" in cli/telemetry

### DIFF
--- a/.changeset/strong-colts-hang.md
+++ b/.changeset/strong-colts-hang.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix "Cannot read properties of null" error in CLI code

--- a/packages/astro/src/cli/telemetry/index.ts
+++ b/packages/astro/src/cli/telemetry/index.ts
@@ -9,7 +9,7 @@ interface TelemetryOptions {
 }
 
 export async function notify() {
-	const packageManager = (await whichPm(process.cwd())).name ?? 'npm';
+	const packageManager = (await whichPm(process.cwd()))?.name ?? 'npm';
 	await telemetry.notify(() => {
 		console.log(msg.telemetryNotice(packageManager) + '\n');
 		return true;


### PR DESCRIPTION
## Changes

Latest version of Astro is throwing the following error on CI:

```
error   Cannot read properties of null (reading 'name')
    File:
      node_modules/astro/dist/cli/telemetry/index.js:5:57
    Code:
      4 | async function notify() {
      > 5 |   const packageManager = (await whichPm(process.cwd())).name ?? "npm";
          |                                                         ^
        6 |   await telemetry.notify(() => {
        7 |     console.log(msg.telemetryNotice(packageManager) + "\n");
        8 |     return true;
    Stacktrace:
  TypeError: Cannot read properties of null (reading 'name')
      at notify (node_modules/astro/dist/cli/telemetry/index.js:5:57)
      at async runCommand (node_modules/astro/dist/cli/index.js:97:3)
      at async cli (node_modules/astro/dist/cli/index.js:144:5)
```

I will add changsets if this gets approved

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
