### PR TITLE
test: move some unit tests to use node:test

### DIFF
--- a/packages/astro/test/units/config/config-resolve.nodetest.js
+++ b/packages/astro/test/units/config/config-resolve.nodetest.js
@@ -1,7 +1,8 @@
-import { expect } from 'chai';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveConfig } from '../../../dist/core/config/index.js';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 
 describe('resolveConfig', () => {
 	it('resolves relative inline root correctly', async () => {
@@ -13,6 +14,6 @@ describe('resolveConfig', () => {
 			'dev'
 		);
 		const expectedRoot = path.join(process.cwd(), 'relative/path/');
-		expect(fileURLToPath(astroConfig.root)).to.equal(expectedRoot);
+		assert.equal(fileURLToPath(astroConfig.root), expectedRoot);
 	});
 });

--- a/packages/astro/test/units/config/config-server.nodetest.js
+++ b/packages/astro/test/units/config/config-server.nodetest.js
@@ -1,7 +1,8 @@
-import { expect } from 'chai';
 import { fileURLToPath } from 'node:url';
 import { flagsToAstroInlineConfig } from '../../../dist/cli/flags.js';
 import { resolveConfig } from '../../../dist/core/config/index.js';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 
 const cwd = fileURLToPath(new URL('../../fixtures/config-host/', import.meta.url));
 
@@ -24,7 +25,7 @@ describe('config.server', () => {
 				host: true,
 			});
 
-			expect(astroConfig.server.host).to.equal(true);
+			assert.equal(astroConfig.server.host, true);
 		});
 	});
 
@@ -37,7 +38,7 @@ describe('config.server', () => {
 					root: fileURLToPath(projectRootURL),
 					config: configFileURL,
 				});
-				expect(astroConfig.server.port).to.equal(8080);
+				assert.equal(astroConfig.server.port, 8080);
 			});
 		});
 
@@ -49,7 +50,7 @@ describe('config.server', () => {
 					root: fileURLToPath(projectRootURL),
 					config: configFileURL,
 				});
-				expect(astroConfig.server.port).to.equal(8080);
+				assert.equal(astroConfig.server.port, 8080);
 			});
 		});
 
@@ -62,9 +63,9 @@ describe('config.server', () => {
 						root: fileURLToPath(projectRootURL),
 						config: configFileURL,
 					});
-					expect(false).to.equal(true, 'this should not have resolved');
+					assert.equal(false, true, 'this should not have resolved');
 				} catch (err) {
-					expect(err.message).to.match(/Unable to resolve/);
+					assert.equal(err.message.includes('Unable to resolve'), true);
 				}
 			});
 		});

--- a/packages/astro/test/units/config/config-tsconfig.nodetest.js
+++ b/packages/astro/test/units/config/config-tsconfig.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadTSConfig, updateTSConfigForFramework } from '../../../dist/core/config/index.js';
@@ -10,31 +11,31 @@ describe('TSConfig handling', () => {
 		it('can load tsconfig.json', async () => {
 			const config = await loadTSConfig(cwd);
 
-			expect(config).to.not.be.undefined;
+			assert.equal(config !== undefined, true);
 		});
 
 		it('can resolve tsconfig.json up directories', async () => {
 			const config = await loadTSConfig(cwd);
 
-			expect(config).to.not.be.undefined;
-			expect(config.tsconfigFile).to.equal(path.join(cwd, 'tsconfig.json'));
-			expect(config.tsconfig.files).to.deep.equal(['im-a-test']);
+			assert.equal(config !== undefined, true);
+			assert.equal(config.tsconfigFile, path.join(cwd, 'tsconfig.json'));
+			assert.deepEqual(config.tsconfig.files, ['im-a-test']);
 		});
 
 		it('can fallback to jsconfig.json if tsconfig.json does not exists', async () => {
 			const config = await loadTSConfig(path.join(cwd, 'jsconfig'));
 
-			expect(config).to.not.be.undefined;
-			expect(config.tsconfigFile).to.equal(path.join(cwd, 'jsconfig', 'jsconfig.json'));
-			expect(config.tsconfig.files).to.deep.equal(['im-a-test-js']);
+			assert.equal(config !== undefined, true);
+			assert.equal(config.tsconfigFile, path.join(cwd, 'jsconfig', 'jsconfig.json'));
+			assert.deepEqual(config.tsconfig.files, ['im-a-test-js']);
 		});
 
 		it('properly return errors when not resolving', async () => {
 			const invalidConfig = await loadTSConfig(path.join(cwd, 'invalid'));
 			const missingConfig = await loadTSConfig(path.join(cwd, 'missing'));
 
-			expect(invalidConfig).to.equal('invalid-config');
-			expect(missingConfig).to.equal('missing-config');
+			assert.equal(invalidConfig, 'invalid-config');
+			assert.equal(missingConfig, 'missing-config');
 		});
 	});
 
