### PR TITLE
[ci] Update `!preview` response

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -76,8 +76,13 @@ jobs:
       - name: Bump Package Versions
         id: changesets
         run: |
-          pnpm exec changeset version --snapshot ${{ steps.getSnapshotName.outputs.result }} > changesets.output.txt 2>&1
-          echo ::set-output name=result::`cat changesets.output.txt`
+          pnpm exec changeset status --output changesets.output.json 2>&1
+          pnpm exec changeset version --snapshot ${{ steps.getSnapshotName.outputs.result }} > changesets-version.output.txt 2>&1
+          {
+            echo 'result<<__EOF'
+            cat changesets.output.json
+            echo __EOF
+          } >> "$GITHUB_OUTPUT"
         env:
           # Needs access to run the script
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -88,7 +93,11 @@ jobs:
           pnpm run release --tag next--${{ steps.getSnapshotName.outputs.result }} > publish.output.txt 2>&1
           echo "Release complete"
           cat publish.output.txt
-          echo ::set-output name=result::`cat publish.output.txt`
+          {
+            echo 'result<<__EOF'
+            cat publish.output.txt
+            echo __EOF
+          } >> "$GITHUB_OUTPUT"
         env:
           # Needs access to publish to npm
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -97,10 +106,23 @@ jobs:
       - name: Pull Request Notification
         uses: actions/github-script@v6
         env:
+          RELEASES: ${{ steps.changesets.outputs.result }}
           MESSAGE: ${{ steps.publish.outputs.result }}
         with:
           script: |
             console.log(process.env.MESSAGE);
+            const changeset = JSON.parse(process.env.RELEASES);
+            const message = 'The following packages have been released:'
+            for (const release of changeset.releases) {
+              if (release.type === 'none') continue;
+              message += `\n- ${release.name}@${release.newVersion}`;
+            }
+            message += '\n';
+            message += '<details><summary>Build Log</summary>\n\n```\n';
+            message += process.env.message;
+            message += '\n```\n\n</details>';
+
+            
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -92,7 +92,7 @@ jobs:
           cat version.output.json
 
           echo "status<<$EOF" >> $GITHUB_OUTPUT
-          echo "$(cat version.output.json)" >> $GITHUB_OUTPUT
+          echo "$(cat version.output.txt)" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
         env:
           # Needs access to run the script

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -110,6 +110,7 @@ jobs:
       - name: Pull Request Notification
         uses: actions/github-script@v6
         env:
+          TAG: ${{ steps.getSnapshotName.outputs.result }}
           RELEASES: ${{ steps.changesets.outputs.result }}
           MESSAGE: ${{ steps.publish.outputs.result }}
         with:
@@ -122,11 +123,11 @@ jobs:
             let message = 'The following packages have been released:'
             for (const release of changeset.releases) {
               if (release.type === 'none') continue;
-              message += `\n- ${release.name}@${release.newVersion}`;
+              message += `\n- ${release.name}@next--${process.env.TAG}`;
             }
             message += '\n';
             message += '<details><summary>Build Log</summary>\n\n```sh\n';
-            message += process.env.message;
+            message += process.env.MESSAGE;
             message += '\n```\n\n</details>';
 
             github.rest.issues.createComment({

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Publish Release
         id: publish
         run: |
-          pnpm run build --log-prefix=none > build.output.txt 2>&1
+          GITHUB_ACTIONS=0 pnpm run build > build.output.txt 2>&1
           pnpm exec changeset publish --tag experimental--${{ steps.getSnapshotName.outputs.result }} > publish.output.txt 2>&1
 
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
@@ -142,7 +142,7 @@ jobs:
             function details(title, body) {
               message += '\n';
               message += `<details><summary><strong>${title}</strong></summary>`
-              message += '\n\n```sh\n';
+              message += '\n\n```\n';
               message += body;
               message += '\n```\n\n</details>';
             }

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -125,7 +125,7 @@ jobs:
               message += `\n- ${release.name}@${release.newVersion}`;
             }
             message += '\n';
-            message += '<details><summary>Build Log</summary>\n\n```\n';
+            message += '<details><summary>Build Log</summary>\n\n```sh\n';
             message += process.env.message;
             message += '\n```\n\n</details>';
 
@@ -133,5 +133,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '```\n' + process.env.MESSAGE + '\n```',
+              body: message,
             })

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -82,17 +82,11 @@ jobs:
         id: changesets
         run: |
           pnpm exec changeset status --output status.output.json 2>&1
-          pnpm exec changeset version --snapshot ${{ steps.getSnapshotName.outputs.result }} > version.output.txt 2>&1
+          pnpm exec changeset version --snapshot ${{ steps.getSnapshotName.outputs.result }}
 
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-
-          echo "version<<$EOF" >> $GITHUB_OUTPUT
-          echo "$(cat version.output.txt)" >> $GITHUB_OUTPUT
-          echo "$EOF" >> $GITHUB_OUTPUT
-          cat version.output.txt
-
           echo "status<<$EOF" >> $GITHUB_OUTPUT
