### PR TITLE
Add .gitignore to component example

### DIFF
--- a/examples/component/.gitignore
+++ b/examples/component/.gitignore
@@ -1,0 +1,21 @@
+# build output
+dist/
+# generated types
+.astro/
+
+# dependencies
+node_modules/
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+
+# environment variables
+.env
+.env.production
+
+# macOS-specific files
+.DS_Store


### PR DESCRIPTION
## Changes

Added `.gitignore` to the component example. Actual content is copied from [blog example](https://github.com/withastro/astro/blob/46d3043a3f41a826061c79241d54ecbd106e4ddd/examples/blog/.gitignore).

## Testing

N/A

## Docs

No updates to docs required as it's just adding `.gitignore` to the component example
