### PR TITLE
Fix flaky streaming test

### DIFF
--- a/packages/astro/test/fixtures/streaming/src/pages/slot.astro
+++ b/packages/astro/test/fixtures/streaming/src/pages/slot.astro
@@ -15,7 +15,7 @@ import Wait from '../components/Wait.astro';
 				<p>Section content</p>
 			</Wait>
 			<h2>Next section</h2>
-			<Wait ms={60}>
+			<Wait ms={100}>
 				<p>Section content</p>
 			</Wait>
 			<p>Paragraph 3</p>


### PR DESCRIPTION
## Changes

Because components that are sibilings are rendered in parallel, the slot streaming tests we use runs with a timeout of `50` and `60`, making only a 10ms gap for the chunk separation, which I _think_ is what makes the macos-14 test keep failing. I extended the `60` to `100` so each wait has a 50ms gap.

I hope this fixes it 😄 

## Testing

Ran the local tests a bunch of times.

## Docs

n/a. test fix.
