### PR TITLE
i18n(domains): validation and updated logic

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2039,9 +2039,9 @@ export interface AstroAssetsFeature {
 
 export interface AstroInternationalizationFeature {
 	/**
-	 * Whether the adapter is able to detect the language of the browser, usually using the `Accept-Language` header.
+	 * The adapter should be able to create the proper redirects
 	 */
-	detectBrowserLanguage?: SupportsKind;
+	domain?: SupportsKind;
 }
 
 export interface AstroAdapter {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1536,6 +1536,33 @@ export interface AstroUserConfig {
 			 *
 			 */
 			routingStrategy?: 'prefix-always' | 'prefix-other-locales';
+
+			/**
+			 * @docs
+			 * @kind h4
+			 * @name experimental.i18n.domains
+			 * @type {Record<string, string> }
+			 * @default '{}'
+			 * @version 3.6.0
+			 * @description
+			 *
+			 * Maps a locale
+			 *
+			 * ```js
+			 * export defualt defineConfig({
+			 *    experimental: {
+			 *        i18n: {
+			 *            defaultLocale: "en",
+			 *            locales: ["en", "fr", "pt-br", "es"],
+			 *            domains: {
+			 *                fr: "https://fr.example.com",
+			 *            }
+			 *        }
+			 *    }
+			 * })
+			 * ```
+			 */
+			domains?: Record<string, string>;
 		};
 		/**
 		 * @docs

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1546,7 +1546,7 @@ export interface AstroUserConfig {
 			 * @version 3.6.0
 			 * @description
 			 *
-			 * Maps a locale
+			 * Maps a locale to a domain (or sub-domain). When a locale is mapped to a domain, all the URLs that belong to it will respond to `https://fr.example.com/blog` and not to `/fr/blog`.
 			 *
 			 * ```js
 			 * export defualt defineConfig({

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -397,11 +397,18 @@ export const AstroConfigSchema = z.object({
 								}
 							}
 							if (domains) {
-								for (const [domainKey] of Object.entries(domains)) {
+								for (const [domainKey, domainValue] of Object.entries(domains)) {
 									if (!locales.includes(domainKey)) {
 										ctx.addIssue({
 											code: z.ZodIssueCode.custom,
 											message: `The locale \`${domainKey}\` key in the \`i18n.domains\` record doesn't exist in the \`i18n.locales\` array.`,
+										});
+									}
+									const domainUrl = new URL(domainValue);
+									if (domainUrl.pathname !== '/') {
+										ctx.addIssue({
+											code: z.ZodIssueCode.custom,
+											message: `The URL \`${domainValue}\` must contain only the origin. A subsequent pathname isn't allowed here. Remove \`${domainUrl.pathname}\`.`,
 										});
 									}
 								}

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -346,6 +346,16 @@ export const AstroConfigSchema = z.object({
 						defaultLocale: z.string(),
 						locales: z.string().array(),
 						fallback: z.record(z.string(), z.string()).optional(),
+						domains: z
+							.record(
+								z.string(),
+								z
+									.string()
+									.url(
+										"The domain value must be a valid URL, and it has to start with 'https' or 'http'."
+									)
+							)
+							.optional(),
 						// TODO: properly add default when the feature goes of experimental
 						routingStrategy: z
 							.enum(['prefix-always', 'prefix-other-locales'])
@@ -355,7 +365,7 @@ export const AstroConfigSchema = z.object({
 					.optional()
 					.superRefine((i18n, ctx) => {
 						if (i18n) {
-							const { defaultLocale, locales, fallback } = i18n;
+							const { defaultLocale, locales, fallback, domains } = i18n;
 							if (!locales.includes(defaultLocale)) {
 								ctx.addIssue({
 									code: z.ZodIssueCode.custom,
@@ -382,6 +392,16 @@ export const AstroConfigSchema = z.object({
 										ctx.addIssue({
 											code: z.ZodIssueCode.custom,
 											message: `The locale \`${fallbackTo}\` value in the \`i18n.fallback\` record doesn't exist in the \`i18n.locales\` array.`,
+										});
+									}
+								}
+							}
+							if (domains) {
+								for (const [domainKey] of Object.entries(domains)) {
+									if (!locales.includes(domainKey)) {
+										ctx.addIssue({
+											code: z.ZodIssueCode.custom,
+											message: `The locale \`${domainKey}\` key in the \`i18n.domains\` record doesn't exist in the \`i18n.locales\` array.`,
 										});
 									}
 								}

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -404,12 +404,16 @@ export const AstroConfigSchema = z.object({
 											message: `The locale \`${domainKey}\` key in the \`i18n.domains\` record doesn't exist in the \`i18n.locales\` array.`,
 										});
 									}
-									const domainUrl = new URL(domainValue);
-									if (domainUrl.pathname !== '/') {
-										ctx.addIssue({
-											code: z.ZodIssueCode.custom,
-											message: `The URL \`${domainValue}\` must contain only the origin. A subsequent pathname isn't allowed here. Remove \`${domainUrl.pathname}\`.`,
-										});
+									try {
+										const domainUrl = new URL(domainValue);
+										if (domainUrl.pathname !== '/') {
+											ctx.addIssue({
+												code: z.ZodIssueCode.custom,
+												message: `The URL \`${domainValue}\` must contain only the origin. A subsequent pathname isn't allowed here. Remove \`${domainUrl.pathname}\`.`,
+											});
+										}
+									} catch {
+										// no need to catch the error
 									}
 								}
 							}

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -75,22 +75,22 @@ export function getLocaleRelativeUrl({
 export function getLocaleAbsoluteUrl({ site, isBuild, ...rest }: GetLocaleAbsoluteUrl) {
 	const localeUrl = getLocaleRelativeUrl(rest);
 	const { domains, locale } = rest;
-	let URL;
+	let url;
 	if (isBuild) {
 		const base = domains[locale];
-		URL = joinPaths(base, localeUrl.replace(`/${rest.locale}`, ''));
+		url = joinPaths(base, localeUrl.replace(`/${rest.locale}`, ''));
 	} else {
 		if (site) {
-			URL = joinPaths(site, localeUrl);
+			url = joinPaths(site, localeUrl);
 		} else {
-			URL = localeUrl;
+			url = localeUrl;
 		}
 	}
 
 	if (shouldAppendForwardSlash(rest.trailingSlash, rest.format)) {
-		return appendForwardSlash(URL);
+		return appendForwardSlash(url);
 	} else {
-		return URL;
+		return url;
 	}
 }
 

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -11,6 +11,8 @@ type AstroInternationalization = {
 export default function astroInternationalization({
 	settings,
 }: AstroInternationalization): vite.Plugin {
+	let isCommandBuild = false;
+
 	return {
 		name: 'astro:i18n',
 		enforce: 'pre',
@@ -18,6 +20,11 @@ export default function astroInternationalization({
 			if (id === virtualModuleId) {
 				return resolvedVirtualModuleId;
 			}
+		},
+
+		config(opts, { command }) {
+			isCommandBuild = command === 'build';
+			return opts;
 		},
 		load(id) {
 			if (id === resolvedVirtualModuleId) {
@@ -35,13 +42,14 @@ export default function astroInternationalization({
 					const format =  ${JSON.stringify(settings.config.build.format)};
 					const site = ${JSON.stringify(settings.config.site)};
 					const i18n = ${JSON.stringify(settings.config.experimental.i18n)};
+					const isBuild = ${isCommandBuild};
 					
 					export const getRelativeLocaleUrl = (locale, path = "", opts) => _getLocaleRelativeUrl({ 
 						locale,
 						path, 
 						base, 
 						trailingSlash, 
-						format,
+						format,					
 						...i18n,
 						...opts 
 					});
@@ -52,13 +60,16 @@ export default function astroInternationalization({
 						trailingSlash, 
 						format, 
 						site, 
+						isBuild,
 						...i18n,
 						...opts 
 					});
 					
 					export const getRelativeLocaleUrlList = (path = "", opts) => _getLocaleRelativeUrlList({ 
 						base, path, trailingSlash, format, ...i18n, ...opts });
-					export const getAbsoluteLocaleUrlList = (path = "", opts) => _getLocaleAbsoluteUrlList({ base, path, trailingSlash, format, site, ...i18n, ...opts });
+					export const getAbsoluteLocaleUrlList = (path = "", opts) => _getLocaleAbsoluteUrlList({ 
+						base, path, trailingSlash, format, site, isBuild, ...i18n, ...opts 
+					});
 				`;
 			}
 		},

--- a/packages/astro/src/integrations/astroFeaturesValidation.ts
+++ b/packages/astro/src/integrations/astroFeaturesValidation.ts
@@ -24,7 +24,7 @@ const ALL_UNSUPPORTED: Required<AstroFeatureMap> = {
 	hybridOutput: UNSUPPORTED,
 	assets: UNSUPPORTED_ASSETS_FEATURE,
 	i18n: {
-		detectBrowserLanguage: UNSUPPORTED,
+		domain: UNSUPPORTED,
 	},
 };
 

--- a/packages/astro/test/fixtures/i18n-routing/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-routing/astro.config.mjs
@@ -6,7 +6,10 @@ export default defineConfig({
 			defaultLocale: 'en',
 			locales: [
 				'en', 'pt', 'it'
-			]
+			],
+			domains: {
+				it: "https://it.example.com"
+			}
 		}
 	},
 })

--- a/packages/astro/test/fixtures/i18n-routing/src/pages/virtual-module.astro
+++ b/packages/astro/test/fixtures/i18n-routing/src/pages/virtual-module.astro
@@ -1,7 +1,8 @@
 ---
-import { getRelativeLocaleUrl } from "astro:i18n";
+import { getRelativeLocaleUrl, getAbsoluteLocaleUrl } from "astro:i18n";
 
 let about = getRelativeLocaleUrl("pt", "about");
+let italianAbout = getAbsoluteLocaleUrl("it", "about");
 
 ---
 
@@ -13,5 +14,6 @@ let about = getRelativeLocaleUrl("pt", "about");
         Virtual module doesn't break
     
         About: {about}
+        About it: {italianAbout}
     </body>
 </html>

--- a/packages/astro/test/i18-routing.test.js
+++ b/packages/astro/test/i18-routing.test.js
@@ -26,6 +26,24 @@ describe('astro:i18n virtual module', () => {
 		const text = await response.text();
 		expect(text).includes("Virtual module doesn't break");
 		expect(text).includes('About: /pt/about');
+		expect(text).includes('About it: /it/about');
+	});
+
+	describe('absolute URLs', () => {
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/i18n-routing/',
+			});
+			await fixture.build();
+		});
+
+		it('correctly renders the absolute URL', async () => {
+			const html = await fixture.readFile('/virtual-module/index.html');
+			let $ = cheerio.load(html);
+
+			expect($('body').text()).includes("Virtual module doesn't break");
+			expect($('body').text()).includes('About it: https://it.example.com/about');
+		});
 	});
 });
 describe('[DEV] i18n routing', () => {

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -159,5 +159,47 @@ describe('Config Validation', () => {
 				"You can't use the default locale as a key. The default locale can only be used as value."
 			);
 		});
+
+		it('errors if a domains key does not exist', async () => {
+			const configError = await validateConfig(
+				{
+					experimental: {
+						i18n: {
+							defaultLocale: 'en',
+							locales: ['es', 'en'],
+							domains: {
+								lorem: 'https://example.com',
+							},
+						},
+					},
+				},
+				process.cwd()
+			).catch((err) => err);
+			expect(configError instanceof z.ZodError).to.equal(true);
+			expect(configError.errors[0].message).to.equal(
+				"The locale `lorem` key in the `i18n.domains` record doesn't exist in the `i18n.locales` array."
+			);
+		});
+
+		it('errors if a domains value is not an URL', async () => {
+			const configError = await validateConfig(
+				{
+					experimental: {
+						i18n: {
+							defaultLocale: 'en',
+							locales: ['es', 'en'],
+							domains: {
+								en: 'www.example.com',
+							},
+						},
+					},
+				},
+				process.cwd()
+			).catch((err) => err);
+			expect(configError instanceof z.ZodError).to.equal(true);
+			expect(configError.errors[0].message).to.equal(
+				"The domain value must be a valid URL, and it has to start with 'https' or 'http'."
+			);
+		});
 	});
 });

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -201,5 +201,26 @@ describe('Config Validation', () => {
 				"The domain value must be a valid URL, and it has to start with 'https' or 'http'."
 			);
 		});
+
+		it('errors if a domain is a URL with a pathname that is not the home', async () => {
+			const configError = await validateConfig(
+				{
+					experimental: {
+						i18n: {
+							defaultLocale: 'en',
+							locales: ['es', 'en'],
+							domains: {
+								en: 'https://www.example.com/blog/page/',
+							},
+						},
+					},
+				},
+				process.cwd()
+			).catch((err) => err);
+			expect(configError instanceof z.ZodError).to.equal(true);
+			expect(configError.errors[0].message).to.equal(
+				"The URL `https://www.example.com/blog/page/` must contain only the origin. A subsequent pathname isn't allowed here. Remove `/blog/page/`."
+			);
+		});
 	});
 });

--- a/packages/astro/test/units/i18n/astro_i18n.js
+++ b/packages/astro/test/units/i18n/astro_i18n.js
@@ -227,7 +227,7 @@ describe('getLocaleRelativeUrl', () => {
 				format: 'directory',
 				normalizeLocale: false,
 			})
-		).to.eq('/blog/en_US/');
+		).to.eq('/blog/en-us/');
 
 		expect(
 			getLocaleRelativeUrl({
@@ -341,7 +341,7 @@ describe('getLocaleRelativeUrlList', () => {
 				trailingSlash: 'never',
 				format: 'directory',
 			})
-		).to.have.members(['/blog', '/blog/en_US', '/blog/es']);
+		).to.have.members(['/blog', '/blog/en-us', '/blog/es']);
 	});
 
 	it('should retrieve the correct list of base URL with locales [format: directory, trailingSlash: always]', () => {
@@ -366,7 +366,7 @@ describe('getLocaleRelativeUrlList', () => {
 				trailingSlash: 'always',
 				format: 'directory',
 			})
-		).to.have.members(['/blog/', '/blog/en_US/', '/blog/es/']);
+		).to.have.members(['/blog/', '/blog/en-us/', '/blog/es/']);
 	});
 
 	it('should retrieve the correct list of base URL with locales [format: file, trailingSlash: always]', () => {
@@ -391,7 +391,7 @@ describe('getLocaleRelativeUrlList', () => {
 				trailingSlash: 'always',
 				format: 'file',
 			})
-		).to.have.members(['/blog/', '/blog/en_US/', '/blog/es/']);
+		).to.have.members(['/blog/', '/blog/en-us/', '/blog/es/']);
 	});
 
 	it('should retrieve the correct list of base URL with locales [format: file, trailingSlash: never]', () => {
@@ -416,7 +416,7 @@ describe('getLocaleRelativeUrlList', () => {
 				trailingSlash: 'never',
 				format: 'file',
 			})
-		).to.have.members(['/blog', '/blog/en_US', '/blog/es']);
+		).to.have.members(['/blog', '/blog/en-us', '/blog/es']);
 	});
 
 	it('should retrieve the correct list of base URL with locales [format: file, trailingSlash: ignore]', () => {
@@ -441,7 +441,7 @@ describe('getLocaleRelativeUrlList', () => {
 				trailingSlash: 'ignore',
 				format: 'file',
 			})
-		).to.have.members(['/blog', '/blog/en_US', '/blog/es']);
+		).to.have.members(['/blog', '/blog/en-us', '/blog/es']);
 	});
 
 	it('should retrieve the correct list of base URL with locales [format: directory, trailingSlash: ignore]', () => {
@@ -466,7 +466,7 @@ describe('getLocaleRelativeUrlList', () => {
 				trailingSlash: 'ignore',
 				format: 'directory',
 			})
-		).to.have.members(['/blog/', '/blog/en_US/', '/blog/es/']);
+		).to.have.members(['/blog/', '/blog/en-us/', '/blog/es/']);
 	});
 
 	it('should retrieve the correct list of base URL with locales [format: directory, trailingSlash: never, routingStategy: prefix-always]', () => {
@@ -492,7 +492,7 @@ describe('getLocaleRelativeUrlList', () => {
 				trailingSlash: 'never',
 				format: 'directory',
 			})
-		).to.have.members(['/blog/en', '/blog/en_US', '/blog/es']);
+		).to.have.members(['/blog/en', '/blog/en-us', '/blog/es']);
 	});
 });
 
@@ -1181,7 +1181,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 			})
 		).to.have.members([
 			'https://example.com/blog',
-			'https://example.com/blog/en_US',
+			'https://example.com/blog/en-us',
 			'https://example.com/blog/es',
 		]);
 	});
@@ -1211,7 +1211,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 			})
 		).to.have.members([
 			'https://example.com/blog/',
-			'https://example.com/blog/en_US/',
+			'https://example.com/blog/en-us/',
 			'https://example.com/blog/es/',
 		]);
 	});
@@ -1241,7 +1241,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 			})
 		).to.have.members([
 			'https://example.com/blog/',
-			'https://example.com/blog/en_US/',
+			'https://example.com/blog/en-us/',
 			'https://example.com/blog/es/',
 		]);
 	});
@@ -1271,7 +1271,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 			})
 		).to.have.members([
 			'https://example.com/blog',
-			'https://example.com/blog/en_US',
+			'https://example.com/blog/en-us',
 			'https://example.com/blog/es',
 		]);
 	});
@@ -1301,7 +1301,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 			})
 		).to.have.members([
 			'https://example.com/blog',
-			'https://example.com/blog/en_US',
+			'https://example.com/blog/en-us',
 			'https://example.com/blog/es',
 		]);
 	});
@@ -1331,7 +1331,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 			})
 		).to.have.members([
 			'https://example.com/blog/',
-			'https://example.com/blog/en_US/',
+			'https://example.com/blog/en-us/',
 			'https://example.com/blog/es/',
 		]);
 	});
@@ -1362,8 +1362,43 @@ describe('getLocaleAbsoluteUrlList', () => {
 			})
 		).to.have.members([
 			'https://example.com/blog/en/',
-			'https://example.com/blog/en_US/',
+			'https://example.com/blog/en-us/',
 			'https://example.com/blog/es/',
+		]);
+	});
+
+	it('should retrieve the correct list of base URLs, swapped with the correct domain', () => {
+		/**
+		 *
+		 * @type {import("../../../dist/@types").AstroUserConfig}
+		 */
+		const config = {
+			experimental: {
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['en', 'en_US', 'es'],
+					routingStrategy: 'prefix-always',
+					domains: {
+						es: 'https://es.example.com',
+						en: 'https://example.uk',
+					},
+				},
+			},
+		};
+		// directory format
+		expect(
+			getLocaleAbsoluteUrlList({
+				base: '/blog/',
+				...config.experimental.i18n,
+				trailingSlash: 'ignore',
+				format: 'directory',
+				site: 'https://example.com',
+				isBuild: true,
+			})
+		).to.have.members([
+			'https://example.uk/blog/',
+			'https://example.com/blog/en-us/',
+			'https://es.example.com/blog/',
 		]);
 	});
 });

