### PR TITLE
Implement i18n's `getLocaleByPath` function

### DIFF
--- a/.changeset/plenty-dingos-relax.md
+++ b/.changeset/plenty-dingos-relax.md
@@ -1,5 +1,5 @@
 ---
-'astro': minor
+'astro': patch
 ---
 
 Implement i18n's `getLocaleByPath` function

--- a/.changeset/plenty-dingos-relax.md
+++ b/.changeset/plenty-dingos-relax.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Implement i18n's `getLocaleByPath` function

--- a/packages/astro/e2e/fixtures/i18n/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/i18n/astro.config.mjs
@@ -1,0 +1,20 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	i18n: {
+		defaultLocale: "en",
+		locales: [
+			"en",
+			"fr",
+			"es",
+			{
+				path: "portugues",
+				codes: [
+					"pt-AO",
+					"pt",
+					"pt-BR",
+				],
+		}],
+	},
+});

--- a/packages/astro/e2e/fixtures/i18n/package.json
+++ b/packages/astro/e2e/fixtures/i18n/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@e2e/i18n",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/e2e/fixtures/i18n/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/i18n/src/pages/index.astro
@@ -1,0 +1,7 @@
+---
+import { getLocaleByPath } from "astro:i18n";
+---
+
+<p>Locale: {getLocaleByPath("en")}</p> <!-- will log "en" -->
+<p>Locale: {getLocaleByPath("fr")}</p> <!-- will log "fr" -->
+<p>Locale: {getLocaleByPath("portugues")}</p> <!-- will log "pt-AO" -->

--- a/packages/astro/e2e/i18n.test.js
+++ b/packages/astro/e2e/i18n.test.js
@@ -1,0 +1,34 @@
+import { expect } from '@playwright/test';
+import { testFactory } from './test-utils.js';
+
+const test = testFactory({
+	root: './fixtures/i18n/',
+	devToolbar: {
+		enabled: false,
+	},
+});
+
+let devServer;
+
+test.beforeAll(async ({ astro }) => {
+	devServer = await astro.startDevServer();
+});
+
+test.afterAll(async () => {
+	await devServer.stop();
+});
+
+test.describe('i18n', () => {
+	test('getLocaleByPath', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/'));
+
+		const p1 = page.locator('p').nth(0);
+		await expect(p1).toHaveText('Locale: en');
+
+		const p2 = page.locator('p').nth(1);
+		await expect(p2).toHaveText('Locale: fr');
+
+		const p3 = page.locator('p').nth(2);
+		await expect(p3).toHaveText('Locale: pt-AO');
+	});
+});

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -157,17 +157,21 @@ export function getPathByLocale(locale: string, locales: Locales) {
 /**
  * An utility function that retrieves the preferred locale that correspond to a path.
  *
- * @param locale
+ * @param path
  * @param locales
  */
 export function getLocaleByPath(path: string, locales: Locales): string | undefined {
 	for (const locale of locales) {
 		if (typeof locale !== 'string') {
-			// the first code is the one that user usually wants
-			const code = locale.codes.at(0);
-			return code;
+			if (locale.path === path) {
+				// the first code is the one that user usually wants
+				const code = locale.codes.at(0);
+				return code;
+			}
 		}
-		1;
+		else if (locale === path) {
+			return locale;
+		}
 	}
 	return undefined;
 }

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -62,7 +62,7 @@ export default function astroInternationalization({
 					export const getAbsoluteLocaleUrlList = (path = "", opts) => _getLocaleAbsoluteUrlList({ base, path, trailingSlash, format, site, ...i18n, ...opts });
 					
 					export const getPathByLocale = (locale) => _getPathByLocale(locale, i18n.locales);
-					export const getLocaleByPath = (locale) => _getLocaleByPath(locale, i18n.locales);
+					export const getLocaleByPath = (path) => _getLocaleByPath(path, i18n.locales);
 				`;
 			}
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1030,6 +1030,12 @@ importers:
         specifier: ^10.19.2
         version: 10.19.2
 
+  packages/astro/e2e/fixtures/i18n:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/e2e/fixtures/lit-component:
     dependencies:
       '@astrojs/lit':


### PR DESCRIPTION
## Changes

<!--
- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`
-->

This PR gives a new implementation for the `getLocaleByPath` function.
It also fixes a parameter name in another `getLocaleByPath` function, one that is exposed to users.

According to the [Internationalization guide](https://docs.astro.build/en/guides/internationalization/#retrieve-the-locale-for-a-custom-path), the following behavior is expected:

For a given configuration:

```
{
    i18n: {
        defaultLocale: "en",
        locales: ["en", "es", "fr", {
            path: "portugues",
            codes: ["pt-AO", "pt", "pt-BR"]
        }]
    }
}
```

The function is expected to behave as:

```js
import { getLocaleByPath } from "astro:i18n";
console.log(getLocaleByPath("en")) // will log "en"
console.log(getLocaleByPath("fr")) // will log "fr"
console.log(getLocaleByPath("portugues")) // will log "pt-AO"
```

However, the behavior for the current implementation is:

```js
import { getLocaleByPath } from "astro:i18n";
console.log(getLocaleByPath("en")) // will log "pt-AO"
console.log(getLocaleByPath("fr")) // will log "pt-AO"
console.log(getLocaleByPath("portugues")) // will log "pt-AO"
```

Explaining the current behavior:
- The current implementation ignores non-object locales (such as "en", "es", "fr").
- The current implementation ignores the given `path` argument.
- The current implementation returns the first object locale, regardless of the `path`.

The new implementation I'm proposing:
- Supports non-object locales, assuming locale == path == code.
- Tries to find a match to the `path` argument.
- Fallbacks to returning `undefined` if no match was found.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I don't think this function is tested. I did not add tests.

I just implemented the function in a project of mine, configuring `i18n` to match the example I gave in the above section, which is the same as the example in the documentation.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

I aimed to match the existing documentation, so no changes are needed.
