### PR TITLE
Vue: Remove `hasDefaultExport` check from `appEntrypoint` logic

### DIFF
--- a/.changeset/selfish-lamps-build.md
+++ b/.changeset/selfish-lamps-build.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vue': patch
+---
+
+Fixes issue with `appEntrypoint` when running `astro dev`

--- a/packages/integrations/vue/test/app-entrypoint.test.js
+++ b/packages/integrations/vue/test/app-entrypoint.test.js
@@ -76,17 +76,6 @@ describe('App Entrypoint no export default (dev)', () => {
 		expect(bar.textContent).to.eq('works');
 	});
 
-	it('component not included on page', async () => {
-		const html = await fixture.fetch('/').then(res => res.text());
-		const { document } = parseHTML(html);
-		const island = document.querySelector('astro-island');
-		const client = island.getAttribute('renderer-url');
-		expect(client).not.to.be.undefined;
-
-		const js = await fixture.fetch(client);
-		expect(js).not.to.match(/\w+\.component\(\"Bar\"/gm);
-	});
-
 	it('loads svg components without transforming them to assets', async () => {
 		const html = await fixture.fetch('/').then(res => res.text());
 		const { document } = parseHTML(html);

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-no-export-default/src/pages/_app.ts
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-no-export-default/src/pages/_app.ts
@@ -1,3 +1,3 @@
-console.log(123);
+export const setup = () => {}
 
 // no default export

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/astro.config.mjs
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/astro.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'astro/config';
+import vue from '@astrojs/vue';
+
+export default defineConfig({
+  integrations: [vue({
+		appEntrypoint: '/src/vue.ts'
+	})]
+})

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/package.json
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@test/vue-app-entrypoint-relative",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "astro": "astro"
+  },
+  "dependencies": {
+    "@astrojs/vue": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/package.json
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/vue-app-entrypoint-relative",
+  "name": "@test/vue-app-entrypoint-src-absolute",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/src/components/Bar.vue
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/src/components/Bar.vue
@@ -1,0 +1,3 @@
+<template>
+	<div id="bar">works</div>
+</template>

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/src/components/Circle.svg
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/src/components/Circle.svg
@@ -1,0 +1,1 @@
+<svg fill="none" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" fill="#ff0" r="40" stroke="#008000" stroke-width="4"/></svg>

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/src/components/Foo.vue
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/src/components/Foo.vue
@@ -1,0 +1,11 @@
+<script setup>
+import Bar from './Bar.vue'
+import Circle from './Circle.svg?component'
+</script>
+
+<template>
+	<div id="foo">
+		<Bar />
+		<Circle/>
+	</div>
+</template>

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/src/pages/index.astro
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/src/pages/index.astro
@@ -1,0 +1,12 @@
+---
+import Foo from '../components/Foo.vue';
+---
+
+<html>
+	<head>
+		<title>Vue App Entrypoint</title>
+	</head>
+	<body>
+		<Foo client:load />
+	</body>
+</html>

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/src/vue.ts
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/src/vue.ts
@@ -1,0 +1,1 @@
+export default () => {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4860,6 +4860,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute:
+    dependencies:
+      '@astrojs/vue':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/vue/test/fixtures/basics:
     dependencies:
       '@astrojs/vue':


### PR DESCRIPTION
## Changes

- Fixes #9330!
- We used `hasDefaultExport`, which is a Rollup API. This is available in `astro build` but not during `astro dev`. 
- Now uses a custom method compatible with either `astro dev` or `astro build`

## Testing

Our previous test suite was missing `astro dev` tests, leading to incompatible behavior getting merged and released.

This PR adds an `astro dev` test while ensuring the previous tests are still passing

## Docs

Bug fix only