### PR TITLE
feat(i18n): rework preferred language and new preferredLanguageList

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1436,32 +1436,6 @@ export interface AstroUserConfig {
              *
              */
             routingStrategy: 'prefix-always' | 'prefix-other-locales';
-
-			/**
-			 * @docs
-			 * @name experimental.i18n.redirectToPreferredLanguage
-			 * @type {boolean}
-			 * @default {false}
-			 * @version 3.*.*
-			 * @description
-			 *
-			 * If enabled, Astro will redirect the user to their preferred language. The preferred language is determined by
-			 * reading the header `Accept-Language`, usually sent by the browser.
-			 *
-			 * Sometimes, the browser of the user is set to accept *multiple* locales with a [quality value].
-			 * Astro will do a redirect to the first locale that matches `i18n.locales`.
-			 *
-			 * The redirect occurs only when:
-			 * - the user navigates the root `/` or the root of the `i18n.defaultLocale`;
-			 * - the preferred locale exists in the list `i18n.locales;
-			 *
-			 * When the user navigates any page of the root that isn't the index, Astro won't do any redirect.
-			 *
-			 * This behaviour is available only in SSR.
-			 *
-			 * [quality value]: https://developer.mozilla.org/en-US/docs/Glossary/Quality_values
-			 */
-			redirectToPreferredLanguage: boolean;
 		};
 	};
 }
@@ -2122,16 +2096,28 @@ export interface APIContext<
 	ResponseWithEncoding: typeof ResponseWithEncoding;
 
 	/**
-	 * Available only when `experimental.i18n` enabled.
-	 * It represents the preferred locale by the browser of the user that has the highest [quality value].
+	 * Available only when `experimental.i18n` enabled and in SSR.
+	 *
+	 * It represents the preferred locale of the user. It's computed by checking the supported locales in `i18n.locales`
+	 * and locales supported by the users's browser via the header `Accept-Language`
+	 *
+	 * For example, given `i18n.locales` equals to `['fr', 'de']`, and the `Accept-Language` value equals to `en, de;q=0.2, fr;q=0.6`, the
+	 * `Astro.preferredLanguage` will be `fr` because `en` is not supported, its [quality value] is the highest.
 	 *
 	 * [quality value]: https://developer.mozilla.org/en-US/docs/Glossary/Quality_values
 	 */
 	preferredLocale: string | undefined;
 
 	/**
-	 * Available only when `experimental.i18n` enabled.
-	 * It represents the list of the preferred locales of the browser. They are sorted by their [quality value].
+	 * Available only when `experimental.i18n` enabled and in SSR.
+	 *
+	 * It represents the list of the preferred locales that are supported by the application. The list is sorted via [quality value].
+	 *
+	 * For example, given `i18n.locales` equals to `['fr', 'pt', 'de']`, and the `Accept-Language` value equals to `en, de;q=0.2, fr;q=0.6`, the
+	 * `Astro.preferredLocaleList` will be equal to `['fs', 'de']` because `en` isn't supported, and `pt` isn't part of the locales contained in the
+	 * header.
+	 *
+	 * When the `Accept-Header` is `*`, the original `i18n.locales` are returned. The value `*` means no preferences, so Astro returns all the supported locales.
 	 *
 	 * [quality value]: https://developer.mozilla.org/en-US/docs/Glossary/Quality_values
 	 */

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1439,17 +1439,29 @@ export interface AstroUserConfig {
 
 			/**
 			 * @docs
-			 * @name experimental.i18n.detectBrowserLanguage
+			 * @name experimental.i18n.redirectToPreferredLanguage
 			 * @type {boolean}
+			 * @default {false}
 			 * @version 3.*.*
 			 * @description
 			 *
-			 * Whether Astro should detect the language of the browser - usually using the `Accept-Language` header. This is a feature
-			 * that should be supported by the adapter. If detected, the adapter can decide to redirect the user to the localised version of the website.
+			 * If enabled, Astro will redirect the user to their preferred language. The preferred language is determined by
+			 * reading the header `Accept-Language`, usually sent by the browser.
 			 *
-			 * When set to `true`, you should make sure that the adapter you're using is able to provide this feature to you.
+			 * Sometimes, the browser of the user is set to accept *multiple* locales with a [quality value].
+			 * Astro will do a redirect to the first locale that matches `i18n.locales`.
+			 *
+			 * The redirect occurs only when:
+			 * - the user navigates the root `/` or the root of the `i18n.defaultLocale`;
+			 * - the preferred locale exists in the list `i18n.locales;
+			 *
+			 * When the user navigates any page of the root that isn't the index, Astro won't do any redirect.
+			 *
+			 * This behaviour is available only in SSR.
+			 *
+			 * [quality value]: https://developer.mozilla.org/en-US/docs/Glossary/Quality_values
 			 */
-			detectBrowserLanguage: boolean;
+			redirectToPreferredLanguage: boolean;
 		};
 	};
 }
