### PR TITLE
Refine content collection warnings

### DIFF
--- a/.changeset/hip-hotels-divide.md
+++ b/.changeset/hip-hotels-divide.md
@@ -2,6 +2,6 @@
 "astro": minor
 ---
 
-Remove content collection warning when a configured collection does not have a matching directory name. This should resolve `i18n` collection warnings for Starlight users.
+Removes content collection warning when a configured collection does not have a matching directory name. This should resolve `i18n` collection warnings for Starlight users.
 
 This also ensures configured collection names are always included in `getCollection()` and `getEntry()` types even when a matching directory is absent. We hope this allows users to discover typos during development by surfacing type information.

--- a/.changeset/hip-hotels-divide.md
+++ b/.changeset/hip-hotels-divide.md
@@ -1,0 +1,7 @@
+---
+"astro": minor
+---
+
+Remove content collection warning when a configured collection does not have a matching directory name. This should resolve `i18n` collection warnings for Starlight users.
+
+This also ensures configured collection names are always included in `getCollection()` and `getEntry()` types even when a matching directory is absent. We hope this allows users to discover typos during development by surfacing type information.

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -62,7 +62,9 @@ export function createGetCollection({
 		} else {
 			// eslint-disable-next-line no-console
 			console.warn(
-				`The collection **${collection}** does not exist or is empty. Ensure a collection directory with this name exists.`
+				`The collection ${JSON.stringify(
+					collection
+				)} does not exist or is empty. Ensure a collection directory with this name exists.`
 			);
 			return;
 		}

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -312,13 +312,6 @@ export async function createContentTypesGenerator({
 				viteServer,
 			});
 			invalidateVirtualMod(viteServer);
-			if (observable.status === 'loaded') {
-				warnNonexistentCollections({
-					logger,
-					contentConfig: observable.config,
-					collectionEntryMap,
-				});
-			}
 		}
 	}
 	return { init, queueEvent };
@@ -454,25 +447,4 @@ async function writeContentFiles({
 		new URL(CONTENT_TYPES_FILE, contentPaths.cacheDir),
 		typeTemplateContent
 	);
-}
-
-function warnNonexistentCollections({
-	contentConfig,
-	collectionEntryMap,
-	logger,
-}: {
-	contentConfig: ContentConfig;
-	collectionEntryMap: CollectionEntryMap;
-	logger: Logger;
-}) {
-	for (const configuredCollection in contentConfig.collections) {
-		if (!collectionEntryMap[JSON.stringify(configuredCollection)]) {
-			logger.warn(
-				'content',
-				`The ${bold(configuredCollection)} collection is defined but no ${bold(
-					'content/' + configuredCollection
-				)} folder exists in the content directory. Create a new folder for the collection, or check your content configuration file for typos.`
-			);
-		}
-	}
 }

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -363,6 +363,9 @@ async function writeContentFiles({
 }) {
 	let contentTypesStr = '';
 	let dataTypesStr = '';
+	for (const [collection, config] of Object.entries(contentConfig?.collections ?? {})) {
+		collectionEntryMap[JSON.stringify(collection)] ??= { type: config.type, entries: {} };
+	}
 	for (const collectionKey of Object.keys(collectionEntryMap).sort()) {
 		const collectionConfig = contentConfig?.collections[JSON.parse(collectionKey)];
 		const collection = collectionEntryMap[collectionKey];

--- a/packages/astro/test/fixtures/content-collections/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections/src/content/config.ts
@@ -31,4 +31,5 @@ export const collections = {
 	'with-custom-slugs': withCustomSlugs,
 	'with-schema-config': withSchemaConfig,
 	'with-union-schema': withUnionSchema,
+	'garbo': withUnionSchema,
 }

--- a/packages/astro/test/fixtures/content-collections/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections/src/content/config.ts
@@ -31,5 +31,4 @@ export const collections = {
 	'with-custom-slugs': withCustomSlugs,
 	'with-schema-config': withSchemaConfig,
 	'with-union-schema': withUnionSchema,
-	'garbo': withUnionSchema,
 }


### PR DESCRIPTION
## Changes

Starlight users have struggled with a warning message for the `i18n` collection:

> [WARN] [content] The **i18n** collection is defined but no content/i18n folder exists in the content directory. Create a new folder for the collection, or check your content configuration file for typos.

This warning was initially added to prevent typos between your configured collection name and the *actual* directory name. Even so, warning logs are easily lost during development. [This GitHub discussion describes hours lost](https://github.com/withastro/roadmap/discussions/817#discussioncomment-8211622) due to this. 

What we want is some indicator during development that there's a mismatch, without excessive console warnings. We landed here:
1. We should **remove the warning** for a configured collection that lacks a directory.
2. **Add type generation** for a configured collection even when the directory _doesn't_ exist. As that discussion above notes, they may have caught their typo sooner if generated types included their misconfigured directory. "Huh, why do I see both `article` and `articles` in my intellisense? Ah, probably a typo."

**Code changes**

- Remove "may be a typo" warning when a configured collection lacks a matching directory
- Respect configured collections in generated types, even when a matching directory DNE

## Testing

N/A - type change only

## Docs

N/A