### PR TITLE
Support --open with url string

### DIFF
--- a/.changeset/cyan-seals-bathe.md
+++ b/.changeset/cyan-seals-bathe.md
@@ -1,0 +1,5 @@
+---
+"astro": minor
+---
+
+Allows passing a string to `--open` and `server.open` to open a specific URL on startup in development

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -153,7 +153,7 @@ export interface CLIFlags {
 	host?: string | boolean;
 	port?: number;
 	config?: string;
-	open?: boolean;
+	open?: string | boolean;
 }
 
 /**
@@ -371,11 +371,12 @@ type ServerConfig = {
 
 	/**
 	 * @name server.open
-	 * @type {boolean}
+	 * @type {string | boolean}
 	 * @default `false`
 	 * @version 2.1.8
 	 * @description
 	 * Control whether the dev server should open in your browser window on startup.
+	 * A URL string can also be passed to specify the URL to open.
 	 *
 	 * ```js
 	 * {
@@ -383,7 +384,7 @@ type ServerConfig = {
 	 * }
 	 * ```
 	 */
-	open?: boolean;
+	open?: string | boolean;
 };
 
 export interface ViteUserConfig extends vite.UserConfig {
@@ -1021,11 +1022,12 @@ export interface AstroUserConfig {
 
 	/**
 	 * @name server.open
-	 * @type {boolean}
+	 * @type {string | boolean}
 	 * @default `false`
 	 * @version 2.1.8
 	 * @description
 	 * Control whether the dev server should open in your browser window on startup.
+	 * A URL string can also be passed to specify the URL to open.
 	 *
 	 * ```js
 	 * {

--- a/packages/astro/src/cli/flags.ts
+++ b/packages/astro/src/cli/flags.ts
@@ -19,7 +19,8 @@ export function flagsToAstroInlineConfig(flags: Flags): AstroInlineConfig {
 			port: typeof flags.port === 'number' ? flags.port : undefined,
 			host:
 				typeof flags.host === 'string' || typeof flags.host === 'boolean' ? flags.host : undefined,
-			open: typeof flags.open === 'boolean' ? flags.open : undefined,
+			open:
+				typeof flags.open === 'string' || typeof flags.open === 'boolean' ? flags.open : undefined,
 		},
 	};
 }

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -63,10 +63,11 @@ export function resolveFlags(flags: Partial<Flags>): CLIFlags {
 		site: typeof flags.site === 'string' ? flags.site : undefined,
 		base: typeof flags.base === 'string' ? flags.base : undefined,
 		port: typeof flags.port === 'number' ? flags.port : undefined,
-		open: typeof flags.open === 'boolean' ? flags.open : undefined,
 		config: typeof flags.config === 'string' ? flags.config : undefined,
 		host:
 			typeof flags.host === 'string' || typeof flags.host === 'boolean' ? flags.host : undefined,
+		open:
+			typeof flags.open === 'string' || typeof flags.open === 'boolean' ? flags.open : undefined,
 	};
 }
 

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -147,7 +147,10 @@ export const AstroConfigSchema = z.object({
 		// validate
 		z
 			.object({
-				open: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.server.open),
+				open: z
+					.union([z.string(), z.boolean()])
+					.optional()
+					.default(ASTRO_CONFIG_DEFAULTS.server.open),
 				host: z
 					.union([z.string(), z.boolean()])
 					.optional()
@@ -464,12 +467,15 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 			// validate
 			z
 				.object({
+					open: z
+						.union([z.string(), z.boolean()])
+						.optional()
+						.default(ASTRO_CONFIG_DEFAULTS.server.open),
 					host: z
 						.union([z.string(), z.boolean()])
 						.optional()
 						.default(ASTRO_CONFIG_DEFAULTS.server.host),
 					port: z.number().optional().default(ASTRO_CONFIG_DEFAULTS.server.port),
-					open: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.server.open),
 					headers: z.custom<OutgoingHttpHeaders>().optional(),
 					streaming: z.boolean().optional().default(true),
 				})

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -54,11 +54,13 @@ export async function createContainer({
 
 	const {
 		base,
-		server: { host, headers, open: shouldOpen },
+		server: { host, headers, open: serverOpen },
 	} = settings.config;
-	// Open server to the correct path
-	const open = shouldOpen ? base : false;
+	// Open server to the correct path. We pass the `base` here as we didn't pass the
+	// base to the initial Vite config
+	const open = typeof serverOpen == 'string' ? serverOpen : serverOpen ? base : false;
 
+	console.log(open)
 	// The client entrypoint for renderers. Since these are imported dynamically
 	// we need to tell Vite to preoptimize them.
 	const rendererClientEntries = settings.renderers


### PR DESCRIPTION
## Changes

close https://github.com/withastro/astro/issues/8192

Supports passing a url string to `server.open` and `--open` to open a specific URL in the browser on dev startup.

## Testing

Tested manually with the basic example. e.g. `pnpm dev --open /test`

## Docs

Updated the JSDoc for `server.open`.

Might need to also update: https://docs.astro.build/en/reference/cli-reference/#--open

`server.open` seems to not be documented, but probably should: https://docs.astro.build/en/reference/configuration-reference/#server-options

