### PR TITLE
Update to Vite 5.1

### DIFF
--- a/.changeset/empty-carrots-film.md
+++ b/.changeset/empty-carrots-film.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Updates and supports Vite 5.1

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -175,7 +175,7 @@
     "tsconfck": "^3.0.0",
     "unist-util-visit": "^5.0.0",
     "vfile": "^6.0.1",
-    "vite": "^5.0.12",
+    "vite": "^5.1.2",
     "vitefu": "^0.2.5",
     "which-pm": "^2.1.1",
     "yargs-parser": "^21.1.1",

--- a/packages/astro/src/core/build/plugins/util.ts
+++ b/packages/astro/src/core/build/plugins/util.ts
@@ -1,5 +1,5 @@
 import { extname } from 'node:path';
-import type { Rollup, Plugin as VitePlugin } from 'vite';
+import type { BuildOptions, Rollup, Plugin as VitePlugin } from 'vite';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type OutputOptionsHook = Extract<VitePlugin['outputOptions'], Function>;
@@ -68,4 +68,21 @@ export function getVirtualModulePageNameFromPath(virtualModulePrefix: string, pa
 export function getPathFromVirtualModulePageName(virtualModulePrefix: string, id: string) {
 	const pageName = id.slice(virtualModulePrefix.length);
 	return pageName.replace(ASTRO_PAGE_EXTENSION_POST_PATTERN, '.');
+}
+
+export function shouldInlineAsset(
+	assetContent: string,
+	assetPath: string,
+	assetsInlineLimit: NonNullable<BuildOptions['assetsInlineLimit']>
+) {
+	if (typeof assetsInlineLimit === 'number') {
+		return Buffer.byteLength(assetContent) < assetsInlineLimit;
+	}
+
+	const result = assetsInlineLimit(assetPath, Buffer.from(assetContent));
+	if (result != null) {
+		return result;
+	}
+
+	return Buffer.byteLength(assetContent) < 4096; // Fallback to 4096kb by default (same as Vite)
 }

--- a/packages/integrations/alpinejs/package.json
+++ b/packages/integrations/alpinejs/package.json
@@ -41,7 +41,7 @@
     "@playwright/test": "1.40.0",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
-    "vite": "^5.0.10"
+    "vite": "^5.1.2"
   },
   "publishConfig": {
     "provenance": true

--- a/packages/integrations/markdoc/package.json
+++ b/packages/integrations/markdoc/package.json
@@ -83,7 +83,7 @@
     "astro-scripts": "workspace:*",
     "devalue": "^4.3.2",
     "linkedom": "^0.16.4",
-    "vite": "^5.0.12"
+    "vite": "^5.1.2"
   },
   "engines": {
     "node": ">=18.14.1"

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -72,7 +72,7 @@
     "remark-shiki-twoslash": "^3.1.3",
     "remark-toc": "^9.0.0",
     "unified": "^11.0.4",
-    "vite": "^5.0.12"
+    "vite": "^5.1.2"
   },
   "engines": {
     "node": ">=18.14.1"

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -57,7 +57,7 @@
     "cheerio": "1.0.0-rc.12",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "vite": "^5.0.12"
+    "vite": "^5.1.2"
   },
   "peerDependencies": {
     "@types/react": "^17.0.50 || ^18.0.21",

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -49,7 +49,7 @@
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "svelte": "^4.2.5",
-    "vite": "^5.0.12"
+    "vite": "^5.1.2"
   },
   "peerDependencies": {
     "astro": "^4.0.0",

--- a/packages/integrations/tailwind/package.json
+++ b/packages/integrations/tailwind/package.json
@@ -41,7 +41,7 @@
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
     "tailwindcss": "^3.3.5",
-    "vite": "^5.0.12"
+    "vite": "^5.1.2"
   },
   "peerDependencies": {
     "astro": "^3.0.0 || ^4.0.0",

--- a/packages/integrations/tailwind/package.json
+++ b/packages/integrations/tailwind/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "autoprefixer": "^10.4.15",
-    "postcss": "^8.4.28",
+    "postcss": "^8.4.35",
     "postcss-load-config": "^4.0.2"
   },
   "devDependencies": {

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -51,7 +51,7 @@
     "astro-scripts": "workspace:*",
     "cheerio": "1.0.0-rc.12",
     "linkedom": "^0.16.4",
-    "vite": "^5.0.12",
+    "vite": "^5.1.2",
     "vue": "^3.3.8"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4661,13 +4661,13 @@ importers:
     dependencies:
       autoprefixer:
         specifier: ^10.4.15
-        version: 10.4.16(postcss@8.4.32)
+        version: 10.4.16(postcss@8.4.35)
       postcss:
-        specifier: ^8.4.28
-        version: 8.4.32
+        specifier: ^8.4.35
+        version: 8.4.35
       postcss-load-config:
         specifier: ^4.0.2
-        version: 4.0.2(postcss@8.4.32)
+        version: 4.0.2(postcss@8.4.35)
     devDependencies:
       astro:
         specifier: workspace:*
@@ -7991,7 +7991,7 @@ packages:
       '@vue/shared': 3.4.3
       estree-walker: 2.0.2
       magic-string: 0.30.5
-      postcss: 8.4.32
+      postcss: 8.4.35
       source-map-js: 1.0.2
 
   /@vue/compiler-ssr@3.4.3:
@@ -8350,6 +8350,22 @@ packages:
       picocolors: 1.0.0
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
+
+  /autoprefixer@10.4.16(postcss@8.4.35):
+    resolution: {integrity: sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+    dependencies:
+      browserslist: 4.22.2
+      caniuse-lite: 1.0.30001572
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.0.0
+      postcss: 8.4.35
+      postcss-value-parser: 4.2.0
+    dev: false
 
   /available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
@@ -13238,25 +13254,25 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-import@15.1.0(postcss@8.4.32):
+  /postcss-import@15.1.0(postcss@8.4.35):
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
-      postcss: 8.4.32
+      postcss: 8.4.35
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.8
 
-  /postcss-js@4.0.1(postcss@8.4.32):
+  /postcss-js@4.0.1(postcss@8.4.35):
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
       postcss: ^8.4.21
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.32
+      postcss: 8.4.35
 
   /postcss-lab-function@6.0.9(postcss@8.4.32):
     resolution: {integrity: sha512-PKFAVTBEWJYsoSTD7Kp/OzeiMsXaLX39Pv75XgUyF5VrbMfeTw+JqCGsvDP3dPhclh6BemdCFHcjXBG9gO4UCg==}
@@ -13271,7 +13287,7 @@ packages:
       postcss: 8.4.32
     dev: true
 
-  /postcss-load-config@4.0.2(postcss@8.4.32):
+  /postcss-load-config@4.0.2(postcss@8.4.35):
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -13284,7 +13300,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 3.0.0
-      postcss: 8.4.32
+      postcss: 8.4.35
       yaml: 2.3.4
 
   /postcss-logical@7.0.1(postcss@8.4.32):
@@ -13297,13 +13313,13 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-nested@6.0.1(postcss@8.4.32):
+  /postcss-nested@6.0.1(postcss@8.4.35):
     resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
-      postcss: 8.4.32
+      postcss: 8.4.35
       postcss-selector-parser: 6.0.15
 
   /postcss-nesting@12.0.2(postcss@8.4.32):
@@ -13468,15 +13484,6 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.0.2
-
-  /postcss@8.4.33:
-    resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
-    dev: false
 
   /postcss@8.4.35:
     resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
@@ -14937,11 +14944,11 @@ packages:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.0.0
-      postcss: 8.4.32
-      postcss-import: 15.1.0(postcss@8.4.32)
-      postcss-js: 4.0.1(postcss@8.4.32)
-      postcss-load-config: 4.0.2(postcss@8.4.32)
-      postcss-nested: 6.0.1(postcss@8.4.32)
+      postcss: 8.4.35
+      postcss-import: 15.1.0(postcss@8.4.35)
+      postcss-js: 4.0.1(postcss@8.4.35)
+      postcss-load-config: 4.0.2(postcss@8.4.35)
+      postcss-nested: 6.0.1(postcss@8.4.35)
       postcss-selector-parser: 6.0.15
       resolve: 1.22.8
       sucrase: 3.35.0
@@ -15782,7 +15789,7 @@ packages:
     dependencies:
       '@types/node': 18.19.4
       esbuild: 0.19.11
-      postcss: 8.4.33
+      postcss: 8.4.35
       rollup: 4.9.2
     optionalDependencies:
       fsevents: 2.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -678,11 +678,11 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+        specifier: ^5.1.2
+        version: 5.1.2(@types/node@18.19.4)(sass@1.69.6)
       vitefu:
         specifier: ^0.2.5
-        version: 0.2.5(vite@5.0.12)
+        version: 0.2.5(vite@5.1.2)
       which-pm:
         specifier: ^2.1.1
         version: 2.1.1
@@ -3812,8 +3812,8 @@ importers:
         specifier: workspace:*
         version: link:../../../scripts
       vite:
-        specifier: ^5.0.10
-        version: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+        specifier: ^5.1.2
+        version: 5.1.2(@types/node@18.19.4)(sass@1.69.6)
 
   packages/integrations/alpinejs/test/fixtures/basics:
     dependencies:
@@ -3945,8 +3945,8 @@ importers:
         specifier: ^0.16.4
         version: 0.16.6
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+        specifier: ^5.1.2
+        version: 5.1.2(@types/node@18.19.4)(sass@1.69.6)
 
   packages/integrations/markdoc/test/fixtures/content-collections:
     dependencies:
@@ -4171,8 +4171,8 @@ importers:
         specifier: ^11.0.4
         version: 11.0.4
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+        specifier: ^5.1.2
+        version: 5.1.2(@types/node@18.19.4)(sass@1.69.6)
 
   packages/integrations/mdx/test/fixtures/css-head-mdx:
     dependencies:
@@ -4519,7 +4519,7 @@ importers:
     dependencies:
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.2.1(vite@5.0.12)
+        version: 4.2.1(vite@5.1.2)
       ultrahtml:
         specifier: ^1.3.0
         version: 1.5.2
@@ -4546,8 +4546,8 @@ importers:
         specifier: ^18.1.0
         version: 18.2.0(react@18.2.0)
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+        specifier: ^5.1.2
+        version: 5.1.2(@types/node@18.19.4)(sass@1.69.6)
 
   packages/integrations/react/test/fixtures/react-component:
     dependencies:
@@ -4639,7 +4639,7 @@ importers:
     dependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.0
-        version: 3.0.1(svelte@4.2.8)(vite@5.0.12)
+        version: 3.0.1(svelte@4.2.8)(vite@5.1.2)
       svelte2tsx:
         specifier: ^0.6.25
         version: 0.6.27(svelte@4.2.8)(typescript@5.2.2)
@@ -4654,8 +4654,8 @@ importers:
         specifier: ^4.2.5
         version: 4.2.8
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+        specifier: ^5.1.2
+        version: 5.1.2(@types/node@18.19.4)(sass@1.69.6)
 
   packages/integrations/tailwind:
     dependencies:
@@ -4679,8 +4679,8 @@ importers:
         specifier: ^3.3.5
         version: 3.4.0
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+        specifier: ^5.1.2
+        version: 5.1.2(@types/node@18.19.4)(sass@1.69.6)
 
   packages/integrations/tailwind/test/fixtures/basic:
     dependencies:
@@ -4924,10 +4924,10 @@ importers:
     dependencies:
       '@vitejs/plugin-vue':
         specifier: ^4.5.0
-        version: 4.6.2(vite@5.0.12)(vue@3.4.3)
+        version: 4.6.2(vite@5.1.2)(vue@3.4.3)
       '@vitejs/plugin-vue-jsx':
         specifier: ^3.1.0
-        version: 3.1.0(vite@5.0.12)(vue@3.4.3)
+        version: 3.1.0(vite@5.1.2)(vue@3.4.3)
       '@vue/babel-plugin-jsx':
         specifier: ^1.1.5
         version: 1.1.5(@babel/core@7.23.7)
@@ -4951,8 +4951,8 @@ importers:
         specifier: ^0.16.4
         version: 0.16.6
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+        specifier: ^5.1.2
+        version: 5.1.2(@types/node@18.19.4)(sass@1.69.6)
       vue:
         specifier: ^3.3.8
         version: 3.4.3(typescript@5.2.2)
@@ -7183,7 +7183,7 @@ packages:
       solid-js: 1.8.7
     dev: false
 
-  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.12):
+  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.1.2):
     resolution: {integrity: sha512-gjr9ZFg1BSlIpfZ4PRewigrvYmHWbDrq2uvvPB1AmTWKuM+dI1JXQSUu2pIrYLb/QncyiIGkFDFKTwJ0XqQZZg==}
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
@@ -7194,15 +7194,15 @@ packages:
       vite:
         optional: true
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.2.8)(vite@5.0.12)
+      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.2.8)(vite@5.1.2)
       debug: 4.3.4(supports-color@8.1.1)
       svelte: 4.2.8
