### PR TITLE
Fix markdown rehype plugin example

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1168,10 +1168,10 @@ export interface AstroUserConfig {
 		 * Pass [rehype plugins](https://github.com/remarkjs/remark-rehype) to customize how your Markdown's output HTML is processed. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 		 *
 		 * ```js
-		 * import rehypeMinifyHtml from 'rehype-minify';
+		 * import { rehypeAccessibleEmojis } from 'rehype-accessible-emojis';
 		 * {
 		 *   markdown: {
-		 *     rehypePlugins: [rehypeMinifyHtml]
+		 *     rehypePlugins: [rehypeAccessibleEmojis]
 		 *   }
 		 * }
 		 * ```


### PR DESCRIPTION
## Changes

- Minor fix on a sample code for the Markdown Rehype plugin docs, as referenced in [this issue](https://github.com/withastro/docs/issues/4549).
- Closes https://github.com/withastro/docs/issues/4549

## Testing

<!-- How was this change tested? -->
Tested manually to verify the sample code shows the updated plugin:

![image](https://github.com/withastro/astro/assets/28495550/6868b259-0266-46e9-bb03-df7fcb14ab05)

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
I made this PR as directed from [the issue from the Astro Docs repo](https://github.com/withastro/docs/issues/4549#issuecomment-1722483590). I simply used the same example plugin already used in [the Markdown & MDX docs page](https://docs.astro.build/en/guides/markdown-content/#markdown-plugins).
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
