### PR TITLE
 feat(i18n): domain with lookup table 

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1520,7 +1520,7 @@ export interface AstroUserConfig {
 			 * @docs
 			 * @kind h4
 			 * @name experimental.i18n.routingStrategy
-			 * @type {'prefix-always' | 'prefix-other-locales'}
+			 * @type {'prefix-always' | 'prefix-other-locales' | 'domain'}
 			 * @default 'prefix-other-locales'
 			 * @version 3.5.0
 			 * @description
@@ -1533,9 +1533,12 @@ export interface AstroUserConfig {
 			 *  - `prefix-always`: All URLs will display a language prefix.
 			 *    URLs will be of the form `example.com/[locale]/content/` for every route, including the default language.
 			 *    Localized folders are used for every language, including the default.
+			 *  - `domain`: SSR only, it enables support for different domains. When a locale is mapped to domain, all the URLs won't have the language prefix.
+			 *    You map `fr` to `fr.example.com`, if you want a to have a blog page to look like `fr.example.com/blog` instead of `example.com/fr/blog`.
+			 *    The localised folders be must in the `src/pages/` folder.
 			 *
 			 */
-			routingStrategy?: 'prefix-always' | 'prefix-other-locales';
+			routingStrategy?: 'prefix-always' | 'prefix-other-locales' | 'domain';
 
 			/**
 			 * @docs
@@ -1556,7 +1559,8 @@ export interface AstroUserConfig {
 			 *            locales: ["en", "fr", "pt-br", "es"],
 			 *            domains: {
 			 *                fr: "https://fr.example.com",
-			 *            }
+			 *            },
+			 *            routingStrategy: "domain"
 			 *        }
 			 *    }
 			 * })

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -55,9 +55,10 @@ export type SSRManifest = {
 
 export type SSRManifestI18n = {
 	fallback?: Record<string, string>;
-	routingStrategy?: 'prefix-always' | 'prefix-other-locales';
+	routingStrategy?: 'prefix-always' | 'prefix-other-locales' | 'domain';
 	locales: string[];
 	defaultLocale: string;
+	domainLookupTable: Record<string, string>;
 };
 
 export type SerializedSSRManifest = Omit<

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -634,6 +634,7 @@ export function createBuildManifest(
 			routingStrategy: settings.config.experimental.i18n.routingStrategy,
 			defaultLocale: settings.config.experimental.i18n.defaultLocale,
 			locales: settings.config.experimental.i18n.locales,
+			domainLookupTable: {},
 		};
 	}
 	return {

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -17,6 +17,7 @@ import { cssOrder, mergeInlineCss, type BuildInternals } from '../internal.js';
 import type { AstroBuildPlugin } from '../plugin.js';
 import type { StaticBuildOptions } from '../types.js';
 import { shouldAppendForwardSlash } from '../util.js';
+import { normalizeTheLocale } from '../../../i18n/index.js';
 
 const manifestReplace = '@@ASTRO_MANIFEST_REPLACE@@';
 const replaceExp = new RegExp(`['"](${manifestReplace})['"]`, 'g');
@@ -236,31 +237,15 @@ function buildManifest(
 			styles,
 			routeData: serializeRouteData(route, settings.config.trailingSlash),
 		});
+	}
 
-		/**
-		 * logic meant for i18n domain support, where we fill the lookup table
-		 */
-		const i18n = settings.config.experimental.i18n;
-		if (i18n && i18n.domains && i18n.routingStrategy === 'domain') {
-			// Domain routing strategy assumes that the locale starts at the beginning of the path, so it's safe to get the first item
-			// This is something like /es/guides/getting-started
-			const segments = route.route.split('/');
-			const pathnameLocale = segments[1];
-			const maybeLocaleDomain = i18n.domains[pathnameLocale];
-			if (maybeLocaleDomain) {
-				// This is something like guides/getting-started
-				let pathnameWithoutLocale = segments
-					.filter((segment) => segment !== pathnameLocale)
-					.slice(1)
-					.join('/');
-				if (shouldAppendForwardSlash(settings.config.trailingSlash, settings.config.build.format)) {
-					pathnameWithoutLocale = appendForwardSlash(pathnameWithoutLocale);
-				}
-				// We build a URL object like this: https://es.example.com/guides/getting-started
-				const domainPath = new URL(pathnameWithoutLocale, maybeLocaleDomain);
-				// We map  https://es.example.com/guides/getting-started -> /es/guides/getting-started
-				domainLookupTable[domainPath.toString()] = route.route;
-			}
+	/**
+	 * logic meant for i18n domain support, where we fill the lookup table
+	 */
+	const i18n = settings.config.experimental.i18n;
+	if (i18n && i18n.domains && i18n.routingStrategy === 'domain') {
+		for (const [locale, domainValue] of Object.entries(i18n.domains)) {
+			domainLookupTable[domainValue] = normalizeTheLocale(locale);
 		}
 	}
 

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -9,14 +9,13 @@ import type {
 	SerializedRouteInfo,
 	SerializedSSRManifest,
 } from '../../app/types.js';
-import { appendForwardSlash, joinPaths, prependForwardSlash } from '../../path.js';
+import { joinPaths, prependForwardSlash } from '../../path.js';
 import { serializeRouteData } from '../../routing/index.js';
 import { addRollupInput } from '../add-rollup-input.js';
 import { getOutFile, getOutFolder } from '../common.js';
 import { cssOrder, mergeInlineCss, type BuildInternals } from '../internal.js';
 import type { AstroBuildPlugin } from '../plugin.js';
 import type { StaticBuildOptions } from '../types.js';
-import { shouldAppendForwardSlash } from '../util.js';
 import { normalizeTheLocale } from '../../../i18n/index.js';
 
 const manifestReplace = '@@ASTRO_MANIFEST_REPLACE@@';

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -356,16 +356,15 @@ export const AstroConfigSchema = z.object({
 									)
 							)
 							.optional(),
-						// TODO: properly add default when the feature goes of experimental
 						routingStrategy: z
-							.enum(['prefix-always', 'prefix-other-locales'])
+							.enum(['prefix-always', 'prefix-other-locales', 'domain'])
 							.optional()
 							.default('prefix-other-locales'),
 					})
 					.optional()
 					.superRefine((i18n, ctx) => {
 						if (i18n) {
-							const { defaultLocale, locales, fallback, domains } = i18n;
+							const { defaultLocale, locales, fallback, domains, routingStrategy } = i18n;
 							if (!locales.includes(defaultLocale)) {
 								ctx.addIssue({
 									code: z.ZodIssueCode.custom,
@@ -397,6 +396,16 @@ export const AstroConfigSchema = z.object({
 								}
 							}
 							if (domains) {
+								const entries = Object.entries(domains);
+								if (entries.length > 0) {
+									if (routingStrategy !== 'domain') {
+										ctx.addIssue({
+											code: z.ZodIssueCode.custom,
+											message: `When specifying some domains, the property \`i18n.routingStrategy\` must be set to \`"domain"\`.`,
+										});
+									}
+								}
+
 								for (const [domainKey, domainValue] of Object.entries(domains)) {
 									if (!locales.includes(domainKey)) {
 										ctx.addIssue({

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -93,6 +93,7 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 			routingStrategy: settings.config.experimental.i18n.routingStrategy,
 			defaultLocale: settings.config.experimental.i18n.defaultLocale,
 			locales: settings.config.experimental.i18n.locales,
+			domainLookupTable: {},
 		};
 	}
 	return {

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -277,11 +277,7 @@ export async function handleRoute({
 
 	const onRequest = middleware?.onRequest as MiddlewareEndpointHandler | undefined;
 	if (config.experimental.i18n) {
-		const i18Middleware = createI18nMiddleware(
-			config.experimental.i18n,
-			config.base,
-			config.trailingSlash
-		);
+		const i18Middleware = createI18nMiddleware(manifest.i18n, config.base, config.trailingSlash);
 
 		if (i18Middleware) {
 			if (onRequest) {

--- a/packages/astro/test/fixtures/i18n-routing-subdomain/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-routing-subdomain/astro.config.mjs
@@ -1,0 +1,19 @@
+import { defineConfig} from "astro/config";
+
+export default defineConfig({
+	trailingSlash: "never",
+	experimental: {
+		i18n: {
+			defaultLocale: 'en',
+			locales: [
+				'en', 'pt', 'it'
+			],
+			domains: {
+				pt: "https://example.pt"
+			},
+			routingStrategy: "domain"
+		},
+		
+	},
+	base: "/new-site"
+})

--- a/packages/astro/test/fixtures/i18n-routing-subdomain/package.json
+++ b/packages/astro/test/fixtures/i18n-routing-subdomain/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/i18n-routing-subdomain",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/i18n-routing-subdomain/src/pages/en/blog/[id].astro
+++ b/packages/astro/test/fixtures/i18n-routing-subdomain/src/pages/en/blog/[id].astro
@@ -1,0 +1,18 @@
+---
+export function getStaticPaths() {
+    return [
+        {params: {id: '1'}, props: { content: "Hello world" }},
+        {params: {id: '2'}, props: { content: "Eat Something" }},
+        {params: {id: '3'}, props: { content: "How are you?" }},
+    ];
+}
+const { content } = Astro.props;
+---
+<html>
+<head>
+    <title>Astro</title>
+</head>
+<body>
+{content}
+</body>
+</html>

--- a/packages/astro/test/fixtures/i18n-routing-subdomain/src/pages/en/index.astro
+++ b/packages/astro/test/fixtures/i18n-routing-subdomain/src/pages/en/index.astro
@@ -1,0 +1,8 @@
+<html>
+<head>
+    <title>Astro</title>
+</head>
+<body>
+Hello
+</body>
+</html>

--- a/packages/astro/test/fixtures/i18n-routing-subdomain/src/pages/en/start.astro
+++ b/packages/astro/test/fixtures/i18n-routing-subdomain/src/pages/en/start.astro
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Astro</title>
+</head>
+<body>
+Start
+</body>
+</html>

--- a/packages/astro/test/fixtures/i18n-routing-subdomain/src/pages/pt/blog/[id].astro
+++ b/packages/astro/test/fixtures/i18n-routing-subdomain/src/pages/pt/blog/[id].astro
@@ -1,0 +1,18 @@
+---
+export function getStaticPaths() {
+    return [
+        {params: {id: '1'}, props: { content: "Hola mundo" }},
+        {params: {id: '2'}, props: { content: "Eat Something" }},
+        {params: {id: '3'}, props: { content: "How are you?" }},
+    ];
+}
+const { content } = Astro.props;
+---
+<html>
+<head>
+    <title>Astro</title>
+</head>
+<body>
+{content}
+</body>
+</html>

--- a/packages/astro/test/fixtures/i18n-routing-subdomain/src/pages/pt/start.astro
+++ b/packages/astro/test/fixtures/i18n-routing-subdomain/src/pages/pt/start.astro
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Astro</title>
+</head>
+<body>
+Oi essa e start
+</body>
+</html>

--- a/packages/astro/test/fixtures/i18n-routing/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-routing/astro.config.mjs
@@ -9,7 +9,8 @@ export default defineConfig({
 			],
 			domains: {
 				it: "https://it.example.com"
-			}
+			},
+			routingStrategy: "domain"
 		}
 	},
 })

--- a/packages/astro/test/i18-routing.test.js
+++ b/packages/astro/test/i18-routing.test.js
@@ -1024,15 +1024,38 @@ describe('[SSR] i18n routing', () => {
 			app = await fixture.loadTestAdapterApp();
 		});
 
-		it('should render the en locale', async () => {
+		it('should render the en locale when X-Forwarded-Host header is passed', async () => {
 			let request = new Request('http://example.pt/new-site/start', {
 				headers: {
-					'X-Forwarded-Host': 'https://example.pt',
+					'X-Forwarded-Host': 'example.pt',
+					'X-Forwarded-Proto': 'https',
 				},
 			});
 			let response = await app.render(request);
 			expect(response.status).to.equal(200);
 			expect(await response.text()).includes('Oi essa e start\n');
+		});
+
+		it('should render the en locale when Host header is passed', async () => {
+			let request = new Request('http://example.pt/new-site/start', {
+				headers: {
+					Host: 'example.pt',
+					'X-Forwarded-Proto': 'https',
+				},
+			});
+			let response = await app.render(request);
+			expect(response.status).to.equal(200);
+			expect(await response.text()).includes('Oi essa e start\n');
+		});
+
+		it('should render a 404 because we could not compute the domain', async () => {
+			let request = new Request('http://example.pt/new-site/start', {
+				headers: {
+					Host: 'example.pt',
+				},
+			});
+			let response = await app.render(request);
+			expect(response.status).to.equal(404);
 		});
 	});
 });

--- a/packages/astro/test/i18-routing.test.js
+++ b/packages/astro/test/i18-routing.test.js
@@ -1067,7 +1067,8 @@ describe('[SSR] i18n routing', () => {
 				},
 			});
 			let response = await app.render(request);
-			expect(response.status).to.equal(404);
+			expect(response.status).to.equal(200);
+			expect(await response.text()).includes('Oi essa e start\n');
 		});
 	});
 });

--- a/packages/astro/test/i18-routing.test.js
+++ b/packages/astro/test/i18-routing.test.js
@@ -1009,4 +1009,30 @@ describe('[SSR] i18n routing', () => {
 			});
 		});
 	});
