### PR TITLE
Fix multi-layout head injection

### DIFF
--- a/.changeset/orange-cheetahs-happen.md
+++ b/.changeset/orange-cheetahs-happen.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix multi-layout head injection

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -421,6 +421,9 @@ function renderAstroComponent(
 	slots: any = {}
 ): RenderInstance {
 	const instance = createAstroComponentInstance(result, displayName, Component, props, slots);
+	// Initialize the instance early so that child components with head propagation
+	// are able to register themselves.
+	instance.init(result);
 	return {
 		async render(destination) {
 			// NOTE: This render call can't be pre-invoked outside of this function as it'll also initialize the slots

--- a/packages/astro/test/units/dev/head-injection.test.js
+++ b/packages/astro/test/units/dev/head-injection.test.js
@@ -123,27 +123,38 @@ describe('head injection', () => {
 						});
 					}
 				`.trim(),
+				'/src/components/Content.astro': `
+				---
+				import { renderEntry } from '../common/head.js';
+				const ExtraHead = renderEntry();
+				---
+				<ExtraHead />
+				`,
+				'/src/components/Inner.astro': `
+				---
+				import Content from './Content.astro';
+				---
+				<Content />
+				`,
 				'/src/components/Layout.astro': `
-					---
-					import { renderEntry } from '../common/head.js';
-					const ExtraHead = renderEntry();
-					---
 					<html>
 						<head>
 							<title>Normal head stuff</title>
 						</head>
 						<body>
 							<slot name="title" />
-							<ExtraHead />
+							<slot name="inner" />
 						</body>
 					</html>
 				`,
 				'/src/pages/index.astro': `
 					---
 					import Layout from '../components/Layout.astro';
+					import Inner from '../components/Inner.astro';
 					---
 					<Layout>
 						<h1 slot="title">Test page</h1>
+						<Inner slot="inner" />
 					</Layout>
 				`,
 			},
@@ -168,8 +179,8 @@ describe('head injection', () => {
 				const html = await text();
 				const $ = cheerio.load(html);
 
-				expect($('link[rel=stylesheet][href="/some/fake/styles.css"]')).to.have.a.lengthOf(1);
-				expect($('#other')).to.have.a.lengthOf(1);
+				expect($('link[rel=stylesheet][href="/some/fake/styles.css"]')).to.have.a.lengthOf(1, 'found inner link');
+				expect($('#other')).to.have.a.lengthOf(1, 'Found the #other div');
 			}
 		);
 	});


### PR DESCRIPTION
## Changes

- How head propagation works in a nutshell:
  1. Every component that has head content to propagate has special metadata.
  2. When we begin to render a page we call `instance.init(result)`.
  3. Components with this metadata add it to the result.
  4. When we buffer head content we wait for each of these `init`s to complete. We do it recursively so that if they have children with head content those are also awaited.
  5. When there's nothing left to wait on, head content is done and rendering begins.
- The bug is that we were not calling `init()` until (5), so it trivially was working for single children, but not for deep children in layouts.
- The fix is to call init when an Astro template runs so that it can register itself.

- Fixes https://github.com/withastro/astro/issues/8399
- Fixes https://github.com/withastro/astro/issues/8392
- Fixes https://github.com/withastro/astro/issues/7761

## Testing

- Updated an existing test case but went deeper to add an extra layer of layout which triggers the need to call `renderAstroComponent` which is where the bug is.

## Docs

N/A, bug fix.