--- a/packages/astro/test/units/i18n/astro_i18n.js
+++ b/packages/astro/test/units/i18n/astro_i18n.js
@@ -497,327 +497,661 @@ describe('getLocaleRelativeUrlList', () => {
 });
 
 describe('getLocaleAbsoluteUrl', () => {
-	it('should correctly return the URL with the base', () => {
-		/**
-		 *
-		 * @type {import("../../../dist/@types").AstroUserConfig}
-		 */
-		const config = {
-			base: '/blog',
-			experimental: {
-				i18n: {
-					defaultLocale: 'en',
-					locales: ['en', 'en_US', 'es'],
-				},
-			},
-		};
-
-		// directory format
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en',
-				base: '/blog/',
-				trailingSlash: 'always',
-				format: 'directory',
-				site: 'https://example.com',
-				...config.experimental.i18n,
-			})
-		).to.eq('https://example.com/blog/');
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'es',
-				base: '/blog/',
-				...config.experimental.i18n,
-				trailingSlash: 'always',
-				format: 'directory',
-				site: 'https://example.com',
-			})
-		).to.eq('https://example.com/blog/es/');
-
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en_US',
-				base: '/blog/',
-				...config.experimental.i18n,
-				trailingSlash: 'always',
-				format: 'directory',
-				site: 'https://example.com',
-			})
-		).to.throw;
-
-		// file format
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en',
-				base: '/blog/',
-				...config.experimental.i18n,
-				trailingSlash: 'always',
-				format: 'file',
-				site: 'https://example.com',
-			})
-		).to.eq('https://example.com/blog/');
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'es',
-				base: '/blog/',
-				...config.experimental.i18n,
-				trailingSlash: 'always',
-				format: 'file',
-				site: 'https://example.com',
-			})
-		).to.eq('https://example.com/blog/es/');
-
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en_US',
-				base: '/blog/',
-				...config.experimental.i18n,
-				trailingSlash: 'always',
-				format: 'file',
-				site: 'https://example.com',
-			})
-		).to.throw;
-	});
-
-	it('should correctly return the URL without base', () => {
-		/**
-		 *
-		 * @type {import("../../../dist/@types").AstroUserConfig}
-		 */
-		const config = {
-			experimental: {
-				i18n: {
-					defaultLocale: 'en',
-					locales: ['en', 'es'],
-				},
-			},
-		};
-
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en',
-				base: '/',
-				...config.experimental.i18n,
-				trailingSlash: 'always',
-				format: 'directory',
-				site: 'https://example.com',
-			})
-		).to.eq('https://example.com/');
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'es',
-				base: '/',
-				...config.experimental.i18n,
-				trailingSlash: 'always',
-				format: 'directory',
-				site: 'https://example.com',
-			})
-		).to.eq('https://example.com/es/');
-	});
-
-	it('should correctly handle the trailing slash', () => {
-		/**
-		 *
-		 * @type {import("../../../dist/@types").AstroUserConfig}
-		 */
-		const config = {
-			experimental: {
-				i18n: {
-					defaultLocale: 'en',
-					locales: ['en', 'es'],
-				},
-			},
-		};
-		// directory format
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en',
+	describe('with [prefix-other-locales]', () => {
+		it('should correctly return the URL with the base', () => {
+			/**
+			 *
+			 * @type {import("../../../dist/@types").AstroUserConfig}
+			 */
+			const config = {
 				base: '/blog',
-				...config.experimental.i18n,
-				trailingSlash: 'never',
-				format: 'directory',
-			})
-		).to.eq('https://example.com/blog');
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'es',
-				base: '/blog/',
-				...config.experimental.i18n,
-				trailingSlash: 'always',
-				format: 'directory',
-			})
-		).to.eq('https://example.com/blog/es/');
-
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en',
-				base: '/blog/',
-				...config.experimental.i18n,
-				trailingSlash: 'ignore',
-				format: 'directory',
-			})
-		).to.eq('https://example.com/blog/');
-
-		// directory file
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en',
-				base: '/blog',
-				...config.experimental.i18n,
-				trailingSlash: 'never',
-				format: 'file',
-			})
-		).to.eq('https://example.com/blog');
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'es',
-				base: '/blog/',
-				...config.experimental.i18n,
-				trailingSlash: 'always',
-				format: 'file',
-			})
-		).to.eq('https://example.com/blog/es/');
-
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en',
-				// ignore + file => no trailing slash
-				base: '/blog',
-				...config.experimental.i18n,
-				trailingSlash: 'ignore',
-				format: 'file',
-			})
-		).to.eq('https://example.com/blog');
-	});
-
-	it('should normalize locales', () => {
-		/**
-		 *
-		 * @type {import("../../../dist/@types").AstroUserConfig}
-		 */
-		const config = {
-			base: '/blog',
-			experimental: {
-				i18n: {
-					defaultLocale: 'en',
-					locales: ['en', 'en_US', 'en_AU'],
+				experimental: {
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['en', 'en_US', 'es'],
+						domains: {
+							es: 'https://es.example.com',
+						},
+						routingStrategy: 'prefix-other-locales',
+					},
 				},
-			},
-		};
+			};
 
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en_US',
-				base: '/blog/',
-				...config.experimental.i18n,
-				trailingSlash: 'always',
-				format: 'directory',
-			})
-		).to.eq('/blog/en-us/');
+			// directory format
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/blog/',
+					trailingSlash: 'always',
+					format: 'directory',
+					site: 'https://example.com',
+					...config.experimental.i18n,
+				})
+			).to.eq('https://example.com/blog/');
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog/es/');
 
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en_AU',
-				base: '/blog/',
-				...config.experimental.i18n,
-				trailingSlash: 'always',
-				format: 'directory',
-			})
-		).to.eq('/blog/en-au/');
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en_US',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+					site: 'https://example.com',
+				})
+			).to.throw;
 
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en_US',
-				base: '/blog/',
-				...config.experimental.i18n,
-				trailingSlash: 'always',
-				format: 'directory',
-				normalizeLocale: true,
-			})
-		).to.eq('/blog/en-us/');
-	});
+			// file format
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'file',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog/');
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'file',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog/es/');
 
