### PR TITLE
feat(i18n): first draft of configuration

### DIFF
--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -120,6 +120,11 @@ declare module 'astro:transitions' {
 	export const ViewTransitions: ViewTransitionsModule['default'];
 }
 
+declare module 'astro:i18n' {
+	type I18nModule = typeof import('./dist/i18n/index.js');
+	export const getI18nBaseUrl: I18nModule['getI18nBaseUrl'];
+}
+
 declare module 'astro:middleware' {
 	export * from 'astro/middleware/namespace';
 }

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -122,7 +122,7 @@ declare module 'astro:transitions' {
 
 declare module 'astro:i18n' {
 	type I18nModule = typeof import('./dist/i18n/index.js');
-	export const getI18nBaseUrl: I18nModule['getI18nBaseUrl'];
+	export const getI18nBaseUrl: (locale: string) => string;
 }
 
 declare module 'astro:middleware' {

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -77,7 +77,8 @@
       "types": "./dist/core/middleware/namespace.d.ts",
       "default": "./dist/core/middleware/namespace.js"
     },
-    "./transitions": "./dist/transitions/index.js"
+    "./transitions": "./dist/transitions/index.js",
+    "./i18n": "./dist/i18n/index.js"
   },
   "imports": {
     "#astro/*": "./dist/*.js"

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1331,21 +1331,65 @@ export interface AstroUserConfig {
 		 */
 		optimizeHoistedScript?: boolean;
 
+		// TODO review with docs team before merging to `main`
 		/**
 		 * @docs
 		 * @name experimental.i18n
-		 * @type {boolean}
 		 * @version 3.*.*
 		 * @description
-		 * Allows to configure
+		 *
+		 * Allows to configure the beaviour of the i18n routing
 		 */
 		i18n?: {
-			// TODO documentation
+			/**
+			 * @docs
+			 * @name experimental.i18n.defaultLocale
+			 * @type {string}
+			 * @version 3.*.*
+			 * @description
+			 *
+			 * The default locale of your website/application
+			 */
 			defaultLocale: string;
-			// TODO documentation
-			locales?: string[];
-			// TODO documentation
+			/**
+			 * @docs
+			 * @name experimental.i18n.locales
+			 * @type {string[]}
+			 * @version 3.*.*
+			 * @description
+			 *
+			 * A list of locales supported by the website.
+			 */
+			locales: string[];
+
+			/**
+			 * @docs
+			 * @name experimental.i18n.fallback
+			 * @type {Record<string, string[]>}
+			 * @version 3.*.*
+			 * @description
+			 *
+			 * The fallback system of the locales. By default, the fallback system affect the **content only**, and it doesn't
+			 * do any redirects.
+			 *
+			 * This means that when attempting to navigate to a page that hasn't been translated, Astro will pull the content
+			 * from the page of the default locale and render it. No redirects will happen.
+			 */
 			fallback?: Record<string, string[]>;
+
+			/**
+			 * @docs
+			 * @name experimental.i18n.detectBrowserLanguage
+			 * @type {boolean}
+			 * @version 3.*.*
+			 * @description
+			 *
+			 * Whether Astro should detect the language of the browser - usually using the `Accept-Language` header. This is a feature
+			 * that should be supported by the adapter. If detected, the adapter can decide to redirect the user to the localised version of the website.
+			 *
+			 * When set to `true`, you should make sure that the adapter you're using is able to provide this feature to you.
+			 */
+			detectBrowserLanguage: boolean;
 		};
 	};
 }
