### PR TITLE
WIP: vite runtime api

### DIFF
--- a/.changeset/rare-balloons-add.md
+++ b/.changeset/rare-balloons-add.md
@@ -1,0 +1,5 @@
+---
+"astro": minor
+---
+
+Vite Runtime API

--- a/packages/astro/src/core/module-loader/vite.ts
+++ b/packages/astro/src/core/module-loader/vite.ts
@@ -1,9 +1,13 @@
 import { EventEmitter } from 'node:events';
 import path from 'node:path';
+import type { ViteRuntime } from 'vite/runtime';
 import type * as vite from 'vite';
 import type { ModuleLoader, ModuleLoaderEventEmitter } from './loader.js';
 
-export function createViteLoader(viteServer: vite.ViteDevServer): ModuleLoader {
+export function createViteLoader(
+	viteServer: vite.ViteDevServer,
+	viteRuntime: ViteRuntime
+): ModuleLoader {
 	const events = new EventEmitter() as ModuleLoaderEventEmitter;
 
 	let isTsconfigUpdated = false;
@@ -50,7 +54,7 @@ export function createViteLoader(viteServer: vite.ViteDevServer): ModuleLoader {
 
 	return {
 		import(src) {
-			return viteServer.ssrLoadModule(src);
+			return viteRuntime.executeUrl(src);
 		},
 		async resolveId(spec, parent) {
 			const ret = await viteServer.pluginContainer.resolveId(spec, parent);


### PR DESCRIPTION
**UPDATE:** After some Discord discussions, we have a better understanding, my goal is to get a `workerd` runtime implement, without caring about backward compatibility &or a default node runtime. If we have a POC for `workerd`, we can decide if we put this behind an external flag, which disables current behavior and only allows custom runtime, or if we want to investigate some more time how to get both running in parallel and automatically choosing the right one

**UPDATE:** After some exploration, I'm pretty sure this is not the correct approach. (see messages following: https://discord.com/channels/830184174198718474/845430950191038464/1212079358701731880)


## Changes

- The goal of this PR is to implement new Vite Runtime API instead of old `server.ssrLoadModule` https://vitejs.dev/guide/api-vite-runtime
- In the long term we want to migrate anyway, since Vite will do the same in v6, but in the short/mid-term I think the best approach would be to have this behind an **experimental flag**
- This will unblock us from running the dev server in `wokerd` if using the Cloudflare adapter, which would make sure that dev has the same runtime as prod, and users won't face issues with incompatible or different behaviour between dev & prod.
- There are some POC implementations already, which use a Vite Plugin to setup the runtime. However we would need to adapt that, to make sure if no runtime is specified by an adapter the "default" one is used.
a) https://github.com/sapphi-red/vite-envs/blob/main/examples/cloudflare-pages/vite.config.ts#L17-L18
b) https://github.com/dario-piotrowicz/vite-runtime-5.1-experimentations/blob/a2d2d9aabbce5f058f530710730a1fdf5773eb80/examples/basic-handler/vite.config.js#L40
c) https://github.com/Shopify/hydrogen/pull/1728
d) https://github.com/hi-ogawa/vite-plugins/tree/ba5d995046cffc0fd368dd3c3a4d05f9d2db29dc/packages/vite-node-miniflare
- The goal is to use a workerd runtime plugin which will be maintained by the Cloudflare team, and we can use that. This is part of our collaboration with them.
- We need to adapt Core to be able to use the new Vite Runtime API, I'm currently exploring different options, however using something similar to this looks promising: https://github.com/sapphi-red/vite-envs/blob/main/packages/example-framework/src/index.ts#L13-L26

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
