### PR TITLE
Filter out Svelte's unexpected data prop warnings

### DIFF
--- a/packages/integrations/svelte/client.js
+++ b/packages/integrations/svelte/client.js
@@ -104,9 +104,11 @@ function finishUsingConsoleFilter() {
  */
 function filteredConsoleWarning(msg, ...rest) {
 	if (consoleFilterRefs > 0 && typeof msg === 'string') {
-		// Astro passes a `class` prop to the Svelte component, which
-		// outputs the following warning, which we can safely filter out.
-		const isKnownSvelteError = msg.endsWith("was created with unknown prop 'class'");
+		// Astro passes `class` and `data` props to the Svelte component, which
+		// output the following warnings, which we can safely filter out.
+		const isKnownSvelteError =
+			msg.endsWith("was created with unknown prop 'class'") ||
+			msg.indexOf("was created with unknown prop") > 0;
 		if (isKnownSvelteError) return;
 	}
 	originalConsoleWarning(msg, ...rest);


### PR DESCRIPTION
## Changes

- What does this change?

Fixes https://github.com/withastro/astro/issues/9508

- Be short and concise. Bullet points can help!

This updates the existing console filter to add another warning that is also produced by Svelte.

- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
Tested by validating the change in a simple Astro app with a Svelte counter component.

Before the fix, the console output contains the following warning:

```
<Counter> was created with unknown prop 'data-astro-cid-j7pv25f6'
```

After the fix is applied and clearing the cache:

```
rm -rf ./node_modules/.vite
```

Run the app again

```
npm run dev
```

The console output is now clear, without any warnings.


## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

N/A -- no docs need to be updated.
