### PR TITLE
fix(create-astro): TypeScript installation failure with yarn

### DIFF
--- a/.changeset/young-avocados-wink.md
+++ b/.changeset/young-avocados-wink.md
@@ -2,4 +2,4 @@
 'create-astro': patch
 ---
 
-Fix TypeScript installation issue with yarn
+Fixes TypeScript installation issue with yarn

--- a/.changeset/young-avocados-wink.md
+++ b/.changeset/young-avocados-wink.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fix TypeScript installation issue with yarn

--- a/packages/create-astro/src/actions/typescript.ts
+++ b/packages/create-astro/src/actions/typescript.ts
@@ -82,12 +82,12 @@ const FILES_TO_UPDATE = {
 		try {
 			// add required dependencies for astro check
 			if (options.ctx.install)
-				await shell(options.ctx.packageManager, ['install', '@astrojs/check', 'typescript'], {
+				await shell(options.ctx.packageManager, ['add', '@astrojs/check', 'typescript'], {
 					cwd: path.dirname(file),
 					stdio: 'ignore',
 				});
 
-			// inject addtional command to build script
+			// inject additional command to build script
 			const data = await readFile(file, { encoding: 'utf-8' });
 			const indent = /(^\s+)/m.exec(data)?.[1] ?? '\t';
 			const parsedPackageJson = JSON.parse(data);


### PR DESCRIPTION
## Changes

To fix the installation issue on TypeScript with yarn since v4.4.0, added the following changes:

- Use the `add` subcommand to add dependencies
    - While `npm` and `pnpm` support both `install` and `add` for adding dependencies, `yarn` requires to use `add` to do it.
- Fixed a minor typo
- Add .changelog

<details><summary>output from `yarn create astro foo --template minimal --install --git --typescript strict`</summary>
<p>

```
$ yarn create astro foo --template minimal --install --git --typescript strict

yarn create v1.22.19
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...

success Installed "create-astro@4.4.1" with binaries:
      - create-astro
[########################################] 40/40
 astro   Launch sequence initiated.

      ◼  dir Using foo as project directory
      ◼  tmpl Using minimal as project template
      ✔  Template copied
      ✔  Dependencies installed
      ◼  ts Using strict TypeScript configuration
      ▲  error Error
error Command failed.
Exit code: 1
Command: /usr/local/bin/create-astro
Arguments: foo --template minimal --install --git --typescript strict
Directory: /private/var/folders/83/90s7fs2956s9kr_l3gc32pjr0000gn/T/tmp.XwhTguO2
Output:

info Visit https://yarnpkg.com/en/docs/cli/create for documentation about this command.
```

</p>
</details> 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Tested manually if the following commands succeed

```
create-astro test-npm --template minimal --install --git --typescript strict
npm_config_user_agent='pnpm/1.22.19 npm/? node/v20.9.0 darwin x64' create-astro test-yarn --template minimal --install --git --typescript strict
npm_config_user_agent='pnpm/8.10.0 npm/? node/v20.9.0 darwin x64' create-astro test-pnpm --template minimal --install --git --typescript strict
```

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
bugfix only

