### PR TITLE
Add terminal/stdout metadata information to telemetry

### DIFF
--- a/.changeset/tender-spies-protect.md
+++ b/.changeset/tender-spies-protect.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/telemetry': patch
+---
+
+Add stdout metadata reporting: height, width, and terminal name

--- a/packages/telemetry/src/system-info.ts
+++ b/packages/telemetry/src/system-info.ts
@@ -40,6 +40,9 @@ export type SystemInfo = {
 	memoryInMb: number;
 	isDocker: boolean;
 	isTTY: boolean;
+	stdoutName: string | undefined;
+	stdoutColumns: number | undefined;
+	stdoutRows: number | undefined;
 	isWSL: boolean;
 	isCI: boolean;
 	ciName: string | null;
@@ -68,9 +71,13 @@ export function getSystemInfo(versions: { viteVersion: string; astroVersion: str
 		cpuModel: cpus.length ? cpus[0].model : null,
 		cpuSpeed: cpus.length ? cpus[0].speed : null,
 		memoryInMb: Math.trunc(os.totalmem() / Math.pow(1024, 2)),
+		// Stdout information
+		isTTY: process.stdout.isTTY,
+		stdoutName: process.env.TERM_PROGRAM,
+		stdoutColumns: process.stdout.columns,
+		stdoutRows: process.stdout.rows,
 		// Environment information
 		isDocker: isDocker(),
-		isTTY: process.stdout.isTTY,
 		isWSL,
 		isCI,
 		ciName,


### PR DESCRIPTION
## Changes

- In #8833, we realized that our project maintainers had an unclear understanding of our user's terminals and how they experienced Astro. This made it difficult to decide on goals when it came to error formatting: should we optimize for terminals with lots of rows/columns, or none? Should we optimize for terminals integrated into code editors, or standalone?
- This PR adds terminal metadata to our SystemInfo telemetry object so that we can have more insight into this. This should help us design better logging and output for Astro going forward.

## Testing

- N/A

## Docs

- N/A