### PR TITLE
feat(shiki): add option to exclude languages from processing

### DIFF
--- a/.changeset/great-swans-talk.md
+++ b/.changeset/great-swans-talk.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/markdown-remark': minor
+'astro': minor
+---
+
+feat(shiki): add option to exclude languages from processing

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -230,6 +230,7 @@ export const AstroConfigSchema = z.object({
 			shikiConfig: z
 				.object({
 					langs: z.custom<ILanguageRegistration>().array().default([]),
+					excludeLangs: z.array(z.string()).default([]),
 					theme: z
 						.enum(BUNDLED_THEMES as [Theme, ...Theme[]])
 						.or(z.custom<IShikiTheme>())

--- a/packages/astro/test/astro-markdown-shiki.test.js
+++ b/packages/astro/test/astro-markdown-shiki.test.js
@@ -92,6 +92,9 @@ describe('Astro Markdown Shiki', () => {
 			expect(unknownLang).to.be.equal(
 				'<span style="color: #e1e4e8">This language does not exist</span>'
 			);
+
+			const excludedLang = $('.language-shell').html().trim();
+			expect(excludedLang).to.be.equal('This language code block is excluded');
 		});
 	});
 

--- a/packages/astro/test/fixtures/astro-markdown-shiki/langs/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-markdown-shiki/langs/astro.config.mjs
@@ -14,6 +14,7 @@ export default {
 					aliases: ['ri'],
 				},
 			],
+			excludeLangs: ['shell']
 		},
 	},
 }

--- a/packages/astro/test/fixtures/astro-markdown-shiki/langs/src/pages/index.md
+++ b/packages/astro/test/fixtures/astro-markdown-shiki/langs/src/pages/index.md
@@ -24,3 +24,7 @@ fin
 ```unknown
 This language does not exist
 ```
+
+```shell
+This language code block is excluded
+```

--- a/packages/markdown/remark/src/index.ts
+++ b/packages/markdown/remark/src/index.ts
@@ -32,6 +32,7 @@ export const markdownConfigDefaults: Omit<Required<AstroMarkdownOptions>, 'draft
 	syntaxHighlight: 'shiki',
 	shikiConfig: {
 		langs: [],
+		excludeLangs: [],
 		theme: 'github-dark',
 		wrap: false,
 	},

--- a/packages/markdown/remark/src/remark-shiki.ts
+++ b/packages/markdown/remark/src/remark-shiki.ts
@@ -12,6 +12,7 @@ const highlighterCacheAsync = new Map<string, Promise<shiki.Highlighter>>();
 
 export function remarkShiki({
 	langs = [],
+	excludeLangs = [],
 	theme = 'github-dark',
 	wrap = false,
 }: ShikiConfig = {}): ReturnType<RemarkPlugin> {
@@ -67,6 +68,8 @@ export function remarkShiki({
 			} else {
 				lang = 'plaintext';
 			}
+
+			if (excludeLangs.includes(lang)) return;
 
 			let html = highlighter.codeToHtml(node.value, { lang });
 

--- a/packages/markdown/remark/src/types.ts
+++ b/packages/markdown/remark/src/types.ts
@@ -36,6 +36,7 @@ export type RemarkRehype = Omit<RemarkRehypeOptions, 'handlers' | 'unknownHandle
 
 export interface ShikiConfig {
 	langs?: ILanguageRegistration[];
+	excludeLangs?: string[];
 	theme?: Theme | IThemeRegistration;
 	wrap?: boolean | null;
 }


### PR DESCRIPTION
## Changes

This PR adds `excludedLangs` to `ShikiConfig` to exclude matching code blocks from being modified by the syntax highlighter. This allows to either simply leave them alone or handle them in another plugin. Example:

```
export default defineConfig({
  markdown: {
    shikiConfig: {
      excludeLangs: ['shell'],
    },
    remarkRehype: {
      handlers: {
        code: myCodePlugin,
      },
    },
  },
});
```

Now `myCodePlugin` can handle the clean nodes (`node.lang === 'shell'`) as desired, without needing to sanitize it from Shiki's soup first.

Alternative option name is `skipLangs`.

Perhaps implementing this feature in Shiki as well makes sense, but I guess we would still need to skip it in the current `remarkShiki` implementation.

## Workaround

Without this PR, a workaround is possible by first setting an unrecognized `node.type`, and use that type to eventually do the same:

```ts
const uncode: RemarkPlugin = () => tree => {
  const visitor: Visitor = node => {
    if (node.type === 'code' && 'lang' in node && node.lang === 'shell') {
      node.type = 'uncode';
    }
  };
  visit(tree, visitor);
};

export default defineConfig({
  markdown: {
    shikiConfig: {
      theme: 'github-dark-dimmed',
    },
    remarkPlugins: [uncode],
    remarkRehype: {
      handlers: {
        uncode: myCodePlugin,
      },
    },
  },
});
```

## Testing

Test coverage added. Let me know if it should go into a separate fixture, etc.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->

/cc @withastro/maintainers-docs for feedback!

I think this little feature deserves a note in the docs.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
