### PR TITLE
Handle Rollup 4 hash change

### DIFF
--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -106,7 +106,7 @@ export default function assets({
 			},
 			// In build, rewrite paths to ESM imported images in code to their final location
 			async renderChunk(code) {
-				const assetUrlRE = /__ASTRO_ASSET_IMAGE__([a-z\d]{8})__(?:_(.*?)__)?/g;
+				const assetUrlRE = /__ASTRO_ASSET_IMAGE__([\w$]{8})__(?:_(.*?)__)?/g;
 
 				let match;
 				let s;

--- a/packages/astro/test/astro-css-bundling.test.js
+++ b/packages/astro/test/astro-css-bundling.test.js
@@ -69,7 +69,7 @@ describe('CSS Bundling', function () {
 
 		it('CSS includes hashes', async () => {
 			const [firstFound] = await fixture.readdir('/_astro');
-			expect(firstFound).to.match(/[a-z]+\.[0-9a-z]{8}\.css/);
+			expect(firstFound).to.match(/[a-z]+\.[\w-]{8}\.css/);
 		});
 	});
 

--- a/packages/astro/test/ssr-manifest.test.js
+++ b/packages/astro/test/ssr-manifest.test.js
@@ -25,7 +25,7 @@ describe('astro:ssr-manifest', () => {
 		const html = await response.text();
 
 		const $ = cheerio.load(html);
-		expect($('#assets').text()).to.equal('["/_astro/index.a8a337e4.css"]');
+		expect($('#assets').text()).to.match(/\["\/_astro\/index.([\w-]{8})\.css"\]/);
 	});
 
 	it('includes compressHTML', async () => {

--- a/packages/astro/test/ssr-split-manifest.test.js
+++ b/packages/astro/test/ssr-split-manifest.test.js
@@ -45,7 +45,9 @@ describe('astro:ssr-manifest, split', () => {
 		const html = await response.text();
 
 		const $ = cheerio.load(html);
-		expect($('#assets').text()).to.equal('["/_astro/index.a8a337e4.css","/prerender/index.html"]');
+		expect($('#assets').text()).to.match(
+			/\["\/_astro\/index\.([\w-]{8})\.css","\/prerender\/index\.html"\]/
+		);
 	});
 
 	it('should give access to entry points that exists on file system', async () => {


### PR DESCRIPTION
## Changes

Handle Vite 5 and Rollup 4 where `emitFile` now returns base64url hash with `-` replaced as `$`, and file name `[hash]` replaced with base64url hash too.

The former hash can be matched with `[\w$]{8}` while the latter `[\w-]{8}`.

Rollup 4 migration guide: https://rollupjs.org/migration/#general-changes

> Otherwise, an obvious change is that Rollup now uses url-safe base64 hashes in file names instead of the older base16 hashes. This provides more hash safety but means that hash length is now limited to at most 22 characters for technical reasons.

NOTE: These new hash regex covers a wider range of characters, so it should be backwards compatible too.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Ran tests locally.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a