### PR TITLE
Move `astro:assets`-specific code out of the main Vite plugin and only use when relevant

### DIFF
--- a/packages/astro/src/vite-plugin-markdown/images.ts
+++ b/packages/astro/src/vite-plugin-markdown/images.ts
@@ -1,0 +1,34 @@
+export type MarkdownImagePath = { raw: string; resolved: string; safeName: string };
+
+export function getMarkdownCodeForImages(imagePaths: MarkdownImagePath[], html: string) {
+	return `
+		import { getImage } from "astro:assets";
+		${imagePaths
+			.map((entry) => `import Astro__${entry.safeName} from ${JSON.stringify(entry.raw)};`)
+			.join('\n')}
+
+		const images = async function() {
+			return {
+				${imagePaths
+					.map((entry) => `"${entry.raw}": await getImage({src: Astro__${entry.safeName}})`)
+					.join(',\n')}
+				}
+			}
+
+			async function updateImageReferences(html) {
+				return images().then((images) => {
+					return html.replaceAll(/__ASTRO_IMAGE_="([^"]+)"/gm, (full, imagePath) =>
+					spreadAttributes({
+						src: images[imagePath].src,
+						...images[imagePath].attributes,
+					})
+					);
+				});
+			}
+
+			// NOTE: This causes a top-level await to appear in the user's code, which can break very easily due to a Rollup
+			// bug and certain adapters not supporting it correctly. See: https://github.com/rollup/rollup/issues/4708
+			// Tread carefully!
+			const html = await updateImageReferences(${JSON.stringify(html)});
+		`;
+}


### PR DESCRIPTION
## Changes

This cleans up the main file of `vite-plugin-markdown` a little bit, especially the generated code so that `astro:assets` stuff is less in the way.

## Testing

Tests should still pass!

## Docs

N/A