### PR TITLE
Remove `create-astro` version cache

### DIFF
--- a/packages/create-astro/src/actions/typescript.ts
+++ b/packages/create-astro/src/actions/typescript.ts
@@ -5,7 +5,6 @@ import { readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import stripJsonComments from 'strip-json-comments';
 import { error, getVersion, info, title, typescriptByDefault } from '../messages.js';
-import { shell } from '../shell.js';
 
 type PickedTypeScriptContext = Pick<
 	Context,

--- a/packages/create-astro/src/index.ts
+++ b/packages/create-astro/src/index.ts
@@ -39,8 +39,8 @@ export async function main() {
 		intro,
 		projectName,
 		template,
-		dependencies,
 		typescript,
+		dependencies,
 
 		// Steps which write to files need to go above git
 		git,

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -9,13 +9,16 @@ import { shell } from './shell.js';
 // checks the user's project type and will return the proper npm registry
 //
 // A copy of this function also exists in the astro package
+let _registry: string;
 async function getRegistry(packageManager: string): Promise<string> {
+	if (_registry) return _registry;
 	try {
 		const { stdout } = await shell(packageManager, ['config', 'get', 'registry']);
-		return stdout?.trim()?.replace(/\/$/, '') || 'https://registry.npmjs.org';
+		_registry = stdout?.trim()?.replace(/\/$/, '') || 'https://registry.npmjs.org';
 	} catch (e) {
-		return 'https://registry.npmjs.org';
+		_registry = 'https://registry.npmjs.org';
 	}
+	return _registry;
 }
 
 let stdout = process.stdout;
@@ -54,19 +57,16 @@ export const getName = () =>
 		});
 	});
 
-let v: string;
-export const getVersion = (packageManager: string, packageName: string) =>
+export const getVersion = (packageManager: string, packageName: string, fallback = '') =>
 	new Promise<string>(async (resolve) => {
-		if (v) return resolve(v);
 		let registry = await getRegistry(packageManager);
 		const { version } = await fetch(`${registry}/${packageName}/latest`, {
 			redirect: 'follow',
 		}).then(
 			(res) => res.json(),
-			() => ({ version: '' })
+			() => ({ version: fallback })
 		);
-		v = version;
-		resolve(version);
+		return resolve(version);
 	});
 
 export const log = (message: string) => stdout.write(message + '\n');


### PR DESCRIPTION
## Changes

- Follow-up to #9813
- After testing the changes in #9813, I noticed that our `getVersion` function had a cache and only ever used the first version it fetched. Removed this!
- I also flipped the order of questions so that TypeScript goes before Dependency Installation. I missed that this was needed when reviewing #9813.
- No changeset needed because this hasn't been released yet!

## Testing

Tested manually. Existing test coverage is still valid.

## Docs

Nope, bug fix for unreleased code