### PR TITLE
feat(markdoc): Add support for using a custom component for images

### DIFF
--- a/.changeset/shaggy-spies-sit.md
+++ b/.changeset/shaggy-spies-sit.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/markdoc": minor
+---
+
+Add support for using a custom component for images

--- a/.changeset/shaggy-spies-sit.md
+++ b/.changeset/shaggy-spies-sit.md
@@ -2,7 +2,7 @@
 "@astrojs/markdoc": minor
 ---
 
-Add support for using a custom tag (component) for optimized images.
+Adds support for using a custom tag (component) for optimized images
 
 Starting from this version, when a tag called `image` is used, its `src` attribute will automatically be resolved if it's a local image. Astro will pass the result `ImageMetadata` object to the underlying component as the `src` prop. For non-local images (i.e. images using URLs or absolute paths), Astro will continue to pass the `src` as a string.
 

--- a/.changeset/shaggy-spies-sit.md
+++ b/.changeset/shaggy-spies-sit.md
@@ -2,4 +2,40 @@
 "@astrojs/markdoc": minor
 ---
 
-Add support for using a custom component for images
+Add support for using a custom tag (component) for optimized images.
+
+Starting from this version, when a tag called `image` is used, its `src` attribute will automatically be resolved if it's a local image. Astro will pass the result `ImageMetadata` object to the underlying component as the `src` prop. For non-local images (i.e. images using URLs or absolute paths), Astro will continue to pass the `src` as a string.
+
+```ts
+// markdoc.config.mjs
+import { component, defineMarkdocConfig, nodes } from '@astrojs/markdoc/config';
+
+export default defineMarkdocConfig({
+	tags: {
+		image: {
+			attributes: nodes.image.attributes,
+			render: component('./src/components/MarkdocImage.astro'),
+		},
+	},
+});
+```
+```astro
+---
+// src/components/MarkdocImage.astro
+import { Image } from "astro:assets";
+
+interface Props {
+  src: ImageMetadata | string;
+  alt: string;
+  width: number;
+  height: number;
+}
+
+const { src, alt, width, height } = Astro.props;
+---
+
+<Image {src} {alt} {width} {height} />
+```
+```mdoc
+{% image src="./astro-logo.png" alt="Astro Logo" width="100" height="100" %}
+``````

--- a/packages/integrations/markdoc/test/fixtures/image-assets/markdoc.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/image-assets/markdoc.config.mjs
@@ -1,0 +1,10 @@
+import { component, defineMarkdocConfig, nodes } from '@astrojs/markdoc/config';
+
+export default defineMarkdocConfig({
+	tags: {
+		image: {
+			attributes: nodes.image.attributes,
+			render: component('./src/components/Image.astro'),
+		},
+	},
+});

--- a/packages/integrations/markdoc/test/fixtures/image-assets/src/components/Image.astro
+++ b/packages/integrations/markdoc/test/fixtures/image-assets/src/components/Image.astro
@@ -1,0 +1,22 @@
+---
+// src/components/MyImage.astro
+import type { ImageMetadata } from 'astro';
+import { Image } from 'astro:assets';
+type Props = {
+	src: string | ImageMetadata;
+	alt: string;
+};
+const { src, alt } = Astro.props;
+---
+{
+	typeof src === 'string' ? (
+		<img class="custom-styles" src={src} alt={alt} />
+	) : (
+		<Image class="custom-styles" {src} {alt} />
+	)
+}
+<style>
+	.custom-styles {
+		border: 1px solid red;
+	}
+</style>

--- a/packages/integrations/markdoc/test/fixtures/image-assets/src/content/docs/intro.mdoc
+++ b/packages/integrations/markdoc/test/fixtures/image-assets/src/content/docs/intro.mdoc
@@ -5,3 +5,5 @@
 ![Oar](../../assets/relative/oar.jpg) {% #relative %}
 
 ![Gray cityscape arial view](~/assets/alias/cityscape.jpg) {% #alias %}
+
+{% image src="../../assets/relative/oar.jpg" alt="oar" /%} {% #component %}

--- a/packages/integrations/markdoc/test/image-assets.test.js
+++ b/packages/integrations/markdoc/test/image-assets.test.js
@@ -51,6 +51,13 @@ describe('Markdoc - Image assets', () => {
 				/\/_image\?href=.*%2Fsrc%2Fassets%2Falias%2Fcityscape.jpg%3ForigWidth%3D420%26origHeight%3D280%26origFormat%3Djpg&f=webp/
 			);
 		});
+
+		it('passes images inside image tags to configured image component', async () => {
+			const res = await baseFixture.fetch('/');
+			const html = await res.text();
+			const { document } = parseHTML(html);
+			assert.equal(document.querySelector('#component > img')?.className, 'custom-styles');
+		});
 	});
 
 	describe('build', () => {
@@ -74,6 +81,13 @@ describe('Markdoc - Image assets', () => {
 			const html = await baseFixture.readFile('/index.html');
 			const { document } = parseHTML(html);
 			assert.match(document.querySelector('#alias > img')?.src, /^\/_astro\/cityscape.*\.webp$/);
+		});
+
+		it('passes images inside image tags to configured image component', async () => {
+			const html = await baseFixture.readFile('/index.html');
+			const { document } = parseHTML(html);
+			assert.equal(document.querySelector('#component > img')?.className, 'custom-styles');
+			assert.match(document.querySelector('#component > img')?.src, /^\/_astro\/oar.*\.webp$/);
 		});
 	});
 });


### PR DESCRIPTION
## Changes

Automatically resolve the `src` attribute on tags named `image`, as it's impossible to build a full image component using the native syntax (Markdoc does not allow attributes on image nodes, see https://github.com/markdoc/markdoc/issues/156)

Technically, it's possible for a plugin to make a full image component using the native syntax, by either modifying the AST manually, or modifying the parser, but it's honestly insanely cumbersome.

## Testing

Added a test

## Docs

Will do, it lives in another repo now, so annoying 😠 (I'm kidding)
