### PR TITLE
Fix dev overlay style leak

### DIFF
--- a/packages/astro/src/runtime/client/dev-overlay/overlay.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/overlay.ts
@@ -35,8 +35,10 @@ export class AstroDevOverlay extends HTMLElement {
 	async connectedCallback() {
 		if (!this.hasBeenInitialized) {
 			this.shadowRoot.innerHTML = `
-    <style>
+			<style>	
 			:host {
+				/* Important! Reset all inherited styles to initial */
+				all: initial;
 				z-index: 999999;
 				view-transition-name: astro-dev-overlay;
 				display: contents;
@@ -44,7 +46,7 @@ export class AstroDevOverlay extends HTMLElement {
 
 			::view-transition-old(astro-dev-overlay),
 			::view-transition-new(astro-dev-overlay) {
-  			animation: none;
+				animation: none;
 			}
 
 			#dev-overlay {

--- a/packages/astro/src/runtime/client/dev-overlay/overlay.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/overlay.ts
@@ -75,7 +75,7 @@ export class AstroDevOverlay extends HTMLElement {
 				visibility: hidden;
 			}
 
-      #dev-bar {
+			#dev-bar {
 				height: 56px;
 				overflow: hidden;
 				pointer-events: auto;
@@ -236,7 +236,7 @@ export class AstroDevOverlay extends HTMLElement {
 				white-space: nowrap;
 				border-width: 0;
 			}
-    </style>
+		</style>
 
 		<div id="dev-overlay">
 			<div id="dev-bar">


### PR DESCRIPTION
## Changes

- Closes PLT-1245
- Sets `all: initial` on the dev overlay to reset style inheritance.
- This fixes a problem where global font-size/line-height and other inheritable styles would break the dev overlay.
- Not including a changeset because it will just go out in the next patch

## Testing

Manually. It works!

## Docs

Nah