### PR TITLE
Feature: add image size to schema metadata

### DIFF
--- a/.changeset/fresh-onions-hide.md
+++ b/.changeset/fresh-onions-hide.md
@@ -1,0 +1,5 @@
+---
+"astro": minor
+---
+
+Adds image file size to content collection schema

--- a/packages/astro/src/assets/types.ts
+++ b/packages/astro/src/assets/types.ts
@@ -37,6 +37,7 @@ export interface ImageMetadata {
 	height: number;
 	format: ImageInputFormat;
 	orientation?: number;
+	size?: number;
 	/** @internal */
 	fsPath: string;
 }

--- a/packages/astro/src/assets/utils/emitAsset.ts
+++ b/packages/astro/src/assets/utils/emitAsset.ts
@@ -27,6 +27,7 @@ export async function emitESMImage(
 	const emittedImage: Omit<ImageMetadata, 'fsPath'> = {
 		src: '',
 		...fileMetadata,
+		size: (await fs.stat(url)).size,
 	};
 
 	// Private for now, we generally don't want users to rely on filesystem paths, but we need it so that we can maybe remove the original asset from the build if it's unused.


### PR DESCRIPTION
## Changes

Add new property to schema metadata for images returning the optimized image file size in bytes.

This change makes it easier to add images to RSS feed posts. The `<enclosure>` tag in the RSS spec requires a non 0 size in bytes for the media item.

Without that change a user needs to implement the logic to get the file size and it is brittle and prone to breaking as it depends on different file paths for both the dev server and build process.

Here is an example of the code implemented on the user side: https://github.com/madcampos/madcampos.github.io/blob/772084331d6c9eb822405d5af14c4337c64c5a90/src/pages/blog/feed.xml.ts#L26-L39

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Tests passed and no new tests were added.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->

It should need an update on the docs for [RSS feeds](https://docs.astro.build/en/guides/rss/) on how to include images for posts.

/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
