### PR TITLE
Prevent errors in rendering from crashing server

### DIFF
--- a/.changeset/breezy-pears-admire.md
+++ b/.changeset/breezy-pears-admire.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Prevent errors in templates from crashing the dev server

--- a/.changeset/breezy-pears-admire.md
+++ b/.changeset/breezy-pears-admire.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Prevent errors in templates from crashing the dev server
+Prevents errors in templates from crashing the server

--- a/packages/astro/src/runtime/server/render/astro/render-template.ts
+++ b/packages/astro/src/runtime/server/render/astro/render-template.ts
@@ -24,7 +24,6 @@ export class RenderTemplateResult {
 				return Promise.resolve(expression).catch((err) => {
 					if (!this.error) {
 						this.error = err;
-						throw err;
 					}
 				});
 			}
@@ -36,6 +35,11 @@ export class RenderTemplateResult {
 		// Render all expressions eagerly and in parallel
 		const expRenders = this.expressions.map((exp) => {
 			return renderToBufferDestination((bufferDestination) => {
+				// If there's an error, render that (will be caught upstream)
+				if(this.error) {
+					return renderChild(bufferDestination, this.error);
+				}
+
 				// Skip render if falsy, except the number 0
 				if (exp || exp === 0) {
 					return renderChild(bufferDestination, exp);

--- a/packages/astro/src/runtime/server/render/astro/render-template.ts
+++ b/packages/astro/src/runtime/server/render/astro/render-template.ts
@@ -24,6 +24,7 @@ export class RenderTemplateResult {
 				return Promise.resolve(expression).catch((err) => {
 					if (!this.error) {
 						this.error = err;
+						return err;
 					}
 				});
 			}
@@ -35,9 +36,13 @@ export class RenderTemplateResult {
 		// Render all expressions eagerly and in parallel
 		const expRenders = this.expressions.map((exp) => {
 			return renderToBufferDestination((bufferDestination) => {
-				// If there's an error, render that (will be caught upstream)
-				if(this.error) {
-					return renderChild(bufferDestination, this.error);
+				if(isPromise(exp)) {
+					return Promise.resolve(exp).then(value => {
+						if(value instanceof Error) {
+							value = Promise.reject(value);
+						}
+						return renderChild(bufferDestination, value);
+					});
 				}
 
 				// Skip render if falsy, except the number 0

--- a/packages/astro/src/runtime/server/render/astro/render-template.ts
+++ b/packages/astro/src/runtime/server/render/astro/render-template.ts
@@ -24,7 +24,7 @@ export class RenderTemplateResult {
 				return Promise.resolve(expression).catch((err) => {
 					if (!this.error) {
 						this.error = err;
-						return err;
+						throw err;
 					}
 				});
 			}
@@ -36,15 +36,6 @@ export class RenderTemplateResult {
 		// Render all expressions eagerly and in parallel
 		const expRenders = this.expressions.map((exp) => {
 			return renderToBufferDestination((bufferDestination) => {
-				if(isPromise(exp)) {
-					return Promise.resolve(exp).then(value => {
-						if(value instanceof Error) {
-							value = Promise.reject(value);
-						}
-						return renderChild(bufferDestination, value);
-					});
-				}
-
 				// Skip render if falsy, except the number 0
 				if (exp || exp === 0) {
 					return renderChild(bufferDestination, exp);

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -174,6 +174,9 @@ export function renderToBufferDestination(bufferRenderFunction: RenderFunction):
 
 	// Don't await for the render to finish to not block streaming
 	const renderPromise = bufferRenderFunction(bufferDestination);
+	// Catch here in case it throws before `renderToFinalDestination` is called,
+	// to prevent an unhandled rejection.
+	Promise.resolve(renderPromise).catch(() => {});
 
 	// Return a closure that writes the buffered chunk
 	return {

--- a/packages/astro/test/error-bad-js.test.js
+++ b/packages/astro/test/error-bad-js.test.js
@@ -1,37 +1,64 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
+import testAdapter from './test-adapter.js';
 
 describe('Errors in JavaScript', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
 
-	/** @type {import('./test-utils').DevServer} */
-	let devServer;
-
 	before(async () => {
 		fixture = await loadFixture({
+			output: 'server',
+			adapter: testAdapter(),
 			root: './fixtures/error-bad-js',
 			vite: {
 				logLevel: 'silent',
 			},
 		});
-		devServer = await fixture.startDevServer();
 	});
 
-	after(async () => {
-		await devServer.stop();
+	describe('dev', () => {
+		/** @type {import('./test-utils').DevServer} */
+		let devServer;
+
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('Does not crash the dev server', async () => {
+			let res = await fixture.fetch('/');
+			let html = await res.text();
+	
+			assert.equal(html.includes('ReferenceError'), true);
+	
+			res = await fixture.fetch('/');
+			await res.text();
+	
+			assert.equal(html.includes('ReferenceError'), true);
+		});
 	});
 
-	it('Does not crash the dev server', async () => {
-		let res = await fixture.fetch('/');
-		let html = await res.text();
+	describe('build', () => {
+		before(async () => {
+			await fixture.build();
+		});
 
-		assert.equal(html.includes('ReferenceError'), true);
+		it('in nested components, does not crash server', async () => {
+			const app = await fixture.loadTestAdapterApp();
+			const request = new Request('http://example.com/in-stream');
+			const response = await app.render(request);
 
-		res = await fixture.fetch('/');
-		await res.text();
-
-		assert.equal(html.includes('ReferenceError'), true);
+			try {
+				await response.text();
+				assert.ok(false, 'error expected');
+			} catch {
+				assert.ok(true, "error caught during render");
+			}
+		});
 	});
 });

--- a/packages/astro/test/fixtures/error-bad-js/src/components/Other.astro
+++ b/packages/astro/test/fixtures/error-bad-js/src/components/Other.astro
@@ -1,0 +1,6 @@
+---
+import other from '../other.js';
+---
+<div>
+	{other()}
+</div>

--- a/packages/astro/test/fixtures/error-bad-js/src/other.js
+++ b/packages/astro/test/fixtures/error-bad-js/src/other.js
@@ -1,0 +1,4 @@
+
+export default function() {
+	return somethingNotExists();
+}

--- a/packages/astro/test/fixtures/error-bad-js/src/pages/in-stream.astro
+++ b/packages/astro/test/fixtures/error-bad-js/src/pages/in-stream.astro
@@ -1,0 +1,17 @@
+---
+import Other from '../components/Other.astro';
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={Astro.generator} />
+		<title>Astro</title>
+	</head>
+	<body>
+		<h1>Astro</h1>
+		<Other />
+	</body>
+</html>

--- a/packages/astro/test/fixtures/error-bad-js/src/something.js
+++ b/packages/astro/test/fixtures/error-bad-js/src/something.js
@@ -1,1 +1,3 @@
 export var foo = bar;
+
+export default foo;


### PR DESCRIPTION
## Changes

- When an error occurs in an expression, capture the error and use it later when rendering occurs.
  - this assures that no error go uncaught. Everything is resolve within the rendering flow.
- Fixes https://github.com/withastro/astro/issues/10062

## Testing

- No test case added

## Docs

N/A, bug fix