### PR TITLE
perf: disable streaming in SSG

### DIFF
--- a/packages/astro/src/core/build/buildPipeline.ts
+++ b/packages/astro/src/core/build/buildPipeline.ts
@@ -62,7 +62,7 @@ export class BuildPipeline extends Pipeline {
 				site: manifest.site,
 				ssr,
 				// NOTE: there's no need to enable streaming in SSG
-				streaming: !ssr,
+				streaming: ssr,
 			})
 		);
 		this.#internals = internals;

--- a/packages/astro/src/core/build/buildPipeline.ts
+++ b/packages/astro/src/core/build/buildPipeline.ts
@@ -61,7 +61,8 @@ export class BuildPipeline extends Pipeline {
 				routeCache: staticBuildOptions.routeCache,
 				site: manifest.site,
 				ssr,
-				streaming: true,
+				// NOTE: there's no need to enable streaming in SSG
+				streaming: !ssr,
 			})
 		);
 		this.#internals = internals;


### PR DESCRIPTION
## Changes

Disable streaming in case we do an SSG build.

Internally, we noticed disabling streaming in certain projects yields to better build times.

## Testing

Manual testing and launch the benchmark job

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
