### PR TITLE
Allow same-page navigations on form posts

### DIFF
--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -89,7 +89,8 @@ const { fallback = 'animate', handleForms } = Astro.props;
 
 				const form = el as HTMLFormElement;
 				const formData = new FormData(form);
-				let action = form.action;
+				// Use the form action, if defined, otherwise fallback to current path.
+				let action = form.action ?? location.pathname;
 				const options: Options = {};
 				if (form.method === 'get') {
 					const params = new URLSearchParams(formData as any);

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/form-two.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/form-two.astro
@@ -1,0 +1,17 @@
+---
+import Layout from '../components/Layout.astro';
+
+if(Astro.request.method === 'POST') {
+	const formData = await Astro.request.formData();
+	const name = formData.get('name');
+	return Astro.redirect(`/form-response?name=${name}`);
+}
+---
+<Layout>
+	<h2>Contact Form</h2>
+	<h3>This form does not have an `action` defined</h3>
+	<form method="post">
+		<input type="hidden" name="name" value="Testing">
+		<input type="submit" value="Submit" id="submit">
+	</form>
+</Layout>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -982,4 +982,26 @@ test.describe('View Transitions', () => {
 		]);
 		expect(reqUrls).toContainEqual('/one');
 	});
+
+	test('form POST with no action handler', async ({ page, astro }) => {
+		const loads = [];
+		page.addListener('load', async (p) => {
+			loads.push(p);
+		});
+
+		await page.goto(astro.resolveUrl('/form-two'));
+
+		let locator = page.locator('h2');
+		await expect(locator, 'should have content').toHaveText('Contact Form');
+
+		// Submit the form
+		await page.click('#submit');
+		const span = page.locator('#contact-name');
+		await expect(span, 'should have content').toHaveText('Testing');
+
+		expect(
+			loads.length,
+			'There should be only 1 page load. No additional loads for the form submission'
+		).toEqual(1);
+	});
 });

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -465,7 +465,7 @@ export function navigate(href: string, options?: Options) {
 	// We do not have page transitions on navigations to the same page (intra-page navigation)
 	// but we want to handle prevent reload on navigation to the same page
 	// Same page means same origin, path and query params (but maybe different hash)
-	if (location.origin === toLocation.origin && samePage(toLocation)) {
+	if (location.origin === toLocation.origin && samePage(toLocation) && !options?.formData) {
 		moveToLocation(toLocation, options?.history === 'replace', true);
 	} else {
 		// different origin will be detected by fetch

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -463,6 +463,7 @@ export function navigate(href: string, options?: Options) {
 	}
 	const toLocation = new URL(href, location.href);
 	// We do not have page transitions on navigations to the same page (intra-page navigation)
+	// *unless* they are form posts which have side-effects and so need to happen
 	// but we want to handle prevent reload on navigation to the same page
 	// Same page means same origin, path and query params (but maybe different hash)
 	if (location.origin === toLocation.origin && samePage(toLocation) && !options?.formData) {


### PR DESCRIPTION
## Changes

- Normally when the user navigates to the same page we do not trigger a fetch + navigation, instead we just navigate to the hash (if there is one).
- This should not be the case for form posts, which have side-effects that need to occur.
- This also makes it possible to omit the `action`.

## Testing

- New test added

## Docs

N/A, bug fix