### PR TITLE
qol(routing): warn when api route method doesn't match the casing of an export

### DIFF
--- a/.changeset/tidy-dogs-remain.md
+++ b/.changeset/tidy-dogs-remain.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds helpful message for when the API Route export is not uppercase.

--- a/.changeset/tidy-dogs-remain.md
+++ b/.changeset/tidy-dogs-remain.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Adds helpful message for when the API Route export is not uppercase.
+Adds a helpful warning message for when an exported API Route is not uppercase.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2235,7 +2235,7 @@ export type APIRoute<Props extends Record<string, any> = Record<string, any>> = 
 ) => Response | Promise<Response>;
 
 export interface EndpointHandler {
-	[method: string]: APIRoute | ((params: Params, request: Request) => Response);
+	[method: string]: APIRoute;
 }
 
 export type Props = Record<string, unknown>;

--- a/packages/astro/src/runtime/server/endpoint.ts
+++ b/packages/astro/src/runtime/server/endpoint.ts
@@ -2,18 +2,6 @@ import { bold } from 'kleur/colors';
 import type { APIContext, EndpointHandler, Params } from '../../@types/astro.js';
 import type { Logger } from '../../core/logger/core.js';
 
-function getHandlerFromModule(mod: EndpointHandler, method: string) {
-	// If there was an exact match on `method`, return that function.
-	if (mod[method]) {
-		return mod[method];
-	}
-	if (mod['ALL']) {
-		return mod['ALL'];
-	}
-	// Otherwise, no handler found.
-	return undefined;
-}
-
 /** Renders an endpoint request to completion, returning the body. */
 export async function renderEndpoint(
 	mod: EndpointHandler,
@@ -23,38 +11,33 @@ export async function renderEndpoint(
 ) {
 	const { request, url } = context;
 
-	const chosenMethod = request.method?.toUpperCase();
-	const handler = getHandlerFromModule(mod, chosenMethod);
-	if (!ssr && ssr === false && chosenMethod && chosenMethod !== 'GET') {
+	const method = request.method.toUpperCase();
+	// use the exact match on `method`, fallback to ALL
+	const handler = mod[method] ?? mod['ALL'];
+	if (!ssr && ssr === false && method && method !== 'GET') {
 		logger.warn(
-			null,
+			"router",
 			`${url.pathname} ${bold(
-				chosenMethod
+				method
 			)} requests are not available for a static site. Update your config to \`output: 'server'\` or \`output: 'hybrid'\` to enable.`
 		);
 	}
-	if (!handler || typeof handler !== 'function') {
+	if (typeof handler !== 'function') {
+		logger.warn(
+			'router',
+			`No API Route handler exists for the method "${method}" for the route ${url.pathname}.\n` +
+			`Found handlers: ${Object.keys(mod).map(method => JSON.stringify(method)).join(', ')}\n`
+		);
 		// No handler found, so this should be a 404. Using a custom header
 		// to signal to the renderer that this is an internal 404 that should
 		// be handled by a custom 404 route if possible.
-		let response = new Response(null, {
+		return new Response(null, {
 			status: 404,
 			headers: {
 				'X-Astro-Response': 'Not-Found',
 			},
 		});
-		return response;
 	}
 
-	const proxy = new Proxy(context, {
-		get(target, prop) {
-			if (prop in target) {
-				return Reflect.get(target, prop);
-			} else {
-				return undefined;
-			}
-		},
-	}) as APIContext & Params;
-
-	return handler.call(mod, proxy, request);
+	return handler.call(mod, context as APIContext & Params, request);
 }

--- a/packages/astro/src/runtime/server/endpoint.ts
+++ b/packages/astro/src/runtime/server/endpoint.ts
@@ -14,7 +14,7 @@ export async function renderEndpoint(
 	const method = request.method.toUpperCase();
 	// use the exact match on `method`, fallback to ALL
 	const handler = mod[method] ?? mod['ALL'];
-	if (!ssr && ssr === false && method && method !== 'GET') {
+	if (!ssr && ssr === false && method !== 'GET') {
 		logger.warn(
 			"router",
 			`${url.pathname} ${bold(
@@ -26,7 +26,8 @@ export async function renderEndpoint(
 		logger.warn(
 			'router',
 			`No API Route handler exists for the method "${method}" for the route ${url.pathname}.\n` +
-			`Found handlers: ${Object.keys(mod).map(method => JSON.stringify(method)).join(', ')}\n`
+			`Found handlers: ${Object.keys(mod).map(exp => JSON.stringify(exp)).join(', ')}\n` +
+			('all' in mod ? `One of the exported handlers is "all" (lowercase), did you mean to export 'ALL'?\n` : '')
 		);
 		// No handler found, so this should be a 404. Using a custom header
 		// to signal to the renderer that this is an internal 404 that should

--- a/packages/astro/src/runtime/server/endpoint.ts
+++ b/packages/astro/src/runtime/server/endpoint.ts
@@ -40,5 +40,5 @@ export async function renderEndpoint(
 		});
 	}
 
-	return handler.call(mod, context as APIContext & Params, request);
+	return handler.call(mod, context);
 }


### PR DESCRIPTION

## Changes

- Closes #9496
- improve messaging for getting the case wrong

## Testing

Does not affect behavior, just messaging - existing tests should pass.

## Docs

Does not affect usage.