### PR TITLE
chore: Migrate `astro-markdown.test.js` to `node:test`

### DIFF
--- a/packages/astro/test/astro-markdown.nodetest.js
+++ b/packages/astro/test/astro-markdown.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import assert from 'node:assert/strict';
+import { describe, before, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture, fixLineEndings } from './test-utils.js';
 
@@ -17,7 +18,8 @@ describe('Astro Markdown', () => {
 	it('Exposes raw markdown content', async () => {
 		const { raw } = JSON.parse(await fixture.readFile('/raw-content.json'));
 
-		expect(fixLineEndings(raw).trim()).to.equal(
+		assert.strictEqual(
+			fixLineEndings(raw).trim(),
 			`# Basic page\n\nLets make sure raw and compiled content look right!`
 		);
 	});
@@ -25,7 +27,8 @@ describe('Astro Markdown', () => {
 	it('Exposes compiled HTML content', async () => {
 		const { compiled } = JSON.parse(await fixture.readFile('/raw-content.json'));
 
-		expect(fixLineEndings(compiled).trim()).to.equal(
+		assert.strictEqual(
+			fixLineEndings(compiled).trim(),
 			`<h1 id="basic-page">Basic page</h1>\n<p>Lets make sure raw and compiled content look right!</p>`
 		);
 	});
@@ -35,7 +38,7 @@ describe('Astro Markdown', () => {
 			const html = await fixture.readFile('/code-in-md/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('pre.astro-code').length).to.not.equal(0);
+			assert.notStrictEqual($('pre.astro-code').length, 0);
 		});
 
 		it('handles Prism', async () => {
@@ -50,7 +53,7 @@ describe('Astro Markdown', () => {
 			const html = await prismFixture.readFile('/code-in-md/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('pre.language-html').length).to.not.equal(0);
+			assert.notStrictEqual($('pre.language-html').length, 0);
 		});
 	});
 
@@ -61,8 +64,8 @@ describe('Astro Markdown', () => {
 		const contentTitle = $('[data-content-title]');
 		const frontmatterTitle = $('[data-frontmatter-title]');
 
-		expect(contentTitle.text()).to.equal('With layout');
-		expect(frontmatterTitle.text()).to.equal('With layout');
+		assert.strictEqual(contentTitle.text(), 'With layout');
+		assert.strictEqual(frontmatterTitle.text(), 'With layout');
 	});
 
 	it('Passes headings to layout via "headings" prop', async () => {
@@ -71,9 +74,9 @@ describe('Astro Markdown', () => {
 
 		const headingSlugs = [...$('body').find('[data-headings] > li')].map((el) => $(el).text());
 
-		expect(headingSlugs.length).to.be.greaterThan(0);
-		expect(headingSlugs).to.contain('section-1');
-		expect(headingSlugs).to.contain('section-2');
+		assert.ok(headingSlugs.length > 0);
+		assert.ok(headingSlugs.includes('section-1'));
+		assert.ok(headingSlugs.includes('section-2'));
 	});
 
 	it('Passes compiled content to layout via "compiledContent" prop', async () => {
@@ -82,7 +85,8 @@ describe('Astro Markdown', () => {
 
 		const compiledContent = $('[data-compiled-content]');
 
-		expect(fixLineEndings(compiledContent.text()).trim()).to.equal(
+		assert.strictEqual(
+			fixLineEndings(compiledContent.text()).trim(),
 			`<h2 id="section-1">Section 1</h2>\n<h2 id="section-2">Section 2</h2>`
 		);
 	});
@@ -93,7 +97,7 @@ describe('Astro Markdown', () => {
 
 		const rawContent = $('[data-raw-content]');
 
-		expect(fixLineEndings(rawContent.text()).trim()).to.equal(`## Section 1\n\n## Section 2`);
+		assert.strictEqual(fixLineEndings(rawContent.text()).trim(), `## Section 1\n\n## Section 2`);
 	});
 
 	it('Exposes getHeadings() on glob imports', async () => {
@@ -101,8 +105,8 @@ describe('Astro Markdown', () => {
 
 		const headingSlugs = headings.map((heading) => heading?.slug);
 
-		expect(headingSlugs).to.contain('section-1');
-		expect(headingSlugs).to.contain('section-2');
+		assert.ok(headingSlugs.includes('section-1'));
+		assert.ok(headingSlugs.includes('section-2'));
 	});
 
 	it('passes "file" and "url" to layout', async () => {
@@ -114,13 +118,14 @@ describe('Astro Markdown', () => {
 		const file = $('[data-file]')?.text();
 		const url = $('[data-url]')?.text();
 
-		expect(frontmatterFile?.endsWith('with-layout.md')).to.equal(
+		assert.strictEqual(
+			frontmatterFile?.endsWith('with-layout.md'),
 			true,
 			'"file" prop does not end with correct path or is undefined'
 		);
-		expect(frontmatterUrl).to.equal('/with-layout');
-		expect(file).to.equal(frontmatterFile);
-		expect(url).to.equal(frontmatterUrl);
+		assert.strictEqual(frontmatterUrl, '/with-layout');
+		assert.strictEqual(file, frontmatterFile);
+		assert.strictEqual(url, frontmatterUrl);
 	});
 
 	describe('Vite env vars (#3412)', () => {
@@ -129,24 +134,24 @@ describe('Astro Markdown', () => {
 			const $ = cheerio.load(html);
 
 			// test 1: referencing an existing var name
-			expect($('code').eq(0).text()).to.equal('import.meta.env.SITE');
-			expect($('li').eq(0).text()).to.equal('import.meta.env.SITE');
-			expect($('code').eq(3).text()).to.contain('site: import.meta.env.SITE');
+			assert.strictEqual($('code').eq(0).text(), 'import.meta.env.SITE');
+			assert.strictEqual($('li').eq(0).text(), 'import.meta.env.SITE');
+			assert.ok($('code').eq(3).text().includes('site: import.meta.env.SITE'));
 
 			// // test 2: referencing a non-existing var name
-			expect($('code').eq(1).text()).to.equal('import.meta.env.TITLE');
-			expect($('li').eq(1).text()).to.equal('import.meta.env.TITLE');
-			expect($('code').eq(3).text()).to.contain('title: import.meta.env.TITLE');
+			assert.strictEqual($('code').eq(1).text(), 'import.meta.env.TITLE');
+			assert.strictEqual($('li').eq(1).text(), 'import.meta.env.TITLE');
+			assert.ok($('code').eq(3).text().includes('title: import.meta.env.TITLE'));
 
 			// // test 3: referencing `import.meta.env` itself (without any var name)
-			expect($('code').eq(2).text()).to.equal('import.meta.env');
-			expect($('li').eq(2).text()).to.equal('import.meta.env');
-			expect($('code').eq(3).text()).to.contain('// Use Vite env vars with import.meta.env');
+			assert.strictEqual($('code').eq(2).text(), 'import.meta.env');
+			assert.strictEqual($('li').eq(2).text(), 'import.meta.env');
+			assert.ok($('code').eq(3).text().includes('// Use Vite env vars with import.meta.env'));
 		});
 		it('Allows referencing import.meta.env in frontmatter', async () => {
 			const { title = '' } = JSON.parse(await fixture.readFile('/vite-env-vars-glob.json'));
-			expect(title).to.contain('import.meta.env.SITE');
-			expect(title).to.contain('import.meta.env.TITLE');
+			assert.ok(title.includes('import.meta.env.SITE'));
+			assert.ok(title.includes('import.meta.env.TITLE'));
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- Part of #9873 
- Progressively migrates `packages/astro/test/astro-markdown.test.js`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tests pass

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Test-only changes.