### PR TITLE
fix(assets): image service bundling for pre-rendered pages non-node runtime regression

### DIFF
--- a/.changeset/red-houses-explode.md
+++ b/.changeset/red-houses-explode.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the regression which broke bundling of image service for pre-rendered pages, which was introduced by [#8854](https://github.com/withastro/astro/pull/8854)

--- a/packages/astro/src/core/build/plugins/plugin-prerender.ts
+++ b/packages/astro/src/core/build/plugins/plugin-prerender.ts
@@ -12,7 +12,11 @@ function vitePluginPrerender(opts: StaticBuildOptions, internals: BuildInternals
 
 		outputOptions(outputOptions) {
 			extendManualChunks(outputOptions, {
-				before(id, meta) {
+				after(id, meta) {
+					// Split the Astro runtime into a separate chunk for readability
+					if (id.includes('astro/dist/runtime')) {
+						return 'astro';
+					}
 					const pageInfo = internals.pagesByViteID.get(id);
 					if (pageInfo) {
 						// prerendered pages should be split into their own chunk


### PR DESCRIPTION
## Changes

- fixes https://github.com/withastro/astro/issues/9059
- see Discord's #dev channel for more context, and [resolution](https://discord.com/channels/830184174198718474/845430950191038464/1173670300567744573)

## Testing

- the fix of the regression was tested manually and compared to `3.4.4` (known good) and `3.5.0` (known bad)
- the content collection cache implications were not tested, hopefully ci catches them

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

- changeset

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
