### PR TITLE
Proposal for pagesDir option

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -450,6 +450,23 @@ export interface AstroUserConfig {
 
 	/**
 	 * @docs
+	 * @name pagesDir
+	 * @type {string}
+	 * @default `"./pages"`
+	 * @description Set the directory that Astro pages are served from.
+	 *
+	 * The value is always relative to the project's source directory.
+	 *
+	 * ```js
+	 * {
+	 *   pagesDir: './site'
+	 * }
+	 * ```
+	 */
+	pagesDir?: string;
+
+	/**
+	 * @docs
 	 * @name publicDir
 	 * @type {string}
 	 * @default `"./public"`

--- a/packages/astro/src/core/build/css-asset-name.ts
+++ b/packages/astro/src/core/build/css-asset-name.ts
@@ -33,8 +33,8 @@ export function createNameHash(baseId: string | undefined, hashIds: string[]): s
 }
 
 export function createSlugger(settings: AstroSettings) {
-	const pagesDir = viteID(new URL('./pages', settings.config.srcDir));
-	const indexPage = viteID(new URL('./pages/index', settings.config.srcDir));
+	const pagesDir = viteID(new URL(settings.config.pagesDir, settings.config.srcDir));
+	const indexPage = viteID(new URL(settings.config.pagesDir + '/index', settings.config.srcDir));
 	const map = new Map<string, Map<string, number>>();
 	const sep = '-';
 	return function (id: string, ctx: { getModuleInfo: GetModuleInfo }): string {

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -24,6 +24,7 @@ type ShikiTheme = NonNullable<ShikiConfig['theme']>;
 const ASTRO_CONFIG_DEFAULTS = {
 	root: '.',
 	srcDir: './src',
+	pagesDir: './pages',
 	publicDir: './public',
 	outDir: './dist',
 	cacheDir: './node_modules/.astro',
@@ -73,6 +74,11 @@ export const AstroConfigSchema = z.object({
 		.string()
 		.optional()
 		.default(ASTRO_CONFIG_DEFAULTS.srcDir)
+		.transform((val) => new URL(val)),
+	pagesDir: z
+		.string()
+		.optional()
+		.default(ASTRO_CONFIG_DEFAULTS.pagesDir)
 		.transform((val) => new URL(val)),
 	publicDir: z
 		.string()
@@ -413,6 +419,10 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 			.default(ASTRO_CONFIG_DEFAULTS.srcDir)
 			.transform((val) => resolveDirAsUrl(val, fileProtocolRoot)),
 		compressHTML: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.compressHTML),
+		pagesDir: z
+			.string()
+			.default(ASTRO_CONFIG_DEFAULTS.pagesDir)
+			.transform((val) => resolveDirAsUrl(val, fileProtocolRoot)),
 		publicDir: z
 			.string()
 			.default(ASTRO_CONFIG_DEFAULTS.publicDir)

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -104,7 +104,7 @@ export function unwrapId(id: string): string {
 }
 
 export function resolvePages(config: AstroConfig) {
-	return new URL('./pages', config.srcDir);
+	return new URL(config.pagesDir, config.srcDir);
 }
 
 function isInPagesDir(file: URL, config: AstroConfig): boolean {


### PR DESCRIPTION
## Changes

- Adds `pagesDir` optional config
- This is still presumed relative to source directory
- Some projects migrating to Astro may need this to avoid retooling their other scripts. Note the recently opened discussion: https://github.com/withastro/roadmap/discussions/796

## Testing

I did no tests yet, sorry. `pnpm run test` seemed to fail for unrelated reasons that may have to do with my setup.

This is not a particularly elaborate change and quite small, so if the maintainers like the idea, it is also worth looking over each line added and edited.

## Docs

/cc @withastro/maintainers-docs for feedback!

I will gladly contribute these too, as appropriate, if my small changes here are deemed sufficient in this project.
