### PR TITLE
graceful exit on ctrl+c with the dev server

### DIFF
--- a/.changeset/old-pants-invite.md
+++ b/.changeset/old-pants-invite.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+add a graceful exit on ctrl+c with the dev server

--- a/packages/astro/src/cli/dev/index.ts
+++ b/packages/astro/src/cli/dev/index.ts
@@ -9,6 +9,12 @@ interface DevOptions {
 }
 
 export async function dev({ flags }: DevOptions) {
+	// Gracefully handle ctrl+c as a successful exit.
+	// This prevents tools like PNPM from showing scary
+	// red "ELIFECYCLE  Command failed." error messages.
+	process.on('SIGINT', function () {
+		process.exit(0);
+	});
 	if (flags.help || flags.h) {
 		printHelp({
 			commandName: 'astro dev',


### PR DESCRIPTION
## Changes

- Exiting the dev server with CTRL+C is an expected way to exit the dev server
- This changes the exit code from 1 (error) to 0 (success) when you abort the dev server with CTRL+C
- Appearance-wise, this removes the scary " ELIFECYCLE  Command failed." log from pnpm or other task runners who read `1` as a fatal error that the user should be notified of.

### Before

<img width="627" alt="Screen Shot 2023-10-13 at 1 24 38 PM" src="https://github.com/withastro/astro/assets/622227/4cf74b4a-b324-4d37-922f-3b933c1b0290">

### After
<img width="595" alt="Screen Shot 2023-10-13 at 1 25 02 PM" src="https://github.com/withastro/astro/assets/622227/6e7388ed-f067-40bd-8110-30cbc22bba39">


## Testing

- Not needed

## Docs

- Not needed
