### PR TITLE
Warn on empty content collections

### DIFF
--- a/.changeset/spotty-jokes-arrive.md
+++ b/.changeset/spotty-jokes-arrive.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Warn on empty content collections

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -1,6 +1,5 @@
 import type { MarkdownHeading } from '@astrojs/markdown-remark';
 import { ZodIssueCode, string as zodString } from 'zod';
-import type { AstroIntegration } from '../@types/astro.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { prependForwardSlash } from '../core/path.js';
 import {
@@ -56,7 +55,9 @@ export function createGetCollection({
 		} else if (collection in dataCollectionToEntryMap) {
 			type = 'data';
 		} else {
-			return warnOfEmptyCollection(collection);
+			// eslint-disable-next-line no-console
+			console.warn(`The collection **${collection}** does not exist or is empty. Ensure a collection directory with this name exists.`);
+			return;
 		}
 		const lazyImports = Object.values(
 			type === 'content'
@@ -389,17 +390,4 @@ type PropagatedAssetsModule = {
 
 function isPropagatedAssetsModule(module: any): module is PropagatedAssetsModule {
 	return typeof module === 'object' && module != null && '__astroPropagation' in module;
-}
-
-function warnOfEmptyCollection(collection: string): AstroIntegration {
-	return {
-		name: 'astro-collection',
-		hooks: {
-			'astro:server:start': ({ logger }) => {
-				logger.warn(
-					`The collection **${collection}** does not exist or is empty. Ensure a collection directory with this name exists.`
-				);
-			},
-		},
-	};
 }

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1158,7 +1158,7 @@ export const ContentSchemaContainsSlugError = {
 /**
  * @docs
  * @message A collection queried via `getCollection()` does not exist.
- * @deprecated Collections that do not exist are no longer an error. A warning is omitted instead.
+ * @deprecated Collections that do not exist no longer result in an error. A warning is omitted instead.
  * @description
  * When querying a collection, ensure a collection directory with the requested name exists under `src/content/`.
  */

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1158,6 +1158,7 @@ export const ContentSchemaContainsSlugError = {
 /**
  * @docs
  * @message A collection queried via `getCollection()` does not exist.
+ * @deprecated Collections that do not exist are no longer an error. A warning is omitted instead.
  * @description
  * When querying a collection, ensure a collection directory with the requested name exists under `src/content/`.
  */


### PR DESCRIPTION
## Changes

- There was a mistake in https://github.com/withastro/astro/pull/8382 that returned an integration when it should have just warned. This replaces that.
- This also deprecates the error that no longer occurs.

## Testing

- Test added in https://github.com/withastro/astro/pull/8382 will still pass

## Docs

N/A