### PR TITLE
Add support for an `--outDir` CLI flag to `astro build`

### DIFF
--- a/packages/astro/src/cli/build/index.ts
+++ b/packages/astro/src/cli/build/index.ts
@@ -15,6 +15,7 @@ export async function build({ flags }: BuildOptions) {
 			tables: {
 				Flags: [
 					['--drafts', `Include Markdown draft pages in the build.`],
+					['--outDir <directory>', `Specify the output directory for the build.`],
 					['--help (-h)', 'See all available flags.'],
 				],
 			},

--- a/packages/astro/src/cli/flags.ts
+++ b/packages/astro/src/cli/flags.ts
@@ -14,6 +14,7 @@ export function flagsToAstroInlineConfig(flags: Flags): AstroInlineConfig {
 		root: typeof flags.root === 'string' ? flags.root : undefined,
 		site: typeof flags.site === 'string' ? flags.site : undefined,
 		base: typeof flags.base === 'string' ? flags.base : undefined,
+		outDir: typeof flags.outDir === 'string' ? flags.outDir : undefined,
 		markdown: {
 			drafts: typeof flags.drafts === 'boolean' ? flags.drafts : undefined,
 		},


### PR DESCRIPTION
## Changes

- Passes the value of an `--outDir` CLI flag through to Astro config, so you can set the build output directory from the command line:

   ```sh
   astro build --outDir ./build
   ```

## Testing

There don’t seem to be any tests for `astro build` as far as I can tell? So not sure how to test exactly.

## Docs

This will need documenting in the [CLI reference docs](https://docs.astro.build/en/reference/cli-reference/).
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
