### PR TITLE
feat: middleware and virtual routes

### DIFF
--- a/.changeset/brown-pets-clean.md
+++ b/.changeset/brown-pets-clean.md
@@ -1,0 +1,7 @@
+---
+"astro": minor
+---
+
+The astro middleware now runs when a matching page or endpoint is not found. Previously, a `pages/404.astro` or `pages/[...catch-all].astro` route had to match to allow middleware. This is now not necessary.
+
+Note that some adapters may need to update to let Astro's SSR code handle the not-found case.

--- a/.changeset/brown-pets-clean.md
+++ b/.changeset/brown-pets-clean.md
@@ -2,6 +2,6 @@
 "astro": minor
 ---
 
-The astro middleware now runs when a matching page or endpoint is not found. Previously, a `pages/404.astro` or `pages/[...catch-all].astro` route had to match to allow middleware. This is now not necessary.
+Allows middleware to run when a matching page or endpoint is not found. Previously, a `pages/404.astro` or `pages/[...catch-all].astro` route had to match to allow middleware. This is now not necessary.
 
 When a route does not match in SSR deployments, your adapter may show a platform-specific 404 page instead of running Astro's SSR code. In these cases, you may still need to add a `404.astro` or fallback route with spread params, or use a routing configuration option if your adapter provides one.

--- a/.changeset/brown-pets-clean.md
+++ b/.changeset/brown-pets-clean.md
@@ -4,4 +4,4 @@
 
 The astro middleware now runs when a matching page or endpoint is not found. Previously, a `pages/404.astro` or `pages/[...catch-all].astro` route had to match to allow middleware. This is now not necessary.
 
-Note that some adapters may need to update to let Astro's SSR code handle the not-found case.
+When a route does not match in SSR deployments, your adapter may show a platform-specific 404 page instead of running Astro's SSR code. In these cases, you may still need to add a `404.astro` or fallback route with spread params, or use a routing configuration option if your adapter provides one.

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -24,6 +24,7 @@ import { RenderContext } from '../render-context.js';
 import { createAssetLink } from '../render/ssr-element.js';
 import { matchRoute } from '../routing/match.js';
 import { AppPipeline } from './pipeline.js';
+import { ensure404Route } from '../routing/astro-designed-error-pages.js';
 export { deserializeManifest } from './common.js';
 
 export interface RenderOptions {
@@ -503,22 +504,4 @@ export class App {
 			}
 		}
 	}
