### PR TITLE
fix: route matching for encoded pathnames

### DIFF
--- a/packages/astro/src/core/routing/match.ts
+++ b/packages/astro/src/core/routing/match.ts
@@ -13,5 +13,5 @@ export function matchRoute(pathname: string, manifest: ManifestData): RouteData 
 
 /** Finds all matching routes from pathname */
 export function matchAllRoutes(pathname: string, manifest: ManifestData): RouteData[] {
-	return manifest.routes.filter((route) => route.pattern.test(pathname));
+	return manifest.routes.filter((route) => route.pattern.test(decodeURI(pathname)));
 }


### PR DESCRIPTION
fix: #9933 

## Changes

Decode `pathnames` to check.

## Testing

I don't know where to add testcases.
Should I add in `dev-routing.test.js`? and also add in `preview-routing.test.js`?

## Docs

I don't think to update.
