### PR TITLE
Patch `set-output` deprecation in workflows

### DIFF
--- a/.github/workflows/check-merge.yml
+++ b/.github/workflows/check-merge.yml
@@ -50,10 +50,10 @@ jobs:
         if: steps.blocked.outputs.result != 'true'
         run: |
           echo "Checking for changesets marked as minor"
-          echo '::set-output name=found::false'
+          echo "found=false" >> $GITHUB_OUTPUT
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             if grep -q "'astro': minor" "$file"; then
-              echo '::set-output name=found::true'
+              echo "found=true" >> $GITHUB_OUTPUT
               echo "$file has a minor release tag"
             fi
           done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,10 +54,10 @@ jobs:
           if [[ $output = '{ "changesets": [], "releases": [] }' ]]
           then
             echo 'No changeset found'
-            echo "::set-output name=run_job::true"
+            echo "run_job=true" >> $GITHUB_OUTPUT
           else
             echo 'changes found, push to latest skipped'
-            echo "::set-output name=run_job::false"
+            echo "run_job=false" >> $GITHUB_OUTPUT
           fi
 
   update:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         id: notification
         if: steps.changesets.outputs.published == 'true'
         run: |
-          message=$(node scripts/notify/index.js '${{ steps.changesets.outputs.publishedPackages }}') && \
+          message=$(node scripts/notify/index.js '${{ steps.changesets.outputs.publishedPackages }}')
           echo "message=${message//$'\n'/'%0A'}" >> $GITHUB_OUTPUT
 
       - name: Discord Notification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,9 @@ jobs:
       - name: Generate Notification
         id: notification
         if: steps.changesets.outputs.published == 'true'
-        run: message=$(node scripts/notify/index.js '${{ steps.changesets.outputs.publishedPackages }}') && echo ::set-output name=message::${message//$'\n'/'%0A'}
+        run: |
+          message=$(node scripts/notify/index.js '${{ steps.changesets.outputs.publishedPackages }}') && \
+          echo "message=${message//$'\n'/'%0A'}" >> $GITHUB_OUTPUT
 
       - name: Discord Notification
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Changes

<!--
- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`
-->

I've noticed some workflows are showing warning about `set-output` deprecation.

This PR updates all workflows that are using `set-output` to use the new environment files instead.

This has been done following GitHub's ["GitHub Actions: Deprecating save-state and set-output commands"](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) blog post and instructions on updating.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I've run syntax checks on the updated workflow files.
Their behavior should not change.

The `check-merge.yml` workflow should run on this PR, succeed, and the step "Check if any changesets contain minor changes" should not show any warning anymore.

The `main.yml` and `release.yml` workflows won't run on this PR. I don't know how to rigorously test them further after syntax checks.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This only fixes a deprecation warning.
