### PR TITLE
fix(cli): load polyfill before loading config during `astro add`

### DIFF
--- a/.changeset/itchy-monkeys-fail.md
+++ b/.changeset/itchy-monkeys-fail.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes an issue where some astro commands failed if an integration used the global `crypto` object.
+Fixes an issue where some astro commands failed if the astro config file or an integration used the global `crypto` object.

--- a/.changeset/itchy-monkeys-fail.md
+++ b/.changeset/itchy-monkeys-fail.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where the `astro add` command failed if an integration used the global `crypto` object.

--- a/.changeset/itchy-monkeys-fail.md
+++ b/.changeset/itchy-monkeys-fail.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes an issue where the `astro add` command failed if an integration used the global `crypto` object.
+Fixes an issue where some astro commands failed if an integration used the global `crypto` object.

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -93,10 +93,10 @@ async function getRegistry(): Promise<string> {
 
 export async function add(names: string[], { flags }: AddOptions) {
 	ensureProcessNodeEnv('production');
+	applyPolyfill();
 	const inlineConfig = flagsToAstroInlineConfig(flags);
 	const { userConfig } = await resolveConfig(inlineConfig, 'add');
 	telemetry.record(eventCliSession('add', userConfig));
-	applyPolyfill();
 	if (flags.help || names.length === 0) {
 		printHelp({
 			commandName: 'astro add',

--- a/packages/astro/src/cli/db/index.ts
+++ b/packages/astro/src/cli/db/index.ts
@@ -3,12 +3,14 @@ import { createLoggerFromFlags, flagsToAstroInlineConfig } from '../flags.js';
 import { getPackage } from '../install-package.js';
 import { resolveConfig } from '../../core/config/config.js';
 import type { AstroConfig } from '../../@types/astro.js';
+import { apply as applyPolyfill } from '../../core/polyfill.js';
 
 type DBPackage = {
 	cli: (args: { flags: Arguments; config: AstroConfig }) => unknown;
 };
 
 export async function db({ flags }: { flags: Arguments }) {
+	applyPolyfill();
 	const logger = createLoggerFromFlags(flags);
 	const getPackageOpts = { skipAsk: flags.yes || flags.y, cwd: flags.root };
 	const dbPackage = await getPackage<DBPackage>('@astrojs/db', logger, getPackageOpts, []);

--- a/packages/astro/src/cli/info/index.ts
+++ b/packages/astro/src/cli/info/index.ts
@@ -8,6 +8,7 @@ import type { AstroConfig, AstroUserConfig } from '../../@types/astro.js';
 import { resolveConfig } from '../../core/config/index.js';
 import { ASTRO_VERSION } from '../../core/constants.js';
 import { flagsToAstroInlineConfig } from '../flags.js';
+import { apply as applyPolyfill } from '../../core/polyfill.js';
 
 interface InfoOptions {
 	flags: yargs.Arguments;
@@ -47,6 +48,7 @@ export async function getInfoOutput({
 }
 
 export async function printInfo({ flags }: InfoOptions) {
+	applyPolyfill();
 	const { userConfig } = await resolveConfig(flagsToAstroInlineConfig(flags), 'info');
 	const output = await getInfoOutput({ userConfig, print: true });
 

--- a/packages/astro/src/cli/preferences/index.ts
+++ b/packages/astro/src/cli/preferences/index.ts
@@ -16,6 +16,7 @@ import { createLoggerFromFlags, flagsToAstroInlineConfig } from '../flags.js';
 import { flattie } from 'flattie';
 import { formatWithOptions } from 'node:util';
 import { collectErrorMetadata } from '../../core/errors/dev/utils.js';
+import { apply as applyPolyfill } from '../../core/polyfill.js';
 
 interface PreferencesOptions {
 	flags: yargs.Arguments;
@@ -45,6 +46,7 @@ export async function preferences(
 	value: string | undefined,
 	{ flags }: PreferencesOptions
 ): Promise<number> {
+	applyPolyfill();
 	if (!isValidSubcommand(subcommand) || flags?.help || flags?.h) {
 		msg.printHelp({
 			commandName: 'astro preferences',

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -12,6 +12,7 @@ import { createSettings } from '../config/settings.js';
 import createStaticPreviewServer from './static-preview-server.js';
 import { getResolvedHostForHttpServer } from './util.js';
 import { ensureProcessNodeEnv } from '../util.js';
+import { apply as applyPolyfills } from '../polyfill.js';
 
 /**
  * Starts a local server to serve your static dist/ directory. This command is useful for previewing
@@ -20,6 +21,7 @@ import { ensureProcessNodeEnv } from '../util.js';
  * @experimental The JavaScript API is experimental
  */
 export default async function preview(inlineConfig: AstroInlineConfig): Promise<PreviewServer> {
+	applyPolyfills();
 	ensureProcessNodeEnv('production');
 	const logger = createNodeLogger(inlineConfig);
 	const { userConfig, astroConfig } = await resolveConfig(inlineConfig ?? {}, 'preview');

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -5,6 +5,7 @@ import type {
 	AstroIntegrationLogger,
 	RouteData,
 } from 'astro';
+import crypto from 'crypto';
 import { AstroError } from 'astro/errors';
 import glob from 'fast-glob';
 import { basename } from 'node:path';

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -5,7 +5,6 @@ import type {
 	AstroIntegrationLogger,
 	RouteData,
 } from 'astro';
-import crypto from 'node:crypto';
 import { AstroError } from 'astro/errors';
 import glob from 'fast-glob';
 import { basename } from 'node:path';

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -5,7 +5,7 @@ import type {
 	AstroIntegrationLogger,
 	RouteData,
 } from 'astro';
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import { AstroError } from 'astro/errors';
 import glob from 'fast-glob';
 import { basename } from 'node:path';


### PR DESCRIPTION
I tried to import Vue Astro adapter and I got an error. The error is the next one:

![image](https://github.com/withastro/astro/assets/20746840/9c6d2b43-84d4-47fb-937c-07212fb03c2c)

And I tried to import any other adapter and I get the same error when using the Vercel serverless adapter.

After seeing the problem, I added the node crypto import into the Vercel adapter and the error gone:

![image](https://github.com/withastro/astro/assets/20746840/9bf45842-0698-4329-9086-2cb68520365a)

Edit:

This is my astro.config.mjs

![image](https://github.com/withastro/astro/assets/20746840/348b579b-c962-43ab-8a1d-1f0ed5777d22)
