### PR TITLE
fix: bundle netlify functions as ESM to support top-level await

### DIFF
--- a/packages/integrations/netlify/src/integration-functions.ts
+++ b/packages/integrations/netlify/src/integration-functions.ts
@@ -1,5 +1,6 @@
 import type { AstroAdapter, AstroConfig, AstroIntegration, RouteData } from 'astro';
-import { extname } from 'node:path';
+import { extname, join } from 'node:path';
+import { writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { generateEdgeMiddleware } from './middleware.js';
 import type { Args } from './netlify-functions.js';
@@ -85,6 +86,16 @@ function netlifyFunctions({
 				}
 			},
 			'astro:build:done': async ({ routes, dir }) => {
+				const functionsConfig = {
+						version: 1,
+						config: {
+							nodeModuleFormat: "esm"
+						}
+				}
+				const functionsConfigPath = join(fileURLToPath(_config.build.server), "entry.json")
+				await writeFile(functionsConfigPath, JSON.stringify(functionsConfig))
+
+				// await writeFile(_config.build.server)
 				const type = builders ? 'builders' : 'functions';
 				const kind = type ?? 'functions';
 


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

https://github.com/withastro/astro/pull/8598 included a change that makes Astro emit functions with top-level await, specifically this line:

https://github.com/withastro/astro/blob/863f5171e8e7516c9d72f2e48ea7db1dea71c4f5/packages/astro/src/vite-plugin-markdown/index.ts#L146

Top-Level await is supported in ESM, but not in CJS. By default, Netlify bundles `.mjs` files into CJS files under the hood, so this will result in build failures. To work around that, this PR adds a config file that tells Netlify to bundle into ESM.

I've tested this out on https://github.com/Hiroki1112/hiroki-dev, which is the site I first noticed this bug with. My change fixed their build process.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