-      vite: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+      vite: 5.1.2(@types/node@18.19.4)(sass@1.69.6)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.2.8)(vite@5.0.12):
+  /@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.2.8)(vite@5.1.2):
     resolution: {integrity: sha512-CGURX6Ps+TkOovK6xV+Y2rn8JKa8ZPUHPZ/NKgCxAmgBrXReavzFl8aOSCj3kQ1xqT7yGJj53hjcV/gqwDAaWA==}
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
@@ -7212,15 +7212,15 @@ packages:
       vite:
         optional: true
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.12)
+      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.1.2)
       debug: 4.3.4(supports-color@8.1.1)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.5
       svelte: 4.2.8
       svelte-hmr: 0.15.3(svelte@4.2.8)
-      vite: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
-      vitefu: 0.2.5(vite@5.0.12)
+      vite: 5.1.2(@types/node@18.19.4)(sass@1.69.6)
+      vitefu: 0.2.5(vite@5.1.2)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7779,7 +7779,7 @@ packages:
       - supports-color
     dev: false
 
-  /@vitejs/plugin-react@4.2.1(vite@5.0.12):
+  /@vitejs/plugin-react@4.2.1(vite@5.1.2):
     resolution: {integrity: sha512-oojO9IDc4nCUUi8qIR11KoQm0XFFLIwsRBwHRR4d/88IWghn1y6ckz/bJ8GHDCsYEJee8mDzqtJxh15/cisJNQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -7793,12 +7793,12 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+      vite: 5.1.2(@types/node@18.19.4)(sass@1.69.6)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@vitejs/plugin-vue-jsx@3.1.0(vite@5.0.12)(vue@3.4.3):
+  /@vitejs/plugin-vue-jsx@3.1.0(vite@5.1.2)(vue@3.4.3):
     resolution: {integrity: sha512-w9M6F3LSEU5kszVb9An2/MmXNxocAnUb3WhRr8bHlimhDrXNt6n6D2nJQR3UXpGlZHh/EsgouOHCsM8V3Ln+WA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -7811,13 +7811,13 @@ packages:
       '@babel/core': 7.23.7
       '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.23.7)
       '@vue/babel-plugin-jsx': 1.1.5(@babel/core@7.23.7)
-      vite: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+      vite: 5.1.2(@types/node@18.19.4)(sass@1.69.6)
       vue: 3.4.3(typescript@5.2.2)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@vitejs/plugin-vue@4.6.2(vite@5.0.12)(vue@3.4.3):
+  /@vitejs/plugin-vue@4.6.2(vite@5.1.2)(vue@3.4.3):
     resolution: {integrity: sha512-kqf7SGFoG+80aZG6Pf+gsZIVvGSCKE98JbiWqcCV9cThtg91Jav0yvYFC9Zb+jKetNGF6ZKeoaxgZfND21fWKw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -7827,7 +7827,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+      vite: 5.1.2(@types/node@18.19.4)(sass@1.69.6)
       vue: 3.4.3(typescript@5.2.2)
     dev: false
 
@@ -13476,6 +13476,15 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: false
+
+  /postcss@8.4.35:
+    resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
 
   /preact-render-to-string@6.3.1(preact@10.19.3):
     resolution: {integrity: sha512-NQ28WrjLtWY6lKDlTxnFpKHZdpjfF+oE6V4tZ0rTrunHrtZp6Dm0oFrcJalt/5PNeqJz4j1DuZDS0Y6rCBoqDA==}
@@ -15687,7 +15696,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+      vite: 5.0.12(@types/node@18.19.4)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15715,7 +15724,7 @@ packages:
       merge-anything: 5.1.7
       solid-js: 1.8.7
       solid-refresh: 0.5.3(solid-js@1.8.7)
-      vitefu: 0.2.5(vite@5.0.12)
+      vitefu: 0.2.5(vite@5.1.2)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -15743,7 +15752,7 @@ packages:
       svgo: 3.2.0
     dev: false
 
-  /vite@5.0.12(@types/node@18.19.4)(sass@1.69.6):
+  /vite@5.0.12(@types/node@18.19.4):
     resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -15775,11 +15784,47 @@ packages:
       esbuild: 0.19.11
       postcss: 8.4.33
       rollup: 4.9.2
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: false
+
+  /vite@5.1.2(@types/node@18.19.4)(sass@1.69.6):
+    resolution: {integrity: sha512-uwiFebQbTWRIGbCaTEBVAfKqgqKNKMJ2uPXsXeLIZxM8MVMjoS3j0cG8NrPxdDIadaWnPSjrkLWffLSC+uiP3Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.19.4
+      esbuild: 0.19.11
+      postcss: 8.4.35
+      rollup: 4.9.2
       sass: 1.69.6
     optionalDependencies:
       fsevents: 2.3.3
 
-  /vitefu@0.2.5(vite@5.0.12):
+  /vitefu@0.2.5(vite@5.1.2):
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0
@@ -15787,7 +15832,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+      vite: 5.1.2(@types/node@18.19.4)(sass@1.69.6)
     dev: false
 
   /vitest@1.2.1(@types/node@18.19.4):
@@ -15834,7 +15879,7 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.1
       tinypool: 0.8.2
-      vite: 5.0.12(@types/node@18.19.4)(sass@1.69.6)
+      vite: 5.0.12(@types/node@18.19.4)
       vite-node: 1.2.1(@types/node@18.19.4)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:


### PR DESCRIPTION
## Changes

Update to Vite 5.1. Also handle the type changes for `vite.build.assetsInlineLimit` that now accepts a function. Other than that, it's just a version bump.

Vite 5.1 has other features that should trim down our code too that I'll send as separate PRs later.

## Testing

Existing tests should pass.

## Docs

n/a. version upgrade.
