### PR TITLE
feat: implement concurrency for asset generation

### DIFF
--- a/.changeset/good-mirrors-bake.md
+++ b/.changeset/good-mirrors-bake.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Add concurrency to asset generation


### PR DESCRIPTION
## Changes

Adds concurrent image generation for `astro:assets` using `p-limit` to improve performance.

## Testing

Actually not sure it needs actual tests, the core functionality is similar.

## Docs

Might be worth mentioning it in docs, but not done anything as of now.
