### PR TITLE
feat(script): allow preloading script's dependencies

### DIFF
--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -212,11 +212,11 @@ export class App {
 				env: this.#pipeline.env,
 				mod: handler as any,
 			});
-		} else {
+		}
 			const pathname = prependForwardSlash(this.removeBase(url.pathname));
 			const info = this.#routeDataToRouteInfo.get(routeData)!;
 			// may be used in the future for handling rel=modulepreload, rel=icon, rel=manifest etc.
-			const links = new Set<never>();
+			const links = new Set(info.links.map(props => ({ props, children: '' })));
 			const styles = createStylesheetElementSet(info.styles);
 
 			let scripts = new Set<SSRElement>();
@@ -245,7 +245,6 @@ export class App {
 				mod,
 				env: this.#pipeline.env,
 			});
-		}
 	}
 
 	/**

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -16,7 +16,10 @@ export type StylesheetAsset =
 export interface RouteInfo {
 	routeData: RouteData;
 	file: string;
-	links: string[];
+	links: Array<{
+		href: string
+		rel: 'modulepreload'
+	}>;
 	scripts: // Integration injected
 	(
 		| { children: string; stage: string }

--- a/packages/astro/src/core/build/page-data.ts
+++ b/packages/astro/src/core/build/page-data.ts
@@ -55,6 +55,11 @@ export async function collectPagesData(
 				propagatedStyles: new Map(),
 				propagatedScripts: new Map(),
 				hoistedScript: undefined,
+				preload: {
+					modules: new Set,
+					fonts: new Set,
+					styles: new Set
+				},
 			};
 
 			clearInterval(routeCollectionLogTimeout);
@@ -78,6 +83,11 @@ export async function collectPagesData(
 			propagatedStyles: new Map(),
 			propagatedScripts: new Map(),
 			hoistedScript: undefined,
+			preload: {
+				modules: new Set,
+				fonts: new Set,
+				styles: new Set
+			},
 		};
 	}
 

--- a/packages/astro/src/core/build/plugins/plugin-hoisted-scripts.ts
+++ b/packages/astro/src/core/build/plugins/plugin-hoisted-scripts.ts
@@ -67,14 +67,17 @@ export function vitePluginHoistedScripts(
 			});
 
 			for (const [id, output] of considerInlining.entries()) {
+				
 				const canBeInlined =
 					importedByOtherScripts.has(output.fileName) === false &&
 					output.imports.length === 0 &&
 					output.dynamicImports.length === 0 &&
 					Buffer.byteLength(output.code) <= assetInlineLimit;
+				
 				let removeFromBundle = false;
-				const facadeId = output.facadeModuleId!;
-				const pages = internals.hoistedScriptIdToPagesMap.get(facadeId)!;
+				
+				const pages = internals.hoistedScriptIdToPagesMap.get(output.facadeModuleId!)!;
+				
 				for (const pathname of pages) {
 					const vid = viteID(new URL('.' + pathname, settings.config.root));
 					const pageInfo = getPageDataByViteID(internals, vid);
@@ -90,6 +93,10 @@ export function vitePluginHoistedScripts(
 								type: 'external',
 								value: id,
 							};
+						}
+						
+						for (const importedScript of output.imports) {
+							pageInfo.preload.modules.add(importedScript)
 						}
 					}
 				}

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -210,7 +210,7 @@ function buildManifest(
 		}
 
 		// may be used in the future for handling rel=modulepreload, rel=icon, rel=manifest etc.
-		const links: [] = [];
+		const links = [...pageData.preload.modules].map(href => ({ rel: 'modulepreload' as const, href }));
 
 		const styles = pageData.styles
 			.sort(cssOrder)

--- a/packages/astro/src/core/build/types.ts
+++ b/packages/astro/src/core/build/types.ts
@@ -25,6 +25,11 @@ export interface PageBuildData {
 	component: ComponentPath;
 	route: RouteData;
 	moduleSpecifier: string;
+	preload: {
+		modules: Set<string>
+		fonts: Set<string>
+		styles: Set<string>
+	};
 	propagatedStyles: Map<string, Set<StylesheetAsset>>;
 	propagatedScripts: Map<string, Set<string>>;
 	hoistedScript: { type: 'inline' | 'external'; value: string } | undefined;

--- a/packages/astro/test/fixtures/preloading/package.json
+++ b/packages/astro/test/fixtures/preloading/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/preloading",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/preloading/src/pages/module1.astro
+++ b/packages/astro/test/fixtures/preloading/src/pages/module1.astro
@@ -1,0 +1,5 @@
+<script>
+    import { shared } from "../to-be-preloaded.js"
+	console.log(shared)
+</script>
+<p></p>

--- a/packages/astro/test/fixtures/preloading/src/pages/module2.astro
+++ b/packages/astro/test/fixtures/preloading/src/pages/module2.astro
@@ -1,0 +1,5 @@
+<script>
+    import { shared } from "../to-be-preloaded.js"
+	console.log(shared)
+</script>
+<p></p>

--- a/packages/astro/test/fixtures/preloading/src/to-be-preloaded.js
+++ b/packages/astro/test/fixtures/preloading/src/to-be-preloaded.js
@@ -1,0 +1,1 @@
+export const shared = {}

--- a/packages/astro/test/preloading.test.js
+++ b/packages/astro/test/preloading.test.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import { loadFixture } from './test-utils.js';
+import * as cheerio from 'cheerio';
+
+describe('preloading', () => {
+	/** @type {import('./test-utils.js').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/preloading/',
+		});
+		await fixture.build()
+	});
+
+	it('rendered page includes a link rel=modulepreload', async () => {
+		const html = await fixture.readFile('/module1/index.html');
+		const $ = cheerio.load(html);
+		const link = $('link')[0];
+		expect(link.attribs).to.deep.include({ rel: 'modulepreload' });
+		expect(link.attribs.href).to.include('to-be-preloaded');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3016,6 +3016,12 @@ importers:
         specifier: ^10.17.1
         version: 10.17.1
 
+  packages/astro/test/fixtures/preloading:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/public-base-404:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes
- A configuration that adds a `<link rel="modulepreload" href="...">` tag for each of hoisted script's dependencies.
```ts
export default defineConfig({
    build: {
        preloadModules: true
    }
})
```
- https://github.com/withastro/roadmap/discussions/561

## Testing
Fixture

## Docs
_Pending_