### PR TITLE
Fix preloading stylesheets in view transitions

### DIFF
--- a/packages/astro/e2e/fixtures/view-transitions/public/one.css
+++ b/packages/astro/e2e/fixtures/view-transitions/public/one.css
@@ -1,0 +1,3 @@
+#one {
+	background-color: whitesmoke;
+}

--- a/packages/astro/e2e/fixtures/view-transitions/public/styles.css
+++ b/packages/astro/e2e/fixtures/view-transitions/public/styles.css
@@ -1,0 +1,3 @@
+h1 {
+	color: blue
+}

--- a/packages/astro/e2e/fixtures/view-transitions/src/components/Layout.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/components/Layout.astro
@@ -18,6 +18,7 @@ const { link } = Astro.props as Props;
 				margin: auto;
 			}	
 		</style>
+		<link rel="stylesheet" href="/style.css">
 		<ViewTransitions />
 		<DarkMode />
 		<meta name="script-executions" content="0">

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../components/Layout.astro';
 ---
-<Layout>
+<Layout link="/one.css">
 	<p id="one">Page 1</p>
 	<a id="click-one" href="#test">test</a>
 	<a id="click-two" href="/two">go to 2</a>

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -292,7 +292,9 @@ async function updateDOM(
 		// Do not preload links that are already on the page.
 		if (
 			!document.querySelector(
-				`[${PERSIST_ATTR}="${el.getAttribute(PERSIST_ATTR)}"], link[rel=stylesheet]`
+				`[${PERSIST_ATTR}="${el.getAttribute(
+					PERSIST_ATTR
+				)}"], link[rel=stylesheet][href="${el.getAttribute('href')}"]`
 			)
 		) {
 			const c = document.createElement('link');


### PR DESCRIPTION
## Changes

Over time, the preload code became a noop in virtually all relevant cases. 
If the current page had a any stylesheet link, no stylesheets were preloaded.
Fixed selector.

Bug fixing. Deliberately no changeset

## Testing

Adaptation of the existing test for testing preloads
Added stylesheet link in Layout to make fixture a bit more realistic

## Docs

N/A: bugfix
sorry Sarah