### PR TITLE
fix(rendering): allow render instructions to propagate while rendering slots

### DIFF
--- a/.changeset/sharp-scissors-think.md
+++ b/.changeset/sharp-scissors-think.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where slotting interactive components within a "client:only" component prevented all component code in the page from running.

--- a/packages/astro/e2e/fixtures/nested-in-react/src/pages/nested-in-only.astro
+++ b/packages/astro/e2e/fixtures/nested-in-react/src/pages/nested-in-only.astro
@@ -1,0 +1,17 @@
+---
+import ReactCounter from '../components/react/ReactCounter.jsx';
+---
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width" />
+		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+	</head>
+	<body>
+		<main>
+			<ReactCounter id="react-counter" client:only="react">
+				<Fragment><ReactCounter id="react-counter-nested" client:only="react" children/></Fragment>
+			</ReactCounter>
+		</main>
+	</body>
+</html>

--- a/packages/astro/e2e/nested-in-react.test.js
+++ b/packages/astro/e2e/nested-in-react.test.js
@@ -114,4 +114,14 @@ test.describe('Nested Frameworks in React', () => {
 
 		await expect(count, 'count incremented by 1').toHaveText('1');
 	});
+
+	test('React counter nested in client:only component', async ({ astro, page }) => {
+		await page.goto(astro.resolveUrl('/nested-in-only'));
+
+		const counter = page.locator('#react-counter');
+		await expect(counter, 'component is visible').toBeVisible();
+
+		const count = counter.locator('#react-counter-count');
+		await expect(count).toBeVisible();
+	});
 });

--- a/packages/astro/playwright.config.js
+++ b/packages/astro/playwright.config.js
@@ -27,16 +27,6 @@ const config = {
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: 'on-first-retry',
 	},
-	projects: [
-		{
-			name: 'Chrome Stable',
-			use: {
-				browserName: 'chromium',
-				channel: 'chrome',
-				args: ['--use-gl=egl'],
-			},
-		},
-	],
 };
 
 export default config;

--- a/packages/astro/playwright.config.js
+++ b/packages/astro/playwright.config.js
@@ -27,6 +27,16 @@ const config = {
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: 'on-first-retry',
 	},
+	projects: [
+		{
+			name: 'Chrome Stable',
+			use: {
+				browserName: 'chromium',
+				channel: 'chrome',
+				args: ['--use-gl=egl'],
+			},
+		},
+	],
 };
 
 export default config;

--- a/packages/astro/src/runtime/server/render/slot.ts
+++ b/packages/astro/src/runtime/server/render/slot.ts
@@ -52,8 +52,16 @@ export async function renderSlotToString(
 	let instructions: null | RenderInstruction[] = null;
 	const temporaryDestination: RenderDestination = {
 		write(chunk) {
-			if (chunk instanceof Response) return;
-			if (typeof chunk === 'object' && 'type' in chunk && typeof chunk.type === 'string') {
+			// if the chunk is already a SlotString, we concatenate
+			if (chunk instanceof SlotString) {
+				content += chunk
+				if (chunk.instructions) {
+					instructions ??= []
+					instructions.push(...chunk.instructions)
+				}
+			}
+			else if (chunk instanceof Response) return;
+			else if (typeof chunk === 'object' && 'type' in chunk && typeof chunk.type === 'string') {
 				if (instructions === null) {
 					instructions = [];
 				}


### PR DESCRIPTION
## Changes

- Fixes #9996
- The slot rendered first eagerly and stringified the island script with it. The slot was then put inside a template tag because the parent component is `client:only`.
- Island script should have been rendered right before the parent component itself. The `RenderDestination`-`RenderInstance` system makes sure that while things execute out of sequence, they get "stringified" in sequence.
- The reason was that slots are rendered in a temporary render destination and some chunk types are not handled there, falling back to stringifying immediately.
- The fix is to defer stringifying to the real destination, accumulating instructions in the `SlotString` untouched.

## Testing
- Added a case in an existing E2E fixture.

## Docs
- Does not affect usage.