### PR TITLE
chore: smoother logging when building pages

### DIFF
--- a/.changeset/popular-meals-yell.md
+++ b/.changeset/popular-meals-yell.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Improved logging of the generated pages during the build
+Improves logging of the generated pages during the build

--- a/.changeset/popular-meals-yell.md
+++ b/.changeset/popular-meals-yell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improved logging of the generated pages during the build

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -306,7 +306,7 @@ async function generatePage(
 			pipeline.getEnvironment().logger.debug('build', `Generating: ${path}`);
 			const filePath = getOutputFilename(pipeline.getConfig(), path, pageData.route.type);
 			const lineIcon = i === paths.length - 1 ? '└─' : '├─';
-			logger.info(null, `  ${blue(lineIcon)} ${dim(filePath)}`, true);
+			logger.info(null, `  ${blue(lineIcon)} ${dim(filePath)}`, false);
 			await generatePath(path, pipeline, generationOptions, route);
 			const timeEnd = performance.now();
 			const timeChange = getTimeStat(prevTimeEnd, timeEnd);

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -304,13 +304,14 @@ async function generatePage(
 		for (let i = 0; i < paths.length; i++) {
 			const path = paths[i];
 			pipeline.getEnvironment().logger.debug('build', `Generating: ${path}`);
+			const filePath = getOutputFilename(pipeline.getConfig(), path, pageData.route.type);
+			const lineIcon = i === paths.length - 1 ? '└─' : '├─';
+			logger.info(null, `  ${blue(lineIcon)} ${dim(filePath)}`, true);
 			await generatePath(path, pipeline, generationOptions, route);
 			const timeEnd = performance.now();
 			const timeChange = getTimeStat(prevTimeEnd, timeEnd);
 			const timeIncrease = `(+${timeChange})`;
-			const filePath = getOutputFilename(pipeline.getConfig(), path, pageData.route.type);
-			const lineIcon = i === paths.length - 1 ? '└─' : '├─';
-			logger.info(null, `  ${blue(lineIcon)} ${dim(filePath)} ${dim(timeIncrease)}`);
+			logger.info('SKIP_FORMAT', ` ${dim(timeIncrease)}`);
 			prevTimeEnd = timeEnd;
 		}
 	}

--- a/packages/astro/src/core/logger/core.ts
+++ b/packages/astro/src/core/logger/core.ts
@@ -2,7 +2,7 @@ import { blue, bold, dim, red, yellow } from 'kleur/colors';
 import stringWidth from 'string-width';
 
 export interface LogWritable<T> {
-	write: (chunk: T, newLine: boolean) => boolean;
+	write: (chunk: T) => boolean;
 }
 
 export type LoggerLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent'; // same as Pino
@@ -56,6 +56,7 @@ export interface LogMessage {
 	label: string | null;
 	level: LoggerLevel;
 	message: string;
+	newLine: boolean;
 }
 
 export const levels: Record<LoggerLevel, number> = {
@@ -80,6 +81,7 @@ export function log(
 		label,
 		level,
 		message,
+		newLine,
 	};
 
 	// test if this level is enabled or not
@@ -87,7 +89,7 @@ export function log(
 		return; // do nothing
 	}
 
-	dest.write(event, newLine);
+	dest.write(event);
 }
 
 export function isLogLevelEnabled(configuredLogLevel: LoggerLevel, level: LoggerLevel) {

--- a/packages/astro/src/core/logger/core.ts
+++ b/packages/astro/src/core/logger/core.ts
@@ -2,7 +2,7 @@ import { blue, bold, dim, red, yellow } from 'kleur/colors';
 import stringWidth from 'string-width';
 
 export interface LogWritable<T> {
-	write: (chunk: T, sameLine: boolean) => boolean;
+	write: (chunk: T, newLine: boolean) => boolean;
 }
 
 export type LoggerLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent'; // same as Pino
@@ -72,7 +72,7 @@ export function log(
 	level: LoggerLevel,
 	label: string | null,
 	message: string,
-	sameLine = false
+	newLine = true
 ) {
 	const logLevel = opts.level;
 	const dest = opts.dest;
@@ -87,7 +87,7 @@ export function log(
 		return; // do nothing
 	}
 
-	dest.write(event, sameLine);
+	dest.write(event, newLine);
 }
 
 export function isLogLevelEnabled(configuredLogLevel: LoggerLevel, level: LoggerLevel) {
@@ -95,18 +95,18 @@ export function isLogLevelEnabled(configuredLogLevel: LoggerLevel, level: Logger
 }
 
 /** Emit a user-facing message. Useful for UI and other console messages. */
-export function info(opts: LogOptions, label: string | null, message: string, sameLine = false) {
-	return log(opts, 'info', label, message, sameLine);
+export function info(opts: LogOptions, label: string | null, message: string, newLine = true) {
+	return log(opts, 'info', label, message, newLine);
 }
 
 /** Emit a warning message. Useful for high-priority messages that aren't necessarily errors. */
-export function warn(opts: LogOptions, label: string | null, message: string, sameLine = false) {
-	return log(opts, 'warn', label, message, sameLine);
+export function warn(opts: LogOptions, label: string | null, message: string, newLine = true) {
+	return log(opts, 'warn', label, message, newLine);
 }
 
 /** Emit a error message, Useful when Astro can't recover from some error. */
-export function error(opts: LogOptions, label: string | null, message: string, sameLine = false) {
-	return log(opts, 'error', label, message, sameLine);
+export function error(opts: LogOptions, label: string | null, message: string, newLine = true) {
+	return log(opts, 'error', label, message, newLine);
 }
 
 type LogFn = typeof info | typeof warn | typeof error;
@@ -197,14 +197,14 @@ export class Logger {
 		this.options = options;
 	}
 
-	info(label: LoggerLabel | null, message: string, sameLine = false) {
-		info(this.options, label, message, sameLine);
+	info(label: LoggerLabel | null, message: string, newLine = true) {
+		info(this.options, label, message, newLine);
 	}
-	warn(label: LoggerLabel | null, message: string, sameLine = false) {
-		warn(this.options, label, message, sameLine);
+	warn(label: LoggerLabel | null, message: string, newLine = true) {
+		warn(this.options, label, message, newLine);
 	}
-	error(label: LoggerLabel | null, message: string, sameLine = false) {
-		error(this.options, label, message, sameLine);
+	error(label: LoggerLabel | null, message: string, newLine = true) {
+		error(this.options, label, message, newLine);
 	}
 	debug(label: LoggerLabel, ...messages: any[]) {
 		debug(label, ...messages);

--- a/packages/astro/src/core/logger/core.ts
+++ b/packages/astro/src/core/logger/core.ts
@@ -2,7 +2,7 @@ import { blue, bold, dim, red, yellow } from 'kleur/colors';
 import stringWidth from 'string-width';
 
 export interface LogWritable<T> {
-	write: (chunk: T) => boolean;
+	write: (chunk: T, sameLine: boolean) => boolean;
 }
 
 export type LoggerLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent'; // same as Pino
@@ -67,7 +67,13 @@ export const levels: Record<LoggerLevel, number> = {
 };
 
 /** Full logging API */
-export function log(opts: LogOptions, level: LoggerLevel, label: string | null, message: string) {
+export function log(
+	opts: LogOptions,
+	level: LoggerLevel,
+	label: string | null,
+	message: string,
+	sameLine = false
+) {
 	const logLevel = opts.level;
 	const dest = opts.dest;
 	const event: LogMessage = {
@@ -81,7 +87,7 @@ export function log(opts: LogOptions, level: LoggerLevel, label: string | null, 
 		return; // do nothing
 	}
 
-	dest.write(event);
+	dest.write(event, sameLine);
 }
 
 export function isLogLevelEnabled(configuredLogLevel: LoggerLevel, level: LoggerLevel) {
@@ -89,18 +95,18 @@ export function isLogLevelEnabled(configuredLogLevel: LoggerLevel, level: Logger
 }
 
 /** Emit a user-facing message. Useful for UI and other console messages. */
-export function info(opts: LogOptions, label: string | null, message: string) {
-	return log(opts, 'info', label, message);
+export function info(opts: LogOptions, label: string | null, message: string, sameLine = false) {
+	return log(opts, 'info', label, message, sameLine);
 }
 
 /** Emit a warning message. Useful for high-priority messages that aren't necessarily errors. */
-export function warn(opts: LogOptions, label: string | null, message: string) {
-	return log(opts, 'warn', label, message);
+export function warn(opts: LogOptions, label: string | null, message: string, sameLine = false) {
+	return log(opts, 'warn', label, message, sameLine);
 }
 
 /** Emit a error message, Useful when Astro can't recover from some error. */
-export function error(opts: LogOptions, label: string | null, message: string) {
-	return log(opts, 'error', label, message);
+export function error(opts: LogOptions, label: string | null, message: string, sameLine = false) {
+	return log(opts, 'error', label, message, sameLine);
 }
 
 type LogFn = typeof info | typeof warn | typeof error;
@@ -191,14 +197,14 @@ export class Logger {
 		this.options = options;
 	}
 
-	info(label: LoggerLabel | null, message: string) {
-		info(this.options, label, message);
+	info(label: LoggerLabel | null, message: string, sameLine = false) {
+		info(this.options, label, message, sameLine);
 	}
-	warn(label: LoggerLabel | null, message: string) {
-		warn(this.options, label, message);
+	warn(label: LoggerLabel | null, message: string, sameLine = false) {
+		warn(this.options, label, message, sameLine);
 	}
-	error(label: LoggerLabel | null, message: string) {
-		error(this.options, label, message);
+	error(label: LoggerLabel | null, message: string, sameLine = false) {
+		error(this.options, label, message, sameLine);
 	}
 	debug(label: LoggerLabel, ...messages: any[]) {
 		debug(label, ...messages);

--- a/packages/astro/src/core/logger/node.ts
+++ b/packages/astro/src/core/logger/node.ts
@@ -7,12 +7,12 @@ type ConsoleStream = Writable & {
 };
 
 export const nodeLogDestination: LogWritable<LogMessage> = {
-	write(event: LogMessage, sameLine = false) {
+	write(event: LogMessage, newLine = true) {
 		let dest: ConsoleStream = process.stderr;
 		if (levels[event.level] < levels['error']) {
 			dest = process.stdout;
 		}
-		let trailingLine = sameLine ? '' : '\n';
+		let trailingLine = newLine ? '\n' : '';
 		if (event.label === 'SKIP_FORMAT') {
 			dest.write(event.message + trailingLine);
 		} else {

--- a/packages/astro/src/core/logger/node.ts
+++ b/packages/astro/src/core/logger/node.ts
@@ -7,15 +7,16 @@ type ConsoleStream = Writable & {
 };
 
 export const nodeLogDestination: LogWritable<LogMessage> = {
-	write(event: LogMessage) {
+	write(event: LogMessage, sameLine = false) {
 		let dest: ConsoleStream = process.stderr;
 		if (levels[event.level] < levels['error']) {
 			dest = process.stdout;
 		}
+		let trailingLine = sameLine ? '' : '\n';
 		if (event.label === 'SKIP_FORMAT') {
-			dest.write(event.message + '\n');
+			dest.write(event.message + trailingLine);
 		} else {
-			dest.write(getEventPrefix(event) + ' ' + event.message + '\n');
+			dest.write(getEventPrefix(event) + ' ' + event.message + trailingLine);
 		}
 		return true;
 	},

--- a/packages/astro/src/core/logger/node.ts
+++ b/packages/astro/src/core/logger/node.ts
@@ -12,7 +12,7 @@ export const nodeLogDestination: LogWritable<LogMessage> = {
 		if (levels[event.level] < levels['error']) {
 			dest = process.stdout;
 		}
-		let trailingLine = newLine ? '\n' : '';
+		let trailingLine = event.newLine ? '\n' : '';
 		if (event.label === 'SKIP_FORMAT') {
 			dest.write(event.message + trailingLine);
 		} else {


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/9335

I added a new option to the logger, that allows us to **not** add a new line at the end of a logging message.

This becomes useful when we build the pages, so we can log the page we are about to build, and then append the timing at the end.

## Testing

I used the docs repo to test it. Here's a small video

https://github.com/withastro/astro/assets/602478/627a2f23-2b8d-4a23-8327-f50a2a42c962


<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
