### PR TITLE
Remove audit role that depends on CJS package

### DIFF
--- a/.changeset/tender-eagles-learn.md
+++ b/.changeset/tender-eagles-learn.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Removes the 'a11y-role-has-required-aria-props' audit rule
+
+This audit rule depends on a CommonJS module. To prevent blocking the 4.0 release the rule is being removed temporarily.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -125,7 +125,6 @@
     "@types/babel__core": "^7.20.4",
     "acorn": "^8.11.2",
     "aria-query": "^5.3.0",
-    "axobject-query": "^4.0.0",
     "boxen": "^7.1.1",
     "chokidar": "^3.5.3",
     "ci-info": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -511,9 +511,6 @@ importers:
       aria-query:
         specifier: ^5.3.0
         version: 5.3.0
-      axobject-query:
-        specifier: ^4.0.0
-        version: 4.0.0
       boxen:
         specifier: ^7.1.1
         version: 7.1.1
@@ -8370,12 +8367,6 @@ packages:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
     dependencies:
       dequal: 2.0.3
-
-  /axobject-query@4.0.0:
-    resolution: {integrity: sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==}
-    dependencies:
-      dequal: 2.0.3
-    dev: false
 
   /b4a@1.6.4:
     resolution: {integrity: sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==}


### PR DESCRIPTION
## Changes

- The package `axobject-query` is CJS and Vite doesn't ESM-ify it, can't add to `optimizedDeps.include`.
- Maybe there's something we can do to shim but removing for 4.0 release.

## Testing

- N/A

## Docs

N/A
