### PR TITLE
Adds an error message for non-string transition:name values

### DIFF
--- a/.changeset/pretty-oranges-heal.md
+++ b/.changeset/pretty-oranges-heal.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Adds an error message for non-string transition:name values

--- a/packages/astro/src/runtime/server/transition.ts
+++ b/packages/astro/src/runtime/server/transition.ts
@@ -91,6 +91,9 @@ export function renderTransition(
 	animationName: TransitionAnimationValue | undefined,
 	transitionName: string
 ) {
+	if (typeof (transitionName ?? '') !== 'string') {
+		throw new Error(`Invalid transition name {${transitionName}}`);
+	}
 	// Default to `fade` (similar to `initial`, but snappier)
 	if (!animationName) animationName = 'fade';
 	const scope = createTransitionScope(result, hash);


### PR DESCRIPTION
## Changes

Closes #10150 

I think throwing an error is pretty brutal but at least it shows up during `astro dev`. 
Is there a way to access a logger here?

I'm unsure whether we really need the check this way: 
IDE integrations and `astro check` warn correctly. 
Only `astro dev` swallows the transition name without any error message, see issue mentioned above. 

## Testing

Manual test

## Docs

n.a. bugfix

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
