### PR TITLE
fix: change strategy for route caching

### DIFF
--- a/.changeset/great-flowers-own.md
+++ b/.changeset/great-flowers-own.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where multiple injected routes with the same `entrypoint` but different `pattern` were incorrectly cached, causing some of them not being rendered in the dev server.

--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -102,14 +102,14 @@ export class RouteCache {
 		// NOTE: This shouldn't be called on an already-cached component.
 		// Warn here so that an unexpected double-call of getStaticPaths()
 		// isn't invisible and developer can track down the issue.
-		if (this.mode === 'production' && this.cache[route.component]?.staticPaths) {
-			this.logger.warn(null, `Internal Warning: route cache overwritten. (${route.component})`);
+		if (this.mode === 'production' && this.cache[route.route]?.staticPaths) {
+			this.logger.warn(null, `Internal Warning: route cache overwritten. (${route.route})`);
 		}
-		this.cache[route.component] = entry;
+		this.cache[route.route] = entry;
 	}
 
 	get(route: RouteData): RouteCacheEntry | undefined {
-		return this.cache[route.component];
+		return this.cache[route.route];
 	}
 }
 

--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -99,17 +99,22 @@ export class RouteCache {
 	}
 
 	set(route: RouteData, entry: RouteCacheEntry): void {
+		const key = this.key(route);
 		// NOTE: This shouldn't be called on an already-cached component.
 		// Warn here so that an unexpected double-call of getStaticPaths()
 		// isn't invisible and developer can track down the issue.
-		if (this.mode === 'production' && this.cache[route.route]?.staticPaths) {
-			this.logger.warn(null, `Internal Warning: route cache overwritten. (${route.route})`);
+		if (this.mode === 'production' && this.cache[key]?.staticPaths) {
+			this.logger.warn(null, `Internal Warning: route cache overwritten. (${key})`);
 		}
-		this.cache[route.route] = entry;
+		this.cache[key] = entry;
 	}
 
 	get(route: RouteData): RouteCacheEntry | undefined {
-		return this.cache[route.route];
+		return this.cache[this.key(route)];
+	}
+
+	key(route: RouteData) {
+		return `${route.route}_${route.component}`;
 	}
 }
 


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/8241
Closes PLT-1716

This PR changes the key of our internal route caching. Previously, we were using `RouteData#component`, which used to cover most of the cases, although it seems too restrictive, because the same component can emit multiple paths.

This means that, given the [minimum use case](https://github.com/withastro/astro/issues/8241#issuecomment-1863928168), the first time we hit `/blog/world`, we correctly render the route and cache its params, props and static paths using the `/blog/[post].astro` as key. When we attempt to render `/fr/blog/world`, we hit the cache because this path is rendered by the same component, although the static paths don't match, so we emit an error and return a 404.

With this change, we use `RouteData#route` as key. Given the previous use case, we cache the entry using the `/blog/[post]` key when rendering `/blog/world`. Then, when we attempt to render `/fr/blog/world`, `RouteData#route` value is `/fr/blog/[post]`, which isn't inside the cache and we correctly resolve the route and its static paths.

## Testing

I tested in a local project, and it works. The current tests should pass.

I tried to add an integration test, but I was receiving a strange error, I will investigate later. 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A, bugfix

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
