### PR TITLE
fix(i18n): redirect the index when `prefix-always` is enabled

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1430,7 +1430,7 @@ export interface AstroUserConfig {
 			 * export defualt defineConfig({
 			 * 	experimental: {
 			 * 		i18n: {
-			 * 			defuaultLocale: "en",
+			 * 			defaultLocale: "en",
 			 * 			locales: ["en", "fr", "pt", "es"],
 			 * 			fallback: {
 			 * 				pt: "es",

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -166,7 +166,7 @@ export class App {
 		);
 		let response;
 		try {
-			let i18nMiddleware = createI18nMiddleware(this.#manifest.i18n);
+			let i18nMiddleware = createI18nMiddleware(this.#manifest.i18n, this.#manifest.base);
 			if (i18nMiddleware) {
 				if (mod.onRequest) {
 					this.#pipeline.setMiddlewareFunction(

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -215,15 +215,6 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 			} else if (routeIsFallback(pageData.route)) {
 				const entry = await getEntryForFallbackRoute(pageData.route, internals, outFolder);
 				await generatePage(pageData, entry, builtPaths, pipeline);
-			} else if (routeIsFallback(pageData.route)) {
-				const entry = await getEntryForFallbackRoute(pageData.route, internals, outFolder);
-				await generatePage(pageData, entry, builtPaths, pipeline);
-			} else if (routeIsFallback(pageData.route)) {
-				const entry = await getEntryForFallbackRoute(pageData.route, internals, outFolder);
-				await generatePage(pageData, entry, builtPaths, pipeline);
-			} else if (routeIsFallback(pageData.route)) {
-				const entry = await getEntryForFallbackRoute(pageData.route, internals, outFolder);
-				await generatePage(pageData, entry, builtPaths, pipeline);
 			} else {
 				const ssrEntryURLPage = createEntryURL(filePath, outFolder);
 				const entry: SinglePageBuiltModule = await import(ssrEntryURLPage.toString());
@@ -285,7 +276,10 @@ async function generatePage(
 
 	const pageModulePromise = ssrEntry.page;
 	const onRequest = ssrEntry.onRequest;
-	const i18nMiddleware = createI18nMiddleware(pipeline.getManifest().i18n);
+	const i18nMiddleware = createI18nMiddleware(
+		pipeline.getManifest().i18n,
+		pipeline.getManifest().base
+	);
 	if (config.experimental.i18n && i18nMiddleware) {
 		if (onRequest) {
 			pipeline.setMiddlewareFunction(

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -277,7 +277,7 @@ export async function handleRoute({
 
 	const onRequest = middleware?.onRequest as MiddlewareEndpointHandler | undefined;
 	if (config.experimental.i18n) {
-		const i18Middleware = createI18nMiddleware(config.experimental.i18n);
+		const i18Middleware = createI18nMiddleware(config.experimental.i18n, config.base);
 
 		if (i18Middleware) {
 			if (onRequest) {

--- a/packages/astro/test/fixtures/i18n-routing-prefix-always/src/pages/en/index.astro
+++ b/packages/astro/test/fixtures/i18n-routing-prefix-always/src/pages/en/index.astro
@@ -1,0 +1,8 @@
+<html>
+<head>
+    <title>Astro</title>
+</head>
+<body>
+Hello
+</body>
+</html>

--- a/packages/astro/test/i18-routing.test.js
+++ b/packages/astro/test/i18-routing.test.js
@@ -175,18 +175,18 @@ describe('[DEV] i18n routing', () => {
 		before(async () => {
 			fixture = await loadFixture({
 				root: './fixtures/i18n-routing-prefix-always/',
-				experimental: {
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['en', 'pt', 'it'],
-					},
-				},
 			});
 			devServer = await fixture.startDevServer();
 		});
 
 		after(async () => {
 			await devServer.stop();
+		});
+
+		it('should redirect to the index of the default locale', async () => {
+			const response = await fixture.fetch('/new-site');
+			expect(response.status).to.equal(200);
+			expect(await response.text()).includes('Hello');
 		});
 
 		it('should not render the default locale without prefix', async () => {
@@ -475,6 +475,12 @@ describe('[SSG] i18n routing', () => {
 			await fixture.build();
 		});
 
+		it('should redirect to the index of the default locale', async () => {
+			const html = await fixture.readFile('/index.html');
+			expect(html).to.include('http-equiv="refresh');
+			expect(html).to.include('url=/new-site/en');
+		});
+
 		it('should render the en locale', async () => {
 			let html = await fixture.readFile('/en/start/index.html');
 			let $ = cheerio.load(html);
@@ -591,6 +597,13 @@ describe('[SSR] i18n routing', () => {
 			});
 			await fixture.build();
 			app = await fixture.loadTestAdapterApp();
+		});
+
+		it('should redirect to the index of the default locale', async () => {
+			let request = new Request('http://example.com/new-site');
+			let response = await app.render(request);
+			expect(response.status).to.equal(302);
+			expect(response.headers.get('location')).to.equal('/new-site/en');
 		});
 
 		it('should render the en locale', async () => {
@@ -722,6 +735,13 @@ describe('[SSR] i18n routing', () => {
 			app = await fixture.loadTestAdapterApp();
 		});
 
+		it('should redirect the index to the default locale', async () => {
+			let request = new Request('http://example.com/new-site');
+			let response = await app.render(request);
+			expect(response.status).to.equal(302);
+			expect(response.headers.get('location')).to.equal('/new-site/en');
+		});
+
 		it('should render the en locale', async () => {
 			let request = new Request('http://example.com/new-site/en/start');
 			let response = await app.render(request);
@@ -845,7 +865,6 @@ describe('[SSR] i18n routing', () => {
 			let response = await app.render(request);
 			const text = await response.text();
 			expect(response.status).to.equal(200);
-			console.log(text);
 			expect(text).includes('Locale: none');
 			expect(text).includes('Locale list: empty');
 		});


### PR DESCRIPTION
## Changes

From the API bash session, it emerged that when we have the routing strategy `prefix-always`, we should always redirect the root index `example.com` to `example.com/<defaultLocale>`.

Not doing this will result in the index having a 404, which is a bad practice. 

Relative change in the RFC: https://github.com/withastro/roadmap/pull/734/commits/26ed3c679c97e51a5bf6f6821fe7e4c921861b52

## Testing

All the existing tests should pass, plus I added new ones to cover the case. 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs



<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs Please review the change in the configuration description

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
