### PR TITLE
Prevent Partytown from hijacking history API

### DIFF
--- a/.changeset/angry-avocados-live.md
+++ b/.changeset/angry-avocados-live.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent Partytown from hijacking history APIs

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -11,8 +11,9 @@ type Events = 'astro:page-load' | 'astro:after-swap';
 
 // Create bound versions of pushState/replaceState so that Partytown doesn't hijack them,
 // which breaks Firefox.
-const pushState = history.pushState.bind(history);
-const replaceState = history.replaceState.bind(history);
+const inBrowser = import.meta.env.SSR === false;
+const pushState = (inBrowser && history.pushState.bind(history)) as typeof history.pushState;
+const replaceState = (inBrowser && history.replaceState.bind(history)) as typeof history.replaceState;
 
 // only update history entries that are managed by us
 // leave other entries alone and do not accidently add state.
@@ -22,7 +23,7 @@ export const updateScrollPosition = (positions: { scrollX: number; scrollY: numb
 		replaceState({ ...history.state, ...positions }, '');
 	}
 };
-const inBrowser = import.meta.env.SSR === false;
+
 
 export const supportsViewTransitions = inBrowser && !!document.startViewTransition;
 

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -9,12 +9,17 @@ type State = {
 };
 type Events = 'astro:page-load' | 'astro:after-swap';
 
+// Create bound versions of pushState/replaceState so that Partytown doesn't hijack them,
+// which breaks Firefox.
+const pushState = history.pushState.bind(history);
+const replaceState = history.replaceState.bind(history);
+
 // only update history entries that are managed by us
 // leave other entries alone and do not accidently add state.
 export const updateScrollPosition = (positions: { scrollX: number; scrollY: number }) => {
 	if (history.state) {
 		history.scrollRestoration = 'manual';
-		history.replaceState({ ...history.state, ...positions }, '');
+		replaceState({ ...history.state, ...positions }, '');
 	}
 };
 const inBrowser = import.meta.env.SSR === false;
@@ -79,7 +84,7 @@ if (inBrowser) {
 	} else if (transitionEnabledOnThisPage()) {
 		// This page is loaded from the browser addressbar or via a link from extern,
 		// it needs a state in the history
-		history.replaceState({ index: currentHistoryIndex, scrollX, scrollY }, '');
+		replaceState({ index: currentHistoryIndex, scrollX, scrollY }, '');
 		history.scrollRestoration = 'manual';
 	}
 }
@@ -170,7 +175,7 @@ const moveToLocation = (to: URL, from: URL, options: Options, historyState?: Sta
 	if (to.href !== location.href && !historyState) {
 		if (options.history === 'replace') {
 			const current = history.state;
-			history.replaceState(
+			replaceState(
 				{
 					...options.state,
 					index: current.index,
@@ -181,7 +186,7 @@ const moveToLocation = (to: URL, from: URL, options: Options, historyState?: Sta
 				to.href
 			);
 		} else {
-			history.pushState(
+			pushState(
 				{ ...options.state, index: ++currentHistoryIndex, scrollX: 0, scrollY: 0 },
 				'',
 				to.href


### PR DESCRIPTION
## Changes

- Binds the `pushState` and `replaceState` methods which break Partytown with Firefox.
- Fixes https://github.com/withastro/astro/issues/8862

## Testing

- Manually

## Docs

N/A, bug fix