### PR TITLE
remove unused prop in blog template

### DIFF
--- a/examples/blog/src/pages/index.astro
+++ b/examples/blog/src/pages/index.astro
@@ -11,7 +11,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
 	</head>
 	<body>
-		<Header  />
+		<Header />
 		<main>
 			<h1>🧑‍🚀 Hello, Astronaut!</h1>
 			<p>

--- a/examples/blog/src/pages/index.astro
+++ b/examples/blog/src/pages/index.astro
@@ -11,7 +11,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
 	</head>
 	<body>
-		<Header title={SITE_TITLE} />
+		<Header  />
 		<main>
 			<h1>🧑‍🚀 Hello, Astronaut!</h1>
 			<p>

--- a/packages/astro/test/units/dev/dev.test.js
+++ b/packages/astro/test/units/dev/dev.test.js
@@ -56,7 +56,7 @@ describe('dev container', () => {
 					<html>
 						<head><title>{name}</title></head>
 						<body class="one">
-							<Header />
+							<Header title={name} />
 						</body>
 					</html>
 				`,
@@ -92,7 +92,7 @@ describe('dev container', () => {
 				<html>
 					<head><title>{name}</title></head>
 					<body class="two">
-						<Header />
+						<Header title={name} />
 					</body>
 				</html>
 			`

--- a/packages/astro/test/units/dev/dev.test.js
+++ b/packages/astro/test/units/dev/dev.test.js
@@ -56,7 +56,7 @@ describe('dev container', () => {
 					<html>
 						<head><title>{name}</title></head>
 						<body class="one">
-							<Header title={name} />
+							<Header />
 						</body>
 					</html>
 				`,
@@ -92,7 +92,7 @@ describe('dev container', () => {
 				<html>
 					<head><title>{name}</title></head>
 					<body class="two">
-						<Header title={name} />
+						<Header />
 					</body>
 				</html>
 			`


### PR DESCRIPTION
## Changes

remove unused prop in `Header` component of blog template, the `SITE_TITLE` is already imported and used within


## Testing
Manually by using the template
## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
