### PR TITLE
Chore: fix noisy peerDependency warnings (it's fine)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,35 +44,6 @@
     "pnpm": ">=8.6.12"
   },
   "packageManager": "pnpm@8.6.12",
-  "pnpm": {
-    "packageExtensions": {
-      "svelte2tsx": {
-        "peerDependenciesMeta": {
-          "typescript": {
-            "optional": true
-          }
-        }
-      }
-    },
-    "overrides": {
-      "organize-imports-cli>ts-morph": "^19.0.0",
-      "tsconfig-resolver>type-fest": "3.0.0"
-    },
-    "peerDependencyRules": {
-      "ignoreMissing": [
-        "rollup",
-        "@babel/core",
-        "@babel/plugin-transform-react-jsx",
-        "vite",
-        "react",
-        "react-dom",
-        "@types/react"
-      ],
-      "allowAny": [
-        "astro"
-      ]
-    }
-  },
   "dependencies": {
     "astro-benchmark": "workspace:*"
   },
@@ -95,5 +66,51 @@
     "tiny-glob": "^0.2.9",
     "turbo": "^1.10.12",
     "typescript": "~5.2.2"
+  },
+  "pnpm": {
+    "packageExtensions": {
+      "vite-svg-loader": {
+        "peerDependenciesMeta": {
+          "vue": {
+            "optional": true
+          }
+        }
+      },
+      "svelte2tsx": {
+        "peerDependenciesMeta": {
+          "typescript": {
+            "optional": true
+          }
+        }
+      },
+      "rehype-pretty-code": {
+        "peerDependenciesMeta": {
+          "shiki": {
+            "optional": true
+          }
+        }
+      }
+    },
+    "overrides": {
+      "organize-imports-cli>ts-morph": "^19.0.0",
+      "tsconfig-resolver>type-fest": "3.0.0"
+    },
+    "peerDependencyRules": {
+      "ignoreMissing": [
+        "rollup",
+        "@babel/core",
+        "@babel/plugin-transform-react-jsx",
+        "vite",
+        "react",
+        "react-dom",
+        "@types/react",
+        "tslib",
+        "quill-delta",
+        "rxjs"
+      ],
+      "allowAny": [
+        "astro"
+      ]
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   organize-imports-cli>ts-morph: ^19.0.0
   tsconfig-resolver>type-fest: 3.0.0
 
-packageExtensionsChecksum: 01871422d489547c532184effb134b35
+packageExtensionsChecksum: 2d0a8c56e33c7d11bb9ef3c997d67c33
 
 importers:
 
@@ -13581,6 +13581,13 @@ packages:
       quill-delta: ^5
       rxjs: '7'
       tslib: '2'
+    peerDependenciesMeta:
+      quill-delta:
+        optional: true
+      rxjs:
+        optional: true
+      tslib:
+        optional: true
     dependencies:
       arg: 5.0.2
       hyperdyperid: 1.2.0
@@ -14334,6 +14341,9 @@ packages:
     engines: {node: '>= 4.0.0'}
     peerDependencies:
       tslib: '2'
+    peerDependenciesMeta:
+      tslib:
+        optional: true
     dependencies:
       json-joy: 9.9.1
       thingies: 1.12.0
@@ -16683,6 +16693,9 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       shiki: 0.x
+    peerDependenciesMeta:
+      shiki:
+        optional: true
     dependencies:
       hash-obj: 4.0.0
       hast-util-to-string: 2.0.0
@@ -18049,6 +18062,9 @@ packages:
     engines: {node: '>=10.18'}
     peerDependencies:
       tslib: ^2
+    peerDependenciesMeta:
+      tslib:
+        optional: true
     dev: true
 
   /throttles@1.0.1:
@@ -18878,6 +18894,9 @@ packages:
     resolution: {integrity: sha512-EUfcuqk1NomuacwiuL3mvCfinkm4XN0AHN8BXG737eDlhC0jnp5jxdCxakV+juP/YhhjV5tq/c/bLcm3waWv4Q==}
     peerDependencies:
       vue: '>=3.2.13'
+    peerDependenciesMeta:
+      vue:
+        optional: true
     dependencies:
       svgo: 3.0.4
     dev: false


### PR DESCRIPTION
## Changes

- Adds some `pnpm` config to ignore noisy peerDependency warnings. They're actually fine and we don't need these!
- Just a chore to make our day-to-day better, no changeset needed

## Testing

`pnpm install`, it is no longer annoying

## Docs

No thanks