### PR TITLE
Bugfixes for back navigation in the view transition client-side router

### DIFF
--- a/.changeset/witty-readers-behave.md
+++ b/.changeset/witty-readers-behave.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Bugfixes for back navigation in the view transition client-side router

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -340,7 +340,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 					ev.preventDefault();
 					// push state on the first navigation but not if we were here already
 					if (location.hash) {
-						history.replaceState({ index: currentHistoryIndex, scrollY: -(scrollY + 1)}, '');
+						history.replaceState({ index: currentHistoryIndex, scrollY: -(scrollY + 1) }, '');
 						const newState: State = { index: ++currentHistoryIndex, scrollY: 0 };
 						history.pushState(newState, '', link.href);
 					}
@@ -387,7 +387,6 @@ const { fallback = 'animate' } = Astro.props as Props;
 			const direction: Direction = nextIndex > currentHistoryIndex ? 'forward' : 'back';
 			currentHistoryIndex = nextIndex;
 			if (state.scrollY < 0) {
-				console.log("restoring", state.scrollY);
 				scrollTo(0, -(state.scrollY + 1));
 			} else {
 				navigate(direction, new URL(location.href), state);

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -263,7 +263,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 		}
 
 		// Now we are sure that we will push state, and it is time to create a state if it is still missing.
-		!state && history.replaceState({ index: currentHistoryIndex, scrollY}, '');
+		!state && history.replaceState({ index: currentHistoryIndex, scrollY }, '');
 
 		document.documentElement.dataset.astroTransition = dir;
 		if (supportsViewTransitions) {
@@ -338,6 +338,12 @@ const { fallback = 'animate' } = Astro.props as Props;
 					// But we want to handle it like any other same page navigation
 					// So we scroll to the top of the page but do not start page transitions
 					ev.preventDefault();
+					// push state on the first navigation but not if we were here already
+					if (location.hash) {
+						history.replaceState({ index: currentHistoryIndex, scrollY: -(scrollY + 1)}, '');
+						const newState: State = { index: ++currentHistoryIndex, scrollY: 0 };
+						history.pushState(newState, '', link.href);
+					}
 					scrollTo({ left: 0, top: 0, behavior: 'instant' });
 					return;
 				}
@@ -350,7 +356,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 
 		addEventListener('popstate', (ev) => {
 			if (!transitionEnabledOnThisPage() && ev.state) {
-				// The current page doesn't have View Transitions enabled 
+				// The current page doesn't have View Transitions enabled
 				// but the page we navigate to does (because it set the state).
 				// Do a full page refresh to reload the client-side router from the new page.
 				// Scroll restauration will then happen during the reload when the router's code is re-executed
@@ -380,7 +386,12 @@ const { fallback = 'animate' } = Astro.props as Props;
 			const nextIndex = state.index;
 			const direction: Direction = nextIndex > currentHistoryIndex ? 'forward' : 'back';
 			currentHistoryIndex = nextIndex;
-			navigate(direction, new URL(location.href), state);
+			if (state.scrollY < 0) {
+				console.log("restoring", state.scrollY);
+				scrollTo(0, -(state.scrollY + 1));
+			} else {
+				navigate(direction, new URL(location.href), state);
+			}
 		});
 
 		['mouseenter', 'touchstart', 'focus'].forEach((evName) => {

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -262,6 +262,9 @@ const { fallback = 'animate' } = Astro.props as Props;
 			return;
 		}
 
+		// Now we are sure that we will push state, and it is time to create a state if it is still missing.
+		!state && history.replaceState({ index: currentHistoryIndex, scrollY}, '');
+
 		document.documentElement.dataset.astroTransition = dir;
 		if (supportsViewTransitions) {
 			finished = document.startViewTransition(() => updateDOM(doc, loc, state)).finished;
@@ -335,28 +338,22 @@ const { fallback = 'animate' } = Astro.props as Props;
 					// But we want to handle it like any other same page navigation
 					// So we scroll to the top of the page but do not start page transitions
 					ev.preventDefault();
-					persistState({ ...history.state, scrollY });
 					scrollTo({ left: 0, top: 0, behavior: 'instant' });
-					if (location.hash) {
-						// last target was different
-						const newState: State = { index: ++currentHistoryIndex, scrollY: 0 };
-						history.pushState(newState, '', link.href);
-					}
 					return;
 				}
 			}
 
 			// these are the cases we will handle: same origin, different page
 			ev.preventDefault();
-			persistState({ index: currentHistoryIndex, scrollY });
 			navigate('forward', new URL(link.href));
 		});
 
 		addEventListener('popstate', (ev) => {
 			if (!transitionEnabledOnThisPage() && ev.state) {
-				// The current page doesn't haven't View Transitions,
-				// respect that with a full page reload
-				// -- but only for transition managed by us (ev.state is set)
+				// The current page doesn't have View Transitions enabled 
+				// but the page we navigate to does (because it set the state).
+				// Do a full page refresh to reload the client-side router from the new page.
+				// Scroll restauration will then happen during the reload when the router's code is re-executed
 				history.scrollRestoration && (history.scrollRestoration = 'manual');
 				location.reload();
 				return;

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -282,6 +282,28 @@ test.describe('View Transitions', () => {
 		await expect(locator).toBeInViewport();
 	});
 
+	test('Scroll position restored when transitioning back to fragment', async ({ page, astro }) => {
+		// Go to the long page
+		await page.goto(astro.resolveUrl('/long-page'));
+		let locator = page.locator('#longpage');
+		await expect(locator).toBeInViewport();
+
+		// Scroll down to middle fragment
+		await page.click('#click-scroll-down');
+		locator = page.locator('#click-one-again');
+		await expect(locator).toBeInViewport();
+
+		// Scroll up to top fragment
+		await page.click('#click-one-again');
+		locator = page.locator('#one');
+		await expect(locator).toHaveText('Page 1');
+
+		// Back to middle of the page
+		await page.goBack();
+		locator = page.locator('#click-one-again');
+		await expect(locator).toBeInViewport();
+	});
+
 	test('Scroll position restored on forward button', async ({ page, astro }) => {
 		// Go to page 1
 		await page.goto(astro.resolveUrl('/one'));


### PR DESCRIPTION
## Changes

L266 + L351: This fix was mainly triggered by a bug I introduced with 3.0.11: backward navigation was no longer possible when starting from a history state that was not pushed by the CSR (e.g. navigate to a #fragment on a VT page and navigate to another page from there). 

~~Other change: the handling of self links used to call pushState, so you would have that jump in the history as well. But that doesn't really work, because we would do transitions at history navigation. (in popstate it is not possible to see if we have been on the same page before, otherwise we could prevent transitions for those).~~

pushState is required for the self-link to update the browser's address bar.  So I have reintroduced it. In popstate, the navigation of self-links is now detected by negative values for scrollY. This way, the history navigation for self-links can be filtered and the scroll position can be updated without starting view transitions. 

\+ Improvement of the comment that describes the reload of the CSR.

## Testing

added e2e test for back navigation after transition form position navigated to by #fragment URL.


## Docs

n/a bug fix
