### PR TITLE
`yarn add` should be used to install packages instead of `yarn install`

### DIFF
--- a/packages/upgrade/src/actions/install.ts
+++ b/packages/upgrade/src/actions/install.ts
@@ -123,6 +123,8 @@ async function runInstallCommand(
 	const cwd = fileURLToPath(ctx.cwd);
 	if (ctx.packageManager === 'yarn') await ensureYarnLock({ cwd });
 
+	const installCmd = ctx.packageManager === 'yarn' ? 'add' : 'install'; 
+
 	await spinner({
 		start: `Installing dependencies with ${ctx.packageManager}...`,
 		end: `Installed dependencies!`,
@@ -132,7 +134,7 @@ async function runInstallCommand(
 					await shell(
 						ctx.packageManager,
 						[
-							'install',
+							installCmd,
 							...dependencies.map(
 								({ name, targetVersion }) => `${name}@${targetVersion.replace(/^\^/, '')}`
 							),
@@ -144,7 +146,7 @@ async function runInstallCommand(
 					await shell(
 						ctx.packageManager,
 						[
-							'install',
+							installCmd,
 							'--save-dev',
 							...devDependencies.map(
 								({ name, targetVersion }) => `${name}@${targetVersion.replace(/^\^/, '')}`
@@ -161,7 +163,7 @@ async function runInstallCommand(
 				error(
 					'error',
 					`Dependencies failed to install, please run the following command manually:\n${color.bold(
-						`${ctx.packageManager} install ${packages}`
+						`${ctx.packageManager} ${installCmd} ${packages}`
 					)}`
 				);
 				return ctx.exit(1);


### PR DESCRIPTION
`yarn install` is used to install all packages for a project, and does nor accept arguments.

## Changes
- Checks if `ctx.packageManager` is `yarn`, and if so, uses `add` instead of `install`


## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

Not sure if this needs to be explicitly stated in the upgrade section.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
