### PR TITLE
Set vite logLevel silent for test

### DIFF
--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -99,6 +99,8 @@ export async function loadFixture(inlineConfig) {
 
 	// Silent by default during tests to not pollute the console output
 	inlineConfig.logLevel = 'silent';
+	inlineConfig.vite ??= {};
+	inlineConfig.vite.logLevel = 'silent';
 
 	let root = inlineConfig.root;
 	// Handle URL, should already be absolute so just convert to path


### PR DESCRIPTION
## Changes

Silent the build logs during test. They weren't shown before, but was surfaced since https://github.com/withastro/astro/pull/8678

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Ran test locally to confirm

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a.