### PR TITLE
Fix missing type import from auto format

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:examples": "turbo run build --filter=\"@example/*\"",
     "dev": "turbo run dev --concurrency=40 --parallel --filter=astro --filter=create-astro --filter=\"@astrojs/*\" --filter=\"@benchmark/*\"",
     "format": "pnpm run format:code",
-    "format:ci": "pnpm run format:imports && pnpm run format:code",
+    "format:ci": "pnpm run format:code",
     "format:code": "prettier -w \"**/*\" --ignore-unknown --cache",
     "format:imports": "organize-imports-cli ./packages/*/tsconfig.json ./packages/*/*/tsconfig.json",
     "test": "turbo run test --concurrency=1 --filter=astro --filter=create-astro --filter=\"@astrojs/*\"",

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -1,4 +1,5 @@
 import MagicString from 'magic-string';
+import type * as vite from 'vite';
 import { normalizePath } from 'vite';
 import type { AstroPluginOptions, ImageTransform } from '../@types/astro.js';
 import { extendManualChunks } from '../core/build/plugins/util.js';

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -2,6 +2,7 @@ import { blue, bold, green } from 'kleur/colors';
 import fs from 'node:fs';
 import { performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';
+import type * as vite from 'vite';
 import type {
 	AstroConfig,
 	AstroInlineConfig,

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -1,4 +1,5 @@
 import { green } from 'kleur/colors';
+import type * as vite from 'vite';
 import fs from 'node:fs';
 import type http from 'node:http';
 import type { AddressInfo } from 'node:net';

--- a/packages/astro/src/core/module-loader/vite.ts
+++ b/packages/astro/src/core/module-loader/vite.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events';
 import path from 'node:path';
+import type * as vite from 'vite';
 import type { ModuleLoader, ModuleLoaderEventEmitter } from './loader.js';
 
 export function createViteLoader(viteServer: vite.ViteDevServer): ModuleLoader {

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -1,3 +1,4 @@
+import type * as vite from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
 
 const virtualModuleId = 'astro:i18n';

--- a/packages/astro/src/prefetch/vite-plugin-prefetch.ts
+++ b/packages/astro/src/prefetch/vite-plugin-prefetch.ts
@@ -1,3 +1,4 @@
+import type * as vite from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
 
 const virtualModuleId = 'astro:prefetch';

--- a/packages/astro/src/transitions/vite-plugin-transitions.ts
+++ b/packages/astro/src/transitions/vite-plugin-transitions.ts
@@ -1,3 +1,4 @@
+import type * as vite from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
 
 const virtualModuleId = 'astro:transitions';

--- a/packages/astro/src/vite-plugin-astro-server/base.ts
+++ b/packages/astro/src/vite-plugin-astro-server/base.ts
@@ -1,3 +1,4 @@
+import type * as vite from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
 
 import { bold } from 'kleur/colors';

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -1,4 +1,5 @@
 import type fs from 'node:fs';
+import type * as vite from 'vite';
 import type { AstroSettings, ManifestData, SSRManifest } from '../@types/astro.js';
 import type { SSRManifestI18n } from '../core/app/types.js';
 import { patchOverlay } from '../core/errors/overlay.js';

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -1,4 +1,5 @@
 import type { SourceDescription } from 'rollup';
+import type * as vite from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
 import type { Logger } from '../core/logger/core.js';
 import type { PluginMetadata as AstroPluginMetadata } from './types.js';

--- a/packages/astro/src/vite-plugin-dev-overlay/vite-plugin-dev-overlay.ts
+++ b/packages/astro/src/vite-plugin-dev-overlay/vite-plugin-dev-overlay.ts
@@ -1,3 +1,4 @@
+import type * as vite from 'vite';
 import type { AstroPluginOptions } from '../@types/astro.js';
 
 const VIRTUAL_MODULE_ID = 'astro:dev-overlay';

--- a/packages/astro/src/vite-plugin-env/index.ts
+++ b/packages/astro/src/vite-plugin-env/index.ts
@@ -1,5 +1,6 @@
 import MagicString from 'magic-string';
 import { fileURLToPath } from 'node:url';
+import type * as vite from 'vite';
 import { loadEnv } from 'vite';
 import type { AstroConfig, AstroSettings } from '../@types/astro.js';
 

--- a/packages/astro/src/vite-plugin-head/index.ts
+++ b/packages/astro/src/vite-plugin-head/index.ts
@@ -1,4 +1,5 @@
 import type { ModuleInfo } from 'rollup';
+import type * as vite from 'vite';
 import type { SSRComponentMetadata, SSRResult } from '../@types/astro.js';
 import type { AstroBuildPlugin } from '../core/build/plugin.js';
 import type { PluginMetadata } from '../vite-plugin-astro/types.js';

--- a/packages/astro/src/vite-plugin-load-fallback/index.ts
+++ b/packages/astro/src/vite-plugin-load-fallback/index.ts
@@ -1,5 +1,6 @@
 import nodeFs from 'node:fs';
 import npath from 'node:path';
+import type * as vite from 'vite';
 import { slash } from '../core/path.js';
 import { cleanUrl } from '../vite-plugin-utils/index.js';
 

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -1,6 +1,7 @@
 import react, { type Options as ViteReactPluginOptions } from '@vitejs/plugin-react';
 import type { AstroIntegration } from 'astro';
 import { version as ReactVersion } from 'react-dom';
+import type * as vite from 'vite';
 
 export type ReactIntegrationOptions = Pick<ViteReactPluginOptions, 'include' | 'exclude'> & {
 	experimentalReactChildren?: boolean;


### PR DESCRIPTION
## Changes

This is not completed yet! For some reason `organize-imports-cli` is stripping away `import type * as vite from 'vite';`, and I couldn't figure out why.

Likely some dependency updates from the `next` branch (now merged into `main`) had triggered this, but I tried to revert versions for `typescript`, `ts-morph`, and `@ts-morph/common>minimatch`, but it still get stripped when I run `pnpm format:ci`

This PR currently only brings in the missing `import type * as vite from 'vite';`. We can't merge it as the auto-formatter would strip it away again.

## Testing

n/a

## Docs

n/a
