### PR TITLE
Provide better ignores for Vercel's file tracer

### DIFF
--- a/.changeset/poor-tips-turn.md
+++ b/.changeset/poor-tips-turn.md
@@ -2,4 +2,11 @@
 "@astrojs/vercel": patch
 ---
 
-Expand on ignores Vercel's file tracer
+Better ignores for Vercel file-tracer
+
+The Vercel adapter has a file-tracer it uses to detect which files should be moved over to the dist folder. When its done it prints warnings for things that it detected that maybe should be moved.
+
+This change expands how we do ignores so that:
+
+- Ignores happen within dot folders like `.pnpm`.
+- `@libsql/client` is ignored, a package we know is not bundled.

--- a/.changeset/poor-tips-turn.md
+++ b/.changeset/poor-tips-turn.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vercel": patch
+---
+
+Expand on ignores Vercel's file tracer

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -55,6 +55,7 @@
     "@vercel/nft": "^0.24.3",
     "esbuild": "^0.19.6",
     "fast-glob": "^3.3.2",
+    "minimatch": "^9.0.3",
     "set-cookie-parser": "^2.6.0",
     "web-vitals": "^3.4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4738,6 +4738,9 @@ importers:
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
+      minimatch:
+        specifier: ^9.0.3
+        version: 9.0.3
       set-cookie-parser:
         specifier: ^2.6.0
         version: 2.6.0


### PR DESCRIPTION
## Changes

- Ignores `@libsql/client` which has a bunch of node imports that Vercel shouldn't be trying to bundle.

## Testing

N/A, can't be unit tested, tested manually

## Docs

N/A, just the changeset