### PR TITLE
Fix esbuild warning for local dev

### DIFF
--- a/packages/astro/src/vite-plugin-scanner/scan.ts
+++ b/packages/astro/src/vite-plugin-scanner/scan.ts
@@ -72,7 +72,7 @@ export async function scan(
 					message: AstroErrorData.InvalidPrerenderExport.message(
 						prefix,
 						suffix,
-						settings?.config.output === 'hybrid' ?? false
+						settings?.config.output === 'hybrid'
 					),
 					location: { file: id },
 				});


### PR DESCRIPTION
## Changes

Recently we upgraded `esbuild`, which (for some reason) does partial linting and flagged this code in `packages/astro`:

```
▲ [WARNING] The "??" operator here will always return the left operand [suspicious-nullish-coalescing]

    src/vite-plugin-scanner/scan.ts:75:43:
      75 │             settings?.config.output === 'hybrid' ?? false
         ╵                                                  ~~

  The left operand of the "??" operator here will never be null or undefined, so it will always be
  returned. This usually indicates a bug in your code:

    src/vite-plugin-scanner/scan.ts:75:6:
      75 │             settings?.config.output === 'hybrid' ?? false
         ╵             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[05:51 PM] ⚠ updated with warnings:
[object Object]
[05:51 PM] ✔ updated
```

I removed the `?? false` in this PR.

## Testing

Existing test should pass

## Docs

n/a. internal refactor.
