### PR TITLE
Vt follow redirects

### DIFF
--- a/.changeset/warm-windows-occur.md
+++ b/.changeset/warm-windows-occur.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+let view transitions handle same origin redirects

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -64,7 +64,9 @@ const { fallback = 'animate' } = Astro.props as Props;
 	};
 
 	async function getHTML(href: string) {
-		const res = await fetch(href);
+		const res = await fetch(href, {
+			redirect: 'manual'
+		});
 		const html = await res.text();
 		return { ok: res.ok, html };
 	}

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -64,11 +64,19 @@ const { fallback = 'animate' } = Astro.props as Props;
 	};
 
 	async function getHTML(href: string) {
-		const res = await fetch(href, {
-			redirect: 'manual'
-		});
+		let res;
+		try {
+			res = await fetch(href);
+		} catch (err) {
+			return { ok: false };
+		}
 		const html = await res.text();
-		return { ok: res.ok, html };
+		return {
+			ok: res.ok,
+			html,
+			redirected: res.redirected ? res.url : undefined,
+			contentType: res.headers.get('content-type'),
+		};
 	}
 
 	function getFallback(): Fallback {
@@ -252,13 +260,16 @@ const { fallback = 'animate' } = Astro.props as Props;
 	async function navigate(dir: Direction, loc: URL, state?: State) {
 		let finished: Promise<void>;
 		const href = loc.href;
-		const { html, ok } = await getHTML(href);
+		const { html, ok, contentType, redirected } = await getHTML(href);
+		// if there was a redirection, show the final URL in the browser's address bar
+		redirected && (loc = new URL(redirected));
 		// If there is a problem fetching the new page, just do an MPA navigation to it.
-		if (!ok) {
+		if (!ok || contentType !== 'text/html') {
 			location.href = href;
 			return;
 		}
-		const doc = parser.parseFromString(html, 'text/html');
+
+		const doc = parser.parseFromString(html, contentType);
 		if (!doc.querySelector('[name="astro-view-transitions-enabled"]')) {
 			location.href = href;
 			return;

--- a/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
@@ -7,6 +7,10 @@ export default defineConfig({
 	output: 'server',
 	adapter: nodejs({ mode: 'standalone' }),
 	integrations: [react()],
+	redirects: {
+		'/redirect-two': '/two',
+		'/redirect-external': 'http://example.com/',
+	},
 	vite: {
 		build: {
 			assetsInlineLimit: 0,

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
@@ -8,6 +8,8 @@ import Layout from '../components/Layout.astro';
 	<a id="click-three" href="/three">go to 3</a>
 	<a id="click-longpage" href="/long-page">go to long page</a>
 	<a id="click-self" href="">go to top</a>
+	<a id="click-redirect-two" href="/redirect-two">go to redirect 2</a>
+	<a id="click-redirect-external" href="/redirect-external">go to a redirect external</a>
 
 	<div id="test">test content</div>
 </Layout>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -544,7 +544,7 @@ test.describe('View Transitions', () => {
 		await expect(p, 'should have content').toHaveText('Page 1');
 	});
 
-	test.skip('Moving to a page which redirects to another', async ({ page, astro }) => {
+	test('Moving to a page which redirects to another', async ({ page, astro }) => {
 		const loads = [];
 		page.addListener('load', (p) => {
 			loads.push(p.title());
@@ -560,10 +560,18 @@ test.describe('View Transitions', () => {
 		p = page.locator('#two');
 		await expect(p, 'should have content').toHaveText('Page 2');
 
-		expect(loads.length, 'There should be 2 page loads').toEqual(2);
+		// go back
+		await page.goBack();
+		p = page.locator('#one');
+		await expect(p, 'should have content').toHaveText('Page 1');
+
+		expect(
+			loads.length,
+			'There should only be the initial page load and two normal transitions'
+		).toEqual(1);
 	});
 
-	test.only('Redirect to external site causes page load', async ({ page, astro }) => {
+	test('Redirect to external site causes page load', async ({ page, astro }) => {
 		const loads = [];
 		page.addListener('load', (p) => {
 			loads.push(p.title());
@@ -576,9 +584,11 @@ test.describe('View Transitions', () => {
 
 		// go to external page
 		await page.click('#click-redirect-external');
+		// doesn't work for playwright when we are too fast
+		await page.waitForTimeout(1000);
 		p = page.locator('h1');
 		await expect(p, 'should have content').toBeVisible();
 
-		expect(loads.length, 'There should be 2 page load').toEqual(2);
+		expect(loads.length, 'There should be 2 page loads').toEqual(2);
 	});
 });

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -543,4 +543,42 @@ test.describe('View Transitions', () => {
 		p = page.locator('#one');
 		await expect(p, 'should have content').toHaveText('Page 1');
 	});
+
+	test.skip('Moving to a page which redirects to another', async ({ page, astro }) => {
+		const loads = [];
+		page.addListener('load', (p) => {
+			loads.push(p.title());
+		});
+
+		// Go to page 1
+		await page.goto(astro.resolveUrl('/one'));
+		let p = page.locator('#one');
+		await expect(p, 'should have content').toHaveText('Page 1');
+
+		// go to page 2
+		await page.click('#click-redirect-two');
+		p = page.locator('#two');
+		await expect(p, 'should have content').toHaveText('Page 2');
+
+		expect(loads.length, 'There should be 2 page loads').toEqual(2);
+	});
+
+	test.only('Redirect to external site causes page load', async ({ page, astro }) => {
+		const loads = [];
+		page.addListener('load', (p) => {
+			loads.push(p.title());
+		});
+
+		// Go to page 1
+		await page.goto(astro.resolveUrl('/one'));
+		let p = page.locator('#one');
+		await expect(p, 'should have content').toHaveText('Page 1');
+
+		// go to external page
+		await page.click('#click-redirect-external');
+		p = page.locator('h1');
+		await expect(p, 'should have content').toBeVisible();
+
+		expect(loads.length, 'There should be 2 page load').toEqual(2);
+	});
 });


### PR DESCRIPTION
## Changes

With redirects, the location had to be updated to reflect the final destination in the browsers address bar.
Redirect errors, like same origin violation, are handled as any other errors of `fetch` by full load of the requested `href` 
(as same origin policy would prevent us from accessing the target DOM)

While we are looking at the response object now, I have also grabbed the content-type for the parser.

## Testing
two new e2e tests

## Docs

n/a bug fix