### PR TITLE
fix(i18n): make `i18n.routing` fields optional

### DIFF
--- a/.changeset/large-planets-kick.md
+++ b/.changeset/large-planets-kick.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where the `i18n.routing` object had all its fields defined as mandatory. Now they all are optionals and shouldn't break when using `astro.config.mts`.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1492,7 +1492,7 @@ export interface AstroUserConfig {
 			 * URLs will be of the form `example.com/[locale]/content/` for every route, including the default language.
 			 * Localized folders are used for every language, including the default.
 			 */
-			prefixDefaultLocale: boolean;
+			prefixDefaultLocale?: boolean;
 
 			/**
 			 * @docs
@@ -1521,7 +1521,7 @@ export interface AstroUserConfig {
 			 * })
 			 *```
 			 * */
-			redirectToDefaultLocale: boolean;
+			redirectToDefaultLocale?: boolean;
 
 			/**
 			 * @name i18n.routing.strategy
@@ -1532,48 +1532,48 @@ export interface AstroUserConfig {
 			 *
 			 * - `"pathname": The strategy is applied to the pathname of the URLs
 			 */
-			strategy: 'pathname';
-
-			/**
-			 * @name i18n.domains
-			 * @type {Record<string, string> }
-			 * @default '{}'
-			 * @version 4.3.0
-			 * @description
-			 *
-			 * Configures the URL pattern of one or more supported languages to use a custom domain (or sub-domain).
-			 *
-			 * When a locale is mapped to a domain, a `/[locale]/` path prefix will not be used.
-			 * However, localized folders within `src/pages/` are still required, including for your configured `defaultLocale`.
-			 *
-			 * Any other locale not configured will default to a localized path-based URL according to your `prefixDefaultLocale` strategy (e.g. `https://example.com/[locale]/blog`).
-			 *
-			 * ```js
-			 * //astro.config.mjs
-			 * export default defineConfig({
-			 * 	 site: "https://example.com",
-			 * 	 output: "server", // required, with no prerendered pages
-			 *   adapter: node({
-			 *     mode: 'standalone',
-			 *   }),
-			 * 	 i18n: {
-			 *     defaultLocale: "en",
-			 *     locales: ["en", "fr", "pt-br", "es"],
-			 *     prefixDefaultLocale: false,
-			 *     domains: {
-			 *       fr: "https://fr.example.com",
-			 *       es: "https://example.es"
-			 *     }
-			 *   },
-			 * })
-			 * ```
-			 *
-			 * Both page routes built and URLs returned by the `astro:i18n` helper functions [`getAbsoluteLocaleUrl()`](https://docs.astro.build/en/guides/internationalization/#getabsolutelocaleurl) and [`getAbsoluteLocaleUrlList()`](https://docs.astro.build/en/guides/internationalization/#getabsolutelocaleurllist) will use the options set in `i18n.domains`.
-			 *
-			 * See the [Internationalization Guide](https://docs.astro.build/en/guides/internationalization/#domains) for more details, including the limitations of this feature.
-			 */
-			domains?: Record<string, string>;
+			strategy?: 'pathname';
 		};
+
+		/**
+		 * @name i18n.domains
+		 * @type {Record<string, string> }
+		 * @default '{}'
+		 * @version 4.3.0
+		 * @description
+		 *
+		 * Configures the URL pattern of one or more supported languages to use a custom domain (or sub-domain).
+		 *
+		 * When a locale is mapped to a domain, a `/[locale]/` path prefix will not be used.
+		 * However, localized folders within `src/pages/` are still required, including for your configured `defaultLocale`.
+		 *
+		 * Any other locale not configured will default to a localized path-based URL according to your `prefixDefaultLocale` strategy (e.g. `https://example.com/[locale]/blog`).
+		 *
+		 * ```js
+		 * //astro.config.mjs
+		 * export default defineConfig({
+		 * 	 site: "https://example.com",
+		 * 	 output: "server", // required, with no prerendered pages
+		 *   adapter: node({
+		 *     mode: 'standalone',
+		 *   }),
+		 * 	 i18n: {
+		 *     defaultLocale: "en",
+		 *     locales: ["en", "fr", "pt-br", "es"],
+		 *     prefixDefaultLocale: false,
+		 *     domains: {
+		 *       fr: "https://fr.example.com",
+		 *       es: "https://example.es"
+		 *     }
+		 *   },
+		 * })
+		 * ```
+		 *
+		 * Both page routes built and URLs returned by the `astro:i18n` helper functions [`getAbsoluteLocaleUrl()`](https://docs.astro.build/en/guides/internationalization/#getabsolutelocaleurl) and [`getAbsoluteLocaleUrlList()`](https://docs.astro.build/en/guides/internationalization/#getabsolutelocaleurllist) will use the options set in `i18n.domains`.
+		 *
+		 * See the [Internationalization Guide](https://docs.astro.build/en/guides/internationalization/#domains) for more details, including the limitations of this feature.
+		 */
+		domains?: Record<string, string>;
 	};
 
 	/** ⚠️ WARNING: SUBJECT TO CHANGE */

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -347,9 +347,9 @@ export const AstroConfigSchema = z.object({
 				fallback: z.record(z.string(), z.string()).optional(),
 				routing: z
 					.object({
-						prefixDefaultLocale: z.boolean().default(false),
-						redirectToDefaultLocale: z.boolean().default(true),
-						strategy: z.enum(['pathname']).default('pathname'),
+						prefixDefaultLocale: z.boolean().optional().default(false),
+						redirectToDefaultLocale: z.boolean().optional().default(true),
+						strategy: z.enum(['pathname']).optional().default('pathname'),
 					})
 					.default({})
 					.refine(

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -351,6 +351,7 @@ export const AstroConfigSchema = z.object({
 						redirectToDefaultLocale: z.boolean().optional().default(true),
 						strategy: z.enum(['pathname']).optional().default('pathname'),
 					})
+					.optional()
 					.default({})
 					.refine(
 						({ prefixDefaultLocale, redirectToDefaultLocale }) => {

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -347,11 +347,10 @@ export const AstroConfigSchema = z.object({
 				fallback: z.record(z.string(), z.string()).optional(),
 				routing: z
 					.object({
-						prefixDefaultLocale: z.boolean().optional().default(false),
-						redirectToDefaultLocale: z.boolean().optional().default(true),
-						strategy: z.enum(['pathname']).optional().default('pathname'),
+						prefixDefaultLocale: z.boolean().default(false),
+						redirectToDefaultLocale: z.boolean().default(true),
+						strategy: z.enum(['pathname']).default('pathname'),
 					})
-					.optional()
 					.default({})
 					.refine(
 						({ prefixDefaultLocale, redirectToDefaultLocale }) => {


### PR DESCRIPTION
## Changes

Addresses the typing issue of https://github.com/withastro/astro/issues/10157

The properties inside `i18n.routing` were incorrectly typed. Now they are optional.

The type of `domains` was placed in the wrong part of the config... ooops! I fixed that too

## Testing

It should compile and current tests should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
