### PR TITLE
Fix invalid URLs being returned from `getRegistry`, synchronize all copies of the function

### DIFF
--- a/.changeset/twelve-waves-matter.md
+++ b/.changeset/twelve-waves-matter.md
@@ -1,0 +1,7 @@
+---
+"create-astro": patch
+"@astrojs/upgrade": patch
+"astro": patch
+---
+
+Fixes an issue where `create astro`, `astro add` and `@astrojs/upgrade` would fail due to unexpected package manager CLI output.

--- a/packages/create-astro/src/messages.ts
+++ b/packages/create-astro/src/messages.ts
@@ -12,11 +12,14 @@ import { shell } from './shell.js';
 let _registry: string;
 async function getRegistry(packageManager: string): Promise<string> {
 	if (_registry) return _registry;
+	const fallback = 'https://registry.npmjs.org';
 	try {
 		const { stdout } = await shell(packageManager, ['config', 'get', 'registry']);
-		_registry = stdout?.trim()?.replace(/\/$/, '') || 'https://registry.npmjs.org';
+		_registry = stdout?.trim()?.replace(/\/$/, '') || fallback;
+		// Detect cases where the shell command returned a non-URL (e.g. a warning)
+		if (!new URL(_registry).host) _registry = fallback;
 	} catch (e) {
-		_registry = 'https://registry.npmjs.org';
+		_registry = fallback;
 	}
 	return _registry;
 }

--- a/packages/upgrade/src/messages.ts
+++ b/packages/upgrade/src/messages.ts
@@ -10,14 +10,20 @@ import { shell } from './shell.js';
 // checks the user's project type and will return the proper npm registry
 //
 // A copy of this function also exists in the astro package
+let _registry: string;
 export async function getRegistry(): Promise<string> {
+	if (_registry) return _registry;
+	const fallback = 'https://registry.npmjs.org';
 	const packageManager = detectPackageManager()?.name || 'npm';
 	try {
 		const { stdout } = await shell(packageManager, ['config', 'get', 'registry']);
-		return stdout?.trim()?.replace(/\/$/, '') || 'https://registry.npmjs.org';
+		_registry = stdout?.trim()?.replace(/\/$/, '') || fallback;
+		// Detect cases where the shell command returned a non-URL (e.g. a warning)
+		if (!new URL(_registry).host) _registry = fallback;
 	} catch (e) {
-		return 'https://registry.npmjs.org';
+		_registry = fallback;
 	}
+	return _registry;
 }
 
 let stdout = process.stdout;


### PR DESCRIPTION
## Changes

- Fixes an issue reported in a [Discord support thread](https://discord.com/channels/830184174198718474/1207399351073247283).
- The `getRegistry` functions used in our CLI tools `create astro`, `astro add` and `@astrojs/upgrade` assumed that the output of the CLI command `<package manager> config get registry` would always be a URL. However, in the reported case, the command output started with a warning message, which was then returned by `getRegistry` without further validation, causing all dependent functionality to fail in unexpected ways.
- This PR validates the output by trying to construct a URL instance from it, which will either throw an error that gets caught by the catch clause, or have an empty `host`. In both cases, our existing fallback URL `https://registry.npmjs.org` will now be used.
- I also synchronized the slightly different 3 copies of the function as far as possible. They all use the caching logic that was already present in `create-astro` now, which could speed up the other CLI commands. In the future, we should investigate if we can actually use the same function from all tools instead of keeping 3 copies.

## Testing

- I tested the changes locally and didn't encounter any issues.

## Docs

- Just a bugfix, no docs should be needed.