### PR TITLE
Remove telemetry for unhandled errors

### DIFF
--- a/.changeset/few-days-relate.md
+++ b/.changeset/few-days-relate.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Removes telemetry for unhandled errors in the dev server

--- a/packages/astro/src/vite-plugin-astro-server/error.ts
+++ b/packages/astro/src/vite-plugin-astro-server/error.ts
@@ -5,7 +5,6 @@ import type DevPipeline from './devPipeline.js';
 import { collectErrorMetadata } from '../core/errors/dev/index.js';
 import { createSafeError } from '../core/errors/index.js';
 import { formatErrorMessage } from '../core/messages.js';
-import { eventError, telemetry } from '../events/index.js';
 
 export function recordServerError(
 	loader: ModuleLoader,
@@ -23,8 +22,6 @@ export function recordServerError(
 	// This is our last line of defense regarding errors where we still might have some information about the request
 	// Our error should already be complete, but let's try to add a bit more through some guesswork
 	const errorWithMetadata = collectErrorMetadata(err, config.root);
-
-	telemetry.record(eventError({ cmd: 'dev', err: errorWithMetadata, isFatal: false }));
 
 	pipeline.logger.error(
 		null,

--- a/packages/astro/src/vite-plugin-astro-server/error.ts
+++ b/packages/astro/src/vite-plugin-astro-server/error.ts
@@ -3,8 +3,9 @@ import type { AstroConfig } from '../@types/astro.js';
 import type DevPipeline from './devPipeline.js';
 
 import { collectErrorMetadata } from '../core/errors/dev/index.js';
-import { createSafeError } from '../core/errors/index.js';
+import { createSafeError, AstroErrorData } from '../core/errors/index.js';
 import { formatErrorMessage } from '../core/messages.js';
+import { eventError, telemetry } from '../events/index.js';
 
 export function recordServerError(
 	loader: ModuleLoader,
@@ -22,6 +23,11 @@ export function recordServerError(
 	// This is our last line of defense regarding errors where we still might have some information about the request
 	// Our error should already be complete, but let's try to add a bit more through some guesswork
 	const errorWithMetadata = collectErrorMetadata(err, config.root);
+
+	// Ignore unhandled rejection errors as they appear A LOT and we cannot record the amount to telemetry
+	if (errorWithMetadata.name !== AstroErrorData.UnhandledRejection.name) {
+		telemetry.record(eventError({ cmd: 'dev', err: errorWithMetadata, isFatal: false }));
+	}
 
 	pipeline.logger.error(
 		null,


### PR DESCRIPTION
## Changes

The telemetry for unhandled errors are a LOT, so removing them for now. I didn't uncomment it out as I don't quite see another way we could enable it in the future.

## Testing

It's a one-line removal, so should still work like before.

## Docs


n/a. not docs related.