### PR TITLE
fix(create-astro): @astrojs/check and typescript addition

### DIFF
--- a/.changeset/seven-kiwis-join.md
+++ b/.changeset/seven-kiwis-join.md
@@ -1,0 +1,5 @@
+---
+"create-astro": patch
+---
+
+Fixes `@astrojs/check` and `typescript` addition to `package.json` dependencies when the user has decided not to auto-install dependencies

--- a/packages/create-astro/src/actions/context.ts
+++ b/packages/create-astro/src/actions/context.ts
@@ -93,7 +93,7 @@ export async function getContext(argv: string[]): Promise<Context> {
 		prompt,
 		packageManager,
 		username: getName(),
-		version: getVersion(packageManager),
+		version: getVersion(packageManager, 'astro'),
 		skipHouston,
 		fancy,
 		dryRun,

--- a/packages/create-astro/src/actions/typescript.ts
+++ b/packages/create-astro/src/actions/typescript.ts
@@ -122,8 +122,8 @@ const FILES_TO_UPDATE = {
 					getVersion(options.ctx.packageManager, 'typescript'),
 				]);
 				parsedPackageJson.dependencies ??= {}
-				parsedPackageJson.dependencies['@astrojs/check'] = astroCheckVersion;
-				parsedPackageJson.dependencies.typescript = typescriptVersion;
+				parsedPackageJson.dependencies['@astrojs/check'] = `^${astroCheckVersion}`;
+				parsedPackageJson.dependencies.typescript = `^${typescriptVersion}`;
 			}
 
 			await writeFile(file, JSON.stringify(parsedPackageJson, null, indent), 'utf-8');

--- a/packages/create-astro/src/actions/typescript.ts
+++ b/packages/create-astro/src/actions/typescript.ts
@@ -4,7 +4,7 @@ import { color } from '@astrojs/cli-kit';
 import { readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import stripJsonComments from 'strip-json-comments';
-import { error, info, title, typescriptByDefault } from '../messages.js';
+import { error, getVersion, info, title, typescriptByDefault } from '../messages.js';
 import { shell } from '../shell.js';
 
 type PickedTypeScriptContext = Pick<
@@ -90,11 +90,18 @@ const FILES_TO_UPDATE = {
 	) => {
 		try {
 			// add required dependencies for astro check
-			if (options.ctx.install)
-				await shell(options.ctx.packageManager, ['add', '@astrojs/check', 'typescript'], {
-					cwd: path.dirname(file),
-					stdio: 'ignore',
-				});
+			let installSucceeded = true;
+			if (options.ctx.install) {
+				const { exitCode } = await shell(
+					options.ctx.packageManager,
+					['add', '@astrojs/check', 'typescript'],
+					{
+						cwd: path.dirname(file),
+						stdio: 'ignore',
+					}
+				);
+				installSucceeded = exitCode === 0;
+			}
 
 			// inject additional command to build script
 			const data = await readFile(file, { encoding: 'utf-8' });
@@ -107,8 +114,19 @@ const FILES_TO_UPDATE = {
 			if (typeof buildScript === 'string' && !buildScript.includes('astro check')) {
 				// Mutate the existing object to avoid changing user-defined script order
 				parsedPackageJson.scripts.build = `astro check && ${buildScript}`;
-				await writeFile(file, JSON.stringify(parsedPackageJson, null, indent), 'utf-8');
 			}
+
+			if (!options.ctx.install || !installSucceeded) {
+				const [astroCheckVersion, typescriptVersion] = await Promise.all([
+					getVersion(options.ctx.packageManager, '@astrojs/check'),
+					getVersion(options.ctx.packageManager, 'typescript'),
+				]);
+				parsedPackageJson.dependencies ??= {}
+				parsedPackageJson.dependencies['@astrojs/check'] = astroCheckVersion;
+				parsedPackageJson.dependencies.typescript = typescriptVersion;
+			}
+
+			await writeFile(file, JSON.stringify(parsedPackageJson, null, indent), 'utf-8');
 		} catch (err) {
 			// if there's no package.json (which is very unlikely), then do nothing
 			if (err && (err as any).code === 'ENOENT') return;

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -55,11 +55,11 @@ export const getName = () =>
 	});
 
 let v: string;
-export const getVersion = (packageManager: string) =>
+export const getVersion = (packageManager: string, packageName = 'astro') =>
 	new Promise<string>(async (resolve) => {
 		if (v) return resolve(v);
 		let registry = await getRegistry(packageManager);
-		const { version } = await fetch(`${registry}/astro/latest`, { redirect: 'follow' }).then(
+		const { version } = await fetch(`${registry}/${packageName}/latest`, { redirect: 'follow' }).then(
 			(res) => res.json(),
 			() => ({ version: '' })
 		);

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -55,7 +55,7 @@ export const getName = () =>
 	});
 
 let v: string;
-export const getVersion = (packageManager: string, packageName = 'astro') =>
+export const getVersion = (packageManager: string, packageName: string) =>
 	new Promise<string>(async (resolve) => {
 		if (v) return resolve(v);
 		let registry = await getRegistry(packageManager);


### PR DESCRIPTION
## Changes

- Closes #9791
- Fixes `@astrojs/check` and `typescript` addition to `package.json` dependencies when the user has decided not to auto-install dependencies

Not sure if it solves https://github.com/withastro/astro/issues/9791#issuecomment-1906722419 though

## Testing

Not tested

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
