### PR TITLE
fix(rss): apply refinement at the point of parsing

### DIFF
--- a/.changeset/angry-dryers-hang.md
+++ b/.changeset/angry-dryers-hang.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/rss": patch
+---
+
+Restores `rssSchema` to a zod object

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -137,7 +137,12 @@ export function pagesGlobToRssItems(items: GlobResult): Promise<ValidatedRSSFeed
 					`[RSS] You can only glob entries within 'src/pages/' when passing import.meta.glob() directly. Consider mapping the result to an array of RSSFeedItems. See the RSS docs for usage examples: https://docs.astro.build/en/guides/rss/#2-list-of-rss-feed-objects`
 				);
 			}
-			const parsedResult = rssSchema.safeParse({ ...frontmatter, link: url }, { errorMap });
+			const parsedResult = rssSchema
+				.refine((val) => val.title || val.description, {
+					message: 'At least title or description must be provided.',
+					path: ['title', 'description'],
+				})
+				.safeParse({ ...frontmatter, link: url }, { errorMap });
 
 			if (parsedResult.success) {
 				return parsedResult.data;

--- a/packages/astro-rss/src/schema.ts
+++ b/packages/astro-rss/src/schema.ts
@@ -1,30 +1,25 @@
 import { z } from 'astro/zod';
 
-export const rssSchema = z
-	.object({
-		title: z.string().optional(),
-		description: z.string().optional(),
-		pubDate: z
-			.union([z.string(), z.number(), z.date()])
-			.optional()
-			.transform((value) => (value === undefined ? value : new Date(value)))
-			.refine((value) => (value === undefined ? value : !isNaN(value.getTime()))),
-		customData: z.string().optional(),
-		categories: z.array(z.string()).optional(),
-		author: z.string().optional(),
-		commentsUrl: z.string().optional(),
-		source: z.object({ url: z.string().url(), title: z.string() }).optional(),
-		enclosure: z
-			.object({
-				url: z.string(),
-				length: z.number().positive().int().finite(),
-				type: z.string(),
-			})
-			.optional(),
-		link: z.string().optional(),
-		content: z.string().optional(),
-	})
-	.refine((val) => val.title || val.description, {
-		message: 'At least title or description must be provided.',
-		path: ['title', 'description'],
-	});
+export const rssSchema = z.object({
+	title: z.string().optional(),
+	description: z.string().optional(),
+	pubDate: z
+		.union([z.string(), z.number(), z.date()])
+		.optional()
+		.transform((value) => (value === undefined ? value : new Date(value)))
+		.refine((value) => (value === undefined ? value : !isNaN(value.getTime()))),
+	customData: z.string().optional(),
+	categories: z.array(z.string()).optional(),
+	author: z.string().optional(),
+	commentsUrl: z.string().optional(),
+	source: z.object({ url: z.string().url(), title: z.string() }).optional(),
+	enclosure: z
+		.object({
+			url: z.string(),
+			length: z.number().positive().int().finite(),
+			type: z.string(),
+		})
+		.optional(),
+	link: z.string().optional(),
+	content: z.string().optional(),
+});

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -1,6 +1,7 @@
 import chai from 'chai';
 import chaiPromises from 'chai-as-promised';
 import chaiXml from 'chai-xml';
+import { z } from 'astro/zod';
 import rss, { getRssString } from '../dist/index.js';
 import { rssSchema } from '../dist/schema.js';
 import {
@@ -213,5 +214,17 @@ describe('getRssString', () => {
 
 		chai.expect(res.success).to.be.false;
 		chai.expect(res.error.issues[0].path[0]).to.equal('pubDate');
+	});
+
+	it('should be extendable', () => {
+		let error = null;
+		try {
+			rssSchema.extend({
+				category: z.string().optional(),
+			});
+		} catch (e) {
+			error = e.message;
+		}
+		chai.expect(error).to.be.null;
 	});
 });


### PR DESCRIPTION
Allows extending, while keeping the validation.

## Changes

- Follow-up on https://github.com/withastro/astro/pull/9746
- Adds test that confirms `.extend` can be called

## Testing

Added a new test for this case.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

Fixes a regression