### PR TITLE
refactor: remove endpoint handling infra

### DIFF
--- a/.changeset/tall-comics-punch.md
+++ b/.changeset/tall-comics-punch.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Simplifies internals that handle endpoints.

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -25,7 +25,7 @@ import {
 	createStylesheetElementSet,
 } from '../render/ssr-element.js';
 import { matchRoute } from '../routing/match.js';
-import { EndpointNotFoundError, SSRRoutePipeline } from './ssrPipeline.js';
+import { SSRRoutePipeline } from './ssrPipeline.js';
 import type { RouteInfo } from './types.js';
 export { deserializeManifest } from './common.js';
 
@@ -271,28 +271,27 @@ export class App {
 			}
 			response = await this.#pipeline.renderRoute(renderContext, pageModule);
 		} catch (err: any) {
-			if (err instanceof EndpointNotFoundError) {
-				return this.#renderError(request, { status: 404, response: err.originalResponse });
-			} else {
-				this.#logger.error(null, err.stack || err.message || String(err));
-				return this.#renderError(request, { status: 500 });
-			}
+			this.#logger.error(null, err.stack || err.message || String(err));
+			return this.#renderError(request, { status: 500 });
 		}
 
-		// endpoints do not participate in implicit rerouting
-		if (routeData.type === 'page' || routeData.type === 'redirect') {
-			if (REROUTABLE_STATUS_CODES.has(response.status)) {
-				return this.#renderError(request, {
-					response,
-					status: response.status as 404 | 500,
-				});
-			}
+		if (REROUTABLE_STATUS_CODES.has(response.status) && response.headers.get("X-Astro-Reroute") !== "no") {
+			return this.#renderError(request, {
+				response,
+				status: response.status as 404 | 500,
+			});
 		}
+
+		if (response.headers.has("X-Astro-Reroute")) {
+			response.headers.delete("X-Astro-Reroute");
+		}
+
 		if (addCookieHeader) {
 			for (const setCookieHeaderValue of App.getSetCookieFromResponse(response)) {
 				response.headers.append('set-cookie', setCookieHeaderValue);
 			}
 		}
+		
 		Reflect.set(response, responseSentSymbol, true);
 		return response;
 	}

--- a/packages/astro/src/core/app/ssrPipeline.ts
+++ b/packages/astro/src/core/app/ssrPipeline.ts
@@ -1,28 +1,3 @@
 import { Pipeline } from '../pipeline.js';
-import type { Environment } from '../render/index.js';
 
-/**
- * Thrown when an endpoint contains a response with the header "X-Astro-Response" === 'Not-Found'
- */
-export class EndpointNotFoundError extends Error {
-	originalResponse: Response;
-	constructor(originalResponse: Response) {
-		super();
-		this.originalResponse = originalResponse;
-	}
-}
-
-export class SSRRoutePipeline extends Pipeline {
-	constructor(env: Environment) {
-		super(env);
-		this.setEndpointHandler(this.#ssrEndpointHandler);
-	}
-
-	// This function is responsible for handling the result coming from an endpoint.
-	async #ssrEndpointHandler(request: Request, response: Response): Promise<Response> {
-		if (response.headers.get('X-Astro-Response') === 'Not-Found') {
-			throw new EndpointNotFoundError(response);
-		}
-		return response;
-	}
-}
+export class SSRRoutePipeline extends Pipeline {}

--- a/packages/astro/src/core/build/buildPipeline.ts
+++ b/packages/astro/src/core/build/buildPipeline.ts
@@ -67,7 +67,6 @@ export class BuildPipeline extends Pipeline {
 		this.#internals = internals;
 		this.#staticBuildOptions = staticBuildOptions;
 		this.#manifest = manifest;
-		this.setEndpointHandler(this.#handleEndpointResult);
 	}
 
 	getInternals(): Readonly<BuildInternals> {
@@ -192,9 +191,5 @@ export class BuildPipeline extends Pipeline {
 		}
 
 		return pages;
-	}
-
-	async #handleEndpointResult(_: Request, response: Response): Promise<Response> {
-		return response;
 	}
 }

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -486,7 +486,8 @@ async function generatePath(
 ) {
 	const { mod, scripts: hoistedScripts, styles: _styles } = gopts;
 	const manifest = pipeline.getManifest();
-	pipeline.getEnvironment().logger.debug('build', `Generating: ${pathname}`);
+	const logger = pipeline.getLogger();
+	logger.debug('build', `Generating: ${pathname}`);
 
 	const links = new Set<never>();
 	const scripts = createModuleScriptsSet(

--- a/packages/astro/src/runtime/server/endpoint.ts
+++ b/packages/astro/src/runtime/server/endpoint.ts
@@ -33,16 +33,14 @@ export async function renderEndpoint(
 					? `One of the exported handlers is "all" (lowercase), did you mean to export 'ALL'?\n`
 					: '')
 		);
-		// No handler found, so this should be a 404. Using a custom header
-		// to signal to the renderer that this is an internal 404 that should
-		// be handled by a custom 404 route if possible.
-		return new Response(null, {
-			status: 404,
-			headers: {
-				'X-Astro-Response': 'Not-Found',
-			},
-		});
+		// No handler matching the verb found, so this should be a
+		// 404. Should be handled by 404.astro route if possible.
+		return new Response(null, { status: 404 });
 	}
 
-	return handler.call(mod, context);
+	const response = await handler.call(mod, context);
+	// Endpoints explicitly returning 404 or 500 response status should
+	// NOT be subject to rerouting to 404.astro or 500.astro.
+	response.headers.set("X-Astro-Reroute", "no");
+	return response;
 }

--- a/packages/astro/src/vite-plugin-astro-server/devPipeline.ts
+++ b/packages/astro/src/vite-plugin-astro-server/devPipeline.ts
@@ -35,7 +35,6 @@ export default class DevPipeline extends Pipeline {
 		this.#devLogger = logger;
 		this.#settings = settings;
 		this.#loader = loader;
-		this.setEndpointHandler(this.#handleEndpointResult);
 	}
 
 	clearRouteCache() {
@@ -86,10 +85,6 @@ export default class DevPipeline extends Pipeline {
 			ssr: isServerLikeOutput(settings.config),
 			streaming: true,
 		});
-	}
-
-	async #handleEndpointResult(_: Request, response: Response): Promise<Response> {
-		return response;
 	}
 
 	async handleFallback() {}


### PR DESCRIPTION
## Changes
- When an endpoint that matches the path does not export the request method. a reroute to 404.astro is performed.
- This was done using "endpointHandler" on `Pipeline` implemented once for each environment. `callEndpoint` created a response with a special header. The endpoint handler recognises the special header and throws a special error. Then `App` recognises the special error and finally performs the rerouting.
- Now, `callEndpoint` creates a response with a special header ("X-Astro-Reroute=no"), and App recognises it to perform the rerouting directly.
- The meaning of the special header is reversed. Previously, it opted certain endpoint responses into rerouting (after endpoints were blanket opted-out). Now, endpoints get no blanket treatment, and the header opts-out individual responses.
- The overarching rerouting behavior will be extracted out into an internal middleware soon.

## Testing
Does not affect behavior. Existing tests should pass.

## Docs
Does not affect usage.