### PR TITLE
chore: migrate `alias` tests to `node:test`

### DIFF
--- a/packages/astro/test/alias-tsconfig-baseurl-only.nodetest.js
+++ b/packages/astro/test/alias-tsconfig-baseurl-only.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import assert from 'node:assert/strict';
+import { describe, before, it, after } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
@@ -51,33 +52,33 @@ describe('Aliases with tsconfig.json - baseUrl only', () => {
 			const $ = cheerio.load(html);
 
 			// Should render aliased element
-			expect($('#client').text()).to.equal('test');
+			assert.equal($('#client').text(), 'test')
 
 			const scripts = $('script').toArray();
-			expect(scripts.length).to.be.greaterThan(0);
+			assert.ok(scripts.length > 0)
 		});
 
 		it('can load via baseUrl', async () => {
 			const html = await fixture.fetch('/').then((res) => res.text());
 			const $ = cheerio.load(html);
 
-			expect($('#foo').text()).to.equal('foo');
-			expect($('#constants-foo').text()).to.equal('foo');
-			expect($('#constants-index').text()).to.equal('index');
+			assert.equal($('#foo').text(), 'foo');
+			assert.equal($('#constants-foo').text(), 'foo');
+			assert.equal($('#constants-index').text(), 'index');
 		});
 
 		it('works in css @import', async () => {
 			const html = await fixture.fetch('/').then((res) => res.text());
 			// imported css should be bundled
-			expect(html).to.include('#style-red');
-			expect(html).to.include('#style-blue');
+			assert.ok(html.includes('#style-red'));
+			assert.ok(html.includes('#style-blue'));
 		});
 
 		it('works in components', async () => {
 			const html = await fixture.fetch('/').then((res) => res.text());
 			const $ = cheerio.load(html);
 
-			expect($('#alias').text()).to.equal('foo');
+			assert.equal($('#alias').text(), 'foo')
 		});
 	});
 
@@ -91,19 +92,19 @@ describe('Aliases with tsconfig.json - baseUrl only', () => {
 			const $ = cheerio.load(html);
 
 			// Should render aliased element
-			expect($('#client').text()).to.equal('test');
+			assert.equal($('#client').text(), 'test')
 
 			const scripts = $('script').toArray();
-			expect(scripts.length).to.be.greaterThan(0);
+			assert.ok(scripts.length > 0)
 		});
 
 		it('can load via baseUrl', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('#foo').text()).to.equal('foo');
-			expect($('#constants-foo').text()).to.equal('foo');
-			expect($('#constants-index').text()).to.equal('index');
+			assert.equal($('#foo').text(), 'foo');
+			assert.equal($('#constants-foo').text(), 'foo');
+			assert.equal($('#constants-index').text(), 'index');
 		});
 
 		it('works in css @import', async () => {
@@ -111,15 +112,15 @@ describe('Aliases with tsconfig.json - baseUrl only', () => {
 			const content = await Promise.all(getLinks(html).map((href) => getLinkContent(href)));
 			const [{ css }] = content;
 			// imported css should be bundled
-			expect(css).to.include('#style-red');
-			expect(css).to.include('#style-blue');
+			assert.ok(css.includes('#style-red'));
+			assert.ok(css.includes('#style-blue'));
 		});
 
 		it('works in components', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('#alias').text()).to.equal('foo');
+			assert.equal($('#alias').text(), 'foo')
 		});
 	});
 });

--- a/packages/astro/test/alias-tsconfig.nodetest.js
+++ b/packages/astro/test/alias-tsconfig.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import assert from 'node:assert/strict';
+import { describe, before, it, after } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
@@ -51,47 +52,47 @@ describe('Aliases with tsconfig.json', () => {
 			const $ = cheerio.load(html);
 
 			// Should render aliased element
-			expect($('#client').text()).to.equal('test');
+			assert.equal($('#client').text(), 'test');
 
 			const scripts = $('script').toArray();
-			expect(scripts.length).to.be.greaterThan(0);
+			assert.ok(scripts.length > 0);
 		});
 
 		it('can load via baseUrl', async () => {
 			const html = await fixture.fetch('/').then((res) => res.text());
 			const $ = cheerio.load(html);
 
-			expect($('#foo').text()).to.equal('foo');
-			expect($('#constants-foo').text()).to.equal('foo');
-			expect($('#constants-index').text()).to.equal('index');
+			assert.equal($('#foo').text(), 'foo');
+			assert.equal($('#constants-foo').text(), 'foo');
+			assert.equal($('#constants-index').text(), 'index');
 		});
 
 		it('can load namespace packages with @* paths', async () => {
 			const html = await fixture.fetch('/').then((res) => res.text());
 			const $ = cheerio.load(html);
 
-			expect($('#namespace').text()).to.equal('namespace');
+			assert.equal($('#namespace').text(), 'namespace');
 		});
 
 		it('works in css @import', async () => {
 			const html = await fixture.fetch('/').then((res) => res.text());
 			// imported css should be bundled
-			expect(html).to.include('#style-red');
-			expect(html).to.include('#style-blue');
+			assert.ok(html.includes('#style-red'));
+			assert.ok(html.includes('#style-blue'));
 		});
 
 		it('works in components', async () => {
 			const html = await fixture.fetch('/').then((res) => res.text());
 			const $ = cheerio.load(html);
 
-			expect($('#alias').text()).to.equal('foo');
+			assert.equal($('#alias').text(), 'foo');
 		});
 
 		it('works for import.meta.glob', async () => {
 			const html = await fixture.fetch('/').then((res) => res.text());
 			const $ = cheerio.load(html);
 
-			expect($('#glob').text()).to.equal('/src/components/glob/a.js');
+			assert.equal($('#glob').text(), '/src/components/glob/a.js');
 		});
 	});
 
