### PR TITLE
[ci]: use M1 mac image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         OS: [ubuntu-latest]
         NODE_VERSION: [18, 20.5.1]
         include:
-          - os: macos-latest
+          - os: macos-14
             NODE_VERSION: 18
           - os: windows-latest
             NODE_VERSION: 18.17.1


### PR DESCRIPTION
## Changes

- Switches to `macos-14` image rather than `macos-latest`
- See the [M1 macOS](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/) announcement from GitHub
- For additional context, `macos-latest` will migrate to `macos-14` in [Q2 FY24 (April – June 2024)](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/). We are just getting ahead of things here.

## Testing

GitHub Actions === no tests! We all know this

## Docs

Nope