### PR TITLE
perf: pre-calculate loop consts

### DIFF
--- a/.changeset/light-glasses-work.md
+++ b/.changeset/light-glasses-work.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+perf: pre-calculate normalised values for double loop

--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -8,14 +8,13 @@ import { ROUTE_TYPE_HEADER } from '../core/constants.js';
 // Checks if the pathname has any locale, exception for the defaultLocale, which is ignored on purpose.
 function pathnameHasLocale(pathname: string, locales: Locales): boolean {
 	const segments = pathname.split('/');
-	for (const segment of segments) {
-		for (const locale of locales) {
-			if (typeof locale === 'string') {
-				if (normalizeTheLocale(segment) === normalizeTheLocale(locale)) {
-					return true;
-				}
-			} else if (segment === locale.path) {
-				return true;
+	const normalizedLocales = locales.map((locale) =>
+		typeof locale === 'string' ? normalizeTheLocale(locale) : locale.path
+	);
+	for (const segment of segments.map(normalizeTheLocale)) {
+		for (const locale of normalizedLocales) {
+			if (segment === locale) {
+				return true
 			}
 		}
 	}


### PR DESCRIPTION
## Changes

- perf: pre-calculate normalised values for double-nested loop

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

No changes in behavior
