### PR TITLE
chore: Migrate `astro-markdown-url.test.js` to `node:test`

### DIFF
--- a/packages/astro/test/astro-markdown-url.nodetest.js
+++ b/packages/astro/test/astro-markdown-url.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
@@ -18,7 +19,7 @@ describe('Astro Markdown URL', () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('#url').attr('href')).to.equal(baseUrl + '/');
+			assert.strictEqual($('#url').attr('href'), baseUrl + '/');
 		});
 
 		it('trailingSlash: never', async () => {
@@ -33,7 +34,7 @@ describe('Astro Markdown URL', () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('#url').attr('href')).to.equal(baseUrl);
+			assert.strictEqual($('#url').attr('href'), baseUrl);
 		});
 
 		it('trailingSlash: ignore', async () => {
@@ -48,7 +49,7 @@ describe('Astro Markdown URL', () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('#url').attr('href')).to.equal(baseUrl);
+			assert.strictEqual($('#url').attr('href'), baseUrl);
 		});
 	});
 
@@ -66,7 +67,7 @@ describe('Astro Markdown URL', () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('#url').attr('href')).to.equal(baseUrl + '/');
+			assert.strictEqual($('#url').attr('href'), baseUrl + '/');
 		});
 
 		it('trailingSlash: never', async () => {
@@ -80,7 +81,7 @@ describe('Astro Markdown URL', () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('#url').attr('href')).to.equal(baseUrl);
+			assert.strictEqual($('#url').attr('href'), baseUrl);
 		});
 
 		it('trailingSlash: ignore', async () => {
@@ -94,7 +95,7 @@ describe('Astro Markdown URL', () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('#url').attr('href')).to.equal(baseUrl);
+			assert.strictEqual($('#url').attr('href'), baseUrl);
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- Part of #9873 
- Progressively migrates `packages/astro/test/astro-markdown-url.test.js`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tests pass.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Test-only changes.