### PR TITLE
Rename Astro app to astro:home

### DIFF
--- a/.changeset/silent-hotels-approve.md
+++ b/.changeset/silent-hotels-approve.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Renames the home Astro Devoolbar App to `astro:home`

--- a/packages/astro/e2e/dev-toolbar-audits.test.js
+++ b/packages/astro/e2e/dev-toolbar-audits.test.js
@@ -16,7 +16,7 @@ test.afterAll(async () => {
 });
 
 test.describe('Dev Toolbar - Audits', () => {
-	test('can warn about perf issues zzz', async ({ page, astro }) => {
+	test('can warn about perf issues', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/audits-perf'));
 
 		const toolbar = page.locator('astro-dev-toolbar');

--- a/packages/astro/e2e/dev-toolbar.test.js
+++ b/packages/astro/e2e/dev-toolbar.test.js
@@ -27,7 +27,7 @@ test.describe('Dev Toolbar', () => {
 		await page.goto(astro.resolveUrl('/'));
 
 		const toolbar = page.locator('astro-dev-toolbar');
-		const appButton = toolbar.locator('button[data-app-id="astro"]');
+		const appButton = toolbar.locator('button[data-app-id="astro:home"]');
 		const appButtonTooltip = appButton.locator('.item-tooltip');
 		await appButton.hover();
 
@@ -38,10 +38,12 @@ test.describe('Dev Toolbar', () => {
 		await page.goto(astro.resolveUrl('/'));
 
 		const toolbar = page.locator('astro-dev-toolbar');
-		const appButton = toolbar.locator('button[data-app-id="astro"]');
+		const appButton = toolbar.locator('button[data-app-id="astro:home"]');
 		await appButton.click();
 
-		const astroAppCanvas = toolbar.locator('astro-dev-toolbar-app-canvas[data-app-id="astro"]');
+		const astroAppCanvas = toolbar.locator(
+			'astro-dev-toolbar-app-canvas[data-app-id="astro:home"]'
+		);
 		const astroWindow = astroAppCanvas.locator('astro-dev-toolbar-window');
 		await expect(astroWindow).toHaveCount(1);
 		await expect(astroWindow).toBeVisible();
@@ -205,10 +207,12 @@ test.describe('Dev Toolbar', () => {
 		await expect(settingsWindow).toBeVisible();
 
 		// Click the astro app
-		appButton = toolbar.locator('button[data-app-id="astro"]');
+		appButton = toolbar.locator('button[data-app-id="astro:home"]');
 		await appButton.click();
 
-		const astroAppCanvas = toolbar.locator('astro-dev-toolbar-app-canvas[data-app-id="astro"]');
+		const astroAppCanvas = toolbar.locator(
+			'astro-dev-toolbar-app-canvas[data-app-id="astro:home"]'
+		);
 		const astroWindow = astroAppCanvas.locator('astro-dev-toolbar-window');
 		await expect(astroWindow).toHaveCount(1);
 		await expect(astroWindow).toBeVisible();

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/astro.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/astro.ts
@@ -27,7 +27,7 @@ interface IntegrationData {
 let integrationData: IntegrationData;
 
 export default {
-	id: 'astro',
+	id: 'astro:home',
 	name: 'Menu',
 	icon: 'astro:logo',
 	async init(canvas, eventTarget) {


### PR DESCRIPTION
## Changes

We use the `astro:` shape for every built-in app, which we then use in telemetry and stuff to detect if an app is ours or not. The homepage however had an old name, so this renames that

## Testing

Updated tests!

## Docs

N/A
