### PR TITLE
fix: remote srcset images not being resized and deduplication not working in certain cases

### DIFF
--- a/.changeset/brown-pumpkins-clean.md
+++ b/.changeset/brown-pumpkins-clean.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix duplicate images being created in some cases when using densities and/or widths

--- a/.changeset/serious-news-yell.md
+++ b/.changeset/serious-news-yell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix remote srcset images not being resized

--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -46,14 +46,13 @@ if (fallbackImage.srcSet.values.length > 0) {
 
 <picture {...pictureAttributes}>
 	{
-		Object.entries(optimizedImages).map(([_, image]) => (
-			<source
-				srcset={`${image.src}${
-					image.srcSet.values.length > 0 ? ' , ' + image.srcSet.attribute : ''
-				}`}
-				type={'image/' + image.options.format}
-			/>
-		))
+		Object.entries(optimizedImages).map(([_, image]) => {
+			const srcsetAttribute =
+				props.densities || (!props.densities && !props.widths)
+					? `${image.src}${image.srcSet.values.length > 0 ? ', ' + image.srcSet.attribute : ''}`
+					: image.srcSet.attribute;
+			return <source srcset={srcsetAttribute} type={'image/' + image.options.format} />;
+		})
 	}
 	<img src={fallbackImage.src} {...additionalAttributes} {...fallbackImage.attributes} />
 </picture>

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -139,6 +139,7 @@
     "common-ancestor-path": "^1.0.1",
     "cookie": "^0.5.0",
     "debug": "^4.3.4",
+    "deterministic-object-hash": "^1.3.1",
     "devalue": "^4.3.2",
     "diff": "^5.1.0",
     "es-module-lexer": "^1.3.0",

--- a/packages/astro/src/assets/services/service.ts
+++ b/packages/astro/src/assets/services/service.ts
@@ -238,7 +238,7 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 		// However, if it's an imported image, we can use the original image's width as a maximum width
 		if (isESMImportedImage(options.src)) {
 			imageWidth = options.src.width;
-			maxWidth = imageWidth ?? Infinity;
+			maxWidth = imageWidth;
 		}
 
 		// If the user passed dimensions, we don't want to add it to the srcset

--- a/packages/astro/src/assets/services/service.ts
+++ b/packages/astro/src/assets/services/service.ts
@@ -206,6 +206,10 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 			options.format = DEFAULT_OUTPUT_FORMAT;
 		}
 