@@ -1807,6 +1851,11 @@ export type AstroFeatureMap = {
 	 * The adapter can emit static assets
 	 */
 	assets?: AstroAssetsFeature;
+
+	/**
+	 * List of features that orbit around the i18n routing
+	 */
+	i18n?: AstroInternalisationFeature;
 };
 
 export interface AstroAssetsFeature {
@@ -1819,6 +1868,13 @@ export interface AstroAssetsFeature {
 	 * Whether if this adapter deploys files in an environment that is compatible with the library `squoosh`
 	 */
 	isSquooshCompatible?: boolean;
+}
+
+export interface AstroInternalisationFeature {
+	/**
+	 * Wether the adapter is able to detect the language of the browser, usually using the `Accept-Language` header.
+	 */
+	detectBrowserLanguage?: SupportsKind;
 }
 
 export interface AstroAdapter {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1335,6 +1335,7 @@ export interface AstroUserConfig {
 		/**
 		 * @docs
 		 * @name experimental.i18n
+		 * @type {object}
 		 * @version 3.*.*
 		 * @description
 		 *

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1330,6 +1330,25 @@ export interface AstroUserConfig {
 		 * ```
 		 */
 		optimizeHoistedScript?: boolean;
+
+		/**
+		 * @docs
+		 * @name experimental.i18n
+		 * @type {boolean}
+		 * @version 3.*.*
+		 * @description
+		 * Allows to configure
+		 */
+		i18n?: {
+			// TODO documentation
+			defaultLocale: string;
+			// TODO documentation
+			locales?: string[];
+			// TODO documentation
+			fallback?: Record<string, string[]>;
+			// TODO documentation
+			customDomains?: Record<string, string>;
+		};
 	};
 }
 

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1346,8 +1346,6 @@ export interface AstroUserConfig {
 			locales?: string[];
 			// TODO documentation
 			fallback?: Record<string, string[]>;
-			// TODO documentation
-			customDomains?: Record<string, string>;
 		};
 	};
 }

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -277,12 +277,11 @@ export const AstroConfigSchema = z.object({
 						defaultLocale: z.string(),
 						locales: z.string().array(),
 						fallback: z.record(z.string(), z.string().array()),
-						customDomains: z.record(z.string(), z.string()),
 					})
 					.optional()
 					.refine((i18n) => {
 						if (i18n) {
-							const { defaultLocale, locales, fallback, customDomains } = i18n;
+							const { defaultLocale, locales, fallback } = i18n;
 							if (!locales.includes(defaultLocale)) {
 								return {
 									message: `The default locale \`${defaultLocale}\` is not present in the \`i18n.locales\` array.`,
@@ -301,14 +300,6 @@ export const AstroConfigSchema = z.object({
 											message: `The locale \`${fallbackArrayKey}\` value in the \`i18n.fallback\` record doesn't exist in the \`i18n.locales\` array.`,
 										};
 									}
-								}
-							}
-
-							for (const customDomainLocale of Object.keys(customDomains)) {
-								if (!locales.includes(customDomainLocale)) {
-									return {
-										message: `The locale \`${customDomainLocale}\` key in the \`i18n.customDomains\` record doesn't exist in the \`i18n.locales\` array.`,
-									};
 								}
 							}
 						}

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -276,29 +276,32 @@ export const AstroConfigSchema = z.object({
 					.object({
 						defaultLocale: z.string(),
 						locales: z.string().array(),
-						fallback: z.record(z.string(), z.string().array()),
+						fallback: z.record(z.string(), z.string().array()).optional(),
+						detectBrowserLanguage: z.boolean().optional().default(false),
 					})
 					.optional()
 					.refine((i18n) => {
 						if (i18n) {
 							const { defaultLocale, locales, fallback } = i18n;
-							if (!locales.includes(defaultLocale)) {
+							if (locales.includes(defaultLocale)) {
 								return {
 									message: `The default locale \`${defaultLocale}\` is not present in the \`i18n.locales\` array.`,
 								};
 							}
-							for (const [fallbackKey, fallbackArray] of Object.entries(fallback)) {
-								if (!locales.includes(fallbackKey)) {
-									return {
-										message: `The locale \`${fallbackKey}\` key in the \`i18n.fallback\` record doesn't exist in the \`i18n.locales\` array.`,
-									};
-								}
-
-								for (const fallbackArrayKey of fallbackArray) {
-									if (!locales.includes(fallbackArrayKey)) {
+							if (fallback) {
+								for (const [fallbackKey, fallbackArray] of Object.entries(fallback)) {
+									if (!locales.includes(fallbackKey)) {
 										return {
-											message: `The locale \`${fallbackArrayKey}\` value in the \`i18n.fallback\` record doesn't exist in the \`i18n.locales\` array.`,
+											message: `The locale \`${fallbackKey}\` key in the \`i18n.fallback\` record doesn't exist in the \`i18n.locales\` array.`,
 										};
+									}
+
+									for (const fallbackArrayKey of fallbackArray) {
+										if (!locales.includes(fallbackArrayKey)) {
+											return {
+												message: `The locale \`${fallbackArrayKey}\` value in the \`i18n.fallback\` record doesn't exist in the \`i18n.locales\` array.`,
+											};
+										}
 									}
 								}
 							}

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -271,6 +271,49 @@ export const AstroConfigSchema = z.object({
 				.boolean()
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.experimental.optimizeHoistedScript),
+			i18n: z.optional(
+				z
+					.object({
+						defaultLocale: z.string(),
+						locales: z.string().array(),
+						fallback: z.record(z.string(), z.string().array()),
+						customDomains: z.record(z.string(), z.string()),
+					})
+					.optional()
+					.refine((i18n) => {
+						if (i18n) {
+							const { defaultLocale, locales, fallback, customDomains } = i18n;
+							if (!locales.includes(defaultLocale)) {
+								return {
+									message: `The default locale \`${defaultLocale}\` is not present in the \`i18n.locales\` array.`,
+								};
+							}
+							for (const [fallbackKey, fallbackArray] of Object.entries(fallback)) {
+								if (!locales.includes(fallbackKey)) {
+									return {
+										message: `The locale \`${fallbackKey}\` key in the \`i18n.fallback\` record doesn't exist in the \`i18n.locales\` array.`,
+									};
+								}
+
+								for (const fallbackArrayKey of fallbackArray) {
+									if (!locales.includes(fallbackArrayKey)) {
+										return {
+											message: `The locale \`${fallbackArrayKey}\` value in the \`i18n.fallback\` record doesn't exist in the \`i18n.locales\` array.`,
+										};
+									}
+								}
+							}
+
+							for (const customDomainLocale of Object.keys(customDomains)) {
+								if (!locales.includes(customDomainLocale)) {
+									return {
+										message: `The locale \`${customDomainLocale}\` key in the \`i18n.customDomains\` record doesn't exist in the \`i18n.locales\` array.`,
+									};
+								}
+							}
+						}
+					})
+			),
 		})
 		.strict(
 			`Invalid or outdated experimental feature.\nCheck for incorrect spelling or outdated Astro version.\nSee https://docs.astro.build/en/reference/configuration-reference/#experimental-flags for a list of all current experiments.`

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -5,11 +5,12 @@ import type { Logger } from '../core/logger/core.js';
  * The base URL
  */
 export function getI18nBaseUrl(locale: string, config: AstroConfig, logger: Logger) {
-	if (!config.experimental.i18n) {
-		logger.debug('i18n', "The project isn't using i18n features, no need to use this function.");
-		return;
-	}
 	const base = config.base;
+
+	if (!config.experimental.i18n) {
+		logger.error('i18n', "The project isn't using i18n features, no need to use this function.");
+		return base ? `/${base}/` : '/';
+	}
 
 	if (base) {
 		logger.debug('i18n', 'The project has a base directory, using it.');

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -1,0 +1,30 @@
+import type { AstroConfig } from '../@types/astro.js';
+import type { Logger } from '../core/logger/core.js';
+
+/**
+ * The base URL
+ */
+export function getI18nBaseUrl(locale: string, config: AstroConfig, logger: Logger) {
+	if (!config.experimental.i18n) {
+		logger.debug('i18n', "The project isn't using i18n features, no need to use this function.");
+		return;
+	}
+	const base = config.base;
+
+	if (config.experimental.i18n.customDomains && config.experimental.i18n.customDomains[locale]) {
+		const customDomain = config.experimental.i18n.customDomains[locale];
+		logger.debug('i18n', `The locale ${locale} is mapped to the custom domain ${customDomain}`);
+		if (base) {
+			return `${customDomain}${base}/`;
+		} else {
+			return `${customDomain}/`;
+		}
+	} else {
+		if (base) {
+			logger.debug('i18n', 'The project has a base directory, using it.');
+			return `${base}/${locale}/`;
+		} else {
+			return `/${locale}/`;
+		}
+	}
+}

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -11,20 +11,10 @@ export function getI18nBaseUrl(locale: string, config: AstroConfig, logger: Logg
 	}
 	const base = config.base;
 
-	if (config.experimental.i18n.customDomains && config.experimental.i18n.customDomains[locale]) {
-		const customDomain = config.experimental.i18n.customDomains[locale];
-		logger.debug('i18n', `The locale ${locale} is mapped to the custom domain ${customDomain}`);
-		if (base) {
-			return `${customDomain}${base}/`;
-		} else {
-			return `${customDomain}/`;
-		}
+	if (base) {
+		logger.debug('i18n', 'The project has a base directory, using it.');
+		return `${base}/${locale}/`;
 	} else {
-		if (base) {
-			logger.debug('i18n', 'The project has a base directory, using it.');
-			return `${base}/${locale}/`;
-		} else {
-			return `/${locale}/`;
-		}
+		return `/${locale}/`;
 	}
 }

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -1,0 +1,26 @@
+import * as vite from 'vite';
+import type { AstroSettings } from '../@types/astro.js';
+import type { Logger } from '../core/logger/core.js';
+
+const virtualModuleId = 'astro:i18n';
+const resolvedVirtualModuleId = '\0' + virtualModuleId;
+
+type AstroInternalization = {
+	settings: AstroSettings;
+	logger: Logger;
+};
+
+export default function astroInternalization({ settings }: AstroInternalization): vite.Plugin {
+	return {
+		name: 'astro:i18n',
+		load(id) {
+			if (id === resolvedVirtualModuleId) {
+				return `
+					import { getI18nBaseUrl as getI18nBaseUrlInternal } from "astro/i18n";
+								
+					export getI18nUrl = (locale) => getI18nBaseUrlInternal(locale, ${settings.config});
+				`;
+			}
+		},
+	};
+}

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -18,7 +18,7 @@ export default function astroInternalization({ settings }: AstroInternalization)
 				return `
 					import { getI18nBaseUrl as getI18nBaseUrlInternal } from "astro/i18n";
 								
-					export getI18nUrl = (locale) => getI18nBaseUrlInternal(locale, ${settings.config});
+					export getI18nBaseUrl = (locale) => getI18nBaseUrlInternal(locale, ${settings.config});
 				`;
 			}
 		},

--- a/packages/astro/src/integrations/astroFeaturesValidation.ts
+++ b/packages/astro/src/integrations/astroFeaturesValidation.ts
@@ -23,6 +23,9 @@ const ALL_UNSUPPORTED: Required<AstroFeatureMap> = {
 	staticOutput: UNSUPPORTED,
 	hybridOutput: UNSUPPORTED,
 	assets: UNSUPPORTED_ASSETS_FEATURE,
+	i18n: {
+		detectBrowserLanguage: UNSUPPORTED,
+	},
 };
 
 type ValidationResult = {

--- a/packages/astro/test/units/i18n/getI18nBaseUrl.test.js
+++ b/packages/astro/test/units/i18n/getI18nBaseUrl.test.js
@@ -40,49 +40,4 @@ describe('getI18nBaseUrl', () => {
 		expect(getI18nBaseUrl('en', config, logger)).to.eq('/en/');
 		expect(getI18nBaseUrl('es', config, logger)).to.eq('/es/');
 	});
-
-	it('should correctly return the URL when a locale is mapped to a custom domain', () => {
-		/**
-		 *
-		 * @type {import("../../../dist/@types").AstroUserConfig}
-		 */
-		const config = {
-			experimental: {
-				i18n: {
-					defaultLocale: 'en',
-					locales: ['en', 'es'],
-					customDomains: {
-						en: 'example.com',
-						es: 'es.example.com',
-					},
-				},
-			},
-		};
-
-		expect(getI18nBaseUrl('en', config, logger)).to.eq('example.com/');
-		expect(getI18nBaseUrl('es', config, logger)).to.eq('es.example.com/');
-	});
-
-	it('should correctly return the URL when a locale is mapped to a custom domain with the base set', () => {
-		/**
-		 *
-		 * @type {import("../../../dist/@types").AstroUserConfig}
-		 */
-		const config = {
-			base: '/docs',
-			experimental: {
-				i18n: {
-					defaultLocale: 'en',
-					locales: ['en', 'es'],
-					customDomains: {
-						en: 'example.com',
-						es: 'es.example.com',
-					},
-				},
-			},
-		};
-
-		expect(getI18nBaseUrl('en', config, logger)).to.eq('example.com/docs/');
-		expect(getI18nBaseUrl('es', config, logger)).to.eq('es.example.com/docs/');
-	});
 });

--- a/packages/astro/test/units/i18n/getI18nBaseUrl.test.js
+++ b/packages/astro/test/units/i18n/getI18nBaseUrl.test.js
@@ -1,0 +1,88 @@
+import { getI18nBaseUrl } from '../../../dist/i18n/index.js';
+import { expect } from 'chai';
+import { Logger } from '../../../dist/core/logger/core.js';
+
+const logger = new Logger();
+describe('getI18nBaseUrl', () => {
+	it('should correctly return the URL with the base', () => {
+		/**
+		 *
+		 * @type {import("../../../dist/@types").AstroUserConfig}
+		 */
+		const config = {
+			base: '/blog',
+			experimental: {
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['en', 'es'],
+				},
+			},
+		};
+
+		expect(getI18nBaseUrl('en', config, logger)).to.eq('/blog/en/');
+		expect(getI18nBaseUrl('es', config, logger)).to.eq('/blog/es/');
+	});
+
+	it('should correctly return the URL without base', () => {
+		/**
+		 *
+		 * @type {import("../../../dist/@types").AstroUserConfig}
+		 */
+		const config = {
+			experimental: {
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['en', 'es'],
+				},
+			},
+		};
+
+		expect(getI18nBaseUrl('en', config, logger)).to.eq('/en/');
+		expect(getI18nBaseUrl('es', config, logger)).to.eq('/es/');
+	});
+
+	it('should correctly return the URL when a locale is mapped to a custom domain', () => {
+		/**
+		 *
+		 * @type {import("../../../dist/@types").AstroUserConfig}
+		 */
+		const config = {
+			experimental: {
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['en', 'es'],
+					customDomains: {
+						en: 'example.com',
+						es: 'es.example.com',
+					},
+				},
+			},
+		};
+
+		expect(getI18nBaseUrl('en', config, logger)).to.eq('example.com/');
+		expect(getI18nBaseUrl('es', config, logger)).to.eq('es.example.com/');
+	});
+
+	it('should correctly return the URL when a locale is mapped to a custom domain with the base set', () => {
+		/**
+		 *
+		 * @type {import("../../../dist/@types").AstroUserConfig}
+		 */
+		const config = {
+			base: '/docs',
+			experimental: {
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['en', 'es'],
+					customDomains: {
+						en: 'example.com',
+						es: 'es.example.com',
+					},
+				},
+			},
+		};
+
+		expect(getI18nBaseUrl('en', config, logger)).to.eq('example.com/docs/');
+		expect(getI18nBaseUrl('es', config, logger)).to.eq('es.example.com/docs/');
+	});
+});


### PR DESCRIPTION
## Changes

This is a first draft of the possible configuration for the upcoming i18n routing. Closes PLT-981

> [!NOTE]
> This PR is against the branch `i18n-routing`

### Configuration

```js
export default defineConfig({
	i18n: {
		defaultLocale: 'en' // mandatory. This locale must be in the locales array
		locales: [
			'en',
			'es', 
			'en-US', 
			'it-IT',
			'pt',
			'pt-BR'
		],
		fallback: {
			/**
			* The fallback system. The fallback system handles cases where certain pages 
			* aren't translated yet.
			* Fallback = Redirect
			* In this example, if a page for `pt-BR` isn't found, Astro will:
			* 1. fallback to `pt`
			* 2. fallback to `en-US`
			* 3. fallback to default locale
			*/
			'pt-BR': ['pt', 'en-US'] 
		},
		detectBrowswerLanguage: false
	}
})
```

### Initial runtime

~~Considering the proposal, we need the presence of some runtime in order to provide enough information to the client. 

By default, users will create files inside directories that have the name of the locale, and eventually the links in the website will look like this: `https://example.com/es/guide/getting-started`

Although, if a user needs a custom domain for a certain locale, the links need to change. So if in the example we opt-in the custom domain for `es` locale, the links will need to look like this: `https://es.example.com/guide/getting-started`

The runtime in this PR provides an example of the functions we should provide to the user to achieve that.~~

Domains was left out of scope for the initial, experimental, release. Instead, the browser detection has introduced as an opt-in feature.

> [!WARNING]
> The proposed code is not optimized yet, but the unit tests should provide enough information of the functionality of the runtime

## Testing

Some unit test. Current CI should pass for the new configuration.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
