### PR TITLE
fix(i18n): fallback should create consistent directories

### DIFF
--- a/.changeset/curvy-sheep-lick.md
+++ b/.changeset/curvy-sheep-lick.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Consistely emit fallback routes in the correct folders.

--- a/packages/astro/src/core/render/params-and-props.ts
+++ b/packages/astro/src/core/render/params-and-props.ts
@@ -50,7 +50,7 @@ export async function getParamsAndProps(opts: GetParamsAndPropsOptions): Promise
 		throw new AstroError({
 			...AstroErrorData.NoMatchingStaticPathFound,
 			message: AstroErrorData.NoMatchingStaticPathFound.message(pathname),
-			hint: AstroErrorData.NoMatchingStaticPathFound.hint([route.route]),
+			hint: AstroErrorData.NoMatchingStaticPathFound.hint([route.component]),
 		});
 	}
 

--- a/packages/astro/src/core/render/params-and-props.ts
+++ b/packages/astro/src/core/render/params-and-props.ts
@@ -50,7 +50,7 @@ export async function getParamsAndProps(opts: GetParamsAndPropsOptions): Promise
 		throw new AstroError({
 			...AstroErrorData.NoMatchingStaticPathFound,
 			message: AstroErrorData.NoMatchingStaticPathFound.message(pathname),
-			hint: AstroErrorData.NoMatchingStaticPathFound.hint([route.component]),
+			hint: AstroErrorData.NoMatchingStaticPathFound.hint([route.route]),
 		});
 	}
 

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -603,22 +603,22 @@ export function createRouteManifest(
 						if (!hasRoute) {
 							let pathname: string | undefined;
 							let route: string;
-							if (fallbackToLocale === i18n.defaultLocale) {
+							if (
+								fallbackToLocale === i18n.defaultLocale &&
+								i18n.routingStrategy === 'prefix-other-locales'
+							) {
 								if (fallbackToRoute.pathname) {
 									pathname = `/${fallbackFromLocale}${fallbackToRoute.pathname}`;
 								}
 								route = `/${fallbackFromLocale}${fallbackToRoute.route}`;
 							} else {
-								pathname = fallbackToRoute.pathname?.replace(
-									`/${fallbackToLocale}`,
-									`/${fallbackFromLocale}`
-								);
-								route = fallbackToRoute.route.replace(
-									`/${fallbackToLocale}`,
-									`/${fallbackFromLocale}`
-								);
+								pathname = fallbackToRoute.pathname
+									?.replace(`/${fallbackToLocale}/`, `/${fallbackFromLocale}/`)
+									.replace(`/${fallbackToLocale}`, `/${fallbackFromLocale}`);
+								route = fallbackToRoute.route
+									.replace(`/${fallbackToLocale}`, `/${fallbackFromLocale}`)
+									.replace(`/${fallbackToLocale}/`, `/${fallbackFromLocale}/`);
 							}
-
 							const segments = removeLeadingForwardSlash(route)
 								.split(path.posix.sep)
 								.filter(Boolean)
@@ -626,7 +626,7 @@ export function createRouteManifest(
 									validateSegment(s);
 									return getParts(s, route);
 								});
-
+							const generate = getRouteGenerator(segments, config.trailingSlash);
 							const index = routes.findIndex((r) => r === fallbackToRoute);
 							if (index) {
 								const fallbackRoute: RouteData = {
@@ -634,6 +634,7 @@ export function createRouteManifest(
 									pathname,
 									route,
 									segments,
+									generate,
 									pattern: getPattern(segments, config, config.trailingSlash),
 									type: 'fallback',
 									fallbackRoutes: [],

--- a/packages/astro/src/core/routing/params.ts
+++ b/packages/astro/src/core/routing/params.ts
@@ -31,7 +31,7 @@ export function getParams(array: string[]) {
 export function stringifyParams(params: GetStaticPathsItem['params'], route: RouteData) {
 	// validate parameter values then stringify each value
 	const validatedParams = Object.entries(params).reduce((acc, next) => {
-		validateGetStaticPathsParameter(next, route.component);
+		validateGetStaticPathsParameter(next, route.route);
 		const [key, value] = next;
 		if (value !== undefined) {
 			acc[key] = typeof value === 'string' ? trimSlashes(value) : value.toString();

--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -41,7 +41,7 @@ export function createI18nMiddleware(
 		}
 
 		const url = context.url;
-		const { locales, defaultLocale, fallback } = i18n;
+		const { locales, defaultLocale, fallback, routingStrategy } = i18n;
 		const response = await next();
 
 		if (response instanceof Response) {
@@ -82,7 +82,7 @@ export function createI18nMiddleware(
 					let newPathname: string;
 					// If a locale falls back to the default locale, we want to **remove** the locale because
 					// the default locale doesn't have a prefix
-					if (fallbackLocale === defaultLocale) {
+					if (fallbackLocale === defaultLocale && routingStrategy === 'prefix-other-locales') {
 						newPathname = url.pathname.replace(`/${urlLocale}`, ``);
 					} else {
 						newPathname = url.pathname.replace(`/${urlLocale}`, `/${fallbackLocale}`);

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -646,6 +646,34 @@ describe('[SSG] i18n routing', () => {
 			expect($('script').text()).includes('console.log("this is a script")');
 		});
 	});
+
+	describe('i18n routing with fallback and [prefix-always]', () => {
+		/** @type {import('./test-utils').Fixture} */
+		let fixture;
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/i18n-routing-prefix-always/',
+				experimental: {
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['en', 'pt', 'it'],
+						fallback: {
+							it: 'en',
+						},
+						routingStrategy: 'prefix-always',
+					},
+				},
+			});
+			await fixture.build();
+		});
+
+		it('should render the en locale', async () => {
+			let html = await fixture.readFile('/it/start/index.html');
+			expect(html).to.include('http-equiv="refresh');
+			expect(html).to.include('url=/new-site/en/start');
+		});
+	});
 });
 describe('[SSR] i18n routing', () => {
 	let app;

--- a/packages/astro/test/ssr-split-manifest.test.js
+++ b/packages/astro/test/ssr-split-manifest.test.js
@@ -109,7 +109,6 @@ describe('astro:ssr-manifest, split', () => {
 			const request = new Request('http://example.com/');
 			const response = await app.render(request);
 			const html = await response.text();
-			console.log(html);
 			expect(html.includes('<title>Testing</title>')).to.be.true;
 		});
 	});


### PR DESCRIPTION
## Changes

Fixes https://github.com/withastro/astro/issues/9096
Fixes https://github.com/withastro/astro/issues/9095
Closes PLT-1230

This PR refactors the fallback system again. There was a business logic flaw in how the routes and paths were computed, plus the flow of things could have been smoother, and that didn't help. 


When rendering a page, the flow **was** like this:
- we extract the styles/links/scripts
- generate the paths using `getStaticPaths`
- loop over the exploded paths
- call the `generatePath` function
- compute more styles and scripts
- create a request and render the response

Now the flow is adapted to the fallback, and a few steps have been moved:
- we extract the styles/links/scripts
- compute more styles and scripts
- **NEW** loop over the exploded routes (itself + fallbacks)
- loop over the exploded paths
- call the `generatePath` function
- create a request and render the response


The function `generatePath` now accepts the styles/scripts/links, and they are already computed; it only needs to render the `Response`.

The function `eachRouteInRouteData` is now called in a different place and its loop is way smaller.

## Testing

I added a new test case that should prevent a regression against the issues we're closing.

The rest of the tests should still pass.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
