### PR TITLE
Fix an issue where audit fails to initialize when encountered `<a>` inside `<svg>`

### DIFF
--- a/.changeset/spotty-cobras-warn.md
+++ b/.changeset/spotty-cobras-warn.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where audit fails to initialize when encountered `<a>` inside `<svg>`

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/a11y.ts
@@ -338,8 +338,8 @@ export const a11y: AuditRuleWithSelector[] = [
 		selector: a11y_required_content.join(','),
 		match(element: HTMLElement) {
 			// innerText is used to ignore hidden text
-			const innerText = element.innerText.trim();
-			if (innerText !== '') return false;
+			const innerText = element.innerText?.trim();
+			if (innerText && innerText !== '') return false;
 
 			// Check for aria-label
 			const ariaLabel = element.getAttribute('aria-label')?.trim();


### PR DESCRIPTION
## Changes

- Fixes an issue where audit fails to initialize when encountered `<a>` inside `<svg>` (`innerText` of an SVG element seems to be `undefined`, hence the error)
  | Before | After |
  | ------ | ----- |
  | ![before](https://github.com/withastro/astro/assets/40516784/76e631f5-dea3-4516-8a62-1c989d2326da) | ![after](https://github.com/withastro/astro/assets/40516784/edf2eaec-3c7b-4fec-b707-ffceed3b62fb) |
- Closes #10146

## Testing

<!-- How was this change tested? -->
- Manually tested with the [minimal reproducible repo](https://stackblitz.com/edit/github-5z8nnr?file=src%2Fpages%2Findex.astro) from [#10146](https://github.com/withastro/astro/issues/10146)

## Docs

- N/A
