### PR TITLE
fix(i18n): names of the functions should match the RFC

### DIFF
--- a/.changeset/rude-lizards-scream.md
+++ b/.changeset/rude-lizards-scream.md
@@ -36,12 +36,12 @@ Organize your content folders by locale depending on your `i18n.routingStrategy`
 │   │   │   ├── index.astro
 ```
 
-Compute relative URLs for your links with `getLocaleRelativeURL` from the new `astro:i18n` module:
+Compute relative URLs for your links with `getRelativeLocaleUrl` from the new `astro:i18n` module:
 
 ```astro
 ---
-import {getLocaleRelativeUrl} from "astro:i18n";
-const aboutUrl = getLocaleRelativeUrl("pt-br", "about");
+import {getRelativeLocaleUrl} from "astro:i18n";
+const aboutUrl = getRelativeLocaleUrl("pt-br", "about");
 ---
 <p>Learn more <a href={aboutURL}>About</a> this site!</p>
 ```

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -144,14 +144,14 @@ declare module 'astro:i18n' {
 	 * ## Examples
 	 *
 	 * ```js
-	 * import { getLocaleRelativeUrl } from "astro:i18n";
-	 * getLocaleRelativeUrl("es"); // /es
-	 * getLocaleRelativeUrl("es", "getting-started"); // /es/getting-started
-	 * getLocaleRelativeUrl("es_US", "getting-started", { prependWith: "blog" }); // /blog/es-us/getting-started
-	 * getLocaleRelativeUrl("es_US", "getting-started", { prependWith: "blog", normalizeLocale: false }); // /blog/es_US/getting-started
+	 * import { getRelativeLocaleUrl } from "astro:i18n";
+	 * getRelativeLocaleUrl("es"); // /es
+	 * getRelativeLocaleUrl("es", "getting-started"); // /es/getting-started
+	 * getRelativeLocaleUrl("es_US", "getting-started", { prependWith: "blog" }); // /blog/es-us/getting-started
+	 * getRelativeLocaleUrl("es_US", "getting-started", { prependWith: "blog", normalizeLocale: false }); // /blog/es_US/getting-started
 	 * ```
 	 */
-	export const getLocaleRelativeUrl: (
+	export const getRelativeLocaleUrl: (
 		locale: string,
 		path?: string,
 		options?: GetLocaleOptions
@@ -176,14 +176,14 @@ declare module 'astro:i18n' {
 	 * If `site` is `https://example.com`:
 	 *
 	 * ```js
-	 * import { getLocaleAbsoluteUrl } from "astro:i18n";
-	 * getLocaleAbsoluteUrl("es"); // https://example.com/es
-	 * getLocaleAbsoluteUrl("es", "getting-started"); // https://example.com/es/getting-started
-	 * getLocaleAbsoluteUrl("es_US", "getting-started", { prependWith: "blog" }); // https://example.com/blog/es-us/getting-started
-	 * getLocaleAbsoluteUrl("es_US", "getting-started", { prependWith: "blog", normalizeLocale: false }); // https://example.com/blog/es_US/getting-started
+	 * import { getAbsoluteLocaleUrl } from "astro:i18n";
+	 * getAbsoluteLocaleUrl("es"); // https://example.com/es
+	 * getAbsoluteLocaleUrl("es", "getting-started"); // https://example.com/es/getting-started
+	 * getAbsoluteLocaleUrl("es_US", "getting-started", { prependWith: "blog" }); // https://example.com/blog/es-us/getting-started
+	 * getAbsoluteLocaleUrl("es_US", "getting-started", { prependWith: "blog", normalizeLocale: false }); // https://example.com/blog/es_US/getting-started
 	 * ```
 	 */
