### PR TITLE
fix: handle error at load for apps

### DIFF
--- a/.changeset/honest-impalas-walk.md
+++ b/.changeset/honest-impalas-walk.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix apps being able to crash the dev toolbar in certain cases

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2594,7 +2594,7 @@ export interface ClientDirectiveConfig {
 export interface DevToolbarApp {
 	id: string;
 	name: string;
-	icon: Icon;
+	icon?: Icon;
 	init?(canvas: ShadowRoot, eventTarget: EventTarget): void | Promise<void>;
 	beforeTogglingOff?(canvas: ShadowRoot): boolean | Promise<boolean>;
 }

--- a/packages/astro/src/core/logger/core.ts
+++ b/packages/astro/src/core/logger/core.ts
@@ -27,6 +27,7 @@ export type LoggerLabel =
 	| 'middleware'
 	| 'preferences'
 	| 'redirects'
+	| 'toolbar'
 	// SKIP_FORMAT: A special label that tells the logger not to apply any formatting.
 	// Useful for messages that are already formatted, like the server start message.
 	| 'SKIP_FORMAT';

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/settings.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/settings.ts
@@ -26,7 +26,7 @@ const settingsRows = [
 
 				settings.updateSetting('disableAppNotification', evt.currentTarget.checked);
 				const action = evt.currentTarget.checked ? 'disabled' : 'enabled';
-				settings.log(`App notification badges ${action}`);
+				settings.logger.verboseLog(`App notification badges ${action}`);
 			}
 		},
 	},
@@ -39,7 +39,7 @@ const settingsRows = [
 			if (evt.currentTarget instanceof HTMLInputElement) {
 				settings.updateSetting('verbose', evt.currentTarget.checked);
 				const action = evt.currentTarget.checked ? 'enabled' : 'disabled';
-				settings.log(`Verbose logging ${action}`);
+				settings.logger.verboseLog(`Verbose logging ${action}`);
 			}
 		},
 	},

--- a/packages/astro/src/runtime/client/dev-toolbar/entrypoint.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/entrypoint.ts
@@ -201,7 +201,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 					const iconContainer = document.createElement('div');
 					const iconElement = document.createElement('template');
-					iconElement.innerHTML = getAppIcon(app.icon);
+					iconElement.innerHTML = app.icon ? getAppIcon(app.icon) : '?';
 					iconContainer.append(iconElement.content.cloneNode(true));
 
 					const notification = document.createElement('div');

--- a/packages/astro/src/runtime/client/dev-toolbar/settings.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/settings.ts
@@ -44,6 +44,13 @@ function getSettings() {
 			return _settings;
 		},
 		updateSetting,
-		log,
+		logger: {
+			log,
+			verboseLog: (message: string) => {
+				if (_settings.verbose) {
+					log(message);
+				}
+			},
+		},
 	};
 }

--- a/packages/astro/src/vite-plugin-dev-toolbar/vite-plugin-dev-toolbar.ts
+++ b/packages/astro/src/vite-plugin-dev-toolbar/vite-plugin-dev-toolbar.ts
@@ -25,18 +25,9 @@ export default function astroDevToolbar({ settings }: AstroPluginOptions): vite.
 				return `
 					export const loadDevToolbarApps = async () => {
 						return [${settings.devToolbarApps
-							.map((plugin) => `await safeLoadPlugin(${JSON.stringify(plugin)})`)
-							.join(',')}].filter(app => app !== undefined));
+							.map((plugin) => `(await import(${JSON.stringify(plugin)})).default`)
+							.join(',')}];
 					};
-
-					async function safeLoadPlugin(entrypoint) {
-						try {
-							return (await import(entrypoint)).default;
-						} catch (err) {
-							console.error("Failed to load dev toolbar app from", entrypoint, err);
-							return undefined;
-						}
-					}
 				`;
 			}
 		},

