### PR TITLE
fix scroll restoration issue on webKit browsers

### DIFF
--- a/.changeset/shaggy-socks-glow.md
+++ b/.changeset/shaggy-socks-glow.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixed view transition issue on webKit browsers that prevented scrolling to #fragments 
+Fixes a view transition issue on webKit browsers that prevented scrolling to #fragments 

--- a/.changeset/shaggy-socks-glow.md
+++ b/.changeset/shaggy-socks-glow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix scroll restoration issue on webKit browsers

--- a/.changeset/shaggy-socks-glow.md
+++ b/.changeset/shaggy-socks-glow.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-fix scroll restoration issue on webKit browsers
+Fixed view transition issue on webKit browsers that prevented scrolling to #fragments 

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -194,7 +194,6 @@ const moveToLocation = (to: URL, from: URL, options: Options, historyState?: Sta
 				to.href
 			);
 		}
-		history.scrollRestoration = 'manual';
 	}
 	// now we are on the new page for non-history navigations!
 	// (with history navigation page change happens before popstate is fired)
@@ -213,12 +212,14 @@ const moveToLocation = (to: URL, from: URL, options: Options, historyState?: Sta
 			// because we are already on the target page ...
 			// ... what comes next is a intra-page navigation
 			// that won't reload the page but instead scroll to the fragment
+			history.scrollRestoration = 'auto';
 			location.href = to.href;
 		} else {
 			if (!scrolledToTop) {
 				scrollTo({ left: 0, top: 0, behavior: 'instant' });
 			}
 		}
+		history.scrollRestoration = 'manual';
 	}
 };
 


### PR DESCRIPTION
## Changes

Scroll to a fragment did not work for webKit-based browsers. It seems that you need to explicitly set scrollRestoration to "auto" before the assignment to location.href (or location.hash) scrolls to the anchor. 

# Test
Tested manually as we do not have automated e2e tests on Safari.

# Doc
n./a. bug fix 