### PR TITLE
fix(rendering): prevent error when slots is keyed into

### DIFF
--- a/.changeset/tall-hotels-argue.md
+++ b/.changeset/tall-hotels-argue.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where the presence of a slot in a page led to an error.

--- a/packages/astro/src/core/render/core.ts
+++ b/packages/astro/src/core/render/core.ts
@@ -76,7 +76,7 @@ export async function renderPage({ mod, renderContext, env, cookies }: RenderPag
 		result,
 		Component,
 		renderContext.props,
-		null,
+		{},
 		env.streaming,
 		renderContext.route
 	);

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -25,7 +25,7 @@ export async function renderPage(
 			componentFactory.name,
 			componentFactory,
 			pageProps,
-			null,
+			{},
 			true,
 			route
 		);

--- a/packages/astro/test/astro-slots.test.js
+++ b/packages/astro/test/astro-slots.test.js
@@ -40,8 +40,15 @@ describe('Slots', () => {
 		expect($('#default').text().trim()).to.equal('Default');
 	});
 
-	it('Slots render fallback content by default', async () => {
+	it('Slots of a component render fallback content by default', async () => {
 		const html = await fixture.readFile('/fallback/index.html');
+		const $ = cheerio.load(html);
+
+		expect($('#default')).to.have.lengthOf(1);
+	});
+
+	it('Slots of a page render fallback content', async () => {
+		const html = await fixture.readFile('/fallback-own/index.html');
 		const $ = cheerio.load(html);
 
 		expect($('#default')).to.have.lengthOf(1);

--- a/packages/astro/test/fixtures/astro-slots/src/pages/fallback-own.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/pages/fallback-own.astro
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <!-- Head Stuff -->
+  </head>
+  <body>
+    <slot>
+      <div id="default"></div>
+    </slot>
+  </body>
+</html>

--- a/packages/astro/test/fixtures/astro-slots/src/pages/fallback.astro
+++ b/packages/astro/test/fixtures/astro-slots/src/pages/fallback.astro
@@ -7,8 +7,6 @@ import Fallback from '../components/Fallback.astro';
     <!-- Head Stuff -->
   </head>
   <body>
-    <div id="fallback">
-      <Fallback />
-    </div>
+    <Fallback />
   </body>
 </html>


### PR DESCRIPTION
## Changes

- Switches a `null` to a `{}`
- Fixes #9178

## Testing
Added a case to `astro-slots.test.js`

## Docs
Does not affect usage
