### PR TITLE
Recommend the VS Code MDX extension

### DIFF
--- a/.changeset/slow-cheetahs-marry.md
+++ b/.changeset/slow-cheetahs-marry.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/mdx": patch
+---
+
+Update the README to suggest that users install the [official MDX extension](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx) for [VS Code](https://code.visualstudio.com/).

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -56,7 +56,7 @@ Then, apply this integration to your `astro.config.*` file using the `integratio
 
 ### Editor Integration
 
-For editor support in [VS Code](https://code.visualstudio.com/), install the [`unifiedjs.vscode-mdx`](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx) extension.
+For editor support in [VS Code](https://code.visualstudio.com/), install the [official MDX extension](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx).
 
 For other editors, use the [MDX language server](https://github.com/mdx-js/mdx-analyzer/tree/main/packages/language-server).
 

--- a/packages/integrations/mdx/README.md
+++ b/packages/integrations/mdx/README.md
@@ -56,15 +56,9 @@ Then, apply this integration to your `astro.config.*` file using the `integratio
 
 ### Editor Integration
 
-[VS Code](https://code.visualstudio.com/) supports Markdown by default. However, for MDX editor support, you may wish to add the following setting in your VSCode config. This ensures authoring MDX files provides a Markdown-like editor experience.
+For editor support in [VS Code](https://code.visualstudio.com/), install the [`unifiedjs.vscode-mdx`](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx) extension.
 
-```json title=".vscode/settings.json"
-{
-  "files.associations": {
-    "*.mdx": "markdown"
-  }
-}
-```
+For other editors, use the [MDX language server](https://github.com/mdx-js/mdx-analyzer/tree/main/packages/language-server).
 
 ## Usage
 


### PR DESCRIPTION
## Changes

This replaces the the old recommendation to mark MDX files as markdown with the recommendation to use the official MDX extension. MDX supports various constructs that markdown doesn’t, so that leads to bad syntax highlighting.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

This is a documentation-only change.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This is a documentation-only change.