### PR TITLE
Rename entryPoint to entrypoint

### DIFF
--- a/.changeset/rude-hairs-whisper.md
+++ b/.changeset/rude-hairs-whisper.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+When inject routes in integrations with the `injectRoute` API, the passed route's `entryPoint` property has been renamed to `entrypoint` to keep consistency with the other APIs

--- a/.changeset/rude-hairs-whisper.md
+++ b/.changeset/rude-hairs-whisper.md
@@ -2,4 +2,4 @@
 'astro': minor
 ---
 
-When inject routes in integrations with the `injectRoute` API, the passed route's `entryPoint` property has been renamed to `entrypoint` to keep consistency with the other APIs
+When injecting routes in integrations with the `injectRoute` API, the passed route's `entryPoint` property is renamed to `entrypoint` to be consistent with other Astro APIs

--- a/.changeset/rude-hairs-whisper.md
+++ b/.changeset/rude-hairs-whisper.md
@@ -2,4 +2,4 @@
 'astro': minor
 ---
 
-When injecting routes in integrations with the `injectRoute` API, the passed route's `entryPoint` property is renamed to `entrypoint` to be consistent with other Astro APIs
+Renames the `entryPoint` property of the `injectRoute` integrations API to `entrypoint` for consistency. A warning will be shown prompting you to update your code when using the old name.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1578,7 +1578,7 @@ export type InjectedScriptStage = 'before-hydration' | 'head-inline' | 'page' | 
 
 export interface InjectedRoute {
 	pattern: string;
-	entryPoint: string;
+	entrypoint: string;
 	prerender?: boolean;
 }
 

