### PR TITLE
Update astro add to install stable peer dep

### DIFF
--- a/.changeset/plenty-pumas-kiss.md
+++ b/.changeset/plenty-pumas-kiss.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+When adding integrations with the `astro add` command, only install the stable version of peer dependencies by default

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -614,9 +614,16 @@ async function getInstallIntegrationsCommand({
 		.map<[string, string | null][]>((i) => [[i.packageName, null], ...i.dependencies])
 		.flat(1)
 		.filter((dep, i, arr) => arr.findIndex((d) => d[0] === dep[0]) === i)
-		.map(([name, version]) =>
-			version === null ? name : `${name}@${version.split(/\s*\|\|\s*/).pop()}`
-		)
+		.map(([name, version]) => {
+			if (version !== null) {
+				// If there are multiple versions, use the last non-prerelease one
+				const versions = version.split(/\s*\|\|\s*/);
+				if (versions.length > 1) {
+					version = versions.reverse().find((v) => !/\-.*?\./.test(v)) ?? version;
+				}
+			}
+			return version === null ? name : `${name}@${version}`;
+		})
 		.sort();
 
 	switch (pm.name) {


### PR DESCRIPTION
## Changes

With the added Svelte 5 (alpha) support for `@astrojs/svelte`, when users run `astro add svelte`, it will incorrectly install `svelte@5.0.0-next.1`:

```
  Astro will run the following command:
  If you skip this step, you can always run it yourself later

 ╭────────────────────────────────────────────────╮
 │ pnpm add @astrojs/svelte svelte@^5.0.0-next.1  │
 ╰────────────────────────────────────────────────╯
```

This PR fixes it by only installing the latest non-prerelease version:

```
  Astro will run the following command:
  If you skip this step, you can always run it yourself later

 ╭─────────────────────────────────────────╮
 │ pnpm add @astrojs/svelte svelte@^4.0.0  │
 ╰─────────────────────────────────────────╯
```

(Originally reported from the [Svelte discord](https://discord.com/channels/457912077277855764/1153350350158450758/1183498971751141506))

## Testing

Tested running `astro add svelte` locally.

## Docs

n/a. bug fix.