### PR TITLE
feat(node): add trailingSlash support

### DIFF
--- a/.changeset/calm-jobs-pay.md
+++ b/.changeset/calm-jobs-pay.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': minor
+---
+
+Add trailingSlash support to NodeJS adapter

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -37,6 +37,7 @@ export function createStaticHandler(app: NodeApp, options: Options) {
 						pathname = urlPath.slice(0, -1) + (urlQuery ? "?" + urlQuery : "");
 						res.statusCode = 301;
 						res.setHeader('Location', pathname);
+						return res.end();
 					} else pathname = urlPath;
 					// intentionally fall through
 				case "ignore":
@@ -52,15 +53,12 @@ export function createStaticHandler(app: NodeApp, options: Options) {
 						pathname = urlPath + '/' +(urlQuery ? "?" + urlQuery : "");
 						res.statusCode = 301;
 						res.setHeader('Location', pathname);
+						return res.end();
 					} else
 						pathname = urlPath;
 				break;
 			}
 			pathname = app.removeBase(pathname);
-
-			if (urlQuery && !pathname.includes('?')) {
-				pathname = pathname + '?' + urlQuery;
-			}
 
 			const stream = send(req, pathname, {
 				root: client,

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -58,7 +58,8 @@ export function createStaticHandler(app: NodeApp, options: Options) {
 						pathname = urlPath;
 				break;
 			}
-			pathname = app.removeBase(pathname);
+			// app.removeBase sometimes returns a path without a leading slash
+			pathname = prependForwardSlash(app.removeBase(pathname));
 
 			const stream = send(req, pathname, {
 				root: client,
@@ -104,6 +105,10 @@ function resolveClientDir(options: Options) {
 	const clientURL = new URL(appendForwardSlash(rel), serverEntryURL);
 	const client = url.fileURLToPath(clientURL);
 	return client;
+}
+
+function prependForwardSlash(pth: string) {
+	return pth.startsWith('/') ? pth : '/' + pth;
 }
 
 function appendForwardSlash(pth: string) {

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -33,7 +33,7 @@ export function createStaticHandler(app: NodeApp, options: Options) {
 			const hasSlash = urlPath.endsWith('/');
 			switch (trailingSlash) {
 				case "never":
-					if (isDirectory && hasSlash) {
+					if (isDirectory && (urlPath != '/') && hasSlash) {
 						pathname = urlPath.slice(0, -1) + (urlQuery ? "?" + urlQuery : "");
 						res.statusCode = 301;
 						res.setHeader('Location', pathname);

--- a/packages/integrations/node/src/server.ts
+++ b/packages/integrations/node/src/server.ts
@@ -8,6 +8,7 @@ import type { Options } from './types.js';
 applyPolyfills();
 export function createExports(manifest: SSRManifest, options: Options) {
 	const app = new NodeApp(manifest);
+	options.trailingSlash = manifest.trailingSlash;
 	return {
 		options: options,
 		handler:

--- a/packages/integrations/node/src/types.ts
+++ b/packages/integrations/node/src/types.ts
@@ -1,5 +1,6 @@
 import type { NodeApp } from 'astro/app/node';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { SSRManifest } from 'astro';
 
 export interface UserOptions {
 	/**
@@ -17,6 +18,7 @@ export interface Options extends UserOptions {
 	server: string;
 	client: string;
 	assets: string;
+	trailingSlash?: SSRManifest['trailingSlash'];
 }
 
 export interface CreateServerOptions {

--- a/packages/integrations/node/test/fixtures/trailing-slash/astro.config.mjs
+++ b/packages/integrations/node/test/fixtures/trailing-slash/astro.config.mjs
@@ -1,0 +1,8 @@
+import node from '@astrojs/node'
+
+export default {
+    base: '/some-base',
+    output: 'hybrid',
+    trailingSlash: 'never',
+    adapter: node({ mode: 'standalone' })
+};

--- a/packages/integrations/node/test/fixtures/trailing-slash/package.json
+++ b/packages/integrations/node/test/fixtures/trailing-slash/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/node-trailingslash",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/node": "workspace:*"
+  }
+}

--- a/packages/integrations/node/test/fixtures/trailing-slash/src/pages/index.astro
+++ b/packages/integrations/node/test/fixtures/trailing-slash/src/pages/index.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>Index</title>
+	</head>
+	<body>
+		<h1>Index</h1>
+	</body>
+</html>

--- a/packages/integrations/node/test/fixtures/trailing-slash/src/pages/one.astro
+++ b/packages/integrations/node/test/fixtures/trailing-slash/src/pages/one.astro
@@ -1,0 +1,11 @@
+---
+export const prerender = true;
+---
+<html>
+	<head>
+		<title>One</title>
+	</head>
+	<body>
+		<h1>One</h1>
+	</body>
+</html>

--- a/packages/integrations/node/test/prerender.test.js
+++ b/packages/integrations/node/test/prerender.test.js
@@ -74,12 +74,14 @@ describe('Prerendering', () => {
 			expect($('h1').text()).to.equal('Two');
 		});
 
-		it('Omitting the trailing slash results in a redirect that includes the base', async () => {
+		it('Can render prerendered route without trailing slash', async () => {
 			const res = await fetch(`http://${server.host}:${server.port}/some-base/two`, {
 				redirect: 'manual',
 			});
-			expect(res.status).to.equal(301);
-			expect(res.headers.get('location')).to.equal('/some-base/two/');
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			expect(res.status).to.equal(200);
+			expect($('h1').text()).to.equal('Two');
 		});
 	});
 
@@ -203,12 +205,14 @@ describe('Hybrid rendering', () => {
 			expect($('h1').text()).to.equal('One');
 		});
 
-		it('Omitting the trailing slash results in a redirect that includes the base', async () => {
+		it('Can render prerendered route without trailing slash', async () => {
 			const res = await fetch(`http://${server.host}:${server.port}/some-base/one`, {
 				redirect: 'manual',
 			});
-			expect(res.status).to.equal(301);
-			expect(res.headers.get('location')).to.equal('/some-base/one/');
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			expect(res.status).to.equal(200);
+			expect($('h1').text()).to.equal('One');
 		});
 	});
 

--- a/packages/integrations/node/test/trailing-slash.js
+++ b/packages/integrations/node/test/trailing-slash.js
@@ -41,6 +41,15 @@ describe('Trailing slash', () => {
 				delete process.env.PRERENDER;
 			});
 
+			it('Can render prerendered base route', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}`);
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('Index');
+			});
+
 			it('Can render prerendered route with redirect', async () => {
 				const res = await fetch(`http://${server.host}:${server.port}/some-base/one`, {
 					redirect : 'manual'
@@ -87,6 +96,15 @@ describe('Trailing slash', () => {
 				await server.stop();
 				await fixture.clean();
 				delete process.env.PRERENDER;
+			});
+
+			it('Can render prerendered base route', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}`);
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('Index');
 			});
 
 			it('Can render prerendered route with redirect', async () => {
@@ -140,6 +158,15 @@ describe('Trailing slash', () => {
 				delete process.env.PRERENDER;
 			});
 
+			it('Can render prerendered base route', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}`);
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('Index');
+			});
+
 			it('Can render prerendered route with redirect', async () => {
 				const res = await fetch(`http://${server.host}:${server.port}/some-base/one/`, {
 					redirect : 'manual'
@@ -187,6 +214,15 @@ describe('Trailing slash', () => {
 				await server.stop();
 				await fixture.clean();
 				delete process.env.PRERENDER;
+			});
+
+			it('Can render prerendered base route', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}`);
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('Index');
 			});
 
 			it('Can render prerendered route with redirect', async () => {
@@ -239,6 +275,15 @@ describe('Trailing slash', () => {
 				await server.stop();
 				await fixture.clean();
 				delete process.env.PRERENDER;
+			});
+
+			it('Can render prerendered base route', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}`);
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('Index');
 			});
 
 			it('Can render prerendered route with slash', async () => {
@@ -306,6 +351,15 @@ describe('Trailing slash', () => {
 				await server.stop();
 				await fixture.clean();
 				delete process.env.PRERENDER;
+			});
+
+			it('Can render prerendered base route', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}`);
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('Index');
 			});
 
 			it('Can render prerendered route with slash', async () => {

--- a/packages/integrations/node/test/trailing-slash.js
+++ b/packages/integrations/node/test/trailing-slash.js
@@ -1,0 +1,351 @@
+import nodejs from '../dist/index.js';
+import { loadFixture } from './test-utils.js';
+import { expect } from 'chai';
+import * as cheerio from 'cheerio';
+
+/**
+ * @typedef {import('../../../astro/test/test-utils').Fixture} Fixture
+ */
+
+async function load() {
+	const mod = await import(`./fixtures/trailing-slash/dist/server/entry.mjs?dropcache=${Date.now()}`);
+	return mod;
+}
+
+describe('Trailing slash', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	let server;
+	describe('Always', async () => {
+		describe('With base', async () => {
+			before(async () => {
+				process.env.ASTRO_NODE_AUTOSTART = 'disabled';
+				process.env.PRERENDER = true;
+
+				fixture = await loadFixture({
+					root: './fixtures/trailing-slash/',
+					base: '/some-base',
+					output: 'hybrid',
+					trailingSlash: 'always',
+					adapter: nodejs({ mode: 'standalone' }),
+				});
+				await fixture.build();
+				const { startServer } = await load();
+				let res = startServer();
+				server = res.server;
+			});
+
+			after(async () => {
+				await server.stop();
+				await fixture.clean();
+				delete process.env.PRERENDER;
+			});
+
+			it('Can render prerendered route with redirect', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/some-base/one`, {
+					redirect : 'manual'
+				});
+				expect(res.status).to.equal(301);
+				expect(res.headers.get('location')).to.equal('/some-base/one/');
+			});
+
+			it('Can render prerendered route with redirect and query params', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/some-base/one?foo=bar`, {
+					redirect : 'manual'
+				});
+				expect(res.status).to.equal(301);
+				expect(res.headers.get('location')).to.equal('/some-base/one/?foo=bar');
+			});
+
+			it('Can render prerendered route with query params', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/some-base/one/?foo=bar`);
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('One');
+			});
+		});
+		describe('Without base', async () => {
+			before(async () => {
+				process.env.ASTRO_NODE_AUTOSTART = 'disabled';
+				process.env.PRERENDER = true;
+
+				fixture = await loadFixture({
+					root: './fixtures/trailing-slash/',
+					output: 'hybrid',
+					trailingSlash: 'always',
+					adapter: nodejs({ mode: 'standalone' }),
+				});
+				await fixture.build();
+				const { startServer } = await load();
+				let res = startServer();
+				server = res.server;
+			});
+
+			after(async () => {
+				await server.stop();
+				await fixture.clean();
+				delete process.env.PRERENDER;
+			});
+
+			it('Can render prerendered route with redirect', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/one`, {
+					redirect : 'manual'
+				});
+				expect(res.status).to.equal(301);
+				expect(res.headers.get('location')).to.equal('/one/');
+			});
+
+			it('Can render prerendered route with redirect and query params', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/one?foo=bar`, {
+					redirect : 'manual'
+				});
+				expect(res.status).to.equal(301);
+				expect(res.headers.get('location')).to.equal('/one/?foo=bar');
+			});
+
+			it('Can render prerendered route with query params', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/one/?foo=bar`);
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('One');
+			});
+		});
+	});
+	describe('Never', async () => {
+		describe('With base', async () => {
+			before(async () => {
+				process.env.ASTRO_NODE_AUTOSTART = 'disabled';
+				process.env.PRERENDER = true;
+
+				fixture = await loadFixture({
+					root: './fixtures/trailing-slash/',
+					base: '/some-base',
+					output: 'hybrid',
+					trailingSlash: 'never',
+					adapter: nodejs({ mode: 'standalone' }),
+				});
+				await fixture.build();
+				const { startServer } = await load();
+				let res = startServer();
+				server = res.server;
+			});
+
+			after(async () => {
+				await server.stop();
+				await fixture.clean();
+				delete process.env.PRERENDER;
+			});
+
+			it('Can render prerendered route with redirect', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/some-base/one/`, {
+					redirect : 'manual'
+				});
+				expect(res.status).to.equal(301);
+				expect(res.headers.get('location')).to.equal('/some-base/one');
+			});
+
+			it('Can render prerendered route with redirect and query params', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/some-base/one/?foo=bar`, {
+					redirect : 'manual'
+				});
+
+				expect(res.status).to.equal(301);
+				expect(res.headers.get('location')).to.equal('/some-base/one?foo=bar');
+			});
+
+			it('Can render prerendered route with query params', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/some-base/one?foo=bar`);
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('One');
+			});
+		});
+		describe('Without base', async () => {
+			before(async () => {
+				process.env.ASTRO_NODE_AUTOSTART = 'disabled';
+				process.env.PRERENDER = true;
+
+				fixture = await loadFixture({
+					root: './fixtures/trailing-slash/',
+					output: 'hybrid',
+					trailingSlash: 'never',
+					adapter: nodejs({ mode: 'standalone' }),
+				});
+				await fixture.build();
+				const { startServer } = await load();
+				let res = startServer();
+				server = res.server;
+			});
+
+			after(async () => {
+				await server.stop();
+				await fixture.clean();
+				delete process.env.PRERENDER;
+			});
+
+			it('Can render prerendered route with redirect', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/one/`, {
+					redirect : 'manual'
+				});
+				expect(res.status).to.equal(301);
+				expect(res.headers.get('location')).to.equal('/one');
+			});
+
+			it('Can render prerendered route with redirect and query params', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/one/?foo=bar`, {
+					redirect : 'manual'
+				});
+
+				expect(res.status).to.equal(301);
+				expect(res.headers.get('location')).to.equal('/one?foo=bar');
+			});
+
+			it('Can render prerendered route and query params', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/one?foo=bar`);
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('One');
+			});
+		});
+	});
+	describe('Ignore', async () => {
+		describe('With base', async () => {
+			before(async () => {
+				process.env.ASTRO_NODE_AUTOSTART = 'disabled';
+				process.env.PRERENDER = true;
+
+				fixture = await loadFixture({
+					root: './fixtures/trailing-slash/',
+					base: '/some-base',
+					output: 'hybrid',
+					trailingSlash: 'ignore',
+					adapter: nodejs({ mode: 'standalone' }),
+				});
+				await fixture.build();
+				const { startServer } = await load();
+				let res = startServer();
+				server = res.server;
+			});
+
+			after(async () => {
+				await server.stop();
+				await fixture.clean();
+				delete process.env.PRERENDER;
+			});
+
+			it('Can render prerendered route with slash', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/some-base/one/`, {
+					redirect : 'manual'
+				});
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('One');
+			});
+
+			it('Can render prerendered route without slash', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/some-base/one`, {
+					redirect : 'manual'
+				});
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('One');
+			});
+
+			it('Can render prerendered route with slash and query params', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/some-base/one/?foo=bar`, {
+					redirect : 'manual'
+				});
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('One');
+			});
+
+			it('Can render prerendered route without slash and with query params', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/some-base/one?foo=bar`, {
+					redirect : 'manual'
+				});
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('One');
+			});
+		});
+		describe('Without base', async () => {
+			before(async () => {
+				process.env.ASTRO_NODE_AUTOSTART = 'disabled';
+				process.env.PRERENDER = true;
+
+				fixture = await loadFixture({
+					root: './fixtures/trailing-slash/',
+					output: 'hybrid',
+					trailingSlash: 'ignore',
+					adapter: nodejs({ mode: 'standalone' }),
+				});
+				await fixture.build();
+				const { startServer } = await load();
+				let res = startServer();
+				server = res.server;
+			});
+
+			after(async () => {
+				await server.stop();
+				await fixture.clean();
+				delete process.env.PRERENDER;
+			});
+
+			it('Can render prerendered route with slash', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/one/`);
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('One');
+			});
+
+			it('Can render prerendered route without slash', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/one`);
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('One');
+			});
+
+			it('Can render prerendered route with slash and query params', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/one/?foo=bar`, {
+					redirect : 'manual'
+				});
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('One');
+			});
+
+			it('Can render prerendered route without slash and with query params', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/one?foo=bar`);
+				const html = await res.text();
+				const $ = cheerio.load(html);
+
+				expect(res.status).to.equal(200);
+				expect($('h1').text()).to.equal('One');
+			});
+		});
+	});
+});
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4387,6 +4387,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/node/test/fixtures/trailing-slash:
+    dependencies:
+      '@astrojs/node':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/node/test/fixtures/url-protocol:
     dependencies:
       '@astrojs/node':


### PR DESCRIPTION
## Changes

- Add logic to support trailingSlash with `ignore`, `always` and `never` values with nodejs adapter
- Closes #7808

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Add tests to use each possible value of trailingSlash and check if expected results are good and not breaking other tests

`trailingSlash = always` &#8594; Should always contain the / at the end (will always return host/pathname/?queryifexists)
`trailingSlash = never` &#8594; Should never contain the / at the end (will always return host/pathname?queryifexists)
`trailingSlash = ignore` &#8594; Should ignore the / at the end (will always work without redirect)

New behaviour of `trailingSlash = ignore` will return 200 and the content of the index.html inside the directory
> I had to change the `prerenderer.test.js` to support this new behaviour and not breaking the test


## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

Should work as expected in current documentation

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

---
I know there's currently an open PR (https://github.com/withastro/astro/pull/8593) about this, but I was not able to make it working and needed this for a personal project 
