### PR TITLE
Fix endpoint response with immutable header

### DIFF
--- a/.changeset/silver-peaches-pump.md
+++ b/.changeset/silver-peaches-pump.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Updated `renderEndpoint` implementation to only append the reroute directive if the response HTTP status code is 404 or 500.
+Fixes an issue where using `Response.redirect` in an endpoint led to an error.

--- a/.changeset/silver-peaches-pump.md
+++ b/.changeset/silver-peaches-pump.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Updated `renderEndpoint` implementation to handle `Response` with immutable headers.

--- a/.changeset/silver-peaches-pump.md
+++ b/.changeset/silver-peaches-pump.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Updated `renderEndpoint` implementation to handle `Response` with immutable headers.
+Updated `renderEndpoint` implementation to only append the reroute directive if the response HTTP status code is 404 or 500.

--- a/packages/astro/src/runtime/server/endpoint.ts
+++ b/packages/astro/src/runtime/server/endpoint.ts
@@ -44,7 +44,7 @@ export async function renderEndpoint(
 	// NOT be subject to rerouting to 404.astro or 500.astro.
 	if (response.status === 404 || response.status === 500) {
 		// Only `Response.redirect` headers are immutable, therefore a `try..catch` is not necessary.
-		// Note: `Response.redirect` can only constructed with HTTP status codes: 301, 302, 303, 307, 308.
+		// Note: `Response.redirect` can only be called with HTTP status codes: 301, 302, 303, 307, 308.
 		// Source: https://developer.mozilla.org/en-US/docs/Web/API/Response/redirect_static#parameters
 		response.headers.set(REROUTE_DIRECTIVE_HEADER, 'no');
 	}

--- a/packages/astro/test/units/routing/endpoints.test.js
+++ b/packages/astro/test/units/routing/endpoints.test.js
@@ -11,7 +11,8 @@ import testAdapter from '../../test-adapter.js';
 
 const root = new URL('../../fixtures/api-routes/', import.meta.url);
 const fileSystem = {
-	'/src/pages/api.ts': `export const GET = ({ url }) => Response.redirect("https://example.com/destination", 307)`,
+	'/src/pages/response-redirect.ts': `export const GET = ({ url }) => Response.redirect("https://example.com/destination", 307)`,
+	'/src/pages/response.ts': `export const GET = ({ url }) => new Response(null, { headers: { Location: "https://example.com/destination" }, status: 307 })`,
 };
 
 describe('endpoints', () => {
@@ -37,9 +38,20 @@ describe('endpoints', () => {
 	});
 
 	it('should return a redirect response with location header', async () => {
-		const { req, res, text, done } = createRequestAndResponse({
+		const { req, res, done } = createRequestAndResponse({
 			method: 'GET',
-			url: '/api',
+			url: '/response-redirect',
+		});
+		container.handle(req, res);
+		await done;
+		expect(res.getHeaders()).to.deep.include({ location: 'https://example.com/destination' });
+		expect(res.statusCode).to.equal(307);
+	});
+
+	it('should return a response with location header', async () => {
+		const { req, res, done } = createRequestAndResponse({
+			method: 'GET',
+			url: '/response',
 		});
 		container.handle(req, res);
 		await done;

--- a/packages/astro/test/units/routing/endpoints.test.js
+++ b/packages/astro/test/units/routing/endpoints.test.js
@@ -48,7 +48,7 @@ describe('endpoints', () => {
 		await done;
 		const headers = res.getHeaders();
 		expect(headers).to.deep.include({ location: 'https://example.com/destination' });
-		expect(headers).not.to.deep.include({ 'X-Astro-Reroute': 'no' });
+		expect(headers).not.to.deep.include({ 'x-astro-reroute': 'no' });
 		expect(res.statusCode).to.equal(307);
 	});
 
@@ -61,7 +61,7 @@ describe('endpoints', () => {
 		await done;
 		const headers = res.getHeaders();
 		expect(headers).to.deep.include({ location: 'https://example.com/destination' });
-		expect(headers).not.to.deep.include({ 'X-Astro-Reroute': 'no' });
+		expect(headers).not.to.deep.include({ 'x-astro-reroute': 'no' });
 		expect(res.statusCode).to.equal(307);
 	});
 


### PR DESCRIPTION
## Changes

Updated the implementation of `renderEndpoint` to only append the reroute header if the response has the HTTP status code 404 or 500.
This should resolve the issue mentioned in https://github.com/withastro/astro/issues/9871.

## Testing

Added tests based on the work of @lilnasy ([cad43ea5c11e58b022df82907cd110e56dd4efed](https://github.com/withastro/astro/commit/cad43ea5c11e58b022df82907cd110e56dd4efed)).
These tests check that the response returned from an endpoint contains the expected headers and doesn't error with an HTTP 500 error.

## Docs

I don't think there is a need to update the documentation because of this change, since it's only internal response rewriting.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
