### PR TITLE
chore: Migrate All `packages/markdown/remark/tests` to node:test

### DIFF
--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -31,7 +31,7 @@
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "postbuild": "astro-scripts copy \"src/**/*.js\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "mocha --exit --timeout 20000"
+    "test": "astro-scripts test \"test/**/*.test.js\""
   },
   "dependencies": {
     "@astrojs/prism": "^3.0.0",

--- a/packages/markdown/remark/test/autolinking.test.js
+++ b/packages/markdown/remark/test/autolinking.test.js
@@ -1,37 +1,43 @@
+import assert from 'node:assert/strict';
+import { describe, it, before } from 'node:test';
 import { createMarkdownProcessor } from '../dist/index.js';
-import chai from 'chai';
 
 describe('autolinking', () => {
-	describe('plain md', async () => {
-		const processor = await createMarkdownProcessor();
+	describe('plain md', () => {
+		let processor;
+
+		before(async () => {
+			processor = await createMarkdownProcessor();
+		});
 
 		it('autolinks URLs starting with a protocol in plain text', async () => {
-			const { code } = await processor.render(`See https://example.com for more.`);
+			const markdown = `See https://example.com for more.`;
+			const { code } = await processor.render(markdown);
 
-			chai
-				.expect(code.replace(/\n/g, ''))
-				.to.equal(`<p>See <a href="https://example.com">https://example.com</a> for more.</p>`);
+			assert.equal(
+				code.replace(/\n/g, ''),
+				`<p>See <a href="https://example.com">https://example.com</a> for more.</p>`
+			);
 		});
 
 		it('autolinks URLs starting with "www." in plain text', async () => {
-			const { code } = await processor.render(`See www.example.com for more.`);
+			const markdown = `See www.example.com for more.`;
+			const { code } = await processor.render(markdown);
 
-			chai
-				.expect(code.trim())
-				.to.equal(`<p>See <a href="http://www.example.com">www.example.com</a> for more.</p>`);
+			assert.equal(
+				code.trim(),
+				`<p>See <a href="http://www.example.com">www.example.com</a> for more.</p>`
+			);
 		});
 
 		it('does not autolink URLs in code blocks', async () => {
-			const { code } = await processor.render(
-				'See `https://example.com` or `www.example.com` for more.'
-			);
+			const markdown = `See \`https://example.com\` or \`www.example.com\` for more.`;
+			const { code } = await processor.render(markdown);
 
-			chai
-				.expect(code.trim())
-				.to.equal(
-					`<p>See <code>https://example.com</code> or ` +
-						`<code>www.example.com</code> for more.</p>`
-				);
+			assert.equal(
+				code.trim(),
+				`<p>See <code>https://example.com</code> or <code>www.example.com</code> for more.</p>`
+			);
 		});
 	});
 });

--- a/packages/markdown/remark/test/browser.test.js
+++ b/packages/markdown/remark/test/browser.test.js
@@ -1,15 +1,20 @@
 import esbuild from 'esbuild';
-import { expect } from 'chai';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 
 describe('Bundle for browsers', async () => {
 	it('esbuild browser build should work', async () => {
-		const result = await esbuild.build({
-			platform: 'browser',
-			entryPoints: ['@astrojs/markdown-remark'],
-			bundle: true,
-			write: false,
-		});
-		// If some non-browser-safe stuff sneaks in, esbuild should error before reaching here
-		expect(result.outputFiles.length).to.be.greaterThan(0);
+		try {
+			const result = await esbuild.build({
+				platform: 'browser',
+				entryPoints: ['@astrojs/markdown-remark'],
+				bundle: true,
+				write: false,
+			});
+			assert.ok(result.outputFiles.length > 0, 'Output files should be generated');
+		} catch (error) {
+			// Capture any esbuild errors and fail the test
+			assert.fail(error.message);
+		}
 	});
 });

--- a/packages/markdown/remark/test/browser.test.js
+++ b/packages/markdown/remark/test/browser.test.js
@@ -11,7 +11,7 @@ describe('Bundle for browsers', async () => {
 				bundle: true,
 				write: false,
 			});
-			assert.ok(result.outputFiles.length > 0, 'Output files should be generated');
+			assert.ok(result.outputFiles.length > 0);
 		} catch (error) {
 			// Capture any esbuild errors and fail the test
 			assert.fail(error.message);

--- a/packages/markdown/remark/test/entities.test.js
+++ b/packages/markdown/remark/test/entities.test.js
@@ -1,12 +1,22 @@
+import assert from 'node:assert/strict';
+import { describe, it, before } from 'node:test';
 import { createMarkdownProcessor } from '../dist/index.js';
-import { expect } from 'chai';
 
 describe('entities', async () => {
-	const processor = await createMarkdownProcessor();
+	let processor;
+
+	before(async () => {
+		processor = await createMarkdownProcessor();
+	});
 
 	it('should not unescape entities in regular Markdown', async () => {
-		const { code } = await processor.render(`&lt;i&gt;This should NOT be italic&lt;/i&gt;`);
+		const markdown = `&lt;i&gt;This should NOT be italic&lt;/i&gt;`;
+		const { code } = await processor.render(markdown);
 
-		expect(code).to.equal(`<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>`);
+		assert.equal(
+			code,
+			`<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>`,
+			'Entities should not be unescaped'
+		);
 	});
 });

--- a/packages/markdown/remark/test/entities.test.js
+++ b/packages/markdown/remark/test/entities.test.js
@@ -13,10 +13,6 @@ describe('entities', async () => {
 		const markdown = `&lt;i&gt;This should NOT be italic&lt;/i&gt;`;
 		const { code } = await processor.render(markdown);
 
-		assert.equal(
-			code,
-			`<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>`,
-			'Entities should not be unescaped'
-		);
+		assert.equal(code, `<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>`);
 	});
 });

--- a/packages/markdown/remark/test/plugins.test.js
+++ b/packages/markdown/remark/test/plugins.test.js
@@ -18,15 +18,11 @@ describe('plugins', () => {
 			],
 		});
 
