### PR TITLE
chore(vercel): deprecate `speedInsights`

### DIFF
--- a/.changeset/lemon-garlics-pretend.md
+++ b/.changeset/lemon-garlics-pretend.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vercel": patch
+---
+
+Marks the `speedInsights` configuration as deprecated. Vercel has migrated features of the Speed Insights API into a framework-agnostic library with `@vercel/speed-insights`. See [Vercel Speed Insights Quickstart](https://vercel.com/docs/speed-insights/quickstart) for instructions on how to use the library instead.

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -74,7 +74,13 @@ export interface VercelServerlessConfig {
 	/** Configuration for [Vercel Web Analytics](https://vercel.com/docs/concepts/analytics). */
 	webAnalytics?: VercelWebAnalyticsConfig;
 
-	/** Configuration for [Vercel Speed Insights](https://vercel.com/docs/concepts/speed-insights). */
+	/**
+	 * @deprecated This option lets you configure the legacy speed insights API which is now deprecated by Vercel.
+	 * 
+	 * See [Vercel Speed Insights Quickstart](https://vercel.com/docs/speed-insights/quickstart) for instructions on how to use the library instead.
+	 * 
+	 * https://vercel.com/docs/speed-insights/quickstart
+	 */
 	speedInsights?: VercelSpeedInsightsConfig;
 
 	/** Force files to be bundled with your function. This is helpful when you notice missing files. */

--- a/packages/integrations/vercel/src/static/adapter.ts
+++ b/packages/integrations/vercel/src/static/adapter.ts
@@ -42,6 +42,13 @@ function getAdapter(): AstroAdapter {
 
 export interface VercelStaticConfig {
 	webAnalytics?: VercelWebAnalyticsConfig;
+	/**
+	 * @deprecated This option lets you configure the legacy speed insights API which is now deprecated by Vercel.
+	 * 
+	 * See [Vercel Speed Insights Quickstart](https://vercel.com/docs/speed-insights/quickstart) for instructions on how to use the library instead.
+	 * 
+	 * https://vercel.com/docs/speed-insights/quickstart
+	 */
 	speedInsights?: VercelSpeedInsightsConfig;
 	imageService?: boolean;
 	imagesConfig?: VercelImageConfig;


### PR DESCRIPTION
## Changes
- Closes #7573
- Closes #9590
- Deprecated API: https://vercel.com/docs/speed-insights/api
- Migration: https://vercel.com/docs/speed-insights/migrating-from-legacy
- New library: https://vercel.com/docs/speed-insights/quickstart

## Testing
Does not affect behavior.

## Docs
- https://github.com/withastro/docs/pull/6082