### PR TITLE
Add autocomplete to button JSX type

### DIFF
--- a/.changeset/beige-zebras-ring.md
+++ b/.changeset/beige-zebras-ring.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add support for autocomplete attribute to the HTML button type.

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -627,6 +627,7 @@ declare namespace astroHTML.JSX {
 	}
 
 	interface ButtonHTMLAttributes extends HTMLAttributes {
+		autocomplete?: string | undefined | null;
 		disabled?: boolean | string | undefined | null;
 		form?: string | undefined | null;
 		formaction?: string | undefined | null;


### PR DESCRIPTION
## Changes

This makes it possible to write `<button autocomplete="off" disabled>Action</button>` without getting type errors in Astro components.

The change extends the JSX type of `ButtonHTMLAttributes` to include the “nonstandard and Firefox-specific” `autocomplete`. While nonstandard, for dynamic front-ends / forms it is often required to include it because of the way Firefox caches disabled-state. (E.g. [this StackOverflow question and answer](https://stackoverflow.com/a/5994462).)

See documentation of the attribute: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#autocomplete

## Testing

No tests are added, this is a singular extra attribute to be defined in the JSX types.

## Docs

No docs are added, this should have no effect on Astro usage outside of type-checked components.