### PR TITLE
Unmount Svelte islands properly on navigation

### DIFF
--- a/.changeset/sweet-sheep-sell.md
+++ b/.changeset/sweet-sheep-sell.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/svelte': patch
+---
+
+Fix potential memory leak when component is unmounted

--- a/packages/integrations/svelte/client.js
+++ b/packages/integrations/svelte/client.js
@@ -3,9 +3,9 @@ const noop = () => {};
 let originalConsoleWarning;
 let consoleFilterRefs = 0;
 
-export default (target) => {
+export default (element) => {
 	return (Component, props, slotted, { client }) => {
-		if (!target.hasAttribute('ssr')) return;
+		if (!element.hasAttribute('ssr')) return;
 		const slots = {};
 		for (const [key, value] of Object.entries(slotted)) {
 			slots[key] = createSlotDefinition(key, value);
@@ -15,7 +15,7 @@ export default (target) => {
 			if (import.meta.env.DEV) useConsoleFilter();
 
 			const component = new Component({
-				target,
+				target: element,
 				props: {
 					...props,
 					$$slots: slots,


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/astro/issues/8435
- `element` variable didn't exist (whoops, another good reason to use TypeScript)
- Renamed `target` to `element` for consistency

## Testing

Manually

## Docs

Bug fix only