### PR TITLE
chore: migrate `static-build-frameworks.test.js` to `node:test`

### DIFF
--- a/packages/astro/test/static-build-frameworks.nodetest.js
+++ b/packages/astro/test/static-build-frameworks.nodetest.js
@@ -1,5 +1,6 @@
-import { expect } from 'chai';
 import * as cheerio from 'cheerio';
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { loadFixture, isWindows } from './test-utils.js';
 
 describe('Static build - frameworks', () => {
@@ -18,25 +19,25 @@ describe('Static build - frameworks', () => {
 
 	it('can build preact', async () => {
 		const html = await fixture.readFile('/preact/index.html');
-		expect(html).to.be.a('string');
+		assert.equal(typeof html, 'string');
 	});
 
 	it('can build react', async () => {
 		const html = await fixture.readFile('/react/index.html');
-		expect(html).to.be.a('string');
+		assert.equal(typeof html, 'string');
 	});
 
 	// SKIP: Lit polyfills the server in a way that breaks `sass` require/import
 	// Leads to CI bugs like: "Cannot read properties of undefined (reading 'length')"
 	it.skip('can build lit', async () => {
 		const html = await fixture.readFile('/lit/index.html');
-		expect(html).to.be.a('string');
+		assert.equal(typeof html, 'string');
 	});
 
 	it('can build nested framework usage', async () => {
 		const html = await fixture.readFile('/nested/index.html');
 		const $ = cheerio.load(html);
 		const counter = $('.nested-counter .counter');
-		expect(counter.length).to.equal(1, 'Found the counter');
+		assert.equal(counter.length, 1, 'Found the counter');
 	});
 });


### PR DESCRIPTION
## Changes

- Migrates `static-build-frameworks.test.js` to `node:test` ([#9873](https://github.com/withastro/astro/issues/9873))

## Testing

- `pnpm --filter astro run test:node`

## Docs

- N/A
