### PR TITLE
[docs] config-reference typo

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1500,7 +1500,7 @@ export interface AstroUserConfig {
 			 * The following example configures your content fallback strategy to redirect unavailable pages in `/pt-br/` to their `es` version, and unavailable pages in `/fr/` to their `en` version. Unavailable `/es/` pages will return a 404.
 			 *
 			 * ```js
-			 * export defualt defineConfig({
+			 * export default defineConfig({
 			 * 	experimental: {
 			 * 		i18n: {
 			 * 			defaultLocale: "en",


### PR DESCRIPTION
## Changes

Fixes a typo for docs

## Testing

No tests!

## Docs

Only docs!