-	it('should return the default locale when routing strategy is [prefix-always]', () => {
-		/**
-		 *
-		 * @type {import("../../../dist/@types").AstroUserConfig}
-		 */
-		const config = {
-			base: '/blog',
-			experimental: {
-				i18n: {
-					defaultLocale: 'en',
-					locales: ['en', 'es', 'en_US', 'en_AU'],
-					routingStrategy: 'prefix-always',
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en_US',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'file',
+					site: 'https://example.com',
+				})
+			).to.throw;
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'file',
+					site: 'https://example.com',
+					isBuild: true,
+				})
+			).to.eq('https://es.example.com/blog/');
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/blog/',
+					prependWith: 'some-name',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'file',
+					site: 'https://example.com',
+					path: 'first-post',
+					isBuild: true,
+				})
+			).to.eq('https://es.example.com/blog/some-name/first-post/');
+
+			// en isn't mapped to a domain
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/blog/',
+					prependWith: 'some-name',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'file',
+					site: 'https://example.com',
+					path: 'first-post',
+					isBuild: true,
+				})
+			).to.eq('/blog/some-name/first-post/');
+		});
+		it('should correctly return the URL without base', () => {
+			/**
+			 *
+			 * @type {import("../../../dist/@types").AstroUserConfig}
+			 */
+			const config = {
+				experimental: {
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['en', 'es'],
+						routingStrategy: 'prefix-other-locales',
+					},
 				},
-			},
-		};
+			};
 
