### PR TITLE
Fix TypeScript type definitions for `Code` component

### DIFF
--- a/.changeset/wicked-houses-occur.md
+++ b/.changeset/wicked-houses-occur.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes TypeScript type definitions for `Code` component

--- a/.changeset/wicked-houses-occur.md
+++ b/.changeset/wicked-houses-occur.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fixes TypeScript type definitions for `Code` component
+Fixes TypeScript type definitions for `Code` component `theme` and `experimentalThemes` props

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -1,7 +1,7 @@
 ---
+import type { ThemePresets } from '@astrojs/markdown-remark';
 import type {
 	BuiltinLanguage,
-	BuiltinTheme,
 	LanguageRegistration,
 	SpecialLanguage,
 	ThemeRegistration,
@@ -28,12 +28,12 @@ interface Props {
 	 *
 	 * @default "github-dark"
 	 */
-	theme?: BuiltinTheme | ThemeRegistration | ThemeRegistrationRaw;
+	theme?: ThemePresets | ThemeRegistration | ThemeRegistrationRaw;
 	/**
 	 * Multiple themes to style with -- alternative to "theme" option.
 	 * Supports all themes found above; see https://github.com/antfu/shikiji#lightdark-dual-themes for more information.
 	 */
-	experimentalThemes?: Record<string, BuiltinTheme | ThemeRegistration | ThemeRegistrationRaw>;
+	experimentalThemes?: Record<string, ThemePresets | ThemeRegistration | ThemeRegistrationRaw>;
 	/**
 	 * Enable word wrapping.
 	 *  - true: enabled.


### PR DESCRIPTION
## Changes

- Replaces `BuiltinTheme` with `ThemePresets` in `Code` component
- Closes #10246

## Testing

- Manually tested with the [minimal reproducible example](https://stackblitz.com/edit/github-uhurkz?file=src%2Fpages%2Findex.astro)

## Docs

- N/A
