### PR TITLE
fix(sitemap): url when rest parameter is used in page file names

### DIFF
--- a/.changeset/sour-ties-sparkle.md
+++ b/.changeset/sour-ties-sparkle.md
@@ -2,4 +2,4 @@
 "@astrojs/sitemap": patch
 ---
 
-Fixes URLs generation for routes using rest parameter
+Fixes URL generation for routes that rest parameters and start with `/`

--- a/.changeset/sour-ties-sparkle.md
+++ b/.changeset/sour-ties-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/sitemap": patch
+---
+
+Fix generating urls while rest parameter in page file names is used

--- a/.changeset/sour-ties-sparkle.md
+++ b/.changeset/sour-ties-sparkle.md
@@ -2,4 +2,4 @@
 "@astrojs/sitemap": patch
 ---
 
-Fix generating urls while rest parameter in page file names is used
+Fixes URLs generation for routes using rest parameter

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -94,6 +94,8 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 						.map((p) => {
 							if (p.pathname !== '' && !finalSiteUrl.pathname.endsWith('/'))
 								finalSiteUrl.pathname += '/';
+							if (p.pathname.startsWith('/'))
+								p.pathname = p.pathname.slice(1);
 							const fullPath = finalSiteUrl.pathname + p.pathname;
 							return new URL(fullPath, finalSiteUrl).href;
 						});

--- a/packages/integrations/sitemap/test/dynamic-path.test.js
+++ b/packages/integrations/sitemap/test/dynamic-path.test.js
@@ -1,0 +1,24 @@
+import {before, describe, it} from "node:test";
+import {loadFixture, readXML} from "./test-utils.js";
+import assert from "node:assert/strict";
+
+describe('Dynamic with rest parameter', () => {
+	/** @type {import('./test-utils.js').Fixture} */
+	let fixture;
+	
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/dynamic',
+		});
+		await fixture.build();
+	});
+	
+	it('Should generate correct urls', async () => {
+		const data = await readXML(fixture.readFile('/sitemap-0.xml'));
+		const urls = data.urlset.url.map((url) => url.loc[0]);
+		
+		assert.ok(urls.includes('http://example.com/'));
+		assert.ok(urls.includes('http://example.com/blog/'));
+		assert.ok(urls.includes('http://example.com/test/'));
+	});
+})

--- a/packages/integrations/sitemap/test/fixtures/dynamic/astro.config.mjs
+++ b/packages/integrations/sitemap/test/fixtures/dynamic/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
+
+export default defineConfig({
+  integrations: [sitemap()],
+	site: 'http://example.com'
+})

--- a/packages/integrations/sitemap/test/fixtures/dynamic/package.json
+++ b/packages/integrations/sitemap/test/fixtures/dynamic/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/sitemap-dynamic",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/sitemap": "workspace:*"
+  }
+}

--- a/packages/integrations/sitemap/test/fixtures/dynamic/src/pages/[...slug].astro
+++ b/packages/integrations/sitemap/test/fixtures/dynamic/src/pages/[...slug].astro
@@ -1,0 +1,21 @@
+---
+export async function getStaticPaths() {
+	return [
+		{
+			params: {
+				slug: undefined,
+			}
+		},
+		{
+			params: {
+				slug: '/blog'
+			}
+		},
+		{
+			params: {
+				slug: '/test'
+			}
+		}
+	];
+}
+---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4577,6 +4577,15 @@ importers:
         specifier: 0.6.2
         version: 0.6.2
 
+  packages/integrations/sitemap/test/fixtures/dynamic:
+    dependencies:
+      '@astrojs/sitemap':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/sitemap/test/fixtures/ssr:
     dependencies:
       '@astrojs/sitemap':


### PR DESCRIPTION
## Changes

* fixes the issue described here: #9946 

## Testing

* I've written unit tests here: `packages/integrations/sitemap/test/dynamic-path.test.js`

## Docs

No docs update required
