### PR TITLE
Fix class property Vue hydration error

### DIFF
--- a/.changeset/dirty-monkeys-bow.md
+++ b/.changeset/dirty-monkeys-bow.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vue": patch
+---
+
+Fixes `class` property hydration error

--- a/packages/integrations/vue/client.js
+++ b/packages/integrations/vue/client.js
@@ -4,7 +4,6 @@ import StaticHtml from './static-html.js';
 
 export default (element) =>
 	async (Component, props, slotted, { client }) => {
-		delete props['class'];
 		if (!element.hasAttribute('ssr')) return;
 
 		// Expose name on host component for Vue devtools


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/9617

The `delete props['class']` was introduced in https://github.com/withastro/astro/pull/1406/commits/1103cb1f9d2a2077f65a0d08aee67ee9bf0e9540, but I'm not sure why. But this should work fine today without the deletion.

## Testing

Existing tests should pass. Also tested this fix with the repro.

## Docs

n/a. bug fix.
