### PR TITLE
Fix issue where 404/500 status codes were logged as "[200]"

### DIFF
--- a/.changeset/modern-mice-shout.md
+++ b/.changeset/modern-mice-shout.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+dev: fix issue where 404 and 500 responses were logged as 200

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -37,7 +37,7 @@ export function req({
 	method?: string;
 	reqTime?: number;
 }): string {
-	const color = statusCode >= 400 ? red : statusCode >= 300 ? yellow : blue;
+	const color = statusCode >= 500 ? red : statusCode >= 300 ? yellow : blue;
 	return (
 		color(`[${statusCode}]`) +
 		` ` +


### PR DESCRIPTION
## Changes

- Fix issue where 404 & 500 status codes were logged as "[200]"
- This happened because the log wasn't respecting the `status` override

## Testing

- N/A, fairly internal change that only impacts a log message

## Docs

- N/A