### PR TITLE
fix: no deletion of scripts during view transition

### DIFF
--- a/.changeset/short-cougars-worry.md
+++ b/.changeset/short-cougars-worry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix: no deletion of scripts during view transition

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -219,13 +219,13 @@ const { fallback = 'animate' } = Astro.props as Props;
 				for (const s2 of newDocument.scripts) {
 					if (
 						// Inline
-						(s1.textContent && s1.textContent === s2.textContent) ||
+						(!s1.src && s1.textContent === s2.textContent) ||
 						// External
-						(s1.type === s2.type && s1.src === s2.src)
+						(s1.src && s1.type === s2.type && s1.src === s2.src)
 					) {
-						s2.remove();
-					} else {
-						s1.remove();
+						// the old script is in the new document: we mark it as executed to prevent re-execution
+						s2.dataset.astroExec = '';
+						break;
 					}
 				}
 			}


### PR DESCRIPTION
## Changes

there were some problems with the deletion of scripts during view transition (to prevent re-execution)
No they are not deleted anymore but simply marked as already executed

## Testing

pass existing e2e tests

## Docs

bug fix, n/a