### PR TITLE
fix: print image path for NoImageMetadata

### DIFF
--- a/.changeset/gentle-rocks-enjoy.md
+++ b/.changeset/gentle-rocks-enjoy.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix NoImageMetadata image path error message

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -649,7 +649,7 @@ export const NoImageMetadata = {
 	name: 'NoImageMetadata',
 	title: 'Could not process image metadata.',
 	message: (imagePath: string | undefined) =>
-		`Could not process image metadata${imagePath ? ' for `${imagePath}`' : ''}.`,
+		`Could not process image metadata${imagePath ? ` for ${imagePath}` : ''}.`,
 	hint: 'This is often caused by a corrupted or malformed image. Re-exporting the image from your image editor may fix this issue.',
 } satisfies ErrorData;
 

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -649,7 +649,7 @@ export const NoImageMetadata = {
 	name: 'NoImageMetadata',
 	title: 'Could not process image metadata.',
 	message: (imagePath: string | undefined) =>
-		`Could not process image metadata${imagePath ? ` for ${imagePath}` : ''}.`,
+		`Could not process image metadata${imagePath ? ` for \`${imagePath}\`` : ''}.`,
 	hint: 'This is often caused by a corrupted or malformed image. Re-exporting the image from your image editor may fix this issue.',
 } satisfies ErrorData;
 


### PR DESCRIPTION
Fixes #8665

## Changes

- Fixes the error message so that it includes the image path

## Testing

I did not add a test or repro, because the bug and fix seem fairly clear to me from the code.

## Docs

I don't think docs need to be updated.
