### PR TITLE
fix(astro): terminal HMR path (close #8831)

### DIFF
--- a/.changeset/two-lamps-tell.md
+++ b/.changeset/two-lamps-tell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the terminal HMR path

--- a/.changeset/two-lamps-tell.md
+++ b/.changeset/two-lamps-tell.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes the terminal HMR path
+Fixed an issue where the dev server logged the full file path on updates.

--- a/.changeset/two-lamps-tell.md
+++ b/.changeset/two-lamps-tell.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixed an issue where the dev server logged the full file path on updates.
+Fixes an issue where the dev server logged the full file path on updates.

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath } from 'node:url';
+import { relative } from "node:path";
 import type { HmrContext, ModuleNode } from 'vite';
 import type { AstroConfig } from '../@types/astro.js';
 import {
@@ -91,7 +92,7 @@ export async function handleHotUpdate(
 	// Bugfix: sometimes style URLs get normalized and end with `lang.css=`
 	// These will cause full reloads, so filter them out here
 	const mods = [...filtered].filter((m) => !m.url.endsWith('='));
-	const file = ctx.file.replace(config.root.pathname, '/');
+	const file = relative(process.cwd(), ctx.file.replace(config.root.pathname, '/'));
 
 	// If only styles are changed, remove the component file from the update list
 	if (isStyleOnlyChange) {

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -91,9 +91,7 @@ export async function handleHotUpdate(
 	// Bugfix: sometimes style URLs get normalized and end with `lang.css=`
 	// These will cause full reloads, so filter them out here
 	const mods = [...filtered].filter((m) => !m.url.endsWith('='));
-	const file = fileURLToPath(`file:///${ctx.file}`)
-		.replace(fileURLToPath(config.root), '/')
-		.replace(/\\/g, '/');
+	const file = ctx.file.replace(fileURLToPath(config.root).replace(/\\/g, '/'), '/');
 
 	// If only styles are changed, remove the component file from the update list
 	if (isStyleOnlyChange) {

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -95,7 +95,7 @@ export async function handleHotUpdate(
 	if (!file.startsWith('/')) {
 		file = `/${file}`
 	}
-	file = file.replace(config.root.pathname, '/')
+	file = file.replaceAll(' ', '%20').replace(config.root.pathname, '/')
 
 	// If only styles are changed, remove the component file from the update list
 	if (isStyleOnlyChange) {

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -91,11 +91,9 @@ export async function handleHotUpdate(
 	// Bugfix: sometimes style URLs get normalized and end with `lang.css=`
 	// These will cause full reloads, so filter them out here
 	const mods = [...filtered].filter((m) => !m.url.endsWith('='));
-	let file = ctx.file;
-	if (!file.startsWith('/')) {
-		file = `/${file}`
-	}
-	file = file.replaceAll(' ', '%20').replace(config.root.pathname, '/')
+	const file = fileURLToPath(`file:///${ctx.file}`)
+		.replace(fileURLToPath(config.root), '/')
+		.replace(/\\/g, '/');
 
 	// If only styles are changed, remove the component file from the update list
 	if (isStyleOnlyChange) {

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -1,5 +1,4 @@
 import { fileURLToPath } from 'node:url';
-import { relative } from "node:path";
 import type { HmrContext, ModuleNode } from 'vite';
 import type { AstroConfig } from '../@types/astro.js';
 import {
@@ -92,7 +91,11 @@ export async function handleHotUpdate(
 	// Bugfix: sometimes style URLs get normalized and end with `lang.css=`
 	// These will cause full reloads, so filter them out here
 	const mods = [...filtered].filter((m) => !m.url.endsWith('='));
-	const file = relative(process.cwd(), ctx.file.replace(config.root.pathname, '/'));
+	let file = ctx.file;
+	if (!file.startsWith('/')) {
+		file = `/${file}`
+	}
+	file = file.replace(config.root.pathname, '/')
 
 	// If only styles are changed, remove the component file from the update list
 	if (isStyleOnlyChange) {

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -1,3 +1,4 @@
+import { slash } from '@astrojs/internal-helpers/path';
 import { fileURLToPath } from 'node:url';
 import type { HmrContext, ModuleNode } from 'vite';
 import type { AstroConfig } from '../@types/astro.js';
@@ -91,7 +92,7 @@ export async function handleHotUpdate(
 	// Bugfix: sometimes style URLs get normalized and end with `lang.css=`
 	// These will cause full reloads, so filter them out here
 	const mods = [...filtered].filter((m) => !m.url.endsWith('='));
-	const file = ctx.file.replace(fileURLToPath(config.root).replace(/\\/g, '/'), '/');
+	const file = ctx.file.replace(slash(fileURLToPath(config.root)), '/');
 
 	// If only styles are changed, remove the component file from the update list
 	if (isStyleOnlyChange) {


### PR DESCRIPTION
## Changes

- #8831
- Uses fileURLToPath and nozmalizes the path between OSs

## Testing

Tested by pointing the `@example/basics` astro version to the local one (`workspace:*`), only on Windows.

## Docs

No change required