### PR TITLE
Fix CSS modules ordering

### DIFF
--- a/.changeset/silent-goats-invent.md
+++ b/.changeset/silent-goats-invent.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes CSS modules ordering by rendering styles before links

--- a/packages/astro/src/runtime/server/render/head.ts
+++ b/packages/astro/src/runtime/server/render/head.ts
@@ -34,6 +34,12 @@ export function renderAllHeadContent(result: SSRResult) {
 		.filter(uniqueElements)
 		.map((link) => renderElement('link', link, false));
 
+	// Order styles -> links -> scripts similar to src/content/runtime.ts
+	// The order is usually fine as the ordering between these groups are mutually exclusive,
+	// except for CSS styles and CSS stylesheet links. However CSS stylesheet links usually
+	// consist of CSS modules which should naturally take precedence over CSS styles, so the
+	// order will still work. In prod, all CSS are stylesheet links.
+	// In the future, it may be better to have only an array of head elements to avoid these assumptions.
 	let content = styles.join('\n') + links.join('\n') + scripts.join('\n');
 
 	if (result._metadata.extraHead.length > 0) {

--- a/packages/astro/src/runtime/server/render/head.ts
+++ b/packages/astro/src/runtime/server/render/head.ts
@@ -34,7 +34,7 @@ export function renderAllHeadContent(result: SSRResult) {
 		.filter(uniqueElements)
 		.map((link) => renderElement('link', link, false));
 
-	let content = links.join('\n') + styles.join('\n') + scripts.join('\n');
+	let content = styles.join('\n') + links.join('\n') + scripts.join('\n');
 
 	if (result._metadata.extraHead.length > 0) {
 		for (const part of result._metadata.extraHead) {

--- a/packages/astro/test/0-css.test.js
+++ b/packages/astro/test/0-css.test.js
@@ -170,6 +170,15 @@ describe('CSS', function () {
 				// 2. check CSS
 				expect(bundledCSS).to.match(new RegExp(`.${moduleClass}[^{]*{font-family:fantasy`));
 			});
+
+			it('.module.css ordering', () => {
+				const globalStyleClassIndex = bundledCSS.indexOf('.module-ordering');
+				const moduleStyleClassIndex = bundledCSS.indexOf('._module_ordering');
+				// css module has higher priority than global style
+				expect(globalStyleClassIndex).to.be.greaterThan(-1);
+				expect(moduleStyleClassIndex).to.be.greaterThan(-1);
+				expect(moduleStyleClassIndex).to.be.greaterThan(globalStyleClassIndex);
+			});
 		});
 
 		describe('Vue', () => {
@@ -410,6 +419,17 @@ describe('CSS', function () {
 				false,
 				'Should not have found a preload for the dynamic CSS'
 			);
+		});
+
+		it('.module.css ordering', () => {
+			const globalStyleTag = $('style[data-vite-dev-id$="default.css"]');
+			const moduleStyleTag = $('link[href$="ModuleOrdering.module.css"]');
+			const globalStyleClassIndex = globalStyleTag.index();
+			const moduleStyleClassIndex = moduleStyleTag.index();
+			// css module has higher priority than global style
+			expect(globalStyleClassIndex).to.be.greaterThan(-1);
+			expect(moduleStyleClassIndex).to.be.greaterThan(-1);
+			expect(moduleStyleClassIndex).to.be.greaterThan(globalStyleClassIndex);
 		});
 
 		it('.css?raw return a string', () => {

--- a/packages/astro/test/fixtures/0-css/src/components/ModuleOrdering.jsx
+++ b/packages/astro/test/fixtures/0-css/src/components/ModuleOrdering.jsx
@@ -1,0 +1,7 @@
+import { module_ordering } from './ModuleOrdering.module.css';
+
+export default function Counter() {
+  return (
+    <p className={`module-ordering ${module_ordering}`}>This should be green</p>
+  )
+}

--- a/packages/astro/test/fixtures/0-css/src/components/ModuleOrdering.module.css
+++ b/packages/astro/test/fixtures/0-css/src/components/ModuleOrdering.module.css
@@ -1,0 +1,3 @@
+.module_ordering {
+  color: green;
+}

--- a/packages/astro/test/fixtures/0-css/src/pages/index.astro
+++ b/packages/astro/test/fixtures/0-css/src/pages/index.astro
@@ -1,4 +1,6 @@
 ---
+import '../styles/default.css'
+
 import AstroComponent from '../components/Astro.astro';
 import AstroComponentNone from '../components/AstroNone.astro';
 import AstroSass from '../components/AstroSass.astro';
@@ -19,6 +21,7 @@ import VueScoped from '../components/VueScoped.vue';
 import VueScss from '../components/VueScss.vue';
 import ReactDynamic from '../components/ReactDynamic.jsx';
 import SvelteDynamic from '../components/SvelteDynamic.svelte';
+import ModuleOrdering from '../components/ModuleOrdering.jsx';
 
 import '../styles/imported-url.css';
 import '../styles/imported.sass';
@@ -76,6 +79,7 @@ import raw from '../styles/raw.css?raw'
       <ReactDynamic client:load />
       <SvelteDynamic client:load />
       <pre id="css-raw">{raw}</pre>
+      <ModuleOrdering />
     </div>
   </body>
 </html>

--- a/packages/astro/test/fixtures/0-css/src/styles/default.css
+++ b/packages/astro/test/fixtures/0-css/src/styles/default.css
@@ -1,0 +1,3 @@
+.module-ordering {
+  color: red;
+}


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/astro/issues/8558

Fix CSS modules ordering by rendering styles first before links. This is needed because in `getStylesForURL`, CSS modules are passed as links (`importedCssUrls`) (CSS module has no `ssrModule.default`):

https://github.com/withastro/astro/blob/5ea6ee0ed494c792a4c94928a83c5c85b9b6ac32/packages/astro/src/vite-plugin-astro-server/css.ts#L34-L46

We then put the CSS module links in `links`, and the other styles (global styles) in `styles`.

https://github.com/withastro/astro/blob/5ea6ee0ed494c792a4c94928a83c5c85b9b6ac32/packages/astro/src/vite-plugin-astro-server/route.ts#L301-L330

Ultimately this creates a tricky situation where we shouldn't actually group head elements this way. Scripts/styles/links should all be in a single array but that takes a larger refactor which we could revisit in the future.

---

Also, the content rendering runtime also has styles first before links:

https://github.com/withastro/astro/blob/5ea6ee0ed494c792a4c94928a83c5c85b9b6ac32/packages/astro/src/content/runtime.ts#L316

---

In most case, non-CSS links could be sorted anywhere though, and I can confirm CSS links are only for CSS modules, so I think this change is harmless. During builds, all CSS are links so there's no ordering issue.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added a new integration test.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
n/a. bug fix.