### PR TITLE
Fix: Markdoc Integration build when root folder contains spaces

### DIFF
--- a/.changeset/seven-files-punch.md
+++ b/.changeset/seven-files-punch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': patch
+---
+
+Fix build process on markdoc integration when root folder contains spaces

--- a/packages/integrations/markdoc/src/content-entry-type.ts
+++ b/packages/integrations/markdoc/src/content-entry-type.ts
@@ -106,7 +106,7 @@ export async function getContentEntryType({
 import { createGetHeadings, createContentComponent } from '@astrojs/markdoc/runtime';
 ${
 	markdocConfigUrl
-		? `import markdocConfig from ${JSON.stringify(markdocConfigUrl.pathname)};`
+		? `import markdocConfig from ${JSON.stringify(decodeURI(markdocConfigUrl.pathname))};`
 		: 'const markdocConfig = {};'
 }
 
@@ -232,7 +232,9 @@ function getStringifiedImports(
 		const resolvedPath =
 			config.type === 'local' ? new URL(config.path, root).pathname : config.path;
 
-		stringifiedComponentImports += `import ${importName} from ${JSON.stringify(resolvedPath)};\n`;
+		stringifiedComponentImports += `import ${importName} from ${JSON.stringify(
+			decodeURI(resolvedPath)
+		)};\n`;
 	}
 	return stringifiedComponentImports;
 }

--- a/packages/integrations/markdoc/test/fixtures/render with-space/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/render with-space/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import markdoc from '@astrojs/markdoc';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [markdoc()],
+});

--- a/packages/integrations/markdoc/test/fixtures/render with-space/package.json
+++ b/packages/integrations/markdoc/test/fixtures/render with-space/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/markdoc-render-with-space",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/markdoc": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/markdoc/test/fixtures/render with-space/src/content/blog/simple.mdoc
+++ b/packages/integrations/markdoc/test/fixtures/render with-space/src/content/blog/simple.mdoc
@@ -1,0 +1,7 @@
+---
+title: Simple post with root folder containing a space
+---
+
+## Simple post with root folder containing a space
+
+This is a simple Markdoc post with root folder containing a space.

--- a/packages/integrations/markdoc/test/fixtures/render with-space/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render with-space/src/pages/index.astro
@@ -1,0 +1,19 @@
+---
+import { getEntryBySlug } from "astro:content";
+
+const post = await getEntryBySlug('blog', 'simple');
+const { Content } = await post.render();
+---
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Content</title>
+</head>
+<body>
+	<Content />	
+</body>
+</html>

--- a/packages/integrations/markdoc/test/render.test.js
+++ b/packages/integrations/markdoc/test/render.test.js
@@ -57,6 +57,18 @@ describe('Markdoc - render', () => {
 
 			await server.stop();
 		});
+
+		it('renders content - with root folder containing space', async () => {
+			const fixture = await getFixture('render with-space');
+			const server = await fixture.startDevServer();
+
+			const res = await fixture.fetch('/');
+			const html = await res.text();
+
+			renderWithRootFolderContainingSpace(html);
+
+			await server.stop();
+		});
 	});
 
 	describe('build', () => {
@@ -94,6 +106,15 @@ describe('Markdoc - render', () => {
 			const html = await fixture.readFile('/index.html');
 
 			renderNullChecks(html);
+		});
+
+		it('renders content - with root folder containing space', async () => {
+			const fixture = await getFixture('render with-space');
+			await fixture.build();
+
+			const html = await fixture.readFile('/index.html');
+
+			renderWithRootFolderContainingSpace(html);
 		});
 	});
 });
@@ -147,4 +168,15 @@ function renderSimpleChecks(html) {
 	expect(h2.textContent).to.equal('Simple post');
 	const p = document.querySelector('p');
 	expect(p.textContent).to.equal('This is a simple Markdoc post.');
+}
+
+/** @param {string} html */
+function renderWithRootFolderContainingSpace(html) {
+	const { document } = parseHTML(html);
+	const h2 = document.querySelector('h2');
+	expect(h2.textContent).to.equal('Simple post with root folder containing a space');
+	const p = document.querySelector('p');
+	expect(p.textContent).to.equal(
+		'This is a simple Markdoc post with root folder containing a space.'
+	);
 }


### PR DESCRIPTION
Hello,
opening this PR to fix Issue #8164.

## Changes

- Added `decodeURI` function call to pathnames representing root folder in `markdoc` plugin

## Testing

- Added a test case for rendering and building with a root project folder that contains spaces
- Manually tested with an existing `markdoc` project with same characteristics:
  - `pnpm link` on local Astro project containing fix
  - `astro build` on the existing project
  - No errors shown, build completed successfully
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
- No workaround needed for the root project folder's name
- No docs were added because this issue wasn't showing on docs

<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
