### PR TITLE
Filter out Svelte's unknown data prop warnings

### DIFF
--- a/.changeset/forty-actors-wash.md
+++ b/.changeset/forty-actors-wash.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/svelte': patch
+---
+
+Filter out Svelte's unknown data prop warnings

--- a/packages/integrations/svelte/client.js
+++ b/packages/integrations/svelte/client.js
@@ -104,9 +104,11 @@ function finishUsingConsoleFilter() {
  */
 function filteredConsoleWarning(msg, ...rest) {
 	if (consoleFilterRefs > 0 && typeof msg === 'string') {
-		// Astro passes a `class` prop to the Svelte component, which
+		// Astro passes `class` and `data-astro-cid` props to the Svelte component, which
 		// outputs the following warning, which we can safely filter out.
-		const isKnownSvelteError = msg.endsWith("was created with unknown prop 'class'");
+		const isKnownSvelteError =
+			msg.endsWith("was created with unknown prop 'class'") ||
+			msg.indexOf("was created with unknown prop 'data-astro-cid") > 0;
 		if (isKnownSvelteError) return;
 	}
 	originalConsoleWarning(msg, ...rest);

--- a/packages/integrations/svelte/client.js
+++ b/packages/integrations/svelte/client.js
@@ -106,6 +106,10 @@ function filteredConsoleWarning(msg, ...rest) {
 	if (consoleFilterRefs > 0 && typeof msg === 'string') {
 		// Astro passes `class` and `data-astro-cid` props to the Svelte component, which
 		// outputs the following warning, which we can safely filter out.
+
+		// NOTE: In practice data-astro-cid props have a hash suffix. Hence the use of a
+		// quoted prop name string without a closing quote.
+
 		const isKnownSvelteError =
 			msg.endsWith("was created with unknown prop 'class'") ||
 			msg.indexOf("was created with unknown prop 'data-astro-cid") > 0;

--- a/packages/integrations/svelte/client.js
+++ b/packages/integrations/svelte/client.js
@@ -112,7 +112,7 @@ function filteredConsoleWarning(msg, ...rest) {
 
 		const isKnownSvelteError =
 			msg.endsWith("was created with unknown prop 'class'") ||
-			msg.indexOf("was created with unknown prop 'data-astro-cid") > 0;
+			msg.includes("was created with unknown prop 'data-astro-cid");
 		if (isKnownSvelteError) return;
 	}
 	originalConsoleWarning(msg, ...rest);


### PR DESCRIPTION
## Changes

- What does this change?
Fixes https://github.com/withastro/astro/issues/9508

- Be short and concise. Bullet points can help!

The existing console filter looked for class attributes. This change adds a check for warnings related to data attributes as well.

- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

Tested by validating the change in a simple Astro app with a Svelte counter component.

Before the fix, the console output contains the following warning:

```
<Counter> was created with unknown prop 'data-astro-cid-j7pv25f6'
```

After patching client.js in node_modules and clearing the cache:

```
rm -rf ./node_modules/.vite
```

Run the app again

```
npm run dev
```

The console output is now clear, without any warnings.

## Docs

N/A - no docs need to be updated. This only removes console warnings, which was already happening automatically.
