### PR TITLE
prevent warning: `Astro.request.headers` is not available in "static" output mode

### DIFF
--- a/.changeset/metal-schools-type.md
+++ b/.changeset/metal-schools-type.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where a warning about headers being accessed in static mode is unnecessarily shown when i18n is enabled.

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -230,7 +230,7 @@ export class RenderContext {
 		// TODO: we are making two calls to computeCurrentLocale(). In various cases, one works and the other doesn't.
 		// Ideally, we could use `renderContext.pathname` which is intended to be the one true "file-system-matchable" path.
 		// - Arsh
-		return this.#currentLocale ??= computeCurrentLocale(url.pathname, locales, strategy, defaultLocale) ?? computeCurrentLocale(routeData.route, locales, strategy, defaultLocale);
+		return this.#currentLocale ??= computeCurrentLocale(routeData.route, locales, strategy, defaultLocale);
 	}
 
 	#preferredLocale: APIContext['preferredLocale'];

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -227,9 +227,6 @@ export class RenderContext {
 		const { url, pipeline: { i18n }, routeData } = this;
 		if (!i18n) return;
 		const { defaultLocale, locales, strategy } = i18n;
-		// TODO: we are making two calls to computeCurrentLocale(). In various cases, one works and the other doesn't.
-		// Ideally, we could use `renderContext.pathname` which is intended to be the one true "file-system-matchable" path.
-		// - Arsh
 		return this.#currentLocale ??= computeCurrentLocale(routeData.route, locales, strategy, defaultLocale);
 	}
 


### PR DESCRIPTION
## Changes
- Makes computing i18n attributes lazy again. Computing `preferredLanguage`, for example, involves reading the `Accept-Language` header.

## Testing
Existing tests should pass.

## Docs
Does not affect usage.