-	export const getLocaleAbsoluteUrl: (
+	export const getAbsoluteLocaleUrl: (
 		locale: string,
 		path?: string,
 		options?: GetLocaleOptions
@@ -194,17 +194,17 @@ declare module 'astro:i18n' {
 	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string[]}
 	 *
-	 * Works like `getLocaleRelativeUrl` but it emits the relative URLs for ALL locales:
+	 * Works like `getRelativeLocaleUrl` but it emits the relative URLs for ALL locales:
 	 */
-	export const getLocaleRelativeUrlList: (path?: string, options?: GetLocaleOptions) => string[];
+	export const getRelativeLocaleUrlList: (path?: string, options?: GetLocaleOptions) => string[];
 	/**
 	 * @param {string} [path=""] An optional path to add after the `locale`.
 	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string[]}
 	 *
-	 * Works like `getLocaleAbsoluteUrl` but it emits the absolute URLs for ALL locales:
+	 * Works like `getAbsoluteLocaleUrl` but it emits the absolute URLs for ALL locales:
 	 */
-	export const getLocaleAbsoluteUrlList: (path?: string, options?: GetLocaleOptions) => string[];
+	export const getAbsoluteLocaleUrlList: (path?: string, options?: GetLocaleOptions) => string[];
 }
 
 declare module 'astro:middleware' {

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -36,7 +36,7 @@ export default function astroInternationalization({
 					const site = ${JSON.stringify(settings.config.site)};
 					const i18n = ${JSON.stringify(settings.config.experimental.i18n)};
 					
-					export const getLocaleRelativeUrl = (locale, path = "", opts) => _getLocaleRelativeUrl({ 
+					export const getRelativeLocaleUrl = (locale, path = "", opts) => _getLocaleRelativeUrl({ 
 						locale,
 						path, 
 						base, 
@@ -45,7 +45,7 @@ export default function astroInternationalization({
 						...i18n,
 						...opts 
 					});
-					export const getLocaleAbsoluteUrl = (locale, path = "", opts) => _getLocaleAbsoluteUrl({ 
+					export const getAbsoluteLocaleUrl = (locale, path = "", opts) => _getLocaleAbsoluteUrl({ 
 						locale, 
 						path, 
 						base, 
@@ -56,9 +56,9 @@ export default function astroInternationalization({
 						...opts 
 					});
 					
-					export const getLocaleRelativeUrlList = (path = "", opts) => _getLocaleRelativeUrlList({ 
+					export const getRelativeLocaleUrlList = (path = "", opts) => _getLocaleRelativeUrlList({ 
 						base, path, trailingSlash, format, ...i18n, ...opts });
-					export const getLocaleAbsoluteUrlList = (path = "", opts) => _getLocaleAbsoluteUrlList({ base, path, trailingSlash, format, site, ...i18n, ...opts });
+					export const getAbsoluteLocaleUrlList = (path = "", opts) => _getLocaleAbsoluteUrlList({ base, path, trailingSlash, format, site, ...i18n, ...opts });
 				`;
 			}
 		},

--- a/packages/astro/test/fixtures/i18n-routing/src/pages/virtual-module.astro
+++ b/packages/astro/test/fixtures/i18n-routing/src/pages/virtual-module.astro
@@ -1,0 +1,17 @@
+---
+import { getRelativeLocaleUrl } from "astro:i18n";
+
+let about = getRelativeLocaleUrl("pt", "about");
+
+---
+
+<html>
+<head>
+    <title>Astro</title>
+</head>
+    <body>
+        Virtual module doesn't break
+    
+        About: {about}
+    </body>
+</html>

--- a/packages/astro/test/i18-routing.test.js
+++ b/packages/astro/test/i18-routing.test.js
@@ -3,6 +3,31 @@ import { expect } from 'chai';
 import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
 
+describe('astro:i18n virtual module', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	/** @type {import('./test-utils').DevServer} */
+	let devServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/i18n-routing/',
+		});
+		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer.stop();
+	});
+
+	it('correctly imports the functions', async () => {
+		const response = await fixture.fetch('/virtual-module');
+		expect(response.status).to.equal(200);
+		const text = await response.text();
+		expect(text).includes("Virtual module doesn't break");
+		expect(text).includes('About: /pt/about');
+	});
+});
 describe('[DEV] i18n routing', () => {
 	describe('i18n routing', () => {
 		/** @type {import('./test-utils').Fixture} */


### PR DESCRIPTION
## Changes

This PR fixes the names of the functions exported by the virtual module `astro:i18n`.

The [RFC](https://github.com/withastro/roadmap/blob/i18n-routing/proposals/0041-i18n-routing.md#getrelativelocaleurllocale-string-path-string-options-options-string) and Docs are correct, although the names exported by Astro incorrect.

This PR aligns their names with the ones of the RFC.

## Testing

I added a new test to make sure it works

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

Changeset not needed

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
