### PR TITLE
fix(create-astro): respect existing `package.json#scripts`

### DIFF
--- a/.changeset/tame-wasps-exercise.md
+++ b/.changeset/tame-wasps-exercise.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Ensure an existing template's `package.json` `scripts` are respected when modifying `build`.

--- a/packages/create-astro/src/actions/typescript.ts
+++ b/packages/create-astro/src/actions/typescript.ts
@@ -96,13 +96,9 @@ const FILES_TO_UPDATE = {
 
 			// in case of any other template already have astro checks defined, we don't want to override it
 			if (typeof buildScript === 'string' && !buildScript.includes('astro check')) {
-				const newPackageJson = Object.assign(parsedPackageJson, {
-					scripts: {
-						build: 'astro check && ' + buildScript,
-					},
-				});
-
-				await writeFile(file, JSON.stringify(newPackageJson, null, indent), 'utf-8');
+				// Mutate the existing object to avoid changing user-defined script order
+				parsedPackageJson.scripts.build = `astro check && ${buildScript}`;
+				await writeFile(file, JSON.stringify(parsedPackageJson, null, indent), 'utf-8');
 			}
 		} catch (err) {
 			// if there's no package.json (which is very unlikely), then do nothing

--- a/packages/create-astro/test/fixtures/not-empty/package.json
+++ b/packages/create-astro/test/fixtures/not-empty/package.json
@@ -2,6 +2,8 @@
   "name": "@test/create-astro-not-empty",
   "private": true,
   "scripts": {
-    "build": "astro build"
+    "dev": "astro dev",
+    "build": "astro check && astro build",
+    "preview": "astro preview"
   }
 }

--- a/packages/create-astro/test/fixtures/not-empty/tsconfig.json
+++ b/packages/create-astro/test/fixtures/not-empty/tsconfig.json
@@ -1,1 +1,3 @@
-{}
+{
+  "extends": "astro/tsconfigs/strictest"
+}

--- a/packages/create-astro/test/typescript.test.js
+++ b/packages/create-astro/test/typescript.test.js
@@ -84,6 +84,8 @@ describe('typescript', () => {
 });
 
 describe('typescript: setup tsconfig', () => {
+	beforeEach(() => resetFixtures());
+	
 	it('none', async () => {
 		const root = new URL('./fixtures/empty/', import.meta.url);
 		const tsconfig = new URL('./tsconfig.json', root);
@@ -92,8 +94,6 @@ describe('typescript: setup tsconfig', () => {
 		expect(JSON.parse(fs.readFileSync(tsconfig, { encoding: 'utf-8' }))).to.deep.eq({
 			extends: 'astro/tsconfigs/strict',
 		});
-
-		await resetFixtures();
 	});
 
 	it('exists', async () => {
@@ -103,20 +103,18 @@ describe('typescript: setup tsconfig', () => {
 		expect(JSON.parse(fs.readFileSync(tsconfig, { encoding: 'utf-8' }))).to.deep.eq({
 			extends: 'astro/tsconfigs/strict',
 		});
-
-		await resetFixtures();
 	});
 });
 
 describe('typescript: setup package', () => {
+	beforeEach(() => resetFixtures());
+
 	it('none', async () => {
 		const root = new URL('./fixtures/empty/', import.meta.url);
 		const packageJson = new URL('./package.json', root);
 
 		await setupTypeScript('strictest', { cwd: fileURLToPath(root), install: false });
 		expect(fs.existsSync(packageJson)).to.be.false;
-
-		await resetFixtures();
 	});
 
 	it('none', async () => {
@@ -127,10 +125,12 @@ describe('typescript: setup package', () => {
 			'astro build'
 		);
 		await setupTypeScript('strictest', { cwd: fileURLToPath(root), install: false });
-		expect(JSON.parse(fs.readFileSync(packageJson, { encoding: 'utf-8' })).scripts.build).to.be.eq(
-			'astro check && astro build'
+		const { scripts } = JSON.parse(fs.readFileSync(packageJson, { encoding: 'utf-8' }));
+		
+		expect(Object.keys(scripts)).to.deep.eq(['dev', 'build', 'preview'], 'does not override existing scripts');
+		expect(scripts.build).to.eq(
+			'astro check && astro build',
+			'prepends astro check command'
 		);
-
-		await resetFixtures();
 	});
 });

--- a/packages/create-astro/test/utils.js
+++ b/packages/create-astro/test/utils.js
@@ -33,18 +33,22 @@ export function setup() {
 
 const resetEmptyFixture = () =>
 	fs.promises.rm(new URL('./fixtures/empty/tsconfig.json', import.meta.url));
+
 const resetNotEmptyFixture = async () => {
 	const packagePath = new URL('./fixtures/not-empty/package.json', import.meta.url);
 	const tsconfigPath = new URL('./fixtures/not-empty/tsconfig.json', import.meta.url);
 
+	const packageJsonData = JSON.parse(await fs.promises.readFile(packagePath, { encoding: 'utf-8' }));
 	const overriddenPackageJson = Object.assign(
-		JSON.parse(await fs.promises.readFile(packagePath, { encoding: 'utf-8' })),
+		packageJsonData,
 		{
 			scripts: {
+				dev: 'astro dev',
 				build: 'astro build',
-			},
+				preview: 'astro preview'
+			}
 		}
-	);
+	)
 
 	return Promise.all([
 		fs.promises.writeFile(packagePath, JSON.stringify(overriddenPackageJson, null, 2), {


### PR DESCRIPTION
## Changes

- There was a regression introduced in https://github.com/withastro/astro/pull/8853 that replaced a template's existing `scripts` with just the new `build` script
- This PR fixes that case by mutating the `packageJsonData.scripts.build` instead of creating a new object.
- Changeset added!

## Testing

Test added. Fixture was updated to verify that this case is handled.

## Docs

N/A, bug fix