### PR TITLE
Remove deprecated markdown-remark APIs

### DIFF
--- a/.changeset/shiny-trees-sip.md
+++ b/.changeset/shiny-trees-sip.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': major
+---
+
+Removes deprecated APIs. All Astro packages had been refactored to not use these APIs.

--- a/packages/markdown/remark/src/frontmatter-injection.ts
+++ b/packages/markdown/remark/src/frontmatter-injection.ts
@@ -32,19 +32,3 @@ export function setVfileFrontmatter(vfile: VFile, frontmatter: Record<string, an
 	vfile.data.astro ??= {};
 	(vfile.data.astro as any).frontmatter = frontmatter;
 }
-
-/**
- * @deprecated Use `setVfileFrontmatter` instead
- */
-export function toRemarkInitializeAstroData({
-	userFrontmatter,
-}: {
-	userFrontmatter: Record<string, any>;
-}) {
-	return () =>
-		function (tree: any, vfile: VFile) {
-			if (!vfile.data.astro) {
-				vfile.data.astro = { frontmatter: userFrontmatter };
-			}
-		};
-}

--- a/packages/markdown/remark/src/index.ts
+++ b/packages/markdown/remark/src/index.ts
@@ -1,10 +1,4 @@
-import type {
-	AstroMarkdownOptions,
-	MarkdownProcessor,
-	MarkdownRenderingOptions,
-	MarkdownRenderingResult,
-	MarkdownVFile,
-} from './types.js';
+import type { AstroMarkdownOptions, MarkdownProcessor, MarkdownVFile } from './types.js';
 
 import {
 	InvalidAstroDataError,
@@ -150,39 +144,8 @@ export async function createMarkdownProcessor(
 					imagePaths: result.data.imagePaths ?? new Set(),
 					frontmatter: astroData.frontmatter ?? {},
 				},
-				// Compat for `renderMarkdown` only. Do not use!
-				__renderMarkdownCompat: {
-					result,
-				},
 			};
 		},
-	};
-}
-
-/**
- * Shared utility for rendering markdown
- *
- * @deprecated Use `createMarkdownProcessor` instead for better performance
- */
-export async function renderMarkdown(
-	content: string,
-	opts: MarkdownRenderingOptions
-): Promise<MarkdownRenderingResult> {
-	const processor = await createMarkdownProcessor(opts);
-
-	const result = await processor.render(content, {
-		fileURL: opts.fileURL,
-		frontmatter: opts.frontmatter,
-	});
-
-	return {
-		code: result.code,
-		metadata: {
-			headings: result.metadata.headings,
-			source: content,
-			html: result.code,
-		},
-		vfile: (result as any).__renderMarkdownCompat.result,
 	};
 }
 

--- a/packages/markdown/remark/src/internal.ts
+++ b/packages/markdown/remark/src/internal.ts
@@ -1,5 +1,1 @@
-export {
-	InvalidAstroDataError,
-	safelyGetAstroData,
-	toRemarkInitializeAstroData,
-} from './frontmatter-injection.js';
+export { InvalidAstroDataError, safelyGetAstroData } from './frontmatter-injection.js';


### PR DESCRIPTION
## Changes

These APIs are not used by us anymore. They're only kept so we can remove them in the next markdown-remark major, like now in the `next` branch

## Testing

Existing tests should work.

## Docs

n/a. internal refactor. Added a changeset though so we can track this change in the future.
