### PR TITLE
chore: Migrate `custom-404-static.test.js` to `node:test`

### DIFF
--- a/packages/astro/test/custom-404-static.nodetest.js
+++ b/packages/astro/test/custom-404-static.nodetest.js
@@ -1,8 +1,9 @@
-import { expect } from 'chai';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
+import assert from 'node:assert/strict';
+import { after, describe, before, it } from 'node:test';
 
-describe('Custom 404', () => {
+describe('Custom 404 with Static', () => {
 	let fixture;
 
 	before(async () => {
@@ -28,18 +29,18 @@ describe('Custom 404', () => {
 			const html = await fixture.fetch('/').then((res) => res.text());
 			$ = cheerio.load(html);
 
-			expect($('h1').text()).to.equal('Home');
+			assert.strictEqual($('h1').text(), 'Home');
 		});
 
 		it('renders 404 for /a', async () => {
 			const res = await fixture.fetch('/a');
-			expect(res.status).to.equal(404);
+			assert.strictEqual(res.status, 404);
 
 			const html = await res.text();
 			$ = cheerio.load(html);
 
-			expect($('h1').text()).to.equal('Page not found');
-			expect($('p').text()).to.equal('/a');
+			assert.strictEqual($('h1').text(), 'Page not found');
+			assert.strictEqual($('p').text(), '/a');
 		});
 	});
 
@@ -50,7 +51,7 @@ describe('Custom 404', () => {
 
 		it('builds to 404.html', async () => {
 			const html = await fixture.readFile('/404.html');
-			expect(html).to.be.ok;
+			assert.ok(html);
 		});
 	});
 });


### PR DESCRIPTION
## Changes

* Part of [☂️ Move Astro tests to `node:test`  #9873](https://github.com/withastro/astro/issues/9873)
* Migrates `packages/astro/test/custom-404-static.test.js`

## Testing

All tests pass.

## Docs

Test-only changes.
