### PR TITLE
Fix history navigation to hash fragment on Firefox when using view transitions

### DIFF
--- a/.changeset/breezy-eyes-teach.md
+++ b/.changeset/breezy-eyes-teach.md
@@ -2,4 +2,7 @@
 "astro": patch
 ---
 
-Fix history navigation to hash fragment on Firefox when using view transitions
+Fixes back navigation to fragment links (e.g. `#about`) in Firefox when using view transitions
+
+Co-authored-by: Florian Lefebvre <69633530+florian-lefebvre@users.noreply.github.com>
+Co-authored-by: Sarah Rainsberger <sarah@rainsberger.ca>

--- a/.changeset/breezy-eyes-teach.md
+++ b/.changeset/breezy-eyes-teach.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes history navigation to hash targets on Firefox when using view transitions
+Fix history navigation to hash fragment on Firefox when using view transitions

--- a/.changeset/breezy-eyes-teach.md
+++ b/.changeset/breezy-eyes-teach.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes history navigation to hash targets on Firefox when using view transitions

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -213,7 +213,9 @@ const moveToLocation = (to: URL, from: URL, options: Options, historyState?: Sta
 			// ... what comes next is a intra-page navigation
 			// that won't reload the page but instead scroll to the fragment
 			history.scrollRestoration = 'auto';
-			location.href = to.href;
+			const savedState = history.state;
+			location.href = to.href; // this kills the history state on Firefox
+			history.replaceState(savedState, ''); // this restores the history state
 		} else {
 			if (!scrolledToTop) {
 				scrollTo({ left: 0, top: 0, behavior: 'instant' });

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -215,7 +215,7 @@ const moveToLocation = (to: URL, from: URL, options: Options, historyState?: Sta
 			history.scrollRestoration = 'auto';
 			const savedState = history.state;
 			location.href = to.href; // this kills the history state on Firefox
-			history.replaceState(savedState, ''); // this restores the history state
+			history.state || history.replaceState(savedState, ''); // this restores the history state
 		} else {
 			if (!scrolledToTop) {
 				scrollTo({ left: 0, top: 0, behavior: 'instant' });


### PR DESCRIPTION
## Changes

Firefox clears the history state on same page navigation, which later breaks history navigation.
This fix prevents that.
From discord user mcoms on #support > View Transitions back/forward not working in Firefox for fragment links:
> In Firefox, on all ViewTransition fallbacks but none, going back to a fragment link (#about) from another page does not work. It stays on the current page without navigating back. For example, if I have a page with a link /#about and then I go to /faq, I press back and the URL changes to /#about but the content is still /faq. This happens until I reach that does not contain a # in the URL, or if the # was initially navigated to. It even doesn't work if the # link had data-astro-reload={true}.

SvelteKit had a [similar issue](https://github.com/sveltejs/kit/issues/8725). 
Their analysis put me on the right track.

## Testing

Tested manually on Firefox as we do not run automated e2e tests on Firefox.

## Docs

n/a bug fix.