### PR TITLE
Fix asset propagation regression in 3.5

### DIFF
--- a/.changeset/quick-parrots-judge.md
+++ b/.changeset/quick-parrots-judge.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix a regression introduced in 3.5.0 related to content collection styles

--- a/packages/astro/src/content/vite-plugin-content-assets.ts
+++ b/packages/astro/src/content/vite-plugin-content-assets.ts
@@ -169,7 +169,7 @@ export function astroConfigBuildPlugin(
 										const pageData = getPageDataByViteID(internals, pageViteID);
 										if (!pageData) continue;
 
-										const _entryCss = internals.propagatedStylesMap?.get(id);
+										const _entryCss = pageData.propagatedStyles?.get(id);
 										const _entryScripts = pageData.propagatedScripts?.get(id);
 										if (_entryCss) {
 											for (const value of _entryCss) {

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -76,7 +76,7 @@ export function astroContentVirtualModPlugin({
 							hydratedComponents: [],
 							clientOnlyComponents: [],
 							scripts: [],
-							containsHead: true,
+							containsHead: false,
 							propagation: 'in-tree',
 							pageOptions: {},
 						},

--- a/packages/astro/src/core/build/plugins/plugin-css.ts
+++ b/packages/astro/src/core/build/plugins/plugin-css.ts
@@ -59,6 +59,8 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 	const pagesToCss: Record<string, Record<string, { order: number; depth: number }>> = {};
 	const pagesToPropagatedCss: Record<string, Record<string, Set<string>>> = {};
 
+	const isContentCollectionCache = options.buildOptions.settings.config.output === 'static' && options.buildOptions.settings.config.experimental.contentCollectionCache;
+
 	const cssBuildPlugin: VitePlugin = {
 		name: 'astro:rollup-plugin-build-css',
 
@@ -93,10 +95,7 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 								// so they can be injected where needed
 								const chunkId = assetName.createNameHash(id, [id]);
 								internals.cssModuleToChunkIdMap.set(id, chunkId);
-								if (
-									options.buildOptions.settings.config.output === 'static' &&
-									options.buildOptions.settings.config.experimental.contentCollectionCache
-								) {
+								if (isContentCollectionCache) {
 									// TODO: Handle inlining?
 									const propagatedStyles =
 										internals.propagatedStylesMap.get(pageInfo.id) ?? new Set();
@@ -251,9 +250,16 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 						// return early if the stylesheet needing propagation has already been included
 						if (pageData.styles.some((s) => s.sheet === sheet)) return;
 
-						const propagatedStyles =
-							internals.propagatedStylesMap.get(pageInfoId) ??
-							internals.propagatedStylesMap.set(pageInfoId, new Set()).get(pageInfoId)!;
+						let propagatedStyles: Set<StylesheetAsset>;
+						if (isContentCollectionCache) {
+							propagatedStyles =
+								internals.propagatedStylesMap.get(pageInfoId) ??
+								internals.propagatedStylesMap.set(pageInfoId, new Set()).get(pageInfoId)!;
+						} else {
+							propagatedStyles =
+								pageData.propagatedStyles.get(pageInfoId) ??
+								pageData.propagatedStyles.set(pageInfoId, new Set()).get(pageInfoId)!;
+						}
 
 						propagatedStyles.add(sheet);
 						sheetAddedToPage = true;

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -95,6 +95,14 @@ describe('Content Collections', () => {
 			});
 		});
 
+		describe('Propagation', () => {
+			it('Applies styles', async () => {
+				const html = await fixture.readFile('/propagation/index.html');
+				const $ = cheerio.load(html);
+				expect($('style').text()).to.include('content:"works!"');
+			});
+		})
+
 		describe('Entry', () => {
 			let json;
 			before(async () => {

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -1010,7 +1010,7 @@ describe('astro:image', () => {
 			await fixture.build();
 		});
 
-		it('dynamic route images are built at response time sss', async () => {
+		it('dynamic route images are built at response time', async () => {
 			const app = await fixture.loadTestAdapterApp();
 			let request = new Request('http://example.com/');
 			let response = await app.render(request);

--- a/packages/astro/test/fixtures/content-collections/src/pages/propagation.astro
+++ b/packages/astro/test/fixtures/content-collections/src/pages/propagation.astro
@@ -1,0 +1,22 @@
+---
+import { getCollection } from "astro:content";
+const posts = await getCollection("with-schema-config");
+---
+
+<html>
+	<body>
+		<div class="foo">
+			<div>Hello World</div>
+			<span>Styles?</span>
+		</div>
+	</body>
+</html>
+
+<style>
+	.foo {
+		background-color: blue;
+	}
+	span::after {
+		content: "works!";
+	}
+</style>


### PR DESCRIPTION
## Changes

- Resolves PLT-1196
- Closes #9066
- Fixes regression in 3.5.x with asset propagation in content collections
- Had to update a few changes made in #8854 to ensure behavior is properly behind a flag

## Testing

Added a regression test

## Docs

Bug fix only