### PR TITLE
Disallow node builtins in runtime

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,5 @@
+const { builtinModules } = require('module')
+
 module.exports = {
   extends: [
     'plugin:@typescript-eslint/recommended-type-checked',
@@ -54,6 +56,16 @@ module.exports = {
     'prefer-const': 'off',
   },
   overrides: [
+    { 
+      // Ensure Node builtins aren't included in Astro's server runtime
+      files: ['packages/astro/src/runtime/**/*.ts'],
+      rules: {
+        "no-restricted-imports": ["error", {
+          "paths": [...builtinModules],
+          "patterns": ["node:*"]
+        }],
+      }
+    },
     {
       files: ['packages/**/test/*.js', 'packages/**/*.js'],
       env: {


### PR DESCRIPTION
## Changes

- Updates our eslint settings to detect Node built-ins that accidentally make their way into our runtime code.
- Closes PLT-572
- Might catch a few issues in the future, but doesn't cover everything.

## Testing

Verified locally

## Docs

N/A