### PR TITLE
Fix view transitions with client:only components

### DIFF
--- a/.changeset/cuddly-vans-reply.md
+++ b/.changeset/cuddly-vans-reply.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Remove `is:raw` from remark Shiki plugin

--- a/.changeset/eleven-buttons-wash.md
+++ b/.changeset/eleven-buttons-wash.md
@@ -1,0 +1,25 @@
+---
+'@astrojs/cloudflare': patch
+'@astrojs/partytown': patch
+'@astrojs/alpinejs': patch
+'@astrojs/prefetch': patch
+'@astrojs/tailwind': patch
+'@astrojs/markdoc': patch
+'@astrojs/sitemap': patch
+'@astrojs/underscore-redirects': patch
+'@astrojs/preact': patch
+'@astrojs/svelte': patch
+'@astrojs/vercel': patch
+'@astrojs/react': patch
+'@astrojs/solid-js': patch
+'@astrojs/node': patch
+'@astrojs/lit': patch
+'@astrojs/mdx': patch
+'@astrojs/vue': patch
+'@astrojs/internal-helpers': patch
+'@astrojs/markdown-remark': patch
+'@astrojs/telemetry': patch
+'astro': patch
+---
+
+Add provenance statement when publishing the library from CI

--- a/.changeset/gentle-hats-dress.md
+++ b/.changeset/gentle-hats-dress.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix view transitions with client:only components

--- a/.changeset/green-crabs-breathe.md
+++ b/.changeset/green-crabs-breathe.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/telemetry': patch
+---
+
+Removed an unnecessary dependency.

--- a/.changeset/red-masks-drop.md
+++ b/.changeset/red-masks-drop.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `tsconfig.json` update causing the server to crash

--- a/.changeset/tasty-meals-buy.md
+++ b/.changeset/tasty-meals-buy.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Remove unused CSS output files when inlined

--- a/.changeset/thirty-ravens-fly.md
+++ b/.changeset/thirty-ravens-fly.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Node-based adapters now create less server-side javascript

--- a/.changeset/tricky-otters-cross.md
+++ b/.changeset/tricky-otters-cross.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/partytown': patch
+---
+
+Expose types for TypeScript users

--- a/.changeset/witty-fishes-heal.md
+++ b/.changeset/witty-fishes-heal.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve `astro info` copy to clipboard compatability

--- a/packages/astro/astro.js
+++ b/packages/astro/astro.js
@@ -3,7 +3,6 @@
 
 // ISOMORPHIC FILE: NO TOP-LEVEL IMPORT/REQUIRE() ALLOWED
 // This file has to run as both ESM and CJS on older Node.js versions
