### PR TITLE
fix: accept the 'switch' aria role during a11y checks

### DIFF
--- a/.changeset/large-phones-guess.md
+++ b/.changeset/large-phones-guess.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Accept aria role `switch` on toolbar audit.

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/a11y.ts
@@ -208,7 +208,7 @@ const ariaAttributes = new Set(
 );
 
 const ariaRoles = new Set(
-	'alert alertdialog application article banner button cell checkbox columnheader combobox complementary contentinfo definition dialog directory document feed figure form grid gridcell group heading img link list listbox listitem log main marquee math menu menubar menuitem menuitemcheckbox menuitemradio navigation none note option presentation progressbar radio radiogroup region row rowgroup rowheader scrollbar search searchbox separator slider spinbutton status tab tablist tabpanel textbox timer toolbar tooltip tree treegrid treeitem'.split(
+	'alert alertdialog application article banner button cell checkbox columnheader combobox complementary contentinfo definition dialog directory document feed figure form grid gridcell group heading img link list listbox listitem log main marquee math menu menubar menuitem menuitemcheckbox menuitemradio navigation none note option presentation progressbar radio radiogroup region row rowgroup rowheader scrollbar search searchbox separator slider spinbutton status switch tab tablist tabpanel textbox timer toolbar tooltip tree treegrid treeitem'.split(
 		' '
 	)
 );


### PR DESCRIPTION
## Changes

Adds [`switch`](https://www.w3.org/TR/wai-aria/#switch) to the list of allowed aria roles for the dev toolbar checks.

## Testing

Tested manually on the minimal example, by adding a `switch` role element.

```html
<body>
  <h1>Astro</h1>
  <span role="switch">Switch Off</span>
</body>
```

Before and after:
<img width="270" alt="Screenshot 2024-01-23 at 9 07 26 PM" src="https://github.com/withastro/astro/assets/5593188/a4570eb6-44e7-4fc1-a230-0c8afb93ce58"> <img width="269" alt="Screenshot 2024-01-23 at 9 06 28 PM" src="https://github.com/withastro/astro/assets/5593188/c4b3eb9c-f661-4a61-8064-02b3123f197e">

Adding `aria-checked` clears the error on the left.

## Docs

Nothing to update. No explicit mention of the behavior for the `switch` role in the docs.
