### PR TITLE
misc(create): Ignore errors removing directory after download failed

### DIFF
--- a/.changeset/soft-berries-prove.md
+++ b/.changeset/soft-berries-prove.md
@@ -2,4 +2,4 @@
 'create-astro': patch
 ---
 
-Skip cleanup after template download failed if the path is `.`, `./` or starts with `../`.
+No longer attempts to delete the directory after a template download fails if the path is `.`, `./` or starts with `../`.

--- a/.changeset/soft-berries-prove.md
+++ b/.changeset/soft-berries-prove.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Skip cleanup after template download failed if the path is `.`, `./` or starts with `../`.

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -93,7 +93,16 @@ export default async function copyTemplate(tmpl: string, ctx: Context) {
 				dir: '.',
 			});
 		} catch (err: any) {
-			fs.rmdirSync(ctx.cwd);
+			// Only remove the directory if it's most likely created by us.
+			if (ctx.cwd !== '.' && ctx.cwd !== './' && !ctx.cwd.startsWith('../')) {
+				try {
+					fs.rmdirSync(ctx.cwd);
+				} catch (_) {
+					// Ignore any errors from removing the directory,
+					// make sure we throw and display the original error.
+				}
+			}
+
 			if (err.message.includes('404')) {
 				throw new Error(`Template ${color.reset(tmpl)} ${color.dim('does not exist!')}`);
 			} else {


### PR DESCRIPTION
## Changes

- Skip cleanup if the path is `.`, `./` or starts with `../`.
- Catches and ignore errors calling `rmdirSync` after template download failed.

This ensures the original "download failed" error is thrown and displayed to the user instead of a "rmdir failed" error which could be confusing.

Closes #8785 

## Testing

No new tests were added.
The changed function is not covered by existing tests.

## Docs

No docs changes were made.
I don't think this behavior detail is worth documenting on `docs.astro.build`.