### PR TITLE
Warn when view transitions run on a prefere-reduced-motion device

### DIFF
--- a/.changeset/wicked-eyes-prove.md
+++ b/.changeset/wicked-eyes-prove.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Adds a warning in DEV mode when using view transitions on a device with prefer-reduced-motion enabled.

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -51,6 +51,9 @@ const { fallback = 'animate' } = Astro.props;
 	}
 
 	if (supportsViewTransitions || getFallback() !== 'none') {
+		if (import.meta.env.DEV && window.matchMedia('(prefers-reduced-motion)').matches) {
+			console.warn(`Astro ViewTransitions: all view transition animations, including fallback animation, are disabled as this device has the prefer-reduced-motion setting enabled.`);
+		}
 		document.addEventListener('click', (ev) => {
 			let link = ev.target;
 			if (ev.composed) {


### PR DESCRIPTION
## Changes

In DEV mode warns in the browser console when view transitions are used on a prefer-reduced-motion device.
A user at discord complained that view transitions wouldn't work at all, and @FredKSchott suggested that this could be the reason. Always fun to use an argument from authority!

***Question: *** I would even remove the restriction for DEV mode as it is really hard to find. What do the approvers think? 

## Testing

Manually tested on Windows with Chrome

## Docs

Basically the warning message copies https://docs.astro.build/en/guides/view-transitions/#prefers-reduced-motion. So docs is more than up-to-date.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
