### PR TITLE
Exit code 1 if node:test fail

### DIFF
--- a/scripts/cmd/test.js
+++ b/scripts/cmd/test.js
@@ -63,6 +63,11 @@ export default async function test() {
 		watch: args['--watch'],
 		timeout: args['--timeout'] ?? defaultTimeout, // Node.js defaults to Infinity, so set better fallback
 	})
+		.on('test:fail', () => {
+			// For some reason, a test fail using the JS API does not set an exit code of 1,
+			// so we set it here manually
+			process.exitCode = 1;
+		})
 		.pipe(new spec())
 		.pipe(process.stdout);
 }


### PR DESCRIPTION
## Changes

Found in https://github.com/withastro/astro/pull/9910, for some reason `node:test` doesn't exit code 1 if a test fail. Luckily the current node:test migrations had all actually passed.

## Testing

Ran the tests locally.

## Docs

n/a
