### PR TITLE
feat: allow setting locale via search string

### DIFF
--- a/.changeset/light-mayflies-juggle.md
+++ b/.changeset/light-mayflies-juggle.md
@@ -1,0 +1,5 @@
+---
+"astro": minor
+---
+
+feat: allow setting locale via search string

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1574,6 +1574,20 @@ export interface AstroUserConfig {
 		 * See the [Internationalization Guide](https://docs.astro.build/en/guides/internationalization/#domains) for more details, including the limitations of this feature.
 		 */
 		domains?: Record<string, string>;
+
+		/**
+		 * @docs
+		 * @name u18n.searchParamVarname
+		 * @type {string}
+		 * @default 'undefined'
+		 * @version 4.5.0
+		 * @description
+		 *
+		 * If set, the `searchParamVarname` option will be used to determine the
+		 * query parameter that will be used to set the locale. This can be useful
+		 * when we have limited control over the URL path.
+		 */
+		searchParamVarname?: string;
 	};
 
 	/** ⚠️ WARNING: SUBJECT TO CHANGE */

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -64,6 +64,7 @@ export type SSRManifestI18n = {
 	locales: Locales;
 	defaultLocale: string;
 	domainLookupTable: Record<string, string>;
+	searchParamVarname?: string;
 };
 
 export type SerializedSSRManifest = Omit<

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -587,6 +587,7 @@ function createBuildManifest(
 			defaultLocale: settings.config.i18n.defaultLocale,
 			locales: settings.config.i18n.locales,
 			domainLookupTable: {},
+			searchParamVarname: settings.config.i18n.searchParamVarname,
 		};
 	}
 	return {

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -353,6 +353,7 @@ export const AstroConfigSchema = z.object({
 								'The option `i18n.redirectToDefaultLocale` is only useful when the `i18n.prefixDefaultLocale` is set to `true`. Remove the option `i18n.redirectToDefaultLocale`, or change its value to `true`.',
 						}
 					),
+				searchParamVarname: z.string().optional(),
 			})
 			.optional()
 			.superRefine((i18n, ctx) => {

--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -23,6 +23,12 @@ function pathnameHasLocale(pathname: string, locales: Locales): boolean {
 	return false;
 }
 
+function urlHasLocale(url: URL, locales: Locales, qStringVarname?: string | undefined): boolean {
+	return pathnameHasLocale(url.pathname, locales) || (
+		typeof qStringVarname === 'string' && locales.includes(url.searchParams.get(qStringVarname)!)
+	);
+}
+
 export function createI18nMiddleware(
 	i18n: SSRManifest['i18n'],
 	base: SSRManifest['base'],
@@ -45,7 +51,7 @@ export function createI18nMiddleware(
 		}
 
 		// Astro can't know where the default locale is supposed to be, so it returns a 404 with no content.
-		else if (!pathnameHasLocale(url.pathname, i18n.locales)) {
+		else if (!urlHasLocale(url, i18n.locales, i18n.searchParamVarname)) {
 			return new Response(null, {
 				status: 404,
 				headers: response.headers,
@@ -87,7 +93,7 @@ export function createI18nMiddleware(
 		// - the current path isn't a root. e.g. / or /<base>
 		// - the URL doesn't contain a locale
 		const isRoot = url.pathname === base + '/' || url.pathname === base;
-		if (!(isRoot || pathnameHasLocale(url.pathname, i18n.locales))) {
+		if (!(isRoot || urlHasLocale(url, i18n.locales, i18n.searchParamVarname))) {
 			return new Response(null, {
 				status: 404,
 				headers: response.headers,


### PR DESCRIPTION
## Changes

- feat: allow setting locale via search string
- [ ] (Pending) Setting `currentLocale` based on search/query string when `searchParamVarname` is set.

## Testing

- [X] Previous Tests
- [ ] New Tests

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
