### PR TITLE
[Toolbar] capture click events inside the toolbar

### DIFF
--- a/packages/astro/src/runtime/client/dev-overlay/overlay.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/overlay.ts
@@ -307,13 +307,14 @@ export class AstroDevOverlay extends HTMLElement {
 	attachEvents() {
 		const items = this.shadowRoot.querySelectorAll<HTMLDivElement>('.item');
 		items.forEach((item) => {
-			item.addEventListener('click', async (e) => {
-				const target = e.currentTarget;
+			item.addEventListener('click', async (event) => {
+				const target = event.currentTarget;
 				if (!target || !(target instanceof HTMLElement)) return;
 				const id = target.dataset.pluginId;
 				if (!id) return;
 				const plugin = this.getPluginById(id);
 				if (!plugin) return;
+				event.stopPropagation();
 				await this.togglePluginStatus(plugin);
 			});
 		});


### PR DESCRIPTION
## Changes

- Stop propagating click events inside the toolbar
- This fixed an issue where the website I was on was listening for document click events to close a modal. This captured my toolbar click, which then closed the modal before I could inspect it.

## Testing

- I checked playwright and it doesn't look like it can detect/listen for events. If anyone has ideas, LMK! 

## Docs

- N/A