@@ -43,15 +44,15 @@ describe('TSConfig handling', () => {
 			const config = await loadTSConfig(cwd);
 			const updatedConfig = updateTSConfigForFramework(config.tsconfig, 'react');
 
-			expect(config.tsconfig).to.not.equal('react-jsx');
-			expect(updatedConfig.compilerOptions.jsx).to.equal('react-jsx');
+			assert.notEqual(config.tsconfig, 'react-jsx');
+			assert.equal(updatedConfig.compilerOptions.jsx, 'react-jsx');
 		});
 
 		it('produce no changes on invalid frameworks', async () => {
 			const config = await loadTSConfig(cwd);
 			const updatedConfig = updateTSConfigForFramework(config.tsconfig, 'doesnt-exist');
 
-			expect(config.tsconfig).to.deep.equal(updatedConfig);
+			assert.deepEqual(config.tsconfig, updatedConfig);
 		});
 	});
 });

--- a/packages/astro/test/units/config/config-validate.nodetest.js
+++ b/packages/astro/test/units/config/config-validate.nodetest.js
@@ -1,24 +1,26 @@
-import { expect } from 'chai';
 import { z } from 'zod';
 import stripAnsi from 'strip-ansi';
 import { formatConfigErrorMessage } from '../../../dist/core/messages.js';
 import { validateConfig } from '../../../dist/core/config/config.js';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 
 describe('Config Validation', () => {
 	it('empty user config is valid', async () => {
-		expect(() => validateConfig({}, process.cwd()).catch((err) => err)).not.to.throw();
+		assert.doesNotThrow(() => validateConfig({}, process.cwd()).catch((err) => err));
 	});
 
 	it('Zod errors are returned when invalid config is used', async () => {
 		const configError = await validateConfig({ site: 42 }, process.cwd()).catch((err) => err);
-		expect(configError instanceof z.ZodError).to.equal(true);
+		assert.equal(configError instanceof z.ZodError, true);
 	});
 
 	it('A validation error can be formatted correctly', async () => {
 		const configError = await validateConfig({ site: 42 }, process.cwd()).catch((err) => err);
-		expect(configError instanceof z.ZodError).to.equal(true);
+		assert.equal(configError instanceof z.ZodError, true);
 		const formattedError = stripAnsi(formatConfigErrorMessage(configError));
-		expect(formattedError).to.equal(
+		assert.equal(
+			formattedError,
 			`[config] Astro found issue(s) with your configuration:
   ! site  Expected string, received number.`
 		);
@@ -30,9 +32,10 @@ describe('Config Validation', () => {
 			build: { format: 'invalid' },
 		};
 		const configError = await validateConfig(veryBadConfig, process.cwd()).catch((err) => err);
-		expect(configError instanceof z.ZodError).to.equal(true);
+		assert.equal(configError instanceof z.ZodError, true);
 		const formattedError = stripAnsi(formatConfigErrorMessage(configError));
-		expect(formattedError).to.equal(
+		assert.equal(
+			formattedError,
 			`[config] Astro found issue(s) with your configuration:
   ! integrations.0  Expected object, received number.
   ! build.format  Invalid input.`
@@ -44,18 +47,18 @@ describe('Config Validation', () => {
 			{ integrations: [0, false, null, undefined] },
 			process.cwd()
 		);
-		expect(result.integrations).to.deep.equal([]);
+		assert.deepEqual(result.integrations, []);
 	});
 	it('normalizes "integration" values', async () => {
 		const result = await validateConfig({ integrations: [{ name: '@astrojs/a' }] }, process.cwd());
-		expect(result.integrations).to.deep.equal([{ name: '@astrojs/a', hooks: {} }]);
+		assert.deepEqual(result.integrations, [{ name: '@astrojs/a', hooks: {} }]);
 	});
 	it('flattens array "integration" values', async () => {
 		const result = await validateConfig(
 			{ integrations: [{ name: '@astrojs/a' }, [{ name: '@astrojs/b' }, { name: '@astrojs/c' }]] },
 			process.cwd()
 		);
-		expect(result.integrations).to.deep.equal([
+		assert.deepEqual(result.integrations, [
 			{ name: '@astrojs/a', hooks: {} },
 			{ name: '@astrojs/b', hooks: {} },
 			{ name: '@astrojs/c', hooks: {} },
@@ -66,14 +69,15 @@ describe('Config Validation', () => {
 			{ integrations: [null, undefined, false, '', ``] },
 			process.cwd()
 		).catch((err) => err);
-		expect(configError).to.be.not.instanceOf(Error);
+		assert.equal(configError instanceof Error, false);
 	});
 	it('Error when outDir is placed within publicDir', async () => {
 		const configError = await validateConfig({ outDir: './public/dist' }, process.cwd()).catch(
 			(err) => err
 		);
-		expect(configError instanceof z.ZodError).to.equal(true);
-		expect(configError.errors[0].message).to.equal(
+		assert.equal(configError instanceof z.ZodError, true);
+		assert.equal(
+			configError.errors[0].message,
 			'The value of `outDir` must not point to a path within the folder set as `publicDir`, this will cause an infinite loop'
 		);
 	});
@@ -89,8 +93,9 @@ describe('Config Validation', () => {
 				},
 				process.cwd()
 			).catch((err) => err);
-			expect(configError instanceof z.ZodError).to.equal(true);
-			expect(configError.errors[0].message).to.equal(
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message,
 				'The default locale `en` is not present in the `i18n.locales` array.'
 			);
 		});
@@ -111,8 +116,8 @@ describe('Config Validation', () => {
 				},
 				process.cwd()
 			).catch((err) => err);
-			expect(configError instanceof z.ZodError).to.equal(true);
-			expect(configError.errors[0].message).to.equal('Array must contain at least 1 element(s)');
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(configError.errors[0].message, 'Array must contain at least 1 element(s)');
 		});
 
 		it('errors if the default locale is not in path', async () => {
@@ -131,8 +136,9 @@ describe('Config Validation', () => {
 				},
 				process.cwd()
 			).catch((err) => err);
-			expect(configError instanceof z.ZodError).to.equal(true);
-			expect(configError.errors[0].message).to.equal(
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message,
 				'The default locale `uk` is not present in the `i18n.locales` array.'
 			);
 		});
@@ -150,8 +156,9 @@ describe('Config Validation', () => {
 				},
 				process.cwd()
 			).catch((err) => err);
-			expect(configError instanceof z.ZodError).to.equal(true);
-			expect(configError.errors[0].message).to.equal(
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message,
 				"The locale `it` value in the `i18n.fallback` record doesn't exist in the `i18n.locales` array."
 			);
 		});
@@ -169,8 +176,9 @@ describe('Config Validation', () => {
 				},
 				process.cwd()
 			).catch((err) => err);
-			expect(configError instanceof z.ZodError).to.equal(true);
-			expect(configError.errors[0].message).to.equal(
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message,
 				"The locale `it` key in the `i18n.fallback` record doesn't exist in the `i18n.locales` array."
 			);
 		});
@@ -188,8 +196,9 @@ describe('Config Validation', () => {
 				},
 				process.cwd()
 			).catch((err) => err);
-			expect(configError instanceof z.ZodError).to.equal(true);
-			expect(configError.errors[0].message).to.equal(
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message,
 				"You can't use the default locale as a key. The default locale can only be used as value."
 			);
 		});
@@ -208,8 +217,9 @@ describe('Config Validation', () => {
 				},
 				process.cwd()
 			).catch((err) => err);
-			expect(configError instanceof z.ZodError).to.equal(true);
-			expect(configError.errors[0].message).to.equal(
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message,
 				'The option `i18n.redirectToDefaultLocale` is only useful when the `i18n.prefixDefaultLocale` is set to `true`. Remove the option `i18n.redirectToDefaultLocale`, or change its value to `true`.'
 			);
 		});
@@ -228,8 +238,9 @@ describe('Config Validation', () => {
 				},
 				process.cwd()
 			).catch((err) => err);
-			expect(configError instanceof z.ZodError).to.equal(true);
-			expect(configError.errors[0].message).to.equal(
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message,
 				"The locale `lorem` key in the `i18n.domains` record doesn't exist in the `i18n.locales` array."
 			);
 		});
