### PR TITLE
Add fallback compile for astro script and style load

### DIFF
--- a/.changeset/friendly-needles-invite.md
+++ b/.changeset/friendly-needles-invite.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Improves HMR for Astro style and script modules


### PR DESCRIPTION
## Changes

Helps https://github.com/withastro/astro/issues/9370 but does not fix it yet. This should reduce the occasional parsing error due to missing Astro compilation cache for its scripts and styles modules, which can often happen in HMR.

It does not fix the issue due to a Vite bug explained in https://github.com/withastro/astro/issues/9370#issuecomment-1887366837. I'm still trying to figure that out, but if I can't, I can probably add a workaround in a later PR too.

## Testing

Tested manually with the issue's repro. I didn't add a test as the bug still exists, but it should not break other tests.

## Docs

n/a. bug fix.
