### PR TITLE
normalize class property

### DIFF
--- a/.changeset/nervous-dodos-compete.md
+++ b/.changeset/nervous-dodos-compete.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/markdown-remark": patch
+---
+
+Normalize class property

--- a/.changeset/nervous-dodos-compete.md
+++ b/.changeset/nervous-dodos-compete.md
@@ -2,4 +2,4 @@
 "@astrojs/markdown-remark": patch
 ---
 
-Normalize class property
+Fixes a case where transformers wouldn't work on the `class` property

--- a/packages/markdown/remark/src/shiki.ts
+++ b/packages/markdown/remark/src/shiki.ts
@@ -62,10 +62,8 @@ export async function createShikiHighlighter({
 								node.tagName = 'code';
 							}
 
-							const classValue = normalizeMaybeArray(node.properties.class) ?? '';
-
-							// Cast to string as shikiji will always pass them as strings instead of any other types
-							const styleValue = (node.properties.style as string) ?? '';
+							const classValue = normalizePropAsString(node.properties.class) ?? '';
+							const styleValue = normalizePropAsString(node.properties.style) ?? '';
 
 							// Replace "shiki" class naming with "astro-code"
 							node.properties.class = classValue.replace(/shiki/g, 'astro-code');
@@ -131,7 +129,7 @@ export async function createShikiHighlighter({
 	};
 }
 
-function normalizeMaybeArray(value: Properties[string]): string | null {
+function normalizePropAsString(value: Properties[string]): string | null {
 	return Array.isArray(value) ? value.join(' ') : (value as string | null);
 }
 

--- a/packages/markdown/remark/src/shiki.ts
+++ b/packages/markdown/remark/src/shiki.ts
@@ -1,5 +1,6 @@
 import { bundledLanguages, createCssVariablesTheme, getHighlighter } from 'shikiji';
 import { visit } from 'unist-util-visit';
+import type { Properties } from 'hast';
 import type { ShikiConfig } from './types.js';
 
 export interface ShikiHighlighter {
@@ -61,8 +62,9 @@ export async function createShikiHighlighter({
 								node.tagName = 'code';
 							}
 
+							const classValue = normalizeMaybeArray(node.properties.class) ?? '';
+
 							// Cast to string as shikiji will always pass them as strings instead of any other types
-							const classValue = (node.properties.class as string) ?? '';
 							const styleValue = (node.properties.style as string) ?? '';
 
 							// Replace "shiki" class naming with "astro-code"
@@ -127,6 +129,10 @@ export async function createShikiHighlighter({
 			});
 		},
 	};
+}
+
+function normalizeMaybeArray(value: Properties[string]): string | null {
+	return Array.isArray(value) ? value.join(' ') : (value as string);
 }
 
 /**

--- a/packages/markdown/remark/src/shiki.ts
+++ b/packages/markdown/remark/src/shiki.ts
@@ -132,7 +132,7 @@ export async function createShikiHighlighter({
 }
 
 function normalizeMaybeArray(value: Properties[string]): string | null {
-	return Array.isArray(value) ? value.join(' ') : (value as string);
+	return Array.isArray(value) ? value.join(' ') : (value as string | null);
 }
 
 /**


### PR DESCRIPTION
## Changes

Attempting to use some of the [common transformers](https://shikiji.netlify.app/packages/transformers) raises an exception:

```
MDXError: classValue.replace is not a function
    at TransformContext.transform (node_modules/@astrojs/mdx/dist/index.js:93:27)
    at async Object.transform (node_modules/vite/dist/node/chunks/dep-V3BH7oO1.js:64060:30)
    at async loadAndTransform (node_modules/vite/dist/node/chunks/dep-V3BH7oO1.js:49741:29)
    at async instantiateModule (node_modules/vite/dist/node/chunks/dep-V3BH7oO1.js:50759:10)
```

This is because `addClassToHast` returns an array of strings. But `Array`s don't have a `.replace`. See: https://github.com/antfu/shikiji/blob/31241ba4dc47c2d4d7809ee08c6573b26b07b812/packages/shikiji-core/src/utils.ts#L44


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I couldn't figure out how to write a unit test for this. But I edited a build version with this logic and it works.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
