### PR TITLE
fix(docs): Fix import in changelog example

### DIFF
--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -9,7 +9,7 @@
   ```astro
   ---
   import type { ComponentProps } from 'astro/types';
-  import { Button } from './Button.astro';
+  import Button from './Button.astro';
 
   type myButtonProps = ComponentProps<typeof Button>;
   ---


### PR DESCRIPTION
## Changes

Astro components have a default export, not a named export. Fixes the example in the changelog for release `astro@4.3.0`

## Testing

No logical change, just release notes.

## Docs

No docs change is needed.