### PR TITLE
[docs] update build.format with note an adapter may set this value

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -722,7 +722,7 @@ export interface AstroUserConfig {
 		 * @typeraw {('file' | 'directory')}
 		 * @default `'directory'`
 		 * @description
-		 * Control the output file format of each page.
+		 * Control the output file format of each page. This value may be set by your adapter for you.
 		 *   - If `'file'`, Astro will generate an HTML file (ex: "/foo.html") for each page.
 		 *   - If `'directory'`, Astro will generate a directory with a nested `index.html` file (ex: "/foo/index.html") for each page.
 		 *
@@ -734,6 +734,8 @@ export interface AstroUserConfig {
 		 *   }
 		 * }
 		 * ```
+		 *
+	   *  
 		 *
 		 * #### Effect on Astro.url
 		 * Setting `build.format` controls what `Astro.url` is set to during the build. When it is:

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -722,7 +722,7 @@ export interface AstroUserConfig {
 		 * @typeraw {('file' | 'directory')}
 		 * @default `'directory'`
 		 * @description
-		 * Control the output file format of each page. This value may be set by your adapter for you.
+		 * Control the output file format of each page. This value may be set by an adapter for you.
 		 *   - If `'file'`, Astro will generate an HTML file (ex: "/foo.html") for each page.
 		 *   - If `'directory'`, Astro will generate a directory with a nested `index.html` file (ex: "/foo/index.html") for each page.
 		 *


### PR DESCRIPTION
## Changes

Adds a short note (`This value may be set by your adapter for you.`) to the `build.format` docs.

## Testing

Not tested. In response to a [Docs issue](https://github.com/withastro/docs/issues/4807) where someone was surprised this value had been changed by installing an adapter.

## Docs

Only docs!