@@ -248,8 +259,9 @@ describe('Config Validation', () => {
 				},
 				process.cwd()
 			).catch((err) => err);
-			expect(configError instanceof z.ZodError).to.equal(true);
-			expect(configError.errors[0].message).to.equal(
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message,
 				"The domain value must be a valid URL, and it has to start with 'https' or 'http'."
 			);
 		});
@@ -268,8 +280,9 @@ describe('Config Validation', () => {
 				},
 				process.cwd()
 			).catch((err) => err);
-			expect(configError instanceof z.ZodError).to.equal(true);
-			expect(configError.errors[0].message).to.equal(
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message,
 				"The domain value must be a valid URL, and it has to start with 'https' or 'http'."
 			);
 		});
@@ -288,8 +301,9 @@ describe('Config Validation', () => {
 				},
 				process.cwd()
 			).catch((err) => err);
-			expect(configError instanceof z.ZodError).to.equal(true);
-			expect(configError.errors[0].message).to.equal(
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message,
 				"The URL `https://www.example.com/blog/page/` must contain only the origin. A subsequent pathname isn't allowed here. Remove `/blog/page/`."
 			);
 		});
@@ -311,8 +325,9 @@ describe('Config Validation', () => {
 				},
 				process.cwd()
 			).catch((err) => err);
-			expect(configError instanceof z.ZodError).to.equal(true);
-			expect(configError.errors[0].message).to.equal(
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message,
 				"The option `site` isn't set. When using the 'domains' strategy for `i18n`, `site` is required to create absolute URLs for locales that aren't mapped to a domain."
 			);
 		});
@@ -335,8 +350,9 @@ describe('Config Validation', () => {
 				},
 				process.cwd()
 			).catch((err) => err);
-			expect(configError instanceof z.ZodError).to.equal(true);
-			expect(configError.errors[0].message).to.equal(
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message,
 				'Domain support is only available when `output` is `"server"`.'
 			);
 		});

--- a/packages/astro/test/units/config/format.nodetest.js
+++ b/packages/astro/test/units/config/format.nodetest.js
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url';
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { createFs, runInContainer } from '../test-utils.js';
 
 const root = new URL('../../fixtures/tailwindcss-ts/', import.meta.url);
