### PR TITLE
fix(i18n): don't consider URLs that start with the name of the defaut locale

### DIFF
--- a/.changeset/tough-socks-change.md
+++ b/.changeset/tough-socks-change.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes a bug where routes with a name that start with the name of the `i18n.defaultLocale` were incorrectly returning a 404 response.

--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -65,7 +65,13 @@ export function createI18nMiddleware(
 	};
 
 	const prefixOtherLocales = (url: URL, response: Response): Response | undefined => {
-		const pathnameContainsDefaultLocale = url.pathname.includes(`/${i18n.defaultLocale}`);
+		let pathnameContainsDefaultLocale = false;
+		for (const segment of url.pathname.split('/')) {
+			if (normalizeTheLocale(segment) === normalizeTheLocale(i18n.defaultLocale)) {
+				pathnameContainsDefaultLocale = true;
+				break;
+			}
+		}
 		if (pathnameContainsDefaultLocale) {
 			const newLocation = url.pathname.replace(`/${i18n.defaultLocale}`, '');
 			response.headers.set('Location', newLocation);

--- a/packages/astro/test/fixtures/i18n-routing/src/pages/endurance.astro
+++ b/packages/astro/test/fixtures/i18n-routing/src/pages/endurance.astro
@@ -1,0 +1,9 @@
+<html>
+<head>
+	<title>Astro</title>
+</head>
+<body>
+Endurance
+</body>
+</html>
+

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -59,6 +59,30 @@ describe('astro:i18n virtual module', () => {
 	});
 });
 describe('[DEV] i18n routing', () => {
+	describe('should render a page that stars with a locale but it is a page', () => {
+		/** @type {import('./test-utils').Fixture} */
+		let fixture;
+		/** @type {import('./test-utils').DevServer} */
+		let devServer;
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/i18n-routing/',
+			});
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('renders the page', async () => {
+			const response = await fixture.fetch('/endurance');
+			expect(response.status).to.equal(200);
+			expect(await response.text()).includes('Endurance');
+		});
+	});
+
 	describe('i18n routing', () => {
 		/** @type {import('./test-utils').Fixture} */
 		let fixture;
@@ -1005,6 +1029,23 @@ describe('[SSG] i18n routing', () => {
 		});
 	});
 
+	describe('should render a page that stars with a locale but it is a page', () => {
+		/** @type {import('./test-utils').Fixture} */
+		let fixture;
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/i18n-routing/',
+			});
+			await fixture.build();
+		});
+
+		it('renders the page', async () => {
+			const html = await fixture.readFile('/endurance/index.html');
+			expect(html).includes('Endurance');
+		});
+	});
+
 	describe('current locale', () => {
 		describe('with [prefix-other-locales]', () => {
 			/** @type {import('./test-utils').Fixture} */
@@ -1068,6 +1109,29 @@ describe('[SSG] i18n routing', () => {
 });
 describe('[SSR] i18n routing', () => {
 	let app;
+
+	describe('should render a page that stars with a locale but it is a page', () => {
+		/** @type {import('./test-utils').Fixture} */
+		let fixture;
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/i18n-routing/',
+				output: 'server',
+				adapter: testAdapter(),
+			});
+			await fixture.build();
+			app = await fixture.loadTestAdapterApp();
+		});
+
+		it('renders the page', async () => {
+			let request = new Request('http://example.com/endurance');
+			let response = await app.render(request);
+			expect(response.status).to.equal(200);
+			expect(await response.text()).includes('Endurance');
+		});
+	});
+
 	describe('default', () => {
 		/** @type {import('./test-utils').Fixture} */
 		let fixture;


### PR DESCRIPTION
## Changes

Closes  #10005

The logic that checks the presence of the default locale was very broad and poor. This new logic should be more robust.

## Testing

I added new test cases 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
