### PR TITLE
Fix transitions with non-recommended headers

### DIFF
--- a/.changeset/khaki-ducks-give.md
+++ b/.changeset/khaki-ducks-give.md
@@ -1,0 +1,9 @@
+---
+'astro': patch
+---
+
+Fixes edge case on view transitions not working for some valid responses
+
+If a page was returned by the server with blank spaces before the `;` separator in the `Content-Type` header,
+the view transition would not work and a full page reload would occur.
+Now such scenarios will have the correct view transition.

--- a/.changeset/khaki-ducks-give.md
+++ b/.changeset/khaki-ducks-give.md
@@ -2,8 +2,4 @@
 'astro': patch
 ---
 
-Fixes edge case on view transitions not working for some valid responses
-
-If a page was returned by the server with blank spaces before the `;` separator in the `Content-Type` header,
-the view transition would not work and a full page reload would occur.
-Now such scenarios will have the correct view transition.
+Fixes an edge case with view transitions where some spec-compliant `Content-Type` headers would cause a valid HTML response to be ignored.

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
@@ -6,6 +6,7 @@ import Layout from '../components/Layout.astro';
 	<a id="click-one" href="#test">test</a>
 	<a id="click-two" href="/two">go to 2</a>
 	<a id="click-three" href="/three">go to 3</a>
+	<a id="click-seven" href="/seven">go to 7</a>
 	<a id="click-longpage" href="/long-page">go to long page</a>
 	<a id="click-self" href="">go to top</a>
 	<a id="click-redirect-two" href="/redirect-two">go to redirect 2</a>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/seven.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/seven.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '../components/Layout.astro';
+
+Astro.response.headers.set('Content-Type', 'text/html ; charset=utf-8');
+---
+<Layout link="/one.css">
+	<p id="seven">Page 7</p>
+
+	<div id="test">test content</div>
+</Layout>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -97,6 +97,25 @@ test.describe('View Transitions', () => {
 		expect(loads.length, 'There should only be 1 page load').toEqual(1);
 	});
 
+	test('Clicking on a link to a page with non-recommended headers', async ({page, astro}) => {
+		const loads = [];
+		page.addListener('load', (p) => {
+			loads.push(p.title());
+		});
+
+		// Go to page 4
+		await page.goto(astro.resolveUrl('/one'));
+		let p = page.locator('#one');
+		await expect(p, 'should have content').toHaveText('Page 1');
+
+		// Go to page 1
+		await page.click('#click-seven');
+		p = page.locator('#seven');
+		await expect(p, 'should have content').toHaveText('Page 7');
+
+		expect(loads.length, 'There should only be 1 page load').toEqual(1);
+	});
+
 	test('Moving to a page without ViewTransitions triggers a full page navigation', async ({
 		page,
 		astro,

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -119,8 +119,9 @@ async function fetchHTML(
 ): Promise<null | { html: string; redirected?: string; mediaType: DOMParserSupportedType }> {
 	try {
 		const res = await fetch(href, init);
+		const contentType = res.headers.get('content-type') ?? '';
 		// drop potential charset (+ other name/value pairs) as parser needs the mediaType
-		const mediaType = res.headers.get('content-type')?.replace(/;.*$/, '');
+		const mediaType = contentType.split(';', 1)[0].trim();
 		// the DOMParser can handle two types of HTML
 		if (mediaType !== 'text/html' && mediaType !== 'application/xhtml+xml') {
 			// everything else (e.g. audio/mp3) will be handled by the browser but not by us


### PR DESCRIPTION
## Changes

The syntax of the Content-Type header specified by the [HTTP Semantics RFC](https://www.rfc-editor.org/rfc/rfc9110#appendix-A) is as follows:
```
Content-Type = media-type

OWS = *( SP / HTAB )

media-type = type "/" subtype parameters

subtype = token
type = token

parameter = parameter-name "=" parameter-value
parameter-name = token
parameter-value = ( token / quoted-string )
parameters = *( OWS ";" OWS [ parameter ] )

tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
 "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
token = 1*tchar
```

The `;` that marks the start of the parameters may, even though not recommended, be preceded by any number of white spaces. The previous implementation of the `fetchHTML` function would not accept a header in that form and do full page reload.

This PR takes that into account and replaces the media type extraction from the header with an implementation that works for any spec-compliant server, even without using recommended practices.

## Testing

A new integration test was added for a page replying with the following header:
```
Content-Type: text/html ; charset=utf-8
```

## Docs

I don't think this needs any docs change