### PR TITLE
fix(NodeApp): fix responses with null bodies never completing

### DIFF
--- a/.changeset/sour-seas-hang.md
+++ b/.changeset/sour-seas-hang.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes a regression where a response created with `Response.redirect` or containing `null` as the body never completed in node-based adapters.

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -98,7 +98,7 @@ export class NodeApp extends App {
 	static async writeResponse(source: Response, destination: ServerResponse) {
 		const { status, headers, body } = source;
 		destination.writeHead(status, createOutgoingHttpHeaders(headers));
-		if (body) {
+		if (!body) return destination.end();
 			try {
 				const reader = body.getReader();
 				destination.on('close', () => {
@@ -123,7 +123,6 @@ export class NodeApp extends App {
 			} catch {
 				destination.end('Internal server error');
 			}
-		}
 	}
 }
 

--- a/packages/integrations/markdoc/package.json
+++ b/packages/integrations/markdoc/package.json
@@ -59,7 +59,7 @@
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test \"test/**/*.test.js\""
+    "test": "astro-scripts test --timeout 40000 \"test/**/*.test.js\""
   },
   "dependencies": {
     "@astrojs/internal-helpers": "workspace:*",

--- a/packages/integrations/node/test/api-route.test.js
+++ b/packages/integrations/node/test/api-route.test.js
@@ -147,7 +147,7 @@ describe('API routes', () => {
 			redirect: 'manual',
 			signal: controller.signal,
 		});
-		assert.equal(response.status, 302);
+		assert.equal(response.status, 307);
 		assert.equal(response.headers.get('location'), new URL('/destination', baseUri));
 	});
 });

--- a/packages/integrations/node/test/api-route.test.js
+++ b/packages/integrations/node/test/api-route.test.js
@@ -20,7 +20,7 @@ describe('API routes', () => {
 		});
 		await fixture.build();
 		previewServer = await fixture.preview();
-		baseUri = new URL(`http://${server.host ?? 'localhost'}:${server.port}/`);
+		baseUri = new URL(`http://${previewServer.host ?? 'localhost'}:${previewServer.port}/`);
 	});
 
 	after(() => previewServer.stop());
@@ -148,6 +148,6 @@ describe('API routes', () => {
 			signal: controller.signal,
 		});
 		assert.equal(response.status, 307);
-		assert.equal(response.headers.get('location'), new URL('/destination', baseUri));
+		assert.equal(response.headers.get('location'), String(new URL('/destination', baseUri)));
 	});
 });

--- a/packages/integrations/node/test/fixtures/api-route/src/pages/astro-redirect.astro
+++ b/packages/integrations/node/test/fixtures/api-route/src/pages/astro-redirect.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/destination', 303);
+---

--- a/packages/integrations/node/test/fixtures/api-route/src/pages/redirect.ts
+++ b/packages/integrations/node/test/fixtures/api-route/src/pages/redirect.ts
@@ -1,0 +1,5 @@
+import { APIContext } from 'astro';
+
+export async function GET({ redirect }: APIContext) {
+    return redirect('/destination');
+}

--- a/packages/integrations/node/test/fixtures/api-route/src/pages/response-redirect.ts
+++ b/packages/integrations/node/test/fixtures/api-route/src/pages/response-redirect.ts
@@ -1,0 +1,5 @@
+import { APIContext } from 'astro';
+
+export async function GET({ url: requestUrl }: APIContext) {
+    return Response.redirect(new URL('/destination', requestUrl), 307);
+}

--- a/packages/integrations/node/test/prerender.test.js
+++ b/packages/integrations/node/test/prerender.test.js
@@ -82,8 +82,7 @@ describe('Prerendering', () => {
 			});
 			const html = await res.text();
 			const $ = cheerio.load(html);
-			assert.equal(res.status, 301);
-			assert.equal(res.headers.get('location'), '/some-base/two/');
+			assert.equal(res.status, 200);
 			assert.equal($('h1').text(), 'Two');
 		});
 	});
@@ -171,8 +170,8 @@ describe('Prerendering', () => {
 			const html = await res.text();
 			const $ = cheerio.load(html);
 
-			expect(res.status).to.equal(200);
-			expect($('h1').text()).to.equal('One');
+			assert.equal(res.status, 200);
+			assert.equal($('h1').text(), 'One');
 		});
 
 		it('Can render prerendered route', async () => {
@@ -180,8 +179,8 @@ describe('Prerendering', () => {
 			const html = await res.text();
 			const $ = cheerio.load(html);
 
-			expect(res.status).to.equal(200);
-			expect($('h1').text()).to.equal('Two');
+			assert.equal(res.status, 200);
+			assert.equal($('h1').text(), 'Two');
 		});
 	});
 });
@@ -252,8 +251,9 @@ describe('Hybrid rendering', () => {
 			const res = await fetch(`http://${server.host}:${server.port}/some-base/one`, {
 				redirect: 'manual',
 			});
-			assert.equal(res.status, 301);
-			assert.equal(res.headers.get('location'), '/some-base/one/');
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal(res.status, 200);
 			assert.equal($('h1').text(), 'One');
 		});
 	});
@@ -342,8 +342,8 @@ describe('Hybrid rendering', () => {
 			const html = await res.text();
 			const $ = cheerio.load(html);
 
-			expect(res.status).to.equal(200);
-			expect($('h1').text()).to.equal('shared');
+			assert.equal(res.status, 200);
+			assert.equal($('h1').text(), 'shared');
 		});
 	});
 });


### PR DESCRIPTION
## Changes
- Fixes #9925

## Testing
- Added a test case for redirects, thanks @friedemannsommer.
- Adjusted a test introduced in #9908 to address flakiness.
- Cherry-picked #9930 to unbreak remaining tests.

## Docs
Does not affect usage.