### PR TITLE
Fix DEV mode on Safari when view transitioning to client:only components

### DIFF
--- a/.changeset/eighty-ladybugs-shake.md
+++ b/.changeset/eighty-ladybugs-shake.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix DEV mode on Safari when view transitioning to `client:only` components

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -529,9 +529,8 @@ async function prepareForClientOnlyComponents(newDocument: Document, toLocation:
 	if (newDocument.body.querySelector(`astro-island[client='only']`)) {
 		// Load the next page with an empty module loader cache
 		const nextPage = document.createElement('iframe');
-		// do not fetch the file from the server, but use the current newDocument
-		nextPage.srcdoc =
-			(newDocument.doctype ? '<!DOCTYPE html>' : '') + newDocument.documentElement.outerHTML;
+		// with srcdoc resolving imports does not work on webkit browsers
+		nextPage.src = toLocation.href;
 		nextPage.style.display = 'none';
 		document.body.append(nextPage);
 		// silence the iframe's console


### PR DESCRIPTION
## Changes

Currently, "iframe.srcdoc" is not equally well supported by all browsers. At least I have not yet found a way that works with the import resolution of Safari. However, it works well with Firefox and Chrome. With great regret I have changed `srcdoc` back to `src`.

Details
Falling back to `src` is not my favorite approach: the reason for using `srcdoc` was that we can render the possibly modified in-memory version of newDocument, not the file provided by the server. 

The reason srcdoc doesn't work on webkit browsers is that srcdoc changes the `documentURI` to `about:srcdoc`, which leads to errors when resolving absolute URLs with no origin. (All browsers set `about:srcdoc` in this way, but the others seem to have special cased the resolution)
I've tried to fix this by rewriting URLs starting with `"/"` to `"http://..."`, using the actual `location.origin` from the main document or setting `<base>` for the `iframe.contentDocument`, but I've had no success so far.

If anyone knows a way to use `srcdoc` across browsers without errors, I would be happy to hear about it :)
We could POST the HTML of the newDocument to the DEV server and GET it back for the `src` attribute. 

## Testing

Tested manually with Webkit on Windows.  

## Docs

n/a, bug fix
Always happy about better .changeset wording