### PR TITLE
fix: add `_` attribute

### DIFF
--- a/.changeset/swift-turtles-vanish.md
+++ b/.changeset/swift-turtles-vanish.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Add `_` to HTMLAttributes for hyperscript

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -517,6 +517,7 @@ declare namespace astroHTML.JSX {
 		contenteditable?: 'true' | 'false' | boolean | 'inherit' | string | undefined | null;
 		dir?: string | undefined | null;
 		draggable?: 'true' | 'false' | boolean | undefined | null;
+		_?: string | undefined | null;
 		enterkeyhint?:
 			| 'enter'
 			| 'done'


### PR DESCRIPTION
## Changes

https://hyperscript.org/docs/ uses `_` (underscore) attribute to embed code directly into elements

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

N/A

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

N/A
