### PR TITLE
[Toolbar] fix issue where requestIdleCallback would take forever

### DIFF
--- a/packages/astro/src/runtime/client/dev-overlay/overlay.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/overlay.ts
@@ -281,7 +281,7 @@ export class AstroDevOverlay extends HTMLElement {
 		if ('requestIdleCallback' in window) {
 			window.requestIdleCallback(async () => {
 				this.plugins.map((plugin) => this.initPlugin(plugin));
-			});
+			}, {timeout: 300});
 		} else {
 			setTimeout(async () => {
 				this.plugins.map((plugin) => this.initPlugin(plugin));


### PR DESCRIPTION
## Changes

- I ran into a problem where requestIdleCallback would never fire (or, would take a very long time to fire).
- When [checking out MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback), I saw this blurb: "Note: A timeout option is strongly recommended for required work, as otherwise it's possible multiple seconds will elapse before the callback is fired."
- Adds a timeout similar to the `setTimeout()` logic we already have for Safari, in case `requestIdleCallback` is taking too long.

## Testing

- Small change, don't think it's possible to test

## Docs

- N/A