### PR TITLE
Allow file URLs to be used as import specifiers

### DIFF
--- a/.changeset/smart-colts-think.md
+++ b/.changeset/smart-colts-think.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allows file URLs as import specifiers

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -33,6 +33,7 @@ import type { Logger } from './logger/core.js';
 import { createViteLogger } from './logger/vite.js';
 import { vitePluginMiddleware } from './middleware/vite-plugin.js';
 import { joinPaths } from './path.js';
+import vitePluginFileURL from '../vite-plugin-fileurl/index.js';
 
 interface CreateViteOptions {
 	settings: AstroSettings;
@@ -141,6 +142,7 @@ export async function createVite(
 			astroPrefetch({ settings }),
 			astroTransitions({ settings }),
 			astroDevOverlay({ settings, logger }),
+			vitePluginFileURL({}),
 			!!settings.config.i18n && astroInternationalization({ settings }),
 		],
 		publicDir: fileURLToPath(settings.config.publicDir),

--- a/packages/astro/src/vite-plugin-fileurl/index.ts
+++ b/packages/astro/src/vite-plugin-fileurl/index.ts
@@ -2,7 +2,7 @@ import type { Plugin as VitePlugin } from 'vite';
 
 export default function vitePluginFileURL({}): VitePlugin {
 	return {
-		name: 'astro:vite-plugin-env',
+		name: 'astro:vite-plugin-file-url',
 		resolveId(source, importer) {
 			if(source.startsWith('file://')) {
 				const rest = source.slice(7);

--- a/packages/astro/src/vite-plugin-fileurl/index.ts
+++ b/packages/astro/src/vite-plugin-fileurl/index.ts
@@ -1,0 +1,13 @@
+import type { Plugin as VitePlugin } from 'vite';
+
+export default function vitePluginFileURL({}): VitePlugin {
+	return {
+		name: 'astro:vite-plugin-env',
+		resolveId(source, importer) {
+			if(source.startsWith('file://')) {
+				const rest = source.slice(7);
+				return this.resolve(rest, importer);
+			}
+		}
+	}
+}

--- a/packages/astro/test/astro-basic.test.js
+++ b/packages/astro/test/astro-basic.test.js
@@ -158,6 +158,13 @@ describe('Astro basics', () => {
 			expect(content2).to.be.ok;
 		});
 
+
+		it('allows file:// urls as module specifiers', async () => {
+			const html = await fixture.readFile('/fileurl/index.html');
+			const $ = cheerio.load(html);
+			expect($('h1').text()).to.equal('WORKS');
+		});
+
 		describe('preview', () => {
 			it('returns 200 for valid URLs', async () => {
 				const result = await fixture.fetch('/');

--- a/packages/astro/test/fixtures/astro-basic/src/pages/fileurl.astro
+++ b/packages/astro/test/fixtures/astro-basic/src/pages/fileurl.astro
@@ -1,0 +1,10 @@
+---
+import {capitalize} from 'file://../strings.js';
+---
+
+<html>
+	<head><title>Testing</title></head>
+	<body>
+		<h1>{capitalize('works')</h1>
+	</body>
+</html>

--- a/packages/astro/test/fixtures/astro-basic/src/strings.js
+++ b/packages/astro/test/fixtures/astro-basic/src/strings.js
@@ -1,0 +1,4 @@
+
+export function capitalize(str) {
+	return str.toUpperCase();
+}


### PR DESCRIPTION
## Changes

- Wanted to support this pattern in integrations: `addDevToolbarApp(new URL('./plugin.ts', import.meta.url))`
- This doesn't currently work because we directly pass this value into the virtual module.
- Vite does not support file URLs.
- A Vite plugin is the answer! Maybe we can talk them into adding this to core.

## Testing

- Test added

## Docs

N/A, bug fix