### PR TITLE
Adds auto completion for `astro:` event names when adding or removing event listeners on `document`

### DIFF
--- a/.changeset/few-worms-rush.md
+++ b/.changeset/few-worms-rush.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Adds auto completion for `astro:` event names when adding or removing event listeners on `document`.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -36,6 +36,7 @@ import type {
 import type { AstroComponentFactory, AstroComponentInstance } from '../runtime/server/index.js';
 import type { DeepPartial, OmitIndexSignature, Simplify } from '../type-utils.js';
 import type { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from './../core/constants.js';
+import type { TransitionBeforePreparationEvent, TransitionBeforeSwapEvent } from '../transitions/events.js';
 
 export { type AstroIntegrationLogger };
 
@@ -2831,11 +2832,16 @@ declare global {
 		'astro-dev-overlay-icon': DevToolbarIcon;
 		'astro-dev-overlay-card': DevToolbarCard;
 	}
-}
-
-declare global {
 	// eslint-disable-next-line @typescript-eslint/no-namespace
 	namespace Config {
 		type Database = Record<string, any>;
+	}
+
+	interface DocumentEventMap {
+		'astro:before-preparation': TransitionBeforePreparationEvent;
+		'astro:after-preparation': Event;
+		'astro:before-swap': TransitionBeforeSwapEvent;
+		'astro:after-swap': Event;
+		'astro:page-load': Event;
 	}
 }


### PR DESCRIPTION
## Changes

Adds auto completion for `astro:` event names when adding or removing event listeners on `document`.

## Testing

VS Code shows completions 

## Docs

n.a.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
