### PR TITLE
Prevent passing slot names as props

### DIFF
--- a/.changeset/swift-suits-drum.md
+++ b/.changeset/swift-suits-drum.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vue': patch
+---
+
+Fixes an issue where Astro slot names were being rendered as attributes in components. Astro slot names will no longer be sent as props to framework components.

--- a/packages/integrations/vue/server.js
+++ b/packages/integrations/vue/server.js
@@ -7,8 +7,10 @@ function check(Component) {
 	return !!Component['ssrRender'] || !!Component['__ssrInlineRender'];
 }
 
-async function renderToStaticMarkup(Component, props, slotted, metadata) {
+async function renderToStaticMarkup(Component, inputProps, slotted, metadata) {
 	const slots = {};
+	const props = { ...inputProps };
+	delete props.slot;
 	for (const [key, value] of Object.entries(slotted)) {
 		slots[key] = () =>
 			h(StaticHtml, {

--- a/packages/integrations/vue/test/basics.test.js
+++ b/packages/integrations/vue/test/basics.test.js
@@ -1,0 +1,24 @@
+import { loadFixture } from './test-utils.js';
+import { expect } from 'chai';
+import { parseHTML } from 'linkedom';
+describe('Basics', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/basics/',
+		});
+		await fixture.build();
+	});
+
+	it('Slots are added without the slot attribute', async () => {
+		const data = await fixture.readFile('/index.html');
+		const { document } = parseHTML(data);
+		const bar = document.querySelector('#foo');
+
+		expect(bar).not.to.be.undefined;
+		expect(bar.getAttribute('slot')).to.be.null;
+	});
+
+});

--- a/packages/integrations/vue/test/fixtures/basics/astro.config.mjs
+++ b/packages/integrations/vue/test/fixtures/basics/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+import vue from '@astrojs/vue';
+
+export default defineConfig({
+  integrations: [vue()],
+})

--- a/packages/integrations/vue/test/fixtures/basics/package.json
+++ b/packages/integrations/vue/test/fixtures/basics/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/vue-basics",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/vue": "workspace:*"
+  }
+}

--- a/packages/integrations/vue/test/fixtures/basics/src/components/Foo.vue
+++ b/packages/integrations/vue/test/fixtures/basics/src/components/Foo.vue
@@ -1,0 +1,4 @@
+
+<template>
+	<div id="foo">bar</div>
+</template>

--- a/packages/integrations/vue/test/fixtures/basics/src/components/Parent.astro
+++ b/packages/integrations/vue/test/fixtures/basics/src/components/Parent.astro
@@ -1,0 +1,4 @@
+<section>
+	<header></header>
+	<footer><slot name="footer"></slot></footer>
+</section>

--- a/packages/integrations/vue/test/fixtures/basics/src/pages/index.astro
+++ b/packages/integrations/vue/test/fixtures/basics/src/pages/index.astro
@@ -1,0 +1,14 @@
+---
+import Parent from '../components/Parent.astro';
+import Bar from '../components/Foo.vue';
+---
+<html>
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<Parent>
+			<Bar slot="footer" />
+		</Parent>
+	</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4795,6 +4795,15 @@ importers:
         specifier: 4.0.0
         version: 4.0.0
 
+  packages/integrations/vue/test/fixtures/basics:
+    dependencies:
+      '@astrojs/vue':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/internal-helpers:
     devDependencies:
       astro-scripts:


### PR DESCRIPTION
## Changes

- Ignore the `slot` prop in Vue components
- Fixes https://github.com/withastro/astro/issues/8921

## Testing

- Test case added

## Docs

N/A, bug fix