### PR TITLE
feature: add config options to miniflare and esbuild external

### DIFF
--- a/.changeset/pink-mugs-begin.md
+++ b/.changeset/pink-mugs-begin.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Cloudflare adapter has new configuration options for esbuild external and Miniflare setup

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -49,6 +49,16 @@ type Options = {
 	 */
 	runtime?: 'off' | 'local' | 'remote';
 	wasmModuleImports?: boolean;
+	/**
+	* Additional externals to add to esbuild. Note that the external property adds to the existing list.
+	*/
+	esbuild?: {
+		external?: string[];
+	}
+	/**
+	* Additional config options to provide to the miniflare initialization object. Note that the options property adds to the existing list.
+	*/
+	miniflare?: object;
 };
 
 interface BuildConfig {
@@ -141,6 +151,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 								kvPersist: true,
 								durableObjects: DOBindings,
 								durableObjectsPersist: true,
+								...(args?.miniflare || {}),
 							});
 							await _mf.ready;
 
@@ -290,7 +301,9 @@ export default function createIntegration(args?: Options): AstroIntegration {
 								'node:stream',
 								'node:string_decoder',
 								'node:util',
+								'node:crypto',
 								'cloudflare:*',
+								...(args?.esbuild?.external || []),
 							],
 							entryPoints: pathsGroup,
 							outbase: absolutePagesDirname,
@@ -372,7 +385,9 @@ export default function createIntegration(args?: Options): AstroIntegration {
 							'node:stream',
 							'node:string_decoder',
 							'node:util',
+							'node:crypto',
 							'cloudflare:*',
+							...(args?.esbuild?.external || [])
 						],
 						entryPoints: [entryPath],
 						outfile: buildPath,


### PR DESCRIPTION
## Changes

- node:crypto support added (fixes https://github.com/withastro/astro/issues/8784)
- Added two new configuration options (esbuild.external and miniflare) to allow clients additional esbuild externals or additional Miniflare constructor parameters.

## Testing

- node:crypto can be imported as its been added to the allowlist
- additional packages can be ignored during build time by using esbuild.external config option
- additional parameters can be used to Miniflare using the new k/v parameter miniflare

## Docs

- Docs are added on the parameters

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
