### PR TITLE
Improve astro add deps error reporting

### DIFF
--- a/.changeset/afraid-socks-rescue.md
+++ b/.changeset/afraid-socks-rescue.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Improves `astro add` error reporting when the dependencies fail to install

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -732,11 +732,12 @@ async function tryToInstallIntegrations({
 				);
 				spinner.succeed();
 				return UpdateResult.updated;
-			} catch (err) {
+			} catch (err: any) {
 				spinner.fail();
 				logger.debug('add', 'Error installing dependencies', err);
+				// NOTE: `err.stdout` can be an empty string, so log the full error instead for a more helpful log
 				// eslint-disable-next-line no-console
-				console.error('\n', (err as any).stdout, '\n');
+				console.error('\n', err.stdout || err.message, '\n');
 				return UpdateResult.failure;
 			}
 		} else {


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/7925

Improve error reporting if fail to install deps in `astro add`

## Testing

Tested in the repro manually:

<img width="900" alt="image" src="https://github.com/withastro/astro/assets/34116392/32046d91-8dbe-4f58-850a-5cbe99d68743">

Note that the "Command failed with E..." is now logged.


## Docs

n/a. bug fix.