### PR TITLE
Fix `@astrojs/markdown-remark` bundling for non-node runtimes

### DIFF
--- a/.changeset/lemon-carrots-cheer.md
+++ b/.changeset/lemon-carrots-cheer.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/markdown-remark": patch
+---
+
+Initializes internal `cwdUrlStr` variable lazily for performance, and workaround Rollup side-effect detection bug when building for non-Node runtimes

--- a/packages/markdown/remark/src/load-plugins.ts
+++ b/packages/markdown/remark/src/load-plugins.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type * as unified from 'unified';
 
-const cwdUrlStr = pathToFileURL(path.join(process.cwd(), 'package.json')).toString();
+let cwdUrlStr: string | undefined;
 
 async function importPlugin(p: string | unified.Plugin): Promise<unified.Plugin> {
 	if (typeof p === 'string') {
@@ -14,6 +14,7 @@ async function importPlugin(p: string | unified.Plugin): Promise<unified.Plugin>
 		} catch {}
 
 		// Try import from user project
+		cwdUrlStr ??= pathToFileURL(path.join(process.cwd(), 'package.json')).toString();
 		const resolved = importMetaResolve(p, cwdUrlStr);
 		const importResult = await import(resolved);
 		return importResult.default;


### PR DESCRIPTION
## Changes

This will help with https://github.com/withastro/adapters/issues/110 (not a complete fix yet)

For some reason, Rollup sees this:

https://github.com/withastro/astro/blob/ea6cbd06a2580527786707ec735079ff9abd0ec0/packages/markdown/remark/src/load-plugins.ts#L6

As side-effectful, so it'll include the import to `pathToFileUrl` in the final bundle, which wouldn't work for Cloudflare builds.

This PR side-steps by initializing the `cwdUrlStr` variable lazily, which is also better for perf.

## Testing

I didn't add a test because it's hard to create a failing test without a very specific build of Astro.

## Docs

n/a. internal change.
