### PR TITLE
Add tailwindcss nesting support

### DIFF
--- a/.changeset/rude-deers-turn.md
+++ b/.changeset/rude-deers-turn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/tailwind': minor
+---
+
+Adds `nesting` option to enable `tailwindcss/nesting` support

--- a/packages/integrations/tailwind/package.json
+++ b/packages/integrations/tailwind/package.json
@@ -29,7 +29,8 @@
   "scripts": {
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
-    "dev": "astro-scripts dev \"src/**/*.ts\""
+    "dev": "astro-scripts dev \"src/**/*.ts\"",
+    "test": "mocha --exit --timeout 20000 test/"
   },
   "dependencies": {
     "autoprefixer": "^10.4.15",
@@ -39,6 +40,8 @@
   "devDependencies": {
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
+    "chai": "^4.3.7",
+    "mocha": "^10.2.0",
     "tailwindcss": "^3.3.5",
     "vite": "^5.0.10"
   },

--- a/packages/integrations/tailwind/test/basic.test.js
+++ b/packages/integrations/tailwind/test/basic.test.js
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import { loadFixture } from '../../../astro/test/test-utils.js';
+
+describe('Basic', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/basic/', import.meta.url),
+		});
+	});
+
+	describe('build', () => {
+		before(async () => {
+			await fixture.build();
+		});
+
+		it('works', async () => {
+			const astroChunkDir = await fixture.readdir('/_astro');
+
+			let css = '';
+			for (const file of astroChunkDir) {
+				if (file.endsWith('.css')) {
+					css += await fixture.readFile(`/_astro/${file}`);
+				}
+			}
+
+			expect(css).to.include('box-sizing:border-box;'); // base css
+			expect(css).to.include('text-red-500'); // class css
+			expect(css).to.match(/\.a\[data-astro-cid-.*?\] \.b\[data-astro-cid-.*?\]/); // nesting
+		});
+	});
+});

--- a/packages/integrations/tailwind/test/fixtures/basic/astro.config.js
+++ b/packages/integrations/tailwind/test/fixtures/basic/astro.config.js
@@ -1,0 +1,12 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'astro/config';
+import tailwind from '@astrojs/tailwind';
+
+export default defineConfig({
+  integrations: [
+    tailwind({
+      configFile: fileURLToPath(new URL('./tailwind.config.js', import.meta.url)),
+      nesting: true
+    }),
+  ]
+});

--- a/packages/integrations/tailwind/test/fixtures/basic/package.json
+++ b/packages/integrations/tailwind/test/fixtures/basic/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@test/tailwind-basic",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/tailwind": "workspace:*"
+  }
+}

--- a/packages/integrations/tailwind/test/fixtures/basic/src/pages/index.astro
+++ b/packages/integrations/tailwind/test/fixtures/basic/src/pages/index.astro
@@ -1,0 +1,13 @@
+<div class="text-red-500">red</div>
+
+<div class="a">
+  <div class="b">nested blue</div>
+</div>
+
+<style>
+  .a {
+    .b {
+      color: blue;
+    }
+  }
+</style>

--- a/packages/integrations/tailwind/test/fixtures/basic/tailwind.config.js
+++ b/packages/integrations/tailwind/test/fixtures/basic/tailwind.config.js
@@ -1,0 +1,6 @@
+import path from 'node:path';
+
+/** @type {import('tailwindcss').Config} */
+export default {
+	content: [path.join(__dirname, 'src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}')],
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4569,9 +4569,6 @@ importers:
       chai:
         specifier: ^4.3.7
         version: 4.3.10
-      cheerio:
-        specifier: 1.0.0-rc.12
-        version: 1.0.0-rc.12
       mocha:
         specifier: ^10.2.0
         version: 10.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4566,12 +4566,30 @@ importers:
       astro-scripts:
         specifier: workspace:*
         version: link:../../../scripts
+      chai:
+        specifier: ^4.3.7
+        version: 4.3.10
+      cheerio:
+        specifier: 1.0.0-rc.12
+        version: 1.0.0-rc.12
+      mocha:
+        specifier: ^10.2.0
+        version: 10.2.0
       tailwindcss:
         specifier: ^3.3.5
         version: 3.3.5
       vite:
         specifier: ^5.0.10
         version: 5.0.10(@types/node@18.18.6)(sass@1.69.5)
+
+  packages/integrations/tailwind/test/fixtures/basic:
+    dependencies:
+      '@astrojs/tailwind':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
 
   packages/integrations/vercel:
     dependencies:


### PR DESCRIPTION
## Changes

close https://github.com/withastro/astro/issues/9526

Add `tailwindcss/nesting` support via an option the user can enable. https://tailwindcss.com/docs/using-with-preprocessors#nesting

## Testing

Added new tests

## Docs

TBA in docs repo. And there's also the added jsdoc.
