### PR TITLE
chore(packaging): allow importing tsconfigs with extension

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -40,7 +40,7 @@
     "./import-meta": "./import-meta.d.ts",
     "./astro-jsx": "./astro-jsx.d.ts",
     "./tsconfigs/*.json": "./tsconfigs/*",
-    "./tsconfigs/*": "./tsconfigs/*.json",
+    "./tsconfigs/*": "./tsconfigs/*",
     "./jsx/*": "./dist/jsx/*",
     "./jsx-runtime": "./dist/jsx-runtime/index.js",
     "./compiler-runtime": "./dist/runtime/compiler/index.js",


### PR DESCRIPTION
## Changes
- `{ "extends": "astro/tsconfigs/strict.json" }` now works.
- `{ "extends": "astro/tsconfigs/strict.json.json" }` now does not work.
- `{ "extends": "astro/tsconfigs/strict" }` continues to work same as before.

## Testing
Does not affect behavior

## Docs
Does not affect usage