### PR TITLE
[docs] update typo in error message

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -206,7 +206,7 @@ export interface AstroGlobal<
 	 * const { name } = Astro.props
 	 * ```
 	 *
-	 * [Astro reference](https://docs.astro.build/en/core-concepts/astro-components/#component-props)
+	 * [Astro reference](https://docs.astro.build/en/basics/astro-components/#component-props)
 	 */
 	props: AstroSharedContext<Props, Params>['props'];
 	/** Information about the current request. This is a standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object
@@ -1684,7 +1684,7 @@ export interface AstroUserConfig {
 		 * @version 4.2.0
 		 * @description
 		 *
-		 * Prioritizes redirects and injected routes equally alongside file-based project routes, following the same [route priority order rules](https://docs.astro.build/en/core-concepts/routing/#route-priority-order) for all routes.
+		 * Prioritizes redirects and injected routes equally alongside file-based project routes, following the same [route priority order rules](https://docs.astro.build/en/guides/routing/#route-priority-order) for all routes.
 		 *
 		 * This allows more control over routing in your project by not automatically prioritizing certain types of routes, and standardizes the route priority ordering for all routes.
 		 *
@@ -2023,7 +2023,7 @@ export type GetStaticPathsResultKeyed = GetStaticPathsResult & {
 };
 
 /**
- * Return an array of pages to generate for a [dynamic route](https://docs.astro.build/en/core-concepts/routing/#dynamic-routes). (**SSG Only**)
+ * Return an array of pages to generate for a [dynamic route](https://docs.astro.build/en/guides/routing/#dynamic-routes). (**SSG Only**)
  *
  * [Astro Reference](https://docs.astro.build/en/reference/api-reference/#getstaticpaths)
  */

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -88,7 +88,7 @@ export const StaticClientAddressNotAvailable = {
  * @see
  * - [getStaticPaths()](https://docs.astro.build/en/reference/api-reference/#getstaticpaths)
  * @description
- * A [dynamic route](https://docs.astro.build/en/core-concepts/routing/#dynamic-routes) was matched, but no corresponding path was found for the requested parameters. This is often caused by a typo in either the generated or the requested path.
+ * A [dynamic route](https://docs.astro.build/en/guides/routing/#dynamic-routes) was matched, but no corresponding path was found for the requested parameters. This is often caused by a typo in either the generated or the requested path.
  */
 export const NoMatchingStaticPathFound = {
 	name: 'NoMatchingStaticPathFound',
@@ -148,7 +148,7 @@ export const MissingMediaQueryDirective = {
  * @docs
  * @message Unable to render `COMPONENT_NAME`. There are `RENDERER_COUNT` renderer(s) configured in your `astro.config.mjs` file, but none were able to server-side render `COMPONENT_NAME`.
  * @see
- * - [Frameworks components](https://docs.astro.build/en/core-concepts/framework-components/)
+ * - [Frameworks components](https://docs.astro.build/en/guides/framework-components/)
  * - [UI Frameworks](https://docs.astro.build/en/guides/integrations-guide/#official-integrations)
  * @description
  * None of the installed integrations were able to render the component you imported. Make sure to install the appropriate integration for the type of component you are trying to include in your page.
@@ -179,13 +179,13 @@ but ${plural ? 'none were' : 'it was not'} able to server-side render \`${compon
 			}`
 }`,
 	hint: (probableRenderers: string) =>
-		`Did you mean to enable the ${probableRenderers} integration?\n\nSee https://docs.astro.build/en/core-concepts/framework-components/ for more information on how to install and configure integrations.`,
+		`Did you mean to enable the ${probableRenderers} integration?\n\nSee https://docs.astro.build/en/guides/framework-components/ for more information on how to install and configure integrations.`,
 } satisfies ErrorData;
 /**
  * @docs
  * @see
  * - [addRenderer option](https://docs.astro.build/en/reference/integrations-reference/#addrenderer-option)
- * - [Hydrating framework components](https://docs.astro.build/en/core-concepts/framework-components/#hydrating-interactive-components)
+ * - [Hydrating framework components](https://docs.astro.build/en/guides/framework-components/#hydrating-interactive-components)
  * @description
  * Astro tried to hydrate a component on the client, but the renderer used does not provide a client entrypoint to use to hydrate.
  *
@@ -352,7 +352,7 @@ export const GetStaticPathsExpectedParams = {
  * ---
  * ```
  *
- * In routes using [rest parameters](https://docs.astro.build/en/core-concepts/routing/#rest-parameters), `undefined` can be used to represent a path with no parameters passed in the URL:
+ * In routes using [rest parameters](https://docs.astro.build/en/guides/routing/#rest-parameters), `undefined` can be used to represent a path with no parameters passed in the URL:
  *
  * ```astro title="/route/[...id].astro"
  * ---
@@ -376,18 +376,18 @@ export const GetStaticPathsInvalidRouteParam = {
 /**
  * @docs
  * @see
- * - [Dynamic Routes](https://docs.astro.build/en/core-concepts/routing/#dynamic-routes)
+ * - [Dynamic Routes](https://docs.astro.build/en/guides/routing/#dynamic-routes)
  * - [`getStaticPaths()`](https://docs.astro.build/en/reference/api-reference/#getstaticpaths)
  * - [Server-side Rendering](https://docs.astro.build/en/guides/server-side-rendering/)
  * @description
- * In [Static Mode](https://docs.astro.build/en/core-concepts/routing/#static-ssg-mode), all routes must be determined at build time. As such, dynamic routes must `export` a `getStaticPaths` function returning the different paths to generate.
+ * In [Static Mode](https://docs.astro.build/en/guides/routing/#static-ssg-mode), all routes must be determined at build time. As such, dynamic routes must `export` a `getStaticPaths` function returning the different paths to generate.
  */
 export const GetStaticPathsRequired = {
 	name: 'GetStaticPathsRequired',
 	title: '`getStaticPaths()` function required for dynamic routes.',
 	message:
 		'`getStaticPaths()` function is required for dynamic routes. Make sure that you `export` a `getStaticPaths` function from your dynamic route.',
-	hint: `See https://docs.astro.build/en/core-concepts/routing/#dynamic-routes for more information on dynamic routes.
+	hint: `See https://docs.astro.build/en/guides/routing/#dynamic-routes for more information on dynamic routes.
 
 Alternatively, set \`output: "server"\` or \`output: "hybrid"\` in your Astro config file to switch to a non-static server build. This error can also occur if using \`export const prerender = true;\`.
 See https://docs.astro.build/en/guides/server-side-rendering/ for more information on non-static rendering.`,
@@ -395,7 +395,7 @@ See https://docs.astro.build/en/guides/server-side-rendering/ for more informati
 /**
  * @docs
  * @see
- * - [Named slots](https://docs.astro.build/en/core-concepts/astro-components/#named-slots)
+ * - [Named slots](https://docs.astro.build/en/basics/astro-components/#named-slots)
  * @description
  * Certain words cannot be used for slot names due to being already used internally.
  */
@@ -468,7 +468,7 @@ export const InvalidComponentArgs = {
 /**
  * @docs
  * @see
- * - [Pagination](https://docs.astro.build/en/core-concepts/routing/#pagination)
+ * - [Pagination](https://docs.astro.build/en/guides/routing/#pagination)
  * @description
  * The page number parameter was not found in your filepath.
  */
@@ -896,9 +896,9 @@ export const RedirectWithNoLocation = {
 /**
  * @docs
  * @see
- * - [Dynamic routes](https://docs.astro.build/en/core-concepts/routing/#dynamic-routes)
+ * - [Dynamic routes](https://docs.astro.build/en/guides/routing/#dynamic-routes)
  * @description
- * A dynamic route param is invalid. This is often caused by an `undefined` parameter or a missing [rest parameter](https://docs.astro.build/en/core-concepts/routing/#rest-parameters).
+ * A dynamic route param is invalid. This is often caused by an `undefined` parameter or a missing [rest parameter](https://docs.astro.build/en/guides/routing/#rest-parameters).
  */
 export const InvalidDynamicRoute = {
 	name: 'InvalidDynamicRoute',

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1020,13 +1020,13 @@ export const MissingIndexForInternationalization = {
 /**
  * @docs
  * @description
- * Static pages aren't yet supported with i18n domains. If you wish to enable this feature, you have to disable pre-rendering.
+ * Static pages aren't yet supported with i18n domains. If you wish to enable this feature, you have to disable prerendering.
  */
 export const NoPrerenderedRoutesWithDomains = {
 	name: 'NoPrerenderedRoutesWithDomains',
-	title: "Pre-rendered routes aren't supported when internationalization domains are enabled.",
+	title: "Prerendered routes aren't supported when internationalization domains are enabled.",
 	message: (component: string) =>
-		`Static pages aren't yet supported with multiple domains. If you wish to enable this feature, you have to disable pre-rendering for the page ${component}`,
+		`Static pages aren't yet supported with multiple domains. If you wish to enable this feature, you have to disable prerendering for the page ${component}`,
 } satisfies ErrorData;
 
 /**


### PR DESCRIPTION
## Changes

We decided that prerender/ed/ing does NOT have a hyphen. This updates an error message to remove hyphens in this word.

... and, this now also updates for docs PR 6620 that changed some URLs round! (Config reference and error messages)

## Testing

No tests, just docs

## Docs

Docs!
