### PR TITLE
fix: properly generate code for multiple images in same markdown file

### DIFF
--- a/.changeset/mean-forks-ring.md
+++ b/.changeset/mean-forks-ring.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix build not working when having multiple images in the same Markdown file

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -120,13 +120,15 @@ export default function markdown({ settings, logger }: AstroPluginOptions): Plug
 
 				${layout ? `import Layout from ${JSON.stringify(layout)};` : ''}
 				import { getImage } from "astro:assets";
-				${imagePaths.map((entry) => `import Astro__${entry.safeName} from ${JSON.stringify(entry.raw)};`)}
+				${imagePaths
+					.map((entry) => `import Astro__${entry.safeName} from ${JSON.stringify(entry.raw)};`)
+					.join('\n')}
 
 				const images = async function() {
 					return {
 						${imagePaths
 							.map((entry) => `"${entry.raw}": await getImage({src: Astro__${entry.safeName}})`)
-							.join('\n')}
+							.join(',\n')}
 					}
 				}
 

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -310,7 +310,7 @@ describe('astro:image', () => {
 
 			it('Adds the <img> tag', () => {
 				let $img = $('img');
-				expect($img).to.have.a.lengthOf(1);
+				expect($img).to.have.a.lengthOf(2);
 
 				// Verbose test for the full URL to make sure the image went through the full pipeline
 				expect(

--- a/packages/astro/test/fixtures/core-image/src/pages/post.md
+++ b/packages/astro/test/fixtures/core-image/src/pages/post.md
@@ -1,3 +1,4 @@
 ![My article cover](../assets/penguin1.jpg)
+![My article cover](../assets/penguin2.jpg)
 
 Image worked


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/8630

## Testing

Updated test to test this. There's another test that has only one image, so both cases are tested

## Docs

N/A
