### PR TITLE
fix(i18n): regression where emitted URLs had `//`

### DIFF
--- a/.changeset/forty-hounds-look.md
+++ b/.changeset/forty-hounds-look.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where `getLocaleAbsoluteUrlList` and `getLocaleAbsoluteUrl` incorrectly adding an additional slash

--- a/.changeset/forty-hounds-look.md
+++ b/.changeset/forty-hounds-look.md
@@ -1,5 +1,0 @@
----
-"astro": patch
----
-
-Fixes an issue where `getLocaleAbsoluteUrlList` and `getLocaleAbsoluteUrl` incorrectly adding an additional slash

--- a/.changeset/tasty-actors-dance.md
+++ b/.changeset/tasty-actors-dance.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes a regression in the `astro:i18n` module, where the functions `getAbsoluteLocaleUrl` and `getAbsoluteLocaleUrlList` returned a URL with double slash with a certain combination of options. 

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -194,7 +194,7 @@ export class App {
 			this.#manifest.i18n &&
 			(this.#manifest.i18n.routing === 'domains-prefix-always' ||
 				this.#manifest.i18n.routing === 'domains-prefix-other-locales' ||
-				this.#manifest.i18n.routing === 'domains-prefix-other-no-redirect')
+				this.#manifest.i18n.routing === 'domains-prefix-always-no-redirect')
 		) {
 			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
 			let host = request.headers.get('X-Forwarded-Host');

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -241,7 +241,7 @@ function buildManifest(
 		i18n.domains &&
 		(i18n.routing === 'domains-prefix-always' ||
 			i18n.routing === 'domains-prefix-other-locales' ||
-			i18n.routing === 'domains-prefix-other-no-redirect')
+			i18n.routing === 'domains-prefix-always-no-redirect')
 	) {
 		for (const [locale, domainValue] of Object.entries(i18n.domains)) {
 			domainLookupTable[domainValue] = normalizeTheLocale(locale);

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -72,7 +72,7 @@ export type RoutingStrategies =
 	| 'pathname-prefix-always-no-redirect'
 	| 'domains-prefix-always'
 	| 'domains-prefix-other-locales'
-	| 'domains-prefix-other-no-redirect';
+	| 'domains-prefix-always-no-redirect';
 
 export const AstroConfigSchema = z.object({
 	root: z
@@ -383,7 +383,7 @@ export const AstroConfigSchema = z.object({
 							if (routing.redirectToDefaultLocale) {
 								strategy = 'domains-prefix-always';
 							} else {
-								strategy = 'domains-prefix-other-no-redirect';
+								strategy = 'domains-prefix-always-no-redirect';
 							}
 						} else {
 							strategy = 'domains-prefix-other-locales';
@@ -439,7 +439,7 @@ export const AstroConfigSchema = z.object({
 						if (entries.length > 0) {
 							if (
 								routing !== 'domains-prefix-other-locales' &&
-								routing !== 'domains-prefix-other-no-redirect' &&
+								routing !== 'domains-prefix-always-no-redirect' &&
 								routing !== 'domains-prefix-always'
 							) {
 								ctx.addIssue({
@@ -627,7 +627,7 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 			if (experimental.i18nDomains) {
 				if (
 					i18n?.routing === 'domains-prefix-other-locales' ||
-					i18n?.routing === 'domains-prefix-other-no-redirect' ||
+					i18n?.routing === 'domains-prefix-always-no-redirect' ||
 					i18n?.routing === 'domains-prefix-always'
 				) {
 					if (!site) {

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -123,7 +123,12 @@ export function getLocaleRelativeUrlList({
 		const pathsToJoin = [base, prependWith];
 		const normalizedLocale = normalizeLocale ? normalizeTheLocale(locale) : locale;
 
-		if (routing === 'pathname-prefix-always' || routing === 'pathname-prefix-always-no-redirect') {
+		if (
+			routing === 'pathname-prefix-always' ||
+			routing === 'pathname-prefix-always-no-redirect' ||
+			routing === 'domains-prefix-always' ||
+			routing === 'domains-prefix-always-no-redirect'
+		) {
 			pathsToJoin.push(normalizedLocale);
 		} else if (locale !== defaultLocale) {
 			pathsToJoin.push(normalizedLocale);
@@ -167,17 +172,25 @@ export function getLocaleAbsoluteUrlList({
 			} else {
 				pathsToJoin.push(site);
 			}
-			pathsToJoin.push(base);
+			// "/" is the default, we don't want to add it here
+			if (base !== '/') {
+				pathsToJoin.push(base);
+			}
 			pathsToJoin.push(prependWith);
 		} else {
 			if (site) {
 				pathsToJoin.push(site);
 			}
-			pathsToJoin.push(base);
+			// "/" is the default, we don't want to add it here
+			if (base !== '/') {
+				pathsToJoin.push(base);
+			}
 			pathsToJoin.push(prependWith);
 			if (
 				routing === 'pathname-prefix-always' ||
-				routing === 'pathname-prefix-always-no-redirect'
+				routing === 'pathname-prefix-always-no-redirect' ||
+				routing === 'domains-prefix-always' ||
+				routing === 'domains-prefix-always-no-redirect'
 			) {
 				pathsToJoin.push(normalizedLocale);
 			} else if (currentLocale !== defaultLocale) {

--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -137,7 +137,7 @@ export function createI18nMiddleware(
 					break;
 				}
 
-				case 'domains-prefix-other-no-redirect': {
+				case 'domains-prefix-always-no-redirect': {
 					if (localeHasntDomain(i18n, currentLocale)) {
 						const result = prefixAlwaysNoRedirect(url, response);
 						if (result) {

--- a/packages/astro/test/i18n-routing.nodetest.js
+++ b/packages/astro/test/i18n-routing.nodetest.js
@@ -1607,15 +1607,6 @@ describe('[SSR] i18n routing', () => {
 					root: './fixtures/i18n-routing/',
 					output: 'server',
 					adapter: testAdapter(),
-					i18n: {
-						defaultLocale: 'en',
-						locales: [
-							{
-								path: 'english',
-								codes: ['en', 'en-AU', 'pt-BR', 'es-US'],
-							},
-						],
-					},
 				});
 				await fixture.build();
 				app = await fixture.loadTestAdapterApp();
@@ -1624,14 +1615,14 @@ describe('[SSR] i18n routing', () => {
 			it('they should be still considered when parsing the Accept-Language header', async () => {
 				let request = new Request('http://example.com/preferred-locale', {
 					headers: {
-						'Accept-Language': 'en-AU;q=0.1,pt-BR;q=0.9',
+						'Accept-Language': 'en-AU;q=0.1,es;q=0.9',
 					},
 				});
 				let response = await app.render(request);
 				const text = await response.text();
 				assert.equal(response.status, 200);
-				assert.equal(text.includes('Locale: english'), true);
-				assert.equal(text.includes('Locale list: english'), true);
+				assert.equal(text.includes('Locale: spanish'), true);
+				assert.equal(text.includes('Locale list: spanish'), true);
 			});
 		});
 	});

--- a/packages/astro/test/units/i18n/astro_i18n.test.js
+++ b/packages/astro/test/units/i18n/astro_i18n.test.js
@@ -658,23 +658,21 @@ describe('getLocaleAbsoluteUrl', () => {
 			 */
 			const config = {
 				base: '/blog',
-				experimental: {
-					i18n: {
-						defaultLocale: 'en',
-						locales: [
-							'en',
-							'en_US',
-							'es',
-							{
-								path: 'italiano',
-								codes: ['it', 'it-VA'],
-							},
-						],
-						domains: {
-							es: 'https://es.example.com',
+				i18n: {
+					defaultLocale: 'en',
+					locales: [
+						'en',
+						'en_US',
+						'es',
+						{
+							path: 'italiano',
+							codes: ['it', 'it-VA'],
 						},
-						routingStrategy: 'prefix-other-locales',
+					],
+					domains: {
+						es: 'https://es.example.com',
 					},
+					routingStrategy: 'prefix-other-locales',
 				},
 			};
 
@@ -686,14 +684,14 @@ describe('getLocaleAbsoluteUrl', () => {
 					trailingSlash: 'always',
 					format: 'directory',
 					site: 'https://example.com',
-					...config.experimental.i18n,
+					...config.i18n,
 				})
 			).to.eq('https://example.com/blog/');
 			expect(
 				getLocaleAbsoluteUrl({
 					locale: 'es',
 					base: '/blog/',
-					...config.experimental.i18n,
+					...config.i18n,
 					trailingSlash: 'always',
 					format: 'directory',
 					site: 'https://example.com',
@@ -704,7 +702,7 @@ describe('getLocaleAbsoluteUrl', () => {
 				getLocaleAbsoluteUrl({
 					locale: 'es',
 					base: '/blog/',
-					...config.experimental.i18n,
+					...config.i18n,
 					trailingSlash: 'always',
 					format: 'directory',
 					site: 'https://example.com',
@@ -716,7 +714,7 @@ describe('getLocaleAbsoluteUrl', () => {
 				getLocaleAbsoluteUrl({
 					locale: 'en_US',
 					base: '/blog/',
-					...config.experimental.i18n,
+					...config.i18n,
 					trailingSlash: 'always',
 					format: 'directory',
 					site: 'https://example.com',
@@ -728,7 +726,7 @@ describe('getLocaleAbsoluteUrl', () => {
 				getLocaleAbsoluteUrl({
 					locale: 'en',
 					base: '/blog/',
-					...config.experimental.i18n,
+					...config.i18n,
 					trailingSlash: 'always',
 					format: 'file',
 					site: 'https://example.com',
@@ -738,7 +736,7 @@ describe('getLocaleAbsoluteUrl', () => {
 				getLocaleAbsoluteUrl({
 					locale: 'es',
 					base: '/blog/',
-					...config.experimental.i18n,
+					...config.i18n,
 					trailingSlash: 'always',
 					format: 'file',
 					site: 'https://example.com',
@@ -749,7 +747,7 @@ describe('getLocaleAbsoluteUrl', () => {
 				getLocaleAbsoluteUrl({
 					locale: 'en_US',
 					base: '/blog/',
-					...config.experimental.i18n,
+					...config.i18n,
 					trailingSlash: 'always',
 					format: 'file',
 					site: 'https://example.com',
@@ -759,7 +757,7 @@ describe('getLocaleAbsoluteUrl', () => {
 				getLocaleAbsoluteUrl({
 					locale: 'it-VA',
 					base: '/blog/',
-					...config.experimental.i18n,
+					...config.i18n,
 					trailingSlash: 'always',
 					format: 'file',
 					site: 'https://example.com',
@@ -770,7 +768,7 @@ describe('getLocaleAbsoluteUrl', () => {
 				getLocaleAbsoluteUrl({
 					locale: 'en_US',
 					base: '/blog/',
-					...config.experimental.i18n,
+					...config.i18n,
 					trailingSlash: 'always',
 					format: 'file',
 					site: 'https://example.com',
@@ -781,7 +779,7 @@ describe('getLocaleAbsoluteUrl', () => {
 				getLocaleAbsoluteUrl({
 					locale: 'es',
 					base: '/blog/',
-					...config.experimental.i18n,
+					...config.i18n,
 					trailingSlash: 'always',
 					format: 'file',
 					site: 'https://example.com',
@@ -794,7 +792,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					locale: 'es',
 					base: '/blog/',
 					prependWith: 'some-name',
-					...config.experimental.i18n,
+					...config.i18n,
 					trailingSlash: 'always',
 					format: 'file',
 					site: 'https://example.com',
@@ -809,14 +807,14 @@ describe('getLocaleAbsoluteUrl', () => {
 					locale: 'en',
 					base: '/blog/',
 					prependWith: 'some-name',
-					...config.experimental.i18n,
+					...config.i18n,
 					trailingSlash: 'always',
 					format: 'file',
 					site: 'https://example.com',
 					path: 'first-post',
 					isBuild: true,
 				})
-			).to.eq('/blog/some-name/first-post/');
+			).to.eq('https://example.com/blog/some-name/first-post/');
 		});
 	});
 	describe('with [prefix-always]', () => {
@@ -1449,34 +1447,39 @@ describe('getLocaleAbsoluteUrl', () => {
 });
 
 describe('getLocaleAbsoluteUrlList', () => {
-	it('should retrieve the correct list of base URL with locales [format: directory, trailingSlash: never]', () => {
+	it('should retrieve the correct list of base URL with locales [format: directory, trailingSlash: never]', async () => {
 		/**
 		 *
 		 * @type {import("../../../dist/@types").AstroUserConfig}
 		 */
-		const config = {
-			i18n: {
-				defaultLocale: 'en',
-				locales: [
-					'en',
-					'en_US',
-					'es',
-					{
-						path: 'italiano',
-						codes: ['it', 'it-VA'],
-					},
-				],
+		const config = await validateConfig(
+			{
+				trailingSlash: 'never',
+				format: 'directory',
+				site: 'https://example.com',
+				base: '/blog',
+				i18n: {
+					defaultLocale: 'en',
+					locales: [
+						'en',
+						'en_US',
+						'es',
+						{
+							path: 'italiano',
+							codes: ['it', 'it-VA'],
+						},
+					],
+				},
 			},
-		};
+			process.cwd()
+		);
 		// directory format
 		expect(
 			getLocaleAbsoluteUrlList({
 				locale: 'en',
-				base: '/blog',
+				...config,
 				...config.i18n,
-				trailingSlash: 'never',
-				format: 'directory',
-				site: 'https://example.com',
+				isBuild: true,
 			})
 		).to.have.members([
 			'https://example.com/blog',


### PR DESCRIPTION
## Changes

This PR fixes a bug where, under certain situations, the absolute URL emitted by the utility has a double slash.

I removed logic that wasn't needed and used the existing logic coming from `getRelativeLocaleUrl`.

## Testing

I added a new unit test and used the `validateConfig` function that emits the correct defaults from the Astro configuration. That's handy because I was struggling to get Astro defaults when running the unit tests. Ideally I could port all tests to use this pattern, and I'll do it in another PR.

I also updated an integration test; for some reason, the configuration passed to that test wasn't updated. Regardless, the test case that I updated works as I wanted. 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
