### PR TITLE
fix(node): Safely create requests

### DIFF
--- a/.changeset/perfect-poets-teach.md
+++ b/.changeset/perfect-poets-teach.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/node": patch
+---
+
+Fixes an issue where malformed requests could cause the server to error in certain cases.

--- a/packages/integrations/node/src/serve-app.ts
+++ b/packages/integrations/node/src/serve-app.ts
@@ -8,7 +8,15 @@ import type { RequestHandler } from './types.js';
  */
 export function createAppHandler(app: NodeApp): RequestHandler {
 	return async (req, res, next, locals) => {
-		const request = NodeApp.createRequest(req);
+		let request;
+		try {
+			request = NodeApp.createRequest(req);
+		} catch (err) {
+			res.statusCode = 500;
+			res.end('Internal Server Error');
+			return;
+		}
+
 		const routeData = app.match(request);
 		if (routeData) {
 			const response = await app.render(request, {


### PR DESCRIPTION
## Changes

`new Request` can throw an error if the request is super malformed, this could crash the server in some situations.
 
## Testing

I couldn't figure out how to test this in our fixtures, Node refuses to create an invalid request that triggers the error 🤔

## Docs

N/A
