### PR TITLE
Fix cssesc from breaking browser code

### DIFF
--- a/.changeset/cuddly-ads-fail.md
+++ b/.changeset/cuddly-ads-fail.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vercel": patch
+---
+
+Fix loading client-scripts in dev with ISR

--- a/.changeset/quick-bottles-march.md
+++ b/.changeset/quick-bottles-march.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Allow content collections to run in browser

--- a/.changeset/quick-bottles-march.md
+++ b/.changeset/quick-bottles-march.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Allow content collections to run in browser
+Fixes an issue related to content collections usage in browser context caused by `csssec`

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -153,8 +153,8 @@ export async function generateContentEntryFile({
 		.replace("'@@DATA_ENTRY_GLOB_PATH@@'", dataEntryGlobResult)
 		.replace("'@@RENDER_ENTRY_GLOB_PATH@@'", renderEntryGlobResult)
 		.replace('/* @@LOOKUP_MAP_ASSIGNMENT@@ */', `lookupMap = ${JSON.stringify(lookupMap)};`) +
-		isClient ? `
-console.warn('astro:content is only supported running server-side. Using it in the browser will lead to bloated bundles and slow down page load. In the future it will not be supported.');` : '';
+		(isClient ? `
+console.warn('astro:content is only supported running server-side. Using it in the browser will lead to bloated bundles and slow down page load. In the future it will not be supported.');` : '');
 
 	return virtualModContents;
 }

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -41,14 +41,10 @@ export function astroContentVirtualModPlugin({
 	fs,
 }: AstroContentVirtualModPluginParams): Plugin {
 	let IS_DEV = false;
-	let command: 'build' | 'serve';
 	const IS_SERVER = isServerLikeOutput(settings.config);
 	return {
 		name: 'astro-content-virtual-mod-plugin',
 		enforce: 'pre',
-		config(_, { command: _command }) {
-			command = _command;
-		},
 		configResolved(config) {
 			IS_DEV = config.mode === 'development';
 		},
@@ -71,7 +67,7 @@ export function astroContentVirtualModPlugin({
 					settings,
 					fs,
 				});
-				const isClient = !args?.ssr && command === 'serve';
+				const isClient = !args?.ssr;
 				const code = await generateContentEntryFile({ settings, fs, lookupMap, IS_DEV, IS_SERVER, isClient });
 
 				return {

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -41,10 +41,14 @@ export function astroContentVirtualModPlugin({
 	fs,
 }: AstroContentVirtualModPluginParams): Plugin {
 	let IS_DEV = false;
+	let command: 'build' | 'serve';
 	const IS_SERVER = isServerLikeOutput(settings.config);
 	return {
 		name: 'astro-content-virtual-mod-plugin',
 		enforce: 'pre',
+		config(_, { command: _command }) {
+			command = _command;
+		},
 		configResolved(config) {
 			IS_DEV = config.mode === 'development';
 		},
@@ -61,13 +65,14 @@ export function astroContentVirtualModPlugin({
 				}
 			}
 		},
-		async load(id) {
+		async load(id, args) {
 			if (id === RESOLVED_VIRTUAL_MODULE_ID) {
 				const lookupMap = await generateLookupMap({
 					settings,
 					fs,
 				});
-				const code = await generateContentEntryFile({ settings, fs, lookupMap, IS_DEV, IS_SERVER });
+				const isClient = !args?.ssr && command === 'serve';
+				const code = await generateContentEntryFile({ settings, fs, lookupMap, IS_DEV, IS_SERVER, isClient });
 
 				return {
 					code,
@@ -102,12 +107,14 @@ export async function generateContentEntryFile({
 	lookupMap,
 	IS_DEV,
 	IS_SERVER,
+	isClient
 }: {
 	settings: AstroSettings;
 	fs: typeof nodeFs;
 	lookupMap: ContentLookupMap;
 	IS_DEV: boolean;
 	IS_SERVER: boolean;
+	isClient: boolean;
 }) {
 	const contentPaths = getContentPaths(settings.config);
 	const relContentDir = rootRelativePath(settings.config.root, contentPaths.contentDir);
@@ -143,13 +150,15 @@ export async function generateContentEntryFile({
 		renderEntryGlobResult = getStringifiedCollectionFromLookup('render', relContentDir, lookupMap);
 	}
 
-	const virtualModContents = nodeFs
+	let virtualModContents = nodeFs
 		.readFileSync(contentPaths.virtualModTemplate, 'utf-8')
 		.replace('@@CONTENT_DIR@@', relContentDir)
 		.replace("'@@CONTENT_ENTRY_GLOB_PATH@@'", contentEntryGlobResult)
 		.replace("'@@DATA_ENTRY_GLOB_PATH@@'", dataEntryGlobResult)
 		.replace("'@@RENDER_ENTRY_GLOB_PATH@@'", renderEntryGlobResult)
-		.replace('/* @@LOOKUP_MAP_ASSIGNMENT@@ */', `lookupMap = ${JSON.stringify(lookupMap)};`);
+		.replace('/* @@LOOKUP_MAP_ASSIGNMENT@@ */', `lookupMap = ${JSON.stringify(lookupMap)};`) +
+		isClient ? `
+console.warn('astro:content is only supported running server-side. Using it in the browser will lead to bloated bundles and slow down page load. In the future it will not be supported.');` : '';
 
 	return virtualModContents;
 }

--- a/packages/astro/src/core/build/plugins/plugin-content.ts
+++ b/packages/astro/src/core/build/plugins/plugin-content.ts
@@ -164,6 +164,7 @@ function vitePluginContent(
 				lookupMap,
 				IS_DEV: false,
 				IS_SERVER: false,
+				isClient: false,
 			});
 			this.emitFile({
 				type: 'prebuilt-chunk',

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -122,11 +122,7 @@ export async function createVite(
 				`${srcDirPattern}pages/**/_*.{js,mjs,ts,mts}`, // Remaining JS/TS files prefixed with `_` (not endpoints)
 				`${srcDirPattern}pages/**/_*/**/*.{js,mjs,ts,mts}`, // Remaining JS/TS files within directories prefixed with `_` (not endpoints)
 			],
-			exclude: [
-				'astro:dev-toolbar',
-				'astro/virtual-modules/prefetch.js',
-				'node-fetch'
-			],
+			exclude: ['astro', 'node-fetch'],
 		},
 		plugins: [
 			configAliasVitePlugin({ settings }),

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -122,7 +122,11 @@ export async function createVite(
 				`${srcDirPattern}pages/**/_*.{js,mjs,ts,mts}`, // Remaining JS/TS files prefixed with `_` (not endpoints)
 				`${srcDirPattern}pages/**/_*/**/*.{js,mjs,ts,mts}`, // Remaining JS/TS files within directories prefixed with `_` (not endpoints)
 			],
-			exclude: ['astro', 'node-fetch'],
+			exclude: [
+				'astro:dev-toolbar',
+				'astro/virtual-modules/prefetch.js',
+				'node-fetch'
+			],
 		},
 		plugins: [
 			configAliasVitePlugin({ settings }),

--- a/packages/astro/src/transitions/vite-plugin-transitions.ts
+++ b/packages/astro/src/transitions/vite-plugin-transitions.ts
@@ -10,6 +10,13 @@ const resolvedVirtualClientModuleId = '\0' + virtualClientModuleId;
 export default function astroTransitions({ settings }: { settings: AstroSettings }): vite.Plugin {
 	return {
 		name: 'astro:transitions',
+		config() {
+			return {
+				optimizeDeps: {
+					include: ['astro > cssesc'],
+				},
+			};
+		},
 		async resolveId(id) {
 			if (id === virtualModuleId) {
 				return resolvedVirtualModuleId;

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -287,20 +287,6 @@ export default function vercelServerless({
 					);
 				}
 			},
-			'astro:server:setup'({ server }) {
-				// isr functions do not have access to search params, this middleware removes them for the dev mode
-				if (isr) {
-					const exclude_ = typeof isr === 'object' ? isr.exclude ?? [] : [];
-					// we create a regex to emulate vercel's production behavior
-					const exclude = exclude_.concat('/_image').map((ex) => new RegExp(escapeRegex(ex)));
-					server.middlewares.use(function removeIsrParams(req, _, next) {
-						const { pathname, search } = new URL(`https://example.com${req.url}`);
-						if (exclude.some((ex) => ex.test(pathname))) return next();
-						req.url = pathname  + search;
-						return next();
-					});
-				}
-			},
 			'astro:build:ssr': async ({ entryPoints, middlewareEntryPoint }) => {
 				_entryPoints = entryPoints;
 				_middlewareEntryPoint = middlewareEntryPoint;

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -294,9 +294,9 @@ export default function vercelServerless({
 					// we create a regex to emulate vercel's production behavior
 					const exclude = exclude_.concat('/_image').map((ex) => new RegExp(escapeRegex(ex)));
 					server.middlewares.use(function removeIsrParams(req, _, next) {
-						const { pathname } = new URL(`https://example.com${req.url}`);
+						const { pathname, search } = new URL(`https://example.com${req.url}`);
 						if (exclude.some((ex) => ex.test(pathname))) return next();
-						req.url = pathname;
+						req.url = pathname  + search;
 						return next();
 					});
 				}


### PR DESCRIPTION
## Changes

- Include `astro > cssesc` as an optimized dep
- Fixes https://github.com/withastro/astro/issues/9880
- Fixes https://github.com/withastro/astro/issues/10187
- Loading `astro:content` loads a lot of Astro's internal server-side code. This includes the server-side portion of View Transitions. This code depends on `cssesc` which is used to correctly escape `view-transition-name` properties to what is valid in CSS. This code is CommonJS and doesn't work in the browser unless optimized. This change makes it so that this module can be optimized.
  - Note that you should not be using `astro:content` in the browser. This is only being fixed because a significant number of people are doing so. This PR will be updated to warn.

## Testing

- Can't be tested in the monorepo, where dependencies are loaded differently.
- Tested manually with a test project: https://stackblitz.com/edit/github-gqosvq?file=src%2Fcontent%2Fconfig.ts,src%2Fpages%2Findex.astro

## Docs

N/A, bug fix