### PR TITLE
Improve error message for dynamic component usage

### DIFF
--- a/.changeset/fair-otters-worry.md
+++ b/.changeset/fair-otters-worry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve error message when user attempts to render a dynamic component reference

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -122,9 +122,10 @@ export async function generateHydrateScript(
 	const { hydrate, componentUrl, componentExport } = metadata;
 
 	if (!componentExport.value) {
-		throw new Error(
-			`Unable to resolve a valid export for "${metadata.displayName}"! Please open an issue at https://astro.build/issues!`
-		);
+		throw new AstroError({
+			...AstroErrorData.NoMatchingImport,
+			message: AstroErrorData.NoMatchingImport.message(metadata.displayName),
+		});
 	}
 
 	const island: SSRElement = {


### PR DESCRIPTION
## Changes

- Closes #8746
- Improves error message when rendering a dynamic component is attempted
- Our old error was likely an old holdover from before we had a proper error system and docs, and we already had an Astro error for this case!
- This PR just replaces our old, unhelpful error with a proper `AstroError`

## Testing

Manually confirmed that this worked

## Docs

No changes to the error data, just referencing an existing error.