### PR TITLE
[@astrojs/preftech] Prefetch images as well

### DIFF
--- a/packages/integrations/prefetch/src/client.ts
+++ b/packages/integrations/prefetch/src/client.ts
@@ -6,6 +6,7 @@ const events = ['mouseenter', 'touchstart', 'focus'];
 
 const preloaded = new Set<string>();
 const loadedStyles = new Set<string>();
+const loadedImages = new Set<string>();
 
 function shouldPreload({ href }: { href: string }) {
 	try {
@@ -52,7 +53,9 @@ async function preloadHref(link: HTMLAnchorElement) {
 
 		const html = parser.parseFromString(contents, 'text/html');
 		const styles = Array.from(html.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]'));
+		const images = Array.from(html.querySelectorAll<HTMLImageElement>('img'));
 
+		
 		await Promise.all(
 			styles
 				.filter((el) => !loadedStyles.has(el.href))
@@ -61,6 +64,15 @@ async function preloadHref(link: HTMLAnchorElement) {
 					return fetch(el.href);
 				})
 		);
+
+		await Promise.all(
+      images
+				.filter((el) => !loadedImages.has(el.src))
+			  .map((el) => {
+          loadedImages.add(el.src);
+          return fetch(el.src);
+        })
+    );
 	} catch {}
 }
 


### PR DESCRIPTION
## Changes

Prefetch images references in `img` tags at the same time the stylesheets are prefetched

## Testing

<!-- How was this change tested? -->
This was tested manually, if it is approved in principle, I'll write a test suite.
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->
I did not expose it as an option, therefore the documentation should just state that it pre-fetches the images. If it is approved in principle, I'll write the necessary documentation.
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
