### PR TITLE
Fix regression on dynamic sibling trees and index inside rest parameter folders

### DIFF
--- a/.changeset/six-shrimps-glow.md
+++ b/.changeset/six-shrimps-glow.md
@@ -9,22 +9,31 @@ Considering the following tree:
 src/pages/
 ├── index.astro
 ├── static.astro
-├── [dynamic]/
+├── [dynamic_file].astro
+├── [...rest_file].astro
+├── blog/
+│   └── index.astro
+├── [dynamic_folder]/
 │   ├── index.astro
-│   ├── [...rest].astro
-│   └── static.astro
-└── [...rest]/
+│   ├── static.astro
+│   └── [...rest].astro
+└── [...rest_folder]/
     ├── index.astro
     └── static.astro
 ```
 
 The routes are sorted in this order:
 ```
-/src/pages/static.astro
 /src/pages/index.astro
-/src/pages/[dynamic]/static.astro
-/src/pages/[dynamic]/index.astro
-/src/pages/[dynamic]/[...rest].astro
-/src/pages/[...rest]/static.astro
-/src/pages/[...rest]/index.astro
+/src/pages/blog/index.astro
+/src/pages/static.astro
+/src/pages/[dynamic_folder]/index.astro
+/src/pages/[dynamic_file].astro
+/src/pages/[dynamic_folder]/static.astro
+/src/pages/[dynamic_folder]/[...rest].astro
+/src/pages/[...rest_folder]/static.astro
+/src/pages/[...rest_folder]/index.astro
+/src/pages/[...rest_file]/index.astro
 ```
+
+This allows for index files to be used as overrides to rest parameter routes on SSR when the rest parameter matching `undefined` is not desired.

--- a/.changeset/six-shrimps-glow.md
+++ b/.changeset/six-shrimps-glow.md
@@ -2,7 +2,7 @@
 "astro": patch
 ---
 
-Fix regression in routing priority for index pages in rest parameter folders and dynamic sybling trees.
+Fixes a regression in routing priority for index pages in rest parameter folders and dynamic sibling trees.
 
 Considering the following tree:
 ```

