### PR TITLE
fix(vercel): prevent build failure with node 21

### DIFF
--- a/.changeset/yellow-yaks-promise.md
+++ b/.changeset/yellow-yaks-promise.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vercel": patch
+---
+
+Fixes an issue where a build could not complete on Node 21.

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -377,19 +377,19 @@ function validateRuntime() {
 	const version = process.version.slice(1); // 'v16.5.0' --> '16.5.0'
 	const major = version.split('.')[0]; // '16.5.0' --> '16'
 	const support = SUPPORTED_NODE_VERSIONS[major];
-	if (support.status === 'beta') {
-		console.warn(
-			`[${PACKAGE_NAME}] The local Node.js version (${major}) is currently in beta for Vercel Serverless Functions.`
-		);
-		console.warn(`[${PACKAGE_NAME}] Make sure to update your Vercel settings to use ${major}.`);
-		return;
-	}
 	if (support === undefined) {
 		console.warn(
 			`[${PACKAGE_NAME}] The local Node.js version (${major}) is not supported by Vercel Serverless Functions.`
 		);
 		console.warn(`[${PACKAGE_NAME}] Your project will use Node.js 18 as the runtime instead.`);
 		console.warn(`[${PACKAGE_NAME}] Consider switching your local version to 18.`);
+		return;
+	}
+	if (support.status === 'beta') {
+		console.warn(
+			`[${PACKAGE_NAME}] The local Node.js version (${major}) is currently in beta for Vercel Serverless Functions.`
+		);
+		console.warn(`[${PACKAGE_NAME}] Make sure to update your Vercel settings to use ${major}.`);
 		return;
 	}
 	if (support.status === 'deprecated') {


### PR DESCRIPTION
## Changes

- Prevents build failure on node 21.
<img width="905" alt="image" src="https://github.com/withastro/astro/assets/69170106/7a588930-00ac-4f73-b312-27e1c832a47b">

## Testing
Ran build on node 21.

## Docs
Does not affect behavior