### PR TITLE
fix(#9216): fix style HMR in certain cases

### DIFF
--- a/.changeset/wicked-books-appear.md
+++ b/.changeset/wicked-books-appear.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix edge case where `<style>` updates inside of `.astro` files would ocassionally fail to update without reloading the page.

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -97,8 +97,8 @@ export async function handleHotUpdate(
 	// If only styles are changed, remove the component file from the update list
 	if (isStyleOnlyChange) {
 		logger.info('astro', msg.hmr({ file, style: true }));
-		// remove base file and hoisted scripts
-		return mods.filter((mod) => mod.id !== ctx.file && !mod.id?.endsWith('.ts'));
+		// Only return the Astro styles that have changed!
+		return mods.filter((mod) => mod.id?.includes('astro&type=style'));
 	}
 
 	// Add hoisted scripts so these get invalidated


### PR DESCRIPTION
## Changes

- Closes PLT-1261
- Adjusts our style HMR logic so that style only changes will only treat the effected style modules as HMR candidates
- This fixes an edge case where updates inside of Astro files _referenced_ by the main page file would cause a full reload because `pages/index.astro` would remain in the module graph.
- This should close #9216, which is a report about this specific edge case. As reported, if the `style` inside of `src/layouts/Layout.astro` was updated, the whole index page would reload. With this fix, updating the `style` inside of `src/layouts/Layout.astro` does not reload the index page but swaps the new styles in seamlessly.

## Testing

Tested manually, our existing HMR tests aren't capable of catching this problem

## Docs

Bug fix only