### PR TITLE
refactor(i18n): compute preferred locales lazily

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1445,7 +1445,7 @@ export interface AstroUserConfig {
 			 * @docs
 			 * @name experimental.i18n.routingStrategy
 			 * @type {'prefix-always' | 'prefix-other-locales'}
-			 * @default {'prefix-other-locales'}
+			 * @default 'prefix-other-locales'
 			 * @version 3.5.0
 			 * @description
 			 *

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -16,12 +16,7 @@ import {
 	removeTrailingForwardSlash,
 } from '../path.js';
 import { RedirectSinglePageBuiltModule } from '../redirects/index.js';
-import {
-	computePreferredLocales,
-	createEnvironment,
-	createRenderContext,
-	type RenderContext,
-} from '../render/index.js';
+import { createEnvironment, createRenderContext, type RenderContext } from '../render/index.js';
 import { RouteCache } from '../render/route-cache.js';
 import {
 	createAssetLink,
@@ -222,13 +217,6 @@ export class App {
 		page: SinglePageBuiltModule,
 		status = 200
 	): Promise<RenderContext> {
-		let preferredLocale: undefined | string = undefined;
-		let preferredLocaleList: undefined | string[] = undefined;
-		if (this.#manifest.i18n) {
-			const result = computePreferredLocales(request, this.#manifest.i18n.locales);
-			preferredLocaleList = result[0];
-			preferredLocale = result[1];
-		}
 		if (routeData.type === 'endpoint') {
 			const pathname = '/' + this.removeBase(url.pathname);
 			const mod = await page.page();
@@ -241,8 +229,7 @@ export class App {
 				status,
 				env: this.#pipeline.env,
 				mod: handler as any,
-				preferredLocale,
-				preferredLocaleList,
+				locales: this.#manifest.i18n ? this.#manifest.i18n.locales : undefined,
 			});
 		} else {
 			const pathname = prependForwardSlash(this.removeBase(url.pathname));
@@ -277,8 +264,7 @@ export class App {
 				status,
 				mod,
 				env: this.#pipeline.env,
-				preferredLocale,
-				preferredLocaleList,
+				locales: this.#manifest.i18n ? this.#manifest.i18n.locales : undefined,
 			});
 		}
 	}

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -39,7 +39,7 @@ import {
 	getRedirectLocationOrThrow,
 	routeIsRedirect,
 } from '../redirects/index.js';
-import { computePreferredLocales, createRenderContext } from '../render/index.js';
+import { createRenderContext } from '../render/index.js';
 import { callGetStaticPaths } from '../render/route-cache.js';
 import {
 	createAssetLink,
@@ -551,14 +551,7 @@ async function generatePath(pathname: string, gopts: GeneratePathOptions, pipeli
 		logger: pipeline.getLogger(),
 		ssr,
 	});
-	let preferredLocale: undefined | string = undefined;
-	let preferredLocaleList: undefined | string[] = undefined;
 	const i18n = pipeline.getConfig().experimental.i18n;
-	if (i18n) {
-		const result = computePreferredLocales(request, i18n.locales);
-		preferredLocaleList = result[0];
-		preferredLocale = result[1];
-	}
 	const renderContext = await createRenderContext({
 		pathname,
 		request,
@@ -569,8 +562,7 @@ async function generatePath(pathname: string, gopts: GeneratePathOptions, pipeli
 		route: pageData.route,
 		env: pipeline.getEnvironment(),
 		mod,
-		preferredLocale,
-		preferredLocaleList,
+		locales: i18n ? i18n.locales : undefined,
 	});
 
 	let body: string | Uint8Array;

--- a/packages/astro/src/core/endpoint/index.ts
+++ b/packages/astro/src/core/endpoint/index.ts
@@ -42,6 +42,9 @@ export function createAPIContext({
 	adapterName,
 	locales,
 }: CreateAPIContext): APIContext {
+	let preferredLocale: string | undefined = undefined;
+	let preferredLocaleList: string[] | undefined = undefined;
+
 	const context = {
 		cookies: new AstroCookies(request),
 		request,
@@ -59,15 +62,25 @@ export function createAPIContext({
 		},
 		ResponseWithEncoding,
 		get preferredLocale(): string | undefined {
-			if (locales) {
-				return computePreferredLocale(request, locales);
+			if (preferredLocale) {
+				return preferredLocale;
 			}
+			if (locales) {
+				preferredLocale = computePreferredLocale(request, locales);
+				return preferredLocale;
+			}
+
 			return undefined;
 		},
 		get preferredLocaleList(): string[] | undefined {
-			if (locales) {
-				return computePreferredLocaleList(request, locales);
+			if (preferredLocaleList) {
+				return preferredLocaleList;
 			}
+			if (locales) {
+				preferredLocaleList = computePreferredLocaleList(request, locales);
+				return preferredLocaleList;
+			}
+
 			return undefined;
 		},
 		url: new URL(request.url),

--- a/packages/astro/src/core/middleware/index.ts
+++ b/packages/astro/src/core/middleware/index.ts
@@ -1,7 +1,6 @@
 import type { MiddlewareEndpointHandler, Params } from '../../@types/astro.js';
 import { createAPIContext } from '../endpoint/index.js';
 import { sequence } from './sequence.js';
-import { computePreferredLocales } from '../render/index.js';
 
 function defineMiddleware(fn: MiddlewareEndpointHandler) {
 	return fn;
@@ -30,17 +29,12 @@ export type CreateContext = {
  * Creates a context to be passed to Astro middleware `onRequest` function.
  */
 function createContext({ request, params, userDefinedLocales = [] }: CreateContext) {
-	const [preferredLocaleList, preferredLocale] = computePreferredLocales(
-		request,
-		userDefinedLocales
-	);
 	return createAPIContext({
 		request,
 		params: params ?? {},
 		props: {},
 		site: undefined,
-		preferredLocale,
-		preferredLocaleList,
+		locales: userDefinedLocales,
 	});
 }
 

--- a/packages/astro/src/core/pipeline.ts
+++ b/packages/astro/src/core/pipeline.ts
@@ -115,8 +115,7 @@ export class Pipeline {
 			props: renderContext.props,
 			site: env.site,
 			adapterName: env.adapterName,
-			preferredLocale: renderContext.preferredLocale,
-			preferredLocaleList: renderContext.preferredLocaleList,
+			locales: renderContext.locales,
 		});
 
 		switch (renderContext.route.type) {
@@ -152,8 +151,7 @@ export class Pipeline {
 					env,
 					renderContext,
 					onRequest,
-					renderContext.preferredLocale,
-					renderContext.preferredLocaleList
+					renderContext.locales
 				);
 			}
 			default:

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -67,8 +67,7 @@ export async function renderPage({ mod, renderContext, env, cookies }: RenderPag
 		status: renderContext.status ?? 200,
 		cookies,
 		locals: renderContext.locals ?? {},
-		preferredLocale: renderContext.preferredLocale,
-		preferredLocaleList: renderContext.preferredLocaleList,
+		locales: renderContext.locales,
 	});
 
 	// TODO: Remove in Astro 4.0

--- a/packages/astro/src/core/render/index.ts
+++ b/packages/astro/src/core/render/index.ts
@@ -1,6 +1,6 @@
 import type { AstroMiddlewareInstance, ComponentInstance, RouteData } from '../../@types/astro.js';
 import type { Environment } from './environment.js';
-export { createRenderContext, computePreferredLocales } from './context.js';
+export { createRenderContext, computePreferredLocale } from './context.js';
 export type { RenderContext } from './context.js';
 export { createEnvironment } from './environment.js';
 export { getParamsAndProps } from './params-and-props.js';

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -126,7 +126,7 @@ class Slots {
 }
 
 export function createResult(args: CreateResultArgs): SSRResult {
-	const { params, request, resolve, locals, locales } = args;
+	const { params, request, resolve, locals } = args;
 
 	const url = new URL(request.url);
 	const headers = new Headers();
@@ -146,6 +146,8 @@ export function createResult(args: CreateResultArgs): SSRResult {
 
 	// Astro.cookies is defined lazily to avoid the cost on pages that do not use it.
 	let cookies: AstroCookies | undefined = args.cookies;
+	let preferredLocale: string | undefined = undefined;
+	let preferredLocaleList: string[] | undefined = undefined;
 
 	// Create the result object that will be passed into the render function.
 	// This object starts here as an empty shell (not yet the result) but then
@@ -195,15 +197,25 @@ export function createResult(args: CreateResultArgs): SSRResult {
 					return cookies;
 				},
 				get preferredLocale(): string | undefined {
-					if (locales) {
-						return computePreferredLocale(request, locales);
+					if (preferredLocale) {
+						return preferredLocale;
 					}
+					if (args.locales) {
+						preferredLocale = computePreferredLocale(request, args.locales);
+						return preferredLocale;
+					}
+
 					return undefined;
 				},
 				get preferredLocaleList(): string[] | undefined {
-					if (locales) {
-						return computePreferredLocaleList(request, locales);
+					if (preferredLocaleList) {
+						return preferredLocaleList;
 					}
+					if (args.locales) {
+						preferredLocaleList = computePreferredLocaleList(request, args.locales);
+						return preferredLocaleList;
+					}
+
 					return undefined;
 				},
 				params,

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -11,7 +11,6 @@ import type {
 import { AstroErrorData, isAstroError } from '../core/errors/index.js';
 import { loadMiddleware } from '../core/middleware/loadMiddleware.js';
 import {
-	computePreferredLocales,
 	createRenderContext,
 	getParamsAndProps,
 	type RenderContext,
@@ -260,14 +259,7 @@ export async function handleRoute({
 			filePath: options.filePath,
 		});
 
-		let preferredLocale: undefined | string = undefined;
-		let preferredLocaleList: undefined | string[] = undefined;
 		const i18n = pipeline.getConfig().experimental.i18n;
-		if (i18n) {
-			const result = computePreferredLocales(options.request, i18n.locales);
-			preferredLocaleList = result[0];
-			preferredLocale = result[1];
-		}
 
 		renderContext = await createRenderContext({
 			request: options.request,
@@ -279,8 +271,7 @@ export async function handleRoute({
 			route: options.route,
 			mod,
 			env,
-			preferredLocale,
-			preferredLocaleList,
+			locales: i18n ? i18n.locales : undefined,
 		});
 	}
 


### PR DESCRIPTION
## Changes

From the API bash session, a suggestion was to compute `preferredLocale` and `preferredLocaleList` lazily. To do so, we agreed that `i18n.locales` cab be passed down to the point where we compute the context for the endpoints, and the `Astro` faux-global.

This PR does that by removing the computation of `preferredLocale` and `preferredLocaleList` from the three pipelines, and instead, we simply pass `locales`. The computation is moved inside two new getters.

## Testing

This is a refactor, so existing functionality should not change and the existing tests should still pass.
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
