### PR TITLE
fix: don't log warning if `i18nDomains` isn't enabled

### DIFF
--- a/.changeset/mean-pugs-nail.md
+++ b/.changeset/mean-pugs-nail.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes a case where a warning was logged even when the feature `i18nDomains` wasn't enabled

--- a/packages/astro/src/integrations/astroFeaturesValidation.ts
+++ b/packages/astro/src/integrations/astroFeaturesValidation.ts
@@ -70,7 +70,7 @@ export function validateSupportedFeatures(
 	);
 	validationResult.assets = validateAssetsFeature(assets, adapterName, config, logger);
 
-	if (i18nDomains && config.experimental.i18nDomains === true) {
+	if (i18nDomains && config?.experimental?.i18nDomains === true && !config.i18n?.domains) {
 		validationResult.i18nDomains = validateSupportKind(
 			i18nDomains,
 			adapterName,

--- a/packages/astro/src/integrations/astroFeaturesValidation.ts
+++ b/packages/astro/src/integrations/astroFeaturesValidation.ts
@@ -70,7 +70,7 @@ export function validateSupportedFeatures(
 	);
 	validationResult.assets = validateAssetsFeature(assets, adapterName, config, logger);
 
-	if (i18nDomains) {
+	if (i18nDomains && config.experimental.i18nDomains === true) {
 		validationResult.i18nDomains = validateSupportKind(
 			i18nDomains,
 			adapterName,


### PR DESCRIPTION
## Changes

This PR fixes a bug where an error log was incorrectly logged inside an adapter

## Testing

Manually tested

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
