### PR TITLE
feat(@astrojs/cloudflare): add default fallback for image service entrypoint

### DIFF
--- a/.changeset/shy-eyes-press.md
+++ b/.changeset/shy-eyes-press.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Remove warnings regarding assets

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -183,6 +183,11 @@ export default function createIntegration(args?: Options): AstroIntegration {
 		hooks: {
 			'astro:config:setup': ({ config, updateConfig }) => {
 				updateConfig({
+					image: config.image ?? {
+						service: {
+							entrypoint: 'astro/assets/services/noop',
+						},
+					},
 					build: {
 						client: new URL(`.${config.base}`, config.outDir),
 						server: new URL(`.${SERVER_BUILD_FOLDER}`, config.outDir),


### PR DESCRIPTION
I have seen many people getting confused about, that they need to set `noop` for assets in the CF Adapter. E.g. https://discord.com/channels/830184174198718474/1154082475547574385

I think it could be worth to add this as the default option to the adapter.
If you disagree, just close the PR, if you like it please review it :)