### PR TITLE
Removes morph animations when setting transition:animate=none

### DIFF
--- a/.changeset/eight-shrimps-enjoy.md
+++ b/.changeset/eight-shrimps-enjoy.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Removes morph animation, too, when setting `transition:animate=none` for view transitions.
+Fixes an issue where `<ViewTransitions transition:animate="none" />` still allowed the browser-native morph animation.

--- a/.changeset/eight-shrimps-enjoy.md
+++ b/.changeset/eight-shrimps-enjoy.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Removes morph animation, too, when setting `transition:animate=none` for view transitions.

--- a/packages/astro/src/runtime/server/transition.ts
+++ b/packages/astro/src/runtime/server/transition.ts
@@ -107,6 +107,7 @@ export function renderTransition(
 		sheet.addFallback('old', 'animation: none; mix-blend-mode: normal;');
 		sheet.addModern('old', 'animation: none; opacity: 0; mix-blend-mode: normal;');
 		sheet.addAnimationRaw('new', 'animation: none; mix-blend-mode: normal;');
+		sheet.addModern('group', 'animation: none');
 	}
 
 	result._metadata.extraHead.push(markHTMLString(`<style>${sheet.toString()}</style>`));


### PR DESCRIPTION
## Changes

`transition:animate="none"` removed animations on old and new image, but not the morph animation on the transition group. Noticed that when analyzing #10241 


## Testing

Mannualy tested, see #10241 
Before
![image](https://github.com/withastro/astro/assets/94928215/517ab613-7e30-4383-b03d-43849fce7ee0)
After:
![image](https://github.com/withastro/astro/assets/94928215/bd1c7831-d11b-4b97-a333-654e69cb920e)


## Docs

n.a

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
