### PR TITLE
Update README.md Web Analytics section.

### DIFF
--- a/packages/integrations/vercel/README.md
+++ b/packages/integrations/vercel/README.md
@@ -91,7 +91,7 @@ To configure this adapter, pass an object to the `vercel()` function call in `as
 **Available for:** Serverless, Edge, Static<br>
 **Added in:** `@astrojs/vercel@3.8.0`
 
-You can enable [Vercel Web Analytics](https://vercel.com/docs/concepts/analytics) by setting `webAnalytics: { enabled: true }`. This will inject Vercel’s tracking scripts into all of your pages.
+You can enable [Vercel Web Analytics](https://vercel.com/docs/concepts/analytics) by setting `analytics: true`. This will inject Vercel’s tracking scripts into all of your pages.
 
 ```js
 // astro.config.mjs
@@ -101,9 +101,7 @@ import vercel from '@astrojs/vercel/serverless';
 export default defineConfig({
   output: 'server',
   adapter: vercel({
-    webAnalytics: {
-      enabled: true,
-    },
+   analytics: true,
   }),
 });
 ```


### PR DESCRIPTION
Updated the Vercel adapter web analytics integration to ``` analytics: true ``` instead of ``` webAnalytics: { enabled:: true } ``` which seems to be deprecated.

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
