### PR TITLE
Update `check-merge` action

### DIFF
--- a/.github/workflows/check-merge.yml
+++ b/.github/workflows/check-merge.yml
@@ -45,22 +45,26 @@ jobs:
           files: |
             .changeset/**/*.md
 
-      - name: Check if any changesets contain minor changes
-        id: minor
+      - name: Check if any changesets contain minor or major changes
+        id: check
         if: steps.blocked.outputs.result != 'true'
         run: |
-          echo "Checking for changesets marked as minor"
+          echo "Checking for changesets marked as minor or major"
           echo "found=false" >> $GITHUB_OUTPUT
+
+          regex="[\"']astro[\"']: (minor|major)"
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            if grep -q "'astro': minor" "$file"; then
-              echo "found=true" >> $GITHUB_OUTPUT
-              echo "$file has a minor release tag"
-            fi
+              if [[ $(cat $file) =~ $regex ]]; then
+                  version="${BASH_REMATCH[1]}"
+                  echo "version=$version" >> $GITHUB_OUTPUT
+                  echo "found=true" >> $GITHUB_OUTPUT
+                  echo "$file has a $version release tag"
+              fi
           done
 
       - name: Add label
         uses: actions/github-script@v6
-        if: steps.minor.outputs.found == 'true'
+        if: steps.check.outputs.found == 'true'
         env:
           issue_number: ${{ github.event.number }}
         with:
@@ -69,12 +73,12 @@ jobs:
               issue_number: process.env.issue_number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ['semver: minor']
+              labels: ['semver: ${{ steps.check.outputs.version }}']
             });
 
       - name: Change PR Status
         uses: actions/github-script@v6
-        if: steps.minor.outputs.found == 'true'
+        if: steps.check.outputs.found == 'true'
         env:
           issue_number: ${{ github.event.number }}
         with:
@@ -84,5 +88,5 @@ jobs:
               repo: context.repo.repo,
               pull_number: process.env.issue_number,
               event: 'REQUEST_CHANGES',
-              body: 'This PR is blocked because it contains a `minor` changeset. A reviewer will merge this at the next release if approved.'
+              body: 'This PR is blocked because it contains a `${{ steps.check.outputs.version }}` changeset. A reviewer will merge this at the next release if approved.'
             });


### PR DESCRIPTION
## Changes

- Updates our `check-merge` GitHub Action.
- Handles single _and_ double quotes, which is what caused https://github.com/withastro/astro/pull/9671 to bypass the action 😅 
- Also handles major releases because regex is neat

## Testing

I tested the bash script locally, but it's GitHub Actions so who knows

## Docs

Nah