### PR TITLE
Define the Vercel adapter's peerDependency

### DIFF
--- a/.changeset/nasty-carrots-study.md
+++ b/.changeset/nasty-carrots-study.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Use the latest astro as the peerDependency

--- a/.changeset/nasty-carrots-study.md
+++ b/.changeset/nasty-carrots-study.md
@@ -2,4 +2,4 @@
 '@astrojs/vercel': patch
 ---
 
-Use the latest astro as the peerDependency
+Uses the latest astro as the peerDependency

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -59,7 +59,7 @@
     "web-vitals": "^3.4.0"
   },
   "peerDependencies": {
-    "astro": "^4.0.0-beta.0"
+    "astro": "^4.0.2"
   },
   "devDependencies": {
     "@types/set-cookie-parser": "^2.4.6",


### PR DESCRIPTION
## Changes

- The Vercel adapter's peerDepedency has to be manually updated.
- This makes it work in 4.0 apps.

## Testing

N/A

## Docs

N/A