### PR TITLE
Improve high contrast mode with the dev overlay

### DIFF
--- a/.changeset/grumpy-seas-switch.md
+++ b/.changeset/grumpy-seas-switch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve high contrast mode with the Dev Overlay

--- a/packages/astro/src/runtime/client/dev-overlay/overlay.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/overlay.ts
@@ -138,7 +138,6 @@ export class AstroDevOverlay extends HTMLElement {
 				pointer-events: none;
 			}
 
-			@
 
 			#dev-bar .item-tooltip::after{
 				content: '';

--- a/packages/astro/src/runtime/client/dev-overlay/overlay.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/overlay.ts
@@ -83,6 +83,12 @@ export class AstroDevOverlay extends HTMLElement {
 				box-shadow: 0px 0px 0px 0px rgba(19, 21, 26, 0.30), 0px 1px 2px 0px rgba(19, 21, 26, 0.29), 0px 4px 4px 0px rgba(19, 21, 26, 0.26), 0px 10px 6px 0px rgba(19, 21, 26, 0.15), 0px 17px 7px 0px rgba(19, 21, 26, 0.04), 0px 26px 7px 0px rgba(19, 21, 26, 0.01);
 			}
 
+			@media (forced-colors: active) {
+				#dev-bar {
+					background: white;
+				}
+			}
+
 			#dev-bar .item {
 				display: flex;
 				justify-content: center;
@@ -132,6 +138,8 @@ export class AstroDevOverlay extends HTMLElement {
 				pointer-events: none;
 			}
 
+			@
+
 			#dev-bar .item-tooltip::after{
 				content: '';
 				position: absolute;
@@ -145,6 +153,12 @@ export class AstroDevOverlay extends HTMLElement {
 			#dev-bar .item:hover .item-tooltip, #dev-bar .item:not(.active):focus-visible .item-tooltip {
 				transition: opacity 0.2s ease-in-out 200ms;
 				opacity: 1;
+			}
+
+			@media (forced-colors: active) {
+				#dev-bar .item:hover .item-tooltip, #dev-bar .item:not(.active):focus-visible .item-tooltip {
+					background: white;
+				}
 			}
 
 			#dev-bar #bar-container .item.active .notification {
@@ -163,6 +177,12 @@ export class AstroDevOverlay extends HTMLElement {
 				height: 24px;
 				display: block;
 				margin: auto;
+			}
+
+			@media (forced-colors: active) {
+				#dev-bar .item svg path[fill="#fff"] {
+					fill: black;
+				}
 			}
 
 			#dev-bar .item .notification {

--- a/packages/astro/src/runtime/client/dev-overlay/plugins/astro.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/plugins/astro.ts
@@ -315,6 +315,12 @@ export default {
 				#integration-list astro-dev-overlay-card p {
 					font-size: 14px;
 				}
+
+				@media (forced-colors: active) {
+					svg path[fill="#fff"] {
+						fill: black;
+					}
+				}
 			</style>
 
 			<header>

--- a/packages/astro/src/runtime/client/dev-overlay/ui-library/icon.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/ui-library/icon.ts
@@ -34,7 +34,19 @@ export class DevOverlayIcon extends HTMLElement {
 	}
 
 	buildTemplate() {
-		this.shadowRoot.innerHTML = `<style>svg { width: 100%; height: 100%;}</style>\n${this.getIconHTML(
+		this.shadowRoot.innerHTML = `
+			<style>
+				svg {
+					width: 100%;
+					height: 100%;
+				}
+
+				@media (forced-colors: active) {
+					svg path[fill="#fff"] {
+						fill: black;
+					}
+				}
+			</style>\n${this.getIconHTML(
 			this._icon
 		)}`;
 	}

--- a/packages/astro/src/runtime/client/dev-overlay/ui-library/toggle.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/ui-library/toggle.ts
@@ -30,6 +30,14 @@ export class DevOverlayToggle extends HTMLElement {
 				position: relative;
 			}
 
+			@media (forced-colors: active) {
+				input::after {
+					border: 1px solid black;
+					top: 0px;
+					left: 0px;
+				}
+			}
+
 			input:checked {
 				border: 1px solid rgba(213, 249, 196, 1);
 				background-color: rgba(61, 125, 31, 1);

--- a/packages/astro/src/runtime/client/dev-overlay/ui-library/window.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/ui-library/window.ts
@@ -29,6 +29,12 @@ export class DevOverlayWindow extends HTMLElement {
 					box-shadow: 0px 0px 0px 0px rgba(19, 21, 26, 0.30), 0px 1px 2px 0px rgba(19, 21, 26, 0.29), 0px 4px 4px 0px rgba(19, 21, 26, 0.26), 0px 10px 6px 0px rgba(19, 21, 26, 0.15), 0px 17px 7px 0px rgba(19, 21, 26, 0.04), 0px 26px 7px 0px rgba(19, 21, 26, 0.01);
 				}
 
+				@media (forced-colors: active) {
+					:host {
+						background: white;
+					}
+				}
+
 				::slotted(h1), ::slotted(h2), ::slotted(h3), ::slotted(h4), ::slotted(h5) {
 					font-weight: 600;
 					color: #fff;


### PR DESCRIPTION
## Changes

- Improves high contrast
- Mostly this is just making backgrounds white and text / fill black.

https://github.com/withastro/astro/assets/361671/44f84144-6857-4435-b810-e33cc47a3f02



## Testing

N/A

## Docs

N/A