### PR TITLE
Document --host and --port flag for preview

### DIFF
--- a/.changeset/sixty-bugs-unite.md
+++ b/.changeset/sixty-bugs-unite.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Documents supported `--host` and `--port` flags in `astro preview --help`

--- a/packages/astro/src/cli/preview/index.ts
+++ b/packages/astro/src/cli/preview/index.ts
@@ -15,6 +15,9 @@ export async function preview({ flags }: PreviewOptions) {
 			usage: '[...flags]',
 			tables: {
 				Flags: [
+					['--port', `Specify which port to run on. Defaults to 4321.`],
+					['--host', `Listen on all addresses, including LAN and public addresses.`],
+					['--host <custom-address>', `Expose on a network IP address at <custom-address>`],
 					['--open', 'Automatically open the app in the browser on server start'],
 					['--help (-h)', 'See all available flags.'],
 				],


### PR DESCRIPTION
## Changes

Ref: https://github.com/withastro/astro/issues/9133#issuecomment-1872238536

We support those flags for all adapters as we collect them here

https://github.com/withastro/astro/blob/e496b2e3b84b673b81c872dad9a6b3f9dd32396a/packages/astro/src/core/preview/index.ts#L20-L22

And then pass them to adapters at:

https://github.com/withastro/astro/blob/e496b2e3b84b673b81c872dad9a6b3f9dd32396a/packages/astro/src/core/preview/index.ts#L59-L68

## Testing

Tested manually in the examples app:

```
> @example/ssr@0.0.1 preview /Users/bjorn/Work/oss/astro/examples/ssr
> astro preview "--port" "4444" "--host"

15:54:49 [@astrojs/node] Preview server listening on 
  local: http://localhost:4444 
  network: http://192.168.68.55:4444
```

```
> @example/basics@0.0.1 preview /Users/bjorn/Work/oss/astro/examples/basics
> astro preview "--port" "4444" "--host"


 astro  v4.0.8 ready in 5 ms

┃ Local    http://localhost:4444/
┃ Network  http://192.168.68.55:4444/
```

## Docs

Looks like it's only documented for `astro dev`: https://docs.astro.build/en/reference/cli-reference/#astro-dev

It should be updated.
