### PR TITLE
chore(ci): run check merge only within the org

### DIFF
--- a/.github/workflows/check-merge.yml
+++ b/.github/workflows/check-merge.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'withastro' }}
     steps:
       - name: Check if there is already a block on this PR
         id: blocked


### PR DESCRIPTION
## Changes
- When contributors have a PR for a `semver: minor` feature, check-merge fails.

## Testing
Does not affect behavior.

## Docs
Does not affect usage.