### PR TITLE
fix: vite security issue

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -172,7 +172,7 @@
     "tsconfck": "^3.0.0",
     "unist-util-visit": "^5.0.0",
     "vfile": "^6.0.1",
-    "vite": "^5.0.10",
+    "vite": "^5.0.12",
     "vitefu": "^0.2.5",
     "which-pm": "^2.1.1",
     "yargs-parser": "^21.1.1",


### PR DESCRIPTION
## Changes

Changes the vite minimum version for astro to 5.0.12 so that the new minimum is marked safe.
Closes #9765 

## Testing

Tested the change, no issue.

## Docs

N/A
