### PR TITLE
fix: update netlify import

### DIFF
--- a/.changeset/friendly-tables-worry.md
+++ b/.changeset/friendly-tables-worry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+update import created for `astro create netlify`

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -677,7 +677,7 @@ export interface AstroUserConfig {
 	 * [See our Server-side Rendering guide](https://docs.astro.build/en/guides/server-side-rendering/) for more on SSR, and [our deployment guides](https://docs.astro.build/en/guides/deploy/) for a complete list of hosts.
 	 *
 	 * ```js
-	 * import netlify from '@astrojs/netlify/functions';
+	 * import netlify from '@astrojs/netlify';
 	 * {
 	 *   // Example: Build for Netlify serverless deployment
 	 *   adapter: netlify(),

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -71,7 +71,7 @@ public-hoist-pattern[]=*lit*
 `;
 
 const OFFICIAL_ADAPTER_TO_IMPORT_MAP: Record<string, string> = {
-	netlify: '@astrojs/netlify/functions',
+	netlify: '@astrojs/netlify',
 	vercel: '@astrojs/vercel/serverless',
 	cloudflare: '@astrojs/cloudflare',
 	node: '@astrojs/node',


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/9459. With the new version of the Astro adapter, `@astrojs/netlify` is the recommended import.

## Testing

Didn't test manually, but expecting it to still work given the change.

## Docs

don't think we need docs changes for this.
