### PR TITLE
fix: add type definitions for markdown content component

### DIFF
--- a/.changeset/wild-rats-dance.md
+++ b/.changeset/wild-rats-dance.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Added type definitions for Content component

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1961,6 +1961,11 @@ export interface AstroInstance {
 	default: AstroComponentFactory;
 }
 
+export interface ContentProps<T extends Record<string, any>> {
+	components: Record<string, AstroComponentFactory>;
+	frontmatter: T;
+}
+
 export interface MarkdownInstance<T extends Record<string, any>> {
 	frontmatter: T;
 	/** Absolute file path (e.g. `/home/user/projects/.../file.md`) */
@@ -1968,7 +1973,7 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 	/** Browser URL for files under `/src/pages` (e.g. `/en/guides/markdown-content`) */
 	url: string | undefined;
 	/** Component to render content in `.astro` files. Usage: `<Content />` */
-	Content: AstroComponentFactory;
+	Content: AstroComponentFactory<ContentProps<T>>;
 	/** raw Markdown file content, excluding layout HTML and YAML frontmatter */
 	rawContent(): string;
 	/** Markdown file compiled to HTML, excluding layout HTML */

--- a/packages/astro/src/runtime/server/render/astro/factory.ts
+++ b/packages/astro/src/runtime/server/render/astro/factory.ts
@@ -5,8 +5,8 @@ import type { RenderTemplateResult } from './render-template.js';
 export type AstroFactoryReturnValue = RenderTemplateResult | Response | HeadAndContent;
 
 // The callback passed to to $$createComponent
-export interface AstroComponentFactory {
-	(result: any, props: any, slots: any): AstroFactoryReturnValue;
+export interface AstroComponentFactory<T = any> {
+	(result: any, props: T, slots: any): AstroFactoryReturnValue;
 	isAstroComponentFactory?: boolean;
 	moduleId?: string | undefined;
 	propagation?: PropagationHint;


### PR DESCRIPTION
## Changes

This is a tentative fix for withastro/roadmap#849

<img src="https://i.giphy.com/VXCPgZwEP7f1e.webp" width="480" height="326" />

## Testing

I haven't tested it. After following "[Setting up your local repo](https://github.com/withastro/astro/blob/main/CONTRIBUTING.md#setting-up-your-local-repo)", my repo is not completely set up (I have a few type errors and missing module errors).

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
Docs are already reflecting the existence of this API, it's more of a DX improvement (IDE integration).
