### PR TITLE
fix: improve error message when a middleware doesn't return a `Response`

### DIFF
--- a/.changeset/selfish-parents-leave.md
+++ b/.changeset/selfish-parents-leave.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Better error message when a middleware doesn't return a `Response`

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -733,8 +733,9 @@ export const ResponseSentError = {
  */
 export const MiddlewareNoDataOrNextCalled = {
 	name: 'MiddlewareNoDataOrNextCalled',
-	title: "The middleware didn't return a response or call `next`.",
-	message: 'The middleware needs to either return a `Response` object or call the `next` function.',
+	title: "The middleware didn't return a response or call and return `next`.",
+	message:
+		'The middleware needs to either return a `Response` object or call the `next` function and return the `Response` that it yields.',
 } satisfies ErrorData;
 
 /**


### PR DESCRIPTION
## Changes

The error message was old and didn't explain well the solution to solve the error.

## Testing

N/A
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
 /cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
