### PR TITLE
Fix asynchronous `appEntrypoint` support

### DIFF
--- a/.changeset/ninety-buses-occur.md
+++ b/.changeset/ninety-buses-occur.md
@@ -1,5 +1,5 @@
 ---
-"@astrojs/vue": minor
+"@astrojs/vue": patch
 ---
 
 Fixes support for async `appEntrypoint`

--- a/.changeset/ninety-buses-occur.md
+++ b/.changeset/ninety-buses-occur.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vue": minor
+---
+
+Fixes support for async `appEntrypoint`

--- a/packages/integrations/vue/src/index.ts
+++ b/packages/integrations/vue/src/index.ts
@@ -63,9 +63,9 @@ function virtualAppEntrypoint(options?: Options): Plugin {
 					return `\
 import * as mod from ${JSON.stringify(appEntrypoint)};
 						
-export const setup = (app) => {
+export const setup = async (app) => {
 	if ('default' in mod) {
-		mod.default(app);
+		await mod.default(app);
 	} else {
 		${
 			!isBuild

--- a/packages/integrations/vue/test/app-entrypoint.test.js
+++ b/packages/integrations/vue/test/app-entrypoint.test.js
@@ -185,3 +185,26 @@ describe('App Entrypoint /src/absolute', () => {
 		expect(js).not.to.match(/\w+\.component\(\"Bar\"/gm);
 	});
 });
+
+describe('App Entrypoint async', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/app-entrypoint-async/',
+		});
+		await fixture.build();
+	});
+
+	it('loads during SSR', async () => {
+		const html = await fixture.readFile('/index.html');
+		const $ = cheerioLoad(html);
+
+		// test 1: component before await renders
+		expect($('#foo > #bar').text()).to.eq('works');
+
+		// test 2: component after await renders
+		expect($('#foo > #baz').text()).to.eq('works');
+	});
+});

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-async/astro.config.mjs
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-async/astro.config.mjs
@@ -1,0 +1,14 @@
+import { defineConfig } from 'astro/config';
+import vue from '@astrojs/vue';
+import ViteSvgLoader from 'vite-svg-loader'
+
+export default defineConfig({
+  integrations: [vue({
+		appEntrypoint: '/src/pages/_app'
+	})],
+	vite: {
+    plugins: [
+      ViteSvgLoader(),
+    ],
+	},
+})

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-async/package.json
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-async/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@test/vue-app-entrypoint-async",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/vue": "workspace:*",
+    "astro": "workspace:*",
+    "vite-svg-loader": "5.0.1"
+  }
+}

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-async/src/components/Bar.vue
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-async/src/components/Bar.vue
@@ -1,0 +1,3 @@
+<template>
+	<div id="bar">works</div>
+</template>

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-async/src/components/Baz.vue
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-async/src/components/Baz.vue
@@ -1,0 +1,3 @@
+<template>
+	<div id="baz">works</div>
+</template>

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-async/src/components/Foo.vue
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-async/src/components/Foo.vue
@@ -1,0 +1,6 @@
+<template>
+	<div id="foo">
+		<Bar />
+		<Baz />
+	</div>
+</template>

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-async/src/pages/_app.ts
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-async/src/pages/_app.ts
@@ -1,0 +1,11 @@
+import type { App } from 'vue'
+import Bar from '../components/Bar.vue'
+import Baz from '../components/Baz.vue'
+
+export default async function setup(app: App) {
+	app.component('Bar', Bar);
+
+	await new Promise(resolve => setTimeout(resolve, 250));
+
+	app.component('Baz', Baz);
+}

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-async/src/pages/index.astro
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-async/src/pages/index.astro
@@ -1,0 +1,12 @@
+---
+import Foo from '../components/Foo.vue';
+---
+
+<html>
+	<head>
+		<title>Vue App Entrypoint</title>
+	</head>
+	<body>
+		<Foo client:load />
+	</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4861,6 +4861,18 @@ importers:
         specifier: 5.0.1
         version: 5.0.1
 
+  packages/integrations/vue/test/fixtures/app-entrypoint-async:
+    dependencies:
+      '@astrojs/vue':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+      vite-svg-loader:
+        specifier: 5.0.1
+        version: 5.0.1
+
   packages/integrations/vue/test/fixtures/app-entrypoint-no-export-default:
     dependencies:
       '@astrojs/vue':


### PR DESCRIPTION
## Changes

Fixes #9557, a regression which has broken the (admittedly niche) use case of an asynchronous `appEntrypoint` function. The changes introduced in #9362 led the potentially asynchronous setup method to be wrapped in a synchronous function, making the `await setup()` in `[server,client].js` more-or-less useless. This PR makes the virtual module's wrapper method `async` as well, bringing back support for asynchronous `appEntrypoint`s.

## Testing

<!-- How was this change tested? -->
A simple test for this scenario was added, which leverages two components registered globally in the `appEntrypoint` script separated by a simulated asynchronous call to ensure that registration works correctly following an async call within an async entrypoint script.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
Not sure if docs will be needed as this is a pretty niche use case, but it is certainly nice to have. I'll be happy to add to the docs if it would be appropriate.
/cc @withastro/maintainers-docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
