### PR TITLE
Fix log message for `Disable notifications`

### DIFF
--- a/.changeset/strange-parrots-promise.md
+++ b/.changeset/strange-parrots-promise.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed the log message to correctly display 'enabled' and 'disabled' when toggling 'Disable notifications' in the Toolbar.

--- a/packages/astro/src/runtime/client/dev-overlay/plugins/settings.ts
+++ b/packages/astro/src/runtime/client/dev-overlay/plugins/settings.ts
@@ -25,7 +25,7 @@ const settingsRows = [
 				}
 
 				settings.updateSetting('disablePluginNotification', evt.currentTarget.checked);
-				const action = evt.currentTarget.checked ? 'enabled' : 'disabled';
+				const action = evt.currentTarget.checked ? 'disabled' : 'enabled';
 				settings.log(`Plugin notification badges ${action}`);
 			}
 		},


### PR DESCRIPTION
## Changes

- Fixed the log message to correctly display 'enabled' and 'disabled' when toggling 'Disable notifications' in the Toolbar.

## Testing

- Ran examples locally and verified that the log message has been corrected.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

- N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
