### PR TITLE
fix(middleware): load while retrieving ssr manifest for prerendering

### DIFF
--- a/.changeset/shaggy-sloths-mix.md
+++ b/.changeset/shaggy-sloths-mix.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes a regression where middleware did not run for prerendered pages and endpoints.

--- a/packages/astro/src/core/build/buildPipeline.ts
+++ b/packages/astro/src/core/build/buildPipeline.ts
@@ -125,6 +125,13 @@ export class BuildPipeline extends Pipeline {
 
 		const renderersEntryUrl = new URL(`renderers.mjs?time=${Date.now()}`, baseDirectory);
 		const renderers = await import(renderersEntryUrl.toString());
+		
+		const middleware = await import(new URL('middleware.mjs', baseDirectory).toString())
+			.then((mod) => mod.onRequest)
+			// middleware.mjs is not emitted if there is no user middleware
+			// in which case the import fails with ERR_MODULE_NOT_FOUND, and we fall back to a no-op middleware
+			.catch(() => manifest.middleware);
+		
 		if (!renderers) {
 			throw new Error(
 				"Astro couldn't find the emitted renderers. This is an internal error, please file an issue."
@@ -133,6 +140,7 @@ export class BuildPipeline extends Pipeline {
 		return {
 			...manifest,
 			renderers: renderers.renderers as SSRLoadedRenderer[],
+			middleware
 		};
 	}
 

--- a/packages/astro/test/fixtures/middleware space/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware space/src/middleware.js
@@ -40,6 +40,8 @@ const first = defineMiddleware(async (context, next) => {
 			status: 200,
 			headers: response.headers,
 		});
+	} else if (context.url.pathname === '/prerendered/') {
+		context.locals.canBeReadDuringPrerendering = "yes they can!";
 	} else {
 		if (context.url.pathname === '/') {
 			context.cookies.set('foo', 'bar');

--- a/packages/astro/test/fixtures/middleware space/src/pages/prerendered.astro
+++ b/packages/astro/test/fixtures/middleware space/src/pages/prerendered.astro
@@ -1,0 +1,4 @@
+---
+export const prerender = true
+---
+<p>{Astro.locals.canBeReadDuringPrerendering}</p>

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -278,6 +278,11 @@ describe('Middleware API in PROD mode, SSR', () => {
 		expect(response.headers.get('content-type')).equal('text/html');
 	});
 
+	it('can set locals for prerendered pages to use', async () => {
+		const text = await fixture.readFile("/client/prerendered/index.html")
+		expect(text.includes('<p>yes they can!</p>')).to.be.true;
+	})
+
 	// keep this last
 	it('the integration should receive the path to the middleware', async () => {
 		fixture = await loadFixture({


### PR DESCRIPTION
## Changes
- Fixes a regression introduced in #9776 (astro 4.2.5+)

## Testing
- Added a test case

## Docs
Does not affect usage.