### PR TITLE
Release markdoc integration as v0.x

### DIFF
--- a/packages/integrations/markdoc/package.json
+++ b/packages/integrations/markdoc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@astrojs/markdoc",
   "description": "Add support for Markdoc in your Astro site",
-  "version": "1.0.0-beta.1",
+  "version": "0.7.2",
   "type": "module",
   "types": "./dist/index.d.ts",
   "author": "withastro",
@@ -75,7 +75,7 @@
     "zod": "^3.22.4"
   },
   "peerDependencies": {
-    "astro": "^4.0.0-beta.0"
+    "astro": "^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@astrojs/markdown-remark": "workspace:*",


### PR DESCRIPTION
## Changes

Revert to 0.7.2 (current latest version) so the next release is 0.8.0. It was bumped as 1.0.0 by changesets because of the peer dep range auto-update. I've updated that to `"astro": "^3.0.0 || ^4.0.0"`

## Testing

Verified that it works with `pnpm changeset version` locally, which bumps the next version as 0.8

## Docs

n/a
