### PR TITLE
Fix bundle size script external for dev toolbar

### DIFF
--- a/.github/scripts/bundle-size.mjs
+++ b/.github/scripts/bundle-size.mjs
@@ -68,7 +68,7 @@ async function bundle(files) {
 		sourcemap: false,
 		target: ['es2018'],
 		outdir: 'out',
-		external: ['astro:*'],
+		external: ['astro:*', 'aria-query', 'axobject-query'],
 		metafile: true,
 	})
 


### PR DESCRIPTION
## Changes

Our bundle size script has been failing on:

```
Error: R] Could not resolve "aria-query"

    main/packages/astro/src/runtime/client/dev-toolbar/apps/audit/a11y.ts:27:28:
      27 │ import { aria, roles } from 'aria-query';
         ╵                             ~~~~~~~~~~~~

  You can mark the path "aria-query" as external to exclude it from the bundle, which will remove this error and leave the unresolved path in the bundle.

Error: R] Could not resolve "axobject-query"

    main/packages/astro/src/runtime/client/dev-toolbar/apps/audit/a11y.ts:29:48:
      29 │ import { AXObjectRoles, elementAXObjects } from 'axobject-query';
         ╵                                                 ~~~~~~~~~~~~~~~~

  You can mark the path "axobject-query" as external to exclude it from the bundle, which will remove this error and leave the unresolved path in the bundle.
```

I added those to external to fix it.

## Testing

n/a. Can't test locally, but should work.

## Docs

n/a.