### PR TITLE
fix(cloudflare): runtime types for Cloudflare caches

### DIFF
--- a/.changeset/unlucky-avocados-brake.md
+++ b/.changeset/unlucky-avocados-brake.md
@@ -2,4 +2,4 @@
 '@astrojs/cloudflare': patch
 ---
 
-add cloudflare cachestorage types to server entrypoints
+fixes `AdvancedRuntime` & `DirectoryRuntime` types to work woth Cloudflare caches

--- a/.changeset/unlucky-avocados-brake.md
+++ b/.changeset/unlucky-avocados-brake.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+add cloudflare cachestorage types to server entrypoints

--- a/packages/integrations/cloudflare/src/entrypoints/server.advanced.ts
+++ b/packages/integrations/cloudflare/src/entrypoints/server.advanced.ts
@@ -11,8 +11,6 @@ if (!isNode) {
 	process.env = getProcessEnvProxy();
 }
 
-declare const caches: CacheStorage;
-
 type Env = {
 	ASSETS: { fetch: (req: Request) => Promise<Response> };
 };
@@ -22,7 +20,7 @@ export interface AdvancedRuntime<T extends object = object> {
 		waitUntil: (promise: Promise<any>) => void;
 		env: Env & T;
 		cf: CFRequest['cf'];
-		caches: typeof caches;
+		caches: CacheStorage;
 	};
 }
 
@@ -56,7 +54,7 @@ export function createExports(manifest: SSRManifest) {
 					},
 					env: env,
 					cf: request.cf,
-					caches: caches,
+					caches: caches as unknown as CacheStorage,
 				},
 			};
 

--- a/packages/integrations/cloudflare/src/entrypoints/server.advanced.ts
+++ b/packages/integrations/cloudflare/src/entrypoints/server.advanced.ts
@@ -1,4 +1,8 @@
-import type { Request as CFRequest, ExecutionContext } from '@cloudflare/workers-types';
+import type {
+	Request as CFRequest,
+	ExecutionContext,
+	CacheStorage,
+} from '@cloudflare/workers-types';
 import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
 import { getProcessEnvProxy, isNode } from '../util.js';
@@ -6,6 +10,8 @@ import { getProcessEnvProxy, isNode } from '../util.js';
 if (!isNode) {
 	process.env = getProcessEnvProxy();
 }
+
+declare const caches: CacheStorage;
 
 type Env = {
 	ASSETS: { fetch: (req: Request) => Promise<Response> };

--- a/packages/integrations/cloudflare/src/entrypoints/server.directory.ts
+++ b/packages/integrations/cloudflare/src/entrypoints/server.directory.ts
@@ -1,4 +1,4 @@
-import type { Request as CFRequest, EventContext } from '@cloudflare/workers-types';
+import type { Request as CFRequest, EventContext, CacheStorage } from '@cloudflare/workers-types';
 import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
 import { getProcessEnvProxy, isNode } from '../util.js';
@@ -7,6 +7,7 @@ if (!isNode) {
 	process.env = getProcessEnvProxy();
 }
 
+declare const caches: CacheStorage;
 export interface DirectoryRuntime<T extends object = object> {
 	runtime: {
 		waitUntil: (promise: Promise<any>) => void;

--- a/packages/integrations/cloudflare/src/entrypoints/server.directory.ts
+++ b/packages/integrations/cloudflare/src/entrypoints/server.directory.ts
@@ -6,14 +6,12 @@ import { getProcessEnvProxy, isNode } from '../util.js';
 if (!isNode) {
 	process.env = getProcessEnvProxy();
 }
-
-declare const caches: CacheStorage;
 export interface DirectoryRuntime<T extends object = object> {
 	runtime: {
 		waitUntil: (promise: Promise<any>) => void;
 		env: EventContext<unknown, string, unknown>['env'] & T;
 		cf: CFRequest['cf'];
-		caches: typeof caches;
+		caches: CacheStorage;
 	};
 }
 
@@ -49,7 +47,7 @@ export function createExports(manifest: SSRManifest) {
 					},
 					env: context.env,
 					cf: request.cf,
-					caches: caches,
+					caches: caches as unknown as CacheStorage,
 				},
 			};
 


### PR DESCRIPTION
## Changes

- Add `CacheStorage` type from [@cloudflare/workers-types](https://www.npmjs.com/package/@cloudflare/workers-types), to override default `dom.d.ts` cache types, which do not match.

## Testing

Typechange only, types compile correctly.

## Docs

This update clarifies types for Runtime Cache, which afaict isn't documented.