### PR TITLE
chore: migrate vue related tests to `node:test`

### DIFF
--- a/packages/astro/test/slots-vue.nodetest.js
+++ b/packages/astro/test/slots-vue.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
@@ -14,43 +15,43 @@ describe('Slots: Vue', () => {
 		const html = await fixture.readFile('/index.html');
 		const $ = cheerio.load(html);
 
-		expect($('#default-self-closing').text().trim()).to.equal('Fallback');
-		expect($('#default-empty').text().trim()).to.equal('Fallback');
-		expect($('#zero').text().trim()).to.equal('0');
-		expect($('#false').text().trim()).to.equal('');
-		expect($('#string').text().trim()).to.equal('');
-		expect($('#content').text().trim()).to.equal('Hello world!');
+		assert.equal($('#default-self-closing').text().trim(), 'Fallback');
+		assert.equal($('#default-empty').text().trim(), 'Fallback');
+		assert.equal($('#zero').text().trim(), '0');
+		assert.equal($('#false').text().trim(), '');
+		assert.equal($('#string').text().trim(), '');
+		assert.equal($('#content').text().trim(), 'Hello world!');
 	});
 
 	it('Renders named slot', async () => {
 		const html = await fixture.readFile('/index.html');
 		const $ = cheerio.load(html);
-		expect($('#named').text().trim()).to.equal('Fallback / Named');
+		assert.equal($('#named').text().trim(), 'Fallback / Named');
 	});
 
 	it('Preserves dash-case slot', async () => {
 		const html = await fixture.readFile('/index.html');
 		const $ = cheerio.load(html);
-		expect($('#dash-case').text().trim()).to.equal('Fallback / Dash Case');
+		assert.equal($('#dash-case').text().trim(), 'Fallback / Dash Case');
 	});
 
 	describe('For MDX Pages', () => {
 		it('Renders default slot', async () => {
 			const html = await fixture.readFile('/mdx/index.html');
 			const $ = cheerio.load(html);
-			expect($('#content').text().trim()).to.equal('Hello world!');
+			assert.equal($('#content').text().trim(), 'Hello world!');
 		});
 
 		it('Renders named slot', async () => {
 			const html = await fixture.readFile('/mdx/index.html');
 			const $ = cheerio.load(html);
-			expect($('#named').text().trim()).to.equal('Fallback / Named');
+			assert.equal($('#named').text().trim(), 'Fallback / Named');
 		});
 
 		it('Converts dash-case slot to camelCase', async () => {
 			const html = await fixture.readFile('/mdx/index.html');
 			const $ = cheerio.load(html);
-			expect($('#dash-case').text().trim()).to.equal('Fallback / Dash Case');
+			assert.equal($('#dash-case').text().trim(), 'Fallback / Dash Case');
 		});
 	});
 });

--- a/packages/astro/test/vue-component.nodetest.js
+++ b/packages/astro/test/vue-component.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { isWindows, loadFixture } from './test-utils.js';
 
@@ -25,23 +26,23 @@ describe('Vue component', () => {
 				.map((el) => $(el).text());
 
 			// test 1: renders all components correctly
-			expect(allPreValues).to.deep.equal(['0', '1', '1', '1', '10', '100', '1000']);
+			assert.deepEqual(allPreValues, ['0', '1', '1', '1', '10', '100', '1000'])
 
 			// test 2: renders 3 <astro-island>s
-			expect($('astro-island')).to.have.lengthOf(6);
-
+			assert.equal($('astro-island').length, 6)
+			
 			// test 3: all <astro-island>s have uid attributes
-			expect($('astro-island[uid]')).to.have.lengthOf(6);
+			assert.equal($('astro-island[uid]').length, 6)
 
 			// test 4: treats <my-button> as a custom element
-			expect($('my-button')).to.have.lengthOf(7);
+			assert.equal($('my-button').length, 7)
 
 			// test 5: components with identical render output and props have been deduplicated
 			const uniqueRootUIDs = $('astro-island').map((i, el) => $(el).attr('uid'));
-			expect(new Set(uniqueRootUIDs).size).to.equal(5);
+			assert.equal(new Set(uniqueRootUIDs).size, 5)
 
 			// test 6: import public files work
-			expect($('#vue-img')).to.be.ok;
+			assert($('#vue-img'));
 		});
 	});
 

--- a/packages/astro/test/vue-component.nodetest.js
+++ b/packages/astro/test/vue-component.nodetest.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it } from 'node:test';
+import { before, describe, it, after } from 'node:test';
 import * as cheerio from 'cheerio';
 import { isWindows, loadFixture } from './test-utils.js';
 
@@ -26,23 +26,23 @@ describe('Vue component', () => {
 				.map((el) => $(el).text());
 
 			// test 1: renders all components correctly
-			assert.deepEqual(allPreValues, ['0', '1', '1', '1', '10', '100', '1000'])
+			assert.deepEqual(allPreValues, ['0', '1', '1', '1', '10', '100', '1000']);
 
 			// test 2: renders 3 <astro-island>s
-			assert.equal($('astro-island').length, 6)
-			
+			assert.equal($('astro-island').length, 6);
+
 			// test 3: all <astro-island>s have uid attributes
-			assert.equal($('astro-island[uid]').length, 6)
+			assert.equal($('astro-island[uid]').length, 6);
 
 			// test 4: treats <my-button> as a custom element
-			assert.equal($('my-button').length, 7)
+			assert.equal($('my-button').length, 7);
 
 			// test 5: components with identical render output and props have been deduplicated
 			const uniqueRootUIDs = $('astro-island').map((i, el) => $(el).attr('uid'));
-			assert.equal(new Set(uniqueRootUIDs).size, 5)
+			assert.equal(new Set(uniqueRootUIDs).size, 5);
 
 			// test 6: import public files work
-			assert($('#vue-img'));
+			assert.ok($('#vue-img'));
 		});
 	});
 
@@ -66,7 +66,8 @@ describe('Vue component', () => {
 			for (const script of $('script').toArray()) {
 				const { src } = script.attribs;
 				if (!src) continue;
-				expect((await fixture.fetch(src)).status, `404: ${src}`).to.equal(200);
+				const response = await fixture.fetch(src);
+				assert.equal(response.status, 200, `404: ${src}`);
 			}
 		});
 	});

--- a/packages/astro/test/vue-jsx.nodetest.js
+++ b/packages/astro/test/vue-jsx.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
@@ -24,7 +25,7 @@ describe('Vue JSX', () => {
 				.toArray()
 				.map((el) => $(el).text());
 
-			expect(allPreValues).to.deep.equal(['2345', '0', '1', '1', '1', '10', '100', '1000']);
+			assert.deepEqual(allPreValues, ['2345', '0', '1', '1', '1', '10', '100', '1000']);
 		});
 	});
 });

--- a/packages/astro/test/vue-with-multi-renderer.nodetest.js
+++ b/packages/astro/test/vue-with-multi-renderer.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('Vue with multi-renderer', () => {
@@ -14,7 +15,7 @@ describe('Vue with multi-renderer', () => {
 		try {
 			await fixture.build();
 		} catch (e) {
-			expect(e).to.equal(undefined, `Should not throw`);
+			assert.equal(e, undefined, `Should not throw`)
 		}
 	});
 });


### PR DESCRIPTION
## Changes

- migrates vue related tests to `node:test`
- related issue #9873 
<!-- - What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset` -->

## Testing

- `pnpm --filter astro run test:node`
- All tests passing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
N/A
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
