### PR TITLE
Fix alias plugin causing CSS ordering issue

### DIFF
--- a/.changeset/serious-wolves-breathe.md
+++ b/.changeset/serious-wolves-breathe.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix alias plugin causing CSS ordering issue

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -111,8 +111,6 @@ export async function createVite(
 			exclude: ['astro', 'node-fetch'],
 		},
 		plugins: [
-			configAliasVitePlugin({ settings }),
-			astroLoadFallbackPlugin({ fs, root: settings.config.root }),
 			astroVitePlugin({ settings, logger }),
 			astroScriptsPlugin({ settings }),
 			// The server plugin is for dev only and having it run during the build causes
@@ -134,6 +132,8 @@ export async function createVite(
 			vitePluginSSRManifest(),
 			astroAssetsPlugin({ settings, logger, mode }),
 			astroTransitions(),
+			configAliasVitePlugin({ settings }),
+			astroLoadFallbackPlugin({ fs, root: settings.config.root }),
 		],
 		publicDir: fileURLToPath(settings.config.publicDir),
 		root: fileURLToPath(settings.config.root),

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -111,6 +111,8 @@ export async function createVite(
 			exclude: ['astro', 'node-fetch'],
 		},
 		plugins: [
+			configAliasVitePlugin({ settings }),
+			astroLoadFallbackPlugin({ fs, root: settings.config.root }),
 			astroVitePlugin({ settings, logger }),
 			astroScriptsPlugin({ settings }),
 			// The server plugin is for dev only and having it run during the build causes
@@ -132,8 +134,6 @@ export async function createVite(
 			vitePluginSSRManifest(),
 			astroAssetsPlugin({ settings, logger, mode }),
 			astroTransitions(),
-			configAliasVitePlugin({ settings }),
-			astroLoadFallbackPlugin({ fs, root: settings.config.root }),
 		],
 		publicDir: fileURLToPath(settings.config.publicDir),
 		root: fileURLToPath(settings.config.root),

--- a/packages/astro/src/vite-plugin-config-alias/index.ts
+++ b/packages/astro/src/vite-plugin-config-alias/index.ts
@@ -70,7 +70,8 @@ export default function configAliasVitePlugin({
 
 	const plugin: VitePlugin = {
 		name: 'astro:tsconfig-alias',
-		enforce: 'pre',
+		// use post to only resolve ids that all other plugins before it can't
+		enforce: 'post',
 		configResolved(config) {
 			patchCreateResolver(config, plugin);
 		},

--- a/packages/astro/src/vite-plugin-config-alias/index.ts
+++ b/packages/astro/src/vite-plugin-config-alias/index.ts
@@ -101,7 +101,7 @@ export default function configAliasVitePlugin({
  *
  * Vite may simplify this soon: https://github.com/vitejs/vite/pull/10555
  */
-function patchCreateResolver(config: ResolvedConfig, prePlugin: VitePlugin) {
+function patchCreateResolver(config: ResolvedConfig, postPlugin: VitePlugin) {
 	const _createResolver = config.createResolver;
 	// @ts-expect-error override readonly property intentionally
 	config.createResolver = function (...args1: any) {
@@ -125,15 +125,16 @@ function patchCreateResolver(config: ResolvedConfig, prePlugin: VitePlugin) {
 				ssr,
 			};
 
+			const result = await resolver.apply(_createResolver, args2);
+			if (result) return result;
+
 			// @ts-expect-error resolveId exists
-			const resolved = await prePlugin.resolveId.apply(fakePluginContext, [
+			const resolved = await postPlugin.resolveId.apply(fakePluginContext, [
 				id,
 				importer,
 				fakeResolveIdOpts,
 			]);
 			if (resolved) return resolved;
-
-			return resolver.apply(_createResolver, args2);
 		};
 	};
 }


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/7508

I don't really know what's happening, for some reason if we eagerly resolve ids with aliases, it affects the CSS ordering of some CSS styles injected to the HTML. Doing it later (giving other plugins first) seems to fix it and is also what the plugin used to do before I changed it. (I didn't think they were issues with it before)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested with the issue's repro only. I can't find a pattern that's causing the issue.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.