### PR TITLE
Add a new `overlay-toggled` event that dev overlay plugins can listen to

### DIFF
--- a/.changeset/warm-horses-hunt.md
+++ b/.changeset/warm-horses-hunt.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add a new `overlay-toggled` event that dev overlay plugins can listen to

--- a/packages/astro/src/runtime/client/dev-overlay/overlay.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/overlay.ts
@@ -528,6 +528,13 @@ export class AstroDevOverlay extends HTMLElement {
 				devBar?.removeAttribute('tabindex');
 			}
 		}
+
+		// Dispatch an event to plugins so they can react accordingly to the overlay being minimized/maximized
+		this.plugins.forEach((plugin) => {
+			plugin.eventTarget.dispatchEvent(
+				new CustomEvent('overlay-toggled', { detail: { state: !this.isHidden() } })
+			);
+		});
 	}
 }
 


### PR DESCRIPTION
## Changes

What the title says. This is useful for instance if you want your plugin to automatically hide itself when the overlay is toggled, 

## Testing

Will be done separately!

## Docs

https://github.com/withastro/docs/pull/5518
