### PR TITLE
Removed `<style>` with `type="text/css"` from inline output at build time

### DIFF
--- a/.changeset/gorgeous-dancers-divide.md
+++ b/.changeset/gorgeous-dancers-divide.md
@@ -1,7 +1,7 @@
 ---
-'@astrojs/deno': minor
-'@astrojs/node': minor
-'astro': minor
+'@astrojs/deno': patch
+'@astrojs/node': patch
+'astro': patch
 ---
 
 Do not add type="text/css" to inline style tag

--- a/.changeset/gorgeous-dancers-divide.md
+++ b/.changeset/gorgeous-dancers-divide.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/deno': minor
+'@astrojs/node': minor
+'astro': minor
+---
+
+Do not add type="text/css" to inline style tag

--- a/.changeset/gorgeous-dancers-divide.md
+++ b/.changeset/gorgeous-dancers-divide.md
@@ -1,6 +1,4 @@
 ---
-'@astrojs/deno': patch
-'@astrojs/node': patch
 'astro': patch
 ---
 

--- a/packages/astro/src/core/render/ssr-element.ts
+++ b/packages/astro/src/core/render/ssr-element.ts
@@ -19,9 +19,7 @@ export function createStylesheetElement(
 ): SSRElement {
 	if (stylesheet.type === 'inline') {
 		return {
-			props: {
-				type: 'text/css',
-			},
+			props: {},
 			children: stylesheet.content,
 		};
 	} else {

--- a/packages/astro/src/runtime/client/hmr.ts
+++ b/packages/astro/src/runtime/client/hmr.ts
@@ -1,8 +1,8 @@
 /// <reference types="vite/client" />
 
 if (import.meta.hot) {
-	// Vite injects `<style type="text/css" data-vite-dev-id>` for ESM imports of styles
-	// but Astro also SSRs with `<style type="text/css" data-astro-dev-id>` blocks. This MutationObserver
+	// Vite injects `<style data-vite-dev-id>` for ESM imports of styles
+	// but Astro also SSRs with `<style data-astro-dev-id>` blocks. This MutationObserver
 	// removes any duplicates as soon as they are hydrated client-side.
 	const injectedStyles = getInjectedStyles();
 	const mo = new MutationObserver((records) => {
@@ -44,7 +44,6 @@ function isStyle(node: Node): node is HTMLStyleElement {
 function isViteInjectedStyle(node: Node): node is HTMLStyleElement {
 	return (
 		isStyle(node) &&
-		node.getAttribute('type') === 'text/css' &&
 		!!node.getAttribute('data-vite-dev-id')
 	);
 }

--- a/packages/astro/src/runtime/server/render/tags.ts
+++ b/packages/astro/src/runtime/server/render/tags.ts
@@ -17,6 +17,6 @@ export function renderUniqueStylesheet(result: SSRResult, sheet: StylesheetAsset
 
 	if (sheet.type === 'inline') {
 		if (Array.from(result.styles).some((s) => s.children.includes(sheet.content))) return '';
-		return renderElement('style', { props: { type: 'text/css' }, children: sheet.content });
+		return renderElement('style', { props: {}, children: sheet.content });
 	}
 }

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -324,7 +324,6 @@ async function getScriptsAndStyles({ pipeline, filePath }: GetScriptsAndStylesPa
 		// But we still want to inject the styles to avoid FOUC
 		styles.add({
 			props: {
-				type: 'text/css',
 				// Track the ID so we can match it to Vite's injected style later
 				'data-astro-dev-id': viteID(new URL(`.${url}`, settings.config.root)),
 			},

--- a/packages/integrations/deno/test/basics.test.ts
+++ b/packages/integrations/deno/test/basics.test.ts
@@ -50,8 +50,6 @@ Deno.test({
 			const doc = new DOMParser().parseFromString(html, `text/html`);
 			const style = doc!.querySelector('style');
 
-			assertEquals(style?.getAttribute('type'), 'text/css');
-
 			assert(style?.textContent?.includes('Courier New'));
 		});
 

--- a/packages/integrations/node/test/prerender-404-500.test.js
+++ b/packages/integrations/node/test/prerender-404-500.test.js
@@ -101,7 +101,7 @@ describe('Prerender 404', () => {
 			const $ = cheerio.load(html);
 
 			// length will be 0 if the stylesheet does not get included
-			expect($('style[type="text/css"]')).to.have.a.lengthOf(1);
+			expect($('style')).to.have.a.lengthOf(1);
 		});
 	});
 


### PR DESCRIPTION
## Changes

- It is deprecated to add `type="text/css"` to style elements.

> Authors should not specify a [type](https://html.spec.whatwg.org/multipage/obsolete.html#attr-style-type) attribute on a [style](https://html.spec.whatwg.org/multipage/semantics.html#the-style-element) element.
> https://html.spec.whatwg.org/multipage/obsolete.html#obsolete-but-conforming-features

> ## Deprecated attributes
> `type`
> This attribute should not be provided
> https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style#deprecated_attributes

- [Nu HTMLChecker](https://validator.w3.org/nu/) will give you a warning

![Warning: The type attribute for the style element is not needed and should be omitted.](https://github.com/withastro/astro/assets/1996642/2d30c438-e965-4c90-8d3b-8381e7c1cd62)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

- Remove the part that detects `type="text/css"`.
  - packages/integrations/deno/test/basics.test.ts
  - packages/integrations/node/test/prerender-404-500.test.js

<!-- ## Docs -->

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
