### PR TITLE
Disable file watcher for internal one-off vite servers

### DIFF
--- a/.changeset/blue-pets-battle.md
+++ b/.changeset/blue-pets-battle.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Disables internal file watcher for one-off Vite servers to improve start-up performance

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -6,7 +6,7 @@ import { debug } from '../logger/core.js';
 
 async function createViteServer(root: string, fs: typeof fsType): Promise<ViteDevServer> {
 	const viteServer = await createServer({
-		server: { middlewareMode: true, hmr: false, watch: { ignored: ['**'] } },
+		server: { middlewareMode: true, hmr: false, watch: null },
 		optimizeDeps: { disabled: true },
 		clearScreen: false,
 		appType: 'custom',

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -81,7 +81,7 @@ export async function syncInternal(
 	const tempViteServer = await createServer(
 		await createVite(
 			{
-				server: { middlewareMode: true, hmr: false, watch: { ignored: ['**'] } },
+				server: { middlewareMode: true, hmr: false, watch: null },
 				optimizeDeps: { disabled: true },
 				ssr: { external: [] },
 				logLevel: 'silent',


### PR DESCRIPTION
## Changes

Small perf improvement by setting `watch: null` in the Vite config so that chokidar is not started up at all. It's a feature from Vite 5.

## Testing

Existing tests should pass.

## Docs

n/a. internal change.
