### PR TITLE
Opt-out ViewTransition for cross-origin form.

### DIFF
--- a/.changeset/poor-cherries-buy.md
+++ b/.changeset/poor-cherries-buy.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Disables View Transition form handling when the `action` property points to an external URL

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -109,7 +109,9 @@ const { fallback = 'animate' } = Astro.props;
 
 			// the "dialog" method is a special keyword used within <dialog> elements
 			// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method
-			if (method === 'dialog') {
+			if (method === 'dialog' || location.origin !== new URL(action, location.href).origin) {
+				// No page transitions in these cases,
+				// Let the browser standard action handle this
 				return;
 			}
 

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/form-five.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/form-five.astro
@@ -1,0 +1,9 @@
+---
+import Layout from '../components/Layout.astro';
+
+---
+<Layout>
+	<form action="https://example.com/" method="POST">
+		<button id="submit">Submit</button>
+	</form>
+</Layout>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -932,6 +932,13 @@ test.describe('View Transitions', () => {
 		).toEqual(1);
 	});
 
+	test('form POST that action for cross-origin is opt-out', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/form-five'));
+		page.on('request', (request) => expect(request.method()).toBe('POST'));
+		// Submit the form
+		await page.click('#submit');
+	});
+
 	test('form GET that redirects to another page is handled', async ({ page, astro }) => {
 		const loads = [];
 		page.addListener('load', async (p) => {


### PR DESCRIPTION
For issue [#9676 ViewTransition doesn't respect form method="post" when the action of form targets external URL](https://github.com/withastro/astro/issues/9676#issue-2078173834)

Leaving the submit handler when the form is cross-origin.

***Edited:***
Closes #9676