### PR TITLE
chore: revert avif support

### DIFF
--- a/.changeset/five-doors-love.md
+++ b/.changeset/five-doors-love.md
@@ -1,5 +1,5 @@
 ---
-'astro': patch
+'astro': minor
 ---
 
 Support AVIF input assets


### PR DESCRIPTION
## Changes

What the title says. This is technically breaking, but we document this shape for all images going forward, AVIF missing was unintended

## Testing

N/A

## Docs

N/A