### PR TITLE
chore: Migrate `ssr-markdown.test.js` to `node:test`

### DIFF
--- a/packages/astro/test/ssr-markdown.nodetest.js
+++ b/packages/astro/test/ssr-markdown.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import assert from 'node:assert/strict';
+import { describe, before, it } from 'node:test';
 import { load as cheerioLoad } from 'cheerio';
 import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
@@ -27,6 +28,6 @@ describe('Markdown pages in SSR', () => {
 	it('Renders markdown pages correctly', async () => {
 		const html = await fetchHTML('/post');
 		const $ = cheerioLoad(html);
-		expect($('#subheading').text()).to.equal('Subheading');
+		assert.strictEqual($('#subheading').text(), 'Subheading');
 	});
 });


### PR DESCRIPTION
## Changes

- Part of #9873 
- Progressively migrates `packages/astro/test/ssr-markdown.test.js`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Test passes.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Test-only change.