### PR TITLE
chore: Migrate `markdown.test.js` to `node:test`

### DIFF
--- a/packages/astro/test/markdown.nodetest.js
+++ b/packages/astro/test/markdown.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import assert from 'node:assert/strict';
+import { describe, before, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
@@ -20,57 +21,57 @@ describe('Markdown tests', () => {
 		it('Can load a markdown page with the `.markdown` extension', async () => {
 			const html = await fixture.readFile('/dot-markdown-page/index.html');
 			const $ = cheerio.load(html);
-			expect($('h1').html()).to.equal('Page with alternative .markdown extension');
-			expect($('p').html()).to.equal('Hope this loads fine 🤞');
+			assert.strictEqual($('h1').html(), 'Page with alternative .markdown extension');
+			assert.strictEqual($('p').html(), 'Hope this loads fine 🤞');
 		});
 
 		it('Can load a markdown page with the `.mdwn` extension', async () => {
 			const html = await fixture.readFile('/dot-mdwn-page/index.html');
 			const $ = cheerio.load(html);
-			expect($('h1').html()).to.equal('Page with alternative .mdwn extension');
-			expect($('p').html()).to.equal('Hope this loads fine 🤞');
+			assert.strictEqual($('h1').html(), 'Page with alternative .mdwn extension');
+			assert.strictEqual($('p').html(), 'Hope this loads fine 🤞');
 		});
 
 		it('Can load a markdown page with the `.mkdn` extension', async () => {
 			const html = await fixture.readFile('/dot-mkdn-page/index.html');
 			const $ = cheerio.load(html);
-			expect($('h1').html()).to.equal('Page with alternative .mkdn extension');
-			expect($('p').html()).to.equal('Hope this loads fine 🤞');
+			assert.strictEqual($('h1').html(), 'Page with alternative .mkdn extension');
+			assert.strictEqual($('p').html(), 'Hope this loads fine 🤞');
 		});
 
 		it('Can load a markdown page with the `.mdown` extension', async () => {
 			const html = await fixture.readFile('/dot-mdown-page/index.html');
 			const $ = cheerio.load(html);
-			expect($('h1').html()).to.equal('Page with alternative .mdown extension');
-			expect($('p').html()).to.equal('Hope this loads fine 🤞');
+			assert.strictEqual($('h1').html(), 'Page with alternative .mdown extension');
+			assert.strictEqual($('p').html(), 'Hope this loads fine 🤞');
 		});
 
 		it('Can load a markdown page with the `.mkd` extension', async () => {
 			const html = await fixture.readFile('/dot-mkd-page/index.html');
 			const $ = cheerio.load(html);
-			expect($('h1').html()).to.equal('Page with alternative .mkd extension');
-			expect($('p').html()).to.equal('Hope this loads fine 🤞');
+			assert.strictEqual($('h1').html(), 'Page with alternative .mkd extension');
+			assert.strictEqual($('p').html(), 'Hope this loads fine 🤞');
 		});
 
 		it('Can load a simple markdown page with Astro', async () => {
 			const html = await fixture.readFile('/post/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('p').first().text()).to.equal('Hello world!');
-			expect($('#first').text()).to.equal('Some content');
-			expect($('#interesting-topic').text()).to.equal('Interesting Topic');
+			assert.strictEqual($('p').first().text(), 'Hello world!');
+			assert.strictEqual($('#first').text(), 'Some content');
+			assert.strictEqual($('#interesting-topic').text(), 'Interesting Topic');
 		});
 
 		it('Can load a realworld markdown page with Astro', async () => {
 			const html = await fixture.readFile('/realworld/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('pre')).to.have.lengthOf(7);
+			assert.strictEqual($('pre').length, 7);
 		});
 
 		it('Does not unescape entities', async () => {
 			const html = await fixture.readFile('/entities/index.html');
-			expect(html).to.match(/&#x3C;i>This should NOT be italic&#x3C;\/i>/);
+			assert.match(html, /&#x3C;i>This should NOT be italic&#x3C;\/i>/);
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- Part of #9873 
- Progressively migrates `packages/astro/test/markdown.test.js`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Tests pass

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
Test-only changes.