### PR TITLE
chore: migrate `static-build-page-url-format.test.js` to `node:test`

### DIFF
--- a/packages/astro/test/static-build-page-url-format.nodetest.js
+++ b/packages/astro/test/static-build-page-url-format.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe("Static build - format: 'file'", () => {
@@ -13,11 +14,11 @@ describe("Static build - format: 'file'", () => {
 
 	it('Builds pages in root', async () => {
 		const html = await fixture.readFile('/one.html');
-		expect(html).to.be.a('string');
+		assert.equal(typeof html, 'string');
 	});
 
 	it('Builds pages in subfolders', async () => {
 		const html = await fixture.readFile('/sub/page.html');
-		expect(html).to.be.a('string');
+		assert.equal(typeof html, 'string');
 	});
 });


### PR DESCRIPTION
## Changes

- Migrates `static-build-page-url-format.test.js` to `node:test` ([#9873](https://github.com/withastro/astro/issues/9873))

## Testing

- `pnpm --filter astro run test:node`

## Docs

- N/A
