### PR TITLE
Remove remaining simple objects usage

### DIFF
--- a/examples/ssr/src/pages/api/cart.ts
+++ b/examples/ssr/src/pages/api/cart.ts
@@ -5,14 +5,12 @@ export function GET({ cookies }: APIContext) {
 	let userId = cookies.get('user-id').value;
 
 	if (!userId || !userCartItems.has(userId)) {
-		return {
-			body: JSON.stringify({ items: [] }),
-		};
+		return Response.json({ items: [] });
 	}
 	let items = userCartItems.get(userId);
 	let array = Array.from(items.values());
 
-	return new Response(JSON.stringify({ items: array }));
+	return Response.json({ items: array });
 }
 
 interface AddToCartItem {
@@ -36,9 +34,5 @@ export async function POST({ cookies, request }: APIContext) {
 		cart.set(item.id, { id: item.id, name: item.name, count: 1 });
 	}
 
-	return new Response(
-		JSON.stringify({
-			ok: true,
-		})
-	);
+	return Response.json({ ok: true });
 }

--- a/examples/ssr/src/pages/login.form.async.ts
+++ b/examples/ssr/src/pages/login.form.async.ts
@@ -1,16 +1,14 @@
 import { APIContext, APIRoute } from 'astro';
 
-export const post: APIRoute = ({ cookies, params, request }: APIContext) => {
+export const POST: APIRoute = ({ cookies }: APIContext) => {
 	// add a new cookie
 	cookies.set('user-id', '1', {
 		path: '/',
 		maxAge: 2592000,
 	});
 
-	return {
-		body: JSON.stringify({
-			ok: true,
-			user: 1,
-		}),
-	};
+	return Response.json({
+		ok: true,
+		user: 1,
+	});
 };

--- a/examples/ssr/src/pages/login.form.ts
+++ b/examples/ssr/src/pages/login.form.ts
@@ -1,6 +1,6 @@
 import { APIContext } from 'astro';
 
-export function post({ cookies, params, request }: APIContext) {
+export function POST({ cookies }: APIContext) {
 	// add a new cookie
 	cookies.set('user-id', '1', {
 		path: '/',

--- a/packages/astro/test/fixtures/content-collection-references/src/pages/welcome-data.json.js
+++ b/packages/astro/test/fixtures/content-collection-references/src/pages/welcome-data.json.js
@@ -4,7 +4,7 @@ export async function GET() {
 	const welcomePost = await getEntry('blog', 'welcome');
 
 	if (!welcomePost?.data) {
-		return Response.json({ error: 'blog/welcome did not return `data`.' })
+		return Response.json({ error: 'blog/welcome did not return `data`.' }, { status: 404 })
 	}
 
 	const banner = await getEntry(welcomePost.data.banner);

--- a/packages/astro/test/fixtures/content-collection-references/src/pages/welcome-data.json.js
+++ b/packages/astro/test/fixtures/content-collection-references/src/pages/welcome-data.json.js
@@ -4,9 +4,7 @@ export async function GET() {
 	const welcomePost = await getEntry('blog', 'welcome');
 
 	if (!welcomePost?.data) {
-		return { 
-			body: { error: 'blog/welcome did not return `data`.' },
-		}
+		return Response.json({ error: 'blog/welcome did not return `data`.' })
 	}
 
 	const banner = await getEntry(welcomePost.data.banner);

--- a/packages/astro/test/fixtures/ssr-api-route-custom-404/src/pages/api/route.js
+++ b/packages/astro/test/fixtures/ssr-api-route-custom-404/src/pages/api/route.js
@@ -1,6 +1,4 @@
 
 export function POST() {
-	return {
-		body: JSON.stringify({ ok: true })
-	};
+	return Response.json({ ok: true });
 }


### PR DESCRIPTION
## Changes

Make sure we don't return simple objects from endpoint anywhere else. Also made sure they're uppercase now.

I like `Response.json`

## Testing

Existing tests should pass.

## Docs

n/a. internal change to tests and examples.