### PR TITLE
fix: use publicDir & base for 'include your base in url' error message

### DIFF
--- a/.changeset/eight-windows-kiss.md
+++ b/.changeset/eight-windows-kiss.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes error message when requesting a public url without your base.
+Makes the warning clearer when having a custom `base` and requesting a public URL without it

--- a/.changeset/eight-windows-kiss.md
+++ b/.changeset/eight-windows-kiss.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes error message when requesting a public url without your base.

--- a/packages/astro/src/vite-plugin-astro-server/base.ts
+++ b/packages/astro/src/vite-plugin-astro-server/base.ts
@@ -3,11 +3,11 @@ import type { AstroSettings } from '../@types/astro.js';
 
 import { bold } from 'kleur/colors';
 import * as fs from 'node:fs';
+import path from 'node:path';
+import { appendForwardSlash } from '@astrojs/internal-helpers/path';
 import type { Logger } from '../core/logger/core.js';
 import notFoundTemplate, { subpathNotUsedTemplate } from '../template/4xx.js';
 import { writeHtmlResponse } from './response.js';
-import { appendForwardSlash, removeTrailingForwardSlash } from '@astrojs/internal-helpers/path';
-import path from 'node:path';
 
 export function baseMiddleware(
 	settings: AstroSettings,

--- a/packages/astro/src/vite-plugin-astro-server/base.ts
+++ b/packages/astro/src/vite-plugin-astro-server/base.ts
@@ -55,7 +55,7 @@ export function baseMiddleware(
 		fs.stat(publicPath, (_err, stats) => {
 			if (stats) {
 				const publicDir = appendForwardSlash(
-					path.relative(config.root.pathname, config.publicDir.pathname)
+					path.posix.relative(config.root.pathname, config.publicDir.pathname)
 				);
 				const expectedLocation = new URL(devRootURL.pathname + url, devRootURL).pathname;
 

--- a/packages/astro/src/vite-plugin-astro-server/base.ts
+++ b/packages/astro/src/vite-plugin-astro-server/base.ts
@@ -6,6 +6,7 @@ import * as fs from 'node:fs';
 import type { Logger } from '../core/logger/core.js';
 import notFoundTemplate, { subpathNotUsedTemplate } from '../template/4xx.js';
 import { writeHtmlResponse } from './response.js';
+import { appendForwardSlash, removeTrailingForwardSlash } from '@astrojs/internal-helpers/path';
 
 export function baseMiddleware(
 	settings: AstroSettings,
@@ -52,7 +53,9 @@ export function baseMiddleware(
 		const publicPath = new URL('.' + req.url, config.publicDir);
 		fs.stat(publicPath, (_err, stats) => {
 			if (stats) {
-				const publicDir = config.publicDir.pathname.replace(/\/$/, '').split('/').pop() + '/';
+				const publicDir = appendForwardSlash(
+					removeTrailingForwardSlash(config.publicDir.pathname).split('/').pop()!
+				);
 				const expectedLocation = new URL(devRootURL.pathname + url, devRootURL).pathname;
 
 				logger.error(

--- a/packages/astro/src/vite-plugin-astro-server/base.ts
+++ b/packages/astro/src/vite-plugin-astro-server/base.ts
@@ -52,11 +52,13 @@ export function baseMiddleware(
 		const publicPath = new URL('.' + req.url, config.publicDir);
 		fs.stat(publicPath, (_err, stats) => {
 			if (stats) {
-				const expectedLocation = new URL('.' + url, devRootURL).pathname;
+				const publicDir = config.publicDir.pathname.replace(/\/$/, '').split('/').pop() + '/';
+				const expectedLocation = new URL(devRootURL.pathname + url, devRootURL).pathname;
+
 				logger.error(
 					'router',
 					`Request URLs for ${bold(
-						'public/'
+						publicDir
 					)} assets must also include your base. "${expectedLocation}" expected, but received "${url}".`
 				);
 				const html = subpathNotUsedTemplate(devRoot, pathname);

--- a/packages/astro/src/vite-plugin-astro-server/base.ts
+++ b/packages/astro/src/vite-plugin-astro-server/base.ts
@@ -7,6 +7,7 @@ import type { Logger } from '../core/logger/core.js';
 import notFoundTemplate, { subpathNotUsedTemplate } from '../template/4xx.js';
 import { writeHtmlResponse } from './response.js';
 import { appendForwardSlash, removeTrailingForwardSlash } from '@astrojs/internal-helpers/path';
+import path from 'node:path';
 
 export function baseMiddleware(
 	settings: AstroSettings,
@@ -54,7 +55,7 @@ export function baseMiddleware(
 		fs.stat(publicPath, (_err, stats) => {
 			if (stats) {
 				const publicDir = appendForwardSlash(
-					removeTrailingForwardSlash(config.publicDir.pathname).split('/').pop()!
+					path.relative(config.root.pathname, config.publicDir.pathname)
 				);
 				const expectedLocation = new URL(devRootURL.pathname + url, devRootURL).pathname;
 


### PR DESCRIPTION
## Changes

Closes #9759 

Fixes error message when requesting a public url without your base.
Now the error message will correctly show the correct publicUrl  and will add your base to the expected.

### Before / After
_With the following config:_
```ts
export default defineConfig({
  base: "/my-page",
  publicDir: "static"
});
```

_Before:_
```
[ERROR] [router] Request URLs for public/ assets must also include your base. "/favicon.svg" expected, but received "/favicon.svg".
```

_After:_
```
[ERROR] [router] Request URLs for static/ assets must also include your base. "/my-page/favicon.svg" expected, but received "/favicon.svg".
```

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Didn't feel like this small "text" change needed it's own test : )

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Doesn't change current behavior only makes the error message more clear.
