### PR TITLE
[docs] escape symbols in error documentation

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -595,7 +595,7 @@ export const ExpectedImage = {
 	name: 'ExpectedImage',
 	title: 'Expected src to be an image.',
 	message: (src: string, typeofOptions: string, fullOptions: string) =>
-		`Expected \`src\` property for \`getImage\` or \`<Image />\` to be either an ESM imported image or a string with the path of a remote image. Received \`${src}\` (type: \`${typeofOptions}\`).\n\nFull serialized options received: \`${fullOptions}\`.`,
+		`Expected \`src\` property for \`getImage\` or \`\<Image /\>\` to be either an ESM imported image or a string with the path of a remote image. Received \`${src}\` (type: \`${typeofOptions}\`).\n\nFull serialized options received: \`${fullOptions}\`.`,
 	hint: "This error can often happen because of a wrong path. Make sure the path to your image is correct. If you're passing an async function, make sure to call and await it.",
 } satisfies ErrorData;
 /**


### PR DESCRIPTION
## Changes

Escapes the `<` and `>` character in an error message.
![Screenshot from 2023-09-14 14-09-50](https://github.com/withastro/astro/assets/5098874/e5f6d8af-5ba2-43d7-bce0-955a8f5fa71f)


## Testing

Docs change.

## Docs

Only docs!