### PR TITLE
fix(dev): preload matched routes sequentially

### DIFF
--- a/.changeset/afraid-seals-tan.md
+++ b/.changeset/afraid-seals-tan.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where the dev server froze when typescript aliases were used.

--- a/packages/astro/src/prerender/routing.ts
+++ b/packages/astro/src/prerender/routing.ts
@@ -40,16 +40,16 @@ async function preloadAndSetPrerenderStatus({
 	matches,
 	settings,
 }: PreloadAndSetPrerenderStatusParams): Promise<PreloadAndSetPrerenderStatusResult[]> {
-	const preloaded = await Promise.all(
-		matches.map(async (route) => {
+	const preloaded = new Array<PreloadAndSetPrerenderStatusResult>
+		for (const route of matches) {
 			const filePath = new URL(`./${route.component}`, settings.config.root);
-
 			if (routeIsRedirect(route)) {
-				return {
+				preloaded.push({
 					preloadedComponent: RedirectComponentInstance,
 					route,
 					filePath,
-				};
+				});
+				continue;
 			}
 
 			const preloadedComponent = await preload({ pipeline, filePath });
@@ -64,9 +64,8 @@ async function preloadAndSetPrerenderStatus({
 				route.prerender = prerenderStatus;
 			}
 
-			return { preloadedComponent, route, filePath };
-		})
-	);
+			preloaded.push({ preloadedComponent, route, filePath });
+		}
 	return preloaded;
 }
 


### PR DESCRIPTION
## Changes

- Closes #9703 
- Workaround for what I think is a race condition in vite.

## Testing
- Manually tested.
- Workaround; existing tests should pass.

## Docs
- Does not affect usage.
