### PR TITLE
Fix indentation formatting in types JSDoc

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1734,7 +1734,7 @@ export interface AstroUserConfig {
 		 *     prefixDefaultLocale: false,
 		 *		  domains: {
 		 *			  fr: "https://fr.example.com",
-		 *       es: "https://example.es"
+		 *			  es: "https://example.es"
 		 *    },
 		 *  experimental: {
 		 *     i18nDomains: true

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1725,21 +1725,22 @@ export interface AstroUserConfig {
 		 * export default defineConfig({
 		 * 	site: "https://example.com",
 		 * 	output: "server", // required, with no prerendered pages
-		 *   adapter: node({
-		 *     mode: 'standalone',
-		 *   }),
+		 * 	adapter: node({
+		 * 		mode: 'standalone',
+		 * 	}),
 		 * 	i18n: {
 		 * 		defaultLocale: "en",
 		 * 		locales: ["en", "fr", "pt-br", "es"],
-		 *     prefixDefaultLocale: false,
-		 *		  domains: {
-		 *			  fr: "https://fr.example.com",
-		 *			  es: "https://example.es"
-		 *    },
-		 *  experimental: {
-		 *     i18nDomains: true
-		 *  }
-		 * })
+		 * 		prefixDefaultLocale: false,
+		 * 		domains: {
+		 * 			fr: "https://fr.example.com",
+		 * 			es: "https://example.es",
+		 * 		},
+		 * 	},
+		 * 	experimental: {
+		 * 		i18nDomains: true,
+		 * 	},
+		 * });
 		 * ```
 		 *
 		 * Both page routes built and URLs returned by the `astro:i18n` helper functions [`getAbsoluteLocaleUrl()`](https://docs.astro.build/en/guides/internationalization/#getabsolutelocaleurl) and [`getAbsoluteLocaleUrlList()`](https://docs.astro.build/en/guides/internationalization/#getabsolutelocaleurllist) will use the options set in `i18n.domains`.


### PR DESCRIPTION
## Changes

- Tabs instead of spaces in a JSDoc type
- Noticed this in https://github.com/withastro/docs/pull/6737

## Testing

n/a docs only

## Docs

n/a docs fix
