### PR TITLE
fix: error in ssr demo when init

### DIFF
--- a/examples/ssr/src/pages/api/cart.ts
+++ b/examples/ssr/src/pages/api/cart.ts
@@ -2,7 +2,7 @@ import { APIContext } from 'astro';
 import { userCartItems } from '../../models/session';
 
 export function GET({ cookies }: APIContext) {
-	let userId = cookies.get('user-id').value;
+	let userId = cookies.get('user-id')?.value;
 
 	if (!userId || !userCartItems.has(userId)) {
 		return Response.json({ items: [] });


### PR DESCRIPTION
I attempt to run the ssr demo, but I found the error:
```
01:34:54 [ERROR] Cannot read properties of undefined (reading 'value')
  Stack trace:
    at Module.GET (/Users/zhangpeng/my/astro/examples/ssr/src/pages/api/cart.ts:5:36)
    [...] See full stack trace in the browser, or rerun with --verbose.
01:34:54 [ERROR] Cannot read properties of null (reading 'items')
  Stack trace:
    at /Users/zhangpeng/my/astro/examples/ssr/src/components/Header.astro:7:24
    [...] See full stack trace in the browser, or rerun with --verbose.
```

this is my step:
```
git clone && cd ...
pnpm install
pnpm run build
cd examples/ssr
pnpm install
pnpm start
```