### PR TITLE
Remove vercel deprecated analytics option

### DIFF
--- a/.changeset/giant-snails-perform.md
+++ b/.changeset/giant-snails-perform.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': major
+---
+
+Removes deprecated `analytics` option. Use the `webAnalytics` option instead.

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -71,11 +71,6 @@ function getAdapter({
 }
 
 export interface VercelServerlessConfig {
-	/**
-	 * @deprecated
-	 */
-	analytics?: boolean;
-
 	/** Configuration for [Vercel Web Analytics](https://vercel.com/docs/concepts/analytics). */
 	webAnalytics?: VercelWebAnalyticsConfig;
 
@@ -108,7 +103,6 @@ export interface VercelServerlessConfig {
 }
 
 export default function vercelServerless({
-	analytics,
 	webAnalytics,
 	speedInsights,
 	includeFiles,
@@ -151,13 +145,7 @@ export default function vercelServerless({
 					);
 				}
 
-				if (webAnalytics?.enabled || analytics) {
-					if (analytics) {
-						logger.warn(
-							`The \`analytics\` property is deprecated. Please use the new \`webAnalytics\` and \`speedInsights\` properties instead.`
-						);
-					}
-
+				if (webAnalytics?.enabled) {
 					injectScript(
 						'head-inline',
 						await getInjectableWebAnalyticsContent({
@@ -165,7 +153,7 @@ export default function vercelServerless({
 						})
 					);
 				}
-				if (command === 'build' && (speedInsights?.enabled || analytics)) {
+				if (command === 'build' && speedInsights?.enabled) {
 					injectScript('page', 'import "@astrojs/vercel/speed-insights"');
 				}
 				const outDir = getVercelOutput(config.root);
@@ -178,7 +166,7 @@ export default function vercelServerless({
 						redirects: false,
 					},
 					vite: {
-						...getSpeedInsightsViteConfig(speedInsights?.enabled || analytics),
+						...getSpeedInsightsViteConfig(speedInsights?.enabled),
 						ssr: {
 							external: ['@vercel/nft'],
 						},

--- a/packages/integrations/vercel/src/static/adapter.ts
+++ b/packages/integrations/vercel/src/static/adapter.ts
@@ -41,10 +41,6 @@ function getAdapter(): AstroAdapter {
 }
 
 export interface VercelStaticConfig {
-	/**
-	 * @deprecated
-	 */
-	analytics?: boolean;
 	webAnalytics?: VercelWebAnalyticsConfig;
 	speedInsights?: VercelSpeedInsightsConfig;
 	imageService?: boolean;
@@ -53,7 +49,6 @@ export interface VercelStaticConfig {
 }
 
 export default function vercelStatic({
-	analytics,
 	webAnalytics,
 	speedInsights,
 	imageService,
@@ -65,14 +60,8 @@ export default function vercelStatic({
 	return {
 		name: '@astrojs/vercel',
 		hooks: {
-			'astro:config:setup': async ({ command, config, injectScript, updateConfig, logger }) => {
-				if (webAnalytics?.enabled || analytics) {
-					if (analytics) {
-						logger.warn(
-							`The \`analytics\` property is deprecated. Please use the new \`webAnalytics\` and \`speedInsights\` properties instead.`
-						);
-					}
-
+			'astro:config:setup': async ({ command, config, injectScript, updateConfig }) => {
+				if (webAnalytics?.enabled) {
 					injectScript(
 						'head-inline',
 						await getInjectableWebAnalyticsContent({
@@ -80,7 +69,7 @@ export default function vercelStatic({
 						})
 					);
 				}
-				if (command === 'build' && (speedInsights?.enabled || analytics)) {
+				if (command === 'build' && speedInsights?.enabled) {
 					injectScript('page', 'import "@astrojs/vercel/speed-insights"');
 				}
 				const outDir = new URL('./static/', getVercelOutput(config.root));
@@ -91,7 +80,7 @@ export default function vercelStatic({
 						redirects: false,
 					},
 					vite: {
-						...getSpeedInsightsViteConfig(speedInsights?.enabled || analytics),
+						...getSpeedInsightsViteConfig(speedInsights?.enabled),
 					},
 					...getAstroImageConfig(
 						imageService,


### PR DESCRIPTION
## Changes

Remove `analytics` option

## Testing

Existing tests should pass.

## Docs

I don't think this needs to be documented in the breaking tracker as this is specific to vercel? The changesets might be enough.