@@ -19,7 +20,8 @@ describe('Astro config formats', () => {
 		);
 
 		await runInContainer({ fs, inlineConfig: { root: fileURLToPath(root) } }, () => {
-			expect(true).to.equal(
+			assert.equal(
+				true,
 				true,
 				'We were able to get into the container which means the config loaded.'
 			);

--- a/packages/astro/test/units/content-collections/error-map.nodetest.js
+++ b/packages/astro/test/units/content-collections/error-map.nodetest.js
@@ -1,7 +1,8 @@
 import { z } from '../../../zod.mjs';
 import { errorMap } from '../../../dist/content/index.js';
 import { fixLineEndings } from '../../test-utils.js';
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 
 describe('Content Collections - error map', () => {
 	it('Prefixes messages with object key', () => {
@@ -16,11 +17,11 @@ describe('Content Collections - error map', () => {
 			{ base: 1, nested: { key: 2 }, union: true }
 		);
 		const msgs = messages(error).sort();
-		expect(msgs).to.have.length(3);
+		assert.equal(msgs.length, 3);
 		// expect "**" for bolding
-		expect(msgs[0].startsWith('**base**')).to.equal(true);
-		expect(msgs[1].startsWith('**nested.key**')).to.equal(true);
-		expect(msgs[2].startsWith('**union**')).to.equal(true);
+		assert.equal(msgs[0].startsWith('**base**'), true);
+		assert.equal(msgs[1].startsWith('**nested.key**'), true);
+		assert.equal(msgs[2].startsWith('**union**'), true);
 	});
 	it('Returns formatted error for type mismatch', () => {
 		const error = getParseError(
@@ -29,7 +30,7 @@ describe('Content Collections - error map', () => {
 			}),
 			{ foo: 1 }
 		);
-		expect(messages(error)).to.deep.equal(['**foo**: Expected type `"string"`, received "number"']);
+		assert.deepEqual(messages(error), ['**foo**: Expected type `"string"`, received "number"']);
 	});
 	it('Returns formatted error for literal mismatch', () => {
 		const error = getParseError(
@@ -38,7 +39,7 @@ describe('Content Collections - error map', () => {
 			}),
 			{ lang: 'es' }
 		);
-		expect(messages(error)).to.deep.equal(['**lang**: Expected `"en"`, received "es"']);
+		assert.deepEqual(messages(error), ['**lang**: Expected `"en"`, received "es"']);
 	});
 	it('Replaces undefined errors with "Required"', () => {
 		const error = getParseError(
@@ -48,14 +49,14 @@ describe('Content Collections - error map', () => {
 			}),
 			{ foo: 'foo' }
 		);
-		expect(messages(error)).to.deep.equal(['**bar**: Required']);
+		assert.deepEqual(messages(error), ['**bar**: Required']);
 	});
 	it('Returns formatted error for basic union mismatch', () => {
 		const error = getParseError(
 			z.union([z.boolean(), z.number()]),
 			'not a boolean or a number, oops!'
 		);
-		expect(messages(error)).to.deep.equal([
+		assert.deepEqual(messages(error), [
 			fixLineEndings(
 				'Did not match union:\n> Expected type `"boolean" | "number"`, received "string"'
 			),
@@ -73,7 +74,7 @@ describe('Content Collections - error map', () => {
 			]),
 			{ type: 'integration-guide' }
 		);
-		expect(messages(error)).to.deep.equal([
+		assert.deepEqual(messages(error), [
 			fixLineEndings(
 				'Did not match union:\n> **type**: Expected `"tutorial" | "article"`, received "integration-guide"'
 			),
@@ -86,7 +87,7 @@ describe('Content Collections - error map', () => {
 			}),
 			{ lang: 'jp' }
 		);
-		expect(messages(error)).to.deep.equal([
+		assert.deepEqual(messages(error), [
 			"**lang**: Invalid enum value. Expected 'en' | 'fr', received 'jp'",
 		]);
 	});
@@ -102,6 +103,6 @@ function messages(error) {
 
 function getParseError(schema, entry, parseOpts = { errorMap }) {
 	const res = schema.safeParse(entry, parseOpts);
-	expect(res.success).to.equal(false, 'Schema should raise error');
+	assert.equal(res.success, false, 'Schema should raise error');
 	return res.error;
 }

--- a/packages/astro/test/units/content-collections/frontmatter.nodetest.js
+++ b/packages/astro/test/units/content-collections/frontmatter.nodetest.js
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url';
 import nodeFS from 'node:fs';
 import path from 'node:path';
-
+import { describe, it } from 'node:test';
 import { attachContentServerListeners } from '../../../dist/content/index.js';
 import { createFs, runInContainer, triggerFSEvent } from '../test-utils.js';
 

--- a/packages/astro/test/units/content-collections/get-entry-info.nodetest.js
+++ b/packages/astro/test/units/content-collections/get-entry-info.nodetest.js
@@ -1,5 +1,6 @@
 import { getContentEntryIdAndSlug, getEntryCollectionName } from '../../../dist/content/utils.js';
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 
 describe('Content Collections - entry info', () => {
 	const contentDir = new URL('src/content/', import.meta.url);
@@ -7,40 +8,40 @@ describe('Content Collections - entry info', () => {
 	it('Returns correct collection name', () => {
 		const entry = new URL('blog/first-post.md', contentDir);
 		const collection = getEntryCollectionName({ entry, contentDir });
-		expect(collection).to.equal('blog');
+		assert.equal(collection, 'blog');
 	});
 
 	it('Detects when entry is outside of a collection', () => {
 		const entry = new URL('base-post.md', contentDir);
 		const collection = getEntryCollectionName({ entry, contentDir });
-		expect(collection).to.be.undefined;
+		assert.equal(collection, undefined);
 	});
 
 	it('Returns correct collection when nested directories used', () => {
 		const entry = new URL('docs/2021/01/01/index.md', contentDir);
 		const collection = getEntryCollectionName({ entry, contentDir });
-		expect(collection).to.equal('docs');
+		assert.equal(collection, 'docs');
 	});
 
 	it('Returns correct entry info', () => {
 		const collection = 'blog';
 		const entry = new URL(`${collection}/first-post.md`, contentDir);
 		const info = getContentEntryIdAndSlug({ entry, contentDir, collection });
-		expect(info.id).to.equal('first-post.md');
-		expect(info.slug).to.equal('first-post');
+		assert.equal(info.id, 'first-post.md');
+		assert.equal(info.slug, 'first-post');
 	});
 
 	it('Returns correct slug when spaces used', () => {
 		const collection = 'blog';
 		const entry = new URL(`${collection}/first post.mdx`, contentDir);
 		const info = getContentEntryIdAndSlug({ entry, contentDir, collection });
-		expect(info.slug).to.equal('first-post');
+		assert.equal(info.slug, 'first-post');
 	});
 
 	it('Returns correct slug when nested directories used', () => {
 		const collection = 'blog';
 		const entry = new URL(`${collection}/2021/01/01/index.md`, contentDir);
 		const info = getContentEntryIdAndSlug({ entry, contentDir, collection });
-		expect(info.slug).to.equal('2021/01/01');
+		assert.equal(info.slug, '2021/01/01');
 	});
 });

--- a/packages/astro/test/units/content-collections/get-entry-type.nodetest.js
+++ b/packages/astro/test/units/content-collections/get-entry-type.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { fileURLToPath } from 'node:url';
 import { getEntryType } from '../../../dist/content/utils.js';
 
@@ -35,7 +36,7 @@ describe('Content Collections - getEntryType', () => {
 				for (const entryPath of ['blog/first-post.md', 'blog/first-post.mdx']) {
 					const entry = fileURLToPath(new URL(entryPath, contentPaths.contentDir));
 					const type = getEntryType(entry, contentPaths, contentFileExts, dataFileExts);
-					expect(type).to.equal('content');
+					assert.equal(type, 'content');
 				}
 			});
 
@@ -47,7 +48,7 @@ describe('Content Collections - getEntryType', () => {
 				]) {
 					const entry = fileURLToPath(new URL(entryPath, contentPaths.contentDir));
 					const type = getEntryType(entry, contentPaths, contentFileExts, dataFileExts);
-					expect(type).to.equal('data');
+					assert.equal(type, 'data');
 				}
 			});
 
@@ -55,34 +56,34 @@ describe('Content Collections - getEntryType', () => {
 				for (const entryPath of ['blog/2021/01/01/index.md', 'blog/2021/01/01/index.mdx']) {
 					const entry = fileURLToPath(new URL(entryPath, contentPaths.contentDir));
 					const type = getEntryType(entry, contentPaths, contentFileExts, dataFileExts);
-					expect(type).to.equal('content');
+					assert.equal(type, 'content');
 				}
 			});
 
 			it('Returns "config" for config files', () => {
 				const entry = fileURLToPath(contentPaths.config.url);
 				const type = getEntryType(entry, contentPaths, contentFileExts, dataFileExts);
-				expect(type).to.equal('config');
+				assert.equal(type, 'config');
 			});
 
 			it('Returns "ignored" for non-Markdown files', () => {
 				for (const entryPath of ['blog/robots.txt', 'blog/first-post.png', '.DS_Store']) {
 					const entry = fileURLToPath(new URL(entryPath, contentPaths.contentDir));
 					const type = getEntryType(entry, contentPaths, contentFileExts, dataFileExts);
-					expect(type).to.equal('ignored');
+					assert.equal(type, 'ignored');
 				}
 			});
 
 			it('Returns "ignored" when using underscore on file name', () => {
 				const entry = fileURLToPath(new URL('blog/_first-post.md', contentPaths.contentDir));
 				const type = getEntryType(entry, contentPaths, contentFileExts, dataFileExts);
-				expect(type).to.equal('ignored');
+				assert.equal(type, 'ignored');
 			});
 
 			it('Returns "ignored" when using underscore on directory name', () => {
 				const entry = fileURLToPath(new URL('blog/_draft/first-post.md', contentPaths.contentDir));
 				const type = getEntryType(entry, contentPaths, contentFileExts, dataFileExts);
-				expect(type).to.equal('ignored');
+				assert.equal(type, 'ignored');
 			});
 		});
 	});

--- a/packages/astro/test/units/cookies/delete.nodetest.js
+++ b/packages/astro/test/units/cookies/delete.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { AstroCookies } from '../../../dist/core/cookies/index.js';
 import { apply as applyPolyfill } from '../../../dist/core/polyfill.js';
 
@@ -13,11 +14,11 @@ describe('astro/src/core/cookies', () => {
 				},
 			});
 			let cookies = new AstroCookies(req);
-			expect(cookies.get('foo').value).to.equal('bar');
+			assert.equal(cookies.get('foo').value, 'bar');
 
 			cookies.delete('foo');
 			let headers = Array.from(cookies.headers());
-			expect(headers).to.have.a.lengthOf(1);
+			assert.equal(headers.length, 1);
 		});
 
 		it('calling cookies.get() after returns undefined', () => {
@@ -27,10 +28,10 @@ describe('astro/src/core/cookies', () => {
 				},
 			});
 			let cookies = new AstroCookies(req);
-			expect(cookies.get('foo').value).to.equal('bar');
+			assert.equal(cookies.get('foo').value, 'bar');
 
 			cookies.delete('foo');
-			expect(cookies.get('foo')).to.equal(undefined);
+			assert.equal(cookies.get('foo'), undefined);
 		});
 
 		it('calling cookies.has() after returns false', () => {
@@ -40,10 +41,10 @@ describe('astro/src/core/cookies', () => {
 				},
 			});
 			let cookies = new AstroCookies(req);
-			expect(cookies.has('foo')).to.equal(true);
+			assert.equal(cookies.has('foo'), true);
 
 			cookies.delete('foo');
-			expect(cookies.has('foo')).to.equal(false);
+			assert.equal(cookies.has('foo'), false);
 		});
 
 		it('can provide a path', () => {
@@ -53,8 +54,8 @@ describe('astro/src/core/cookies', () => {
 				path: '/subpath/',
 			});
 			let headers = Array.from(cookies.headers());
-			expect(headers).to.have.a.lengthOf(1);
-			expect(headers[0]).to.match(/Path=\/subpath\//);
+			assert.equal(headers.length, 1);
+			assert.equal(/Path=\/subpath\//.test(headers[0]), true);
 		});
 
 		it('can provide a domain', () => {
@@ -64,8 +65,8 @@ describe('astro/src/core/cookies', () => {
 				domain: '.example.com',
 			});
 			let headers = Array.from(cookies.headers());
-			expect(headers).to.have.a.lengthOf(1);
-			expect(headers[0]).to.match(/Domain=\.example\.com/);
+			assert.equal(headers.length, 1);
+			assert.equal(/Domain=\.example\.com/.test(headers[0]), true);
 		});
 	});
 });

--- a/packages/astro/test/units/cookies/error.nodetest.js
+++ b/packages/astro/test/units/cookies/error.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { AstroCookies } from '../../../dist/core/cookies/index.js';
 import { apply as applyPolyfill } from '../../../dist/core/polyfill.js';
 
@@ -12,9 +13,9 @@ describe('astro/src/core/cookies', () => {
 			req[Symbol.for('astro.responseSent')] = true;
 			try {
 				cookies.set('foo', 'bar');
-				expect(false).to.equal(true);
+				assert.equal(false, true);
 			} catch (err) {
-				expect(err.name).to.equal('ResponseSentError');
+				assert.equal(err.name, 'ResponseSentError');
 			}
 		});
 	});

--- a/packages/astro/test/units/cookies/get.nodetest.js
+++ b/packages/astro/test/units/cookies/get.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { AstroCookies } from '../../../dist/core/cookies/index.js';
 import { apply as applyPolyfill } from '../../../dist/core/polyfill.js';
 
@@ -13,7 +14,7 @@ describe('astro/src/core/cookies', () => {
 				},
 			});
 			const cookies = new AstroCookies(req);
-			expect(cookies.get('foo').value).to.equal('bar');
+			assert.equal(cookies.get('foo').value, 'bar');
 		});
 
 		it('gets the cookie value with default decode', () => {
@@ -25,7 +26,7 @@ describe('astro/src/core/cookies', () => {
 			});
 			const cookies = new AstroCookies(req);
 			// by default decodeURIComponent is used on the value
-			expect(cookies.get('url').value).to.equal(url);
+			assert.equal(cookies.get('url').value, url);
 		});
 
 		it('gets the cookie value with custom decode', () => {
@@ -37,14 +38,14 @@ describe('astro/src/core/cookies', () => {
 			});
 			const cookies = new AstroCookies(req);
 			// set decode to the identity function to prevent decodeURIComponent on the value
-			expect(cookies.get('url', { decode: (o) => o }).value).to.equal(encodeURIComponent(url));
+			assert.equal(cookies.get('url', { decode: (o) => o }).value, encodeURIComponent(url));
 		});
 
 		it("Returns undefined is the value doesn't exist", () => {
 			const req = new Request('http://example.com/');
 			let cookies = new AstroCookies(req);
 			let cookie = cookies.get('foo');
-			expect(cookie).to.equal(undefined);
+			assert.equal(cookie, undefined);
 		});
 
 		describe('.json()', () => {
@@ -57,8 +58,8 @@ describe('astro/src/core/cookies', () => {
 				let cookies = new AstroCookies(req);
 
 				const json = cookies.get('foo').json();
-				expect(json).to.be.an('object');
-				expect(json.key).to.equal('value');
+				assert.equal(typeof json, 'object');
+				assert.equal(json.key, 'value');
 			});
 		});
 
