### PR TITLE
Remove unused CSS output files when inlined

### DIFF
--- a/.changeset/tasty-meals-buy.md
+++ b/.changeset/tasty-meals-buy.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Remove unused CSS output files when inlined

--- a/packages/astro/src/core/build/plugins/plugin-css.ts
+++ b/packages/astro/src/core/build/plugins/plugin-css.ts
@@ -200,7 +200,7 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 			const inlineConfig = settings.config.build.inlineStylesheets;
 			const { assetsInlineLimit = 4096 } = settings.config.vite?.build ?? {};
 
-			Object.entries(bundle).forEach(([_, stylesheet]) => {
+			Object.entries(bundle).forEach(([id, stylesheet]) => {
 				if (
 					stylesheet.type !== 'asset' ||
 					stylesheet.name?.endsWith('.css') !== true ||
@@ -224,10 +224,15 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 					: { type: 'external', src: stylesheet.fileName };
 
 				const pages = Array.from(eachPageData(internals));
+				let sheetAddedToPage = false;
 
 				pages.forEach((pageData) => {
 					const orderingInfo = pagesToCss[pageData.moduleSpecifier]?.[stylesheet.fileName];
-					if (orderingInfo !== undefined) return pageData.styles.push({ ...orderingInfo, sheet });
+					if (orderingInfo !== undefined) {
+						pageData.styles.push({ ...orderingInfo, sheet });
+						sheetAddedToPage = true;
+						return;
+					}
 
 					const propagatedPaths = pagesToPropagatedCss[pageData.moduleSpecifier];
 					if (propagatedPaths === undefined) return;
@@ -243,8 +248,21 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 							pageData.propagatedStyles.set(pageInfoId, new Set()).get(pageInfoId)!;
 
 						propagatedStyles.add(sheet);
+						sheetAddedToPage = true;
 					});
 				});
+
+				if (toBeInlined && sheetAddedToPage) {
+					// CSS is already added to all used pages, we can delete it from the bundle
+					// and make sure no chunks reference it via `importedCss` (for Vite preloading)
+					// to avoid duplicate CSS.
+					delete bundle[id];
+					for (const chunk of Object.values(bundle)) {
+						if (chunk.type === 'chunk') {
+							chunk.viteMetadata?.importedCss?.delete(id);
+						}
+					}
+				}
 			});
 		},
 	};


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/8567

Fixes 2 issues:
1. Fix Vite preloading CSS references by updating `importedCss`.
2. CSS files inlined to any pages should not be deleted.

I'm actually unsure if there's a bug in no2, where in the `css-dangling-references` fixture, the CSS is not inlined/duplicated to both the pages.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
The existing tests (especially `css-dangling-references`) should pass

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.