### PR TITLE
refactor: singular middleware

### DIFF
--- a/.changeset/twenty-papayas-agree.md
+++ b/.changeset/twenty-papayas-agree.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Simplifies internals that handle middleware.

--- a/packages/astro/src/core/app/common.ts
+++ b/packages/astro/src/core/app/common.ts
@@ -18,8 +18,7 @@ export function deserializeManifest(serializedManifest: SerializedSSRManifest): 
 	const clientDirectives = new Map(serializedManifest.clientDirectives);
 
 	return {
-		// serialized manifest will always contain the middleware (see plugin-ssr.ts)
-		// this is expected to be overwritten, but is present for types
+		// in case user middleware exists, this no-op middleware will be reassigned (see plugin-ssr.ts)
 		middleware(_, next) { return next() },
 		...serializedManifest,
 		assets,

--- a/packages/astro/src/core/app/common.ts
+++ b/packages/astro/src/core/app/common.ts
@@ -18,6 +18,9 @@ export function deserializeManifest(serializedManifest: SerializedSSRManifest): 
 	const clientDirectives = new Map(serializedManifest.clientDirectives);
 
 	return {
+		// serialized manifest will always contain the middleware (see plugin-ssr.ts)
+		// this is expected to be overwritten, but is present for types
+		middleware(_, next) { return next() },
 		...serializedManifest,
 		assets,
 		componentMetadata,

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -76,7 +76,7 @@ export interface RenderErrorOptions {
 	response?: Response;
 	status: 404 | 500;
 	/**
-	 * Whether to skip onRequest() while rendering the error page. Defaults to false.
+	 * Whether to skip middleware while rendering the error page. Defaults to false.
 	 */
 	skipMiddleware?: boolean;
 }
@@ -259,16 +259,10 @@ export class App {
 				this.#manifest.buildFormat
 			);
 			if (i18nMiddleware) {
-				if (mod.onRequest) {
-					this.#pipeline.setMiddlewareFunction(sequence(i18nMiddleware, mod.onRequest));
-				} else {
-					this.#pipeline.setMiddlewareFunction(i18nMiddleware);
-				}
+				this.#pipeline.setMiddlewareFunction(sequence(i18nMiddleware, this.#manifest.middleware));
 				this.#pipeline.onBeforeRenderRoute(i18nPipelineHook);
 			} else {
-				if (mod.onRequest) {
-					this.#pipeline.setMiddlewareFunction(mod.onRequest);
-				}
+				this.#pipeline.setMiddlewareFunction(this.#manifest.middleware);
 			}
 			response = await this.#pipeline.renderRoute(renderContext, pageModule);
 		} catch (err: any) {
@@ -428,8 +422,8 @@ export class App {
 					status
 				);
 				const page = (await mod.page()) as any;
-				if (skipMiddleware === false && mod.onRequest) {
-					this.#pipeline.setMiddlewareFunction(mod.onRequest);
+				if (skipMiddleware === false) {
+					this.#pipeline.setMiddlewareFunction(this.#manifest.middleware);
 				}
 				if (skipMiddleware) {
 					// make sure middleware set by other requests is cleared out
@@ -439,7 +433,7 @@ export class App {
 				return this.#mergeResponses(response, originalResponse);
 			} catch {
 				// Middleware may be the cause of the error, so we try rendering 404/500.astro without it.
-				if (skipMiddleware === false && mod.onRequest) {
+				if (skipMiddleware === false) {
 					return this.#renderError(request, {
 						status,
 						response: originalResponse,

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -1,5 +1,6 @@
 import type {
 	Locales,
+	MiddlewareHandler,
 	RouteData,
 	SerializedRouteData,
 	SSRComponentMetadata,
@@ -54,6 +55,7 @@ export type SSRManifest = {
 	pageModule?: SinglePageBuiltModule;
 	pageMap?: Map<ComponentPath, ImportComponentInstance>;
 	i18n: SSRManifestI18n | undefined;
+	middleware: MiddlewareHandler;
 };
 
 export type SSRManifestI18n = {
@@ -65,7 +67,7 @@ export type SSRManifestI18n = {
 
 export type SerializedSSRManifest = Omit<
 	SSRManifest,
-	'routes' | 'assets' | 'componentMetadata' | 'clientDirectives'
+	'middleware' | 'routes' | 'assets' | 'componentMetadata' | 'clientDirectives'
 > & {
 	routes: SerializedRouteInfo[];
 	assets: string[];

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -146,7 +146,10 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 		const baseDirectory = getOutputDirectory(opts.settings.config);
 		const renderersEntryUrl = new URL('renderers.mjs', baseDirectory);
 		const renderers = await import(renderersEntryUrl.toString());
-		const { onRequest: middleware } = await import(new URL('middleware.mjs', baseDirectory).toString());
+		let middleware: MiddlewareHandler = (_, next) => next();
+		try {
+			middleware = await import(new URL('middleware.mjs', baseDirectory).toString()).then(mod => mod.onRequest);
+		} catch {}
 		manifest = createBuildManifest(
 			opts.settings,
 			internals,

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -148,6 +148,8 @@ export async function generatePages(opts: StaticBuildOptions, internals: BuildIn
 		const renderers = await import(renderersEntryUrl.toString());
 		let middleware: MiddlewareHandler = (_, next) => next();
 		try {
+			// middleware.mjs is not emitted if there is no user middleware
+			// in which case the import fails with ERR_MODULE_NOT_FOUND, and we fall back to a no-op middleware
 			middleware = await import(new URL('middleware.mjs', baseDirectory).toString()).then(mod => mod.onRequest);
 		} catch {}
 		manifest = createBuildManifest(

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -42,22 +42,18 @@ function vitePluginManifest(options: StaticBuildOptions, internals: BuildInterna
 		},
 		async load(id) {
 			if (id === RESOLVED_SSR_MANIFEST_VIRTUAL_MODULE_ID) {
-				const imports = [];
-				const contents = [];
-				const exports = [];
-				imports.push(
+				const imports = [
 					`import { deserializeManifest as _deserializeManifest } from 'astro/app'`,
 					`import { _privateSetManifestDontUseThis } from 'astro:ssr-manifest'`
-				);
-
-				contents.push(`
-const manifest = _deserializeManifest('${manifestReplace}');
-_privateSetManifestDontUseThis(manifest);
-`);
-
-				exports.push('export { manifest }');
-
-				return `${imports.join('\n')}${contents.join('\n')}${exports.join('\n')}`;
+				];
+				const contents = [
+					`const manifest = _deserializeManifest('${manifestReplace}');`,
+					`_privateSetManifestDontUseThis(manifest);`
+				];
+				const exports = [
+					`export { manifest }`
+				];
+				return [...imports, ...contents, ...exports].join('\n');
 			}
 		},
 

--- a/packages/astro/src/core/build/plugins/plugin-pages.ts
+++ b/packages/astro/src/core/build/plugins/plugin-pages.ts
@@ -1,12 +1,10 @@
 import { extname } from 'node:path';
 import type { Plugin as VitePlugin } from 'vite';
-import type { AstroSettings } from '../../../@types/astro.js';
 import { routeIsRedirect } from '../../redirects/index.js';
 import { addRollupInput } from '../add-rollup-input.js';
 import { eachPageFromAllPages, type BuildInternals } from '../internal.js';
 import type { AstroBuildPlugin } from '../plugin.js';
 import type { StaticBuildOptions } from '../types.js';
-import { MIDDLEWARE_MODULE_ID } from './plugin-middleware.js';
 import { RENDERERS_MODULE_ID } from './plugin-renderers.js';
 import { ASTRO_PAGE_EXTENSION_POST_PATTERN, getPathFromVirtualModulePageName } from './util.js';
 
@@ -37,7 +35,6 @@ export function getVirtualModulePageIdFromPath(path: string) {
 function vitePluginPages(opts: StaticBuildOptions, internals: BuildInternals): VitePlugin {
 	return {
 		name: '@astro/plugin-build-pages',
-
 		options(options) {
 			if (opts.settings.config.output === 'static') {
 				const inputs = new Set<string>();
@@ -52,13 +49,11 @@ function vitePluginPages(opts: StaticBuildOptions, internals: BuildInternals): V
 				return addRollupInput(options, Array.from(inputs));
 			}
 		},
-
 		resolveId(id) {
 			if (id.startsWith(ASTRO_PAGE_MODULE_ID)) {
 				return '\0' + id;
 			}
 		},
-
 		async load(id) {
 			if (id.startsWith(ASTRO_PAGE_RESOLVED_MODULE_ID)) {
 				const imports: string[] = [];
@@ -74,28 +69,12 @@ function vitePluginPages(opts: StaticBuildOptions, internals: BuildInternals): V
 						imports.push(`import { renderers } from "${RENDERERS_MODULE_ID}";`);
 						exports.push(`export { renderers };`);
 
-						// The middleware should not be imported by the pages
-						if (shouldBundleMiddleware(opts.settings)) {
-							const middlewareModule = await this.resolve(MIDDLEWARE_MODULE_ID);
-							if (middlewareModule) {
-								imports.push(`import { onRequest } from "${middlewareModule.id}";`);
-								exports.push(`export { onRequest };`);
-							}
-						}
-
 						return `${imports.join('\n')}${exports.join('\n')}`;
 					}
 				}
 			}
 		},
 	};
-}
-
-export function shouldBundleMiddleware(settings: AstroSettings) {
-	if (settings.adapter?.adapterFeatures?.edgeMiddleware === true) {
-		return false;
-	}
-	return true;
 }
 
 export function pluginPages(opts: StaticBuildOptions, internals: BuildInternals): AstroBuildPlugin {

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { Plugin as VitePlugin } from 'vite';
-import type { AstroAdapter, AstroConfig } from '../../../@types/astro.js';
+import type { AstroAdapter } from '../../../@types/astro.js';
 import { isFunctionPerRouteEnabled } from '../../../integrations/index.js';
 import { isServerLikeOutput } from '../../../prerender/utils.js';
 import { routeIsRedirect } from '../../redirects/index.js';
@@ -14,6 +14,7 @@ import { SSR_MANIFEST_VIRTUAL_MODULE_ID } from './plugin-manifest.js';
 import { ASTRO_PAGE_MODULE_ID } from './plugin-pages.js';
 import { RENDERERS_MODULE_ID } from './plugin-renderers.js';
 import { getPathFromVirtualModulePageName, getVirtualModulePageNameFromPath } from './util.js';
+import { MIDDLEWARE_MODULE_ID } from './plugin-middleware.js';
 
 export const SSR_VIRTUAL_MODULE_ID = '@astrojs-ssr-virtual-entry';
 export const RESOLVED_SSR_VIRTUAL_MODULE_ID = '\0' + SSR_VIRTUAL_MODULE_ID;
@@ -52,7 +53,7 @@ function vitePluginSSR(
 					if (module) {
 						const variable = `_page${i}`;
 						// we need to use the non-resolved ID in order to resolve correctly the virtual module
-						imports.push(`const ${variable}  = () => import("${virtualModuleName}");`);
+						imports.push(`const ${variable} = () => import("${virtualModuleName}");`);
 
 						const pageData2 = internals.pagesByComponent.get(path);
 						if (pageData2) {
@@ -61,13 +62,13 @@ function vitePluginSSR(
 						i++;
 					}
 				}
-
-				contents.push(`const pageMap = new Map([${pageMap.join(',')}]);`);
+				contents.push(`const pageMap = new Map([\n    ${pageMap.join(',\n    ')}\n]);`);
 				exports.push(`export { pageMap }`);
-				const ssrCode = generateSSRCode(options.settings.config, adapter);
+				const middleware = await this.resolve(MIDDLEWARE_MODULE_ID);
+				const ssrCode = generateSSRCode(adapter, middleware!.id);
 				imports.push(...ssrCode.imports);
 				contents.push(...ssrCode.contents);
-				return `${imports.join('\n')}${contents.join('\n')}${exports.join('\n')}`;
+				return [...imports, ...contents, ...exports].join('\n');
 			}
 			return void 0;
 		},
@@ -174,14 +175,14 @@ function vitePluginSSRSplit(
 					// we need to use the non-resolved ID in order to resolve correctly the virtual module
 					imports.push(`import * as pageModule from "${virtualModuleName}";`);
 				}
-
-				const ssrCode = generateSSRCode(options.settings.config, adapter);
+				const middleware = await this.resolve(MIDDLEWARE_MODULE_ID);
+				const ssrCode = generateSSRCode(adapter, middleware!.id);
 				imports.push(...ssrCode.imports);
 				contents.push(...ssrCode.contents);
 
 				exports.push('export { pageModule }');
 
-				return `${imports.join('\n')}${contents.join('\n')}${exports.join('\n')}`;
+				return [...imports, ...contents, ...exports].join('\n');
 			}
 			return void 0;
 		},
@@ -233,45 +234,36 @@ export function pluginSSRSplit(
 	};
 }
 
-function generateSSRCode(config: AstroConfig, adapter: AstroAdapter) {
-	const imports: string[] = [];
-	const contents: string[] = [];
-	let pageMap;
-	if (isFunctionPerRouteEnabled(adapter)) {
-		pageMap = 'pageModule';
-	} else {
-		pageMap = 'pageMap';
-	}
+function generateSSRCode(adapter: AstroAdapter, middlewareId: string) {
+	const edgeMiddleware = adapter?.adapterFeatures?.edgeMiddleware ?? false;
+	const pageMap = isFunctionPerRouteEnabled(adapter) ? 'pageModule' : 'pageMap';
 
-	contents.push(`import * as adapter from '${adapter.serverEntrypoint}';
-import { renderers } from '${RENDERERS_MODULE_ID}';
-import { manifest as defaultManifest} from '${SSR_MANIFEST_VIRTUAL_MODULE_ID}';
-const _manifest = Object.assign(defaultManifest, {
-	${pageMap},
-	renderers,
-});
-const _args = ${adapter.args ? JSON.stringify(adapter.args) : 'undefined'};
+	const imports = [
+		`import { renderers } from '${RENDERERS_MODULE_ID}';`,
+		`import { manifest as defaultManifest } from '${SSR_MANIFEST_VIRTUAL_MODULE_ID}';`,
+		`import * as serverEntrypointModule from '${adapter.serverEntrypoint}';`,
+		edgeMiddleware ? `` : `import { onRequest as middleware } from '${middlewareId}';`,
+	];
 
-${
-	adapter.exports
-		? `const _exports = adapter.createExports(_manifest, _args);
-${adapter.exports
-	.map((name) => {
-		if (name === 'default') {
-			return `const _default = _exports['default'];
-export { _default as default };`;
-		} else {
-			return `export const ${name} = _exports['${name}'];`;
-		}
-	})
-	.join('\n')}
-`
-		: ''
-}
-const _start = 'start';
-if(_start in adapter) {
-	adapter[_start](_manifest, _args);
-}`);
+	const contents = [
+		edgeMiddleware ? `const middleware = (_, next) => next()` : '',
+		`const _manifest = Object.assign(defaultManifest, {`,
+		`    ${pageMap},`,
+		`    renderers,`,
+		`    middleware`,
+		`});`,
+		`const _args = ${adapter.args ? JSON.stringify(adapter.args, null, 4) : 'undefined'};`,
+		adapter.exports ? `const _exports = serverEntrypointModule.createExports(_manifest, _args);` : '',
+		...adapter.exports?.map((name) => {
+			if (name === 'default') {
+				return `export default _exports.default;`;
+			} else {
+				return `export const ${name} = _exports['${name}'];`;
+			}
+		}) ?? [],
+		`serverEntrypointModule.start?.(_manifest, _args);`,
+	];
+
 	return {
 		imports,
 		contents,

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -140,5 +140,8 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 			: settings.config.site,
 		componentMetadata: new Map(),
 		i18n: i18nManifest,
+		middleware(_, next) {
+			return next()
+		}
 	};
 }

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -276,10 +276,8 @@ export async function handleRoute({
 			pathname,
 			request,
 			route,
+			middleware
 		};
-		if (middleware) {
-			options.middleware = middleware;
-		}
 
 		mod = options.preload;
 
@@ -306,7 +304,7 @@ export async function handleRoute({
 		});
 	}
 
-	const onRequest = middleware?.onRequest as MiddlewareHandler | undefined;
+	const onRequest: MiddlewareHandler = middleware.onRequest;
 	if (config.i18n) {
 		const i18Middleware = createI18nMiddleware(
 			config.i18n,
@@ -316,16 +314,12 @@ export async function handleRoute({
 		);
 
 		if (i18Middleware) {
-			if (onRequest) {
-				pipeline.setMiddlewareFunction(sequence(i18Middleware, onRequest));
-			} else {
-				pipeline.setMiddlewareFunction(i18Middleware);
-			}
+			pipeline.setMiddlewareFunction(sequence(i18Middleware, onRequest));
 			pipeline.onBeforeRenderRoute(i18nPipelineHook);
-		} else if (onRequest) {
+		} else {
 			pipeline.setMiddlewareFunction(onRequest);
 		}
-	} else if (onRequest) {
+	} else {
 		pipeline.setMiddlewareFunction(onRequest);
 	}
 


### PR DESCRIPTION
## Changes
- The `onRequest` function is internally re-exported from each page and endpoint, and loaded after the request matches a particular one.
- The middleware is singular in astro and the current arrangement prevents enhancement that require the middleware to be independent.
- This PR moves `onRequest` from page chunks to the manifest, where it can be loaded sooner than route data.

## Testing
Does not affect behavior. Existing tests should pass.

## Docs
Does not affect usage.