### PR TITLE
Make `@astrojs/markdown-remark` browser-safe

### DIFF
--- a/.changeset/thick-carrots-run.md
+++ b/.changeset/thick-carrots-run.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/markdown-remark": minor
+---
+
+Uses subpath imports to allow the package to be used in browser environments

--- a/.changeset/thick-carrots-run.md
+++ b/.changeset/thick-carrots-run.md
@@ -2,4 +2,4 @@
 "@astrojs/markdown-remark": minor
 ---
 
-Uses subpath imports to allow the package to be used in browser environments
+Fixes usage in browser environments by using subpath imports

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -16,6 +16,12 @@
     ".": "./dist/index.js",
     "./dist/internal.js": "./dist/internal.js"
   },
+  "imports": {
+    "#import-plugin": {
+      "browser": "./dist/import-plugin-browser.js",
+      "default": "./dist/import-plugin-default.js"
+    }
+  },
   "files": [
     "dist"
   ],
@@ -52,6 +58,7 @@
     "@types/unist": "^3.0.2",
     "astro-scripts": "workspace:*",
     "chai": "^4.3.7",
+    "esbuild": "^0.19.6",
     "mdast-util-mdx-expression": "^2.0.0",
     "mocha": "^10.2.0"
   },

--- a/packages/markdown/remark/src/import-plugin-browser.ts
+++ b/packages/markdown/remark/src/import-plugin-browser.ts
@@ -1,0 +1,8 @@
+// This file should be imported as `#import-plugin`
+import type * as unified from 'unified';
+
+// In the browser, we can try to do a plain import
+export async function importPlugin(p: string): Promise<unified.Plugin> {
+	const importResult = await import(p);
+	return importResult.default;
+}

--- a/packages/markdown/remark/src/import-plugin-default.ts
+++ b/packages/markdown/remark/src/import-plugin-default.ts
@@ -1,0 +1,22 @@
+// This file should be imported as `#import-plugin`
+import { resolve as importMetaResolve } from 'import-meta-resolve';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type * as unified from 'unified';
+
+let cwdUrlStr: string | undefined;
+
+// In non-browser enviroments, we can try to resolve from the filesystem too
+export async function importPlugin(p: string): Promise<unified.Plugin> {
+	// Try import from this package first
+	try {
+		const importResult = await import(p);
+		return importResult.default;
+	} catch {}
+
+	// Try import from user project
+	cwdUrlStr ??= pathToFileURL(path.join(process.cwd(), 'package.json')).toString();
+	const resolved = importMetaResolve(p, cwdUrlStr);
+	const importResult = await import(resolved);
+	return importResult.default;
+}

--- a/packages/markdown/remark/src/load-plugins.ts
+++ b/packages/markdown/remark/src/load-plugins.ts
@@ -1,5 +1,4 @@
 import type * as unified from 'unified';
-// @ts-ignore Types may not exist if you have not run `pnpm build` first
 import { importPlugin as _importPlugin } from '#import-plugin';
 
 async function importPlugin(p: string | unified.Plugin<any[], any>) {

--- a/packages/markdown/remark/src/load-plugins.ts
+++ b/packages/markdown/remark/src/load-plugins.ts
@@ -1,26 +1,13 @@
-import { resolve as importMetaResolve } from 'import-meta-resolve';
-import path from 'node:path';
-import { pathToFileURL } from 'node:url';
 import type * as unified from 'unified';
+// @ts-ignore Types may not exist if you have not run `pnpm build` first
+import { importPlugin as _importPlugin } from '#import-plugin';
 
-let cwdUrlStr: string | undefined;
-
-async function importPlugin(p: string | unified.Plugin): Promise<unified.Plugin> {
+async function importPlugin(p: string | unified.Plugin<any[], any>) {
 	if (typeof p === 'string') {
-		// Try import from this package first
-		try {
-			const importResult = await import(p);
-			return importResult.default;
-		} catch {}
-
-		// Try import from user project
-		cwdUrlStr ??= pathToFileURL(path.join(process.cwd(), 'package.json')).toString();
-		const resolved = importMetaResolve(p, cwdUrlStr);
-		const importResult = await import(resolved);
-		return importResult.default;
+		return await _importPlugin(p);
+	} else {
+		return p;
 	}
-
-	return p;
 }
 
 export function loadPlugins(

--- a/packages/markdown/remark/test/browser.test.js
+++ b/packages/markdown/remark/test/browser.test.js
@@ -1,0 +1,15 @@
+import esbuild from 'esbuild';
+import { expect } from 'chai';
+
+describe('Bundle for browsers', async () => {
+	it('esbuild browser build should work', async () => {
+		const result = await esbuild.build({
+			platform: 'browser',
+			entryPoints: ['@astrojs/markdown-remark'],
+			bundle: true,
+			write: false,
+		});
+		// If some non-browser-safe stuff sneaks in, esbuild should error before reaching here
+		expect(result.outputFiles.length).to.be.greaterThan(0);
+	});
+});

--- a/packages/markdown/remark/tsconfig.json
+++ b/packages/markdown/remark/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "."
   }
 }

--- a/packages/markdown/remark/tsconfig.json
+++ b/packages/markdown/remark/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["src"],
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "."
+    "rootDir": "./src",
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5059,6 +5059,9 @@ importers:
       chai:
         specifier: ^4.3.7
         version: 4.3.10
+      esbuild:
+        specifier: ^0.19.6
+        version: 0.19.11
       mdast-util-mdx-expression:
         specifier: ^2.0.0
         version: 2.0.0


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/adapters/issues/110

Uses [imports mapping](https://nodejs.org/api/packages.html#imports) to split the `importPlugin()` function as a browser-safe and non-browser-safe version.

## Testing

Created a test that runs esbuild to build a browser version.

## Docs

n/a. the dependency is internal.
