### PR TITLE
fix(astro): build config from astro conflict with vite.config.js

### DIFF
--- a/.changeset/fresh-lizards-whisper.md
+++ b/.changeset/fresh-lizards-whisper.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Only use Vite config from astro.config.mjs as source of truth

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -232,6 +232,8 @@ async function ssrBuild(
 		plugins: [...vitePlugins, ...(viteConfig.plugins || []), ...lastVitePlugins],
 		envPrefix: viteConfig.envPrefix ?? 'PUBLIC_',
 		base: settings.config.base,
+		// Tell Vite not to combine config from vite.config.js with our provided inline config
+		configFile: false,
 	};
 
 	const updatedViteBuildConfig = await runHookBuildSetup({

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -232,8 +232,6 @@ async function ssrBuild(
 		plugins: [...vitePlugins, ...(viteConfig.plugins || []), ...lastVitePlugins],
 		envPrefix: viteConfig.envPrefix ?? 'PUBLIC_',
 		base: settings.config.base,
-		// Tell Vite not to combine config from vite.config.js with our provided inline config
-		configFile: false,
 	};
 
 	const updatedViteBuildConfig = await runHookBuildSetup({

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -100,6 +100,8 @@ export async function createVite(
 
 	// Start with the Vite configuration that Astro core needs
 	const commonConfig: vite.InlineConfig = {
+		// Tell Vite not to combine config from vite.config.js with our provided inline config
+		configFile: false,
 		cacheDir: fileURLToPath(new URL('./node_modules/.vite/', settings.config.root)), // using local caches allows Astro to be used in monorepos, etc.
 		clearScreen: false, // we want to control the output, not Vite
 		logLevel: 'warn', // log warnings and errors only


### PR DESCRIPTION
## Changes

- `configFile: false` added to specifically tell Vite not to automatically find, read, and merge config from `vite.config.js`. which could conflict with Astro's vite config ([docs](https://vitejs.dev/guide/api-javascript.html#inlineconfig))

fixes https://github.com/withastro/astro/issues/8702

## Testing

N/A

## Docs

N/A. Docs already said in the way to modify Vite behavior via `astro.config.mjs`
