### PR TITLE
Add a label for PRs that include documentation changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-README.md @withastro/maintainers-docs
-packages/astro/src/@types/astro.ts @withastro/maintainers-docs
-packages/astro/src/core/errors/errors-data.ts @withastro/maintainers-docs

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,3 +35,8 @@
 
 'pkg: vue':
 - packages/integrations/vue/**
+
+'documentation pr':
+- README.md
+- packages/astro/src/@types/astro.ts
+- packages/astro/src/core/errors/errors-data.ts


### PR DESCRIPTION
## Changes

- Add a `documentation pr` label to Pull Requests that change the files that affects the docs site.
- This is intended to be used instead of the review assignee, for a better workflow for the docs team.

## Testing

N/A

## Docs

N/A