### PR TITLE
chore: add 'astro-scripts' to the workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "workspaces": [
     "packages/markdown/*",
     "packages/integrations/*",
-    "packages/*"
+    "packages/*",
+    "scripts/*"
   ],
   "engines": {
     "node": ">=18.14.1",


### PR DESCRIPTION
## Changes

The `astro-scripts` package wasn't part of the workspace and it was causing issues when linking the package `astro` using the `pnpm link` command.

## Testing

The `pnpm link` command now works

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
