### PR TITLE
fix(slots): consume eagerly rendered slot after one use

### DIFF
--- a/.changeset/plenty-spiders-act.md
+++ b/.changeset/plenty-spiders-act.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes an issue where a slot rendered multiple times resulted in the same output each time.
+Fixes an issue where rendering the same slot multiple times invoked it only once.

--- a/.changeset/plenty-spiders-act.md
+++ b/.changeset/plenty-spiders-act.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where a slot rendered multiple times resulted in the same output each time.

--- a/packages/astro/src/runtime/server/render/astro/instance.ts
+++ b/packages/astro/src/runtime/server/render/astro/instance.ts
@@ -32,13 +32,13 @@ export class AstroComponentInstance {
 		this.slotValues = {};
 		for (const name in slots) {
 			// prerender the slots eagerly to make collection entries propagate styles and scripts
-			let value: ReturnType<typeof slots[string]> | null = slots[name](result);
+			let didRender = false;
+			let value = slots[name](result);
 			this.slotValues[name] = () => {
 				// use prerendered value only once
-				if (value !== null) {
-					const consumedValue = value
-					value = null
-					return consumedValue
+				if (!didRender) {
+					didRender = true;
+					return value;
 				}
 				// render afresh for the advanced use-case where the same slot is rendered multiple times 
 				return slots[name](result);

--- a/packages/astro/src/runtime/server/render/astro/instance.ts
+++ b/packages/astro/src/runtime/server/render/astro/instance.ts
@@ -31,8 +31,18 @@ export class AstroComponentInstance {
 		this.factory = factory;
 		this.slotValues = {};
 		for (const name in slots) {
-			const value = slots[name](result);
-			this.slotValues[name] = () => value;
+			// prerender the slots eagerly to make collection entries propagate styles and scripts
+			let value: ReturnType<typeof slots[string]> | null = slots[name](result);
+			this.slotValues[name] = () => {
+				// use prerendered value only once
+				if (value !== null) {
+					const consumedValue = value
+					value = null
+					return consumedValue
+				}
+				// render afresh for the advanced use-case where the same slot is rendered multiple times 
+				return slots[name](result);
+			};
 		}
 	}
 

--- a/packages/astro/test/astro-slots.test.js
+++ b/packages/astro/test/astro-slots.test.js
@@ -148,5 +148,19 @@ describe('Slots', () => {
 			expect($('#render-args span')).to.have.lengthOf(1);
 			expect($('#render-args').text()).to.equal('render-args');
 		}
+
+		{
+			const html = await fixture.readFile('/rendered-multiple-times/index.html');
+			const $ = cheerio.load(html);
+			
+			const elements = $('div');
+			expect(elements).to.have.lengthOf(10);
+
+			const [ first, second, third ] = elements;
+
+			expect(first.children[0].data).to.not.equal(second.children[0].data);
+			expect(second.children[0].data).to.not.equal(third.children[0].data);
+			expect(third.children[0].data).to.not.equal(first.children[0].data);
+		}
 	});
 });

--- a/packages/astro/test/fixtures/astro-slots/src/components/Random.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/components/Random.astro
@@ -1,0 +1,6 @@
+---
+const randomNumber = Math.random();
+---
+<div>
+	{randomNumber}
+</div>

--- a/packages/astro/test/fixtures/astro-slots/src/components/RenderMultipleTimes.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/components/RenderMultipleTimes.astro
@@ -1,0 +1,15 @@
+---
+interface Props {
+    count: number;
+}
+const {count} = Astro.props;
+
+const renders: string[] = [];
+for (let i = 0; i < count; i++) {
+    renders.push(await Astro.slots.render('default'));
+}
+---
+
+{renders.map(
+    (render, i) => <Fragment key={i} set:html={render} />
+)}

--- a/packages/astro/test/fixtures/astro-slots/src/pages/rendered-multiple-times.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/pages/rendered-multiple-times.astro
@@ -1,0 +1,7 @@
+---
+import RandomCard from '../components/Random.astro';
+import RenderMulti from '../components/RenderMultipleTimes.astro';
+---
+<RenderMulti count={10}>
+	<RandomCard/>
+</RenderMulti>


### PR DESCRIPTION
## Changes
- Fixes #7068 

## Testing
Added a case to an existing fixture.

## Docs
Does not affect usage.