### PR TITLE
chore(@astrojs/mdx): use Node.js for testing

### DIFF
--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -30,8 +30,7 @@
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "mocha --exit --timeout 20000",
-    "test:match": "mocha --timeout 20000 -g"
+    "test": "astro-scripts test --timeout 50000 \"test/**/*.test.js\""
   },
   "dependencies": {
     "@astrojs/markdown-remark": "workspace:*",
@@ -61,12 +60,10 @@
     "@types/yargs-parser": "^21.0.3",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
-    "chai": "^4.3.7",
     "cheerio": "1.0.0-rc.12",
     "linkedom": "^0.16.4",
     "mdast-util-mdx": "^3.0.0",
     "mdast-util-to-string": "^4.0.0",
-    "mocha": "^10.2.0",
     "reading-time": "^1.5.0",
     "rehype-mathjax": "^5.0.0",
     "rehype-pretty-code": "^0.10.2",

--- a/packages/integrations/mdx/test/css-head-mdx.test.js
+++ b/packages/integrations/mdx/test/css-head-mdx.test.js
@@ -1,7 +1,8 @@
 import mdx from '@astrojs/mdx';
 
-import { expect } from 'chai';
 import { parseHTML } from 'linkedom';
+import { describe, it, before } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 import * as cheerio from 'cheerio';
 
@@ -27,10 +28,10 @@ describe('Head injection w/ MDX', () => {
 			const { document } = parseHTML(html);
 
 			const links = document.querySelectorAll('head link[rel=stylesheet]');
-			expect(links).to.have.a.lengthOf(1);
+			assert.equal(links.length, 1);
 
 			const scripts = document.querySelectorAll('head script[type=module]');
-			expect(scripts).to.have.a.lengthOf(1);
+			assert.equal(scripts.length, 1);
 		});
 
 		it('injects into the head for content collections', async () => {
@@ -38,7 +39,7 @@ describe('Head injection w/ MDX', () => {
 			const { document } = parseHTML(html);
 
 			const links = document.querySelectorAll('head link[rel=stylesheet]');
-			expect(links).to.have.a.lengthOf(1);
+			assert.equal(links.length, 1);
 		});
 
 		it('injects content from a component using Content#render()', async () => {
@@ -46,10 +47,10 @@ describe('Head injection w/ MDX', () => {
 			const { document } = parseHTML(html);
 
 			const links = document.querySelectorAll('head link[rel=stylesheet]');
-			expect(links).to.have.a.lengthOf(1);
+			assert.equal(links.length, 1);
 
 			const scripts = document.querySelectorAll('head script[type=module]');
-			expect(scripts).to.have.a.lengthOf(2);
+			assert.equal(scripts.length, 2);
 		});
 
 		it('Using component using slots.render() API', async () => {
@@ -57,7 +58,7 @@ describe('Head injection w/ MDX', () => {
 			const { document } = parseHTML(html);
 
 			const links = document.querySelectorAll('head link[rel=stylesheet]');
-			expect(links).to.have.a.lengthOf(1);
+			assert.equal(links.length, 1);
 		});
 
 		it('Using component but no layout', async () => {
@@ -66,10 +67,10 @@ describe('Head injection w/ MDX', () => {
 			const $ = cheerio.load(html);
 
 			const headLinks = $('head link[rel=stylesheet]');
-			expect(headLinks).to.have.a.lengthOf(1);
+			assert.equal(headLinks.length, 1);
 
 			const bodyLinks = $('body link[rel=stylesheet]');
-			expect(bodyLinks).to.have.a.lengthOf(0);
+			assert.equal(bodyLinks.length, 0);
 		});
 
 		it('JSX component rendering Astro children within head buffering phase', async () => {
@@ -78,10 +79,10 @@ describe('Head injection w/ MDX', () => {
 			const $ = cheerio.load(html);
 
 			const headLinks = $('head link[rel=stylesheet]');
-			expect(headLinks).to.have.a.lengthOf(1);
+			assert.equal(headLinks.length, 1);
 
 			const bodyLinks = $('body link[rel=stylesheet]');
-			expect(bodyLinks).to.have.a.lengthOf(0);
+			assert.equal(bodyLinks.length, 0);
 		});
 
 		it('Injection caused by delayed slots', async () => {
@@ -91,10 +92,10 @@ describe('Head injection w/ MDX', () => {
 			const $ = cheerio.load(html);
 
 			const headLinks = $('head link[rel=stylesheet]');
-			expect(headLinks).to.have.a.lengthOf(1);
+			assert.equal(headLinks.length, 1);
 
 			const bodyLinks = $('body link[rel=stylesheet]');
-			expect(bodyLinks).to.have.a.lengthOf(0);
+			assert.equal(bodyLinks.length, 0);
 		});
 	});
 });

--- a/packages/integrations/mdx/test/invalid-mdx-component.test.js
+++ b/packages/integrations/mdx/test/invalid-mdx-component.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 import mdx from '../dist/index.js';
 
@@ -28,8 +29,9 @@ describe('MDX component with runtime error', () => {
 		});
 
 		it('Throws the right error', async () => {
-			expect(error).to.exist;
-			expect(error?.hint).to.match(
+			assert.ok(error);
+			assert.match(
+				error?.hint,
 				/This issue often occurs when your MDX component encounters runtime errors/
 			);
 		});

--- a/packages/integrations/mdx/test/mdx-astro-markdown-remarkRehype.test.js
+++ b/packages/integrations/mdx/test/mdx-astro-markdown-remarkRehype.test.js
@@ -1,6 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
@@ -21,8 +22,9 @@ describe('MDX with Astro Markdown remark-rehype config', () => {
 		const html = await fixture.readFile('/index.html');
 		const { document } = parseHTML(html);
 
-		expect(document.querySelector('#footnote-label').textContent).to.equal('Catatan kaki');
-		expect(document.querySelector('.data-footnote-backref').getAttribute('aria-label')).to.equal(
+		assert.equal(document.querySelector('#footnote-label').textContent, 'Catatan kaki');
+		assert.equal(
+			document.querySelector('.data-footnote-backref').getAttribute('aria-label'),
 			'Kembali ke konten'
 		);
 	});
@@ -49,8 +51,9 @@ describe('MDX with Astro Markdown remark-rehype config', () => {
 		const html = await fixture.readFile('/index.html');
 		const { document } = parseHTML(html);
 
-		expect(document.querySelector('#footnote-label').textContent).to.equal('Catatan kaki');
-		expect(document.querySelector('.data-footnote-backref').getAttribute('aria-label')).to.equal(
+		assert.equal(document.querySelector('#footnote-label').textContent, 'Catatan kaki');
+		assert.equal(
+			document.querySelector('.data-footnote-backref').getAttribute('aria-label'),
 			'Kembali ke konten'
 		);
 	});
@@ -77,8 +80,9 @@ describe('MDX with Astro Markdown remark-rehype config', () => {
 		const html = await fixture.readFile('/index.html');
 		const { document } = parseHTML(html);
 
-		expect(document.querySelector('#footnote-label').textContent).to.equal('Catatan kaki');
-		expect(document.querySelector('.data-footnote-backref').getAttribute('aria-label')).to.equal(
+		assert.equal(document.querySelector('#footnote-label').textContent, 'Catatan kaki');
+		assert.equal(
+			document.querySelector('.data-footnote-backref').getAttribute('aria-label'),
 			'Back to reference 1'
 		);
 	});

--- a/packages/integrations/mdx/test/mdx-component.test.js
+++ b/packages/integrations/mdx/test/mdx-component.test.js
@@ -1,6 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { expect } from 'chai';
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
@@ -26,8 +27,8 @@ describe('MDX Component', () => {
 			const h1 = document.querySelector('h1');
 			const foo = document.querySelector('#foo');
 
-			expect(h1.textContent).to.equal('Hello component!');
-			expect(foo.textContent).to.equal('bar');
+			assert.equal(h1.textContent, 'Hello component!');
+			assert.equal(foo.textContent, 'bar');
 		});
 
 		it('supports glob imports - <Component.default />', async () => {
@@ -37,8 +38,8 @@ describe('MDX Component', () => {
 			const h1 = document.querySelector('[data-default-export] h1');
 			const foo = document.querySelector('[data-default-export] #foo');
 
-			expect(h1.textContent).to.equal('Hello component!');
-			expect(foo.textContent).to.equal('bar');
+			assert.equal(h1.textContent, 'Hello component!');
+			assert.equal(foo.textContent, 'bar');
 		});
 
 		it('supports glob imports - <Content />', async () => {
@@ -48,8 +49,8 @@ describe('MDX Component', () => {
 			const h1 = document.querySelector('[data-content-export] h1');
 			const foo = document.querySelector('[data-content-export] #foo');
 
-			expect(h1.textContent).to.equal('Hello component!');
-			expect(foo.textContent).to.equal('bar');
+			assert.equal(h1.textContent, 'Hello component!');
+			assert.equal(foo.textContent, 'bar');
 		});
 
 		describe('with <Fragment>', () => {
@@ -60,8 +61,8 @@ describe('MDX Component', () => {
 				const h1 = document.querySelector('h1');
 				const p = document.querySelector('p');
 
-				expect(h1.textContent).to.equal('MDX containing <Fragment />');
-				expect(p.textContent).to.equal('bar');
+				assert.equal(h1.textContent, 'MDX containing <Fragment />');
+				assert.equal(p.textContent, 'bar');
 			});
 
 			it('supports glob imports - <Component.default />', async () => {
@@ -71,8 +72,8 @@ describe('MDX Component', () => {
 				const h = document.querySelector('[data-default-export] [data-file="WithFragment.mdx"] h1');
 				const p = document.querySelector('[data-default-export] [data-file="WithFragment.mdx"] p');
 
-				expect(h.textContent).to.equal('MDX containing <Fragment />');
-				expect(p.textContent).to.equal('bar');
+				assert.equal(h.textContent, 'MDX containing <Fragment />');
+				assert.equal(p.textContent, 'bar');
 			});
 
 			it('supports glob imports - <Content />', async () => {
@@ -82,8 +83,8 @@ describe('MDX Component', () => {
 				const h = document.querySelector('[data-content-export] [data-file="WithFragment.mdx"] h1');
 				const p = document.querySelector('[data-content-export] [data-file="WithFragment.mdx"] p');
 
-				expect(h.textContent).to.equal('MDX containing <Fragment />');
-				expect(p.textContent).to.equal('bar');
+				assert.equal(h.textContent, 'MDX containing <Fragment />');
+				assert.equal(p.textContent, 'bar');
 			});
 		});
 	});
@@ -102,7 +103,7 @@ describe('MDX Component', () => {
 		it('supports top-level imports', async () => {
 			const res = await fixture.fetch('/');
 
-			expect(res.status).to.equal(200);
+			assert.equal(res.status, 200);
 
 			const html = await res.text();
 			const { document } = parseHTML(html);
@@ -110,14 +111,14 @@ describe('MDX Component', () => {
 			const h1 = document.querySelector('h1');
 			const foo = document.querySelector('#foo');
 
-			expect(h1.textContent).to.equal('Hello component!');
-			expect(foo.textContent).to.equal('bar');
+			assert.equal(h1.textContent, 'Hello component!');
+			assert.equal(foo.textContent, 'bar');
 		});
 
 		it('supports glob imports - <Component.default />', async () => {
 			const res = await fixture.fetch('/glob');
 
-			expect(res.status).to.equal(200);
+			assert.equal(res.status, 200);
 
 			const html = await res.text();
 			const { document } = parseHTML(html);
@@ -125,14 +126,14 @@ describe('MDX Component', () => {
 			const h1 = document.querySelector('[data-default-export] h1');
 			const foo = document.querySelector('[data-default-export] #foo');
 
-			expect(h1.textContent).to.equal('Hello component!');
-			expect(foo.textContent).to.equal('bar');
+			assert.equal(h1.textContent, 'Hello component!');
+			assert.equal(foo.textContent, 'bar');
 		});
 
 		it('supports glob imports - <Content />', async () => {
 			const res = await fixture.fetch('/glob');
 
-			expect(res.status).to.equal(200);
+			assert.equal(res.status, 200);
 
 			const html = await res.text();
 			const { document } = parseHTML(html);
@@ -140,14 +141,15 @@ describe('MDX Component', () => {
 			const h1 = document.querySelector('[data-content-export] h1');
 			const foo = document.querySelector('[data-content-export] #foo');
 
-			expect(h1.textContent).to.equal('Hello component!');
-			expect(foo.textContent).to.equal('bar');
+			assert.equal(h1.textContent, 'Hello component!');
+			assert.equal(foo.textContent, 'bar');
 		});
 
 		describe('with <Fragment>', () => {
 			it('supports top-level imports', async () => {
 				const res = await fixture.fetch('/w-fragment');
-				expect(res.status).to.equal(200);
+
+				assert.equal(res.status, 200);
 
 				const html = await res.text();
 				const { document } = parseHTML(html);
@@ -155,13 +157,14 @@ describe('MDX Component', () => {
 				const h1 = document.querySelector('h1');
 				const p = document.querySelector('p');
 
-				expect(h1.textContent).to.equal('MDX containing <Fragment />');
-				expect(p.textContent).to.equal('bar');
+				assert.equal(h1.textContent, 'MDX containing <Fragment />');
+				assert.equal(p.textContent, 'bar');
 			});
 
 			it('supports glob imports - <Component.default />', async () => {
 				const res = await fixture.fetch('/glob');
-				expect(res.status).to.equal(200);
+
+				assert.equal(res.status, 200);
 
 				const html = await res.text();
 				const { document } = parseHTML(html);
@@ -169,13 +172,14 @@ describe('MDX Component', () => {
 				const h = document.querySelector('[data-default-export] [data-file="WithFragment.mdx"] h1');
 				const p = document.querySelector('[data-default-export] [data-file="WithFragment.mdx"] p');
 
-				expect(h.textContent).to.equal('MDX containing <Fragment />');
-				expect(p.textContent).to.equal('bar');
+				assert.equal(h.textContent, 'MDX containing <Fragment />');
+				assert.equal(p.textContent, 'bar');
 			});
 
 			it('supports glob imports - <Content />', async () => {
 				const res = await fixture.fetch('/glob');
-				expect(res.status).to.equal(200);
+
+				assert.equal(res.status, 200);
 
 				const html = await res.text();
 				const { document } = parseHTML(html);
@@ -183,8 +187,8 @@ describe('MDX Component', () => {
 				const h = document.querySelector('[data-content-export] [data-file="WithFragment.mdx"] h1');
 				const p = document.querySelector('[data-content-export] [data-file="WithFragment.mdx"] p');
 
-				expect(h.textContent).to.equal('MDX containing <Fragment />');
-				expect(p.textContent).to.equal('bar');
+				assert.equal(h.textContent, 'MDX containing <Fragment />');
+				assert.equal(p.textContent, 'bar');
 			});
 		});
 	});

--- a/packages/integrations/mdx/test/mdx-escape.test.js
+++ b/packages/integrations/mdx/test/mdx-escape.test.js
@@ -1,6 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { expect } from 'chai';
+import { describe, it, before } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
@@ -20,13 +21,13 @@ describe('MDX frontmatter', () => {
 		const html = await fixture.readFile('/index.html');
 		const { document } = parseHTML(html);
 
-		expect(document.body.textContent).to.not.include('<em');
+		assert.equal(document.body.textContent.includes('<em'), false);
 	});
 
 	it('does not have unescaped HTML inside html tags', async () => {
 		const html = await fixture.readFile('/html-tag/index.html');
 		const { document } = parseHTML(html);
 
-		expect(document.body.textContent).to.not.include('<em');
+		assert.equal(document.body.textContent.includes('<em'), false);
 	});
 });

--- a/packages/integrations/mdx/test/mdx-frontmatter-injection.test.js
+++ b/packages/integrations/mdx/test/mdx-frontmatter-injection.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
@@ -17,8 +18,8 @@ describe('MDX frontmatter injection', () => {
 	it('remark supports custom vfile data - get title', async () => {
 		const frontmatterByPage = JSON.parse(await fixture.readFile('/glob.json'));
 		const titles = frontmatterByPage.map((frontmatter = {}) => frontmatter.title);
-		expect(titles).to.contain('Page 1');
-		expect(titles).to.contain('Page 2');
+		assert.equal(titles.includes('Page 1'), true);
+		assert.equal(titles.includes('Page 2'), true);
 	});
 
 	it('rehype supports custom vfile data - reading time', async () => {
@@ -26,18 +27,24 @@ describe('MDX frontmatter injection', () => {
 		const readingTimes = frontmatterByPage.map(
 			(frontmatter = {}) => frontmatter.injectedReadingTime
 		);
-		expect(readingTimes.length).to.be.greaterThan(0);
+		assert.equal(readingTimes.length > 0, true);
 		for (let readingTime of readingTimes) {
-			expect(readingTime).to.not.be.null;
-			expect(readingTime.text).match(/^\d+ min read/);
+			assert.notEqual(readingTime, null);
+			assert.match(readingTime.text, /^\d+ min read/);
 		}
 	});
 
 	it('allow user frontmatter mutation', async () => {
 		const frontmatterByPage = JSON.parse(await fixture.readFile('/glob.json'));
 		const descriptions = frontmatterByPage.map((frontmatter = {}) => frontmatter.description);
-		expect(descriptions).to.contain('Processed by remarkDescription plugin: Page 1 description');
-		expect(descriptions).to.contain('Processed by remarkDescription plugin: Page 2 description');
+		assert.equal(
+			descriptions.includes('Processed by remarkDescription plugin: Page 1 description'),
+			true
+		);
+		assert.equal(
+			descriptions.includes('Processed by remarkDescription plugin: Page 2 description'),
+			true
+		);
 	});
 
 	it('passes injected frontmatter to layouts', async () => {
@@ -47,7 +54,7 @@ describe('MDX frontmatter injection', () => {
 		const title1 = parseHTML(html1).document.querySelector('title');
 		const title2 = parseHTML(html2).document.querySelector('title');
 
-		expect(title1.innerHTML).to.equal('Page 1');
-		expect(title2.innerHTML).to.equal('Page 2');
+		assert.equal(title1.innerHTML, 'Page 1');
+		assert.equal(title2.innerHTML, 'Page 2');
 	});
 });

--- a/packages/integrations/mdx/test/mdx-frontmatter.test.js
+++ b/packages/integrations/mdx/test/mdx-frontmatter.test.js
@@ -1,6 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { expect } from 'chai';
+import { describe, it, before } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
@@ -16,12 +17,12 @@ describe('MDX frontmatter', () => {
 		await fixture.build();
 	});
 	it('builds when "frontmatter.property" is in JSX expression', async () => {
-		expect(true).to.equal(true);
+		assert.equal(true, true);
 	});
 
 	it('extracts frontmatter to "frontmatter" export', async () => {
 		const { titles } = JSON.parse(await fixture.readFile('/glob.json'));
-		expect(titles).to.include('Using YAML frontmatter');
+		assert.equal(titles.includes('Using YAML frontmatter'), true);
 	});
 
 	it('renders layout from "layout" frontmatter property', async () => {
@@ -30,7 +31,7 @@ describe('MDX frontmatter', () => {
 
 		const layoutParagraph = document.querySelector('[data-layout-rendered]');
 
-		expect(layoutParagraph).to.not.be.null;
+		assert.notEqual(layoutParagraph, null);
 	});
 
 	it('passes frontmatter to layout via "content" and "frontmatter" props', async () => {
@@ -40,8 +41,8 @@ describe('MDX frontmatter', () => {
 		const contentTitle = document.querySelector('[data-content-title]');
 		const frontmatterTitle = document.querySelector('[data-frontmatter-title]');
 
-		expect(contentTitle.textContent).to.equal('Using YAML frontmatter');
-		expect(frontmatterTitle.textContent).to.equal('Using YAML frontmatter');
+		assert.equal(contentTitle.textContent, 'Using YAML frontmatter');
+		assert.equal(frontmatterTitle.textContent, 'Using YAML frontmatter');
 	});
 
 	it('passes headings to layout via "headings" prop', async () => {
@@ -52,9 +53,9 @@ describe('MDX frontmatter', () => {
 			(el) => el.textContent
 		);
 
-		expect(headingSlugs.length).to.be.greaterThan(0);
-		expect(headingSlugs).to.contain('section-1');
-		expect(headingSlugs).to.contain('section-2');
+		assert.equal(headingSlugs.length > 0, true);
+		assert.equal(headingSlugs.includes('section-1'), true);
+		assert.equal(headingSlugs.includes('section-2'), true);
 	});
 
 	it('passes "file" and "url" to layout', async () => {
@@ -66,12 +67,13 @@ describe('MDX frontmatter', () => {
 		const file = document.querySelector('[data-file]')?.textContent;
 		const url = document.querySelector('[data-url]')?.textContent;
 
-		expect(frontmatterFile?.endsWith('with-headings.mdx')).to.equal(
+		assert.equal(
+			frontmatterFile?.endsWith('with-headings.mdx'),
 			true,
 			'"file" prop does not end with correct path or is undefined'
 		);
-		expect(frontmatterUrl).to.equal('/with-headings');
-		expect(file).to.equal(frontmatterFile);
-		expect(url).to.equal(frontmatterUrl);
+		assert.equal(frontmatterUrl, '/with-headings');
+		assert.equal(file, frontmatterFile);
+		assert.equal(url, frontmatterUrl);
 	});
 });

--- a/packages/integrations/mdx/test/mdx-get-headings.test.js
+++ b/packages/integrations/mdx/test/mdx-get-headings.test.js
@@ -2,7 +2,8 @@ import { rehypeHeadingIds } from '@astrojs/markdown-remark';
 import mdx from '@astrojs/mdx';
 import { visit } from 'unist-util-visit';
 
-import { expect } from 'chai';
+import { describe, it, before } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
@@ -24,17 +25,18 @@ describe('MDX getHeadings', () => {
 
 		const h2Ids = document.querySelectorAll('h2').map((el) => el?.id);
 		const h3Ids = document.querySelectorAll('h3').map((el) => el?.id);
-		expect(document.querySelector('h1').id).to.equal('heading-test');
-		expect(h2Ids).to.contain('section-1');
-		expect(h2Ids).to.contain('section-2');
-		expect(h3Ids).to.contain('subsection-1');
-		expect(h3Ids).to.contain('subsection-2');
+		assert.equal(document.querySelector('h1').id, 'heading-test');
+		assert.equal(h2Ids.includes('section-1'), true);
+		assert.equal(h2Ids.includes('section-2'), true);
+		assert.equal(h3Ids.includes('subsection-1'), true);
+		assert.equal(h3Ids.includes('subsection-2'), true);
 	});
 
 	it('generates correct getHeadings() export', async () => {
 		const { headingsByPage } = JSON.parse(await fixture.readFile('/pages.json'));
 		// TODO: make this a snapshot test :)
-		expect(JSON.stringify(headingsByPage['./test.mdx'])).to.equal(
+		assert.equal(
+			JSON.stringify(headingsByPage['./test.mdx']),
 			JSON.stringify([
 				{ depth: 1, slug: 'heading-test', text: 'Heading test' },
 				{ depth: 2, slug: 'section-1', text: 'Section 1' },
@@ -47,7 +49,8 @@ describe('MDX getHeadings', () => {
 
 	it('generates correct getHeadings() export for JSX expressions', async () => {
 		const { headingsByPage } = JSON.parse(await fixture.readFile('/pages.json'));
-		expect(JSON.stringify(headingsByPage['./test-with-jsx-expressions.mdx'])).to.equal(
+		assert.equal(
+			JSON.stringify(headingsByPage['./test-with-jsx-expressions.mdx']),
 			JSON.stringify([
 				{
 					depth: 1,
@@ -91,18 +94,20 @@ describe('MDX heading IDs can be customized by user plugins', () => {
 		const { document } = parseHTML(html);
 
 		const h1 = document.querySelector('h1');
-		expect(h1?.textContent).to.equal('Heading test');
-		expect(h1?.getAttribute('id')).to.equal('0');
+		assert.equal(h1?.textContent, 'Heading test');
+		assert.equal(h1?.getAttribute('id'), '0');
 
 		const headingIDs = document.querySelectorAll('h1,h2,h3').map((el) => el.id);
-		expect(JSON.stringify(headingIDs)).to.equal(
+		assert.equal(
+			JSON.stringify(headingIDs),
 			JSON.stringify(Array.from({ length: headingIDs.length }, (_, idx) => String(idx)))
 		);
 	});
 
 	it('generates correct getHeadings() export', async () => {
 		const { headingsByPage } = JSON.parse(await fixture.readFile('/pages.json'));
-		expect(JSON.stringify(headingsByPage['./test.mdx'])).to.equal(
+		assert.equal(
+			JSON.stringify(headingsByPage['./test.mdx']),
 			JSON.stringify([
 				{ depth: 1, slug: '0', text: 'Heading test' },
 				{ depth: 2, slug: '1', text: 'Section 1' },
@@ -145,8 +150,8 @@ describe('MDX heading IDs can be injected before user plugins', () => {
 		const { document } = parseHTML(html);
 
 		const h1 = document.querySelector('h1');
-		expect(h1?.textContent).to.equal('Heading test heading-test');
-		expect(h1?.id).to.equal('heading-test');
+		assert.equal(h1?.textContent, 'Heading test heading-test');
+		assert.equal(h1?.id, 'heading-test');
 	});
 });
 
@@ -168,18 +173,19 @@ describe('MDX headings with frontmatter', () => {
 
 		const h3Ids = document.querySelectorAll('h3').map((el) => el?.id);
 
-		expect(document.querySelector('h1').id).to.equal('the-frontmatter-title');
-		expect(document.querySelector('h2').id).to.equal('frontmattertitle');
-		expect(h3Ids).to.contain('keyword-2');
-		expect(h3Ids).to.contain('tag-1');
-		expect(document.querySelector('h4').id).to.equal('item-2');
-		expect(document.querySelector('h5').id).to.equal('nested-item-3');
-		expect(document.querySelector('h6').id).to.equal('frontmatterunknown');
+		assert.equal(document.querySelector('h1').id, 'the-frontmatter-title');
+		assert.equal(document.querySelector('h2').id, 'frontmattertitle');
+		assert.equal(h3Ids.includes('keyword-2'), true);
+		assert.equal(h3Ids.includes('tag-1'), true);
+		assert.equal(document.querySelector('h4').id, 'item-2');
+		assert.equal(document.querySelector('h5').id, 'nested-item-3');
+		assert.equal(document.querySelector('h6').id, 'frontmatterunknown');
 	});
 
 	it('generates correct getHeadings() export', async () => {
 		const { headingsByPage } = JSON.parse(await fixture.readFile('/pages.json'));
-		expect(JSON.stringify(headingsByPage['./test-with-frontmatter.mdx'])).to.equal(
+		assert.equal(
+			JSON.stringify(headingsByPage['./test-with-frontmatter.mdx']),
 			JSON.stringify([
 				{ depth: 1, slug: 'the-frontmatter-title', text: 'The Frontmatter Title' },
 				{ depth: 2, slug: 'frontmattertitle', text: 'frontmatter.title' },

--- a/packages/integrations/mdx/test/mdx-get-static-paths.test.js
+++ b/packages/integrations/mdx/test/mdx-get-static-paths.test.js
@@ -1,6 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { expect } from 'chai';
+import { describe, it, before } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 import * as cheerio from 'cheerio';
 
@@ -21,11 +22,12 @@ describe('getStaticPaths', () => {
 		const html = await fixture.readFile('/one/index.html');
 
 		const $ = cheerio.load(html);
-		expect($('p').text()).to.equal('First mdx file');
-		expect($('#one').text()).to.equal('hello', 'Frontmatter included');
-		expect($('#url').text()).to.equal('src/content/1.mdx', 'url is included');
-		expect($('#file').text()).to.contain(
-			'fixtures/mdx-get-static-paths/src/content/1.mdx',
+		assert.equal($('p').text(), 'First mdx file');
+		assert.equal($('#one').text(), 'hello', 'Frontmatter included');
+		assert.equal($('#url').text(), 'src/content/1.mdx', 'url is included');
+		assert.equal(
+			$('#file').text().includes('fixtures/mdx-get-static-paths/src/content/1.mdx'),
+			true,
 			'file is included'
 		);
 	});

--- a/packages/integrations/mdx/test/mdx-images.test.js
+++ b/packages/integrations/mdx/test/mdx-images.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
@@ -22,41 +23,41 @@ describe('MDX Page', () => {
 	describe('Optimized images in MDX', () => {
 		it('works', async () => {
 			const res = await fixture.fetch('/');
-			expect(res.status).to.equal(200);
+			assert.equal(res.status, 200);
 
 			const html = await res.text();
 			const { document } = parseHTML(html);
 
 			const imgs = document.getElementsByTagName('img');
-			expect(imgs.length).to.equal(4);
+			assert.equal(imgs.length, 4);
 			// Image using a relative path
-			expect(imgs.item(0).src.startsWith('/_image')).to.be.true;
+			assert.equal(imgs.item(0).src.startsWith('/_image'), true);
 			// Image using an aliased path
-			expect(imgs.item(1).src.startsWith('/_image')).to.be.true;
+			assert.equal(imgs.item(1).src.startsWith('/_image'), true);
 			// Image with title
-			expect(imgs.item(2).title).to.equal('Houston title');
+			assert.equal(imgs.item(2).title, 'Houston title');
 			// Image with spaces in the path
-			expect(imgs.item(3).src.startsWith('/_image')).to.be.true;
+			assert.equal(imgs.item(3).src.startsWith('/_image'), true);
 		});
 
 		for (const route of imageTestRoutes) {
 			it(`supports img component - ${route}`, async () => {
 				const res = await fixture.fetch(`/${route}`);
-				expect(res.status).to.equal(200);
+				assert.equal(res.status, 200);
 
 				const html = await res.text();
 				const { document } = parseHTML(html);
 
 				const imgs = document.getElementsByTagName('img');
-				expect(imgs.length).to.equal(2);
+				assert.equal(imgs.length, 2);
 
 				const assetsImg = imgs.item(0);
-				expect(assetsImg.src.startsWith('/_image')).to.be.true;
-				expect(assetsImg.hasAttribute('data-my-image')).to.be.true;
+				assert.equal(assetsImg.src.startsWith('/_image'), true);
+				assert.equal(assetsImg.hasAttribute('data-my-image'), true);
 
 				const publicImg = imgs.item(1);
-				expect(publicImg.src).to.equal('/favicon.svg');
-				expect(publicImg.hasAttribute('data-my-image')).to.be.true;
+				assert.equal(publicImg.src, '/favicon.svg');
+				assert.equal(publicImg.hasAttribute('data-my-image'), true);
 			});
 		}
 	});

--- a/packages/integrations/mdx/test/mdx-infinite-loop.test.js
+++ b/packages/integrations/mdx/test/mdx-infinite-loop.test.js
@@ -1,6 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { expect } from 'chai';
+import { describe, it, before } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
 describe('MDX Infinite Loop', () => {
@@ -24,7 +25,7 @@ describe('MDX Infinite Loop', () => {
 		});
 
 		it('does not hang forever if an error is thrown', async () => {
-			expect(!!err).to.be.true;
+			assert.equal(!!err, true);
 		});
 	});
 });

--- a/packages/integrations/mdx/test/mdx-math.test.js
+++ b/packages/integrations/mdx/test/mdx-math.test.js
@@ -1,5 +1,6 @@
 import mdx from '@astrojs/mdx';
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 import remarkMath from 'remark-math';
@@ -25,10 +26,14 @@ describe('MDX math', () => {
 			const { document } = parseHTML(html);
 
 			const mjxContainer = document.querySelector('mjx-container[jax="SVG"]');
-			expect(mjxContainer).to.not.be.null;
+			assert.notEqual(mjxContainer, null);
 
 			const mjxStyle = document.querySelector('style').innerHTML;
-			expect(mjxStyle).to.include('mjx-container[jax="SVG"]', 'style should not be html-escaped');
+			assert.equal(
+				mjxStyle.includes('mjx-container[jax="SVG"]'),
+				true,
+				'style should not be html-escaped'
+			);
 		});
 
 		it('works with chtml', async () => {
@@ -55,10 +60,14 @@ describe('MDX math', () => {
 			const { document } = parseHTML(html);
 
 			const mjxContainer = document.querySelector('mjx-container[jax="CHTML"]');
-			expect(mjxContainer).to.not.be.null;
+			assert.notEqual(mjxContainer, null);
 
 			const mjxStyle = document.querySelector('style').innerHTML;
-			expect(mjxStyle).to.include('mjx-container[jax="CHTML"]', 'style should not be html-escaped');
+			assert.equal(
+				mjxStyle.includes('mjx-container[jax="CHTML"]'),
+				true,
+				'style should not be html-escaped'
+			);
 		});
 	});
 });

--- a/packages/integrations/mdx/test/mdx-namespace.test.js
+++ b/packages/integrations/mdx/test/mdx-namespace.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
@@ -23,8 +24,8 @@ describe('MDX Namespace', () => {
 			const island = document.querySelector('astro-island');
 			const component = document.querySelector('#component');
 
-			expect(island).not.undefined;
-			expect(component.textContent).equal('Hello world');
+			assert.notEqual(island, undefined);
+			assert.equal(component.textContent, 'Hello world');
 		});
 
 		it('works for star', async () => {
@@ -34,8 +35,8 @@ describe('MDX Namespace', () => {
 			const island = document.querySelector('astro-island');
 			const component = document.querySelector('#component');
 
-			expect(island).not.undefined;
-			expect(component.textContent).equal('Hello world');
+			assert.notEqual(island, undefined);
+			assert.equal(component.textContent, 'Hello world');
 		});
 	});
 
@@ -53,7 +54,7 @@ describe('MDX Namespace', () => {
 		it('works for object', async () => {
 			const res = await fixture.fetch('/object');
 
-			expect(res.status).to.equal(200);
+			assert.equal(res.status, 200);
 
 			const html = await res.text();
 			const { document } = parseHTML(html);
@@ -61,14 +62,14 @@ describe('MDX Namespace', () => {
 			const island = document.querySelector('astro-island');
 			const component = document.querySelector('#component');
 
-			expect(island).not.undefined;
-			expect(component.textContent).equal('Hello world');
+			assert.notEqual(island, undefined);
+			assert.equal(component.textContent, 'Hello world');
 		});
 
 		it('works for star', async () => {
 			const res = await fixture.fetch('/star');
 
-			expect(res.status).to.equal(200);
+			assert.equal(res.status, 200);
 
 			const html = await res.text();
 			const { document } = parseHTML(html);
@@ -76,8 +77,8 @@ describe('MDX Namespace', () => {
 			const island = document.querySelector('astro-island');
 			const component = document.querySelector('#component');
 
-			expect(island).not.undefined;
-			expect(component.textContent).equal('Hello world');
+			assert.notEqual(island, undefined);
+			assert.equal(component.textContent, 'Hello world');
 		});
 	});
 });

--- a/packages/integrations/mdx/test/mdx-optimize.test.js
+++ b/packages/integrations/mdx/test/mdx-optimize.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
@@ -17,31 +18,33 @@ describe('MDX optimize', () => {
 		const html = await fixture.readFile('/index.html');
 		const { document } = parseHTML(html);
 
-		expect(document.querySelector('h1').textContent).include('MDX page');
-		expect(document.querySelector('p').textContent).include(
-			'I once heard a very inspirational quote:'
+		assert.equal(document.querySelector('h1').textContent.includes('MDX page'), true);
+		assert.equal(
+			document.querySelector('p').textContent.includes('I once heard a very inspirational quote:'),
+			true
 		);
 
 		const blockquote = document.querySelector('blockquote.custom-blockquote');
-		expect(blockquote).to.not.be.null;
-		expect(blockquote.textContent).to.include('I like pancakes');
+		assert.notEqual(blockquote, null);
+		assert.equal(blockquote.textContent.includes('I like pancakes'), true);
 
 		const code = document.querySelector('pre.astro-code');
-		expect(code).to.not.be.null;
-		expect(code.textContent).to.include(`const pancakes = 'yummy'`);
+		assert.notEqual(code, null);
+		assert.equal(code.textContent.includes(`const pancakes = 'yummy'`), true);
 	});
 
 	it('renders an Astro page that imports MDX fine', async () => {
 		const html = await fixture.readFile('/import/index.html');
 		const { document } = parseHTML(html);
 
-		expect(document.querySelector('h1').textContent).include('Astro page');
-		expect(document.querySelector('p').textContent).include(
-			'I once heard a very inspirational quote:'
+		assert.equal(document.querySelector('h1').textContent.includes('Astro page'), true);
+		assert.equal(
+			document.querySelector('p').textContent.includes('I once heard a very inspirational quote:'),
+			true
 		);
 
 		const blockquote = document.querySelector('blockquote.custom-blockquote');
-		expect(blockquote).to.not.be.null;
-		expect(blockquote.textContent).to.include('I like pancakes');
+		assert.notEqual(blockquote, null);
+		assert.equal(blockquote.textContent.includes('I like pancakes'), true);
 	});
 });

--- a/packages/integrations/mdx/test/mdx-page.test.js
+++ b/packages/integrations/mdx/test/mdx-page.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
@@ -24,7 +25,7 @@ describe('MDX Page', () => {
 
 			const h1 = document.querySelector('h1');
 
-			expect(h1.textContent).to.equal('Hello page!');
+			assert.equal(h1.textContent, 'Hello page!');
 		});
 
 		it('injects style imports when layout is not applied', async () => {
@@ -33,7 +34,7 @@ describe('MDX Page', () => {
 
 			const stylesheet = document.querySelector('link[rel="stylesheet"]');
 
-			expect(stylesheet).to.not.be.null;
+			assert.notEqual(stylesheet, null);
 		});
 	});
 
@@ -51,14 +52,14 @@ describe('MDX Page', () => {
 		it('works', async () => {
 			const res = await fixture.fetch('/');
 
-			expect(res.status).to.equal(200);
+			assert.equal(res.status, 200);
 
 			const html = await res.text();
 			const { document } = parseHTML(html);
 
 			const h1 = document.querySelector('h1');
 
-			expect(h1.textContent).to.equal('Hello page!');
+			assert.equal(h1.textContent, 'Hello page!');
 		});
 	});
 });

--- a/packages/integrations/mdx/test/mdx-plugins.test.js
+++ b/packages/integrations/mdx/test/mdx-plugins.test.js
@@ -1,6 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { expect } from 'chai';
+import { describe, it, before } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 import remarkToc from 'remark-toc';
@@ -22,7 +23,7 @@ describe('MDX plugins', () => {
 		const html = await fixture.readFile(FILE);
 		const { document } = parseHTML(html);
 
-		expect(selectTocLink(document)).to.not.be.null;
+		assert.notEqual(selectTocLink(document), null);
 	});
 
 	it('Applies GFM by default', async () => {
@@ -33,7 +34,7 @@ describe('MDX plugins', () => {
 		const html = await fixture.readFile(FILE);
 		const { document } = parseHTML(html);
 
-		expect(selectGfmLink(document)).to.not.be.null;
+		assert.notEqual(selectGfmLink(document), null);
 	});
 
 	it('Applies SmartyPants by default', async () => {
@@ -45,8 +46,8 @@ describe('MDX plugins', () => {
 		const { document } = parseHTML(html);
 
 		const quote = selectSmartypantsQuote(document);
-		expect(quote).to.not.be.null;
-		expect(quote.textContent).to.contain('“Smartypants” is — awesome');
+		assert.notEqual(quote, null);
+		assert.equal(quote.textContent.includes('“Smartypants” is — awesome'), true);
 	});
 
 	it('supports custom rehype plugins', async () => {
@@ -60,7 +61,7 @@ describe('MDX plugins', () => {
 		const html = await fixture.readFile(FILE);
 		const { document } = parseHTML(html);
 
-		expect(selectRehypeExample(document)).to.not.be.null;
+		assert.notEqual(selectRehypeExample(document), null);
 	});
 
 	it('supports custom rehype plugins with namespaced attributes', async () => {
@@ -74,7 +75,7 @@ describe('MDX plugins', () => {
 		const html = await fixture.readFile(FILE);
 		const { document } = parseHTML(html);
 
-		expect(selectRehypeSvg(document)).to.not.be.null;
+		assert.notEqual(selectRehypeSvg(document), null);
 	});
 
 	it('extends markdown config by default', async () => {
@@ -89,8 +90,8 @@ describe('MDX plugins', () => {
 		const html = await fixture.readFile(FILE);
 		const { document } = parseHTML(html);
 
-		expect(selectRemarkExample(document)).to.not.be.null;
-		expect(selectRehypeExample(document)).to.not.be.null;
+		assert.notEqual(selectRemarkExample(document), null);
+		assert.notEqual(selectRehypeExample(document), null);
 	});
 
 	it('ignores string-based plugins in markdown config', async () => {
@@ -104,7 +105,7 @@ describe('MDX plugins', () => {
 		const html = await fixture.readFile(FILE);
 		const { document } = parseHTML(html);
 
-		expect(selectTocLink(document)).to.be.null;
+		assert.equal(selectTocLink(document), null);
 	});
 
 	for (const extendMarkdownConfig of [true, false]) {
@@ -131,20 +132,21 @@ describe('MDX plugins', () => {
 				const html = await fixture.readFile(FILE);
 				const { document } = parseHTML(html);
 
-				expect(selectRemarkExample(document, 'MDX remark plugins not applied.')).to.not.be.null;
-				expect(selectRehypeExample(document, 'MDX rehype plugins not applied.')).to.not.be.null;
+				assert.notEqual(selectRemarkExample(document, 'MDX remark plugins not applied.'), null);
+				assert.notEqual(selectRehypeExample(document, 'MDX rehype plugins not applied.'), null);
 			});
 
 			it('Handles Markdown plugins', async () => {
 				const html = await fixture.readFile(FILE);
 				const { document } = parseHTML(html);
 
-				expect(
+				assert.equal(
 					selectTocLink(
 						document,
 						'`remarkToc` plugin applied unexpectedly. Should override Markdown config.'
-					)
-				).to.be.null;
+					),
+					null
+				);
 			});
 
 			it('Handles gfm', async () => {
@@ -152,9 +154,9 @@ describe('MDX plugins', () => {
 				const { document } = parseHTML(html);
 
 				if (extendMarkdownConfig === true) {
-					expect(selectGfmLink(document), 'Does not respect `markdown.gfm` option.').to.be.null;
+					assert.equal(selectGfmLink(document), null, 'Does not respect `markdown.gfm` option.');
 				} else {
-					expect(selectGfmLink(document), 'Respects `markdown.gfm` unexpectedly.').to.not.be.null;
+					assert.notEqual(selectGfmLink(document), null, 'Respects `markdown.gfm` unexpectedly.');
 				}
 			});
 
@@ -165,12 +167,16 @@ describe('MDX plugins', () => {
 				const quote = selectSmartypantsQuote(document);
 
 				if (extendMarkdownConfig === true) {
-					expect(quote.textContent, 'Does not respect `markdown.smartypants` option.').to.contain(
-						'"Smartypants" is -- awesome'
+					assert.equal(
+						quote.textContent.includes('"Smartypants" is -- awesome'),
+						true,
+						'Does not respect `markdown.smartypants` option.'
 					);
 				} else {
-					expect(quote.textContent, 'Respects `markdown.smartypants` unexpectedly.').to.contain(
-						'“Smartypants” is — awesome'
+					assert.equal(
+						quote.textContent.includes('“Smartypants” is — awesome'),
+						true,
+						'Respects `markdown.smartypants` unexpectedly.'
 					);
 				}
 			});
@@ -189,7 +195,7 @@ describe('MDX plugins', () => {
 		const html = await fixture.readFile(FILE);
 		const { document } = parseHTML(html);
 
-		expect(selectRecmaExample(document)).to.not.be.null;
+		assert.notEqual(selectRecmaExample(document), null);
 	});
 });
 

--- a/packages/integrations/mdx/test/mdx-plus-react.test.js
+++ b/packages/integrations/mdx/test/mdx-plus-react.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
@@ -32,18 +33,18 @@ describe('MDX and React', () => {
 
 		const p = document.querySelector('p');
 
-		expect(p.textContent).to.equal('Hello world');
+		assert.equal(p.textContent, 'Hello world');
 	});
 
 	it('mdx renders fine', async () => {
 		const html = await fixture.readFile('/post/index.html');
 		const { document } = parseHTML(html);
 		const h = document.querySelector('#testing');
-		expect(h.textContent).to.equal('Testing');
+		assert.equal(h.textContent, 'Testing');
 	});
 
 	it('does not get a invalid hook call warning', () => {
 		const errors = unhook();
-		expect(errors).to.have.a.lengthOf(0);
+		assert.equal(errors.length === 0, true);
 	});
 });

--- a/packages/integrations/mdx/test/mdx-script-style-raw.test.js
+++ b/packages/integrations/mdx/test/mdx-script-style-raw.test.js
@@ -1,5 +1,6 @@
 import mdx from '@astrojs/mdx';
-import { expect } from 'chai';
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
@@ -24,20 +25,22 @@ describe('MDX script style raw', () => {
 
 		it('works with with raw script and style strings', async () => {
 			const res = await fixture.fetch('/index.html');
-			expect(res.status).to.equal(200);
+			assert.equal(res.status, 200);
 
 			const html = await res.text();
 			const { document } = parseHTML(html);
 
 			const scriptContent = document.getElementById('test-script').innerHTML;
-			expect(scriptContent).to.include(
-				"console.log('raw script')",
+			assert.equal(
+				scriptContent.includes("console.log('raw script')"),
+				true,
 				'script should not be html-escaped'
 			);
 
 			const styleContent = document.getElementById('test-style').innerHTML;
-			expect(styleContent).to.include(
-				'h1[id="script-style-raw"]',
+			assert.equal(
+				styleContent.includes('h1[id="script-style-raw"]'),
+				true,
 				'style should not be html-escaped'
 			);
 		});
@@ -55,14 +58,16 @@ describe('MDX script style raw', () => {
 			const { document } = parseHTML(html);
 
 			const scriptContent = document.getElementById('test-script').innerHTML;
-			expect(scriptContent).to.include(
-				"console.log('raw script')",
+			assert.equal(
+				scriptContent.includes("console.log('raw script')"),
+				true,
 				'script should not be html-escaped'
 			);
 
 			const styleContent = document.getElementById('test-style').innerHTML;
-			expect(styleContent).to.include(
-				'h1[id="script-style-raw"]',
+			assert.equal(
+				styleContent.includes('h1[id="script-style-raw"]'),
+				true,
 				'style should not be html-escaped'
 			);
 		});

--- a/packages/integrations/mdx/test/mdx-slots.test.js
+++ b/packages/integrations/mdx/test/mdx-slots.test.js
@@ -1,6 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { expect } from 'chai';
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
@@ -27,9 +28,9 @@ describe('MDX slots', () => {
 			const defaultSlot = document.querySelector('[data-default-slot]');
 			const namedSlot = document.querySelector('[data-named-slot]');
 
-			expect(h1.textContent).to.equal('Hello slotted component!');
-			expect(defaultSlot.textContent).to.equal('Default content.');
-			expect(namedSlot.textContent).to.equal('Content for named slot.');
+			assert.equal(h1.textContent, 'Hello slotted component!');
+			assert.equal(defaultSlot.textContent, 'Default content.');
+			assert.equal(namedSlot.textContent, 'Content for named slot.');
 		});
 
 		it('supports glob imports - <Component.default />', async () => {
@@ -40,9 +41,9 @@ describe('MDX slots', () => {
 			const defaultSlot = document.querySelector('[data-default-export] [data-default-slot]');
 			const namedSlot = document.querySelector('[data-default-export] [data-named-slot]');
 
-			expect(h1.textContent).to.equal('Hello slotted component!');
-			expect(defaultSlot.textContent).to.equal('Default content.');
-			expect(namedSlot.textContent).to.equal('Content for named slot.');
+			assert.equal(h1.textContent, 'Hello slotted component!');
+			assert.equal(defaultSlot.textContent, 'Default content.');
+			assert.equal(namedSlot.textContent, 'Content for named slot.');
 		});
 
 		it('supports glob imports - <Content />', async () => {
@@ -53,9 +54,9 @@ describe('MDX slots', () => {
 			const defaultSlot = document.querySelector('[data-content-export] [data-default-slot]');
 			const namedSlot = document.querySelector('[data-content-export] [data-named-slot]');
 
-			expect(h1.textContent).to.equal('Hello slotted component!');
-			expect(defaultSlot.textContent).to.equal('Default content.');
-			expect(namedSlot.textContent).to.equal('Content for named slot.');
+			assert.equal(h1.textContent, 'Hello slotted component!');
+			assert.equal(defaultSlot.textContent, 'Default content.');
+			assert.equal(namedSlot.textContent, 'Content for named slot.');
 		});
 	});
 
@@ -73,7 +74,7 @@ describe('MDX slots', () => {
 		it('supports top-level imports', async () => {
 			const res = await fixture.fetch('/');
 
-			expect(res.status).to.equal(200);
+			assert.equal(res.status, 200);
 
 			const html = await res.text();
 			const { document } = parseHTML(html);
@@ -82,15 +83,15 @@ describe('MDX slots', () => {
 			const defaultSlot = document.querySelector('[data-default-slot]');
 			const namedSlot = document.querySelector('[data-named-slot]');
 
-			expect(h1.textContent).to.equal('Hello slotted component!');
-			expect(defaultSlot.textContent).to.equal('Default content.');
-			expect(namedSlot.textContent).to.equal('Content for named slot.');
+			assert.equal(h1.textContent, 'Hello slotted component!');
+			assert.equal(defaultSlot.textContent, 'Default content.');
+			assert.equal(namedSlot.textContent, 'Content for named slot.');
 		});
 
 		it('supports glob imports - <Component.default />', async () => {
 			const res = await fixture.fetch('/glob');
 
-			expect(res.status).to.equal(200);
+			assert.equal(res.status, 200);
 
 			const html = await res.text();
 			const { document } = parseHTML(html);
@@ -99,15 +100,15 @@ describe('MDX slots', () => {
 			const defaultSlot = document.querySelector('[data-default-export] [data-default-slot]');
 			const namedSlot = document.querySelector('[data-default-export] [data-named-slot]');
 
-			expect(h1.textContent).to.equal('Hello slotted component!');
-			expect(defaultSlot.textContent).to.equal('Default content.');
-			expect(namedSlot.textContent).to.equal('Content for named slot.');
+			assert.equal(h1.textContent, 'Hello slotted component!');
+			assert.equal(defaultSlot.textContent, 'Default content.');
+			assert.equal(namedSlot.textContent, 'Content for named slot.');
 		});
 
 		it('supports glob imports - <Content />', async () => {
 			const res = await fixture.fetch('/glob');
 
-			expect(res.status).to.equal(200);
+			assert.equal(res.status, 200);
 
 			const html = await res.text();
 			const { document } = parseHTML(html);
@@ -116,9 +117,9 @@ describe('MDX slots', () => {
 			const defaultSlot = document.querySelector('[data-content-export] [data-default-slot]');
 			const namedSlot = document.querySelector('[data-content-export] [data-named-slot]');
 
-			expect(h1.textContent).to.equal('Hello slotted component!');
-			expect(defaultSlot.textContent).to.equal('Default content.');
-			expect(namedSlot.textContent).to.equal('Content for named slot.');
+			assert.equal(h1.textContent, 'Hello slotted component!');
+			assert.equal(defaultSlot.textContent, 'Default content.');
+			assert.equal(namedSlot.textContent, 'Content for named slot.');
 		});
 	});
 });

--- a/packages/integrations/mdx/test/mdx-syntax-highlighting.test.js
+++ b/packages/integrations/mdx/test/mdx-syntax-highlighting.test.js
@@ -1,6 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 import shikiTwoslash from 'remark-shiki-twoslash';
@@ -24,8 +25,8 @@ describe('MDX syntax highlighting', () => {
 			const { document } = parseHTML(html);
 
 			const shikiCodeBlock = document.querySelector('pre.astro-code');
-			expect(shikiCodeBlock).to.not.be.null;
-			expect(shikiCodeBlock.getAttribute('style')).to.contain('background-color:#24292e');
+			assert.notEqual(shikiCodeBlock, null);
+			assert.equal(shikiCodeBlock.getAttribute('style').includes('background-color:#24292e'), true);
 		});
 
 		it('respects markdown.shikiConfig.theme', async () => {
@@ -45,8 +46,8 @@ describe('MDX syntax highlighting', () => {
 			const { document } = parseHTML(html);
 
 			const shikiCodeBlock = document.querySelector('pre.astro-code');
-			expect(shikiCodeBlock).to.not.be.null;
-			expect(shikiCodeBlock.getAttribute('style')).to.contain('background-color:#282A36');
+			assert.notEqual(shikiCodeBlock, null);
+			assert.equal(shikiCodeBlock.getAttribute('style').includes('background-color:#282A36'), true);
 		});
 	});
 
@@ -65,7 +66,7 @@ describe('MDX syntax highlighting', () => {
 			const { document } = parseHTML(html);
 
 			const prismCodeBlock = document.querySelector('pre.language-astro');
-			expect(prismCodeBlock).to.not.be.null;
+			assert.notEqual(prismCodeBlock, null);
 		});
 
 		for (const extendMarkdownConfig of [true, false]) {
@@ -88,9 +89,9 @@ describe('MDX syntax highlighting', () => {
 				const { document } = parseHTML(html);
 
 				const shikiCodeBlock = document.querySelector('pre.astro-code');
-				expect(shikiCodeBlock, 'Markdown config syntaxHighlight used unexpectedly').to.be.null;
+				assert.equal(shikiCodeBlock, null, 'Markdown config syntaxHighlight used unexpectedly');
 				const prismCodeBlock = document.querySelector('pre.language-astro');
-				expect(prismCodeBlock).to.not.be.null;
+				assert.notEqual(prismCodeBlock, null);
 			});
 		}
 	});
@@ -113,7 +114,7 @@ describe('MDX syntax highlighting', () => {
 		const { document } = parseHTML(html);
 
 		const twoslashCodeBlock = document.querySelector('pre.shiki');
-		expect(twoslashCodeBlock).to.not.be.null;
+		assert.notEqual(twoslashCodeBlock, null);
 	});
 
 	it('supports custom highlighter - rehype-pretty-code', async () => {
@@ -140,6 +141,6 @@ describe('MDX syntax highlighting', () => {
 		await fixture.build();
 
 		const html = await fixture.readFile('/index.html');
-		expect(html).to.include('style="background-color:#000000"');
+		assert.equal(html.includes('style="background-color:#000000"'), true);
 	});
 });

--- a/packages/integrations/mdx/test/mdx-url-export.test.js
+++ b/packages/integrations/mdx/test/mdx-url-export.test.js
@@ -1,6 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { expect } from 'chai';
+import { describe, it, before } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
 describe('MDX url export', () => {
@@ -17,12 +18,12 @@ describe('MDX url export', () => {
 
 	it('generates correct urls in glob result', async () => {
 		const { urls } = JSON.parse(await fixture.readFile('/pages.json'));
-		expect(urls).to.include('/test-1');
-		expect(urls).to.include('/test-2');
+		assert.equal(urls.includes('/test-1'), true);
+		assert.equal(urls.includes('/test-2'), true);
 	});
 
 	it('respects "export url" overrides in glob result', async () => {
 		const { urls } = JSON.parse(await fixture.readFile('/pages.json'));
-		expect(urls).to.include('/AH!');
+		assert.equal(urls.includes('/AH!'), true);
 	});
 });

--- a/packages/integrations/mdx/test/mdx-vite-env-vars.test.js
+++ b/packages/integrations/mdx/test/mdx-vite-env-vars.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
@@ -15,31 +16,38 @@ describe('MDX - Vite env vars', () => {
 		const html = await fixture.readFile('/vite-env-vars/index.html');
 		const { document } = parseHTML(html);
 
-		expect(document.querySelector('h1')?.innerHTML).to.contain('import.meta.env.SITE');
-		expect(document.querySelector('code')?.innerHTML).to.contain('import.meta.env.SITE');
-		expect(document.querySelector('pre')?.innerHTML).to.contain('import.meta.env.SITE');
+		assert.equal(document.querySelector('h1')?.innerHTML.includes('import.meta.env.SITE'), true);
+		assert.equal(document.querySelector('code')?.innerHTML.includes('import.meta.env.SITE'), true);
+		assert.equal(document.querySelector('pre')?.innerHTML.includes('import.meta.env.SITE'), true);
 	});
 	it('Allows referencing `import.meta.env` in frontmatter', async () => {
 		const { title = '' } = JSON.parse(await fixture.readFile('/frontmatter.json'));
-		expect(title).to.contain('import.meta.env.SITE');
+		assert.equal(title.includes('import.meta.env.SITE'), true);
 	});
 	it('Transforms `import.meta.env` in {JSX expressions}', async () => {
 		const html = await fixture.readFile('/vite-env-vars/index.html');
 		const { document } = parseHTML(html);
 
-		expect(document.querySelector('[data-env-site]')?.innerHTML).to.contain(
-			'https://mdx-is-neat.com/blog/cool-post'
+		assert.equal(
+			document
+				.querySelector('[data-env-site]')
+				?.innerHTML.includes('https://mdx-is-neat.com/blog/cool-post'),
+			true
 		);
 	});
 	it('Transforms `import.meta.env` in variable exports', async () => {
 		const html = await fixture.readFile('/vite-env-vars/index.html');
 		const { document } = parseHTML(html);
 
-		expect(document.querySelector('[data-env-variable-exports]')?.innerHTML).to.contain(
-			'MODE works'
+		assert.equal(
+			document.querySelector('[data-env-variable-exports]')?.innerHTML.includes('MODE works'),
+			true
 		);
-		expect(document.querySelector('[data-env-variable-exports-unknown]')?.innerHTML).to.contain(
-			'exports: ””' // NOTE: these double quotes are special unicode quotes emitted in the HTML file
+		assert.equal(
+			document
+				.querySelector('[data-env-variable-exports-unknown]')
+				?.innerHTML.includes('exports: ””'), // NOTE: these double quotes are special unicode quotes emitted in the HTML file
+			true
 		);
 	});
 	it('Transforms `import.meta.env` in HTML attributes', async () => {
@@ -47,11 +55,11 @@ describe('MDX - Vite env vars', () => {
 		const { document } = parseHTML(html);
 
 		const dataAttrDump = document.querySelector('[data-env-dump]');
-		expect(dataAttrDump).to.not.be.null;
+		assert.notEqual(dataAttrDump, null);
 
-		expect(dataAttrDump.getAttribute('data-env-prod')).to.not.be.null;
-		expect(dataAttrDump.getAttribute('data-env-dev')).to.be.null;
-		expect(dataAttrDump.getAttribute('data-env-base-url')).to.equal('/');
-		expect(dataAttrDump.getAttribute('data-env-mode')).to.equal('production');
+		assert.notEqual(dataAttrDump.getAttribute('data-env-prod'), null);
+		assert.equal(dataAttrDump.getAttribute('data-env-dev'), null);
+		assert.equal(dataAttrDump.getAttribute('data-env-base-url'), '/');
+		assert.equal(dataAttrDump.getAttribute('data-env-mode'), 'production');
 	});
 });

--- a/packages/integrations/mdx/test/remark-imgattr.test.js
+++ b/packages/integrations/mdx/test/remark-imgattr.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert/strict';
 import * as cheerio from 'cheerio';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
@@ -34,16 +35,14 @@ describe('Testing remark plugins for image processing', () => {
 
 			it('<img> has correct attributes', async () => {
 				let $img = $('img');
-				expect($img.attr('id')).to.equal('test');
-				expect($img.attr('sizes')).to.equal('(min-width: 600px) 600w, 300w');
-				expect($img.attr('srcset')).to.not.be.empty;
+				assert.equal($img.attr('id'), 'test');
+				assert.equal($img.attr('sizes'), '(min-width: 600px) 600w, 300w');
+				assert.ok($img.attr('srcset'));
 			});
 
 			it('<img> was processed properly', async () => {
 				let $img = $('img');
-				expect(new URL($img.attr('src'), 'http://example.com').searchParams.get('w')).to.equal(
-					'300'
-				);
+				assert.equal(new URL($img.attr('src'), 'http://example.com').searchParams.get('w'), '300');
 			});
 		});
 	});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4146,9 +4146,6 @@ importers:
       astro-scripts:
         specifier: workspace:*
         version: link:../../../scripts
-      chai:
-        specifier: ^4.3.7
-        version: 4.3.10
       cheerio:
         specifier: 1.0.0-rc.12
         version: 1.0.0-rc.12
@@ -4161,9 +4158,6 @@ importers:
       mdast-util-to-string:
         specifier: ^4.0.0
         version: 4.0.0
-      mocha:
-        specifier: ^10.2.0
-        version: 10.2.0
       reading-time:
         specifier: ^1.5.0
         version: 1.5.0
@@ -4181,7 +4175,7 @@ importers:
         version: 11.0.0
       remark-shiki-twoslash:
         specifier: ^3.1.3
-        version: 3.1.3(typescript@5.2.2)
+        version: 3.1.3
       remark-toc:
         specifier: ^9.0.0
         version: 9.0.0
@@ -4190,7 +4184,7 @@ importers:
         version: 11.0.4
       vite:
         specifier: ^5.0.12
-        version: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+        version: 5.0.12
 
   packages/integrations/mdx/test/fixtures/css-head-mdx:
     dependencies:
@@ -7748,7 +7742,7 @@ packages:
     resolution: {integrity: sha512-kTwMUQ8xtAZaC4wb2XuLkPqFVBj2dNBueMQ89NWEuw87k2nLBbuafeG5cob/QEr6YduxIdTVUjix0MtC7mPlmg==}
     dependencies:
       '@typescript/vfs': 1.3.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       lz-string: 1.5.0
     transitivePeerDependencies:
       - supports-color
@@ -7757,7 +7751,7 @@ packages:
   /@typescript/vfs@1.3.4:
     resolution: {integrity: sha512-RbyJiaAGQPIcAGWFa3jAXSuAexU4BFiDRF1g3hy7LmRqfNpYlTQWGXjcrOaVZjJ8YkkpuwG0FcsYvtWQpd9igQ==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7765,7 +7759,7 @@ packages:
   /@typescript/vfs@1.3.5:
     resolution: {integrity: sha512-pI8Saqjupf9MfLw7w2+og+fmb0fZS0J6vsKXXrp4/PDXEFvntgzXmChCXC/KefZZS0YGS6AT8e0hGAJcTsdJlg==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8107,7 +8101,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -9194,6 +9188,17 @@ packages:
     dependencies:
       ms: 2.1.3
     dev: false
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
 
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -10776,7 +10781,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10786,7 +10791,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12242,7 +12247,7 @@ packages:
     resolution: {integrity: sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
@@ -13982,7 +13987,7 @@ packages:
       unified: 11.0.4
       vfile: 6.0.1
 
-  /remark-shiki-twoslash@3.1.3(typescript@5.2.2):
+  /remark-shiki-twoslash@3.1.3:
     resolution: {integrity: sha512-4e8OH3ySOCw5wUbDcPszokOKjKuebOqlP2WlySvC7ITBOq27BiGsFlq+FNWhxppZ+JzhTWah4gQrnMjX3KDbAQ==}
     peerDependencies:
       typescript: '>3'
@@ -13993,9 +13998,8 @@ packages:
       fenceparser: 1.1.1
       regenerator-runtime: 0.13.11
       shiki: 0.10.1
-      shiki-twoslash: 3.1.2(typescript@5.2.2)
+      shiki-twoslash: 3.1.2
       tslib: 2.1.0
-      typescript: 5.2.2
       unist-util-visit: 2.0.3
     transitivePeerDependencies:
       - supports-color
@@ -14348,7 +14352,7 @@ packages:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
     dev: true
 
-  /shiki-twoslash@3.1.2(typescript@5.2.2):
+  /shiki-twoslash@3.1.2:
     resolution: {integrity: sha512-JBcRIIizi+exIA/OUhYkV6jtyeZco0ykCkIRd5sgwIt1Pm4pz+maoaRZpm6SkhPwvif4fCA7xOtJOykhpIV64Q==}
     peerDependencies:
       typescript: '>3'
@@ -14357,7 +14361,6 @@ packages:
       '@typescript/vfs': 1.3.4
       fenceparser: 1.1.1
       shiki: 0.10.1
-      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -15713,6 +15716,41 @@ packages:
     dependencies:
       svgo: 3.2.0
     dev: false
+
+  /vite@5.0.12:
+    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.19.11
+      postcss: 8.4.33
+      rollup: 4.9.2
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
 
   /vite@5.0.12(@types/node@18.19.4)(sass@1.69.6):
     resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}


### PR DESCRIPTION
## Changes

- This PR moves `@astrojs/mdx` to use Node.js for testing
- Related issue: [☂️ Move Astro tests to node:test  #9873](https://github.com/withastro/astro/issues/9873)
- timeout set to 50000 for the test script as the tests timed out from the default 20000 on my end

## Testing

`pnpm test --filter @astrojs/mdx`

Tests should pass

## Docs

N/A