+		// Sometimes users will pass number generated from division, which can result in floating point numbers
+		if (options.width) options.width = Math.round(options.width);
+		if (options.height) options.height = Math.round(options.height);
+
 		return options;
 	},
 	getHTMLAttributes(options) {

--- a/packages/astro/src/assets/services/service.ts
+++ b/packages/astro/src/assets/services/service.ts
@@ -251,21 +251,24 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 				// If the user passed dimensions, we don't want to add it to the srcset
 				const { width: transformWidth, height: transformHeight, ...rest } = options;
 
-				const srcSetValue = {
-					transform: {
-						...rest,
-					},
+				let srcSetValue = {
+					transform: {},
 					descriptor: `${densityValues[index]}x`,
 					attributes: {
-						type: `image/${targetFormat}`,
-					},
+						type: `image/${targetFormat}`
+					}
 				};
 
 				// Only set width and height if they are different from the original image or if the image is remote
 				// to avoid duplicated final images
 				if (!isESMImportedImage(options.src) || maxTargetWidth !== imageWidth) {
-					srcSetValue.transform.width = maxTargetWidth;
-					srcSetValue.transform.height = Math.round(maxTargetWidth / aspectRatio);
+					srcSetValue.transform = {
+						width: maxTargetWidth,
+						height: Math.round(maxTargetWidth / aspectRatio),
+						...rest
+					};
+				} else {
+					srcSetValue.transform = { ...rest };
 				}
 
 				if (targetFormat !== options.format) {

--- a/packages/astro/src/assets/services/service.ts
+++ b/packages/astro/src/assets/services/service.ts
@@ -229,7 +229,7 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 
 		const aspectRatio = targetWidth / targetHeight;
 		const imageWidth = isESMImportedImage(options.src) ? options.src.width : options.width;
-		const maxWidth = imageWidth ?? Infinity;
+		const maxWidth = isESMImportedImage(options.src) ? imageWidth ?? Infinity : Infinity;
 
 		// REFACTOR: Could we merge these two blocks?
 		if (densities) {
@@ -261,8 +261,9 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 					},
 				};
 
-				// Only set width and height if they are different from the original image, to avoid duplicated final images
-				if (maxTargetWidth !== imageWidth) {
+				// Only set width and height if they are different from the original image or if the image is remote
+				// to avoid duplicated final images
+				if (!isESMImportedImage(options.src) || maxTargetWidth !== imageWidth) {
 					srcSetValue.transform.width = maxTargetWidth;
 					srcSetValue.transform.height = Math.round(maxTargetWidth / aspectRatio);
 				}

--- a/packages/astro/src/assets/utils/transformToPath.ts
+++ b/packages/astro/src/assets/utils/transformToPath.ts
@@ -1,3 +1,4 @@
+import { deterministicString } from 'deterministic-object-hash';
 import { basename, extname } from 'node:path';
 import { removeQueryString } from '../../core/path.js';
 import { shorthash } from '../../runtime/server/shorthash.js';
@@ -19,5 +20,5 @@ export function hashTransform(transform: ImageTransform, imageService: string) {
 	// Extract the fields we want to hash
 	const { alt, class: className, style, widths, densities, ...rest } = transform;
 	const hashFields = { ...rest, imageService };
-	return shorthash(JSON.stringify(hashFields));
+	return shorthash(deterministicString(hashFields));
 }

--- a/packages/astro/src/assets/utils/transformToPath.ts
+++ b/packages/astro/src/assets/utils/transformToPath.ts
@@ -19,5 +19,5 @@ export function hashTransform(transform: ImageTransform, imageService: string) {
 	// Extract the fields we want to hash
 	const { alt, class: className, style, widths, densities, ...rest } = transform;
 	const hashFields = { ...rest, imageService };
-	return shorthash(JSON.stringify(hashFields));
+	return shorthash(JSON.stringify(hashFields, Object.keys(hashFields).sort()));
 }

--- a/packages/astro/src/assets/utils/transformToPath.ts
+++ b/packages/astro/src/assets/utils/transformToPath.ts
@@ -19,5 +19,5 @@ export function hashTransform(transform: ImageTransform, imageService: string) {
 	// Extract the fields we want to hash
 	const { alt, class: className, style, widths, densities, ...rest } = transform;
 	const hashFields = { ...rest, imageService };
-	return shorthash(JSON.stringify(hashFields, Object.keys(hashFields).sort()));
+	return shorthash(JSON.stringify(hashFields));
 }

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -219,6 +219,60 @@ describe('astro:image', () => {
 				expect(srcset2.every((src) => src.url.startsWith('/_image'))).to.equal(true);
 				expect(srcset2.map((src) => src.w)).to.deep.equal([undefined, 207]);
 			});
+
+			it('properly deduplicate srcset images', async () => {
+				let res = await fixture.fetch('/srcset');
+				let html = await res.text();
+				$ = cheerio.load(html);
+
+				let localImage = $('#local-3-images img');
+				expect(
+					new Set([
+						...parseSrcset(localImage.attr('srcset')).map((src) => src.url),
+						localImage.attr('src'),
+					]).size
+				).to.equal(3);
+
+				let remoteImage = $('#remote-3-images img');
+				expect(
+					new Set([
+						...parseSrcset(remoteImage.attr('srcset')).map((src) => src.url),
+						remoteImage.attr('src'),
+					]).size
+				).to.equal(3);
+
+				let local1x = $('#local-1x img');
+				expect(
+					new Set([
+						...parseSrcset(local1x.attr('srcset')).map((src) => src.url),
+						local1x.attr('src'),
+					]).size
+				).to.equal(1);
+
+				let remote1x = $('#remote-1x img');
+				expect(
+					new Set([
+						...parseSrcset(remote1x.attr('srcset')).map((src) => src.url),
+						remote1x.attr('src'),
+					]).size
+				).to.equal(1);
+
+				let local2Widths = $('#local-2-widths img');
+				expect(
+					new Set([
+						...parseSrcset(local2Widths.attr('srcset')).map((src) => src.url),
+						local2Widths.attr('src'),
+					]).size
+				).to.equal(2);
+
+				let remote2Widths = $('#remote-2-widths img');
+				expect(
+					new Set([
+						...parseSrcset(remote2Widths.attr('srcset')).map((src) => src.url),
+						remote2Widths.attr('src'),
+					]).size
+				).to.equal(2);
+			});
 		});
 
 		describe('vite-isms', () => {

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -217,7 +217,7 @@ describe('astro:image', () => {
 
 				const srcset2 = parseSrcset($source.attr('srcset'));
 				expect(srcset2.every((src) => src.url.startsWith('/_image'))).to.equal(true);
-				expect(srcset2.map((src) => src.w)).to.deep.equal([undefined, 207]);
+				expect(srcset2.map((src) => src.w)).to.deep.equal([207]);
 			});
 
 			it('properly deduplicate srcset images', async () => {

--- a/packages/astro/test/fixtures/core-image/src/pages/srcset.astro
+++ b/packages/astro/test/fixtures/core-image/src/pages/srcset.astro
@@ -1,0 +1,59 @@
+---
+import { Image } from "astro:assets";
+import image from "../assets/penguin2.jpg";
+
+---
+
+<div id="local-3-images">
+	<!--
+		In this example, only three images should be generated :
+		- The base image
+		- The 1.5x image
+		- The 2x image
+	-->
+	<Image src={image} width={image.width / 2} densities={[1.5, 2]} alt="" />
+</div>
+
+<div id="remote-3-images">
+	<!--
+		In this example, only three images should be generated :
+		- The base image
+		- The 1.5x image
+		- The 2x image
+	-->
+	<Image src={"https://avatars.githubusercontent.com/u/622227?s=64"} width={32} height={32} densities={[1.5, 2]} alt="" />
+</div>
+
+<div id="local-1x">
+	<!--
+		In this example, only one image should be generated :
+		- The base image, 1x density should be the same as the base image
+	-->
+	<Image src={image} width={image.width / 2} densities={[1]} alt="" />
+</div>
+
+<div id="remote-1x">
+	<!--
+		In this example, only one image should be generated :
+		- The base image, 1x density should be the same as the base image
+	-->
+	<Image src={"https://avatars.githubusercontent.com/u/622227?s=64"} width={32} height={32} densities={[1]} alt="" />
+</div>
+
+<div id="local-2-widths">
+	<!--
+		In this example, only two images should be generated :
+		- The base image
+		- The 2x image
+	-->
+	<Image src={image} width={image.width / 2} widths={[image.width]} alt="" />
+</div>
+
+<div id="remote-2-widths">
+	<!--
+		In this example, only two images should be generated :
+		- The base image
+		- The 2x image
+	-->
+	<Image src={"https://avatars.githubusercontent.com/u/622227?s=64"} width={32} height={32} widths={[64]} alt="" />
+</div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,6 +541,9 @@ importers:
       debug:
         specifier: ^4.3.4
         version: 4.3.4(supports-color@8.1.1)
+      deterministic-object-hash:
+        specifier: ^1.3.1
+        version: 1.3.1
       devalue:
         specifier: ^4.3.2
         version: 4.3.2
@@ -10943,6 +10946,10 @@ packages:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
     engines: {node: '>=8'}
     requiresBuild: true
+
+  /deterministic-object-hash@1.3.1:
+    resolution: {integrity: sha512-kQDIieBUreEgY+akq0N7o4FzZCr27dPG1xr3wq267vPwDlSXQ3UMcBXHqTGUBaM/5WDS1jwTYjxRhUzHeuiAvw==}
+    dev: false
 
   /devalue@4.3.2:
     resolution: {integrity: sha512-KqFl6pOgOW+Y6wJgu80rHpo2/3H07vr8ntR9rkkFIRETewbf5GaYYcakYfiKz89K+sLsuPkQIZaXDMjUObZwWg==}


### PR DESCRIPTION
## Changes

Continuation of https://github.com/withastro/astro/pull/8819

This PR also reworks completely how we do the transforms for `srcset`, putting special care into avoiding regenerating images when unnecessary. It's possible that there's still some edge cases where it doesn't work, nonetheless as far as I could tell, it does work!

This also fixes https://github.com/withastro/astro/issues/8839, since it's in the same area.

## Testing

Added tests!

## Docs

N/A
