### PR TITLE
chore: Migrate `custom-404-injected-from-dep.test.js` to `node:test`

### DIFF
--- a/packages/astro/test/custom-404-injected-from-dep.nodetest.js
+++ b/packages/astro/test/custom-404-injected-from-dep.nodetest.js
@@ -1,5 +1,6 @@
-import { expect } from 'chai';
 import { loadFixture } from './test-utils.js';
+import assert from 'node:assert/strict';
+import { describe, before, it } from 'node:test';
 
 describe('Custom 404 with injectRoute from dependency', () => {
 	describe('build', () => {
@@ -16,7 +17,7 @@ describe('Custom 404 with injectRoute from dependency', () => {
 
 		it('Build succeeds', async () => {
 			const html = await fixture.readFile('/404.html');
-			expect(html).to.contain('<!DOCTYPE html>');
+			assert.strictEqual(html.includes('<!DOCTYPE html>'), true);
 		});
 	});
 });


### PR DESCRIPTION
## Changes

* Part of [☂️ Move Astro tests to `node:test`  #9873](https://github.com/withastro/astro/issues/9873)
* Migrates `packages/astro/test/custom-404-injected-from-dep.test.js`

## Testing

All tests pass.

## Docs

Test-only changes.
