### PR TITLE
Improve `astro info` compatability

### DIFF
--- a/.changeset/witty-fishes-heal.md
+++ b/.changeset/witty-fishes-heal.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve `astro info` copy to clipboard compatability

--- a/packages/astro/src/cli/info/index.ts
+++ b/packages/astro/src/cli/info/index.ts
@@ -56,7 +56,8 @@ async function copyToClipboard(text: string) {
 	if (!shouldCopy) return;
 	const command = system === 'darwin' ? 'pbcopy' : 'clip';
 	try {
-		execSync(`echo ${JSON.stringify(text.trim())} | ${command}`, {
+		execSync(command, {
+			input: text.trim(),
 			encoding: 'utf8',
 			stdio: 'ignore',
 		});

--- a/packages/astro/src/cli/info/index.ts
+++ b/packages/astro/src/cli/info/index.ts
@@ -59,7 +59,6 @@ async function copyToClipboard(text: string) {
 		execSync(command, {
 			input: text.trim(),
 			encoding: 'utf8',
-			stdio: 'ignore',
 		});
 	} catch (e) {
 		console.error(

--- a/packages/astro/src/cli/info/index.ts
+++ b/packages/astro/src/cli/info/index.ts
@@ -41,10 +41,22 @@ export async function printInfo({ flags }: InfoOptions) {
 	await copyToClipboard(output.trim());
 }
 
-const SUPPORTED_SYSTEM = new Set(['darwin', 'win32']);
 async function copyToClipboard(text: string) {
 	const system = platform();
-	if (!SUPPORTED_SYSTEM.has(system)) return;
+	let command = '';
+	if (system === 'darwin') {
+		command = 'pbcopy';
+	} else if (system === 'win32') { 
+		command = 'clip';
+	} else {
+		// Unix: check if `xclip` is installed
+		const output = execSync('which xclip', { encoding: 'utf8' });
+		if (output[0] !== '/') {
+			// Did not find a path for xclip, bail out!
+			return;
+		}
+		command = 'xclip -sel clipboard -l 1';
+	}
 
 	console.log();
 	const { shouldCopy } = await prompts({
@@ -54,7 +66,7 @@ async function copyToClipboard(text: string) {
 		initial: true,
 	});
 	if (!shouldCopy) return;
-	const command = system === 'darwin' ? 'pbcopy' : 'clip';
+
 	try {
 		execSync(command, {
 			input: text.trim(),


### PR DESCRIPTION
## Changes

- On Windows terminals, `astro info`'s copy to clipboard feature was copying the entire JSON-encoded string rather than the unencoded string as expected.
- With some help from @lilnasy, we debugged this and landed on passing the input directly to `clip`.

## Testing

Tested manually

## Docs

N/A