-		// directory format
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en',
-				base: '/blog/',
-				trailingSlash: 'always',
-				site: 'https://example.com',
-				format: 'directory',
-				...config.experimental.i18n,
-			})
-		).to.eq('https://example.com/blog/en/');
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'es',
-				base: '/blog/',
-				...config.experimental.i18n,
-				site: 'https://example.com',
-				trailingSlash: 'always',
-				format: 'directory',
-			})
-		).to.eq('https://example.com/blog/es/');
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/');
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/es/');
+		});
 
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en_US',
-				base: '/blog/',
-				...config.experimental.i18n,
-				site: 'https://example.com',
-				trailingSlash: 'always',
-				format: 'directory',
-			})
-		).to.throw;
+		it('should correctly handle the trailing slash', () => {
+			/**
+			 *
+			 * @type {import("../../../dist/@types").AstroUserConfig}
+			 */
+			const config = {
+				experimental: {
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['en', 'es'],
+						routingStrategy: 'prefix-other-locales',
+					},
+				},
+			};
+			// directory format
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/blog',
+					...config.experimental.i18n,
+					trailingSlash: 'never',
+					format: 'directory',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog');
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog/es/');
 
-		// file format
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en',
-				base: '/blog/',
-				...config.experimental.i18n,
-				site: 'https://example.com',
-				trailingSlash: 'always',
-				format: 'file',
-			})
-		).to.eq('https://example.com/blog/en/');
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'es',
-				base: '/blog/',
-				...config.experimental.i18n,
-				site: 'https://example.com',
-				trailingSlash: 'always',
-				format: 'file',
-			})
-		).to.eq('https://example.com/blog/es/');
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'ignore',
+					format: 'directory',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog/');
 