-          echo "$(cat version.output.txt)" >> $GITHUB_OUTPUT
+          echo "$(cat status.output.json)" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
         env:
           # Needs access to run the script
@@ -131,7 +125,6 @@ jobs:
         env:
           TAG: ${{ steps.getSnapshotName.outputs.result }}
           STATUS_DATA: ${{ steps.changesets.outputs.status }}
-          VERSION_LOG: ${{ steps.changesets.outputs.version }}
           BUILD_LOG: ${{ steps.publish.outputs.build }}
           PUBLISH_LOG: ${{ steps.publish.outputs.publish }}
         with:
@@ -154,9 +147,8 @@ jobs:
               message += '\n```\n\n</details>';
             }
 
-            details('Version Log', process.env.VERSION_LOG);
-            details('Build Log', process.env.BUILD_LOG);
             details('Publish Log', process.env.PUBLISH_LOG);
+            details('Build Log', process.env.BUILD_LOG);
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   snapshot-release:
     name: Create a snapshot release of a pull request
-    if: ${{ github.repository_owner == 'withastro' && github.event.issue.pull_request && startsWith(github.event.comment.body, '!preview') }}
+    if: ${{ github.repository_owner == 'withastro' && github.event.issue.pull_request && contains(fromJSON('["!preview", "/preview", "!snapshot", "/snapshot"]'), github.event.comment.body) }}
     runs-on: ubuntu-latest
     permissions: 
       contents: read 
@@ -37,14 +37,19 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const splitComment = context.payload.comment.body.split(' ');
-            splitComment.length !== 2 && (github.rest.issues.createComment({
+            const { body } = context.payload.comment;
+            const PREVIEW_RE = /^[!\/](?:preview|snapshot)\s+(\S*)\s*$/gim;
+            const [_, name] = PREVIEW_RE.exec(body) ?? [];
+            if (name) return name;
+
+            const error = 'Invalid command. Expected: "/preview <snapshot-name>"'
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Invalid comment format. Expected: "!preview <one-word-snapshot-name>"',
-            }) || core.setFailed('Invalid comment format. Expected: "!preview <one-word-snapshot-name>"'));
-            return splitComment[1].trim();
+              body: error,
+            })
+            core.setFailed(error)
           result-encoding: string
 
       - name: resolve pr refs
@@ -76,11 +81,18 @@ jobs:
       - name: Bump Package Versions
         id: changesets
         run: |
-          pnpm exec changeset status --output changesets.output.json 2>&1
-          pnpm exec changeset version --snapshot ${{ steps.getSnapshotName.outputs.result }} > changesets-version.output.txt 2>&1
+          pnpm exec changeset status --output status.output.json 2>&1
+          pnpm exec changeset version --snapshot ${{ steps.getSnapshotName.outputs.result }} > version.output.txt 2>&1
+
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "result<<$EOF" >> $GITHUB_OUTPUT
-          echo "$(cat changesets.output.json)" >> $GITHUB_OUTPUT
+
+          echo "version<<$EOF" >> $GITHUB_OUTPUT
+          echo "$(cat version.output.json)" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+          cat version.output.json
+
+          echo "status<<$EOF" >> $GITHUB_OUTPUT
+          echo "$(cat status.output.json)" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
         env:
           # Needs access to run the script
@@ -92,13 +104,20 @@ jobs:
       - name: Publish Release
         id: publish
         run: |
-          pnpm run release --tag next--${{ steps.getSnapshotName.outputs.result }} > publish.output.txt 2>&1
-          echo "Release complete"
-          cat publish.output.txt
+          pnpm run build --log-prefix=none > build.output.txt 2>&1
+          pnpm exec changeset publish --tag experimental--${{ steps.getSnapshotName.outputs.result }} > publish.output.txt 2>&1
+
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "result<<$EOF" >> $GITHUB_OUTPUT
+
+          echo "build<<$EOF" >> $GITHUB_OUTPUT
+          echo "$(cat build.output.txt)" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+          cat build.output.txt
+
+          echo "publish<<$EOF" >> $GITHUB_OUTPUT
           echo "$(cat publish.output.txt)" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
+          cat publish.output.txt
         env:
           # Needs access to publish to npm
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -111,24 +130,33 @@ jobs:
         uses: actions/github-script@v6
         env:
           TAG: ${{ steps.getSnapshotName.outputs.result }}
-          RELEASES: ${{ steps.changesets.outputs.result }}
-          MESSAGE: ${{ steps.publish.outputs.result }}
+          STATUS_DATA: ${{ steps.changesets.outputs.status }}
+          VERSION_LOG: ${{ steps.changesets.outputs.version }}
+          BUILD_LOG: ${{ steps.publish.outputs.build }}
+          PUBLISH_LOG: ${{ steps.publish.outputs.publish }}
         with:
           script: |
