### PR TITLE
Increase the scroll restoration throttle time

### DIFF
--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -515,7 +515,7 @@ if (inBrowser) {
 		addEventListener('popstate', onPopState);
 		addEventListener('load', onPageLoad);
 		if ('onscrollend' in window) addEventListener('scrollend', onScroll);
-		else addEventListener('scroll', throttle(onScroll, 300));
+		else addEventListener('scroll', throttle(onScroll, 350));
 	}
 	for (const script of document.scripts) {
 		script.dataset.astroExec = '';


### PR DESCRIPTION
## Changes

- This increases the throttle time to ever 350ms.
- Safari adds a warning in the console if you exceed 100 calls to `replaceState` ever 30 seconds. 30/100 == 300ms. So our previous throttle would hit the threshold. The new one will not, we only will call it a max of 99 times.

## Testing

- Tested manually scrolling around a lot.

## Docs

N/A, bug fix