### PR TITLE
refactor(i18n): changes (again) the signature of the APIs after feedback

### DIFF
--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -172,7 +172,7 @@ declare module 'astro:i18n' {
 	 *
 	 * ```js
 	 * import { getLocaleAbsoluteUrl } from "astro:i18n";
-	 * getLocaleAbsoluteUrl("es""); // https://example.com/es
+	 * getLocaleAbsoluteUrl("es"); // https://example.com/es
 	 * getLocaleAbsoluteUrl("es", "getting-started"); // https://example.com/es/getting-started
 	 * getLocaleAbsoluteUrl("es", "getting-started", { prependWith: "blog" }); // https://example.com/blog/es/getting-started
 	 * getLocaleAbsoluteUrl("es_US", "getting-started", { prependWith: "blog", normalizeLocale: true }); // https://example.com/blog/es-us/getting-started

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -122,12 +122,11 @@ declare module 'astro:transitions/client' {
 }
 
 declare module 'astro:i18n' {
-	type I18nModule = typeof import('./dist/i18n/index.js');
-
 	export type GetLocaleOptions = import('./dist/i18n/index.js').GetLocaleOptions;
 
 	/**
 	 * @param {string} locale A locale
+	 * @param {string} path A path to add after the `locale`. Use `""` if you don't want to add anything after the locale.
 	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string}
 	 *
@@ -141,17 +140,22 @@ declare module 'astro:i18n' {
 	 *
 	 * ```js
 	 * import { getLocaleRelativeUrl } from "astro:i18n";
-	 * getLocaleRelativeUrl("es"); // /es
-	 * getLocaleRelativeUrl("es", { path: "getting-started" }); // /es/getting-started
-	 * getLocaleRelativeUrl("es", { path: "getting-started", prependWith: "blog" }); // /blog/es/getting-started
-	 * getLocaleRelativeUrl("es_US", { path: "getting-started", prependWith: "blog", normalizeLocale: true }); // /blog/es-us/getting-started
+	 * getLocaleRelativeUrl("es", ""); // /es
+	 * getLocaleRelativeUrl("es", "getting-started"); // /es/getting-started
+	 * getLocaleRelativeUrl("es", "getting-started", { prependWith: "blog" }); // /blog/es/getting-started
+	 * getLocaleRelativeUrl("es_US", "getting-started", { prependWith: "blog", normalizeLocale: true }); // /blog/es-us/getting-started
 	 * ```
 	 */
-	export const getLocaleRelativeUrl: (locale: string, options?: GetLocaleOptions) => string;
+	export const getLocaleRelativeUrl: (
+		locale: string,
+		path: string,
+		options?: GetLocaleOptions
+	) => string;
 
 	/**
 	 *
 	 * @param {string} locale A locale
+	 * @param {string} path A path to add after the `locale`. Use `""` if you don't want to add anything after the locale.
 	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string}
 	 *
@@ -168,28 +172,34 @@ declare module 'astro:i18n' {
 	 *
 	 * ```js
 	 * import { getLocaleAbsoluteUrl } from "astro:i18n";
-	 * getLocaleAbsoluteUrl("es"); // https://example.com/es
-	 * getLocaleAbsoluteUrl("es", { path: "getting-started" }); // https://example.com/es/getting-started
-	 * getLocaleAbsoluteUrl("es", { path: "getting-started", prependWith: "blog" }); // https://example.com/blog/es/getting-started
-	 * getLocaleAbsoluteUrl("es_US", { path: "getting-started", prependWith: "blog", normalizeLocale: true }); // https://example.com/blog/es-us/getting-started
+	 * getLocaleAbsoluteUrl("es", ""); // https://example.com/es
+	 * getLocaleAbsoluteUrl("es", "getting-started"); // https://example.com/es/getting-started
+	 * getLocaleAbsoluteUrl("es", "getting-started", { prependWith: "blog" }); // https://example.com/blog/es/getting-started
+	 * getLocaleAbsoluteUrl("es_US", "getting-started", { prependWith: "blog", normalizeLocale: true }); // https://example.com/blog/es-us/getting-started
 	 * ```
 	 */
-	export const getLocaleAbsoluteUrl: (locale: string, options?: GetLocaleOptions) => string;
+	export const getLocaleAbsoluteUrl: (
+		locale: string,
+		path: string,
+		options?: GetLocaleOptions
+	) => string;
 
 	/**
+	 * @param {string} path A path to add after the `locale`. Use `""` if you don't want to add anything after the locale.
 	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string[]}
 	 *
 	 * Works like `getLocaleRelativeUrl` but it emits the relative URLs for ALL locales:
 	 */
-	export const getLocaleRelativeUrlList: (options?: GetLocaleOptions) => string[];
+	export const getLocaleRelativeUrlList: (path: string, options?: GetLocaleOptions) => string[];
 	/**
+	 * @param {string} path A path to add after the `locale`. Use `""` if you don't want to add anything after the locale.
 	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string[]}
 	 *
 	 * Works like `getLocaleAbsoluteUrl` but it emits the absolute URLs for ALL locales:
 	 */
-	export const getLocaleAbsoluteUrlList: (options?: GetLocaleOptions) => string[];
+	export const getLocaleAbsoluteUrlList: (path: string, options?: GetLocaleOptions) => string[];
 }
 
 declare module 'astro:middleware' {

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -126,7 +126,7 @@ declare module 'astro:i18n' {
 
 	/**
 	 * @param {string} locale A locale
-	 * @param {string} path A path to add after the `locale`. Use `""` if you don't want to add anything after the locale.
+	 * @param {string} [path=""] An optional path to add after the `locale`.
 	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string}
 	 *
@@ -140,7 +140,7 @@ declare module 'astro:i18n' {
 	 *
 	 * ```js
 	 * import { getLocaleRelativeUrl } from "astro:i18n";
-	 * getLocaleRelativeUrl("es", ""); // /es
+	 * getLocaleRelativeUrl("es"); // /es
 	 * getLocaleRelativeUrl("es", "getting-started"); // /es/getting-started
 	 * getLocaleRelativeUrl("es", "getting-started", { prependWith: "blog" }); // /blog/es/getting-started
 	 * getLocaleRelativeUrl("es_US", "getting-started", { prependWith: "blog", normalizeLocale: true }); // /blog/es-us/getting-started
@@ -148,14 +148,14 @@ declare module 'astro:i18n' {
 	 */
 	export const getLocaleRelativeUrl: (
 		locale: string,
-		path: string,
+		path?: string,
 		options?: GetLocaleOptions
 	) => string;
 
 	/**
 	 *
 	 * @param {string} locale A locale
-	 * @param {string} path A path to add after the `locale`. Use `""` if you don't want to add anything after the locale.
+	 * @param {string} [path=""] An optional path to add after the `locale`.
 	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string}
 	 *
@@ -172,7 +172,7 @@ declare module 'astro:i18n' {
 	 *
 	 * ```js
 	 * import { getLocaleAbsoluteUrl } from "astro:i18n";
-	 * getLocaleAbsoluteUrl("es", ""); // https://example.com/es
+	 * getLocaleAbsoluteUrl("es""); // https://example.com/es
 	 * getLocaleAbsoluteUrl("es", "getting-started"); // https://example.com/es/getting-started
 	 * getLocaleAbsoluteUrl("es", "getting-started", { prependWith: "blog" }); // https://example.com/blog/es/getting-started
 	 * getLocaleAbsoluteUrl("es_US", "getting-started", { prependWith: "blog", normalizeLocale: true }); // https://example.com/blog/es-us/getting-started
@@ -180,26 +180,26 @@ declare module 'astro:i18n' {
 	 */
 	export const getLocaleAbsoluteUrl: (
 		locale: string,
-		path: string,
+		path?: string,
 		options?: GetLocaleOptions
 	) => string;
 
 	/**
-	 * @param {string} path A path to add after the `locale`. Use `""` if you don't want to add anything after the locale.
+	 * @param {string} [path=""] An optional path to add after the `locale`.
 	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string[]}
 	 *
 	 * Works like `getLocaleRelativeUrl` but it emits the relative URLs for ALL locales:
 	 */
-	export const getLocaleRelativeUrlList: (path: string, options?: GetLocaleOptions) => string[];
+	export const getLocaleRelativeUrlList: (path?: string, options?: GetLocaleOptions) => string[];
 	/**
-	 * @param {string} path A path to add after the `locale`. Use `""` if you don't want to add anything after the locale.
+	 * @param {string} [path=""] An optional path to add after the `locale`.
 	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string[]}
 	 *
 	 * Works like `getLocaleAbsoluteUrl` but it emits the absolute URLs for ALL locales:
 	 */
-	export const getLocaleAbsoluteUrlList: (path: string, options?: GetLocaleOptions) => string[];
+	export const getLocaleAbsoluteUrlList: (path?: string, options?: GetLocaleOptions) => string[];
 }
 
 declare module 'astro:middleware' {

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -36,11 +36,11 @@ export default function astroInternalization({ settings }: AstroInternalization)
 					const format =  ${JSON.stringify(settings.config.build.format)};
 					const site = ${JSON.stringify(settings.config.site)};
 					
-					export const getLocaleRelativeUrl = (locale, opts) => _getLocaleRelativeUrl({ locale, base, locales, trailingSlash, format, ...opts });
-					export const getLocaleAbsoluteUrl = (locale, opts) => _getLocaleAbsoluteUrl({ locale, base, locales, trailingSlash, format, site, ...opts });
+					export const getLocaleRelativeUrl = (locale, path, opts) => _getLocaleRelativeUrl({ locale, path, base, locales, trailingSlash, format, ...opts });
+					export const getLocaleAbsoluteUrl = (locale, path, opts) => _getLocaleAbsoluteUrl({ locale, path, base, locales, trailingSlash, format, site, ...opts });
 					
-					export const getLocaleRelativeUrlList = (opts) => _getLocaleRelativeUrlList({ base, locales, trailingSlash, format, ...opts });
-					export const getLocaleAbsoluteUrlList = (opts) => _getLocaleAbsoluteUrlList({ base, locales, trailingSlash, format, site, ...opts });
+					export const getLocaleRelativeUrlList = (path, opts) => _getLocaleRelativeUrlList({ base, path, locales, trailingSlash, format, ...opts });
+					export const getLocaleAbsoluteUrlList = (path, opts) => _getLocaleAbsoluteUrlList({ base, path, locales, trailingSlash, format, site, ...opts });
 				`;
 			}
 		},

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -36,11 +36,11 @@ export default function astroInternalization({ settings }: AstroInternalization)
 					const format =  ${JSON.stringify(settings.config.build.format)};
 					const site = ${JSON.stringify(settings.config.site)};
 					
-					export const getLocaleRelativeUrl = (locale, path, opts) => _getLocaleRelativeUrl({ locale, path, base, locales, trailingSlash, format, ...opts });
-					export const getLocaleAbsoluteUrl = (locale, path, opts) => _getLocaleAbsoluteUrl({ locale, path, base, locales, trailingSlash, format, site, ...opts });
+					export const getLocaleRelativeUrl = (locale, path = "", opts) => _getLocaleRelativeUrl({ locale, path, base, locales, trailingSlash, format, ...opts });
+					export const getLocaleAbsoluteUrl = (locale, path = "", opts) => _getLocaleAbsoluteUrl({ locale, path, base, locales, trailingSlash, format, site, ...opts });
 					
-					export const getLocaleRelativeUrlList = (path, opts) => _getLocaleRelativeUrlList({ base, path, locales, trailingSlash, format, ...opts });
-					export const getLocaleAbsoluteUrlList = (path, opts) => _getLocaleAbsoluteUrlList({ base, path, locales, trailingSlash, format, site, ...opts });
+					export const getLocaleRelativeUrlList = (path = "", opts) => _getLocaleRelativeUrlList({ base, path, locales, trailingSlash, format, ...opts });
+					export const getLocaleAbsoluteUrlList = (path = "", opts) => _getLocaleAbsoluteUrlList({ base, path, locales, trailingSlash, format, site, ...opts });
 				`;
 			}
 		},


### PR DESCRIPTION
## Changes

Applies changes to the virtual module after Chris's feedback in #8908 

> While there is the edge case of / where path can be omitted, most uses will provide a path (or will provide one programmatically, so may provide one even when the variable’s value is '/' or ''). That makes requiring { path: ... } feel a bit fiddly.

## Testing

Current tests should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
 /cc @withastro/maintainers-docs for feedback! 
 
 I updated the documentation of the APIs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
