### PR TITLE
Fix static build when out dir is not within the cwd

### DIFF
--- a/.changeset/lorem-ipsum-dolor
+++ b/.changeset/lorem-ipsum-dolor
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes static builds when `config.outDir` is located outside of the astro project

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -335,7 +335,7 @@ async function runPostBuildHooks(
 			? mutation.targets.includes('server')
 				? build.server
 				: build.client
-			: config.outDir;
+			: getOutDirWithinCwd(config.outDir);
 		const fullPath = path.join(fileURLToPath(root), fileName);
 		const fileURL = pathToFileURL(fullPath);
 		await fs.promises.mkdir(new URL('./', fileURL), { recursive: true });


### PR DESCRIPTION
## Changes

We had an issue where some styles were not loading in the static build. We managed to pinpoint it to this - and noticed `clientBuild` calls this function on `config.outDir` - but the mutations don't. I'm not 100% sure this is the correct fix, but it certainly fixed it for us

## Testing

Local testing & repo tests

## Docs

Fixes static builds when `config.outDir` is located outside of the astro project
