### PR TITLE
Enable releasing from 3-legacy branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - main
       - "1-legacy"
       - "2-legacy"
+      - "3-legacy"
       - next
 
 defaults:


### PR DESCRIPTION
## Changes

So that we can backport and release stuff from the `3-legacy` branch that we'l create later.

## Testing

n/a

## Docs

n/a