### PR TITLE
fix(i18n): pass `build.format` when computing the redirect

### DIFF
--- a/.changeset/fifty-pots-greet.md
+++ b/.changeset/fifty-pots-greet.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+The i18n redirects should consider the `build.format` configuration

--- a/.changeset/fifty-pots-greet.md
+++ b/.changeset/fifty-pots-greet.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-The i18n redirects should consider the `build.format` configuration
+Makes i18n redirects take the `build.format` configuration into account

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -255,7 +255,8 @@ export class App {
 			const i18nMiddleware = createI18nMiddleware(
 				this.#manifest.i18n,
 				this.#manifest.base,
-				this.#manifest.trailingSlash
+				this.#manifest.trailingSlash,
+				this.#manifest.buildFormat
 			);
 			if (i18nMiddleware) {
 				if (mod.onRequest) {

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -40,6 +40,7 @@ export type SSRManifest = {
 	site?: string;
 	base: string;
 	trailingSlash: 'always' | 'never' | 'ignore';
+	buildFormat: 'file' | 'directory';
 	compressHTML: boolean;
 	assetsPrefix?: string;
 	renderers: SSRLoadedRenderer[];

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -265,7 +265,8 @@ async function generatePage(
 	const i18nMiddleware = createI18nMiddleware(
 		pipeline.getManifest().i18n,
 		pipeline.getManifest().base,
-		pipeline.getManifest().trailingSlash
+		pipeline.getManifest().trailingSlash,
+		pipeline.getManifest().buildFormat
 	);
 	if (config.i18n && i18nMiddleware) {
 		if (onRequest) {
@@ -657,5 +658,6 @@ export function createBuildManifest(
 			: settings.config.site,
 		componentMetadata: internals.componentMetadata,
 		i18n: i18nManifest,
+		buildFormat: settings.config.build.format,
 	};
 }

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -264,5 +264,6 @@ function buildManifest(
 		entryModules,
 		assets: staticFiles.map(prefixAssetPath),
 		i18n: i18nManifest,
+		buildFormat: settings.config.build.format,
 	};
 }

--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -2,6 +2,7 @@ import { appendForwardSlash, joinPaths } from '@astrojs/internal-helpers/path';
 import type { Locales, MiddlewareHandler, RouteData, SSRManifest } from '../@types/astro.js';
 import type { PipelineHookFunction } from '../core/pipeline.js';
 import { getPathByLocale, normalizeTheLocale } from './index.js';
+import { shouldAppendForwardSlash } from '../core/build/util.js';
 
 const routeDataSymbol = Symbol.for('astro.routeData');
 
@@ -26,7 +27,8 @@ function pathnameHasLocale(pathname: string, locales: Locales): boolean {
 export function createI18nMiddleware(
 	i18n: SSRManifest['i18n'],
 	base: SSRManifest['base'],
-	trailingSlash: SSRManifest['trailingSlash']
+	trailingSlash: SSRManifest['trailingSlash'],
+	buildFormat: SSRManifest['buildFormat']
 ): MiddlewareHandler | undefined {
 	if (!i18n) {
 		return undefined;
@@ -83,7 +85,7 @@ export function createI18nMiddleware(
 
 				case 'pathname-prefix-always': {
 					if (url.pathname === base + '/' || url.pathname === base) {
-						if (trailingSlash === 'always') {
+						if (shouldAppendForwardSlash(trailingSlash, buildFormat)) {
 							return context.redirect(`${appendForwardSlash(joinPaths(base, i18n.defaultLocale))}`);
 						} else {
 							return context.redirect(`${joinPaths(base, i18n.defaultLocale)}`);

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -125,6 +125,7 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 	}
 	return {
 		trailingSlash: settings.config.trailingSlash,
+		buildFormat: settings.config.build.format,
 		compressHTML: settings.config.compressHTML,
 		assets: new Set(),
 		entryModules: {},

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -308,7 +308,12 @@ export async function handleRoute({
 
 	const onRequest = middleware?.onRequest as MiddlewareHandler | undefined;
 	if (config.i18n) {
-		const i18Middleware = createI18nMiddleware(config.i18n, config.base, config.trailingSlash);
+		const i18Middleware = createI18nMiddleware(
+			config.i18n,
+			config.base,
+			config.trailingSlash,
+			config.build.format
+		);
 
 		if (i18Middleware) {
 			if (onRequest) {

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -675,6 +675,7 @@ describe('[SSG] i18n routing', () => {
 		it('should redirect to the index of the default locale', async () => {
 			const html = await fixture.readFile('/index.html');
 			expect(html).to.include('http-equiv="refresh');
+			expect(html).to.include('http-equiv="refresh');
 			expect(html).to.include('url=/new-site/en');
 		});
 
@@ -940,7 +941,7 @@ describe('[SSR] i18n routing', () => {
 			let request = new Request('http://example.com/new-site');
 			let response = await app.render(request);
 			expect(response.status).to.equal(302);
-			expect(response.headers.get('location')).to.equal('/new-site/en');
+			expect(response.headers.get('location')).to.equal('/new-site/en/');
 		});
 
 		it('should render the en locale', async () => {
@@ -1118,7 +1119,7 @@ describe('[SSR] i18n routing', () => {
 			let request = new Request('http://example.com/new-site');
 			let response = await app.render(request);
 			expect(response.status).to.equal(302);
-			expect(response.headers.get('location')).to.equal('/new-site/en');
+			expect(response.headers.get('location')).to.equal('/new-site/en/');
 		});
 
 		it('should render the en locale', async () => {


### PR DESCRIPTION
## Changes

This PR adds `build.format` to the SSR Manifest.

This information is eventually needed by the i18n middleware to correctly compute the redirect.

## Testing

Existing tests should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
