### PR TITLE
Fix normalize inconsistency between load & transform for filename

### DIFF
--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -11,7 +11,6 @@ import {
 	type CompileProps,
 } from '../core/compile/index.js';
 import { isRelativePath } from '../core/path.js';
-import { normalizeFilename } from '../vite-plugin-utils/index.js';
 import { cachedFullCompilation } from './compile.js';
 import { handleHotUpdate } from './hmr.js';
 import { parseAstroRequest } from './query.js';
@@ -45,7 +44,7 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 				return null;
 			}
 			// For CSS / hoisted scripts, the main Astro module should already be cached
-			const filename = normalizePath(normalizeFilename(parsedId.filename, config.root));
+			const filename = normalizePath(parsedId.filename);
 			const compileResult = getCachedCompileResult(config, filename);
 			if (!compileResult) {
 				return null;


### PR DESCRIPTION
- Some build systems symlink node_modules into the root, if normalized against config.root then the cache key between set & get will be different.

## Changes

- During `transform`: `cacheFullCompilation` normalizes filename via `normalizePath(parsedId.filename)`
- During `load`: `getCachedCompileResult` normalizes filename via `normalizePath(normalizeFilename(parsedId.filename, config.root))`
- This causes a cache miss when using a package manager (Nix in my case) that symlinks `node_modules` into project root
- Due to cache miss, `compileResult == null`, so the `code` portion doesn't become `/* client hoisted script, empty in SSR: ${id} */`
- Then, the entire `.astro` file gets sent to esbuild transform, which doesn't work because astro files aren't valid typescript.

Alternatively, we can go the other way and ensure during `transform` we also normalize via `normalizePath(normalizeFilename(parsedId.filename, config.root))`.

## Testing

<!-- How was this change tested? -->
Starlight doesn't work without this change. After this change applied, it was fixed. I also patched the code to `console.log` the `parserId.filename` before and after normalization to confirm that it indeed changed the cache key in a bad way.

## Docs

This affects the out-of-the-box experience with package managers that symlink `node_modules`.
