### PR TITLE
chore: migrate `static-build-dir.test.js` to `node:test`

### DIFF
--- a/packages/astro/test/static-build-dir.nodetest.js
+++ b/packages/astro/test/static-build-dir.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('Static build: dir takes the URL path to the output directory', () => {
@@ -27,9 +28,10 @@ describe('Static build: dir takes the URL path to the output directory', () => {
 	});
 	it('dir takes the URL path to the output directory', async () => {
 		const removeTrailingSlash = (str) => str.replace(/\/$/, '');
-		expect(removeTrailingSlash(checkDir.toString())).to.be.equal(
+		assert.equal(
+			removeTrailingSlash(checkDir.toString()),
 			removeTrailingSlash(new URL('./fixtures/static-build-dir/dist', import.meta.url).toString())
 		);
-		expect(checkDir.toString()).to.be.equal(checkGeneratedDir.toString());
+		assert.equal(checkDir.toString(), checkGeneratedDir.toString());
 	});
 });


### PR DESCRIPTION
## Changes

- Migrates `static-build-dir.test.js` to `node:test` ([#9873](https://github.com/withastro/astro/issues/9873))

## Testing

- `pnpm --filter astro run test:node`

## Docs

- N/A