+
+	describe('i18n routing with routing strategy [subdomain]', () => {
+		/** @type {import('./test-utils').Fixture} */
+		let fixture;
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/i18n-routing-subdomain/',
+				output: 'server',
+				adapter: testAdapter(),
+			});
+			await fixture.build();
+			app = await fixture.loadTestAdapterApp();
+		});
+
+		it('should render the en locale', async () => {
+			let request = new Request('http://example.pt/new-site/start', {
+				headers: {
+					'X-Forwarded-Host': 'https://example.pt',
+				},
+			});
+			let response = await app.render(request);
+			expect(response.status).to.equal(200);
+			expect(await response.text()).includes('Oi essa e start\n');
+		});
+	});
 });

--- a/packages/astro/test/i18-routing.test.js
+++ b/packages/astro/test/i18-routing.test.js
@@ -1048,8 +1048,20 @@ describe('[SSR] i18n routing', () => {
 			expect(await response.text()).includes('Oi essa e start\n');
 		});
 
-		it('should render a 404 because we could not compute the domain', async () => {
+		it('should render the en locale when Host header is passed and it has the port', async () => {
 			let request = new Request('http://example.pt/new-site/start', {
+				headers: {
+					Host: 'example.pt:8080',
+					'X-Forwarded-Proto': 'https',
+				},
+			});
+			let response = await app.render(request);
+			expect(response.status).to.equal(200);
+			expect(await response.text()).includes('Oi essa e start\n');
+		});
+
+		it('should render when the protocol header we fallback to the one of the host', async () => {
+			let request = new Request('https://example.pt/new-site/start', {
 				headers: {
 					Host: 'example.pt',
 				},

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -191,6 +191,7 @@ describe('Config Validation', () => {
 							domains: {
 								en: 'www.example.com',
 							},
+							routingStrategy: 'domain',
 						},
 					},
 				},
@@ -212,6 +213,7 @@ describe('Config Validation', () => {
 							domains: {
 								en: 'https://www.example.com/blog/page/',
 							},
+							routingStrategy: 'domain',
 						},
 					},
 				},
@@ -220,6 +222,27 @@ describe('Config Validation', () => {
 			expect(configError instanceof z.ZodError).to.equal(true);
 			expect(configError.errors[0].message).to.equal(
 				"The URL `https://www.example.com/blog/page/` must contain only the origin. A subsequent pathname isn't allowed here. Remove `/blog/page/`."
+			);
+		});
+
+		it('errors if there are domains, and the routing strategy is not correct', async () => {
+			const configError = await validateConfig(
+				{
+					experimental: {
+						i18n: {
+							defaultLocale: 'en',
+							locales: ['es', 'en'],
+							domains: {
+								en: 'https://www.example.com/',
+							},
+						},
+					},
+				},
+				process.cwd()
+			).catch((err) => err);
+			expect(configError instanceof z.ZodError).to.equal(true);
+			expect(configError.errors[0].message).to.equal(
+				'When specifying some domains, the property `i18n.routingStrategy` must be set to `"domain"`.'
 			);
 		});
 	});

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -170,6 +170,7 @@ describe('Config Validation', () => {
 							domains: {
 								lorem: 'https://example.com',
 							},
+							routingStrategy: 'domain',
 						},
 					},
 				},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2833,6 +2833,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/i18n-routing-subdomain:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/import-ts-with-js:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

Relative RFC change: https://github.com/withastro/roadmap/commit/713fce74bb742f18ad985055758c3818b5eed9aa

This PR adds the basic logic for supporting the new routing strategy called `domain`. We require a new routing strategy because Astro needs to make assumptions** in order to provide the correct user experience.

This assumption is that the localised folders must be at the root - `src/pages` folder. With that, the logic works as follow: during the build phase, we add to the manifest a new information called `domainLookupTable`. This table is a map that will look like this:

```js
const domainLookupTable = {
	"https://fr.example.com": "fr",
	"https://example.pt": "pt",
}
```

It's essentially the configuration of `i18n.domains`, reversed :)

This table maps what we are supposed to get from the server to the correct route. When we extract the correct route, we can load and render the component for that route.

In a server environment, Astro will work with the following headers:
- [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host)
- [Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) as fallback of `X-Forwarded-Host`
- [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto)

If Astro can't crate a `URL` from those heasers, it will return a 404. I believe this is an important information and I will make sure to add it to the RFC later.

I will have to do some testing, even on a serverless environment and check if that information is available. I want to do more testing **after** merging this PR.

Closes PLT-1218

## Testing

I added some basic testing to show the feature, although I want to add more tests **in another PR**.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