-            console.log(process.env.MESSAGE);
             let changeset = { releases: [] };
             try {
-              changeset = JSON.parse(process.env.RELEASES);
+              changeset = JSON.parse(process.env.STATUS_DATA);
             } catch (e) {}
-            let message = 'The following packages have been released:'
+            let message = 'Snapshots have been released for the following packages:'
             for (const release of changeset.releases) {
               if (release.type === 'none') continue;
-              message += `\n- ${release.name}@next--${process.env.TAG}`;
+              message += `\n- \`${release.name}@experimental--${process.env.TAG}\``;
             }
-            message += '\n';
-            message += '<details><summary>Build Log</summary>\n\n```sh\n';
-            message += process.env.MESSAGE;
-            message += '\n```\n\n</details>';
+
+            function details(title, body) {
+              message += '\n';
+              message += `<details><summary><strong>${title}</strong></summary>`
+              message += '\n\n```sh\n';
+              message += body;
+              message += '\n```\n\n</details>';
+            }
+
+            details('Version Log', process.env.VERSION_LOG);
+            details('Build Log', process.env.BUILD_LOG);
+            details('Publish Log', process.env.PUBLISH_LOG);
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -12,7 +12,7 @@ defaults:
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-  FORCE_COLOR: true
+  FORCE_COLOR: 1
 
 jobs:
   snapshot-release:
@@ -85,6 +85,9 @@ jobs:
         env:
           # Needs access to run the script
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Disable color
+          FORCE_COLOR: 0
+          NO_COLOR: 1
 
       - name: Publish Release
         id: publish
@@ -100,6 +103,9 @@ jobs:
           # Needs access to publish to npm
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Disable color
+          FORCE_COLOR: 0
+          NO_COLOR: 1
 
       - name: Pull Request Notification
         uses: actions/github-script@v6

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -92,7 +92,7 @@ jobs:
           cat version.output.json
 
           echo "status<<$EOF" >> $GITHUB_OUTPUT
-          echo "$(cat status.output.json)" >> $GITHUB_OUTPUT
+          echo "$(cat version.output.json)" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
         env:
           # Needs access to run the script

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -113,7 +113,7 @@ jobs:
             try {
               changeset = JSON.parse(process.env.RELEASES);
             } catch (e) {}
-            const message = 'The following packages have been released:'
+            let message = 'The following packages have been released:'
             for (const release of changeset.releases) {
               if (release.type === 'none') continue;
               message += `\n- ${release.name}@${release.newVersion}`;

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -87,9 +87,9 @@ jobs:
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
 
           echo "version<<$EOF" >> $GITHUB_OUTPUT
-          echo "$(cat version.output.json)" >> $GITHUB_OUTPUT
+          echo "$(cat version.output.txt)" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
-          cat version.output.json
+          cat version.output.txt
 
           echo "status<<$EOF" >> $GITHUB_OUTPUT
           echo "$(cat version.output.txt)" >> $GITHUB_OUTPUT

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -78,11 +78,10 @@ jobs:
         run: |
           pnpm exec changeset status --output changesets.output.json 2>&1
           pnpm exec changeset version --snapshot ${{ steps.getSnapshotName.outputs.result }} > changesets-version.output.txt 2>&1
-          {
-            echo 'result<<__EOF'
-            cat changesets.output.json
-            echo __EOF
-          } >> "$GITHUB_OUTPUT"
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "result<<$EOF" >> $GITHUB_OUTPUT
+          echo "$(cat changesets.output.json)" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
         env:
           # Needs access to run the script
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -93,11 +92,10 @@ jobs:
           pnpm run release --tag next--${{ steps.getSnapshotName.outputs.result }} > publish.output.txt 2>&1
           echo "Release complete"
           cat publish.output.txt
-          {
-            echo 'result<<__EOF'
-            cat publish.output.txt
-            echo __EOF
-          } >> "$GITHUB_OUTPUT"
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "result<<$EOF" >> $GITHUB_OUTPUT
+          echo "$(cat publish.output.txt)" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
         env:
           # Needs access to publish to npm
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -111,7 +109,10 @@ jobs:
         with:
           script: |
             console.log(process.env.MESSAGE);
-            const changeset = JSON.parse(process.env.RELEASES);
+            let changeset = { releases: [] };
+            try {
+              changeset = JSON.parse(process.env.RELEASES);
+            } catch (e) {}
             const message = 'The following packages have been released:'
             for (const release of changeset.releases) {
               if (release.type === 'none') continue;
@@ -122,7 +123,6 @@ jobs:
             message += process.env.message;
             message += '\n```\n\n</details>';
 
-            
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,


### PR DESCRIPTION
## Changes

- Updates our snapshot release workflow
- Moves away from the deprecated `::set-output` to the new `>> $GITHUB_OUTPUT` method for passing values between job steps.
- Hopefully fixes some formatting in the response message (but this is difficult to test)

## Testing

Not sure how I can test this, tbh...

## Docs

N/A