### PR TITLE
Fixes edge middleware calling nested routes

### DIFF
--- a/.changeset/popular-turtles-sort.md
+++ b/.changeset/popular-turtles-sort.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vercel": patch
+---
+
+Fixes edge middleware calling nested routes

--- a/packages/integrations/vercel/src/serverless/middleware.ts
+++ b/packages/integrations/vercel/src/serverless/middleware.ts
@@ -90,7 +90,7 @@ export default async function middleware(request, context) {
 	ctx.locals = ${handlerTemplateCall};
 	const { origin } = new URL(request.url);
 	const next = () =>
-		fetch(new URL('${NODE_PATH}', request.url), {
+		fetch(new URL('/${NODE_PATH}', request.url), {
 			headers: {
 				...Object.fromEntries(request.headers.entries()),
 				'${ASTRO_MIDDLEWARE_SECRET_HEADER}': '${middlewareSecret}',


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/10069
- The call to the downstream function was being resolve relative to the input url. So if that's `/first/second` then it resolves to `/first/_render` which it should always resolve to `/_render`. This fixes that.


## Testing

- Preview release with the reproduction working:

<img width="1029" alt="Screen Shot 2024-02-23 at 8 59 34 AM" src="https://github.com/withastro/astro/assets/361671/73d3c2f7-45c4-4b4c-95e4-7dbda6e3aa58">

## Docs

N/A, bug fix