### PR TITLE
Fixes warning for external URL redirects

### DIFF
--- a/.changeset/gentle-chefs-glow.md
+++ b/.changeset/gentle-chefs-glow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Update warning for external URL redirects to use destination address

--- a/.changeset/gentle-chefs-glow.md
+++ b/.changeset/gentle-chefs-glow.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Update warning for external URL redirects to use destination address
+Fixes warning for external URL redirects

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -461,7 +461,7 @@ export function createRouteManifest(
 			if (/^https?:\/\//.test(destination)) {
 				logger.warn(
 					'redirects',
-					`Redirecting to an external URL is not officially supported: ${from} -> ${to}`
+					`Redirecting to an external URL is not officially supported: ${from} -> ${destination}`
 				);
 			}
 		}


### PR DESCRIPTION
## Changes

Updates warning e.g. 

`Redirecting to an external URL is not officially supported: /external -> [object Object]` 

to 

`Redirecting to an external URL is not officially supported: /external -> https://example.com`

## Testing

`pnpm run test:match "core"`

## Docs

N/A
