### PR TITLE
Update README.md: Fix incorrect import in example code

### DIFF
--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -320,7 +320,7 @@ This is an opt-in feature, and the `edgeMiddleware` option needs to be set to `t
 ```js
 // astro.config.mjs
 import { defineConfig } from 'astro/config';
-import vercel from '@astrojs/vercel';
+import vercel from '@astrojs/vercel/serverless';
 export default defineConfig({
   output: 'server',
   adapter: vercel({


### PR DESCRIPTION
## Changes
- Fixes a small typo in the import line for the code block explaining how to use Vercel serverless with Astro middleware.
- The import line needs to import `vercel` from `'@astrojs/vercel/serverless'`. Otherwise, astro throws an "Unable to load your Astro config" error due to being unable to resolve the "@astrojs/vercel" package.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
- No testing performed as there are no changes to Astro packages, just to docs.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

- Just a fix to docs, so no additional documentation needed (but other translations may also need to be fixed!)
