### PR TITLE
Fix Svelte editor tooling not working under relaxed TypeScripts projects

### DIFF
--- a/.changeset/gold-baboons-drum.md
+++ b/.changeset/gold-baboons-drum.md
@@ -1,5 +1,5 @@
 ---
-"@astrojs/svelte": patch
+"@astrojs/svelte": minor
 ---
 
 Adds TypeScript as a required peer dependency as it is required for Svelte's editor tooling to work correctly.

--- a/.changeset/gold-baboons-drum.md
+++ b/.changeset/gold-baboons-drum.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/svelte": patch
+---
+
+Adds TypeScript as a required peer dependency as it is required for Svelte's editor tooling to work correctly.

--- a/package.json
+++ b/package.json
@@ -81,13 +81,6 @@
           }
         }
       },
-      "svelte2tsx": {
-        "peerDependenciesMeta": {
-          "typescript": {
-            "optional": true
-          }
-        }
-      },
       "rehype-pretty-code": {
         "peerDependenciesMeta": {
           "shiki": {

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
-    "svelte2tsx": "^0.6.25"
+    "svelte2tsx": "^0.6.27"
   },
   "devDependencies": {
     "astro": "workspace:*",
@@ -53,7 +53,8 @@
   },
   "peerDependencies": {
     "astro": "^4.0.0",
-    "svelte": "^4.0.0 || ^5.0.0-next.56"
+    "svelte": "^4.0.0 || ^5.0.0-next.56",
+    "typescript": "^5.3.3"
   },
   "engines": {
     "node": ">=18.14.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   organize-imports-cli>ts-morph: ^19.0.0
   tsconfig-resolver>type-fest: 3.0.0
 
-packageExtensionsChecksum: 2d0a8c56e33c7d11bb9ef3c997d67c33
+packageExtensionsChecksum: 43e9b7451c9943c617aef017ec172155
 
 importers:
 
@@ -4804,7 +4804,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.1(svelte@4.2.8)(vite@5.1.2)
       svelte2tsx:
-        specifier: ^0.6.25
+        specifier: ^0.6.27
         version: 0.6.27(svelte@4.2.8)(typescript@5.2.2)
     devDependencies:
       astro:
@@ -15678,9 +15678,6 @@ packages:
     peerDependencies:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2


### PR DESCRIPTION
## Changes

Svelte's tool for editor tooling (`svelte2tsx`) require TypeScript to work. A long time ago, we were able to provide it from our language server directly, but this hasn't been the case for a long time now.

An alternative fix upstream would be for `svelte2tsx` to take in an instance of TypeScript, however at the moment it imports it from a bunch of top level places and it would be a significant refactor.

Svelte's own tooling does not suffer from this because it's all bundled together, unlike us where Svelte's specific tooling is only in its own integration.
  
Fix https://github.com/withastro/language-tools/issues/652

## Testing

N/A

## Docs

N/A