### PR TITLE
fix(react): support void children in experimentalReactChildren

### DIFF
--- a/.changeset/cool-jokes-unite.md
+++ b/.changeset/cool-jokes-unite.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': patch
+---
+
+Update `experimentalReactChildren` behavior to support void tags

--- a/packages/integrations/react/vnode-children.js
+++ b/packages/integrations/react/vnode-children.js
@@ -1,9 +1,12 @@
 import { parse, walkSync, DOCUMENT_NODE, ELEMENT_NODE, TEXT_NODE } from 'ultrahtml';
 import { createElement, Fragment } from 'react';
 
+let ids = 0;
 export default function convert(children) {
 	const nodeMap = new WeakMap();
 	let doc = parse(children.toString().trim());
+	let id = ids++;
+	let key = 0;
 	let root = createElement(Fragment, { children: [] });
 
 	walkSync(doc, (node, parent, index) => {
@@ -12,23 +15,18 @@ export default function convert(children) {
 			nodeMap.set(node, root);
 		} else if (node.type === ELEMENT_NODE) {
 			const { class: className, ...props } = node.attributes;
-			newNode = createElement(node.name, { ...props, className, children: [] });
+			// NOTE: do not manually pass `children`, React handles this internally
+			newNode = createElement(node.name, { ...props, className, key: `${id}-${key++}` });
 			nodeMap.set(node, newNode);
 			if (parent) {
 				const newParent = nodeMap.get(parent);
 				newParent.props.children[index] = newNode;
 			}
 		} else if (node.type === TEXT_NODE) {
-			newNode = node.value.trim();
-			if (newNode.trim()) {
-				if (parent) {
-					const newParent = nodeMap.get(parent);
-					if (parent.children.length === 1) {
-						newParent.props.children[0] = newNode;
-					} else {
-						newParent.props.children[index] = newNode;
-					}
-				}
+			newNode = node.value;
+			if (newNode.trim() && parent) {
+				const newParent = nodeMap.get(parent);
+				newParent.props.children[index] = newNode;
 			}
 		}
 	});


### PR DESCRIPTION
## Changes

- Fixes #8432
- We were manually creating children with a `{ children: [] }` prop, which broke void elements like `hr` and `img`.
- Turns out that React creates `props.children` on the vnode automatically, so it's already there if we need to push children onto the stack.
- Also cleaned up some `key` warnings by automatically generating a unique ID for each child.

## Testing

Tested manually with the repro provided

## Docs

N/A, bug fix only