### PR TITLE
Add 'starlight' to displayed options under 'add' option in CLI

### DIFF
--- a/.changeset/tall-mayflies-deliver.md
+++ b/.changeset/tall-mayflies-deliver.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+"astro": patch
 ---
 
-Add 'starlight' to displayed options under 'add' option in CLI
+Adds 'starlight' to the displayed options for `astro add`

--- a/.changeset/tall-mayflies-deliver.md
+++ b/.changeset/tall-mayflies-deliver.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Add 'starlight' to displayed options under 'add' option in CLI

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -114,6 +114,9 @@ export async function add(names: string[], { flags }: AddOptions) {
 					['lit', 'astro add lit'],
 					['alpinejs', 'astro add alpinejs'],
 				],
+				'Documentation Frameworks': [
+					['starlight', 'astro add starlight'],
+				],
 				'SSR Adapters': [
 					['netlify', 'astro add netlify'],
 					['vercel', 'astro add vercel'],


### PR DESCRIPTION
I was surprised not to find Starlight in the astro CLI, so I added it. :)

This adds the Starlight to the options displayed by the CLI under a new category of "Documentation Frameworks".

## Changes

- Adds Startlight to CLI's displayed options

## Docs

/cc @withastro/maintainers-docs for feedback!
I'm not sure if there are docs for the CLI which might also need to be added...