### PR TITLE
feat: Expose ASTRO_ASSET field for return type of ImageFunction

### DIFF
--- a/.changeset/good-beers-deliver.md
+++ b/.changeset/good-beers-deliver.md
@@ -1,0 +1,5 @@
+---
+"astro": minor
+---
+
+Expose ASTRO_ASSET (string) field for return type of ImageFunction

--- a/packages/astro/content-types.template.d.ts
+++ b/packages/astro/content-types.template.d.ts
@@ -36,6 +36,7 @@ declare module 'astro:content' {
 				import('astro/zod').ZodLiteral<'avif'>,
 			]
 		>;
+		ASTRO_ASSET: import('astro/zod').ZodString;
 	}>;
 
 	type BaseSchemaWithoutEffects =


### PR DESCRIPTION
## Changes

Solves [#9852](https://github.com/withastro/astro/issues/9852) by adding `ASTRO_ASSET` (string) field to type ImageFunction return value.

## Testing

- I ran `pnpm run test`
- Other tests success, but `pnpm run test -- -m "@astrojs/node#test"` fails with:
    ```ansi
    Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:test/reporters
    ```
    ... but this test fails already with `main` branch even without any changes. So that leads me to think that test regression has nothing to do with my changes.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!--/cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
I don't think docs update is necessary as [Images in Content Collections](https://docs.astro.build/en/guides/images/#images-in-content-collections) documentation does not contain detailed documentation about the return values of `image()` function anyway.
