### PR TITLE
[Content collections] Remove "unsupported file type" warning

### DIFF
--- a/.changeset/itchy-clouds-invite.md
+++ b/.changeset/itchy-clouds-invite.md
@@ -1,0 +1,14 @@
+---
+"astro": minor
+---
+
+Remove underscore prefix requirement for assets inside content collections. For colocated files like `.js` or `.css`, you can now remove underscores without raising a warning:
+
+```diff
+src/content/blog/
+post.mdx
+- _styles.css
+- _Component.astro
++ styles.css
++ Component.astro
+```

--- a/.changeset/itchy-clouds-invite.md
+++ b/.changeset/itchy-clouds-invite.md
@@ -2,7 +2,7 @@
 "astro": minor
 ---
 
-Remove underscore prefix requirement for assets inside content collections. For extensions like `.astro` or `.css`, you can now remove underscores without raising a warning:
+Removes the requirement for non-content files and assets inside content collections to be prefixed with an underscore. For files with extensions like `.astro` or `.css`, you can now remove underscores without seeing a warning in the terminal.
 
 ```diff
 src/content/blog/

--- a/.changeset/itchy-clouds-invite.md
+++ b/.changeset/itchy-clouds-invite.md
@@ -12,3 +12,5 @@ post.mdx
 + styles.css
 + Component.astro
 ```
+
+Continue to use underscores in your content collections to exclude individual content files, such as drafts, from the build output.

--- a/.changeset/itchy-clouds-invite.md
+++ b/.changeset/itchy-clouds-invite.md
@@ -2,7 +2,7 @@
 "astro": minor
 ---
 
-Remove underscore prefix requirement for assets inside content collections. For colocated files like `.js` or `.css`, you can now remove underscores without raising a warning:
+Remove underscore prefix requirement for assets inside content collections. For extensions like `.astro` or `.css`, you can now remove underscores without raising a warning:
 
 ```diff
 src/content/blog/

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -247,15 +247,11 @@ export function getEntryType(
 	paths: Pick<ContentPaths, 'config' | 'contentDir'>,
 	contentFileExts: string[],
 	dataFileExts: string[]
-): 'content' | 'data' | 'config' | 'ignored' | 'unsupported' {
-	const { ext, base } = path.parse(entryPath);
+): 'content' | 'data' | 'config' | 'ignored' {
+	const { ext } = path.parse(entryPath);
 	const fileUrl = pathToFileURL(entryPath);
 
-	if (
-		hasUnderscoreBelowContentDirectoryPath(fileUrl, paths.contentDir) ||
-		isOnIgnoreList(base) ||
-		isImageAsset(ext)
-	) {
+	if (hasUnderscoreBelowContentDirectoryPath(fileUrl, paths.contentDir)) {
 		return 'ignored';
 	} else if (contentFileExts.includes(ext)) {
 		return 'content';
@@ -264,19 +260,8 @@ export function getEntryType(
 	} else if (fileUrl.href === paths.config.url.href) {
 		return 'config';
 	} else {
-		return 'unsupported';
+		return 'ignored';
 	}
-}
-
-function isOnIgnoreList(fileName: string) {
-	return ['.DS_Store'].includes(fileName);
-}
-
-/**
- * Return if a file extension is a valid image asset, so we can avoid outputting a warning for them.
- */
-function isImageAsset(fileExt: string) {
-	return VALID_INPUT_FORMATS.includes(fileExt.slice(1) as ImageInputFormat);
 }
 
 export function hasUnderscoreBelowContentDirectoryPath(

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -11,9 +11,7 @@ import type {
 	AstroSettings,
 	ContentEntryType,
 	DataEntryType,
-	ImageInputFormat,
 } from '../@types/astro.js';
-import { VALID_INPUT_FORMATS } from '../assets/consts.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 
 import { formatYAMLException, isYAMLException } from '../core/errors/utils.js';

--- a/packages/astro/test/units/content-collections/get-entry-type.test.js
+++ b/packages/astro/test/units/content-collections/get-entry-type.test.js
@@ -65,22 +65,12 @@ describe('Content Collections - getEntryType', () => {
 				expect(type).to.equal('config');
 			});
 
-			it('Returns "unsupported" for non-Markdown files', () => {
-				const entry = fileURLToPath(new URL('blog/robots.txt', contentPaths.contentDir));
-				const type = getEntryType(entry, contentPaths, contentFileExts, dataFileExts);
-				expect(type).to.equal('unsupported');
-			});
-
-			it('Returns "ignored" for .DS_Store', () => {
-				const entry = fileURLToPath(new URL('blog/.DS_Store', contentPaths.contentDir));
-				const type = getEntryType(entry, contentPaths, contentFileExts, dataFileExts);
-				expect(type).to.equal('ignored');
-			});
-
-			it('Returns "ignored" for unsupported files using an underscore', () => {
-				const entry = fileURLToPath(new URL('blog/_draft-robots.txt', contentPaths.contentDir));
-				const type = getEntryType(entry, contentPaths, contentFileExts, dataFileExts);
-				expect(type).to.equal('ignored');
+			it('Returns "ignored" for non-Markdown files', () => {
+				for (const entryPath of ['blog/robots.txt', 'blog/first-post.png', '.DS_Store']) {
+					const entry = fileURLToPath(new URL(entryPath, contentPaths.contentDir));
+					const type = getEntryType(entry, contentPaths, contentFileExts, dataFileExts);
+					expect(type).to.equal('ignored');
+				}
 			});
 
 			it('Returns "ignored" when using underscore on file name', () => {
@@ -91,12 +81,6 @@ describe('Content Collections - getEntryType', () => {
 
 			it('Returns "ignored" when using underscore on directory name', () => {
 				const entry = fileURLToPath(new URL('blog/_draft/first-post.md', contentPaths.contentDir));
-				const type = getEntryType(entry, contentPaths, contentFileExts, dataFileExts);
-				expect(type).to.equal('ignored');
-			});
-
-			it('Returns "ignored" for images', () => {
-				const entry = fileURLToPath(new URL('blog/first-post.png', contentPaths.contentDir));
 				const type = getEntryType(entry, contentPaths, contentFileExts, dataFileExts);
 				expect(type).to.equal('ignored');
 			});


### PR DESCRIPTION
We decided to remove the "unsupported file type" warning from Content Collections [during our roadmap discussions](https://github.com/withastro/roadmap/discussions/805#discussioncomment-8006117). This requirement led to several bugs and special cases overtime, including an "ignore list" for `.DS_Store` and special handling for image assets.

Now, all files that are _not_ content (`.md`) or data (`.json`) are ignored by default. This means underscores are no longer required for these files. You can still use underscores to hide content or data entries from collection queries.

## Changes

- Remove `unsupported` file type from warning logs and type-generation internals

## Testing

- Update tests that expect `unsupported` to now expect `ignored`
- Remove one-off tests for `DS_Store` and image assets

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
