### PR TITLE
fix(assets): add the missing `await` to getHTMLAttributes

### DIFF
--- a/.changeset/young-taxis-battle.md
+++ b/.changeset/young-taxis-battle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix an issue where HTML attributes do not render if getHTMLAttributes in an image service returns a Promise

--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -111,7 +111,7 @@ export async function getImage(
 		src: imageURL,
 		attributes:
 			service.getHTMLAttributes !== undefined
-				? service.getHTMLAttributes(validatedOptions, imageConfig)
+				? await service.getHTMLAttributes(validatedOptions, imageConfig)
 				: {},
 	};
 }


### PR DESCRIPTION
## Changes

This pull request adds the missing `await` to properly use values returned by `getHTMLAttribute` in image services. It fixes an issue where HTML attributes do not render if getHTMLAttributes in an image service returns a Promise.

Minimum repro for this issue: [StackBlitz](https://stackblitz.com/edit/repro-astro-image-service-async-gethtmlattributes?file=src%2Fimage-service-async.ts) (You can see that the custom HTML attributes are not rendered in the HTML if `getHTMLAttribute` returns a Promise instead a plain object)

Definition for `getHTMLAttribute`:

https://github.com/withastro/astro/blob/30de324361bc261956eb9fc08fe60a82ff602a9b/packages/astro/src/assets/services/service.ts#L41-L50

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

No tests were added as this is a one-line fix. It should have no impact if `getHTMLAttributes` returns a non-Promise. 

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No docs were needed as this fix does not change the expected behavior.
