### PR TITLE
fix: remote `srcset` images not being resized

### DIFF
--- a/.changeset/serious-news-yell.md
+++ b/.changeset/serious-news-yell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix remote srcset images not being resized

--- a/packages/astro/src/assets/services/service.ts
+++ b/packages/astro/src/assets/services/service.ts
@@ -251,21 +251,24 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 				// If the user passed dimensions, we don't want to add it to the srcset
 				const { width: transformWidth, height: transformHeight, ...rest } = options;
 
-				const srcSetValue = {
-					transform: {
-						...rest,
-					},
+				let srcSetValue = {
+					transform: {},
 					descriptor: `${densityValues[index]}x`,
 					attributes: {
-						type: `image/${targetFormat}`,
-					},
+						type: `image/${targetFormat}`
+					}
 				};
 
 				// Only set width and height if they are different from the original image or if the image is remote
 				// to avoid duplicated final images
 				if (!isESMImportedImage(options.src) || maxTargetWidth !== imageWidth) {
-					srcSetValue.transform.width = maxTargetWidth;
-					srcSetValue.transform.height = Math.round(maxTargetWidth / aspectRatio);
+					srcSetValue.transform = {
+						width: maxTargetWidth,
+						height: Math.round(maxTargetWidth / aspectRatio),
+						...rest
+					};
+				} else {
+					srcSetValue.transform = { ...rest };
 				}
 
 				if (targetFormat !== options.format) {

--- a/packages/astro/src/assets/services/service.ts
+++ b/packages/astro/src/assets/services/service.ts
@@ -229,7 +229,7 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 
 		const aspectRatio = targetWidth / targetHeight;
 		const imageWidth = isESMImportedImage(options.src) ? options.src.width : options.width;
-		const maxWidth = imageWidth ?? Infinity;
+		const maxWidth = isESMImportedImage(options.src) ? imageWidth ?? Infinity : Infinity;
 
 		// REFACTOR: Could we merge these two blocks?
 		if (densities) {
@@ -261,8 +261,9 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 					},
 				};
 
-				// Only set width and height if they are different from the original image, to avoid duplicated final images
-				if (maxTargetWidth !== imageWidth) {
+				// Only set width and height if they are different from the original image or if the image is remote
+				// to avoid duplicated final images
+				if (!isESMImportedImage(options.src) || maxTargetWidth !== imageWidth) {
 					srcSetValue.transform.width = maxTargetWidth;
 					srcSetValue.transform.height = Math.round(maxTargetWidth / aspectRatio);
 				}

--- a/packages/astro/src/assets/utils/transformToPath.ts
+++ b/packages/astro/src/assets/utils/transformToPath.ts
@@ -19,5 +19,5 @@ export function hashTransform(transform: ImageTransform, imageService: string) {
 	// Extract the fields we want to hash
 	const { alt, class: className, style, widths, densities, ...rest } = transform;
 	const hashFields = { ...rest, imageService };
-	return shorthash(JSON.stringify(hashFields));
+	return shorthash(JSON.stringify(hashFields, Object.keys(hashFields).sort()));
 }

--- a/packages/astro/src/assets/utils/transformToPath.ts
+++ b/packages/astro/src/assets/utils/transformToPath.ts
@@ -19,5 +19,5 @@ export function hashTransform(transform: ImageTransform, imageService: string) {
 	// Extract the fields we want to hash
 	const { alt, class: className, style, widths, densities, ...rest } = transform;
 	const hashFields = { ...rest, imageService };
-	return shorthash(JSON.stringify(hashFields, Object.keys(hashFields).sort()));
+	return shorthash(JSON.stringify(hashFields));
 }


### PR DESCRIPTION
## Changes

Fixed the just released `srcset` support for remote images. They are not getting resized, at all.

Something to think about is to maybe avoid duplicating the base `src` with a potential `srcset` of 1x, even though 1x *can* be omitted per the spec:

https://html.spec.whatwg.org/multipage/images.html#creating-a-source-set-from-attributes (point 4)

## Testing

Fixes current functionality.
