### PR TITLE
fix(vercel): fallback to static 404.html

### DIFF
--- a/.changeset/stale-pandas-count.md
+++ b/.changeset/stale-pandas-count.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vercel": patch
+---
+
+Fixes an issue where the serverless function could not respond with a prerendered 404 page.

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -287,9 +287,15 @@ You can set functionPerRoute: false to prevent surpassing the limit.`
 						excludeFiles,
 						maxDuration,
 					});
-					routeDefinitions.push({ src: '/.*', dest: 'render' });
+					for (const route of routes) {
+						if (route.prerender) continue
+						routeDefinitions.push({
+							src: route.pattern.source,
+							dest: 'render',
+						})
+					}
 				}
-
+				const fourOhFourRoute = routes.find((route) => route.pathname === '/404');
 				// Output configuration
 				// https://vercel.com/docs/build-output-api/v3#build-output-configuration
 				await writeJson(new URL(`./config.json`, _config.outDir), {
@@ -303,6 +309,11 @@ You can set functionPerRoute: false to prevent surpassing the limit.`
 						},
 						{ handle: 'filesystem' },
 						...routeDefinitions,
+						...fourOhFourRoute ? [{
+								src: '/.*',
+								dest: fourOhFourRoute.prerender ? '/404.html' : 'render',
+								status: 404,
+							}] : [],
 					],
 					...(imageService || imagesConfig
 						? {

--- a/packages/integrations/vercel/test/fixtures/prerendered-error-pages/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/prerendered-error-pages/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import vercel from '@astrojs/vercel/serverless';
+
+export default defineConfig({
+	output: 'server',
+	adapter: vercel()
+});

--- a/packages/integrations/vercel/test/fixtures/prerendered-error-pages/package.json
+++ b/packages/integrations/vercel/test/fixtures/prerendered-error-pages/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/astro-vercel-prerendered-error-pages",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/vercel": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/vercel/test/fixtures/prerendered-error-pages/src/pages/404.astro
+++ b/packages/integrations/vercel/test/fixtures/prerendered-error-pages/src/pages/404.astro
@@ -1,0 +1,4 @@
+---
+export const prerender = true
+---
+<h1>404</h1>

--- a/packages/integrations/vercel/test/fixtures/prerendered-error-pages/src/pages/one.astro
+++ b/packages/integrations/vercel/test/fixtures/prerendered-error-pages/src/pages/one.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>One</title>
+	</head>
+	<body>
+		<h1>One</h1>
+	</body>
+</html>

--- a/packages/integrations/vercel/test/fixtures/prerendered-error-pages/src/pages/two.astro
+++ b/packages/integrations/vercel/test/fixtures/prerendered-error-pages/src/pages/two.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>Two</title>
+	</head>
+	<body>
+		<h1>Two</h1>
+	</body>
+</html>

--- a/packages/integrations/vercel/test/prerendered-error-pages.test.js
+++ b/packages/integrations/vercel/test/prerendered-error-pages.test.js
@@ -1,21 +1,20 @@
 import { loadFixture } from './test-utils.js';
 import { expect } from 'chai';
 
-describe('static routing', () => {
+describe('prerendered error pages routing', () => {
 	/** @type {import('./test-utils.js').Fixture} */
 	let fixture;
 
 	before(async () => {
 		fixture = await loadFixture({
-			root: './fixtures/static/',
+			root: './fixtures/prerendered-error-pages/',
 		});
 		await fixture.build();
 	});
 
 	it('falls back to 404.html', async () => {
 		const deploymentConfig = JSON.parse(await fixture.readFile('../.vercel/output/config.json'));
-		// change the index if necesseary
-		expect(deploymentConfig.routes[2]).to.deep.include({
+		expect(deploymentConfig.routes.at(-1)).to.deep.include({
 			src: '/.*',
 			dest: '/404.html',
 			status: 404,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4749,6 +4749,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/vercel/test/fixtures/prerendered-error-pages:
+    dependencies:
+      '@astrojs/vercel':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/vercel/test/fixtures/redirects:
     dependencies:
       '@astrojs/vercel':


### PR DESCRIPTION
## Changes

- Closes #9028 The issue exposes a weak point in routing - a code path where astro has to make a fetch call to itself. While this one specific side-effect is addressed, the error-prone approach remains in the codebase.
- Closes #9615
- If `404.astro` exists and is prerendered, it is used as the catch all route.
- All on-demand rendered routes now have an entry that points the serverless function. Previously, a single catch-all route pointed to the serverless function.

## Testing
![image](https://github.com/withastro/astro/assets/69170106/22e70d12-eec2-4ef5-89b5-ef1539312cd6)


## Docs
Does not affect usage.