--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -19,7 +19,7 @@ export function injectImageEndpoint(settings: AstroSettings, mode: 'dev' | 'buil
 
 	settings.injectedRoutes.push({
 		pattern: '/_image',
-		entryPoint: endpointEntrypoint,
+		entrypoint: endpointEntrypoint,
 		prerender: false,
 	});
 

--- a/packages/astro/src/core/build/buildPipeline.ts
+++ b/packages/astro/src/core/build/buildPipeline.ts
@@ -142,15 +142,15 @@ export class BuildPipeline extends Pipeline {
 	retrieveRoutesToGenerate(): Map<PageBuildData, string> {
 		const pages = new Map<PageBuildData, string>();
 
-		for (const [entryPoint, filePath] of this.#internals.entrySpecifierToBundleMap) {
+		for (const [entrypoint, filePath] of this.#internals.entrySpecifierToBundleMap) {
 			// virtual pages can be emitted with different prefixes:
 			// - the classic way are pages emitted with prefix ASTRO_PAGE_RESOLVED_MODULE_ID -> plugin-pages
 			// - pages emitted using `build.split`, in this case pages are emitted with prefix RESOLVED_SPLIT_MODULE_ID
 			if (
-				entryPoint.includes(ASTRO_PAGE_RESOLVED_MODULE_ID) ||
-				entryPoint.includes(RESOLVED_SPLIT_MODULE_ID)
+				entrypoint.includes(ASTRO_PAGE_RESOLVED_MODULE_ID) ||
+				entrypoint.includes(RESOLVED_SPLIT_MODULE_ID)
 			) {
-				const [, pageName] = entryPoint.split(':');
+				const [, pageName] = entrypoint.split(':');
 				const pageData = this.#internals.pagesByComponent.get(
 					`${pageName.replace(ASTRO_PAGE_EXTENSION_POST_PATTERN, '.')}`
 				);

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -268,15 +268,15 @@ export function* eachPageFromAllPages(allPages: AllPagesData): Generator<[string
 export function* eachPageDataFromEntryPoint(
 	internals: BuildInternals
 ): Generator<[PageBuildData, string]> {
-	for (const [entryPoint, filePath] of internals.entrySpecifierToBundleMap) {
+	for (const [entrypoint, filePath] of internals.entrySpecifierToBundleMap) {
 		// virtual pages can be emitted with different prefixes:
 		// - the classic way are pages emitted with prefix ASTRO_PAGE_RESOLVED_MODULE_ID -> plugin-pages
 		// - pages emitted using `build.split`, in this case pages are emitted with prefix RESOLVED_SPLIT_MODULE_ID
 		if (
-			entryPoint.includes(ASTRO_PAGE_RESOLVED_MODULE_ID) ||
-			entryPoint.includes(RESOLVED_SPLIT_MODULE_ID)
+			entrypoint.includes(ASTRO_PAGE_RESOLVED_MODULE_ID) ||
+			entrypoint.includes(RESOLVED_SPLIT_MODULE_ID)
 		) {
-			const [, pageName] = entryPoint.split(':');
+			const [, pageName] = entrypoint.split(':');
 			const pageData = internals.pagesByComponent.get(
 				`${pageName.replace(ASTRO_PAGE_EXTENSION_POST_PATTERN, '.')}`
 			);

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -184,13 +184,13 @@ function comparator(a: Item, b: Item) {
 
 function injectedRouteToItem(
 	{ config, cwd }: { config: AstroConfig; cwd?: string },
-	{ pattern, entryPoint }: InjectedRoute
+	{ pattern, entrypoint }: InjectedRoute
 ): Item {
 	let resolved: string;
 	try {
-		resolved = require.resolve(entryPoint, { paths: [cwd || fileURLToPath(config.root)] });
+		resolved = require.resolve(entrypoint, { paths: [cwd || fileURLToPath(config.root)] });
 	} catch (e) {
-		resolved = fileURLToPath(new URL(entryPoint, config.root));
+		resolved = fileURLToPath(new URL(entrypoint, config.root));
 	}
 
 	const ext = path.extname(pattern);
@@ -368,12 +368,12 @@ export function createRouteManifest(
 			comparator(injectedRouteToItem({ config, cwd }, a), injectedRouteToItem({ config, cwd }, b))
 		)
 		.reverse() // prepend to the routes array from lowest to highest priority
-		.forEach(({ pattern: name, entryPoint, prerender: prerenderInjected }) => {
+		.forEach(({ pattern: name, entrypoint, prerender: prerenderInjected }) => {
 			let resolved: string;
 			try {
-				resolved = require.resolve(entryPoint, { paths: [cwd || fileURLToPath(config.root)] });
+				resolved = require.resolve(entrypoint, { paths: [cwd || fileURLToPath(config.root)] });
 			} catch (e) {
-				resolved = fileURLToPath(new URL(entryPoint, config.root));
+				resolved = fileURLToPath(new URL(entrypoint, config.root));
 			}
 			const component = slash(path.relative(cwd || fileURLToPath(config.root), resolved));
 

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -127,7 +127,7 @@ export async function runHookConfigSetup({
 					updatedConfig = mergeConfig(updatedConfig, newConfig) as AstroConfig;
 				},
 				injectRoute: (injectRoute) => {
-					if ('entryPoint' in injectRoute) {
+					if (injectRoute.entrypoint == null && 'entryPoint' in injectRoute) {
 						logger.warn(
 							null,
 							`The injected route "${injectRoute.pattern}" by ${integration.name} specifies the entry point with the "entryPoint" property. This property is deprecated, please use "entrypoint" instead.`

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -127,6 +127,15 @@ export async function runHookConfigSetup({
 					updatedConfig = mergeConfig(updatedConfig, newConfig) as AstroConfig;
 				},
 				injectRoute: (injectRoute) => {
+					// @ts-expect-error entryPoint is no longer typed as it's deprecated
+					if (injectRoute.entryPoint) {
+						logger.warn(
+							null,
+							`The injected route "${injectRoute.pattern}" by ${integration.name} specifies the entry point with the "entryPoint" property. This property is deprecated, please use "entrypoint" instead.`
+						);
+						// @ts-expect-error same as above
+						injectRoute.entrypoint = injectRoute.entryPoint;
+					}
 					updatedSettings.injectedRoutes.push(injectRoute);
 				},
 				addWatchFile: (path) => {

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -127,14 +127,12 @@ export async function runHookConfigSetup({
 					updatedConfig = mergeConfig(updatedConfig, newConfig) as AstroConfig;
 				},
 				injectRoute: (injectRoute) => {
-					// @ts-expect-error entryPoint is no longer typed as it's deprecated
-					if (injectRoute.entryPoint) {
+					if ('entryPoint' in injectRoute) {
 						logger.warn(
 							null,
 							`The injected route "${injectRoute.pattern}" by ${integration.name} specifies the entry point with the "entryPoint" property. This property is deprecated, please use "entrypoint" instead.`
 						);
-						// @ts-expect-error same as above
-						injectRoute.entrypoint = injectRoute.entryPoint;
+						injectRoute.entrypoint = injectRoute.entryPoint as string;
 					}
 					updatedSettings.injectedRoutes.push(injectRoute);
 				},

--- a/packages/astro/src/vite-plugin-integrations-container/index.ts
+++ b/packages/astro/src/vite-plugin-integrations-container/index.ts
@@ -34,7 +34,7 @@ async function resolveEntryPoint(
 	this: PluginContext,
 	route: InjectedRoute
 ): Promise<ResolvedInjectedRoute> {
-	const resolvedId = await this.resolve(route.entryPoint)
+	const resolvedId = await this.resolve(route.entrypoint)
 		.then((res) => res?.id)
 		.catch(() => undefined);
 	if (!resolvedId) return route;

--- a/packages/astro/test/astro-scripts.test.js
+++ b/packages/astro/test/astro-scripts.test.js
@@ -145,7 +145,7 @@ describe('Scripts (hoisted and not)', () => {
 						hooks: {
 							'astro:config:setup': ({ injectRoute, injectScript }) => {
 								injectScript('page', `import '/src/scripts/something.js';`);
-								injectRoute({ pattern: 'injected-route', entryPoint: 'src/external-page.astro' });
+								injectRoute({ pattern: 'injected-route', entrypoint: 'src/external-page.astro' });
 							},
 						},
 					},

--- a/packages/astro/test/fixtures/custom-404-injected-from-dep/astro.config.mjs
+++ b/packages/astro/test/fixtures/custom-404-injected-from-dep/astro.config.mjs
@@ -9,7 +9,7 @@ export default defineConfig({
         'astro:config:setup': ({ injectRoute }) => {
           injectRoute({
             pattern: '404',
-            entryPoint: '@test/custom-404-pkg/404.astro',
+            entrypoint: '@test/custom-404-pkg/404.astro',
           });
         },
       },

--- a/packages/astro/test/fixtures/custom-404-injected/astro.config.mjs
+++ b/packages/astro/test/fixtures/custom-404-injected/astro.config.mjs
@@ -9,7 +9,7 @@ export default defineConfig({
         'astro:config:setup': ({ injectRoute }) => {
           injectRoute({
             pattern: '404',
-            entryPoint: 'src/404.astro',
+            entrypoint: 'src/404.astro',
           });
         },
       },

--- a/packages/astro/test/fixtures/routing-priority/integration.mjs
+++ b/packages/astro/test/fixtures/routing-priority/integration.mjs
@@ -5,15 +5,15 @@ export default function() {
 				'astro:config:setup': ({ injectRoute }) => {
 					injectRoute({
 						pattern: '/injected',
-						entryPoint: './src/to-inject.astro'
+						entrypoint: './src/to-inject.astro'
 					});
 					injectRoute({
 						pattern: '/_injected',
-						entryPoint: './src/_to-inject.astro'
+						entrypoint: './src/_to-inject.astro'
 					});
 					injectRoute({
 						pattern: '/[id]',
-						entryPoint: './src/[id].astro'
+						entrypoint: './src/[id].astro'
 					});
 				}
 			}

--- a/packages/astro/test/ssr-dynamic.test.js
+++ b/packages/astro/test/ssr-dynamic.test.js
@@ -18,7 +18,7 @@ describe('Dynamic pages in SSR', () => {
 						'astro:config:setup': ({ injectRoute }) => {
 							injectRoute({
 								pattern: '/path-alias/[id]',
-								entryPoint: './src/pages/api/products/[id].js',
+								entrypoint: './src/pages/api/products/[id].js',
 							});
 						},
 					},

--- a/packages/astro/test/units/dev/dev.test.js
+++ b/packages/astro/test/units/dev/dev.test.js
@@ -133,7 +133,7 @@ describe('dev container', () => {
 								'astro:config:setup': ({ injectRoute }) => {
 									injectRoute({
 										pattern: '/another-[slug]',
-										entryPoint: './src/components/test.astro',
+										entrypoint: './src/components/test.astro',
 									});
 								},
 							},
@@ -184,7 +184,7 @@ describe('dev container', () => {
 								'astro:config:setup': ({ injectRoute }) => {
 									injectRoute({
 										pattern: '/404',
-										entryPoint: './src/components/404.astro',
+										entrypoint: './src/components/404.astro',
 									});
 								},
 							},


### PR DESCRIPTION
## Changes

There's only one instance where we use `entryPoint` which is for the `injectRoute()` API. This PR renames it to `entrypoint`, and emit a warning if the old name is used

## Testing

Existing tests should pass.

## Docs

https://github.com/withastro/docs/pull/5475

I also added a warning at `packages/astro/src/integrations/index.ts`
