### PR TITLE
feat(audits): Add initial perf audits

### DIFF
--- a/.github/workflows/test-hosts.yml
+++ b/.github/workflows/test-hosts.yml
@@ -2,7 +2,7 @@ name: Hosted tests
 
 on:
   schedule:
-    - cron:  '0 0 * * 0'
+    - cron: '0 0 * * 0'
 
 env:
   ASTRO_TELEMETRY_DISABLED: true
@@ -28,24 +28,21 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: "pnpm"
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install
-      
+
       - name: Build Astro
-        run: pnpm turbo build --filter astro --filter @astrojs/vercel 
+        run: pnpm turbo build --filter astro --filter @astrojs/vercel
 
       - name: Build test project
         working-directory: ./packages/integrations/vercel/test/hosted/hosted-astro-project
-        run:
-          pnpm run build
-      
+        run: pnpm run build
+
       - name: Deploy to Vercel
         working-directory: ./packages/integrations/vercel/test/hosted/hosted-astro-project
-        run:
-          pnpm dlx vercel --prod --prebuilt
+        run: pnpm dlx vercel --prod --prebuilt
 
       - name: Test
-        run:
-          pnpm run test:e2e:hosts
+        run: pnpm run test:e2e:hosts

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ package-lock.json
 *.env
 
 packages/astro/src/**/*.prebuilt.ts
+packages/astro/src/**/*.prebuilt-dev.ts
 !packages/astro/vendor/vite/dist
 packages/integrations/**/.netlify/
 

--- a/packages/astro/components/Image.astro
+++ b/packages/astro/components/Image.astro
@@ -29,6 +29,10 @@ const additionalAttributes: HTMLAttributes<'img'> = {};
 if (image.srcSet.values.length > 0) {
 	additionalAttributes.srcset = image.srcSet.attribute;
 }
+
+if (import.meta.env.DEV) {
+    additionalAttributes['data-image-component'] = 'true';
+}
 ---
 
 <img src={image.src} {...additionalAttributes} {...image.attributes} />

