### PR TITLE
feat(astro): improve `astro:content` types

### DIFF
--- a/.changeset/young-bulldogs-tickle.md
+++ b/.changeset/young-bulldogs-tickle.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Improves the types for the `astro:content` module by making `defineCollection` and `z` exports available without running `astro sync`

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -160,6 +160,10 @@ declare module 'astro:components' {
 	export * from 'astro/components';
 }
 
+declare module 'astro:content' {
+	export * from 'astro/virtual-modules/content.js'
+}
+
 type MD = import('./dist/@types/astro.js').MarkdownInstance<Record<string, any>>;
 interface ExportedMarkdownModuleEntities {
 	frontmatter: MD['frontmatter'];

--- a/packages/astro/content-types.template.d.ts
+++ b/packages/astro/content-types.template.d.ts
@@ -9,8 +9,6 @@ declare module 'astro:content' {
 }
 
 declare module 'astro:content' {
-	export { z } from 'astro/zod';
-
 	type Flatten<T> = T extends { [K: string]: infer U } ? U : never;
 
 	export type CollectionKey = keyof AnyEntryMap;
@@ -18,53 +16,6 @@ declare module 'astro:content' {
 
 	export type ContentCollectionKey = keyof ContentEntryMap;
 	export type DataCollectionKey = keyof DataEntryMap;
-
-	// This needs to be in sync with ImageMetadata
-	export type ImageFunction = () => import('astro/zod').ZodObject<{
-		src: import('astro/zod').ZodString;
-		width: import('astro/zod').ZodNumber;
-		height: import('astro/zod').ZodNumber;
-		format: import('astro/zod').ZodUnion<
-			[
-				import('astro/zod').ZodLiteral<'png'>,
-				import('astro/zod').ZodLiteral<'jpg'>,
-				import('astro/zod').ZodLiteral<'jpeg'>,
-				import('astro/zod').ZodLiteral<'tiff'>,
-				import('astro/zod').ZodLiteral<'webp'>,
-				import('astro/zod').ZodLiteral<'gif'>,
-				import('astro/zod').ZodLiteral<'svg'>,
-				import('astro/zod').ZodLiteral<'avif'>,
-			]
-		>;
-	}>;
-
-	type BaseSchemaWithoutEffects =
-		| import('astro/zod').AnyZodObject
-		| import('astro/zod').ZodUnion<[BaseSchemaWithoutEffects, ...BaseSchemaWithoutEffects[]]>
-		| import('astro/zod').ZodDiscriminatedUnion<string, import('astro/zod').AnyZodObject[]>
-		| import('astro/zod').ZodIntersection<BaseSchemaWithoutEffects, BaseSchemaWithoutEffects>;
-
-	type BaseSchema =
-		| BaseSchemaWithoutEffects
-		| import('astro/zod').ZodEffects<BaseSchemaWithoutEffects>;
-
-	export type SchemaContext = { image: ImageFunction };
-
-	type DataCollectionConfig<S extends BaseSchema> = {
-		type: 'data';
-		schema?: S | ((context: SchemaContext) => S);
-	};
-
-	type ContentCollectionConfig<S extends BaseSchema> = {
-		type?: 'content';
-		schema?: S | ((context: SchemaContext) => S);
-	};
-
-	type CollectionConfig<S> = ContentCollectionConfig<S> | DataCollectionConfig<S>;
-
-	export function defineCollection<S extends BaseSchema>(
-		input: CollectionConfig<S>
-	): CollectionConfig<S>;
 
 	type AllValuesOf<T> = T extends any ? T[keyof T] : never;
 	type ValidContentEntrySlug<C extends keyof ContentEntryMap> = AllValuesOf<

--- a/packages/astro/src/virtual-modules/content.ts
+++ b/packages/astro/src/virtual-modules/content.ts
@@ -1,0 +1,52 @@
+import { defineCollection as _defineCollection } from '../content/runtime.js';
+export { z } from 'astro/zod';
+
+// This needs to be in sync with ImageMetadata
+export type ImageFunction = () => import('astro/zod').ZodObject<{
+	src: import('astro/zod').ZodString;
+	width: import('astro/zod').ZodNumber;
+	height: import('astro/zod').ZodNumber;
+	format: import('astro/zod').ZodUnion<
+		[
+			import('astro/zod').ZodLiteral<'png'>,
+			import('astro/zod').ZodLiteral<'jpg'>,
+			import('astro/zod').ZodLiteral<'jpeg'>,
+			import('astro/zod').ZodLiteral<'tiff'>,
+			import('astro/zod').ZodLiteral<'webp'>,
+			import('astro/zod').ZodLiteral<'gif'>,
+			import('astro/zod').ZodLiteral<'svg'>,
+			import('astro/zod').ZodLiteral<'avif'>,
+		]
+	>;
+}>;
+
+// @ts-ignore complains about circular dependency but used to work in the types template
+type BaseSchemaWithoutEffects =
+	| import('astro/zod').AnyZodObject
+	| import('astro/zod').ZodUnion<[BaseSchemaWithoutEffects, ...BaseSchemaWithoutEffects[]]>
+	| import('astro/zod').ZodDiscriminatedUnion<string, import('astro/zod').AnyZodObject[]>
+	| import('astro/zod').ZodIntersection<BaseSchemaWithoutEffects, BaseSchemaWithoutEffects>;
+
+type BaseSchema =
+	| BaseSchemaWithoutEffects
+	| import('astro/zod').ZodEffects<BaseSchemaWithoutEffects>;
+
+export type SchemaContext = { image: ImageFunction };
+
+type DataCollectionConfig<S extends BaseSchema> = {
+	type: 'data';
+	schema?: S | ((context: SchemaContext) => S);
+};
+
+type ContentCollectionConfig<S extends BaseSchema> = {
+	type?: 'content';
+	schema?: S | ((context: SchemaContext) => S);
+};
+
+type CollectionConfig<S> = ContentCollectionConfig<S> | DataCollectionConfig<S>;
+
+export function defineCollection<S extends BaseSchema>(
+	input: CollectionConfig<S>
+): CollectionConfig<S> {
+	return _defineCollection(input);
+}

--- a/packages/astro/tsconfig.json
+++ b/packages/astro/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "allowJs": true,
     "declarationDir": "./dist",
+    "rootDir": ".",
     "outDir": "./dist",
     "jsx": "preserve",
     "types": ["@types/dom-view-transitions"]


### PR DESCRIPTION
## Changes

Currently, the `astro:content` module is not typed before `astro sync` is run, although exported `defineCollection` and `z` do not depend on codegen. This PR moves them from types template to a "static" virtual module type declaration.

## Testing

Manually in the `blog` example. Tests should still pass.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

I think parts of the docs will need to be updated, I'm thinking about the tutorial. Basically reverting this https://github.com/withastro/docs/pull/6272/files#diff-ec9625e9b89360bd7a29d0d392017cbb704e8890a12534044ca2374dddb9fdb5R181

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
