### PR TITLE
Allow async functions in the Vercel edge middleware integration

### DIFF
--- a/.changeset/young-spoons-rescue.md
+++ b/.changeset/young-spoons-rescue.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': minor
+---
+
+Allow async functions in the Vercel edge middleware integration.

--- a/.changeset/young-spoons-rescue.md
+++ b/.changeset/young-spoons-rescue.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/vercel': minor
+'@astrojs/vercel': patch
 ---
 
 Allows the edge middleware to be an async function.

--- a/.changeset/young-spoons-rescue.md
+++ b/.changeset/young-spoons-rescue.md
@@ -2,4 +2,4 @@
 '@astrojs/vercel': minor
 ---
 
-Allow async functions in the Vercel edge middleware integration.
+Allows the edge middleware to be an async function.

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@astrojs/vercel",
   "description": "Deploy your site to Vercel",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "type": "module",
   "author": "withastro",
   "license": "MIT",

--- a/packages/integrations/vercel/src/serverless/middleware.ts
+++ b/packages/integrations/vercel/src/serverless/middleware.ts
@@ -53,7 +53,7 @@ function edgeMiddlewareTemplate(middlewarePath: string, vercelEdgeMiddlewareHand
 	if (existsSync(filePathEdgeMiddleware + '.js') || existsSync(filePathEdgeMiddleware + '.ts')) {
 		const stringified = JSON.stringify(filePathEdgeMiddleware.replace(/\\/g, '/'));
 		handlerTemplateImport = `import handler from ${stringified}`;
-		handlerTemplateCall = `handler({ request, context })`;
+		handlerTemplateCall = `await handler({ request, context })`;
 	} else {
 	}
 	return `


### PR DESCRIPTION
## Changes

Vercel's Edge Middleware allows async functions so should the Astro wrapper.

Note: I bumped the minor version in this commit. Was I supposed to do that? It wasn't clear in the CONTRIBUTE.md

## Testing

No tests needed. This is a very small change that doesn't break anything. The `await` keyword in JavaScript waits for a Promise to resolve, if it is a Promise. Otherwise, `await` returns the value it's being called on.

## Docs

No docs added. This is just a bugfix.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
