### PR TITLE
fix: signal request close

### DIFF
--- a/.changeset/eight-goats-peel.md
+++ b/.changeset/eight-goats-peel.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Signals request close on nodejs

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -65,9 +65,14 @@ export class NodeApp extends App {
 			('encrypted' in req.socket && req.socket.encrypted ? 'https' : 'http');
 		const hostname = req.headers.host || req.headers[':authority'];
 		const url = `${protocol}://${hostname}${req.url}`;
+		const controller = new AbortController();
+		req.on('close', () => {
+			controller.abort();
+		})
 		const options: RequestInit = {
 			method: req.method || 'GET',
 			headers: makeRequestHeaders(req),
+			signal: controller.signal,
 		};
 		const bodyAllowed = options.method !== 'HEAD' && options.method !== 'GET' && skipBody === false;
 		if (bodyAllowed) {


### PR DESCRIPTION
## Changes

The "signal" property on "APIContext.request" is supposed to inform when the request was aborted/canceled. Right now, it is not working and this PR fixes it.

![image](https://github.com/withastro/astro/assets/25470308/9f4d3531-3067-453c-a88b-9300a0e52133)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Well, this is my first time contributing to Astro, and I did not find where the code that I changed was being tested.

## Docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

I think its more like an internal behavior, and not sure where it could fit in the docs.