### PR TITLE
docs: better explanation for `base` configuration 

### DIFF
--- a/.changeset/thin-flies-notice.md
+++ b/.changeset/thin-flies-notice.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Enrich the explanation of the `base` configuration with examples.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -580,7 +580,28 @@ export interface AstroUserConfig {
 	 *
 	 * When using this option, all of your static asset imports and URLs should add the base as a prefix. You can access this value via `import.meta.env.BASE_URL`.
 	 *
-	 * The value of `import.meta.env.BASE_URL` respects your `trailingSlash` config and will include a trailing slash if you explicitly include one or if `trailingSlash: "always"` is set. If `trailingSlash: "never"` is set, `BASE_URL` will not include a trailing slash, even if `base` includes one.
+	 * The value of `import.meta.env.BASE_URL` and configuration value `config.base` respects your `trailingSlash` config and will include a trailing slash if you explicitly include one or if `trailingSlash: "always"` is set. If `trailingSlash: "never"` is set, `BASE_URL` will not include a trailing slash, even if `base` includes one.
+	 *
+	 * This means with a configuration like this:
+	 * ```js
+	 * {
+	 * 	 base: '/docs/',
+	 * 	 trailingSlash: "never"
+	 * }
+	 * ```
+	 *
+	 * `import.meta.env.BASE_URL` and `config.base` will be `/docs`.
+	 *
+	 * In a configuration like this:
+	 *
+	 * ```js
+	 * {
+	 * 	 base: '/docs',
+	 * 	 trailingSlash: "always"
+	 * }
+	 * ```
+	 *
+	 * `import.meta.env.BASE_URL` and `config.base` will be `/docs/`.
 	 */
 	base?: string;
 


### PR DESCRIPTION
## Changes

The documentation wasn't extensive enough IMHO. I didn't understand that `config.base` is also manipulated by Astro accordingly, this is important because `base` is read by integrations too.

I also added some practical examples.

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
 /cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
