### PR TITLE
chore: change behaviour of `prefix-other-locales`

### DIFF
--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -37,8 +37,8 @@ export function createI18nMiddleware(
 				const content = await response.text();
 				const newLocation = url.pathname.replace(`/${defaultLocale}`, '');
 				response.headers.set('Location', newLocation);
-				return new Response(content, {
-					status: 302,
+				return new Response(null, {
+					status: 404,
 					headers: response.headers,
 				});
 			}

--- a/packages/astro/test/i18-routing.test.js
+++ b/packages/astro/test/i18-routing.test.js
@@ -136,6 +136,14 @@ describe('[DEV] i18n routing', () => {
 			expect(await response2.text()).includes('Hello world');
 		});
 
+		it('should return 404 when route contains the default locale', async () => {
+			const response = await fixture.fetch('/new-site/en/start');
+			expect(response.status).to.equal(404);
+
+			const response2 = await fixture.fetch('/new-site/en/blog/1');
+			expect(response2.status).to.equal(404);
+		});
+
 		it('should render localised page correctly', async () => {
 			const response = await fixture.fetch('/new-site/pt/start');
 			expect(response.status).to.equal(200);
@@ -412,6 +420,17 @@ describe('[SSG] i18n routing', () => {
 			expect($('body').text()).includes('Hello world');
 		});
 
+		it('should return 404 when route contains the default locale', async () => {
+			try {
+				await fixture.readFile('/start/en/index.html');
+				// failed
+				return false;
+			} catch {
+				// success
+				return true;
+			}
+		});
+
 		it('should render localised page correctly', async () => {
 			let html = await fixture.readFile('/pt/start/index.html');
 			let $ = cheerio.load(html);
@@ -542,7 +561,6 @@ describe('[SSG] i18n routing', () => {
 		it('should redirect to the english locale, which is the first fallback', async () => {
 			const html = await fixture.readFile('/it/start/index.html');
 			expect(html).to.include('http-equiv="refresh');
-			console.log(html);
 			expect(html).to.include('url=/new-site/start');
 		});
 
@@ -662,6 +680,12 @@ describe('[SSR] i18n routing', () => {
 			let response = await app.render(request);
 			expect(response.status).to.equal(200);
 			expect(await response.text()).includes('Start');
+		});
+
+		it('should return 404 if route contains the default locale', async () => {
+			let request = new Request('http://example.com/new-site/en/start');
+			let response = await app.render(request);
+			expect(response.status).to.equal(404);
 		});
 
 		it('should render localised page correctly', async () => {


### PR DESCRIPTION
## Changes

Relevant change in the RFC  https://github.com/withastro/roadmap/pull/734/commits/989ecc1c40eb4ad43acea78be3212ea3f688f974

The behaviour change is more in line with what was discussed with Chris the other, where redirects are bad practices, so Astro should not try to be smart.

This is also in line with some existing behaviour, of the trailing slash, for example. 

## Testing

I added some test case to cover the change in logic.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
