### PR TITLE
Don't try to load partytown scripts in the main thread during view transitions

### DIFF
--- a/.changeset/early-taxis-love.md
+++ b/.changeset/early-taxis-love.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes an issue caused by trying to load text/partytown scripts during View Transitions
+Fixes an issue caused by trying to load text/partytown scripts during view transitions

--- a/.changeset/early-taxis-love.md
+++ b/.changeset/early-taxis-love.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue caused by trying to load text/partytown scripts during View Transitions

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -151,12 +151,14 @@ function runScripts() {
 	let wait = Promise.resolve();
 	for (const script of Array.from(document.scripts)) {
 		if (script.dataset.astroExec === '') continue;
+		const type = script.getAttribute('type');
+		if (type && type !== 'module' && type !== 'text/javascript') continue;
 		const newScript = document.createElement('script');
 		newScript.innerHTML = script.innerHTML;
 		for (const attr of script.attributes) {
 			if (attr.name === 'src') {
 				const p = new Promise((r) => {
-					newScript.onload = r;
+					newScript.onload = newScript.onerror = r;
 				});
 				wait = wait.then(() => p as any);
 			}


### PR DESCRIPTION
## Changes

runScripts now only loads what should be executed in the main thread
+ stop waiting on errors, too.

## Testing

manually tested

## Docs

n.a./bug fix

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