@@ -72,8 +73,8 @@ describe('astro/src/core/cookies', () => {
 				let cookies = new AstroCookies(req);
 
 				const value = cookies.get('foo').number();
-				expect(value).to.be.an('number');
-				expect(value).to.equal(22);
+				assert.equal(typeof value, 'number');
+				assert.equal(value, 22);
 			});
 
 			it('Coerces non-number into NaN', () => {
@@ -85,8 +86,8 @@ describe('astro/src/core/cookies', () => {
 				let cookies = new AstroCookies(req);
 
 				const value = cookies.get('foo').number();
-				expect(value).to.be.an('number');
-				expect(Number.isNaN(value)).to.equal(true);
+				assert.equal(typeof value, 'number');
+				assert.equal(Number.isNaN(value), true);
 			});
 		});
 
@@ -100,8 +101,8 @@ describe('astro/src/core/cookies', () => {
 				let cookies = new AstroCookies(req);
 
 				const value = cookies.get('foo').boolean();
-				expect(value).to.be.an('boolean');
-				expect(value).to.equal(true);
+				assert.equal(typeof value, 'boolean');
+				assert.equal(value, true);
 			});
 
 			it('Coerces false into `false`', () => {
@@ -113,8 +114,8 @@ describe('astro/src/core/cookies', () => {
 				let cookies = new AstroCookies(req);
 
 				const value = cookies.get('foo').boolean();
-				expect(value).to.be.an('boolean');
-				expect(value).to.equal(false);
+				assert.equal(typeof value, 'boolean');
+				assert.equal(value, false);
 			});
 
 			it('Coerces 1 into `true`', () => {
@@ -126,8 +127,8 @@ describe('astro/src/core/cookies', () => {
 				let cookies = new AstroCookies(req);
 
 				const value = cookies.get('foo').boolean();
-				expect(value).to.be.an('boolean');
-				expect(value).to.equal(true);
+				assert.equal(typeof value, 'boolean');
+				assert.equal(value, true);
 			});
 
 			it('Coerces 0 into `false`', () => {
@@ -139,8 +140,8 @@ describe('astro/src/core/cookies', () => {
 				let cookies = new AstroCookies(req);
 
 				const value = cookies.get('foo').boolean();
-				expect(value).to.be.an('boolean');
-				expect(value).to.equal(false);
+				assert.equal(typeof value, 'boolean');
+				assert.equal(value, false);
 			});
 
 			it('Coerces truthy strings into `true`', () => {
@@ -152,8 +153,8 @@ describe('astro/src/core/cookies', () => {
 				let cookies = new AstroCookies(req);
 
 				const value = cookies.get('foo').boolean();
-				expect(value).to.be.an('boolean');
-				expect(value).to.equal(true);
+				assert.equal(typeof value, 'boolean');
+				assert.equal(value, true);
 			});
 		});
 	});

--- a/packages/astro/test/units/cookies/has.nodetest.js
+++ b/packages/astro/test/units/cookies/has.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { AstroCookies } from '../../../dist/core/cookies/index.js';
 import { apply as applyPolyfill } from '../../../dist/core/polyfill.js';
 
@@ -13,20 +14,20 @@ describe('astro/src/core/cookies', () => {
 				},
 			});
 			let cookies = new AstroCookies(req);
-			expect(cookies.has('foo')).to.equal(true);
+			assert.equal(cookies.has('foo'), true);
 		});
 
 		it('returns false if the request does not have the cookie', () => {
 			let req = new Request('http://example.com/');
 			let cookies = new AstroCookies(req);
-			expect(cookies.has('foo')).to.equal(false);
+			assert.equal(cookies.has('foo'), false);
 		});
 
 		it('returns true if the cookie has been set', () => {
 			let req = new Request('http://example.com/');
 			let cookies = new AstroCookies(req);
 			cookies.set('foo', 'bar');
-			expect(cookies.has('foo')).to.equal(true);
+			assert.equal(cookies.has('foo'), true);
 		});
 	});
 });

