### PR TITLE
Fix Lit integration hydration ordering

### DIFF
--- a/.changeset/spotty-rings-crash.md
+++ b/.changeset/spotty-rings-crash.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/lit': patch
+---
+
+Fix hydration ordering of nested custom elements. Child components will now wait for their parents to hydrate before hydrating themselves.

--- a/packages/integrations/lit/server.js
+++ b/packages/integrations/lit/server.js
@@ -62,7 +62,7 @@ function* render(Component, attrs, slots) {
 	const shadowContents = instance.renderShadow({
 		elementRenderers: [LitElementRenderer],
 		customElementInstanceStack: [instance],
-		customElementHostStack: [],
+		customElementHostStack: [instance],
 		deferHydration: false,
 	});
 	if (shadowContents !== undefined) {

--- a/packages/integrations/lit/test/server.test.js
+++ b/packages/integrations/lit/test/server.test.js
@@ -112,6 +112,9 @@ describe('renderToStaticMarkup', () => {
 		const render = await renderToStaticMarkup(tagName);
 		const $ = cheerio.load(render.html);
 		expect($(`${tagName} template`).text()).to.contain('child');
+		// Child component should have `defer-hydration` attribute so it'll only
+		// hydrate after the parent hydrates
+		expect($(childTagName).attr('defer-hydration')).to.equal('');
 	});
 
 	it('should render DSD attributes based on shadowRootOptions', async () => {


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/9017
- Hydration will now happen top to bottom with child custom elements getting `defer-hydration` attribute from Lit SSR

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added an extra assertion in nested component test that looks for `defer-hydration` attribute on the child element.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Bug fix only. No change in docs necessary.