### PR TITLE
fix(ssg): consider trailingSlash for url

### DIFF
--- a/.changeset/wet-rivers-do.md
+++ b/.changeset/wet-rivers-do.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where setting trailingSlash to "never" had no effect on `Astro.url`.

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import PQueue from 'p-queue';
 import type { OutputAsset, OutputChunk } from 'rollup';
 import type {
+	AstroConfig,
 	AstroSettings,
 	ComponentInstance,
 	GetStaticPathsItem,
@@ -455,7 +456,8 @@ function getUrlForPath(
 	pathname: string,
 	base: string,
 	origin: string,
-	format: 'directory' | 'file',
+	format: AstroConfig["build"]["format"],
+	trailingSlash: AstroConfig["trailingSlash"],
 	routeType: RouteType
 ): URL {
 	/**
@@ -463,7 +465,7 @@ function getUrlForPath(
 	 * pathname: /, /foo
 	 * base: /
 	 */
-	const ending = format === 'directory' ? '/' : '.html';
+	const ending = format === 'directory' ? trailingSlash === 'never' ? '' : '/' : '.html';
 	let buildPathname: string;
 	if (pathname === '/' || pathname === '') {
 		buildPathname = base;
@@ -538,6 +540,7 @@ async function generatePath(
 		pipeline.getConfig().base,
 		pipeline.getStaticBuildOptions().origin,
 		pipeline.getConfig().build.format,
+		pipeline.getConfig().trailingSlash,
 		route.type
 	);
 

--- a/packages/astro/test/astro-get-static-paths.test.js
+++ b/packages/astro/test/astro-get-static-paths.test.js
@@ -10,6 +10,7 @@ describe('getStaticPaths - build calls', () => {
 		fixture = await loadFixture({
 			root: './fixtures/astro-get-static-paths/',
 			site: 'https://mysite.dev/',
+			trailingSlash: 'never',
 			base: '/blog',
 		});
 		await fixture.build();
@@ -29,7 +30,7 @@ describe('getStaticPaths - build calls', () => {
 		const html = await fixture.readFile('/food/tacos/index.html');
 		const $ = cheerio.load(html);
 
-		expect($('#url').text()).to.equal('/blog/food/tacos/');
+		expect($('#url').text()).to.equal('/blog/food/tacos');
 	});
 });
 


### PR DESCRIPTION
## Changes
- Fixes #9870

## Testing
Updated a getStaticPaths test case to include trailingSlash.

## Docs
Does not affect usage.