### PR TITLE
Improve env var handling in SSR

### DIFF
--- a/.changeset/curvy-socks-rhyme.md
+++ b/.changeset/curvy-socks-rhyme.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Improves environment variables replacement in SSR

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -149,9 +149,9 @@ export async function createVite(
 		root: fileURLToPath(settings.config.root),
 		envPrefix: settings.config.vite?.envPrefix ?? 'PUBLIC_',
 		define: {
-			'import.meta.env.SITE': settings.config.site
-				? JSON.stringify(settings.config.site)
-				: 'undefined',
+			'import.meta.env.SITE': stringifyForDefine(settings.config.site),
+			'import.meta.env.BASE_URL': stringifyForDefine(settings.config.base),
+			'import.meta.env.ASSETS_PREFIX': stringifyForDefine(settings.config.build.assetsPrefix),
 		},
 		server: {
 			hmr:
@@ -307,4 +307,8 @@ function isCommonNotAstro(dep: string): boolean {
 					: dep.substring(dep.lastIndexOf('/') + 1).startsWith(prefix) // check prefix omitting @scope/
 		)
 	);
+}
+
+function stringifyForDefine(value: string | undefined): string {
+	return typeof value === 'string' ? JSON.stringify(value) : 'undefined';
 }

--- a/packages/astro/src/vite-plugin-env/index.ts
+++ b/packages/astro/src/vite-plugin-env/index.ts
@@ -48,12 +48,6 @@ function getPrivateEnv(
 			}
 		}
 	}
-	privateEnv.SITE = astroConfig.site ? JSON.stringify(astroConfig.site) : 'undefined';
-	privateEnv.SSR = JSON.stringify(true);
-	privateEnv.BASE_URL = astroConfig.base ? JSON.stringify(astroConfig.base) : 'undefined';
-	privateEnv.ASSETS_PREFIX = astroConfig.build.assetsPrefix
-		? JSON.stringify(astroConfig.build.assetsPrefix)
-		: 'undefined';
 	return privateEnv;
 }
 
@@ -74,18 +68,6 @@ export default function envVitePlugin({ settings }: EnvPluginOptions): vite.Plug
 	return {
 		name: 'astro:vite-plugin-env',
 		enforce: 'pre',
-		config() {
-			return {
-				define: {
-					'import.meta.env.BASE_URL': astroConfig.base
-						? JSON.stringify(astroConfig.base)
-						: 'undefined',
-					'import.meta.env.ASSETS_PREFIX': astroConfig.build.assetsPrefix
-						? JSON.stringify(astroConfig.build.assetsPrefix)
-						: 'undefined',
-				},
-			};
-		},
 		configResolved(resolvedConfig) {
 			viteConfig = resolvedConfig;
 		},


### PR DESCRIPTION
## Changes

Some env var replacement can be relayed to Vite to replace instead, which is more accurate as we're using plain string replacements. I'm currently working on improving Astro's env replacement too and notice this stop gap improvement.

## Testing

Existing env vars tests should pass.

## Docs

n/a. internal refactor.
