### PR TITLE
fix(upgrade): point beta changelogs to main

### DIFF
--- a/.changeset/modern-lies-thank.md
+++ b/.changeset/modern-lies-thank.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/upgrade': patch
+---
+
+Fix CHANGELOG links for beta

--- a/packages/upgrade/src/actions/verify.ts
+++ b/packages/upgrade/src/actions/verify.ts
@@ -157,7 +157,9 @@ async function resolveTargetVersion(packageInfo: PackageInfo, registry: string):
 			throw new Error(`Unable to resolve "${packageInfo.name}"`);
 		}
 		const { repository } = await latestMetadata.json();
-		const branch = bump === 'premajor' ? 'next' : 'main';
+		// If actively using the `next` branch, use the following:
+		// const branch = bump === 'premajor' ? 'next' : 'main';
+		const branch = 'main';
 		packageInfo.changelogURL = extractChangelogURLFromRepository(repository, version, branch);
 		packageInfo.changelogTitle = 'CHANGELOG';
 	} else {


### PR DESCRIPTION
## Changes

- `@astrojs/upgrade beta` was pointing CHANGELOG links to the `next` branch
- The `next` branch has been merged to `main`.
- This PR updates the links to point to `main` instead.

## Testing

Manual

## Docs

Bug fix