### PR TITLE
feat(i18n): better APIs

### DIFF
--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -135,7 +135,7 @@ declare module 'astro:i18n' {
 	 *
 	 * ## Errors
 	 *
-	 * It throws an error if the locale doesn't exist in the list of locales defined in the configuration.
+	 * Throws an error if the locale doesn't exist in the list of locales defined in the configuration.
 	 *
 	 * ## Examples
 	 *
@@ -160,7 +160,7 @@ declare module 'astro:i18n' {
 	 *
 	 * ## Errors
 	 *
-	 * It throws an error if the locale doesn't exist in the list of locales defined in the configuration.
+	 * Throws an error if the locale doesn't exist in the list of locales defined in the configuration.
 	 *
 	 * ## Examples
 	 *
@@ -180,14 +180,14 @@ declare module 'astro:i18n' {
 	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string[]}
 	 *
-	 * It works like `getLocaleRelativeUrl` but it emits the relative URLs for ALL locales:
+	 * Works like `getLocaleRelativeUrl` but it emits the relative URLs for ALL locales:
 	 */
 	export const getLocaleRelativeUrlList: (options?: GetLocaleOptions) => string[];
 	/**
 	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string[]}
 	 *
-	 * It works like `getLocaleAbsoluteUrl` but it emits the absolute URLs for ALL locales:
+	 * Works like `getLocaleAbsoluteUrl` but it emits the absolute URLs for ALL locales:
 	 */
 	export const getLocaleAbsoluteUrlList: (options?: GetLocaleOptions) => string[];
 }

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -124,13 +124,72 @@ declare module 'astro:transitions/client' {
 declare module 'astro:i18n' {
 	type I18nModule = typeof import('./dist/i18n/index.js');
 
-	// TODO: documentation
-	export const getLocaleRelativeUrl: (locale: string) => string;
-	export const getLocaleAbsoluteUrl: (locale: string) => string;
+	export type GetLocaleOptions = import('./dist/i18n/index.js').GetLocaleOptions;
 
-	// TODO: documentation
-	export const getLocaleRelativeUrlList: () => string[];
-	export const getLocaleAbsoluteUrlList: () => string[];
+	/**
+	 * @param {string} locale A locale
+	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
+	 * @return {string}
+	 *
+	 * Returns a _relative_ path with passed locale.
+	 *
+	 * ## Errors
+	 *
+	 * It throws an error if the locale doesn't exist in the
+	 *
+	 * ## Examples
+	 *
+	 * ```js
+	 * import { getLocaleRelativeUrl } from "astro:i18n";
+	 * getLocaleRelativeUrl("es"); // /es
+	 * getLocaleRelativeUrl("es", { path: "getting-started" }); // /es/getting-started
+	 * getLocaleRelativeUrl("es", { path: "getting-started", prependWith: "blog" }); // /blog/es/getting-started
+	 * getLocaleRelativeUrl("es_US", { path: "getting-started", prependWith: "blog", normalizeLocale: true }); // /blog/es-us/getting-started
+	 * ```
+	 */
+	export const getLocaleRelativeUrl: (locale: string, options?: GetLocaleOptions) => string;
+
+	/**
+	 *
+	 * @param {string} locale A locale
+	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
+	 * @return {string}
+	 *
+	 * Returns an absolute path with the passed locale. The behaviour is subject to change based on `site` configuration.
+	 * If _not_ provided, the function will return a _relative_ URL.
+	 *
+	 * ## Errors
+	 *
+	 * It throws an error if the locale doesn't exist in the
+	 *
+	 * ## Examples
+	 *
+	 * If `site` is `https://example.com`:
+	 *
+	 * ```js
+	 * import { getLocaleAbsoluteUrl } from "astro:i18n";
+	 * getLocaleAbsoluteUrl("es"); // https://example.com/es
+	 * getLocaleAbsoluteUrl("es", { path: "getting-started" }); // https://example.com/es/getting-started
+	 * getLocaleAbsoluteUrl("es", { path: "getting-started", prependWith: "blog" }); // https://example.com/blog/es/getting-started
+	 * getLocaleAbsoluteUrl("es_US", { path: "getting-started", prependWith: "blog", normalizeLocale: true }); // https://example.com/blog/es-us/getting-started
+	 * ```
+	 */
+	export const getLocaleAbsoluteUrl: (locale: string, options?: GetLocaleOptions) => string;
+
+	/**
+	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
+	 * @return {string[]}
+	 *
+	 * It works like `getLocaleRelativeUrl` but it emits the relative URLs for ALL locales:
+	 */
+	export const getLocaleRelativeUrlList: (options?: GetLocaleOptions) => string[];
+	/**
+	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
+	 * @return {string[]}
+	 *
+	 * It works like `getLocaleAbsoluteUrl` but it emits the absolute URLs for ALL locales:
+	 */
+	export const getLocaleAbsoluteUrlList: (options?: GetLocaleOptions) => string[];
 }
 
 declare module 'astro:middleware' {

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -135,7 +135,7 @@ declare module 'astro:i18n' {
 	 *
 	 * ## Errors
 	 *
-	 * It throws an error if the locale doesn't exist in the
+	 * It throws an error if the locale doesn't exist in the list of locales defined in the configuration.
 	 *
 	 * ## Examples
 	 *
@@ -160,7 +160,7 @@ declare module 'astro:i18n' {
 	 *
 	 * ## Errors
 	 *
-	 * It throws an error if the locale doesn't exist in the
+	 * It throws an error if the locale doesn't exist in the list of locales defined in the configuration.
 	 *
 	 * ## Examples
 	 *

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -14,7 +14,7 @@ type GetLocaleRelativeUrl = GetLocaleOptions & {
 
 export type GetLocaleOptions = {
 	/**
-	 * It makes the locale URL-friendly by replacing underscores with dashes, and making the locale lower case.
+	 * Makes the locale URL-friendly by replacing underscores with dashes, and converting the locale to lower case.
 	 */
 	normalizeLocale?: boolean;
 	/**

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -14,11 +14,11 @@ type GetLocaleRelativeUrl = GetLocaleOptions & {
 
 export type GetLocaleOptions = {
 	/**
-	 * If the locale needs to be normalized
+	 * It makes the locale URL-friendly by replacing underscores with dashes, and making the locale lower case.
 	 */
 	normalizeLocale?: boolean;
 	/**
-	 * An optional path to prepend to `locale`
+	 * An optional path to add after the `locale`
 	 */
 	path?: string;
 	/**

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -36,10 +36,11 @@ export default function astroInternalization({ settings }: AstroInternalization)
 					const format =  ${JSON.stringify(settings.config.build.format)};
 					const site = ${JSON.stringify(settings.config.site)};
 					
-					export const getLocaleRelativeUrl = (locale) => _getLocaleRelativeUrl({ locale, base, locales, trailingSlash, format });
-					export const getLocaleRelativeUrlList = () => _getLocaleRelativeUrlList({ base, locales, trailingSlash, format });
-					export const getLocaleAbsoluteUrl = (locale) => _getLocaleAbsoluteUrl({ locale, base, locales, trailingSlash, format, site });
-					export const getLocaleAbsoluteUrlList = () => _getLocaleAbsoluteUrlList({ base, locales, trailingSlash, format, site });
+					export const getLocaleRelativeUrl = (locale, opts) => _getLocaleRelativeUrl({ locale, base, locales, trailingSlash, format, ...opts });
+					export const getLocaleAbsoluteUrl = (locale, opts) => _getLocaleAbsoluteUrl({ locale, base, locales, trailingSlash, format, site, ...opts });
+					
+					export const getLocaleRelativeUrlList = (opts) => _getLocaleRelativeUrlList({ base, locales, trailingSlash, format, ...opts });
+					export const getLocaleAbsoluteUrlList = (opts) => _getLocaleAbsoluteUrlList({ base, locales, trailingSlash, format, site, ...opts });
 				`;
 			}
 		},

--- a/packages/astro/test/units/i18n/astro_i18n.js
+++ b/packages/astro/test/units/i18n/astro_i18n.js
@@ -215,6 +215,17 @@ describe('getLocaleRelativeUrl', () => {
 				trailingSlash: 'always',
 				format: 'directory',
 			})
+		).to.eq('/blog/en_US/');
+
+		expect(
+			getLocaleRelativeUrl({
+				locale: 'en_US',
+				base: '/blog/',
+				locales: config.experimental.i18n.locales,
+				trailingSlash: 'always',
+				format: 'directory',
+				normalizeLocale: true,
+			})
 		).to.eq('/blog/en-us/');
 
 		expect(
@@ -225,7 +236,7 @@ describe('getLocaleRelativeUrl', () => {
 				trailingSlash: 'always',
 				format: 'directory',
 			})
-		).to.eq('/blog/en-au/');
+		).to.eq('/blog/en_AU/');
 	});
 });
 
@@ -252,7 +263,7 @@ describe('getLocaleRelativeUrlList', () => {
 				trailingSlash: 'never',
 				format: 'directory',
 			})
-		).to.have.members(['/blog/en', '/blog/en-us', '/blog/es']);
+		).to.have.members(['/blog/en', '/blog/en_US', '/blog/es']);
 	});
 
 	it('should retrieve the correct list of base URL with locales [format: directory, trailingSlash: always]', () => {
@@ -277,7 +288,7 @@ describe('getLocaleRelativeUrlList', () => {
 				trailingSlash: 'always',
 				format: 'directory',
 			})
-		).to.have.members(['/blog/en/', '/blog/en-us/', '/blog/es/']);
+		).to.have.members(['/blog/en/', '/blog/en_US/', '/blog/es/']);
 	});
 
 	it('should retrieve the correct list of base URL with locales [format: file, trailingSlash: always]', () => {
@@ -302,7 +313,7 @@ describe('getLocaleRelativeUrlList', () => {
 				trailingSlash: 'always',
 				format: 'file',
 			})
-		).to.have.members(['/blog/en/', '/blog/en-us/', '/blog/es/']);
+		).to.have.members(['/blog/en/', '/blog/en_US/', '/blog/es/']);
 	});
 
 	it('should retrieve the correct list of base URL with locales [format: file, trailingSlash: never]', () => {
@@ -327,7 +338,7 @@ describe('getLocaleRelativeUrlList', () => {
 				trailingSlash: 'never',
 				format: 'file',
 			})
-		).to.have.members(['/blog/en', '/blog/en-us', '/blog/es']);
+		).to.have.members(['/blog/en', '/blog/en_US', '/blog/es']);
 	});
 
 	it('should retrieve the correct list of base URL with locales [format: file, trailingSlash: ignore]', () => {
@@ -352,7 +363,7 @@ describe('getLocaleRelativeUrlList', () => {
 				trailingSlash: 'ignore',
 				format: 'file',
 			})
-		).to.have.members(['/blog/en', '/blog/en-us', '/blog/es']);
+		).to.have.members(['/blog/en', '/blog/en_US', '/blog/es']);
 	});
 
 	it('should retrieve the correct list of base URL with locales [format: directory, trailingSlash: ignore]', () => {
@@ -377,7 +388,7 @@ describe('getLocaleRelativeUrlList', () => {
 				trailingSlash: 'ignore',
 				format: 'directory',
 			})
-		).to.have.members(['/blog/en/', '/blog/en-us/', '/blog/es/']);
+		).to.have.members(['/blog/en/', '/blog/en_US/', '/blog/es/']);
 	});
 });
 
@@ -598,7 +609,7 @@ describe('getLocaleAbsoluteUrl', () => {
 				trailingSlash: 'always',
 				format: 'directory',
 			})
-		).to.eq('/blog/en-us/');
+		).to.eq('/blog/en_US/');
 
 		expect(
 			getLocaleRelativeUrl({
@@ -608,7 +619,18 @@ describe('getLocaleAbsoluteUrl', () => {
 				trailingSlash: 'always',
 				format: 'directory',
 			})
-		).to.eq('/blog/en-au/');
+		).to.eq('/blog/en_AU/');
+
+		expect(
+			getLocaleRelativeUrl({
+				locale: 'en_US',
+				base: '/blog/',
+				locales: config.experimental.i18n.locales,
+				trailingSlash: 'always',
+				format: 'directory',
+				normalizeLocale: true,
+			})
+		).to.eq('/blog/en-us/');
 	});
 });
 
@@ -638,7 +660,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 			})
 		).to.have.members([
 			'https://example.com/blog/en',
-			'https://example.com/blog/en-us',
+			'https://example.com/blog/en_US',
 			'https://example.com/blog/es',
 		]);
 	});
@@ -668,7 +690,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 			})
 		).to.have.members([
 			'https://example.com/blog/en/',
-			'https://example.com/blog/en-us/',
+			'https://example.com/blog/en_US/',
 			'https://example.com/blog/es/',
 		]);
 	});
@@ -698,7 +720,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 			})
 		).to.have.members([
 			'https://example.com/blog/en/',
-			'https://example.com/blog/en-us/',
+			'https://example.com/blog/en_US/',
 			'https://example.com/blog/es/',
 		]);
 	});
@@ -728,7 +750,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 			})
 		).to.have.members([
 			'https://example.com/blog/en',
-			'https://example.com/blog/en-us',
+			'https://example.com/blog/en_US',
 			'https://example.com/blog/es',
 		]);
 	});
@@ -758,7 +780,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 			})
 		).to.have.members([
 			'https://example.com/blog/en',
-			'https://example.com/blog/en-us',
+			'https://example.com/blog/en_US',
 			'https://example.com/blog/es',
 		]);
 	});
@@ -788,7 +810,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 			})
 		).to.have.members([
 			'https://example.com/blog/en/',
-			'https://example.com/blog/en-us/',
+			'https://example.com/blog/en_US/',
 			'https://example.com/blog/es/',
 		]);
 	});


### PR DESCRIPTION
## Changes

This PR changes the APIs of the virtual module after some discussion in the [RFC](https://github.com/withastro/roadmap/pull/734). 

This PR changes the signature of the PRs, by passing a locale mandatory argument, and then a second argument: an object with a set of options.

This type of signature will allow us to add more options in the future.

The reason why this change was needed is that users might need:
- to add a path after the locale, without bothering with trailing slashes
- to add a path before the locale, without bothering with trailing slashes 
- opt-in the normalisation of the locale, not always needed

## Testing

I updated the tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

This time I need feedback on the APIs, especially the documentation. I will update the RFC accordingly later 

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
