### PR TITLE
fix noop overwrite image service regression

### DIFF
--- a/.changeset/witty-waves-rhyme.md
+++ b/.changeset/witty-waves-rhyme.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Moves the logic for overriding the image service out of core and into adapters. Also fixes a regression where a valid `astro:assets` image service configuration could be overridden.

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -235,16 +235,6 @@ export async function runHookConfigDone({
 									);
 								}
 							}
-							if (!validationResult.assets) {
-								logger.warn(
-									'astro',
-									`The selected adapter ${adapter.name} does not support image optimization. To allow your project to build with the original, unoptimized images, the image service has been automatically switched to the 'noop' option. See https://docs.astro.build/en/reference/configuration-reference/#imageservice`
-								);
-								settings.config.image.service = {
-									entrypoint: 'astro/assets/services/noop',
-									config: {},
-								};
-							}
 						}
 						settings.adapter = adapter;
 					},


### PR DESCRIPTION
## Changes

- for context see messages after: https://discord.com/channels/830184174198718474/845430950191038464/1165031078722011238
- I've added PRs to the two known edge runtimes:

- https://github.com/denoland/deno-astro-adapter/pull/7
- https://github.com/withastro/adapters/pull/33
