### PR TITLE
fix: add types for `is:inline` on slots

### DIFF
--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -36,6 +36,7 @@ declare namespace astroHTML.JSX {
 		AstroDefineVarsAttribute;
 	type AstroStyleAttributes = import('./dist/@types/astro.js').AstroStyleAttributes &
 		AstroDefineVarsAttribute;
+	type AstroSlotAttributes = import('./dist/@types/astro.js').AstroSlotAttributes;
 
 	// This is an unfortunate use of `any`, but unfortunately we can't make a type that works for every framework
 	// without importing every single framework's types (which comes with its own set of problems).
@@ -1415,7 +1416,7 @@ declare namespace astroHTML.JSX {
 		ruby: HTMLAttributes;
 		s: HTMLAttributes;
 		samp: HTMLAttributes;
-		slot: SlotHTMLAttributes;
+		slot: SlotHTMLAttributes & AstroSlotAttributes;
 		script: ScriptHTMLAttributes & AstroScriptAttributes;
 		section: HTMLAttributes;
 		select: SelectHTMLAttributes;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -132,6 +132,10 @@ export interface AstroScriptAttributes {
 	'is:inline'?: boolean;
 }
 
+export interface AstroSlotAttributes {
+	'is:inline'?: boolean;
+}
+
 export interface AstroComponentMetadata {
 	displayName: string;
 	hydrate?: 'load' | 'idle' | 'visible' | 'media' | 'only';


### PR DESCRIPTION
## Changes

I always forget we have this thing.

Fix https://github.com/withastro/astro/issues/9329

## Testing

Tested manually

## Docs

N/A
