### PR TITLE
quality of life updates for `App`

### DIFF
--- a/.changeset/cool-foxes-talk.md
+++ b/.changeset/cool-foxes-talk.md
@@ -1,0 +1,34 @@
+---
+"astro": minor
+---
+
+Adds new helper functions for integration developers.
+
+- Symbols used to represent `Astro.locals` and `Astro.clientAddress` are now available as static properties on the `App` class: `App.Symbol.locals` and `App.Symbol.clientAddress`.
+
+- `Astro.clientAddress` can now be passed directly to the `app.render()` method.
+```ts
+const response = await app.render(request, { clientAddress: "012.123.23.3" })
+```
+
+- Helper functions for converting node http request and response objects to web-compatible `Request` and `Response` objects are now provided as static methods on the `NodeApp` class.
+```ts
+http.createServer((nodeReq, nodeRes) => {
+    const request: Request = NodeApp.createRequest(nodeReq)
+    const response = await app.render(request)
+    NodeApp.writeResponse(response, nodeRes)
+})
+```
+
+- Cookies added via `Astro.cookies.set()` can now be automatically added to the `Response` object by passing the `addCookieHeader` option to `app.render()`.
+```diff
+-const response = await app.render(request)
+-const setCookieHeaders: Array<string> = Array.from(app.setCookieHeaders(webResponse));
+
+-if (setCookieHeaders.length) {
+-    for (const setCookieHeader of setCookieHeaders) {
+-        headers.append('set-cookie', setCookieHeader);
+-    }
+-}
++const response = await app.render(request, { addCookieHeader: true })
+```

--- a/.changeset/cool-foxes-talk.md
+++ b/.changeset/cool-foxes-talk.md
@@ -2,7 +2,7 @@
 "astro": minor
 ---
 
-Adds new helper functions for integration developers.
+Adds new helper functions for adapter developers.
 
 - Symbols used to represent `Astro.locals` and `Astro.clientAddress` are now available as static properties on the `App` class: `App.Symbol.locals` and `App.Symbol.clientAddress`.
 
