### PR TITLE
fix: logging build trace of pages

### DIFF
--- a/.changeset/angry-cows-hug.md
+++ b/.changeset/angry-cows-hug.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where logs that weren't grouped together by route when building the app.


### PR DESCRIPTION
## Changes

This PR fixes logs the emitted during the build

## Testing

Tested on the starlight template, locally:


<img width="528" alt="Screenshot 2023-12-05 at 14 18 11" src="https://github.com/withastro/astro/assets/602478/bd283612-805c-4882-b183-22a4f551e973">


<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
