### PR TITLE
[i18n] During fallback, only remove locale if prefix-always is false

### DIFF
--- a/.changeset/happy-beans-protect.md
+++ b/.changeset/happy-beans-protect.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix i18n fallback routing with routing strategy of always-prefix

--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -81,8 +81,8 @@ export function createI18nMiddleware(
 					const fallbackLocale = fallback[urlLocale];
 					let newPathname: string;
 					// If a locale falls back to the default locale, we want to **remove** the locale because
-					// the default locale doesn't have a prefix
-					if (fallbackLocale === defaultLocale) {
+					// the default locale doesn't have a prefix, but _only_ if prefix-always is false
+					if (fallbackLocale === defaultLocale && i18n.routingStrategy !== 'prefix-always') {
 						newPathname = url.pathname.replace(`/${urlLocale}`, ``);
 					} else {
 						newPathname = url.pathname.replace(`/${urlLocale}`, `/${fallbackLocale}`);

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -961,6 +961,35 @@ describe('[SSR] i18n routing', () => {
 			let response = await app.render(request);
 			expect(response.status).to.equal(404);
 		});
+
+		describe('with routing strategy [prefix-always]', () => {
+			before(async () => {
+				fixture = await loadFixture({
+					root: './fixtures/i18n-routing-fallback/',
+					output: 'server',
+					adapter: testAdapter(),
+					experimental: {
+						i18n: {
+							defaultLocale: 'en',
+							locales: ['en', 'pt', 'it'],
+							fallback: {
+								it: 'en',
+							},
+							routingStrategy: 'prefix-always',
+						},
+					},
+				});
+				await fixture.build();
+				app = await fixture.loadTestAdapterApp();
+			});
+
+			it('should redirect to the english locale, which is the first fallback', async () => {
+				let request = new Request('http://example.com/new-site/it/start');
+				let response = await app.render(request);
+				expect(response.status).to.equal(302);
+				expect(response.headers.get('location')).to.equal('/new-site/en/start');
+			});
+		});
 	});
 
 	describe('preferred locale', () => {


### PR DESCRIPTION
## Changes

- Closes #9223
- Adds conditional that checks that `prefix-always` is false before removing locale in fallback routing

## Testing

I made this change locally in my project's `node_modules` and added a unit test.

## Docs

No doc changes needed, as this restores functionality to match docs