### PR TITLE
chore: import sorting for test folder and e2e folder

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
   "files": {
-    "include": ["*.test.js"],
+    "include": ["test/**", "e2e/**"],
     "ignore": ["vendor"]
   },
   "organizeImports": {

--- a/packages/astro/e2e/fixtures/astro-component/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/astro-component/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/astro-component/src/components/Counter.jsx
+++ b/packages/astro/e2e/fixtures/astro-component/src/components/Counter.jsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from 'preact';
+import { Fragment, h } from 'preact';
 import { useState } from 'preact/hooks';
 import './Counter.css';
 

--- a/packages/astro/e2e/fixtures/astro-envs/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/astro-envs/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/client-only/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/client-only/astro.config.mjs
@@ -1,9 +1,9 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
 import react from '@astrojs/react';
+import solid from '@astrojs/solid-js';
 import svelte from '@astrojs/svelte';
 import vue from '@astrojs/vue';
-import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/content-collections/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/content-collections/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/custom-client-directives/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/custom-client-directives/astro.config.mjs
@@ -1,6 +1,6 @@
+import { fileURLToPath } from 'node:url';
 import react from "@astrojs/react";
 import { defineConfig } from 'astro/config';
-import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   integrations: [astroClientClickDirective(), astroClientPasswordDirective(), astroHasOptionsDirective(), react()],

--- a/packages/astro/e2e/fixtures/error-cyclic/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/error-cyclic/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/errors/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/errors/astro.config.mjs
@@ -1,9 +1,9 @@
-import { defineConfig } from 'astro/config';
-import react from '@astrojs/react';
 import preact from '@astrojs/preact';
+import react from '@astrojs/react';
 import solid from '@astrojs/solid-js';
 import svelte from '@astrojs/svelte';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/lit-component/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/lit-component/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import lit from '@astrojs/lit';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/multiple-frameworks/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/multiple-frameworks/astro.config.mjs
@@ -1,9 +1,9 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
 import react from '@astrojs/react';
+import solid from '@astrojs/solid-js';
 import svelte from '@astrojs/svelte';
 import vue from '@astrojs/vue';
-import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/namespaced-component/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/namespaced-component/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
-import preact from '@astrojs/preact';
 import mdx from "@astrojs/mdx";
+import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/nested-in-preact/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/nested-in-preact/astro.config.mjs
@@ -1,9 +1,9 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
 import react from '@astrojs/react';
+import solid from '@astrojs/solid-js';
 import svelte from '@astrojs/svelte';
 import vue from '@astrojs/vue';
-import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/nested-in-react/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/nested-in-react/astro.config.mjs
@@ -1,9 +1,9 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
 import react from '@astrojs/react';
+import solid from '@astrojs/solid-js';
 import svelte from '@astrojs/svelte';
 import vue from '@astrojs/vue';
-import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/nested-in-solid/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/nested-in-solid/astro.config.mjs
@@ -1,9 +1,9 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
 import react from '@astrojs/react';
+import solid from '@astrojs/solid-js';
 import svelte from '@astrojs/svelte';
 import vue from '@astrojs/vue';
-import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/nested-in-svelte/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/nested-in-svelte/astro.config.mjs
@@ -1,9 +1,9 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
 import react from '@astrojs/react';
+import solid from '@astrojs/solid-js';
 import svelte from '@astrojs/svelte';
 import vue from '@astrojs/vue';
-import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/nested-in-vue/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/nested-in-vue/astro.config.mjs
@@ -1,9 +1,9 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
 import react from '@astrojs/react';
+import solid from '@astrojs/solid-js';
 import svelte from '@astrojs/svelte';
 import vue from '@astrojs/vue';
-import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/nested-recursive/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/nested-recursive/astro.config.mjs
@@ -1,9 +1,9 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
 import react from '@astrojs/react';
+import solid from '@astrojs/solid-js';
 import svelte from '@astrojs/svelte';
 import vue from '@astrojs/vue';
-import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/pass-js/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/pass-js/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/preact-compat-component/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/preact-compat-component/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/preact-component/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/preact-component/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
-import preact from '@astrojs/preact';
 import mdx from '@astrojs/mdx';
+import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/preact-component/src/components/Counter.jsx
+++ b/packages/astro/e2e/fixtures/preact-component/src/components/Counter.jsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from 'preact';
+import { Fragment, h } from 'preact';
 import { useState } from 'preact/hooks';
 import './Counter.css';
 

--- a/packages/astro/e2e/fixtures/preact-lazy-component/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/preact-lazy-component/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
-import preact from '@astrojs/preact';
 import mdx from '@astrojs/mdx';
+import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/preact-lazy-component/src/components/Counter.jsx
+++ b/packages/astro/e2e/fixtures/preact-lazy-component/src/components/Counter.jsx
@@ -1,6 +1,6 @@
-import { h, Fragment } from 'preact';
-import { useState } from 'preact/hooks';
+import { Fragment, h } from 'preact';
 import { Suspense, lazy } from 'preact/compat';
+import { useState } from 'preact/hooks';
 import './Counter.css';
 
 const LazyCounterMessage = lazy(() => import('./CounterMessage'))

--- a/packages/astro/e2e/fixtures/react-component/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/react-component/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
-import react from '@astrojs/react';
 import mdx from '@astrojs/mdx';
+import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/solid-circular/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/solid-circular/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/solid-component/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/solid-component/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/solid-recurse/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/solid-recurse/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/svelte-component/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/svelte-component/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
-import svelte from '@astrojs/svelte';
 import mdx from '@astrojs/mdx';
+import svelte from '@astrojs/svelte';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/tailwindcss/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/tailwindcss/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
-import tailwind from '@astrojs/tailwind';
 import { fileURLToPath } from 'node:url';
+import tailwind from '@astrojs/tailwind';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/ts-resolution/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/ts-resolution/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
@@ -1,8 +1,8 @@
-import { defineConfig } from 'astro/config';
-import react from '@astrojs/react';
-import vue from '@astrojs/vue';
-import svelte from '@astrojs/svelte';
 import nodejs from '@astrojs/node';
+import react from '@astrojs/react';
+import svelte from '@astrojs/svelte';
+import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/fixtures/vue-component/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/vue-component/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
-import vue from '@astrojs/vue';
 import mdx from '@astrojs/mdx';
+import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/e2e/test-utils.js
+++ b/packages/astro/e2e/test-utils.js
@@ -1,7 +1,7 @@
-import { expect, test as testBase } from '@playwright/test';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { expect, test as testBase } from '@playwright/test';
 import { loadFixture as baseLoadFixture } from '../test/test-utils.js';
 
 export const isWindows = process.platform === 'win32';

--- a/packages/astro/test/fixtures/0-css/astro.config.mjs
+++ b/packages/astro/test/fixtures/0-css/astro.config.mjs
@@ -1,7 +1,7 @@
-import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 import svelte from '@astrojs/svelte';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/alias-tsconfig-baseurl-only/astro.config.mjs
+++ b/packages/astro/test/fixtures/alias-tsconfig-baseurl-only/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import svelte from '@astrojs/svelte';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/alias-tsconfig/astro.config.mjs
+++ b/packages/astro/test/fixtures/alias-tsconfig/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import svelte from '@astrojs/svelte';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/alias/astro.config.mjs
+++ b/packages/astro/test/fixtures/alias/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import svelte from '@astrojs/svelte';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/astro-attrs/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-attrs/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/astro-basic/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-basic/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
-import preact from '@astrojs/preact';
 import mdx from '@astrojs/mdx';
+import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/astro-children/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-children/astro.config.mjs
@@ -1,7 +1,7 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
-import vue from '@astrojs/vue';
 import svelte from '@astrojs/svelte';
+import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/astro-client-only/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-client-only/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
-import svelte from '@astrojs/svelte';
 import react from '@astrojs/react';
+import svelte from '@astrojs/svelte';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/astro-component-bundling/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-component-bundling/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/astro-dynamic/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-dynamic/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 import svelte from '@astrojs/svelte';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/astro-envs/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-envs/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/astro-expr/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-expr/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/astro-fallback/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-fallback/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/astro-jsx/src/components/PreactCounter.tsx
+++ b/packages/astro/test/fixtures/astro-jsx/src/components/PreactCounter.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from 'preact';
+import { Fragment, h } from 'preact';
 import { useState } from 'preact/hooks';
 
 /** a counter written in Preact */

--- a/packages/astro/test/fixtures/astro-markdown-frontmatter-injection/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-markdown-frontmatter-injection/astro.config.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from 'astro/config';
-import { rehypeReadingTime, remarkTitle, remarkDescription } from './src/markdown-plugins.mjs'
+import { rehypeReadingTime, remarkDescription, remarkTitle } from './src/markdown-plugins.mjs'
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/astro-markdown-frontmatter-injection/src/markdown-plugins.mjs
+++ b/packages/astro/test/fixtures/astro-markdown-frontmatter-injection/src/markdown-plugins.mjs
@@ -1,5 +1,5 @@
-import getReadingTime from 'reading-time';
 import { toString } from 'mdast-util-to-string';
+import getReadingTime from 'reading-time';
 import { visit } from 'unist-util-visit';
 
 export function rehypeReadingTime() {

--- a/packages/astro/test/fixtures/astro-markdown/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-markdown/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import svelte from "@astrojs/svelte";
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.json.js
+++ b/packages/astro/test/fixtures/astro-markdown/src/pages/raw-content.json.js
@@ -1,4 +1,4 @@
-import { rawContent, compiledContent } from './basic.md';
+import { compiledContent, rawContent } from './basic.md';
 
 export async function GET() {
 	return Response.json({

--- a/packages/astro/test/fixtures/astro-partial-html/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-partial-html/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/astro-scripts/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-scripts/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
-import tailwind from '@astrojs/tailwind';
 import { fileURLToPath } from 'node:url';
+import tailwind from '@astrojs/tailwind';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	integrations: [

--- a/packages/astro/test/fixtures/astro-slot-with-client/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-slot-with-client/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	integrations: [

--- a/packages/astro/test/fixtures/astro-slots-nested/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-slots-nested/astro.config.mjs
@@ -1,9 +1,9 @@
-import { defineConfig } from 'astro/config';
-import react from '@astrojs/react';
 import preact from '@astrojs/preact';
+import react from '@astrojs/react';
 import solid from '@astrojs/solid-js';
 import svelte from '@astrojs/svelte';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	integrations: [

--- a/packages/astro/test/fixtures/astro-slots-nested/src/components/preact/PassesChildrenP.tsx
+++ b/packages/astro/test/fixtures/astro-slots-nested/src/components/preact/PassesChildrenP.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from 'preact';
+import { Fragment, h } from 'preact';
 
 export default function PassesChildren({ children }) {
 	return <Fragment>{ children }</Fragment>;

--- a/packages/astro/test/fixtures/astro-slots-nested/src/components/react/Parent.jsx
+++ b/packages/astro/test/fixtures/astro-slots-nested/src/components/react/Parent.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function Parent({ children }) {
   const [show, setShow] = useState(false);

--- a/packages/astro/test/fixtures/before-hydration/astro.config.mjs
+++ b/packages/astro/test/fixtures/before-hydration/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	integrations: [preact()]

--- a/packages/astro/test/fixtures/component-library/astro.config.mjs
+++ b/packages/astro/test/fixtures/component-library/astro.config.mjs
@@ -1,7 +1,7 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
 import react from '@astrojs/react';
 import svelte from '@astrojs/svelte';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	integrations: [preact(), react(), svelte()],

--- a/packages/astro/test/fixtures/content with spaces in folder name/src/content/config.ts
+++ b/packages/astro/test/fixtures/content with spaces in folder name/src/content/config.ts
@@ -1,4 +1,4 @@
-import { z, defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 
 const withCustomSlugs = defineCollection({
 	schema: z.object({}),

--- a/packages/astro/test/fixtures/content-collection-references/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collection-references/src/content/config.ts
@@ -1,4 +1,4 @@
-import { defineCollection, z, reference } from 'astro:content';
+import { defineCollection, reference, z } from 'astro:content';
 
 const banners = defineCollection({
 	type: 'data',

--- a/packages/astro/test/fixtures/content-collection-references/src/pages/welcome-data.json.js
+++ b/packages/astro/test/fixtures/content-collection-references/src/pages/welcome-data.json.js
@@ -1,4 +1,4 @@
-import { getEntry, getEntries } from 'astro:content';
+import { getEntries, getEntry } from 'astro:content';
 
 export async function GET() {
 	const welcomePost = await getEntry('blog', 'welcome');

--- a/packages/astro/test/fixtures/content-collections-base/astro.config.mjs
+++ b/packages/astro/test/fixtures/content-collections-base/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/content-collections-base/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections-base/src/content/config.ts
@@ -1,4 +1,4 @@
-import { z, defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 
 
 const docs = defineCollection({

--- a/packages/astro/test/fixtures/content-collections-empty-dir/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections-empty-dir/src/content/config.ts
@@ -1,4 +1,4 @@
-import { z, defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 
 const blog = defineCollection({
 	schema: z.object({

--- a/packages/astro/test/fixtures/content-collections-empty-md-file/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections-empty-md-file/src/content/config.ts
@@ -1,4 +1,4 @@
-import { z, defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 
 const blog = defineCollection({
 	schema: z.object({

--- a/packages/astro/test/fixtures/content-collections-with-config-mjs/src/content/config.mjs
+++ b/packages/astro/test/fixtures/content-collections-with-config-mjs/src/content/config.mjs
@@ -1,4 +1,4 @@
-import { z, defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 
 const blog = defineCollection({
 	schema: z.object({

--- a/packages/astro/test/fixtures/content-collections-with-config-mts/src/content/config.mts
+++ b/packages/astro/test/fixtures/content-collections-with-config-mts/src/content/config.mts
@@ -1,4 +1,4 @@
-import { z, defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 
 const blog = defineCollection({
 	schema: z.object({

--- a/packages/astro/test/fixtures/content-collections/astro.config.mjs
+++ b/packages/astro/test/fixtures/content-collections/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/content-collections/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections/src/content/config.ts
@@ -1,4 +1,4 @@
-import { z, defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 
 const withCustomSlugs = defineCollection({
 	// Ensure schema passes even when `slug` is present

--- a/packages/astro/test/fixtures/content-collections/src/pages/collections.json.js
+++ b/packages/astro/test/fixtures/content-collections/src/pages/collections.json.js
@@ -1,6 +1,6 @@
-import { getCollection } from 'astro:content';
 import * as devalue from 'devalue';
 import { stripAllRenderFn } from '../utils.js';
+import { getCollection } from 'astro:content';
 
 export async function GET() {
 	const withoutConfig = stripAllRenderFn(await getCollection('without-config'));

--- a/packages/astro/test/fixtures/content-collections/src/pages/entries.json.js
+++ b/packages/astro/test/fixtures/content-collections/src/pages/entries.json.js
@@ -1,6 +1,6 @@
-import { getEntryBySlug } from 'astro:content';
 import * as devalue from 'devalue';
 import { stripRenderFn } from '../utils.js';
+import { getEntryBySlug } from 'astro:content';
 
 export async function GET() {
 	const columbiaWithoutConfig = stripRenderFn(await getEntryBySlug('without-config', 'columbia'));

--- a/packages/astro/test/fixtures/content-ssr-integration/astro.config.mjs
+++ b/packages/astro/test/fixtures/content-ssr-integration/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/content-static-paths-integration/astro.config.mjs
+++ b/packages/astro/test/fixtures/content-static-paths-integration/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/content/astro.config.mjs
+++ b/packages/astro/test/fixtures/content/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   integrations: [mdx()],

--- a/packages/astro/test/fixtures/content/src/content/config.ts
+++ b/packages/astro/test/fixtures/content/src/content/config.ts
@@ -1,4 +1,4 @@
-import { z, defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 
 const blog = defineCollection({
 	schema: z.object({

--- a/packages/astro/test/fixtures/css-dangling-references/astro.config.ts
+++ b/packages/astro/test/fixtures/css-dangling-references/astro.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import svelte from '@astrojs/svelte';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/css-order-import/astro.config.mjs
+++ b/packages/astro/test/fixtures/css-order-import/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import react from '@astrojs/react'
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/custom-assets-name/astro.config.mjs
+++ b/packages/astro/test/fixtures/custom-assets-name/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import path from "path";
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 import node from "@astrojs/node";

--- a/packages/astro/test/fixtures/entry-file-names/astro.config.mjs
+++ b/packages/astro/test/fixtures/entry-file-names/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/impostor-mdx-file/astro.config.mjs
+++ b/packages/astro/test/fixtures/impostor-mdx-file/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/jsx/astro.config.mjs
+++ b/packages/astro/test/fixtures/jsx/astro.config.mjs
@@ -1,11 +1,11 @@
-import { defineConfig } from 'astro/config';
-import renderer from 'astro/jsx/renderer.js';
 import mdx from '@astrojs/mdx';
 import preact from '@astrojs/preact';
 import react from '@astrojs/react';
+import solid from '@astrojs/solid-js';
 import svelte from '@astrojs/svelte';
 import vue from '@astrojs/vue';
-import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
+import renderer from 'astro/jsx/renderer.js';
 
 
 export default defineConfig({

--- a/packages/astro/test/fixtures/jsx/src/components/preact/PreactCounter.tsx
+++ b/packages/astro/test/fixtures/jsx/src/components/preact/PreactCounter.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from 'preact';
+import { Fragment, h } from 'preact';
 import { useState } from 'preact/hooks';
 
 /** a counter written in Preact */

--- a/packages/astro/test/fixtures/large-array/astro.config.mjs
+++ b/packages/astro/test/fixtures/large-array/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/lit-element/astro.config.mjs
+++ b/packages/astro/test/fixtures/lit-element/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import lit from '@astrojs/lit';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/lit-element/src/components/non-deferred-element.ts
+++ b/packages/astro/test/fixtures/lit-element/src/components/non-deferred-element.ts
@@ -1,5 +1,5 @@
 import { LitElement, html } from 'lit';
-import { property, customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 
 @customElement('non-deferred-counter')
 export class NonDeferredCounter extends LitElement {

--- a/packages/astro/test/fixtures/markdown/astro.config.mjs
+++ b/packages/astro/test/fixtures/markdown/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/middleware space/astro.config.mjs
+++ b/packages/astro/test/fixtures/middleware space/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	integrations: [

--- a/packages/astro/test/fixtures/middleware-no-user-middleware/astro.config.mjs
+++ b/packages/astro/test/fixtures/middleware-no-user-middleware/astro.config.mjs
@@ -1,5 +1,5 @@
-import {defineConfig} from "astro/config";
 import {fileURLToPath} from "node:url";
+import {defineConfig} from "astro/config";
 
 export default defineConfig({
 	integrations: [

--- a/packages/astro/test/fixtures/middleware-ssg/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware-ssg/src/middleware.js
@@ -1,4 +1,4 @@
-import { sequence, defineMiddleware } from 'astro:middleware';
+import { defineMiddleware, sequence } from 'astro:middleware';
 
 const first = defineMiddleware(async (context, next) => {
 	if (context.request.url.includes('/second')) {

--- a/packages/astro/test/fixtures/middleware-tailwind/astro.config.mjs
+++ b/packages/astro/test/fixtures/middleware-tailwind/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
-import tailwind from '@astrojs/tailwind';
 import { fileURLToPath } from 'node:url';
+import tailwind from '@astrojs/tailwind';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/partials/astro.config.mjs
+++ b/packages/astro/test/fixtures/partials/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/postcss/astro.config.mjs
+++ b/packages/astro/test/fixtures/postcss/astro.config.mjs
@@ -1,7 +1,7 @@
-import { defineConfig } from 'astro/config';
 import solid from '@astrojs/solid-js';
 import svelte from '@astrojs/svelte';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/preact-compat-component/astro.config.mjs
+++ b/packages/astro/test/fixtures/preact-compat-component/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/preact-component/astro.config.mjs
+++ b/packages/astro/test/fixtures/preact-component/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/preact-component/src/components/Class.jsx
+++ b/packages/astro/test/fixtures/preact-component/src/components/Class.jsx
@@ -1,4 +1,4 @@
-import { h, Component } from 'preact';
+import { Component, h } from 'preact';
 
 export default class extends Component {
   render() {

--- a/packages/astro/test/fixtures/preact-component/src/components/EmptyFrag.jsx
+++ b/packages/astro/test/fixtures/preact-component/src/components/EmptyFrag.jsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from 'preact';
+import { Fragment, h } from 'preact';
 
 export default function() {
   return <Fragment></Fragment>

--- a/packages/astro/test/fixtures/preact-component/src/components/Function.jsx
+++ b/packages/astro/test/fixtures/preact-component/src/components/Function.jsx
@@ -1,4 +1,4 @@
-import { h, Component } from 'preact';
+import { Component, h } from 'preact';
 
 export default function() {
   return <div id="fn-component"></div>;

--- a/packages/astro/test/fixtures/react-and-solid/astro.config.mjs
+++ b/packages/astro/test/fixtures/react-and-solid/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	integrations: [react(), solid()]

--- a/packages/astro/test/fixtures/react-jsx-export/astro.config.mjs
+++ b/packages/astro/test/fixtures/react-jsx-export/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
 export default defineConfig({
 	integrations: [
 		react()

--- a/packages/astro/test/fixtures/slots-preact/astro.config.mjs
+++ b/packages/astro/test/fixtures/slots-preact/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/slots-preact/src/components/Counter.jsx
+++ b/packages/astro/test/fixtures/slots-preact/src/components/Counter.jsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from 'preact';
+import { Fragment, h } from 'preact';
 import { useState } from 'preact/hooks'
 
 export default function Counter({ named, dashCase, children, count: initialCount, case: id }) {

--- a/packages/astro/test/fixtures/slots-react/astro.config.mjs
+++ b/packages/astro/test/fixtures/slots-react/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/slots-solid/astro.config.mjs
+++ b/packages/astro/test/fixtures/slots-solid/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/slots-svelte/astro.config.mjs
+++ b/packages/astro/test/fixtures/slots-svelte/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import svelte from '@astrojs/svelte';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/slots-vue/astro.config.mjs
+++ b/packages/astro/test/fixtures/slots-vue/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/solid-component/astro.config.mjs
+++ b/packages/astro/test/fixtures/solid-component/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import solid from '@astrojs/solid-js';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/solid-component/src/components/async-components.jsx
+++ b/packages/astro/test/fixtures/solid-component/src/components/async-components.jsx
@@ -1,4 +1,4 @@
-import { createResource, createSignal, createUniqueId, ErrorBoundary, Show } from 'solid-js';
+import { ErrorBoundary, Show, createResource, createSignal, createUniqueId } from 'solid-js';
 
 // It may be good to try short and long sleep times.
 // But short is faster for testing.

--- a/packages/astro/test/fixtures/sourcemap/astro.config.mjs
+++ b/packages/astro/test/fixtures/sourcemap/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	integrations: [react()],

--- a/packages/astro/test/fixtures/special-chars-in-component-imports/astro.config.mjs
+++ b/packages/astro/test/fixtures/special-chars-in-component-imports/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
-import react from '@astrojs/react';
 import mdx from '@astrojs/mdx';
+import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/ssr-api-route/astro.config.mjs
+++ b/packages/astro/test/fixtures/ssr-api-route/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import node from '@astrojs/node';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/ssr-partytown/astro.config.mjs
+++ b/packages/astro/test/fixtures/ssr-partytown/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import partytown from '@astrojs/partytown';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/ssr-scripts/astro.config.mjs
+++ b/packages/astro/test/fixtures/ssr-scripts/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/static-build-frameworks/astro.config.mjs
+++ b/packages/astro/test/fixtures/static-build-frameworks/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
-import react from '@astrojs/react';
 import preact from '@astrojs/preact';
+import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/static-build-ssr/astro.config.mjs
+++ b/packages/astro/test/fixtures/static-build-ssr/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import nodejs from '@astrojs/node';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	adapter: nodejs({ mode: 'middleware' }),

--- a/packages/astro/test/fixtures/static-build/astro.config.mjs
+++ b/packages/astro/test/fixtures/static-build/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/svelte-component/astro.config.mjs
+++ b/packages/astro/test/fixtures/svelte-component/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import svelte from '@astrojs/svelte';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/tailwindcss-ts/astro.config.ts
+++ b/packages/astro/test/fixtures/tailwindcss-ts/astro.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
-import tailwind from '@astrojs/tailwind';
 import { fileURLToPath } from 'node:url';
+import tailwind from '@astrojs/tailwind';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/tailwindcss/astro.config.mjs
+++ b/packages/astro/test/fixtures/tailwindcss/astro.config.mjs
@@ -1,7 +1,7 @@
-import { defineConfig } from 'astro/config';
-import tailwind from '@astrojs/tailwind';
-import mdx from '@astrojs/mdx';
 import { fileURLToPath } from 'node:url';
+import mdx from '@astrojs/mdx';
+import tailwind from '@astrojs/tailwind';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/view-transitions/astro.config.mjs
+++ b/packages/astro/test/fixtures/view-transitions/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/vue-component/astro.config.mjs
+++ b/packages/astro/test/fixtures/vue-component/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/vue-jsx/astro.config.mjs
+++ b/packages/astro/test/fixtures/vue-jsx/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/fixtures/vue-with-multi-renderer/astro.config.mjs
+++ b/packages/astro/test/fixtures/vue-with-multi-renderer/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
 import svelte from '@astrojs/svelte';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -1,19 +1,19 @@
-import { execa } from 'execa';
-import fastGlob from 'fast-glob';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { execa } from 'execa';
+import fastGlob from 'fast-glob';
 import stripAnsi from 'strip-ansi';
 import { check } from '../dist/cli/check/index.js';
-import { dev, preview } from '../dist/core/index.js';
 import build from '../dist/core/build/index.js';
-import sync from '../dist/core/sync/index.js';
 import { RESOLVED_SPLIT_MODULE_ID } from '../dist/core/build/plugins/plugin-ssr.js';
 import { getVirtualModulePageNameFromPath } from '../dist/core/build/plugins/util.js';
 import { makeSplitEntryPointFileName } from '../dist/core/build/static-build.js';
 import { mergeConfig, resolveConfig } from '../dist/core/config/index.js';
+import { dev, preview } from '../dist/core/index.js';
 import { nodeLogDestination } from '../dist/core/logger/node.js';
+import sync from '../dist/core/sync/index.js';
 
 // Disable telemetry when running tests
 process.env.ASTRO_TELEMETRY_DISABLED = true;

--- a/packages/astro/test/units/test-utils.js
+++ b/packages/astro/test/units/test-utils.js
@@ -1,18 +1,18 @@
-import { Volume } from 'memfs';
-import httpMocks from 'node-mocks-http';
 import { EventEmitter } from 'node:events';
 import realFS from 'node:fs';
 import npath from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { Volume } from 'memfs';
+import httpMocks from 'node-mocks-http';
 import { getDefaultClientDirectives } from '../../dist/core/client-directive/index.js';
-import { nodeLogDestination } from '../../dist/core/logger/node.js';
-import { Pipeline } from '../../dist/core/render/index.js';
-import { RouteCache } from '../../dist/core/render/route-cache.js';
 import { resolveConfig } from '../../dist/core/config/index.js';
 import { createBaseSettings } from '../../dist/core/config/settings.js';
 import { createContainer } from '../../dist/core/dev/container.js';
-import { unixify } from './correct-path.js';
 import { Logger } from '../../dist/core/logger/core.js';
+import { nodeLogDestination } from '../../dist/core/logger/node.js';
+import { Pipeline } from '../../dist/core/render/index.js';
+import { RouteCache } from '../../dist/core/render/route-cache.js';
+import { unixify } from './correct-path.js';
 
 /** @type {import('../../src/core/logger/core').Logger} */
 export const defaultLogger = new Logger({

--- a/packages/create-astro/test/utils.js
+++ b/packages/create-astro/test/utils.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
-import { setStdout } from '../dist/index.js';
-import stripAnsi from 'strip-ansi';
 import { before, beforeEach } from 'node:test';
+import stripAnsi from 'strip-ansi';
+import { setStdout } from '../dist/index.js';
 
 export function setup() {
 	const ctx = { messages: [] };

--- a/packages/integrations/alpinejs/test/fixtures/basics/astro.config.mjs
+++ b/packages/integrations/alpinejs/test/fixtures/basics/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import alpine from '@astrojs/alpinejs';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   integrations: [alpine()],

--- a/packages/integrations/alpinejs/test/fixtures/directive/astro.config.mjs
+++ b/packages/integrations/alpinejs/test/fixtures/directive/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import alpine from '@astrojs/alpinejs';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   integrations: [alpine({

--- a/packages/integrations/alpinejs/test/fixtures/plugin-script-import/astro.config.mjs
+++ b/packages/integrations/alpinejs/test/fixtures/plugin-script-import/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import alpine from '@astrojs/alpinejs';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   integrations: [alpine()],

--- a/packages/integrations/alpinejs/test/test-utils.js
+++ b/packages/integrations/alpinejs/test/test-utils.js
@@ -1,7 +1,7 @@
-import { expect, test as testBase } from '@playwright/test';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { expect, test as testBase } from '@playwright/test';
 import { loadFixture as baseLoadFixture } from '../../../astro/test/test-utils.js';
 
 export const isWindows = process.platform === 'win32';

--- a/packages/integrations/markdoc/test/fixtures/content-collections/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/content-collections/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import markdoc from '@astrojs/markdoc';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/integrations/markdoc/test/fixtures/content-collections/src/pages/collection.json.js
+++ b/packages/integrations/markdoc/test/fixtures/content-collections/src/pages/collection.json.js
@@ -1,6 +1,6 @@
-import { getCollection } from 'astro:content';
 import { stringify } from 'devalue';
 import { stripAllRenderFn } from '../../utils.js';
+import { getCollection } from 'astro:content';
 
 export async function GET() {
 	const posts = await getCollection('blog');

--- a/packages/integrations/markdoc/test/fixtures/content-collections/src/pages/entry.json.js
+++ b/packages/integrations/markdoc/test/fixtures/content-collections/src/pages/entry.json.js
@@ -1,6 +1,6 @@
-import { getEntryBySlug } from 'astro:content';
 import { stringify } from 'devalue';
 import { stripRenderFn } from '../../utils.js';
+import { getEntryBySlug } from 'astro:content';
 
 export async function GET() {
 	const post = await getEntryBySlug('blog', 'post-1');

--- a/packages/integrations/markdoc/test/fixtures/headings-custom/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/headings-custom/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import markdoc from '@astrojs/markdoc';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/integrations/markdoc/test/fixtures/headings-custom/markdoc.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/headings-custom/markdoc.config.mjs
@@ -1,4 +1,4 @@
-import { defineMarkdocConfig, component, nodes } from '@astrojs/markdoc/config';
+import { component, defineMarkdocConfig, nodes } from '@astrojs/markdoc/config';
 
 export default defineMarkdocConfig({
 	nodes: {

--- a/packages/integrations/markdoc/test/fixtures/headings/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/headings/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import markdoc from '@astrojs/markdoc';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/integrations/markdoc/test/fixtures/propagated-assets/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/propagated-assets/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import markdoc from '@astrojs/markdoc';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/integrations/markdoc/test/fixtures/propagated-assets/markdoc.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/propagated-assets/markdoc.config.mjs
@@ -1,4 +1,4 @@
-import { defineMarkdocConfig, component } from '@astrojs/markdoc/config';
+import { component, defineMarkdocConfig } from '@astrojs/markdoc/config';
 
 export default defineMarkdocConfig({
 	tags: {

--- a/packages/integrations/markdoc/test/fixtures/render with-space/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/render with-space/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import markdoc from '@astrojs/markdoc';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/integrations/markdoc/test/fixtures/render-html/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/render-html/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import markdoc from '@astrojs/markdoc';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/integrations/markdoc/test/fixtures/render-html/markdoc.config.ts
+++ b/packages/integrations/markdoc/test/fixtures/render-html/markdoc.config.ts
@@ -1,4 +1,4 @@
-import { defineMarkdocConfig, component } from '@astrojs/markdoc/config';
+import { component, defineMarkdocConfig } from '@astrojs/markdoc/config';
 
 export default defineMarkdocConfig({
 	tags: {

--- a/packages/integrations/markdoc/test/fixtures/render-null/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/render-null/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import markdoc from '@astrojs/markdoc';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/integrations/markdoc/test/fixtures/render-simple/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/render-simple/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import markdoc from '@astrojs/markdoc';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/integrations/markdoc/test/fixtures/render-with-components/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/render-with-components/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import markdoc from '@astrojs/markdoc';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/integrations/markdoc/test/fixtures/render-with-components/markdoc.config.ts
+++ b/packages/integrations/markdoc/test/fixtures/render-with-components/markdoc.config.ts
@@ -1,4 +1,4 @@
-import { defineMarkdocConfig, component } from '@astrojs/markdoc/config';
+import { component, defineMarkdocConfig } from '@astrojs/markdoc/config';
 
 export default defineMarkdocConfig({
 	nodes: {

--- a/packages/integrations/markdoc/test/fixtures/render-with-config/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/render-with-config/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import markdoc from '@astrojs/markdoc';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/integrations/markdoc/test/fixtures/render-with-indented-components/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/render-with-indented-components/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import markdoc from '@astrojs/markdoc';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/integrations/markdoc/test/fixtures/render-with-indented-components/markdoc.config.ts
+++ b/packages/integrations/markdoc/test/fixtures/render-with-indented-components/markdoc.config.ts
@@ -1,4 +1,4 @@
-import { defineMarkdocConfig, component } from '@astrojs/markdoc/config';
+import { component, defineMarkdocConfig } from '@astrojs/markdoc/config';
 
 export default defineMarkdocConfig({
 	nodes: {

--- a/packages/integrations/markdoc/test/fixtures/variables/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/variables/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import markdoc from '@astrojs/markdoc';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/integrations/mdx/test/fixtures/image-remark-imgattr/astro.config.mjs
+++ b/packages/integrations/mdx/test/fixtures/image-remark-imgattr/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
+import { defineConfig } from 'astro/config';
 import plugin from "./remarkPlugin"
 
 // https://astro.build/config

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/astro.config.mjs
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
+import { defineConfig } from 'astro/config';
 import { rehypeReadingTime, remarkDescription, remarkTitle } from './src/markdown-plugins.mjs';
 
 // https://astro.build/config

--- a/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/markdown-plugins.mjs
+++ b/packages/integrations/mdx/test/fixtures/mdx-frontmatter-injection/src/markdown-plugins.mjs
@@ -1,5 +1,5 @@
-import getReadingTime from 'reading-time';
 import { toString } from 'mdast-util-to-string';
+import getReadingTime from 'reading-time';
 import { visit } from 'unist-util-visit';
 
 export function rehypeReadingTime() {

--- a/packages/integrations/node/test/test-utils.js
+++ b/packages/integrations/node/test/test-utils.js
@@ -1,5 +1,5 @@
-import httpMocks from 'node-mocks-http';
 import { EventEmitter } from 'node:events';
+import httpMocks from 'node-mocks-http';
 import { loadFixture as baseLoadFixture } from '../../../astro/test/test-utils.js';
 
 process.env.ASTRO_NODE_AUTOSTART = 'disabled';

--- a/packages/integrations/node/test/trailing-slash.js
+++ b/packages/integrations/node/test/trailing-slash.js
@@ -1,7 +1,7 @@
-import nodejs from '../dist/index.js';
-import { loadFixture } from './test-utils.js';
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
+import nodejs from '../dist/index.js';
+import { loadFixture } from './test-utils.js';
 
 /**
  * @typedef {import('../../../astro/test/test-utils').Fixture} Fixture

--- a/packages/integrations/react/test/fixtures/react-component/astro.config.mjs
+++ b/packages/integrations/react/test/fixtures/react-component/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/integrations/sitemap/test/fixtures/dynamic/astro.config.mjs
+++ b/packages/integrations/sitemap/test/fixtures/dynamic/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   integrations: [sitemap()],

--- a/packages/integrations/sitemap/test/fixtures/ssr/astro.config.mjs
+++ b/packages/integrations/sitemap/test/fixtures/ssr/astro.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'astro/config';
-import sitemap from '@astrojs/sitemap';
 import nodeServer from '@astrojs/node'
+import sitemap from '@astrojs/sitemap';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   integrations: [sitemap()],

--- a/packages/integrations/sitemap/test/fixtures/static/astro.config.mjs
+++ b/packages/integrations/sitemap/test/fixtures/static/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   integrations: [sitemap()],

--- a/packages/integrations/sitemap/test/fixtures/trailing-slash/astro.config.mjs
+++ b/packages/integrations/sitemap/test/fixtures/trailing-slash/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   integrations: [sitemap()],

--- a/packages/integrations/sitemap/test/test-utils.js
+++ b/packages/integrations/sitemap/test/test-utils.js
@@ -1,5 +1,5 @@
-import { loadFixture as baseLoadFixture } from '../../../astro/test/test-utils.js';
 import * as xml2js from 'xml2js';
+import { loadFixture as baseLoadFixture } from '../../../astro/test/test-utils.js';
 
 /**
  * @typedef {import('../../../astro/test/test-utils').Fixture} Fixture

--- a/packages/integrations/tailwind/test/fixtures/basic/astro.config.js
+++ b/packages/integrations/tailwind/test/fixtures/basic/astro.config.js
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url';
-import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   integrations: [

--- a/packages/integrations/vercel/test/fixtures/basic/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/basic/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/serverless';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	adapter: vercel({

--- a/packages/integrations/vercel/test/fixtures/functionPerRoute/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/functionPerRoute/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/serverless';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	adapter: vercel({

--- a/packages/integrations/vercel/test/fixtures/isr/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/isr/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/serverless';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	output: "server",

--- a/packages/integrations/vercel/test/fixtures/max-duration/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/max-duration/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/serverless';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	output: "server",

--- a/packages/integrations/vercel/test/fixtures/middleware-with-edge-file/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/middleware-with-edge-file/astro.config.mjs
@@ -1,5 +1,5 @@
-import {defineConfig} from "astro/config";
 import vercel from "@astrojs/vercel/serverless";
+import {defineConfig} from "astro/config";
 
 export default defineConfig({
     adapter: vercel({

--- a/packages/integrations/vercel/test/fixtures/middleware-without-edge-file/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/middleware-without-edge-file/astro.config.mjs
@@ -1,5 +1,5 @@
-import {defineConfig} from "astro/config";
 import vercel from "@astrojs/vercel/serverless";
+import {defineConfig} from "astro/config";
 
 export default defineConfig({
     adapter: vercel({

--- a/packages/integrations/vercel/test/fixtures/no-output/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/no-output/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/serverless';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	adapter: vercel()

--- a/packages/integrations/vercel/test/fixtures/prerendered-error-pages/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/prerendered-error-pages/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/serverless';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	output: 'server',

--- a/packages/integrations/vercel/test/fixtures/redirects-serverless/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/redirects-serverless/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/serverless';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	output: 'hybrid',

--- a/packages/integrations/vercel/test/fixtures/redirects/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/redirects/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/static';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	adapter: vercel(),

--- a/packages/integrations/vercel/test/fixtures/serverless-prerender/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/serverless-prerender/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/serverless';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	adapter: vercel({

--- a/packages/integrations/vercel/test/fixtures/serverless-with-dynamic-routes/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/serverless-with-dynamic-routes/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/serverless';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	adapter: vercel({

--- a/packages/integrations/vercel/test/fixtures/static/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/static/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/static';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	adapter: vercel()

--- a/packages/integrations/vercel/test/fixtures/streaming/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/streaming/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/serverless';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	output: "server",

--- a/packages/integrations/vercel/test/fixtures/with-speed-insights-enabled/output-as-server/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/with-speed-insights-enabled/output-as-server/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/serverless';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	adapter: vercel({

--- a/packages/integrations/vercel/test/fixtures/with-speed-insights-enabled/output-as-static/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/with-speed-insights-enabled/output-as-static/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/static';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	adapter: vercel({

--- a/packages/integrations/vercel/test/fixtures/with-web-analytics-enabled/output-as-static/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/with-web-analytics-enabled/output-as-static/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel/static';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
 	adapter: vercel({

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-async/astro.config.mjs
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-async/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 import ViteSvgLoader from 'vite-svg-loader'
 
 export default defineConfig({

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-css/astro.config.mjs
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-css/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   integrations: [

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-css/src/app.ts
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-css/src/app.ts
@@ -1,7 +1,7 @@
 import type { App } from 'vue'
-import Bar from './components/Bar.vue'
 // Important! Test that styles here are injected to the page
 import '/src/main.css'
+import Bar from './components/Bar.vue'
 
 
 export default function setup(app: App) {

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-no-export-default/astro.config.mjs
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-no-export-default/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 import ViteSvgLoader from 'vite-svg-loader'
 
 export default defineConfig({

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-relative/astro.config.mjs
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-relative/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   integrations: [vue({

--- a/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/astro.config.mjs
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint-src-absolute/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   integrations: [vue({

--- a/packages/integrations/vue/test/fixtures/app-entrypoint/astro.config.mjs
+++ b/packages/integrations/vue/test/fixtures/app-entrypoint/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 import ViteSvgLoader from 'vite-svg-loader'
 
 export default defineConfig({

--- a/packages/integrations/vue/test/fixtures/basics/astro.config.mjs
+++ b/packages/integrations/vue/test/fixtures/basics/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
 import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   integrations: [vue()],

--- a/packages/upgrade/test/utils.js
+++ b/packages/upgrade/test/utils.js
@@ -1,6 +1,6 @@
 import { before, beforeEach } from 'node:test';
-import { setStdout } from '../dist/index.js';
 import stripAnsi from 'strip-ansi';
+import { setStdout } from '../dist/index.js';
 
 export function setup() {
 	const ctx = { messages: [] };


### PR DESCRIPTION
## Changes

This PR applies import sorting for the `test` folders and the `e2e` folders.

I will make a later PR to ignore the commit from git.

## Testing

Current CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
