### PR TITLE
fix(portfolio): set min-height to 100% on html and body

### DIFF
--- a/examples/portfolio/src/styles/global.css
+++ b/examples/portfolio/src/styles/global.css
@@ -117,7 +117,7 @@
 
 html,
 body {
-	height: 100%;
+	min-height: 100%;
 	overflow-x: hidden;
 }
 


### PR DESCRIPTION
Setting height: 100% breaks the scroll-to-top functionality on iOS, i.e. tapping the top of the screen should scroll you to the top of the page. Setting min-height: 100% instead fixes scroll-to-top.
