### PR TITLE
Fix assets not getting optimized when `outDir` is outside the CWD

### DIFF
--- a/.changeset/little-onions-relax.md
+++ b/.changeset/little-onions-relax.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix asset optimization failing when outDir is outside the project directory

--- a/packages/astro/src/assets/build/generate.ts
+++ b/packages/astro/src/assets/build/generate.ts
@@ -49,7 +49,7 @@ export async function generateImage(
 		serverRoot = config.build.server;
 		clientRoot = config.build.client;
 	} else {
-		serverRoot = config.outDir;
+		serverRoot = getOutDirWithinCwd(config.outDir);
 		clientRoot = config.outDir;
 	}
 
@@ -104,13 +104,9 @@ export async function generateImage(
 
 	// If the image is local, we can just read it directly, otherwise we need to download it
 	if (isLocalImage) {
-		const outDir = isServerLikeOutput(config)
-			? config.build.server
-			: getOutDirWithinCwd(config.outDir);
-
 		imageData = await fs.promises.readFile(
 			new URL(
-				prependForwardSlash(join(outDir.pathname + config.build.assets, basename(originalImagePath))),
+				'.' + prependForwardSlash(join(config.build.assets, basename(originalImagePath))),
 				serverRoot
 			)
 		);

--- a/packages/astro/src/assets/build/generate.ts
+++ b/packages/astro/src/assets/build/generate.ts
@@ -7,7 +7,7 @@ import { getConfiguredImageService, isESMImportedImage } from '../internal.js';
 import type { LocalImageService } from '../services/service.js';
 import type { ImageMetadata, ImageTransform } from '../types.js';
 import { loadRemoteImage, type RemoteCacheEntry } from './remote.js';
-import { getOutDirWithinCwd } from "#astro/core/build/common";
+import { getOutDirWithinCwd } from "../../core/build/common.js";
 
 interface GenerationDataUncached {
 	cached: false;

--- a/packages/astro/src/assets/build/generate.ts
+++ b/packages/astro/src/assets/build/generate.ts
@@ -103,9 +103,13 @@ export async function generateImage(
 
 	// If the image is local, we can just read it directly, otherwise we need to download it
 	if (isLocalImage) {
+		const outDir = isServerLikeOutput(config)
+			? config.build.server
+			: getOutDirWithinCwd(config.outDir);
+		
 		imageData = await fs.promises.readFile(
 			new URL(
-				'.' + prependForwardSlash(join(config.build.assets, basename(originalImagePath))),
+				prependForwardSlash(join(outDir.pathname + config.build.assets, basename(originalImagePath))),
 				serverRoot
 			)
 		);

--- a/packages/astro/src/assets/build/generate.ts
+++ b/packages/astro/src/assets/build/generate.ts
@@ -7,6 +7,7 @@ import { getConfiguredImageService, isESMImportedImage } from '../internal.js';
 import type { LocalImageService } from '../services/service.js';
 import type { ImageMetadata, ImageTransform } from '../types.js';
 import { loadRemoteImage, type RemoteCacheEntry } from './remote.js';
+import { getOutDirWithinCwd } from "#astro/core/build/common";
 
 interface GenerationDataUncached {
 	cached: false;
@@ -106,7 +107,7 @@ export async function generateImage(
 		const outDir = isServerLikeOutput(config)
 			? config.build.server
 			: getOutDirWithinCwd(config.outDir);
-		
+
 		imageData = await fs.promises.readFile(
 			new URL(
 				prependForwardSlash(join(outDir.pathname + config.build.assets, basename(originalImagePath))),


### PR DESCRIPTION
## Changes

- Resolves #8668 
- Fixes a build failure when using `astro:assets` and setting `outDir` to a folder outside of the project. For example `outDir: '../outside-the-project'`
- It's caused by some assets being constrained in the project folder/cwd, by using `getOutDirWithinCwd`
- `astro:assets` does not use `getOutDirWithinCwd`, so it ends up looking for the unoptimised assets at the wrong place

I wrote a slightly deeper explanation in https://github.com/withastro/astro/issues/8668#issuecomment-1735465977.

## Testing

The minimal reproducible example in the issue above (https://github.com/MichailiK/astro-images-outdir-bug) was used to test this change. I don't think this would cause regressions. I believe this change just ensures that Astro is trying to obtain the unoptimised asset from the correct folder. 

## Docs

Since this is a bug, caused by an inconsistency between where `astro:assets` is looking for the assets & where they are actually located, I don't believe this needs docs changes.  
