### PR TITLE
fix(errors): Remove duplicate logging of errors

### DIFF
--- a/.changeset/light-masks-watch.md
+++ b/.changeset/light-masks-watch.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes errors being logged twice in some cases

--- a/packages/astro/src/vite-plugin-astro-server/response.ts
+++ b/packages/astro/src/vite-plugin-astro-server/response.ts
@@ -83,9 +83,8 @@ export async function writeWebResponse(res: http.ServerResponse, webResponse: Re
 		} else {
 			const reader = body.getReader();
 			res.on('close', () => {
-				reader.cancel().catch((error: unknown) => {
-					// eslint-disable-next-line no-console
-					console.error('An unexpected error occurred in the middle of the stream.', error);
+				reader.cancel().catch(() => {
+					// Don't log here, or errors will get logged twice in most cases
 				});
 			});
 			while (true) {


### PR DESCRIPTION
## Changes

Since about a week ago, we were logging errors twice wrongly

## Testing

Tested manually

## Docs

N/A
