### PR TITLE
Three small improvements for handling client-only in view transitions

### DIFF
--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -537,7 +537,8 @@ async function prepareForClientOnlyComponents(newDocument: Document, toLocation:
 			(newDocument.doctype ? '<!DOCTYPE html>' : '') + newDocument.documentElement.outerHTML;
 		nextPage.style.display = 'none';
 		document.body.append(nextPage);
-		// @ts-ignore silence the iframes console
+		// silence the iframe's console
+		// @ts-ignore
 		nextPage.contentWindow!.console = Object.keys(console).reduce((acc: any, key) => {
 			acc[key] = () => {};
 			return acc;

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -532,9 +532,16 @@ async function prepareForClientOnlyComponents(newDocument: Document, toLocation:
 	if (newDocument.body.querySelector(`astro-island[client='only']`)) {
 		// Load the next page with an empty module loader cache
 		const nextPage = document.createElement('iframe');
-		nextPage.setAttribute('src', toLocation.href);
+		// do not fetch the file from the server, but use the current newDocument
+		nextPage.srcdoc =
+			(newDocument.doctype ? '<!DOCTYPE html>' : '') + newDocument.documentElement.outerHTML;
 		nextPage.style.display = 'none';
 		document.body.append(nextPage);
+		// @ts-ignore silence the iframes console
+		nextPage.contentWindow!.console = Object.keys(console).reduce((acc: any, key) => {
+			acc[key] = () => {};
+			return acc;
+		}, {});
 		await hydrationDone(nextPage);
 
 		const nextHead = nextPage.contentDocument?.head;
@@ -552,7 +559,7 @@ async function prepareForClientOnlyComponents(newDocument: Document, toLocation:
 			viteIds.forEach((id) => {
 				const style = document.head.querySelector(`style[${VITE_ID}="${id}"]`);
 				if (style && !newDocument.head.querySelector(`style[${VITE_ID}="${id}"]`)) {
-					newDocument.head.appendChild(style);
+					newDocument.head.appendChild(style.cloneNode(true));
 				}
 			});
 		}


### PR DESCRIPTION
## Changes

Three changes:
1. Copy and paste styles, not cut and paste: This is really a bug, ~~although no one has complained yet~~. Moving the styles from the current document to the newDocument deletes them from the current document, which is visible in view transitions. Cloning helps! Closes #8946
2. Don't load from the target URL, but load the actual contents of newDocument to simulate loading with an empty module loader: This is to prepare for the new API events where interceptors might transform newDocument after it is loaded.
3. Silence the iframe's console to reduce the observable impact of behind-the-scenes loading: This actually closes #8944  

## Testing

Existing e2e tests

## Docs

n/a bugfix
