### PR TITLE
[docs] Update Current Example for `site:` in the Configuration Reference

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -563,7 +563,7 @@ export interface AstroUserConfig {
 	 *
 	 * ```js
 	 * {
-	 *   site: 'https://www.my-site.dev'
+	 *   site: 'https://www.my-site.dev/'
 	 * }
 	 * ```
 	 */


### PR DESCRIPTION
## Changes

**Docs Update**
The currently displayed setting for the `site:` configuration property does not contain a trailing slash, despite the change to this behaviour in `v2` (https://github.com/withastro/astro/issues/5604, https://github.com/withastro/astro/pull/5608).

This closes https://github.com/withastro/docs/issues/6255.

## Testing

This is only a docs change

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
