### PR TITLE
Simplify HMR for circular imports and CSS

### DIFF
--- a/.changeset/curvy-seas-explain.md
+++ b/.changeset/curvy-seas-explain.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/mdx": patch
+---
+
+Removes redundant HMR handling code

--- a/.changeset/tidy-planets-whisper.md
+++ b/.changeset/tidy-planets-whisper.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Simplifies HMR handling, improves circular dependency invalidation, and fixes Astro styles invalidation

--- a/packages/astro/e2e/fixtures/tailwindcss/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/tailwindcss/astro.config.mjs
@@ -7,6 +7,7 @@ export default defineConfig({
 	integrations: [
 		tailwind({
 			configFile: fileURLToPath(new URL('./tailwind.config.js', import.meta.url)),
+			applyBaseStyles: false
 		}),
 	],
 	devToolbar: {

--- a/packages/astro/e2e/fixtures/tailwindcss/src/components/Layout.astro
+++ b/packages/astro/e2e/fixtures/tailwindcss/src/components/Layout.astro
@@ -1,0 +1,16 @@
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<title>Astro + TailwindCSS</title>
+	</head>
+	<body class="bg-dawn text-midnight">
+    <slot/>
+  </body>
+</html>
+
+<style is:global>
+  @tailwind base;
+
+  @tailwind utilities;
+</style>

--- a/packages/astro/e2e/fixtures/tailwindcss/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/tailwindcss/src/pages/index.astro
@@ -1,18 +1,11 @@
 ---
 // Component Imports
+import Layout from '../components/Layout.astro';
 import Button from '../components/Button.astro';
 import Complex from '../components/Complex.astro';
 ---
 
-<html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
-		<title>Astro + TailwindCSS</title>
-	</head>
-
-	<body class="bg-dawn text-midnight">
-		<Button>I’m a Tailwind Button!</Button>
-		<Complex />
-	</body>
-</html>
+<Layout>
+	<Button>I’m a Tailwind Button!</Button>
+	<Complex />
+</Layout>

--- a/packages/astro/src/core/logger/vite.ts
+++ b/packages/astro/src/core/logger/vite.ts
@@ -6,7 +6,7 @@ import { isLogLevelEnabled, type Logger as AstroLogger } from './core.js';
 
 const PKG_PREFIX = fileURLToPath(new URL('../../../', import.meta.url));
 const E2E_PREFIX = fileURLToPath(new URL('../../../e2e', import.meta.url));
-export function isAstroSrcFile(id: string | null) {
+function isAstroSrcFile(id: string | null) {
 	return id?.startsWith(PKG_PREFIX) && !id.startsWith(E2E_PREFIX);
 }
 

--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -76,11 +76,6 @@ export async function cachedFullCompilation({
 		}
 	}
 
-	// Prefer live reload to HMR in `.astro` files
-	if (!compileProps.viteConfig.isProduction) {
-		SUFFIX += `\nif (import.meta.hot) { import.meta.hot.decline() }`;
-	}
-
 	return {
 		...transformResult,
 		code: esbuildResult.code + SUFFIX,

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -32,7 +32,9 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 	// Tailwind styles could register Astro files as dependencies of other Astro files,
 	// causing circular imports which trips Vite's HMR. This set is passed to `handleHotUpdate`
 	// to force a page reload when these dependency files are updated
-	let astroFileToCssAstroDeps: Map<string, Set<string>>;
+	// NOTE: We need to initialize a map here and in `buildStart` because our unit tests don't
+	// call `buildStart` (test bug)
+	let astroFileToCssAstroDeps = new Map<string, Set<string>>();
 
 	// Variables for determining if an id starts with /src...
 	const srcRootWeb = config.srcDir.pathname.slice(config.root.pathname.length - 1);

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -168,8 +168,8 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 			};
 
 			// We invalidate and then compile again as we know Vite will only call this `transform`
-			// is the cache its cache is invalidated.
-			// TODO: Do the compilation directly.
+			// when its cache is invalidated.
+			// TODO: Do the compilation directly and remove our cache so we rely on Vite only.
 			invalidateCompilation(config, compileProps.filename);
 			const transformResult = await cachedFullCompilation({ compileProps, logger });
 

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -9,6 +9,7 @@ import {
 	cachedCompilation,
 	getCachedCompileResult,
 	type CompileProps,
+	invalidateCompilation,
 } from '../core/compile/index.js';
 import { isRelativePath } from '../core/path.js';
 import { normalizeFilename } from '../vite-plugin-utils/index.js';
@@ -27,7 +28,11 @@ interface AstroPluginOptions {
 export default function astro({ settings, logger }: AstroPluginOptions): vite.Plugin[] {
 	const { config } = settings;
 	let resolvedConfig: vite.ResolvedConfig;
-	let server: vite.ViteDevServer;
+	let server: vite.ViteDevServer | undefined;
+	// Tailwind styles could register Astro files as dependencies of other Astro files,
+	// causing circular imports which trips Vite's HMR. This set is passed to `handleHotUpdate`
+	// to force a page reload when these dependency files are updated
+	let astroFileToCssAstroDeps: Map<string, Set<string>>;
 
 	// Variables for determining if an id starts with /src...
 	const srcRootWeb = config.srcDir.pathname.slice(config.root.pathname.length - 1);
@@ -41,6 +46,9 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 		},
 		configureServer(_server) {
 			server = _server;
+		},
+		buildStart() {
+			astroFileToCssAstroDeps = new Map();
 		},
 		async load(id, opts) {
 			const parsedId = parseAstroRequest(id);
@@ -157,10 +165,38 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 				source,
 			};
 
+			// We invalidate and then compile again as we know Vite will only call this `transform`
+			// is the cache its cache is invalidated.
+			// TODO: Do the compilation directly.
+			invalidateCompilation(config, compileProps.filename);
 			const transformResult = await cachedFullCompilation({ compileProps, logger });
 
+			// Register dependencies of this module
+			const astroDeps = new Set<string>();
 			for (const dep of transformResult.cssDeps) {
+				if (dep.endsWith('.astro')) {
+					astroDeps.add(dep);
+				}
 				this.addWatchFile(dep);
+			}
+			astroFileToCssAstroDeps.set(id, astroDeps);
+
+			// When a dependency from the styles are updated, the dep and Astro module will get invalidated.
+			// However, the Astro style virtual module is not invalidated because we didn't register that the virtual
+			// module has that dependency. We currently can't do that either because of a Vite bug.
+			// https://github.com/vitejs/vite/pull/15608
+			// Here we manually invalidate the virtual modules ourselves when we're compiling the Astro module.
+			// When that bug is resolved, we can add the dependencies to the virtual module directly and remove this.
+			if (server) {
+				const mods = server.moduleGraph.getModulesByFile(compileProps.filename);
+				if (mods) {
+					const seen = new Set(mods);
+					for (const mod of mods) {
+						if (mod.url.includes('?astro')) {
+							server.moduleGraph.invalidateModule(mod, seen);
+						}
+					}
+				}
 			}
 
 			const astroMetadata: AstroPluginMetadata['astro'] = {
@@ -200,6 +236,7 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 			return handleHotUpdate(context, {
 				config,
 				logger,
+				astroFileToCssAstroDeps,
 				compile,
 				source,
 			});

--- a/packages/astro/src/vite-plugin-astro/query.ts
+++ b/packages/astro/src/vite-plugin-astro/query.ts
@@ -35,8 +35,3 @@ export function parseAstroRequest(id: string): ParsedRequestResult {
 		query,
 	};
 }
-
-export function isAstroScript(id: string): boolean {
-	const parsed = parseAstroRequest(id);
-	return parsed.query.type === 'script';
-}

--- a/packages/astro/test/units/vite-plugin-astro/compile.test.js
+++ b/packages/astro/test/units/vite-plugin-astro/compile.test.js
@@ -62,11 +62,6 @@ const name = 'world
 		expect(result).to.be.undefined;
 	});
 
-	it('injects hmr code', async () => {
-		const result = await compile(`<h1>Hello World</h1>`, '/src/components/index.astro');
-		expect(result.code).to.include('import.meta.hot');
-	});
-
 	it('has file and url exports for markdwon compat', async () => {
 		const result = await compile(`<h1>Hello World</h1>`, '/src/components/index.astro');
 		await init;

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -40,14 +40,8 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 		name: '@astrojs/mdx',
 		hooks: {
 			'astro:config:setup': async (params) => {
-				const {
-					updateConfig,
-					config,
-					addPageExtension,
-					addContentEntryType,
-					command,
-					addRenderer,
-				} = params as SetupHookParams;
+				const { updateConfig, config, addPageExtension, addContentEntryType, addRenderer } =
+					params as SetupHookParams;
 
 				addRenderer(astroJSXRenderer);
 				addPageExtension('.mdx');
@@ -209,12 +203,6 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 									code += `\nContent[Symbol.for('astro.needsHeadRendering')] = !Boolean(frontmatter.layout);`;
 									code += `\nContent.moduleId = ${JSON.stringify(id)};`;
 
-									if (command === 'dev') {
-										// TODO: decline HMR updates until we have a stable approach
-										code += `\nif (import.meta.hot) {
-											import.meta.hot.decline();
-										}`;
-									}
 									return { code, map: null };
 								},
 							},


### PR DESCRIPTION
## Changes

This PR removes a good portion of the HMR code with an approach that lets Vite invalidates the modules accordingly instead. The highlights are:

1. Simplify `handleHotUpdate`. It now only does two things: "check style-only updates" and "handle circular dep edge case" (latter can be removed in the future)
2. Simplify Astro compilation caching and invalidation.
3. Remove redundant `import.meta.hot.decline()` calls. They don't work in Vite.

## Testing

Added a test from https://github.com/withastro/astro/issues/9370

While this should fix it https://github.com/withastro/astro/issues/9370, I'd like to further improve HMR more noted in the `TODO`s, including:

- Refactoring away Astro compilation cache. Vite already has its own cache and we can rely on that instead. (Saves on memory)
- Fine-grained CSS updates (When the Vite PR lands)

## Docs

n/a. should be internal refactor and HMR will work as expected
