### PR TITLE
fix(cloudflare): support for 'cloudflare:*' imports

### DIFF
--- a/.changeset/heavy-elephants-tan.md
+++ b/.changeset/heavy-elephants-tan.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Adding cloudflare:sockets compile support

--- a/.changeset/heavy-elephants-tan.md
+++ b/.changeset/heavy-elephants-tan.md
@@ -2,4 +2,4 @@
 '@astrojs/cloudflare': patch
 ---
 
-Adding cloudflare:sockets compile support
+Adds `cloudflare:sockets` compile support

--- a/packages/integrations/cloudflare/README.md
+++ b/packages/integrations/cloudflare/README.md
@@ -357,6 +357,10 @@ import { Buffer } from 'node:buffer';
 
 Additionally, you'll need to enable the Compatibility Flag in Cloudflare. The configuration for this flag may vary based on where you deploy your Astro site. For detailed guidance, please refer to the [Cloudflare documentation on enabling Node.js compatibility](https://developers.cloudflare.com/workers/runtime-apis/nodejs).
 
+## Cloudflare module support
+
+All Cloudflare namespaced packages (like `cloudflare:sockets`) are whitelisted for use. Note that the package `cloudflare:sockets` does not work locally without using Wrangler dev mode.
+
 ## Preview with Wrangler
 
 To use [`wrangler`](https://developers.cloudflare.com/workers/wrangler/) to run your application locally, update the preview script:

--- a/packages/integrations/cloudflare/README.md
+++ b/packages/integrations/cloudflare/README.md
@@ -359,7 +359,7 @@ Additionally, you'll need to enable the Compatibility Flag in Cloudflare. The co
 
 ## Cloudflare module support
 
-All Cloudflare namespaced packages (like `cloudflare:sockets`) are whitelisted for use. Note that the package `cloudflare:sockets` does not work locally without using Wrangler dev mode.
+All Cloudflare namespaced packages (e.g. `cloudflare:sockets`) are allowlisted for use. Note that the package `cloudflare:sockets` does not work locally without using Wrangler dev mode.
 
 ## Preview with Wrangler
 

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -290,7 +290,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 								'node:stream',
 								'node:string_decoder',
 								'node:util',
-								'cloudflare:sockets'
+								'cloudflare:*'
 							],
 							entryPoints: pathsGroup,
 							outbase: absolutePagesDirname,
@@ -372,7 +372,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 							'node:stream',
 							'node:string_decoder',
 							'node:util',
-							'cloudflare:sockets'
+							'cloudflare:*'
 						],
 						entryPoints: [entryPath],
 						outfile: buildPath,

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -290,6 +290,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 								'node:stream',
 								'node:string_decoder',
 								'node:util',
+								'cloudflare:sockets'
 							],
 							entryPoints: pathsGroup,
 							outbase: absolutePagesDirname,
@@ -371,6 +372,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 							'node:stream',
 							'node:string_decoder',
 							'node:util',
+							'cloudflare:sockets'
 						],
 						entryPoints: [entryPath],
 						outfile: buildPath,


### PR DESCRIPTION
## Changes

- Allow the use of the runtime library `cloudflare:sockets` without throwing a build error by adding it to the external list.


## WHY?

This update is needed for merge in order to further work on Postgres.js to allow for SQL socket connections for the CF tcp connec() api.

## Testing

Try to reference cloudflare:sockets in an import.

## Docs

https://blog.cloudflare.com/workers-tcp-socket-api-connect-databases/