### PR TITLE
fix broken link in code examples

### DIFF
--- a/examples/framework-alpine/src/components/Counter.astro
+++ b/examples/framework-alpine/src/components/Counter.astro
@@ -1,6 +1,6 @@
 ---
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 
 interface Props {
 	initialCount?: number;

--- a/examples/framework-alpine/src/pages/index.astro
+++ b/examples/framework-alpine/src/pages/index.astro
@@ -3,7 +3,7 @@
 import Counter from '../components/Counter.astro';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <html lang="en">

--- a/examples/framework-lit/src/pages/index.astro
+++ b/examples/framework-lit/src/pages/index.astro
@@ -4,7 +4,7 @@ import { CalcAdd } from '../components/calc-add.js';
 import { MyCounter } from '../components/my-counter.js';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <!doctype html>

--- a/examples/framework-multiple/src/pages/index.astro
+++ b/examples/framework-multiple/src/pages/index.astro
@@ -12,7 +12,7 @@ import VueCounter from '../components/vue/VueCounter.vue';
 import SvelteCounter from '../components/svelte/SvelteCounter.svelte';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <html lang="en">

--- a/examples/framework-preact/src/pages/index.astro
+++ b/examples/framework-preact/src/pages/index.astro
@@ -5,7 +5,7 @@ import Counter from '../components/Counter';
 import { signal } from '@preact/signals';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 
 const count = signal(0);
 ---

--- a/examples/framework-react/src/pages/index.astro
+++ b/examples/framework-react/src/pages/index.astro
@@ -6,7 +6,7 @@ const someProps = {
 };
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <html lang="en">

--- a/examples/framework-solid/src/pages/index.astro
+++ b/examples/framework-solid/src/pages/index.astro
@@ -3,7 +3,7 @@
 import Counter from '../components/Counter';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <html lang="en">

--- a/examples/framework-svelte/src/pages/index.astro
+++ b/examples/framework-svelte/src/pages/index.astro
@@ -3,7 +3,7 @@
 import Counter from '../components/Counter.svelte';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <html lang="en">

--- a/examples/framework-vue/src/pages/index.astro
+++ b/examples/framework-vue/src/pages/index.astro
@@ -3,7 +3,7 @@
 import Counter from '../components/Counter.vue';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <html lang="en">

--- a/examples/portfolio/src/pages/index.astro
+++ b/examples/portfolio/src/pages/index.astro
@@ -22,7 +22,7 @@ const projects = (await getCollection('work'))
 	.slice(0, 4);
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <BaseLayout>

--- a/examples/with-tailwindcss/src/pages/index.astro
+++ b/examples/with-tailwindcss/src/pages/index.astro
@@ -3,7 +3,7 @@
 import Button from '../components/Button.astro';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <html lang="en">

--- a/packages/astro/e2e/fixtures/client-only/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/client-only/src/pages/index.astro
@@ -6,7 +6,7 @@ import VueCounter from '../components/vue/VueCounter.vue';
 import SvelteCounter from '../components/svelte/SvelteCounter.svelte';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <html lang="en">

--- a/packages/astro/e2e/fixtures/multiple-frameworks/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/multiple-frameworks/src/pages/index.astro
@@ -10,7 +10,7 @@ import VueCounter from '../components/vue/VueCounter.vue';
 import SvelteCounter from '../components/svelte/SvelteCounter.svelte';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <html lang="en">

--- a/packages/astro/e2e/fixtures/nested-in-preact/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-preact/src/pages/index.astro
@@ -6,7 +6,7 @@ import VueCounter from '../components/vue/VueCounter.vue';
 import SvelteCounter from '../components/svelte/SvelteCounter.svelte';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <html lang="en">

--- a/packages/astro/e2e/fixtures/nested-in-react/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-react/src/pages/index.astro
@@ -6,7 +6,7 @@ import VueCounter from '../components/vue/VueCounter.vue';
 import SvelteCounter from '../components/svelte/SvelteCounter.svelte';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <html lang="en">

--- a/packages/astro/e2e/fixtures/nested-in-solid/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-solid/src/pages/index.astro
@@ -6,7 +6,7 @@ import VueCounter from '../components/vue/VueCounter.vue';
 import SvelteCounter from '../components/svelte/SvelteCounter.svelte';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <html lang="en">

--- a/packages/astro/e2e/fixtures/nested-in-svelte/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-svelte/src/pages/index.astro
@@ -6,7 +6,7 @@ import VueCounter from '../components/vue/VueCounter.vue';
 import SvelteCounter from '../components/svelte/SvelteCounter.svelte';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <html lang="en">

--- a/packages/astro/e2e/fixtures/nested-in-vue/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/nested-in-vue/src/pages/index.astro
@@ -6,7 +6,7 @@ import VueCounter from '../components/vue/VueCounter.vue';
 import SvelteCounter from '../components/svelte/SvelteCounter.svelte';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <html lang="en">

--- a/packages/astro/test/fixtures/hydration-race/src/pages/slot.astro
+++ b/packages/astro/test/fixtures/hydration-race/src/pages/slot.astro
@@ -4,7 +4,7 @@ import Demo from '../components/One.jsx';
 import WithSlot from '../components/WithSlot.astro';
 
 // Full Astro Component Syntax:
-// https://docs.astro.build/core-concepts/astro-components/
+// https://docs.astro.build/basics/astro-components/
 ---
 
 <html lang="en">


### PR DESCRIPTION
## Changes

Fixes link that gives error 404, copied across several files.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

https://docs.astro.build/core-concepts/astro-components/ gives 404, appears to be moved to https://docs.astro.build/basics/astro-components/ 

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
