### PR TITLE
fix(i18n): compute current locale from route instead of request

### DIFF
--- a/.changeset/large-kangaroos-camp.md
+++ b/.changeset/large-kangaroos-camp.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes a bug in `Astro.currentLocale`, where the returned was incorrectly computed during the build.

--- a/.changeset/large-kangaroos-camp.md
+++ b/.changeset/large-kangaroos-camp.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes a bug in `Astro.currentLocale`, where the returned was incorrectly computed during the build.
+Fixes a bug in `Astro.currentLocale` where the value was incorrectly computed during the build.

--- a/packages/astro/src/core/constants.ts
+++ b/packages/astro/src/core/constants.ts
@@ -13,3 +13,5 @@ export const SUPPORTED_MARKDOWN_FILE_EXTENSIONS = [
 
 // The folder name where to find the middleware
 export const MIDDLEWARE_PATH_SEGMENT_NAME = 'middleware';
+
+export const ROUTE_DATA_SYMBOL = 'astro.routeData';

--- a/packages/astro/src/core/render/context.ts
+++ b/packages/astro/src/core/render/context.ts
@@ -12,8 +12,10 @@ import { AstroError, AstroErrorData } from '../errors/index.js';
 import type { Environment } from './environment.js';
 import { getParamsAndProps } from './params-and-props.js';
 import type { RoutingStrategies } from '../config/schema.js';
+import { ROUTE_DATA_SYMBOL } from '../constants.js';
 
 const clientLocalsSymbol = Symbol.for('astro.locals');
+const routeDataSymbol = Symbol.for(ROUTE_DATA_SYMBOL);
 
 /**
  * The RenderContext represents the parts of rendering that are specific to one request.
@@ -243,8 +245,12 @@ export function computeCurrentLocale(
 	routingStrategy: RoutingStrategies | undefined,
 	defaultLocale: string | undefined
 ): undefined | string {
-	const requestUrl = new URL(request.url);
-	for (const segment of requestUrl.pathname.split('/')) {
+	const routeData: RouteData | undefined = Reflect.get(request, routeDataSymbol);
+	if (!routeData) {
+		return defaultLocale;
+	}
+
+	for (const segment of routeData.route.split('/')) {
 		for (const locale of locales) {
 			if (typeof locale === 'string') {
 				if (normalizeTheLocale(locale) === normalizeTheLocale(segment)) {

--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -3,8 +3,9 @@ import type { Locales, MiddlewareHandler, RouteData, SSRManifest } from '../@typ
 import type { PipelineHookFunction } from '../core/pipeline.js';
 import { getPathByLocale, normalizeTheLocale } from './index.js';
 import { shouldAppendForwardSlash } from '../core/build/util.js';
+import { ROUTE_DATA_SYMBOL } from '../core/constants.js';
 
-const routeDataSymbol = Symbol.for('astro.routeData');
+const routeDataSymbol = Symbol.for(ROUTE_DATA_SYMBOL);
 
 // Checks if the pathname has any locale, exception for the defaultLocale, which is ignored on purpose.
 function pathnameHasLocale(pathname: string, locales: Locales): boolean {

--- a/packages/astro/test/fixtures/i18n-routing-fallback/src/pages/pt/start.astro
+++ b/packages/astro/test/fixtures/i18n-routing-fallback/src/pages/pt/start.astro
@@ -1,8 +1,12 @@
+---
+const currentLocale = Astro.currentLocale;
+---
+
 <html>
 <head>
 	<title>Astro</title>
 </head>
 <body>
-Oi essa e start
+Oi essa e start: {currentLocale}
 </body>
 </html>

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -844,7 +844,7 @@ describe('[SSG] i18n routing', () => {
 		it('should render localised page correctly', async () => {
 			let html = await fixture.readFile('/pt/start/index.html');
 			let $ = cheerio.load(html);
-			expect($('body').text()).includes('Oi essa e start');
+			expect($('body').text()).includes('Oi essa e start: pt');
 
 			html = await fixture.readFile('/pt/blog/1/index.html');
 			$ = cheerio.load(html);


### PR DESCRIPTION
## Changes
Closes https://github.com/withastro/astro/issues/9847
Closes PLT-1511

During the build, the `url.pathname` contains the the extension e.g. `en.html`, so Astro could never find the correct locale.

With this fix, we use `RouteData` instead, which is an object that we attach to the request using a pipeline hook. We attach this information here:

https://github.com/withastro/astro/blob/f27f790b922247c168eb167394cea8dd4c3e3390/packages/astro/src/core/build/generate.ts#L284

And this is the value of the function

https://github.com/withastro/astro/blob/f27f790b922247c168eb167394cea8dd4c3e3390/packages/astro/src/i18n/middleware.ts#L137-L139

## Testing

I modified and existing test to render the current locale

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
