### PR TITLE
Prevent client-side navigation for method="dialog"

### DIFF
--- a/.changeset/rich-keys-rescue.md
+++ b/.changeset/rich-keys-rescue.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-View Transitions no longer respond to events emitted from form with method "dialog"
+Fixes an edge case for `<form method="dialog">` when using View Transitions. Forms with `method="dialog"` no longer require an additional `data-astro-reload` attribute.

--- a/.changeset/rich-keys-rescue.md
+++ b/.changeset/rich-keys-rescue.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+View Transitions no longer respond to events emitted from form with method "dialog"

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -104,6 +104,12 @@ const { fallback = 'animate' } = Astro.props;
 			let action = submitter?.getAttribute('formaction') ?? form.action ?? location.pathname;
 			const method = submitter?.getAttribute('formmethod') ?? form.method;
 
+			// the "dialog" method is a special keyword used within <dialog> elements
+			// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method
+			if (method === "dialog") {
+				return
+			}
+
 			const options: Options = { sourceElement: submitter ?? form };
 			if (method === 'get') {
 				const params = new URLSearchParams(formData as any);
@@ -113,6 +119,7 @@ const { fallback = 'animate' } = Astro.props;
 			} else {
 				options.formData = formData;
 			}
+			
 			ev.preventDefault();
 			navigate(action, options);
 		});

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/dialog.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/dialog.astro
@@ -1,0 +1,16 @@
+---
+import { ViewTransitions } from "astro:transitions";
+---
+<html>
+	<head>
+    <ViewTransitions />
+	</head>
+	<body>
+    <button id="open" onclick="modal.showModal()">Open Modal</button>
+    <dialog id="modal">
+      <form method="dialog">
+        <button id="close">Close</button>
+      </form>
+    </dialog>
+	</body>
+</html>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -1074,4 +1074,18 @@ test.describe('View Transitions', () => {
 		await page.click('#three');
 		await expect(page).toHaveURL(expected);
 	});
+
+	test('Dialog using form with method of "dialog" should not trigger navigation', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/dialog'));
+
+		let requests = [];
+		page.on('request', request => requests.push(`${request.method()} ${request.url()}`));
+
+		await page.click('#open');
+		await expect(page.locator("dialog")).toHaveAttribute("open")
+		await page.click('#close');
+		await expect(page.locator("dialog")).not.toHaveAttribute("open")
+
+		expect(requests).toHaveLength(0)
+	});
 });


### PR DESCRIPTION
## Changes

- View Transitions no longer cause navigation due to events emitted from `<form method="dialog">`
- Resolves https://github.com/withastro/astro/issues/9320

## Testing

Added new E2E test confirming new requests are not sent when modal is opened and then closed using a button/form.

## Docs

Documentation does not need to be updated. Behavior should now match that of Astro 3.
