### PR TITLE
Updates rule for adding 'docs pr' label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -37,7 +37,5 @@
 - packages/integrations/vue/**
 
 'docs pr':
-- README.md
 - packages/astro/src/@types/astro.ts
 - packages/astro/src/core/errors/errors-data.ts
-- .changeset/*.md


### PR DESCRIPTION
## Changes

This updates `labeler.yml` rules for applying the `docs pr` label.

- `README.md` is no longer needed since we maintain these docs in the docs repo now.
- `changeset.md` meant that almost *every* PR was getting labelled, making the label less useful.

Now, only PRs with changes that will end up on the docs site are labelled. Changesets for minors are automatically reviewed because they are included in the Milestone, so a separate label is not necessary and obscures the PRs with actual changes to the docs. This change would help the docs maintainers better triage the most important PRs for reviewing.

Changesets for patches are still haphazardly reviewed, often on demand. But, more maintainers have been stepping up and serving as quality control for these. So, still moving in the right direction!

## Testing

Not tested. Just edited the list of files to trigger the label.

## Docs

No docs.