### PR TITLE
chore: markdown-remark peerDependencies

### DIFF
--- a/.changeset/gorgeous-buttons-remember.md
+++ b/.changeset/gorgeous-buttons-remember.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Fixes an issue where this package could not be installed alongside Astro 4.0.

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -27,9 +27,6 @@
     "dev": "astro-scripts dev \"src/**/*.ts\"",
     "test": "mocha --exit --timeout 20000"
   },
-  "peerDependencies": {
-    "astro": "^4.0.0-beta.0"
-  },
   "dependencies": {
     "@astrojs/prism": "^3.0.0",
     "github-slugger": "^2.0.0",


### PR DESCRIPTION
## Changes

- Removes peerDependencies from `@astrojs/markdown-remark`

## Testing

Does not affect behavior

## Docs

Does not affect usage
