### PR TITLE
Fixes an issue where view transitions to the 404-page did not work

### DIFF
--- a/.changeset/big-knives-own.md
+++ b/.changeset/big-knives-own.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where view transitions to 404 page did not work

--- a/.changeset/big-knives-own.md
+++ b/.changeset/big-knives-own.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes an issue where view transitions to 404 page did not work
+Fixes an issue where view transitions to the 404-page did not work

--- a/.changeset/big-knives-own.md
+++ b/.changeset/big-knives-own.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes an issue where view transitions to the 404-page did not work
+Fixes an issue where View Transitions did not work when navigating to the 404 page 

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/404.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/404.astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../components/Layout.astro';
+---
+<Layout>
+	<p id="FourOhFour">Page not found</p>
+</Layout>
+</script>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
@@ -11,6 +11,7 @@ import Layout from '../components/Layout.astro';
 	<a id="click-self" href="">go to top</a>
 	<a id="click-redirect-two" href="/redirect-two">go to redirect 2</a>
 	<a id="click-redirect-external" href="/redirect-external">go to a redirect external</a>
+	<a id="click-404" href="/undefined-page">go to undefined page</a>
 
 	<div id="test">test content</div>
 </Layout>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -1187,4 +1187,23 @@ test.describe('View Transitions', () => {
 
 		expect(requests).toHaveLength(0);
 	});
+	
+	test('view transition should also work with 404 page', async ({ page, astro }) => {
+		const loads = [];
+		page.addListener('load', (p) => {
+			loads.push(p.title());
+		});
+
+		// Go to page 1
+		await page.goto(astro.resolveUrl('/one'));
+		let p = page.locator('#one');
+		await expect(p, 'should have content').toHaveText('Page 1');
+
+		// go to 404
+		await page.click('#click-404');
+		p = page.locator('#FourOhFour');
+		await expect(p, 'should have content').toHaveText('Page not found');
+
+		expect(loads.length, 'There should only be 1 page load').toEqual(1);
+	});
 });

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -370,7 +370,11 @@ export async function handleRoute({
 	// Apply the `status` override to the response object before responding.
 	// Response.status is read-only, so a clone is required to override.
 	if (status && response.status !== status && (status === 404 || status === 500)) {
-		response = new Response(response.body, { ...response, status });
+		response = new Response(response.body, {
+			status: status,
+			statusText: status === 404 ? 'Not Found' : 'Internal Server Error',
+			headers: response.headers
+		});
 	}
 	await writeSSRResult(request, response, incomingResponse);
 }

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -372,7 +372,6 @@ export async function handleRoute({
 	if (status && response.status !== status && (status === 404 || status === 500)) {
 		response = new Response(response.body, {
 			status: status,
-			statusText: status === 404 ? 'Not Found' : 'Internal Server Error',
 			headers: response.headers
 		});
 	}


### PR DESCRIPTION
## Changes

Changed the cloning of a Response in route.ts to retain the original headers.
With the headers the content type of the 404 page was lost.
The view transition loader expected text/html and did a full reload due to the missing header.
Closes #9629 

## Testing

new e2e test to confirm that we can transition to 404 / undefined pages without reloads

## Docs

n.a. / bug fix