### PR TITLE
fix getDataEntryById to lookup by base name

### DIFF
--- a/.changeset/spicy-walls-wave.md
+++ b/.changeset/spicy-walls-wave.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix getDataEntryById to lookup by basename

--- a/packages/astro/content-module.template.mjs
+++ b/packages/astro/content-module.template.mjs
@@ -70,7 +70,7 @@ export const getEntryBySlug = createGetEntryBySlug({
 });
 
 export const getDataEntryById = createGetDataEntryById({
-	dataCollectionToEntryMap,
+	getEntryImport: createGlobLookup(dataCollectionToEntryMap),
 });
 
 export const getEntry = createGetEntry({

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -137,13 +137,12 @@ export function createGetEntryBySlug({
 }
 
 export function createGetDataEntryById({
-	dataCollectionToEntryMap,
+	getEntryImport,
 }: {
-	dataCollectionToEntryMap: CollectionToEntryMap;
+	getEntryImport: GetEntryImport;
 }) {
 	return async function getDataEntryById(collection: string, id: string) {
-		const lazyImport =
-			dataCollectionToEntryMap[collection]?.[/*TODO: filePathToIdMap*/ id + '.json'];
+		const lazyImport = await getEntryImport(collection, id);
 
 		// TODO: AstroError
 		if (!lazyImport) throw new Error(`Entry ${collection} → ${id} was not found.`);

--- a/packages/astro/test/data-collections.test.js
+++ b/packages/astro/test/data-collections.test.js
@@ -41,6 +41,17 @@ describe('Content Collections - data collections', () => {
 		});
 	});
 
+	describe('getDataEntryById', () => {
+		let json;
+		before(async () => {
+			const rawJson = await fixture.readFile('/translations/by-id.json');
+			json = JSON.parse(rawJson);
+		});
+		it('Grabs the item by the base file name', () => {
+			expect(json.id).to.equal('en');
+		});
+	});
+
 	describe('Authors Entry', () => {
 		for (const authorId of authorIds) {
 			let json;

--- a/packages/astro/test/fixtures/data-collections/src/pages/translations/by-id.json.js
+++ b/packages/astro/test/fixtures/data-collections/src/pages/translations/by-id.json.js
@@ -1,0 +1,9 @@
+import { getDataEntryById } from 'astro:content';
+
+export async function GET() {
+	const item = await getDataEntryById('i18n', 'en');
+
+	return {
+		body: JSON.stringify(item),
+	}
+}


### PR DESCRIPTION
## Changes

- Found this bug while working on a VT demo.
- Was expecting the lookup map to be by base id, but it is not, so instead using `createGlobLookup` like the other lookup functions do.

## Testing

- New test case added

## Docs

N/A, bug fix