### PR TITLE
Fix Preact Forwarded Ref components not working in astro files when React integration is enabled

### DIFF
--- a/.changeset/breezy-hairs-yell.md
+++ b/.changeset/breezy-hairs-yell.md
@@ -2,4 +2,4 @@
 '@astrojs/react': patch
 ---
 
-Prevent React integration from picking up forward-ref Preact function components that it cannot render.
+Prevents unsupported `forwardRef` components created by Preact from being rendered by React

--- a/.changeset/breezy-hairs-yell.md
+++ b/.changeset/breezy-hairs-yell.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/react': patch
+---
+
+Prevent React integration from picking up forward-ref Preact function components that it cannot render.

--- a/packages/integrations/react/server.js
+++ b/packages/integrations/react/server.js
@@ -24,7 +24,7 @@ async function check(Component, props, children) {
 	if (typeof Component !== 'function') return false;
 
 	// Preact forwarded-ref components can be functions, which React does not support
-	if (typeof Component === 'function' && Component['$$typeof'] === Symbol.for('react.forward_ref') return false;
+	if (typeof Component === 'function' && Component['$$typeof'] === Symbol.for('react.forward_ref')) return false;
 
 	if (Component.prototype != null && typeof Component.prototype.render === 'function') {
 		return React.Component.isPrototypeOf(Component) || React.PureComponent.isPrototypeOf(Component);

--- a/packages/integrations/react/server.js
+++ b/packages/integrations/react/server.js
@@ -24,7 +24,7 @@ async function check(Component, props, children) {
 	if (typeof Component !== 'function') return false;
 
 	// Preact forwarded-ref components can be functions, which React does not support
-	if (typeof Component === 'function' && Component['$$typeof'].toString() === 'Symbol(react.forward_ref)') return false;
+	if (typeof Component === 'function' && Component['$$typeof']?.toString() === 'Symbol(react.forward_ref)') return false;
 
 	if (Component.prototype != null && typeof Component.prototype.render === 'function') {
 		return React.Component.isPrototypeOf(Component) || React.PureComponent.isPrototypeOf(Component);

--- a/packages/integrations/react/server.js
+++ b/packages/integrations/react/server.js
@@ -23,6 +23,9 @@ async function check(Component, props, children) {
 	}
 	if (typeof Component !== 'function') return false;
 
+	// Preact forwarded-ref components can be functions, which React does not support
+	if (typeof Component === 'function' && Component['$$typeof'].toString() === 'Symbol(react.forward_ref)') return false;
+
 	if (Component.prototype != null && typeof Component.prototype.render === 'function') {
 		return React.Component.isPrototypeOf(Component) || React.PureComponent.isPrototypeOf(Component);
 	}

--- a/packages/integrations/react/server.js
+++ b/packages/integrations/react/server.js
@@ -24,7 +24,7 @@ async function check(Component, props, children) {
 	if (typeof Component !== 'function') return false;
 
 	// Preact forwarded-ref components can be functions, which React does not support
-	if (typeof Component === 'function' && Component['$$typeof']?.toString() === 'Symbol(react.forward_ref)') return false;
+	if (typeof Component === 'function' && Component['$$typeof'] === Symbol.for('react.forward_ref') return false;
 
 	if (Component.prototype != null && typeof Component.prototype.render === 'function') {
 		return React.Component.isPrototypeOf(Component) || React.PureComponent.isPrototypeOf(Component);


### PR DESCRIPTION
## Changes

Fixes #9402

Preact's `forwardRef` from `preact/compat` can return function components which forward refs, which React does not support (React forward ref components are always objects, never functions, even when `forwardRef` is wrapping a function component).

## Testing

I have not tested this change. What would qualify as a sufficient test as far as the astro maintainers are concerned?

## Docs

No need for docs, this just prevents the React integration from picking up Preact components that it cannot render.
