### PR TITLE
Add a name property for DetailsHTMLAttributes

### DIFF
--- a/.changeset/old-jokes-complain.md
+++ b/.changeset/old-jokes-complain.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Adds the attribute `name` to the `<details>` tag.

--- a/.changeset/old-jokes-complain.md
+++ b/.changeset/old-jokes-complain.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Adds the attribute `name` to the `<details>` tag.
+Adds the `name` attribute to the `<details>` tag type

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -670,6 +670,7 @@ declare namespace astroHTML.JSX {
 
 	interface DetailsHTMLAttributes extends HTMLAttributes {
 		open?: boolean | string | undefined | null;
+		name?: string | undefined | null;
 	}
 
 	interface DelHTMLAttributes extends HTMLAttributes {


### PR DESCRIPTION
## Changes

- Added a property `name` for `<details>` HTML element to group several `<details>`elements.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
