### PR TITLE
Update index.ts

### DIFF
--- a/packages/integrations/deno/src/index.ts
+++ b/packages/integrations/deno/src/index.ts
@@ -183,6 +183,9 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					banner: {
 						js: SHIM,
 					},
+					logOverride: {
+						'ignored-bare-import': 'silent'
+					},
 				});
 
 				// Remove chunks, if they exist. Since we have bundled via esbuild these chunks are trash.


### PR DESCRIPTION
## Changes

Remove false warnings from Deno integration adapter  build.

Deno integration adapter  issues warnings when build with astro build. These warnings typically arise from packages labeled with "sideEffects": false," which are included in the Vite built output because they are considered external. 