### PR TITLE
fix(transitions router): no-op on the server

### DIFF
--- a/.changeset/forty-singers-ring.md
+++ b/.changeset/forty-singers-ring.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed an issue where the transitions router did not work within framework components.

--- a/packages/astro/e2e/fixtures/view-transitions/src/components/ClickToNavigate.jsx
+++ b/packages/astro/e2e/fixtures/view-transitions/src/components/ClickToNavigate.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
 import { navigate } from "astro:transitions/client";
 export default function ClickToNavigate({ to, id }) {
-	return <button id={id} onClick={() => navigate(to)}>Navigate to `{to}`</button>;
+    return <button id={id} onClick={() => navigate(to)}>Navigate to `{to}`</button>;
 }

--- a/packages/astro/e2e/fixtures/view-transitions/src/components/ClickToNavigate.jsx
+++ b/packages/astro/e2e/fixtures/view-transitions/src/components/ClickToNavigate.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { navigate } from "astro:transitions/client";
 export default function ClickToNavigate({ to, id }) {
 	return <button id={id} onClick={() => navigate(to)}>Navigate to `{to}`</button>;
 }

--- a/packages/astro/e2e/fixtures/view-transitions/src/components/ClickToNavigate.jsx
+++ b/packages/astro/e2e/fixtures/view-transitions/src/components/ClickToNavigate.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function ClickToNavigate({ to, id }) {
+	return <button id={id} onClick={() => navigate(to)}>Navigate to `{to}`</button>;
+}

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/client-load.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/client-load.astro
@@ -1,4 +1,12 @@
 ---
 import ClickToNavigate from "../components/ClickToNavigate.jsx"
+import { ViewTransitions } from "astro:transitions";
 ---
-<ClickToNavigate id="react-client-load-navigate-button" to="/two" client:load/>
+<html>
+	<head>
+		<ViewTransitions />
+	</head>
+	<body>
+		<ClickToNavigate id="react-client-load-navigate-button" to="/two" client:load/>
+	</body>
+</html>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/client-load.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/client-load.astro
@@ -1,0 +1,4 @@
+---
+import ClickToNavigate from "../components/ClickToNavigate.jsx"
+---
+<ClickToNavigate id="react-client-load-navigate-button" to="/two" client:load/>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -753,6 +753,21 @@ test.describe('View Transitions', () => {
 		await expect(p, 'should have content').toHaveText('Page 1');
 	});
 
