### PR TITLE
remove outdated devoverlay config and defaultstate config

### DIFF
--- a/packages/astro/e2e/astro-envs.test.js
+++ b/packages/astro/e2e/astro-envs.test.js
@@ -3,7 +3,7 @@ import { testFactory } from './test-utils.js';
 
 const test = testFactory({
 	root: './fixtures/astro-envs/',
-	devOverlay: {
+	devToolbar: {
 		enabled: false,
 	},
 });

--- a/packages/astro/e2e/css.test.js
+++ b/packages/astro/e2e/css.test.js
@@ -3,7 +3,7 @@ import { testFactory } from './test-utils.js';
 
 const test = testFactory({
 	root: './fixtures/css/',
-	devOverlay: {
+	devToolbar: {
 		enabled: false,
 	},
 });

--- a/packages/astro/e2e/dev-overlay.test.js
+++ b/packages/astro/e2e/dev-overlay.test.js
@@ -19,8 +19,8 @@ test.describe('Dev Overlay', () => {
 	test('dev overlay exists in the page', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/'));
 
-		const devOVerlay = page.locator('astro-dev-toolbar');
-		await expect(devOVerlay).toHaveCount(1);
+		const devToolbar = page.locator('astro-dev-toolbar');
+		await expect(devToolbar).toHaveCount(1);
 	});
 
 	test('shows plugin name on hover', async ({ page, astro }) => {

--- a/packages/astro/e2e/fixtures/astro-component/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/astro-component/astro.config.mjs
@@ -4,7 +4,7 @@ import preact from '@astrojs/preact'
 // https://astro.build/config
 export default defineConfig({
   integrations: [preact()],
-	devOverlay: {
+	devToolbar: {
 		enabled: false,
 	}
 });

--- a/packages/astro/e2e/fixtures/astro-envs/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/astro-envs/astro.config.mjs
@@ -5,7 +5,7 @@ import vue from '@astrojs/vue';
 export default defineConfig({
 	site: 'http://example.com',
 	base: '/blog',
-	devOverlay: {
+	devToolbar: {
 		enabled: false,
 	},
 	integrations: [vue()],

--- a/packages/astro/e2e/fixtures/lit-component/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/lit-component/astro.config.mjs
@@ -4,7 +4,7 @@ import lit from '@astrojs/lit';
 // https://astro.build/config
 export default defineConfig({
 	integrations: [lit()],
-	devOverlay: {
+	devToolbar: {
 		enabled: false,
 	}
 });

--- a/packages/astro/e2e/fixtures/prefetch/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/prefetch/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
-	devOverlay: {
+	devToolbar: {
 		enabled: false,
 	},
 	prefetch: true

--- a/packages/astro/e2e/fixtures/tailwindcss/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/tailwindcss/astro.config.mjs
@@ -9,7 +9,7 @@ export default defineConfig({
 			configFile: fileURLToPath(new URL('./tailwind.config.js', import.meta.url)),
 		}),
 	],
-	devOverlay: {
+	devToolbar: {
 		enabled: false,
 	},
 	vite: {

--- a/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
@@ -13,7 +13,7 @@ export default defineConfig({
 		'/redirect-two': '/two',
 		'/redirect-external': 'http://example.com/',
 	},
-	devOverlay: {
+	devToolbar: {
 		enabled: false,
 	},
 	vite: {

--- a/packages/astro/e2e/hmr.test.js
+++ b/packages/astro/e2e/hmr.test.js
@@ -3,7 +3,7 @@ import { testFactory } from './test-utils.js';
 
 const test = testFactory({
 	root: './fixtures/hmr/',
-	devOverlay: {
+	devToolbar: {
 		enabled: false,
 	},
 });

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1158,35 +1158,6 @@ export interface AstroUserConfig {
 	/**
 	 * @docs
 	 * @kind heading
-	 * @name Dev Overlay Options
-	 * @deprecated Use `devToolbar` instead.
-	 */
-	devOverlay?: {
-		/**
-		 * @docs
-		 * @name devOverlay.enabled
-		 * @type {boolean}
-		 * @default `true`
-		 * @description
-		 * Whether to enable the dev overlay. This overlay allows you to inspect your page islands, see helpful audits on performance and accessibility, and more.
-		 *
-		 * This option is scoped to the entire project, to only disable the overlay for yourself, run `npm run astro preferences disable devOverlay`. To disable the overlay for all your Astro projects, run `npm run astro preferences disable devOverlay --global`.
-		 */
-		enabled: boolean;
-		/**
-		 * @docs
-		 * @name devOverlay.defaultState
-		 * @type {'minimized' | 'expanded'}
-		 * @default `minimized`
-		 * @description
-		 * Whether the dev overlay should be expanded or minimized by default.
-		 */
-		defaultState: 'minimized' | 'expanded';
-	};
-
-	/**
-	 * @docs
-	 * @kind heading
 	 * @name Dev Toolbar Options
 	 */
 	devToolbar?: {
@@ -1201,15 +1172,6 @@ export interface AstroUserConfig {
 		 * This option is scoped to the entire project, to only disable the toolbar for yourself, run `npm run astro preferences disable devToolbar`. To disable the toolbar for all your Astro projects, run `npm run astro preferences disable devToolbar --global`.
 		 */
 		enabled: boolean;
-		/**
-		 * @docs
-		 * @name devToolbar.defaultState
-		 * @type {'minimized' | 'expanded'}
-		 * @default `minimized`
-		 * @description
-		 * Whether the Dev Toolbar should be expanded or minimized by default.
-		 */
-		defaultState: 'minimized' | 'expanded';
 	};
 
 	/**
@@ -2591,7 +2553,6 @@ export type DevOverlayPlugin = DevToolbarApp;
 export type DevOverlayMetadata = Window &
 	typeof globalThis & {
 		__astro_dev_overlay__: {
-			defaultState: AstroConfig['devOverlay']['defaultState'];
 			root: string;
 			version: string;
 			debugInfo: string;

--- a/packages/astro/src/core/compile/compile.ts
+++ b/packages/astro/src/core/compile/compile.ts
@@ -48,7 +48,7 @@ export async function compile({
 			resultScopedSlot: true,
 			transitionsAnimationURL: 'astro/components/viewtransitions.css',
 			annotateSourceFile:
-				!viteConfig.isProduction && astroConfig.devOverlay && astroConfig.devOverlay.enabled,
+				!viteConfig.isProduction && astroConfig.devToolbar && astroConfig.devToolbar.enabled,
 			preprocessStyle: createStylePreprocessor({
 				filename,
 				viteConfig,

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -41,13 +41,8 @@ const ASTRO_CONFIG_DEFAULTS = {
 	image: {
 		service: { entrypoint: 'astro/assets/services/sharp', config: {} },
 	},
-	devOverlay: {
-		enabled: true,
-		defaultState: 'minimized',
-	},
 	devToolbar: {
 		enabled: true,
-		defaultState: 'minimized',
 	},
 	compressHTML: true,
 	server: {
@@ -232,20 +227,9 @@ export const AstroConfigSchema = z.object({
 				.default([]),
 		})
 		.default(ASTRO_CONFIG_DEFAULTS.image),
-	devOverlay: z
-		.object({
-			enabled: z.boolean().default(ASTRO_CONFIG_DEFAULTS.devOverlay.enabled),
-			defaultState: z
-				.enum(['minimized', 'expanded'])
-				.default(ASTRO_CONFIG_DEFAULTS.devOverlay.defaultState),
-		})
-		.default(ASTRO_CONFIG_DEFAULTS.devOverlay),
 	devToolbar: z
 		.object({
 			enabled: z.boolean().default(ASTRO_CONFIG_DEFAULTS.devToolbar.enabled),
-			defaultState: z
-				.enum(['minimized', 'expanded'])
-				.default(ASTRO_CONFIG_DEFAULTS.devToolbar.defaultState),
 		})
 		.default(ASTRO_CONFIG_DEFAULTS.devToolbar),
 	markdown: z

--- a/packages/astro/src/runtime/client/dev-overlay/overlay.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/overlay.ts
@@ -228,12 +228,7 @@ export class AstroDevOverlay extends HTMLElement {
 				width: 1px;
 			}
 		</style>
-		<div id="dev-overlay"${
-			((window as DevOverlayMetadata)?.__astro_dev_overlay__?.defaultState ?? 'minimized') ===
-			'minimized'
-				? ' data-hidden '
-				: ''
-		} ${settings.config.disablePluginNotification ? 'data-no-notification' : ''}>
+		<div id="dev-overlay" data-hidden ${settings.config.disablePluginNotification ? 'data-no-notification' : ''}>
 			<div id="dev-bar-hitbox-above"></div>
 			<div id="dev-bar">
 				<div id="bar-container">

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -396,7 +396,7 @@ async function getScriptsAndStyles({ pipeline, filePath }: GetScriptsAndStylesPa
 		});
 
 		if (
-			settings.config.devOverlay.enabled &&
+			settings.config.devToolbar.enabled &&
 			(await settings.preferences.get('devToolbar.enabled'))
 		) {
 			scripts.add({
@@ -408,7 +408,6 @@ async function getScriptsAndStyles({ pipeline, filePath }: GetScriptsAndStylesPa
 			});
 
 			const additionalMetadata: DevOverlayMetadata['__astro_dev_overlay__'] = {
-				defaultState: settings.config.devOverlay.defaultState,
 				root: fileURLToPath(settings.config.root),
 				version: ASTRO_VERSION,
 				debugInfo: await getInfoOutput({ userConfig: settings.config, print: false }),


### PR DESCRIPTION
## Changes

- `devOverlay` config was introduced in the `4.0.0-beta.X` release branch, meaning it is not covered by semver now that it has been renamed to `devToolbar`. The only people who would have been using this were people experimenting with early versions of the Astro 4.0 beta.
- This PR removes that no-longer-used config for the official 4.0 release.
- This PR also fixes a bug where `devOverlay` was being checked, instead of `devToolbar`
- This PR also updates tests to use `devToolbar` instead of `devOverlay`
- This PR also removes an outdated `defaultState` config, which was removed in #9230 but the config was missed. This is now a no-op and doesn't make conceptual sense since the toolbar now shows/hides based on hover/focus.

## Testing

- Updated tests

## Docs

- Updated docs in JSDoc
- @matthewp want your signoff first before I involve docs!