--- a/.changeset/six-shrimps-glow.md
+++ b/.changeset/six-shrimps-glow.md
@@ -1,0 +1,30 @@
+---
+"astro": patch
+---
+
+Fix regression in routing priority for index pages in rest parameter folders and dynamic sybling trees.
+
+Considering the following tree:
+```
+src/pages/
+├── index.astro
+├── static.astro
+├── [dynamic]/
+│   ├── index.astro
+│   ├── [...rest].astro
+│   └── static.astro
+└── [...rest]/
+    ├── index.astro
+    └── static.astro
+```
+
+The routes are sorted in this order:
+```
+/src/pages/static.astro
+/src/pages/index.astro
+/src/pages/[dynamic]/static.astro
+/src/pages/[dynamic]/index.astro
+/src/pages/[dynamic]/[...rest].astro
+/src/pages/[...rest]/static.astro
+/src/pages/[...rest]/index.astro
+```

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -202,6 +202,16 @@ function routeComparator(a: ManifestRouteData, b: ManifestRouteData) {
 		
 		const aIsStatic = aSegment.every((part) => !part.dynamic && !part.spread);
 		const bIsStatic = bSegment.every((part) => !part.dynamic && !part.spread);
+		
+		if (aIsStatic && bIsStatic) {
+			// Both segments are static, they are sorted alphabetically if they are different
+			const aContent = aSegment.map((part) => part.content).join('');
+			const bContent = bSegment.map((part) => part.content).join('');
+			
+			if (aContent !== bContent) {
+				return aContent.localeCompare(bContent);
+			}
+		}
 
 		// Sort static routes before dynamic routes
 		if (aIsStatic !== bIsStatic) {

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -194,47 +194,66 @@ function isSemanticallyEqualSegment(segmentA: RoutePart[], segmentB: RoutePart[]
  *   The definition of "alphabetically" is dependent on the default locale of the running system.
  */
 function routeComparator(a: ManifestRouteData, b: ManifestRouteData) {
+	const commonLength = Math.min(a.segments.length, b.segments.length);
+
+	for (let index = 0; index < commonLength; index++) {
+		const aSegment = a.segments[index];
+		const bSegment = b.segments[index];
+		
+		const aIsStatic = aSegment.every((part) => !part.dynamic && !part.spread);
+		const bIsStatic = bSegment.every((part) => !part.dynamic && !part.spread);
+
+		// Sort static routes before dynamic routes
+		if (aIsStatic !== bIsStatic) {
+			return aIsStatic ? -1 : 1;
+		}
+
+		const aHasSpread = aSegment.some((part) => part.spread);
+		const bHasSpread = bSegment.some((part) => part.spread);
+
+		// Sort dynamic routes with rest parameters after dynamic routes with single parameters
+		// (also after static, but that is already covered by the previous condition)
+		if (aHasSpread !== bHasSpread) {
+			return aHasSpread ? 1 : -1;
+		}
+	}
+	
 	// For sorting purposes, an index route is considered to have one more segment than the URL it represents.
 	const aLength = a.isIndex ? a.segments.length + 1 : a.segments.length;
 	const bLength = b.isIndex ? b.segments.length + 1 : b.segments.length;
+	
+	if (a.isIndex || b.isIndex) {
+		// Index pages are lower priority than other static segments in the same prefix.
+		// They match the path up to their parent, but are more specific than the parent.
+		// For example:
+		//  - `/foo/index.astro` is sorted before `/foo`
+		//  - `/foo/index.astro` is sorted before `/foo/[bar].astro`
+		//  - `/[...foo]/index.astro` is sorted after `/[...foo]/bar.astro`
 
-	// Sort more specific routes before less specific routes
-	if (aLength !== bLength) {
+		if (a.isIndex) {
+			const followingBSegment = b.segments.at(a.segments.length);
+			const followingBSegmentIsStatic = followingBSegment?.every((part) => !part.dynamic && !part.spread);
+			
+			return followingBSegmentIsStatic ? 1 : -1;
+		}
+
+		const followingASegment = a.segments.at(b.segments.length);
+		const followingASegmentIsStatic = followingASegment?.every((part) => !part.dynamic && !part.spread);
+
+		return followingASegmentIsStatic ? -1 : 1;
+	}
+
+	if (aLength !== bLength){
+		// Routes are equal up to the smaller of the two lengths, so the longer route is more specific
 		return aLength > bLength ? -1 : 1;
 	}
-
-	const aIsStatic = a.segments.every((segment) =>
-		segment.every((part) => !part.dynamic && !part.spread)
-	);
-	const bIsStatic = b.segments.every((segment) =>
-		segment.every((part) => !part.dynamic && !part.spread)
-	);
-
-	// Sort static routes before dynamic routes
-	if (aIsStatic !== bIsStatic) {
-		return aIsStatic ? -1 : 1;
-	}
-
-	const aHasSpread = a.segments.some((segment) => segment.some((part) => part.spread));
-	const bHasSpread = b.segments.some((segment) => segment.some((part) => part.spread));
-
-	// Sort dynamic routes with rest parameters after dynamic routes with single parameters
-	// (also after static, but that is already covered by the previous condition)
-	if (aHasSpread !== bHasSpread) {
-		return aHasSpread ? 1 : -1;
-	}
-
-	// Sort prerendered routes before non-prerendered routes
-	if (a.prerender !== b.prerender) {
-		return a.prerender ? -1 : 1;
-	}
-
+	
 	// Sort endpoints before pages
 	if ((a.type === 'endpoint') !== (b.type === 'endpoint')) {
 		return a.type === 'endpoint' ? -1 : 1;
 	}
 
-	// Sort alphabetically
+	// Both routes have segments with the same properties
 	return a.route.localeCompare(b.route);
 }
 

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -203,14 +203,6 @@ function routeComparator(a: ManifestRouteData, b: ManifestRouteData) {
 		const aIsStatic = aSegment.every((part) => !part.dynamic && !part.spread);
 		const bIsStatic = bSegment.every((part) => !part.dynamic && !part.spread);
 
-		// Both segments are static, sort them alphabetically
-		// if (aIsStatic && bIsStatic) {
-		// 	const aContent = aSegment.map((part) => part.content).join('');
-		// 	const bContent = bSegment.map((part) => part.content).join('');
-		//	
-		// 	return aContent.localeCompare(bContent);
-		// }
-
 		// Sort static routes before dynamic routes
 		if (aIsStatic !== bIsStatic) {
 			return aIsStatic ? -1 : 1;

--- a/packages/astro/src/prerender/utils.ts
+++ b/packages/astro/src/prerender/utils.ts
@@ -6,7 +6,7 @@ export function isServerLikeOutput(config: AstroConfig) {
 }
 
 export function getPrerenderDefault(config: AstroConfig) {
-	return config.output === 'hybrid';
+	return config.output !== 'server';
 }
 
 /**

--- a/packages/astro/test/units/routing/manifest.test.js
+++ b/packages/astro/test/units/routing/manifest.test.js
@@ -181,6 +181,10 @@ describe('routing - createRouteManifest', () => {
 
 		expect(getManifestRoutes(manifest)).to.deep.equal([
 			{
+				"route": "/",
+				"type": "page",
+			},
+			{
 				"route": "/blog",
 				"type": "page",
 			},
@@ -189,7 +193,11 @@ describe('routing - createRouteManifest', () => {
 				"type": "page",
 			},
 			{
-				"route": "/",
+				"route": "/[dynamic]",
+				"type": "page",
+			},
+			{
+				"route": "/[other]",
 				"type": "page",
 			},
 			{
@@ -197,15 +205,7 @@ describe('routing - createRouteManifest', () => {
 				"type": "page",
 			},
 			{
-				"route": "/[dynamic]",
-				"type": "page",
-			},
-			{
 				"route": "/[dynamic]/[...rest]",
-				"type": "page",
-			},
-			{
-				"route": "/[other]",
 				"type": "page",
 			},
 			{

--- a/packages/astro/test/units/routing/manifest.test.js
+++ b/packages/astro/test/units/routing/manifest.test.js
@@ -130,11 +130,11 @@ describe('routing - createRouteManifest', () => {
 
 		expect(getManifestRoutes(manifest)).to.deep.equal([
 			{
-				route: '/static',
+				route: '/',
 				type: 'page',
 			},
 			{
-				route: '/',
+				route: '/static',
 				type: 'page',
 			},
 			{
@@ -317,11 +317,11 @@ describe('routing - createRouteManifest', () => {
 				type: 'page',
 			},
 			{
-				route: '/contributing',
+				route: '/',
 				type: 'page',
 			},
 			{
-				route: '/',
+				route: '/contributing',
 				type: 'page',
 			},
 			{

--- a/packages/astro/test/units/routing/manifest.test.js
+++ b/packages/astro/test/units/routing/manifest.test.js
@@ -52,8 +52,8 @@ describe('routing - createRouteManifest', () => {
 	it('endpoint routes are sorted before page routes', async () => {
 		const fs = createFs(
 			{
-				'/src/pages/contact-me.astro': `<h1>test</h1>`,
-				'/src/pages/sendContact.ts': `<h1>test</h1>`,
+				'/src/pages/[contact].astro': `<h1>test</h1>`,
+				'/src/pages/[contact].ts': `<h1>test</h1>`,
 			},
 			root
 		);
@@ -85,19 +85,19 @@ describe('routing - createRouteManifest', () => {
 
 		expect(getManifestRoutes(manifest)).to.deep.equal([
 			{
-				route: '/api',
-				type: 'endpoint',
-			},
-			{
-				route: '/sendcontact',
-				type: 'endpoint',
-			},
-			{
 				route: '/about',
 				type: 'page',
 			},
 			{
-				route: '/contact-me',
+				route: '/api',
+				type: 'endpoint',
+			},
+			{
+				route: '/[contact]',
+				type: 'endpoint',
+			},
+			{
+				route: '/[contact]',
 				type: 'page',
 			},
 		]);

--- a/packages/astro/test/units/routing/manifest.test.js
+++ b/packages/astro/test/units/routing/manifest.test.js
@@ -130,11 +130,11 @@ describe('routing - createRouteManifest', () => {
 
 		expect(getManifestRoutes(manifest)).to.deep.equal([
 			{
-				route: '/',
+				route: '/static',
 				type: 'page',
 			},
 			{
-				route: '/static',
+				route: '/',
 				type: 'page',
 			},
 			{
@@ -144,6 +144,66 @@ describe('routing - createRouteManifest', () => {
 			{
 				route: '/[...rest]',
 				type: 'page',
+			},
+		]);
+	});
+
+	it('route sorting respects the file tree', async () => {
+		const fs = createFs(
+			{
+				'/src/pages/[dynamic]/static.astro': `<h1>test</h1>`,
+				'/src/pages/[dynamic]/index.astro': `<h1>test</h1>`,
+				'/src/pages/[dynamic]/[...rest].astro': `<h1>test</h1>`,
+				'/src/pages/[...rest]/static.astro': `<h1>test</h1>`,
+				'/src/pages/[...rest]/index.astro': `<h1>test</h1>`,
+				'/src/pages/static.astro': `<h1>test</h1>`,
+				'/src/pages/index.astro': `<h1>test</h1>`,
+			},
+			root
+		);
+		const settings = await createBasicSettings({
+			root: fileURLToPath(root),
+			base: '/search',
+			trailingSlash: 'never',
+			experimental: {
+				globalRoutePriority: true,
+			},
+		});
+
+		const manifest = createRouteManifest({
+			cwd: fileURLToPath(root),
+			settings,
+			fsMod: fs,
+		});
+
+		expect(getManifestRoutes(manifest)).to.deep.equal([
+			{
+				"route": "/static",
+				"type": "page",
+			},
+			{
+				"route": "/",
+				"type": "page",
+			},
+			{
+				"route": "/[dynamic]/static",
+				"type": "page",
+			},
+			{
+				"route": "/[dynamic]",
+				"type": "page",
+			},
+			{
+				"route": "/[dynamic]/[...rest]",
+				"type": "page",
+			},
+			{
+				"route": "/[...rest]/static",
+				"type": "page",
+			},
+			{
+				"route": "/[...rest]",
+				"type": "page",
 			},
 		]);
 	});
@@ -242,11 +302,11 @@ describe('routing - createRouteManifest', () => {
 				type: 'page',
 			},
 			{
-				route: '/',
+				route: '/contributing',
 				type: 'page',
 			},
 			{
-				route: '/contributing',
+				route: '/',
 				type: 'page',
 			},
 			{

--- a/packages/astro/test/units/routing/manifest.test.js
+++ b/packages/astro/test/units/routing/manifest.test.js
@@ -156,6 +156,9 @@ describe('routing - createRouteManifest', () => {
 				'/src/pages/[dynamic]/[...rest].astro': `<h1>test</h1>`,
 				'/src/pages/[...rest]/static.astro': `<h1>test</h1>`,
 				'/src/pages/[...rest]/index.astro': `<h1>test</h1>`,
+				'/src/pages/blog/index.astro': `<h1>test</h1>`,
+				'/src/pages/[other].astro': `<h1>test</h1>`,
+				'/src/pages/[...other].astro': `<h1>test</h1>`,
 				'/src/pages/static.astro': `<h1>test</h1>`,
 				'/src/pages/index.astro': `<h1>test</h1>`,
 			},
@@ -178,6 +181,10 @@ describe('routing - createRouteManifest', () => {
 
 		expect(getManifestRoutes(manifest)).to.deep.equal([
 			{
+				"route": "/blog",
+				"type": "page",
+			},
+			{
 				"route": "/static",
 				"type": "page",
 			},
@@ -198,11 +205,19 @@ describe('routing - createRouteManifest', () => {
 				"type": "page",
 			},
 			{
+				"route": "/[other]",
+				"type": "page",
+			},
+			{
 				"route": "/[...rest]/static",
 				"type": "page",
 			},
 			{
 				"route": "/[...rest]",
+				"type": "page",
+			},
+			{
+				"route": "/[...other]",
 				"type": "page",
 			},
 		]);

--- a/packages/astro/test/units/routing/manifest.test.js
+++ b/packages/astro/test/units/routing/manifest.test.js
@@ -151,13 +151,13 @@ describe('routing - createRouteManifest', () => {
 	it('route sorting respects the file tree', async () => {
 		const fs = createFs(
 			{
-				'/src/pages/[dynamic]/static.astro': `<h1>test</h1>`,
-				'/src/pages/[dynamic]/index.astro': `<h1>test</h1>`,
-				'/src/pages/[dynamic]/[...rest].astro': `<h1>test</h1>`,
+				'/src/pages/[dynamic_folder]/static.astro': `<h1>test</h1>`,
+				'/src/pages/[dynamic_folder]/index.astro': `<h1>test</h1>`,
+				'/src/pages/[dynamic_folder]/[...rest].astro': `<h1>test</h1>`,
 				'/src/pages/[...rest]/static.astro': `<h1>test</h1>`,
 				'/src/pages/[...rest]/index.astro': `<h1>test</h1>`,
 				'/src/pages/blog/index.astro': `<h1>test</h1>`,
-				'/src/pages/[other].astro': `<h1>test</h1>`,
+				'/src/pages/[dynamic_file].astro': `<h1>test</h1>`,
 				'/src/pages/[...other].astro': `<h1>test</h1>`,
 				'/src/pages/static.astro': `<h1>test</h1>`,
 				'/src/pages/index.astro': `<h1>test</h1>`,
@@ -193,19 +193,19 @@ describe('routing - createRouteManifest', () => {
 				"type": "page",
 			},
 			{
-				"route": "/[dynamic]",
+				"route": "/[dynamic_folder]",
 				"type": "page",
 			},
 			{
-				"route": "/[other]",
+				"route": "/[dynamic_file]",
 				"type": "page",
 			},
 			{
-				"route": "/[dynamic]/static",
+				"route": "/[dynamic_folder]/static",
 				"type": "page",
 			},
 			{
-				"route": "/[dynamic]/[...rest]",
+				"route": "/[dynamic_folder]/[...rest]",
 				"type": "page",
 			},
 			{


### PR DESCRIPTION
## Changes

- Fixes #9770
- Fixes #9779

## Testing

The new test includes a nested structure of dynamic parameters as folders with indexes, including rest parameters in the middle of the route.

## Docs

The rules remain the same but now apply per-segment instead of the whole route at once.
Unclear to me whether this needs to be made more clear on the docs.