### PR TITLE
Silently ignore adapters that don't export `start()`

### DIFF
--- a/.changeset/tiny-moose-melt.md
+++ b/.changeset/tiny-moose-melt.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where some adapters that do not include a `start()` export would error rather than silently proceed

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -263,7 +263,14 @@ function generateSSRCode(adapter: AstroAdapter, middlewareId: string) {
 				return `export const ${name} = _exports['${name}'];`;
 			}
 		}) ?? []),
-		`serverEntrypointModule.start?.(_manifest, _args);`,
+		// NOTE: This is intentionally obfuscated!
+		// Do NOT simplify this to something like `serverEntrypointModule.start?.(_manifest, _args)`
+		// They are NOT equivalent! Some bundlers will throw if `start` is not exported, but we
+		// only want to silently ignore it... hence the dynamic, obfuscated weirdness.
+		`const _start = 'start';
+if (_start in serverEntrypointModule) {
+	serverEntrypointModule[_start](_manifest, _args);
+}`,
 	];
 
 	return {


### PR DESCRIPTION
## Changes

- Fixes a regression introduced by https://github.com/withastro/astro/pull/9776/files#diff-524e25c0bd5feda71ed7489963414a0c1f06da3caa327933574a72b85b668bddR264
- We got a report on Discord about Cloudflare failing to build in Astro 4.2.5
- Turns out that the obfuscated way this was originally written was very intentional because it bypasses some static analysis that bundlers try to do to warn against missing exports
- I added a comment to this effect so that this doesn't happen again

## Testing

We unfortunately don't have automated adapter tests

## Docs

N/A, bug fix only