### PR TITLE
test: mocha should ignore `nodetest.js` files during unit testing

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -107,7 +107,7 @@
     "build:ci": "pnpm run prebuild && astro-scripts build \"src/**/*.{ts,js}\" && pnpm run postbuild",
     "dev": "astro-scripts dev --copy-wasm --prebuild \"src/runtime/server/astro-island.ts\" --prebuild \"src/runtime/client/{idle,load,media,only,visible}.ts\" \"src/**/*.{ts,js}\"",
     "postbuild": "astro-scripts copy \"src/**/*.astro\" && astro-scripts copy \"src/**/*.wasm\"",
-    "test:unit": "mocha --exit --timeout 30000 ./test/units/**/*.test.js",
+    "test:unit": "mocha --exit --timeout 30000 ./test/units/**/*.test.js --ignore **/*.nodetest.js",
     "test:unit:match": "mocha --exit --timeout 30000 ./test/units/**/*.test.js -g --ignore **/*.nodetest.js",
     "test": "pnpm run test:node && pnpm run test:unit && mocha --exit --timeout 30000 --ignore **/*.nodetest.js --ignore **/lit-element.test.js && mocha --timeout 30000 **/lit-element.test.js --ignore **/*.nodetest.js",
     "test:match": "mocha --timeout 30000 -g",


### PR DESCRIPTION
## Changes

As per title, there was still one script missing

## Testing

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
