### PR TITLE
chore: use biome to sort imports - only test files

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,7 @@
 		"enabled": true
 	},
 	"linter": {
-		"enabled": false,
+		"enabled": false
 	},
   "formatter": {
     "enabled": false

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
+  "files": {
+    "include": ["*.test.js"],
+    "ignore": ["vendor"]
+  },
+	"organizeImports": {
+		"enabled": true
+	},
+	"linter": {
+		"enabled": false,
+	},
+  "formatter": {
+    "enabled": false
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "format": "pnpm run format:code",
     "format:ci": "pnpm run format:code",
     "format:code": "prettier -w \"**/*\" --ignore-unknown --cache",
-    "format:imports": "organize-imports-cli ./packages/*/tsconfig.json ./packages/*/*/tsconfig.json",
+    "format:imports": "biome check --apply .",
     "test": "turbo run test --concurrency=1 --filter=astro --filter=create-astro --filter=\"@astrojs/*\"",
     "test:match": "cd packages/astro && pnpm run test:match",
     "test:unit": "cd packages/astro && pnpm run test:unit",
@@ -45,6 +45,7 @@
   },
   "packageManager": "pnpm@8.6.12",
   "dependencies": {
+    "@biomejs/biome": "^1.5.3",
     "astro-benchmark": "workspace:*"
   },
   "devDependencies": {

--- a/packages/astro-rss/test/pagesGlobToRssItems.test.js
+++ b/packages/astro-rss/test/pagesGlobToRssItems.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { phpFeedItem, web1FeedItem } from './test-utils.js';
 import { pagesGlobToRssItems } from '../dist/index.js';
+import { phpFeedItem, web1FeedItem } from './test-utils.js';
 
 describe('pagesGlobToRssItems', () => {
 	it('should generate on valid result', async () => {

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -6,6 +6,7 @@ import rss, { getRssString } from '../dist/index.js';
 import { rssSchema } from '../dist/schema.js';
 import {
 	description,
+	parseXmlString,
 	phpFeedItem,
 	phpFeedItemWithContent,
 	phpFeedItemWithCustomData,
@@ -14,7 +15,6 @@ import {
 	web1FeedItem,
 	web1FeedItemWithAllData,
 	web1FeedItemWithContent,
-	parseXmlString,
 } from './test-utils.js';
 
 // note: I spent 30 minutes looking for a nice node-based snapshot tool

--- a/packages/astro/e2e/error-cyclic.test.js
+++ b/packages/astro/e2e/error-cyclic.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { testFactory, getErrorOverlayContent } from './test-utils.js';
+import { getErrorOverlayContent, testFactory } from './test-utils.js';
 
 const test = testFactory({
 	root: './fixtures/error-cyclic/',

--- a/packages/astro/e2e/error-sass.test.js
+++ b/packages/astro/e2e/error-sass.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { testFactory, getErrorOverlayContent } from './test-utils.js';
+import { getErrorOverlayContent, testFactory } from './test-utils.js';
 
 const test = testFactory({
 	root: './fixtures/error-sass/',

--- a/packages/astro/e2e/nested-recursive.test.js
+++ b/packages/astro/e2e/nested-recursive.test.js
@@ -1,4 +1,4 @@
-import { test as base, expect } from '@playwright/test';
+import { expect, test as base } from '@playwright/test';
 import { loadFixture, waitForHydrate } from './test-utils.js';
 
 const test = base.extend({

--- a/packages/astro/e2e/vue-component.test.js
+++ b/packages/astro/e2e/vue-component.test.js
@@ -1,5 +1,5 @@
-import { prepareTestFactory } from './shared-component-tests.js';
 import { expect } from '@playwright/test';
+import { prepareTestFactory } from './shared-component-tests.js';
 const { test, createTests } = prepareTestFactory({ root: './fixtures/vue-component/' });
 
 const config = {

--- a/packages/astro/test/0-css.test.js
+++ b/packages/astro/test/0-css.test.js
@@ -5,7 +5,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { describe, before, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/alias-tsconfig-baseurl-only.test.js
+++ b/packages/astro/test/alias-tsconfig-baseurl-only.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/alias-tsconfig.test.js
+++ b/packages/astro/test/alias-tsconfig.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/alias.test.js
+++ b/packages/astro/test/alias.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { isWindows, loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/asset-url-base.test.js
+++ b/packages/astro/test/asset-url-base.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/astro-assets-prefix.test.js
+++ b/packages/astro/test/astro-assets-prefix.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';

--- a/packages/astro/test/astro-assets.test.js
+++ b/packages/astro/test/astro-assets.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import srcsetParse from 'srcset-parse';
+import { loadFixture } from './test-utils.js';
 
 // This package isn't real ESM, so have to coerce it
 const matchSrcset = srcsetParse.default;

--- a/packages/astro/test/astro-attrs.test.js
+++ b/packages/astro/test/astro-attrs.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/astro-basic.test.js
+++ b/packages/astro/test/astro-basic.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/astro-children.test.js
+++ b/packages/astro/test/astro-children.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/astro-class-list.test.js
+++ b/packages/astro/test/astro-class-list.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/astro-client-only.test.js
+++ b/packages/astro/test/astro-client-only.test.js
@@ -1,6 +1,6 @@
-import { load as cheerioLoad } from 'cheerio';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { load as cheerioLoad } from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Client only components', () => {

--- a/packages/astro/test/astro-component-bundling.test.js
+++ b/packages/astro/test/astro-component-bundling.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('Component bundling', () => {

--- a/packages/astro/test/astro-component-code.test.js
+++ b/packages/astro/test/astro-component-code.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('<Code>', () => {

--- a/packages/astro/test/astro-cookies.test.js
+++ b/packages/astro/test/astro-cookies.test.js
@@ -1,8 +1,8 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Astro.cookies', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/astro-css-bundling.test.js
+++ b/packages/astro/test/astro-css-bundling.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 // note: the hashes should be deterministic, but updating the file contents will change hashes

--- a/packages/astro/test/astro-directives.test.js
+++ b/packages/astro/test/astro-directives.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Directives', async () => {

--- a/packages/astro/test/astro-doctype.test.js
+++ b/packages/astro/test/astro-doctype.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Doctype', () => {

--- a/packages/astro/test/astro-dynamic.test.js
+++ b/packages/astro/test/astro-dynamic.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Dynamic components', () => {

--- a/packages/astro/test/astro-envs.test.js
+++ b/packages/astro/test/astro-envs.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
 import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
 
 describe('Environment Variables', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/astro-expr.test.js
+++ b/packages/astro/test/astro-expr.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Expressions', () => {

--- a/packages/astro/test/astro-external-files.test.js
+++ b/packages/astro/test/astro-external-files.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('External file references', () => {

--- a/packages/astro/test/astro-fallback.test.js
+++ b/packages/astro/test/astro-fallback.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Dynamic component fallback', () => {

--- a/packages/astro/test/astro-generator.test.js
+++ b/packages/astro/test/astro-generator.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/astro-get-static-paths.test.js
+++ b/packages/astro/test/astro-get-static-paths.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { after, afterEach, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('getStaticPaths - build calls', () => {

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Astro Global', () => {

--- a/packages/astro/test/astro-head.test.js
+++ b/packages/astro/test/astro-head.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/astro-markdown-frontmatter-injection.test.js
+++ b/packages/astro/test/astro-markdown-frontmatter-injection.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 const FIXTURE_ROOT = './fixtures/astro-markdown-frontmatter-injection/';

--- a/packages/astro/test/astro-markdown-plugins.test.js
+++ b/packages/astro/test/astro-markdown-plugins.test.js
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import addClasses from './fixtures/astro-markdown-plugins/add-classes.mjs';
+import { loadFixture } from './test-utils.js';
 
 const defaultMarkdownConfig = {
 	gfm: true,

--- a/packages/astro/test/astro-markdown-remarkRehype.test.js
+++ b/packages/astro/test/astro-markdown-remarkRehype.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/astro-markdown-shiki.test.js
+++ b/packages/astro/test/astro-markdown-shiki.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/astro-markdown.test.js
+++ b/packages/astro/test/astro-markdown.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture, fixLineEndings } from './test-utils.js';
+import { fixLineEndings, loadFixture } from './test-utils.js';
 
 const FIXTURE_ROOT = './fixtures/astro-markdown/';
 

--- a/packages/astro/test/astro-not-response.test.js
+++ b/packages/astro/test/astro-not-response.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 // Asset bundling

--- a/packages/astro/test/astro-object-style.test.js
+++ b/packages/astro/test/astro-object-style.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Object style', async () => {

--- a/packages/astro/test/astro-pageDirectoryUrl.test.js
+++ b/packages/astro/test/astro-pageDirectoryUrl.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('build format', () => {

--- a/packages/astro/test/astro-pages.test.js
+++ b/packages/astro/test/astro-pages.test.js
@@ -1,7 +1,7 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
-import { loadFixture, isWindows } from './test-utils.js';
+import * as cheerio from 'cheerio';
+import { isWindows, loadFixture } from './test-utils.js';
 
 describe('Pages', () => {
 	let fixture;

--- a/packages/astro/test/astro-pagination-root-spread.test.js
+++ b/packages/astro/test/astro-pagination-root-spread.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/astro-pagination.test.js
+++ b/packages/astro/test/astro-pagination.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/astro-partial-html.test.js
+++ b/packages/astro/test/astro-partial-html.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Partial HTML', async () => {

--- a/packages/astro/test/astro-public.test.js
+++ b/packages/astro/test/astro-public.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('Public', () => {

--- a/packages/astro/test/astro-response.test.js
+++ b/packages/astro/test/astro-response.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 // Asset bundling

--- a/packages/astro/test/astro-scripts.test.js
+++ b/packages/astro/test/astro-scripts.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Scripts (hoisted and not)', () => {

--- a/packages/astro/test/astro-slot-with-client.test.js
+++ b/packages/astro/test/astro-slot-with-client.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/astro-slots-nested.test.js
+++ b/packages/astro/test/astro-slots-nested.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Nested Slots', () => {

--- a/packages/astro/test/astro-slots.test.js
+++ b/packages/astro/test/astro-slots.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/before-hydration.test.js
+++ b/packages/astro/test/before-hydration.test.js
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import { preact } from './fixtures/before-hydration/deps.mjs';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Astro Scripts before-hydration', () => {
 	describe('SSG', () => {

--- a/packages/astro/test/build-assets.test.js
+++ b/packages/astro/test/build-assets.test.js
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import { preact } from './fixtures/before-hydration/deps.mjs';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('build assets (static)', () => {
 	describe('with default configuration', () => {

--- a/packages/astro/test/cli.test.js
+++ b/packages/astro/test/cli.test.js
@@ -1,12 +1,12 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
-import { cli, parseCliDevStart, cliServerLogSetup, loadFixture } from './test-utils.js';
-import stripAnsi from 'strip-ansi';
 import { promises as fs, readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { isIPv4 } from 'node:net';
 import { join } from 'node:path';
 import { Writable } from 'node:stream';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import stripAnsi from 'strip-ansi';
+import { cli, cliServerLogSetup, loadFixture, parseCliDevStart } from './test-utils.js';
 
 describe('astro cli', () => {
 	const cliServerLogSetupWithFixture = (flags, cmd) => {

--- a/packages/astro/test/client-address.test.js
+++ b/packages/astro/test/client-address.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, it, after } from 'node:test';
-import { loadFixture } from './test-utils.js';
-import testAdapter from './test-adapter.js';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
+import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Astro.clientAddress', () => {
 	describe('SSR', () => {

--- a/packages/astro/test/code-component.test.js
+++ b/packages/astro/test/code-component.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/component-library.test.js
+++ b/packages/astro/test/component-library.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { load as cheerioLoad } from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/config-mode.test.js
+++ b/packages/astro/test/config-mode.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { before, describe, it } from 'node:test';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('AstroConfig - config.output', () => {
 	describe(`output: 'server'`, () => {

--- a/packages/astro/test/config-vite-css-target.test.js
+++ b/packages/astro/test/config-vite-css-target.test.js
@@ -3,7 +3,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/config-vite.test.js
+++ b/packages/astro/test/config-vite.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/content-collection-references.test.js
+++ b/packages/astro/test/content-collection-references.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { fixLineEndings, loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/content-collections-render.test.js
+++ b/packages/astro/test/content-collections-render.test.js
@@ -1,8 +1,8 @@
 import * as assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture, isWindows } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { isWindows, loadFixture } from './test-utils.js';
 
 if (!isWindows) {
 	describe();

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -1,10 +1,10 @@
-import * as devalue from 'devalue';
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import * as devalue from 'devalue';
 import testAdapter from './test-adapter.js';
 import { preventNodeBuiltinDependencyPlugin } from './test-plugins.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Content Collections', () => {
 	describe('Query', () => {

--- a/packages/astro/test/core-image-infersize.test.js
+++ b/packages/astro/test/core-image-infersize.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { describe, before, after, it } from 'node:test';
-import * as cheerio from 'cheerio';
 import { Writable } from 'node:stream';
+import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 
 import { Logger } from '../dist/core/logger/core.js';
 import { loadFixture } from './test-utils.js';

--- a/packages/astro/test/core-image-remark-imgattr.test.js
+++ b/packages/astro/test/core-image-remark-imgattr.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { describe, before, after, it } from 'node:test';
-import * as cheerio from 'cheerio';
 import { Writable } from 'node:stream';
+import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 
 import { Logger } from '../dist/core/logger/core.js';
 import { loadFixture } from './test-utils.js';

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, after, it } from 'node:test';
-import * as cheerio from 'cheerio';
 import { basename } from 'node:path';
 import { Writable } from 'node:stream';
+import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import parseSrcset from 'parse-srcset';
 import { removeDir } from '../dist/core/fs/index.js';
 import { Logger } from '../dist/core/logger/core.js';

--- a/packages/astro/test/css-assets.test.js
+++ b/packages/astro/test/css-assets.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/css-dangling-references.test.js
+++ b/packages/astro/test/css-dangling-references.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 const cssAssetReferenceRegExp = /_astro\/[A-Za-z\d\-]+\.[\da-f]{8}\.css/g;

--- a/packages/astro/test/css-import-as-inline.test.js
+++ b/packages/astro/test/css-import-as-inline.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { describe, before, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/css-inline-stylesheets.test.js
+++ b/packages/astro/test/css-inline-stylesheets.test.js
@@ -1,8 +1,8 @@
 import * as assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Setting inlineStylesheets to never in static output', () => {
 	let fixture;

--- a/packages/astro/test/css-no-code-split.test.js
+++ b/packages/astro/test/css-no-code-split.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/css-order-import.test.js
+++ b/packages/astro/test/css-order-import.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { describe, before, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/css-order-layout.test.js
+++ b/packages/astro/test/css-order-layout.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/css-order.test.js
+++ b/packages/astro/test/css-order.test.js
@@ -1,8 +1,8 @@
 import * as assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('CSS production ordering', () => {
 	function getLinks(html) {

--- a/packages/astro/test/custom-404-html.test.js
+++ b/packages/astro/test/custom-404-html.test.js
@@ -1,7 +1,7 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
-import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
 
 describe('Custom 404.html', () => {
 	let fixture;

--- a/packages/astro/test/custom-404-implicit-rerouting.test.js
+++ b/packages/astro/test/custom-404-implicit-rerouting.test.js
@@ -1,6 +1,6 @@
-import { loadFixture } from './test-utils.js';
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
 
 for (const caseNumber of [1, 2, 3, 4]) {
 	describe(`Custom 404 with implicit rerouting - Case #${caseNumber}`, () => {

--- a/packages/astro/test/custom-404-injected-from-dep.test.js
+++ b/packages/astro/test/custom-404-injected-from-dep.test.js
@@ -1,6 +1,6 @@
-import { loadFixture } from './test-utils.js';
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
 
 describe('Custom 404 with injectRoute from dependency', () => {
 	describe('build', () => {

--- a/packages/astro/test/custom-404-injected.test.js
+++ b/packages/astro/test/custom-404-injected.test.js
@@ -1,7 +1,7 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
-import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
 
 describe('Custom 404 with injectRoute', () => {
 	let fixture;

--- a/packages/astro/test/custom-404-md.test.js
+++ b/packages/astro/test/custom-404-md.test.js
@@ -1,7 +1,7 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
-import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
 
 describe('Custom 404 Markdown', () => {
 	let fixture;

--- a/packages/astro/test/custom-404-static.test.js
+++ b/packages/astro/test/custom-404-static.test.js
@@ -1,7 +1,7 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
-import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
 
 describe('Custom 404 with Static', () => {
 	let fixture;

--- a/packages/astro/test/custom-assets-name.test.js
+++ b/packages/astro/test/custom-assets-name.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('custom the assets name function', () => {

--- a/packages/astro/test/data-collections.test.js
+++ b/packages/astro/test/data-collections.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 const authorIds = ['Ben Holmes', 'Fred K Schott', 'Nate Moore'];

--- a/packages/astro/test/debug-component.test.js
+++ b/packages/astro/test/debug-component.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
-import { loadFixture, isMacOS } from './test-utils.js';
+import { after, before, describe, it } from 'node:test';
+import { isMacOS, loadFixture } from './test-utils.js';
 
 // TODO: fix this tests in macOS
 if (!isMacOS) {

--- a/packages/astro/test/dev-routing.test.js
+++ b/packages/astro/test/dev-routing.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('Development Routing', () => {

--- a/packages/astro/test/dont-delete-root.test.js
+++ b/packages/astro/test/dont-delete-root.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
 import * as fs from 'node:fs';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('outDir set to project root', async () => {

--- a/packages/astro/test/dynamic-endpoint-collision.test.js
+++ b/packages/astro/test/dynamic-endpoint-collision.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { load as cheerioLoad } from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/dynamic-route-build-file.test.js
+++ b/packages/astro/test/dynamic-route-build-file.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/entry-file-names.test.js
+++ b/packages/astro/test/entry-file-names.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/error-bad-js.test.js
+++ b/packages/astro/test/error-bad-js.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('Errors in JavaScript', () => {

--- a/packages/astro/test/error-non-error.test.js
+++ b/packages/astro/test/error-non-error.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('Can handle errors that are not instanceof Error', () => {

--- a/packages/astro/test/experimental-content-collection-references.test.js
+++ b/packages/astro/test/experimental-content-collection-references.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, after, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { fixLineEndings, loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/experimental-content-collections-css-inline-stylesheets.test.js
+++ b/packages/astro/test/experimental-content-collections-css-inline-stylesheets.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, after, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Experimental Content Collections cache inlineStylesheets', () => {
 	let fixture;

--- a/packages/astro/test/experimental-content-collections-render.test.js
+++ b/packages/astro/test/experimental-content-collections-render.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, after, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture, isWindows } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { isWindows, loadFixture } from './test-utils.js';
 
 if (!isWindows) {
 	describe('Experimental Content Collections cache - render()', () => {

--- a/packages/astro/test/experimental-content-collections.test.js
+++ b/packages/astro/test/experimental-content-collections.test.js
@@ -1,10 +1,10 @@
-import * as devalue from 'devalue';
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
-import { describe, before, after, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import * as devalue from 'devalue';
 import testAdapter from './test-adapter.js';
 import { preventNodeBuiltinDependencyPlugin } from './test-plugins.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Experimental Content Collections cache', () => {
 	describe('Query', () => {

--- a/packages/astro/test/featuresSupport.test.js
+++ b/packages/astro/test/featuresSupport.test.js
@@ -1,7 +1,7 @@
-import { loadFixture } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Adapter', () => {
 	let fixture;

--- a/packages/astro/test/fetch.test.js
+++ b/packages/astro/test/fetch.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/fontsource.test.js
+++ b/packages/astro/test/fontsource.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/get-static-paths-pages.test.js
+++ b/packages/astro/test/get-static-paths-pages.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/glob-pages-css.test.js
+++ b/packages/astro/test/glob-pages-css.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/head-injection.test.js
+++ b/packages/astro/test/head-injection.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/hoisted-imports.test.js
+++ b/packages/astro/test/hoisted-imports.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
 
 describe('Hoisted Imports', () => {
 	let fixture;

--- a/packages/astro/test/html-component.test.js
+++ b/packages/astro/test/html-component.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/html-escape-complex.test.js
+++ b/packages/astro/test/html-escape-complex.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/html-escape.test.js
+++ b/packages/astro/test/html-escape.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/html-page.test.js
+++ b/packages/astro/test/html-page.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/html-slots.test.js
+++ b/packages/astro/test/html-slots.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/hydration-race.test.js
+++ b/packages/astro/test/hydration-race.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -1,8 +1,8 @@
+import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
-import { describe, it, before, after } from 'node:test';
-import * as assert from 'node:assert/strict';
 
 describe('astro:i18n virtual module', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/image-deletion.test.js
+++ b/packages/astro/test/image-deletion.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, it, before } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { testImageService } from './test-image-service.js';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/import-ts-with-js.test.js
+++ b/packages/astro/test/import-ts-with-js.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/impostor-mdx-file.test.js
+++ b/packages/astro/test/impostor-mdx-file.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { isWindows, loadFixture } from './test-utils.js';
 
 let fixture;

--- a/packages/astro/test/integration-add-page-extension.test.js
+++ b/packages/astro/test/integration-add-page-extension.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/integration-server-setup.test.js
+++ b/packages/astro/test/integration-server-setup.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('Integration server setup', () => {

--- a/packages/astro/test/jsx.test.js
+++ b/packages/astro/test/jsx.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/lazy-layout.test.js
+++ b/packages/astro/test/lazy-layout.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/lit-element.test.js
+++ b/packages/astro/test/lit-element.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/markdown.test.js
+++ b/packages/astro/test/markdown.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
-import * as cheerio from 'cheerio';
 import { existsSync, readFileSync } from 'node:fs';
+import { after, before, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/minification-html.test.js
+++ b/packages/astro/test/minification-html.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { after, before, describe, it } from 'node:test';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 const NEW_LINES = /[\r\n]+/g;
 

--- a/packages/astro/test/multiple-renderers.test.js
+++ b/packages/astro/test/multiple-renderers.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, it, before } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/non-ascii-path.test.js
+++ b/packages/astro/test/non-ascii-path.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, it, before } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/non-html-pages.test.js
+++ b/packages/astro/test/non-html-pages.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, it, before } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('Non-HTML Pages', () => {

--- a/packages/astro/test/partials.test.js
+++ b/packages/astro/test/partials.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('Partials', () => {

--- a/packages/astro/test/preact-compat-component.test.js
+++ b/packages/astro/test/preact-compat-component.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/preview-routing.test.js
+++ b/packages/astro/test/preview-routing.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/public-base-404.test.js
+++ b/packages/astro/test/public-base-404.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { after, before, describe, it } from 'node:test';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Astro.redirect', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/routing-priority.test.js
+++ b/packages/astro/test/routing-priority.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { load as cheerioLoad } from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/scoped-style-strategy.test.js
+++ b/packages/astro/test/scoped-style-strategy.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, it, before } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/set-html.test.js
+++ b/packages/astro/test/set-html.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/solid-component.test.js
+++ b/packages/astro/test/solid-component.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { isWindows, loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/space-in-folder-name.test.js
+++ b/packages/astro/test/space-in-folder-name.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/special-chars-in-component-imports.test.js
+++ b/packages/astro/test/special-chars-in-component-imports.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { load as cheerioLoad } from 'cheerio';
 import { isWindows, loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/ssr-adapter-build-config.test.js
+++ b/packages/astro/test/ssr-adapter-build-config.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { before, describe, it } from 'node:test';
 import { viteID } from '../dist/core/util.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Integration buildConfig hook', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/ssr-api-route.test.js
+++ b/packages/astro/test/ssr-api-route.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
 import net from 'node:net';
+import { after, before, describe, it } from 'node:test';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/ssr-assets.test.js
+++ b/packages/astro/test/ssr-assets.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { before, describe, it } from 'node:test';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('SSR Assets', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/ssr-dynamic.test.js
+++ b/packages/astro/test/ssr-dynamic.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { load as cheerioLoad } from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Dynamic pages in SSR', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/ssr-env.test.js
+++ b/packages/astro/test/ssr-env.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('SSR Environment Variables', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/ssr-error-pages.test.js
+++ b/packages/astro/test/ssr-error-pages.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
-import { loadFixture } from './test-utils.js';
-import testAdapter from './test-adapter.js';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
+import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('404 and 500 pages', () => {
 	/** @type {import('./test-utils.js').Fixture} */

--- a/packages/astro/test/ssr-hoisted-script.test.js
+++ b/packages/astro/test/ssr-hoisted-script.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { after, describe, before, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { load as cheerioLoad } from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 async function fetchHTML(fixture, path) {
 	const app = await fixture.loadTestAdapterApp();

--- a/packages/astro/test/ssr-large-array.test.js
+++ b/packages/astro/test/ssr-large-array.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('SSR with Large Array and client rendering', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/ssr-lit.test.js
+++ b/packages/astro/test/ssr-lit.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { load as cheerioLoad } from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Lit integration in SSR', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/ssr-locals.test.js
+++ b/packages/astro/test/ssr-locals.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('SSR Astro.locals from server', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/ssr-manifest.test.js
+++ b/packages/astro/test/ssr-manifest.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
-import testAdapter from './test-adapter.js';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
+import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('astro:ssr-manifest', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/ssr-markdown.test.js
+++ b/packages/astro/test/ssr-markdown.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { load as cheerioLoad } from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Markdown pages in SSR', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/ssr-params.test.js
+++ b/packages/astro/test/ssr-params.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Astro.params in SSR', () => {
 	/** @type {import('./test-utils.js').Fixture} */

--- a/packages/astro/test/ssr-partytown.test.js
+++ b/packages/astro/test/ssr-partytown.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { load as cheerioLoad } from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Using the Partytown integration in SSR', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/ssr-prerender-get-static-paths.test.js
+++ b/packages/astro/test/ssr-prerender-get-static-paths.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { after, afterEach, describe, before, it } from 'node:test';
+import { after, afterEach, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';

--- a/packages/astro/test/ssr-prerender.test.js
+++ b/packages/astro/test/ssr-prerender.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('SSR: prerender', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/ssr-preview.test.js
+++ b/packages/astro/test/ssr-preview.test.js
@@ -1,6 +1,6 @@
-import { loadFixture } from './test-utils.js';
-import testAdapter from './test-adapter.js';
 import { before, describe, it } from 'node:test';
+import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 describe('SSR Preview', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;

--- a/packages/astro/test/ssr-request.test.js
+++ b/packages/astro/test/ssr-request.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { load as cheerioLoad } from 'cheerio';
-import { loadFixture } from './test-utils.js';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Using Astro.request in SSR', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/ssr-response.test.js
+++ b/packages/astro/test/ssr-response.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { before, describe, it } from 'node:test';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('Using Astro.response in SSR', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/ssr-scripts.test.js
+++ b/packages/astro/test/ssr-scripts.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { before, describe, it } from 'node:test';
 import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('SSR Hydrated component scripts', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/ssr-split-manifest.test.js
+++ b/packages/astro/test/ssr-split-manifest.test.js
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict';
-import { describe, before, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
-import testAdapter from './test-adapter.js';
-import * as cheerio from 'cheerio';
-import { fileURLToPath } from 'node:url';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import * as cheerio from 'cheerio';
+import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
 
 describe('astro:ssr-manifest, split', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/astro/test/static-build-code-component.test.js
+++ b/packages/astro/test/static-build-code-component.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Code component inside static build', () => {

--- a/packages/astro/test/static-build-frameworks.test.js
+++ b/packages/astro/test/static-build-frameworks.test.js
@@ -1,7 +1,7 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
-import { loadFixture, isWindows } from './test-utils.js';
+import * as cheerio from 'cheerio';
+import { isWindows, loadFixture } from './test-utils.js';
 
 describe('Static build - frameworks', () => {
 	if (isWindows) {

--- a/packages/astro/test/static-build.test.js
+++ b/packages/astro/test/static-build.test.js
@@ -1,8 +1,8 @@
-import { load as cheerioLoad } from 'cheerio';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
-import { loadFixture } from './test-utils.js';
+import { load as cheerioLoad } from 'cheerio';
 import { Logger } from '../dist/core/logger/core.js';
+import { loadFixture } from './test-utils.js';
 
 function addLeadingSlash(path) {
 	return path.startsWith('/') ? path : '/' + path;

--- a/packages/astro/test/streaming.test.js
+++ b/packages/astro/test/streaming.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
 import { isWindows, loadFixture, streamAsyncIterator } from './test-utils.js';

--- a/packages/astro/test/svelte-component.test.js
+++ b/packages/astro/test/svelte-component.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { isWindows, loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/third-party-astro.test.js
+++ b/packages/astro/test/third-party-astro.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/units/app/headers.test.js
+++ b/packages/astro/test/units/app/headers.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { createOutgoingHttpHeaders } from '../../../dist/core/app/createOutgoingHttpHeaders.js';
 
 describe('createOutgoingHttpHeaders', () => {

--- a/packages/astro/test/units/assets/remote-pattern.test.js
+++ b/packages/astro/test/units/assets/remote-pattern.test.js
@@ -1,11 +1,11 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import {
-	matchProtocol,
-	matchPort,
 	matchHostname,
 	matchPathname,
 	matchPattern,
+	matchPort,
+	matchProtocol,
 } from '../../../dist/assets/utils/remotePattern.js';
 
 describe('astro/src/assets/utils/remotePattern', () => {

--- a/packages/astro/test/units/build/static-build.test.js
+++ b/packages/astro/test/units/build/static-build.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { makeAstroPageEntryPointFileName } from '../../../dist/core/build/static-build.js';
 
 describe('astro/src/core/build', () => {

--- a/packages/astro/test/units/compile/invalid-css.test.js
+++ b/packages/astro/test/units/compile/invalid-css.test.js
@@ -1,9 +1,9 @@
-import { resolveConfig } from 'vite';
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { pathToFileURL } from 'node:url';
+import { resolveConfig } from 'vite';
 import { compile } from '../../../dist/core/compile/index.js';
 import { AggregateError } from '../../../dist/core/errors/index.js';
-import { pathToFileURL } from 'node:url';
 
 describe('astro/src/core/compile', () => {
 	describe('Invalid CSS', () => {

--- a/packages/astro/test/units/config/config-resolve.test.js
+++ b/packages/astro/test/units/config/config-resolve.test.js
@@ -1,8 +1,8 @@
+import * as assert from 'node:assert/strict';
 import path from 'node:path';
+import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { resolveConfig } from '../../../dist/core/config/index.js';
-import { describe, it } from 'node:test';
-import * as assert from 'node:assert/strict';
 
 describe('resolveConfig', () => {
 	it('resolves relative inline root correctly', async () => {

--- a/packages/astro/test/units/config/config-server.test.js
+++ b/packages/astro/test/units/config/config-server.test.js
@@ -1,8 +1,8 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { flagsToAstroInlineConfig } from '../../../dist/cli/flags.js';
 import { resolveConfig } from '../../../dist/core/config/index.js';
-import { describe, it } from 'node:test';
-import * as assert from 'node:assert/strict';
 
 const cwd = fileURLToPath(new URL('../../fixtures/config-host/', import.meta.url));
 

--- a/packages/astro/test/units/config/config-tsconfig.test.js
+++ b/packages/astro/test/units/config/config-tsconfig.test.js
@@ -1,6 +1,6 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
 import * as path from 'node:path';
+import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { loadTSConfig, updateTSConfigForFramework } from '../../../dist/core/config/index.js';
 

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -1,9 +1,9 @@
-import { z } from 'zod';
-import stripAnsi from 'strip-ansi';
-import { formatConfigErrorMessage } from '../../../dist/core/messages.js';
-import { validateConfig } from '../../../dist/core/config/config.js';
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import stripAnsi from 'strip-ansi';
+import { z } from 'zod';
+import { validateConfig } from '../../../dist/core/config/config.js';
+import { formatConfigErrorMessage } from '../../../dist/core/messages.js';
 
 describe('Config Validation', () => {
 	it('empty user config is valid', async () => {

--- a/packages/astro/test/units/config/format.test.js
+++ b/packages/astro/test/units/config/format.test.js
@@ -1,6 +1,6 @@
-import { fileURLToPath } from 'node:url';
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 import { createFs, runInContainer } from '../test-utils.js';
 
 const root = new URL('../../fixtures/tailwindcss-ts/', import.meta.url);

--- a/packages/astro/test/units/content-collections/error-map.test.js
+++ b/packages/astro/test/units/content-collections/error-map.test.js
@@ -1,8 +1,8 @@
-import { z } from '../../../zod.mjs';
-import { errorMap } from '../../../dist/content/index.js';
-import { fixLineEndings } from '../../test-utils.js';
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { errorMap } from '../../../dist/content/index.js';
+import { z } from '../../../zod.mjs';
+import { fixLineEndings } from '../../test-utils.js';
 
 describe('Content Collections - error map', () => {
 	it('Prefixes messages with object key', () => {

--- a/packages/astro/test/units/content-collections/frontmatter.test.js
+++ b/packages/astro/test/units/content-collections/frontmatter.test.js
@@ -1,7 +1,7 @@
-import { fileURLToPath } from 'node:url';
 import nodeFS from 'node:fs';
 import path from 'node:path';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 import { attachContentServerListeners } from '../../../dist/content/index.js';
 import { createFs, runInContainer, triggerFSEvent } from '../test-utils.js';
 

--- a/packages/astro/test/units/content-collections/get-entry-info.test.js
+++ b/packages/astro/test/units/content-collections/get-entry-info.test.js
@@ -1,6 +1,6 @@
-import { getContentEntryIdAndSlug, getEntryCollectionName } from '../../../dist/content/utils.js';
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { getContentEntryIdAndSlug, getEntryCollectionName } from '../../../dist/content/utils.js';
 
 describe('Content Collections - entry info', () => {
 	const contentDir = new URL('src/content/', import.meta.url);

--- a/packages/astro/test/units/content-collections/get-entry-type.test.js
+++ b/packages/astro/test/units/content-collections/get-entry-type.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { getEntryType } from '../../../dist/content/utils.js';
 

--- a/packages/astro/test/units/cookies/delete.test.js
+++ b/packages/astro/test/units/cookies/delete.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { AstroCookies } from '../../../dist/core/cookies/index.js';
 import { apply as applyPolyfill } from '../../../dist/core/polyfill.js';
 

--- a/packages/astro/test/units/cookies/error.test.js
+++ b/packages/astro/test/units/cookies/error.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { AstroCookies } from '../../../dist/core/cookies/index.js';
 import { apply as applyPolyfill } from '../../../dist/core/polyfill.js';
 

--- a/packages/astro/test/units/cookies/get.test.js
+++ b/packages/astro/test/units/cookies/get.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { AstroCookies } from '../../../dist/core/cookies/index.js';
 import { apply as applyPolyfill } from '../../../dist/core/polyfill.js';
 

--- a/packages/astro/test/units/cookies/has.test.js
+++ b/packages/astro/test/units/cookies/has.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { AstroCookies } from '../../../dist/core/cookies/index.js';
 import { apply as applyPolyfill } from '../../../dist/core/polyfill.js';
 

--- a/packages/astro/test/units/cookies/set.test.js
+++ b/packages/astro/test/units/cookies/set.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { AstroCookies } from '../../../dist/core/cookies/index.js';
 import { apply as applyPolyfill } from '../../../dist/core/polyfill.js';
 

--- a/packages/astro/test/units/dev/base.test.js
+++ b/packages/astro/test/units/dev/base.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { createFs, createRequestAndResponse, runInContainer } from '../test-utils.js';
 

--- a/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
+++ b/packages/astro/test/units/dev/collections-mixed-content-errors.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import _sync from '../../../dist/core/sync/index.js';
 import { createFsWithFallback } from '../test-utils.js';

--- a/packages/astro/test/units/dev/collections-renderentry.test.js
+++ b/packages/astro/test/units/dev/collections-renderentry.test.js
@@ -1,8 +1,8 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
-import * as cheerio from 'cheerio';
 import os from 'node:os';
+import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import * as cheerio from 'cheerio';
 
 import { attachContentServerListeners } from '../../../dist/content/server-listeners.js';
 import { createFsWithFallback, createRequestAndResponse, runInContainer } from '../test-utils.js';

--- a/packages/astro/test/units/dev/dev.test.js
+++ b/packages/astro/test/units/dev/dev.test.js
@@ -1,7 +1,7 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
-import * as cheerio from 'cheerio';
+import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import * as cheerio from 'cheerio';
 import {
 	createFs,
 	createRequestAndResponse,

--- a/packages/astro/test/units/dev/head-injection.test.js
+++ b/packages/astro/test/units/dev/head-injection.test.js
@@ -1,7 +1,7 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
-import * as cheerio from 'cheerio';
+import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import * as cheerio from 'cheerio';
 import { createFs, createRequestAndResponse, runInContainer } from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);

--- a/packages/astro/test/units/dev/hydration.test.js
+++ b/packages/astro/test/units/dev/hydration.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { createFs, createRequestAndResponse, runInContainer } from '../test-utils.js';
 

--- a/packages/astro/test/units/dev/restart.test.js
+++ b/packages/astro/test/units/dev/restart.test.js
@@ -1,7 +1,7 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
-import * as cheerio from 'cheerio';
+import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import * as cheerio from 'cheerio';
 
 import {
 	createContainerWithAutomaticRestart,

--- a/packages/astro/test/units/dev/styles.test.js
+++ b/packages/astro/test/units/dev/styles.test.js
@@ -1,7 +1,7 @@
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
-import { getStylesForURL } from '../../../dist/vite-plugin-astro-server/css.js';
+import { before, describe, it } from 'node:test';
 import { viteID } from '../../../dist/core/util.js';
+import { getStylesForURL } from '../../../dist/vite-plugin-astro-server/css.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 

--- a/packages/astro/test/units/i18n/astro_i18n.test.js
+++ b/packages/astro/test/units/i18n/astro_i18n.test.js
@@ -1,16 +1,16 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { MissingLocale } from '#astro/core/errors/errors-data';
+import { AstroError } from '#astro/core/errors/index';
+import { toRoutingStrategy } from '#astro/i18n/utils';
+import { validateConfig } from '../../../dist/core/config/config.js';
 import {
-	getLocaleRelativeUrl,
-	getLocaleRelativeUrlList,
 	getLocaleAbsoluteUrl,
 	getLocaleAbsoluteUrlList,
+	getLocaleRelativeUrl,
+	getLocaleRelativeUrlList,
 } from '../../../dist/i18n/index.js';
 import { parseLocale } from '../../../dist/i18n/utils.js';
-import { describe, it } from 'node:test';
-import * as assert from 'node:assert/strict';
-import { validateConfig } from '../../../dist/core/config/config.js';
-import { AstroError } from '#astro/core/errors/index';
-import { MissingLocale } from '#astro/core/errors/errors-data';
-import { toRoutingStrategy } from '#astro/i18n/utils';
 
 describe('getLocaleRelativeUrl', () => {
 	it('should correctly return the URL with the base', () => {

--- a/packages/astro/test/units/integrations/api.test.js
+++ b/packages/astro/test/units/integrations/api.test.js
@@ -1,8 +1,8 @@
-import { runHookBuildSetup, runHookConfigSetup } from '../../../dist/integrations/index.js';
-import { validateSupportedFeatures } from '../../../dist/integrations/astroFeaturesValidation.js';
-import { defaultLogger } from '../test-utils.js';
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { validateSupportedFeatures } from '../../../dist/integrations/astroFeaturesValidation.js';
+import { runHookBuildSetup, runHookConfigSetup } from '../../../dist/integrations/index.js';
+import { defaultLogger } from '../test-utils.js';
 
 describe('Integration API', () => {
 	it('runHookBuildSetup should work', async () => {

--- a/packages/astro/test/units/logger/locale.test.js
+++ b/packages/astro/test/units/logger/locale.test.js
@@ -1,5 +1,5 @@
-import { describe, it, after } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { after, describe, it } from 'node:test';
 
 const LOCALES = ['en_US', 'sv_SE', 'es_419.UTF-8', 'es_ES@euro', 'C'];
 

--- a/packages/astro/test/units/render/chunk.test.js
+++ b/packages/astro/test/units/render/chunk.test.js
@@ -1,7 +1,7 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
-import * as cheerio from 'cheerio';
+import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import * as cheerio from 'cheerio';
 import { createFs, createRequestAndResponse, runInContainer } from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);

--- a/packages/astro/test/units/render/components.test.js
+++ b/packages/astro/test/units/render/components.test.js
@@ -1,7 +1,7 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
-import * as cheerio from 'cheerio';
+import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import * as cheerio from 'cheerio';
 import { createFs, createRequestAndResponse, runInContainer } from '../test-utils.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);

--- a/packages/astro/test/units/render/head.test.js
+++ b/packages/astro/test/units/render/head.test.js
@@ -1,17 +1,17 @@
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import { RenderContext } from '../../../dist/core/render-context.js';
 import {
+	Fragment,
 	createComponent,
+	maybeRenderHead,
 	render,
 	renderComponent,
-	renderSlot,
-	maybeRenderHead,
 	renderHead,
-	Fragment,
+	renderSlot,
 } from '../../../dist/runtime/server/index.js';
-import { RenderContext } from '../../../dist/core/render-context.js';
 import { createBasicPipeline } from '../test-utils.js';
-import * as cheerio from 'cheerio';
 
 const createAstroModule = (AstroComponent) => ({ default: AstroComponent });
 

--- a/packages/astro/test/units/render/jsx.test.js
+++ b/packages/astro/test/units/render/jsx.test.js
@@ -1,15 +1,15 @@
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import { RenderContext } from '../../../dist/core/render-context.js';
+import { loadRenderer } from '../../../dist/core/render/index.js';
+import { jsx } from '../../../dist/jsx-runtime/index.js';
+import { createAstroJSXComponent, renderer as jsxRenderer } from '../../../dist/jsx/index.js';
 import {
 	createComponent,
 	render,
 	renderComponent,
 	renderSlot,
 } from '../../../dist/runtime/server/index.js';
-import { jsx } from '../../../dist/jsx-runtime/index.js';
-import { loadRenderer } from '../../../dist/core/render/index.js';
-import { RenderContext } from '../../../dist/core/render-context.js';
-import { createAstroJSXComponent, renderer as jsxRenderer } from '../../../dist/jsx/index.js';
 import { createBasicPipeline } from '../test-utils.js';
 
 const createAstroModule = (AstroComponent) => ({ default: AstroComponent });

--- a/packages/astro/test/units/routing/endpoints.test.js
+++ b/packages/astro/test/units/routing/endpoints.test.js
@@ -1,14 +1,14 @@
+import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { createContainer } from '../../../dist/core/dev/container.js';
+import testAdapter from '../../test-adapter.js';
 import {
 	createBasicSettings,
 	createFs,
 	createRequestAndResponse,
 	defaultLogger,
 } from '../test-utils.js';
-import { fileURLToPath } from 'node:url';
-import { describe, it, before, after } from 'node:test';
-import * as assert from 'node:assert/strict';
-import { createContainer } from '../../../dist/core/dev/container.js';
-import testAdapter from '../../test-adapter.js';
 
 const root = new URL('../../fixtures/api-routes/', import.meta.url);
 const fileSystem = {

--- a/packages/astro/test/units/routing/manifest.test.js
+++ b/packages/astro/test/units/routing/manifest.test.js
@@ -1,9 +1,9 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { Logger } from '../../../dist/core/logger/core.js';
 import { createRouteManifest } from '../../../dist/core/routing/manifest/create.js';
 import { createBasicSettings, createFs } from '../test-utils.js';
-import { Logger } from '../../../dist/core/logger/core.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 

--- a/packages/astro/test/units/routing/route-matching.test.js
+++ b/packages/astro/test/units/routing/route-matching.test.js
@@ -1,20 +1,20 @@
+import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import * as cheerio from 'cheerio';
+import { createContainer } from '../../../dist/core/dev/container.js';
+import { createViteLoader } from '../../../dist/core/module-loader/vite.js';
+import { createRouteManifest, matchAllRoutes } from '../../../dist/core/routing/index.js';
+import { getSortedPreloadedMatches } from '../../../dist/prerender/routing.js';
+import { DevPipeline } from '../../../dist/vite-plugin-astro-server/pipeline.js';
+import { createDevelopmentManifest } from '../../../dist/vite-plugin-astro-server/plugin.js';
+import testAdapter from '../../test-adapter.js';
 import {
 	createBasicSettings,
 	createFs,
 	createRequestAndResponse,
 	defaultLogger,
 } from '../test-utils.js';
-import { createRouteManifest, matchAllRoutes } from '../../../dist/core/routing/index.js';
-import { fileURLToPath } from 'node:url';
-import { createViteLoader } from '../../../dist/core/module-loader/vite.js';
-import { describe, it, before, after } from 'node:test';
-import * as assert from 'node:assert/strict';
-import { createContainer } from '../../../dist/core/dev/container.js';
-import * as cheerio from 'cheerio';
-import testAdapter from '../../test-adapter.js';
-import { getSortedPreloadedMatches } from '../../../dist/prerender/routing.js';
-import { createDevelopmentManifest } from '../../../dist/vite-plugin-astro-server/plugin.js';
-import { DevPipeline } from '../../../dist/vite-plugin-astro-server/pipeline.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 const fileSystem = {

--- a/packages/astro/test/units/routing/route-sanitization.test.js
+++ b/packages/astro/test/units/routing/route-sanitization.test.js
@@ -1,15 +1,15 @@
+import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import * as cheerio from 'cheerio';
+import { createContainer } from '../../../dist/core/dev/container.js';
+import testAdapter from '../../test-adapter.js';
 import {
 	createBasicSettings,
 	createFs,
 	createRequestAndResponse,
 	defaultLogger,
 } from '../test-utils.js';
-import { fileURLToPath } from 'node:url';
-import { describe, it, before, after } from 'node:test';
-import * as assert from 'node:assert/strict';
-import { createContainer } from '../../../dist/core/dev/container.js';
-import * as cheerio from 'cheerio';
-import testAdapter from '../../test-adapter.js';
 
 const root = new URL('../../fixtures/alias/', import.meta.url);
 const fileSystem = {

--- a/packages/astro/test/units/routing/trailing-slash.test.js
+++ b/packages/astro/test/units/routing/trailing-slash.test.js
@@ -1,14 +1,14 @@
+import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { createContainer } from '../../../dist/core/dev/container.js';
+import testAdapter from '../../test-adapter.js';
 import {
 	createBasicSettings,
 	createFs,
 	createRequestAndResponse,
 	defaultLogger,
 } from '../test-utils.js';
-import { fileURLToPath } from 'node:url';
-import { describe, it, before, after } from 'node:test';
-import * as assert from 'node:assert/strict';
-import { createContainer } from '../../../dist/core/dev/container.js';
-import testAdapter from '../../test-adapter.js';
 
 const root = new URL('../../fixtures/api-routes/', import.meta.url);
 const fileSystem = {

--- a/packages/astro/test/units/runtime/astro-global.test.js
+++ b/packages/astro/test/units/runtime/astro-global.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { createAstro } from '../../../dist/runtime/server/index.js';
 
 describe('astro global', () => {

--- a/packages/astro/test/units/vite-plugin-astro-server/controller.test.js
+++ b/packages/astro/test/units/vite-plugin-astro-server/controller.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { createLoader } from '../../../dist/core/module-loader/index.js';
 import {
 	createController,

--- a/packages/astro/test/units/vite-plugin-astro-server/request.test.js
+++ b/packages/astro/test/units/vite-plugin-astro-server/request.test.js
@@ -1,9 +1,11 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { createLoader } from '../../../dist/core/module-loader/index.js';
 import { createRouteManifest } from '../../../dist/core/routing/index.js';
 import { createComponent, render } from '../../../dist/runtime/server/index.js';
 import { createController, handleRequest } from '../../../dist/vite-plugin-astro-server/index.js';
+import { DevPipeline } from '../../../dist/vite-plugin-astro-server/pipeline.js';
+import { createDevelopmentManifest } from '../../../dist/vite-plugin-astro-server/plugin.js';
 import {
 	createAstroModule,
 	createBasicSettings,
@@ -11,8 +13,6 @@ import {
 	createRequestAndResponse,
 	defaultLogger,
 } from '../test-utils.js';
-import { createDevelopmentManifest } from '../../../dist/vite-plugin-astro-server/plugin.js';
-import { DevPipeline } from '../../../dist/vite-plugin-astro-server/pipeline.js';
 
 async function createDevPipeline(overrides = {}) {
 	const settings = overrides.settings ?? (await createBasicSettings({ root: '/' }));

--- a/packages/astro/test/units/vite-plugin-astro-server/response.test.js
+++ b/packages/astro/test/units/vite-plugin-astro-server/response.test.js
@@ -1,14 +1,14 @@
+import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { createContainer } from '../../../dist/core/dev/container.js';
+import testAdapter from '../../test-adapter.js';
 import {
 	createBasicSettings,
 	createFs,
 	createRequestAndResponse,
 	defaultLogger,
 } from '../test-utils.js';
-import { fileURLToPath } from 'node:url';
-import { describe, it, before, after } from 'node:test';
-import * as assert from 'node:assert/strict';
-import { createContainer } from '../../../dist/core/dev/container.js';
-import testAdapter from '../../test-adapter.js';
 
 const root = new URL('../../fixtures/api-routes/', import.meta.url);
 const fileSystem = {

--- a/packages/astro/test/units/vite-plugin-astro/compile.test.js
+++ b/packages/astro/test/units/vite-plugin-astro/compile.test.js
@@ -1,9 +1,9 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { pathToFileURL } from 'node:url';
+import { init, parse } from 'es-module-lexer';
 import { resolveConfig } from 'vite';
 import { compileAstro } from '../../../dist/vite-plugin-astro/compile.js';
-import { init, parse } from 'es-module-lexer';
-import { pathToFileURL } from 'node:url';
 
 const viteConfig = await resolveConfig({ configFile: false }, 'serve');
 

--- a/packages/astro/test/units/vite-plugin-astro/hmr.test.js
+++ b/packages/astro/test/units/vite-plugin-astro/hmr.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { isStyleOnlyChanged } from '../../../dist/vite-plugin-astro/hmr.js';
 
 describe('isStyleOnlyChanged', () => {

--- a/packages/astro/test/units/vite-plugin-scanner/scan.test.js
+++ b/packages/astro/test/units/vite-plugin-scanner/scan.test.js
@@ -1,5 +1,5 @@
-import { describe, it, before, after } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
 import { scan } from '../../../dist/vite-plugin-scanner/scan.js';
 
 describe('astro scan', () => {

--- a/packages/astro/test/view-transitions.test.js
+++ b/packages/astro/test/view-transitions.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/astro/test/vue-component.test.js
+++ b/packages/astro/test/vue-component.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { isWindows, loadFixture } from './test-utils.js';
 

--- a/packages/create-astro/test/context.test.js
+++ b/packages/create-astro/test/context.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
 import os from 'node:os';
+import { describe, it } from 'node:test';
 import { getContext } from '../dist/index.js';
 describe('context', () => {
 	it('no arguments', async () => {

--- a/packages/create-astro/test/dependencies.test.js
+++ b/packages/create-astro/test/dependencies.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { dependencies } from '../dist/index.js';
 import { describe, it } from 'node:test';
+import { dependencies } from '../dist/index.js';
 import { setup } from './utils.js';
 describe('dependencies', () => {
 	const fixture = setup();

--- a/packages/create-astro/test/git.test.js
+++ b/packages/create-astro/test/git.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
-import { mkdir, writeFile } from 'node:fs/promises';
 import { rmSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { after, before, describe, it } from 'node:test';
 
 import { git } from '../dist/index.js';
 import { setup } from './utils.js';

--- a/packages/create-astro/test/typescript.test.js
+++ b/packages/create-astro/test/typescript.test.js
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
-import { describe, it, beforeEach } from 'node:test';
 import fs from 'node:fs';
+import { beforeEach, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-import { typescript, setupTypeScript } from '../dist/index.js';
-import { setup, resetFixtures } from './utils.js';
+import { setupTypeScript, typescript } from '../dist/index.js';
+import { resetFixtures, setup } from './utils.js';
 
 describe('typescript', async () => {
 	const fixture = setup();

--- a/packages/create-astro/test/verify.test.js
+++ b/packages/create-astro/test/verify.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { setup } from './utils.js';
 import { verify } from '../dist/index.js';
+import { setup } from './utils.js';
 
 describe('verify', async () => {
 	const fixture = setup();

--- a/packages/integrations/lit/test/sass.test.js
+++ b/packages/integrations/lit/test/sass.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 
 describe('check', () => {
 	it('should be able to load sass', async () => {

--- a/packages/integrations/lit/test/server.test.js
+++ b/packages/integrations/lit/test/server.test.js
@@ -1,10 +1,10 @@
-import { LitElement, html } from 'lit';
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import { LitElement, html } from 'lit';
 // Must come after lit import because @lit/reactive-element defines
 // globalThis.customElements which the server shim expects to be defined.
 import server from '../server.js';
-import * as cheerio from 'cheerio';
 
 const { check, renderToStaticMarkup } = server;
 

--- a/packages/integrations/markdoc/test/content-collections.test.js
+++ b/packages/integrations/markdoc/test/content-collections.test.js
@@ -1,8 +1,8 @@
-import { parse as parseDevalue } from 'devalue';
-import { loadFixture, fixLineEndings } from '../../../astro/test/test-utils.js';
-import markdoc from '../dist/index.js';
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
+import { parse as parseDevalue } from 'devalue';
+import { fixLineEndings, loadFixture } from '../../../astro/test/test-utils.js';
+import markdoc from '../dist/index.js';
 
 function formatPost(post) {
 	return {

--- a/packages/integrations/markdoc/test/headings.test.js
+++ b/packages/integrations/markdoc/test/headings.test.js
@@ -1,7 +1,7 @@
-import { parseHTML } from 'linkedom';
-import { loadFixture } from '../../../astro/test/test-utils.js';
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
+import { parseHTML } from 'linkedom';
+import { loadFixture } from '../../../astro/test/test-utils.js';
 
 async function getFixture(name) {
 	return await loadFixture({

--- a/packages/integrations/markdoc/test/image-assets.test.js
+++ b/packages/integrations/markdoc/test/image-assets.test.js
@@ -1,7 +1,7 @@
-import { parseHTML } from 'linkedom';
-import { loadFixture } from '../../../astro/test/test-utils.js';
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
+import { parseHTML } from 'linkedom';
+import { loadFixture } from '../../../astro/test/test-utils.js';
 
 const root = new URL('./fixtures/image-assets/', import.meta.url);
 

--- a/packages/integrations/markdoc/test/propagated-assets.test.js
+++ b/packages/integrations/markdoc/test/propagated-assets.test.js
@@ -1,7 +1,7 @@
-import { parseHTML } from 'linkedom';
-import { loadFixture } from '../../../astro/test/test-utils.js';
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
+import { parseHTML } from 'linkedom';
+import { loadFixture } from '../../../astro/test/test-utils.js';
 
 describe('Markdoc - propagated assets', () => {
 	let fixture;

--- a/packages/integrations/markdoc/test/render-html.test.js
+++ b/packages/integrations/markdoc/test/render-html.test.js
@@ -1,7 +1,7 @@
-import { parseHTML } from 'linkedom';
-import { loadFixture } from '../../../astro/test/test-utils.js';
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
+import { parseHTML } from 'linkedom';
+import { loadFixture } from '../../../astro/test/test-utils.js';
 
 async function getFixture(name) {
 	return await loadFixture({

--- a/packages/integrations/markdoc/test/render.test.js
+++ b/packages/integrations/markdoc/test/render.test.js
@@ -1,7 +1,7 @@
-import { parseHTML } from 'linkedom';
-import { loadFixture } from '../../../astro/test/test-utils.js';
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { parseHTML } from 'linkedom';
+import { loadFixture } from '../../../astro/test/test-utils.js';
 
 async function getFixture(name) {
 	return await loadFixture({

--- a/packages/integrations/markdoc/test/syntax-highlighting.test.js
+++ b/packages/integrations/markdoc/test/syntax-highlighting.test.js
@@ -1,11 +1,11 @@
-import { parseHTML } from 'linkedom';
-import Markdoc from '@markdoc/markdoc';
-import shiki from '../dist/extensions/shiki.js';
-import prism from '../dist/extensions/prism.js';
-import { setupConfig } from '../dist/runtime.js';
-import { isHTMLString } from 'astro/runtime/server/index.js';
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import Markdoc from '@markdoc/markdoc';
+import { isHTMLString } from 'astro/runtime/server/index.js';
+import { parseHTML } from 'linkedom';
+import prism from '../dist/extensions/prism.js';
+import shiki from '../dist/extensions/shiki.js';
+import { setupConfig } from '../dist/runtime.js';
 
 const entry = `
 \`\`\`ts

--- a/packages/integrations/markdoc/test/variables.test.js
+++ b/packages/integrations/markdoc/test/variables.test.js
@@ -1,8 +1,8 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 import markdoc from '../dist/index.js';
-import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
 
 const root = new URL('./fixtures/variables/', import.meta.url);
 

--- a/packages/integrations/mdx/test/css-head-mdx.test.js
+++ b/packages/integrations/mdx/test/css-head-mdx.test.js
@@ -1,10 +1,10 @@
 import mdx from '@astrojs/mdx';
 
-import { parseHTML } from 'linkedom';
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
-import { loadFixture } from '../../../astro/test/test-utils.js';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
+import { parseHTML } from 'linkedom';
+import { loadFixture } from '../../../astro/test/test-utils.js';
 
 describe('Head injection w/ MDX', () => {
 	let fixture;

--- a/packages/integrations/mdx/test/invalid-mdx-component.test.js
+++ b/packages/integrations/mdx/test/invalid-mdx-component.test.js
@@ -1,5 +1,5 @@
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 import mdx from '../dist/index.js';
 

--- a/packages/integrations/mdx/test/mdx-astro-markdown-remarkRehype.test.js
+++ b/packages/integrations/mdx/test/mdx-astro-markdown-remarkRehype.test.js
@@ -1,7 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/mdx/test/mdx-component.test.js
+++ b/packages/integrations/mdx/test/mdx-component.test.js
@@ -1,7 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { describe, it, before, after } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/mdx/test/mdx-escape.test.js
+++ b/packages/integrations/mdx/test/mdx-escape.test.js
@@ -1,7 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/mdx/test/mdx-frontmatter-injection.test.js
+++ b/packages/integrations/mdx/test/mdx-frontmatter-injection.test.js
@@ -1,5 +1,5 @@
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/mdx/test/mdx-frontmatter.test.js
+++ b/packages/integrations/mdx/test/mdx-frontmatter.test.js
@@ -1,7 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/mdx/test/mdx-get-headings.test.js
+++ b/packages/integrations/mdx/test/mdx-get-headings.test.js
@@ -2,8 +2,8 @@ import { rehypeHeadingIds } from '@astrojs/markdown-remark';
 import mdx from '@astrojs/mdx';
 import { visit } from 'unist-util-visit';
 
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/mdx/test/mdx-get-static-paths.test.js
+++ b/packages/integrations/mdx/test/mdx-get-static-paths.test.js
@@ -1,9 +1,9 @@
 import mdx from '@astrojs/mdx';
 
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
-import { loadFixture } from '../../../astro/test/test-utils.js';
+import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
+import { loadFixture } from '../../../astro/test/test-utils.js';
 
 const FIXTURE_ROOT = new URL('./fixtures/mdx-get-static-paths', import.meta.url);
 

--- a/packages/integrations/mdx/test/mdx-images.test.js
+++ b/packages/integrations/mdx/test/mdx-images.test.js
@@ -1,5 +1,5 @@
-import { describe, it, before, after } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/mdx/test/mdx-infinite-loop.test.js
+++ b/packages/integrations/mdx/test/mdx-infinite-loop.test.js
@@ -1,7 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
 describe('MDX Infinite Loop', () => {

--- a/packages/integrations/mdx/test/mdx-math.test.js
+++ b/packages/integrations/mdx/test/mdx-math.test.js
@@ -1,11 +1,11 @@
-import mdx from '@astrojs/mdx';
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import mdx from '@astrojs/mdx';
 import { parseHTML } from 'linkedom';
-import { loadFixture } from '../../../astro/test/test-utils.js';
-import remarkMath from 'remark-math';
 import rehypeMathjaxSvg from 'rehype-mathjax';
 import rehypeMathjaxChtml from 'rehype-mathjax/chtml';
+import remarkMath from 'remark-math';
+import { loadFixture } from '../../../astro/test/test-utils.js';
 
 const FIXTURE_ROOT = new URL('./fixtures/mdx-math/', import.meta.url);
 

--- a/packages/integrations/mdx/test/mdx-namespace.test.js
+++ b/packages/integrations/mdx/test/mdx-namespace.test.js
@@ -1,5 +1,5 @@
-import { describe, it, before, after } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/mdx/test/mdx-optimize.test.js
+++ b/packages/integrations/mdx/test/mdx-optimize.test.js
@@ -1,5 +1,5 @@
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/mdx/test/mdx-page.test.js
+++ b/packages/integrations/mdx/test/mdx-page.test.js
@@ -1,5 +1,5 @@
-import { describe, it, before, after } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/mdx/test/mdx-plugins.test.js
+++ b/packages/integrations/mdx/test/mdx-plugins.test.js
@@ -1,11 +1,11 @@
 import mdx from '@astrojs/mdx';
 
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
-import { parseHTML } from 'linkedom';
-import { loadFixture } from '../../../astro/test/test-utils.js';
-import remarkToc from 'remark-toc';
+import { before, describe, it } from 'node:test';
 import { visit as estreeVisit } from 'estree-util-visit';
+import { parseHTML } from 'linkedom';
+import remarkToc from 'remark-toc';
+import { loadFixture } from '../../../astro/test/test-utils.js';
 
 const FIXTURE_ROOT = new URL('./fixtures/mdx-plugins/', import.meta.url);
 const FILE = '/with-plugins/index.html';

--- a/packages/integrations/mdx/test/mdx-plus-react.test.js
+++ b/packages/integrations/mdx/test/mdx-plus-react.test.js
@@ -1,5 +1,5 @@
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/mdx/test/mdx-script-style-raw.test.js
+++ b/packages/integrations/mdx/test/mdx-script-style-raw.test.js
@@ -1,6 +1,6 @@
-import mdx from '@astrojs/mdx';
-import { describe, it, before, after } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import mdx from '@astrojs/mdx';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/mdx/test/mdx-slots.test.js
+++ b/packages/integrations/mdx/test/mdx-slots.test.js
@@ -1,7 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { describe, it, before, after } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/mdx/test/mdx-syntax-highlighting.test.js
+++ b/packages/integrations/mdx/test/mdx-syntax-highlighting.test.js
@@ -1,11 +1,11 @@
 import mdx from '@astrojs/mdx';
 
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
-import { loadFixture } from '../../../astro/test/test-utils.js';
-import shikiTwoslash from 'remark-shiki-twoslash';
 import rehypePrettyCode from 'rehype-pretty-code';
+import shikiTwoslash from 'remark-shiki-twoslash';
+import { loadFixture } from '../../../astro/test/test-utils.js';
 
 const FIXTURE_ROOT = new URL('./fixtures/mdx-syntax-hightlighting/', import.meta.url);
 

--- a/packages/integrations/mdx/test/mdx-url-export.test.js
+++ b/packages/integrations/mdx/test/mdx-url-export.test.js
@@ -1,7 +1,7 @@
 import mdx from '@astrojs/mdx';
 
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
 describe('MDX url export', () => {

--- a/packages/integrations/mdx/test/mdx-vite-env-vars.test.js
+++ b/packages/integrations/mdx/test/mdx-vite-env-vars.test.js
@@ -1,5 +1,5 @@
-import { describe, it, before } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/mdx/test/remark-imgattr.test.js
+++ b/packages/integrations/mdx/test/remark-imgattr.test.js
@@ -1,5 +1,5 @@
-import { describe, it, before, after } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/node/test/api-route.test.js
+++ b/packages/integrations/node/test/api-route.test.js
@@ -1,8 +1,8 @@
-import nodejs from '../dist/index.js';
-import { loadFixture, createRequestAndResponse } from './test-utils.js';
-import crypto from 'node:crypto';
-import { describe, it, before, after } from 'node:test';
 import * as assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { after, before, describe, it } from 'node:test';
+import nodejs from '../dist/index.js';
+import { createRequestAndResponse, loadFixture } from './test-utils.js';
 
 describe('API routes', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/integrations/node/test/assets.test.js
+++ b/packages/integrations/node/test/assets.test.js
@@ -1,8 +1,8 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import nodejs from '../dist/index.js';
 import { loadFixture } from './test-utils.js';
-import * as cheerio from 'cheerio';
 
 describe('Assets', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/integrations/node/test/bad-urls.test.js
+++ b/packages/integrations/node/test/bad-urls.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import nodejs from '../dist/index.js';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/integrations/node/test/encoded.test.js
+++ b/packages/integrations/node/test/encoded.test.js
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before } from 'node:test';
+import { before, describe, it } from 'node:test';
 import nodejs from '../dist/index.js';
-import { loadFixture, createRequestAndResponse } from './test-utils.js';
+import { createRequestAndResponse, loadFixture } from './test-utils.js';
 
 describe('Encoded Pathname', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/integrations/node/test/errors.test.js
+++ b/packages/integrations/node/test/errors.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import nodejs from '../dist/index.js';
 import { loadFixture } from './test-utils.js';
-import * as cheerio from 'cheerio';
 
 describe('Errors', () => {
 	let fixture;

--- a/packages/integrations/node/test/headers.test.js
+++ b/packages/integrations/node/test/headers.test.js
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before } from 'node:test';
+import { before, describe, it } from 'node:test';
 import nodejs from '../dist/index.js';
-import { loadFixture, createRequestAndResponse } from './test-utils.js';
+import { createRequestAndResponse, loadFixture } from './test-utils.js';
 
 describe('Node Adapter Headers', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/integrations/node/test/image.test.js
+++ b/packages/integrations/node/test/image.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import nodejs from '../dist/index.js';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/integrations/node/test/locals.test.js
+++ b/packages/integrations/node/test/locals.test.js
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before } from 'node:test';
+import { before, describe, it } from 'node:test';
 import nodejs from '../dist/index.js';
-import { loadFixture, createRequestAndResponse } from './test-utils.js';
+import { createRequestAndResponse, loadFixture } from './test-utils.js';
 
 describe('API routes', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/integrations/node/test/node-middleware.test.js
+++ b/packages/integrations/node/test/node-middleware.test.js
@@ -1,9 +1,9 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
-import nodejs from '../dist/index.js';
-import { loadFixture, waitServerListen } from './test-utils.js';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import express from 'express';
+import nodejs from '../dist/index.js';
+import { loadFixture, waitServerListen } from './test-utils.js';
 
 /**
  * @typedef {import('../../../astro/test/test-utils').Fixture} Fixture

--- a/packages/integrations/node/test/prerender-404-500.test.js
+++ b/packages/integrations/node/test/prerender-404-500.test.js
@@ -1,8 +1,8 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import nodejs from '../dist/index.js';
 import { loadFixture, waitServerListen } from './test-utils.js';
-import * as cheerio from 'cheerio';
 
 /**
  * @typedef {import('../../../astro/test/test-utils').Fixture} Fixture

--- a/packages/integrations/node/test/prerender.test.js
+++ b/packages/integrations/node/test/prerender.test.js
@@ -1,8 +1,8 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import nodejs from '../dist/index.js';
 import { loadFixture, waitServerListen } from './test-utils.js';
-import * as cheerio from 'cheerio';
 
 /**
  * @typedef {import('../../../astro/test/test-utils').Fixture} Fixture

--- a/packages/integrations/node/test/url-protocol.test.js
+++ b/packages/integrations/node/test/url-protocol.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { TLSSocket } from 'node:tls';
 import nodejs from '../dist/index.js';
 import { createRequestAndResponse, loadFixture } from './test-utils.js';

--- a/packages/integrations/node/test/well-known-locations.test.js
+++ b/packages/integrations/node/test/well-known-locations.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import nodejs from '../dist/index.js';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/integrations/react/test/react-component.test.js
+++ b/packages/integrations/react/test/react-component.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { load as cheerioLoad } from 'cheerio';
 import { isWindows, loadFixture } from '../../../astro/test/test-utils.js';
 

--- a/packages/integrations/sitemap/test/base-path.test.js
+++ b/packages/integrations/sitemap/test/base-path.test.js
@@ -1,6 +1,6 @@
-import { loadFixture, readXML } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { loadFixture, readXML } from './test-utils.js';
 
 describe('URLs with base path', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/integrations/sitemap/test/dynamic-path.test.js
+++ b/packages/integrations/sitemap/test/dynamic-path.test.js
@@ -1,6 +1,6 @@
+import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 import { loadFixture, readXML } from './test-utils.js';
-import assert from 'node:assert/strict';
 
 describe('Dynamic with rest parameter', () => {
 	/** @type {import('./test-utils.js').Fixture} */

--- a/packages/integrations/sitemap/test/filter.test.js
+++ b/packages/integrations/sitemap/test/filter.test.js
@@ -1,7 +1,7 @@
-import { loadFixture, readXML } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 import { sitemap } from './fixtures/static/deps.mjs';
+import { loadFixture, readXML } from './test-utils.js';
 
 describe('Filter support', () => {
 	/** @type {import('./test-utils.js').Fixture} */

--- a/packages/integrations/sitemap/test/prefix.test.js
+++ b/packages/integrations/sitemap/test/prefix.test.js
@@ -1,7 +1,7 @@
-import { loadFixture, readXML } from './test-utils.js';
-import { sitemap } from './fixtures/static/deps.mjs';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { sitemap } from './fixtures/static/deps.mjs';
+import { loadFixture, readXML } from './test-utils.js';
 
 describe('Prefix support', () => {
 	/** @type {import('./test-utils.js').Fixture} */

--- a/packages/integrations/sitemap/test/routes.test.js
+++ b/packages/integrations/sitemap/test/routes.test.js
@@ -1,6 +1,6 @@
-import { loadFixture, readXML } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { loadFixture, readXML } from './test-utils.js';
 
 describe('routes', () => {
 	/** @type {import('./test-utils.js').Fixture} */

--- a/packages/integrations/sitemap/test/ssr.test.js
+++ b/packages/integrations/sitemap/test/ssr.test.js
@@ -1,6 +1,6 @@
-import { loadFixture, readXML } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { loadFixture, readXML } from './test-utils.js';
 
 describe('SSR support', () => {
 	/** @type {import('./test-utils.js').Fixture} */

--- a/packages/integrations/sitemap/test/staticPaths.test.js
+++ b/packages/integrations/sitemap/test/staticPaths.test.js
@@ -1,6 +1,6 @@
-import { loadFixture, readXML } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { loadFixture, readXML } from './test-utils.js';
 
 describe('getStaticPaths support', () => {
 	/** @type {import('./test-utils.js').Fixture} */

--- a/packages/integrations/sitemap/test/trailing-slash.test.js
+++ b/packages/integrations/sitemap/test/trailing-slash.test.js
@@ -1,6 +1,6 @@
-import { loadFixture, readXML } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { loadFixture, readXML } from './test-utils.js';
 
 describe('Trailing slash', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/integrations/tailwind/test/basic.test.js
+++ b/packages/integrations/tailwind/test/basic.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert/strict';
-import { describe, it, before } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { loadFixture } from '../../../astro/test/test-utils.js';
 
 describe('Basic', () => {

--- a/packages/integrations/vercel/test/image.test.js
+++ b/packages/integrations/vercel/test/image.test.js
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Image', () => {

--- a/packages/integrations/vercel/test/isr.test.js
+++ b/packages/integrations/vercel/test/isr.test.js
@@ -1,6 +1,6 @@
-import { loadFixture } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
 
 describe('ISR', () => {
 	/** @type {import('./test-utils.js').Fixture} */

--- a/packages/integrations/vercel/test/max-duration.test.js
+++ b/packages/integrations/vercel/test/max-duration.test.js
@@ -1,6 +1,6 @@
-import { loadFixture } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
 
 describe('maxDuration', () => {
 	/** @type {import('./test-utils.js').Fixture} */

--- a/packages/integrations/vercel/test/no-output.test.js
+++ b/packages/integrations/vercel/test/no-output.test.js
@@ -1,6 +1,6 @@
-import { loadFixture } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
 
 describe('Missing output config', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/integrations/vercel/test/prerendered-error-pages.test.js
+++ b/packages/integrations/vercel/test/prerendered-error-pages.test.js
@@ -1,6 +1,6 @@
-import { loadFixture } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
 
 describe('prerendered error pages routing', () => {
 	/** @type {import('./test-utils.js').Fixture} */

--- a/packages/integrations/vercel/test/speed-insights.test.js
+++ b/packages/integrations/vercel/test/speed-insights.test.js
@@ -1,6 +1,6 @@
-import { loadFixture } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
 
 describe('Vercel Speed Insights', () => {
 	describe('output: server', () => {

--- a/packages/integrations/vercel/test/split.test.js
+++ b/packages/integrations/vercel/test/split.test.js
@@ -1,6 +1,6 @@
-import { loadFixture } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
 
 describe('build: split', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/integrations/vercel/test/static.test.js
+++ b/packages/integrations/vercel/test/static.test.js
@@ -1,6 +1,6 @@
-import { loadFixture } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
 
 describe('static routing', () => {
 	/** @type {import('./test-utils.js').Fixture} */

--- a/packages/integrations/vercel/test/streaming.test.js
+++ b/packages/integrations/vercel/test/streaming.test.js
@@ -1,6 +1,6 @@
-import { loadFixture } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
 
 describe('streaming', () => {
 	/** @type {import('./test-utils.js').Fixture} */

--- a/packages/integrations/vercel/test/web-analytics.test.js
+++ b/packages/integrations/vercel/test/web-analytics.test.js
@@ -1,6 +1,6 @@
-import { loadFixture } from './test-utils.js';
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
 
 describe('Vercel Web Analytics', () => {
 	describe('output: static', () => {

--- a/packages/integrations/vue/test/app-entrypoint-css.test.js
+++ b/packages/integrations/vue/test/app-entrypoint-css.test.js
@@ -1,7 +1,7 @@
-import { loadFixture } from './test-utils.js';
 import * as assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { load as cheerioLoad } from 'cheerio';
+import { loadFixture } from './test-utils.js';
 
 describe('App Entrypoint CSS', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/integrations/vue/test/app-entrypoint.test.js
+++ b/packages/integrations/vue/test/app-entrypoint.test.js
@@ -1,8 +1,8 @@
-import { loadFixture } from './test-utils.js';
 import * as assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { load as cheerioLoad } from 'cheerio';
 import { parseHTML } from 'linkedom';
+import { loadFixture } from './test-utils.js';
 
 describe('App Entrypoint', () => {
 	/** @type {import('./test-utils').Fixture} */

--- a/packages/integrations/vue/test/basics.test.js
+++ b/packages/integrations/vue/test/basics.test.js
@@ -1,7 +1,7 @@
-import { loadFixture } from './test-utils.js';
 import * as assert from 'node:assert/strict';
-import { describe, it, before } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { parseHTML } from 'linkedom';
+import { loadFixture } from './test-utils.js';
 describe('Basics', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;

--- a/packages/markdown/remark/test/autolinking.test.js
+++ b/packages/markdown/remark/test/autolinking.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, it, before } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { createMarkdownProcessor } from '../dist/index.js';
 
 describe('autolinking', () => {

--- a/packages/markdown/remark/test/browser.test.js
+++ b/packages/markdown/remark/test/browser.test.js
@@ -1,6 +1,6 @@
-import esbuild from 'esbuild';
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import esbuild from 'esbuild';
 
 describe('Bundle for browsers', async () => {
 	it('esbuild browser build should work', async () => {

--- a/packages/markdown/remark/test/entities.test.js
+++ b/packages/markdown/remark/test/entities.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, it, before } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { createMarkdownProcessor } from '../dist/index.js';
 
 describe('entities', async () => {

--- a/packages/markdown/remark/test/plugins.test.js
+++ b/packages/markdown/remark/test/plugins.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { createMarkdownProcessor } from '../dist/index.js';
 import { fileURLToPath } from 'node:url';
+import { createMarkdownProcessor } from '../dist/index.js';
 
 describe('plugins', () => {
 	it('should be able to get file path when passing fileURL', async () => {

--- a/packages/markdown/remark/test/remark-collect-images.test.js
+++ b/packages/markdown/remark/test/remark-collect-images.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, it, before } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { createMarkdownProcessor } from '../dist/index.js';
 
 describe('collect images', async () => {

--- a/packages/telemetry/test/index.test.js
+++ b/packages/telemetry/test/index.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, it, before, after } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { AstroTelemetry } from '../dist/index.js';
 
 function setup() {

--- a/packages/underscore-redirects/test/astro.test.js
+++ b/packages/underscore-redirects/test/astro.test.js
@@ -1,6 +1,6 @@
-import { createRedirectsFromAstroRoutes } from '../dist/index.js';
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { createRedirectsFromAstroRoutes } from '../dist/index.js';
 
 describe('Astro', () => {
 	const serverConfig = {

--- a/packages/underscore-redirects/test/print.test.js
+++ b/packages/underscore-redirects/test/print.test.js
@@ -1,6 +1,6 @@
-import { Redirects } from '../dist/index.js';
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { Redirects } from '../dist/index.js';
 
 describe('Printing', () => {
 	it('Formats long lines in a pretty way', () => {

--- a/packages/underscore-redirects/test/weight.test.js
+++ b/packages/underscore-redirects/test/weight.test.js
@@ -1,6 +1,6 @@
-import { Redirects } from '../dist/index.js';
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { Redirects } from '../dist/index.js';
 
 describe('Weight', () => {
 	it('Puts higher weighted definitions on top', () => {

--- a/packages/upgrade/test/context.test.js
+++ b/packages/upgrade/test/context.test.js
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { getContext } from '../dist/index.js';
 
 describe('context', () => {

--- a/packages/upgrade/test/install.test.js
+++ b/packages/upgrade/test/install.test.js
@@ -1,7 +1,7 @@
-import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
-import { setup } from './utils.js';
+import { describe, it } from 'node:test';
 import { install } from '../dist/index.js';
+import { setup } from './utils.js';
 
 describe('install', () => {
 	const fixture = setup();

--- a/packages/upgrade/test/verify.test.js
+++ b/packages/upgrade/test/verify.test.js
@@ -1,5 +1,5 @@
-import { describe, it, beforeEach } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
 import { collectPackageInfo } from '../dist/index.js';
 
 describe('collectPackageInfo', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   .:
     dependencies:
+      '@biomejs/biome':
+        specifier: ^1.5.3
+        version: 1.5.3
       astro-benchmark:
         specifier: workspace:*
         version: link:benchmark
@@ -5755,6 +5758,94 @@ packages:
       '@babel/helper-string-parser': 7.23.4
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
+
+  /@biomejs/biome@1.5.3:
+    resolution: {integrity: sha512-yvZCa/g3akwTaAQ7PCwPWDCkZs3Qa5ONg/fgOUT9e6wAWsPftCjLQFPXBeGxPK30yZSSpgEmRCfpGTmVbUjGgg==}
+    engines: {node: '>=14.*'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.5.3
+      '@biomejs/cli-darwin-x64': 1.5.3
+      '@biomejs/cli-linux-arm64': 1.5.3
+      '@biomejs/cli-linux-arm64-musl': 1.5.3
+      '@biomejs/cli-linux-x64': 1.5.3
+      '@biomejs/cli-linux-x64-musl': 1.5.3
+      '@biomejs/cli-win32-arm64': 1.5.3
+      '@biomejs/cli-win32-x64': 1.5.3
+    dev: false
+
+  /@biomejs/cli-darwin-arm64@1.5.3:
+    resolution: {integrity: sha512-ImU7mh1HghEDyqNmxEZBoMPr8SxekkZuYcs+gynKlNW+TALQs7swkERiBLkG9NR0K1B3/2uVzlvYowXrmlW8hw==}
+    engines: {node: '>=14.*'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@biomejs/cli-darwin-x64@1.5.3:
+    resolution: {integrity: sha512-vCdASqYnlpq/swErH7FD6nrFz0czFtK4k/iLgj0/+VmZVjineFPgevOb+Sr9vz0tk0GfdQO60bSpI74zU8M9Dw==}
+    engines: {node: '>=14.*'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@biomejs/cli-linux-arm64-musl@1.5.3:
+    resolution: {integrity: sha512-DYuMizUYUBYfS0IHGjDrOP1RGipqWfMGEvNEJ398zdtmCKLXaUvTimiox5dvx4X15mBK5M2m8wgWUgOP1giUpQ==}
+    engines: {node: '>=14.*'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@biomejs/cli-linux-arm64@1.5.3:
+    resolution: {integrity: sha512-cupBQv0sNF1OKqBfx7EDWMSsKwRrBUZfjXawT4s6hKV6ALq7p0QzWlxr/sDmbKMLOaLQtw2Qgu/77N9rm+f9Rg==}
+    engines: {node: '>=14.*'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@biomejs/cli-linux-x64-musl@1.5.3:
+    resolution: {integrity: sha512-UUHiAnlDqr2Y/LpvshBFhUYMWkl2/Jn+bi3U6jKuav0qWbbBKU/ByHgR4+NBxpKBYoCtWxhnmatfH1bpPIuZMw==}
+    engines: {node: '>=14.*'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@biomejs/cli-linux-x64@1.5.3:
+    resolution: {integrity: sha512-YQrSArQvcv4FYsk7Q91Yv4uuu5F8hJyORVcv3zsjCLGkjIjx2RhjYLpTL733SNL7v33GmOlZY0eFR1ko38tuUw==}
+    engines: {node: '>=14.*'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@biomejs/cli-win32-arm64@1.5.3:
+    resolution: {integrity: sha512-HxatYH7vf/kX9nrD+pDYuV2GI9GV8EFo6cfKkahAecTuZLPxryHx1WEfJthp5eNsE0+09STGkKIKjirP0ufaZA==}
+    engines: {node: '>=14.*'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@biomejs/cli-win32-x64@1.5.3:
+    resolution: {integrity: sha512-fMvbSouZEASU7mZH8SIJSANDm5OqsjgtVXlbUqxwed6BP7uuHRSs396Aqwh2+VoW8fwTpp6ybIUoC9FrzB0kyA==}
+    engines: {node: '>=14.*'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@builder.io/partytown@0.8.1:
     resolution: {integrity: sha512-p4xhEtQCPe8YFJ8e7KT9RptnT+f4lvtbmXymbp1t0bLp+USkNMTxrRMNc3Dlr2w2fpxyX7uA0CyAeU3ju84O4A==}


### PR DESCRIPTION
## Changes

That's how I would like to start introducing Biome in the repository. 

Import sorting of the test files. They should not change the logic of the source code.

## Testing

CI should work.

After merging this PR, I will make a new PR to ignore the commit from git.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
