### PR TITLE
fix(vercel): make Astro.cookies work again

### DIFF
--- a/.changeset/two-ducks-give.md
+++ b/.changeset/two-ducks-give.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vercel": patch
+---
+
+Fixes an issue where the serverless function ignored cookies added using Astro.cookies.

--- a/packages/integrations/vercel/src/serverless/entrypoint.ts
+++ b/packages/integrations/vercel/src/serverless/entrypoint.ts
@@ -20,7 +20,7 @@ export const createExports = (manifest: SSRManifest) => {
 				: Array.isArray(localsHeader)
 					? JSON.parse(localsHeader[0])
 					: {};
-		const webResponse = await app.render(req, { locals, clientAddress });
+		const webResponse = await app.render(req, { addCookieHeader: true, clientAddress, locals });
 		await NodeApp.writeResponse(webResponse, res);
 	};
 


### PR DESCRIPTION
## Changes
- Makes sure that cookies added using Astro.cookies are added as a header.
- This slipped during the Astro 4.2 "app enhancements" refactors.
- Noticed while attempting to reproduce #9801.

## Testing
- Runtime tests for vercel do not seem to be set up.

## Docs
- Does not affect usage.