### PR TITLE
Simply React component check

### DIFF
--- a/.changeset/dull-ways-laugh.md
+++ b/.changeset/dull-ways-laugh.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/react': patch
+---
+
+Simplify React component check
+
+In Astro 3 we added the `include` and `exclude` config options for controlling which type of JSX component to build. Because of that we can now simplify our React check function and prevent swallowing errors/warnings that have occured in the past.

--- a/packages/integrations/react/server.js
+++ b/packages/integrations/react/server.js
@@ -15,7 +15,7 @@ function errorIsComingFromPreactComponent(err) {
 	);
 }
 
-async function check(Component, props, children) {
+async function check(Component) {
 	// Note: there are packages that do some unholy things to create "components".
 	// Checking the $$typeof property catches most of these patterns.
 	if (typeof Component === 'object') {
@@ -27,29 +27,7 @@ async function check(Component, props, children) {
 		return React.Component.isPrototypeOf(Component) || React.PureComponent.isPrototypeOf(Component);
 	}
 
-	let error = null;
-	let isReactComponent = false;
-	function Tester(...args) {
-		try {
-			const vnode = Component(...args);
-			if (vnode && vnode['$$typeof'] === reactTypeof) {
-				isReactComponent = true;
-			}
-		} catch (err) {
-			if (!errorIsComingFromPreactComponent(err)) {
-				error = err;
-			}
-		}
-
-		return React.createElement('div');
-	}
-
-	await renderToStaticMarkup(Tester, props, children, {});
-
-	if (error) {
-		throw error;
-	}
-	return isReactComponent;
+	return true;
 }
 
 async function getNodeWritable() {

--- a/packages/integrations/react/test/fixtures/react-component/package.json
+++ b/packages/integrations/react/test/fixtures/react-component/package.json
@@ -6,8 +6,8 @@
     "@astrojs/react": "workspace:*",
     "@astrojs/vue": "workspace:*",
     "astro": "workspace:*",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "vue": "^3.3.4"
   }
 }

--- a/packages/integrations/react/test/fixtures/react-component/src/components/ListWarning.tsx
+++ b/packages/integrations/react/test/fixtures/react-component/src/components/ListWarning.tsx
@@ -1,0 +1,9 @@
+export default function Example({ list }) {
+  return (
+    <ul>
+      {list.map((i) => (
+        <li>{i}</li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/integrations/react/test/fixtures/react-component/src/pages/list-warning.astro
+++ b/packages/integrations/react/test/fixtures/react-component/src/pages/list-warning.astro
@@ -1,0 +1,11 @@
+---
+import ListWarning from '../components/ListWarning';
+---
+<html>
+<head>
+	<title>Testing</title>
+</head>
+<body>
+	<ListWarning list={[1, 2, 3, 4, 5]} />
+</body>
+</html>

--- a/packages/integrations/react/test/react-component.test.js
+++ b/packages/integrations/react/test/react-component.test.js
@@ -113,6 +113,12 @@ describe('React Components', () => {
 			const $ = cheerioLoad(html);
 			expect($('[data-react-children]')).to.have.lengthOf(1);
 		});
+
+		it('Lists missing the `key` prop produce warning instead of erroring', async () => {
+			const html = await fixture.readFile('/list-warning/index.html');
+			const $ = cheerioLoad(html);
+			expect($('ul li')).to.have.lengthOf(5);
+		});
 	});
 
 	if (isWindows) return;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4495,10 +4495,10 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
       react:
-        specifier: ^18.1.0
+        specifier: ^18.2.0
         version: 18.2.0
       react-dom:
-        specifier: ^18.1.0
+        specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       vue:
         specifier: ^3.3.4


### PR DESCRIPTION
## Changes

- This removes the vnode check logic from the React renderer.
- In the past this was used to check if the component output React or some other library (like Preact) components.
- In 3.0 we changed how multi-jsx works to use the `include` config instead, so this code is no longer needed.
- Additionally, this code could swallow warnings/errors when it looked like check() failed but actually the component just throw.
- Fixes https://github.com/withastro/astro/issues/9110

## Testing

- New test case added that previously failed.

## Docs

N/A, bug fix