### PR TITLE
Update `vitefu` version

### DIFF
--- a/.changeset/beige-gorillas-camp.md
+++ b/.changeset/beige-gorillas-camp.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates an internal dependency ([`vitefu`](https://github.com/svitejs/vitefu)) to avoid a common `peerDependency` warning

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -169,7 +169,7 @@
     "unist-util-visit": "^5.0.0",
     "vfile": "^6.0.1",
     "vite": "^5.0.0",
-    "vitefu": "^0.2.4",
+    "vitefu": "^0.2.5",
     "which-pm": "^2.1.1",
     "yargs-parser": "^21.1.1",
     "zod": "^3.22.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -644,7 +644,7 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(@types/node@18.18.6)(sass@1.69.5)
       vitefu:
-        specifier: ^0.2.4
+        specifier: ^0.2.5
         version: 0.2.5(vite@5.0.0)
       which-pm:
         specifier: ^2.1.1


### PR DESCRIPTION
## Changes

- `vitefu` added support for Vite 5 in a patch but that isn't always picked up by package managers.
- Bumping `vitefu` to the minimum version that supports Vite 5.
- This will avoid `peerDependency` warnings that have been reported

## Testing

N/A

## Docs

N/A