@@ -11,7 +11,7 @@ Adds new helper functions for integration developers.
 const response = await app.render(request, { clientAddress: "012.123.23.3" })
 ```
 
-- Helper functions for converting node http request and response objects to web-compatible `Request` and `Response` objects are now provided as static methods on the `NodeApp` class.
+- Helper functions for converting Node.js HTTP request and response objects to web-compatible `Request` and `Response` objects are now provided as static methods on the `NodeApp` class.
 ```ts
 http.createServer((nodeReq, nodeRes) => {
     const request: Request = NodeApp.createRequest(nodeReq)

--- a/packages/astro/src/core/app/createOutgoingHttpHeaders.ts
+++ b/packages/astro/src/core/app/createOutgoingHttpHeaders.ts
@@ -1,0 +1,34 @@
+import type { OutgoingHttpHeaders } from 'node:http';
+
+/**
+ * Takes in a nullable WebAPI Headers object and produces a NodeJS OutgoingHttpHeaders object suitable for usage
+ * with ServerResponse.writeHead(..) or ServerResponse.setHeader(..)
+ *
+ * @param headers WebAPI Headers object
+ * @returns {OutgoingHttpHeaders} NodeJS OutgoingHttpHeaders object with multiple set-cookie handled as an array of values
+ */
+export const createOutgoingHttpHeaders = (
+	headers: Headers | undefined | null
+): OutgoingHttpHeaders | undefined => {
+	if (!headers) {
+		return undefined;
+	}
+
+	// at this point, a multi-value'd set-cookie header is invalid (it was concatenated as a single CSV, which is not valid for set-cookie)
+	const nodeHeaders: OutgoingHttpHeaders = Object.fromEntries(headers.entries());
+
+	if (Object.keys(nodeHeaders).length === 0) {
+		return undefined;
+	}
+
+	// if there is > 1 set-cookie header, we have to fix it to be an array of values
+	if (headers.has('set-cookie')) {
+		const cookieHeaders = headers.getSetCookie();
+		if (cookieHeaders.length > 1) {
+			// the Headers.entries() API already normalized all header names to lower case so we can safely index this as 'set-cookie'
+			nodeHeaders['set-cookie'] = cookieHeaders;
+		}
+	}
+
+	return nodeHeaders;
+};

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -29,15 +29,44 @@ import { EndpointNotFoundError, SSRRoutePipeline } from './ssrPipeline.js';
 import type { RouteInfo } from './types.js';
 export { deserializeManifest } from './common.js';
 
-const clientLocalsSymbol = Symbol.for('astro.locals');
-
 const responseSentSymbol = Symbol.for('astro.responseSent');
 
-const STATUS_CODES = new Set([404, 500]);
+/**
+ * A response with one of these status codes will be rewritten
+ * with the result of rendering the respective error page.
+ */
+const REROUTABLE_STATUS_CODES = new Set([404, 500]);
 
 export interface RenderOptions {
-	routeData?: RouteData;
+	/**
+	 * Whether to automatically add all cookies written by `Astro.cookie.set()` to the response headers.
+	 * 
+	 * When set to `true`, they will be added to the `Set-Cookie` header as comma-separated key=value pairs. You can use the standard `response.headers.getSetCookie()` API to read them individually.
+	 * 
+	 * When set to `false`, the cookies will only be available from `App.getSetCookieFromResponse(response)`.
+	 * 
+	 * Default: `false`
+	 */
+	addCookieHeader?: boolean;
+
+	/**
+	 * The client IP address that will be made available as `Astro.clientAddress` in pages, and as `ctx.clientAddress` in API routes and middleware.
+	 * 
+	 * Default: `request[Symbol.for("astro.clientAddress")]`
+	 */
+	clientAddress?: string;
+
+	/**
+	 * The mutable object that will be made available as `Astro.locals` in pages, and as `ctx.locals` in API routes and middleware.
+	 */
 	locals?: object;
+
+	/**
+	 * **Advanced API**: you probably do not need to use this.
+	 * 
+	 * Default: `app.match(request)`
+	 */
+	routeData?: RouteData;
 }
 
 export interface RenderErrorOptions {
@@ -51,6 +80,15 @@ export interface RenderErrorOptions {
 }
 
 export class App {
+
+	/**
+	 * Symbols that the Astro app reads on the passed Request instance. Use these when you can't directly provide these values to `app.render()`.
+	 */
+	static readonly Symbol = Object.freeze({
+		locals: Symbol.for('astro.locals'),
+		clientAddress: Symbol.for('astro.clientAddress'),
+	})
+
 	/**
 	 * The current environment of the application
 	 */
@@ -178,7 +216,16 @@ export class App {
 				this.#logRenderOptionsDeprecationWarning();
 			}
 		}
-
+		if (locals) {
+			Reflect.set(request, App.Symbol.locals, locals);
+		}
+		if (
+			typeof routeDataOrOptions === "object" &&
+			"clientAddress" in routeDataOrOptions &&
+			routeDataOrOptions.clientAddress
+		) {
+			Reflect.set(request, App.Symbol.clientAddress, routeDataOrOptions.clientAddress)
+		}
 		// Handle requests with duplicate slashes gracefully by cloning with a cleaned-up request URL
 		if (request.url !== collapseDuplicateSlashes(request.url)) {
 			request = new Request(collapseDuplicateSlashes(request.url), request);
@@ -189,7 +236,6 @@ export class App {
 		if (!routeData) {
 			return this.#renderError(request, { status: 404 });
 		}
-		Reflect.set(request, clientLocalsSymbol, locals ?? {});
 		const pathname = this.#getPathnameFromRequest(request);
 		const defaultStatus = this.#getDefaultStatusCode(routeData, pathname);
 		const mod = await this.#getModuleForRoute(routeData);
@@ -206,7 +252,7 @@ export class App {
 		);
 		let response;
 		try {
-			let i18nMiddleware = createI18nMiddleware(
+			const i18nMiddleware = createI18nMiddleware(
 				this.#manifest.i18n,
 				this.#manifest.base,
 				this.#manifest.trailingSlash
@@ -233,16 +279,23 @@ export class App {
 			}
 		}
 
+		// endpoints do not participate in implicit rerouting
 		if (routeData.type === 'page' || routeData.type === 'redirect') {
-			if (STATUS_CODES.has(response.status)) {
+			if (REROUTABLE_STATUS_CODES.has(response.status)) {
 				return this.#renderError(request, {
 					response,
 					status: response.status as 404 | 500,
 				});
 			}
-			Reflect.set(response, responseSentSymbol, true);
-			return response;
 		}
+		if (
+			typeof routeDataOrOptions === "object" &&
+			"addCookieHeader" in routeDataOrOptions &&
+			routeDataOrOptions.addCookieHeader
+		) {
+			App.#addCookieHeader(response);
+		}
+		Reflect.set(response, responseSentSymbol, true);
 		return response;
 	}
 
@@ -257,6 +310,25 @@ export class App {
 
 	setCookieHeaders(response: Response) {
 		return getSetCookiesFromResponse(response);
+	}
+
+	/**
+	 * Reads all the cookies written by `Astro.cookie.set()` onto the passed response.
+	 * For example,
+	 * ```ts
+	 * for (const cookie_ of App.getSetCookiesFromResponse(response)) {
+	 *     const cookie: string = cookie_
+	 * }
+	 * ```
+	 * @param response The response to read cookies from.
+	 * @returns An iterator that yields key-value pairs as equal-sign-separated strings.
+	 */
+	static getSetCookieFromResponse = getSetCookiesFromResponse
+
+	static #addCookieHeader(response: Response) {
+		for (const setCookieHeaderValue of getSetCookiesFromResponse(response)) {
+			response.headers.append('set-cookie', setCookieHeaderValue);
+		}
 	}
 
 	/**

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -45,7 +45,7 @@ export interface RenderOptions {
 	 * 
 	 * When set to `false`, the cookies will only be available from `App.getSetCookieFromResponse(response)`.
 	 * 
-	 * Default: `false`
+	 * @default {false}
 	 */
 	addCookieHeader?: boolean;
 

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -173,8 +173,8 @@ export async function loadApp(rootFolder: URL): Promise<NodeApp> {
  * Takes in a nullable WebAPI Headers object and produces a NodeJS OutgoingHttpHeaders object suitable for usage
  * with ServerResponse.writeHead(..) or ServerResponse.setHeader(..)
  *
- * @param webHeaders WebAPI Headers object
- * @returns NodeJS OutgoingHttpHeaders object with multiple set-cookie handled as an array of values
+ * @param headers WebAPI Headers object
+ * @returns {OutgoingHttpHeaders} NodeJS OutgoingHttpHeaders object with multiple set-cookie handled as an array of values
  */
 export const createOutgoingHttpHeaders = (
 	headers: Headers | undefined | null

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -16,8 +16,6 @@ interface NodeRequest extends IncomingMessage {
 	body?: unknown;
 }
 
-const addCookieHeader = true;
-
 export class NodeApp extends App {
 	match(req: NodeRequest | Request) {
 		if (!(req instanceof Request)) {
@@ -51,6 +49,16 @@ export class NodeApp extends App {
 
 	/**
 	 * Converts a NodeJS IncomingMessage into a web standard Request.
+	 * ```js
+	 * import { NodeApp } from 'astro/app/node';
+	 * import { createServer } from 'node:http';
+	 * 
+	 * const server = createServer(async (req, res) => {
+     *     const request = NodeApp.createRequest(req);
+     *     const response = await app.render(request);
+     *     await NodeApp.writeResponse(response, res);
+	 * })
+	 * ```
 	 */
 	static createRequest(
 		req: NodeRequest,
@@ -77,6 +85,16 @@ export class NodeApp extends App {
 
 	/**
 	 * Streams a web-standard Response into a NodeJS Server Response.
+	 * ```js
+	 * import { NodeApp } from 'astro/app/node';
+	 * import { createServer } from 'node:http';
+	 * 
+	 * const server = createServer(async (req, res) => {
+     *     const request = NodeApp.createRequest(req);
+     *     const response = await app.render(request);
+     *     await NodeApp.writeResponse(response, res);
+	 * })
+	 * ```
 	 * @param source WhatWG Response 
 	 * @param destination NodeJS ServerResponse
 	 */

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import { App } from './index.js';
 import { deserializeManifest } from './common.js';
-import type { IncomingMessage, ServerResponse, OutgoingHttpHeaders } from 'node:http';
+import { createOutgoingHttpHeaders } from './createOutgoingHttpHeaders.js';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { RouteData } from '../../@types/astro.js';
 import type { RenderOptions } from './index.js';
 import type { SerializedSSRManifest, SSRManifest } from './types.js';
@@ -186,36 +187,3 @@ export async function loadApp(rootFolder: URL): Promise<NodeApp> {
 	const manifest = await loadManifest(rootFolder);
 	return new NodeApp(manifest);
 }
-
-/**
- * Takes in a nullable WebAPI Headers object and produces a NodeJS OutgoingHttpHeaders object suitable for usage
- * with ServerResponse.writeHead(..) or ServerResponse.setHeader(..)
- *
- * @param headers WebAPI Headers object
- * @returns {OutgoingHttpHeaders} NodeJS OutgoingHttpHeaders object with multiple set-cookie handled as an array of values
- */
-export const createOutgoingHttpHeaders = (
-	headers: Headers | undefined | null
-): OutgoingHttpHeaders | undefined => {
-	if (!headers) {
-		return undefined;
-	}
-
-	// at this point, a multi-value'd set-cookie header is invalid (it was concatenated as a single CSV, which is not valid for set-cookie)
-	const nodeHeaders: OutgoingHttpHeaders = Object.fromEntries(headers.entries());
-
-	if (Object.keys(nodeHeaders).length === 0) {
-		return undefined;
-	}
-
-	// if there is > 1 set-cookie header, we have to fix it to be an array of values
-	if (headers.has('set-cookie')) {
-		const cookieHeaders = headers.getSetCookie();
-		if (cookieHeaders.length > 1) {
-			// the Headers.entries() API already normalized all header names to lower case so we can safely index this as 'set-cookie'
-			nodeHeaders['set-cookie'] = cookieHeaders;
-		}
-	}
-
-	return nodeHeaders;
-};

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -1,51 +1,109 @@
+import fs from 'node:fs';
+import { App } from './index.js';
+import { deserializeManifest } from './common.js';
+import type { IncomingMessage, ServerResponse, OutgoingHttpHeaders } from 'node:http';
 import type { RouteData } from '../../@types/astro.js';
 import type { RenderOptions } from './index.js';
 import type { SerializedSSRManifest, SSRManifest } from './types.js';
 
-import * as fs from 'node:fs';
-import { IncomingMessage } from 'node:http';
-import { TLSSocket } from 'node:tls';
-import { deserializeManifest } from './common.js';
-import { App } from './index.js';
 export { apply as applyPolyfills } from '../polyfill.js';
 
-const clientAddressSymbol = Symbol.for('astro.clientAddress');
-
-type CreateNodeRequestOptions = {
-	emptyBody?: boolean;
-};
-
-type BodyProps = Partial<RequestInit>;
-
-function createRequestFromNodeRequest(
-	req: NodeIncomingMessage,
-	options?: CreateNodeRequestOptions
-): Request {
-	const protocol =
-		req.socket instanceof TLSSocket || req.headers['x-forwarded-proto'] === 'https'
-			? 'https'
-			: 'http';
-	const hostname = req.headers.host || req.headers[':authority'];
-	const url = `${protocol}://${hostname}${req.url}`;
-	const headers = makeRequestHeaders(req);
-	const method = req.method || 'GET';
-	let bodyProps: BodyProps = {};
-	const bodyAllowed = method !== 'HEAD' && method !== 'GET' && !options?.emptyBody;
-	if (bodyAllowed) {
-		bodyProps = makeRequestBody(req);
-	}
-	const request = new Request(url, {
-		method,
-		headers,
-		...bodyProps,
-	});
-	if (req.socket?.remoteAddress) {
-		Reflect.set(request, clientAddressSymbol, req.socket.remoteAddress);
-	}
-	return request;
+/**
+ * Allow the request body to be explicitly overridden. For example, this
+ * is used by the Express JSON middleware.
+ */
+interface NodeRequest extends IncomingMessage {
+	body?: unknown;
 }
 
-function makeRequestHeaders(req: NodeIncomingMessage): Headers {
+const addCookieHeader = true;
+
+export class NodeApp extends App {
+	match(req: NodeRequest | Request) {
+		if (!(req instanceof Request)) {
+			req = NodeApp.createRequest(req, {
+				skipBody: true,
+			});
+		}
+		return super.match(req);
+	}
+	render(request: NodeRequest | Request, options?: RenderOptions): Promise<Response>;
+	/**
+	 * @deprecated Instead of passing `RouteData` and locals individually, pass an object with `routeData` and `locals` properties.
+	 * See https://github.com/withastro/astro/pull/9199 for more information.
+	 */
+	render(
+		request: NodeRequest | Request,
+		routeData?: RouteData,
+		locals?: object
+	): Promise<Response>;
+	render(
+		req: NodeRequest | Request,
+		routeDataOrOptions?: RouteData | RenderOptions,
+		maybeLocals?: object
+	) {
+		if (!(req instanceof Request)) {
+			req = NodeApp.createRequest(req);
+		}
+		// @ts-expect-error The call would have succeeded against the implementation, but implementation signatures of overloads are not externally visible.
+		return super.render(req, routeDataOrOptions, maybeLocals);
+	}
+
+	/**
+	 * Converts a NodeJS IncomingMessage into a web standard Request.
+	 */
+	static createRequest(
+		req: NodeRequest,
+		{ skipBody = false } = {}
+	): Request {
+		const protocol = req.headers['x-forwarded-proto'] ??
+			('encrypted' in req.socket && req.socket.encrypted ? 'https' : 'http');
+		const hostname = req.headers.host || req.headers[':authority'];
+		const url = `${protocol}://${hostname}${req.url}`;
+		const options: RequestInit = {
+			method: req.method || 'GET',
+			headers: makeRequestHeaders(req),
+		}
+		const bodyAllowed = options.method !== 'HEAD' && options.method !== 'GET' && skipBody === false;
+		if (bodyAllowed) {
+			Object.assign(options, makeRequestBody(req));
+		}
+		const request = new Request(url, options);
+		if (req.socket?.remoteAddress) {
+			Reflect.set(request, App.Symbol.clientAddress, req.socket.remoteAddress);
+		}
+		return request;
+	}
+
+	/**
+	 * Streams a web-standard Response into a NodeJS Server Response.
+	 * @param source WhatWG Response 
+	 * @param destination NodeJS ServerResponse
+	 */
+	static async writeResponse(source: Response, destination: ServerResponse) {
+		const { status, headers, body } = source;
+		destination.writeHead(status, createOutgoingHttpHeaders(headers));
+		if (body) {
+			try {
+				const reader = body.getReader();
+				destination.on('close', () => {
+					reader.cancel();
+				});
+				let result = await reader.read();
+				while (!result.done) {
+					destination.write(result.value);
+					result = await reader.read();
+				}
+			} catch (err: any) {
+				console.error(err?.stack || err?.message || String(err));
+				destination.write('Internal server error');
+			}
+		}
+		destination.end();
+	};
+}
+
+function makeRequestHeaders(req: NodeRequest): Headers {
 	const headers = new Headers();
 	for (const [name, value] of Object.entries(req.headers)) {
 		if (value === undefined) {
@@ -62,7 +120,7 @@ function makeRequestHeaders(req: NodeIncomingMessage): Headers {
 	return headers;
 }
 
-function makeRequestBody(req: NodeIncomingMessage): BodyProps {
+function makeRequestBody(req: NodeRequest): RequestInit {
 	if (req.body !== undefined) {
 		if (typeof req.body === 'string' && req.body.length > 0) {
 			return { body: Buffer.from(req.body) };
@@ -86,7 +144,7 @@ function makeRequestBody(req: NodeIncomingMessage): BodyProps {
 	return asyncIterableToBodyProps(req);
 }
 
-function asyncIterableToBodyProps(iterable: AsyncIterable<any>): BodyProps {
+function asyncIterableToBodyProps(iterable: AsyncIterable<any>): RequestInit {
 	return {
 		// Node uses undici for the Request implementation. Undici accepts
 		// a non-standard async iterable for the body.
@@ -95,49 +153,8 @@ function asyncIterableToBodyProps(iterable: AsyncIterable<any>): BodyProps {
 		// The duplex property is required when using a ReadableStream or async
 		// iterable for the body. The type definitions do not include the duplex
 		// property because they are not up-to-date.
-		// @ts-expect-error
 		duplex: 'half',
-	} satisfies BodyProps;
-}
-
-class NodeIncomingMessage extends IncomingMessage {
-	/**
-	 * Allow the request body to be explicitly overridden. For example, this
-	 * is used by the Express JSON middleware.
-	 */
-	body?: unknown;
-}
-
-export class NodeApp extends App {
-	match(req: NodeIncomingMessage | Request) {
-		if (!(req instanceof Request)) {
-			req = createRequestFromNodeRequest(req, {
-				emptyBody: true,
-			});
-		}
-		return super.match(req);
-	}
-	render(request: NodeIncomingMessage | Request, options?: RenderOptions): Promise<Response>;
-	/**
-	 * @deprecated Instead of passing `RouteData` and locals individually, pass an object with `routeData` and `locals` properties.
-	 * See https://github.com/withastro/astro/pull/9199 for more information.
-	 */
-	render(
-		request: NodeIncomingMessage | Request,
-		routeData?: RouteData,
-		locals?: object
-	): Promise<Response>;
-	render(
-		req: NodeIncomingMessage | Request,
-		routeDataOrOptions?: RouteData | RenderOptions,
-		maybeLocals?: object
-	) {
-		if (!(req instanceof Request)) {
-			req = createRequestFromNodeRequest(req);
-		}
-		// @ts-expect-error The call would have succeeded against the implementation, but implementation signatures of overloads are not externally visible.
-		return super.render(req, routeDataOrOptions, maybeLocals);
-	}
+	};
 }
 
 export async function loadManifest(rootFolder: URL): Promise<SSRManifest> {
@@ -151,3 +168,36 @@ export async function loadApp(rootFolder: URL): Promise<NodeApp> {
 	const manifest = await loadManifest(rootFolder);
 	return new NodeApp(manifest);
 }
+
+/**
+ * Takes in a nullable WebAPI Headers object and produces a NodeJS OutgoingHttpHeaders object suitable for usage
+ * with ServerResponse.writeHead(..) or ServerResponse.setHeader(..)
+ *
+ * @param webHeaders WebAPI Headers object
+ * @returns NodeJS OutgoingHttpHeaders object with multiple set-cookie handled as an array of values
+ */
+export const createOutgoingHttpHeaders = (
+	headers: Headers | undefined | null
+): OutgoingHttpHeaders | undefined => {
+	if (!headers) {
+		return undefined;
+	}
+
+	// at this point, a multi-value'd set-cookie header is invalid (it was concatenated as a single CSV, which is not valid for set-cookie)
+	const nodeHeaders: OutgoingHttpHeaders = Object.fromEntries(headers.entries());
+
+	if (Object.keys(nodeHeaders).length === 0) {
+		return undefined;
+	}
+
+	// if there is > 1 set-cookie header, we have to fix it to be an array of values
+	if (headers.has('set-cookie')) {
+		const cookieHeaders = headers.getSetCookie();
+		if (cookieHeaders.length > 1) {
+			// the Headers.entries() API already normalized all header names to lower case so we can safely index this as 'set-cookie'
+			nodeHeaders['set-cookie'] = cookieHeaders;
+		}
+	}
+
+	return nodeHeaders;
+};

--- a/packages/astro/test/astro-cookies.test.js
+++ b/packages/astro/test/astro-cookies.test.js
@@ -89,6 +89,24 @@ describe('Astro.cookies', () => {
 			expect(headers[0]).to.match(/Expires/);
 		});
 
+		it('app.render can include the cookie in the Set-Cookie header', async () => {
+			const request = new Request('http://example.com/set-value', {
+				method: 'POST',
+			});
+			const response = await app.render(request, { addCookieHeader: true })
+			expect(response.status).to.equal(200);
+			expect(response.headers.get("Set-Cookie")).to.be.a('string').and.satisfy(value => value.startsWith("admin=true; Expires="));
+		});
+
+		it('app.render can exclude the cookie from the Set-Cookie header', async () => {
+			const request = new Request('http://example.com/set-value', {
+				method: 'POST',
+			});
+			const response = await app.render(request, { addCookieHeader: false })
+			expect(response.status).to.equal(200);
+			expect(response.headers.get("Set-Cookie")).to.equal(null);
+		});
+
 		it('Early returning a Response still includes set headers', async () => {
 			const response = await fetchResponse('/early-return', {
 				headers: {

--- a/packages/astro/test/client-address.test.js
+++ b/packages/astro/test/client-address.test.js
@@ -29,6 +29,15 @@ describe('Astro.clientAddress', () => {
 				const $ = cheerio.load(html);
 				expect($('#address').text()).to.equal('0.0.0.0');
 			});
+
+			it('app.render can provide the address', async () => {
+				const app = await fixture.loadTestAdapterApp();
+				const request = new Request('http://example.com/');
+				const response = await app.render(request, { clientAddress: "1.1.1.1" });
+				const html = await response.text();
+				const $ = cheerio.load(html);
+				expect($('#address').text()).to.equal('1.1.1.1');
+			});
 		});
 
 		describe('Development', () => {

--- a/packages/astro/test/units/app/headers.test.js
+++ b/packages/astro/test/units/app/headers.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { createOutgoingHttpHeaders } from '../dist/createOutgoingHttpHeaders.js';
+import { createOutgoingHttpHeaders } from '../../../dist/core/app/createOutgoingHttpHeaders.js';
 
 describe('createOutgoingHttpHeaders', () => {
 	it('undefined input headers', async () => {


### PR DESCRIPTION
## Why?
This came from working on 5 adapters over the past month. The logic for dealing with cookies and `node:http` is always duplicated. `NodeApp` takes care of converting the request, but the logic of converting response is duplicated across the node and the vercel adapters. Cookies had to be handled manually for legacy reasons (I think), but all adapters we maintain are now doing the same thing.

## Changes
- Exposes well-known symbols as a static property on App. (`App.Symbol.locals`, `App.Symbol.clientAddress`)
- Adds helper functions for node-based runtimes to manage WHATWG Request and Response objects as static methods on `NodeApp`.
- `App.getSetCookieFromResponse()` in favor of `app.setCookieHeaders()` (confusing name)
- `app.render(request, { addCookieHeader: true })`


## Testing
Tests for most of the functionality here are already present. This PR only exposes the APIs on App and NodeApp to prevent duplication across adapters.

## Docs
_Pending_