### PR TITLE
fix(astro:content): include required type declarations

### DIFF
--- a/.changeset/cool-walls-fail.md
+++ b/.changeset/cool-walls-fail.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes a regression where types for the `astro:content` module did not include required exports, leading tp type errors.
+Fixes a regression where types for the `astro:content` module did not include required exports, leading to typescript errors.

--- a/.changeset/cool-walls-fail.md
+++ b/.changeset/cool-walls-fail.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes a regression where types for the `astro:content` module did not include required exports, leading tp type errors.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -96,6 +96,7 @@
     "content-types.template.d.ts",
     "content-module.template.mjs",
     "astro-jsx.d.ts",
+    "types/content.d.ts",
     "types.d.ts",
     "README.md",
     "vendor"


### PR DESCRIPTION
## Changes

- https://github.com/withastro/astro/pull/10013 introduced a new folder and file for types that are supposed to be shipped without processing.
- This file was not included in the npm package.

## Testing
- Manually, existing tests should pass.

## Docs
Does not affect usage.