### PR TITLE
Fix logLevel passed to Vite build

### DIFF
--- a/.changeset/fast-glasses-remain.md
+++ b/.changeset/fast-glasses-remain.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix logLevel passed to Vite build

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -154,7 +154,8 @@ async function ssrBuild(
 	const viteBuildConfig: vite.InlineConfig = {
 		...viteConfig,
 		mode: viteConfig.mode || 'production',
-		logLevel: opts.viteConfig.logLevel ?? 'error',
+		// Check using `settings...` as `viteConfig` always defaults to `warn` by Astro
+		logLevel: settings.config.vite.logLevel ?? 'error',
 		build: {
 			target: 'esnext',
 			// Vite defaults cssMinify to false in SSR by default, but we want to minify it
@@ -260,7 +261,8 @@ async function clientBuild(
 	const viteBuildConfig: vite.InlineConfig = {
 		...viteConfig,
 		mode: viteConfig.mode || 'production',
-		logLevel: 'info',
+		// Check using `settings...` as `viteConfig` always defaults to `warn` by Astro
+		logLevel: settings.config.vite.logLevel ?? 'info',
 		build: {
 			target: 'esnext',
 			...viteConfig.build,

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -243,8 +243,6 @@ export async function createVite(
 	}
 	result = vite.mergeConfig(result, commandConfig);
 
-	result.customLogger = vite.createLogger(result.logLevel ?? 'warn');
-
 	return result;
 }
 


### PR DESCRIPTION
## Changes

The `customLogger` passed was suppressing the `logLevel` set here:

https://github.com/withastro/astro/blob/9fe4b9596988dc8b498825eae266805daf4b435b/packages/astro/src/core/build/static-build.ts#L263

Hence it never kicked in. I removed the `customLogger` as it doesn't seem to be useful. I did tweak the `logLevel` handling in `static-build.ts` so the user config value is still respected.

Before:
```
> @example/framework-svelte@0.0.1 build /Users/bjorn/Work/oss/astro/examples/framework-svelte
> astro build

09:17:22 PM [content] No content directory found. Skipping type generation.
09:17:22 PM [build] output target: static
09:17:22 PM [build] Collecting build info...
09:17:22 PM [build] Completed in 95ms.
09:17:22 PM [build] Building static entrypoints...
09:17:22 PM [build] Completed in 461ms.

 building client 
Completed in 125ms.


 generating static routes 
▶ src/pages/index.astro
  └─ /index.html (+10ms)
Completed in 11ms.

09:17:22 PM [build] 1 page(s) built in 700ms
09:17:22 PM [build] Complete!
```

After:

```
> @example/framework-svelte@0.0.1 build /Users/bjorn/Work/oss/astro/examples/framework-svelte
> astro build

09:13:42 PM [content] No content directory found. Skipping type generation.
09:13:42 PM [build] output target: static
09:13:42 PM [build] Collecting build info...
09:13:42 PM [build] Completed in 95ms.
09:13:42 PM [build] Building static entrypoints...
09:13:42 PM [build] Completed in 440ms.

 building client 
vite v4.4.9 building for production...
✓ 26 modules transformed.
dist/_astro/index.23f6f9ce.css   0.17 kB │ gzip: 0.15 kB
dist/_astro/client.ef651e53.js   0.62 kB │ gzip: 0.43 kB
dist/_astro/Counter.229d4a9b.js  7.68 kB │ gzip: 3.20 kB
✓ built in 121ms
Completed in 124ms.


 generating static routes 
▶ src/pages/index.astro
  └─ /index.html (+9ms)
Completed in 11ms.

09:13:42 PM [build] 1 page(s) built in 679ms
09:13:42 PM [build] Complete!
```

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested manually

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. should be a bug fix. the written code's intention didn't work before.