### PR TITLE
fix: added onError functionality to spinner 

### DIFF
--- a/.changeset/silent-experts-sip.md
+++ b/.changeset/silent-experts-sip.md
@@ -1,0 +1,5 @@
+---
+'create-astro': major
+---
+
+Fixed spinner to handle errors if install dependencies fails

--- a/.changeset/silent-experts-sip.md
+++ b/.changeset/silent-experts-sip.md
@@ -2,4 +2,4 @@
 'create-astro': major
 ---
 
-Fixed spinner to handle errors if install dependencies fails
+Fixes an issue where a successful "Dependencies installed" message is displayed even when installing dependencies fails.

--- a/.changeset/silent-experts-sip.md
+++ b/.changeset/silent-experts-sip.md
@@ -1,5 +1,5 @@
 ---
-'create-astro': major
+'create-astro': patch
 ---
 
 Fixes an issue where a successful "Dependencies installed" message is displayed even when installing dependencies fails.

--- a/packages/create-astro/package.json
+++ b/packages/create-astro/package.json
@@ -31,7 +31,7 @@
   "//a": "MOST PACKAGES SHOULD GO IN DEV_DEPENDENCIES! THEY WILL BE BUNDLED.",
   "//b": "DEPENDENCIES IS FOR UNBUNDLED PACKAGES",
   "dependencies": {
-    "@astrojs/cli-kit": "^0.3.0",
+    "@astrojs/cli-kit": "^0.3.1",
     "giget": "1.1.2"
   },
   "devDependencies": {

--- a/packages/create-astro/src/actions/dependencies.ts
+++ b/packages/create-astro/src/actions/dependencies.ts
@@ -36,9 +36,7 @@ export async function dependencies(
 					)} to install them manually after setup.`
 				);
 			},
-			while: () => {
-				return install({ packageManager: ctx.packageManager, cwd: ctx.cwd }).catch((e) => { throw e });
-			},
+			while: () => install({ packageManager: ctx.packageManager, cwd: ctx.cwd }),
 		});
 	} else {
 		await info(

--- a/packages/create-astro/src/actions/dependencies.ts
+++ b/packages/create-astro/src/actions/dependencies.ts
@@ -27,16 +27,17 @@ export async function dependencies(
 		await spinner({
 			start: `Installing dependencies with ${ctx.packageManager}...`,
 			end: 'Dependencies installed',
+			onError: (e) => {
+				error('error', e);
+				error(
+					'error',
+					`Dependencies failed to install, please run ${color.bold(
+						ctx.packageManager + ' install'
+					)} to install them manually after setup.`
+				);
+			},
 			while: () => {
-				return install({ packageManager: ctx.packageManager, cwd: ctx.cwd }).catch((e) => {
-					error('error', e);
-					error(
-						'error',
-						`Dependencies failed to install, please run ${color.bold(
-							ctx.packageManager + ' install'
-						)}  to install them manually after setup.`
-					);
-				});
+				return install({ packageManager: ctx.packageManager, cwd: ctx.cwd }).catch((e) => { throw e });
 			},
 		});
 	} else {

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -31,6 +31,7 @@ export async function say(messages: string | string[], { clear = false, hat = ''
 export async function spinner(args: {
 	start: string;
 	end: string;
+	onError?: (error: any) => void;
 	while: (...args: any) => Promise<any>;
 }) {
 	await load(args, { stdout });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3634,8 +3634,8 @@ importers:
   packages/create-astro:
     dependencies:
       '@astrojs/cli-kit':
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.3.1
+        version: 0.3.1
       giget:
         specifier: 1.1.2
         version: 1.1.2
@@ -5070,8 +5070,8 @@ packages:
       - prettier-plugin-astro
     dev: true
 
-  /@astrojs/cli-kit@0.3.0:
-    resolution: {integrity: sha512-nil0Kz2xuzR3xQX+FVHg2W8g+FvbeUeoCeU53duQjAFuHRJrbqWRmgfjYeM6f2780dsSuGiYMXmY+IaJqaqiaw==}
+  /@astrojs/cli-kit@0.3.1:
+    resolution: {integrity: sha512-BEzf3gudr4XrrrInJKD+GSS5O+GXRTukLUpOfgqdTSq6d48EWVhigNHobmlQGbpa9FEAw+sZmvmHmhS29QhnwA==}
     engines: {node: '>=18.14.1'}
     dependencies:
       chalk: 5.3.0


### PR DESCRIPTION
This PR is a fixed version of the closed by mistake PR: https://github.com/withastro/astro/pull/8993

@ematipico - sorry, made an error and have to reopen new PR

## Changes

Added onError function to handle errors inside spinner if while function throws an errors.

new onError property inside dependencies.ts spinner
while function catches and throws an error if installing dependencies fails
messages.ts/spinner accept new args

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

Manual testing.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

This PR does not require changes in docs.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
