### PR TITLE
chore(ci): pin CI Node version to 18.17.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
     strategy:
       matrix:
         OS: [ubuntu-latest, windows-latest]
-        NODE_VERSION: [18]
+        NODE_VERSION: [18.17.1]
       fail-fast: false
     env:
       NODE_VERSION: ${{ matrix.NODE_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         OS: [ubuntu-latest]
-        NODE_VERSION: [18, 20.5.1]
+        NODE_VERSION: [18.17.1, 20.5.1]
         include:
           - os: macos-latest
             NODE_VERSION: 18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,10 +108,10 @@ jobs:
     strategy:
       matrix:
         OS: [ubuntu-latest]
-        NODE_VERSION: [18.17.1, 20.5.1]
+        NODE_VERSION: [18, 20.5.1]
         include:
           - os: macos-latest
-            NODE_VERSION: 18
+            NODE_VERSION: 18.17.1
           - os: windows-latest
             NODE_VERSION: 18
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,9 @@ jobs:
         NODE_VERSION: [18, 20.5.1]
         include:
           - os: macos-latest
-            NODE_VERSION: 18.17.1
-          - os: windows-latest
             NODE_VERSION: 18
+          - os: windows-latest
+            NODE_VERSION: 18.17.1
       fail-fast: false
     env:
       NODE_VERSION: ${{ matrix.NODE_VERSION }}


### PR DESCRIPTION
## Changes
- CI - Node 18.18 breaks ~~playwright~~ (not just playwright) on windows.

## Testing
- Does not affect behavior.

## Docs
- Does not affect usage.