### PR TITLE
chore: Migrate `custom-404-html.test.js` to `node:test`

### DIFF
--- a/packages/astro/test/custom-404-html.nodetest.js
+++ b/packages/astro/test/custom-404-html.nodetest.js
@@ -1,6 +1,7 @@
-import { expect } from 'chai';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
+import assert from 'node:assert/strict';
+import { after, describe, before, it } from 'node:test';
 
 describe('Custom 404.html', () => {
 	let fixture;
@@ -28,18 +29,18 @@ describe('Custom 404.html', () => {
 			const html = await fixture.fetch('/').then((res) => res.text());
 			$ = cheerio.load(html);
 
-			expect($('h1').text()).to.equal('Home');
+			assert.strictEqual($('h1').text(), 'Home');
 		});
 
 		it('renders 404 for /a', async () => {
 			const res = await fixture.fetch('/a');
-			expect(res.status).to.equal(404);
+			assert.strictEqual(res.status, 404);
 
 			const html = await res.text();
 			$ = cheerio.load(html);
 
-			expect($('h1').text()).to.equal('Page not found');
-			expect($('p').text()).to.equal('This 404 is a static HTML file.');
+			assert.strictEqual($('h1').text(), 'Page not found');
+			assert.strictEqual($('p').text(), 'This 404 is a static HTML file.');
 		});
 	});
 });


### PR DESCRIPTION
## Changes

* Part of [☂️ Move Astro tests to `node:test`  #9873](https://github.com/withastro/astro/issues/9873)
* Migrates `packages/astro/test/custom-404-html.test.js`

## Testing

All tests pass.

## Docs

Test-only changes.
