### PR TITLE
fix(vercel): include 404.html as fallback in the static adapter

### DIFF
--- a/.changeset/brown-turtles-invite.md
+++ b/.changeset/brown-turtles-invite.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vercel": patch
+---
+
+Fixes an issue where 404.astro was not used in static mode.

--- a/packages/integrations/vercel/src/static/adapter.ts
+++ b/packages/integrations/vercel/src/static/adapter.ts
@@ -118,6 +118,11 @@ export default function vercelStatic({
 							continue: true,
 						},
 						{ handle: 'filesystem' },
+						{
+							src: `/*`,
+							dest: `/404.html`,
+							status: 404,
+						}
 					],
 					...(imageService || imagesConfig
 						? {

--- a/packages/integrations/vercel/src/static/adapter.ts
+++ b/packages/integrations/vercel/src/static/adapter.ts
@@ -118,11 +118,11 @@ export default function vercelStatic({
 							continue: true,
 						},
 						{ handle: 'filesystem' },
-						{
-							src: `/*`,
+						...routes.find(route => route.component.endsWith("/pages/404.astro")) ? [{
+							src: `/.*`,
 							dest: `/404.html`,
 							status: 404,
-						}
+						}] : [],
 					],
 					...(imageService || imagesConfig
 						? {

--- a/packages/integrations/vercel/src/static/adapter.ts
+++ b/packages/integrations/vercel/src/static/adapter.ts
@@ -118,7 +118,7 @@ export default function vercelStatic({
 							continue: true,
 						},
 						{ handle: 'filesystem' },
-						...routes.find(route => route.component.endsWith("/pages/404.astro")) ? [{
+						...routes.find(route => route.pathname === "/404") ? [{
 							src: `/.*`,
 							dest: `/404.html`,
 							status: 404,

--- a/packages/integrations/vercel/test/fixtures/static/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/static/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+import vercel from '@astrojs/vercel/static';
+
+export default defineConfig({
+	adapter: vercel()
+});

--- a/packages/integrations/vercel/test/fixtures/static/package.json
+++ b/packages/integrations/vercel/test/fixtures/static/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/astro-vercel-static",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/vercel": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/vercel/test/fixtures/static/src/pages/404.astro
+++ b/packages/integrations/vercel/test/fixtures/static/src/pages/404.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>404</title>
+	</head>
+	<body>
+		<h1>404</h1>
+	</body>
+</html>

--- a/packages/integrations/vercel/test/fixtures/static/src/pages/one.astro
+++ b/packages/integrations/vercel/test/fixtures/static/src/pages/one.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>One</title>
+	</head>
+	<body>
+		<h1>One</h1>
+	</body>
+</html>

--- a/packages/integrations/vercel/test/fixtures/static/src/pages/two.astro
+++ b/packages/integrations/vercel/test/fixtures/static/src/pages/two.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>Two</title>
+	</head>
+	<body>
+		<h1>Two</h1>
+	</body>
+</html>

--- a/packages/integrations/vercel/test/static.test.js
+++ b/packages/integrations/vercel/test/static.test.js
@@ -1,0 +1,26 @@
+import { loadFixture } from './test-utils.js';
+import { expect } from 'chai';
+
+describe('maxDuration', () => {
+	/** @type {import('./test-utils.js').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/static/',
+		});
+		await fixture.build();
+	});
+
+	it('falls back to 404.html', async () => {
+		const deploymentConfig = JSON.parse(
+			await fixture.readFile('../.vercel/output/config.json')
+		);
+		// change the index if necesseary
+		expect(deploymentConfig.routes[2]).to.deep.include({
+			src: '/.*',
+			dest: '/404.html',
+			status: 404
+		});
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4767,6 +4767,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/vercel/test/fixtures/static:
+    dependencies:
+      '@astrojs/vercel':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/vercel/test/fixtures/static-assets:
     dependencies:
       '@astrojs/vercel':


### PR DESCRIPTION
## Changes
- Closes #9578

## Testing
Added `static.test.js` along with a fixture.

## Docs
Does not affect behavior.