### PR TITLE
chore: add rule `switch-exhaustiveness-check`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,6 +16,7 @@ module.exports = {
   plugins: ['@typescript-eslint', 'prettier', 'no-only-tests'],
   rules: {
     // These off/configured-differently-by-default rules fit well for us
+    '@typescript-eslint/switch-exhaustiveness-check': 'error',
     '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
     '@typescript-eslint/no-unused-vars': [
       'warn',

--- a/packages/astro/src/assets/services/squoosh.ts
+++ b/packages/astro/src/assets/services/squoosh.ts
@@ -48,6 +48,8 @@ async function getRotationForEXIF(
 		case 7:
 		case 8:
 			return { type: 'rotate', numRotations: 3 };
+		default:
+			return undefined;
 	}
 }
 

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -211,6 +211,8 @@ export async function add(names: string[], { flags }: AddOptions) {
 		case UpdateResult.failure: {
 			throw createPrettyError(new Error(`Unable to install dependencies`));
 		}
+		case UpdateResult.none:
+			break;
 	}
 
 	const rawConfigPath = await resolveConfigPath({

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -60,7 +60,7 @@ export type SSRManifest = {
 
 export type SSRManifestI18n = {
 	fallback?: Record<string, string>;
-	routing?: RoutingStrategies;
+	routing: RoutingStrategies;
 	locales: Locales;
 	defaultLocale: string;
 };

--- a/packages/astro/src/preferences/index.ts
+++ b/packages/astro/src/preferences/index.ts
@@ -66,7 +66,12 @@ export function coerce(key: string, value: unknown) {
 		case 'boolean': {
 			if (value === 'true' || value === 1) return true;
 			if (value === 'false' || value === 0) return false;
+			break;
 		}
+		// @ematipico: what should we do with the other types?
+		//  "bigint" | "symbol" | "undefined" | "object" | "function"
+		default:
+			break;
 	}
 	return value as any;
 }

--- a/packages/astro/src/preferences/index.ts
+++ b/packages/astro/src/preferences/index.ts
@@ -68,10 +68,8 @@ export function coerce(key: string, value: unknown) {
 			if (value === 'false' || value === 0) return false;
 			break;
 		}
-		// @ematipico: what should we do with the other types?
-		//  "bigint" | "symbol" | "undefined" | "object" | "function"
 		default:
-			break;
+			throw new Error(`Incorrect value for ${key}`);
 	}
 	return value as any;
 }

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/settings.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/settings.ts
@@ -161,6 +161,10 @@ export default {
 						astroToggle.input.addEventListener('change', setting.changeEvent);
 						astroToggle.input.checked = settings.config[setting.settingKey];
 						label.append(astroToggle);
+						break;
+					}
+					default: {
+						break;
 					}
 				}
 

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/settings.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/settings.ts
@@ -163,9 +163,8 @@ export default {
 						label.append(astroToggle);
 						break;
 					}
-					default: {
+					default:
 						break;
-					}
 				}
 
 				return label;

--- a/packages/astro/src/runtime/server/scripts.ts
+++ b/packages/astro/src/runtime/server/scripts.ts
@@ -42,9 +42,8 @@ export function getPrescripts(result: SSRResult, type: PrescriptType, directive:
 			)};${islandScript}</script>`;
 		case 'directive':
 			return `<script>${getDirectiveScriptText(result, directive)}</script>`;
-		case null: {
+		case null:
 			break;
-		}
 	}
 	return '';
 }

--- a/packages/astro/src/runtime/server/scripts.ts
+++ b/packages/astro/src/runtime/server/scripts.ts
@@ -42,6 +42,9 @@ export function getPrescripts(result: SSRResult, type: PrescriptType, directive:
 			)};${islandScript}</script>`;
 		case 'directive':
 			return `<script>${getDirectiveScriptText(result, directive)}</script>`;
+		case null: {
+			break;
+		}
 	}
 	return '';
 }

--- a/packages/astro/src/vite-plugin-astro/types.ts
+++ b/packages/astro/src/vite-plugin-astro/types.ts
@@ -1,6 +1,5 @@
 import type { HoistedScript, TransformResult } from '@astrojs/compiler';
 import type { PropagationHint } from '../@types/astro.js';
-import type { CompileAstroResult } from './compile.js';
 
 export interface PageOptions {
 	prerender?: boolean;

--- a/packages/integrations/node/test/encoded.test.js
+++ b/packages/integrations/node/test/encoded.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
+import { describe, it, before } from 'node:test';
 import nodejs from '../dist/index.js';
 import { loadFixture, createRequestAndResponse } from './test-utils.js';
 

--- a/packages/integrations/node/test/headers.test.js
+++ b/packages/integrations/node/test/headers.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
+import { describe, it, before } from 'node:test';
 import nodejs from '../dist/index.js';
 import { loadFixture, createRequestAndResponse } from './test-utils.js';
 

--- a/packages/integrations/node/test/locals.test.js
+++ b/packages/integrations/node/test/locals.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
+import { describe, it, before } from 'node:test';
 import nodejs from '../dist/index.js';
 import { loadFixture, createRequestAndResponse } from './test-utils.js';
 


### PR DESCRIPTION
## Changes

This PR adds the rule [switch-exhaustiveness-check](https://typescript-eslint.io/rules/switch-exhaustiveness-check/)

I find this rule very important because we don't want to "forget" to handle variants inside a `switch` statement.

## Testing

Current CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
