### PR TITLE
refactor(assets): Move things around to avoid importing image service unnecessarily

### DIFF
--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -1,7 +1,7 @@
 ---
 import { getImage, type LocalImageProps, type RemoteImageProps } from 'astro:assets';
 import type { GetImageResult, ImageOutputFormat } from '../dist/@types/astro';
-import { isESMImportedImage } from '../dist/assets/internal';
+import { isESMImportedImage } from '../dist/assets/utils/imageKind';
 import { AstroError, AstroErrorData } from '../dist/core/errors/index.js';
 import type { HTMLAttributes } from '../types';
 

--- a/packages/astro/src/assets/build/generate.ts
+++ b/packages/astro/src/assets/build/generate.ts
@@ -10,9 +10,10 @@ import type { Logger } from '../../core/logger/core.js';
 import { isRemotePath, prependForwardSlash } from '../../core/path.js';
 import { isServerLikeOutput } from '../../prerender/utils.js';
 import type { MapValue } from '../../type-utils.js';
-import { getConfiguredImageService, isESMImportedImage } from '../internal.js';
+import { getConfiguredImageService } from '../internal.js';
 import type { LocalImageService } from '../services/service.js';
 import type { AssetsGlobalStaticImagesList, ImageMetadata, ImageTransform } from '../types.js';
