### PR TITLE
Error when getImage() is passed an undefined src

### DIFF
--- a/.changeset/brown-apricots-kick.md
+++ b/.changeset/brown-apricots-kick.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Error when getImage is passed an undefined src

--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -79,6 +79,12 @@ export async function getImage(
 			message: AstroErrorData.ExpectedImageOptions.message(JSON.stringify(options)),
 		});
 	}
+	if(typeof options.src === 'undefined') {
+		throw new AstroError({
+			...AstroErrorData.ExpectedImage,
+			message: AstroErrorData.ExpectedImage.message(options.src, 'undefined', JSON.stringify(options))
+		});
+	}
 
 	const service = await getConfiguredImageService();
 

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -640,14 +640,13 @@ describe('astro:image', () => {
 			expect(logs[0].message).to.contain('Expected getImage() parameter');
 		});
 
-		// TODO: For some reason, this error crashes the dev server?
-		it.skip('properly error when src is undefined', async () => {
+		it('properly error when src is undefined', async () => {
 			logs.length = 0;
 			let res = await fixture.fetch('/get-image-undefined');
 			await res.text();
 
 			expect(logs).to.have.a.lengthOf(1);
-			expect(logs[0].message).to.contain('Expected src to be an image.');
+			expect(logs[0].message).to.contain('Expected `src` property');
 		});
 
 		it('properly error image in Markdown frontmatter is not found', async () => {

--- a/packages/astro/test/fixtures/core-image-errors/src/pages/get-image-undefined.astro
+++ b/packages/astro/test/fixtures/core-image-errors/src/pages/get-image-undefined.astro
@@ -1,5 +1,5 @@
 ---
 import { getImage } from "astro:assets";
 
-const myImage = getImage({src: undefined});
+const myImage = await getImage({src: undefined});
 ---


### PR DESCRIPTION
## Changes

- `getImage({ src: undefined })` should throw a good error. Now it does.

## Testing

- Existing test case was skipped, now its not.

## Docs

N/A, bug fix