### PR TITLE
refactor(i18n): make `normalizePath` to default to `true`

### DIFF
--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -142,8 +142,8 @@ declare module 'astro:i18n' {
 	 * import { getLocaleRelativeUrl } from "astro:i18n";
 	 * getLocaleRelativeUrl("es"); // /es
 	 * getLocaleRelativeUrl("es", "getting-started"); // /es/getting-started
-	 * getLocaleRelativeUrl("es", "getting-started", { prependWith: "blog" }); // /blog/es/getting-started
-	 * getLocaleRelativeUrl("es_US", "getting-started", { prependWith: "blog", normalizeLocale: true }); // /blog/es-us/getting-started
+	 * getLocaleRelativeUrl("es_US", "getting-started", { prependWith: "blog" }); // /blog/es-us/getting-started
+	 * getLocaleRelativeUrl("es_US", "getting-started", { prependWith: "blog", normalizeLocale: false }); // /blog/es_US/getting-started
 	 * ```
 	 */
 	export const getLocaleRelativeUrl: (
@@ -174,8 +174,8 @@ declare module 'astro:i18n' {
 	 * import { getLocaleAbsoluteUrl } from "astro:i18n";
 	 * getLocaleAbsoluteUrl("es"); // https://example.com/es
 	 * getLocaleAbsoluteUrl("es", "getting-started"); // https://example.com/es/getting-started
-	 * getLocaleAbsoluteUrl("es", "getting-started", { prependWith: "blog" }); // https://example.com/blog/es/getting-started
-	 * getLocaleAbsoluteUrl("es_US", "getting-started", { prependWith: "blog", normalizeLocale: true }); // https://example.com/blog/es-us/getting-started
+	 * getLocaleAbsoluteUrl("es_US", "getting-started", { prependWith: "blog" }); // https://example.com/blog/es-us/getting-started
+	 * getLocaleAbsoluteUrl("es_US", "getting-started", { prependWith: "blog", normalizeLocale: false }); // https://example.com/blog/es_US/getting-started
 	 * ```
 	 */
 	export const getLocaleAbsoluteUrl: (

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -15,14 +15,15 @@ type GetLocaleRelativeUrl = GetLocaleOptions & {
 export type GetLocaleOptions = {
 	/**
 	 * Makes the locale URL-friendly by replacing underscores with dashes, and converting the locale to lower case.
+	 * @default true
 	 */
 	normalizeLocale?: boolean;
 	/**
-	 * An optional path to add after the `locale`
+	 * An optional path to add after the `locale`.
 	 */
 	path?: string;
 	/**
-	 *  An optional path to prepend to `locale`
+	 *  An optional path to prepend to `locale`.
 	 */
 	prependWith?: string;
 };
@@ -41,7 +42,7 @@ export function getLocaleRelativeUrl({
 	format,
 	path,
 	prependWith,
-	normalizeLocale = false,
+	normalizeLocale = true,
 }: GetLocaleRelativeUrl) {
 	if (!locales.includes(locale)) {
 		throw new AstroError({

--- a/packages/astro/test/units/i18n/astro_i18n.js
+++ b/packages/astro/test/units/i18n/astro_i18n.js
@@ -193,7 +193,7 @@ describe('getLocaleRelativeUrl', () => {
 		).to.eq('/blog/en');
 	});
 
-	it('should normalize locales', () => {
+	it('should normalize locales by default', () => {
 		/**
 		 *
 		 * @type {import("../../../dist/@types").AstroUserConfig}
@@ -216,7 +216,7 @@ describe('getLocaleRelativeUrl', () => {
 				trailingSlash: 'always',
 				format: 'directory',
 			})
-		).to.eq('/blog/en_US/');
+		).to.eq('/blog/en-us/');
 
 		expect(
 			getLocaleRelativeUrl({
@@ -225,9 +225,9 @@ describe('getLocaleRelativeUrl', () => {
 				locales: config.experimental.i18n.locales,
 				trailingSlash: 'always',
 				format: 'directory',
-				normalizeLocale: true,
+				normalizeLocale: false,
 			})
-		).to.eq('/blog/en-us/');
+		).to.eq('/blog/en_US/');
 
 		expect(
 			getLocaleRelativeUrl({
@@ -237,7 +237,7 @@ describe('getLocaleRelativeUrl', () => {
 				trailingSlash: 'always',
 				format: 'directory',
 			})
-		).to.eq('/blog/en_AU/');
+		).to.eq('/blog/en-au/');
 	});
 });
 


### PR DESCRIPTION
## Changes

From API bash session, we agreed that it makes sense to have the option `normalizePath` set to `true` as a default value because that's what users would want most of the times.

## Testing

Updated the tests 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Update the examples

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
