### PR TITLE
Fix ts errors for component template

### DIFF
--- a/examples/component/tsconfig.json
+++ b/examples/component/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "astro/tsconfigs/base"
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "jsx": "preserve"
+  }
 }


### PR DESCRIPTION
## Changes

close https://github.com/withastro/astro/issues/8786

Add `jsx: 'preserve'` to prevent TS errors. I also updated the examples check script a bit so it works better locally.

## Testing

Ran `pnpm test:check-examples` locally.

I also noticed that the `with-markdoc` example has a similar `compilerOptions` config, so I think this PR change should also work correctly when e.g. you choose the strictest tsconfig.

## Docs

n/a. bug fix to the template.
