### PR TITLE
chore: correct description of `attribute` option in `scopedStyleStrategy`

### DIFF
--- a/.changeset/itchy-clouds-design.md
+++ b/.changeset/itchy-clouds-design.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+chore: correct description of `attribute` option in `scopedStyleStrategy`

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -620,7 +620,7 @@ export interface AstroUserConfig {
 	 * Specify the strategy used for scoping styles within Astro components. Choose from:
 	 *   - `'where'` 		- Use `:where` selectors, causing no specifity increase.
 	 *   - `'class'` 		- Use class-based selectors, causing a +1 specifity increase.
-	 *   - `'attribute'` 	- Use `data-` attributes, causing no specifity increase.
+	 *   - `'attribute'` 	- Use `data-` attributes, causing a +1 specifity increase.
 	 *
 	 * Using `'class'` is helpful when you want to ensure that element selectors within an Astro component override global style defaults (e.g. from a global stylesheet).
 	 * Using `'where'` gives you more control over specifity, but requires that you use higher-specifity selectors, layers, and other tools to control which selectors are applied.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -618,12 +618,12 @@ export interface AstroUserConfig {
 	 * @description
 	 *
 	 * Specify the strategy used for scoping styles within Astro components. Choose from:
-	 *   - `'where'` 		- Use `:where` selectors, causing no specifity increase.
-	 *   - `'class'` 		- Use class-based selectors, causing a +1 specifity increase.
-	 *   - `'attribute'` 	- Use `data-` attributes, causing a +1 specifity increase.
+	 *   - `'where'` 		- Use `:where` selectors, causing no specificity increase.
+	 *   - `'class'` 		- Use class-based selectors, causing a +1 specificity increase.
+	 *   - `'attribute'` 	- Use `data-` attributes, causing a +1 specificity increase.
 	 *
 	 * Using `'class'` is helpful when you want to ensure that element selectors within an Astro component override global style defaults (e.g. from a global stylesheet).
-	 * Using `'where'` gives you more control over specifity, but requires that you use higher-specifity selectors, layers, and other tools to control which selectors are applied.
+	 * Using `'where'` gives you more control over specificity, but requires that you use higher-specificity selectors, layers, and other tools to control which selectors are applied.
 	 * Using `'attribute'` is useful when you are manipulating the `class` attribute of elements and need to avoid conflicts between your own styling logic and Astro's application of styles.
 	 */
 	scopedStyleStrategy?: 'where' | 'class' | 'attribute';


### PR DESCRIPTION
## Changes
fix: #8474

It was commented that setting `scopedStyleStrategy` to `attribute` causes specificity increase is intentional, so the JSDoc regarding this has been updated to reflect it.

## Testing
N/A (JSDoc fixes only)

## Docs
N/A
