### PR TITLE
fix: links with same path but different search params not prefetched

### DIFF
--- a/.changeset/brown-jars-lick.md
+++ b/.changeset/brown-jars-lick.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-fix: links with same path but different search params not prefetched
+Fixes an issue where links with the same pathname as the current page, but different search params, were not prefetched.

--- a/.changeset/brown-jars-lick.md
+++ b/.changeset/brown-jars-lick.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix: links with same path but different search params not prefetched

--- a/packages/astro/e2e/fixtures/prefetch/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/prefetch/src/pages/index.astro
@@ -9,6 +9,8 @@
     <br>
     <a id="prefetch-false" href="/prefetch-false" data-astro-prefetch="false">false</a>
     <br>
+    <a id="prefetch-search-param" href="?search-param=true" data-astro-prefetch="hover">search param</a>
+    <br>
     <a id="prefetch-tap" href="/prefetch-tap" data-astro-prefetch="tap">tap</a>
     <br>
     <a id="prefetch-hover" href="/prefetch-hover" data-astro-prefetch="hover">hover</a>

--- a/packages/astro/e2e/prefetch.test.js
+++ b/packages/astro/e2e/prefetch.test.js
@@ -16,7 +16,8 @@ test.describe('Prefetch (default)', () => {
 
 	test.beforeEach(async ({ page }) => {
 		page.on('request', (req) => {
-			reqUrls.push(new URL(req.url()).pathname);
+			const urlObj = new URL(req.url());
+			reqUrls.push(urlObj.pathname + urlObj.search);
 		});
 	});
 
@@ -36,6 +37,16 @@ test.describe('Prefetch (default)', () => {
 	test('data-astro-prefetch="false" should not prefetch', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/'));
 		expect(reqUrls).not.toContainEqual('/prefetch-false');
+	});
+
+	test('Link with search param should prefetch', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/'));
+		expect(reqUrls).not.toContainEqual('/?search-param=true');
+		await Promise.all([
+			page.waitForEvent('request'), // wait prefetch request
+			page.locator('#prefetch-search-param').hover(),
+		]);
+		expect(reqUrls).toContainEqual('/?search-param=true');
 	});
 
 	test('data-astro-prefetch="tap" should prefetch on tap', async ({ page, astro }) => {
@@ -102,7 +113,8 @@ test.describe("Prefetch (prefetchAll: true, defaultStrategy: 'tap')", () => {
 
 	test.beforeEach(async ({ page }) => {
 		page.on('request', (req) => {
-			reqUrls.push(new URL(req.url()).pathname);
+			const urlObj = new URL(req.url());
+			reqUrls.push(urlObj.pathname + urlObj.search);
 		});
 	});
 
@@ -127,6 +139,16 @@ test.describe("Prefetch (prefetchAll: true, defaultStrategy: 'tap')", () => {
 	test('data-astro-prefetch="false" should not prefetch', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/'));
 		expect(reqUrls).not.toContainEqual('/prefetch-false');
+	});
+
+	test('Link with search param should prefetch', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/'));
+		expect(reqUrls).not.toContainEqual('/?search-param=true');
+		await Promise.all([
+			page.waitForEvent('request'), // wait prefetch request
+			page.locator('#prefetch-search-param').hover(),
+		]);
+		expect(reqUrls).toContainEqual('/?search-param=true');
 	});
 
 	test('data-astro-prefetch="tap" should prefetch on tap', async ({ page, astro }) => {

--- a/packages/astro/src/prefetch/index.ts
+++ b/packages/astro/src/prefetch/index.ts
@@ -226,7 +226,7 @@ function canPrefetchUrl(url: string, ignoreSlowConnection: boolean) {
 		const urlObj = new URL(url, location.href);
 		return (
 			location.origin === urlObj.origin &&
-			location.pathname !== urlObj.pathname &&
+			(location.pathname !== urlObj.pathname || location.search !== urlObj.search) &&
 			!prefetchedUrls.has(url)
 		);
 	} catch {}


### PR DESCRIPTION
## Changes

Links where the path is the same, but search params are not, are prefetched

## Testing

e2e test

## Docs

As far as I can tell from reading the docs, they do not mention prefetching behavior in this case at all. Since this change aligns it more with expected behavior, I don't think more information would need to be added, but I can write something if necessary.

### Open Issue:

fix https://github.com/withastro/astro/issues/9185
