### PR TITLE
fix: add metadata to build error pages

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1318,6 +1318,11 @@ export const UnsupportedConfigTransformError = {
 	hint: 'See the devalue library for all supported types: https://github.com/rich-harris/devalue',
 } satisfies ErrorData;
 
+/**
+ * @docs
+ * @description
+ * Astro can't find the requested locale.
+ */
 export const MissingLocale = {
 	name: 'MissingLocaleError',
 	title: 'The provided locale does not exist.',
@@ -1326,6 +1331,12 @@ export const MissingLocale = {
 	},
 } satisfies ErrorData;
 
+/**
+ * @docs
+ * @description
+ * When rendering a route, Astro couldn't find an associated file. This should never happen, this means that this is
+ * an Astro error and not a user error.
+ */
 export const CantRenderPage = {
 	name: 'CantRenderPage',
 	title: "Astro can't render the route.",
@@ -1337,6 +1348,11 @@ export const CantRenderPage = {
 // Generic catch-all - Only use this in extreme cases, like if there was a cosmic ray bit flip
 export const UnknownError = { name: 'UnknownError', title: 'Unknown Error.' } satisfies ErrorData;
 
+/**
+ * @docs
+ * @description
+ * Emitted when some user code doesn't handle the reject of promise `Promise`.
+ */
 export const UnhandledRejection = {
 	name: 'UnhandledRejection',
 	title: 'Unhandled rejection',
@@ -1344,4 +1360,4 @@ export const UnhandledRejection = {
 		return `Astro detected an unhandled rejection. Here's the stack trace:\n${stack}`;
 	},
 	hint: 'Make sure your promises all have an `await` or a `.catch()` handler.',
-};
+} satisfies ErrorData;

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1321,7 +1321,7 @@ export const UnsupportedConfigTransformError = {
 /**
  * @docs
  * @description
- * Astro can't find the requested locale.
+ * Astro can't find the requested locale. All supported locales must be configured in [i18n.locales](en/reference/configuration-reference/#i18nlocales) and have corresponding directories within `src/pages/`.
  */
 export const MissingLocale = {
 	name: 'MissingLocaleError',
@@ -1334,8 +1334,7 @@ export const MissingLocale = {
 /**
  * @docs
  * @description
- * When rendering a route, Astro couldn't find an associated file. This should never happen, this means that this is
- * an Astro error and not a user error.
+ * Astro could not find an associated file with content while trying to render the route. This is an Astro error and not a user error.  If restarting the dev server does not fix the problem, please file an issue.
  */
 export const CantRenderPage = {
 	name: 'CantRenderPage',
@@ -1351,7 +1350,7 @@ export const UnknownError = { name: 'UnknownError', title: 'Unknown Error.' } sa
 /**
  * @docs
  * @description
- * Emitted when some user code doesn't handle the reject of promise `Promise`.
+ * Astro could not find any code to handle a rejected  `Promise`. Make sure all your promises have an `await` or `.catch()` handler.
  */
 export const UnhandledRejection = {
 	name: 'UnhandledRejection',


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/9630

Closes PLT-1384

Some errors didn't have the metadata that are needed by docs to generate error pages.

## Testing

Proof reading

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
