### PR TITLE
Fix an issue where Vercel adapter may create functions for prerendered routes

### DIFF
--- a/.changeset/four-shoes-rule.md
+++ b/.changeset/four-shoes-rule.md
@@ -2,4 +2,4 @@
 "@astrojs/vercel": patch
 ---
 
-Fixes an issue where Vercel adapter may create functions for prerendered routes
+Fixes an issue where functions were also created for prerendered routes with `functionPerRoute` enabled.

--- a/.changeset/four-shoes-rule.md
+++ b/.changeset/four-shoes-rule.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vercel": patch
+---
+
+Fixes an issue where Vercel adapter may create functions for prerendered routes

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -288,7 +288,10 @@ export default function vercelServerless({
 				}
 			},
 			'astro:build:ssr': async ({ entryPoints, middlewareEntryPoint }) => {
-				_entryPoints = entryPoints;
+				const entryPointsWithoutPrerenderedRoutes = new Map(
+					Array.from(entryPoints).filter(([routeData]) => !routeData.prerender)
+				);
+				_entryPoints = entryPointsWithoutPrerenderedRoutes;
 				_middlewareEntryPoint = middlewareEntryPoint;
 			},
 			'astro:build:done': async ({ routes, logger }) => {

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -288,10 +288,9 @@ export default function vercelServerless({
 				}
 			},
 			'astro:build:ssr': async ({ entryPoints, middlewareEntryPoint }) => {
-				const entryPointsWithoutPrerenderedRoutes = new Map(
+				_entryPoints = new Map(
 					Array.from(entryPoints).filter(([routeData]) => !routeData.prerender)
 				);
-				_entryPoints = entryPointsWithoutPrerenderedRoutes;
 				_middlewareEntryPoint = middlewareEntryPoint;
 			},
 			'astro:build:done': async ({ routes, logger }) => {

--- a/packages/integrations/vercel/test/fixtures/functionPerRoute/src/pages/prerender.astro
+++ b/packages/integrations/vercel/test/fixtures/functionPerRoute/src/pages/prerender.astro
@@ -1,0 +1,12 @@
+---
+export const prerender = true;
+---
+
+<html>
+	<head>
+		<title>Prerendered Page</title>
+	</head>
+	<body>
+		<h1>Prerendered Page</h1>
+	</body>
+</html>

--- a/packages/integrations/vercel/test/split.test.js
+++ b/packages/integrations/vercel/test/split.test.js
@@ -14,14 +14,19 @@ describe('build: split', () => {
 		await fixture.build();
 	});
 
-	it('creates separate functions for each page', async () => {
+	it('creates separate functions for non-prerendered pages', async () => {
 		const files = await fixture.readdir('../.vercel/output/functions/');
 		assert.equal(files.length, 3);
+		assert.equal(files.includes('prerender.astro.func'), false);
 	});
 
 	it('creates the route definitions in the config.json', async () => {
 		const json = await fixture.readFile('../.vercel/output/config.json');
 		const config = JSON.parse(json);
 		assert.equal(config.routes.length, 5);
+		assert.equal(
+			config.routes.some((route) => route.dest === 'prerender.astro'),
+			false
+		);
 	});
 });


### PR DESCRIPTION
## Changes

- Filters out prerendered routes for Vercel adapter
- Closes #10211

## Testing

- Test cases updated

## Docs

- N/A