### PR TITLE
doc: usage trend

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Several official projects are maintained outside of this repo:
 - [Open Governance & Voting](https://github.com/withastro/.github/blob/main/GOVERNANCE.md)
 - [Project Funding](https://github.com/withastro/.github/blob/main/FUNDING.md)
 - [Website](https://astro.build/)
+- [Usage Trend of Astro Packages](https://npm-compare.com/astro,create-astro,@astrojs/react,@astrojs/preact,@astrojs/solid-js,@astrojs/svelte,@astrojs/vue,@astrojs/lit,@astrojs/deno,@astrojs/netlify,@astrojs/node,@astrojs/vercel,@astrojs/cloudflare,@astrojs/partytown,@astrojs/sitemap,@astrojs/tailwind,@astrojs/alpinejs,@astrojs/mdx,@astrojs/prefetch)
 
 ## Sponsors
 


### PR DESCRIPTION
 I am reaching out to request a small addition to the README file of the Astro family packages repository.

As an Astro.js user, I believe it would greatly benefit the community if we could include a link to the npm usage trend for the Astro.js family packages. Including this link in the README will provide a quick and convenient way for users to access this valuable information and stay updated with the Astro.js ecosystem.

Please consider this request, and if you find it reasonable. Thank you for considering my suggestion.