### PR TITLE
Ensure `appEntrypoint` is referenced in Vue components

### DIFF
--- a/.changeset/odd-rivers-learn.md
+++ b/.changeset/odd-rivers-learn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vue': patch
+---
+
+Fixes a bug that caused styles referenced by `appEntrypoint` to be excluded from the build

--- a/packages/integrations/vue/src/index.ts
+++ b/packages/integrations/vue/src/index.ts
@@ -4,6 +4,7 @@ import vue from '@vitejs/plugin-vue';
 import type { Options as VueJsxOptions } from '@vitejs/plugin-vue-jsx';
 import type { AstroIntegration, AstroRenderer } from 'astro';
 import type { Plugin, UserConfig } from 'vite';
+import { MagicString } from '@vue/compiler-sfc';
 
 interface Options extends VueOptions {
 	jsx?: boolean | VueJsxOptions;
@@ -39,6 +40,7 @@ function virtualAppEntrypoint(options?: Options): Plugin {
 
 	let isBuild: boolean;
 	let root: string;
+	let appEntrypoint: string | undefined;
 
 	return {
 		name: '@astrojs/vue/virtual-app',
@@ -47,6 +49,11 @@ function virtualAppEntrypoint(options?: Options): Plugin {
 		},
 		configResolved(config) {
 			root = config.root;
+			if (options?.appEntrypoint) {
+				appEntrypoint = options.appEntrypoint.startsWith('.')
+					? path.resolve(root, options.appEntrypoint)
+					: options.appEntrypoint;
+			}
 		},
 		resolveId(id: string) {
 			if (id == virtualModuleId) {
@@ -55,11 +62,7 @@ function virtualAppEntrypoint(options?: Options): Plugin {
 		},
 		load(id: string) {
 			if (id === resolvedVirtualModuleId) {
-				if (options?.appEntrypoint) {
-					const appEntrypoint = options.appEntrypoint.startsWith('.')
-						? path.resolve(root, options.appEntrypoint)
-						: options.appEntrypoint;
-
+				if (appEntrypoint) {
 					return `\
 import * as mod from ${JSON.stringify(appEntrypoint)};
 						
@@ -78,6 +81,20 @@ export const setup = async (app) => {
 }`;
 				}
 				return `export const setup = () => {};`;
+			}
+		},
+		// Ensure that Vue components reference appEntrypoint directly
+		// This allows Astro to assosciate global styles imported in this file
+		// with the pages they should be injected to
+		transform(code, id) {
+			if (!appEntrypoint) return;
+			if (id.endsWith('.vue')) {
+				const s = new MagicString(code);
+				s.prepend(`import "${appEntrypoint}";\n`);
+				return {
+					code: s.toString(),
+					map: s.generateMap()
+				}
 			}
 		},
 	};

--- a/packages/integrations/vue/src/index.ts
+++ b/packages/integrations/vue/src/index.ts
@@ -51,9 +51,8 @@ function virtualAppEntrypoint(options?: Options): Plugin {
 			root = config.root;
 			if (options?.appEntrypoint) {
 				appEntrypoint = options.appEntrypoint.startsWith('.')
-					? path.resolve(root, options.appEntrypoint).replace(root, '')
+					? path.resolve(root, options.appEntrypoint)
 					: options.appEntrypoint;
-				appEntrypoint = appEntrypoint?.replaceAll('\\', '/')
 			}
 		},
 		resolveId(id: string) {
@@ -91,7 +90,7 @@ export const setup = async (app) => {
 			if (!appEntrypoint) return;
 			if (id.endsWith('.vue')) {
 				const s = new MagicString(code);
-				s.prepend(`import "${appEntrypoint}";\n`);
+				s.prepend(`import ${JSON.stringify(appEntrypoint)};\n`);
 				return {
 					code: s.toString(),
 					map: s.generateMap({ hires: 'boundary' })

--- a/packages/integrations/vue/src/index.ts
+++ b/packages/integrations/vue/src/index.ts
@@ -94,7 +94,7 @@ export const setup = async (app) => {
 				s.prepend(`import "${appEntrypoint}";\n`);
 				return {
 					code: s.toString(),
-					map: s.generateMap()
+					map: s.generateMap({ hires: 'boundary' })
 				}
 			}
 		},

--- a/packages/integrations/vue/src/index.ts
+++ b/packages/integrations/vue/src/index.ts
@@ -51,8 +51,9 @@ function virtualAppEntrypoint(options?: Options): Plugin {
 			root = config.root;
 			if (options?.appEntrypoint) {
 				appEntrypoint = options.appEntrypoint.startsWith('.')
-					? path.resolve(root, options.appEntrypoint)
+					? path.resolve(root, options.appEntrypoint).replace(root, '')
 					: options.appEntrypoint;
+				appEntrypoint = appEntrypoint?.replaceAll('\\', '/')
 			}
 		},
 		resolveId(id: string) {

--- a/packages/integrations/vue/test/app-entrypoint-css.test.js
+++ b/packages/integrations/vue/test/app-entrypoint-css.test.js
@@ -1,0 +1,67 @@
+import { loadFixture } from './test-utils.js';
+import { expect } from 'chai';
+import { load as cheerioLoad } from 'cheerio';
+
+describe('App Entrypoint CSS', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/app-entrypoint-css/',
+		});
+	})
+
+	describe('build', () => {
+		before(async () => {
+			await fixture.build();
+		})
+
+		it('injects styles referenced in appEntrypoint', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerioLoad(html);
+
+			// test 1: basic component renders
+			expect($('#foo > #bar').text()).to.eq('works');
+
+			// test 2: injects the global style on the page
+			expect($('style').first().text().trim()).to.eq(':root{background-color:red}');
+		});
+
+		it('does not inject styles to pages without a Vue component', async () => {
+			const html = await fixture.readFile('/unrelated/index.html');
+			const $ = cheerioLoad(html);
+
+			expect($('style').length).to.eq(0);
+			expect($('link[rel="stylesheet"]').length).to.eq(0);
+		});
+	})
+
+	describe('dev', () => {
+		let devServer;
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		})
+		after(async () => {
+			await devServer.stop();
+		})
+
+		it('loads during SSR', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			const $ = cheerioLoad(html);
+			
+			// test 1: basic component renders
+			expect($('#foo > #bar').text()).to.eq('works');
+			// test 2: injects the global style on the page
+			expect($('style').first().text().replace(/\s+/g, '')).to.eq(':root{background-color:red;}');
+		});
+
+		it('does not inject styles to pages without a Vue component', async () => {
+			const html = await fixture.fetch('/unrelated').then((res) => res.text());
+			const $ = cheerioLoad(html);
+
+			expect($('style').length).to.eq(0);
+			expect($('link[rel="stylesheet"]').length).to.eq(0);
+		});
+	})
+});

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-css/astro.config.mjs
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-css/astro.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'astro/config';
+import vue from '@astrojs/vue';
+
+export default defineConfig({
+  integrations: [
+    vue({ appEntrypoint: '/src/app.ts' })
+  ],
+})

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-css/package.json
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-css/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/vue-app-entrypoint-css",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/vue": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-css/src/app.ts
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-css/src/app.ts
@@ -1,0 +1,9 @@
+import type { App } from 'vue'
+import Bar from './components/Bar.vue'
+// Important! Test that styles here are injected to the page
+import '/src/main.css'
+
+
+export default function setup(app: App) {
+	app.component('Bar', Bar);
+}

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-css/src/components/Bar.vue
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-css/src/components/Bar.vue
@@ -1,0 +1,3 @@
+<template>
+	<div id="bar">works</div>
+</template>

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-css/src/components/Foo.vue
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-css/src/components/Foo.vue
@@ -1,0 +1,5 @@
+<template>
+	<div id="foo">
+		<Bar />
+	</div>
+</template>

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-css/src/main.css
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-css/src/main.css
@@ -1,0 +1,3 @@
+:root {
+    background-color: red;
+}

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-css/src/pages/index.astro
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-css/src/pages/index.astro
@@ -1,0 +1,12 @@
+---
+import Foo from '../components/Foo.vue';
+---
+
+<html>
+	<head>
+		<title>Vue App Entrypoint</title>
+	</head>
+	<body>
+		<Foo client:load />
+	</body>
+</html>

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-css/src/pages/unrelated.astro
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-css/src/pages/unrelated.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>Unrelated page</title>
+	</head>
+	<body>
+		<h1>I shouldn't have styles</h1>
+	</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4906,6 +4906,15 @@ importers:
         specifier: 5.0.1
         version: 5.0.1
 
+  packages/integrations/vue/test/fixtures/app-entrypoint-css:
+    dependencies:
+      '@astrojs/vue':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/vue/test/fixtures/app-entrypoint-no-export-default:
     dependencies:
       '@astrojs/vue':


### PR DESCRIPTION
## Changes

- Closes #6827, closes PLT-1346
- Fixes bundling for styles referenced in the Vue integration's `appEntrypoint` file.
- Rather than hacking Astro's internals to treat the virtual entrypoint as a special file, this PR adds a side-effectual import to every `.vue` component. It may not be the cleanest method, but this does allow Astro to associate styles referenced by the `appEntrypoint` with pages where Vue components are rendered.
- This is probably fine to release as a patch

## Testing

New test suite added for dev and build behavior

Tested manually, too

## Docs

N/A, bug fix only