### PR TITLE
Increase consistency between navigation with and without ViewTransitions

### DIFF
--- a/.changeset/nervous-beans-peel.md
+++ b/.changeset/nervous-beans-peel.md
@@ -2,4 +2,9 @@
 'astro': minor
 ---
 
-Greater consistency between navigations with and without `<ViewTransitions>`: Navigation to the current page starts view transition processing if the target URL is specified without a hash target. Navigation to different origin targets is excluded from view transition processing and is handled by the browser.
+Greater consistency between navigations with and without `<ViewTransitions>`: 
+
+- New for direct calls to `navigate()`: Navigation to a URL whose origin does not match the origin of the current page is excluded from view transition processing and triggers the standard navigation of the browser.
+- New: Navigation to the current page (= same path name and same search parameters) without a hash fragment triggers view transition processing.
+- New for form submission: Navigation to a non-empty hash target on the current page does not trigger view transitions, but updates the browser history directly and scrolls to the target position. 
+

--- a/.changeset/nervous-beans-peel.md
+++ b/.changeset/nervous-beans-peel.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Greater consistency between navigations with and without `<ViewTransitions>`: Navigation to the current page starts view transition processing if the target URL is specified without a hash target. Navigation to different origin targets is excluded from view transition processing and is handled by the browser.

--- a/.changeset/nervous-beans-peel.md
+++ b/.changeset/nervous-beans-peel.md
@@ -2,9 +2,5 @@
 'astro': minor
 ---
 
-Greater consistency between navigations with and without `<ViewTransitions>`: 
-
-- New for direct calls to `navigate()`: Navigation to a URL whose origin does not match the origin of the current page is excluded from view transition processing and triggers the standard navigation of the browser.
-- New: Navigation to the current page (= same path name and same search parameters) without a hash fragment triggers view transition processing.
-- New for form submission: Navigation to a non-empty hash target on the current page does not trigger view transitions, but updates the browser history directly and scrolls to the target position. 
+Improves consistency between navigations with and without `<ViewTransitions>`. See [#9279](https://github.com/withastro/astro/pull/9279) for more details.
 

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/long-page.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/long-page.astro
@@ -52,6 +52,7 @@ import Layout from '../components/Layout.astro';
 	</article>
 </Layout>
 <script is:inline>
+	// let playwright know when navigate() is done
 	document.addEventListener('astro:before-swap', (e) => {
 		e.viewTransition.ready.then(()=>console.log("ready"))
 	});

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/long-page.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/long-page.astro
@@ -51,3 +51,8 @@ import Layout from '../components/Layout.astro';
 		Libero id faucibus nisl tincidunt eget nullam non. Faucibus a pellentesque sit amet porttitor eget dolor. Posuere urna nec tincidunt praesent semper feugiat nibh sed. Suspendisse ultrices gravida dictum fusce. Porttitor eget dolor morbi non arcu. Neque egestas congue quisque egestas diam in. Suscipit tellus mauris a diam maecenas sed enim ut sem. Luctus accumsan tortor posuere ac. Tortor posuere ac ut consequat semper viverra. Egestas tellus rutrum tellus pellentesque eu tincidunt tortor aliquam nulla. Senectus et netus et malesuada fames ac turpis egestas. Sed libero enim sed faucibus turpis in eu mi bibendum. Sollicitudin tempor id eu nisl nunc mi.
 	</article>
 </Layout>
+<script is:inline>
+	document.addEventListener('astro:before-swap', (e) => {
+		e.viewTransition.ready.then(()=>console.log("ready"))
+	});
+</script>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -394,14 +394,17 @@ test.describe('View Transitions', () => {
 		await expect(locator).toBeInViewport();
 
 		// Scroll back to top
+		// back returns immediately, but we need to wait for navigate() to complete
+		const waitForReady = page.waitForEvent('console');
 		await page.goBack();
+		await waitForReady;
 		locator = page.locator('#longpage');
 		await expect(locator).toBeInViewport();
 
 		// Forward to middle of page
 		await page.goForward();
 		locator = page.locator('#click-one-again');
-		await expect(locator).toBeVisible();
+		await expect(locator).toBeInViewport();
 	});
 
 	test('<Image /> component forwards transitions to the <img>', async ({ page, astro }) => {

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -401,7 +401,7 @@ test.describe('View Transitions', () => {
 		// Forward to middle of page
 		await page.goForward();
 		locator = page.locator('#click-one-again');
-		await expect(locator).toBeInViewport();
+		await expect(locator).toBeVisible();
 	});
 
 	test('<Image /> component forwards transitions to the <img>', async ({ page, astro }) => {

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -433,10 +433,10 @@ async function transition(
 		  ? 'replace'
 		  : 'push';
 
+	if (navigationType !== 'traverse') {
+		updateScrollPosition({ scrollX, scrollY });
+	}
 	if (samePage(from, to) && !!to.hash) {
-		if (navigationType !== 'traverse') {
-			updateScrollPosition({ scrollX, scrollY });
-		}
 		moveToLocation(to, from, options, historyState);
 		return;
 	}

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -430,10 +430,10 @@ async function transition(
 	const navigationType = historyState
 		? 'traverse'
 		: options.history === 'replace'
-		? 'replace'
-		: 'push';
+		  ? 'replace'
+		  : 'push';
 
-	if (samePage(from, to) && to.hash) {
+	if (samePage(from, to) && !!to.hash) {
 		if (navigationType !== 'traverse') {
 			updateScrollPosition({ scrollX, scrollY });
 		}
@@ -495,6 +495,7 @@ async function transition(
 
 		const links = preloadStyleLinks(preparationEvent.newDocument);
 		links.length && (await Promise.all(links));
+
 		if (import.meta.env.DEV)
 			await prepareForClientOnlyComponents(preparationEvent.newDocument, preparationEvent.to);
 	}

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -30,8 +30,7 @@ export const transitionEnabledOnThisPage = () =>
 	inBrowser && !!document.querySelector('[name="astro-view-transitions-enabled"]');
 
 const samePage = (thisLocation: URL, otherLocation: URL) =>
-	thisLocation.pathname === otherLocation.pathname &&
-	thisLocation.search === otherLocation.search;
+	thisLocation.pathname === otherLocation.pathname && thisLocation.search === otherLocation.search;
 
 // When we traverse the history, the window.location is already set to the new location.
 // This variable tells us where we came from
@@ -431,8 +430,8 @@ async function transition(
 	const navigationType = historyState
 		? 'traverse'
 		: options.history === 'replace'
-		  ? 'replace'
-		  : 'push';
+		? 'replace'
+		: 'push';
 
 	if (samePage(from, to) && to.hash) {
 		if (navigationType !== 'traverse') {
@@ -498,7 +497,6 @@ async function transition(
 		links.length && (await Promise.all(links));
 		if (import.meta.env.DEV)
 			await prepareForClientOnlyComponents(preparationEvent.newDocument, preparationEvent.to);
-		}
 	}
 
 	skipTransition = false;


### PR DESCRIPTION
## Changes

Greater consistency between navigations with and without `<ViewTransitions>`: 
- New for direct calls to `navigate()`: Navigation to a URL whose origin does not match the origin of the current page is excluded from view transition processing and triggers the standard navigation of the browser.
- New: Navigation to the current page (= same path name and same search parameters) without a hash fragment triggers view transition processing.
- New for form submission: Navigation to a non-empty hash target on the current page does not trigger view transitions, but updates the browser history directly and scrolls to the target position. 


## Testing

Had to fix one test because page.back() does not wait for asynchronous actions. 

## Docs

Details have never been documented before, so there is nothing to update.