### PR TITLE
Adds source file properties to HTML elements only if devToolbar is enabled

### DIFF
--- a/.changeset/famous-bobcats-vanish.md
+++ b/.changeset/famous-bobcats-vanish.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds source file properties to HTML elements only if devToolbar is enabled

--- a/packages/astro/src/core/compile/compile.ts
+++ b/packages/astro/src/core/compile/compile.ts
@@ -10,10 +10,12 @@ import { AggregateError, CompilerError } from '../errors/errors.js';
 import { AstroErrorData } from '../errors/index.js';
 import { resolvePath } from '../util.js';
 import { createStylePreprocessor } from './style.js';
+import type { AstroPreferences } from '../../preferences/index.js';
 
 export interface CompileProps {
 	astroConfig: AstroConfig;
 	viteConfig: ResolvedConfig;
+	preferences: AstroPreferences;
 	filename: string;
 	source: string;
 }
@@ -26,6 +28,7 @@ export interface CompileResult extends TransformResult {
 export async function compile({
 	astroConfig,
 	viteConfig,
+	preferences,
 	filename,
 	source,
 }: CompileProps): Promise<CompileResult> {
@@ -48,7 +51,10 @@ export async function compile({
 			resultScopedSlot: true,
 			transitionsAnimationURL: 'astro/components/viewtransitions.css',
 			annotateSourceFile:
-				viteConfig.command === 'serve' && astroConfig.devToolbar && astroConfig.devToolbar.enabled,
+				viteConfig.command === 'serve' &&
+				astroConfig.devToolbar &&
+				astroConfig.devToolbar.enabled &&
+				(await preferences.get('devToolbar.enabled')),
 			preprocessStyle: createStylePreprocessor({
 				filename,
 				viteConfig,

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -139,6 +139,7 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 			const compileProps: CompileProps = {
 				astroConfig: config,
 				viteConfig: resolvedConfig,
+				preferences: settings.preferences,
 				filename: normalizePath(parsedId.filename),
 				source,
 			};
@@ -179,6 +180,7 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 				cachedCompilation({
 					astroConfig: config,
 					viteConfig: resolvedConfig,
+					preferences: settings.preferences,
 					filename,
 					source,
 				});


### PR DESCRIPTION
## Changes

When the compiler was called, only astro.config.devToolbar was checked to activate the source annotations, but not AstroPerferences.
Now the code mimics the check that we use in router.ts to activate devToolbar.

Closes #9324 

Note: The astro.config setting currently takes precedence over preferences. If astro.config.devToolbar === false, preferences cannot turn it back on. I think we should not use preferences and astro.config together or at least give astro.config a lower priority between preferences.global and preferences.default.  See thread in #maintainers from this morning (6:40 GMT)

## Testing

Manually tested

## Docs

Depending on how complicate the final solution might get :)