### PR TITLE
Fix dot files not being copied over on non-root builds (#9740)

### DIFF
--- a/.changeset/slimy-jobs-smash.md
+++ b/.changeset/slimy-jobs-smash.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix dot files not being copied over on non-root builds

--- a/.changeset/slimy-jobs-smash.md
+++ b/.changeset/slimy-jobs-smash.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fix dot files not being copied over on non-root builds
+Fixes an issue where dot files were not copied over from the public folder to the output folder when build command was run inside a subfolder.

--- a/.changeset/slimy-jobs-smash.md
+++ b/.changeset/slimy-jobs-smash.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes an issue where dot files were not copied over from the public folder to the output folder when build command was run inside a subfolder.
+Fixes an issue where dot files were not copied over from the public folder to the output folder, when build command was run in a folder other than the root of the project.

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -439,7 +439,7 @@ async function cleanServerOutput(
 	// Clean out directly if the outDir is outside of root
 	if (out.toString() !== opts.settings.config.outDir.toString()) {
 		// Copy assets before cleaning directory if outside root
-		await copyFiles(out, opts.settings.config.outDir);
+		await copyFiles(out, opts.settings.config.outDir, true);
 		await fs.promises.rm(out, { recursive: true });
 		return;
 	}


### PR DESCRIPTION
## Changes

Fixes https://github.com/withastro/astro/issues/9740

When running `astro build` outside of where the astro files are, dotfiles are not copied over because the `includeDotfiles` parameter is not passed in. This PR adds a `true` `includeDotfiles` value to `copyFiles` to fix this.

## Testing

1. Check out this PR locally
1. Download astro bug example https://stackblitz.com/edit/github-es2mdg-tnkbfm?file=README.md
1. Check bug

   ```bash
   cd another-astro
   pnpm install
   npm run astro build -- --root ../
   ls -la ../dist
   # Notice that there is no `.htaccess` file

   pnpm link [PR-root]/astro/packages/astro
   npm run astro build -- --root ../
   ls -la ../dist
   # Now there is a `.htaccess` file
   ```

Not sure if this requires an e2e test, but if so, please point me in the direction of an example of how one is set up.

## Docs

Fixes a bug with build, so shouldn't affect any of the docs
