### PR TITLE
fix: mention which feature is experimental/deprecated

### DIFF
--- a/.changeset/fifty-pets-hunt.md
+++ b/.changeset/fifty-pets-hunt.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds the feature name to logs about feature deprecation / experimental status.

--- a/packages/astro/src/integrations/astroFeaturesValidation.ts
+++ b/packages/astro/src/integrations/astroFeaturesValidation.ts
@@ -80,9 +80,9 @@ function validateSupportKind(
 	if (supportKind === STABLE) {
 		return true;
 	} else if (supportKind === DEPRECATED) {
-		featureIsDeprecated(adapterName, logger);
+		featureIsDeprecated(adapterName, logger, featureName);
 	} else if (supportKind === EXPERIMENTAL) {
-		featureIsExperimental(adapterName, logger);
+		featureIsExperimental(adapterName, logger, featureName);
 	}
 
 	if (hasCorrectConfig() && supportKind === UNSUPPORTED) {
@@ -94,20 +94,20 @@ function validateSupportKind(
 }
 
 function featureIsUnsupported(adapterName: string, logger: Logger, featureName: string) {
-	logger.error('config', `The feature ${featureName} is not supported (used by ${adapterName}).`);
+	logger.error('config', `The feature "${featureName}" is not supported (used by ${adapterName}).`);
 }
 
-function featureIsExperimental(adapterName: string, logger: Logger) {
+function featureIsExperimental(adapterName: string, logger: Logger, featureName: string) {
 	logger.warn(
 		'config',
-		`The feature is experimental and subject to change (used by ${adapterName}).`
+		`The feature "${featureName}" is experimental and subject to change (used by ${adapterName}).`
 	);
 }
 
-function featureIsDeprecated(adapterName: string, logger: Logger) {
+function featureIsDeprecated(adapterName: string , logger: Logger, featureName: string,) {
 	logger.warn(
 		'config',
-		`The feature is deprecated and will be removed in the future (used by ${adapterName}).`
+		`The feature "${featureName}" is deprecated and will be removed in the future (used by ${adapterName}).`
 	);
 }
 


### PR DESCRIPTION
## Changes

Adds the feature name to logs about feature deprecation / experimental status, so users know what feature the log is about.

## Testing

Didn't add any tests, because I couldn't find any test for this part of the code. Let me know where to add a test, and i'm happy to write one!

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

No docs update needed, because this doesn't change any behaviour that applications depend on.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
