### PR TITLE
Write index routes as index.html with build.format: 'file'

### DIFF
--- a/.changeset/tame-flies-confess.md
+++ b/.changeset/tame-flies-confess.md
@@ -1,0 +1,11 @@
+---
+'astro': major
+---
+
+build.format: 'file' now honors index routes
+
+Prior to Astro 4, using `build.format: 'file'`, a method to produce HTML files that are *not* all within folders, would only produce `index.html` for the base path of `/`. This meant that even if you created explicit index pages with, for example, `page/index.astro`, it would write these out as `page.html`.
+
+This was unexpected behavior as `build.format: 'file'` is intended to match the file system routing exactly. Now in Astro 4 it does, with index routes being written just as they are in your source directly. `page/index.astro` becomes `page/index.html`.
+
+This change only affects SSG when using `build.format: 'file'`.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2363,6 +2363,7 @@ export interface RouteData {
 	redirect?: RedirectConfig;
 	redirectRoute?: RouteData;
 	fallbackRoutes: RouteData[];
+	index: boolean;
 }
 
 export type RedirectRouteData = RouteData & {

--- a/packages/astro/src/core/build/common.ts
+++ b/packages/astro/src/core/build/common.ts
@@ -1,6 +1,6 @@
 import npath from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import type { AstroConfig, RouteType } from '../../@types/astro.js';
+import type { AstroConfig, RouteData } from '../../@types/astro.js';
 import { appendForwardSlash } from '../../core/path.js';
 
 const STATUS_CODE_PAGES = new Set(['/404', '/500']);
@@ -17,9 +17,10 @@ function getOutRoot(astroConfig: AstroConfig): URL {
 export function getOutFolder(
 	astroConfig: AstroConfig,
 	pathname: string,
-	routeType: RouteType
+	routeData: RouteData
 ): URL {
 	const outRoot = getOutRoot(astroConfig);
+	const routeType = routeData.type;
 
 	// This is the root folder to write to.
 	switch (routeType) {
@@ -36,8 +37,15 @@ export function getOutFolder(
 					return new URL('.' + appendForwardSlash(pathname), outRoot);
 				}
 				case 'file': {
-					const d = pathname === '' ? pathname : npath.dirname(pathname);
-					return new URL('.' + appendForwardSlash(d), outRoot);
+					let dir;
+					// If the pathname is '' then this is the root index.html
+					// If this is an index route, the folder should be the pathname, not the parent
+					if(pathname === '' || routeData.index) {
+						dir = pathname;
+					} else {
+						dir = npath.dirname(pathname);
+					}
+					return new URL('.' + appendForwardSlash(dir), outRoot);
 				}
 			}
 	}
@@ -47,8 +55,9 @@ export function getOutFile(
 	astroConfig: AstroConfig,
 	outFolder: URL,
 	pathname: string,
-	routeType: RouteType
+	routeData: RouteData
 ): URL {
+	const routeType = routeData.type;
 	switch (routeType) {
 		case 'endpoint':
 			return new URL(npath.basename(pathname), outFolder);
@@ -64,8 +73,13 @@ export function getOutFile(
 					return new URL('./index.html', outFolder);
 				}
 				case 'file': {
-					const baseName = npath.basename(pathname);
-					return new URL('./' + (baseName || 'index') + '.html', outFolder);
+					let baseName = npath.basename(pathname);
+					// If there is no base name this is the root route.
+					// If this is an index route, the name should be `index.html`.
+					if(!baseName || routeData.index) {
+						baseName = 'index';
+					}
+					return new URL(`./${baseName}.html`, outFolder);
 				}
 			}
 	}

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -601,8 +601,8 @@ async function generatePath(pathname: string, gopts: GeneratePathOptions, pipeli
 			body = Buffer.from(await response.arrayBuffer());
 		}
 
-		const outFolder = getOutFolder(pipeline.getConfig(), pathname, route.type);
-		const outFile = getOutFile(pipeline.getConfig(), outFolder, pathname, route.type);
+		const outFolder = getOutFolder(pipeline.getConfig(), pathname, route);
+		const outFile = getOutFile(pipeline.getConfig(), outFolder, pathname, route);
 		route.distURL = outFile;
 
 		await fs.promises.mkdir(outFolder, { recursive: true });

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -176,8 +176,8 @@ function buildManifest(
 		if (!route.prerender) continue;
 		if (!route.pathname) continue;
 
-		const outFolder = getOutFolder(opts.settings.config, route.pathname, route.type);
-		const outFile = getOutFile(opts.settings.config, outFolder, route.pathname, route.type);
+		const outFolder = getOutFolder(opts.settings.config, route.pathname, route);
+		const outFile = getOutFile(opts.settings.config, outFolder, route.pathname, route);
 		const file = outFile.toString().replace(opts.settings.config.build.client.toString(), '');
 		routes.push({
 			file,

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -347,6 +347,7 @@ export function createRouteManifest(
 					generate,
 					pathname: pathname || undefined,
 					prerender,
+					index: item.isIndex,
 					fallbackRoutes: [],
 				});
 			}
@@ -424,6 +425,7 @@ export function createRouteManifest(
 				pathname: pathname || void 0,
 				prerender: prerenderInjected ?? prerender,
 				fallbackRoutes: [],
+				index: false,
 			});
 		});
 
