### PR TITLE
Fix env var replacement for export const prerender

### DIFF
--- a/.changeset/strange-students-shake.md
+++ b/.changeset/strange-students-shake.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes environment variables replacement for `export const prerender`

--- a/packages/astro/src/vite-plugin-env/index.ts
+++ b/packages/astro/src/vite-plugin-env/index.ts
@@ -14,6 +14,9 @@ const importMetaEnvOnlyRe = /\bimport\.meta\.env\b(?!\.)/;
 // Match valid JS variable names (identifiers), which accepts most alphanumeric characters,
 // except that the first character cannot be a number.
 const isValidIdentifierRe = /^[_$a-zA-Z][_$a-zA-Z0-9]*$/;
+// Match `export const prerender = import.meta.env.*` since `vite=plugin-scanner` requires
+// the `import.meta.env.*` to always be replaced.
+const exportConstPrerenderRe = /\bexport\s+const\s+prerender\s*=\s*import\.meta\.env\.(.+?)\b/;
 
 function getPrivateEnv(
 	viteConfig: vite.ResolvedConfig,
@@ -156,6 +159,7 @@ export default function envVitePlugin({ settings }: EnvPluginOptions): vite.Plug
 			// In dev, we can assign the private env vars to `import.meta.env` directly for performance
 			if (isDev) {
 				const s = new MagicString(source);
+
 				if (!devImportMetaEnvPrepend) {
 					devImportMetaEnvPrepend = `Object.assign(import.meta.env,{`;
 					for (const key in privateEnv) {
@@ -164,6 +168,16 @@ export default function envVitePlugin({ settings }: EnvPluginOptions): vite.Plug
 					devImportMetaEnvPrepend += '});';
 				}
 				s.prepend(devImportMetaEnvPrepend);
+
+				// EDGE CASE: We need to do a static replacement for `export const prerender` for `vite-plugin-scanner`
+				s.replace(exportConstPrerenderRe, (m, key) => {
+					if (privateEnv[key] != null) {
+						return `export const prerender = ${privateEnv[key]}`;
+					} else {
+						return m;
+					}
+				});
+
 				return {
 					code: s.toString(),
 					map: s.generateMap({ hires: 'boundary' }),

--- a/packages/integrations/node/test/prerender.test.js
+++ b/packages/integrations/node/test/prerender.test.js
@@ -140,6 +140,44 @@ describe('Prerendering', () => {
 			expect($('h1').text()).to.equal('Two');
 		});
 	});
+
+	describe('Dev', () => {
+		let devServer;
+
+		before(async () => {
+			process.env.PRERENDER = true;
+
+			fixture = await loadFixture({
+				root: './fixtures/prerender/',
+				output: 'server',
+				adapter: nodejs({ mode: 'standalone' }),
+			});
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+			delete process.env.PRERENDER;
+		});
+
+		it('Can render SSR route', async () => {
+			const res = await fixture.fetch(`/one`);
+			const html = await res.text();
+			const $ = cheerio.load(html);
+
+			expect(res.status).to.equal(200);
+			expect($('h1').text()).to.equal('One');
+		});
+
+		it('Can render prerendered route', async () => {
+			const res = await fixture.fetch(`/two`);
+			const html = await res.text();
+			const $ = cheerio.load(html);
+
+			expect(res.status).to.equal(200);
+			expect($('h1').text()).to.equal('Two');
+		});
+	});
 });
 
 describe('Hybrid rendering', () => {


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/9734

`vite-plugin-scanner` uses static analysis to detect the value of `export const prerender = import.meta.env.*`. That means the env var needs to be statically replaced before it can detect it. In #9652, I removed the static replacement in favour of a more performant approach (that assigns `import.meta.env` in runtime), however it didn't work well for this case.

While the `export const prerender` is mainly for builds only, I think the early warning in dev is still good to keep. So I made a quick fix to statically replace for `export const prerender` only for now.

## Testing

Added a dev test. We only tested the feature in build.

## Docs

n/a. bug fix.
