### PR TITLE
[docs] remove outdated anchor links

### DIFF
--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -17,7 +17,7 @@ pnpm i @astrojs/rss
 
 ## Example usage
 
-The `@astrojs/rss` package provides helpers for generating RSS feeds within [Astro endpoints][astro-endpoints]. This unlocks both static builds _and_ on-demand generation when using an [SSR adapter](https://docs.astro.build/en/guides/server-side-rendering/#enabling-ssr-in-your-project).
+The `@astrojs/rss` package provides helpers for generating RSS feeds within [Astro endpoints][astro-endpoints]. This unlocks both static builds _and_ on-demand generation when using an [SSR adapter](https://docs.astro.build/en/guides/server-side-rendering/).
 
 For instance, say you need to generate an RSS feed for all posts under `src/content/blog/` using content collections.
 

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -220,7 +220,7 @@ export interface AstroGlobal<
 	 * }
 	 * ```
 	 *
-	 * [Astro reference](https://docs.astro.build/en/guides/server-side-rendering/#astroredirect)
+	 * [Astro reference](https://docs.astro.build/en/guides/server-side-rendering/)
 	 */
 	redirect: AstroSharedContext['redirect'];
 	/**

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -407,7 +407,6 @@ export const ReservedSlotName = {
  * @docs
  * @see
  * - [Server-side Rendering](https://docs.astro.build/en/guides/server-side-rendering/)
- * - [Adding an Adapter](https://docs.astro.build/en/guides/server-side-rendering/)
  * @description
  * To use server-side rendering, an adapter needs to be installed so Astro knows how to generate the proper output for your targeted deployment platform.
  */

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -36,7 +36,7 @@ export const UnknownCompilerError = {
 /**
  * @docs
  * @see
- * - [Enabling SSR in Your Project](https://docs.astro.build/en/guides/server-side-rendering/#enabling-ssr-in-your-project)
+ * - [Enabling SSR in Your Project](https://docs.astro.build/en/guides/server-side-rendering/)
  * - [Astro.redirect](https://docs.astro.build/en/reference/api-reference/#astroredirect)
  * @description
  * The `Astro.redirect` function is only available when [Server-side rendering](/en/guides/server-side-rendering/) is enabled.
@@ -49,7 +49,7 @@ export const StaticRedirectNotAvailable = {
 	title: '`Astro.redirect` is not available in static mode.',
 	message:
 		"Redirects are only available when using `output: 'server'` or `output: 'hybrid'`. Update your Astro config if you need SSR features.",
-	hint: 'See https://docs.astro.build/en/guides/server-side-rendering/#enabling-ssr-in-your-project for more information on how to enable SSR.',
+	hint: 'See https://docs.astro.build/en/guides/server-side-rendering/ for more information on how to enable SSR.',
 } satisfies ErrorData;
 /**
  * @docs
@@ -68,7 +68,7 @@ export const ClientAddressNotAvailable = {
 /**
  * @docs
  * @see
- * - [Enabling SSR in Your Project](https://docs.astro.build/en/guides/server-side-rendering/#enabling-ssr-in-your-project)
+ * - [Enabling SSR in Your Project](https://docs.astro.build/en/guides/server-side-rendering/)
  * - [Astro.clientAddress](https://docs.astro.build/en/reference/api-reference/#astroclientaddress)
  * @description
  * The `Astro.clientAddress` property is only available when [Server-side rendering](https://docs.astro.build/en/guides/server-side-rendering/) is enabled.
@@ -80,7 +80,7 @@ export const StaticClientAddressNotAvailable = {
 	title: '`Astro.clientAddress` is not available in static mode.',
 	message:
 		"`Astro.clientAddress` is only available when using `output: 'server'` or `output: 'hybrid'`. Update your Astro config if you need SSR features.",
-	hint: 'See https://docs.astro.build/en/guides/server-side-rendering/#enabling-ssr-in-your-project for more information on how to enable SSR.',
+	hint: 'See https://docs.astro.build/en/guides/server-side-rendering/ for more information on how to enable SSR.',
 } satisfies ErrorData;
 /**
  * @docs
@@ -407,7 +407,7 @@ export const ReservedSlotName = {
  * @docs
  * @see
  * - [Server-side Rendering](https://docs.astro.build/en/guides/server-side-rendering/)
- * - [Adding an Adapter](https://docs.astro.build/en/guides/server-side-rendering/#adding-an-adapter)
+ * - [Adding an Adapter](https://docs.astro.build/en/guides/server-side-rendering/)
  * @description
  * To use server-side rendering, an adapter needs to be installed so Astro knows how to generate the proper output for your targeted deployment platform.
  */


### PR DESCRIPTION
## Changes

Some headings on our SSR page in docs either have changed or will change, making some existing anchor links out of date. 

This simply removes the specific anchor link and just points links to the page.  If more specific links are appropriate after the page has been refreshed, I'll come back and add new ones back in.

## Testing

No tests, just docs.

## Docs

Just some docs link updates!