-}
-
-function ensure404Route(manifest: ManifestData) {
-	if (!manifest.routes.some(route => route.route === '/404')) {
-		manifest.routes.push({
-			component: 'astro-default-404',
-			generate: () => '',
-			params: [],
-			pattern: /\/404/,
-			prerender: false,
-			segments: [],
-			type: 'endpoint',
-			route: '',
-			fallbackRoutes: [],
-			isIndex: false,
-		})
-	}
-	return manifest;
 }

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -2,6 +2,7 @@ import { normalizeTheLocale } from '../../i18n/index.js';
 import type { ComponentInstance, ManifestData, RouteData, SSRManifest } from '../../@types/astro.js';
 import type { SinglePageBuiltModule } from '../build/types.js';
 import {
+	DEFAULT_404_COMPONENT,
 	REROUTABLE_STATUS_CODES,
 	REROUTE_DIRECTIVE_HEADER,
 	clientAddressSymbol,
@@ -476,7 +477,7 @@ export class App {
 	}
 
 	async #getModuleForRoute(route: RouteData): Promise<SinglePageBuiltModule> {
-		if (route.component === 'astro-default-404') {
+		if (route.component === DEFAULT_404_COMPONENT) {
 			return {
 				page: async () => ({ default: () => new Response(null, { status: 404 }) }) as ComponentInstance,
 				renderers: []

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -478,7 +478,7 @@ export class App {
 	async #getModuleForRoute(route: RouteData): Promise<SinglePageBuiltModule> {
 		if (route.component === 'astro-default-404') {
 			return {
-				page: async () => ({ ALL: () => new Response(null, { status: 404 }) }) as any as ComponentInstance,
+				page: async () => ({ default: () => new Response(null, { status: 404 }) }) as ComponentInstance,
 				renderers: []
 			}
 		}

--- a/packages/astro/src/core/constants.ts
+++ b/packages/astro/src/core/constants.ts
@@ -4,6 +4,8 @@ export const ASTRO_VERSION = process.env.PACKAGE_VERSION ?? 'development';
 export const REROUTE_DIRECTIVE_HEADER = 'X-Astro-Reroute';
 export const ROUTE_TYPE_HEADER = 'X-Astro-Route-Type';
 
+export const DEFAULT_404_COMPONENT = 'astro-default-404';
+
 /**
  * A response with one of these status codes will be rewritten
  * with the result of rendering the respective error page.

--- a/packages/astro/src/core/render/params-and-props.ts
+++ b/packages/astro/src/core/render/params-and-props.ts
@@ -24,7 +24,7 @@ export async function getProps(opts: GetParamsAndPropsOptions): Promise<Props> {
 		return {};
 	}
 
-	if (routeIsRedirect(route) || routeIsFallback(route)) {
+	if (routeIsRedirect(route) || routeIsFallback(route) || route.component === 'astro-default-404') {
 		return {};
 	}
 

--- a/packages/astro/src/core/render/params-and-props.ts
+++ b/packages/astro/src/core/render/params-and-props.ts
@@ -1,4 +1,5 @@
 import type { ComponentInstance, Params, Props, RouteData } from '../../@types/astro.js';
+import { DEFAULT_404_COMPONENT } from '../constants.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 import type { Logger } from '../logger/core.js';
 import { routeIsFallback } from '../redirects/helpers.js';
@@ -24,7 +25,7 @@ export async function getProps(opts: GetParamsAndPropsOptions): Promise<Props> {
 		return {};
 	}
 
-	if (routeIsRedirect(route) || routeIsFallback(route) || route.component === 'astro-default-404') {
+	if (routeIsRedirect(route) || routeIsFallback(route) || route.component === DEFAULT_404_COMPONENT) {
 		return {};
 	}
 

--- a/packages/astro/src/core/routing/astro-designed-error-pages.ts
+++ b/packages/astro/src/core/routing/astro-designed-error-pages.ts
@@ -9,7 +9,7 @@ export function ensure404Route(manifest: ManifestData) {
 			pattern: /\/404/,
 			prerender: false,
 			segments: [],
-			type: 'endpoint',
+			type: 'page',
 			route: '/404',
 			fallbackRoutes: [],
 			isIndex: false,

--- a/packages/astro/src/core/routing/astro-designed-error-pages.ts
+++ b/packages/astro/src/core/routing/astro-designed-error-pages.ts
@@ -1,0 +1,19 @@
+import type { ManifestData } from "../../@types/astro.js";
+
+export function ensure404Route(manifest: ManifestData) {
+	if (!manifest.routes.some(route => route.route === '/404')) {
+		manifest.routes.push({
+			component: 'astro-default-404',
+			generate: () => '',
+			params: [],
+			pattern: /\/404/,
+			prerender: false,
+			segments: [],
+			type: 'endpoint',
+			route: '/404',
+			fallbackRoutes: [],
+			isIndex: false,
+		})
+	}
+	return manifest;
+}

--- a/packages/astro/src/core/routing/astro-designed-error-pages.ts
+++ b/packages/astro/src/core/routing/astro-designed-error-pages.ts
@@ -1,9 +1,10 @@
 import type { ManifestData } from "../../@types/astro.js";
+import { DEFAULT_404_COMPONENT } from "../constants.js";
 
 export function ensure404Route(manifest: ManifestData) {
 	if (!manifest.routes.some(route => route.route === '/404')) {
 		manifest.routes.push({
-			component: 'astro-default-404',
+			component: DEFAULT_404_COMPONENT,
 			generate: () => '',
 			params: [],
 			pattern: /\/404/,

--- a/packages/astro/src/runtime/server/render/astro/factory.ts
+++ b/packages/astro/src/runtime/server/render/astro/factory.ts
@@ -6,7 +6,7 @@ export type AstroFactoryReturnValue = RenderTemplateResult | Response | HeadAndC
 
 // The callback passed to to $$createComponent
 export interface AstroComponentFactory {
-	(result: any, props: any, slots: any): AstroFactoryReturnValue;
+	(result: any, props: any, slots: any): AstroFactoryReturnValue | Promise<AstroFactoryReturnValue>;
 	isAstroComponentFactory?: boolean;
 	moduleId?: string | undefined;
 	propagation?: PropagationHint;

--- a/packages/astro/src/runtime/server/render/astro/instance.ts
+++ b/packages/astro/src/runtime/server/render/astro/instance.ts
@@ -57,7 +57,7 @@ export class AstroComponentInstance {
 			await this.init(this.result);
 		}
 
-		let value: AstroFactoryReturnValue | undefined = this.returnValue;
+		let value: Promise<AstroFactoryReturnValue> | AstroFactoryReturnValue | undefined = this.returnValue;
 		if (isPromise(value)) {
 			value = await value;
 		}

--- a/packages/astro/src/vite-plugin-astro-server/pipeline.ts
+++ b/packages/astro/src/vite-plugin-astro-server/pipeline.ts
@@ -10,7 +10,7 @@ import type {
 } from '../@types/astro.js';
 import { getInfoOutput } from '../cli/info/index.js';
 import type { HeadElements } from '../core/base-pipeline.js';
-import { ASTRO_VERSION } from '../core/constants.js';
+import { ASTRO_VERSION, DEFAULT_404_COMPONENT } from '../core/constants.js';
 import { enhanceViteSSRError } from '../core/errors/dev/index.js';
 import { AggregateError, CSSError, MarkdownError } from '../core/errors/index.js';
 import type { Logger } from '../core/logger/core.js';
@@ -137,7 +137,7 @@ export class DevPipeline extends Pipeline {
 
 	async preload(filePath: URL) {
 		const { loader } = this;
-		if (filePath.href === new URL('astro-default-404', this.config.root).href) {
+		if (filePath.href === new URL(DEFAULT_404_COMPONENT, this.config.root).href) {
 			return { default: default404Page } as any as ComponentInstance
 		}
 

--- a/packages/astro/src/vite-plugin-astro-server/pipeline.ts
+++ b/packages/astro/src/vite-plugin-astro-server/pipeline.ts
@@ -23,6 +23,7 @@ import { getStylesForURL } from './css.js';
 import { getComponentMetadata } from './metadata.js';
 import { createResolve } from './resolve.js';
 import { getScriptsForURL } from './scripts.js';
+import { apiRoute404 } from './response.js';
 
 export class DevPipeline extends Pipeline {
 	// renderers are loaded on every request,
@@ -136,6 +137,9 @@ export class DevPipeline extends Pipeline {
 
 	async preload(filePath: URL) {
 		const { loader } = this;
+		if (filePath.href === new URL('astro-default-404', this.config.root).href) {
+			return { ALL: apiRoute404 } as any as ComponentInstance
+		}
 
 		// Important: This needs to happen first, in case a renderer provides polyfills.
 		const renderers__ = this.settings.renderers.map((r) => loadRenderer(r, loader));

--- a/packages/astro/src/vite-plugin-astro-server/pipeline.ts
+++ b/packages/astro/src/vite-plugin-astro-server/pipeline.ts
@@ -23,7 +23,7 @@ import { getStylesForURL } from './css.js';
 import { getComponentMetadata } from './metadata.js';
 import { createResolve } from './resolve.js';
 import { getScriptsForURL } from './scripts.js';
-import { apiRoute404 } from './response.js';
+import { default404Page } from './response.js';
 
 export class DevPipeline extends Pipeline {
 	// renderers are loaded on every request,
@@ -138,7 +138,7 @@ export class DevPipeline extends Pipeline {
 	async preload(filePath: URL) {
 		const { loader } = this;
 		if (filePath.href === new URL('astro-default-404', this.config.root).href) {
-			return { ALL: apiRoute404 } as any as ComponentInstance
+			return { default: default404Page } as any as ComponentInstance
 		}
 
 		// Important: This needs to happen first, in case a renderer provides polyfills.

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -17,6 +17,7 @@ import { recordServerError } from './error.js';
 import { DevPipeline } from './pipeline.js';
 import { handleRequest } from './request.js';
 import { setRouteError } from './server-state.js';
+import { ensure404Route } from '../core/routing/astro-designed-error-pages.js';
 
 export interface AstroPluginOptions {
 	settings: AstroSettings;
@@ -35,15 +36,15 @@ export default function createVitePluginAstroServer({
 			const loader = createViteLoader(viteServer);
 			const manifest = createDevelopmentManifest(settings);
 			const pipeline = DevPipeline.create({ loader, logger, manifest, settings });
-			let manifestData: ManifestData = createRouteManifest({ settings, fsMod }, logger);
+			let manifestData: ManifestData = ensure404Route(createRouteManifest({ settings, fsMod }, logger));
 			const controller = createController({ loader });
 			const localStorage = new AsyncLocalStorage();
-
+			
 			/** rebuild the route cache + manifest, as needed. */
 			function rebuildManifest(needsManifestRebuild: boolean) {
 				pipeline.clearRouteCache();
 				if (needsManifestRebuild) {
-					manifestData = createRouteManifest({ settings }, logger);
+					manifestData = ensure404Route(createRouteManifest({ settings }, logger));
 				}
 			}
 			// Rebuild route manifest on file change, if needed.

--- a/packages/astro/src/vite-plugin-astro-server/response.ts
+++ b/packages/astro/src/vite-plugin-astro-server/response.ts
@@ -23,6 +23,18 @@ export async function handle404Response(
 	writeHtmlResponse(res, 404, html);
 }
 
+export async function apiRoute404(
+	{ request }: { request: Request }
+) {
+	const pathname = decodeURI(new URL(request.url).pathname);
+	return new Response(notFoundTemplate({
+		statusCode: 404,
+		title: 'Not found',
+		tabTitle: '404: Not Found',
+		pathname,
+	}), { status: 404, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}
+
 export async function handle500Response(
 	loader: ModuleLoader,
 	res: http.ServerResponse,

--- a/packages/astro/src/vite-plugin-astro-server/response.ts
+++ b/packages/astro/src/vite-plugin-astro-server/response.ts
@@ -23,10 +23,9 @@ export async function handle404Response(
 	writeHtmlResponse(res, 404, html);
 }
 
-export async function apiRoute404(
-	{ request }: { request: Request }
+export async function default404Page(
+	{ pathname }: { pathname: string }
 ) {
-	const pathname = decodeURI(new URL(request.url).pathname);
 	return new Response(notFoundTemplate({
 		statusCode: 404,
 		title: 'Not found',
@@ -34,6 +33,8 @@ export async function apiRoute404(
 		pathname,
 	}), { status: 404, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
 }
+// mark the function as an AstroComponentFactory for the rendering internals
+default404Page.isAstroComponentFactory = true;
 
 export async function handle500Response(
 	loader: ModuleLoader,

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -1,6 +1,6 @@
 import type http from 'node:http';
 import type { ComponentInstance, ManifestData, RouteData } from '../@types/astro.js';
-import { REROUTE_DIRECTIVE_HEADER, clientLocalsSymbol } from '../core/constants.js';
+import { DEFAULT_404_COMPONENT, REROUTE_DIRECTIVE_HEADER, clientLocalsSymbol } from '../core/constants.js';
 import { AstroErrorData, isAstroError } from '../core/errors/index.js';
 import { req } from '../core/messages.js';
 import { loadMiddleware } from '../core/middleware/loadMiddleware.js';
@@ -95,7 +95,7 @@ export async function matchRoute(
 
 	const custom404 = getCustom404Route(manifestData);
 	
-	if (custom404 && custom404.component === 'astro-default-404') {
+	if (custom404 && custom404.component === DEFAULT_404_COMPONENT) {
 		const component: ComponentInstance = {
 			default: default404Page
 		}

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -11,7 +11,7 @@ import { matchAllRoutes } from '../core/routing/index.js';
 import { normalizeTheLocale } from '../i18n/index.js';
 import { getSortedPreloadedMatches } from '../prerender/routing.js';
 import type { DevPipeline } from './pipeline.js';
-import { handle404Response, writeSSRResult, writeWebResponse } from './response.js';
+import { apiRoute404, handle404Response, writeSSRResult, writeWebResponse } from './response.js';
 
 type AsyncReturnType<T extends (...args: any) => Promise<any>> = T extends (
 	...args: any
@@ -94,6 +94,19 @@ export async function matchRoute(
 	}
 
 	const custom404 = getCustom404Route(manifestData);
+	
+	if (custom404 && custom404.component === 'astro-default-404') {
+		const component: any = {
+			ALL: apiRoute404
+		}
+		return {
+			route: custom404,
+			filePath: new URL(`file://${custom404.component}`),
+			resolvedPathname: pathname,
+			preloadedComponent: component,
+			mod: component,
+		}
+	}
 
 	if (custom404) {
 		const filePath = new URL(`./${custom404.component}`, config.root);

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -96,7 +96,7 @@ export async function matchRoute(
 	const custom404 = getCustom404Route(manifestData);
 	
 	if (custom404 && custom404.component === 'astro-default-404') {
-		const component: any = {
+		const component: ComponentInstance = {
 			default: default404Page
 		}
 		return {

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -11,7 +11,7 @@ import { matchAllRoutes } from '../core/routing/index.js';
 import { normalizeTheLocale } from '../i18n/index.js';
 import { getSortedPreloadedMatches } from '../prerender/routing.js';
 import type { DevPipeline } from './pipeline.js';
-import { apiRoute404, handle404Response, writeSSRResult, writeWebResponse } from './response.js';
+import { default404Page, handle404Response, writeSSRResult, writeWebResponse } from './response.js';
 
 type AsyncReturnType<T extends (...args: any) => Promise<any>> = T extends (
 	...args: any
@@ -97,7 +97,7 @@ export async function matchRoute(
 	
 	if (custom404 && custom404.component === 'astro-default-404') {
 		const component: any = {
-			ALL: apiRoute404
+			default: default404Page
 		}
 		return {
 			route: custom404,

--- a/packages/astro/test/astro-dev-headers.test.js
+++ b/packages/astro/test/astro-dev-headers.test.js
@@ -31,10 +31,10 @@ describe('Astro dev headers', () => {
 			assert.equal(Object.fromEntries(result.headers)['x-astro'], headers['x-astro']);
 		});
 
-		it('does not return custom headers for invalid URLs', async () => {
+		it('returns custom headers in the default 404 response', async () => {
 			const result = await fixture.fetch('/bad-url');
 			assert.equal(result.status, 404);
-			assert.equal(Object.fromEntries(result.headers).hasOwnProperty('x-astro'), false);
+			assert.equal(Object.fromEntries(result.headers).hasOwnProperty('x-astro'), true);
 		});
 	});
 });

--- a/packages/astro/test/fixtures/virtual-routes/astro.config.js
+++ b/packages/astro/test/fixtures/virtual-routes/astro.config.js
@@ -1,0 +1,6 @@
+import testAdapter from '../../test-adapter.js';
+
+export default {
+    output: 'server',
+    adapter: testAdapter(),
+};

--- a/packages/astro/test/fixtures/virtual-routes/package.json
+++ b/packages/astro/test/fixtures/virtual-routes/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "@test/virtual-routes",
+    "dependencies": {
+      "astro": "workspace:*"
+    }
+  }
+  

--- a/packages/astro/test/fixtures/virtual-routes/src/middleware.js
+++ b/packages/astro/test/fixtures/virtual-routes/src/middleware.js
@@ -1,0 +1,8 @@
+export function onRequest (context, next) {
+    if (context.request.url.includes('/virtual')) {
+		return new Response('<span>Virtual!!</span>', {
+			status: 200,
+		});
+	}
+    return next()
+}

--- a/packages/astro/test/units/routing/trailing-slash.test.js
+++ b/packages/astro/test/units/routing/trailing-slash.test.js
@@ -54,7 +54,8 @@ describe('trailingSlash', () => {
 			url: '/api',
 		});
 		container.handle(req, res);
-		assert.equal(await text(), '');
+		const html = await text();
+		assert.equal(html.includes(`<span class="statusMessage">Not found</span>`), true);
 		assert.equal(res.statusCode, 404);
 	});
 });

--- a/packages/astro/test/virtual-routes.test.js
+++ b/packages/astro/test/virtual-routes.test.js
@@ -13,7 +13,7 @@ describe('virtual routes - dev', () => {
         await fixture.build();
 	});
     
-    it.skip('should render a virtual route - dev', async () => {
+    it('should render a virtual route - dev', async () => {
 		const devServer = await fixture.startDevServer();
         const response = await fixture.fetch('/virtual');
         const html = await response.text();

--- a/packages/astro/test/virtual-routes.test.js
+++ b/packages/astro/test/virtual-routes.test.js
@@ -13,7 +13,7 @@ describe('virtual routes - dev', () => {
         await fixture.build();
 	});
     
-    it('should render a virtual route - dev', async () => {
+    it.skip('should render a virtual route - dev', async () => {
 		const devServer = await fixture.startDevServer();
         const response = await fixture.fetch('/virtual');
         const html = await response.text();

--- a/packages/astro/test/virtual-routes.test.js
+++ b/packages/astro/test/virtual-routes.test.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
+
+describe('virtual routes - dev', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/virtual-routes/',
+		});
+        await fixture.build();
+	});
+    
+    it('should render a virtual route - dev', async () => {
+		const devServer = await fixture.startDevServer();
+        const response = await fixture.fetch('/virtual');
+        const html = await response.text();
+        assert.equal(html.includes('Virtual!!'), true);
+		await devServer.stop();
+    });
+
+    it('should render a virtual route - app', async () => {
+		const app = await fixture.loadTestAdapterApp();
+        const response = await app.render(new Request('https://example.com/virtual'));
+        const html = await response.text();
+        assert.equal(html.includes('Virtual!!'), true);
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3731,6 +3731,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/virtual-routes:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/vue-component:
     dependencies:
       '@astrojs/vue':


### PR DESCRIPTION
## Changes

- Allows middleware to run for 404 responses without needing a 404.astro in the project.
- Fixes https://github.com/withastro/astro/issues/8244
- Fixes https://github.com/withastro/astro/issues/8226

## Testing
- Adapted from https://github.com/withastro/astro/pull/10185/files

## Docs
Mentions of `404.astro` or spread routes needing to exist to run middleware should be removed.