### PR TITLE
feat: Add APIRoute second generic

### DIFF
--- a/.changeset/fair-bottles-lie.md
+++ b/.changeset/fair-bottles-lie.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Adds a second generic parameter to `APIRoute` to type the `params`

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2262,8 +2262,8 @@ type Routing = {
 	strategy: 'pathname';
 };
 
-export type APIRoute<Props extends Record<string, any> = Record<string, any>> = (
-	context: APIContext<Props>
+export type APIRoute<Props extends Record<string, any> = Record<string, any>, APIParams extends Record<string, string | undefined> = Record<string, string | undefined>> = (
+	context: APIContext<Props, APIParams>
 ) => Response | Promise<Response>;
 
 export interface EndpointHandler {


### PR DESCRIPTION
## Changes

To set up the second generic of APIContext, we added one more generic to APIRoute.

fix https://github.com/withastro/astro/issues/9612

## Testing

I tested it on a personal project and it worked well.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
