### PR TITLE
Small polish to the overlay

### DIFF
--- a/.changeset/tricky-dragons-explain.md
+++ b/.changeset/tricky-dragons-explain.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Small polish to the dev overlay:
+- Links inside the Astro panel now open in a new tab
+- The "Copy debug info" button will now reset back to its original state after 3.5 seconds without needing to toggle off the plugin

--- a/.changeset/tricky-dragons-explain.md
+++ b/.changeset/tricky-dragons-explain.md
@@ -2,6 +2,4 @@
 'astro': patch
 ---
 
-Small polish to the dev overlay:
-- Links inside the Astro panel now open in a new tab
-- The "Copy debug info" button will now reset back to its original state after 3.5 seconds without needing to toggle off the plugin
+Fixes a number of small user experience bugs with the dev overlay

--- a/packages/astro/src/runtime/client/dev-overlay/plugins/astro.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/plugins/astro.ts
@@ -330,7 +330,7 @@ export default {
 
 			<div id="main-container">
 				<div>
-					<header><h2>Top integrations</h2><a href="https://astro.build/integrations/">View all</a></header>
+					<header><h2>Top integrations</h2><a href="https://astro.build/integrations/" target="_blank">View all</a></header>
 						<div id="integration-list-wrapper">
 							<section id="integration-list">
 								<div class="integration-skeleton" style="--i:0;"></div>
@@ -366,7 +366,7 @@ export default {
 
 				setTimeout(() => {
 					resetDebugButton();
-				}, 2000);
+				}, 3500);
 			});
 
 			canvas.append(windowComponent);

--- a/packages/astro/src/runtime/client/dev-overlay/plugins/astro.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/plugins/astro.ts
@@ -324,7 +324,7 @@ export default {
 					(window as DevOverlayMetadata).__astro_dev_overlay__.version
 				}</astro-dev-overlay-badge>
 				</section>
-				<astro-dev-overlay-button id="copy-debug-button">Get debug info <astro-dev-overlay-icon icon="copy" /></astro-dev-overlay-button>
+				<astro-dev-overlay-button id="copy-debug-button">Copy debug info <astro-dev-overlay-icon icon="copy" /></astro-dev-overlay-button>
 			</header>
 			<hr />
 
@@ -345,7 +345,7 @@ export default {
 				${links
 					.map(
 						(link) =>
-							`<a href="${link.link}"><astro-dev-overlay-icon ${
+							`<a href="${link.link}" target="_blank"><astro-dev-overlay-icon ${
 								isDefinedIcon(link.icon) ? `icon="${link.icon}">` : `>${link.icon}`
 							}</astro-dev-overlay-icon>${link.name}</a>`
 					)
@@ -362,7 +362,11 @@ export default {
 				navigator.clipboard.writeText(
 					'```\n' + (window as DevOverlayMetadata).__astro_dev_overlay__.debugInfo + '\n```'
 				);
-				copyDebugButton.textContent = 'Copied to clipboard';
+				copyDebugButton.textContent = 'Copied to clipboard!';
+
+				setTimeout(() => {
+					resetDebugButton();
+				}, 2000);
 			});
 
 			canvas.append(windowComponent);
@@ -372,7 +376,7 @@ export default {
 			const copyDebugButton = canvas.querySelector<HTMLButtonElement>('#copy-debug-button');
 			if (!copyDebugButton) return;
 
-			copyDebugButton.innerHTML = 'Get debug info <astro-dev-overlay-icon icon="copy" />';
+			copyDebugButton.innerHTML = 'Copy debug info <astro-dev-overlay-icon icon="copy" />';
 		}
 
 		function refreshIntegrationList() {

--- a/packages/astro/src/runtime/client/dev-overlay/plugins/audit.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/plugins/audit.ts
@@ -71,7 +71,6 @@ export default {
 				const noAuditIcon = getIconElement('check-circle');
 				const text = document.createElement('div');
 				text.textContent = 'No issues found!';
-				text.role = 'alert';
 
 				if (noAuditIcon) {
 					noAuditIcon.style.width = '24px';

--- a/packages/astro/src/runtime/client/dev-overlay/plugins/audit.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/plugins/audit.ts
@@ -71,6 +71,7 @@ export default {
 				const noAuditIcon = getIconElement('check-circle');
 				const text = document.createElement('div');
 				text.textContent = 'No issues found!';
+				text.role = 'alert';
 
 				if (noAuditIcon) {
 					noAuditIcon.style.width = '24px';


### PR DESCRIPTION
## Changes

Some small changes that came up from the dev overlay bug bash:
- Links now open in a new tab
- "Copy debug info" button now resets automatically after a delay and is a bit more clear
- "No issues found" alert now has the proper ARIA role

## Testing

N/A

## Docs

N/A