### PR TITLE
Improves HMR logic with proper parser

### DIFF
--- a/packages/astro/src/core/compile/cache.ts
+++ b/packages/astro/src/core/compile/cache.ts
@@ -5,6 +5,16 @@ type CompilationCache = Map<string, CompileResult>;
 
 const configCache = new WeakMap<AstroConfig, CompilationCache>();
 
+interface CachedFile { 
+	timestamp: number;
+	content: string;
+}
+const fileCache = new Map<string, CachedFile>;
+
+export function getCachedFileContent(filename: string) {
+	return fileCache.get(filename);
+}
+
 export function isCached(config: AstroConfig, filename: string) {
 	return configCache.has(config) && configCache.get(config)!.has(filename);
 }
@@ -36,6 +46,7 @@ export async function cachedCompilation(props: CompileProps): Promise<CompileRes
 	if (cache.has(filename)) {
 		return cache.get(filename)!;
 	}
+	fileCache.set(props.filename, { timestamp: Date.now(), content: props.source });
 	const compileResult = await compile(props);
 	cache.set(filename, compileResult);
 	return compileResult;


### PR DESCRIPTION
## Changes

- Resolves https://github.com/withastro/astro/issues/9262
- This PR improves our HMR logic by refactoring our style detection to actually use the AST provided by the compiler.
- Previously, we were doing a best-effort attempt at determining if only a style had changed. This approach had some subtly inconsistent behavior due to the order in which modules were invalidated.
- Since our compiler now has a proper `parse` mode that provides a full AST, our HMR logic can be much more exact.

## Testing

Tested manually, but will try to add an E2E test to replicate the issue reported

## Docs

N/A, bug fixes