### PR TITLE
fix: reference base types

### DIFF
--- a/.changeset/giant-lions-dance.md
+++ b/.changeset/giant-lions-dance.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Fix type definitions for `astro:db`

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -4,12 +4,12 @@
   "description": "",
   "license": "MIT",
   "type": "module",
-  "types": "./dist/index.d.ts",
   "author": "withastro",
+  "types": "./index.d.ts",
   "main": "./dist/index.js",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./index.d.ts",
       "import": "./dist/index.js"
     },
     "./utils": {
@@ -51,7 +51,6 @@
   },
   "files": [
     "index.d.ts",
-    "config-augment.d.ts",
     "dist"
   ],
   "keywords": [

--- a/packages/db/src/runtime/db-client.ts
+++ b/packages/db/src/runtime/db-client.ts
@@ -9,7 +9,6 @@ const isWebContainer = !!process.versions?.webcontainer;
 
 export function createLocalDatabaseClient({ dbUrl }: { dbUrl: string }): LibSQLDatabase {
 	const url = isWebContainer ? 'file:content.db' : dbUrl;
-	console.log('memory', process.env.TEST_IN_MEMORY_DB);
 	const client = createClient({ url: process.env.TEST_IN_MEMORY_DB ? ':memory:' : url });
 	const db = drizzleLibsql(client);
 


### PR DESCRIPTION
## Changes

- Update db package to reference base `index.d.ts` to ensure `astro:db` is defined.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
