### PR TITLE
Revert "Provide better ignores for Vercel's file tracer (#9885)"

### DIFF
--- a/.changeset/gold-ways-attend.md
+++ b/.changeset/gold-ways-attend.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vercel": patch
+---
+
+Fix regression with bundling of @libsql/client

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -55,7 +55,6 @@
     "@vercel/nft": "^0.24.3",
     "esbuild": "^0.19.6",
     "fast-glob": "^3.3.2",
-    "minimatch": "^9.0.3",
     "set-cookie-parser": "^2.6.0",
     "web-vitals": "^3.4.0"
   },

--- a/packages/integrations/vercel/src/lib/nft.ts
+++ b/packages/integrations/vercel/src/lib/nft.ts
@@ -2,14 +2,6 @@ import type { AstroIntegrationLogger } from 'astro';
 import { relative, relative as relativePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { copyFilesToFunction } from './fs.js';
-import { Minimatch } from 'minimatch';
-
-const matchers = [
-	// Never venture into OS folders
-	'/dev/**',
-	// libsql contains many native deps that are false-positives.
-	'**/@libsql/client/**/*',
-].map((pattern) => new Minimatch(pattern, { dot: true }));
 
 export async function copyDependenciesToFunction(
 	{
@@ -46,14 +38,7 @@ export async function copyDependenciesToFunction(
 		base: fileURLToPath(base),
 		// If you have a route of /dev this appears in source and NFT will try to
 		// scan your local /dev :8
-		ignore(path) {
-			for (const minimatch of matchers) {
-				if (minimatch.match(path)) {
-					return true;
-				}
-			}
-			return false;
-		},
+		ignore: ['/dev/**'],
 		cache,
 	});
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4708,9 +4708,6 @@ importers:
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
-      minimatch:
-        specifier: ^9.0.3
-        version: 9.0.3
       set-cookie-parser:
         specifier: ^2.6.0
         version: 2.6.0


### PR DESCRIPTION
This reverts commit 49e0c24d7f90d00e986533fcf546665967540ce7.

## Changes

This commit inadvertently preventing bundling of `@libsql/client` for some people that needed it. 3 reports so far, so reverting and figuring out a different approach to the warnings.

- Fixes https://github.com/withastro/astro/issues/9936
- Fixes https://github.com/withastro/astro/issues/9935

## Testing

N/A

## Docs

N/A