-// Needed for Stackblitz: https://github.com/stackblitz/webcontainer-core/issues/281
 
 const CI_INSTRUCTIONS = {
 	NETLIFY: 'https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-and-javascript',
@@ -16,15 +15,11 @@ const CI_INSTRUCTIONS = {
 const engines = '>=18.14.1';
 const skipSemverCheckIfAbove = 19;
 
-// HACK (2023-08-18) Stackblitz does not support Node 18 yet, so we'll fake Node 16 support for some time until it's supported
-// TODO: Remove when Node 18 is supported on Stackblitz
-const isStackblitz = process.env.SHELL === '/bin/jsh' && process.versions.webcontainer != null;
-
 /** `astro *` */
 async function main() {
 	const version = process.versions.node;
 	// Fast-path for higher Node.js versions
-	if (!isStackblitz && (parseInt(version) || 0) <= skipSemverCheckIfAbove) {
+	if ((parseInt(version) || 0) <= skipSemverCheckIfAbove) {
 		try {
 			const semver = await import('semver');
 			if (!semver.satisfies(version, engines)) {

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/client-only-one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/client-only-one.astro
@@ -3,6 +3,7 @@ import Layout from '../components/Layout.astro';
 import Island from '../components/Island';
 ---
 <Layout>
+	<p id="page-one">Page 1</p>
 	<a id="click-two" href="/client-only-two">go to page 2</a>
 	<div transition:persist="island">
 		<Island client:only count={5}>message here</Island>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/client-only-two.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/client-only-two.astro
@@ -4,6 +4,7 @@ import Island from '../components/Island';
 ---
 <Layout>
 	<p id="page-two">Page 2</p>
+	<a id="click-one" href="/client-only-one">go to page 1</a>
 	<div transition:persist="island">
 		<Island client:only count={5}>message here</Island>
 	</div>

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -226,5 +226,8 @@
   "engines": {
     "node": ">=18.14.1",
     "npm": ">=6.14.0"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -168,7 +168,6 @@
     "string-width": "^6.1.0",
     "strip-ansi": "^7.1.0",
     "tsconfig-resolver": "^3.0.1",
-    "undici": "^5.23.0",
     "unist-util-visit": "^4.1.2",
     "vfile": "^5.3.7",
     "vite": "^4.4.9",

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1168,10 +1168,10 @@ export interface AstroUserConfig {
 		 * Pass [rehype plugins](https://github.com/remarkjs/remark-rehype) to customize how your Markdown's output HTML is processed. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 		 *
 		 * ```js
-		 * import rehypeMinifyHtml from 'rehype-minify';
+		 * import { rehypeAccessibleEmojis } from 'rehype-accessible-emojis';
 		 * {
 		 *   markdown: {
-		 *     rehypePlugins: [rehypeMinifyHtml]
+		 *     rehypePlugins: [rehypeAccessibleEmojis]
 		 *   }
 		 * }
 		 * ```

--- a/packages/astro/src/cli/info/index.ts
+++ b/packages/astro/src/cli/info/index.ts
@@ -46,7 +46,7 @@ async function copyToClipboard(text: string) {
 	let command = '';
 	if (system === 'darwin') {
 		command = 'pbcopy';
-	} else if (system === 'win32') { 
+	} else if (system === 'win32') {
 		command = 'clip';
 	} else {
 		// Unix: check if `xclip` is installed

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -148,9 +148,15 @@ export const _internal = {
 								hasContentFlag(modUrl, DATA_FLAG) ||
 								Boolean(getContentRendererByViteId(modUrl, settings))
 							) {
-								const mod = await viteServer.moduleGraph.getModuleByUrl(modUrl);
-								if (mod) {
-									viteServer.moduleGraph.invalidateModule(mod);
+								try {
+									const mod = await viteServer.moduleGraph.getModuleByUrl(modUrl);
+									if (mod) {
+										viteServer.moduleGraph.invalidateModule(mod);
+									}
+								} catch (e: any) {
+									// The server may be closed due to a restart caused by this file change
+									if (e.code === 'ERR_CLOSED_SERVER') break;
+									throw e;
 								}
 							}
 						}

--- a/packages/astro/src/core/build/plugins/plugin-css.ts
+++ b/packages/astro/src/core/build/plugins/plugin-css.ts
@@ -200,7 +200,7 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 			const inlineConfig = settings.config.build.inlineStylesheets;
 			const { assetsInlineLimit = 4096 } = settings.config.vite?.build ?? {};
 
-			Object.entries(bundle).forEach(([_, stylesheet]) => {
+			Object.entries(bundle).forEach(([id, stylesheet]) => {
 				if (
 					stylesheet.type !== 'asset' ||
 					stylesheet.name?.endsWith('.css') !== true ||
@@ -224,10 +224,15 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 					: { type: 'external', src: stylesheet.fileName };
 
 				const pages = Array.from(eachPageData(internals));
+				let sheetAddedToPage = false;
 
 				pages.forEach((pageData) => {
 					const orderingInfo = pagesToCss[pageData.moduleSpecifier]?.[stylesheet.fileName];
-					if (orderingInfo !== undefined) return pageData.styles.push({ ...orderingInfo, sheet });
+					if (orderingInfo !== undefined) {
+						pageData.styles.push({ ...orderingInfo, sheet });
+						sheetAddedToPage = true;
+						return;
+					}
 
 					const propagatedPaths = pagesToPropagatedCss[pageData.moduleSpecifier];
 					if (propagatedPaths === undefined) return;
@@ -243,8 +248,21 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 							pageData.propagatedStyles.set(pageInfoId, new Set()).get(pageInfoId)!;
 
 						propagatedStyles.add(sheet);
+						sheetAddedToPage = true;
 					});
 				});
+
+				if (toBeInlined && sheetAddedToPage) {
+					// CSS is already added to all used pages, we can delete it from the bundle
+					// and make sure no chunks reference it via `importedCss` (for Vite preloading)
+					// to avoid duplicate CSS.
+					delete bundle[id];
+					for (const chunk of Object.values(bundle)) {
+						if (chunk.type === 'chunk') {
+							chunk.viteMetadata?.importedCss?.delete(id);
+						}
+					}
+				}
 			});
 		},
 	};

--- a/packages/astro/src/core/compile/compile.ts
+++ b/packages/astro/src/core/compile/compile.ts
@@ -69,12 +69,6 @@ export async function compile({
 		});
 	}
 
-	if (viteConfig.mode === 'development') {
-		transformResult.clientOnlyComponents.forEach((component) => {
-			transformResult.code += `\nimport '${component.specifier}';\n`;
-		});
-	}
-
 	handleCompileResultErrors(transformResult, cssTransformErrors);
 
 	return {

--- a/packages/astro/src/core/compile/compile.ts
+++ b/packages/astro/src/core/compile/compile.ts
@@ -69,6 +69,12 @@ export async function compile({
 		});
 	}
 
+	if (viteConfig.mode === 'development') {
+		transformResult.clientOnlyComponents.forEach((component) => {
+			transformResult.code += `\nimport '${component.specifier}';\n`;
+		});
+	}
+
 	handleCompileResultErrors(transformResult, cssTransformErrors);
 
 	return {

--- a/packages/astro/src/core/endpoint/index.ts
+++ b/packages/astro/src/core/endpoint/index.ts
@@ -39,7 +39,6 @@ export function createAPIContext({
 	props,
 	adapterName,
 }: CreateAPIContext): APIContext {
-	initResponseWithEncoding();
 	const context = {
 		cookies: new AstroCookies(request),
 		request,
@@ -92,10 +91,7 @@ export function createAPIContext({
 
 type ResponseParameters = ConstructorParameters<typeof Response>;
 
-export let ResponseWithEncoding: ReturnType<typeof initResponseWithEncoding>;
-// TODO Remove this after StackBlitz supports Node 18.
-let initResponseWithEncoding = () => {
-	class LocalResponseWithEncoding extends Response {
+	export class ResponseWithEncoding extends Response {
 		constructor(
 			body: ResponseParameters[0],
 			init: ResponseParameters[1],
@@ -121,15 +117,6 @@ let initResponseWithEncoding = () => {
 			}
 		}
 	}
-
-	// Set the module scoped variable.
-	ResponseWithEncoding = LocalResponseWithEncoding;
-
-	// Turn this into a noop.
-	initResponseWithEncoding = (() => {}) as any;
-
-	return LocalResponseWithEncoding;
-};
 
 export async function callEndpoint<MiddlewareResult = Response | EndpointOutput>(
 	mod: EndpointHandler,

--- a/packages/astro/src/core/endpoint/index.ts
+++ b/packages/astro/src/core/endpoint/index.ts
@@ -91,32 +91,28 @@ export function createAPIContext({
 
 type ResponseParameters = ConstructorParameters<typeof Response>;
 
-	export class ResponseWithEncoding extends Response {
-		constructor(
-			body: ResponseParameters[0],
-			init: ResponseParameters[1],
-			encoding?: BufferEncoding
-		) {
-			// If a body string is given, try to encode it to preserve the behaviour as simple objects.
-			// We don't do the full handling as simple objects so users can control how headers are set instead.
-			if (typeof body === 'string') {
-				// In NodeJS, we can use Buffer.from which supports all BufferEncoding
-				if (typeof Buffer !== 'undefined' && Buffer.from) {
-					body = Buffer.from(body, encoding);
-				}
-				// In non-NodeJS, use the web-standard TextEncoder for utf-8 strings
-				else if (encoding == null || encoding === 'utf8' || encoding === 'utf-8') {
-					body = encoder.encode(body);
-				}
+export class ResponseWithEncoding extends Response {
+	constructor(body: ResponseParameters[0], init: ResponseParameters[1], encoding?: BufferEncoding) {
+		// If a body string is given, try to encode it to preserve the behaviour as simple objects.
+		// We don't do the full handling as simple objects so users can control how headers are set instead.
+		if (typeof body === 'string') {
+			// In NodeJS, we can use Buffer.from which supports all BufferEncoding
+			if (typeof Buffer !== 'undefined' && Buffer.from) {
+				body = Buffer.from(body, encoding);
 			}
-
-			super(body, init);
-
-			if (encoding) {
-				this.headers.set('X-Astro-Encoding', encoding);
+			// In non-NodeJS, use the web-standard TextEncoder for utf-8 strings
+			else if (encoding == null || encoding === 'utf8' || encoding === 'utf-8') {
+				body = encoder.encode(body);
 			}
 		}
+
+		super(body, init);
+
+		if (encoding) {
+			this.headers.set('X-Astro-Encoding', encoding);
+		}
 	}
+}
 
 export async function callEndpoint<MiddlewareResult = Response | EndpointOutput>(
 	mod: EndpointHandler,

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1158,7 +1158,7 @@ export const ContentSchemaContainsSlugError = {
 /**
  * @docs
  * @message A collection queried via `getCollection()` does not exist.
- * @deprecated Collections that do not exist no longer result in an error. A warning is omitted instead.
+ * @deprecated Collections that do not exist no longer result in an error. A warning is given instead.
  * @description
  * When querying a collection, ensure a collection directory with the requested name exists under `src/content/`.
  */

--- a/packages/astro/src/core/module-loader/vite.ts
+++ b/packages/astro/src/core/module-loader/vite.ts
@@ -1,19 +1,52 @@
 import { EventEmitter } from 'node:events';
+import path from 'node:path';
 import type * as vite from 'vite';
 import type { ModuleLoader, ModuleLoaderEventEmitter } from './loader.js';
 
 export function createViteLoader(viteServer: vite.ViteDevServer): ModuleLoader {
 	const events = new EventEmitter() as ModuleLoaderEventEmitter;
 
-	viteServer.watcher.on('add', (...args) => events.emit('file-add', args));
-	viteServer.watcher.on('unlink', (...args) => events.emit('file-unlink', args));
-	viteServer.watcher.on('change', (...args) => events.emit('file-change', args));
+	let isTsconfigUpdated = false;
+	function isTsconfigUpdate(filePath: string) {
+		const result = path.basename(filePath) === 'tsconfig.json';
+		if (result) isTsconfigUpdated = true;
+		return result;
+	}
 
-	wrapMethod(viteServer.ws, 'send', (msg) => {
+	// Skip event emit on tsconfig change as Vite restarts the server, and we don't
+	// want to trigger unnecessary work that will be invalidated shortly.
+	viteServer.watcher.on('add', (...args) => {
+		if (!isTsconfigUpdate(args[0])) {
+			events.emit('file-add', args);
+		}
+	});
+	viteServer.watcher.on('unlink', (...args) => {
+		if (!isTsconfigUpdate(args[0])) {
+			events.emit('file-unlink', args);
+		}
+	});
+	viteServer.watcher.on('change', (...args) => {
+		if (!isTsconfigUpdate(args[0])) {
+			events.emit('file-change', args);
+		}
+	});
+
+	const _wsSend = viteServer.ws.send;
+	viteServer.ws.send = function (...args: any) {
+		// If the tsconfig changed, Vite will trigger a reload as it invalidates the module.
+		// However in Astro, the whole server is restarted when the tsconfig changes. If we
+		// do a restart and reload at the same time, the browser will refetch and the server
+		// is not ready yet, causing a blank page. Here we block that reload from happening.
+		if (isTsconfigUpdated) {
+			isTsconfigUpdated = false;
+			return;
+		}
+		const msg = args[0] as vite.HMRPayload;
 		if (msg?.type === 'error') {
 			events.emit('hmr-error', msg);
 		}
-	});
+		_wsSend.apply(this, args);
+	};
 
 	return {
 		import(src) {
@@ -54,13 +87,5 @@ export function createViteLoader(viteServer: vite.ViteDevServer): ModuleLoader {
 			return !!viteServer.config.server.https;
 		},
 		events,
-	};
-}
-
-function wrapMethod(object: any, method: string, newFn: (...args: any[]) => void) {
-	const orig = object[method];
-	object[method] = function (...args: any[]) {
-		newFn.apply(this, args);
-		return orig.apply(this, args);
 	};
 }

--- a/packages/astro/src/core/polyfill.ts
+++ b/packages/astro/src/core/polyfill.ts
@@ -1,5 +1,5 @@
-import crypto from 'node:crypto';
 import buffer from 'node:buffer';
+import crypto from 'node:crypto';
 
 export function apply() {
 	// Remove when Node 18 is dropped for Node 20

--- a/packages/astro/src/core/polyfill.ts
+++ b/packages/astro/src/core/polyfill.ts
@@ -1,63 +1,7 @@
 import crypto from 'node:crypto';
-import {
-	ByteLengthQueuingStrategy,
-	CountQueuingStrategy,
-	ReadableByteStreamController,
-	ReadableStream,
-	ReadableStreamBYOBReader,
-	ReadableStreamBYOBRequest,
-	ReadableStreamDefaultController,
-	ReadableStreamDefaultReader,
-	TransformStream,
-	WritableStream,
-	WritableStreamDefaultController,
-	WritableStreamDefaultWriter,
-} from 'node:stream/web';
-import { File, FormData, Headers, Request, Response, fetch } from 'undici';
-
-// NOTE: This file does not intend to polyfill everything that exists, its main goal is to make life easier
-// for users deploying to runtime that do support these features. In the future, we hope for this file to disappear.
-
-// HACK (2023-08-18) Stackblitz does not support Node 18 yet, so we'll fake Node 16 support for some time until it's supported
-// TODO: Remove when Node 18 is supported on Stackblitz. File should get imported from `node:buffer` instead of `undici` once this is removed
-const isStackblitz = process.env.SHELL === '/bin/jsh' && process.versions.webcontainer != null;
+import buffer from 'node:buffer';
 
 export function apply() {
-	if (isStackblitz) {
-		const neededPolyfills = {
-			ByteLengthQueuingStrategy,
-			CountQueuingStrategy,
-			ReadableByteStreamController,
-			ReadableStream,
-			ReadableStreamBYOBReader,
-			ReadableStreamBYOBRequest,
-			ReadableStreamDefaultController,
-			ReadableStreamDefaultReader,
-			TransformStream,
-			WritableStream,
-			WritableStreamDefaultController,
-			WritableStreamDefaultWriter,
-			File,
-			FormData,
-			Headers,
-			Request,
-			Response,
-			fetch,
-		};
-
-		for (let polyfillName of Object.keys(neededPolyfills)) {
-			if (Object.hasOwnProperty.call(globalThis, polyfillName)) continue;
-
-			// Add polyfill to globalThis
-			Object.defineProperty(globalThis, polyfillName, {
-				configurable: true,
-				enumerable: true,
-				writable: true,
-				value: neededPolyfills[polyfillName as keyof typeof neededPolyfills],
-			});
-		}
-	}
-
 	// Remove when Node 18 is dropped for Node 20
 	if (!globalThis.crypto) {
 		Object.defineProperty(globalThis, 'crypto', {
@@ -68,7 +12,7 @@ export function apply() {
 	// Remove when Node 18 is dropped for Node 20
 	if (!globalThis.File) {
 		Object.defineProperty(globalThis, 'File', {
-			value: File,
+			value: buffer.File,
 		});
 	}
 }

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -42,11 +42,6 @@ const announce = () => {
 };
 const PERSIST_ATTR = 'data-astro-transition-persist';
 const parser = new DOMParser();
-// explained at its usage
-let noopEl: HTMLDivElement;
-if (import.meta.env.DEV) {
-	noopEl = document.createElement('div');
-}
 
 // The History API does not tell you if navigation is forward or back, so
 // you can figure it using an index. On pushState the index is incremented so you

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -198,22 +198,6 @@ async function updateDOM(
 			const href = el.getAttribute('href');
 			return newDocument.head.querySelector(`link[rel=stylesheet][href="${href}"]`);
 		}
-		// What follows is a fix for an issue (#8472) with missing client:only styles after transition.
-		// That problem exists only in dev mode where styles are injected into the page by Vite.
-		// Returning a noop element ensures that the styles are not removed from the old document.
-		// Guarding the code below with the dev mode check
-		// allows tree shaking to remove this code in production.
-		if (import.meta.env.DEV) {
-			if (el.tagName === 'STYLE' && el.dataset.viteDevId) {
-				const devId = el.dataset.viteDevId;
-				// If this same style tag exists, remove it from the new page
-				return (
-					newDocument.querySelector(`style[data-vite-dev-id="${devId}"]`) ||
-					// Otherwise, keep it anyways. This is client:only styles.
-					noopEl
-				);
-			}
-		}
 		return null;
 	};
 

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -170,7 +170,7 @@ export async function loadFixture(inlineConfig) {
 			try {
 				return await fetch(resolvedUrl, init);
 			} catch (err) {
-				// undici throws a vague error when it fails, so we log the url here to easily debug it
+				// node fetch throws a vague error when it fails, so we log the url here to easily debug it
 				if (err.message?.includes('fetch failed')) {
 					console.error(`[astro test] failed to fetch ${resolvedUrl}`);
 					console.error(err);

--- a/packages/integrations/alpinejs/package.json
+++ b/packages/integrations/alpinejs/package.json
@@ -39,5 +39,8 @@
   "devDependencies": {
     "astro": "workspace:*",
     "astro-scripts": "workspace:*"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -58,5 +58,8 @@
     "cheerio": "1.0.0-rc.12",
     "mocha": "^10.2.0",
     "wrangler": "^3.5.1"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/integrations/lit/package.json
+++ b/packages/integrations/lit/package.json
@@ -59,5 +59,8 @@
   "peerDependencies": {
     "@webcomponents/template-shadowroot": "^0.2.1",
     "lit": "^2.7.0"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/integrations/markdoc/package.json
+++ b/packages/integrations/markdoc/package.json
@@ -94,5 +94,8 @@
   },
   "engines": {
     "node": ">=18.14.1"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -79,5 +79,8 @@
   },
   "engines": {
     "node": ">=18.14.1"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -49,8 +49,7 @@
     "cheerio": "1.0.0-rc.12",
     "express": "^4.18.2",
     "mocha": "^10.2.0",
-    "node-mocks-http": "^1.13.0",
-    "undici": "^5.23.0"
+    "node-mocks-http": "^1.13.0"
   },
   "publishConfig": {
     "provenance": true

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -51,5 +51,8 @@
     "mocha": "^10.2.0",
     "node-mocks-http": "^1.13.0",
     "undici": "^5.23.0"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/integrations/node/src/createOutgoingHttpHeaders.ts
+++ b/packages/integrations/node/src/createOutgoingHttpHeaders.ts
@@ -13,7 +13,7 @@ export const createOutgoingHttpHeaders = (
 	if (!headers) {
 		return undefined;
 	}
-	
+
 	// at this point, a multi-value'd set-cookie header is invalid (it was concatenated as a single CSV, which is not valid for set-cookie)
 	const nodeHeaders: OutgoingHttpHeaders = Object.fromEntries(headers.entries());
 

--- a/packages/integrations/node/src/createOutgoingHttpHeaders.ts
+++ b/packages/integrations/node/src/createOutgoingHttpHeaders.ts
@@ -8,15 +8,12 @@ import type { OutgoingHttpHeaders } from 'node:http';
  * @returns NodeJS OutgoingHttpHeaders object with multiple set-cookie handled as an array of values
  */
 export const createOutgoingHttpHeaders = (
-	webHeaders: Headers | undefined | null
+	headers: Headers | undefined | null
 ): OutgoingHttpHeaders | undefined => {
-	if (!webHeaders) {
+	if (!headers) {
 		return undefined;
 	}
-
-	// re-type to access Header.getSetCookie()
-	const headers = webHeaders as HeadersWithGetSetCookie;
-
+	
 	// at this point, a multi-value'd set-cookie header is invalid (it was concatenated as a single CSV, which is not valid for set-cookie)
 	const nodeHeaders: OutgoingHttpHeaders = Object.fromEntries(headers.entries());
 
@@ -26,7 +23,8 @@ export const createOutgoingHttpHeaders = (
 
 	// if there is > 1 set-cookie header, we have to fix it to be an array of values
 	if (headers.has('set-cookie')) {
-		const cookieHeaders = headers.getSetCookie();
+		// @ts-expect-error
+		const cookieHeaders = headers.getSetCookie() as string[];
 		if (cookieHeaders.length > 1) {
 			// the Headers.entries() API already normalized all header names to lower case so we can safely index this as 'set-cookie'
 			nodeHeaders['set-cookie'] = cookieHeaders;
@@ -35,8 +33,3 @@ export const createOutgoingHttpHeaders = (
 
 	return nodeHeaders;
 };
-
-interface HeadersWithGetSetCookie extends Headers {
-	// the @astrojs/webapi polyfill makes this available (as of undici@5.19.0), but tsc doesn't pick it up on the built-in Headers type from DOM lib
-	getSetCookie(): string[];
-}

--- a/packages/integrations/partytown/package.json
+++ b/packages/integrations/partytown/package.json
@@ -38,5 +38,8 @@
   "devDependencies": {
     "astro": "workspace:*",
     "astro-scripts": "workspace:*"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/integrations/partytown/src/index.ts
+++ b/packages/integrations/partytown/src/index.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 import sirv from './sirv.js';
 const resolve = createRequire(import.meta.url).resolve;
 
-type PartytownOptions = {
+export type PartytownOptions = {
 	config?: PartytownConfig;
 };
 

--- a/packages/integrations/preact/package.json
+++ b/packages/integrations/preact/package.json
@@ -52,5 +52,8 @@
   },
   "engines": {
     "node": ">=18.14.1"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/integrations/prefetch/package.json
+++ b/packages/integrations/prefetch/package.json
@@ -40,5 +40,8 @@
   },
   "dependencies": {
     "throttles": "^1.0.1"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -67,5 +67,8 @@
   },
   "engines": {
     "node": ">=18.14.1"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/integrations/sitemap/package.json
+++ b/packages/integrations/sitemap/package.json
@@ -43,5 +43,8 @@
     "chai": "^4.3.7",
     "mocha": "^10.2.0",
     "xml2js": "0.6.2"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/integrations/solid/package.json
+++ b/packages/integrations/solid/package.json
@@ -47,5 +47,8 @@
   },
   "engines": {
     "node": ">=18.14.1"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -53,5 +53,8 @@
   },
   "engines": {
     "node": ">=18.14.1"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/integrations/tailwind/package.json
+++ b/packages/integrations/tailwind/package.json
@@ -45,5 +45,8 @@
   "peerDependencies": {
     "astro": "workspace:^3.2.2",
     "tailwindcss": "^3.0.24"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -72,5 +72,8 @@
     "chai-jest-snapshot": "^2.0.0",
     "cheerio": "1.0.0-rc.12",
     "mocha": "^10.2.0"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -61,5 +61,8 @@
   },
   "engines": {
     "node": ">=18.14.1"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/internal-helpers/package.json
+++ b/packages/internal-helpers/package.json
@@ -37,5 +37,8 @@
   "keywords": [
     "astro",
     "astro-component"
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -57,5 +57,8 @@
     "chai": "^4.3.7",
     "mdast-util-mdx-expression": "^1.3.2",
     "mocha": "^10.2.0"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/markdown/remark/src/remark-shiki.ts
+++ b/packages/markdown/remark/src/remark-shiki.ts
@@ -76,8 +76,8 @@ export function remarkShiki({
 			// It would become this before hitting our regexes:
 			// &lt;span class=&quot;line&quot;
 
-			// Replace "shiki" class naming with "astro" and add "is:raw".
-			html = html.replace(/<pre class="(.*?)shiki(.*?)"/, `<pre is:raw class="$1astro-code$2"`);
+			// Replace "shiki" class naming with "astro".
+			html = html.replace(/<pre class="(.*?)shiki(.*?)"/, `<pre class="$1astro-code$2"`);
 			// Add "user-select: none;" for "+"/"-" diff symbols
 			if (node.lang === 'diff') {
 				html = html.replace(

--- a/packages/markdown/remark/test/shiki.js
+++ b/packages/markdown/remark/test/shiki.js
@@ -5,12 +5,8 @@ describe('shiki syntax highlighting', async () => {
 	const processor = await createMarkdownProcessor();
 
 	it('does not add is:raw to the output', async () => {
-		const {
-			code,
-		} = await processor.render('```\ntest\n```');
+		const { code } = await processor.render('```\ntest\n```');
 
-		chai
-			.expect(code)
-			.not.to.contain("is:raw");
+		chai.expect(code).not.to.contain('is:raw');
 	});
 });

--- a/packages/markdown/remark/test/shiki.js
+++ b/packages/markdown/remark/test/shiki.js
@@ -1,0 +1,16 @@
+import { createMarkdownProcessor } from '../dist/index.js';
+import chai from 'chai';
+
+describe('shiki syntax highlighting', async () => {
+	const processor = await createMarkdownProcessor();
+
+	it('does not add is:raw to the output', async () => {
+		const {
+			code,
+		} = await processor.render('```\ntest\n```');
+
+		chai
+			.expect(code)
+			.not.to.contain("is:raw");
+	});
+});

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -49,5 +49,8 @@
   },
   "engines": {
     "node": ">=18.14.1"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -35,7 +35,6 @@
     "dset": "^3.1.2",
     "is-docker": "^3.0.0",
     "is-wsl": "^3.0.0",
-    "undici": "^5.23.0",
     "which-pm-runs": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/telemetry/src/post.ts
+++ b/packages/telemetry/src/post.ts
@@ -1,5 +1,4 @@
 const ASTRO_TELEMETRY_ENDPOINT = `https://telemetry.astro.build/api/v1/record`;
-import { fetch } from 'undici';
 
 export function post(body: Record<string, any>): Promise<any> {
 	return fetch(ASTRO_TELEMETRY_ENDPOINT, {

--- a/packages/underscore-redirects/package.json
+++ b/packages/underscore-redirects/package.json
@@ -38,5 +38,8 @@
   "keywords": [
     "astro",
     "astro-component"
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -628,9 +628,6 @@ importers:
       tsconfig-resolver:
         specifier: ^3.0.1
         version: 3.0.1
-      undici:
-        specifier: ^5.23.0
-        version: 5.23.0
       unist-util-visit:
         specifier: ^4.1.2
         version: 4.1.2
@@ -4307,9 +4304,6 @@ importers:
       node-mocks-http:
         specifier: ^1.13.0
         version: 1.13.0
-      undici:
-        specifier: ^5.23.0
-        version: 5.23.0
 
   packages/integrations/node/test/fixtures/api-route:
     dependencies:
@@ -5005,9 +4999,6 @@ importers:
       is-wsl:
         specifier: ^3.0.0
         version: 3.0.0
-      undici:
-        specifier: ^5.23.0
-        version: 5.23.0
       which-pm-runs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -17276,6 +17267,7 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       busboy: 1.6.0
+    dev: true
 
   /unherit@3.0.1:
     resolution: {integrity: sha512-akOOQ/Yln8a2sgcLj4U0Jmx0R5jpIg2IUyRrWOzmEbjBtGzBdHtSeFKgoEcoH4KYIG/Pb8GQ/BwtYm0GCq1Sqg==}


### PR DESCRIPTION
## Changes

The original issue is #8114. Persistent `client:only` components lose their styling on transition.
This only happens with `astro dev`, not with `astro build`.
The reason was that the HTML files contained only statically generated styles, and the comparison between the old DOM and the new file removed the client-side generated styles.
Fix #8472 fixed this by attempting to identify these client-generated styles and retain them.
This caused several issues where old styles were not deleted during the transition, even though they should have been. (#8604, #8674)

## Testing

Manually tested with code from #8604.

## Docs

n/a, bug fix
