### PR TITLE
Fallback URL

### DIFF
--- a/.changeset/honest-eyes-retire.md
+++ b/.changeset/honest-eyes-retire.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Fixes build error with fallback URL if env is undefined

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -79,7 +79,7 @@ import {collectionToTable, createRemoteDatabaseClient} from ${RUNTIME_IMPORT};
 
 export const db = await createRemoteDatabaseClient(${JSON.stringify(
 		appToken
-	)}, import.meta.env.ASTRO_STUDIO_REMOTE_DB_URL);
+	)}, import.meta.env.ASTRO_STUDIO_REMOTE_DB_URL || 'https://db.services.astro.build');
 export * from ${RUNTIME_DRIZZLE_IMPORT};
 
 ${getStringifiedCollectionExports(tables)}


### PR DESCRIPTION
## Changes

- Fixes PLT-1712
- Uses same fallback URL technique in `vite-plugin-db` as used here:
	https://github.com/withastro/astro/blob/7e34bdcc1806ece58bee04c099be885f9e5ad4f7/packages/db/src/core/utils.ts#L11-L14

## Testing

- Used this same change as a patch in a working project

## Docs

n/a
