### PR TITLE
Fix for #9673

### DIFF
--- a/.changeset/breezy-plants-smoke.md
+++ b/.changeset/breezy-plants-smoke.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+🏷️ update type generation for content config.

--- a/.changeset/breezy-plants-smoke.md
+++ b/.changeset/breezy-plants-smoke.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-🏷️ update type generation for content config.
+Fixes types generation from Content Collections config file

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -363,25 +363,19 @@ function invalidateVirtualMod(viteServer: ViteDevServer) {
 }
 
 /**
- * Takes a configPath and returns a normalized relative version:
+ * Takes the source (`from`) and destination (`to`) of a config path and
+ * returns a normalized relative version:
  *  -   If is not relative, it adds `./` to the beginning.
- *  -   If it ends with `.ts`, it removes the extension.
- *  -   It adds `.js` to the end.
- *  -   It stringifies the result (adds `""` around it).
- * @param from Config path from path.
- * @param to Config path to path.
+ *  -   If it ends with `.ts`, it replaces it with `.js`.
+ *  -   It adds `""` around the string.
+ * @param from Config path source.
+ * @param to Config path destination.
  * @returns Normalized config path.
  */
 function normalizeConfigPath(from: string, to: string) {
-	const normalizedConfigPath = path.relative(from, to);
+	const configPath = path.relative(from, to).replace(/\.ts$/, '.js');
 
-	return JSON.stringify(
-		`${isRelativePath(normalizedConfigPath) ? '' : './'}${
-			normalizedConfigPath.endsWith('.ts')
-				? normalizedConfigPath.replace(/\.ts$/, '')
-				: normalizedConfigPath
-		}.js`
-	);
+	return `"${isRelativePath(configPath) ? '' : './'}${configPath}"` as const;
 }
 
 async function writeContentFiles({


### PR DESCRIPTION
## Changes

Closes #9673

-   Added a `.js` to the end of the `configPath` for types, making it work for verbatim modules in TypeScript.
-   I also moved the logic to its own function, making it more readable.

## Testing

Ran all the tests with no errors reported. I didn't add tests because I didn't think they were needed, but if you think otherwise, I'll need guidance on testing different TSConfigs on a given file.

## Docs

Docs don't need to be updated. This is a fix for users with verbatim modules in TypeScript, but it works the same for users without that setting.
