### PR TITLE
Handle unhandledrejections in the dev server

### DIFF
--- a/.changeset/curvy-lobsters-crash.md
+++ b/.changeset/curvy-lobsters-crash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevent dev server from crashing on unhandled rejections

--- a/.changeset/curvy-lobsters-crash.md
+++ b/.changeset/curvy-lobsters-crash.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Prevent dev server from crashing on unhandled rejections
+Prevents dev server from crashing on unhandled rejections, and adds a helpful error message

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1292,3 +1292,12 @@ export const CantRenderPage = {
 
 // Generic catch-all - Only use this in extreme cases, like if there was a cosmic ray bit flip
 export const UnknownError = { name: 'UnknownError', title: 'Unknown Error.' } satisfies ErrorData;
+
+export const UnhandledRejection = {
+	name: 'UnhandledRejection',
+	title: 'Unhandled rejection',
+	message: (stack: string) => {
+		return `Astro detected an unhandled rejection. Here's the stack trace:\n${stack}`;
+	},
+	hint: 'Make sure your promises all have an `await` or a `.catch()` handler.'
+}

--- a/packages/astro/src/vite-plugin-astro-server/error.ts
+++ b/packages/astro/src/vite-plugin-astro-server/error.ts
@@ -7,7 +7,7 @@ import { createSafeError } from '../core/errors/index.js';
 import { formatErrorMessage } from '../core/messages.js';
 import { eventError, telemetry } from '../events/index.js';
 
-export function recordServerError(loader: ModuleLoader, config: AstroConfig, pipeline: DevPipeline, _err: unknown): Error {
+export function recordServerError(loader: ModuleLoader, config: AstroConfig, pipeline: DevPipeline, _err: unknown) {
 	const err = createSafeError(_err);
 
 	// This could be a runtime error from Vite's SSR module, so try to fix it here
@@ -26,5 +26,8 @@ export function recordServerError(loader: ModuleLoader, config: AstroConfig, pip
 		formatErrorMessage(errorWithMetadata, pipeline.logger.level() === 'debug')
 	);
 
-	return err;
+	return {
+		error: err,
+		errorWithMetadata
+	};
 }

--- a/packages/astro/src/vite-plugin-astro-server/error.ts
+++ b/packages/astro/src/vite-plugin-astro-server/error.ts
@@ -1,0 +1,30 @@
+import type { ModuleLoader } from '../core/module-loader/index.js'
+import type { AstroConfig } from '../@types/astro.js';
+import type DevPipeline from './devPipeline.js';
+
+import { collectErrorMetadata } from '../core/errors/dev/index.js';
+import { createSafeError } from '../core/errors/index.js';
+import { formatErrorMessage } from '../core/messages.js';
+import { eventError, telemetry } from '../events/index.js';
+
+export function recordServerError(loader: ModuleLoader, config: AstroConfig, pipeline: DevPipeline, _err: unknown): Error {
+	const err = createSafeError(_err);
+
+	// This could be a runtime error from Vite's SSR module, so try to fix it here
+	try {
+		loader.fixStacktrace(err);
+	} catch {}
+
+	// This is our last line of defense regarding errors where we still might have some information about the request
+	// Our error should already be complete, but let's try to add a bit more through some guesswork
+	const errorWithMetadata = collectErrorMetadata(err, config.root);
+
+	telemetry.record(eventError({ cmd: 'dev', err: errorWithMetadata, isFatal: false }));
+
+	pipeline.logger.error(
+		null,
+		formatErrorMessage(errorWithMetadata, pipeline.logger.level() === 'debug')
+	);
+
+	return err;
+}

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -10,6 +10,7 @@ import { baseMiddleware } from './base.js';
 import { createController } from './controller.js';
 import DevPipeline from './devPipeline.js';
 import { handleRequest } from './request.js';
+import { AstroError, AstroErrorData } from '../core/errors/index.js';
 
 export interface AstroPluginOptions {
 	settings: AstroSettings;
@@ -42,6 +43,16 @@ export default function createVitePluginAstroServer({
 			viteServer.watcher.on('add', rebuildManifest.bind(null, true));
 			viteServer.watcher.on('unlink', rebuildManifest.bind(null, true));
 			viteServer.watcher.on('change', rebuildManifest.bind(null, false));
+
+			function handleUnhandledRejection(rejection: any) {
+				const error = new AstroError({
+					...AstroErrorData.UnhandledRejection,
+					message: AstroErrorData.UnhandledRejection.message(rejection?.stack || rejection)
+				})
+				logger.error(null, error.message);
+			}
+
+			process.on('unhandledRejection', handleUnhandledRejection);
 
 			return () => {
 				// Push this middleware to the front of the stack so that it can intercept responses.

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -11,6 +11,7 @@ import { createController } from './controller.js';
 import DevPipeline from './devPipeline.js';
 import { handleRequest } from './request.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
+import { getViteErrorPayload } from '../core/errors/dev/index.js';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { IncomingMessage } from 'node:http';
 import { setRouteError } from './server-state.js';
@@ -58,9 +59,9 @@ export default function createVitePluginAstroServer({
 				if(store instanceof IncomingMessage) {
 					const request = store;
 					setRouteError(controller.state, request.url!, error);
-					loader.clientReload();
 				}
-				recordServerError(loader, settings.config, pipeline, error);
+				const { errorWithMetadata } = recordServerError(loader, settings.config, pipeline, error);
+				setTimeout(async () => loader.webSocketSend(await getViteErrorPayload(errorWithMetadata)), 200)
 			}
 
 			process.on('unhandledRejection', handleUnhandledRejection);

--- a/packages/astro/src/vite-plugin-astro-server/request.ts
+++ b/packages/astro/src/vite-plugin-astro-server/request.ts
@@ -90,8 +90,9 @@ export async function handleRequest({
 			});
 		},
 		onError(_err) {
-			const err = recordServerError(moduleLoader, config, pipeline, _err);
-			return err;
+			const { error, errorWithMetadata } = recordServerError(moduleLoader, config, pipeline, _err);
+			handle500Response(moduleLoader, incomingResponse, errorWithMetadata);
+			return error;
 		},
 	});
 }


### PR DESCRIPTION
## Changes

- Unhandled rejections, caused by having a promise that rejects but has no `.catch()`, will crash the dev server. We can prevent it using `process.on('unhandledRejection')`.

<img width="998" alt="Screen Shot 2023-12-13 at 9 35 02 AM" src="https://github.com/withastro/astro/assets/361671/4b1761c7-1d8c-4b68-97d3-b77ae751f31f">

---

<img width="1492" alt="Screen Shot 2023-12-13 at 5 59 39 PM" src="https://github.com/withastro/astro/assets/361671/721f3966-bcc6-496d-82e3-8fcdce684366">


## Testing

- Manually in demo project. See above screenshot. Server does not crash, good error message is displayed.

## Docs

N/A, bug fix