### PR TITLE
Fix getCollection when collection is empty

### DIFF
--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -1,6 +1,5 @@
 import type { MarkdownHeading } from '@astrojs/markdown-remark';
 import { ZodIssueCode, string as zodString } from 'zod';
-import type { AstroIntegration } from '../@types/astro.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { prependForwardSlash } from '../core/path.js';
 import {
@@ -56,7 +55,8 @@ export function createGetCollection({
 		} else if (collection in dataCollectionToEntryMap) {
 			type = 'data';
 		} else {
-			return warnOfEmptyCollection(collection);
+      console.warn(`The collection **${collection}** does not exist or is empty. Ensure a collection directory with this name exists.`);
+			return [];
 		}
 		const lazyImports = Object.values(
 			type === 'content'
@@ -389,17 +389,4 @@ type PropagatedAssetsModule = {
 
 function isPropagatedAssetsModule(module: any): module is PropagatedAssetsModule {
 	return typeof module === 'object' && module != null && '__astroPropagation' in module;
-}
-
-function warnOfEmptyCollection(collection: string): AstroIntegration {
-	return {
-		name: 'astro-collection',
-		hooks: {
-			'astro:server:start': ({ logger }) => {
-				logger.warn(
-					`The collection **${collection}** does not exist or is empty. Ensure a collection directory with this name exists.`
-				);
-			},
-		},
-	};
 }


### PR DESCRIPTION
## Changes

Fixes `getCollection` when the collection is empty. `3.1.2` included #8382 which was meant to prevent an error from throwing, and replace it with a warning. The implementation instead returned an Astro integration from `getCollection`. This PR removes that, and replaces it with a `console.warn` before returning an empty array.

#### Other options

- We could revert the PR entirely,.
- We can return `undefined` if we want to explicitely show the collection does not exist.

## Testing

The previous PR had testing to confirm it was no longer throwing an error.

## Docs

I need to check if docs need updating, but in any case the current behaviour is already undocumented. @Princesseuh did mention that the previous PR deprecated an error, so that will likely also need addressing.

/cc @withastro/maintainers-docs for feedback!
