### PR TITLE
loosen typing of `getEntries()` params

### DIFF
--- a/.changeset/short-suns-sparkle.md
+++ b/.changeset/short-suns-sparkle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Loosen typing of `getEntries()` params

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -238,8 +238,18 @@ export function createGetEntry({
 
 export function createGetEntries(getEntry: ReturnType<typeof createGetEntry>) {
 	return async function getEntries(
-		entries: { collection: string; id: string }[] | { collection: string; slug: string }[]
+		entries:
+			| { collection: string; id: string }[]
+			| { collection: string; slug: string }[]
+			| undefined
 	) {
+		if (!entries) {
+			throw new AstroError({
+				...AstroErrorData.PassedUndefinedToGetEntriesError,
+				message:
+					'`getEntries() requires an array of entries (either { collection: string; id: string }[] or { collection: string; slug: string }[] )`',
+			});
+		}
 		return Promise.all(entries.map((e) => getEntry(e)));
 	};
 }

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1244,3 +1244,14 @@ export const UnsupportedConfigTransformError = {
 
 // Generic catch-all - Only use this in extreme cases, like if there was a cosmic ray bit flip
 export const UnknownError = { name: 'UnknownError', title: 'Unknown Error.' } satisfies ErrorData;
+
+/**
+ * @docs
+ * @message `undefined` has been passed to the `getEntries()` function.
+ * @description
+ * When querying a collection with getEntries(), ensure that an array of entries is passed.
+ */
+export const PassedUndefinedToGetEntriesError = {
+	name: 'PassedUndefinedToGetEntriesError',
+	title: '`undefined` passed to `getEntries()`.',
+} satisfies ErrorData;


### PR DESCRIPTION
## Changes

- This PR loosens the types of the `getEntries()` params
- now, also `undefined` can be passed to the function
- this might be necessary if for example `blogPost.data.relatedPosts` is undefined
- if `undefined` is passed, an AstroError gets thrown

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
`getEntries()` is untested currently, I don't know how to test this

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
I'm not sure if an update to the docs (either [here](https://docs.astro.build/en/guides/content-collections/#accessing-referenced-data) or [here](https://docs.astro.build/en/reference/api-reference/#getentries)) is needed
 /cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

closes #8450