### PR TITLE
Fallback to tap prefetch strategy on slow connection

### DIFF
--- a/.changeset/neat-mangos-judge.md
+++ b/.changeset/neat-mangos-judge.md
@@ -2,5 +2,4 @@
 'astro': minor
 ---
 
-#9092 - Fallback to `tap` prefetch strategy on slow connection, instead of bailing.
-#9092 - Add `ignoreSlowConnection` option to prefetch API, which lets manually prefetch even on data saver mode or slow connection.
+Fallback to the `tap` prefetch strategy on slow connection, instead of bailing.

--- a/.changeset/neat-mangos-judge.md
+++ b/.changeset/neat-mangos-judge.md
@@ -1,0 +1,6 @@
+---
+'astro': minor
+---
+
+#9092 - Fallback to `tap` prefetch strategy on slow connection, instead of bailing.
+#9092 - Add `ignoreSlowConnection` option to prefetch API, which lets manually prefetch even on data saver mode or slow connection.

--- a/.changeset/neat-mangos-judge.md
+++ b/.changeset/neat-mangos-judge.md
@@ -2,4 +2,4 @@
 'astro': minor
 ---
 
-Fallback to the `tap` prefetch strategy on slow connection, instead of bailing.
+Changes the fallback prefetch behavior on slow connections and when data saver mode is enabled. Instead of disabling prefetch entirely, the `tap` strategy will be used.

--- a/.changeset/six-owls-trade.md
+++ b/.changeset/six-owls-trade.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Adds a `ignoreSlowConnection` option to the `prefetch()` API to prefetch even on data saver mode or slow connection.

--- a/packages/astro/src/prefetch/index.ts
+++ b/packages/astro/src/prefetch/index.ts
@@ -104,7 +104,7 @@ function initHoverStrategy() {
 			clearTimeout(timeout);
 		}
 		timeout = setTimeout(() => {
-			prefetch(href, { with: 'fetch', ignoreSlowConnection: true });
+			prefetch(href, { with: 'fetch' });
 		}, 80) as unknown as number;
 	}
 
@@ -155,7 +155,7 @@ function createViewportIntersectionObserver() {
 					setTimeout(() => {
 						observer.unobserve(anchor);
 						timeouts.delete(anchor);
-						prefetch(anchor.href, { with: 'link', ignoreSlowConnection: true });
+						prefetch(anchor.href, { with: 'link' });
 					}, 300) as unknown as number
 				);
 			} else {
@@ -244,8 +244,8 @@ function elMatchesStrategy(el: EventTarget | null, strategy: string): el is HTML
 	}
 
 	// Fallback to tap strategy if using data saver mode or slow connection
-	if ((attrValue != null || prefetchAll) && isSlowConnection()) {
-		return strategy === 'tap';
+	if (strategy === 'tap' && (attrValue != null || prefetchAll) && isSlowConnection()) {
+		return true;
 	}
 
 	// If anchor has no dataset but we want to prefetch all, or has dataset but no value,

--- a/packages/astro/src/prefetch/index.ts
+++ b/packages/astro/src/prefetch/index.ts
@@ -245,7 +245,7 @@ function elMatchesStrategy(el: EventTarget | null, strategy: string): el is HTML
 
 	// Fallback to tap strategy if using data saver mode or slow connection
 	if ((attrValue != null || prefetchAll) && isSlowConnection()) {
-		return strategy === "tap";
+		return strategy === 'tap';
 	}
 
 	// If anchor has no dataset but we want to prefetch all, or has dataset but no value,


### PR DESCRIPTION
## Changes

1. Fallback to `tap` prefetch strategy on slow connection, instead of bailing.
2. Add `ignoreSlowConnection` option to prefetch API, which lets manually prefetch even on data saver mode or slow connection.

## Testing

Tested on test cases added in this PR https://github.com/withastro/astro/pull/8951

## Docs

Docs: https://github.com/withastro/docs/pull/5393

This PR also has changesets and JSDoc for review.