### PR TITLE
react: with experimentalReactChildren, convert style css string to string

### DIFF
--- a/.changeset/swift-eggs-approve.md
+++ b/.changeset/swift-eggs-approve.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/react": patch
+---
+
+experimentalReactChildren: convert style string to style object compatible with react

--- a/packages/integrations/react/client.js
+++ b/packages/integrations/react/client.js
@@ -1,5 +1,6 @@
 import { createElement, startTransition } from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
+import styleToObject from 'style-to-object';
 import StaticHtml from './static-html.js';
 
 function isAlreadyHydrated(element) {
@@ -13,7 +14,11 @@ function isAlreadyHydrated(element) {
 function createReactElementFromDOMElement(element) {
 	let attrs = {};
 	for (const attr of element.attributes) {
-		attrs[attr.name] = attr.value;
+		if (attr.name === 'style' && typeof attr.value === 'string') {
+			attrs['style'] = styleToObject(attr.value);
+		} else {
+			attrs[attr.name] = attr.value;
+		}
 	}
 
 	return createElement(

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -46,10 +46,13 @@
     "test": "astro-scripts test \"test/**/*.test.js\""
   },
   "dependencies": {
+    "html-escaper": "^3.0.3",
+    "style-to-object": "^1.0.5",
     "@vitejs/plugin-react": "^4.2.0",
     "ultrahtml": "^1.3.0"
   },
   "devDependencies": {
+    "@types/html-escaper": "^3.0.2",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "astro": "workspace:*",

--- a/packages/integrations/react/vnode-children.js
+++ b/packages/integrations/react/vnode-children.js
@@ -1,5 +1,7 @@
 import { parse, DOCUMENT_NODE, ELEMENT_NODE, TEXT_NODE } from 'ultrahtml';
 import { createElement, Fragment } from 'react';
+import styleToObject from 'style-to-object';
+import { unescape } from 'html-escaper';
 
 let ids = 0;
 export default function convert(children) {
@@ -16,11 +18,12 @@ export default function convert(children) {
 		if (node.type === DOCUMENT_NODE) {
 			return createElement(Fragment, {}, childVnodes);
 		} else if (node.type === ELEMENT_NODE) {
-			const { class: className, ...props } = node.attributes;
-			return createElement(node.name, { ...props, className, key: `${id}-${key++}` }, childVnodes);
+			const { class: className, style: styleCss, ...props } = node.attributes;
+			const style = styleToObject(styleCss);
+			return createElement(node.name, { ...props, className, style, key: `${id}-${key++}` }, childVnodes);
 		} else if (node.type === TEXT_NODE) {
 			// 0-length text gets omitted in JSX
-			return node.value.trim() ? node.value : undefined;
+			return node.value.trim() ? unescape(node.value) : undefined;
 		}
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4526,10 +4526,19 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.2.0
         version: 4.2.1(vite@5.0.12)
+      html-escaper:
+        specifier: ^3.0.3
+        version: 3.0.3
+      style-to-object:
+        specifier: ^1.0.5
+        version: 1.0.5
       ultrahtml:
         specifier: ^1.3.0
         version: 1.5.2
     devDependencies:
+      '@types/html-escaper':
+        specifier: ^3.0.2
+        version: 3.0.2
       '@types/react':
         specifier: ^18.2.37
         version: 18.2.46


### PR DESCRIPTION
## Changes

Motivation: I am use shadcn tabs which make use of React's Context. Astro does not support this as [context's are not available between islands](https://github.com/withastro/roadmap/discussions/742). I want to have tabs in `mdx` but the content of those tabs should be astro generated code blocks:

<img width="773" alt="Screenshot 2024-01-31 at 12 03 19 PM" src="https://github.com/withastro/astro/assets/940094/a47ea658-39fd-4bdd-86af-9ad65d7391bf">

This means I want to mix React and MDX, so just using a React component island doesn't work for me. So I created a custom React component and thought I could just parse the children and build the component tree manually. The `experimentalReactChildren` solves this problem for me. However I was unable to get it to work because the props that were passed to React were valid JSX. Specifically it was sending the `style` prop as a string instead of an object.

This PR modifies the react component to convert the style prop into an object before `React.createElement` is called.

## Testing

The existing tests should suffice for this feature.

## Docs

This feature is technically a fix and should not need any documentation updates.
