### PR TITLE
Improves YAML error handling consistency

### DIFF
--- a/.changeset/twelve-humans-remain.md
+++ b/.changeset/twelve-humans-remain.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Improves handling of YAML parsing errors

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -14,7 +14,8 @@ import type {
 } from '../@types/astro.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 
-import { formatYAMLException, isYAMLException } from '../core/errors/utils.js';
+import { MarkdownError } from '../core/errors/index.js';
+import { isYAMLException } from '../core/errors/utils.js';
 import { CONTENT_FLAGS, CONTENT_TYPES_FILE } from './consts.js';
 import { errorMap } from './error-map.js';
 import { createImage } from './runtime-assets.js';
@@ -287,18 +288,31 @@ function getYAMLErrorLine(rawData: string | undefined, objectKey: string) {
 	return numNewlinesBeforeKey;
 }
 
-export function parseFrontmatter(fileContents: string) {
+
+export function safeParseFrontmatter(source: string, id?: string) {
 	try {
-		// `matter` is empty string on cache results
-		// clear cache to prevent this
-		(matter as any).clearCache();
-		return matter(fileContents);
-	} catch (e) {
-		if (isYAMLException(e)) {
-			throw formatYAMLException(e);
-		} else {
-			throw e;
+		return matter(source);
+	} catch (err: any) {
+		const markdownError = new MarkdownError({
+			name: 'MarkdownError',
+			message: err.message,
+			stack: err.stack,
+			location: id ? {
+				file: id,
+			} : undefined,
+		});
+
+		if (isYAMLException(err)) {
+			markdownError.setLocation({
+				file: id,
+				line: err.mark.line,
+				column: err.mark.column,
+			});
+
+			markdownError.setMessage(err.reason);
 		}
+
+		throw markdownError;
 	}
 }
 

--- a/packages/astro/src/vite-plugin-markdown/content-entry-type.ts
+++ b/packages/astro/src/vite-plugin-markdown/content-entry-type.ts
@@ -1,10 +1,11 @@
+import { fileURLToPath } from 'node:url';
 import type { ContentEntryType } from '../@types/astro.js';
-import { parseFrontmatter } from '../content/utils.js';
+import { safeParseFrontmatter } from '../content/utils.js';
 
 export const markdownContentEntryType: ContentEntryType = {
 	extensions: ['.md'],
-	async getEntryInfo({ contents }: { contents: string }) {
-		const parsed = parseFrontmatter(contents);
+	async getEntryInfo({ contents, fileUrl }: { contents: string, fileUrl: URL }) {
+		const parsed = safeParseFrontmatter(contents, fileURLToPath(fileUrl));
 		return {
 			data: parsed.data,
 			body: parsed.content,


### PR DESCRIPTION
## Changes

- We have multiple places in the codebase that use slightly different YAML/Frontmatter parsing logic
- This removes one of those instances which wasn't throwing a useful error, replacing it with a shared utility.

## Testing

Tested manually with user code shared on Discord. Existing tests should pass

## Docs

N/A, bug fix only