### PR TITLE
Deprecate `@astrojs/prefetch`

### DIFF
--- a/packages/integrations/prefetch/README.md
+++ b/packages/integrations/prefetch/README.md
@@ -1,5 +1,7 @@
 # @astrojs/prefetch 🔗
 
+> NOTE: `@astrojs/prefetch` is deprecated. Use the `prefetch` feature in Astro 3.5 instead. Check out the [migration guide](https://docs.astro.build/en/guides/prefetch/#migrating-from-astrojsprefetch).
+
 - <strong>[Why Prefetch?](#why-prefetch)</strong>
 - <strong>[Installation](#installation)</strong>
 - <strong>[Usage](#usage)</strong>


### PR DESCRIPTION
## Changes

This should be merged/coordinated after https://github.com/withastro/astro/pull/8951

---

Not now, but when it's time to deprecate, we should do this:

```
npm deprecate @astrojs/prefetch "Use the prefetch feature in Astro 3.5 instead"
```

## Testing

n/a

## Docs

Updated `@astrojs/prefetch` readme.
