### PR TITLE
Force re-execution of Partytown's head snippet on view transitions

### DIFF
--- a/.changeset/afraid-suits-beam.md
+++ b/.changeset/afraid-suits-beam.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/partytown": patch
+---
+
+Fixes an issue where Partytown scripts didn't execute after view transition

--- a/packages/integrations/partytown/src/index.ts
+++ b/packages/integrations/partytown/src/index.ts
@@ -21,7 +21,7 @@ export default function createPlugin(options?: PartytownOptions): AstroIntegrati
 	let partytownSnippetHtml: string;
 	const partytownEntrypoint = resolve('@builder.io/partytown/package.json');
 	const partytownLibDirectory = path.resolve(partytownEntrypoint, '../lib');
-	const SELF_DESTRUCT_ON_VIEW_TRANSITION = `;((d,s)=>(s=d.currentScript,d.addEventListener('astro:before-swap',()=>s?.remove(),{once:true})))(document);`
+	const SELF_DESTRUCT_ON_VIEW_TRANSITION = `;((d,s)=>(s=d.currentScript,d.addEventListener('astro:before-swap',()=>s.remove(),{once:true})))(document);`
 	return {
 		name: '@astrojs/partytown',
 		hooks: {

--- a/packages/integrations/partytown/src/index.ts
+++ b/packages/integrations/partytown/src/index.ts
@@ -21,6 +21,7 @@ export default function createPlugin(options?: PartytownOptions): AstroIntegrati
 	let partytownSnippetHtml: string;
 	const partytownEntrypoint = resolve('@builder.io/partytown/package.json');
 	const partytownLibDirectory = path.resolve(partytownEntrypoint, '../lib');
+	const SELF_DESTRUCT_ON_VIEW_TRANSITION = `;((d,s)=>(s=d.currentScript,d.addEventListener('astro:before-swap',()=>s?.remove(),{once:true})))(document);`
 	return {
 		name: '@astrojs/partytown',
 		hooks: {
@@ -32,6 +33,7 @@ export default function createPlugin(options?: PartytownOptions): AstroIntegrati
 					debug: options?.config?.debug ?? command === 'dev',
 				};
 				partytownSnippetHtml = partytownSnippet(partytownConfig);
+				partytownSnippetHtml += SELF_DESTRUCT_ON_VIEW_TRANSITION;
 				injectScript('head-inline', partytownSnippetHtml);
 			},
 			'astro:server:setup': ({ server }) => {
@@ -60,4 +62,6 @@ export default function createPlugin(options?: PartytownOptions): AstroIntegrati
 			},
 		},
 	};
+
+
 }


### PR DESCRIPTION
## Changes

Just before the view transition swap(), remove the Partytown `<head>` snippet.
This forces a re-execution on the target page.

## Testing

Manually tested

## Docs
n.a. / bug fix

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
