### PR TITLE
Fix flickering during view transitions

### DIFF
--- a/.changeset/seven-seas-hide.md
+++ b/.changeset/seven-seas-hide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix for #8711

--- a/.changeset/seven-seas-hide.md
+++ b/.changeset/seven-seas-hide.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fix for #8711
+Fix flickering during view transitions

--- a/packages/astro/e2e/fixtures/view-transitions/src/components/listener-layout.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/components/listener-layout.astro
@@ -1,0 +1,34 @@
+---
+import { ViewTransitions } from 'astro:transitions';
+---
+<html>
+	<head>
+		<ViewTransitions/>
+	</head>
+	<body>
+		<p>Local transitions</p>
+		<slot/>
+		<script>
+			document.addEventListener("astro:after-swap", () => {
+				document.querySelector("p").addEventListener("transitionstart", () => {
+					console.info("transitionstart");
+				});
+				document.documentElement.setAttribute("class", "blue");
+			});
+			document.dispatchEvent(new Event("astro:after-swap"));
+		</script>
+	</body>
+	<style>
+		p {
+			transition: background-color 1s;
+		}
+		p {
+			background-color: #0ee;
+			color: red;
+		}
+		.blue p {
+			background-color: #ee0;
+			color: blue;
+		}
+	</style>
+</html>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/listener-one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/listener-one.astro
@@ -1,0 +1,6 @@
+---
+import ListenerLayout from '../components/listener-layout.astro';
+---
+<ListenerLayout>
+	<a id="totwo" href="/listener-two">Go to listener two</a>
+</ListenerLayout>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/listener-two.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/listener-two.astro
@@ -1,0 +1,6 @@
+---
+import ListenerLayout from '../components/listener-layout.astro';
+---
+<ListenerLayout>
+	<a id="toone" href="/listener-one">Go to listener one</a>
+</ListenerLayout>

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -151,7 +151,11 @@ const updateHistoryAndScrollPosition = (toLocation: URL, replace: boolean, intra
 			history.replaceState({ ...history.state }, '', toLocation.href);
 		} else {
 			history.replaceState({ ...history.state, intraPage }, '');
-			history.pushState({ index: ++currentHistoryIndex, scrollX, scrollY }, '', toLocation.href);
+			history.pushState(
+				{ index: ++currentHistoryIndex, scrollX: 0, scrollY: 0 },
+				'',
+				toLocation.href
+			);
 		}
 		// now we are on the new page for non-history navigations!
 		// (with history navigation page change happens before popstate is fired)

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -146,6 +146,7 @@ function isInfinite(animation: Animation) {
 
 const updateHistoryAndScrollPosition = (toLocation: URL, replace: boolean, intraPage: boolean) => {
 	const fresh = !samePage(toLocation);
+	let scrolledToTop = false;
 	if (toLocation.href !== location.href) {
 		if (replace) {
 			history.replaceState({ ...history.state }, '', toLocation.href);
@@ -162,6 +163,7 @@ const updateHistoryAndScrollPosition = (toLocation: URL, replace: boolean, intra
 		// freshly loaded pages start from the top
 		if (fresh) {
 			scrollTo({ left: 0, top: 0, behavior: 'instant' });
+			scrolledToTop = true;
 		}
 	}
 	if (toLocation.hash) {
@@ -170,7 +172,9 @@ const updateHistoryAndScrollPosition = (toLocation: URL, replace: boolean, intra
 		// that won't reload the page but instead scroll to the fragment
 		location.href = toLocation.href;
 	} else {
-		scrollTo({ left: 0, top: 0, behavior: 'instant' });
+		if (!scrolledToTop) {
+			scrollTo({ left: 0, top: 0, behavior: 'instant' });
+		}
 	}
 };
 


### PR DESCRIPTION
## Changes

Reading `window.scrollY` after replacing the body's DOM triggered additional CSS transitions on elements during swap()
Swap() should be atomic with respect to page renders. This is important so users can restore attributes and classes in astro:after-swap.  Intermediate state should not be observable.

Closes #8711

## Testing

Added e2e test

## Docs

n/a bug fix