### PR TITLE
fix(cli): prevent production install on add cmd

### DIFF
--- a/.changeset/great-queens-yawn.md
+++ b/.changeset/great-queens-yawn.md
@@ -1,5 +1,5 @@
 ---
-'astro': minor
+'astro': patch
 ---
 
 prevent production install on astro add cmd

--- a/.changeset/great-queens-yawn.md
+++ b/.changeset/great-queens-yawn.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+prevent production install on astro add cmd

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -700,7 +700,11 @@ async function tryToInstallIntegrations({
 						...inheritedFlags,
 						...installCommand.dependencies,
 					],
-					{ cwd }
+					{
+						cwd,
+						// reset NODE_ENV to ensure install command run in dev mode
+						env: { NODE_ENV: undefined },
+					}
 				);
 				spinner.succeed();
 				return UpdateResult.updated;


### PR DESCRIPTION
## Changes

- force `NODE_ENV=development` on installation command run when using `astro add` command to prevent installation to remove `devDependencies`

## Testing

no real way to test

## Docs

no need
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

fix #8037