+	test('Use the client side router in framework components', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/client-load'));
+		
+		// the button is set to naviagte() to /two
+		const button = page.locator('#react-client-load-navigate-button');
+
+		await expect(button, 'should have content').toHaveText('Navigate to `/two`');
+		
+		await button.click();
+
+		const p = page.locator('#two');
+
+		await expect(p, 'should have content').toHaveText('Page 2');
+	});
+
 	test('body inline scripts do not re-execute on navigation', async ({ page, astro }) => {
 		const errors = [];
 		page.addListener('pageerror', (err) => {

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -19,7 +19,7 @@ const inBrowser = import.meta.env.SSR === false;
 export const supportsViewTransitions = inBrowser && !!document.startViewTransition;
 
 export const transitionEnabledOnThisPage = () =>
-    supportsViewTransitions && !!document.querySelector('[name="astro-view-transitions-enabled"]');
+    inBrowser && !!document.querySelector('[name="astro-view-transitions-enabled"]');
 
 const samePage = (otherLocation: URL) =>
 	location.pathname === otherLocation.pathname && location.search === otherLocation.search;

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -14,7 +14,9 @@ type Events = 'astro:page-load' | 'astro:after-swap';
 // leave other entries alone and do not accidently add state.
 const persistState = (state: State) => history.state && history.replaceState(state, '');
 
-export const supportsViewTransitions = import.meta.env.SSR === false && !!document.startViewTransition;
+const inBrowser = import.meta.env.SSR === false;
+
+export const supportsViewTransitions = inBrowser && !!document.startViewTransition;
 
 export const transitionEnabledOnThisPage = () =>
     supportsViewTransitions && !!document.querySelector('[name="astro-view-transitions-enabled"]');
@@ -387,7 +389,7 @@ let navigateOnServerWarned = false;
 
 export function navigate(href: string, options?: Options) {
 	
-	if (import.meta.env.SSR) {
+	if (inBrowser === false) {
 		if (!navigateOnServerWarned) {
 			// instantiate an error for the stacktrace to show to user.
 			const warning = new Error("The view transtions client API was called during a server side render. This may be unintentional as the navigate() function is expected to be called in response to user interactions. Please make sure that your usage is correct.");
@@ -457,7 +459,7 @@ function onPopState(ev: PopStateEvent) {
 		}
 	}
 
-if (import.meta.env.SSR == false) {
+if (inBrowser) {
 if (supportsViewTransitions || getFallback() !== 'none') {
 	addEventListener('popstate', onPopState);
 	addEventListener('load', onPageLoad);

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -383,17 +383,17 @@ async function transition(
 	}
 }
 
-let navigateOnSeverWarned = false;
+let navigateOnServerWarned = false;
 
 export function navigate(href: string, options?: Options) {
 	
 	if (import.meta.env.SSR) {
-		if (!navigateOnSeverWarned) {
+		if (!navigateOnServerWarned) {
 			// instantiate an error for the stacktrace to show to user.
 			const warning = new Error("The view transtions client API was called during a server side render. This may be unintentional as the navigate() function is expected to be called in response to user interactions. Please make sure that your usage is correct.");
 			warning.name = "Warning";
 			console.warn(warning);
-			navigateOnSeverWarned = true;
+			navigateOnServerWarned = true;
 		}
 		return;
 	}

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -13,9 +13,12 @@ type Events = 'astro:page-load' | 'astro:after-swap';
 // only update history entries that are managed by us
 // leave other entries alone and do not accidently add state.
 const persistState = (state: State) => history.state && history.replaceState(state, '');
-export const supportsViewTransitions = !!document.startViewTransition;
+
+export const supportsViewTransitions = import.meta.env.SSR === false && !!document.startViewTransition;
+
 export const transitionEnabledOnThisPage = () =>
-	!!document.querySelector('[name="astro-view-transitions-enabled"]');
+	import.meta.env.SSR === false && !!document.querySelector('[name="astro-view-transitions-enabled"]');
+
 const samePage = (otherLocation: URL) =>
 	location.pathname === otherLocation.pathname && location.search === otherLocation.search;
 const triggerEvent = (name: Events) => document.dispatchEvent(new Event(name));
@@ -40,13 +43,17 @@ const announce = () => {
 		60
 	);
 };
+
 const PERSIST_ATTR = 'data-astro-transition-persist';
-const parser = new DOMParser();
+
+let parser: DOMParser
 
 // The History API does not tell you if navigation is forward or back, so
 // you can figure it using an index. On pushState the index is incremented so you
 // can use that to determine popstate if going forward or back.
 let currentHistoryIndex = 0;
+
+if (import.meta.env.SSR === false) {
 if (history.state) {
 	// we reloaded a page with history state
 	// (e.g. history navigation from non-transition page or browser reload)
@@ -55,6 +62,8 @@ if (history.state) {
 } else if (transitionEnabledOnThisPage()) {
 	history.replaceState({ index: currentHistoryIndex, scrollX, scrollY, intraPage: false }, '');
 }
+}
+
 const throttle = (cb: (...args: any[]) => any, delay: number) => {
 	let wait = false;
 	// During the waiting time additional events are lost.
@@ -336,6 +345,8 @@ async function transition(
 		toLocation = new URL(response.redirected);
 	}
 
+	parser ??= new DOMParser()
+	
 	const newDocument = parser.parseFromString(response.html, response.mediaType);
 	// The next line might look like a hack,
 	// but it is actually necessary as noscript elements
@@ -373,6 +384,9 @@ async function transition(
 }
 
 export function navigate(href: string, options?: Options) {
+	
+	if (import.meta.env.SSR) return;
+	
 	// not ours
 	if (!transitionEnabledOnThisPage()) {
 		location.href = href;
@@ -390,6 +404,7 @@ export function navigate(href: string, options?: Options) {
 	}
 }
 
+if (import.meta.env.SSR === false) {
 if (supportsViewTransitions || getFallback() !== 'none') {
 	addEventListener('popstate', (ev) => {
 		if (!transitionEnabledOnThisPage() && ev.state) {
@@ -444,4 +459,5 @@ if (supportsViewTransitions || getFallback() !== 'none') {
 	else addEventListener('scroll', throttle(updateState, 300));
 
 	markScriptsExec();
+}
 }

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -17,7 +17,7 @@ const persistState = (state: State) => history.state && history.replaceState(sta
 export const supportsViewTransitions = import.meta.env.SSR === false && !!document.startViewTransition;
 
 export const transitionEnabledOnThisPage = () =>
-	import.meta.env.SSR === false && !!document.querySelector('[name="astro-view-transitions-enabled"]');
+    supportsViewTransitions && !!document.querySelector('[name="astro-view-transitions-enabled"]');
 
 const samePage = (otherLocation: URL) =>
 	location.pathname === otherLocation.pathname && location.search === otherLocation.search;
@@ -53,7 +53,7 @@ let parser: DOMParser
 // can use that to determine popstate if going forward or back.
 let currentHistoryIndex = 0;
 
-if (import.meta.env.SSR === false) {
+if (supportsViewTransitions) {
 if (history.state) {
 	// we reloaded a page with history state
 	// (e.g. history navigation from non-transition page or browser reload)
@@ -385,7 +385,7 @@ async function transition(
 
 export function navigate(href: string, options?: Options) {
 	
-	if (import.meta.env.SSR) return;
+	if (!supportsViewTransitions) return;
 	
 	// not ours
 	if (!transitionEnabledOnThisPage()) {
@@ -446,7 +446,7 @@ function onPopState(ev: PopStateEvent) {
 		}
 	}
 
-if (import.meta.env.SSR === false && (supportsViewTransitions || getFallback() !== 'none')) {
+if (supportsViewTransitions && getFallback() !== 'none') {
 	addEventListener('popstate', onPopState);
 	addEventListener('load', onPageLoad);
 	// There's not a good way to record scroll position before a back button.

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -457,7 +457,8 @@ function onPopState(ev: PopStateEvent) {
 		}
 	}
 
-if (supportsViewTransitions && getFallback() !== 'none') {
+if (import.meta.env.SSR == false) {
+if (supportsViewTransitions || getFallback() !== 'none') {
 	addEventListener('popstate', onPopState);
 	addEventListener('load', onPageLoad);
 	// There's not a good way to record scroll position before a back button.
@@ -471,4 +472,4 @@ if (supportsViewTransitions && getFallback() !== 'none') {
 
 	markScriptsExec();
 }
-
+}

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -404,9 +404,7 @@ export function navigate(href: string, options?: Options) {
 	}
 }
 
-if (import.meta.env.SSR === false) {
-if (supportsViewTransitions || getFallback() !== 'none') {
-	addEventListener('popstate', (ev) => {
+function onPopState(ev: PopStateEvent) {
 		if (!transitionEnabledOnThisPage() && ev.state) {
 			// The current page doesn't have View Transitions enabled
 			// but the page we navigate to does (because it set the state).
@@ -446,8 +444,10 @@ if (supportsViewTransitions || getFallback() !== 'none') {
 			currentHistoryIndex = nextIndex;
 			transition(direction, new URL(location.href), {}, state);
 		}
-	});
+	}
 
+if (import.meta.env.SSR === false && (supportsViewTransitions || getFallback() !== 'none')) {
+	addEventListener('popstate', onPopState);
 	addEventListener('load', onPageLoad);
 	// There's not a good way to record scroll position before a back button.
 	// So the way we do it is by listening to scrollend if supported, and if not continuously record the scroll position.
@@ -460,4 +460,4 @@ if (supportsViewTransitions || getFallback() !== 'none') {
 
 	markScriptsExec();
 }
-}
+

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -55,7 +55,7 @@ let parser: DOMParser
 // can use that to determine popstate if going forward or back.
 let currentHistoryIndex = 0;
 
-if (supportsViewTransitions) {
+if (inBrowser) {
 if (history.state) {
 	// we reloaded a page with history state
 	// (e.g. history navigation from non-transition page or browser reload)

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -383,9 +383,20 @@ async function transition(
 	}
 }
 
+let navigateOnSeverWarned = false;
+
 export function navigate(href: string, options?: Options) {
 	
-	if (!supportsViewTransitions) return;
+	if (!supportsViewTransitions) {
+		if (!navigateOnSeverWarned) {
+			// instantiate an error for the stacktrace to show to user.
+			const warning = new Error("The view transtions client API was called during a server side render. This may be unintentional as the navigate() function is expected to be called in response to user interactions. Please make sure that your usage is correct.");
+			warning.name = "Warning";
+			console.warn(warning);
+			navigateOnSeverWarned = true;
+		}
+		return;
+	}
 	
 	// not ours
 	if (!transitionEnabledOnThisPage()) {

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -387,7 +387,7 @@ let navigateOnSeverWarned = false;
 
 export function navigate(href: string, options?: Options) {
 	
-	if (!supportsViewTransitions) {
+	if (import.meta.env.SSR) {
 		if (!navigateOnSeverWarned) {
 			// instantiate an error for the stacktrace to show to user.
 			const warning = new Error("The view transtions client API was called during a server side render. This may be unintentional as the navigate() function is expected to be called in response to user interactions. Please make sure that your usage is correct.");


### PR DESCRIPTION
## Changes
- Prevents import side-effects from running during SSR.
- Makes `navigate()` do nothing on the server.

## Testing
_Pending_.

## Docs
There should be a note about framework usage somewhere. _Pending_.