### PR TITLE
fix(windows): ensure drive letter is uppercase

### DIFF
--- a/.changeset/large-clouds-sip.md
+++ b/.changeset/large-clouds-sip.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed an issue on Windows where lowercase drive letters in current working directory led to missing scripts and styles.

--- a/packages/astro/astro.js
+++ b/packages/astro/astro.js
@@ -32,6 +32,13 @@ async function main() {
 		}
 	}
 
+  // windows drive letters can sometimes be lowercase, which vite cannot process
+  if (process.platform === 'win32') {
+    const cwd = process.cwd()
+    const correctedCwd = cwd.slice(0, 1).toUpperCase() + cwd.slice(1)
+    process.chdir(correctedCwd)
+  }
+
 	return import('./dist/cli/index.js')
 		.then(({ cli }) => cli(process.argv))
 		.catch((error) => {

--- a/packages/astro/astro.js
+++ b/packages/astro/astro.js
@@ -36,7 +36,7 @@ async function main() {
   if (process.platform === 'win32') {
     const cwd = process.cwd()
     const correctedCwd = cwd.slice(0, 1).toUpperCase() + cwd.slice(1)
-    process.chdir(correctedCwd)
+    if (correctedCwd !== cwd) process.chdir(correctedCwd)
   }
 
 	return import('./dist/cli/index.js')


### PR DESCRIPTION
## Changes
- Fix for #8470
- Issue still affects Vite.

## Testing
😶‍🌫️

## Docs
Does not affect usage.