### PR TITLE
fix: Changelog formatting for 3.6.0 View Transition events

### DIFF
--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -9,9 +9,9 @@
   Three new events now complement the existing `astro:after-swap` and `astro:page-load` events:
 
   ```javascript
-  astro: before - preparation; // Control how the DOM and other resources of the target page are loaded
-  astro: after - preparation; // Last changes before taking off? Remove that loading indicator? Here you go!
-  astro: before - swap; // Control how the DOM is updated to match the new page
+  'astro:before-preparation'; // Control how the DOM and other resources of the target page are loaded
+  'astro:after-preparation'; // Last changes before taking off? Remove that loading indicator? Here you go!
+  'astro:before-swap'; // Control how the DOM is updated to match the new page
   ```
 
   The `astro:before-*` events allow you to change properties and strategies of the view transition implementation.


### PR DESCRIPTION
redo #9174 after ci formatting undid it 