### PR TITLE
fix: accidentally breakage of charset in response header

### DIFF
--- a/.changeset/nine-books-clap.md
+++ b/.changeset/nine-books-clap.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix: accidentally breakage of charset in response header

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -58,6 +58,11 @@ export async function renderPage(
 	// Create final response from body
 	const init = result.response;
 	const headers = new Headers(init.headers);
+
+	// We know that the response is always HTML here, so set the Content-Type
+	// will be fine.
+	headers.set('Content-Type', 'text/html; charset=utf-8');
+
 	// For non-streaming, convert string to byte array to calculate Content-Length
 	if (!streaming && typeof body === 'string') {
 		body = encoder.encode(body);


### PR DESCRIPTION
## Changes

With [This][1] plugin change to use `renderComponent`, causing [this][2] branch to be false and we lost the `Content-Type: text/html; charset=utf-8` header below, and I think it's an accident change, right?

[1]: https://github.com/withastro/astro/blob/main/packages/astro/src/vite-plugin-markdown/index.ts#L180
[2]: https://github.com/withastro/astro/blob/f5c617e3a3ed8f010ff28f0cfe0f322ad54ed6e0/packages/astro/src/runtime/server/render/page.ts#L17C9-L17C9

### Before
![image](https://github.com/withastro/astro/assets/25167721/5bf6bc49-418b-4f39-8ec1-3fa883ff654d)

### After
![image](https://github.com/withastro/astro/assets/25167721/9904bab1-4d8a-4144-b1c1-06bbcf45227a)


Fixed: https://github.com/withastro/astro/issues/8676
## Testing
None

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
None

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
