### PR TITLE
Fix RemarkRehype types

### DIFF
--- a/.changeset/khaki-fans-sell.md
+++ b/.changeset/khaki-fans-sell.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Fixes `RemarkRehype` type's `handler` and `handlers` properties

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -35,7 +35,6 @@
     "github-slugger": "^2.0.0",
     "import-meta-resolve": "^4.0.0",
     "mdast-util-definitions": "^6.0.0",
-    "mdast-util-to-hast": "13.0.2",
     "rehype-raw": "^7.0.0",
     "rehype-stringify": "^10.0.0",
     "remark-gfm": "^4.0.0",

--- a/packages/markdown/remark/src/index.ts
+++ b/packages/markdown/remark/src/index.ts
@@ -102,7 +102,7 @@ export async function createMarkdownProcessor(
 	}
 
 	// Remark -> Rehype
-	parser.use(remarkRehype as any, {
+	parser.use(remarkRehype, {
 		allowDangerousHtml: true,
 		passThrough: [],
 		...remarkRehypeOptions,

--- a/packages/markdown/remark/src/types.ts
+++ b/packages/markdown/remark/src/types.ts
@@ -1,7 +1,6 @@
 import type * as hast from 'hast';
 import type * as mdast from 'mdast';
 import type { Options as RemarkRehypeOptions } from 'remark-rehype';
-import type { State } from 'mdast-util-to-hast';
 import type {
 	BuiltinTheme,
 	LanguageRegistration,
@@ -10,9 +9,6 @@ import type {
 } from 'shikiji';
 import type * as unified from 'unified';
 import type { VFile } from 'vfile';
-
-type Handler = State['one'];
-type Handlers = State['all'];
 
 export type { Node } from 'unist';
 
@@ -34,10 +30,7 @@ export type RehypePlugin<PluginParameters extends any[] = any[]> = unified.Plugi
 
 export type RehypePlugins = (string | [string, any] | RehypePlugin | [RehypePlugin, any])[];
 
-export type RemarkRehype = Omit<RemarkRehypeOptions, 'handlers' | 'unknownHandler'> & {
-	handlers?: Handlers;
-	handler?: Handler;
-};
+export type RemarkRehype = RemarkRehypeOptions;
 
 export interface ShikiConfig {
 	langs?: LanguageRegistration[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4905,9 +4905,6 @@ importers:
       mdast-util-definitions:
         specifier: ^6.0.0
         version: 6.0.0
-      mdast-util-to-hast:
-        specifier: 13.0.2
-        version: 13.0.2
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0


### PR DESCRIPTION
## Changes

Supersedes and closes https://github.com/withastro/astro/pull/6211

The linked PR above explains why the types is incorrect today. This PR merges into `next` which includes the latest versions of the remark/rehype plugins, which I think should work now.

## Testing

Existing test should pass. Also tested the types in an Astro config manually.

## Docs

n/a. bug fix.
