### PR TITLE
chore: include CHANGELOG.md in NPM packages

### DIFF
--- a/.changeset/chatty-coins-fry.md
+++ b/.changeset/chatty-coins-fry.md
@@ -1,0 +1,24 @@
+---
+"@astrojs/partytown": patch
+"@astrojs/alpinejs": patch
+"@astrojs/tailwind": patch
+"@astrojs/markdoc": patch
+"@astrojs/sitemap": patch
+"@astrojs/underscore-redirects": patch
+"@astrojs/preact": patch
+"@astrojs/svelte": patch
+"@astrojs/vercel": patch
+"@astrojs/react": patch
+"@astrojs/solid-js": patch
+"@astrojs/node": patch
+"@astrojs/lit": patch
+"@astrojs/mdx": patch
+"@astrojs/vue": patch
+"@astrojs/markdown-remark": patch
+"@astrojs/prism": patch
+"@astrojs/rss": patch
+"@astrojs/telemetry": patch
+"astro": patch
+---
+
+chore: include CHANGELOG.md in NPM packages

--- a/packages/astro-prism/package.json
+++ b/packages/astro-prism/package.json
@@ -24,6 +24,7 @@
     "./dist/highlighter": "./dist/highlighter.js"
   },
   "files": [
+    "CHANGELOG.md",
     "dist",
     "Prism.astro"
   ],

--- a/packages/astro-rss/package.json
+++ b/packages/astro-rss/package.json
@@ -18,6 +18,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "CHANGELOG.md",
     "dist"
   ],
   "scripts": {

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -81,6 +81,7 @@
     "astro": "astro.js"
   },
   "files": [
+    "CHANGELOG.md",
     "components",
     "tsconfigs",
     "dist",

--- a/packages/integrations/alpinejs/package.json
+++ b/packages/integrations/alpinejs/package.json
@@ -25,6 +25,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "CHANGELOG.md",
     "dist"
   ],
   "scripts": {

--- a/packages/integrations/lit/package.json
+++ b/packages/integrations/lit/package.json
@@ -28,6 +28,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "CHANGELOG.md",
     "dist",
     "client-shim.js",
     "client-shim.min.js",

--- a/packages/integrations/markdoc/package.json
+++ b/packages/integrations/markdoc/package.json
@@ -51,6 +51,7 @@
     }
   },
   "files": [
+    "CHANGELOG.md",
     "components",
     "dist",
     "template"

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -23,6 +23,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "CHANGELOG.md",
     "dist",
     "template"
   ],

--- a/packages/integrations/node/package.json
+++ b/packages/integrations/node/package.json
@@ -24,6 +24,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "CHANGELOG.md",
     "dist"
   ],
   "scripts": {

--- a/packages/integrations/partytown/package.json
+++ b/packages/integrations/partytown/package.json
@@ -24,6 +24,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "CHANGELOG.md",
     "dist"
   ],
   "scripts": {

--- a/packages/integrations/preact/package.json
+++ b/packages/integrations/preact/package.json
@@ -27,6 +27,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "CHANGELOG.md",
     "dist"
   ],
   "scripts": {

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -29,6 +29,7 @@
     "./jsx-runtime": "./jsx-runtime.js"
   },
   "files": [
+    "CHANGELOG.md",
     "dist",
     "client.js",
     "client-v17.js",

--- a/packages/integrations/sitemap/package.json
+++ b/packages/integrations/sitemap/package.json
@@ -24,6 +24,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "CHANGELOG.md",
     "dist"
   ],
   "scripts": {

--- a/packages/integrations/solid/package.json
+++ b/packages/integrations/solid/package.json
@@ -27,6 +27,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "CHANGELOG.md",
     "dist"
   ],
   "scripts": {

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -30,6 +30,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "CHANGELOG.md",
     "dist",
     "client.js",
     "client-v5.js",

--- a/packages/integrations/tailwind/package.json
+++ b/packages/integrations/tailwind/package.json
@@ -23,6 +23,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "CHANGELOG.md",
     "dist",
     "base.css"
   ],

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -40,6 +40,7 @@
     }
   },
   "files": [
+    "CHANGELOG.md",
     "dist"
   ],
   "scripts": {

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -28,6 +28,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "CHANGELOG.md",
     "dist",
     "client.js",
     "server.js",

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -17,6 +17,7 @@
     "./dist/internal.js": "./dist/internal.js"
   },
   "files": [
+    "CHANGELOG.md",
     "dist"
   ],
   "scripts": {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -26,6 +26,7 @@
     "test": "mocha --exit --timeout 20000 test/"
   },
   "files": [
+    "CHANGELOG.md",
     "dist"
   ],
   "dependencies": {

--- a/packages/underscore-redirects/package.json
+++ b/packages/underscore-redirects/package.json
@@ -17,6 +17,7 @@
     ".": "./dist/index.js"
   },
   "files": [
+    "CHANGELOG.md",
     "dist"
   ],
   "scripts": {


### PR DESCRIPTION
## Changes

Add CHANGELOG.md to the published NPM packages, enabling consumption by [changelogs.xyz](https://changelogs.xyz/).

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
No specific tests are required for this change.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
No additional documentation is needed. A potential enhancement to consider is displaying a link to the changelog of all the  packages updated with `@astrojs/upgrade`, not just the ones with breaking changes.
