### PR TITLE
fix(NodeApp): end with "Internal server error" on mid-stream error

### DIFF
--- a/.changeset/clever-roses-sleep.md
+++ b/.changeset/clever-roses-sleep.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Improves http behavior relating to errors encountered while streaming a response.

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -118,12 +118,12 @@ export class NodeApp extends App {
 					destination.write(result.value);
 					result = await reader.read();
 				}
+				destination.end();
 				// the error will be logged by the "on end" callback above
 			} catch {
-				destination.write('Internal server error');
+				destination.end('Internal server error');
 			}
 		}
-		destination.end();
 	}
 }
 

--- a/packages/integrations/node/test/errors.test.js
+++ b/packages/integrations/node/test/errors.test.js
@@ -1,4 +1,4 @@
-import * as assert from 'node:assert/strict';
+import assert from 'node:assert/strict';
 import { describe, it, before, after } from 'node:test';
 import nodejs from '../dist/index.js';
 import { loadFixture } from './test-utils.js';
@@ -22,11 +22,26 @@ describe('Errors', () => {
 	after(async () => {
 		await devPreview.stop();
 	});
-	it('when mode is standalone', async () => {
+
+	it.skip('rejected promise in template', async () => {
 		const res = await fixture.fetch('/in-stream');
 		const html = await res.text();
 		const $ = cheerio.load(html);
 
 		assert.equal($('p').text().trim(), 'Internal server error');
+	});
+	
+	it('generator that throws called in template', async () => {
+		/** @type {Response} */
+		const res = await fixture.fetch('/generator');
+		const reader = res.body.getReader();
+		const decoder = new TextDecoder();
+		const expect = async ({ done, value }) => {
+			const result = await reader.read();
+			assert.equal(result.done, done);
+			if (!done) assert.equal(decoder.decode(result.value), value);
+		}
+		await expect({ done: false, value: "<!DOCTYPE html><h1>Astro</h1> 1Internal server error" });
+		await expect({ done: true });
 	});
 });

--- a/packages/integrations/node/test/errors.test.js
+++ b/packages/integrations/node/test/errors.test.js
@@ -23,7 +23,7 @@ describe('Errors', () => {
 		await devPreview.stop();
 	});
 
-	it.skip('rejected promise in template', async () => {
+	it('rejected promise in template', async () => {
 		const res = await fixture.fetch('/in-stream');
 		const html = await res.text();
 		const $ = cheerio.load(html);

--- a/packages/integrations/node/test/fixtures/errors/src/pages/generator.astro
+++ b/packages/integrations/node/test/fixtures/errors/src/pages/generator.astro
@@ -1,0 +1,11 @@
+---
+function * generator () {
+    yield 1
+    throw Error('ohnoes')
+}
+---
+<h1>Astro</h1>
+{generator()}
+<footer>
+	Footer
+</footer>


### PR DESCRIPTION
## Changes
- Closes #8714 
- `curl --raw -i http://localhost:4321`
<details>
<summary>Before</summary>

<img width="600" alt="image" src="https://github.com/withastro/astro/assets/69170106/7437d84b-0c51-4e1b-b859-df1137950542">

</details>

<details>
<summary>After</summary>

<img width="600" alt="image" src="https://github.com/withastro/astro/assets/69170106/e6a73095-e5e0-43fd-ac9c-db0a42b6bc95">

</details>

## Testing
Added a test case to errors.test.js

## Docs
Does not affect usage.