### PR TITLE
Update Vite ws property to hot

### DIFF
--- a/.changeset/flat-rabbits-pump.md
+++ b/.changeset/flat-rabbits-pump.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Updates Vite calls to use `hot` instead of deprecated `ws`

--- a/.changeset/flat-rabbits-pump.md
+++ b/.changeset/flat-rabbits-pump.md
@@ -1,5 +1,0 @@
----
-"astro": patch
----
-
-Updates Vite calls to use `hot` instead of deprecated `ws`

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -172,7 +172,7 @@ export async function createContentTypesGenerator({
 					}
 					const collectionInfo = collectionEntryMap[collectionKey];
 					if (collectionInfo.type === 'content') {
-						viteServer.ws.send({
+						viteServer.hot.send({
 							type: 'error',
 							err: new AstroError({
 								...AstroErrorData.MixedContentDataCollectionError,
@@ -212,7 +212,7 @@ export async function createContentTypesGenerator({
 		}
 		const collectionInfo = collectionEntryMap[collectionKey];
 		if (collectionInfo.type === 'data') {
-			viteServer.ws.send({
+			viteServer.hot.send({
 				type: 'error',
 				err: new AstroError({
 					...AstroErrorData.MixedContentDataCollectionError,
@@ -359,7 +359,7 @@ async function writeContentFiles({
 	typeTemplateContent: string;
 	contentEntryTypes: Pick<ContentEntryType, 'contentModuleTypes'>[];
 	contentConfig?: ContentConfig;
-	viteServer: Pick<ViteDevServer, 'ws'>;
+	viteServer: Pick<ViteDevServer, 'hot'>;
 }) {
 	let contentTypesStr = '';
 	let dataTypesStr = '';
@@ -374,7 +374,7 @@ async function writeContentFiles({
 			collection.type !== 'unknown' &&
 			collection.type !== collectionConfig.type
 		) {
-			viteServer.ws.send({
+			viteServer.hot.send({
 				type: 'error',
 				err: new AstroError({
 					...AstroErrorData.ContentCollectionTypeMismatchError,
@@ -387,7 +387,7 @@ async function writeContentFiles({
 						collection.type === 'data'
 							? "Try adding `type: 'data'` to your collection config."
 							: undefined,
-					location: { file: '' /** required for error overlay `ws` messages */ },
+					location: { file: '' /** required for error overlay `hot` messages */ },
 				}) as any,
 			});
 			return;

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -80,7 +80,7 @@ export async function restartContainer(container: Container): Promise<Container 
 			);
 		}
 		// Inform connected clients of the config error
-		container.viteServer.ws.send({
+		container.viteServer.hot.send({
 			type: 'error',
 			err: {
 				message: error.message,

--- a/packages/astro/src/core/module-loader/vite.ts
+++ b/packages/astro/src/core/module-loader/vite.ts
@@ -31,8 +31,8 @@ export function createViteLoader(viteServer: vite.ViteDevServer): ModuleLoader {
 		}
 	});
 
-	const _wsSend = viteServer.ws.send;
-	viteServer.ws.send = function (...args: any) {
+	const _wsSend = viteServer.hot.send;
+	viteServer.hot.send = function (...args: any) {
 		// If the tsconfig changed, Vite will trigger a reload as it invalidates the module.
 		// However in Astro, the whole server is restarted when the tsconfig changes. If we
 		// do a restart and reload at the same time, the browser will refetch and the server
@@ -75,13 +75,13 @@ export function createViteLoader(viteServer: vite.ViteDevServer): ModuleLoader {
 			return viteServer.ssrFixStacktrace(err);
 		},
 		clientReload() {
-			viteServer.ws.send({
+			viteServer.hot.send({
 				type: 'full-reload',
 				path: '*',
 			});
 		},
 		webSocketSend(msg) {
-			return viteServer.ws.send(msg);
+			return viteServer.hot.send(msg);
 		},
 		isHttps() {
 			return !!viteServer.config.server.https;

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -101,10 +101,10 @@ export async function syncInternal(
 		)
 	);
 
-	// Patch `ws.send` to bubble up error events
-	// `ws.on('error')` does not fire for some reason
-	const wsSend = tempViteServer.ws.send;
-	tempViteServer.ws.send = (payload: HMRPayload) => {
+	// Patch `hot.send` to bubble up error events
+	// `hot.on('error')` does not fire for some reason
+	const wsSend = tempViteServer.hot.send;
+	tempViteServer.hot.send = (payload: HMRPayload) => {
 		if (payload.type === 'error') {
 			throw payload.err;
 		}

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -103,12 +103,12 @@ export async function syncInternal(
 
 	// Patch `hot.send` to bubble up error events
 	// `hot.on('error')` does not fire for some reason
-	const wsSend = tempViteServer.hot.send;
+	const hotSend = tempViteServer.hot.send;
 	tempViteServer.hot.send = (payload: HMRPayload) => {
 		if (payload.type === 'error') {
 			throw payload.err;
 		}
-		return wsSend(payload);
+		return hotSend(payload);
 	};
 
 	try {

--- a/packages/astro/src/vite-plugin-astro/hmr.ts
+++ b/packages/astro/src/vite-plugin-astro/hmr.ts
@@ -54,7 +54,7 @@ export async function handleHotUpdate(
 					ctx.server.moduleGraph.invalidateModule(mod);
 				}
 			}
-			ctx.server.ws.send({ type: 'full-reload', path: '*' });
+			ctx.server.hot.send({ type: 'full-reload', path: '*' });
 		}
 	}
 }

--- a/packages/astro/src/vite-plugin-dev-toolbar/vite-plugin-dev-toolbar.ts
+++ b/packages/astro/src/vite-plugin-dev-toolbar/vite-plugin-dev-toolbar.ts
@@ -25,21 +25,21 @@ export default function astroDevToolbar({ settings, logger }: AstroPluginOptions
 			}
 		},
 		configureServer(server) {
-			server.ws.on('astro:devtoolbar:error:load', (args) => {
+			server.hot.on('astro:devtoolbar:error:load', (args) => {
 				logger.error(
 					'toolbar',
 					`Failed to load dev toolbar app from ${args.entrypoint}: ${args.error}`
 				);
 			});
 
-			server.ws.on('astro:devtoolbar:error:init', (args) => {
+			server.hot.on('astro:devtoolbar:error:init', (args) => {
 				logger.error(
 					'toolbar',
 					`Failed to initialize dev toolbar app ${args.app.name} (${args.app.id}):\n${args.error}`
 				);
 			});
 
-			server.ws.on('astro:devtoolbar:app:toggled', (args) => {
+			server.hot.on('astro:devtoolbar:app:toggled', (args) => {
 				// Debounce telemetry to avoid recording events when the user is rapidly toggling apps for debugging
 				clearTimeout(telemetryTimeout);
 				telemetryTimeout = setTimeout(() => {


### PR DESCRIPTION
## Changes

Migrate from `ws` to `hot`, which provides the same interface, but allows signalling all HMR clients (not just the browser but also SSR) about certain events. `ws` was deprecated in Vite 5.1.

This unblocks one of the hurdles when using the new Vite Runtime API. cc @alexanderniebuhr 

## Testing

Existing tests should pass.

## Docs

n/a. Didn't add a changeset as there shouldn't be any visible changes.
