### PR TITLE
Fixes titles in the browser's dropdown for back / forwards traversals through the browser history

### DIFF
--- a/.changeset/silent-rabbits-cross.md
+++ b/.changeset/silent-rabbits-cross.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes page titles in the browser's drop-down for back / forward navigation when using view transitions 
+Fixes page titles in the browser's drop-down for back / forward navigation when using view transitions

--- a/.changeset/silent-rabbits-cross.md
+++ b/.changeset/silent-rabbits-cross.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes titles in the browser's dropdown for back / forwards traversals through the browser history
+Fixes page titles in the browser's drop-down for back / forward navigation when using view transitions 

--- a/.changeset/silent-rabbits-cross.md
+++ b/.changeset/silent-rabbits-cross.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes titles in the browser's dropdown for back / forwards traversals through the browser history

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -170,8 +170,17 @@ function runScripts() {
 
 // Add a new entry to the browser history. This also sets the new page in the browser addressbar.
 // Sets the scroll position according to the hash fragment of the new location.
-const moveToLocation = (to: URL, from: URL, options: Options, historyState?: State) => {
+const moveToLocation = (
+	to: URL,
+	from: URL,
+	options: Options,
+	historyTitle: string,
+	historyState?: State
+) => {
 	const intraPage = samePage(from, to);
+
+	const savedDocumentTitle = document.title;
+	document.title = historyTitle;
 
 	let scrolledToTop = false;
 	if (to.href !== location.href && !historyState) {
@@ -223,6 +232,7 @@ const moveToLocation = (to: URL, from: URL, options: Options, historyState?: Sta
 		}
 		history.scrollRestoration = 'manual';
 	}
+	document.title = savedDocumentTitle;
 };
 
 function preloadStyleLinks(newDocument: Document) {
@@ -409,8 +419,9 @@ async function updateDOM(
 		throw new DOMException('Transition was skipped');
 	}
 
+	const historyTitle = document.title; // document.title will be overridden by swap()
 	const swapEvent = await doSwap(preparationEvent, viewTransition!, defaultSwap);
-	moveToLocation(swapEvent.to, swapEvent.from, options, historyState);
+	moveToLocation(swapEvent.to, swapEvent.from, options, historyTitle, historyState);
 	triggerEvent(TRANSITION_AFTER_SWAP);
 
 	if (fallback === 'animate' && !skipTransition) {
@@ -441,7 +452,7 @@ async function transition(
 		updateScrollPosition({ scrollX, scrollY });
 	}
 	if (samePage(from, to) && !!to.hash) {
-		moveToLocation(to, from, options, historyState);
+		moveToLocation(to, from, options, document.title, historyState);
 		return;
 	}
 

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -174,13 +174,13 @@ const moveToLocation = (
 	to: URL,
 	from: URL,
 	options: Options,
-	historyTitle: string,
+	pageTitleForBrowserHistory: string,
 	historyState?: State
 ) => {
 	const intraPage = samePage(from, to);
 
-	const savedDocumentTitle = document.title;
-	document.title = historyTitle;
+	const targetPageTitle = document.title;
+	document.title = pageTitleForBrowserHistory;
 
 	let scrolledToTop = false;
 	if (to.href !== location.href && !historyState) {
@@ -232,7 +232,7 @@ const moveToLocation = (
 		}
 		history.scrollRestoration = 'manual';
 	}
-	document.title = savedDocumentTitle;
+	document.title = targetPageTitle;
 };
 
 function preloadStyleLinks(newDocument: Document) {
@@ -419,9 +419,9 @@ async function updateDOM(
 		throw new DOMException('Transition was skipped');
 	}
 
-	const historyTitle = document.title; // document.title will be overridden by swap()
+	const pageTitleForBrowserHistory = document.title; // document.title will be overridden by swap()
 	const swapEvent = await doSwap(preparationEvent, viewTransition!, defaultSwap);
-	moveToLocation(swapEvent.to, swapEvent.from, options, historyTitle, historyState);
+	moveToLocation(swapEvent.to, swapEvent.from, options, pageTitleForBrowserHistory, historyState);
 	triggerEvent(TRANSITION_AFTER_SWAP);
 
 	if (fallback === 'animate' && !skipTransition) {


### PR DESCRIPTION
## Changes

It's strange that nobody has complained yet:
The page titles displayed in the browser UI drop-downs for the history navigation were off by one because we call `pushState()` only after the DOM swap during view transitions. 

One way to fix this would be to update the history before the swap. However, I prefer to keep history management and scroll restoration together as they are interdependent. And reaching the scroll target position may not be possible until after the swap. 

Therefore, the original page title is now saved before the swap and used later when updating the history.

# Testing
Manually tested.
No idea how to automatically test this. 

## Docs
n.a. bug fix