### PR TITLE
fix(i18n): use `define` to deliver config to virtual module

### DIFF
--- a/.changeset/silent-buckets-retire.md
+++ b/.changeset/silent-buckets-retire.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where `astro:i18n` could not be used in framework components.

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -31,7 +31,7 @@ export default function astroInternationalization({
 		config(config) {
 			const i18nConfig: I18nInternalConfig = { base, format, site, trailingSlash, i18n };
 			config.define ??= {}
-			config.define["import.meta.env._ASTRO_INTERNAL_I18N_CONFIG"] = JSON.stringify(i18nConfig);
+			config.define.__ASTRO_INTERNAL_I18N_CONFIG__ = JSON.stringify(i18nConfig);
 		},
 		resolveId(id) {
 			if (id === virtualModuleId) {

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -30,8 +30,11 @@ export default function astroInternationalization({
 		enforce: 'pre',
 		config(config) {
 			const i18nConfig: I18nInternalConfig = { base, format, site, trailingSlash, i18n };
-			config.define ??= {}
-			config.define.__ASTRO_INTERNAL_I18N_CONFIG__ = JSON.stringify(i18nConfig);
+			return {
+				define: {
+					__ASTRO_INTERNAL_I18N_CONFIG__: JSON.stringify(i18nConfig)
+				}
+			}
 		},
 		resolveId(id) {
 			if (id === virtualModuleId) {

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -11,8 +11,9 @@ type AstroInternationalization = {
 
 export interface I18nInternalConfig
 	extends Pick<AstroConfig, 'base' | 'site' | 'trailingSlash'>,
-		NonNullable<AstroConfig['i18n']>,
-		Pick<AstroConfig['build'], 'format'> {}
+	Pick<AstroConfig['build'], 'format'> {
+		i18n: AstroConfig['i18n'];
+	}
 
 export default function astroInternationalization({
 	settings,
@@ -28,8 +29,7 @@ export default function astroInternationalization({
 		name: 'astro:i18n',
 		enforce: 'pre',
 		config(config) {
-			const { defaultLocale, locales, routing, fallback } = i18n!;
-			const i18nConfig: I18nInternalConfig = { base, format, site, trailingSlash, defaultLocale, locales, routing, fallback };
+			const i18nConfig: I18nInternalConfig = { base, format, site, trailingSlash, i18n };
 			config.define ??= {}
 			config.define["import.meta.env._ASTRO_INTERNAL_I18N_CONFIG"] = JSON.stringify(i18nConfig);
 		},

--- a/packages/astro/src/i18n/vite-plugin-i18n.ts
+++ b/packages/astro/src/i18n/vite-plugin-i18n.ts
@@ -4,8 +4,6 @@ import { AstroError } from '../core/errors/errors.js';
 import { AstroErrorData } from '../core/errors/index.js';
 
 const virtualModuleId = 'astro:i18n';
-const configId = 'astro-internal:i18n-config';
-const resolvedConfigId = `\0${configId}`;
 
 type AstroInternationalization = {
 	settings: AstroSettings;
@@ -29,28 +27,17 @@ export default function astroInternationalization({
 	return {
 		name: 'astro:i18n',
 		enforce: 'pre',
-		async resolveId(id) {
+		config(config) {
+			const { defaultLocale, locales, routing, fallback } = i18n!;
+			const i18nConfig: I18nInternalConfig = { base, format, site, trailingSlash, defaultLocale, locales, routing, fallback };
+			config.define ??= {}
+			config.define["import.meta.env._ASTRO_INTERNAL_I18N_CONFIG"] = JSON.stringify(i18nConfig);
+		},
+		resolveId(id) {
 			if (id === virtualModuleId) {
 				if (i18n === undefined) throw new AstroError(AstroErrorData.i18nNotEnabled);
 				return this.resolve('astro/virtual-modules/i18n.js');
 			}
-			if (id === configId) return resolvedConfigId;
-		},
-		load(id) {
-			if (id === resolvedConfigId) {
-				const { defaultLocale, locales, routing, fallback } = i18n!;
-				const config: I18nInternalConfig = {
-					base,
-					format,
-					site,
-					trailingSlash,
-					defaultLocale,
-					locales,
-					routing,
-					fallback,
-				};
-				return `export default ${JSON.stringify(config)};`;
-			}
-		},
+		}
 	};
 }

--- a/packages/astro/src/virtual-modules/i18n.ts
+++ b/packages/astro/src/virtual-modules/i18n.ts
@@ -2,7 +2,8 @@ import * as I18nInternals from '../i18n/index.js';
 import type { I18nInternalConfig } from '../i18n/vite-plugin-i18n.js';
 export { normalizeTheLocale, toCodes, toPaths } from '../i18n/index.js';
 
-const { trailingSlash, format, site, defaultLocale, locales, routing } = import.meta.env._ASTRO_INTERNAL_I18N_CONFIG as I18nInternalConfig;
+const { trailingSlash, format, site, i18n } = import.meta.env._ASTRO_INTERNAL_I18N_CONFIG as I18nInternalConfig;
+const { defaultLocale, locales, routing } = i18n!;
 const base = import.meta.env.BASE_URL;
 
 export type GetLocaleOptions = I18nInternals.GetLocaleOptions;

--- a/packages/astro/src/virtual-modules/i18n.ts
+++ b/packages/astro/src/virtual-modules/i18n.ts
@@ -2,7 +2,8 @@ import * as I18nInternals from '../i18n/index.js';
 import type { I18nInternalConfig } from '../i18n/vite-plugin-i18n.js';
 export { normalizeTheLocale, toCodes, toPaths } from '../i18n/index.js';
 
-const { trailingSlash, format, site, i18n } = import.meta.env._ASTRO_INTERNAL_I18N_CONFIG as I18nInternalConfig;
+// @ts-expect-error
+const { trailingSlash, format, site, i18n } = __ASTRO_INTERNAL_I18N_CONFIG__ as I18nInternalConfig;
 const { defaultLocale, locales, routing } = i18n!;
 const base = import.meta.env.BASE_URL;
 

--- a/packages/astro/src/virtual-modules/i18n.ts
+++ b/packages/astro/src/virtual-modules/i18n.ts
@@ -1,10 +1,8 @@
 import * as I18nInternals from '../i18n/index.js';
 import type { I18nInternalConfig } from '../i18n/vite-plugin-i18n.js';
 export { normalizeTheLocale, toCodes, toPaths } from '../i18n/index.js';
-// @ts-expect-error
-import config from 'astro-internal:i18n-config';
-const { trailingSlash, format, site, defaultLocale, locales, routing } =
-	config as I18nInternalConfig;
+
+const { trailingSlash, format, site, defaultLocale, locales, routing } = import.meta.env._ASTRO_INTERNAL_I18N_CONFIG as I18nInternalConfig;
 const base = import.meta.env.BASE_URL;
 
 export type GetLocaleOptions = I18nInternals.GetLocaleOptions;


### PR DESCRIPTION
## Changes
- Switches the approach used to deliver i18n config to the `astro:i18n` module.
- The virtual module approach broke in mysterious ways.

## Testing
Existing tests should pass.

## Docs
Does not affect usage.
