### PR TITLE
Ensure cookies are attached when middleware changes the Response

### DIFF
--- a/.changeset/curvy-owls-rest.md
+++ b/.changeset/curvy-owls-rest.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Ensure cookies are attached when middleware changes the Response

--- a/packages/astro/src/core/cookies/index.ts
+++ b/packages/astro/src/core/cookies/index.ts
@@ -1,2 +1,2 @@
 export { AstroCookies } from './cookies.js';
-export { attachCookiesToResponse, getSetCookiesFromResponse } from './response.js';
+export { attachCookiesToResponse, responseHasCookies, getSetCookiesFromResponse } from './response.js';

--- a/packages/astro/src/core/cookies/response.ts
+++ b/packages/astro/src/core/cookies/response.ts
@@ -6,6 +6,10 @@ export function attachCookiesToResponse(response: Response, cookies: AstroCookie
 	Reflect.set(response, astroCookiesSymbol, cookies);
 }
 
+export function responseHasCookies(response: Response): boolean {
+	return Reflect.has(response, astroCookiesSymbol);
+}
+
 function getFromResponse(response: Response): AstroCookies | undefined {
 	let cookies = Reflect.get(response, astroCookiesSymbol);
 	if (cookies != null) {

--- a/packages/astro/test/fixtures/middleware space/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware space/src/middleware.js
@@ -24,7 +24,7 @@ const first = defineMiddleware(async (context, next) => {
 		const /** @type {string} */ html = await newResponse.text();
 		const newhtml = html.replace('<h1>testing</h1>', '<h1>it works</h1>');
 		return new Response(newhtml, { status: 200, headers: response.headers });
-	} else if(context.url.pathname = '/return-response-cookies') {
+	} else if(context.url.pathname === '/return-response-cookies') {
 		const response = await next();
     const html = await response.text();
 

--- a/packages/astro/test/fixtures/middleware space/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware space/src/middleware.js
@@ -24,6 +24,14 @@ const first = defineMiddleware(async (context, next) => {
 		const /** @type {string} */ html = await newResponse.text();
 		const newhtml = html.replace('<h1>testing</h1>', '<h1>it works</h1>');
 		return new Response(newhtml, { status: 200, headers: response.headers });
+	} else if(context.url.pathname = '/return-response-cookies') {
+		const response = await next();
+    const html = await response.text();
+
+    return new Response(html, {
+        status: 200,
+        headers: response.headers
+    });
 	} else {
 		if (context.url.pathname === '/') {
 			context.cookies.set('foo', 'bar');

--- a/packages/astro/test/fixtures/middleware space/src/pages/return-response-cookies.astro
+++ b/packages/astro/test/fixtures/middleware space/src/pages/return-response-cookies.astro
@@ -1,0 +1,8 @@
+---
+Astro.cookies.set("astro", "cookie", {
+	httpOnly: true,
+	path: "/",
+	sameSite: "strict",
+	maxAge: 1704085200,
+});
+---

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -79,6 +79,12 @@ describe('Middleware in DEV mode', () => {
 		let html = await res.text();
 		expect(html).to.contain('<h1>it works</h1>');
 	});
+
+	it('should forward cookies set in a component when the middleware returns a new response', async () => {
+		let res = await fixture.fetch('/return-response-cookies');
+		let headers = res.headers;
+		expect(headers.get('set-cookie')).to.not.equal(null);
+	});
 });
 
 describe('Middleware in PROD mode, SSG', () => {


### PR DESCRIPTION
## Changes

- When middleware return `new Response` we need to attach cookies to it.
- This aligns with how components work as well, if you return a new Response from a page component the cookies that have been set via `Astro.cookies.set()` go along for the ride.

## Testing

New test case added

## Docs

N/A, bug fix