### PR TITLE
Improve the message of `MiddlewareCantBeLoaded` for clarity

### DIFF
--- a/.changeset/tall-papayas-drive.md
+++ b/.changeset/tall-papayas-drive.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Improves the message of `MiddlewareCantBeLoaded` for clarity

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -828,7 +828,7 @@ export const LocalsNotAnObject = {
 export const MiddlewareCantBeLoaded = {
 	name: 'MiddlewareCantBeLoaded',
 	title: "Can't load the middleware.",
-	message: 'The middleware threw an error while Astro was trying to loading it.',
+	message: 'An unknown error was thrown while loading your middleware.',
 } satisfies ErrorData;
 
 /**


### PR DESCRIPTION
## Changes

- Updates the message of `MiddlewareCantBeLoaded`

  | Before                                                              | After                                                      |
  | ------------------------------------------------------------------- | ---------------------------------------------------------- |
  | The middleware threw an error while Astro was trying to loading it. | An unknown error was thrown while loading your middleware. |

## Testing

- No tests added. Current tests should pass

## Docs

- Error reference on the docs seems to be auto-generated