### PR TITLE
rename devOverlay to devToolbar

### DIFF
--- a/packages/astro/src/runtime/client/dev-overlay/plugins/settings.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/plugins/settings.ts
@@ -131,7 +131,7 @@ export default {
 				<h2 id="general">General</h2>
 				<hr />
 				<h3>Hide overlay</h3>
-				<p>Run <code>astro preferences disable devOverlay</code> in your terminal to disable this dev overlay in this project. <a href="https://docs.astro.build/en/reference/cli-reference/#astro-preferences">Learn more</a>.</p>
+				<p>Run <code>astro preferences disable devToolbar</code> in your terminal to disable this dev overlay in this project. <a href="https://docs.astro.build/en/reference/cli-reference/#astro-preferences">Learn more</a>.</p>
 				`
 			);
 			const general = windowElement.querySelector('#general')!;


### PR DESCRIPTION
## Changes

Settings mentioned the old name, which leads to an error when used

## Testing

manually

## Docs

n/a