### PR TITLE
Fix an issue where ReadableStream wasn't canceled in dev mode

### DIFF
--- a/.changeset/thin-kangaroos-exist.md
+++ b/.changeset/thin-kangaroos-exist.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where ReadableStream wasn't canceled in dev mode

--- a/packages/astro/src/vite-plugin-astro-server/response.ts
+++ b/packages/astro/src/vite-plugin-astro-server/response.ts
@@ -82,6 +82,12 @@ export async function writeWebResponse(res: http.ServerResponse, webResponse: Re
 			res.write(body);
 		} else {
 			const reader = body.getReader();
+			res.on('close', () => {
+				reader.cancel().catch((error: unknown) => {
+					// eslint-disable-next-line no-console
+					console.error('An unexpected error occurred in the middle of the stream.', error);
+				});
+			});
 			while (true) {
 				const { done, value } = await reader.read();
 				if (done) break;


### PR DESCRIPTION
## Changes

- Applies the same fix from [#9071](https://github.com/withastro/astro/pull/9071) to `vite-plugin-astro-server`
- Closes #9698

## Testing

- Manually tested with the [minimal reproduction repo](https://github.com/pilcrowOnPaper/astro-readable-stream-bug) from [#9068](https://github.com/withastro/astro/issues/9068)
- I would need some help if tests are required 🙏

## Docs

- N/A
