### PR TITLE
Enable source map on dev builds

### DIFF
--- a/scripts/cmd/build.js
+++ b/scripts/cmd/build.js
@@ -108,6 +108,7 @@ export default async function build(...args) {
 		entryPoints,
 		outdir,
 		format,
+		sourcemap: 'linked',
 		plugins: [
 			rebuildPlugin,
 			svelte({ isDev }),


### PR DESCRIPTION
## Changes

Debugging and following errors on Astro internals when contributing currently requires looking at transpiled JS and manually finding the original TS code. Errors are reported with their transpiled positions and debug points only work on transpiled JS.

This PR just enables sourcemaps for the dev builds, allowing for debuggers (in IDEs or using Chrome's debug tools) to refer to the original TS files when stepping through code and also for Errors to report the position in the original code (so long as the option `--enable-source-maps` is passed to Node)

How an error looks without source maps:
```
Error: Example error
    at file:///home/lotus/IsoWorkspaces/OSS/astro/astro/packages/astro/dist/core/routing/manifest/create.js:325:11
    at Array.forEach (<anonymous>)
    at createRouteManifest (file:///home/lotus/IsoWorkspaces/OSS/astro/astro/packages/astro/dist/core/routing/manifest/create.js:300:45)
    at Context.<anonymous> (file:///home/lotus/IsoWorkspaces/OSS/astro/astro/packages/astro/test/units/routing/manifest.test.js:49:20)
```

How it looks with source maps:
```
Error: Example error
    at <anonymous> (src/core/routing/manifest/create.ts:469:9)
    at Array.forEach (<anonymous>)
    at createRouteManifest (src/core/routing/manifest/create.ts:430:44)
    at Context.<anonymous> (file:///home/lotus/IsoWorkspaces/OSS/astro/astro/packages/astro/test/units/routing/manifest.test.js:49:20)

```

Debugging without source maps, debug points have to be on JS files without comments:
![image](https://github.com/withastro/astro/assets/11063910/2571fbc5-dc2a-4b4f-b1c6-ea2e87cf7bf3)

Debugging with source maps, debug points can be on the TS file with all the context around it:
![image](https://github.com/withastro/astro/assets/11063910/6537cc18-103c-492d-bb2a-ebc78d7ab402)


## Testing

This doesn't change any behavior, so also no test changed.

## Docs

Same for docs.