### PR TITLE
chore: migrate `static-build-code-component.test.js` to `node:test`

### DIFF
--- a/packages/astro/test/static-build-code-component.nodetest.js
+++ b/packages/astro/test/static-build-code-component.nodetest.js
@@ -1,5 +1,6 @@
-import { expect } from 'chai';
 import * as cheerio from 'cheerio';
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('Code component inside static build', () => {
@@ -15,6 +16,6 @@ describe('Code component inside static build', () => {
 	it('Is able to build successfully', async () => {
 		const html = await fixture.readFile('/index.html');
 		const $ = cheerio.load(html);
-		expect($('pre').length, 1, 'pre tag loaded');
+		assert.equal($('pre').length, 1, 'pre tag loaded');
 	});
 });


### PR DESCRIPTION
## Changes

- Migrates `static-build-code-component.test.js` to `node:test` ([#9873](https://github.com/withastro/astro/issues/9873))

## Testing

- `pnpm --filter astro run test:node`

## Docs

- N/A