### PR TITLE
fix(i18n): better filtering and search for preferred locales

### DIFF
--- a/packages/astro/src/core/render/context.ts
+++ b/packages/astro/src/core/render/context.ts
@@ -187,7 +187,7 @@ export function computePreferredLocale(request: Request, locales: string[]): str
 
 export function computePreferredLocaleList(request: Request, locales: string[]) {
 	const acceptHeader = request.headers.get('Accept-Language');
-	let result: string[] | undefined = undefined;
+	let result: string[] = [];
 	if (acceptHeader) {
 		const browserLocaleList = sortAndFilterLocales(parseLocale(acceptHeader), locales);
 
@@ -195,7 +195,6 @@ export function computePreferredLocaleList(request: Request, locales: string[]) 
 		if (browserLocaleList.length === 1 && browserLocaleList.at(0)!.locale === '*') {
 			return locales;
 		} else if (browserLocaleList.length > 0) {
-			result = [];
 			for (const browserLocale of browserLocaleList) {
 				const found = locales.find(
 					(l) => normalizeTheLocale(l) === normalizeTheLocale(browserLocale.locale)

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -55,10 +55,11 @@ export function getLocaleRelativeUrl({
 		});
 	}
 	const pathsToJoin = [base, prependWith];
+	const normalizedLocale = normalizeLocale ? normalizeTheLocale(locale) : locale;
 	if (routingStrategy === 'prefix-always') {
-		pathsToJoin.push(normalizeTheLocale(locale, normalizeLocale));
+		pathsToJoin.push(normalizedLocale);
 	} else if (locale !== defaultLocale) {
-		pathsToJoin.push(normalizeTheLocale(locale, normalizeLocale));
+		pathsToJoin.push(normalizedLocale);
 	}
 	pathsToJoin.push(path);
 
@@ -103,10 +104,12 @@ export function getLocaleRelativeUrlList({
 }: GetLocalesBaseUrl) {
 	return locales.map((locale) => {
 		const pathsToJoin = [base, prependWith];
+		const normalizedLocale = normalizeLocale ? normalizeTheLocale(locale) : locale;
+
 		if (routingStrategy === 'prefix-always') {
-			pathsToJoin.push(normalizeTheLocale(locale, normalizeLocale));
+			pathsToJoin.push(normalizedLocale);
 		} else if (locale !== defaultLocale) {
-			pathsToJoin.push(normalizeTheLocale(locale, normalizeLocale));
+			pathsToJoin.push(normalizedLocale);
 		}
 		pathsToJoin.push(path);
 		if (shouldAppendForwardSlash(trailingSlash, format)) {
@@ -134,9 +137,6 @@ export function getLocaleAbsoluteUrlList({ site, ...rest }: GetLocaleAbsoluteUrl
  * - replaces the `_` with a `-`;
  * - transforms all letters to be lower case;
  */
-function normalizeTheLocale(locale: string, shouldNormalize: boolean): string {
-	if (!shouldNormalize) {
-		return locale;
-	}
+export function normalizeTheLocale(locale: string): string {
 	return locale.replaceAll('_', '-').toLowerCase();
 }

--- a/packages/astro/test/fixtures/i18n-routing/src/pages/preferred-locale.astro
+++ b/packages/astro/test/fixtures/i18n-routing/src/pages/preferred-locale.astro
@@ -10,6 +10,6 @@ const localeList = Astro.preferredLocaleList;
 </head>
 <body>
 	Locale: {locale ? locale : "none"}
-	Locale list: {localeList?.length > 0 ? localeList.join(", ") : "empty"}
+	Locale list: {localeList.length > 0 ? localeList.join(", ") : "empty"}
 </body>
 </html>

--- a/packages/astro/test/fixtures/i18n-routing/src/pages/preferred-locale.astro
+++ b/packages/astro/test/fixtures/i18n-routing/src/pages/preferred-locale.astro
@@ -10,6 +10,6 @@ const localeList = Astro.preferredLocaleList;
 </head>
 <body>
 	Locale: {locale ? locale : "none"}
-	Locale list: {localeList.length > 0 ? localeList.join(", ") : "empty"}
+	Locale list: {localeList?.length > 0 ? localeList.join(", ") : "empty"}
 </body>
 </html>


### PR DESCRIPTION
## Changes

This PR fixes some edge cases that could happen when looking for the preferred locales.

Since this feature doesn't enforce a restriction on how the locales should be written, this could be a problem when reading the locales coming from the browser. This will become a problem with the four-letter locales, e.g. `pt_BR`.

The `Accept-Language` header has a value like this `pt-BR`, but a user **might** have their routes and folders like this: `src/pages/pt-br/index.astro` and `example.com/pt-br`.

This PR fixes this issue by:
- normalizing both sources: the locales coming from the browser and the locales coming from the configuration, it use the same function we use for the virtual module
- returning the locales of the configuration, and not the locale of the browser


## Testing

Added a new test case

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
 N/A