### PR TITLE
adapter enhancement: revert exposing symbols

### DIFF
--- a/.changeset/cool-foxes-talk.md
+++ b/.changeset/cool-foxes-talk.md
@@ -4,8 +4,6 @@
 
 Adds new helper functions for adapter developers.
 
-- Symbols used to represent `Astro.locals` and `Astro.clientAddress` are now available as static properties on the `App` class: `App.Symbol.locals` and `App.Symbol.clientAddress`.
-
 - `Astro.clientAddress` can now be passed directly to the `app.render()` method.
 ```ts
 const response = await app.render(request, { clientAddress: "012.123.23.3" })
@@ -16,7 +14,7 @@ const response = await app.render(request, { clientAddress: "012.123.23.3" })
 http.createServer((nodeReq, nodeRes) => {
     const request: Request = NodeApp.createRequest(nodeReq)
     const response = await app.render(request)
-    NodeApp.writeResponse(response, nodeRes)
+    await NodeApp.writeResponse(response, nodeRes)
 })
 ```
 

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -29,6 +29,8 @@ import { EndpointNotFoundError, SSRRoutePipeline } from './ssrPipeline.js';
 import type { RouteInfo } from './types.js';
 export { deserializeManifest } from './common.js';
 
+const localsSymbol = Symbol.for('astro.locals');
+const clientAddressSymbol = Symbol.for('astro.clientAddress');
 const responseSentSymbol = Symbol.for('astro.responseSent');
 
 /**
@@ -80,15 +82,6 @@ export interface RenderErrorOptions {
 }
 
 export class App {
-
-	/**
-	 * Symbols that the Astro app reads on the passed Request instance. Use these when you can't directly provide these values to `app.render()`.
-	 */
-	static readonly Symbol = Object.freeze({
-		locals: Symbol.for('astro.locals'),
-		clientAddress: Symbol.for('astro.clientAddress'),
-	})
-
 	/**
 	 * The current environment of the application
 	 */
@@ -230,10 +223,10 @@ export class App {
 			}
 		}
 		if (locals) {
-			Reflect.set(request, App.Symbol.locals, locals);
+			Reflect.set(request, localsSymbol, locals);
 		}
 		if (clientAddress) {
-			Reflect.set(request, App.Symbol.clientAddress, clientAddress)
+			Reflect.set(request, clientAddressSymbol, clientAddress)
 		}
 		// Handle requests with duplicate slashes gracefully by cloning with a cleaned-up request URL
 		if (request.url !== collapseDuplicateSlashes(request.url)) {

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -9,6 +9,8 @@ import type { SerializedSSRManifest, SSRManifest } from './types.js';
 
 export { apply as applyPolyfills } from '../polyfill.js';
 
+const clientAddressSymbol = Symbol.for('astro.clientAddress');
+
 /**
  * Allow the request body to be explicitly overridden. For example, this
  * is used by the Express JSON middleware.
@@ -79,7 +81,7 @@ export class NodeApp extends App {
 		}
 		const request = new Request(url, options);
 		if (req.socket?.remoteAddress) {
-			Reflect.set(request, App.Symbol.clientAddress, req.socket.remoteAddress);
+			Reflect.set(request, clientAddressSymbol, req.socket.remoteAddress);
 		}
 		return request;
 	}

--- a/packages/integrations/node/src/serve-app.ts
+++ b/packages/integrations/node/src/serve-app.ts
@@ -13,7 +13,7 @@ export function createAppHandler(app: NodeApp): RequestHandler {
         if (routeData) {
             const response = await app.render(request, {
                 addCookieHeader: true,
-                locals: locals ?? Reflect.get(req, NodeApp.Symbol.locals),
+                locals,
                 routeData,
             });
             await NodeApp.writeResponse(response, res);


### PR DESCRIPTION
## Changes
- We are planning refactors which will likely change where locals and client address are stored for the duration of rendering a page.
- Currently they are stored as symbols on the request object.
- Future features will likely involve multiple request objects per render, and the involvement of symbols in the new pipeline is uncertain.
- Chances are, the current mechanism of passing data as symbol fields will become legacy, especially considering that the `render()` method of `App` now explicitly accepts options.
- As such, we would not want to encourage the use of symbols.
- This PR removes `App.Symbol.locals`, and `App.Symbol.clientAddress` from a feature branch not yet merged into main.
- After this change, #9661 will be ready to review.

## Testing
Existing tests should pass.

## Docs
Removed the section for symbols from Astro 4.2 changest.