### PR TITLE
chore(@astrojs/integrations/sitemap): use Node.js for testing

### DIFF
--- a/packages/integrations/sitemap/package.json
+++ b/packages/integrations/sitemap/package.json
@@ -30,7 +30,7 @@
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "mocha --timeout 20000"
+    "test": "astro-scripts test \"test/**/*.test.js\""
   },
   "dependencies": {
     "sitemap": "^7.1.1",
@@ -40,8 +40,6 @@
     "@astrojs/node": "workspace:*",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
-    "chai": "^4.3.7",
-    "mocha": "^10.2.0",
     "xml2js": "0.6.2"
   },
   "publishConfig": {

--- a/packages/integrations/sitemap/test/base-path.test.js
+++ b/packages/integrations/sitemap/test/base-path.test.js
@@ -1,39 +1,40 @@
 import { loadFixture, readXML } from './test-utils.js';
-import { expect } from 'chai';
+import * as assert from 'node:assert/strict';
+import { describe, it, before } from 'node:test';
 
 describe('URLs with base path', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
+ /** @type {import('./test-utils').Fixture} */
+ let fixture;
 
-	describe('using node adapter', () => {
-		before(async () => {
-			fixture = await loadFixture({
-				root: './fixtures/ssr/',
-				base: '/base',
-			});
-			await fixture.build();
-		});
+ describe('using node adapter', () => {
+   before(async () => {
+     fixture = await loadFixture({
+       root: './fixtures/ssr/',
+       base: '/base',
+     });
+     await fixture.build();
+   });
 
-		it('Base path is concatenated correctly', async () => {
-			const data = await readXML(fixture.readFile('/client/sitemap-0.xml'));
-			const urls = data.urlset.url;
-			expect(urls[0].loc[0]).to.equal('http://example.com/base/one/');
-		});
-	});
+   it('Base path is concatenated correctly', async () => {
+     const data = await readXML(fixture.readFile('/client/sitemap-0.xml'));
+     const urls = data.urlset.url;
+     assert.equal(urls[0].loc[0], 'http://example.com/base/one/');
+   });
+ });
 
-	describe('static', () => {
-		before(async () => {
-			fixture = await loadFixture({
-				root: './fixtures/static/',
-				base: '/base',
-			});
-			await fixture.build();
-		});
+ describe('static', () => {
+   before(async () => {
+     fixture = await loadFixture({
+       root: './fixtures/static/',
+       base: '/base',
+     });
+     await fixture.build();
+   });
 
-		it('Base path is concatenated correctly', async () => {
-			const data = await readXML(fixture.readFile('/sitemap-0.xml'));
-			const urls = data.urlset.url;
-			expect(urls[0].loc[0]).to.equal('http://example.com/base/123/');
-		});
-	});
+   it('Base path is concatenated correctly', async () => {
+     const data = await readXML(fixture.readFile('/sitemap-0.xml'));
+     const urls = data.urlset.url;
+     assert.equal(urls[0].loc[0], 'http://example.com/base/123/');
+   });
+ });
 });

--- a/packages/integrations/sitemap/test/filter.test.js
+++ b/packages/integrations/sitemap/test/filter.test.js
@@ -1,6 +1,8 @@
 import { loadFixture, readXML } from './test-utils.js';
-import { expect } from 'chai';
 import { sitemap } from './fixtures/static/deps.mjs';
+import * as assert from 'node:assert/strict';
+import { describe, it, before } from 'node:test';
+
 
 describe('Filter support', () => {
 	/** @type {import('./test-utils.js').Fixture} */
@@ -22,7 +24,7 @@ describe('Filter support', () => {
 		it('Just one page is added', async () => {
 			const data = await readXML(fixture.readFile('/sitemap-0.xml'));
 			const urls = data.urlset.url;
-			expect(urls.length).to.equal(1);
+			assert.equal(urls.length, 1);
 		});
 	});
 
@@ -42,7 +44,7 @@ describe('Filter support', () => {
 		it('Just one page is added', async () => {
 			const data = await readXML(fixture.readFile('/client/sitemap-0.xml'));
 			const urls = data.urlset.url;
-			expect(urls.length).to.equal(1);
+			assert.equal(urls.length, 1);
 		});
 	});
 });

--- a/packages/integrations/sitemap/test/routes.test.js
+++ b/packages/integrations/sitemap/test/routes.test.js
@@ -1,5 +1,6 @@
 import { loadFixture, readXML } from './test-utils.js';
-import { expect } from 'chai';
+import * as assert from 'node:assert/strict';
+import { describe, it, before } from 'node:test';
 
 describe('routes', () => {
 	/** @type {import('./test-utils.js').Fixture} */
@@ -17,10 +18,10 @@ describe('routes', () => {
 	});
 
 	it('does not include endpoints', async () => {
-		expect(urls).to.not.include('http://example.com/endpoint.json');
+		assert.equal(urls.indexOf('http://example.com/endpoint.json'), -1);
 	});
 
 	it('does not include redirects', async () => {
-		expect(urls).to.not.include('http://example.com/redirect');
+		assert.equal(urls.indexOf('http://example.com/endpoint.json'), -1);
 	});
 });

--- a/packages/integrations/sitemap/test/ssr.test.js
+++ b/packages/integrations/sitemap/test/ssr.test.js
@@ -1,5 +1,6 @@
 import { loadFixture, readXML } from './test-utils.js';
-import { expect } from 'chai';
+import * as assert from 'node:assert/strict';
+import { describe, it, before } from 'node:test';
 
 describe('SSR support', () => {
 	/** @type {import('./test-utils.js').Fixture} */
@@ -16,7 +17,7 @@ describe('SSR support', () => {
 		const data = await readXML(fixture.readFile('/client/sitemap-0.xml'));
 		const urls = data.urlset.url;
 
-		expect(urls[0].loc[0]).to.equal('http://example.com/one/');
-		expect(urls[1].loc[0]).to.equal('http://example.com/two/');
+		assert.equal(urls[0].loc[0],'http://example.com/one/')
+		assert.equal(urls[1].loc[0],'http://example.com/two/')
 	});
 });

