### PR TITLE
Fix regression in the routing priority of index routes

### DIFF
--- a/.changeset/smart-rules-train.md
+++ b/.changeset/smart-rules-train.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix regression in routing priority between `index.astro` routes and dynamic routes with rest parameters

--- a/.changeset/smart-rules-train.md
+++ b/.changeset/smart-rules-train.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fix regression in routing priority between `index.astro` routes and dynamic routes with rest parameters
+Fixes a regression in routing priority between `index.astro` and dynamic routes with rest parameters

--- a/packages/astro/test/units/routing/manifest.test.js
+++ b/packages/astro/test/units/routing/manifest.test.js
@@ -103,6 +103,51 @@ describe('routing - createRouteManifest', () => {
 		]);
 	});
 
+	it('static routes are sorted before dynamic and rest routes', async () => {
+		const fs = createFs(
+			{
+				'/src/pages/[dynamic].astro': `<h1>test</h1>`,
+				'/src/pages/[...rest].astro': `<h1>test</h1>`,
+				'/src/pages/static.astro': `<h1>test</h1>`,
+				'/src/pages/index.astro': `<h1>test</h1>`,
+			},
+			root
+		);
+		const settings = await createBasicSettings({
+			root: fileURLToPath(root),
+			base: '/search',
+			trailingSlash: 'never',
+			experimental: {
+				globalRoutePriority: true,
+			},
+		});
+
+		const manifest = createRouteManifest({
+			cwd: fileURLToPath(root),
+			settings,
+			fsMod: fs,
+		});
+
+		expect(getManifestRoutes(manifest)).to.deep.equal([
+				{
+					"route": "/",
+					"type": "page",
+				},
+				{
+					"route": "/static",
+					"type": "page",
+				},
+				{
+					"route": "/[dynamic]",
+					"type": "page",
+				},
+				{
+					"route": "/[...rest]",
+					"type": "page",
+				},
+			]);
+	});
+
 	it('injected routes are sorted in legacy mode above filesystem routes', async () => {
 		const fs = createFs(
 			{
@@ -197,15 +242,15 @@ describe('routing - createRouteManifest', () => {
 				type: 'page',
 			},
 			{
+				route: '/',
+				type: 'page',
+			},
+			{
 				route: '/contributing',
 				type: 'page',
 			},
 			{
 				route: '/[...slug]',
-				type: 'page',
-			},
-			{
-				route: '/',
 				type: 'page',
 			},
 		]);


### PR DESCRIPTION
## Changes

- Fix regression that causes pages ending with `index.astro` to be overridden by dynamic routes with rest parameters.
- Closes #9724

## Testing

There was an incorrect test for the index priority, that was fixed and a new test for the full combination of routes in the same directory was added.

## Docs

No changes in docs since this was an unintended regression. The docs already reflect the correct behavior.