### PR TITLE
Refactor virtual modules exports

### DIFF
--- a/.changeset/sour-games-burn.md
+++ b/.changeset/sour-games-burn.md
@@ -2,4 +2,10 @@
 "astro": patch
 ---
 
-Refactors virtual modules exports. This should not break your projects unless you imported Astro's internal modules.
+Refactors virtual modules exports. This should not break your project unless you import Astro's internal modules, including:
+
+- `astro/middleware/namespace`
+- `astro/transitions`
+- `astro/transitions/router`
+- `astro/prefetch`
+- `astro/i18n`

--- a/.changeset/sour-games-burn.md
+++ b/.changeset/sour-games-burn.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Refactors virtual modules exports. This should not break your projects unless you imported Astro's internal modules.

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -106,7 +106,7 @@ declare module '*.avif' {
 }
 
 declare module 'astro:transitions' {
-	type TransitionModule = typeof import('./dist/transitions/index.js');
+	type TransitionModule = typeof import('./dist/virtual-modules/transitions.js');
 	export const slide: TransitionModule['slide'];
 	export const fade: TransitionModule['fade'];
 
@@ -115,24 +115,24 @@ declare module 'astro:transitions' {
 }
 
 declare module 'astro:transitions/client' {
-	type TransitionRouterModule = typeof import('./dist/transitions/router.js');
+	type TransitionRouterModule = typeof import('./dist/virtual-modules/transitions-router.js');
 	export const supportsViewTransitions: TransitionRouterModule['supportsViewTransitions'];
 	export const transitionEnabledOnThisPage: TransitionRouterModule['transitionEnabledOnThisPage'];
 	export const navigate: TransitionRouterModule['navigate'];
-	export type Options = import('./dist/transitions/router.js').Options;
+	export type Options = import('./dist/virtual-modules/transitions-router.js').Options;
 }
 
 declare module 'astro:prefetch' {
-	export { prefetch, PrefetchOptions } from 'astro/prefetch';
+	export { prefetch, PrefetchOptions } from 'astro/virtual-modules/prefetch.js';
 }
 
 declare module 'astro:i18n' {
-	export type GetLocaleOptions = import('./dist/i18n/index.js').GetLocaleOptions;
+	export type GetLocaleOptions = import('./dist/virtual-modules/i18n.js').GetLocaleOptions;
 
 	/**
 	 * @param {string} locale A locale
 	 * @param {string} [path=""] An optional path to add after the `locale`.
-	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
+	 * @param {import('./dist/virtual-modules/i18n.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string}
 	 *
 	 * Returns a _relative_ path with passed locale.
@@ -161,7 +161,7 @@ declare module 'astro:i18n' {
 	 *
 	 * @param {string} locale A locale
 	 * @param {string} [path=""] An optional path to add after the `locale`.
-	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
+	 * @param {import('./dist/virtual-modules/i18n.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string}
 	 *
 	 * Returns an absolute path with the passed locale. The behaviour is subject to change based on `site` configuration.
@@ -191,7 +191,7 @@ declare module 'astro:i18n' {
 
 	/**
 	 * @param {string} [path=""] An optional path to add after the `locale`.
-	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
+	 * @param {import('./dist/virtual-modules/i18n.jss').GetLocaleOptions} options Customise the generated path
 	 * @return {string[]}
 	 *
 	 * Works like `getRelativeLocaleUrl` but it emits the relative URLs for ALL locales:
@@ -199,7 +199,7 @@ declare module 'astro:i18n' {
 	export const getRelativeLocaleUrlList: (path?: string, options?: GetLocaleOptions) => string[];
 	/**
 	 * @param {string} [path=""] An optional path to add after the `locale`.
-	 * @param {import('./dist/i18n/index.js').GetLocaleOptions} options Customise the generated path
+	 * @param {import('./dist/virtual-modules/i18n.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string[]}
 	 *
 	 * Works like `getAbsoluteLocaleUrl` but it emits the absolute URLs for ALL locales:
@@ -208,7 +208,7 @@ declare module 'astro:i18n' {
 }
 
 declare module 'astro:middleware' {
-	export * from 'astro/middleware/namespace';
+	export * from 'astro/virtual-modules/middleware.js';
 }
 
 declare module 'astro:components' {

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -191,7 +191,7 @@ declare module 'astro:i18n' {
 
 	/**
 	 * @param {string} [path=""] An optional path to add after the `locale`.
-	 * @param {import('./dist/virtual-modules/i18n.jss').GetLocaleOptions} options Customise the generated path
+	 * @param {import('./dist/virtual-modules/i18n.js').GetLocaleOptions} options Customise the generated path
 	 * @return {string[]}
 	 *
 	 * Works like `getRelativeLocaleUrl` but it emits the relative URLs for ALL locales:

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -29,8 +29,8 @@ const { fallback = 'animate', handleForms } = Astro.props;
 <script>
 	import type { Options } from 'astro:transitions/client';
 	import { supportsViewTransitions, navigate } from 'astro:transitions/client';
-	// NOTE: import from `astro/prefetch` as `astro:prefetch` requires the `prefetch` config to be enabled
-	import { init } from 'astro/prefetch';
+	// NOTE: import from `astro/virtual-modules/prefetch.js` as `astro:prefetch` requires the `prefetch` config to be enabled
+	import { init } from 'astro/virtual-modules/prefetch.js';
 
 	export type Fallback = 'none' | 'animate' | 'swap';
 

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -22,10 +22,7 @@
         "./dist/core/app/*"
       ],
       "middleware": [
-        "./dist/core/middleware/index.d.ts"
-      ],
-      "middleware/namespace": [
-        "./dist/core/middleware/namespace.d.ts"
+        "./dist/virtual-modules/middleware.d.ts"
       ]
     }
   },
@@ -73,14 +70,7 @@
       "types": "./dist/core/middleware/index.d.ts",
       "default": "./dist/core/middleware/index.js"
     },
-    "./middleware/namespace": {
-      "types": "./dist/core/middleware/namespace.d.ts",
-      "default": "./dist/core/middleware/namespace.js"
-    },
-    "./transitions": "./dist/transitions/index.js",
-    "./transitions/router": "./dist/transitions/router.js",
-    "./prefetch": "./dist/prefetch/index.js",
-    "./i18n": "./dist/i18n/index.js"
+    "./virtual-modules/*": "./dist/virtual-modules/*"
   },
   "imports": {
     "#astro/*": "./dist/*.js"

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -192,7 +192,7 @@ export async function createVite(
 				},
 				{
 					find: 'astro:middleware',
-					replacement: 'astro/middleware/namespace',
+					replacement: 'astro/virtual-modules/middleware.js',
 				},
 				{
 					find: 'astro:components',

--- a/packages/astro/src/core/middleware/namespace.ts
+++ b/packages/astro/src/core/middleware/namespace.ts
@@ -1,1 +1,0 @@
-export { defineMiddleware, sequence } from './index.js';

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -28,7 +28,7 @@ export default function astroInternationalization({
 						getLocaleAbsoluteUrl as _getLocaleAbsoluteUrl, 
 						getLocaleAbsoluteUrlList as _getLocaleAbsoluteUrlList,
 						 
-					} from "astro/i18n";
+					} from "astro/virtual-modules/i18n.js";
 					
 					const base =  ${JSON.stringify(settings.config.base)};
 					const trailingSlash =  ${JSON.stringify(settings.config.trailingSlash)};

--- a/packages/astro/src/prefetch/vite-plugin-prefetch.ts
+++ b/packages/astro/src/prefetch/vite-plugin-prefetch.ts
@@ -4,7 +4,7 @@ import type { AstroSettings } from '../@types/astro.js';
 const virtualModuleId = 'astro:prefetch';
 const resolvedVirtualModuleId = '\0' + virtualModuleId;
 const prefetchInternalModuleFsSubpath = 'astro/dist/prefetch/index.js';
-const prefetchCode = `import { init } from 'astro/prefetch';init()`;
+const prefetchCode = `import { init } from 'astro/virtual-modules/prefetch.js';init()`;
 
 export default function astroPrefetch({ settings }: { settings: AstroSettings }): vite.Plugin {
 	const prefetchOption = settings.config.prefetch;
@@ -19,7 +19,7 @@ export default function astroPrefetch({ settings }: { settings: AstroSettings })
 		// Inject prefetch script to all pages
 		settings.scripts.push({
 			stage: 'page',
-			content: `import { init } from 'astro/prefetch';init()`,
+			content: `import { init } from 'astro/virtual-modules/prefetch.js';init()`,
 		});
 	}
 
@@ -40,7 +40,7 @@ export default function astroPrefetch({ settings }: { settings: AstroSettings })
 		load(id) {
 			if (id === resolvedVirtualModuleId) {
 				if (!prefetch) throwPrefetchNotEnabledError();
-				return `export { prefetch } from "astro/prefetch";`;
+				return `export { prefetch } from "astro/virtual-modules/prefetch.js";`;
 			}
 		},
 		transform(code, id) {

--- a/packages/astro/src/transitions/vite-plugin-transitions.ts
+++ b/packages/astro/src/transitions/vite-plugin-transitions.ts
@@ -21,13 +21,13 @@ export default function astroTransitions({ settings }: { settings: AstroSettings
 		load(id) {
 			if (id === resolvedVirtualModuleId) {
 				return `
-				export * from "astro/transitions";
+				export * from "astro/virtual-modules/transitions.js";
 				export { default as ViewTransitions } from "astro/components/ViewTransitions.astro";
 			`;
 			}
 			if (id === resolvedVirtualClientModuleId) {
 				return `
-				export * from "astro/transitions/router";
+				export * from "astro/virtual-modules/transitions-router.js";
 			`;
 			}
 		},

--- a/packages/astro/src/virtual-modules/README.md
+++ b/packages/astro/src/virtual-modules/README.md
@@ -1,0 +1,3 @@
+# virtual-modules
+
+This directory contains the entry points for Astro virtual modules. For example, `astro:foobar` would re-export or use `astro/virtual-modules/foobar.js` which maps to the internal file `astro/dist/virtual-modules/foobar.js`.

--- a/packages/astro/src/virtual-modules/i18n.ts
+++ b/packages/astro/src/virtual-modules/i18n.ts
@@ -1,0 +1,1 @@
+export * from '../i18n/index.js';

--- a/packages/astro/src/virtual-modules/middleware.ts
+++ b/packages/astro/src/virtual-modules/middleware.ts
@@ -1,0 +1,1 @@
+export { defineMiddleware, sequence } from '../core/middleware/index.js';

--- a/packages/astro/src/virtual-modules/prefetch.ts
+++ b/packages/astro/src/virtual-modules/prefetch.ts
@@ -1,0 +1,1 @@
+export * from '../prefetch/index.js';

--- a/packages/astro/src/virtual-modules/transitions-router.ts
+++ b/packages/astro/src/virtual-modules/transitions-router.ts
@@ -1,0 +1,1 @@
+export * from '../transitions/router.js';

--- a/packages/astro/src/virtual-modules/transitions.ts
+++ b/packages/astro/src/virtual-modules/transitions.ts
@@ -1,0 +1,1 @@
+export * from '../transitions/index.js';


### PR DESCRIPTION
## Changes

Group the files used for `astro:middleware`, `astro:transitions`, `astro:transitions/router`, `astro:i18n`, and `astro:prefetch` under an internal export at `astro/virtual-modules/*`

## Testing

Existing tests should pass.

## Docs

n/a. internal refactor
