### PR TITLE
fix semver check in CLI entrypoint

### DIFF
--- a/packages/astro/astro.js
+++ b/packages/astro/astro.js
@@ -20,8 +20,8 @@ async function main() {
 	const version = process.versions.node;
 	// Fast-path for higher Node.js versions
 	if ((parseInt(version) || 0) <= skipSemverCheckIfAbove) {
+		const semver = await import('semver');
 		try {
-			const semver = await import('semver');
 			if (!semver.satisfies(version, engines)) {
 				await errorNodeUnsupported();
 				return;


### PR DESCRIPTION
## Changes

- On a bad install, the user can get to a place where `semver` isn't installed
- This import would fail, even if the user's node version was correct

## Testing

- Manually tested

## Docs

- N/A