--- a/packages/astro/test/units/cookies/set.nodetest.js
+++ b/packages/astro/test/units/cookies/set.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 import { AstroCookies } from '../../../dist/core/cookies/index.js';
 import { apply as applyPolyfill } from '../../../dist/core/polyfill.js';
 
@@ -11,8 +12,8 @@ describe('astro/src/core/cookies', () => {
 			let cookies = new AstroCookies(req);
 			cookies.set('foo', 'bar');
 			let headers = Array.from(cookies.headers());
-			expect(headers).to.have.a.lengthOf(1);
-			expect(headers[0]).to.equal('foo=bar');
+			assert.equal(headers.length, 1);
+			assert.equal(headers[0], 'foo=bar');
 		});
 
 		it('Sets a cookie value that can be serialized w/ defaultencodeURIComponent behavior', () => {
@@ -21,9 +22,9 @@ describe('astro/src/core/cookies', () => {
 			const url = 'http://localhost/path';
 			cookies.set('url', url);
 			let headers = Array.from(cookies.headers());
-			expect(headers).to.have.a.lengthOf(1);
+			assert.equal(headers.length, 1);
 			// by default cookie value is URI encoded
-			expect(headers[0]).to.equal(`url=${encodeURIComponent(url)}`);
+			assert.equal(headers[0], `url=${encodeURIComponent(url)}`);
 		});
 
 		it('Sets a cookie value that can be serialized w/ custom encode behavior', () => {
@@ -33,9 +34,9 @@ describe('astro/src/core/cookies', () => {
 			// set encode option to the identity function
 			cookies.set('url', url, { encode: (o) => o });
 			let headers = Array.from(cookies.headers());
-			expect(headers).to.have.a.lengthOf(1);
+			assert.equal(headers.length, 1);
 			// no longer URI encoded
-			expect(headers[0]).to.equal(`url=${url}`);
+			assert.equal(headers[0], `url=${url}`);
 		});
 
 		it('Can set cookie options', () => {
@@ -46,8 +47,8 @@ describe('astro/src/core/cookies', () => {
 				path: '/subpath/',
 			});
 			let headers = Array.from(cookies.headers());
-			expect(headers).to.have.a.lengthOf(1);
-			expect(headers[0]).to.equal('foo=bar; Path=/subpath/; HttpOnly');
+			assert.equal(headers.length, 1);
+			assert.equal(headers[0], 'foo=bar; Path=/subpath/; HttpOnly');
 		});
 
 		it('Can pass a JavaScript object that will be serialized', () => {
@@ -55,8 +56,8 @@ describe('astro/src/core/cookies', () => {
 			let cookies = new AstroCookies(req);
 			cookies.set('options', { one: 'two', three: 4 });
 			let headers = Array.from(cookies.headers());
-			expect(headers).to.have.a.lengthOf(1);
-			expect(JSON.parse(decodeURIComponent(headers[0].slice(8))).one).to.equal('two');
+			assert.equal(headers.length, 1);
+			assert.equal(JSON.parse(decodeURIComponent(headers[0].slice(8))).one, 'two');
 		});
 
 		it('Can pass a number', () => {
@@ -64,18 +65,18 @@ describe('astro/src/core/cookies', () => {
 			let cookies = new AstroCookies(req);
 			cookies.set('one', 2);
 			let headers = Array.from(cookies.headers());
-			expect(headers).to.have.a.lengthOf(1);
-			expect(headers[0]).to.equal('one=2');
+			assert.equal(headers.length, 1);
+			assert.equal(headers[0], 'one=2');
 		});
 
 		it('Can pass a boolean', () => {
 			let req = new Request('http://example.com/');
 			let cookies = new AstroCookies(req);
 			cookies.set('admin', true);
-			expect(cookies.get('admin').boolean()).to.equal(true);
+			assert.equal(cookies.get('admin').boolean(), true);
 			let headers = Array.from(cookies.headers());
-			expect(headers).to.have.a.lengthOf(1);
-			expect(headers[0]).to.equal('admin=true');
+			assert.equal(headers.length, 1);
+			assert.equal(headers[0], 'admin=true');
 		});
 
 		it('Can get the value after setting', () => {
@@ -83,7 +84,7 @@ describe('astro/src/core/cookies', () => {
 			let cookies = new AstroCookies(req);
 			cookies.set('foo', 'bar');
 			let r = cookies.get('foo');
-			expect(r.value).to.equal('bar');
+			assert.equal(r.value, 'bar');
 		});
 
 		it('Can get the JavaScript object after setting', () => {
@@ -92,10 +93,10 @@ describe('astro/src/core/cookies', () => {
 			cookies.set('options', { one: 'two', three: 4 });
 			let cook = cookies.get('options');
 			let value = cook.json();
-			expect(value).to.be.an('object');
-			expect(value.one).to.equal('two');
-			expect(value.three).to.be.a('number');
-			expect(value.three).to.equal(4);
+			assert.equal(typeof value, 'object');
+			assert.equal(value.one, 'two');
+			assert.equal(typeof value.three, 'number');
+			assert.equal(value.three, 4);
 		});
 
 		it('Overrides a value in the request', () => {
@@ -105,11 +106,11 @@ describe('astro/src/core/cookies', () => {
 				},
 			});
 			let cookies = new AstroCookies(req);
-			expect(cookies.get('foo').value).to.equal('bar');
+			assert.equal(cookies.get('foo').value, 'bar');
 
 			// Set a new value
 			cookies.set('foo', 'baz');
-			expect(cookies.get('foo').value).to.equal('baz');
+			assert.equal(cookies.get('foo').value, 'baz');
 		});
 	});
 });


### PR DESCRIPTION
## Changes

Moves `units/content-collections`, `units/cookies` and `units/config`.

Part of #9873 

## Testing

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
