### PR TITLE
fix(i18n): match default locale correctly when it is removed because of `prefixDefaultLocale: false`

### DIFF
--- a/.changeset/silver-dolphins-cheer.md
+++ b/.changeset/silver-dolphins-cheer.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+fix: match default locale correctly when it is removed because of `prefixDefaultLocale: false`. Previously, the i18n middleware would match parts of the URL that were not actually a locale.

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -279,6 +279,28 @@ export function toPaths(locales: Locales): string[] {
 		}
 	});
 }
+/**
+ * Returns the pathname with a given locale either removed
+ * or optionally replaced. Does not touch parts of the
+ * pathname that look like a locale but aren’t
+ * @param pathname 
+ * @param localeToRemove 
+ * @param replacement 
+ */
+export function removeOrReplaceLocaleFromPathname(locale: string, pathname: string, replacement?: string) {
+	// We want to remove the default locale only when it is followed
+	// by `/` or nothing, not when it is part of a URL fragment, eg. 
+	// `/en/crypto/enigma` should not become 
+	// `/cryptoigma` if the default locale of `en` is stripped
+	const regex = new RegExp(`/${locale}(/|$)`)
+	let result
+	if (replacement) {
+		result = pathname.replace(regex, `$1${replacement}$1`)
+	} else {
+		result = pathname.replace(regex, '$1')
+	}
+	return result
+}
 
 function peekCodePathToUse(locales: Locales, locale: string): undefined | string {
 	for (const loopLocale of locales) {

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -287,17 +287,12 @@ export function toPaths(locales: Locales): string[] {
  * @param localeToRemove 
  * @param replacement 
  */
-export function removeOrReplaceLocaleFromPathname(locale: string, pathname: string, replacement?: string) {
-	// We want to remove the default locale only when it is followed
-	// by `/` or nothing, not when it is part of a URL fragment, eg. 
-	// `/en/crypto/enigma` should not become 
-	// `/cryptoigma` if the default locale of `en` is stripped
-	const regex = new RegExp(`/${locale}(/|$)`)
+export function removeOrReplaceLocaleFromPathname(localeRegex: RegExp, pathname: string, replacement?: string) {
 	let result
 	if (replacement) {
-		result = pathname.replace(regex, `$1${replacement}$1`)
+		result = pathname.replace(localeRegex, `$1${replacement}$1`)
 	} else {
-		result = pathname.replace(regex, '$1')
+		result = pathname.replace(localeRegex, '$1')
 	}
 	return result
 }
@@ -324,9 +319,9 @@ class Unreachable extends Error {
 	constructor() {
 		super(
 			'Astro encountered an unexpected line of code.\n' +
-				'In most cases, this is not your fault, but a bug in astro code.\n' +
-				"If there isn't one already, please create an issue.\n" +
-				'https://astro.build/issues'
+			'In most cases, this is not your fault, but a bug in astro code.\n' +
+			"If there isn't one already, please create an issue.\n" +
+			'https://astro.build/issues'
 		);
 	}
 }

--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -7,7 +7,7 @@ import type {
 	SSRManifest,
 } from '../@types/astro.js';
 import type { PipelineHookFunction } from '../core/pipeline.js';
-import { getPathByLocale, normalizeTheLocale } from './index.js';
+import { getPathByLocale, normalizeTheLocale, removeOrReplaceLocaleFromPathname } from './index.js';
 import { shouldAppendForwardSlash } from '../core/build/util.js';
 import { ROUTE_DATA_SYMBOL } from '../core/constants.js';
 import type { SSRManifestI18n } from '../core/app/types.js';
@@ -65,9 +65,9 @@ export function createI18nMiddleware(
 	};
 
 	const prefixOtherLocales = (url: URL, response: Response): Response | undefined => {
-		const pathnameContainsDefaultLocale = url.pathname.includes(`/${i18n.defaultLocale}`);
+		const pathnameContainsDefaultLocale = url.pathname.split('/').includes(i18n.defaultLocale);
 		if (pathnameContainsDefaultLocale) {
-			const newLocation = url.pathname.replace(`/${i18n.defaultLocale}`, '');
+			const newLocation = removeOrReplaceLocaleFromPathname(i18n.defaultLocale, url.pathname)
 			response.headers.set('Location', newLocation);
 			return new Response(null, {
 				status: 404,
@@ -193,9 +193,9 @@ export function createI18nMiddleware(
 					// If a locale falls back to the default locale, we want to **remove** the locale because
 					// the default locale doesn't have a prefix
 					if (pathFallbackLocale === defaultLocale && routing === 'pathname-prefix-other-locales') {
-						newPathname = url.pathname.replace(`/${urlLocale}`, ``);
+						newPathname = removeOrReplaceLocaleFromPathname(urlLocale, url.pathname)
 					} else {
-						newPathname = url.pathname.replace(`/${urlLocale}`, `/${pathFallbackLocale}`);
+						newPathname = removeOrReplaceLocaleFromPathname(urlLocale, url.pathname, pathFallbackLocale);
 					}
 
 					return context.redirect(newPathname);

--- a/packages/astro/test/fixtures/i18n-routing-prefix-other-locales/src/pages/spanish/enigma.astro
+++ b/packages/astro/test/fixtures/i18n-routing-prefix-other-locales/src/pages/spanish/enigma.astro
@@ -1,0 +1,13 @@
+---
+const currentLocale = Astro.currentLocale;
+---
+<html>
+<head>
+	<title>Astro Enigma</title>
+</head>
+<body>
+Espanol
+Current Locale: {currentLocale ? currentLocale : "none"}
+Astro Enigma
+</body>
+</html>

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -218,6 +218,14 @@ describe('[DEV] i18n routing', () => {
 			expect(await response2.text()).includes('Hello world');
 		});
 
+		it('should only match the default locale string in URLs where it is actually used as a locale', async () => {
+			// It should _not_ match `/en` from `/spanish/enigma` 
+			// and should respond with a 200
+			const response = await fixture.fetch('/new-site/spanish/enigma');
+			expect(response.status).to.equal(200);
+			expect(await response.text()).includes('Astro Enigma');
+		});
+
 		it('should return 404 when route contains the default locale', async () => {
 			const response = await fixture.fetch('/new-site/en/start');
 			expect(response.status).to.equal(404);
@@ -699,6 +707,19 @@ describe('[SSG] i18n routing', () => {
 				// success
 				return true;
 			}
+		});
+
+		it('should only match the default locale string in URLs where it is actually used as a locale', async () => {
+			// It should _not_ match `/en` from `/spanish/enigma` 
+			// and should respond with a 200
+			let html = ''
+			try {
+				html = await fixture.readFile('/spanish/enigma/index.html');
+			} catch {
+				// catch block just here so the test can fail cleanly
+			}
+			let $ = cheerio.load(html);
+			expect($('body').text()).includes('Astro Enigma');
 		});
 	});
 
@@ -1215,6 +1236,15 @@ describe('[SSR] i18n routing', () => {
 			let request = new Request('http://example.com/new-site/fr/start');
 			let response = await app.render(request);
 			expect(response.status).to.equal(404);
+		});
+
+		it('should only match the default locale string in URLs where it is actually used as a locale', async () => {
+			// It should _not_ match `/en` from `/spanish/enigma` 
+			// and should respond with a 200
+			let request = new Request('http://example.com/new-site/spanish/enigma');
+			let response = await app.render(request);
+			expect(response.status).to.equal(200);
+			expect(await response.text()).includes('Astro Enigma');
 		});
 	});
 

--- a/packages/astro/test/units/i18n/astro_i18n.test.js
+++ b/packages/astro/test/units/i18n/astro_i18n.test.js
@@ -3,6 +3,7 @@ import {
 	getLocaleRelativeUrlList,
 	getLocaleAbsoluteUrl,
 	getLocaleAbsoluteUrlList,
+	removeOrReplaceLocaleFromPathname
 } from '../../../dist/i18n/index.js';
 import { parseLocale } from '../../../dist/core/render/context.js';
 import { expect } from 'chai';
@@ -1777,5 +1778,29 @@ describe('parse accept-header', () => {
 		expect(parseLocale('fr;q=1000')).to.have.deep.members([
 			{ locale: 'fr', qualityValue: undefined },
 		]);
+	});
+});
+
+describe('remove or replace locale in pathname', () => {
+	it('should remove the locale if it is the entire pathname', () => {
+		const result = removeOrReplaceLocaleFromPathname('en', '/en')
+		expect(result).to.eq('')
+	});
+	it('should remove the locale if it is part of a longer pathname', () => {
+		const result = removeOrReplaceLocaleFromPathname('en', '/en/introduction')
+		expect(result).to.eq('/introduction')
+	});
+	it('should remove the locale if it is doesn’t occur at the start of a longer pathname', () => {
+		const result = removeOrReplaceLocaleFromPathname('en', '/documentation/en/introduction')
+		expect(result).to.eq('/documentation/introduction')
+	});
+	it('should not remove the locale if it occurs as part of an unrelated fragment', () => {
+		// Should not touch the `/en` from `/energy`
+		const result = removeOrReplaceLocaleFromPathname('en', '/en/departments/energy')
+		expect(result).to.eq('/departments/energy')
+	});
+	it('should correctly replace the locale if a replacement is specified', () => {
+		const result = removeOrReplaceLocaleFromPathname('en', '/en/departments/energy', 'de')
+		expect(result).to.eq('/de/departments/energy')
 	});
 });

--- a/packages/astro/test/units/i18n/astro_i18n.test.js
+++ b/packages/astro/test/units/i18n/astro_i18n.test.js
@@ -1783,24 +1783,24 @@ describe('parse accept-header', () => {
 
 describe('remove or replace locale in pathname', () => {
 	it('should remove the locale if it is the entire pathname', () => {
-		const result = removeOrReplaceLocaleFromPathname('en', '/en')
+		const result = removeOrReplaceLocaleFromPathname(/\/en(\/|$)/, '/en')
 		expect(result).to.eq('')
 	});
 	it('should remove the locale if it is part of a longer pathname', () => {
-		const result = removeOrReplaceLocaleFromPathname('en', '/en/introduction')
+		const result = removeOrReplaceLocaleFromPathname(/\/en(\/|$)/, '/en/introduction')
 		expect(result).to.eq('/introduction')
 	});
 	it('should remove the locale if it is doesn’t occur at the start of a longer pathname', () => {
-		const result = removeOrReplaceLocaleFromPathname('en', '/documentation/en/introduction')
+		const result = removeOrReplaceLocaleFromPathname(/\/en(\/|$)/, '/documentation/en/introduction')
 		expect(result).to.eq('/documentation/introduction')
 	});
 	it('should not remove the locale if it occurs as part of an unrelated fragment', () => {
 		// Should not touch the `/en` from `/energy`
-		const result = removeOrReplaceLocaleFromPathname('en', '/en/departments/energy')
+		const result = removeOrReplaceLocaleFromPathname(/\/en(\/|$)/, '/en/departments/energy')
 		expect(result).to.eq('/departments/energy')
 	});
 	it('should correctly replace the locale if a replacement is specified', () => {
-		const result = removeOrReplaceLocaleFromPathname('en', '/en/departments/energy', 'de')
+		const result = removeOrReplaceLocaleFromPathname(/\/en(\/|$)/, '/en/departments/energy', 'de')
 		expect(result).to.eq('/de/departments/energy')
 	});
 });


### PR DESCRIPTION
## Changes

Fixes the following i18n middleware bug:

**Bug description:** when the i18n router is in its default setting of `prefixDefaultLocale: false`, the default locale is detected and removed from the `url.pathname` too agressively, breaking URLs in which the default locale string appears as part of non-locale URL fragments, eg. `/en` appearing in `/enigma`.

**Examples** current buggy behaviour with a default locale of `en`:

- `/en/test` becomes `/test`, this is correct ✅
- `/en/random/encounter` becomes `/random/encounter`, this is also correct ✅
- `/random/encounter` becomes `/randomcounter`, this is obviously false ❌
- `/de/test/entwicklung` becomes `/de/testtwicklung`, this URL should not be touched at all, since it doesn’t actually contain the `/en` locale ❌

This can be demonstrated with a curl request against such a route:

```bash
▸ curl -vI http://localhost:4321/de/softwareentwicklung/entwicklung
*   Trying 127.0.0.1:4321...
* connect to 127.0.0.1 port 4321 failed: Connection refused
*   Trying [::1]:4321...
* Connected to localhost (::1) port 4321 (#0)
> HEAD /de/softwareentwicklung/entwicklung HTTP/1.1
> Host: localhost:4321
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 404 Not Found
< Access-Control-Allow-Origin: *
< content-type: text/html
< location: /de/softwareentwicklungtwicklung
< Date: Wed, 31 Jan 2024 09:30:58 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
```

The response location value of `/de/softwareentwicklungtwicklung` indicates that the default locale is matched incorrectly, since the same method is used to determine whether to respond with `404` (`pathnameContainsDefaultLocale`) and how to modify the `location` in the repsonse (`newLocation`).

The fix requires modifying two parts of the i18n middleware:
- The detection of whether the `url.pathname` actually contains the default locale _as a locale_, the simplest way was to do `pathname.split('/').includes(localeString)`. There is another method doing a similar thing, `pathnameHasLocale`, but this explicitly _shouldn’t_ match the default locale, not exactly sure why or whether it actually does. So not touching that for now.
- Correct removal of the default locale for the response `location`, in this case, using a Regex was easier.

Since Astro explicitly allows locales to be in arbitrary positions in a route ("The localized folders do not need to be at the root of the /pages/ folder.", [source](https://docs.astro.build/en/guides/internationalization/#configure-i18n-routing)), simply matching the default locale at the start of the `url.pathname` is insufficient. We only want to match the default locale when it is followed by `/` or nothing, regardless of where in the pathname it is. 

This fix does that.

## Testing

Adds tests for the i18n middleware (and modifies a fixture), and also adds unit tests for the new `removeOrReplaceLocaleFromPathname()` utility. 

## Docs

No docs changed or added because it just works as you would expect it to now. 
