### PR TITLE
[enhance:prefetch] Add global ignoreSlowConnection and 'none' to defaultStrategy enum

### DIFF
--- a/.changeset/two-hats-arrive.md
+++ b/.changeset/two-hats-arrive.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+Add global ignoreSlowConnection and 'none' to defaultStrategy enum in prefetch

--- a/packages/astro/e2e/fixtures/prefetch/src/pages/prefetch-none.astro
+++ b/packages/astro/e2e/fixtures/prefetch/src/pages/prefetch-none.astro
@@ -1,0 +1,1 @@
+<h1>Prefetch none</h1>

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -947,7 +947,7 @@ export interface AstroUserConfig {
 				/**
 				 * @docs
 				 * @name prefetch.defaultStrategy
-				 * @type {'tap' | 'hover' | 'viewport'}
+				 * @type {'tap' | 'hover' | 'viewport' | 'none'}
 				 * @default `'hover'`
 				 * @description
 				 * The default prefetch strategy to use when the `data-astro-prefetch` attribute is set on a link with no value.
@@ -955,6 +955,7 @@ export interface AstroUserConfig {
 				 * - `'tap'`: Prefetch just before you click on the link.
 				 * - `'hover'`: Prefetch when you hover over or focus on the link. (default)
 				 * - `'viewport'`: Prefetch as the links enter the viewport.
+				 * - `'none'`: Prefetch the link without any restrictions.
 				 *
 				 * You can override this default value and select a different strategy for any individual link by setting a value on the attribute.
 				 *
@@ -962,7 +963,28 @@ export interface AstroUserConfig {
 				 * <a href="/about" data-astro-prefetch="viewport">About</a>
 				 * ```
 				 */
-				defaultStrategy?: 'tap' | 'hover' | 'viewport';
+				defaultStrategy?: 'tap' | 'hover' | 'viewport' | 'none';
+
+				/**
+				 * @docs
+				 * @name prefetch.ignoreSlowConnection
+				 * @type {boolean}
+				 * @description
+				 * Ignore slow connection detection.
+				 *
+				 * ```js
+				 * prefetch: {
+				 * 	ignoreSlowConnection: true
+				 * }
+				 * ```
+				 *
+				 * When set to `true`, you can enable slow connection detection by adding `{ ignoreSlowConnection: false }` to the parameters of `prefetch` manually .
+				 *
+				 * ```js
+				 * prefetch('/about', { ignoreSlowConnection: false });
+				 *```
+				 */
+				ignoreSlowConnection?: boolean;
 		  };
 
 	/**

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -182,7 +182,8 @@ export const AstroConfigSchema = z.object({
 			z.boolean(),
 			z.object({
 				prefetchAll: z.boolean().optional(),
-				defaultStrategy: z.enum(['tap', 'hover', 'viewport']).optional(),
+				defaultStrategy: z.enum(['tap', 'hover', 'viewport', 'none']).optional(),
+				ignoreSlowConnection: z.boolean().optional(),
 			}),
 		])
 		.optional(),

--- a/packages/astro/src/prefetch/vite-plugin-prefetch.ts
+++ b/packages/astro/src/prefetch/vite-plugin-prefetch.ts
@@ -49,7 +49,11 @@ export default function astroPrefetch({ settings }: { settings: AstroSettings })
 			if (id.includes(prefetchInternalModuleFsSubpath)) {
 				return code
 					.replace('__PREFETCH_PREFETCH_ALL__', JSON.stringify(prefetch?.prefetchAll))
-					.replace('__PREFETCH_DEFAULT_STRATEGY__', JSON.stringify(prefetch?.defaultStrategy));
+					.replace('__PREFETCH_DEFAULT_STRATEGY__', JSON.stringify(prefetch?.defaultStrategy))
+					.replace(
+						'__PREFETCH_IGNORE_SLOW_CONNECTION__',
+						JSON.stringify(prefetch?.ignoreSlowConnection)
+					);
 			}
 		},
 	};


### PR DESCRIPTION

## Changes

- Add global ignoreSlowConnection in prefetch config.
- `defaultStrategy` in `prefetch` config can be `none`.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
I have add a e2e test in `packages\astro\e2e\prefetch.test.js`, named `Prefetch (prefetchAll: true, defaultStrategy: 'none')`

## Docs

- Users can set a global ignore slow connection detection.
- Users can set `defaultStrategy` to be `'none'`.

The comments in code:
```js
{
	/**
	 * @docs
	 * @name prefetch.prefetchAll
	 * @type {boolean}
	 * @description
	 * Enable prefetching for all links, including those without the `data-astro-prefetch` attribute.
	 * This value defaults to `true` when using the `<ViewTransitions />` router. Otherwise, the default value is `false`.
	 *
	 * ```js
	 * prefetch: {
	 * 	prefetchAll: true
	 * }
	 * ```
	 *
	 * When set to `true`, you can disable prefetching individually by setting `data-astro-prefetch="false"` on any individual links.
	 *
	 * ```html
	 * <a href="/about" data-astro-prefetch="false">About</a>
	 *```
	 */
	prefetchAll?: boolean;

	/**
	 * @docs
	 * @name prefetch.defaultStrategy
	 * @type {'tap' | 'hover' | 'viewport' | 'none'}
	 * @default `'hover'`
	 * @description
	 * The default prefetch strategy to use when the `data-astro-prefetch` attribute is set on a link with no value.
	 *
	 * - `'tap'`: Prefetch just before you click on the link.
	 * - `'hover'`: Prefetch when you hover over or focus on the link. (default)
	 * - `'viewport'`: Prefetch as the links enter the viewport.
	 * - `'none'`: Prefetch the link without any restrictions.
	 *
	 * You can override this default value and select a different strategy for any individual link by setting a value on the attribute.
	 *
	 * ```html
	 * <a href="/about" data-astro-prefetch="viewport">About</a>
	 * ```
	 */
	defaultStrategy?: 'tap' | 'hover' | 'viewport' | 'none';

	/**
	 * @docs
	 * @name prefetch.ignoreSlowConnection
	 * @type {boolean}
	 * @description
	 * Ignore slow connection detection.
	 *
	 * ```js
	 * prefetch: {
	 * 	ignoreSlowConnection: true
	 * }
	 * ```
	 *
	 * When set to `true`, you can enable slow connection detection by adding `{ ignoreSlowConnection: false }` to the parameters of `prefetch` manually .
	 *
	 * ```js
	 * prefetch('/about', { ignoreSlowConnection: false });
	 *```
	 */
	ignoreSlowConnection?: boolean;
};
```
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
