### PR TITLE
Set default NODE_ENV for JS API

### DIFF
--- a/.changeset/six-bottles-mix.md
+++ b/.changeset/six-bottles-mix.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Sets correct `process.env.NODE_ENV` default when using the JS API

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -27,7 +27,7 @@ import * as msg from '../../core/messages.js';
 import { printHelp } from '../../core/messages.js';
 import { appendForwardSlash } from '../../core/path.js';
 import { apply as applyPolyfill } from '../../core/polyfill.js';
-import { parseNpmName } from '../../core/util.js';
+import { ensureProcessNodeEnv, parseNpmName } from '../../core/util.js';
 import { eventCliSession, telemetry } from '../../events/index.js';
 import { createLoggerFromFlags, flagsToAstroInlineConfig } from '../flags.js';
 import { generate, parse, t, visit } from './babel.js';
@@ -92,6 +92,7 @@ async function getRegistry(): Promise<string> {
 }
 
 export async function add(names: string[], { flags }: AddOptions) {
+	ensureProcessNodeEnv('production');
 	const inlineConfig = flagsToAstroInlineConfig(flags);
 	const { userConfig } = await resolveConfig(inlineConfig, 'add');
 	telemetry.record(eventCliSession('add', userConfig));

--- a/packages/astro/src/cli/check/index.ts
+++ b/packages/astro/src/cli/check/index.ts
@@ -2,8 +2,10 @@ import path from 'node:path';
 import type { Arguments } from 'yargs-parser';
 import { createLoggerFromFlags, flagsToAstroInlineConfig } from '../flags.js';
 import { getPackage } from '../install-package.js';
+import { ensureProcessNodeEnv } from '../../core/util.js';
 
 export async function check(flags: Arguments) {
+	ensureProcessNodeEnv('production');
 	const logger = createLoggerFromFlags(flags);
 	const getPackageOpts = { skipAsk: flags.yes || flags.y, cwd: flags.root };
 	const checkPackage = await getPackage<typeof import('@astrojs/check')>(

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -131,11 +131,6 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 		enableVerboseLogging();
 	}
 
-	// Start with a default NODE_ENV so Vite doesn't set an incorrect default when loading the Astro config
-	if (!process.env.NODE_ENV) {
-		process.env.NODE_ENV = cmd === 'dev' ? 'development' : 'production';
-	}
-
 	const { notify } = await import('./telemetry/index.js');
 	await notify();
 

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -33,6 +33,7 @@ import { collectPagesData } from './page-data.js';
 import { staticBuild, viteBuild } from './static-build.js';
 import type { StaticBuildOptions } from './types.js';
 import { getTimeStat } from './util.js';
+import { ensureProcessNodeEnv } from '../util.js';
 
 export interface BuildOptions {
 	/**
@@ -63,6 +64,7 @@ export default async function build(
 	inlineConfig: AstroInlineConfig,
 	options: BuildOptions = {}
 ): Promise<void> {
+	ensureProcessNodeEnv('production');
 	applyPolyfill();
 	const logger = createNodeLogger(inlineConfig);
 	const { userConfig, astroConfig } = await resolveConfig(inlineConfig, 'build');

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -10,6 +10,7 @@ import { telemetry } from '../../events/index.js';
 import * as msg from '../messages.js';
 import { startContainer } from './container.js';
 import { createContainerWithAutomaticRestart } from './restart.js';
+import { ensureProcessNodeEnv } from '../util.js';
 
 export interface DevServer {
 	address: AddressInfo;
@@ -25,6 +26,7 @@ export interface DevServer {
  * @experimental The JavaScript API is experimental
  */
 export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevServer> {
+	ensureProcessNodeEnv('development');
 	const devStart = performance.now();
 	await telemetry.record([]);
 

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -10,6 +10,7 @@ import { createNodeLogger } from '../config/logging.js';
 import { createSettings } from '../config/settings.js';
 import createStaticPreviewServer from './static-preview-server.js';
 import { getResolvedHostForHttpServer } from './util.js';
+import { ensureProcessNodeEnv } from '../util.js';
 
 /**
  * Starts a local server to serve your static dist/ directory. This command is useful for previewing
@@ -18,6 +19,7 @@ import { getResolvedHostForHttpServer } from './util.js';
  * @experimental The JavaScript API is experimental
  */
 export default async function preview(inlineConfig: AstroInlineConfig): Promise<PreviewServer> {
+	ensureProcessNodeEnv('production');
 	const logger = createNodeLogger(inlineConfig);
 	const { userConfig, astroConfig } = await resolveConfig(inlineConfig ?? {}, 'preview');
 	telemetry.record(eventCliSession('preview', userConfig));

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -17,6 +17,7 @@ import { createSettings } from '../config/settings.js';
 import { createVite } from '../create-vite.js';
 import { AstroError, AstroErrorData, createSafeError, isAstroError } from '../errors/index.js';
 import type { Logger } from '../logger/core.js';
+import { ensureProcessNodeEnv } from '../util.js';
 
 export type ProcessExit = 0 | 1;
 
@@ -41,6 +42,7 @@ export default async function sync(
 	inlineConfig: AstroInlineConfig,
 	options?: SyncOptions
 ): Promise<ProcessExit> {
+	ensureProcessNodeEnv('production');
 	const logger = createNodeLogger(inlineConfig);
 	const { userConfig, astroConfig } = await resolveConfig(inlineConfig ?? {}, 'sync');
 	telemetry.record(eventCliSession('sync', userConfig));

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -231,3 +231,12 @@ export function resolvePath(specifier: string, importer: string) {
 		return specifier;
 	}
 }
+
+/**
+ * Set a default NODE_ENV so Vite doesn't set an incorrect default when loading the Astro config
+ */
+export function ensureProcessNodeEnv(defaultNodeEnv: string) {
+	if (!process.env.NODE_ENV) {
+		process.env.NODE_ENV = defaultNodeEnv;
+	}
+}


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/9574

We set a fallback `process.env.NODE_ENV` in the CLI, but we didn't set it for manual JS API calls, causing cases where `build()` has `NODE_ENV` `"development"` instead due to we calling the Vite server to load the config, before we call the Vite build.

https://github.com/withastro/astro/blob/e496b2e3b84b673b81c872dad9a6b3f9dd32396a/packages/astro/src/cli/index.ts#L134-L138

This PR moves the above code to each individual JS API calls to fix it.

## Testing

Tried adding a unit test, but it's tricky to test `NODE_ENV` without actually executing the JS APIs, which can be a bit slow, and needs duplicated work from `test-utils.js` to tear it down.

I manually tested with the repro for now.

## Docs

n/a. `NODE_ENV` quirks prominently affects `import.meta.env.DEV` and `import.meta.env.PROD`. So I suppose those can be refered at https://vitejs.dev/guide/env-and-mode.html#node-env-and-modes already.