--- a/packages/integrations/sitemap/test/staticPaths.test.js
+++ b/packages/integrations/sitemap/test/staticPaths.test.js
@@ -1,5 +1,6 @@
 import { loadFixture, readXML } from './test-utils.js';
-import { expect } from 'chai';
+import * as assert from 'node:assert/strict';
+import { describe, it, before } from 'node:test';
 
 describe('getStaticPaths support', () => {
 	/** @type {import('./test-utils.js').Fixture} */
@@ -19,24 +20,24 @@ describe('getStaticPaths support', () => {
 	});
 
 	it('requires zero config for getStaticPaths', async () => {
-		expect(urls).to.include('http://example.com/one/');
-		expect(urls).to.include('http://example.com/two/');
+		assert.strictEqual(urls.includes('http://example.com/one/'),true);
+		assert.strictEqual(urls.includes('http://example.com/two/'),true)
 	});
 
 	it('does not include 404 pages', () => {
-		expect(urls).to.not.include('http://example.com/404/');
+		assert.strictEqual(urls.includes('http://example.com/de/404/'),false);
 	});
 
 	it('does not include nested 404 pages', () => {
-		expect(urls).to.not.include('http://example.com/de/404/');
+		assert.strictEqual(urls.includes('http://example.com/de/404/'),false);
 	});
 
 	it('includes numerical pages', () => {
-		expect(urls).to.include('http://example.com/123/');
+		assert.strictEqual(urls.includes('http://example.com/123/'),true);
 	});
 
 	it('should render the endpoint', async () => {
 		const page = await fixture.readFile('./it/manifest');
-		expect(page).to.contain('I\'m a route in the "it" language.');
+		assert.strictEqual(page.includes('I\'m a route in the "it" language.'),true);
 	});
 });

--- a/packages/integrations/sitemap/test/trailing-slash.test.js
+++ b/packages/integrations/sitemap/test/trailing-slash.test.js
@@ -1,5 +1,6 @@
 import { loadFixture, readXML } from './test-utils.js';
-import { expect } from 'chai';
+import * as assert from 'node:assert/strict';
+import { describe, it, before } from 'node:test';
 
 describe('Trailing slash', () => {
 	/** @type {import('./test-utils').Fixture} */
@@ -21,7 +22,7 @@ describe('Trailing slash', () => {
 			it('URLs end with trailing slash', async () => {
 				const data = await readXML(fixture.readFile('/sitemap-0.xml'));
 				const urls = data.urlset.url;
-				expect(urls[0].loc[0]).to.equal('http://example.com/one/');
+				assert.equal(urls[0].loc[0],'http://example.com/one/');
 			});
 		});
 
@@ -40,7 +41,7 @@ describe('Trailing slash', () => {
 			it('URLs do not end with trailing slash', async () => {
 				const data = await readXML(fixture.readFile('/sitemap-0.xml'));
 				const urls = data.urlset.url;
-				expect(urls[0].loc[0]).to.equal('http://example.com/one');
+				assert.equal(urls[0].loc[0],'http://example.com/one');
 			});
 		});
 	});
@@ -57,7 +58,7 @@ describe('Trailing slash', () => {
 		it('URLs do no end with trailing slash', async () => {
 			const data = await readXML(fixture.readFile('/sitemap-0.xml'));
 			const urls = data.urlset.url;
-			expect(urls[0].loc[0]).to.equal('http://example.com/one');
+			assert.equal(urls[0].loc[0],'http://example.com/one');
 		});
 		describe('with base path', () => {
 			before(async () => {
@@ -72,7 +73,7 @@ describe('Trailing slash', () => {
 			it('URLs do not end with trailing slash', async () => {
 				const data = await readXML(fixture.readFile('/sitemap-0.xml'));
 				const urls = data.urlset.url;
-				expect(urls[0].loc[0]).to.equal('http://example.com/base/one');
+				assert.equal(urls[0].loc[0],'http://example.com/base/one');
 			});
 		});
 	});
@@ -89,7 +90,7 @@ describe('Trailing slash', () => {
 		it('URLs end with trailing slash', async () => {
 			const data = await readXML(fixture.readFile('/sitemap-0.xml'));
 			const urls = data.urlset.url;
-			expect(urls[0].loc[0]).to.equal('http://example.com/one/');
+			assert.equal(urls[0].loc[0],'http://example.com/one/');
 		});
 		describe('with base path', () => {
 			before(async () => {
@@ -104,7 +105,7 @@ describe('Trailing slash', () => {
 			it('URLs end with trailing slash', async () => {
 				const data = await readXML(fixture.readFile('/sitemap-0.xml'));
 				const urls = data.urlset.url;
-				expect(urls[0].loc[0]).to.equal('http://example.com/base/one/');
+				assert.equal(urls[0].loc[0],'http://example.com/base/one/');
 			});
 		});
 	});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4612,12 +4612,6 @@ importers:
       astro-scripts:
         specifier: workspace:*
         version: link:../../../scripts
-      chai:
-        specifier: ^4.3.7
-        version: 4.3.10
-      mocha:
-        specifier: ^10.2.0
-        version: 10.2.0
       xml2js:
         specifier: 0.6.2
         version: 0.6.2


### PR DESCRIPTION
## Changes

- This PR moves @astrojs/integrations/sitemap to use Node.js for testing
- See #9873 for details

## Testing

Tests should pass!

## Docs

No docs added as this only affects testing.