### PR TITLE
Fix error overlay display on malformed uri

### DIFF
--- a/.changeset/great-beans-check.md
+++ b/.changeset/great-beans-check.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes error overlay display on URI malformed error

--- a/packages/astro/src/core/errors/dev/vite.ts
+++ b/packages/astro/src/core/errors/dev/vite.ts
@@ -111,7 +111,7 @@ export interface AstroErrorPayload {
 		hint?: string;
 		docslink?: string;
 		highlightedCode?: string;
-		loc: {
+		loc?: {
 			file?: string;
 			line?: number;
 			column?: number;

--- a/packages/astro/src/core/errors/overlay.ts
+++ b/packages/astro/src/core/errors/overlay.ts
@@ -631,7 +631,7 @@ class ErrorOverlay extends HTMLElement {
 		}
 
 		const code = this.root.querySelector<HTMLElement>('#code');
-		if (code && err.loc.file) {
+		if (code && err.loc?.file) {
 			code.style.display = 'block';
 			const codeHeader = code.querySelector<HTMLHeadingElement>('#code header');
 			const codeContent = code.querySelector<HTMLDivElement>('#code-content');
@@ -670,7 +670,7 @@ class ErrorOverlay extends HTMLElement {
 						}
 
 						// Add an empty line below the error line so we can show a caret under the error
-						if (err.loc.column) {
+						if (err.loc?.column) {
 							errorLine.insertAdjacentHTML(
 								'afterend',
 								`\n<span class="line error-caret"><span style="padding-left:${

--- a/packages/astro/src/vite-plugin-astro-server/base.ts
+++ b/packages/astro/src/vite-plugin-astro-server/base.ts
@@ -20,12 +20,12 @@ export function baseMiddleware(
 	return function devBaseMiddleware(req, res, next) {
 		const url = req.url!;
 
-		let pathname = url;
+		let pathname: string;
 		try {
-			pathname = decodeURI(pathname);
+			pathname = decodeURI(new URL(url, 'http://localhost').pathname);
 		} catch (e) {
 			/* malform uri */
-			return next(e)
+			return next(e);
 		}
 
 		if (pathname.startsWith(devRoot)) {

--- a/packages/astro/src/vite-plugin-astro-server/base.ts
+++ b/packages/astro/src/vite-plugin-astro-server/base.ts
@@ -20,7 +20,13 @@ export function baseMiddleware(
 	return function devBaseMiddleware(req, res, next) {
 		const url = req.url!;
 
-		const pathname = decodeURI(new URL(url, 'http://localhost').pathname);
+		let pathname = url;
+		try {
+			pathname = decodeURI(pathname);
+		} catch (e) {
+			/* malform uri */
+			return next(e)
+		}
 
 		if (pathname.startsWith(devRoot)) {
 			req.url = url.replace(devRoot, devRootReplacement);


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/8274

The issue is that Vite would signal an error [here](https://github.com/vitejs/vite/blob/56ae92c33cba6c86ab5819877c19b9ea39f7121b/packages/vite/src/node/server/middlewares/error.ts#L54-L57), which error doesn't have the `loc` property. However the error overlay expected so as it assume all errors are processed by Astro.

I fixed it by making `loc` undefined-able for now, and handling that in the error overlay.

## Testing

With the repro, I'm seeing a proper error message page now:
<img width="1428" alt="image" src="https://github.com/withastro/astro/assets/34116392/5bf35547-f7ce-47f2-a40f-d8065089706b">


## Docs

n/a. bug fix