### PR TITLE
Fixes: Shiki syntax highlighting adds is:raw attribute to the HTML output

### DIFF
--- a/.changeset/cuddly-vans-reply.md
+++ b/.changeset/cuddly-vans-reply.md
@@ -2,4 +2,4 @@
 '@astrojs/markdown-remark': patch
 ---
 
-Remove is:raw from remark Shiki plugin
+Remove `is:raw` from remark Shiki plugin

--- a/.changeset/cuddly-vans-reply.md
+++ b/.changeset/cuddly-vans-reply.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Remove is:raw from remark Shiki plugin

--- a/packages/markdown/remark/src/remark-shiki.ts
+++ b/packages/markdown/remark/src/remark-shiki.ts
@@ -76,8 +76,8 @@ export function remarkShiki({
 			// It would become this before hitting our regexes:
 			// &lt;span class=&quot;line&quot;
 
-			// Replace "shiki" class naming with "astro" and add "is:raw".
-			html = html.replace(/<pre class="(.*?)shiki(.*?)"/, `<pre is:raw class="$1astro-code$2"`);
+			// Replace "shiki" class naming with "astro".
+			html = html.replace(/<pre class="(.*?)shiki(.*?)"/, `<pre class="$1astro-code$2"`);
 			// Add "user-select: none;" for "+"/"-" diff symbols
 			if (node.lang === 'diff') {
 				html = html.replace(

--- a/packages/markdown/remark/test/shiki.js
+++ b/packages/markdown/remark/test/shiki.js
@@ -1,0 +1,16 @@
+import { createMarkdownProcessor } from '../dist/index.js';
+import chai from 'chai';
+
+describe('shiki syntax highlighting', async () => {
+	const processor = await createMarkdownProcessor();
+
+	it('does not add is:raw to the output', async () => {
+		const {
+			code,
+		} = await processor.render('```\ntest\n```');
+
+		chai
+			.expect(code)
+			.not.to.contain("is:raw");
+	});
+});


### PR DESCRIPTION
I recently ran my page through the W3C validator and it showed me a bunch of errors and warnings about `is:raw` being not allowed. Afaik `is:raw` is an Astro specific directive that should now appear on the static page output.

The raw-attribute appears only in the Shiki highlighted syntax.

To reproduce it, you can use this template https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-markdown-shiki

## Changes

I removed the part of the `shiki` plugin that adds the `is:raw` to the `pre`-tags. The fact that `is:raw` is in the HTML output implies that `is:raw` or a similar mechanic is already used higher up the chain.

## Testing

I added a Mocha test to verify the fix.

## Docs

The attribute is hidden from the user and only visible when inspecting the page HTML. Browsers seem to ignore it and it only appeared as a "problem" when running a HTML validator on the page.
