### PR TITLE
Fix the blog example content collections configuration

### DIFF
--- a/examples/blog/src/content/config.ts
+++ b/examples/blog/src/content/config.ts
@@ -1,6 +1,8 @@
 import { defineCollection, z } from 'astro:content';
 
 const blog = defineCollection({
+	// Type must either be 'content' for showing page content or 'data' for data files (json, yaml, etc)
+	type: 'content',
 	// Type-check frontmatter using a schema
 	schema: z.object({
 		title: z.string(),


### PR DESCRIPTION
## Changes

Resolves an issue in the blog starter template, missing "type" declaration for the blog content collection.

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Fired up the blog example using `pnpm --filter @example/blog run dev`, ensured astro was able to compile and run the example -> works.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No changes to the docs needed.
