### PR TITLE
fix(preact): Fixes passing children to server-rendered components causing an error

### DIFF
--- a/.changeset/three-deers-glow.md
+++ b/.changeset/three-deers-glow.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/preact": patch
+---
+
+Fixes passing children to server-rendered components causing an error

--- a/packages/integrations/preact/package.json
+++ b/packages/integrations/preact/package.json
@@ -40,7 +40,7 @@
     "@preact/preset-vite": "^2.7.0",
     "@preact/signals": "^1.2.1",
     "babel-plugin-transform-hook-names": "^1.0.2",
-    "preact-render-to-string": "^6.3.1",
+    "preact-render-to-string": "~6.3.1",
     "preact-ssr-prepass": "^1.2.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4487,7 +4487,7 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       preact-render-to-string:
-        specifier: ^6.3.1
+        specifier: ~6.3.1
         version: 6.3.1(preact@10.19.3)
       preact-ssr-prepass:
         specifier: ^1.2.1


### PR DESCRIPTION
## Changes

`preact-render-to-string`'s last version has a regression, and it now returns an array of string instead of a string in some situations. 

Fix https://github.com/withastro/astro/issues/10191

## Testing

We actually have a test for this, but it didn't catch it since we were not using the latest version of the library, oops.

## Docs

N/A