### PR TITLE
Expose `ContentConfig` type from `astro:content`

### DIFF
--- a/.changeset/famous-seas-press.md
+++ b/.changeset/famous-seas-press.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Expose `ContentConfig` type from `astro:content`

--- a/packages/astro/content-types.template.d.ts
+++ b/packages/astro/content-types.template.d.ts
@@ -183,5 +183,5 @@ declare module 'astro:content' {
 
 	type AnyEntryMap = ContentEntryMap & DataEntryMap;
 
-	type ContentConfig = '@@CONTENT_CONFIG_TYPE@@';
+	export type ContentConfig = '@@CONTENT_CONFIG_TYPE@@';
 }


### PR DESCRIPTION
## Changes

- Exports the `ContentConfig` type publicly from `astro:content`
- We realised in https://github.com/withastro/starlight/pull/1175 that we needed access not just to a user’s schema output type (`CollectionEntry['data']`), but also the schema input type. While accessing the actual schema at runtime is possible, getting its type is much trickier. Exposing this would make that simpler. (Also open to other ideas if people have them.)

## Testing

Existing tests should pass; types only change.

## Docs

n/a — this is a rarely needed API, but handy in some edge cases.
