### PR TITLE
Fix: support `strict()` on content collection schemas when `slug` is present

### DIFF
--- a/.changeset/strong-pets-rhyme.md
+++ b/.changeset/strong-pets-rhyme.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Support `.strict()` on content collection schemas when a custom `slug` is present.

--- a/.changeset/strong-pets-rhyme.md
+++ b/.changeset/strong-pets-rhyme.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Support `.strict()` on content collection schemas when a custom `slug` is present.
+Adds support for `.strict()` on content collection schemas when a custom `slug` is present.

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -126,7 +126,7 @@ export async function getEntryData(
 
 		// Use `safeParseAsync` to allow async transforms
 		let formattedError;
-		const parsed = await (schema as z.ZodSchema).safeParseAsync(entry.unvalidatedData, {
+		const parsed = await (schema as z.ZodSchema).safeParseAsync(data, {
 			errorMap(error, ctx) {
 				if (error.code === 'custom' && error.params?.isHoistedAstroError) {
 					formattedError = error.params?.astroError;

--- a/packages/astro/test/fixtures/content-collections/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections/src/content/config.ts
@@ -1,7 +1,8 @@
 import { z, defineCollection } from 'astro:content';
 
 const withCustomSlugs = defineCollection({
-	schema: z.object({}),
+	// Ensure schema passes even when `slug` is present
+	schema: z.object({}).strict(),
 });
 
 const withSchemaConfig = defineCollection({


### PR DESCRIPTION
## Changes

Resolves #8871

Support `strict()` extension on content collection schemas when `slug` is present. Before, we would accidentally parse `slug` with the user's content schema.

## Testing

- Add `.strict()` to the content collection slug fixture

## Docs

N/A