### PR TITLE
fix(docs): Update `@astrojs/sitemap` readme to clarify build output location

### DIFF
--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -78,7 +78,7 @@ export default defineConfig({
 
 Note that unlike other configuration options, `site` is set in the root `defineConfig` object, rather than inside the `sitemap()` call.
 
-Now, [build your site for production](https://docs.astro.build/en/reference/cli-reference/#astro-build) via the `astro build` command. You should find your sitemap under `dist/` for both `sitemap-index.xml` and `sitemap-0.xml`!
+Now, [build your site for production](https://docs.astro.build/en/reference/cli-reference/#astro-build) via the `astro build` command. You should find both `sitemap-index.xml` and `sitemap-0.xml` in your output directory—by default, `/dist`.
 
 > **Warning**
 > If you forget to add a `site`, you'll get a friendly warning when you build, and the `sitemap-index.xml` file won't be generated.

--- a/packages/integrations/sitemap/README.md
+++ b/packages/integrations/sitemap/README.md
@@ -78,7 +78,7 @@ export default defineConfig({
 
 Note that unlike other configuration options, `site` is set in the root `defineConfig` object, rather than inside the `sitemap()` call.
 
-Now, [build your site for production](https://docs.astro.build/en/reference/cli-reference/#astro-build) via the `astro build` command. You should find both `sitemap-index.xml` and `sitemap-0.xml` in your output directory—by default, `/dist`.
+Now, [build your site for production](https://docs.astro.build/en/reference/cli-reference/#astro-build) via the `astro build` command. You will find both `sitemap-index.xml` and `sitemap-0.xml` in the `dist/` folder (or your custom [output directory](https://docs.astro.build/en/reference/configuration-reference/#outdir) if set).
 
 > **Warning**
 > If you forget to add a `site`, you'll get a friendly warning when you build, and the `sitemap-index.xml` file won't be generated.


### PR DESCRIPTION
## Changes

- This slightly modifies the language in the docs to clarify that `/dist` is the default output, but generated files may live elsewhere (a confusion that cost me a silly amount of time trying to debug).
- I considered adding a note that the Vercel adapter will output to `.vercel/output` and that other adapters may output code to a place other than `/dist`, but this felt too in-the-weeds. If this is helpful to call out, happy to make edits!
- Resolves https://github.com/withastro/docs/issues/4919 (~~Not sure if Github will auto-close this PR since it's in a separate repo, but the sitemap docs get auto-generated from this README~~)
- Also pairs with @silent1mezzo's improvements to the CLI text: https://github.com/withastro/astro/pull/8824

## Testing

Docs-only change.