--- a/packages/astro/src/vite-plugin-dev-toolbar/vite-plugin-dev-toolbar.ts
+++ b/packages/astro/src/vite-plugin-dev-toolbar/vite-plugin-dev-toolbar.ts
@@ -25,9 +25,18 @@ export default function astroDevToolbar({ settings }: AstroPluginOptions): vite.
 				return `
 					export const loadDevToolbarApps = async () => {
 						return [${settings.devToolbarApps
-							.map((plugin) => `(await import(${JSON.stringify(plugin)})).default`)
-							.join(',')}];
+							.map((plugin) => `await safeLoadPlugin(${JSON.stringify(plugin)})`)
+							.join(',')}].filter(app => app !== undefined));
 					};
+
+					async function safeLoadPlugin(entrypoint) {
+						try {
+							return (await import(entrypoint)).default;
+						} catch (err) {
+							console.error("Failed to load dev toolbar app from", entrypoint, err);
+							return undefined;
+						}
+					}
 				`;
 			}
 		},

--- a/packages/astro/src/vite-plugin-dev-toolbar/vite-plugin-dev-toolbar.ts
+++ b/packages/astro/src/vite-plugin-dev-toolbar/vite-plugin-dev-toolbar.ts
@@ -4,7 +4,7 @@ import type { AstroPluginOptions } from '../@types/astro.js';
 const VIRTUAL_MODULE_ID = 'astro:dev-toolbar';
 const resolvedVirtualModuleId = '\0' + VIRTUAL_MODULE_ID;
 
-export default function astroDevToolbar({ settings }: AstroPluginOptions): vite.Plugin {
+export default function astroDevToolbar({ settings, logger }: AstroPluginOptions): vite.Plugin {
 	return {
 		name: 'astro:dev-toolbar',
 		config() {
@@ -20,14 +20,55 @@ export default function astroDevToolbar({ settings }: AstroPluginOptions): vite.
 				return resolvedVirtualModuleId;
 			}
 		},
+		configureServer(server) {
+			server.ws.on('astro:devtoolbar:error:load', (args) => {
+				logger.error(
+					'toolbar',
+					`Failed to load dev toolbar app from ${args.entrypoint}: ${args.error}`
+				);
+			});
+
+			server.ws.on('astro:devtoolbar:error:init', (args) => {
+				logger.error(
+					'toolbar',
+					`Failed to initialize dev toolbar app ${args.app.name} (${args.app.id}):\n${args.error}`
+				);
+			});
+		},
 		async load(id) {
 			if (id === resolvedVirtualModuleId) {
+				// TODO: In Astro 5.0, we should change the addDevToolbarApp function to separate the logic from the app's metadata.
+				// That way, we can pass the app's data to the dev toolbar without having to load the app's entrypoint, which will allow
+				// for a better UI in the browser where we could still show the app's name and icon even if the app's entrypoint fails to load.
+				// ex: `addDevToolbarApp({ id: 'astro:dev-toolbar:app', name: 'App', icon: '🚀', entrypoint: "./src/something.ts" })`
 				return `
 					export const loadDevToolbarApps = async () => {
-						return [${settings.devToolbarApps
-							.map((plugin) => `(await import(${JSON.stringify(plugin)})).default`)
-							.join(',')}];
+						return (await Promise.all([${settings.devToolbarApps
+							.map((plugin) => `safeLoadPlugin(${JSON.stringify(plugin)})`)
+							.join(',')}])).filter(app => app);
 					};
+
+					async function safeLoadPlugin(entrypoint) {
+						try {
+							const app = (await import(/* @vite-ignore */ entrypoint)).default;
+
+							if (typeof app !== 'object' || !app.id || !app.name) {
+								throw new Error("Apps must default export an object with an id, and a name.");
+							}
+
+							return app;
+						} catch (err) {
+							console.error(\`Failed to load dev toolbar app from \${entrypoint}: \${err.message}\`);
+
+							if (import.meta.hot) {
+  							import.meta.hot.send('astro:devtoolbar:error:load', { entrypoint: entrypoint, error: err.message })
+							}
+
+							return undefined;
+						}
+
+						return undefined;
+					}
 				`;
 			}
 		},


### PR DESCRIPTION
## Changes

This PR attempt to handle errors inside apps better so that they don't crash the dev toolbar and it's better shown to users that apps crashed. For instance, now errors on loading and init will be shown in the server-side terminal so that users are sure to see it (it's kinda not obvious for users that the dev toolbar runs.. in the client so the logs are elsewhere, bit wonky.)

## Testing

Tested manually!

## Docs

N/A
