### PR TITLE
[Toolbar] Improve third party plugin load performance

### DIFF
--- a/packages/astro/src/runtime/client/dev-overlay/entrypoint.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/entrypoint.ts
@@ -1,12 +1,14 @@
 import type { DevOverlayPlugin as DevOverlayPluginDefinition } from '../../../@types/astro.js';
 import { type AstroDevOverlay, type DevOverlayPlugin } from './overlay.js';
 import { settings } from './settings.js';
+// @ts-expect-error
+import {loadDevOverlayPlugins} from 'astro:dev-overlay';
 
 let overlay: AstroDevOverlay;
 
 document.addEventListener('DOMContentLoaded', async () => {
 	const [
-		{ loadDevOverlayPlugins },
+		customPluginsDefinitions,
 		{ default: astroDevToolPlugin },
 		{ default: astroAuditPlugin },
 		{ default: astroXrayPlugin },
@@ -23,8 +25,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 			DevOverlayIcon,
 		},
 	] = await Promise.all([
-		// @ts-expect-error
-		import('astro:dev-overlay'),
+		loadDevOverlayPlugins() as DevOverlayPluginDefinition[],
 		import('./plugins/astro.js'),
 		import('./plugins/audit.js'),
 		import('./plugins/xray.js'),
@@ -239,7 +240,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 		},
 	} satisfies DevOverlayPluginDefinition;
 
-	const customPluginsDefinitions = (await loadDevOverlayPlugins()) as DevOverlayPluginDefinition[];
 	const plugins: DevOverlayPlugin[] = [
 		...[
 			astroDevToolPlugin,


### PR DESCRIPTION
## Changes

- Third-party toolbar apps loaded after first-party apps
- This split the `import` step into two parts, slowing down the overall loading experience and slowing down the third-party loading experience
- This impacted Spotlight during testing, delaying how long it took Spotlight to start up (~800ms until `init()` was called after startup), which delayed how long it took before they could start tracking errors.

## Testing

- Tested manually
- @Princesseuh would love your confirmation that this wasn't intentional, and that I'm not missing anything important by making this change!

## Docs

- N/A