### PR TITLE
fix(redirects): handle non-verbatim targets

### DIFF
--- a/.changeset/silly-cycles-clap.md
+++ b/.changeset/silly-cycles-clap.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where redirects did not replace slugs when the target of the redirect rule was not a verbatim route in the project.

--- a/packages/astro/src/core/redirects/helpers.ts
+++ b/packages/astro/src/core/redirects/helpers.ts
@@ -20,6 +20,7 @@ export function redirectRouteGenerate(redirectRoute: RouteData, data: Params): s
 	if (typeof routeData !== 'undefined') {
 		return routeData?.generate(data) || routeData?.pathname || '/';
 	} else if (typeof route === 'string') {
+		console.log({ data, pattern: route});
 		return route;
 	} else if (typeof route === 'undefined') {
 		return '/';

--- a/packages/astro/src/core/redirects/helpers.ts
+++ b/packages/astro/src/core/redirects/helpers.ts
@@ -20,7 +20,16 @@ export function redirectRouteGenerate(redirectRoute: RouteData, data: Params): s
 	if (typeof routeData !== 'undefined') {
 		return routeData?.generate(data) || routeData?.pathname || '/';
 	} else if (typeof route === 'string') {
-		console.log({ data, pattern: route});
+		// TODO: this logic is duplicated between here and manifest/create.ts
+		if (Object.keys(data).length > 0) {
+			let target = route
+			for (const param in data) {
+				const paramValue = data[param]!
+				target = target.replace(`[${param}]`, paramValue)
+				target = target.replace(`[...${param}]`, paramValue)
+			}
+			return target
+		}
 		return route;
 	} else if (typeof route === 'undefined') {
 		return '/';

--- a/packages/astro/src/core/redirects/helpers.ts
+++ b/packages/astro/src/core/redirects/helpers.ts
@@ -21,16 +21,13 @@ export function redirectRouteGenerate(redirectRoute: RouteData, data: Params): s
 		return routeData?.generate(data) || routeData?.pathname || '/';
 	} else if (typeof route === 'string') {
 		// TODO: this logic is duplicated between here and manifest/create.ts
-		if (Object.keys(data).length > 0) {
-			let target = route
-			for (const param in data) {
-				const paramValue = data[param]!
-				target = target.replace(`[${param}]`, paramValue)
-				target = target.replace(`[...${param}]`, paramValue)
-			}
-			return target
+		let target = route
+		for (const param of Object.keys(data)) {
+			const paramValue = data[param]!
+			target = target.replace(`[${param}]`, paramValue)
+			target = target.replace(`[...${param}]`, paramValue)
 		}
-		return route;
+		return target
 	} else if (typeof route === 'undefined') {
 		return '/';
 	}

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -15,6 +15,13 @@ describe('Astro.redirect', () => {
 				redirects: {
 					'/api/redirect': '/test',
 					'/external/redirect': 'https://example.com/',
+					// for example, the real file handling the target path may be called
+					// src/pages/not-verbatim/target1/[something-other-than-dynamic].astro
+					'/source/[dynamic]': '/not-verbatim/target1/[dynamic]',
+					// may be called src/pages/not-verbatim/target2/[abc]/[xyz].astro
+					'/source/[dynamic]/[route]': '/not-verbatim/target2/[dynamic]/[route]',
+					// may be called src/pages/not-verbatim/target3/[...rest].astro
+					'/source/[...spread]': '/not-verbatim/target3/[...spread]',
 				},
 			});
 			await fixture.build();
@@ -29,7 +36,7 @@ describe('Astro.redirect', () => {
 		});
 
 		// ref: https://github.com/withastro/astro/pull/9287
-		it.skip('Ignores external redirect', async () => {
+		it('Ignores external redirect', async () => {
 			const app = await fixture.loadTestAdapterApp();
 			const request = new Request('http://example.com/external/redirect');
 			const response = await app.render(request);
@@ -67,6 +74,27 @@ describe('Astro.redirect', () => {
 				});
 				const response = await app.render(request);
 				expect(response.status).to.equal(308);
+			});
+
+			it('Forwards params to the target path - single param', async () => {
+				const app = await fixture.loadTestAdapterApp();
+				const request = new Request('http://example.com/source/x');
+				const response = await app.render(request);
+				expect(response.headers.get("Location")).to.equal("/not-verbatim/target1/x");
+			});
+
+			it('Forwards params to the target path - multiple params', async () => {
+				const app = await fixture.loadTestAdapterApp();
+				const request = new Request('http://example.com/source/x/y');
+				const response = await app.render(request);
+				expect(response.headers.get("Location")).to.equal("/not-verbatim/target1/x/y");
+			});
+
+			it('Forwards params to the target path - spread param', async () => {
+				const app = await fixture.loadTestAdapterApp();
+				const request = new Request('http://example.com/source/x/y/z');
+				const response = await app.render(request);
+				expect(response.headers.get("Location")).to.equal("/not-verbatim/target1/x/y/z");
 			});
 		});
 	});

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -87,14 +87,14 @@ describe('Astro.redirect', () => {
 				const app = await fixture.loadTestAdapterApp();
 				const request = new Request('http://example.com/source/x/y');
 				const response = await app.render(request);
-				expect(response.headers.get("Location")).to.equal("/not-verbatim/target1/x/y");
+				expect(response.headers.get("Location")).to.equal("/not-verbatim/target2/x/y");
 			});
 
 			it('Forwards params to the target path - spread param', async () => {
 				const app = await fixture.loadTestAdapterApp();
 				const request = new Request('http://example.com/source/x/y/z');
 				const response = await app.render(request);
-				expect(response.headers.get("Location")).to.equal("/not-verbatim/target1/x/y/z");
+				expect(response.headers.get("Location")).to.equal("/not-verbatim/target3/x/y/z");
 			});
 		});
 	});

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -36,7 +36,7 @@ describe('Astro.redirect', () => {
 		});
 
 		// ref: https://github.com/withastro/astro/pull/9287
-		it('Ignores external redirect', async () => {
+		it.skip('Ignores external redirect', async () => {
 			const app = await fixture.loadTestAdapterApp();
 			const request = new Request('http://example.com/external/redirect');
 			const response = await app.render(request);


### PR DESCRIPTION
## Changes
- Fixes #8914

## Testing
- Added 3 cases to [redirects.test.js](https://github.com/withastro/astro/pull/9089/files#diff-f0e8bf856624a391d496c98638e77e91ca1f9ad3a3c30d4d14ff722ff6e6da97)

## Docs
Does not affect usage.
