### PR TITLE
chore(@astrojs/integrations/tailwind): use Node.js for testing

### DIFF
--- a/packages/integrations/tailwind/package.json
+++ b/packages/integrations/tailwind/package.json
@@ -30,7 +30,7 @@
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "mocha --exit --timeout 20000 test/"
+    "test": "astro-scripts test \"test/**/*.test.js\""
   },
   "dependencies": {
     "autoprefixer": "^10.4.15",
@@ -40,8 +40,6 @@
   "devDependencies": {
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
-    "chai": "^4.3.7",
-    "mocha": "^10.2.0",
     "tailwindcss": "^3.3.5",
     "vite": "^5.0.12"
   },

--- a/packages/integrations/tailwind/test/basic.test.js
+++ b/packages/integrations/tailwind/test/basic.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import * as assert from 'node:assert/strict';
+import { describe, it, before } from 'node:test';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
 describe('Basic', () => {
@@ -25,9 +26,12 @@ describe('Basic', () => {
 				}
 			}
 
-			expect(css).to.include('box-sizing:border-box;'); // base css
-			expect(css).to.include('text-red-500'); // class css
-			expect(css).to.match(/\.a\[data-astro-cid-.*?\] \.b\[data-astro-cid-.*?\]/); // nesting
+			assert.equal(css.includes('box-sizing:border-box;'), true); // base css
+			assert.equal(css.includes('text-red-500'), true); // class css
+			assert.equal(
+				new RegExp(/\.a\[data-astro-cid-.*?\] \.b\[data-astro-cid-.*?\]/).test(css),
+				true
+			); // nesting
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- This PR moves @astrojs/integrations/tailwind to use Node.js for testing
- Part of #9873 
## Testing

Tests should pass

## Docs

N/A
