### PR TITLE
chore(@astrojs/integrations/lit): use Node.js for testing

### DIFF
--- a/packages/integrations/lit/package.json
+++ b/packages/integrations/lit/package.json
@@ -39,7 +39,7 @@
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "mocha"
+    "test": "astro-scripts test \"test/**/*.test.js\""
   },
   "dependencies": {
     "@lit-labs/ssr": "^3.2.0",
@@ -55,10 +55,8 @@
   "devDependencies": {
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
-    "chai": "^4.3.7",
     "cheerio": "1.0.0-rc.12",
     "lit": "^3.1.0",
-    "mocha": "^10.2.0",
     "sass": "^1.69.5"
   },
   "peerDependencies": {

--- a/packages/integrations/lit/test/sass.test.js
+++ b/packages/integrations/lit/test/sass.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 
 describe('check', () => {
 	it('should be able to load sass', async () => {
@@ -9,6 +10,6 @@ describe('check', () => {
 		} catch (e) {
 			error = e;
 		}
-		expect(error).to.be.null;
+		assert.equal(error, null);
 	});
 });

--- a/packages/integrations/lit/test/server.test.js
+++ b/packages/integrations/lit/test/server.test.js
@@ -1,5 +1,6 @@
-import { expect } from 'chai';
 import { LitElement, html } from 'lit';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 // Must come after lit import because @lit/reactive-element defines
 // globalThis.customElements which the server shim expects to be defined.
 import server from '../server.js';
@@ -9,7 +10,7 @@ const { check, renderToStaticMarkup } = server;
 
 describe('check', () => {
 	it('should be false with no component', async () => {
-		expect(await check()).to.equal(false);
+		assert.equal(await check(), false);
 	});
 
 	it('should be false with a registered non-lit component', async () => {
@@ -19,13 +20,13 @@ describe('check', () => {
 			globalThis.HTMLElement = class {};
 		}
 		customElements.define(tagName, class TestComponent extends HTMLElement {});
-		expect(await check(tagName)).to.equal(false);
+		assert.equal(await check(tagName), false);
 	});
 
 	it('should be true with a registered lit component', async () => {
 		const tagName = 'lit-component';
 		customElements.define(tagName, class extends LitElement {});
-		expect(await check(tagName)).to.equal(true);
+		assert.equal(await check(tagName), true);
 	});
 });
 
@@ -35,7 +36,7 @@ describe('renderToStaticMarkup', () => {
 		try {
 			await renderToStaticMarkup(tagName);
 		} catch (e) {
-			expect(e).to.be.an.instanceOf(TypeError);
+			assert.equal(e instanceof TypeError, true);
 		}
 	});
 
@@ -43,7 +44,7 @@ describe('renderToStaticMarkup', () => {
 		const tagName = 'nothing-component';
 		customElements.define(tagName, class extends LitElement {});
 		const render = await renderToStaticMarkup(tagName);
-		expect(render).to.deep.equal({
+		assert.deepEqual(render, {
 			html: `<${tagName}><template shadowroot="open" shadowrootmode="open"><!--lit-part--><!--/lit-part--></template></${tagName}>`,
 		});
 	});
@@ -60,7 +61,7 @@ describe('renderToStaticMarkup', () => {
 		);
 		const render = await renderToStaticMarkup(tagName);
 		const $ = cheerio.load(render.html);
-		expect($(`${tagName} template`).html()).to.contain('<p>hola</p>');
+		assert.equal($(`${tagName} template`).html().includes('<p>hola</p>'), true);
 	});
 
 	it('should render component with properties and attributes', async () => {
@@ -86,8 +87,8 @@ describe('renderToStaticMarkup', () => {
 		);
 		const render = await renderToStaticMarkup(tagName, { prop1, attr1 });
 		const $ = cheerio.load(render.html);
-		expect($(tagName).attr('attr1')).to.equal(attr1);
-		expect($(`${tagName} template`).text()).to.contain(`Hello ${prop1}`);
+		assert.equal($(tagName).attr('attr1'), attr1);
+		assert.equal($(`${tagName} template`).text().includes(`Hello ${prop1}`), true);
 	});
 
 	it('should render nested components', async () => {
@@ -111,10 +112,10 @@ describe('renderToStaticMarkup', () => {
 		);
 		const render = await renderToStaticMarkup(tagName);
 		const $ = cheerio.load(render.html);
-		expect($(`${tagName} template`).text()).to.contain('child');
+		assert.equal($(`${tagName} template`).text().includes('child'), true);
 		// Child component should have `defer-hydration` attribute so it'll only
 		// hydrate after the parent hydrates
-		expect($(childTagName).attr('defer-hydration')).to.equal('');
+		assert.equal($(childTagName).attr('defer-hydration'), '');
 	});
 
 	it('should render DSD attributes based on shadowRootOptions', async () => {
@@ -126,7 +127,7 @@ describe('renderToStaticMarkup', () => {
 			}
 		);
 		const render = await renderToStaticMarkup(tagName);
-		expect(render).to.deep.equal({
+		assert.deepEqual(render, {
 			html: `<${tagName}><template shadowroot=\"open\" shadowrootmode=\"open\" shadowrootdelegatesfocus><!--lit-part--><!--/lit-part--></template></${tagName}>`,
 		});
 	});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3883,18 +3883,12 @@ importers:
       astro-scripts:
         specifier: workspace:*
         version: link:../../../scripts
-      chai:
-        specifier: ^4.3.7
-        version: 4.3.10
       cheerio:
         specifier: 1.0.0-rc.12
         version: 1.0.0-rc.12
       lit:
         specifier: ^3.1.0
         version: 3.1.0
-      mocha:
-        specifier: ^10.2.0
-        version: 10.2.0
       sass:
         specifier: ^1.69.5
         version: 1.69.6


### PR DESCRIPTION
## Changes

- This PR moves @astrojs/integrations/lit to use Node.js for testing
- See #9873 for details

## Testing

Tests should pass!

## Docs

No docs added as this only affects testing.
