### PR TITLE
Allow img attributes for Picture component

### DIFF
--- a/.changeset/bright-waves-scream.md
+++ b/.changeset/bright-waves-scream.md
@@ -1,0 +1,5 @@
+---
+"astro": major
+---
+
+Allowing for img attributes for the Picture component

--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -9,6 +9,7 @@ type Props = (LocalImageProps | RemoteImageProps) & {
 	formats?: ImageOutputFormat[];
 	fallbackFormat?: ImageOutputFormat;
 	pictureAttributes?: HTMLAttributes<'picture'>;
+	imgAttributes?: HTMLAttributes<'img'>;
 };
 
 const defaultFormats = ['webp'] as const;
@@ -21,7 +22,7 @@ const defaultFallbackFormat = 'png' as const;
 // For those, we'll use the original format as the fallback instead.
 const specialFormatsFallback = ['gif', 'svg', 'jpg', 'jpeg'] as const;
 
-const { formats = defaultFormats, pictureAttributes = {}, fallbackFormat, ...props } = Astro.props;
+const { formats = defaultFormats, pictureAttributes = {}, imgAttributes = {}, fallbackFormat, ...props } = Astro.props;
 
 if (props.alt === undefined || props.alt === null) {
 	throw new AstroError(AstroErrorData.ImageMissingAlt);
@@ -50,7 +51,6 @@ const fallbackImage = await getImage({
 	densities: props.densities,
 });
 
-const imgAdditionalAttributes: HTMLAttributes<'img'> = {};
 const sourceAdditionaAttributes: HTMLAttributes<'source'> = {};
 
 // Propagate the `sizes` attribute to the `source` elements
@@ -59,7 +59,7 @@ if (props.sizes) {
 }
 
 if (fallbackImage.srcSet.values.length > 0) {
-	imgAdditionalAttributes.srcset = fallbackImage.srcSet.attribute;
+	imgAttributes.srcset = fallbackImage.srcSet.attribute;
 }
 ---
 
@@ -79,5 +79,5 @@ if (fallbackImage.srcSet.values.length > 0) {
 			);
 		})
 	}
-	<img src={fallbackImage.src} {...imgAdditionalAttributes} {...fallbackImage.attributes} />
+	<img src={fallbackImage.src} {...imgAttributes} {...fallbackImage.attributes} />
 </picture>


### PR DESCRIPTION
## Changes

Adds a option allowing for attributes for the Picture component's img tag.

## Testing

<!-- How was this change tested? -->
By importing the Picture componet and add the following: 
```
<Picture width="50" height="50" src="/favicon.svg" alt="test" pictureAttributes={{
	class: "picture-class",
}} imgAttributes={{
	class: "image-class",
}}/>
```
Output:
![image](https://github.com/withastro/astro/assets/16895360/db7a0ec3-e226-4bce-935a-f78ee8d4c20f)


## Docs
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
Yes should be added as a option under: https://docs.astro.build/en/guides/images/#picture-
/cc @withastro/maintainers-docs for feedback! 

<!-- https://github.com/withastro/docs -->
