### PR TITLE
fix(rss): rssSchema definition to allow calling standard zod object methods

### DIFF
--- a/.changeset/mighty-icons-try.md
+++ b/.changeset/mighty-icons-try.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/rss": patch
+---
+
+Fixes `rssSchema` definition to allow calling standard zod object methods (like `extend`)

--- a/packages/astro-rss/src/schema.ts
+++ b/packages/astro-rss/src/schema.ts
@@ -22,7 +22,7 @@ export const rssSchema = z.object({
 		.optional(),
 	link: z.string().optional(),
 	content: z.string().optional(),
-}).refine(val => !val.title && !val.description, {
+}).refine(val => val.title || val.description, {
 	message: "At least title or description must be provided.",
 	path: ["title", "description"]
 })

--- a/packages/astro-rss/src/schema.ts
+++ b/packages/astro-rss/src/schema.ts
@@ -1,6 +1,8 @@
 import { z } from 'astro/zod';
 
-const sharedSchema = z.object({
+export const rssSchema = z.object({
+	title: z.string().optional(),
+	description: z.string().optional(),
 	pubDate: z
 		.union([z.string(), z.number(), z.date()])
 		.optional()
@@ -20,19 +22,7 @@ const sharedSchema = z.object({
 		.optional(),
 	link: z.string().optional(),
 	content: z.string().optional(),
-});
-
-export const rssSchema = z.union([
-	z
-		.object({
-			title: z.string(),
-			description: z.string().optional(),
-		})
-		.merge(sharedSchema),
-	z
-		.object({
-			title: z.string().optional(),
-			description: z.string(),
-		})
-		.merge(sharedSchema),
-]);
+}).refine(val => !val.title && !val.description, {
+	message: "At least title or description must be provided.",
+	path: ["title", "description"]
+})


### PR DESCRIPTION
## Changes

- Close #9744
- Uses `object` and `refine` instead of an union

## Testing

Tests are still passing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
