### PR TITLE
Fix duplicated CSS modules inlining

### DIFF
--- a/.changeset/blue-ladybugs-march.md
+++ b/.changeset/blue-ladybugs-march.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes duplicated CSS modules content when it's imported by both Astro files and framework components

--- a/packages/astro/src/content/vite-plugin-content-assets.ts
+++ b/packages/astro/src/content/vite-plugin-content-assets.ts
@@ -64,11 +64,7 @@ export function astroContentAssetPropagationPlugin({
 					if (!devModuleLoader.getModuleById(basePath)?.ssrModule) {
 						await devModuleLoader.import(basePath);
 					}
-					const { styles, urls } = await getStylesForURL(
-						pathToFileURL(basePath),
-						devModuleLoader,
-						'development'
-					);
+					const { styles, urls } = await getStylesForURL(pathToFileURL(basePath), devModuleLoader);
 
 					const hoistedScripts = await getScriptsForURL(
 						pathToFileURL(basePath),

--- a/packages/astro/src/vite-plugin-astro-server/css.ts
+++ b/packages/astro/src/vite-plugin-astro-server/css.ts
@@ -1,4 +1,3 @@
-import type { RuntimeMode } from '../@types/astro.js';
 import type { ModuleLoader } from '../core/module-loader/index.js';
 import { viteID } from '../core/util.js';
 import { isBuildableCSSRequest } from './util.js';
@@ -13,8 +12,7 @@ interface ImportedStyle {
 /** Given a filePath URL, crawl Vite’s module graph to find all style imports. */
 export async function getStylesForURL(
 	filePath: URL,
-	loader: ModuleLoader,
-	mode: RuntimeMode
+	loader: ModuleLoader
 ): Promise<{ urls: Set<string>; styles: ImportedStyle[] }> {
 	const importedCssUrls = new Set<string>();
 	// Map of url to injected style object. Use a `url` key to deduplicate styles
@@ -22,12 +20,6 @@ export async function getStylesForURL(
 
 	for await (const importedModule of crawlGraph(loader, viteID(filePath), true)) {
 		if (isBuildableCSSRequest(importedModule.url)) {
-			// In production, we can simply assign the styles as URLs
-			if (mode !== 'development') {
-				importedCssUrls.add(importedModule.url);
-				continue;
-			}
-
 			// In dev, we inline all styles if possible
 			let css = '';
 			// If this is a plain CSS module, the default export should be a string

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -436,11 +436,7 @@ async function getScriptsAndStyles({ pipeline, filePath }: GetScriptsAndStylesPa
 	}
 
 	// Pass framework CSS in as style tags to be appended to the page.
-	const { urls: styleUrls, styles: importedStyles } = await getStylesForURL(
-		filePath,
-		moduleLoader,
-		mode
-	);
+	const { urls: styleUrls, styles: importedStyles } = await getStylesForURL(filePath, moduleLoader);
 	let links = new Set<SSRElement>();
 	[...styleUrls].forEach((href) => {
 		links.add({

--- a/packages/astro/test/0-css.test.js
+++ b/packages/astro/test/0-css.test.js
@@ -367,7 +367,7 @@ describe('CSS', function () {
 				'ReactModules.module.sass',
 			];
 			for (const style of styles) {
-				const href = $(`link[href$="${style}"]`).attr('href');
+				const href = $(`style[data-vite-dev-id$="${style}"]`).attr('data-vite-dev-id');
 				expect((await fixture.fetch(href)).status, style).to.equal(200);
 			}
 
@@ -423,7 +423,7 @@ describe('CSS', function () {
 
 		it('.module.css ordering', () => {
 			const globalStyleTag = $('style[data-vite-dev-id$="default.css"]');
-			const moduleStyleTag = $('link[href$="ModuleOrdering.module.css"]');
+			const moduleStyleTag = $('style[data-vite-dev-id$="ModuleOrdering.module.css"]');
 			const globalStyleClassIndex = globalStyleTag.index();
 			const moduleStyleClassIndex = moduleStyleTag.index();
 			// css module has higher priority than global style

--- a/packages/astro/test/units/dev/styles.test.js
+++ b/packages/astro/test/units/dev/styles.test.js
@@ -75,11 +75,7 @@ describe('Crawling graph for CSS', () => {
 	it("importedModules is checked against the child's importers", async () => {
 		// In dev mode, HMR modules tracked are added to importedModules. We use `importers`
 		// to verify that they are true importers.
-		const res = await getStylesForURL(
-			new URL('./src/pages/index.astro', root),
-			loader,
-			'development'
-		);
+		const res = await getStylesForURL(new URL('./src/pages/index.astro', root), loader);
 		expect(res.styles.length).to.equal(1);
 	});
 });

--- a/packages/astro/test/units/dev/styles.test.js
+++ b/packages/astro/test/units/dev/styles.test.js
@@ -15,6 +15,17 @@ class TestLoader {
 	getModulesByFile(id) {
 		return this.modules.has(id) ? [this.modules.get(id)] : [];
 	}
+	import(id) {
+		// try to normalize inline CSS requests so we can map to the existing modules value
+		id = id.replace(/(\?|&)inline=?(&|$)/, (_, start, end) => (end ? start : '')).replace(/=$/, '');
+		for (const mod of this.modules.values()) {
+			for (const importedMod of mod.importedModules) {
+				if (importedMod.id === id) {
+					return importedMod.ssrModule;
+				}
+			}
+		}
+	}
 }
 
 describe('Crawling graph for CSS', () => {
@@ -35,7 +46,7 @@ describe('Crawling graph for CSS', () => {
 						id: indexId + '?astro&style.css',
 						url: indexId + '?astro&style.css',
 						importers: new Set([{ id: indexId }]),
-						ssrModule: {},
+						ssrModule: { default: '.index {}' },
 					},
 				],
 				importers: new Set(),
@@ -50,7 +61,7 @@ describe('Crawling graph for CSS', () => {
 						id: aboutId + '?astro&style.css',
 						url: aboutId + '?astro&style.css',
 						importers: new Set([{ id: aboutId }]),
-						ssrModule: {},
+						ssrModule: { default: '.about {}' },
 					},
 				],
 				importers: new Set(),
@@ -69,6 +80,6 @@ describe('Crawling graph for CSS', () => {
 			loader,
 			'development'
 		);
-		expect(res.urls.size).to.equal(1);
+		expect(res.styles.length).to.equal(1);
 	});
 });


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/6885

When a `.module.css` file is imported by both an Astro file and framework component, it gets inlined by Astro to prevent a FOUC. However, the way we inline it before (using a `link`) is not how Vite handles it when it's loaded in the client (via the framework component). Vite expects the CSS module to be a `style` tag inlined.

This PR uses a `style` tag instead to fix it, which potentially causes different ordering with other style tags now (since CSS modules used to be links and they're rendered separately), but since we had changed the ordering before at https://github.com/withastro/astro/pull/8877 (which I think worked fine?), I think we can tweak this a little bit more.

## Testing

Updated tests

## Docs

n/a. bug fix.