+import { isESMImportedImage } from '../utils/imageKind.js';
 import { loadRemoteImage, type RemoteCacheEntry } from './remote.js';
 
 interface GenerationDataUncached {

--- a/packages/astro/src/assets/endpoint/config.ts
+++ b/packages/astro/src/assets/endpoint/config.ts
@@ -1,0 +1,15 @@
+import type { AstroSettings } from '../../@types/astro.js';
+
+export function injectImageEndpoint(settings: AstroSettings, mode: 'dev' | 'build') {
+	const endpointEntrypoint =
+		settings.config.image.endpoint ??
+		(mode === 'dev' ? 'astro/assets/endpoint/node' : 'astro/assets/endpoint/generic');
+
+	settings.injectedRoutes.push({
+		pattern: '/_image',
+		entrypoint: endpointEntrypoint,
+		prerender: false,
+	});
+
+	return settings;
+}

--- a/packages/astro/src/assets/endpoint/generic.ts
+++ b/packages/astro/src/assets/endpoint/generic.ts
@@ -1,10 +1,11 @@
 import { isRemotePath } from '@astrojs/internal-helpers/path';
 import mime from 'mime/lite.js';
 import type { APIRoute } from '../../@types/astro.js';
-import { getConfiguredImageService, isRemoteAllowed } from '../internal.js';
+import { getConfiguredImageService } from '../internal.js';
 import { etag } from '../utils/etag.js';
 // @ts-expect-error
 import { imageConfig } from 'astro:assets';
+import { isRemoteAllowed } from '../utils/remotePattern.js';
 
 async function loadRemoteImage(src: URL) {
 	try {

--- a/packages/astro/src/assets/endpoint/node.ts
+++ b/packages/astro/src/assets/endpoint/node.ts
@@ -3,10 +3,11 @@ import { readFile } from 'fs/promises';
 import mime from 'mime/lite.js';
 import os from 'os';
 import type { APIRoute } from '../../@types/astro.js';
-import { getConfiguredImageService, isRemoteAllowed } from '../internal.js';
+import { getConfiguredImageService } from '../internal.js';
 import { etag } from '../utils/etag.js';
 // @ts-expect-error
 import { assetsDir, imageConfig } from 'astro:assets';
+import { isRemoteAllowed } from '../utils/remotePattern.js';
 
 function replaceFileSystemReferences(src: string) {
 	return os.platform().includes('win32') ? src.replace(/^\/@fs\//, '') : src.replace(/^\/@fs/, '');

--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -1,54 +1,14 @@
-import { isRemotePath } from '@astrojs/internal-helpers/path';
-import type { AstroConfig, AstroSettings } from '../@types/astro.js';
+import type { AstroConfig } from '../@types/astro.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { DEFAULT_HASH_PROPS } from './consts.js';
 import { isLocalService, type ImageService } from './services/service.js';
 import type {
 	GetImageResult,
-	ImageMetadata,
 	ImageTransform,
 	SrcSetValue,
 	UnresolvedImageTransform,
 } from './types.js';
-import { matchHostname, matchPattern } from './utils/remotePattern.js';
-
-export function injectImageEndpoint(settings: AstroSettings, mode: 'dev' | 'build') {
-	const endpointEntrypoint =
-		settings.config.image.endpoint ??
-		(mode === 'dev' ? 'astro/assets/endpoint/node' : 'astro/assets/endpoint/generic');
-
-	settings.injectedRoutes.push({
-		pattern: '/_image',
-		entrypoint: endpointEntrypoint,
-		prerender: false,
-	});
-
-	return settings;
-}
-
-export function isESMImportedImage(src: ImageMetadata | string): src is ImageMetadata {
-	return typeof src === 'object';
-}
-
-export function isRemoteImage(src: ImageMetadata | string): src is string {
-	return typeof src === 'string';
-}
-
-export function isRemoteAllowed(
-	src: string,
-	{
-		domains = [],
-		remotePatterns = [],
-	}: Partial<Pick<AstroConfig['image'], 'domains' | 'remotePatterns'>>
-): boolean {
-	if (!isRemotePath(src)) return false;
-
-	const url = new URL(src);
-	return (
-		domains.some((domain) => matchHostname(url, domain)) ||
-		remotePatterns.some((remotePattern) => matchPattern(url, remotePattern))
-	);
-}
+import { isESMImportedImage, isRemoteImage } from './utils/imageKind.js';
 
 export async function getConfiguredImageService(): Promise<ImageService> {
 	if (!globalThis?.astroAsset?.imageService) {

--- a/packages/astro/src/assets/services/service.ts
+++ b/packages/astro/src/assets/services/service.ts
@@ -2,8 +2,9 @@ import type { AstroConfig } from '../../@types/astro.js';
 import { AstroError, AstroErrorData } from '../../core/errors/index.js';
 import { isRemotePath, joinPaths } from '../../core/path.js';
 import { DEFAULT_HASH_PROPS, DEFAULT_OUTPUT_FORMAT, VALID_SUPPORTED_FORMATS } from '../consts.js';
-import { isESMImportedImage, isRemoteAllowed } from '../internal.js';
 import type { ImageOutputFormat, ImageTransform, UnresolvedSrcSetValue } from '../types.js';
+import { isESMImportedImage } from '../utils/imageKind.js';
+import { isRemoteAllowed } from '../utils/remotePattern.js';
 
 export type ImageService = LocalImageService | ExternalImageService;
 

--- a/packages/astro/src/assets/utils/imageKind.ts
+++ b/packages/astro/src/assets/utils/imageKind.ts
@@ -1,0 +1,9 @@
+import type { ImageMetadata } from '../types.js';
+
+export function isESMImportedImage(src: ImageMetadata | string): src is ImageMetadata {
+	return typeof src === 'object';
+}
+
+export function isRemoteImage(src: ImageMetadata | string): src is string {
+	return typeof src === 'string';
+}

--- a/packages/astro/src/assets/utils/index.ts
+++ b/packages/astro/src/assets/utils/index.ts
@@ -1,4 +1,14 @@
 export { emitESMImage } from './emitAsset.js';
+export { isESMImportedImage, isRemoteImage } from './imageKind.js';
 export { imageMetadata } from './metadata.js';
 export { getOrigQueryParams } from './queryParams.js';
+export {
+	isRemoteAllowed,
+	matchHostname,
+	matchPathname,
+	matchPattern,
+	matchPort,
+	matchProtocol,
+	type RemotePattern,
+} from './remotePattern.js';
 export { hashTransform, propsToFilename } from './transformToPath.js';

--- a/packages/astro/src/assets/utils/remotePattern.ts
+++ b/packages/astro/src/assets/utils/remotePattern.ts
@@ -1,3 +1,6 @@
+import { isRemotePath } from '@astrojs/internal-helpers/path';
+import type { AstroConfig } from '../../@types/astro.js';
+
 export type RemotePattern = {
 	hostname?: string;
 	pathname?: string;
@@ -60,4 +63,20 @@ export function matchPathname(url: URL, pathname?: string, allowWildcard?: boole
 	}
 
 	return false;
+}
+
+export function isRemoteAllowed(
+	src: string,
+	{
+		domains = [],
+		remotePatterns = [],
+	}: Partial<Pick<AstroConfig['image'], 'domains' | 'remotePatterns'>>
+): boolean {
+	if (!isRemotePath(src)) return false;
+
+	const url = new URL(src);
+	return (
+		domains.some((domain) => matchHostname(url, domain)) ||
+		remotePatterns.some((remotePattern) => matchPattern(url, remotePattern))
+	);
 }

--- a/packages/astro/src/assets/utils/transformToPath.ts
+++ b/packages/astro/src/assets/utils/transformToPath.ts
@@ -2,8 +2,8 @@ import { deterministicString } from 'deterministic-object-hash';
 import { basename, extname } from 'node:path';
 import { removeQueryString } from '../../core/path.js';
 import { shorthash } from '../../runtime/server/shorthash.js';
-import { isESMImportedImage } from '../internal.js';
 import type { ImageTransform } from '../types.js';
+import { isESMImportedImage } from './imageKind.js';
 
 export function propsToFilename(transform: ImageTransform, hash: string) {
 	let filename = removeQueryString(

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -12,8 +12,8 @@ import {
 } from '../core/path.js';
 import { isServerLikeOutput } from '../prerender/utils.js';
 import { VALID_INPUT_FORMATS, VIRTUAL_MODULE_ID, VIRTUAL_SERVICE_ID } from './consts.js';
-import { isESMImportedImage } from './internal.js';
 import { emitESMImage } from './utils/emitAsset.js';
+import { isESMImportedImage } from './utils/imageKind.js';
 import { getProxyCode } from './utils/proxy.js';
 import { hashTransform, propsToFilename } from './utils/transformToPath.js';
 

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -10,7 +10,7 @@ import type {
 	ManifestData,
 	RuntimeMode,
 } from '../../@types/astro.js';
-import { injectImageEndpoint } from '../../assets/internal.js';
+import { injectImageEndpoint } from '../../assets/endpoint/config.js';
 import { telemetry } from '../../events/index.js';
 import { eventCliSession } from '../../events/session.js';
 import {

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -4,7 +4,7 @@ import type { AstroInlineConfig, AstroSettings } from '../../@types/astro.js';
 
 import nodeFs from 'node:fs';
 import * as vite from 'vite';
-import { injectImageEndpoint } from '../../assets/internal.js';
+import { injectImageEndpoint } from '../../assets/endpoint/config.js';
 import {
 	runHookConfigDone,
 	runHookConfigSetup,


### PR DESCRIPTION
## Changes

In the way of trying to solve https://github.com/withastro/adapters/pull/58, I realized there's some instances where the image service could get imported by accident because some utils were next to the code that loads it. This refactor move away everything unrelated to that elsewhere, so that people and adapters can import the utilities without anything else coming in by accident. 

This doesn't unblock the linked PR just yet, some other bundling nonsense is in the way, however it's a step forward!

## Testing

Tests should pass, this is just a refactor!

## Docs

N/A
