### PR TITLE
remove deprecated `matchNotFound` options

### DIFF
--- a/.changeset/weak-wolves-bow.md
+++ b/.changeset/weak-wolves-bow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Removes depreacted `app.match()` option, `matchNotFound`

--- a/.changeset/weak-wolves-bow.md
+++ b/.changeset/weak-wolves-bow.md
@@ -1,5 +1,5 @@
 ---
-'astro': patch
+'astro': major
 ---
 
 Removes depreacted `app.match()` option, `matchNotFound`

--- a/.changeset/weak-wolves-bow.md
+++ b/.changeset/weak-wolves-bow.md
@@ -2,4 +2,4 @@
 'astro': major
 ---
 
-Removes depreacted `app.match()` option, `matchNotFound`
+Removes deprecated `app.match()` option, `matchNotFound`

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -36,7 +36,6 @@ const responseSentSymbol = Symbol.for('astro.responseSent');
 const STATUS_CODES = new Set([404, 500]);
 
 export interface MatchOptions {
-	matchNotFound?: boolean | undefined;
 }
 export interface RenderErrorOptions {
 	routeData?: RouteData;

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -35,8 +35,6 @@ const responseSentSymbol = Symbol.for('astro.responseSent');
 
 const STATUS_CODES = new Set([404, 500]);
 
-export interface MatchOptions {
-}
 export interface RenderErrorOptions {
 	routeData?: RouteData;
 	response?: Response;
@@ -132,7 +130,7 @@ export class App {
 		return pathname;
 	}
 
-	match(request: Request, _opts: MatchOptions = {}): RouteData | undefined {
+	match(request: Request): RouteData | undefined {
 		const url = new URL(request.url);
 		// ignore requests matching public assets
 		if (this.#manifest.assets.has(url.pathname)) return undefined;

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -5,7 +5,7 @@ import * as fs from 'node:fs';
 import { IncomingMessage } from 'node:http';
 import { TLSSocket } from 'node:tls';
 import { deserializeManifest } from './common.js';
-import { App, type MatchOptions } from './index.js';
+import { App } from './index.js';
 export { apply as applyPolyfills } from '../polyfill.js';
 
 const clientAddressSymbol = Symbol.for('astro.clientAddress');
@@ -108,13 +108,13 @@ class NodeIncomingMessage extends IncomingMessage {
 }
 
 export class NodeApp extends App {
-	match(req: NodeIncomingMessage | Request, opts: MatchOptions = {}) {
+	match(req: NodeIncomingMessage | Request) {
 		if (!(req instanceof Request)) {
 			req = createRequestFromNodeRequest(req, {
 				emptyBody: true,
 			});
 		}
-		return super.match(req, opts);
+		return super.match(req);
 	}
 	render(req: NodeIncomingMessage | Request, routeData?: RouteData, locals?: object) {
 		if (!(req instanceof Request)) {

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -251,7 +251,7 @@ describe('Middleware API in PROD mode, SSR', () => {
 
 	it('should correctly call the middleware function for 404', async () => {
 		const request = new Request('http://example.com/funky-url');
-		const routeData = app.match(request, { matchNotFound: true });
+		const routeData = app.match(request);
 		const response = await app.render(request, routeData);
 		const text = await response.text();
 		expect(text.includes('Error')).to.be.true;
@@ -260,7 +260,7 @@ describe('Middleware API in PROD mode, SSR', () => {
 
 	it('should render 500.astro when the middleware throws an error', async () => {
 		const request = new Request('http://example.com/throw');
-		const routeData = app.match(request, { matchNotFound: true });
+		const routeData = app.match(request);
 
 		const response = await app.render(request, routeData);
 		expect(response).to.deep.include({ status: 500 });

--- a/packages/astro/test/ssr-404-500-pages.test.js
+++ b/packages/astro/test/ssr-404-500-pages.test.js
@@ -56,7 +56,7 @@ describe('404 and 500 pages', () => {
 		it('404 page returned when a route does not match and passing routeData', async () => {
 			const app = await fixture.loadTestAdapterApp();
 			const request = new Request('http://example.com/some/fake/route');
-			const routeData = app.match(request, { matchNotFound: true });
+			const routeData = app.match(request);
 			const response = await app.render(request, routeData);
 			expect(response.status).to.equal(404);
 			const html = await response.text();


### PR DESCRIPTION
## Changes

- This PR removes `matchNotFound`
- As discussed here: https://discord.com/channels/830184174198718474/845430950191038464/1174600194810204201

## Testing

- existing tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

- no doc changes

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
