### PR TITLE
fix(audits): Don't warn about loading on data URIs

### DIFF
--- a/.changeset/warm-buttons-agree.md
+++ b/.changeset/warm-buttons-agree.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes dev toolbar warning about using the proper loading attributes on images using `data:` URIs

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/perf.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/perf.ts
@@ -38,6 +38,9 @@ export const perf: AuditRuleWithSelector[] = [
 			// Ignore elements that are above the fold, they should be loaded eagerly
 			if (htmlElement.offsetTop < window.innerHeight) return false;
 
+			// Ignore elements using `data:` URI, the `loading` attribute doesn't do anything for these
+			if (htmlElement.src.startsWith('data:')) return false;
+
 			return true;
 		},
 	},
@@ -52,6 +55,9 @@ export const perf: AuditRuleWithSelector[] = [
 
 			// Ignore elements that are below the fold, they should be loaded lazily
 			if (htmlElement.offsetTop > window.innerHeight) return false;
+
+			// Ignore elements using `data:` URI, the `loading` attribute doesn't do anything for these
+			if (htmlElement.src.startsWith('data:')) return false;
 
 			return true;
 		},


### PR DESCRIPTION
## Changes

So, I can't find any spec on this, but I feel like the `loading` attribute cannot possibly be doing something on `data:` URIs. `decoding`? Sure, but `loading`?
 
## Testing

N/A

## Docs

N/A