--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -61,6 +61,10 @@ if (props.sizes) {
 if (fallbackImage.srcSet.values.length > 0) {
 	imgAdditionalAttributes.srcset = fallbackImage.srcSet.attribute;
 }
+
+if (import.meta.env.DEV) {
+    imgAdditionalAttributes['data-image-component'] = 'true';
+}
 ---
 
 <picture {...pictureAttributes}>

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/index.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/index.ts
@@ -157,10 +157,10 @@ export default {
 						}
 					</style>
 					<header>
-						<h1><astro-dev-toolbar-icon icon="check-circle"></astro-dev-toolbar-icon>No accessibility issues detected.</h1>
+						<h1><astro-dev-toolbar-icon icon="check-circle"></astro-dev-toolbar-icon>No accessibility or performance issues detected.</h1>
 					</header>
 					<p>
-						Nice work! This app scans the page and highlights common accessibility issues for you, like a missing "alt" attribute on an image.
+						Nice work! This app scans the page and highlights common accessibility and performance issues for you, like a missing "alt" attribute on an image, or a image not using performant attributes.
 					</p>
 					`
 				);

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/index.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/index.ts
@@ -8,6 +8,7 @@ import {
 } from '../utils/highlight.js';
 import { createWindowElement } from '../utils/window.js';
 import { a11y } from './a11y.js';
+import { perf } from './perf.js';
 
 const icon =
 	'<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 1 20 16"><path fill="#fff" d="M.6 2A1.1 1.1 0 0 1 1.7.9h16.6a1.1 1.1 0 1 1 0 2.2H1.6A1.1 1.1 0 0 1 .8 2Zm1.1 7.1h6a1.1 1.1 0 0 0 0-2.2h-6a1.1 1.1 0 0 0 0 2.2ZM9.3 13H1.8a1.1 1.1 0 1 0 0 2.2h7.5a1.1 1.1 0 1 0 0-2.2Zm11.3 1.9a1.1 1.1 0 0 1-1.5 0l-1.7-1.7a4.1 4.1 0 1 1 1.6-1.6l1.6 1.7a1.1 1.1 0 0 1 0 1.6Zm-5.3-3.4a1.9 1.9 0 1 0 0-3.8 1.9 1.9 0 0 0 0 3.8Z"/></svg>';
@@ -28,10 +29,20 @@ export interface ResolvedAuditRule {
 
 export interface AuditRuleWithSelector extends AuditRule {
 	selector: string;
-	match?: (element: Element) => boolean | null | undefined | void;
+	match?: (
+		element: Element
+	) =>
+		| boolean
+		| null
+		| undefined
+		| void
+		| Promise<boolean>
+		| Promise<void>
+		| Promise<null>
+		| Promise<undefined>;
 }
 
-const rules = [...a11y];
+const rules = [...a11y, ...perf];
 
 const dynamicAuditRuleKeys: Array<keyof AuditRule> = ['title', 'message'];
 function resolveAuditRule(rule: AuditRule, element: Element): ResolvedAuditRule {
@@ -93,7 +104,7 @@ export default {
 					matches = Array.from(elements);
 				} else {
 					for (const element of elements) {
-						if (rule.match(element)) {
+						if (await rule.match(element)) {
 							matches.push(element);
 						}
 					}

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/perf.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/perf.ts
@@ -1,0 +1,73 @@
+import type { AuditRuleWithSelector } from './index.js';
+
+// A regular expression to match external URLs
+const externalUrlRe = new RegExp('^(?:[a-z+]+:)?//', 'i');
+
+export const perf: AuditRuleWithSelector[] = [
+	{
+		code: 'perf-use-image-component',
+		title: 'Use the Image component',
+		message: 'This image could be replaced with the Image component to improve performance.',
+		selector: 'img:not([data-image-component])',
+		async match(element) {
+			const src = element.getAttribute('src');
+			if (!src) return false;
+
+			// Don't match data URIs, they're typically used for specific use-cases that the image component doesn't help with
+			if (src.startsWith('data:')) return false;
+
+			// Ignore images that are smaller than 20KB, most of the time the image component won't really help with these, or they're used for specific use-cases (pixel tracking, etc.)
+			// Ignore this test for remote images for now, fetching them can be very slow and possibly dangerous
+			if (!externalUrlRe.test(src)) {
+				const imageData = await fetch(src).then((response) => response.blob());
+				if (imageData.size < 20 * 1024) return false;
+			}
+
+			return true;
+		},
+	},
+	{
+		code: 'perf-use-loading-lazy',
+		title: 'Use the loading="lazy" attribute',
+		message: (element) =>
+			`This ${element.tagName} is below the fold and could be lazy-loaded to improve performance.`,
+		selector:
+			'img:not([loading]), img[loading="eager"], iframe:not([loading]), iframe[loading="eager"]',
+		match(element) {
+			// Ignore elements that are above the fold, they should be loaded eagerly
+			if (element.getBoundingClientRect().top < window.innerHeight) return false;
+		},
+	},
+	{
+		code: 'perf-use-loading-eager',
+		title: 'Use the loading="eager" attribute',
+		message: (element) =>
+			`This ${element.tagName} is above the fold and could be eagerly-loaded to improve performance.`,
+		selector: 'img[loading="lazy"], iframe[loading="lazy"]',
+		match(element) {
+			// Ignore elements that are below the fold, they should be loaded lazily
+			if (element.getBoundingClientRect().top > window.innerHeight) return false;
+		},
+	},
+	{
+		code: 'perf-use-videos',
+		title: 'Use videos instead of GIFs for large animations',
+		message: 'This GIF could be replaced with a video to improve performance.',
+		selector: 'img[src$=".gif"]',
+		async match(element) {
+			const src = element.getAttribute('src');
+			if (!src) return false;
+
+			// Ignore remote URLs
+			if (externalUrlRe.test(src)) return false;
+
+			// Ignore GIFs that are smaller than 100KB, those are typically small enough to not be a problem
+			if (!externalUrlRe.test(src)) {
+				const imageData = await fetch(src).then((response) => response.blob());
+				if (imageData.size < 100 * 1024) return false;
+			}
+
+			return true;
+		},
+	},
+];

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/perf.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/perf.ts
@@ -70,4 +70,48 @@ export const perf: AuditRuleWithSelector[] = [
 			return true;
 		},
 	},
+	{
+		code: 'perf-slow-component-server-render',
+		title: 'Server-rendered component took a long time to render',
+		message: (element) =>
+			`This component took an unusually long time to render on the server (${getCleanRenderingTime(
+				element.getAttribute('server-render-time')
+			)}.). This might be a sign that it's doing too much work on the server, or something is blocking rendering.`,
+		selector: 'astro-island[server-render-time]',
+		match(element) {
+			const serverRenderTime = element.getAttribute('server-render-time');
+			if (!serverRenderTime) return false;
+
+			const renderingTime = parseFloat(serverRenderTime);
+			if (Number.isNaN(renderingTime)) return false;
+
+			return renderingTime > 500;
+		},
+	},
+	{
+		code: 'perf-slow-component-client-hydration',
+		title: 'Client-rendered component took a long time to hydrate',
+		message: (element) =>
+			`This component took an unusually long time to render on the server (${getCleanRenderingTime(
+				element.getAttribute('client-render-time')
+			)}.). This could be a sign that something is blocking the main thread and preventing the component from hydrating quickly.`,
+		selector: 'astro-island[client-render-time]',
+		match(element) {
+			const clientRenderTime = element.getAttribute('client-render-time');
+			if (!clientRenderTime) return false;
+
+			const renderingTime = parseFloat(clientRenderTime);
+			if (Number.isNaN(renderingTime)) return false;
+
+			return renderingTime > 500;
+		},
+	},
 ];
