### PR TITLE
Prevent Vercel serverless generate static redirect pages

### DIFF
--- a/.changeset/poor-steaks-confess.md
+++ b/.changeset/poor-steaks-confess.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Prevents the Vercel serverless adapter from generating static redirect pages in hybrid mode

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -175,6 +175,7 @@ export default function vercelServerless({
 						serverEntry: 'entry.mjs',
 						client: new URL('./static/', outDir),
 						server: new URL('./dist/', config.root),
+						redirects: false,
 					},
 					vite: {
 						...getSpeedInsightsViteConfig(speedInsights?.enabled || analytics),

--- a/packages/integrations/vercel/test/fixtures/redirects-serverless/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/redirects-serverless/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import vercel from '@astrojs/vercel/serverless';
+
+export default defineConfig({
+	output: 'hybrid',
+	adapter: vercel(),
+});

--- a/packages/integrations/vercel/test/fixtures/redirects-serverless/package.json
+++ b/packages/integrations/vercel/test/fixtures/redirects-serverless/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/astro-vercel-redirects-serverless",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/vercel": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/vercel/test/fixtures/redirects-serverless/src/pages/index.astro
+++ b/packages/integrations/vercel/test/fixtures/redirects-serverless/src/pages/index.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<h1>Testing</h1>
+	</body>
+</html>

--- a/packages/integrations/vercel/test/redirects-serverless.test.js
+++ b/packages/integrations/vercel/test/redirects-serverless.test.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { loadFixture } from './test-utils.js';
+
+describe('Redirects Serverless', () => {
+	/** @type {import('astro/test/test-utils.js').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/redirects-serverless/',
+			redirects: {
+				'/one': '/',
+				'/other': '/subpage',
+			},
+		});
+		await fixture.build();
+	});
+
+	it('does not create .html files', async () => {
+		let hasErrored = false;
+		try {
+			await fixture.readFile('../.vercel/output/static/other/index.html');
+		} catch {
+			hasErrored = true;
+		}
+		expect(hasErrored).to.equal(true, 'this file should not exist');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4650,6 +4650,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/vercel/test/fixtures/redirects-serverless:
+    dependencies:
+      '@astrojs/vercel':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/vercel/test/fixtures/serverless-prerender:
     dependencies:
       '@astrojs/vercel':


### PR DESCRIPTION
## Changes

Similar to https://github.com/withastro/astro/pull/7805
Fixes https://github.com/withastro/astro/issues/7889

Prevent generate static redirect pages as `vercel.json` redirects already covers it. This aligns with the behaviour in `@astrojs/vercel/static` and dev.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added a new test based on https://github.com/withastro/astro/pull/7805. Also tested a published vercel project.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Added changeset