### PR TITLE
deps: bump peer deps to 4.0

### DIFF
--- a/examples/component/package.json
+++ b/examples/component/package.json
@@ -18,6 +18,6 @@
     "astro": "^4.2.3"
   },
   "peerDependencies": {
-    "astro": "^3.0.0"
+    "astro": "^4.0.0"
   }
 }

--- a/examples/integration/package.json
+++ b/examples/integration/package.json
@@ -18,6 +18,6 @@
     "astro": "^4.2.3"
   },
   "peerDependencies": {
-    "astro": "^3.0.0"
+    "astro": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Changes

According to #8893 peer deps should be tracked manually.
It was confirmed by Nate in the discord.

![image](https://github.com/withastro/astro/assets/117351089/ceb44786-409c-492a-b599-8e76e6caa255)


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tested locally. Packages under `packages/` folder have already been updated.

## Docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
