### PR TITLE
fix(node app): only include undici in output when on stackblitz

### DIFF
--- a/.changeset/thirty-ravens-fly.md
+++ b/.changeset/thirty-ravens-fly.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Node-based adapters now create less server-side javascript

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -6,7 +6,12 @@ import { IncomingMessage } from 'node:http';
 import { TLSSocket } from 'node:tls';
 import { deserializeManifest } from './common.js';
 import { App, type MatchOptions } from './index.js';
-export { apply as applyPolyfills } from '../polyfill.js';
+
+// These are dynamic imports because undici did not get tree shaken away otherwise. - arsh
+export const applyPolyfills =
+	import.meta.env.IS_STACKBLITZ
+		? await import('../polyfill.js').then(mod => mod.apply)
+		: await import('../polyfill-prod.js').then(mod => mod.apply);
 
 const clientAddressSymbol = Symbol.for('astro.clientAddress');
 

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -142,6 +142,7 @@ export async function createVite(
 			'import.meta.env.SITE': settings.config.site
 				? JSON.stringify(settings.config.site)
 				: 'undefined',
+			'import.meta.env.IS_STACKBLITZ': process.env.SHELL === '/bin/jsh' && process.versions.webcontainer != null ? 'true' : 'false',
 		},
 		server: {
 			hmr:

--- a/packages/astro/src/core/polyfill-prod.ts
+++ b/packages/astro/src/core/polyfill-prod.ts
@@ -1,0 +1,18 @@
+import crypto from 'node:crypto';
+import buffer from 'node:buffer';
+
+export function apply() {
+	// Remove when Node 18 is dropped for Node 20
+	if (!globalThis.crypto) {
+		Object.defineProperty(globalThis, 'crypto', {
+			value: crypto.webcrypto,
+		});
+	}
+
+	// Remove when Node 18 is dropped for Node 20
+	if (!globalThis.File) {
+		Object.defineProperty(globalThis, 'File', {
+			value: buffer.File,
+		});
+	}
+}


### PR DESCRIPTION
## Changes
- Allows polyfill to be removed with tree-shaking.
- Results from the blog template with `@astrojs/vercel`:

|            | Before  | After |
| ------------- | ------------- | ------------- |
Single Function| 1,312 kB  | 535 kB |
functionPerRoute | 1200~1300 kB  | 430~550 kB  |


## Testing
Does not attempt to change behavior; existing tests should pass.

## Docs
Does not affect usage.