### PR TITLE
fix(react): safer experimentalReactChildren communication

### DIFF
--- a/.changeset/popular-news-talk.md
+++ b/.changeset/popular-news-talk.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': patch
+---
+
+Fixed an issue where builds failed.

--- a/packages/integrations/react/server.js
+++ b/packages/integrations/react/server.js
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/server';
 import StaticHtml from './static-html.js';
 import { incrementId } from './context.js';
-import opts from 'astro:react:opts';
 
 const slotName = (str) => str.trim().replace(/[-_]([a-z])/g, (_, w) => w.toUpperCase());
 const reactTypeof = Symbol.for('react.element');
@@ -86,7 +85,7 @@ async function renderToStaticMarkup(Component, props, { default: children, ...sl
 		...slots,
 	};
 	const newChildren = children ?? props.children;
-	if (children && opts.experimentalReactChildren) {
+	if (children && import.meta.env.EXPERIMENTAL_REACT_CHILDREN) {
 		const convert = await import('./vnode-children.js').then((mod) => mod.default);
 		newProps.children = convert(children);
 	} else if (newChildren != null) {

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -23,23 +23,15 @@ function getRenderer() {
 }
 
 function optionsPlugin(experimentalReactChildren: boolean): vite.Plugin {
-	const virtualModule = 'astro:react:opts';
-	const virtualModuleId = '\0' + virtualModule;
 	return {
 		name: '@astrojs/react:opts',
-		resolveId(id) {
-			if (id === virtualModule) {
-				return virtualModuleId;
-			}
-		},
-		load(id) {
-			if (id === virtualModuleId) {
-				return {
-					code: `export default {
-						experimentalReactChildren: ${JSON.stringify(experimentalReactChildren)}
-					}`,
-				};
-			}
+		enforce: 'pre',
+		config() {
+			return {
+				define: {
+					'import.meta.env.EXPERIMENTAL_REACT_CHILDREN': experimentalReactChildren ? 'true' : 'false',
+				},
+			};
 		},
 	};
 }


### PR DESCRIPTION
## Changes
- Fixes #8390 
- Use `import.meta.env` instead of virtual modules to let react's SSR runtime know whether to use experimentalReactChildren.

## Testing
Existing tests should pass.

## Docs
Does not affect usage.