### PR TITLE
Improves `@astrojs/upgrade` dependency handling

### DIFF
--- a/.changeset/poor-otters-doubt.md
+++ b/.changeset/poor-otters-doubt.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/upgrade': patch
+---
+
+Improves dependency handling by ignoring packages that don't use a semver version

--- a/packages/upgrade/src/index.ts
+++ b/packages/upgrade/src/index.ts
@@ -2,7 +2,7 @@ import { getContext } from './actions/context.js';
 
 import { help } from './actions/help.js';
 import { install } from './actions/install.js';
-import { verify } from './actions/verify.js';
+import { verify, collectPackageInfo } from './actions/verify.js';
 import { setStdout } from './messages.js';
 
 const exit = () => process.exit(0);
@@ -29,4 +29,4 @@ export async function main() {
 	process.exit(0);
 }
 
-export { getContext, install, setStdout, verify };
+export { getContext, install, setStdout, verify, collectPackageInfo };

--- a/packages/upgrade/test/verify.test.js
+++ b/packages/upgrade/test/verify.test.js
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import { collectPackageInfo } from '../dist/index.js';
+
+describe('collectPackageInfo', () => {
+	const context = {
+		cwd: '',
+		version: 'latest',
+		packageManager: 'npm',
+		dryRun: true,
+		packages: []
+	};
+
+	beforeEach(() => {
+		context.packages = [];
+	})
+
+	it('detects astro', async () => {
+		collectPackageInfo(context, { "astro": "1.0.0" }, {});
+		expect(context.packages).deep.equal([{ name: 'astro', currentVersion: '1.0.0', targetVersion: 'latest' }]);
+	});
+
+	it('detects @astrojs', async () => {
+		collectPackageInfo(context, { "@astrojs/preact": "1.0.0" }, {});
+		expect(context.packages).deep.equal([{ name: '@astrojs/preact', currentVersion: '1.0.0', targetVersion: 'latest' }]);
+	});
+
+	it('supports ^ prefixes', async () => {
+		collectPackageInfo(context, { "astro": "^1.0.0" }, {});
+		expect(context.packages).deep.equal([{ name: 'astro', currentVersion: '^1.0.0', targetVersion: 'latest' }]);
+	});
+
+	it('supports ~ prefixes', async () => {
+		collectPackageInfo(context, { "astro": "~1.0.0" }, {});
+		expect(context.packages).deep.equal([{ name: 'astro', currentVersion: '~1.0.0', targetVersion: 'latest' }]);
+	});
+
+	it('supports prereleases', async () => {
+		collectPackageInfo(context, { "astro": "1.0.0-beta.0" }, {});
+		expect(context.packages).deep.equal([{ name: 'astro', currentVersion: '1.0.0-beta.0', targetVersion: 'latest' }]);
+	});
+
+	it('ignores self', async () => {
+		collectPackageInfo(context, { "@astrojs/upgrade": "0.0.1" }, {});
+		expect(context.packages).deep.equal([]);
+	});
+
+	it('ignores linked packages', async () => {
+		collectPackageInfo(context, { "@astrojs/preact": "link:../packages/preact" }, {});
+		expect(context.packages).deep.equal([]);
+	});
+
+	it('ignores workspace packages', async () => {
+		collectPackageInfo(context, { "@astrojs/preact": "workspace:*" }, {});
+		expect(context.packages).deep.equal([]);
+	});
+
+	it('ignores github packages', async () => {
+		collectPackageInfo(context, { "@astrojs/preact": "github:withastro/astro" }, {});
+		expect(context.packages).deep.equal([]);
+	});
+
+	it('ignores tag', async () => {
+		collectPackageInfo(context, { "@astrojs/preact": "beta" }, {});
+		expect(context.packages).deep.equal([]);
+	});
+});


### PR DESCRIPTION
## Changes

- Previously, `@astrojs/upgrade` would fail when packages weren't found in the NPM registry.
- This PR improves dependency handling so that packages without semver versions are ignored.
- In effect, this change ensures that dependencies using `link:`, `github:`, and `workspace:` protocols are ignored. It's also implemented in a future-proof way by only allowing valid semver identifiers rather than allow-listing known protocols.
- ✅ Changeset added

## Testing

New test suite added for the `verify` step, unit testing this function's behavior specifically

## Docs

N/A, bug fix