### PR TITLE
chore(deps): unpin tsconfck and use 3.0.0 release

### DIFF
--- a/.changeset/red-socks-peel.md
+++ b/.changeset/red-socks-peel.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+---
+
+deps: unpin and update tsconfck from `3.0.0-next.9` to `^3.0.0`  
+

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -167,7 +167,7 @@
     "shikiji": "^0.6.8",
     "string-width": "^6.1.0",
     "strip-ansi": "^7.1.0",
-    "tsconfck": "3.0.0-next.9",
+    "tsconfck": "^3.0.0",
     "unist-util-visit": "^4.1.2",
     "vfile": "^5.3.7",
     "vite": "^4.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -626,8 +626,8 @@ importers:
         specifier: ^7.1.0
         version: 7.1.0
       tsconfck:
-        specifier: 3.0.0-next.9
-        version: 3.0.0-next.9(typescript@5.1.6)
+        specifier: ^3.0.0
+        version: 3.0.0(typescript@5.1.6)
       unist-util-visit:
         specifier: ^4.1.2
         version: 4.1.2
@@ -17138,8 +17138,8 @@ packages:
       code-block-writer: 12.0.0
     dev: true
 
-  /tsconfck@3.0.0-next.9(typescript@5.1.6):
-    resolution: {integrity: sha512-bgVlu3qcRUZpm9Au1IHiPDkb8XU+72bRkXrBaJsiAjIlixtkbKLe4q1odrrqG0rVHvh0Q4R3adT/nh1FwzftXA==}
+  /tsconfck@3.0.0(typescript@5.1.6):
+    resolution: {integrity: sha512-w3wnsIrJNi7avf4Zb0VjOoodoO0woEqGgZGQm+LHH9przdUI+XDKsWAXwxHA1DaRTjeuZNcregSzr7RaA8zG9A==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
3.0.0 is identical to 3.0.0-next.9, this allows astro users to update tsconfck more easily.


## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

no tests added because this is just updating a dependency version where both versions have identical code (and i'm not aware of any tests that cover the use of tsconfck in astro) 

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
