### PR TITLE
feat(markdoc): allowIndentation integration option

### DIFF
--- a/.changeset/hip-rockets-glow.md
+++ b/.changeset/hip-rockets-glow.md
@@ -2,4 +2,4 @@
 '@astrojs/markdoc': minor
 ---
 
-Added allowIndentation as a markdoc integration option to enable better readability
+Added ignoreIndentation as a markdoc integration option to enable better readability of source code.

--- a/.changeset/hip-rockets-glow.md
+++ b/.changeset/hip-rockets-glow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': minor
+---
+
+Added allowIndentation as a markdoc integration option to enable better readability

--- a/packages/integrations/markdoc/README.md
+++ b/packages/integrations/markdoc/README.md
@@ -458,6 +458,40 @@ To achieve a more Markdown-like experience, where HTML elements can be included 
 > **Warning**
 > When `allowHTML` is enabled, HTML markup inside Markdoc documents will be rendered as actual HTML elements (including `<script>`), making attack vectors like XSS possible. Ensure that any HTML markup comes from trusted sources.
 
+### `allowIndentation`
+
+By default, any content that is indented by four spaces is treated as a code block. Unfortunately, this behavior makes it difficult to use arbitrary levels of indentation to improve the readability of documents with complex structure.
+
+When using nested tags in Markdoc, it can be helpful to indent the content inside of tags so that the level of depth is clear. To support arbitrary indentation, we have to disable the indent-based code blocks and modify several other markdown-it parsing rules that account for indent-based code blocks. These changes can be applied by enabling the allowIndentation option.
+
+```diff lang="js" "allowIndentation: true"
+  // astro.config.mjs
+  import { defineConfig } from 'astro/config';
+  import markdoc from '@astrojs/markdoc';
+
+  export default defineConfig({
+    // ...
++   integrations: [markdoc({ allowIndentation: true })],
+    //                       ^^^^^^^^^^^^^^^^^^^^^^
+  });
+```
+
+```md
+# Welcome to Markdoc with indented tags 👋
+# Note: Can use either spaces or tabs for indentation
+
+{% custom-tag %}
+  {% custom-tag %}
+    ### Tags can be indented for better readability
+
+    {% another-custom-tag %}
+      This is easier to follow when there is a lot of nesting
+    {% /another-custom-tag %}
+
+  {% /custom-tag %}
+{% /custom-tag %}
+```
+
 ## Examples
 
 - The [Astro Markdoc starter template](https://github.com/withastro/astro/tree/latest/examples/with-markdoc) shows how to use Markdoc files in your Astro project.

--- a/packages/integrations/markdoc/README.md
+++ b/packages/integrations/markdoc/README.md
@@ -458,21 +458,21 @@ To achieve a more Markdown-like experience, where HTML elements can be included 
 > **Warning**
 > When `allowHTML` is enabled, HTML markup inside Markdoc documents will be rendered as actual HTML elements (including `<script>`), making attack vectors like XSS possible. Ensure that any HTML markup comes from trusted sources.
 
-### `allowIndentation`
+### `ignoreIndentation`
 
 By default, any content that is indented by four spaces is treated as a code block. Unfortunately, this behavior makes it difficult to use arbitrary levels of indentation to improve the readability of documents with complex structure.
 
-When using nested tags in Markdoc, it can be helpful to indent the content inside of tags so that the level of depth is clear. To support arbitrary indentation, we have to disable the indent-based code blocks and modify several other markdown-it parsing rules that account for indent-based code blocks. These changes can be applied by enabling the allowIndentation option.
+When using nested tags in Markdoc, it can be helpful to indent the content inside of tags so that the level of depth is clear. To support arbitrary indentation, we have to disable the indent-based code blocks and modify several other markdown-it parsing rules that account for indent-based code blocks. These changes can be applied by enabling the ignoreIndentation option.
 
-```diff lang="js" "allowIndentation: true"
+```diff lang="js" "ignoreIndentation: true"
   // astro.config.mjs
   import { defineConfig } from 'astro/config';
   import markdoc from '@astrojs/markdoc';
 
   export default defineConfig({
     // ...
-+   integrations: [markdoc({ allowIndentation: true })],
-    //                       ^^^^^^^^^^^^^^^^^^^^^^
++   integrations: [markdoc({ ignoreIndentation: true })],
+    //                       ^^^^^^^^^^^^^^^^^^^^^^^
   });
 ```
 

--- a/packages/integrations/markdoc/src/options.ts
+++ b/packages/integrations/markdoc/src/options.ts
@@ -1,4 +1,4 @@
 export interface MarkdocIntegrationOptions {
 	allowHTML?: boolean;
-	allowIndentation?: boolean;
+	ignoreIndentation?: boolean;
 }

--- a/packages/integrations/markdoc/src/options.ts
+++ b/packages/integrations/markdoc/src/options.ts
@@ -1,3 +1,4 @@
 export interface MarkdocIntegrationOptions {
 	allowHTML?: boolean;
+	allowIndentation?: boolean;
 }

--- a/packages/integrations/markdoc/src/tokenizer.ts
+++ b/packages/integrations/markdoc/src/tokenizer.ts
@@ -20,7 +20,7 @@ export function getMarkdocTokenizer(options: MarkdocIntegrationOptions | undefin
 			// enable HTML token detection in markdown-it
 			tokenizerOptions.html = true;
 		}
-		if (options?.allowIndentation) {
+		if (options?.ignoreIndentation) {
 			// allow indentation so nested Markdoc tags can be formatted for better readability
 			tokenizerOptions.allowIndentation = true;
 		}

--- a/packages/integrations/markdoc/src/tokenizer.ts
+++ b/packages/integrations/markdoc/src/tokenizer.ts
@@ -15,10 +15,14 @@ export function getMarkdocTokenizer(options: MarkdocIntegrationOptions | undefin
 		};
 
 		if (options?.allowHTML) {
-			// we want to allow indentation for Markdoc tags that are interleaved inside HTML block elements
+			// allow indentation for Markdoc tags that are interleaved inside HTML block elements
 			tokenizerOptions.allowIndentation = true;
 			// enable HTML token detection in markdown-it
 			tokenizerOptions.html = true;
+		}
+		if (options?.allowIndentation) {
+			// allow indentation so nested Markdoc tags can be formatted for better readability
+			tokenizerOptions.allowIndentation = true;
 		}
 
 		_cachedMarkdocTokenizers[key] = new Markdoc.Tokenizer(tokenizerOptions);

--- a/packages/integrations/markdoc/test/fixtures/render-with-indented-components/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/render-with-indented-components/astro.config.mjs
@@ -3,5 +3,5 @@ import markdoc from '@astrojs/markdoc';
 
 // https://astro.build/config
 export default defineConfig({
-	integrations: [markdoc({ allowIndentation: true })],
+	integrations: [markdoc({ ignoreIndentation: true })],
 });

--- a/packages/integrations/markdoc/test/fixtures/render-with-indented-components/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/render-with-indented-components/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import markdoc from '@astrojs/markdoc';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [markdoc({ allowIndentation: true })],
+});

--- a/packages/integrations/markdoc/test/fixtures/render-with-indented-components/markdoc.config.ts
+++ b/packages/integrations/markdoc/test/fixtures/render-with-indented-components/markdoc.config.ts
@@ -1,0 +1,26 @@
+import { defineMarkdocConfig, component } from '@astrojs/markdoc/config';
+
+export default defineMarkdocConfig({
+	nodes: {
+		fence: {
+			render: component('./src/components/Code.astro'),
+			attributes: {
+				language: { type: String },
+				content: { type: String },
+			},
+		},
+	},
+	tags: {
+		'marquee-element': {
+			render: component('./src/components/CustomMarquee.astro'),
+			attributes: {
+				direction: {
+					type: String,
+					default: 'left',
+					matches: ['left', 'right', 'up', 'down'],
+					errorLevel: 'critical',
+				},
+			},
+		},
+	},
+})

--- a/packages/integrations/markdoc/test/fixtures/render-with-indented-components/package.json
+++ b/packages/integrations/markdoc/test/fixtures/render-with-indented-components/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/markdoc-render-with-indented-components",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/markdoc": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/markdoc/test/fixtures/render-with-indented-components/src/components/Code.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-indented-components/src/components/Code.astro
@@ -1,0 +1,12 @@
+---
+import { Code } from 'astro/components';
+
+type Props = {
+	content: string;
+	language: string;
+}
+
+const { content, language } = Astro.props as Props;
+---
+
+<Code lang={language} code={content} />

--- a/packages/integrations/markdoc/test/fixtures/render-with-indented-components/src/components/CustomMarquee.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-indented-components/src/components/CustomMarquee.astro
@@ -1,0 +1,1 @@
+<marquee data-custom-marquee {...Astro.props}><slot /></marquee>

--- a/packages/integrations/markdoc/test/fixtures/render-with-indented-components/src/content/blog/with-indented-components.mdoc
+++ b/packages/integrations/markdoc/test/fixtures/render-with-indented-components/src/content/blog/with-indented-components.mdoc
@@ -1,0 +1,24 @@
+---
+title: Post with indented components
+---
+
+## Post with indented components
+
+This uses a custom marquee component with a shortcode:
+
+{% marquee-element direction="right" %}
+	I'm a marquee too!
+
+	{% marquee-element direction="right" %}
+		I'm an indented marquee!
+
+		### I am an h3!
+	{% /marquee-element %}
+
+	And a nested code block:
+
+	```js
+	const isRenderedWithShiki = true;
+	```
+{% /marquee-element %}
+

--- a/packages/integrations/markdoc/test/fixtures/render-with-indented-components/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-indented-components/src/pages/index.astro
@@ -1,0 +1,19 @@
+---
+import { getEntryBySlug } from "astro:content";
+
+const post = await getEntryBySlug('blog', 'with-indented-components');
+const { Content } = await post.render();
+---
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Content</title>
+</head>
+<body>
+	<Content />	
+</body>
+</html>

--- a/packages/integrations/markdoc/test/render.test.js
+++ b/packages/integrations/markdoc/test/render.test.js
@@ -46,6 +46,19 @@ describe('Markdoc - render', () => {
 			await server.stop();
 		});
 
+		it('renders content - with indented components', async () => {
+			const fixture = await getFixture('render-with-indented-components');
+			const server = await fixture.startDevServer();
+
+			const res = await fixture.fetch('/');
+			const html = await res.text();
+
+			renderIndentedComponentsChecks(html);
+
+			await server.stop();
+
+		});
+
 		it('renders content - with `render: null` in document', async () => {
 			const fixture = await getFixture('render-null');
 			const server = await fixture.startDevServer();
@@ -87,6 +100,15 @@ describe('Markdoc - render', () => {
 			renderComponentsChecks(html);
 		});
 
+		it('renders content - with indented components', async () => {
+			const fixture = await getFixture('render-with-indented-components');
+			await fixture.build();
+
+			const html = await fixture.readFile('/index.html');
+
+			renderIndentedComponentsChecks(html);
+		});
+
 		it('renders content - with `render: null` in document', async () => {
 			const fixture = await getFixture('render-null');
 			await fixture.build();
@@ -118,6 +140,26 @@ function renderComponentsChecks(html) {
 	const marquee = document.querySelector('marquee');
 	expect(marquee).to.not.be.null;
 	expect(marquee.hasAttribute('data-custom-marquee')).to.equal(true);
+
+	// Renders Astro Code component
+	const pre = document.querySelector('pre');
+	expect(pre).to.not.be.null;
+	expect(pre.className).to.equal('astro-code github-dark');
+}
+
+/** @param {string} html */
+function renderIndentedComponentsChecks(html) {
+	const { document } = parseHTML(html);
+	const h2 = document.querySelector('h2');
+	expect(h2.textContent).to.equal('Post with indented components');
+
+	// Renders custom shortcode components
+	const marquees = document.querySelectorAll('marquee');
+	expect(marquees.length).to.equal(2);
+
+	// Renders h3
+	const h3 = document.querySelector('h3');
+	expect(h3.textContent).to.equal('I am an h3!');
 
 	// Renders Astro Code component
 	const pre = document.querySelector('pre');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3869,6 +3869,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/markdoc/test/fixtures/render-with-indented-components:
+    dependencies:
+      '@astrojs/markdoc':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/markdoc/test/fixtures/variables:
     dependencies:
       '@astrojs/markdoc':


### PR DESCRIPTION
## Changes

- Added allowIndentation to the markdoc integration options which allows indentation of markdoc tags for better readability.
- Updated README to reflect changes

There is an existing `allowHTML` integration option which also enables allowIndentation so this change does not introduce new functionality. This was added in https://github.com/withastro/astro/pull/7597

It's nice to enable better readability without also enabling raw HTML in markdoc files. I think allowIndentation should be enabled by default once it comes out of it's experimental phase.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
- Added unit tests similar to those that test the `allowHTML` integration option.
- Tested with a local astro project using the markdoc integration. No issues encountered. 


## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs

This change requires an update to the docs as per the changes in the README. Looks like there is some automation in place to do this.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->