### PR TITLE
fix: small issue with fallback format for `<Picture />`

### DIFF
--- a/.changeset/bright-panthers-rescue.md
+++ b/.changeset/bright-panthers-rescue.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fixes precedence issue for fallback format in <Picture />

--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -25,11 +25,12 @@ const optimizedImages: GetImageResult[] = await Promise.all(
 );
 
 const fallbackFormat =
-	props.fallbackFormat ?? isESMImportedImage(props.src)
+	props.fallbackFormat ??
+	(isESMImportedImage(props.src)
 		? ['svg', 'gif'].includes(props.src.format)
 			? props.src.format
 			: 'png'
-		: 'png';
+		: 'png');
 
 const fallbackImage = await getImage({
 	...props,


### PR DESCRIPTION
## Changes

Fixes a small issue which makes it so the bullish operator in this code is not the first part that's evaluated by adding parenthesis.

```js
const fallbackFormat =
	props.fallbackFormat ?? isESMImportedImage(props.src)
		? ['svg', 'gif'].includes(props.src.format)
			? props.src.format
			: 'png'
		: 'png';
```

## Testing

Tested with pre and post code checking of the values.

## Docs

Bug fix.