### PR TITLE
fix(i18n): emit an error when the index isn't found

### DIFF
--- a/.changeset/proud-guests-bake.md
+++ b/.changeset/proud-guests-bake.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Adds an error during the build phase incase `i18n.routing.prefixDefaultLocale` is set to `true` and the index page is missing.
+Adds an error during the build phase in case `i18n.routing.prefixDefaultLocale` is set to `true` and the index page is missing.

--- a/.changeset/proud-guests-bake.md
+++ b/.changeset/proud-guests-bake.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Adds an error during the build phase incase `i18n.routing.prefixDefaultLocale` is set to `true` and the index page is missing.

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1003,7 +1003,7 @@ export const MissingLocale = {
 
 export const MissingIndexForInternationalization = {
 	name: 'MissingIndexForInternationalizationError',
-	title: 'Index URL not found.',
+	title: 'Index page not found.',
 	message: (src: string) =>
 		`Astro couldn't find the index URL. This index page is required to create a redirect from the index URL to the index URL of the default locale. \nCreate an index page in \`${src}\``,
 } satisfies ErrorData;

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1001,6 +1001,13 @@ export const MissingLocale = {
 		`The locale/path \`${locale}\` does not exist in the configured \`i18n.locales\`.`,
 } satisfies ErrorData;
 
+export const MissingIndexForInternalisation = {
+	name: 'MissingIndexForInternalisationError',
+	title: 'Index URL not found.',
+	message: (src: string) =>
+		`Astro couldn't find the index URL. This index page is required to create a redirect from the index URL to the index URL of the default locale. \nCreate an index page in \`${src}\``,
+} satisfies ErrorData;
+
 /**
  * @docs
  * @description

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1001,8 +1001,8 @@ export const MissingLocale = {
 		`The locale/path \`${locale}\` does not exist in the configured \`i18n.locales\`.`,
 } satisfies ErrorData;
 
-export const MissingIndexForInternalisation = {
-	name: 'MissingIndexForInternalisationError',
+export const MissingIndexForInternationalization = {
+	name: 'MissingIndexForInternationalizationError',
 	title: 'Index URL not found.',
 	message: (src: string) =>
 		`Astro couldn't find the index URL. This index page is required to create a redirect from the index URL to the index URL of the default locale. \nCreate an index page in \`${src}\``,

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -19,7 +19,7 @@ import { removeLeadingForwardSlash, slash } from '../../path.js';
 import { resolvePages } from '../../util.js';
 import { getRouteGenerator } from './generator.js';
 import { AstroError } from '../../errors/index.js';
-import { MissingIndexForInternalisation } from '../../errors/errors-data.js';
+import { MissingIndexForInternationalization } from '../../errors/errors-data.js';
 const require = createRequire(import.meta.url);
 
 interface Item {
@@ -524,8 +524,8 @@ export function createRouteManifest(
 					fileURLToPath(new URL('pages', settings.config.srcDir))
 				);
 				throw new AstroError({
-					...MissingIndexForInternalisation,
-					message: MissingIndexForInternalisation.message(relativePath),
+					...MissingIndexForInternationalization,
+					message: MissingIndexForInternationalization.message(relativePath),
 				});
 			}
 		}

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -18,6 +18,8 @@ import { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from '../../constants.js';
 import { removeLeadingForwardSlash, slash } from '../../path.js';
 import { resolvePages } from '../../util.js';
 import { getRouteGenerator } from './generator.js';
+import { AstroError } from '../../errors/index.js';
+import { MissingIndexForInternalisation } from '../../errors/errors-data.js';
 const require = createRequire(import.meta.url);
 
 interface Item {
@@ -513,6 +515,21 @@ export function createRouteManifest(
 	});
 	const i18n = settings.config.i18n;
 	if (i18n) {
+		// First we check if the user doesn't have an index page.
+		if (i18n.routing === 'prefix-always') {
+			let index = routes.find((route) => route.route === '/');
+			if (!index) {
+				let relativePath = path.relative(
+					fileURLToPath(settings.config.root),
+					fileURLToPath(new URL('pages', settings.config.srcDir))
+				);
+				throw new AstroError({
+					...MissingIndexForInternalisation,
+					message: MissingIndexForInternalisation.message(relativePath),
+				});
+			}
+		}
+
 		// In this block of code we group routes based on their locale
 
 		// A map like: locale => RouteData[]


### PR DESCRIPTION
## Changes

We've had more than one report where users didn't add a index page when they use the option `i18n.routing.prefixDefaultLocale` to `true`.

The index page is required to create a redirect from `/` to `/<defaultLocale>`.

This PR adds a check during the build, and emits an error if the index is missing.

## Testing

There was a case where a fixture didn't have the index, and the test cases were still passing. 
These fixtures were now raising an error, and I added the index page.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs


<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
