### PR TITLE
Ensure dev-overlay-window is anchored to the bottom

### DIFF
--- a/.changeset/famous-eels-trade.md
+++ b/.changeset/famous-eels-trade.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Ensure the dev-overlay-window is anchored to the bottom

--- a/packages/astro/src/runtime/client/dev-overlay/ui-library/window.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/ui-library/window.ts
@@ -23,7 +23,8 @@ export class DevOverlayWindow extends HTMLElement {
 					color: rgba(204, 206, 216, 1);
 					position: fixed;
 					z-index: 999999999;
-					top: 55%;
+					/* -7.5em is a magic number that seems to keep it anchored with the dev bar */
+					bottom: calc(7.5% + -150px);
 					left: 50%;
 					transform: translate(-50%, -50%);
 					box-shadow: 0px 0px 0px 0px rgba(19, 21, 26, 0.30), 0px 1px 2px 0px rgba(19, 21, 26, 0.29), 0px 4px 4px 0px rgba(19, 21, 26, 0.26), 0px 10px 6px 0px rgba(19, 21, 26, 0.15), 0px 17px 7px 0px rgba(19, 21, 26, 0.04), 0px 26px 7px 0px rgba(19, 21, 26, 0.01);


### PR DESCRIPTION
## Changes


https://github.com/withastro/astro/assets/361671/362231af-9cfb-4a21-b3ca-83fe97dc7bc5



- Uses bottom calculation (7.5%, which is the devbar's bottom + a magic number)
- works in all tested apps

## Testing

Manually

## Docs

N/A