### PR TITLE
chore: Update docs for TS 5 presets

### DIFF
--- a/packages/astro/tsconfigs/base.json
+++ b/packages/astro/tsconfigs/base.json
@@ -4,7 +4,7 @@
     // Enable top-level await, and other modern ESM features.
     "target": "ESNext",
     "module": "ESNext",
-    // Enable node-style module resolution, for things like npm package imports.
+    // Enable module resolution without file extensions on relative paths, for things like npm package imports.
     "moduleResolution": "Bundler",
     // Allow importing TypeScript files using their native extension (.ts(x)).
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
## Changes

My change updates the comment for the `moduleResolution` setting as this setting has been changed in #7785

The current comment says it enables "node-style module resolution" but the resolution value got changed from `node` to `Bundler` and the [TypeScript's moduleResolution documentation](https://www.typescriptlang.org/tsconfig#moduleResolution) says that this change has a major difference which I think is worth being mentioned:

> unlike the Node.js resolution modes, `bundler` never requires file extensions on relative paths in imports

## Testing

It's only updating the comment, no behaviour change gets introduced.

## Docs

 /cc @withastro/maintainers-docs for feedback!
