### PR TITLE
FIX: allow rss feeds to have an enclosure with length of 0

### DIFF
--- a/.changeset/tidy-spoons-suffer.md
+++ b/.changeset/tidy-spoons-suffer.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/rss": patch
+---
+
+Update validation to allow for enclosures to have a length of 0

--- a/.changeset/tidy-spoons-suffer.md
+++ b/.changeset/tidy-spoons-suffer.md
@@ -2,4 +2,4 @@
 "@astrojs/rss": patch
 ---
 
-Update validation to allow for enclosures to have a length of 0
+Allows `enclosure' to have a length of 0

--- a/packages/astro-rss/src/schema.ts
+++ b/packages/astro-rss/src/schema.ts
@@ -16,7 +16,7 @@ export const rssSchema = z.object({
 	enclosure: z
 		.object({
 			url: z.string(),
-			length: z.number().positive().int().finite(),
+			length: z.number().nonnegative().int().finite(),
 			type: z.string(),
 		})
 		.optional(),

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -227,4 +227,27 @@ describe('getRssString', () => {
 		}
 		chai.expect(error).to.be.null;
 	});
+
+	it('should not fail when an enclosure has a length of 0', async () => {
+		const str = awaitgetRssString({
+			title,
+			description,
+			items: [
+				{
+					title: 'Title',
+					pubDate: new Date().toISOString(),
+					description: 'Description',
+					link: '/link',
+					enclosure: {
+						url: '/enclosure',
+						length: 0,
+						type: 'audio/mpeg',
+					},
+				},
+			],
+			site,
+		});
+
+		chai.expect(str).to.not.throw;
+	});
 });

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -229,7 +229,7 @@ describe('getRssString', () => {
 	});
 
 	it('should not fail when an enclosure has a length of 0', async () => {
-		const str = awaitgetRssString({
+		const str = await getRssString({
 			title,
 			description,
 			items: [


### PR DESCRIPTION
## Changes

It allows for an `enclosure` in an RSS feed to have a length of `0`.

Reference on this change: https://www.rssboard.org/rss-profile#element-channel-item-enclosure:~:text=When%20an%20enclosure%27s%20size%20cannot%20be%20determined%2C%20a%20publisher%20SHOULD%20use%20a%20length%20of%200.


## Testing

Added unit test.

## Docs

It would be nice to point people to use a value of `0` for `enclosure` `length` if they are processing the images with Astro.

/cc @withastro/maintainers-docs