### PR TITLE
chore(i18n): reworked fallback, docs, types and validation

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1449,14 +1449,14 @@ export interface AstroUserConfig {
 			 * @version 3.5.0
 			 * @description
 			 *
-			 * Controls the routing strategyto determine your site URLs.
-             *
+			 * Controls the routing strategy to determine your site URLs.
+			 *
 			 *  - `prefix-other-locales`(default): Only non-default languages will display a language prefix. The `defaultLocale` will not show a language prefix.
-			 *		URLs will be of the form `example.com/[lang]/content/` for all non-default languages, but `example.com/content/` for the default locale.
+			 *    URLs will be of the form `example.com/[lang]/content/` for all non-default languages, but `example.com/content/` for the default locale.
 			 *  - `prefix-always`: All URLs will display a language prefix.
-             *  URLs will be of the form `example.com/[lang]/content/` for every route, including the default language.
-             *
-             * Note: Astro requires all content to exist within a `/[lang]/` folder, even for the default language.
+			 *    URLs will be of the form `example.com/[lang]/content/` for every route, including the default language.
+			 *
+			 * Note: Astro requires all content to exist within a `/[lang]/` folder, even for the default language.
 			 */
 			routingStrategy: 'prefix-always' | 'prefix-other-locales';
 		};

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1422,7 +1422,7 @@ export interface AstroUserConfig {
 			 *
 			 * #### Examples
 			 *
-			 * In this example, we configure Astro to redirect pages that belong to the `pt` locale to their `es` version, and pages that belong to the `fr` locale to their `en` version.
+			 * The following example configures your content fallback strategy to redirect unavailable pages in `/pt/` to their `es` version, and unavailable pages in `/fr/` to their `en` version. Unavailable `/es/` pages will return a 404.
 			 *
 			 * ```js
 			 * export defualt defineConfig({

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1381,7 +1381,7 @@ export interface AstroUserConfig {
 		 * @docs
 		 * @name experimental.i18n
 		 * @type {object}
-		 * @version 3.*.*
+		 * @version 3.5.0
 		 * @type {object}
 		 * @description
 		 *
@@ -1392,7 +1392,7 @@ export interface AstroUserConfig {
 			 * @docs
 			 * @name experimental.i18n.defaultLocale
 			 * @type {string}
-			 * @version 3.*.*
+			 * @version 3.5.0
 			 * @description
 			 *
 			 * The default locale of your website/application
@@ -1402,7 +1402,7 @@ export interface AstroUserConfig {
 			 * @docs
 			 * @name experimental.i18n.locales
 			 * @type {string[]}
-			 * @version 3.*.*
+			 * @version 3.5.0
 			 * @description
 			 *
 			 * A list of all locales supported by the website. e.g. `['en', 'fr', 'es']` This list should/should not include the `defaultLocale`.
@@ -1412,37 +1412,53 @@ export interface AstroUserConfig {
 			/**
 			 * @docs
 			 * @name experimental.i18n.fallback
-			 * @type {Record<string, string[]>}
-			 * @version 3.*.*
+			 * @type {Record<string, string>}
+			 * @version 3.5.0
 			 * @description
 			 *
-			 * The fallback system of the locales. By default, the fallback system affect the **content only**, and it doesn't
-			 * do any redirects.
+			 * The content fallback strategy when navigating to pages in non-default languages that do not exist. (e.g. a translated page has not been created).
 			 *
-			 * This means that when attempting to navigate to a page that hasn't been translated, Astro will pull the content
-			 * from the page of the default locale and render it. No redirects will happen.
+			 * This a plain object, where a key is a locale that hasn't traslated pages, and the corresponding value is the locale where you want to redirect the missing page to.
+			 *
+			 * #### Examples
+			 *
+			 * In this example, we configure Astro to redirect pages that belong to the `pt` locale to their `es` version, and pages that belong to the `fr` locale to their `en` version.
+			 *
+			 * ```js
+			 * export defualt defineConfig({
+			 * 	experimental: {
+			 * 		i18n: {
+			 * 			defuaultLocale: "en",
+			 * 			locales: ["en", "fr", "pt", "es"],
+			 * 			fallback: {
+			 * 				pt: "es",
+			 * 			  fr: "en"
+			 * 			}
+			 * 		}
+			 * 	}
+			 * })
+			 * ```
 			 */
-			fallback?: Record<string, string[]>;
+			fallback?: Record<string, string>;
 
-            /**
-             * @docs
-             * @name experimental.i18n.routingStrategy
-             * @type {'prefix-always' | 'prefix-other-locales'}
-             * @default {'prefix-other-locales'}
-             * @version 3.*.*
-             * @description
+			/**
+			 * @docs
+			 * @name experimental.i18n.routingStrategy
+			 * @type {'prefix-always' | 'prefix-other-locales'}
+			 * @default {'prefix-other-locales'}
+			 * @version 3.5.0
+			 * @description
+			 *
+			 * Controls the routing strategyto determine your site URLs.
              *
-             * Controls the routing strategy to determine your site URLs.
-             *
-             *  - `prefix-other-locales` (default): Only non-default languages will display a language prefix. The `defaultLocale` will not show a language prefix.
-             * URLs will be of the form `example.com/[lang]/content/` for all non-default languages, but `example.com/content/` for the default locale.
-     
-             *  - `prefix-always`: All URLs will display a language prefix.
+			 *  - `prefix-other-locales`(default): Only non-default languages will display a language prefix. The `defaultLocale` will not show a language prefix.
+			 *		URLs will be of the form `example.com/[lang]/content/` for all non-default languages, but `example.com/content/` for the default locale.
+			 *  - `prefix-always`: All URLs will display a language prefix.
              *  URLs will be of the form `example.com/[lang]/content/` for every route, including the default language.
              *
              * Note: Astro requires all content to exist within a `/[lang]/` folder, even for the default language.
-             */
-            routingStrategy: 'prefix-always' | 'prefix-other-locales';
+			 */
+			routingStrategy: 'prefix-always' | 'prefix-other-locales';
 		};
 	};
 }

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -310,10 +310,11 @@ export const AstroConfigSchema = z.object({
 						locales: z.string().array(),
 						fallback: z.record(z.string(), z.string()).optional(),
 						// TODO: properly add default when the feature goes of experimental
-                        routingStrategy: z
-                            .enum(['prefix-always', 'prefix-other-locales'])
-                            .optional()
-                            .default('prefix-other-locales'),					})
+						routingStrategy: z
+							.enum(['prefix-always', 'prefix-other-locales'])
+							.optional()
+							.default('prefix-other-locales'),
+					})
 					.optional()
 					.superRefine((i18n, ctx) => {
 						if (i18n) {
@@ -330,6 +331,13 @@ export const AstroConfigSchema = z.object({
 										ctx.addIssue({
 											code: z.ZodIssueCode.custom,
 											message: `The locale \`${fallbackFrom}\` key in the \`i18n.fallback\` record doesn't exist in the \`i18n.locales\` array.`,
+										});
+									}
+
+									if (fallbackFrom === defaultLocale) {
+										ctx.addIssue({
+											code: z.ZodIssueCode.custom,
+											message: `You can't use the default locale as a key. The default locale can only be used as value.`,
 										});
 									}
 

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -11,7 +11,8 @@ import type {
 import { AstroErrorData, isAstroError } from '../core/errors/index.js';
 import { loadMiddleware } from '../core/middleware/loadMiddleware.js';
 import {
-	computePreferredLocales,createRenderContext,
+	computePreferredLocales,
+	createRenderContext,
 	getParamsAndProps,
 	type RenderContext,
 	type SSROptions,

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -138,5 +138,26 @@ describe('Config Validation', () => {
 				"The locale `it` key in the `i18n.fallback` record doesn't exist in the `i18n.locales` array."
 			);
 		});
+
+		it('errors if a fallback key contains the default locale', async () => {
+			const configError = await validateConfig(
+				{
+					experimental: {
+						i18n: {
+							defaultLocale: 'en',
+							locales: ['es', 'en'],
+							fallback: {
+								en: 'es',
+							},
+						},
+					},
+				},
+				process.cwd()
+			).catch((err) => err);
+			expect(configError instanceof z.ZodError).to.equal(true);
+			expect(configError.errors[0].message).to.equal(
+				"You can't use the default locale as a key. The default locale can only be used as value."
+			);
+		});
 	});
 });


### PR DESCRIPTION
## Changes

There was some issue with the types of `i18n.fallback`, and I added another level of validation to zod.

## Testing

Added a test case to cover the new logic

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
 /cc @withastro/maintainers-docs for feedback!

@sarah11918 we can use this PR to land the correct [documentation for fallback](https://github.com/withastro/astro/pull/8974#discussion_r1380679252) 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