@@ -464,6 +466,7 @@ export function createRouteManifest(
 			redirect: to,
 			redirectRoute: routes.find((r) => r.route === to),
 			fallbackRoutes: [],
+			index: false,
 		};
 
 		const lastSegmentIsDynamic = (r: RouteData) => !!r.segments.at(-1)?.at(-1)?.dynamic;

--- a/packages/astro/src/core/routing/manifest/serialization.ts
+++ b/packages/astro/src/core/routing/manifest/serialization.ts
@@ -38,5 +38,6 @@ export function deserializeRouteData(rawRouteData: SerializedRouteData): RouteDa
 		fallbackRoutes: rawRouteData.fallbackRoutes.map((fallback) => {
 			return deserializeRouteData(fallback);
 		}),
+		index: rawRouteData.index,
 	};
 }

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -216,6 +216,7 @@ export async function handleRoute({
 				type: 'fallback',
 				route: '',
 				fallbackRoutes: [],
+				index: false,
 			};
 			renderContext = await createRenderContext({
 				request,

--- a/packages/astro/test/astro-pageDirectoryUrl.test.js
+++ b/packages/astro/test/astro-pageDirectoryUrl.test.js
@@ -16,7 +16,7 @@ describe('build format', () => {
 
 	it('outputs', async () => {
 		expect(await fixture.readFile('/client.html')).to.be.ok;
-		expect(await fixture.readFile('/nested-md.html')).to.be.ok;
-		expect(await fixture.readFile('/nested-astro.html')).to.be.ok;
+		expect(await fixture.readFile('/nested-md/index.html')).to.be.ok;
+		expect(await fixture.readFile('/nested-astro/index.html')).to.be.ok;
 	});
 });

--- a/packages/astro/test/fixtures/page-format/src/pages/nested/index.astro
+++ b/packages/astro/test/fixtures/page-format/src/pages/nested/index.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<h1>Testing</h1>
+	</body>
+</html>

--- a/packages/astro/test/page-format.test.js
+++ b/packages/astro/test/page-format.test.js
@@ -47,6 +47,12 @@ describe('build.format', () => {
 				let $ = cheerio.load(html);
 				expect($('#another').attr('href')).to.equal('/nested/another/');
 			});
+
+			it('index files are written as index.html', async () => {
+				let html = await fixture.readFile('/nested/index.html');
+				let $ = cheerio.load(html);
+				expect($('h1').text()).to.equal('Testing');
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- Previously we ignored whether a route was an index route (aka `index.astro` or `index.md`) when writing files with `build.format: 'file'`. This is because the logic only looked at the pathname and didn't know it was an index route.
- This was unexpected given the nature of file-based routing. The fix is to keep track of index routes in routing and use that to write out the correct file.
- Fixes https://github.com/withastro/astro/issues/6947

## Testing

- Test case added

## Docs

- https://github.com/withastro/docs/issues/5390#issuecomment-1829850862