### PR TITLE
chore: remove `experimental` from i18n configuration

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1385,6 +1385,124 @@ export interface AstroUserConfig {
 	 * Astro offers experimental flags to give users early access to new features.
 	 * These flags are not guaranteed to be stable.
 	 */
+
+	/**
+	 * @docs
+	 * @name experimental.i18n
+	 * @type {object}
+	 * @version 3.5.0
+	 * @type {object}
+	 * @description
+	 *
+	 * Configures experimental i18n routing and allows you to specify some customization options.
+	 *
+	 * See our guide for more information on [internationalization in Astro](/en/guides/internationalization/)
+	 */
+	i18n?: {
+		/**
+		 * @docs
+		 * @kind h4
+		 * @name experimental.i18n.defaultLocale
+		 * @type {string}
+		 * @version 3.5.0
+		 * @description
+		 *
+		 * The default locale of your website/application. This is a required field.
+		 *
+		 * No particular language format or syntax is enforced, but we suggest using lower-case and hyphens as needed (e.g. "es", "pt-br") for greatest compatibility.
+		 */
+		defaultLocale: string;
+		/**
+		 * @docs
+		 * @kind h4
+		 * @name experimental.i18n.locales
+		 * @type {Locales}
+		 * @version 3.5.0
+		 * @description
+		 *
+		 * A list of all locales supported by the website, including the `defaultLocale`. This is a required field.
+		 *
+		 * Languages can be listed either as individual codes (e.g. `['en', 'es', 'pt-br']`) or mapped to a shared `path` of codes (e.g.  `{ path: "english", codes: ["en", "en-US"]}`). These codes will be used to determine the URL structure of your deployed site.
+		 *
+		 * No particular language code format or syntax is enforced, but your project folders containing your content files must match exactly the `locales` items in the list. In the case of multiple `codes` pointing to a custom URL path prefix, store your content files in a folder with the same name as the `path` configured.
+		 */
+		locales: Locales;
+
+		/**
+		 * @docs
+		 * @kind h4
+		 * @name experimental.i18n.fallback
+		 * @type {Record<string, string>}
+		 * @version 3.5.0
+		 * @description
+		 *
+		 * The fallback strategy when navigating to pages that do not exist (e.g. a translated page has not been created).
+		 *
+		 * Use this object to declare a fallback `locale` route for each language you support. If no fallback is specified, then unavailable pages will return a 404.
+		 *
+		 * ##### Example
+		 *
+		 * The following example configures your content fallback strategy to redirect unavailable pages in `/pt-br/` to their `es` version, and unavailable pages in `/fr/` to their `en` version. Unavailable `/es/` pages will return a 404.
+		 *
+		 * ```js
+		 * export default defineConfig({
+		 * 	experimental: {
+		 * 		i18n: {
+		 * 			defaultLocale: "en",
+		 * 			locales: ["en", "fr", "pt-br", "es"],
+		 * 			fallback: {
+		 * 				pt: "es",
+		 * 			  fr: "en"
+		 * 			}
+		 * 		}
+		 * 	}
+		 * })
+		 * ```
+		 */
+		fallback?: Record<string, string>;
+
+		/**
+		 * @docs
+		 * @kind h4
+		 * @name experimental.i18n.routing
+		 * @type {Routing}
+		 * @version 3.7.0
+		 * @description
+		 *
+		 * Controls the routing strategy to determine your site URLs. Set this based on your folder/URL path configuration for your default language.
+		 */
+		routing?: {
+			/**
+			 * @docs
+			 * @name experimental.i18n.routing.prefixDefaultLocale
+			 * @type {boolean}
+			 * @default `false`
+			 * @version 3.7.0
+			 * @description
+			 *
+			 * When `false`, only non-default languages will display a language prefix.
+			 * The `defaultLocale` will not show a language prefix and content files do not exist in a localized folder.
+			 *  URLs will be of the form `example.com/[locale]/content/` for all non-default languages, but `example.com/content/` for the default locale.
+			 *
+			 * When `true`, all URLs will display a language prefix.
+			 * URLs will be of the form `example.com/[locale]/content/` for every route, including the default language.
+			 * Localized folders are used for every language, including the default.
+			 */
+			prefixDefaultLocale: boolean;
+
+			/**
+			 * @name experimental.i18n.routing.strategy
+			 * @type {"pathname"}
+			 * @default `"pathname"`
+			 * @version 3.7.0
+			 * @description
+			 *
+			 * - `"pathanme": The strategy is applied to the pathname of the URLs
+			 */
+			strategy: 'pathname';
+		};
+	};
+
 	experimental?: {
 		/**
 		 * @docs
@@ -1408,122 +1526,6 @@ export interface AstroUserConfig {
 		 */
 		optimizeHoistedScript?: boolean;
 
-		/**
-		 * @docs
-		 * @name experimental.i18n
-		 * @type {object}
-		 * @version 3.5.0
-		 * @type {object}
-		 * @description
-		 *
-		 * Configures experimental i18n routing and allows you to specify some customization options.
-		 *
-		 * See our guide for more information on [internationalization in Astro](/en/guides/internationalization/)
-		 */
-		i18n?: {
-			/**
-			 * @docs
-			 * @kind h4
-			 * @name experimental.i18n.defaultLocale
-			 * @type {string}
-			 * @version 3.5.0
-			 * @description
-			 *
-			 * The default locale of your website/application. This is a required field.
-			 *
-			 * No particular language format or syntax is enforced, but we suggest using lower-case and hyphens as needed (e.g. "es", "pt-br") for greatest compatibility.
-			 */
-			defaultLocale: string;
-			/**
-			 * @docs
-			 * @kind h4
-			 * @name experimental.i18n.locales
-			 * @type {Locales}
-			 * @version 3.5.0
-			 * @description
-			 *
-			 * A list of all locales supported by the website, including the `defaultLocale`. This is a required field.
-			 *
-			 * Languages can be listed either as individual codes (e.g. `['en', 'es', 'pt-br']`) or mapped to a shared `path` of codes (e.g.  `{ path: "english", codes: ["en", "en-US"]}`). These codes will be used to determine the URL structure of your deployed site.
-			 *
-			 * No particular language code format or syntax is enforced, but your project folders containing your content files must match exactly the `locales` items in the list. In the case of multiple `codes` pointing to a custom URL path prefix, store your content files in a folder with the same name as the `path` configured.
-			 */
-			locales: Locales;
-
-			/**
-			 * @docs
-			 * @kind h4
-			 * @name experimental.i18n.fallback
-			 * @type {Record<string, string>}
-			 * @version 3.5.0
-			 * @description
-			 *
-			 * The fallback strategy when navigating to pages that do not exist (e.g. a translated page has not been created).
-			 *
-			 * Use this object to declare a fallback `locale` route for each language you support. If no fallback is specified, then unavailable pages will return a 404.
-			 *
-			 * ##### Example
-			 *
-			 * The following example configures your content fallback strategy to redirect unavailable pages in `/pt-br/` to their `es` version, and unavailable pages in `/fr/` to their `en` version. Unavailable `/es/` pages will return a 404.
-			 *
-			 * ```js
-			 * export default defineConfig({
-			 * 	experimental: {
-			 * 		i18n: {
-			 * 			defaultLocale: "en",
-			 * 			locales: ["en", "fr", "pt-br", "es"],
-			 * 			fallback: {
-			 * 				pt: "es",
-			 * 			  fr: "en"
-			 * 			}
-			 * 		}
-			 * 	}
-			 * })
-			 * ```
-			 */
-			fallback?: Record<string, string>;
-
-			/**
-			 * @docs
-			 * @kind h4
-			 * @name experimental.i18n.routing
-			 * @type {Routing}
-			 * @version 3.7.0
-			 * @description
-			 *
-			 * Controls the routing strategy to determine your site URLs. Set this based on your folder/URL path configuration for your default language.
-			 */
-			routing?: {
-				/**
-				 * @docs
-				 * @name experimental.i18n.routing.prefixDefaultLocale
-				 * @type {boolean}
-				 * @default `false`
-				 * @version 3.7.0
-				 * @description
-				 *
-				 * When `false`, only non-default languages will display a language prefix.
-				 * The `defaultLocale` will not show a language prefix and content files do not exist in a localized folder.
-				 *  URLs will be of the form `example.com/[locale]/content/` for all non-default languages, but `example.com/content/` for the default locale.
-				 *
-				 * When `true`, all URLs will display a language prefix.
-				 * URLs will be of the form `example.com/[locale]/content/` for every route, including the default language.
-				 * Localized folders are used for every language, including the default.
-				 */
-				prefixDefaultLocale: boolean;
-
-				/**
-				 * @name experimental.i18n.routing.strategy
-				 * @type {"pathname"}
-				 * @default `"pathname"`
-				 * @version 3.7.0
-				 * @description
-				 *
-				 * - `"pathanme": The strategy is applied to the pathname of the URLs
-				 */
-				strategy: 'pathname';
-			};
-		};
 		/**
 		 * @docs
 		 * @name experimental.contentCollectionCache

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1388,7 +1388,7 @@ export interface AstroUserConfig {
 
 	/**
 	 * @docs
-	 * @name experimental.i18n
+	 * @name i18n
 	 * @type {object}
 	 * @version 3.5.0
 	 * @type {object}
@@ -1402,7 +1402,7 @@ export interface AstroUserConfig {
 		/**
 		 * @docs
 		 * @kind h4
-		 * @name experimental.i18n.defaultLocale
+		 * @name i18n.defaultLocale
 		 * @type {string}
 		 * @version 3.5.0
 		 * @description
@@ -1415,7 +1415,7 @@ export interface AstroUserConfig {
 		/**
 		 * @docs
 		 * @kind h4
-		 * @name experimental.i18n.locales
+		 * @name i18n.locales
 		 * @type {Locales}
 		 * @version 3.5.0
 		 * @description
@@ -1431,7 +1431,7 @@ export interface AstroUserConfig {
 		/**
 		 * @docs
 		 * @kind h4
-		 * @name experimental.i18n.fallback
+		 * @name i18n.fallback
 		 * @type {Record<string, string>}
 		 * @version 3.5.0
 		 * @description
@@ -1464,7 +1464,7 @@ export interface AstroUserConfig {
 		/**
 		 * @docs
 		 * @kind h4
-		 * @name experimental.i18n.routing
+		 * @name i18n.routing
 		 * @type {Routing}
 		 * @version 3.7.0
 		 * @description
@@ -1474,7 +1474,7 @@ export interface AstroUserConfig {
 		routing?: {
 			/**
 			 * @docs
-			 * @name experimental.i18n.routing.prefixDefaultLocale
+			 * @name i18n.routing.prefixDefaultLocale
 			 * @type {boolean}
 			 * @default `false`
 			 * @version 3.7.0
@@ -1491,7 +1491,7 @@ export interface AstroUserConfig {
 			prefixDefaultLocale: boolean;
 
 			/**
-			 * @name experimental.i18n.routing.strategy
+			 * @name i18n.routing.strategy
 			 * @type {"pathname"}
 			 * @default `"pathname"`
 			 * @version 3.7.0

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -270,7 +270,7 @@ async function generatePage(
 		pipeline.getManifest().base,
 		pipeline.getManifest().trailingSlash
 	);
-	if (config.experimental.i18n && i18nMiddleware) {
+	if (config.i18n && i18nMiddleware) {
 		if (onRequest) {
 			pipeline.setMiddlewareFunction(sequence(i18nMiddleware, onRequest));
 		} else {
@@ -546,7 +546,7 @@ async function generatePath(
 		logger: pipeline.getLogger(),
 		ssr,
 	});
-	const i18n = pipeline.getConfig().experimental.i18n;
+	const i18n = pipeline.getConfig().i18n;
 
 	const renderContext = await createRenderContext({
 		pathname,
@@ -629,12 +629,12 @@ export function createBuildManifest(
 	renderers: SSRLoadedRenderer[]
 ): SSRManifest {
 	let i18nManifest: SSRManifestI18n | undefined = undefined;
-	if (settings.config.experimental.i18n) {
+	if (settings.config.i18n) {
 		i18nManifest = {
-			fallback: settings.config.experimental.i18n.fallback,
-			routing: settings.config.experimental.i18n.routing,
-			defaultLocale: settings.config.experimental.i18n.defaultLocale,
-			locales: settings.config.experimental.i18n.locales,
+			fallback: settings.config.i18n.fallback,
+			routing: settings.config.i18n.routing,
+			defaultLocale: settings.config.i18n.defaultLocale,
+			locales: settings.config.i18n.locales,
 		};
 	}
 	return {

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -240,12 +240,12 @@ function buildManifest(
 		entryModules[BEFORE_HYDRATION_SCRIPT_ID] = '';
 	}
 	let i18nManifest: SSRManifestI18n | undefined = undefined;
-	if (settings.config.experimental.i18n) {
+	if (settings.config.i18n) {
 		i18nManifest = {
-			fallback: settings.config.experimental.i18n.fallback,
-			routing: settings.config.experimental.i18n.routing,
-			locales: settings.config.experimental.i18n.locales,
-			defaultLocale: settings.config.experimental.i18n.defaultLocale,
+			fallback: settings.config.i18n.fallback,
+			routing: settings.config.i18n.routing,
+			locales: settings.config.i18n.locales,
+			defaultLocale: settings.config.i18n.defaultLocale,
 		};
 	}
 

--- a/packages/astro/src/core/build/util.ts
+++ b/packages/astro/src/core/build/util.ts
@@ -29,9 +29,9 @@ export function shouldAppendForwardSlash(
 }
 
 export function i18nHasFallback(config: AstroConfig): boolean {
-	if (config.experimental.i18n && config.experimental.i18n.fallback) {
+	if (config.i18n && config.i18n.fallback) {
 		// we have some fallback and the control is not none
-		return Object.keys(config.experimental.i18n.fallback).length > 0;
+		return Object.keys(config.i18n.fallback).length > 0;
 	}
 
 	return false;

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -141,7 +141,7 @@ export async function createVite(
 			astroPrefetch({ settings }),
 			astroTransitions({ settings }),
 			astroDevOverlay({ settings, logger }),
-			!!settings.config.experimental.i18n && astroInternationalization({ settings }),
+			!!settings.config.i18n && astroInternationalization({ settings }),
 		],
 		publicDir: fileURLToPath(settings.config.publicDir),
 		root: fileURLToPath(settings.config.root),

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -18,7 +18,6 @@ import { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from '../../constants.js';
 import { removeLeadingForwardSlash, slash } from '../../path.js';
 import { resolvePages } from '../../util.js';
 import { getRouteGenerator } from './generator.js';
-import { getPathByLocale } from '../../../i18n/index.js';
 const require = createRequire(import.meta.url);
 
 interface Item {
@@ -491,7 +490,7 @@ export function createRouteManifest(
 		// Didn't find a good place, insert last
 		routes.push(routeData);
 	});
-	const i18n = settings.config.experimental.i18n;
+	const i18n = settings.config.i18n;
 	if (i18n) {
 		// In this block of code we group routes based on their locale
 

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -35,7 +35,7 @@ export default function astroInternationalization({
 					const trailingSlash =  ${JSON.stringify(settings.config.trailingSlash)};
 					const format =  ${JSON.stringify(settings.config.build.format)};
 					const site = ${JSON.stringify(settings.config.site)};
-					const i18n = ${JSON.stringify(settings.config.experimental.i18n)};
+					const i18n = ${JSON.stringify(settings.config.i18n)};
 					
 					export const getRelativeLocaleUrl = (locale, path = "", opts) => _getLocaleRelativeUrl({ 
 						locale,

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -87,12 +87,12 @@ export default function createVitePluginAstroServer({
  */
 export function createDevelopmentManifest(settings: AstroSettings): SSRManifest {
 	let i18nManifest: SSRManifestI18n | undefined = undefined;
-	if (settings.config.experimental.i18n) {
+	if (settings.config.i18n) {
 		i18nManifest = {
-			fallback: settings.config.experimental.i18n.fallback,
-			routing: settings.config.experimental.i18n.routing,
-			defaultLocale: settings.config.experimental.i18n.defaultLocale,
-			locales: settings.config.experimental.i18n.locales,
+			fallback: settings.config.i18n.fallback,
+			routing: settings.config.i18n.routing,
+			defaultLocale: settings.config.i18n.defaultLocale,
+			locales: settings.config.i18n.locales,
 		};
 	}
 	return {

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -173,7 +173,7 @@ export async function handleRoute({
 	const config = pipeline.getConfig();
 	const moduleLoader = pipeline.getModuleLoader();
 	const { logger } = env;
-	if (!matchedRoute && !config.experimental.i18n) {
+	if (!matchedRoute && !config.i18n) {
 		if (isLoggedRequest(pathname)) {
 			logger.info(null, req({ url: pathname, method: incomingRequest.method, statusCode: 404 }));
 		}
@@ -190,8 +190,8 @@ export async function handleRoute({
 	const middleware = await loadMiddleware(moduleLoader);
 
 	if (!matchedRoute) {
-		if (config.experimental.i18n) {
-			const locales = config.experimental.i18n.locales;
+		if (config.i18n) {
+			const locales = config.i18n.locales;
 			const pathNameHasLocale = pathname
 				.split('/')
 				.filter(Boolean)
@@ -288,7 +288,7 @@ export async function handleRoute({
 			filePath: options.filePath,
 		});
 
-		const i18n = pipeline.getConfig().experimental.i18n;
+		const i18n = pipeline.getConfig().i18n;
 
 		renderContext = await createRenderContext({
 			request: options.request,
@@ -307,12 +307,8 @@ export async function handleRoute({
 	}
 
 	const onRequest = middleware?.onRequest as MiddlewareHandler | undefined;
-	if (config.experimental.i18n) {
-		const i18Middleware = createI18nMiddleware(
-			config.experimental.i18n,
-			config.base,
-			config.trailingSlash
-		);
+	if (config.i18n) {
+		const i18Middleware = createI18nMiddleware(config.i18n, config.base, config.trailingSlash);
 
 		if (i18Middleware) {
 			if (onRequest) {

--- a/packages/astro/test/fixtures/i18n-routing-base/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-routing-base/astro.config.mjs
@@ -2,7 +2,6 @@ import { defineConfig} from "astro/config";
 
 export default defineConfig({
 	base: "new-site",
-	experimental: {
 		i18n: {
 			defaultLocale: 'en',
 			locales: [
@@ -14,6 +13,5 @@ export default defineConfig({
 			routing: {
 				prefixDefaultLocale: true
 			}
-		}
 	}
 })

--- a/packages/astro/test/fixtures/i18n-routing-fallback/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-routing-fallback/astro.config.mjs
@@ -2,7 +2,6 @@ import { defineConfig} from "astro/config";
 
 export default defineConfig({
     base: "new-site",
-    experimental: {
         i18n: {
             defaultLocale: 'en',
             locales: [
@@ -13,5 +12,4 @@ export default defineConfig({
                 pt: "en"
             }
         }
-    }
 })

--- a/packages/astro/test/fixtures/i18n-routing-prefix-always/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-routing-prefix-always/astro.config.mjs
@@ -1,7 +1,6 @@
 import { defineConfig} from "astro/config";
 
 export default defineConfig({
-	experimental: {
 		i18n: {
 			defaultLocale: 'en',
 			locales: [
@@ -13,7 +12,6 @@ export default defineConfig({
 			routing: {
 				prefixDefaultLocale: true
 			}
-		}
-	},
+		},
 	base: "/new-site"
 })

--- a/packages/astro/test/fixtures/i18n-routing-prefix-other-locales/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-routing-prefix-other-locales/astro.config.mjs
@@ -1,14 +1,11 @@
 import { defineConfig} from "astro/config";
 
 export default defineConfig({
-	experimental: {
-		i18n: {
-			defaultLocale: 'en',
-			locales: [
-				'en', 'pt', 'it'
-			],
-		},
-		
+	i18n: {
+		defaultLocale: 'en',
+		locales: [
+			'en', 'pt', 'it'
+		],
 	},
 	base: "/new-site"
 })

--- a/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-routing-redirect-preferred-language/astro.config.mjs
@@ -1,12 +1,10 @@
 import { defineConfig} from "astro/config";
 
 export default defineConfig({
-	experimental: {
-		i18n: {
-			defaultLocale: 'en',
-			locales: [
-				'en', 'pt', 'it'
-			]
-		}
-	},
+	i18n: {
+		defaultLocale: 'en',
+		locales: [
+			'en', 'pt', 'it'
+		]
+	}
 })

--- a/packages/astro/test/fixtures/i18n-routing/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-routing/astro.config.mjs
@@ -1,7 +1,6 @@
 import { defineConfig} from "astro/config";
 
 export default defineConfig({
-	experimental: {
 		i18n: {
 			defaultLocale: 'en',
 			locales: [
@@ -14,5 +13,4 @@ export default defineConfig({
 				}
 			]
 		}
-	},
 })

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -157,22 +157,20 @@ describe('[DEV] i18n routing', () => {
 		before(async () => {
 			fixture = await loadFixture({
 				root: './fixtures/i18n-routing-prefix-other-locales/',
-				experimental: {
-					i18n: {
-						defaultLocale: 'en',
-						locales: [
-							'en',
-							'pt',
-							'it',
-							{
-								path: 'spanish',
-								codes: ['es', 'es-AR'],
-							},
-						],
-						fallback: {
-							it: 'en',
-							spanish: 'en',
+				i18n: {
+					defaultLocale: 'en',
+					locales: [
+						'en',
+						'pt',
+						'it',
+						{
+							path: 'spanish',
+							codes: ['es', 'es-AR'],
 						},
+					],
+					fallback: {
+						it: 'en',
+						spanish: 'en',
 					},
 				},
 			});
@@ -336,25 +334,23 @@ describe('[DEV] i18n routing', () => {
 		before(async () => {
 			fixture = await loadFixture({
 				root: './fixtures/i18n-routing-fallback/',
-				experimental: {
-					i18n: {
-						defaultLocale: 'en',
-						locales: [
-							'en',
-							'pt',
-							'it',
-							{
-								path: 'spanish',
-								codes: ['es', 'es-AR'],
-							},
-						],
-						fallback: {
-							it: 'en',
-							spanish: 'en',
+				i18n: {
+					defaultLocale: 'en',
+					locales: [
+						'en',
+						'pt',
+						'it',
+						{
+							path: 'spanish',
+							codes: ['es', 'es-AR'],
 						},
-						routing: {
-							prefixDefaultLocale: false,
-						},
+					],
+					fallback: {
+						it: 'en',
+						spanish: 'en',
+					},
+					routing: {
+						prefixDefaultLocale: false,
 					},
 				},
 			});
@@ -703,22 +699,20 @@ describe('[SSG] i18n routing', () => {
 		before(async () => {
 			fixture = await loadFixture({
 				root: './fixtures/i18n-routing-fallback/',
-				experimental: {
-					i18n: {
-						defaultLocale: 'en',
-						locales: [
-							'en',
-							'pt',
-							'it',
-							{
-								path: 'spanish',
-								codes: ['es', 'es-AR'],
-							},
-						],
-						fallback: {
-							it: 'en',
-							spanish: 'en',
+				i18n: {
+					defaultLocale: 'en',
+					locales: [
+						'en',
+						'pt',
+						'it',
+						{
+							path: 'spanish',
+							codes: ['es', 'es-AR'],
 						},
+					],
+					fallback: {
+						it: 'en',
+						spanish: 'en',
 					},
 				},
 			});
@@ -783,16 +777,14 @@ describe('[SSG] i18n routing', () => {
 		before(async () => {
 			fixture = await loadFixture({
 				root: './fixtures/i18n-routing-prefix-always/',
-				experimental: {
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['en', 'pt', 'it'],
-						fallback: {
-							it: 'en',
-						},
-						routing: {
-							prefixDefaultLocale: true,
-						},
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['en', 'pt', 'it'],
+					fallback: {
+						it: 'en',
+					},
+					routing: {
+						prefixDefaultLocale: true,
 					},
 				},
 			});
@@ -816,13 +808,11 @@ describe('[SSG] i18n routing', () => {
 				redirects: {
 					'/': '/en',
 				},
-				experimental: {
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['en', 'pt', 'it'],
-						fallback: {
-							it: 'en',
-						},
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['en', 'pt', 'it'],
+					fallback: {
+						it: 'en',
 					},
 				},
 			});
@@ -847,16 +837,14 @@ describe('[SSG] i18n routing', () => {
 				build: {
 					format: 'directory',
 				},
-				experimental: {
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['en', 'pt', 'it'],
-						fallback: {
-							it: 'en',
-						},
-						routing: {
-							prefixDefaultLocale: false,
-						},
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['en', 'pt', 'it'],
+					fallback: {
+						it: 'en',
+					},
+					routing: {
+						prefixDefaultLocale: false,
 					},
 				},
 			});
@@ -1106,22 +1094,20 @@ describe('[SSR] i18n routing', () => {
 				root: './fixtures/i18n-routing-fallback/',
 				output: 'server',
 				adapter: testAdapter(),
-				experimental: {
-					i18n: {
-						defaultLocale: 'en',
-						locales: [
-							'en',
-							'pt',
-							'it',
-							{
-								codes: ['es', 'es-AR'],
-								path: 'spanish',
-							},
-						],
-						fallback: {
-							it: 'en',
-							spanish: 'en',
+				i18n: {
+					defaultLocale: 'en',
+					locales: [
+						'en',
+						'pt',
+						'it',
+						{
+							codes: ['es', 'es-AR'],
+							path: 'spanish',
 						},
+					],
+					fallback: {
+						it: 'en',
+						spanish: 'en',
 					},
 				},
 			});
@@ -1169,16 +1155,14 @@ describe('[SSR] i18n routing', () => {
 					root: './fixtures/i18n-routing-fallback/',
 					output: 'server',
 					adapter: testAdapter(),
-					experimental: {
-						i18n: {
-							defaultLocale: 'en',
-							locales: ['en', 'pt', 'it'],
-							fallback: {
-								it: 'en',
-							},
-							routing: {
-								prefixDefaultLocale: false,
-							},
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['en', 'pt', 'it'],
+						fallback: {
+							it: 'en',
+						},
+						routing: {
+							prefixDefaultLocale: false,
 						},
 					},
 				});
@@ -1263,11 +1247,9 @@ describe('[SSR] i18n routing', () => {
 					root: './fixtures/i18n-routing/',
 					output: 'server',
 					adapter: testAdapter(),
-					experimental: {
-						i18n: {
-							defaultLocale: 'en',
-							locales: ['en_AU', 'pt_BR', 'es_US'],
-						},
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['en_AU', 'pt_BR', 'es_US'],
 					},
 				});
 				await fixture.build();
@@ -1294,16 +1276,14 @@ describe('[SSR] i18n routing', () => {
 					root: './fixtures/i18n-routing/',
 					output: 'server',
 					adapter: testAdapter(),
-					experimental: {
-						i18n: {
-							defaultLocale: 'en',
-							locales: [
-								{
-									path: 'english',
-									codes: ['en', 'en-AU', 'pt-BR', 'es-US'],
-								},
-							],
-						},
+					i18n: {
+						defaultLocale: 'en',
+						locales: [
+							{
+								path: 'english',
+								codes: ['en', 'en-AU', 'pt-BR', 'es-US'],
+							},
+						],
 					},
 				});
 				await fixture.build();
@@ -1401,11 +1381,9 @@ describe('i18n routing does not break assets and endpoints', () => {
 		before(async () => {
 			fixture = await loadFixture({
 				root: './fixtures/core-image-base/',
-				experimental: {
-					i18n: {
-						defaultLocale: 'en',
-						locales: ['en', 'es'],
-					},
+				i18n: {
+					defaultLocale: 'en',
+					locales: ['en', 'es'],
 				},
 				base: '/blog',
 			});

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -82,11 +82,9 @@ describe('Config Validation', () => {
 		it('defaultLocale is not in locales', async () => {
 			const configError = await validateConfig(
 				{
-					experimental: {
-						i18n: {
-							defaultLocale: 'en',
-							locales: ['es'],
-						},
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['es'],
 					},
 				},
 				process.cwd()
@@ -100,17 +98,15 @@ describe('Config Validation', () => {
 		it('errors if codes are empty', async () => {
 			const configError = await validateConfig(
 				{
-					experimental: {
-						i18n: {
-							defaultLocale: 'uk',
-							locales: [
-								'es',
-								{
-									path: 'something',
-									codes: [],
-								},
-							],
-						},
+					i18n: {
+						defaultLocale: 'uk',
+						locales: [
+							'es',
+							{
+								path: 'something',
+								codes: [],
+							},
+						],
 					},
 				},
 				process.cwd()
@@ -122,17 +118,15 @@ describe('Config Validation', () => {
 		it('errors if the default locale is not in path', async () => {
 			const configError = await validateConfig(
 				{
-					experimental: {
-						i18n: {
-							defaultLocale: 'uk',
-							locales: [
-								'es',
-								{
-									path: 'something',
-									codes: ['en-UK'],
-								},
-							],
-						},
+					i18n: {
+						defaultLocale: 'uk',
+						locales: [
+							'es',
+							{
+								path: 'something',
+								codes: ['en-UK'],
+							},
+						],
 					},
 				},
 				process.cwd()
@@ -146,13 +140,11 @@ describe('Config Validation', () => {
 		it('errors if a fallback value does not exist', async () => {
 			const configError = await validateConfig(
 				{
-					experimental: {
-						i18n: {
-							defaultLocale: 'en',
-							locales: ['es', 'en'],
-							fallback: {
-								es: 'it',
-							},
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['es', 'en'],
+						fallback: {
+							es: 'it',
 						},
 					},
 				},
@@ -167,13 +159,11 @@ describe('Config Validation', () => {
 		it('errors if a fallback key does not exist', async () => {
 			const configError = await validateConfig(
 				{
-					experimental: {
-						i18n: {
-							defaultLocale: 'en',
-							locales: ['es', 'en'],
-							fallback: {
-								it: 'en',
-							},
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['es', 'en'],
+						fallback: {
+							it: 'en',
 						},
 					},
 				},
@@ -188,13 +178,11 @@ describe('Config Validation', () => {
 		it('errors if a fallback key contains the default locale', async () => {
 			const configError = await validateConfig(
 				{
-					experimental: {
-						i18n: {
-							defaultLocale: 'en',
-							locales: ['es', 'en'],
-							fallback: {
-								en: 'es',
-							},
+					i18n: {
+						defaultLocale: 'en',
+						locales: ['es', 'en'],
+						fallback: {
+							en: 'es',
 						},
 					},
 				},


### PR DESCRIPTION
## Changes

This PR moves i18n configuration out of the `experimental` flag.

This PR must be merged AFTER the RFC https://github.com/withastro/roadmap/pull/734 is merged

## Testing

The whole test suite should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs to quickly check if the JSDoc are correct

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
