### PR TITLE
fix: wrong link in deno adapter's readme

### DIFF
--- a/packages/integrations/deno/README.md
+++ b/packages/integrations/deno/README.md
@@ -1,3 +1,3 @@
 # @astrojs/deno 🦖
 
-This adapter is no longer maintained by Astro. Please see [the new repository for the Deno adapter](https://github.com/withastro/netlify-adapter) which is now maintained by the Deno organization.
+This adapter is no longer maintained by Astro. Please see [the new repository for the Deno adapter](https://github.com/denoland/deno-astro-adapter) which is now maintained by the Deno organization.


### PR DESCRIPTION
## Changes

fixed link

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

docs only

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

just a link fix