### PR TITLE
feat: add extendable `CSSProperties` interface

### DIFF
--- a/.changeset/slow-kiwis-own.md
+++ b/.changeset/slow-kiwis-own.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Add extendable `CSSProperties` interface to style attribute

--- a/.changeset/slow-kiwis-own.md
+++ b/.changeset/slow-kiwis-own.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Add extendable `CSSProperties` interface to style attribute
+Adds a `CSSProperties` interface that allows extending the style attribute

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -499,6 +499,15 @@ declare namespace astroHTML.JSX {
 		KebabCSSDOMProperties & DOMCSSProperties & AllCSSProperties
 	>;
 
+	interface CSSProperties extends StyleObject {
+		/**
+		 * Extend namespace to add properties or an index signature of your own.
+		 *
+		 * For more information, visit:
+		 * https://docs.astro.build/en/guides/typescript/#built-in-html-attributes
+		 */
+	}
+
 	interface HTMLAttributes extends AriaAttributes, DOMAttributes, AstroBuiltinAttributes {
 		// Standard HTML Attributes
 		accesskey?: string | undefined | null;
@@ -547,7 +556,7 @@ declare namespace astroHTML.JSX {
 		popover?: boolean | string | undefined | null;
 		slot?: string | undefined | null;
 		spellcheck?: 'true' | 'false' | boolean | undefined | null;
-		style?: string | StyleObject | undefined | null;
+		style?: string | CSSProperties | undefined | null;
 		tabindex?: number | string | undefined | null;
 		title?: string | undefined | null;
 		translate?: 'yes' | 'no' | '' | undefined | null;


### PR DESCRIPTION
## Changes

Adds a `CSSProperties` interface to the `style` attribute that consumers can extend to add their own custom properties. This matches the approach from other frameworks, e.g React and SolidJS.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I can't seem to find tests for the types, but please do point me in the right direction if they exist somewhere.


https://github.com/withastro/astro/assets/175330/15a84647-8d15-4d5f-8948-cacc7d3ddd95



## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->

https://github.com/withastro/docs/pull/6062

/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
