### PR TITLE
fix(build): skip only the configured redirects

### DIFF
--- a/.changeset/fifty-buttons-clean.md
+++ b/.changeset/fifty-buttons-clean.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where returning redirect responses resulted in missing files with certain adapters.

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -522,8 +522,9 @@ async function generatePath(
 	}
 
 	if (response.status >= 300 && response.status < 400) {
-		// If redirects is set to false, don't output the HTML
-		if (!config.build.redirects) {
+		// Adapters may handle redirects themselves, turning off Astro's redirect handling using `config.build.redirects` in the process.
+		// In that case, we skip rendering static files for the redirect routes.
+		if (routeIsRedirect(route) && !config.build.redirects) {
 			return;
 		}
 		const locationSite = getRedirectLocationOrThrow(response.headers);

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -263,12 +263,18 @@ describe('Astro.redirect', () => {
 			await fixture.build();
 		});
 
-		it('Does not output redirect HTML', async () => {
+		it('Does not output redirect HTML for redirect routes', async () => {
 			let oneHtml = undefined;
 			try {
 				oneHtml = await fixture.readFile('/one/index.html');
 			} catch {}
 			assert.equal(oneHtml, undefined);
+		});
+
+		it('Outputs redirect HTML for user routes that return a redirect response', async () => {
+			let secretHtml = await fixture.readFile('/secret/index.html');
+			assert.equal(secretHtml.includes("Redirecting from <code>/secret/</code>"), true);
+			assert.equal(secretHtml.includes("to <code>/login</code>"), true);
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- Reported here: https://github.com/withastro/astro/issues/10164#issuecomment-1957016426.
- A middleware returned redirects which made files disappear in build only with the vercel adapter.

## Testing
- Added a case in `test/redirects.test.js`.

## Docs
- Does not affect usage.
