### PR TITLE
Fix transition attributes on islands

### DIFF
--- a/.changeset/wise-lions-lay.md
+++ b/.changeset/wise-lions-lay.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix transition attributes on islands

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -15,10 +15,12 @@ export interface HydrationMetadata {
 	componentExport: { value: string };
 }
 
+type Props = Record<string | number | symbol, any>;
+
 interface ExtractedProps {
 	isPage: boolean;
 	hydration: HydrationMetadata | null;
-	props: Record<string | number | symbol, any>;
+	props: Props;
 }
 
 const transitionDirectivesToCopyOnIsland = Object.freeze([
@@ -26,10 +28,18 @@ const transitionDirectivesToCopyOnIsland = Object.freeze([
 	'data-astro-transition-persist',
 ]);
 
+export function withoutTransitionAttributes(props: Props): Props {
+	const res: Props = Object.fromEntries(Object.entries(props).filter(([key]) => !transitionDirectivesToCopyOnIsland.includes(key)));
+	for (const sym of Object.getOwnPropertySymbols(props)) {
+		res[sym] = props[sym];
+	}
+	return res;
+}
+
 // Used to extract the directives, aka `client:load` information about a component.
 // Finds these special props and removes them from what gets passed into the component.
 export function extractDirectives(
-	inputProps: Record<string | number | symbol, any>,
+	inputProps: Props,
 	clientDirectives: SSRResult['clientDirectives']
 ): ExtractedProps {
 	let extracted: ExtractedProps = {

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -9,7 +9,7 @@ import { createRenderInstruction, type RenderInstruction } from './instruction.j
 import { clsx } from 'clsx';
 import { AstroError, AstroErrorData } from '../../../core/errors/index.js';
 import { HTMLBytes, markHTMLString } from '../escape.js';
-import { extractDirectives, generateHydrateScript } from '../hydration.js';
+import { extractDirectives, generateHydrateScript, withoutTransitionAttributes } from '../hydration.js';
 import { serializeProps } from '../serialize.js';
 import { shorthash } from '../shorthash.js';
 import { isPromise } from '../util.js';
@@ -93,6 +93,7 @@ async function renderFrameworkComponent(
 	};
 
 	const { hydration, isPage, props } = extractDirectives(_props, clientDirectives);
+	const propsWithoutTransitionAttributes = withoutTransitionAttributes(props);
 	let html = '';
 	let attrs: Record<string, string> | undefined = undefined;
 
@@ -217,7 +218,7 @@ async function renderFrameworkComponent(
 				({ html, attrs } = await renderer.ssr.renderToStaticMarkup.call(
 					{ result },
 					Component,
-					props,
+					propsWithoutTransitionAttributes,
 					children,
 					metadata
 				));
@@ -242,7 +243,7 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 			({ html, attrs } = await renderer.ssr.renderToStaticMarkup.call(
 				{ result },
 				Component,
-				props,
+				propsWithoutTransitionAttributes,
 				children,
 				metadata
 			));

--- a/packages/astro/test/fixtures/view-transitions/astro.config.mjs
+++ b/packages/astro/test/fixtures/view-transitions/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [react()],
+});

--- a/packages/astro/test/fixtures/view-transitions/package.json
+++ b/packages/astro/test/fixtures/view-transitions/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "astro": "workspace:*"
+    "astro": "workspace:*",
+    "@astrojs/react": "workspace:*",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0"
   }
 }

--- a/packages/astro/test/fixtures/view-transitions/src/components/Island.css
+++ b/packages/astro/test/fixtures/view-transitions/src/components/Island.css
@@ -1,0 +1,11 @@
+.counter {
+	display: grid;
+	font-size: 2em;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	margin-top: 2em;
+	place-items: center;
+}
+
+.counter-message {
+	text-align: center;
+}

--- a/packages/astro/test/fixtures/view-transitions/src/components/Island.jsx
+++ b/packages/astro/test/fixtures/view-transitions/src/components/Island.jsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+import './Island.css';
+
+export default function Counter({ children, count: initialCount, id }) {
+	const [count, setCount] = useState(initialCount);
+	const add = () => setCount((i) => i + 1);
+	const subtract = () => setCount((i) => i - 1);
+
+	return (
+		<>
+			<div id={id} className="counter">
+				<button className="decrement" onClick={subtract}>-</button>
+				<pre>{count}</pre>
+				<button className="increment" onClick={add}>+</button>
+			</div>
+			<div className="counter-message">{children}</div>
+		</>
+	);
+}

--- a/packages/astro/test/fixtures/view-transitions/src/pages/hasIsland.astro
+++ b/packages/astro/test/fixtures/view-transitions/src/pages/hasIsland.astro
@@ -1,0 +1,10 @@
+---
+import Island from '../components/Island.jsx';
+---
+<html>
+	<head>
+	</head>
+	<body>
+		<Island id="1" count="{1}" children="Greetings!" transition:persist="here" client:load/>
+	</body>
+</html>

--- a/packages/astro/test/view-transitions.test.js
+++ b/packages/astro/test/view-transitions.test.js
@@ -22,4 +22,14 @@ describe('View Transitions styles', () => {
 
 		expect($('head style')).to.have.a.lengthOf(3);
 	});
+
+	it('should not duplicate transition attributes on island contents', async () => {
+		let res = await fixture.fetch('/hasIsland');
+		let html = await res.text();
+		let $ = cheerio.load(html);
+		expect($('astro-island[data-astro-transition-persist]')).to.have.a.lengthOf(1);
+		expect(
+			$('astro-island[data-astro-transition-persist] > [data-astro-transition-persist]')
+		).to.have.a.lengthOf(0);
+	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3531,9 +3531,18 @@ importers:
 
   packages/astro/test/fixtures/view-transitions:
     dependencies:
+      '@astrojs/react':
+        specifier: workspace:*
+        version: link:../../../../integrations/react
       astro:
         specifier: workspace:*
         version: link:../../..
+      react:
+        specifier: ^18.1.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.1.0
+        version: 18.2.0(react@18.2.0)
 
   packages/astro/test/fixtures/virtual-astro-file:
     dependencies:


### PR DESCRIPTION
## Changes

Transition attributes where set on astro-island and their contents.
data-astro-transition-persist attributes on nested elements cause the elements to be lost on transitions.
The fix ensures that transition attributes are not inserted on island content, only on the island itself.

Closes #8361

## Testing

Added mocha test

## Docs

n/a bug fix