### PR TITLE
fix(i18n): fix regression in current locale

### DIFF
--- a/.changeset/shy-wolves-ring.md
+++ b/.changeset/shy-wolves-ring.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes bug in `Astro.currentLocale` wasn't returning the correct locale when a locale is configured via `path`
+Fixes a bug in `Astro.currentLocale` that wasn't returning the correct locale when a locale is configured via `path`

--- a/.changeset/shy-wolves-ring.md
+++ b/.changeset/shy-wolves-ring.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes bug in `Astro.currentLocale` wasn't returning the correct locale when a locale is configured via `path`

--- a/.changeset/six-fishes-beg.md
+++ b/.changeset/six-fishes-beg.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an regression in `Astro.currentLocale`, where it stopped working properly with dynamic routes

--- a/.changeset/six-fishes-beg.md
+++ b/.changeset/six-fishes-beg.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes an regression in `Astro.currentLocale`, where it stopped working properly with dynamic routes
+Fixes a regression in `Astro.currentLocale` where it stopped working properly with dynamic routes

--- a/packages/astro/test/fixtures/i18n-routing/src/pages/blog/[...lang]/index.astro
+++ b/packages/astro/test/fixtures/i18n-routing/src/pages/blog/[...lang]/index.astro
@@ -1,0 +1,22 @@
+---
+const currentLocale = Astro.currentLocale;
+
+
+export async function getStaticPaths() {
+	return [
+		{ params: { lang: undefined } },
+		{ params: { lang: 'es' } }
+	]
+}
+
+---
+
+
+<html>
+<head>
+	<title>Astro</title>
+</head>
+<body>
+Current Locale: {currentLocale ? currentLocale : "none"}
+</body>
+</html>

--- a/packages/astro/test/fixtures/i18n-routing/src/pages/spanish/index.astro
+++ b/packages/astro/test/fixtures/i18n-routing/src/pages/spanish/index.astro
@@ -1,0 +1,13 @@
+---
+const currentLocale = Astro.currentLocale;
+
+---
+
+<html>
+<head>
+	<title>Astro</title>
+</head>
+<body>
+Current Locale: {currentLocale ? currentLocale : "none"}
+</body>
+</html>

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -1589,7 +1589,6 @@ describe('[SSR] i18n routing', () => {
 				let request = new Request('http://example.com/blog/es', {});
 				let response = await app.render(request);
 				let text = await response.text();
-				console.log('text', text);
 				expect(response.status).to.equal(200);
 				// expect(await response.text()).includes('Current Locale: en');
 			});

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -52,7 +52,6 @@ describe('astro:i18n virtual module', () => {
 			let html = await response.text();
 			let $ = cheerio.load(html);
 
-			console.log(html);
 			expect($('body').text()).includes("Virtual module doesn't break");
 			expect($('body').text()).includes('Absolute URL pt: https://example.pt/about');
 			expect($('body').text()).includes('Absolute URL it: http://it.example.com/');
@@ -1005,6 +1004,67 @@ describe('[SSG] i18n routing', () => {
 			expect(html).to.include('Redirecting to: /new-site/');
 		});
 	});
+
+	describe('current locale', () => {
+		describe('with [prefix-other-locales]', () => {
+			/** @type {import('./test-utils').Fixture} */
+			let fixture;
+
+			before(async () => {
+				fixture = await loadFixture({
+					root: './fixtures/i18n-routing/',
+				});
+				await fixture.build();
+			});
+
+			it('should return the default locale', async () => {
+				const html = await fixture.readFile('/current-locale/index.html');
+				expect(html).includes('Current Locale: en');
+			});
+
+			it('should return the default locale when rendering a route with spread operator', async () => {
+				const html = await fixture.readFile('/blog/es/index.html');
+				expect(html).includes('Current Locale: es');
+			});
+
+			it('should return the default locale of the current URL', async () => {
+				const html = await fixture.readFile('/pt/start/index.html');
+				expect(html).includes('Current Locale: pt');
+			});
+
+			it('should return the default locale when a route is dynamic', async () => {
+				const html = await fixture.readFile('/dynamic/lorem/index.html');
+				expect(html).includes('Current Locale: en');
+			});
+
+			it('should returns the correct locale when requesting a locale via path', async () => {
+				const html = await fixture.readFile('/spanish/index.html');
+				expect(html).includes('Current Locale: es');
+			});
+		});
+
+		describe('with [pathname-prefix-always]', () => {
+			/** @type {import('./test-utils').Fixture} */
+			let fixture;
+
+			before(async () => {
+				fixture = await loadFixture({
+					root: './fixtures/i18n-routing-prefix-always/',
+				});
+				await fixture.build();
+			});
+
+			it('should return the locale of the current URL (en)', async () => {
+				const html = await fixture.readFile('/en/start/index.html');
+				expect(html).includes('Current Locale: en');
+			});
+
+			it('should return the locale of the current URL (pt)', async () => {
+				const html = await fixture.readFile('/pt/start/index.html');
+				expect(html).includes('Current Locale: pt');
+			});
+		});
+	});
 });
 describe('[SSR] i18n routing', () => {
 	let app;
@@ -1523,6 +1583,15 @@ describe('[SSR] i18n routing', () => {
 				let response = await app.render(request);
 				expect(response.status).to.equal(200);
 				expect(await response.text()).includes('Current Locale: en');
+			});
+
+			it('should return the default locale when rendering a route with spread operator', async () => {
+				let request = new Request('http://example.com/blog/es', {});
+				let response = await app.render(request);
+				let text = await response.text();
+				console.log('text', text);
+				expect(response.status).to.equal(200);
+				// expect(await response.text()).includes('Current Locale: en');
 			});
 
 			it('should return the default locale of the current URL', async () => {

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -1588,9 +1588,8 @@ describe('[SSR] i18n routing', () => {
 			it('should return the default locale when rendering a route with spread operator', async () => {
 				let request = new Request('http://example.com/blog/es', {});
 				let response = await app.render(request);
-				let text = await response.text();
 				expect(response.status).to.equal(200);
-				// expect(await response.text()).includes('Current Locale: en');
+				expect(await response.text()).includes('Current Locale: es');
 			});
 
 			it('should return the default locale of the current URL', async () => {


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/9970

I reverted the change to use `pathname` instead for `RouteData::route`.`.route` contains the actual name of the file e.g. `/blog/[...locale`, which is not what I needed.

So, I reverted the code to use `RouteData::pathname` first and then `URL::pathname` in the former isn't present. `RouteData::pathname` covers SSR cases.

This PR also fixes another issue where `Astro.currentLocale` wasn't returning the correct value in case a locale is configured using the `path` property

## Testing

I added new test cases.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
