### PR TITLE
refactor: move type utils into a single file

### DIFF
--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -57,17 +57,15 @@ declare module 'astro:assets' {
 		Image: typeof import('./components/Image.astro').default;
 	};
 
-	type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
-	type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {};
-	type ImgAttributes = WithRequired<
+	type ImgAttributes = import('./dist/type-utils.js').WithRequired<
 		Omit<import('./types').HTMLAttributes<'img'>, 'src' | 'width' | 'height'>,
 		'alt'
 	>;
 
-	export type LocalImageProps = Simplify<
+	export type LocalImageProps = import('./dist/type-utils.js').Simplify<
 		import('./dist/assets/types.js').LocalImageProps<ImgAttributes>
 	>;
-	export type RemoteImageProps = Simplify<
+	export type RemoteImageProps = import('./dist/type-utils.js').Simplify<
 		import('./dist/assets/types.js').RemoteImageProps<ImgAttributes>
 	>;
 	export const { getImage, getConfiguredImageService, imageConfig, Image }: AstroAssets;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -22,6 +22,7 @@ import type { AstroCookies } from '../core/cookies';
 import type { ResponseWithEncoding } from '../core/endpoint/index.js';
 import type { AstroIntegrationLogger, Logger, LoggerLevel } from '../core/logger/core';
 import type { AstroComponentFactory, AstroComponentInstance } from '../runtime/server';
+import type { OmitIndexSignature, Simplify } from '../type-utils';
 import type { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from './../core/constants.js';
 
 export { type AstroIntegrationLogger };
@@ -1725,14 +1726,6 @@ export interface Page<T = any> {
 	};
 }
 
-type OmitIndexSignature<ObjectType> = {
-	// eslint-disable-next-line @typescript-eslint/ban-types
-	[KeyType in keyof ObjectType as {} extends Record<KeyType, unknown>
-		? never
-		: KeyType]: ObjectType[KeyType];
-};
-// eslint-disable-next-line @typescript-eslint/ban-types
-type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {};
 export type PaginateFunction = <
 	PaginateData,
 	AdditionalPaginateProps extends Props,

--- a/packages/astro/src/assets/types.ts
+++ b/packages/astro/src/assets/types.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-types */
+import type { WithRequired } from '../type-utils.js';
 import type { VALID_INPUT_FORMATS, VALID_OUTPUT_FORMATS } from './consts.js';
 import type { ImageService } from './services/service.js';
 
@@ -50,7 +51,6 @@ export interface GetImageResult {
 	attributes: Record<string, any>;
 }
 
-type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 type ImageSharedProps<T> = T & {
 	/**
 	 * Width of the image, the value of this property will be used to assign the `width` property on the final `img` element.

--- a/packages/astro/src/runtime/server/serialize.ts
+++ b/packages/astro/src/runtime/server/serialize.ts
@@ -1,6 +1,5 @@
 import type { AstroComponentMetadata } from '../../@types/astro';
-
-type ValueOf<T> = T[keyof T];
+import type { ValueOf } from '../../type-utils';
 
 const PROP_TYPE = {
 	Value: 0,

--- a/packages/astro/src/type-utils.ts
+++ b/packages/astro/src/type-utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-types */
 // Q: Why is this not in @types?
 // A: `@types` is for types that are part of the public API. This is just a bunch of utilities we use throughout the codebase. (Mostly by Erika)
 

--- a/packages/astro/src/type-utils.ts
+++ b/packages/astro/src/type-utils.ts
@@ -1,0 +1,20 @@
+// Q: Why is this not in @types?
+// A: `@types` is for types that are part of the public API. This is just a bunch of utilities we use throughout the codebase. (Mostly by Erika)
+
+// Merge all the intersection of a type into one type. This is useful for making tooltips better in the editor for complex types
+// Ex: The Image component props are a merge of all the properties that can be on an `img` tag and our props, in the editor
+// this results in a very opaque type that just says `ImgAttributes & ImageComponentProps`. With this, all the props shows.
+export type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {};
+
+// Mark certain properties of a type as required. Think of it like "This type, with those specific properties required"
+export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+
+// Name is pretty self descriptive, but it removes the index signature of an object
+export type OmitIndexSignature<ObjectType> = {
+	[KeyType in keyof ObjectType as {} extends Record<KeyType, unknown>
+		? never
+		: KeyType]: ObjectType[KeyType];
+};
+
+// Similar to `keyof`, gets the type of all the values of an object
+export type ValueOf<T> = T[keyof T];


### PR DESCRIPTION
## Changes

I love `Simplify<T>`, but I'll admit I don't need 3 of it in the same code base

## Testing

N/A

## Docs

N/A
