### PR TITLE
feat: options to avoid processing images at build in hybrid mode

### DIFF
--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -110,6 +110,7 @@ export async function getImage(
 
 	if (
 		isLocalService(service) &&
+		globalThis.astroAsset?.isStaticImage?.(validatedOptions) &&
 		globalThis.astroAsset.addStaticImage &&
 		!(isRemoteImage(validatedOptions.src) && imageURL === validatedOptions.src)
 	) {

--- a/packages/astro/src/assets/services/service.ts
+++ b/packages/astro/src/assets/services/service.ts
@@ -213,6 +213,10 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 			options.format = DEFAULT_OUTPUT_FORMAT;
 		}
 
+		if (!options.transform) {
+			options.transform = 'eager';
+		}
+
 		// Sometimes users will pass number generated from division, which can result in floating point numbers
 		if (options.width) options.width = Math.round(options.width);
 		if (options.height) options.height = Math.round(options.height);
@@ -221,8 +225,18 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 	},
 	getHTMLAttributes(options) {
 		const { targetWidth, targetHeight } = getTargetDimensions(options);
-		const { src, width, height, format, quality, densities, widths, formats, ...attributes } =
-			options;
+		const {
+			src,
+			width,
+			height,
+			format,
+			quality,
+			densities,
+			widths,
+			formats,
+			transform,
+			...attributes
+		} = options;
 
 		return {
 			...attributes,
@@ -337,7 +351,7 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 		};
 
 		Object.entries(params).forEach(([param, key]) => {
-			options[key] && searchParams.append(param, options[key].toString());
+			key in options && searchParams.append(param, options[key].toString());
 		});
 
 		const imageEndpoint = joinPaths(import.meta.env.BASE_URL, '/_image');

--- a/packages/astro/src/assets/types.ts
+++ b/packages/astro/src/assets/types.ts
@@ -12,6 +12,7 @@ declare global {
 	// eslint-disable-next-line no-var
 	var astroAsset: {
 		imageService?: ImageService;
+		isStaticImage?: ((options: ImageTransform) => boolean) | undefined;
 		addStaticImage?: ((options: ImageTransform) => string) | undefined;
 		staticImages?: Map<string, { path: string; options: ImageTransform }>;
 	};
@@ -52,6 +53,7 @@ export type ImageTransform = {
 	height?: number | undefined;
 	quality?: ImageQuality | undefined;
 	format?: ImageOutputFormat | undefined;
+	transform?: 'eager' | 'lazy';
 	[key: string]: any;
 };
 
@@ -97,6 +99,22 @@ type ImageSharedProps<T> = T & {
 	 * ```
 	 */
 	height?: number | `${number}`;
+
+	/**
+	 * When `output: hybrid` **only**, otherwise it will be ignored. Defaults to 'eager'.
+	 * This allows to choose if the image will be transformed at build (eager) or at runtime (lazy).
+	 *
+	 * This can be useful when:
+	 * 1. having a very large number of images which are unlikely to be visited often and for which you'd prefer to have them processed on demand, rather than increasing your build time (typically, page 4 and further of a paginated list)
+	 * 2. deploying to a provider which has efficient dynamic cdn/cache layer (such as aws cloudfront) and you'd prefer to generate/cache the images dynamically depending on the size requested.
+	 *
+	 * **Example**:
+	 * ```astro
+	 * <Image src={...} height={300} alt="..." transform={pagination < 4 ? 'eager' : 'lazy'} />
+	 * <Image src={...} height={300} alt="..." transform="lazy" />
+	 * ```
+	 */
+	transform?: 'eager' | 'lazy';
 } & (
 		| {
 				/**

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -76,6 +76,12 @@ export default function assets({
 					return;
 				}
 
+				const { output } = settings.config;
+
+				globalThis.astroAsset.isStaticImage = (options) => {
+					return output !== 'hybrid' || options.transform !== 'lazy';
+				};
+
 				globalThis.astroAsset.addStaticImage = (options) => {
 					if (!globalThis.astroAsset.staticImages) {
 						globalThis.astroAsset.staticImages = new Map<

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -145,6 +145,7 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 	// HACK! `astro:assets` relies on a global to know if its running in dev, prod, ssr, ssg, full moon
 	// If we don't delete it here, it's technically not impossible (albeit improbable) for it to leak
 	if (ssr && !hasPrerenderedPages(internals)) {
+		delete globalThis?.astroAsset?.isStaticImage;
 		delete globalThis?.astroAsset?.addStaticImage;
 		return;
 	}
@@ -212,6 +213,7 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 		);
 	}
 
+	delete globalThis?.astroAsset?.isStaticImage;
 	delete globalThis?.astroAsset?.addStaticImage;
 
 	await runHookBuildGenerated({


### PR DESCRIPTION
## Changes

This adds a `transform: 'eager' | 'lazy'` parameter to astro asset's `getImage`/`<Image />` which allows for image NOT to build processed at build, but rather let it flow to runtime processing.

## Motivation

I'm deploying my website on AWS with a "standard" serverless stack (cloudfront/lambda@edge/s3) and since CloudFront has a good dynamic cache policy, I wanted to let the lambda@edge process my images and update CF's cache instead of building the images at build.

_PS: I can't use a full `output: server` because our CMS does not perform well and TTFB could be > 5s in some cases, so i must prebuild the html pages._

I believe this could also serve a use-case where consumers of this feature would like to have control over what image is transformed at build and what image is transformed at runtime. One could want to transform at build the first 10 pages of a 100 pages product list, but for the "furthest" pages which nobody look at, having runtime transform could help decrease the build time (pre-processing images for potentially no reason).

## Testing

I've a pet project which i toggle between `output: 'static'` and `output: 'hybrid'` and inspect the build manually. The pet project only route is `src/pages/index.astro` and contains:

```tsx
---
import { Image } from 'astro:assets'
---

<html lang="en">
  <body>
    <Image
      src="http://placekitten.com/200/300"
      width={200}
      height={300}
      alt=""
    />
    <Image
      src="http://placekitten.com/200/300"
      width={200}
      height={300}
      alt=""
      transform="lazy" 
    />
  </body>
</html>
```
The acceptance criteria is that when running `npm run build` in static mode, both images are transformed, url is replaced by a `/_astro/` url and image is in the `dist/_astro` folder whereas in hybrid mode, only the 1st one is transformed and the 2nd one has a `/_image?href=` url instead.

## Note

I'm not really sure of what's the best way to code this. I wanted to avoid having the  `globalThis.astroAsset.isStaticImage` but there's a need to get the `settings.config.output` to know if we need to `addStaticImage` or not.

I first thought of modifying `addStaticImage` to `maybeAddStaticImage` but i preferred keeping separation of concern intact and a simple `addStaticImage` with no early exit for this specific case.

If the `config.output` could be brought to `getImage()` directly, there would be no need for this function and we could simply write `option.transform !== 'lazy'` instead.

I also was not sure of what should be the parameter name, should it be a boolean or not. I tried `skipTransformAtBuild` or `prerender` or else, but none were satisfactory when writing code with both `getImage` and `<Image />` so i thought it'd be nicer to follow the same interface than `loading`.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
