### PR TITLE
style: highlight markdown Tip Note section CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 We welcome contributions of any size and skill level. As an open source project, we believe in giving back to our contributors and are happy to help with guidance on PRs, technical writing, and turning any feature idea into a reality.
 
-> **Tip for new contributors:**
-> Take a look at [https://github.com/firstcontributions/first-contributions](https://github.com/firstcontributions/first-contributions) for helpful information on contributing
+> [!Tip]
+> **For new contributors:** Take a look at [https://github.com/firstcontributions/first-contributions](https://github.com/firstcontributions/first-contributions) for helpful information on contributing
 
 ## Quick Guide
 
@@ -46,7 +46,8 @@ To get started, create a codespace for this repository by clicking this 👇
 
 Your new codespace will open in a web-based version of Visual Studio Code. All development dependencies will be preinstalled, and the tests will run automatically ensuring you've got a green base from which to start working.
 
-**Note**: Dev containers is now an open spec which is supported by [GitHub Codespaces](https://github.com/codespaces) and [other supporting tools](https://containers.dev/supporting).
+> [!Note]
+> Dev containers is now an open spec which is supported by [GitHub Codespaces](https://github.com/codespaces) and [other supporting tools](https://containers.dev/supporting).
 
 ### Development
 
@@ -187,7 +188,7 @@ Understanding in which environment code runs, and at which stage in the process,
 
 Active Astro development happens on the [`main`](https://github.com/withastro/astro/tree/main) branch. `main` always reflects the latest code.
 
-> **Note:**
+> [!Note]
 > During certain periods, we put `main` into a [**prerelease**](https://github.com/changesets/changesets/blob/main/docs/prereleases.md#prereleases) state. Read more about [Releasing Astro](#releasing-astro).
 
 ### `latest`
@@ -198,7 +199,8 @@ By default, `create-astro` and [astro.new](https://astro.new) point to this bran
 
 ## Releasing Astro
 
-_Note: Only [core maintainers (L3+)](https://github.com/withastro/.github/blob/main/GOVERNANCE.md#level-3-l3---core) can release new versions of Astro._
+> [!Note]
+> _Only [core maintainers (L3+)](https://github.com/withastro/.github/blob/main/GOVERNANCE.md#level-3-l3---core) can release new versions of Astro._
 
 The repo is set up with automatic releases, using the changeset GitHub action & bot.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ By default, `create-astro` and [astro.new](https://astro.new) point to this bran
 ## Releasing Astro
 
 > [!Note]
-> _Only [core maintainers (L3+)](https://github.com/withastro/.github/blob/main/GOVERNANCE.md#level-3-l3---core) can release new versions of Astro._
+> Only [core maintainers (L3+)](https://github.com/withastro/.github/blob/main/GOVERNANCE.md#level-3-l3---core) can release new versions of Astro.
 
 The repo is set up with automatic releases, using the changeset GitHub action & bot.
 


### PR DESCRIPTION
## Changes

Giving convenient look to Tip and Note section by available [markdown](https://github.com/orgs/community/discussions/16925) for [Contributor Manual](https://github.com/withastro/astro/blob/main/CONTRIBUTING.md).

Example of Tip by previous markdown.

![Screenshot from 2023-11-17 17-33-16](https://github.com/withastro/astro/assets/36249910/e51b40c6-a797-4f9f-9891-7f61d7d6218f)

Example of Tip available markdown.

![Screenshot from 2023-11-17 17-32-22](https://github.com/withastro/astro/assets/36249910/33dec241-f861-4d71-a3ce-5716289217f4)

---

Part of Note section for previous markdown.

![Screenshot from 2023-11-17 17-38-17](https://github.com/withastro/astro/assets/36249910/396b7a79-04cf-48ec-b516-93bd47064560)

And lastly part of Note section available markdown.

![Screenshot from 2023-11-17 17-39-08](https://github.com/withastro/astro/assets/36249910/282b53bb-328f-41af-b526-ad2d50ac2647)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
