### PR TITLE
Fix/content type gen windows

### DIFF
--- a/.changeset/funny-mice-help.md
+++ b/.changeset/funny-mice-help.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix content type reference to content config on windows.

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -345,8 +345,10 @@ function invalidateVirtualMod(viteServer: ViteDevServer) {
  */
 function normalizeConfigPath(from: string, to: string) {
 	const configPath = path.relative(from, to).replace(/\.ts$/, '.js');
+	// on windows `path.relative` will use backslashes, these must be replaced with forward slashes
+	const normalizedPath = configPath.replaceAll('\\', '/');
 
-	return `"${isRelativePath(configPath) ? '' : './'}${configPath}"` as const;
+	return `"${isRelativePath(configPath) ? '' : './'}${normalizedPath}"` as const;
 }
 
 async function writeContentFiles({


### PR DESCRIPTION
## Changes

Closes #9869 

- Replaces backslashes generated by using `path.replace` on windows with forward slashes,

## Testing

All tests ran without errors. A test confirming this behaviour would be great, but I would need guidance on how to run this function with a mocked `node:path` module.

## Docs

No docs updates needed.
