### PR TITLE
Fix limitInputPixels type

### DIFF
--- a/.changeset/slow-impalas-taste.md
+++ b/.changeset/slow-impalas-taste.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes the Sharp image service `limitInputPixels` option type

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1118,7 +1118,7 @@ export interface AstroUserConfig {
 		 * @docs
 		 * @name image.service.config.limitInputPixels
 		 * @kind h4
-		 * @type {boolean}
+		 * @type {number | boolean}
 		 * @default `true`
 		 * @version 4.1.0
 		 * @description

--- a/packages/astro/src/assets/services/sharp.ts
+++ b/packages/astro/src/assets/services/sharp.ts
@@ -12,7 +12,7 @@ export interface SharpImageServiceConfig {
 	/**
 	 * The `limitInputPixels` option passed to Sharp. See https://sharp.pixelplumbing.com/api-constructor for more information
 	 */
-	limitInputPixels?: number;
+	limitInputPixels?: number | boolean;
 }
 
 let sharp: typeof import('sharp');

--- a/packages/astro/src/assets/services/sharp.ts
+++ b/packages/astro/src/assets/services/sharp.ts
@@ -1,4 +1,4 @@
-import type { FormatEnum } from 'sharp';
+import type { FormatEnum, SharpOptions } from 'sharp';
 import { AstroError, AstroErrorData } from '../../core/errors/index.js';
 import type { ImageOutputFormat, ImageQualityPreset } from '../types.js';
 import {
@@ -12,7 +12,7 @@ export interface SharpImageServiceConfig {
 	/**
 	 * The `limitInputPixels` option passed to Sharp. See https://sharp.pixelplumbing.com/api-constructor for more information
 	 */
-	limitInputPixels?: number | boolean;
+	limitInputPixels?: SharpOptions['limitInputPixels'];
 }
 
 let sharp: typeof import('sharp');


### PR DESCRIPTION
## Changes

ref https://github.com/withastro/astro/pull/9546#issuecomment-1877736238

I mistyped `limitInputPixels`. It should be `number | boolean` as accepted by Sharp as well.

## Testing

n/a. Should still work

## Docs

Updated jsdoc as well.