@@ -105,26 +106,26 @@ describe('Aliases with tsconfig.json', () => {
 			const $ = cheerio.load(html);
 
 			// Should render aliased element
-			expect($('#client').text()).to.equal('test');
+			assert.equal($('#client').text(), 'test');
 
 			const scripts = $('script').toArray();
-			expect(scripts.length).to.be.greaterThan(0);
+			assert.ok(scripts.length > 0);
 		});
 
 		it('can load via baseUrl', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('#foo').text()).to.equal('foo');
-			expect($('#constants-foo').text()).to.equal('foo');
-			expect($('#constants-index').text()).to.equal('index');
+			assert.equal($('#foo').text(), 'foo');
+			assert.equal($('#constants-foo').text(), 'foo');
+			assert.equal($('#constants-index').text(), 'index');
 		});
 
 		it('can load namespace packages with @* paths', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('#namespace').text()).to.equal('namespace');
+			assert.equal($('#namespace').text(), 'namespace');
 		});
 
 		it('works in css @import', async () => {
@@ -132,22 +133,22 @@ describe('Aliases with tsconfig.json', () => {
 			const content = await Promise.all(getLinks(html).map((href) => getLinkContent(href)));
 			const [{ css }] = content;
 			// imported css should be bundled
-			expect(css).to.include('#style-red');
-			expect(css).to.include('#style-blue');
+			assert.ok(css.includes('#style-red'));
+			assert.ok(css.includes('#style-blue'));
 		});
 
 		it('works in components', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('#alias').text()).to.equal('foo');
+			assert.equal($('#alias').text(), 'foo');
 		});
 
 		it('works for import.meta.glob', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 
-			expect($('#glob').text()).to.equal('/src/components/glob/a.js');
+			assert.equal($('#glob').text(), '/src/components/glob/a.js');
 		});
 	});
 });

--- a/packages/astro/test/alias.nodetest.js
+++ b/packages/astro/test/alias.nodetest.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import assert from 'node:assert/strict';
+import { describe, before, it, after } from 'node:test';
 import * as cheerio from 'cheerio';
 import { isWindows, loadFixture } from './test-utils.js';
 
@@ -29,10 +30,10 @@ describe('Aliases', () => {
 			const $ = cheerio.load(html);
 
 			// Should render aliased element
-			expect($('#client').text()).to.equal('test');
+			assert.equal($('#client').text(), 'test');
 
 			const scripts = $('script').toArray();
-			expect(scripts.length).to.be.greaterThan(0);
+			assert.ok(scripts.length > 0);
 		});
 	});
 
@@ -46,10 +47,10 @@ describe('Aliases', () => {
 			const $ = cheerio.load(html);
 
 			// Should render aliased element
-			expect($('#client').text()).to.equal('test');
+			assert.equal($('#client').text(), 'test');
 
 			const scripts = $('script').toArray();
-			expect(scripts.length).to.be.greaterThan(0);
+			assert.ok(scripts.length > 0);
 		});
 
 		it('can use aliases and relative in same project', async () => {
@@ -57,10 +58,10 @@ describe('Aliases', () => {
 			const $ = cheerio.load(html);
 
 			// Should render aliased element
-			expect($('#client').text()).to.equal('test');
+			assert.equal($('#client').text(), 'test');
 
 			const scripts = $('script').toArray();
-			expect(scripts.length).to.be.greaterThan(0);
+			assert.ok(scripts.length > 0);
 		});
 	});
 });


### PR DESCRIPTION
## Changes
 - related issue #9873 
 - migrating `alias` related tests to `node:test`
<!-- - What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`-->

## Testing
All tests passing. `alias.nodetest.js` seems to be skipped on local testing (probably because of isWindows util)
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
N/A
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
