### PR TITLE
fix(assets): Only use src to hash files generated by the passthrough service

### DIFF
--- a/.changeset/famous-hats-teach.md
+++ b/.changeset/famous-hats-teach.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix Passthrough image service generating multiple images with the same content in certain cases

--- a/packages/astro/src/assets/services/noop.ts
+++ b/packages/astro/src/assets/services/noop.ts
@@ -2,6 +2,7 @@ import { baseService, type LocalImageService } from './service.js';
 
 // Empty service used for platforms that neither support Squoosh or Sharp.
 const noopService: LocalImageService = {
+	propertiesToHash: ['src'],
 	validateOptions: baseService.validateOptions,
 	getURL: baseService.getURL,
 	parseURL: baseService.parseURL,


### PR DESCRIPTION
## Changes

Only uses the `src` to hash images on the passthrough service, that way attributes don't cause multiple files to be generated.

Fix https://github.com/withastro/astro/issues/9002

## Testing

We have tests that are testing this hook of the image service API

## Docs

N/A
