### PR TITLE
makes the output of 'astro preferences list' more verbose

### DIFF
--- a/.changeset/selfish-donuts-approve.md
+++ b/.changeset/selfish-donuts-approve.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-makes the output of 'astro preferences list' more verbose
+Improves the CLI output of `astro preferences list` to include additional relevant information

--- a/.changeset/selfish-donuts-approve.md
+++ b/.changeset/selfish-donuts-approve.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+makes the output of 'astro preferences list' more verbose

--- a/packages/astro/src/cli/preferences/index.ts
+++ b/packages/astro/src/cli/preferences/index.ts
@@ -228,11 +228,13 @@ function userValues(
 		if (key in flatProject) {
 			result[key] = {
 				value: flatProject[key],
-				annotation: 'for this project',
-			};
-			if (key in flatGlobal) result[key].annotation += ` (and globally set to ${flatGlobal[key]})`;
+				annotation: '',
+			}
+			if (key in flatGlobal) {
+				result[key].annotation += ` (also modified globally)`;
+			}
 		} else if (key in flatGlobal) {
-			result[key] = { value: flatGlobal[key], annotation: 'globally' };
+			result[key] = { value: flatGlobal[key], annotation: '(global)' };
 		}
 	}
 	return result;

--- a/packages/astro/src/preferences/index.ts
+++ b/packages/astro/src/preferences/index.ts
@@ -35,6 +35,7 @@ type DeepPartial<T> = T extends object
 
 export type PreferenceKey = DotKeys<Preferences>;
 export interface PreferenceList extends Record<PreferenceLocation, DeepPartial<Preferences>> {
+	fromAstroConfig: DeepPartial<Preferences>;
 	defaults: Preferences;
 }
 
@@ -95,8 +96,15 @@ export default function createPreferences(config: AstroConfig): AstroPreferences
 			return {
 				global: stores['global'].getAll(),
 				project: stores['project'].getAll(),
+				fromAstroConfig: mapFrom(DEFAULT_PREFERENCES, config),
 				defaults: DEFAULT_PREFERENCES,
 			};
+
+			function mapFrom(defaults: Preferences, astroConfig: Record<string, any>) {
+				return Object.fromEntries(
+					Object.entries(defaults).map(([key, _]) => [key, astroConfig[key]])
+				);
+			}
 		},
 	};
 }


### PR DESCRIPTION
## Changes
Shows whether preferences are project local or global and **warns in cases where astroConfig overrules preferences**.

It would be great if a native speaker could check the wording.
If we want to pursue this suggestion, we could also integrate the table with the defaults into the main table (stating that the value is neither project nor global but the default value). 
If we don't want to proceed with the modified table, I'd still like to keep the warning message, as I still find it very confusing in the case of the devToolbar that user preferences can override a `true` astroConfig value, but that they can't override a `false` astroConfig value.

## Indicates whether the prefrences are set per project or globally.
![image](https://github.com/withastro/astro/assets/94928215/bda56ff9-2b56-4396-a92d-8a1c3c9d564a)

## Issues a warning if the devToolbar preferences are true but the toolbar is disabled in astroConfig
![image](https://github.com/withastro/astro/assets/94928215/bb9b0cc3-db90-4670-a251-d1f4a140e86e)
![image](https://github.com/withastro/astro/assets/94928215/778bad38-8af7-46ff-88fc-804710cbd0f0)

## Testing

manually tested

## Docs

