### PR TITLE
fix(logger): namespace label in debug logger

### DIFF
--- a/.changeset/dirty-zoos-fail.md
+++ b/.changeset/dirty-zoos-fail.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix namespace label in debug logger

--- a/.changeset/dirty-zoos-fail.md
+++ b/.changeset/dirty-zoos-fail.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fix display of debug messages when using the `--verbose` flag
+Fixes display of debug messages when using the `--verbose` flag

--- a/.changeset/dirty-zoos-fail.md
+++ b/.changeset/dirty-zoos-fail.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fix namespace label in debug logger
+Fix display of debug messages when using the `--verbose` flag

--- a/packages/astro/src/core/logger/core.ts
+++ b/packages/astro/src/core/logger/core.ts
@@ -142,8 +142,8 @@ export class Logger {
 	error(label: string | null, message: string) {
 		error(this.options, label, message);
 	}
-	debug(label: string | null, message: string, ...args: any[]) {
-		debug(this.options, label, message, args);
+	debug(label: string | null, ...messages: any[]) {
+		debug(label, ...messages);
 	}
 
 	level() {
@@ -181,6 +181,6 @@ export class AstroIntegrationLogger {
 		error(this.options, this.label, message);
 	}
 	debug(message: string) {
-		debug(this.options, this.label, message);
+		debug(this.label, message);
 	}
 }


### PR DESCRIPTION
## Changes

- Fixes #9060 
- `this.options` argument is not needed in `debug` function (see below). Passing it as a first argument causes `[object Object]` in the namespace label as described in the issue
- https://github.com/withastro/astro/blob/13ca6d989b91c4575517495647fc10ba8306cf88/packages/astro/src/core/logger/node.ts#L110-L114

## Testing

Tested via `pnpm --filter @example/minimal run build --verbose`

## Docs

\-
