### PR TITLE
chore: migrate `static-build.test.js` to `node:test`

### DIFF
--- a/packages/astro/test/static-build.nodetest.js
+++ b/packages/astro/test/static-build.nodetest.js
@@ -1,5 +1,6 @@
-import { expect } from 'chai';
 import { load as cheerioLoad } from 'cheerio';
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 import { Logger } from '../dist/core/logger/core.js';
 
@@ -46,12 +47,12 @@ describe('Static build', () => {
 		const $ = cheerioLoad(html);
 		const link = $('link[rel="canonical"]');
 		const href = link.attr('href');
-		expect(href).to.contain('http');
+		assert.match(href, /http/);
 	});
 
 	it('Builds out .astro pages', async () => {
 		const html = await fixture.readFile('/index.html');
-		expect(html).to.be.a('string');
+		assert.equal(typeof html, 'string');
 	});
 
 	it('can build pages using Astro.glob()', async () => {
@@ -59,24 +60,24 @@ describe('Static build', () => {
 		const $ = cheerioLoad(html);
 		const link = $('.posts a');
 		const href = link.attr('href');
-		expect(href).to.be.equal('/subpath/posts/thoughts');
+		assert.equal(href, '/subpath/posts/thoughts');
 	});
 
 	it('Builds out .md pages', async () => {
 		const html = await fixture.readFile('/posts/thoughts/index.html');
-		expect(html).to.be.a('string');
+		assert.equal(typeof html, 'string');
 	});
 
 	it('Builds out .json files', async () => {
 		const content = await fixture.readFile('/company.json').then((text) => JSON.parse(text));
-		expect(content.name).to.equal('Astro Technology Company');
-		expect(content.url).to.equal('https://astro.build/');
+		assert.equal(content.name, 'Astro Technology Company');
+		assert.equal(content.url, 'https://astro.build/');
 	});
 
 	it('Builds out async .json files', async () => {
 		const content = await fixture.readFile('/posts.json').then((text) => JSON.parse(text));
-		expect(Array.isArray(content)).to.equal(true);
-		expect(content).deep.equal([
+		assert.equal(Array.isArray(content), true);
+		assert.deepEqual(content, [
 			{
 				filename: './posts/nested/more.md',
 				title: 'More post',
@@ -93,9 +94,9 @@ describe('Static build', () => {
 
 		for (const slug of slugs) {
 			const content = await fixture.readFile(`/data/${slug}.json`).then((text) => JSON.parse(text));
-			expect(content.name).to.equal('Astro Technology Company');
-			expect(content.url).to.equal('https://astro.build/');
-			expect(content.slug).to.equal(slug);
+			assert.equal(content.name, 'Astro Technology Company');
+			assert.equal(content.url, 'https://astro.build/');
+			assert.equal(content.slug, slug);
 		}
 	});
 
@@ -108,7 +109,7 @@ describe('Static build', () => {
 				const href = $(link).attr('href');
 
 				// The imported .scss file should include the base subpath in the href
-				expect(href.startsWith('/subpath/')).to.be.true;
+				assert.equal(href.startsWith('/subpath/'), true);
 
 				/**
 				 * The link should be built with the config's `base` included
@@ -132,7 +133,7 @@ describe('Static build', () => {
 
 		it('Page level CSS is added', async () => {
 			const found = await findEvidence('/index.html');
-			expect(found).to.equal(true, 'Did not find page-level CSS on this page');
+			assert.equal(found, true, 'Did not find page-level CSS on this page');
 		});
 	});
 
@@ -141,12 +142,12 @@ describe('Static build', () => {
 
 		it('Included on the index page', async () => {
 			const found = await findEvidence('/index.html');
-			expect(found).to.equal(true, 'Did not find shared CSS on this page');
+			assert.equal(found, true, 'Did not find shared CSS on this page');
 		});
 
 		it('Included on a md page', async () => {
 			const found = await findEvidence('/posts/thoughts/index.html');
-			expect(found).to.equal(true, 'Did not find shared CSS on this page');
+			assert.equal(found, true, 'Did not find shared CSS on this page');
 		});
 	});
 
@@ -155,7 +156,7 @@ describe('Static build', () => {
 
 		it('Is included in the index CSS', async () => {
 			const found = await findEvidence('/index.html');
-			expect(found).to.equal(true, 'Did not find shared CSS module code');
+			assert.equal(found, true, 'Did not find shared CSS module code');
 		});
 	});
 
@@ -163,7 +164,7 @@ describe('Static build', () => {
 		it('Get bundled together on the page', async () => {
 			const html = await fixture.readFile('/hoisted/index.html');
 			const $ = cheerioLoad(html);
-			expect($('script[type="module"]').length).to.equal(1, 'hoisted script added');
+			assert.equal($('script[type="module"]').length, 1, 'hoisted script added');
 		});
 
 		it('Do not get added to the wrong page', async () => {
@@ -172,14 +173,14 @@ describe('Static build', () => {
 			const href = $('script[type="module"]').attr('src');
 			const indexHTML = await fixture.readFile('/index.html');
 			const $$ = cheerioLoad(indexHTML);
-			expect($$(`script[src="${href}"]`).length).to.equal(0, 'no script added to different page');
+			assert.equal($$(`script[src="${href}"]`).length, 0, 'no script added to different page');
 		});
 	});
 
 	it('honors ssr config', async () => {
 		const html = await fixture.readFile('/index.html');
 		const $ = cheerioLoad(html);
-		expect($('#ssr-config').text()).to.equal('testing');
+		assert.equal($('#ssr-config').text(), 'testing');
 	});
 
 	it('warns when accessing headers', async () => {
@@ -189,7 +190,7 @@ describe('Static build', () => {
 				found = true;
 			}
 		}
-		expect(found).to.equal(true, 'Found the log message');
+		assert.equal(found, true, 'Found the log message');
 	});
 });
 
@@ -200,7 +201,7 @@ describe('Static build SSR', () => {
 		});
 		await fixture.build();
 
-		await fixture.readFile('/client/nested/asset2.txt');
-		await fixture.readFile('/client/.well-known/apple-app-site-association');
+		assert.ok(await fixture.readFile('/client/nested/asset2.txt'));
+		assert.ok(await fixture.readFile('/client/.well-known/apple-app-site-association'));
 	});
 });


### PR DESCRIPTION
## Changes

- Migrates `static-build.test.js` to `node:test` ([#9873](https://github.com/withastro/astro/issues/9873))

## Testing

- `pnpm --filter astro run test:node`

## Docs

- N/A
