### PR TITLE
Avoid vite 5.1 warning

### DIFF
--- a/.changeset/green-rivers-speak.md
+++ b/.changeset/green-rivers-speak.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Refactors Vite config to avoid Vite 5.1 warnings

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -7,7 +7,7 @@ import { debug } from '../logger/core.js';
 async function createViteServer(root: string, fs: typeof fsType): Promise<ViteDevServer> {
 	const viteServer = await createServer({
 		server: { middlewareMode: true, hmr: false, watch: null },
-		optimizeDeps: { disabled: true },
+		optimizeDeps: { noDiscovery: true },
 		clearScreen: false,
 		appType: 'custom',
 		ssr: {

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -82,7 +82,7 @@ export async function syncInternal(
 		await createVite(
 			{
 				server: { middlewareMode: true, hmr: false, watch: null },
-				optimizeDeps: { disabled: true },
+				optimizeDeps: { noDiscovery: true },
 				ssr: { external: [] },
 				logLevel: 'silent',
 			},


### PR DESCRIPTION
## Changes

Vite 5.1 deprecates the `optimizeDeps.disabled` experimental option. It will emit this warning:

```
(!) Experimental optimizeDeps.disabled and deps pre-bundling during build were removed in Vite 5.1.
    To disable the deps optimizer, set optimizeDeps.noDiscovery to true and optimizeDeps.include as undefined or empty. 
    Please remove optimizeDeps.disabled from your config.
```

This PR updates to its suggested configuration.

## Testing

Existing tests should pass

## Docs

n/a. internal refactor.