+
+function getCleanRenderingTime(time: string | null) {
+	if (!time) return 'unknown';
+	const renderingTime = parseFloat(time);
+	if (Number.isNaN(renderingTime)) return 'unknown';
+
+	return renderingTime.toFixed(2) + 's';
+}

--- a/packages/astro/src/runtime/server/astro-island.ts
+++ b/packages/astro/src/runtime/server/astro-island.ts
@@ -178,9 +178,16 @@ declare const Astro: {
 						);
 						throw e;
 					}
+					let hydrationTimeStart;
+					if (process.env.NODE_ENV === 'development') hydrationTimeStart = performance.now();
 					await this.hydrator(this)(this.Component, props, slots, {
 						client: this.getAttribute('client'),
 					});
+					if (process.env.NODE_ENV === 'development' && hydrationTimeStart)
+						this.setAttribute(
+							'client-render-time',
+							(performance.now() - hydrationTimeStart).toString()
+						);
 					this.removeAttribute('ssr');
 					this.dispatchEvent(new CustomEvent('astro:hydrate'));
 				};

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -184,6 +184,7 @@ async function renderFrameworkComponent(
 		}
 	}
 
+	let componentServerRenderEndTime;
 	// If no one claimed the renderer
 	if (!renderer) {
 		if (metadata.hydrate === 'only') {
@@ -241,6 +242,7 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 		if (metadata.hydrate === 'only') {
 			html = await renderSlotToString(result, slots?.fallback);
 		} else {
+			const componentRenderStartTime = performance.now();
 			({ html, attrs } = await renderer.ssr.renderToStaticMarkup.call(
 				{ result },
 				Component,
@@ -248,6 +250,7 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 				children,
 				metadata
 			));
+			componentServerRenderEndTime = performance.now() - componentRenderStartTime;
 		}
 	}
 
@@ -326,6 +329,8 @@ If you're still stuck, please open an issue on GitHub or join us at https://astr
 		{ renderer: renderer!, result, astroId, props, attrs },
 		metadata as Required<AstroComponentMetadata>
 	);
+
+	island.props['server-render-time'] = componentServerRenderEndTime;
 
 	// Render template if not all astro fragments are provided.
 	let unrenderedSlots: string[] = [];

--- a/packages/astro/src/runtime/server/scripts.ts
+++ b/packages/astro/src/runtime/server/scripts.ts
@@ -1,5 +1,6 @@
 import type { SSRResult } from '../../@types/astro.js';
 import islandScript from './astro-island.prebuilt.js';
+import islandScriptDev from './astro-island.prebuilt-dev.js';
 
 const ISLAND_STYLES = `<style>astro-island,astro-slot,astro-static-slot{display:contents}</style>`;
 
@@ -36,10 +37,9 @@ export function getPrescripts(result: SSRResult, type: PrescriptType, directive:
 	// deps to be loaded immediately.
 	switch (type) {
 		case 'both':
-			return `${ISLAND_STYLES}<script>${getDirectiveScriptText(
-				result,
-				directive
-			)};${islandScript}</script>`;
+			return `${ISLAND_STYLES}<script>${getDirectiveScriptText(result, directive)};${
+				process.env.NODE_ENV === 'development' ? islandScriptDev : islandScript
+			}</script>`;
 		case 'directive':
 			return `<script>${getDirectiveScriptText(result, directive)}</script>`;
 		case null:


### PR DESCRIPTION
## Changes

This PR adds a beginning of perf audits and infrastructure for it, most notably, this includes a `server-render-time` and `client-render-time` attribute on islands, allowing us to provide audits when an island take a suspicious amount of time to render.

## Testing

Will do

## Docs

N/A
