### PR TITLE
Prevent malformed  redirect URLs from crashing the build

### DIFF
--- a/.changeset/shaggy-pans-sleep.md
+++ b/.changeset/shaggy-pans-sleep.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent malformed redirect URLs from crashing build

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -55,10 +55,10 @@ export async function viteBuild(opts: StaticBuildOptions) {
 		const astroModuleURL = new URL('./' + component, settings.config.root);
 		const astroModuleId = prependForwardSlash(component);
 
-		// Track the page data in internals
-		trackPageData(internals, component, pageData, astroModuleId, astroModuleURL);
-
 		if (!routeIsRedirect(pageData.route)) {
+			// Track the page data in internals
+			trackPageData(internals, component, pageData, astroModuleId, astroModuleURL);
+
 			pageInput.add(astroModuleId);
 		}
 	}

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -91,6 +91,10 @@ describe('Astro.redirect', () => {
 						'/more/old/[dynamic]': '/more/[dynamic]',
 						'/more/old/[dynamic]/[route]': '/more/[dynamic]/[route]',
 						'/more/old/[...spread]': '/more/new/[...spread]',
+
+						// Test that crazy URLs do not break the build
+						'/blogs/%e3%83%9b%e3%83%bc%e3%83%a0%e3%83%9a%e3%83%bc%e3%82%b8%e5%85%ac%e9%96%8b%e5%89%8d%e3%81%ab%e7%a2%ba%e8%aa%8d%e3%81%99%e3%81%b9%e3%81%8d%e3%83%81%e3':
+      '/blogs/checklist-website-before-released',
 					},
 				});
 				await fixture.build();


### PR DESCRIPTION
## Changes

- We track page data during the build, but redirects do not need this. If there is a malformed URL it would throw expecting a valid ViteID. This avoids that.

## Testing

- Test case added to the redirects test.

## Docs

N/A, bug fix