### PR TITLE
ci: increase node timeout

### DIFF
--- a/scripts/cmd/test.js
+++ b/scripts/cmd/test.js
@@ -7,7 +7,7 @@ import arg from 'arg';
 import glob from 'tiny-glob';
 
 const isCI = !!process.env.CI;
-const defaultTimeout = isCI ? 900000 : 600000;
+const defaultTimeout = isCI ? 1200000 : 600000;
 
 export default async function test() {
 	const args = arg({


### PR DESCRIPTION
## Changes

This PR increased the timeout of the node tests.

We touched a timeout here: https://github.com/withastro/astro/actions/runs/7871758088/job/21475712185

## Testing

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
