### PR TITLE
@astrojs/sitemap: Fixes generated URLs when using a `base` with a SSR adapter

### DIFF
--- a/.changeset/curly-seals-count.md
+++ b/.changeset/curly-seals-count.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/sitemap": patch
+---
+
+Fix base path formatting for ssr adapters.

--- a/.changeset/curly-seals-count.md
+++ b/.changeset/curly-seals-count.md
@@ -2,4 +2,4 @@
 "@astrojs/sitemap": patch
 ---
 
-Fix base path formatting for ssr adapters.
+Fixes generated URLs when using a `base` with a SSR adapter

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -107,11 +107,12 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 						 */
 						if (r.pathname) {
 							if (isStatusCodePage(r.pathname ?? r.route)) return urls;
-							/**
-							 * remove the initial slash from relative pathname
-							 * because `finalSiteUrl` always has trailing slash
-							 */
-							const fullPath = finalSiteUrl.pathname + r.generate(r.pathname).substring(1);
+
+							// `finalSiteUrl` may end with a trailing slash
+							// or not because of base paths.
+							let fullPath = finalSiteUrl.pathname;
+							if (fullPath.endsWith('/')) fullPath += r.generate(r.pathname).substring(1);
+							else fullPath += r.generate(r.pathname);
 
 							let newUrl = new URL(fullPath, finalSiteUrl).href;
 

--- a/packages/integrations/sitemap/test/base-path.test.js
+++ b/packages/integrations/sitemap/test/base-path.test.js
@@ -1,0 +1,39 @@
+import { loadFixture, readXML } from './test-utils.js';
+import { expect } from 'chai';
+
+describe('URLs with base path', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	describe('using node adapter', () => {
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/ssr/',
+				base: '/base',
+			});
+			await fixture.build();
+		});
+
+		it('Base path is concatenated correctly', async () => {
+			const data = await readXML(fixture.readFile('/client/sitemap-0.xml'));
+			const urls = data.urlset.url;
+			expect(urls[0].loc[0]).to.equal('http://example.com/base/one/');
+		});
+	});
+
+	describe('static', () => {
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/static/',
+				base: '/base',
+			});
+			await fixture.build();
+		});
+
+		it('Base path is concatenated correctly', async () => {
+			const data = await readXML(fixture.readFile('/sitemap-0.xml'));
+			const urls = data.urlset.url;
+			expect(urls[0].loc[0]).to.equal('http://example.com/base/123/');
+		});
+	});
+});


### PR DESCRIPTION
## Changes

fixes #9701 

The URLs from sitemap were being wrongfully generated if base path and ssr adapters were setup.

## Testing

I added some tests.

## Docs
n/a
