### PR TITLE
fix(assets): Implement all hooks in the passthrough image service

### DIFF
--- a/.changeset/long-mangos-walk.md
+++ b/.changeset/long-mangos-walk.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix the passthrough image service not generating `srcset` values properly

--- a/packages/astro/src/assets/services/noop.ts
+++ b/packages/astro/src/assets/services/noop.ts
@@ -2,11 +2,8 @@ import { baseService, type LocalImageService } from './service.js';
 
 // Empty service used for platforms that neither support Squoosh or Sharp.
 const noopService: LocalImageService = {
+	...baseService,
 	propertiesToHash: ['src'],
-	validateOptions: baseService.validateOptions,
-	getURL: baseService.getURL,
-	parseURL: baseService.parseURL,
-	getHTMLAttributes: baseService.getHTMLAttributes,
 	async transform(inputBuffer, transformOptions) {
 		return {
 			data: inputBuffer,


### PR DESCRIPTION
## Changes

Using Picture + the noop image service didn't work properly because it didn't implement the ability to generate a srcset, this fixes that

## Testing

Tested manually

## Docs

N/A
