### PR TITLE
feat(vercel): maxDuration config

### DIFF
--- a/.changeset/lazy-actors-enjoy.md
+++ b/.changeset/lazy-actors-enjoy.md
@@ -1,0 +1,14 @@
+---
+'@astrojs/vercel': minor
+---
+
+You can now configure how long your functions can run before timing out.
+
+```diff
+export default defineConfig({
+    output: "server",
+    adapter: vercel({
++       maxDuration: 60
+    }),
+});
+```

--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -261,6 +261,26 @@ export default defineConfig({
 });
 ```
 
+### maxDuration
+
+**Type:** `number`<br>
+**Available for:** Serverless
+
+Use this property to extend or limit the maximum duration (in seconds) that the Serverless Function can run before timing out. See [Vercel documentation](https://vercel.com/docs/functions/serverless-functions/runtimes#maxduration) to find out the valid range for your plan. 
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import vercel from '@astrojs/vercel/serverless';
+
+export default defineConfig({
+    output: "server",
+    adapter: vercel({
++       maxDuration: 60
+    }),
+});
+```
+
 ### Function bundling configuration
 
 The Vercel adapter combines all of your routes into a single function by default.

--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -266,9 +266,9 @@ export default defineConfig({
 **Type:** `number`<br>
 **Available for:** Serverless
 
-Use this property to extend or limit the maximum duration (in seconds) that the Serverless Function can run before timing out. See [Vercel documentation](https://vercel.com/docs/functions/serverless-functions/runtimes#maxduration) to find out the valid range for your plan. 
+Use this property to extend or limit the maximum duration (in seconds) that Serverless Functions can run before timing out. See the [Vercel documentation](https://vercel.com/docs/functions/serverless-functions/runtimes#maxduration) for the default and maximum limit for your account plan. 
 
-```js
+```diff lang="js"
 // astro.config.mjs
 import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/serverless';

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -27,7 +27,6 @@ import {
 	type VercelWebAnalyticsConfig,
 } from '../lib/web-analytics.js';
 import { generateEdgeMiddleware } from './middleware.js';
-import { type } from 'node:os';
 
 const PACKAGE_NAME = '@astrojs/vercel/serverless';
 export const ASTRO_LOCALS_HEADER = 'x-astro-locals';

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -103,7 +103,7 @@ export interface VercelServerlessConfig {
 	/** Whether to split builds into a separate function for each route. */
 	functionPerRoute?: boolean;
 
-	/** Maximum duration (in seconds) that the function can for before timing out. See [Vercel documentation](https://vercel.com/docs/functions/serverless-functions/runtimes#maxduration) for the allowed values for your plan. */
+	/** The maximum duration (in seconds) that Serverless Functions can run before timing out. See the [Vercel documentation](https://vercel.com/docs/functions/serverless-functions/runtimes#maxduration) for the default and maximum limit for your account plan. */
 	maxDuration?: number;
 }
 

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -75,18 +75,35 @@ export interface VercelServerlessConfig {
 	 * @deprecated
 	 */
 	analytics?: boolean;
+
+	/** Configuration for [Vercel Web Analytics](https://vercel.com/docs/concepts/analytics). */
 	webAnalytics?: VercelWebAnalyticsConfig;
+
+	/** Configuration for [Vercel Speed Insights](https://vercel.com/docs/concepts/speed-insights). */
 	speedInsights?: VercelSpeedInsightsConfig;
+
+	/** Force files to be bundled with your function. This is helpful when you notice missing files. */
 	includeFiles?: string[];
+
+	/** Exclude any files from the bundling process that would otherwise be included. */
 	excludeFiles?: string[];
+
+	/** When enabled, an Image Service powered by the Vercel Image Optimization API will be automatically configured and used in production. In development, the image service specified by devImageService will be used instead. */
 	imageService?: boolean;
+
+	/** Configuration options for [Vercel’s Image Optimization API](https://vercel.com/docs/concepts/image-optimization). See [Vercel’s image configuration documentation](https://vercel.com/docs/build-output-api/v3/configuration#images) for a complete list of supported parameters. */
 	imagesConfig?: VercelImageConfig;
+
+	/** Allows you to configure which image service to use in development when imageService is enabled. */
 	devImageService?: DevImageService;
+
+	/** Whether to create the Vercel Edge middleware from an Astro middleware in your code base. */
 	edgeMiddleware?: boolean;
+	
+	/** Whether to split builds into a separate function for each route. */
 	functionPerRoute?: boolean;
-	/**
-	 * Maximum duration (in seconds) that will be allowed for the Serverless Function.
-	 */
+
+	/** Maximum duration (in seconds) that will be allowed for the Serverless Function. */
 	maxDuration?: number;
 }
 

--- a/packages/integrations/vercel/test/fixtures/max-duration/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/max-duration/astro.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from 'astro/config';
+import vercel from '@astrojs/vercel/serverless';
+
+export default defineConfig({
+	output: "server",
+	adapter: vercel({
+		maxDuration: 60
+	})
+});

--- a/packages/integrations/vercel/test/fixtures/max-duration/package.json
+++ b/packages/integrations/vercel/test/fixtures/max-duration/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "@test/vercel-max-duration",
+    "version": "0.0.0",
+    "private": true,
+    "dependencies": {
+        "@astrojs/vercel": "workspace:*",
+        "astro": "workspace:*"
+    }
+}
+  

--- a/packages/integrations/vercel/test/fixtures/max-duration/src/pages/one.astro
+++ b/packages/integrations/vercel/test/fixtures/max-duration/src/pages/one.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>One</title>
+	</head>
+	<body>
+		<h1>One</h1>
+	</body>
+</html>

--- a/packages/integrations/vercel/test/fixtures/max-duration/src/pages/two.astro
+++ b/packages/integrations/vercel/test/fixtures/max-duration/src/pages/two.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>Two</title>
+	</head>
+	<body>
+		<h1>Two</h1>
+	</body>
+</html>

--- a/packages/integrations/vercel/test/max-duration.test.js
+++ b/packages/integrations/vercel/test/max-duration.test.js
@@ -1,0 +1,19 @@
+import { loadFixture } from './test-utils.js';
+import { expect } from 'chai';
+
+describe('maxDuration', () => {
+    /** @type {import('./test-utils.js').Fixture} */
+    let fixture;
+
+    before(async () => {
+        fixture = await loadFixture({
+            root: './fixtures/max-duration/',
+        });
+        await fixture.build();
+    });
+
+    it('makes it to vercel function configuration', async () => {
+        const vcConfig = JSON.parse(await fixture.readFile('../.vercel/output/functions/render.func/.vc-config.json'));
+        expect(vcConfig).to.deep.include({ maxDuration: 60 });
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4605,6 +4605,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/vercel/test/fixtures/max-duration:
+    dependencies:
+      '@astrojs/vercel':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/vercel/test/fixtures/middleware-with-edge-file:
     dependencies:
       '@astrojs/vercel':


### PR DESCRIPTION
## Changes
- Closes #8829
- Introduces an adapter configuration to allow longer than normal function timeouts.
<img width="600" alt="image" src="https://github.com/withastro/astro/assets/69170106/610b7a16-25cc-462e-b1e5-098ab950ad42">

## Testing
Added a fixture and test that `.vc-config.json` has the expected field.

## Docs
Added a section to the README.