-		expect(
-			getLocaleAbsoluteUrl({
-				locale: 'en_US',
-				base: '/blog/',
-				...config.experimental.i18n,
-				site: 'https://example.com',
-				trailingSlash: 'always',
-				format: 'file',
-			})
-		).to.throw;
+			// directory file
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/blog',
+					...config.experimental.i18n,
+					trailingSlash: 'never',
+					format: 'file',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog');
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'file',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog/es/');
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					// ignore + file => no trailing slash
+					base: '/blog',
+					...config.experimental.i18n,
+					trailingSlash: 'ignore',
+					format: 'file',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog');
+		});
+
+		it('should normalize locales', () => {
+			/**
+			 *
+			 * @type {import("../../../dist/@types").AstroUserConfig}
+			 */
+			const config = {
+				base: '/blog',
+				experimental: {
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['en', 'en_US', 'en_AU'],
+						routingStrategy: 'prefix-other-locales',
+					},
+				},
+			};
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en_US',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+				})
+			).to.eq('/blog/en-us/');
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en_AU',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+				})
+			).to.eq('/blog/en-au/');
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en_US',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+					normalizeLocale: true,
+				})
+			).to.eq('/blog/en-us/');
+		});
+	});
+	describe('with [prefix-always]', () => {
+		it('should correctly return the URL with the base', () => {
+			/**
+			 *
+			 * @type {import("../../../dist/@types").AstroUserConfig}
+			 */
+			const config = {
+				base: '/blog',
+				experimental: {
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['en', 'en_US', 'es'],
+						domains: {
+							es: 'https://es.example.com',
+						},
+						routingStrategy: 'prefix-always',
+					},
+				},
+			};
+
+			// directory format
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/blog/',
+					trailingSlash: 'always',
+					format: 'directory',
+					site: 'https://example.com',
+					...config.experimental.i18n,
+				})
+			).to.eq('https://example.com/blog/en/');
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog/es/');
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en_US',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+					site: 'https://example.com',
+				})
+			).to.throw;
+
+			// file format
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'file',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog/en/');
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'file',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog/es/');
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en_US',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'file',
+					site: 'https://example.com',
+				})
+			).to.throw;
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'file',
+					site: 'https://example.com',
+					isBuild: true,
+				})
+			).to.eq('https://es.example.com/blog/');
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/blog/',
+					prependWith: 'some-name',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'file',
+					site: 'https://example.com',
+					path: 'first-post',
+					isBuild: true,
+				})
+			).to.eq('https://es.example.com/blog/some-name/first-post/');
+		});
+		it('should correctly return the URL without base', () => {
+			/**
+			 *
+			 * @type {import("../../../dist/@types").AstroUserConfig}
+			 */
+			const config = {
+				experimental: {
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['en', 'es'],
+						routingStrategy: 'prefix-always',
+					},
+				},
+			};
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/en/');
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/es/');
+		});
+
+		it('should correctly handle the trailing slash', () => {
+			/**
+			 *
+			 * @type {import("../../../dist/@types").AstroUserConfig}
+			 */
+			const config = {
+				experimental: {
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['en', 'es'],
+						routingStrategy: 'prefix-always',
+					},
+				},
+			};
+			// directory format
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/blog',
+					...config.experimental.i18n,
+					trailingSlash: 'never',
+					format: 'directory',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog/en');
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog/es/');
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'ignore',
+					format: 'directory',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog/en/');
+
+			// directory file
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/blog',
+					...config.experimental.i18n,
+					trailingSlash: 'never',
+					format: 'file',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog/en');
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'file',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog/es/');
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					// ignore + file => no trailing slash
+					base: '/blog',
+					...config.experimental.i18n,
+					trailingSlash: 'ignore',
+					format: 'file',
+					site: 'https://example.com',
+				})
+			).to.eq('https://example.com/blog/en');
+		});
+
+		it('should normalize locales', () => {
+			/**
+			 *
+			 * @type {import("../../../dist/@types").AstroUserConfig}
+			 */
+			const config = {
+				base: '/blog',
+				experimental: {
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['en', 'en_US', 'en_AU'],
+						routingStrategy: 'prefix-always',
+					},
+				},
+			};
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en_US',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+				})
+			).to.eq('/blog/en-us/');
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en_AU',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+				})
+			).to.eq('/blog/en-au/');
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en_US',
+					base: '/blog/',
+					...config.experimental.i18n,
+					trailingSlash: 'always',
+					format: 'directory',
+					normalizeLocale: true,
+				})
+			).to.eq('/blog/en-us/');
+		});
+
+		it('should return the default locale', () => {
+			/**
+			 *
+			 * @type {import("../../../dist/@types").AstroUserConfig}
+			 */
+			const config = {
+				base: '/blog',
+				experimental: {
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['en', 'es', 'en_US', 'en_AU'],
+						routingStrategy: 'prefix-always',
+					},
+				},
+			};
+
+			// directory format
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/blog/',
+					trailingSlash: 'always',
+					site: 'https://example.com',
+					format: 'directory',
+					...config.experimental.i18n,
+				})
+			).to.eq('https://example.com/blog/en/');
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/blog/',
+					...config.experimental.i18n,
+					site: 'https://example.com',
+					trailingSlash: 'always',
+					format: 'directory',
+				})
+			).to.eq('https://example.com/blog/es/');
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en_US',
+					base: '/blog/',
+					...config.experimental.i18n,
+					site: 'https://example.com',
+					trailingSlash: 'always',
+					format: 'directory',
+				})
+			).to.throw;
+
+			// file format
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en',
+					base: '/blog/',
+					...config.experimental.i18n,
+					site: 'https://example.com',
+					trailingSlash: 'always',
+					format: 'file',
+				})
+			).to.eq('https://example.com/blog/en/');
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'es',
+					base: '/blog/',
+					...config.experimental.i18n,
+					site: 'https://example.com',
+					trailingSlash: 'always',
+					format: 'file',
+				})
+			).to.eq('https://example.com/blog/es/');
+
+			expect(
+				getLocaleAbsoluteUrl({
+					locale: 'en_US',
+					base: '/blog/',
+					...config.experimental.i18n,
+					site: 'https://example.com',
+					trailingSlash: 'always',
+					format: 'file',
+				})
+			).to.throw;
+		});
 	});
 });
 


### PR DESCRIPTION
## Changes

This PR starts the work around domain support. Here are the changes:

- updated the schema with proper validation for the `domains` configuration;
- updated the Astro features with the `domains` support capability. I am not aware of any esoteric case, so notifying Astro with `SupportKind` should be enough
- updated the `getAsbsoluteLocaleUrl` function, which now accepts `domains` and a `isBuild` flag. `isBuild` is required because we can only use the URLs with domains when building the website, otherwise the dev server is broken

Closes: 	PLT-994, PLT-992 and PLT-1206

## Testing

I added various cases to test the implemented features

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Added some basic documentation

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
