### PR TITLE
fix(vercel): handle error pages using vercel APIs

### DIFF
--- a/packages/integrations/vercel/src/serverless/entrypoint.ts
+++ b/packages/integrations/vercel/src/serverless/entrypoint.ts
@@ -29,7 +29,7 @@ export const createExports = (manifest: SSRManifest) => {
 				locals = JSON.parse(localsAsString);
 			}
 		}
-		await setResponse(app, res, await app.render(request, { routeData, locals }));
+		await setResponse(app, res, await app.render(request, { routeData, handleErrorPages: false, locals }));
 	};
 
 	return { default: handler };


### PR DESCRIPTION
## Changes
- Fixes #9028
- [x] Introduces an opt-out for implicit rerouting with `app,render(request, { handleErrorPages: false })`
- [ ] Makes vercel perform the rewrites instead.

## Testing
_Pending_

## Docs
Does not affect usage.