### PR TITLE
Fix scripts run with <ViewTransitions> on fallback swap and multiple inline <head> scripts 

### DIFF
--- a/.changeset/stale-planes-prove.md
+++ b/.changeset/stale-planes-prove.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix scripts run with <ViewTransitions> on fallback swap and multiple inline <head> scripts

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -122,7 +122,7 @@ const { fallback = 'animate' } = Astro.props as Props;
 						// Inline
 						(s1.textContent && s1.textContent === s2.textContent) ||
 						// External
-						(s1.type === s2.type && s1.src === s2.src)
+						(s1.type === s2.type && s1.src && s1.src === s2.src)
 					) {
 						return s2;
 					}
@@ -225,18 +225,21 @@ const { fallback = 'animate' } = Astro.props as Props;
 
 			// Trigger the animations
 			document.documentElement.dataset.astroTransitionFallback = 'old';
-			const fallbackSwap = () => {
-				removeEventListener('animationend', fallbackSwap);
-				clearTimeout(timeout);
-				swap();
-				document.documentElement.dataset.astroTransitionFallback = 'new';
-			};
-			// If there are any animations, want for the animationend event.
-			addEventListener('animationend', fallbackSwap, { once: true });
-			// If there are no animations, go ahead and swap on next tick
-			// This is necessary because we do not know if there are animations.
-			// The setTimeout is a fallback in case there are none.
-			let timeout = setTimeout(() => !isAnimating && fallbackSwap());
+			await new Promise((resolve) => {
+			  const fallbackSwap = () => {
+			    removeEventListener('animationend', fallbackSwap);
+			    clearTimeout(timeout);
+			    swap();
+			    resolve(true);
+			    document.documentElement.dataset.astroTransitionFallback = 'new';
+			  };
+			  // If there are any animations, want for the animationend event.
+			  addEventListener('animationend', fallbackSwap, { once: true });
+			  // If there are no animations, go ahead and swap on next tick
+			  // This is necessary because we do not know if there are animations.
+			  // The setTimeout is a fallback in case there are none.
+			  let timeout = setTimeout(() => !isAnimating && fallbackSwap());
+			});
 		} else {
 			swap();
 		}


### PR DESCRIPTION
Fixes for <ViewTransitions> with "SPA" mode on v2 (not sure about v3):

## Changes

1. Multiple <head> inline scripts are removed cause second one is being considered external with `(s1.type === s2.type && s1.src === s2.src)` (s1.src === s2.src === undefined), an [example real use case](https://github.com/ecomplus/cloud-commerce/blob/main/packages/storefront/src/lib/layouts/BaseHead.astro#L172-L176) with a persistent inline script (all site shared state) plus a page-context inline script (page state);

2. `runScripts` is called before DOM replacement on fallback mode (Firefox) cause fallback swap is async and not awaited, this cause scripts not being executed on first page transition, on next transition (3º page) the scripts of past page (2º) are executed...

## Testing

I'm using a custom <ViewTransitions> component [here](https://github.com/ecomplus/cloud-commerce/blob/main/packages/storefront/src/lib/components/ViewTransitions.astro) to [fix these problems](https://github.com/ecomplus/cloud-commerce/commit/2e5320718bfa76c6e7f6258031a546e3f9089aa4) , both bugs resolved after changes.

I can try to create a minimal reproduction on Stackblitz later if necessary.

## Docs

N/A