-		await processor.render('test', {
+		await processor.render(`test`, {
 			fileURL: new URL('virtual.md', import.meta.url),
 		});
 
-		assert.ok(typeof context === 'object', 'Context should be an object');
-		assert.equal(
-			context.path,
-			fileURLToPath(new URL('virtual.md', import.meta.url)),
-			'Context path should match expected file path'
-		);
+		assert.ok(typeof context === 'object');
+		assert.equal(context.path, fileURLToPath(new URL('virtual.md', import.meta.url)));
 	});
 });

--- a/packages/markdown/remark/test/plugins.test.js
+++ b/packages/markdown/remark/test/plugins.test.js
@@ -1,30 +1,32 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { createMarkdownProcessor } from '../dist/index.js';
-import chai from 'chai';
-
 import { fileURLToPath } from 'node:url';
 
 describe('plugins', () => {
-	// https://github.com/withastro/astro/issues/3264
 	it('should be able to get file path when passing fileURL', async () => {
 		let context;
 
 		const processor = await createMarkdownProcessor({
 			remarkPlugins: [
-				function () {
+				() => {
 					const transformer = (tree, file) => {
 						context = file;
 					};
-
 					return transformer;
 				},
 			],
 		});
 
-		await processor.render(`test`, {
+		await processor.render('test', {
 			fileURL: new URL('virtual.md', import.meta.url),
 		});
 
-		chai.expect(typeof context).to.equal('object');
-		chai.expect(context.path).to.equal(fileURLToPath(new URL('virtual.md', import.meta.url)));
+		assert.ok(typeof context === 'object', 'Context should be an object');
+		assert.equal(
+			context.path,
+			fileURLToPath(new URL('virtual.md', import.meta.url)),
+			'Context path should match expected file path'
+		);
 	});
 });

--- a/packages/markdown/remark/test/remark-collect-images.test.js
+++ b/packages/markdown/remark/test/remark-collect-images.test.js
@@ -1,39 +1,43 @@
-import { createMarkdownProcessor } from '../dist/index.js';
-import chai from 'chai';
+import assert from 'node:assert/strict';
+import { describe, it, before } from 'node:test';
+import { createMarkdownProcessor } from '../dist/index.js'; // Ensure path is correct
 
 describe('collect images', async () => {
-	const processor = await createMarkdownProcessor();
+	let processor;
+
+	before(async () => {
+		processor = await createMarkdownProcessor();
+	});
 
 	it('should collect inline image paths', async () => {
-		const {
+		const markdown = `Hello ![inline image url](./img.png)`;
+		const fileURL = 'file.md';
+
+		const { code, metadata } = await processor.render(markdown, { fileURL });
+
+		// Use `assert.equal` for direct string comparisons
+		assert.equal(
 			code,
-			metadata: { imagePaths },
-		} = await processor.render(`Hello ![inline image url](./img.png)`, {
-			fileURL: 'file.md',
-		});
+			'<p>Hello <img __ASTRO_IMAGE_="{&#x22;src&#x22;:&#x22;./img.png&#x22;,&#x22;alt&#x22;:&#x22;inline image url&#x22;,&#x22;index&#x22;:0}"></p>'
+		);
 
-		chai
-			.expect(code)
-			.to.equal(
-				'<p>Hello <img __ASTRO_IMAGE_="{&#x22;src&#x22;:&#x22;./img.png&#x22;,&#x22;alt&#x22;:&#x22;inline image url&#x22;,&#x22;index&#x22;:0}"></p>'
-			);
-
-		chai.expect(Array.from(imagePaths)).to.deep.equal(['./img.png']);
+		// Use `assert.deepStrictEqual` for exact object comparison
+		assert.deepStrictEqual(Array.from(metadata.imagePaths), ['./img.png']);
 	});
 
 	it('should add image paths from definition', async () => {
-		const {
-			code,
-			metadata: { imagePaths },
-		} = await processor.render(`Hello ![image ref][img-ref]\n\n[img-ref]: ./img.webp`, {
-			fileURL: 'file.md',
-		});
+		const markdown = `Hello ![image ref][img-ref]\n\n[img-ref]: ./img.webp`;
+		const fileURL = 'file.md';
 
-		chai
-			.expect(code)
-			.to.equal(
-				'<p>Hello <img __ASTRO_IMAGE_="{&#x22;src&#x22;:&#x22;./img.webp&#x22;,&#x22;alt&#x22;:&#x22;image ref&#x22;,&#x22;index&#x22;:0}"></p>'
-			);
-		chai.expect(Array.from(imagePaths)).to.deep.equal(['./img.webp']);
+		const { code, metadata } = await processor.render(markdown, { fileURL });
+
+		// Use `assert.equal` for direct string comparisons
+		assert.equal(
+			code,
+			'<p>Hello <img __ASTRO_IMAGE_="{&#x22;src&#x22;:&#x22;./img.webp&#x22;,&#x22;alt&#x22;:&#x22;image ref&#x22;,&#x22;index&#x22;:0}"></p>'
+		);
+
+		// Use `assert.deepStrictEqual` for exact object comparison
+		assert.deepStrictEqual(Array.from(metadata.imagePaths), ['./img.webp']);
 	});
 });

--- a/packages/markdown/remark/test/remark-collect-images.test.js
+++ b/packages/markdown/remark/test/remark-collect-images.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it, before } from 'node:test';
-import { createMarkdownProcessor } from '../dist/index.js'; // Ensure path is correct
+import { createMarkdownProcessor } from '../dist/index.js';
 
 describe('collect images', async () => {
 	let processor;
@@ -13,16 +13,17 @@ describe('collect images', async () => {
 		const markdown = `Hello ![inline image url](./img.png)`;
 		const fileURL = 'file.md';
 
-		const { code, metadata } = await processor.render(markdown, { fileURL });
+		const {
+			code,
+			metadata: { imagePaths },
+		} = await processor.render(markdown, { fileURL });
 
-		// Use `assert.equal` for direct string comparisons
 		assert.equal(
 			code,
 			'<p>Hello <img __ASTRO_IMAGE_="{&#x22;src&#x22;:&#x22;./img.png&#x22;,&#x22;alt&#x22;:&#x22;inline image url&#x22;,&#x22;index&#x22;:0}"></p>'
 		);
 
-		// Use `assert.deepStrictEqual` for exact object comparison
-		assert.deepStrictEqual(Array.from(metadata.imagePaths), ['./img.png']);
+		assert.deepStrictEqual(Array.from(imagePaths), ['./img.png']);
 	});
 
 	it('should add image paths from definition', async () => {
@@ -31,13 +32,11 @@ describe('collect images', async () => {
 
 		const { code, metadata } = await processor.render(markdown, { fileURL });
 
-		// Use `assert.equal` for direct string comparisons
 		assert.equal(
 			code,
 			'<p>Hello <img __ASTRO_IMAGE_="{&#x22;src&#x22;:&#x22;./img.webp&#x22;,&#x22;alt&#x22;:&#x22;image ref&#x22;,&#x22;index&#x22;:0}"></p>'
 		);
 
-		// Use `assert.deepStrictEqual` for exact object comparison
 		assert.deepStrictEqual(Array.from(metadata.imagePaths), ['./img.webp']);
 	});
 });

--- a/packages/markdown/remark/test/shiki.test.js
+++ b/packages/markdown/remark/test/shiki.test.js
@@ -1,12 +1,13 @@
-import { createMarkdownProcessor, createShikiHighlighter } from '../dist/index.js';
-import chai from 'chai';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createMarkdownProcessor, createShikiHighlighter } from '../dist/index.js'; // Ensure path is correct
 
 describe('shiki syntax highlighting', () => {
 	it('does not add is:raw to the output', async () => {
 		const processor = await createMarkdownProcessor();
 		const { code } = await processor.render('```\ntest\n```');
 
-		chai.expect(code).not.to.contain('is:raw');
+		assert.ok(!code.includes('is:raw'), 'Output should not contain is:raw');
 	});
 
 	it('supports light/dark themes', async () => {
@@ -21,11 +22,12 @@ describe('shiki syntax highlighting', () => {
 		const { code } = await processor.render('```\ntest\n```');
 
 		// light theme is there:
-		chai.expect(code).to.contain('background-color:');
-		chai.expect(code).to.contain('github-light');
+		assert.match(code, /background-color:/);
+		assert.match(code, /github-light/);
+
 		// dark theme is there:
-		chai.expect(code).to.contain('--shiki-dark-bg:');
-		chai.expect(code).to.contain('github-dark');
+		assert.match(code, /--shiki-dark-bg:/);
+		assert.match(code, /github-dark/);
 	});
 
 	it('createShikiHighlighter works', async () => {
@@ -33,8 +35,8 @@ describe('shiki syntax highlighting', () => {
 
 		const html = highlighter.highlight('const foo = "bar";', 'js');
 
-		chai.expect(html).to.contain('astro-code github-dark');
-		chai.expect(html).to.contain('background-color:#24292e;color:#e1e4e8;');
+		assert.match(html, /astro-code github-dark/);
+		assert.match(html, /background-color:#24292e;color:#e1e4e8;/);
 	});
 
 	it('diff +/- text has user-select: none', async () => {
@@ -46,8 +48,9 @@ describe('shiki syntax highlighting', () => {
 + const foo = "world";`,
 			'diff'
 		);
-		chai.expect(html).to.contain('user-select: none');
-		chai.expect(html).to.contain('>-</span>');
-		chai.expect(html).to.contain('>+</span>');
+
+		assert.match(html, /user-select: none/);
+		assert.match(html, />-<\/span>/);
+		assert.match(html, />+<\/span>/);
 	});
 });

--- a/packages/markdown/remark/test/shiki.test.js
+++ b/packages/markdown/remark/test/shiki.test.js
@@ -1,13 +1,13 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { createMarkdownProcessor, createShikiHighlighter } from '../dist/index.js'; // Ensure path is correct
+import { createMarkdownProcessor, createShikiHighlighter } from '../dist/index.js';
 
 describe('shiki syntax highlighting', () => {
 	it('does not add is:raw to the output', async () => {
 		const processor = await createMarkdownProcessor();
 		const { code } = await processor.render('```\ntest\n```');
 
-		assert.ok(!code.includes('is:raw'), 'Output should not contain is:raw');
+		assert.ok(!code.includes('is:raw'));
 	});
 
 	it('supports light/dark themes', async () => {


### PR DESCRIPTION
### Changes
Migrates all mocha tests to node:test of `packages/markdown/remark/`
Part of ☂️ Move Astro tests to node:test  #9873 


### Testing
All test passed!

### Docs
No docs added as this only affects testing.