@@ -2001,6 +2013,12 @@ interface AstroSharedContext<
 	 * The current locale that is computed from the `Accept-Language` header of the browser (**SSR Only**).
 	 */
 	preferredLocale: string | undefined;
+
+	/**
+	 * The list of locales computed from the `Accept-Language` header of the browser, sorted by quality value (**SSR Only**).
+	 */
+
+	preferredLocaleList: string[] | undefined;
 }
 
 export interface APIContext<
@@ -2105,9 +2123,19 @@ export interface APIContext<
 
 	/**
 	 * Available only when `experimental.i18n` enabled.
+	 * It represents the preferred locale by the browser of the user that has the highest [quality value].
 	 *
+	 * [quality value]: https://developer.mozilla.org/en-US/docs/Glossary/Quality_values
 	 */
 	preferredLocale: string | undefined;
+
+	/**
+	 * Available only when `experimental.i18n` enabled.
+	 * It represents the list of the preferred locales of the browser. They are sorted by their [quality value].
+	 *
+	 * [quality value]: https://developer.mozilla.org/en-US/docs/Glossary/Quality_values
+	 */
+	preferredLocaleList: string[] | undefined;
 }
 
 export type EndpointOutput =

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -225,7 +225,7 @@ export class App {
 		let preferredLocale: undefined | string = undefined;
 		let preferredLocaleList: undefined | string[] = undefined;
 		if (this.#manifest.i18n) {
-			const result = computePreferredLocales(request);
+			const result = computePreferredLocales(request, this.#manifest.i18n.locales);
 			preferredLocaleList = result[0];
 			preferredLocale = result[1];
 		}
@@ -265,6 +265,7 @@ export class App {
 				}
 			}
 			const mod = await page.page();
+
 			return await createRenderContext({
 				request,
 				pathname,

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -17,7 +17,7 @@ import {
 } from '../path.js';
 import { RedirectSinglePageBuiltModule } from '../redirects/index.js';
 import {
-	computePreferredLocale,
+	computePreferredLocales,
 	createEnvironment,
 	createRenderContext,
 	type RenderContext,
@@ -222,9 +222,12 @@ export class App {
 		page: SinglePageBuiltModule,
 		status = 200
 	): Promise<RenderContext> {
-		let currentLocale: undefined | string = undefined;
+		let preferredLocale: undefined | string = undefined;
+		let preferredLocaleList: undefined | string[] = undefined;
 		if (this.#manifest.i18n) {
-			currentLocale = computePreferredLocale(request);
+			const result = computePreferredLocales(request);
+			preferredLocaleList = result[0];
+			preferredLocale = result[1];
 		}
 		if (routeData.type === 'endpoint') {
 			const pathname = '/' + this.removeBase(url.pathname);
@@ -238,7 +241,8 @@ export class App {
 				status,
 				env: this.#pipeline.env,
 				mod: handler as any,
-				preferredLocale: currentLocale,
+				preferredLocale,
+				preferredLocaleList,
 			});
 		} else {
 			const pathname = prependForwardSlash(this.removeBase(url.pathname));
@@ -272,7 +276,8 @@ export class App {
 				status,
 				mod,
 				env: this.#pipeline.env,
-				preferredLocale: currentLocale,
+				preferredLocale,
+				preferredLocaleList,
 			});
 		}
 	}

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -57,7 +57,6 @@ export type SSRManifestI18n = {
 	routingStrategy?: 'prefix-always' | 'prefix-other-locales';
 	locales: string[];
 	defaultLocale: string;
-	redirectToPreferredLanguage: boolean;
 };
 
 export type SerializedSSRManifest = Omit<

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -57,6 +57,7 @@ export type SSRManifestI18n = {
 	routingStrategy?: 'prefix-always' | 'prefix-other-locales';
 	locales: string[];
 	defaultLocale: string;
+	redirectToPreferredLanguage: boolean;
 };
 
 export type SerializedSSRManifest = Omit<

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -39,7 +39,7 @@ import {
 	getRedirectLocationOrThrow,
 	routeIsRedirect,
 } from '../redirects/index.js';
-import { computePreferredLocale, createRenderContext } from '../render/index.js';
+import { computePreferredLocales, createRenderContext } from '../render/index.js';
 import { callGetStaticPaths } from '../render/route-cache.js';
 import {
 	createAssetLink,
@@ -551,9 +551,12 @@ async function generatePath(pathname: string, gopts: GeneratePathOptions, pipeli
 		logger: pipeline.getLogger(),
 		ssr,
 	});
-	let currentLocale: undefined | string = undefined;
+	let preferredLocale: undefined | string = undefined;
+	let preferredLocaleList: undefined | string[] = undefined;
 	if (pipeline.getConfig().experimental.i18n) {
-		currentLocale = computePreferredLocale(request);
+		const result = computePreferredLocales(request);
+		preferredLocaleList = result[0];
+		preferredLocale = result[1];
 	}
 	const renderContext = await createRenderContext({
 		pathname,
@@ -565,7 +568,8 @@ async function generatePath(pathname: string, gopts: GeneratePathOptions, pipeli
 		route: pageData.route,
 		env: pipeline.getEnvironment(),
 		mod,
-		preferredLocale: currentLocale,
+		preferredLocale,
+		preferredLocaleList,
 	});
 
 	let body: string | Uint8Array;
@@ -642,6 +646,7 @@ export function createBuildManifest(
 			routingStrategy: settings.config.experimental.i18n.routingStrategy,
 			defaultLocale: settings.config.experimental.i18n.defaultLocale,
 			locales: settings.config.experimental.i18n.locales,
+			redirectToPreferredLanguage: settings.config.experimental.i18n.redirectToPreferredLanguage,
 		};
 	}
 	return {

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -553,8 +553,9 @@ async function generatePath(pathname: string, gopts: GeneratePathOptions, pipeli
 	});
 	let preferredLocale: undefined | string = undefined;
 	let preferredLocaleList: undefined | string[] = undefined;
-	if (pipeline.getConfig().experimental.i18n) {
-		const result = computePreferredLocales(request);
+	const i18n = pipeline.getConfig().experimental.i18n;
+	if (i18n) {
+		const result = computePreferredLocales(request, i18n.locales);
 		preferredLocaleList = result[0];
 		preferredLocale = result[1];
 	}
@@ -646,7 +647,6 @@ export function createBuildManifest(
 			routingStrategy: settings.config.experimental.i18n.routingStrategy,
 			defaultLocale: settings.config.experimental.i18n.defaultLocale,
 			locales: settings.config.experimental.i18n.locales,
-			redirectToPreferredLanguage: settings.config.experimental.i18n.redirectToPreferredLanguage,
 		};
 	}
 	return {

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -245,6 +245,7 @@ function buildManifest(
 			routingStrategy: settings.config.experimental.i18n.routingStrategy,
 			locales: settings.config.experimental.i18n.locales,
 			defaultLocale: settings.config.experimental.i18n.defaultLocale,
+			redirectToPreferredLanguage: settings.config.experimental.i18n.redirectToPreferredLanguage,
 		};
 	}
 

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -245,7 +245,6 @@ function buildManifest(
 			routingStrategy: settings.config.experimental.i18n.routingStrategy,
 			locales: settings.config.experimental.i18n.locales,
 			defaultLocale: settings.config.experimental.i18n.defaultLocale,
-			redirectToPreferredLanguage: settings.config.experimental.i18n.redirectToPreferredLanguage,
 		};
 	}
 

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -309,7 +309,7 @@ export const AstroConfigSchema = z.object({
 						defaultLocale: z.string(),
 						locales: z.string().array(),
 						fallback: z.record(z.string(), z.string()).optional(),
-						detectBrowserLanguage: z.boolean().optional().default(false),
+						redirectToPreferredLanguage: z.boolean().optional().default(false),
 						// TODO: properly add default when the feature goes of experimental
                         routingStrategy: z
                             .enum(['prefix-always', 'prefix-other-locales'])

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -309,7 +309,6 @@ export const AstroConfigSchema = z.object({
 						defaultLocale: z.string(),
 						locales: z.string().array(),
 						fallback: z.record(z.string(), z.string()).optional(),
-						redirectToPreferredLanguage: z.boolean().optional().default(false),
 						// TODO: properly add default when the feature goes of experimental
                         routingStrategy: z
                             .enum(['prefix-always', 'prefix-other-locales'])

--- a/packages/astro/src/core/endpoint/index.ts
+++ b/packages/astro/src/core/endpoint/index.ts
@@ -12,7 +12,7 @@ import { ASTRO_VERSION } from '../constants.js';
 import { AstroCookies, attachCookiesToResponse } from '../cookies/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 import { callMiddleware } from '../middleware/callMiddleware.js';
-import { type Environment, type RenderContext, computePreferredLocale } from '../render/index.js';
+import { type Environment, type RenderContext, computePreferredLocales } from '../render/index.js';
 
 const encoder = new TextEncoder();
 
@@ -26,6 +26,7 @@ type CreateAPIContext = {
 	props: Record<string, any>;
 	adapterName?: string;
 	preferredLocale: string | undefined;
+	preferredLocaleList: string[] | undefined;
 };
 
 /**
@@ -40,6 +41,7 @@ export function createAPIContext({
 	props,
 	adapterName,
 	preferredLocale,
+	preferredLocaleList,
 }: CreateAPIContext): APIContext {
 	const context = {
 		cookies: new AstroCookies(request),
@@ -58,6 +60,7 @@ export function createAPIContext({
 		},
 		ResponseWithEncoding,
 		preferredLocale: preferredLocale,
+		preferredLocaleList: preferredLocaleList,
 		url: new URL(request.url),
 		get clientAddress() {
 			if (clientAddressSymbol in request) {
@@ -128,8 +131,9 @@ export async function callEndpoint<MiddlewareResult = Response | EndpointOutput>
 	mod: EndpointHandler,
 	env: Environment,
 	ctx: RenderContext,
-	onRequest?: MiddlewareHandler<MiddlewareResult> | undefined,
-	currentLocale?: undefined | string
+	onRequest: MiddlewareHandler<MiddlewareResult> | undefined,
+	preferredLocale: undefined | string,
+	preferredLocaleList: undefined | string[]
 ): Promise<Response> {
 	const context = createAPIContext({
 		request: ctx.request,
@@ -137,7 +141,8 @@ export async function callEndpoint<MiddlewareResult = Response | EndpointOutput>
 		props: ctx.props,
 		site: env.site,
 		adapterName: env.adapterName,
-		preferredLocale: currentLocale,
+		preferredLocale,
+		preferredLocaleList,
 	});
 
 	let response;

--- a/packages/astro/src/core/middleware/index.ts
+++ b/packages/astro/src/core/middleware/index.ts
@@ -1,6 +1,7 @@
 import type { MiddlewareEndpointHandler, Params } from '../../@types/astro.js';
 import { createAPIContext } from '../endpoint/index.js';
 import { sequence } from './sequence.js';
+import { computePreferredLocales } from '../render/index.js';
 
 function defineMiddleware(fn: MiddlewareEndpointHandler) {
 	return fn;
@@ -24,12 +25,14 @@ export type CreateContext = {
  * Creates a context to be passed to Astro middleware `onRequest` function.
  */
 function createContext({ request, params }: CreateContext) {
+	const [preferredLocaleList, preferredLocale] = computePreferredLocales(request);
 	return createAPIContext({
 		request,
 		params: params ?? {},
 		props: {},
 		site: undefined,
-		preferredLocale: undefined,
+		preferredLocale,
+		preferredLocaleList,
 	});
 }
 

--- a/packages/astro/src/core/middleware/index.ts
+++ b/packages/astro/src/core/middleware/index.ts
@@ -19,13 +19,21 @@ export type CreateContext = {
 	 * Optional parameters
 	 */
 	params?: Params;
+
+	/**
+	 * A list of locales that are supported by the user
+	 */
+	userDefinedLocales?: string[];
 };
 
 /**
  * Creates a context to be passed to Astro middleware `onRequest` function.
  */
-function createContext({ request, params }: CreateContext) {
-	const [preferredLocaleList, preferredLocale] = computePreferredLocales(request);
+function createContext({ request, params, userDefinedLocales = [] }: CreateContext) {
+	const [preferredLocaleList, preferredLocale] = computePreferredLocales(
+		request,
+		userDefinedLocales
+	);
 	return createAPIContext({
 		request,
 		params: params ?? {},

--- a/packages/astro/src/core/pipeline.ts
+++ b/packages/astro/src/core/pipeline.ts
@@ -116,6 +116,7 @@ export class Pipeline {
 			site: env.site,
 			adapterName: env.adapterName,
 			preferredLocale: renderContext.preferredLocale,
+			preferredLocaleList: renderContext.preferredLocaleList,
 		});
 
 		switch (renderContext.route.type) {
@@ -146,7 +147,14 @@ export class Pipeline {
 				}
 			}
 			case 'endpoint': {
-				return await callEndpoint(mod as any as EndpointHandler, env, renderContext, onRequest);
+				return await callEndpoint(
+					mod as any as EndpointHandler,
+					env,
+					renderContext,
+					onRequest,
+					renderContext.preferredLocale,
+					renderContext.preferredLocaleList
+				);
 			}
 			default:
 				throw new Error(`Couldn't find route of type [${renderContext.route.type}]`);

--- a/packages/astro/src/core/render/context.ts
+++ b/packages/astro/src/core/render/context.ts
@@ -28,6 +28,7 @@ export interface RenderContext {
 	props: Props;
 	locals?: object;
 	preferredLocale: string | undefined;
+	preferredLocaleList: string[] | undefined;
 }
 
 export type CreateRenderContextArgs = Partial<
@@ -59,6 +60,7 @@ export async function createRenderContext(
 		params,
 		props,
 		preferredLocale: options.preferredLocale,
+		preferredLocaleList: options.preferredLocaleList,
 	};
 
 	// We define a custom property, so we can check the value passed to locals
@@ -144,12 +146,18 @@ export function parseLocale(header: string): BrowserLocale[] {
  * If multiple locales are present in the header, they are sorted by their quality value and the highest is selected as current locale.
  *
  */
-export function computePreferredLocale(request: Request): string | undefined {
+export function computePreferredLocales(
+	request: Request
+): [preferredLocaleList: string[] | undefined, preferredLocale: string | undefined] {
 	const acceptHeader = request.headers.get('Accept-Language');
+	const result: [preferredLocaleList: string[] | undefined, preferredLocale: string | undefined] = [
+		undefined,
+		undefined,
+	];
 	if (acceptHeader) {
-		const result = parseLocale(acceptHeader);
-		if (result) {
-			result.sort((a, b) => {
+		const parsedResult = parseLocale(acceptHeader);
+		if (parsedResult) {
+			parsedResult.sort((a, b) => {
 				if (a.qualityValue && b.qualityValue) {
 					if (a.qualityValue > b.qualityValue) {
 						return -1;
@@ -159,12 +167,17 @@ export function computePreferredLocale(request: Request): string | undefined {
 				}
 				return 0;
 			});
-			const firstResult = result.at(0);
+			result[0] = parsedResult.map((item) => {
+				return item.locale;
+			});
+			const firstResult = parsedResult.at(0);
 			if (firstResult) {
 				if (firstResult.locale !== '*') {
-					return firstResult.locale;
+					result[1] = firstResult.locale;
 				}
 			}
 		}
 	}
+
+	return result;
 }

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -68,6 +68,7 @@ export async function renderPage({ mod, renderContext, env, cookies }: RenderPag
 		cookies,
 		locals: renderContext.locals ?? {},
 		preferredLocale: renderContext.preferredLocale,
+		preferredLocaleList: renderContext.preferredLocaleList,
 	});
 
 	// TODO: Remove in Astro 4.0

--- a/packages/astro/src/core/render/index.ts
+++ b/packages/astro/src/core/render/index.ts
@@ -1,6 +1,6 @@
 import type { AstroMiddlewareInstance, ComponentInstance, RouteData } from '../../@types/astro.js';
 import type { Environment } from './environment.js';
-export { createRenderContext, computePreferredLocale } from './context.js';
+export { createRenderContext, computePreferredLocales } from './context.js';
 export type { RenderContext } from './context.js';
 export { createEnvironment } from './environment.js';
 export { getParamsAndProps } from './params-and-props.js';

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -46,6 +46,7 @@ export interface CreateResultArgs {
 	locals: App.Locals;
 	cookies?: AstroCookies;
 	preferredLocale: string | undefined;
+	preferredLocaleList: string[] | undefined;
 }
 
 function getFunctionExpression(slot: any) {

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -126,7 +126,7 @@ class Slots {
 }
 
 export function createResult(args: CreateResultArgs): SSRResult {
-	const { params, request, resolve, locals, preferredLocale } = args;
+	const { params, request, resolve, locals, preferredLocale, preferredLocaleList } = args;
 
 	const url = new URL(request.url);
 	const headers = new Headers();
@@ -199,7 +199,8 @@ export function createResult(args: CreateResultArgs): SSRResult {
 				locals,
 				request,
 				url,
-				preferredLocale: preferredLocale,
+				preferredLocale,
+				preferredLocaleList,
 				redirect(path, status) {
 					// If the response is already sent, error as we cannot proceed with the redirect.
 					if ((request as any)[responseSentSymbol]) {

--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -24,18 +24,8 @@ export function createI18nMiddleware(
 			return await next();
 		}
 
-		const { locales, defaultLocale, redirectToPreferredLanguage, fallback } = i18n;
+		const { locales, defaultLocale, fallback } = i18n;
 		const url = context.url;
-
-		if (redirectToPreferredLanguage && context.preferredLocaleList) {
-			if (url.pathname === '/' || url.pathname.startsWith(`/${defaultLocale}`)) {
-				for (const preferredLocale of context.preferredLocaleList) {
-					if (locales.includes(preferredLocale)) {
-						return context.redirect(`/${preferredLocale}`);
-					}
-				}
-			}
-		}
 
 		const response = await next();
 
@@ -59,7 +49,7 @@ export function createI18nMiddleware(
 					headers: response.headers,
 				});
 			}
-			if (response.status >= 300 && i18n.fallback) {
+			if (response.status >= 300 && fallback) {
 				const fallbackKeys = i18n.fallback ? Object.keys(i18n.fallback) : [];
 
 				const urlLocale = separators.find((s) => locales.includes(s));

--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -1,6 +1,5 @@
 import type { MiddlewareEndpointHandler } from '../@types/astro.js';
 import type { SSRManifest } from '../@types/astro.js';
-import type { Environment } from '../core/render/index.js';
 
 // Checks if the pathname doesn't have any locale, exception for the defaultLocale, which is ignored on purpose
 function checkIsLocaleFree(pathname: string, locales: string[]): boolean {
@@ -19,22 +18,34 @@ export function createI18nMiddleware(
 	if (!i18n) {
 		return undefined;
 	}
-	const locales = i18n.locales;
 
 	return async (context, next) => {
 		if (!i18n) {
 			return await next();
 		}
+
+		const { locales, defaultLocale, redirectToPreferredLanguage, fallback } = i18n;
+		const url = context.url;
+
+		if (redirectToPreferredLanguage && context.preferredLocaleList) {
+			if (url.pathname === '/' || url.pathname.startsWith(`/${defaultLocale}`)) {
+				for (const preferredLocale of context.preferredLocaleList) {
+					if (locales.includes(preferredLocale)) {
+						return context.redirect(`/${preferredLocale}`);
+					}
+				}
+			}
+		}
+
 		const response = await next();
 
-		const url = context.url;
 		if (response instanceof Response) {
 			const separators = url.pathname.split('/');
-			const pathnameContainsDefaultLocale = url.pathname.includes(`/${i18n.defaultLocale}`);
+			const pathnameContainsDefaultLocale = url.pathname.includes(`/${defaultLocale}`);
 			const isLocaleFree = checkIsLocaleFree(url.pathname, i18n.locales);
 			if (i18n.routingStrategy === 'prefix-other-locales' && pathnameContainsDefaultLocale) {
 				const content = await response.text();
-				const newLocation = url.pathname.replace(`/${i18n.defaultLocale}`, '');
+				const newLocation = url.pathname.replace(`/${defaultLocale}`, '');
 				response.headers.set('Location', newLocation);
 				return new Response(content, {
 					status: 302,
@@ -54,11 +65,11 @@ export function createI18nMiddleware(
 				const urlLocale = separators.find((s) => locales.includes(s));
 
 				if (urlLocale && fallbackKeys.includes(urlLocale)) {
-					const fallbackLocale = i18n.fallback[urlLocale];
+					const fallbackLocale = fallback[urlLocale];
 					let newPathname: string;
 					// If a locale falls back to the default locale, we want to **remove** the locale because
 					// the default locale doesn't have a prefix
-					if (fallbackLocale === i18n.defaultLocale) {
+					if (fallbackLocale === defaultLocale) {
 						newPathname = url.pathname.replace(`/${urlLocale}`, ``);
 					} else {
 						newPathname = url.pathname.replace(`/${urlLocale}`, `/${fallbackLocale}`);

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -93,7 +93,6 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 			routingStrategy: settings.config.experimental.i18n.routingStrategy,
 			defaultLocale: settings.config.experimental.i18n.defaultLocale,
 			locales: settings.config.experimental.i18n.locales,
-			redirectToPreferredLanguage: settings.config.experimental.i18n.redirectToPreferredLanguage,
 		};
 	}
 	return {

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -93,6 +93,7 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 			routingStrategy: settings.config.experimental.i18n.routingStrategy,
 			defaultLocale: settings.config.experimental.i18n.defaultLocale,
 			locales: settings.config.experimental.i18n.locales,
+			redirectToPreferredLanguage: settings.config.experimental.i18n.redirectToPreferredLanguage,
 		};
 	}
 	return {

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -11,7 +11,7 @@ import type {
 import { AstroErrorData, isAstroError } from '../core/errors/index.js';
 import { loadMiddleware } from '../core/middleware/loadMiddleware.js';
 import {
-	computePreferredLocale,createRenderContext,
+	computePreferredLocales,createRenderContext,
 	getParamsAndProps,
 	type RenderContext,
 	type SSROptions,
@@ -260,8 +260,11 @@ export async function handleRoute({
 		});
 
 		let preferredLocale: undefined | string = undefined;
+		let preferredLocaleList: undefined | string[] = undefined;
 		if (pipeline.getConfig().experimental.i18n) {
-			preferredLocale = computePreferredLocale(options.request);
+			const result = computePreferredLocales(options.request);
+			preferredLocaleList = result[0];
+			preferredLocale = result[1];
 		}
 
 		renderContext = await createRenderContext({
@@ -274,7 +277,8 @@ export async function handleRoute({
 			route: options.route,
 			mod,
 			env,
-			preferredLocale: preferredLocale,
+			preferredLocale,
+			preferredLocaleList,
 		});
 	}
 

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -261,8 +261,9 @@ export async function handleRoute({
 
 		let preferredLocale: undefined | string = undefined;
 		let preferredLocaleList: undefined | string[] = undefined;
-		if (pipeline.getConfig().experimental.i18n) {
-			const result = computePreferredLocales(options.request);
+		const i18n = pipeline.getConfig().experimental.i18n;
+		if (i18n) {
+			const result = computePreferredLocales(options.request, i18n.locales);
 			preferredLocaleList = result[0];
 			preferredLocale = result[1];
 		}

--- a/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/astro.config.mjs
@@ -6,8 +6,7 @@ export default defineConfig({
 			defaultLocale: 'en',
 			locales: [
 				'en', 'pt', 'it'
-			],
-			redirectToPreferredLanguage: true
+			]
 		}
 	},
 })

--- a/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/astro.config.mjs
@@ -6,7 +6,8 @@ export default defineConfig({
 			defaultLocale: 'en',
 			locales: [
 				'en', 'pt', 'it'
-			]
+			],
+			redirectToPreferredLanguage: true
 		}
 	},
 })

--- a/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/package.json
+++ b/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/i18n-routing-preferred-language",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/en/blog/[id].astro
+++ b/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/en/blog/[id].astro
@@ -1,0 +1,18 @@
+---
+export function getStaticPaths() {
+    return [
+        {params: {id: '1'}, props: { content: "Hello world" }},
+        {params: {id: '2'}, props: { content: "Eat Something" }},
+        {params: {id: '3'}, props: { content: "How are you?" }},
+    ];
+}
+const { content } = Astro.props;
+---
+<html>
+<head>
+    <title>Astro</title>
+</head>
+<body>
+{content}
+</body>
+</html>

--- a/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/en/end.astro
+++ b/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/en/end.astro
@@ -1,0 +1,8 @@
+<html>
+<head>
+    <title>Astro</title>
+</head>
+<body>
+End
+</body>
+</html>

--- a/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/en/start.astro
+++ b/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/en/start.astro
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Astro</title>
+</head>
+<body>
+Hello
+</body>
+</html>

--- a/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/index.astro
+++ b/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/index.astro
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Astro</title>
+</head>
+<body>
+	Hello
+</body>
+</html>

--- a/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/preferred-locale.astro
+++ b/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/preferred-locale.astro
@@ -1,5 +1,6 @@
 ---
 const locale = Astro.preferredLocale;
+const localeList = Astro.preferredLocaleList;
 ---
 
 <html>

--- a/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/preferred-locale.astro
+++ b/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/preferred-locale.astro
@@ -1,0 +1,12 @@
+---
+const locale = Astro.preferredLocale;
+---
+
+<html>
+<head>
+	<title>Astro</title>
+</head>
+<body>
+	Locale: {locale ? locale : "none"}
+</body>
+</html>

--- a/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/pt/blog/[id].astro
+++ b/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/pt/blog/[id].astro
@@ -1,0 +1,18 @@
+---
+export function getStaticPaths() {
+    return [
+        {params: {id: '1'}, props: { content: "Hola mundo" }},
+        {params: {id: '2'}, props: { content: "Eat Something" }},
+        {params: {id: '3'}, props: { content: "How are you?" }},
+    ];
+}
+const { content } = Astro.props;
+---
+<html>
+<head>
+    <title>Astro</title>
+</head>
+<body>
+{content}
+</body>
+</html>

--- a/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/pt/start.astro
+++ b/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/src/pages/pt/start.astro
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Astro</title>
+</head>
+<body>
+Hola
+</body>
+</html>

--- a/packages/astro/test/fixtures/i18n-routing/src/pages/preferred-locale.astro
+++ b/packages/astro/test/fixtures/i18n-routing/src/pages/preferred-locale.astro
@@ -1,5 +1,7 @@
 ---
 const locale = Astro.preferredLocale;
+const localeList = Astro.preferredLocaleList;
+
 ---
 
 <html>
@@ -8,5 +10,6 @@ const locale = Astro.preferredLocale;
 </head>
 <body>
 	Locale: {locale ? locale : "none"}
+	Locale list: {localeList.length > 0 ? localeList.join(", ") : "empty"}
 </body>
 </html>

--- a/packages/astro/test/i18-routing.test.js
+++ b/packages/astro/test/i18-routing.test.js
@@ -801,107 +801,42 @@ describe('[SSR] i18n routing', () => {
 			expect(await response.text()).includes('Locale: none');
 		});
 
-		it('should render the locale fr', async () => {
+		it('should render the locale pt', async () => {
 			let request = new Request('http://example.com/preferred-locale', {
 				headers: {
-					'Accept-Language': 'fr',
+					'Accept-Language': 'pt',
 				},
 			});
 			let response = await app.render(request);
 			expect(response.status).to.equal(200);
-			expect(await response.text()).includes('Locale: fr');
+			expect(await response.text()).includes('Locale: pt');
 		});
 
-		it('should render the locale fr-AU', async () => {
+		it('should render empty locales', async () => {
 			let request = new Request('http://example.com/preferred-locale', {
 				headers: {
 					'Accept-Language': 'fr;q=0.1,fr-AU;q=0.9',
 				},
 			});
 			let response = await app.render(request);
+			const text = await response.text();
 			expect(response.status).to.equal(200);
-			expect(await response.text()).includes('Locale: fr-AU');
-		});
-	});
-
-	describe('redirect to preferred language', () => {
-		/** @type {import('./test-utils').Fixture} */
-		let fixture;
-
-		before(async () => {
-			fixture = await loadFixture({
-				root: './fixtures/i18n-routing-redirect-preferred-language/',
-				output: 'server',
-				adapter: testAdapter(),
-			});
-			await fixture.build();
-			app = await fixture.loadTestAdapterApp();
+			console.log(text);
+			expect(text).includes('Locale: none');
+			expect(text).includes('Locale list: empty');
 		});
 
-		it('should not redirect when the preferred language is *', async () => {
-			let request = new Request('http://example.com/', {
+		it('should render none as preferred locale, but have a list of locales that correspond to the initial locales', async () => {
+			let request = new Request('http://example.com/preferred-locale', {
 				headers: {
 					'Accept-Language': '*',
 				},
 			});
 			let response = await app.render(request);
+			const text = await response.text();
 			expect(response.status).to.equal(200);
-			expect(await response.text()).includes('Hello');
-		});
-
-		it('should redirect to the PT page', async () => {
-			let request = new Request('http://example.com/', {
-				headers: {
-					'Accept-Language': 'pt',
-				},
-			});
-			let response = await app.render(request);
-			expect(response.status).to.equal(302);
-			expect(response.headers.get('Location')).to.equal('/pt');
-		});
-
-		it('should redirect to the PT page because it is the locale that has the highest quality value ', async () => {
-			let request = new Request('http://example.com/', {
-				headers: {
-					'Accept-Language': 'fr;q=0.1,pt;q=0.9',
-				},
-			});
-			let response = await app.render(request);
-			expect(response.status).to.equal(302);
-			expect(response.headers.get('Location')).to.equal('/pt');
-		});
-
-		it('should redirect to the PT page because the locale is part of the preferred languages, even though its quality value is not the hightest', async () => {
-			let request = new Request('http://example.com/', {
-				headers: {
-					'Accept-Language': 'en_AU;q=0.5,pt;q=0.1',
-				},
-			});
-			let response = await app.render(request);
-			expect(response.status).to.equal(302);
-			expect(response.headers.get('Location')).to.equal('/pt');
-		});
-
-		it('should NOT redirect the the locale because the preferred language is not supported by the configuration', async () => {
-			let request = new Request('http://example.com/', {
-				headers: {
-					'Accept-Language': 'fr',
-				},
-			});
-			let response = await app.render(request);
-			expect(response.status).to.equal(200);
-			expect(await response.text()).includes('Hello');
-		});
-
-		it('should NOT redirect the the locale because we are browsing a URL that is not the root', async () => {
-			let request = new Request('http://example.com/en/end', {
-				headers: {
-					'Accept-Language': 'fr',
-				},
-			});
-			let response = await app.render(request);
-			expect(response.status).to.equal(200);
-			expect(await response.text()).includes('End');
+			expect(text).includes('Locale: none');
+			expect(text).includes('Locale list: en, pt, it');
 		});
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2821,6 +2821,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/i18n-routing-redirect-preferred-language:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/import-ts-with-js:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

This PR adds two new features to i18n routing:
- new property to the `Astro` global, called `preferredLocaleList`, which represents a sorted list of the locales requested by the browser. This list is filtered with `i18n.locales`. 
- reviewed how `preferredLocale` is computed; now it takes into consideration `i18n.locales`

Here are the changes reflected to the RFC: https://github.com/withastro/roadmap/pull/734/commits/e07aef715688703ebcadf297c3f5ed543ed2c14c

## Testing

I added new test cases to cover the new feature.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
 /cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
