### PR TITLE
fix(Astro global): parity with `ctx.site`

### DIFF
--- a/.changeset/sour-apples-try.md
+++ b/.changeset/sour-apples-try.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where `ctx.site` included the configured `base` in API routes and middleware, unlike `Astro.site` in astro pages.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2701,7 +2701,7 @@ export interface SSRResult {
 		slots: Record<string, any> | null
 	): AstroGlobal;
 	resolve: (s: string) => Promise<string>;
-	response: ResponseInit;
+	response: AstroGlobal["response"];
 	renderers: SSRLoadedRenderer[];
 	/**
 	 * Map of directive name (e.g. `load`) to the directive script code

--- a/packages/astro/src/core/base-pipeline.ts
+++ b/packages/astro/src/core/base-pipeline.ts
@@ -45,7 +45,7 @@ export abstract class Pipeline {
 		/**
 		 * Used for `Astro.site`.
 		 */
-		readonly site = manifest.site
+		readonly site = manifest.site ? new URL(manifest.site) : undefined,
 	) {
 		this.internalMiddleware = [
 			createI18nMiddleware(i18n, manifest.base, manifest.trailingSlash, manifest.buildFormat),

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -609,9 +609,7 @@ function createBuildManifest(
 		renderers,
 		base: settings.config.base,
 		assetsPrefix: settings.config.build.assetsPrefix,
-		site: settings.config.site
-			? new URL(settings.config.base, settings.config.site).toString()
-			: settings.config.site,
+		site: settings.config.site,
 		componentMetadata: internals.componentMetadata,
 		i18n: i18nManifest,
 		buildFormat: settings.config.build.format,

--- a/packages/astro/src/core/compile/compile.ts
+++ b/packages/astro/src/core/compile/compile.ts
@@ -56,6 +56,8 @@ export async function compile({
 			normalizedFilename: normalizeFilename(filename, astroConfig.root),
 			sourcemap: 'both',
 			internalURL: 'astro/compiler-runtime',
+			// TODO: this is no longer neccessary for `Astro.site`
+			// but it somehow allows working around caching issues in content collections for some tests
 			astroGlobalArgs: JSON.stringify(astroConfig.site),
 			scopedStyleStrategy: astroConfig.scopedStyleStrategy,
 			resultScopedSlot: true,

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -792,7 +792,7 @@ export const MiddlewareNotAResponse = {
  * @docs
  * @description
  *
- * Thrown in development mode when `locals` is overwritten with something that is not an object
+ * Thrown when `locals` is overwritten with something that is not an object
  *
  * For example:
  * ```ts
@@ -809,6 +809,19 @@ export const LocalsNotAnObject = {
 	message:
 		'`locals` can only be assigned to an object. Other values like numbers, strings, etc. are not accepted.',
 	hint: 'If you tried to remove some information from the `locals` object, try to use `delete` or set the property to `undefined`.',
+} satisfies ErrorData;
+
+/**
+ * @docs
+ * @description
+ * Thrown when a value is being set as the `headers` field on the `ResponseInit` object available as `Astro.response`.
+ */
+export const AstroResponseHeadersReassigned = {
+	name: 'AstroResponseHeadersReassigned',
+	title: '`Astro.response.headers` must not be reassigned.',
+	message:
+		'Individual headers can be added to and removed from `Astro.response.headers`, but it must not be replaced with another instance of `Headers` altogether.',
+	hint: 'Consider using `Astro.response.headers.add()`, and `Astro.response.headers.delete()`.',
 } satisfies ErrorData;
 
 /**

--- a/packages/astro/src/core/middleware/index.ts
+++ b/packages/astro/src/core/middleware/index.ts
@@ -74,8 +74,6 @@ function createContext({
 			return (currentLocale ??= computeCurrentLocale(
 				route,
 				userDefinedLocales,
-				undefined,
-				undefined
 			));
 		},
 		url,

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -189,14 +189,17 @@ export class RenderContext {
 			(await pipeline.componentMetadata(routeData)) ?? manifest.componentMetadata;
 		const headers = new Headers({ 'Content-Type': 'text/html' });
 		const partial = Boolean(mod.partial);
-		const response = { status, statusText: 'OK', headers } satisfies AstroGlobal["response"];
-
-		// Disallow `Astro.response.headers = new Headers`
-		Object.defineProperty(response, 'headers', {
-			value: response.headers,
-			enumerable: true,
-			writable: false,
-		});
+		const response = {
+			status,
+			statusText: 'OK',
+			get headers() {
+				return headers
+			},
+			// Disallow `Astro.response.headers = new Headers`
+			set headers(_) {
+				throw new AstroError(AstroErrorData.AstroResponseHeadersReassigned);
+			}
+		} satisfies AstroGlobal["response"];
 
 		// Create the result object that will be passed into the renderPage function.
 		// This object starts here as an empty shell (not yet the result) but then

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -137,7 +137,6 @@ export class RenderContext {
 		const generator = `Astro v${ASTRO_VERSION}`;
 		const redirect = (path: string, status = 302) =>
 			new Response(null, { status, headers: { Location: path } });
-		const site = pipeline.site ? new URL(pipeline.site) : undefined;
 		return {
 			cookies,
 			get currentLocale() {
@@ -154,7 +153,7 @@ export class RenderContext {
 			props,
 			redirect,
 			request,
-			site,
+			site: pipeline.site,
 			url,
 			get clientAddress() {
 				if (clientAddressSymbol in request) {
@@ -281,6 +280,7 @@ export class RenderContext {
 			request,
 			response,
 			slots,
+			site: pipeline.site,
 			url,
 			get clientAddress() {
 				if (clientAddressSymbol in request) {

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -139,35 +139,13 @@ export class RenderContext {
 			new Response(null, { status, headers: { Location: path } });
 		return {
 			cookies,
+			get clientAddress() {
+				return renderContext.clientAddress()
+			},
 			get currentLocale() {
 				return renderContext.computeCurrentLocale();
 			},
 			generator,
-			params,
-			get preferredLocale() {
-				return renderContext.computePreferredLocale();
-			},
-			get preferredLocaleList() {
-				return renderContext.computePreferredLocaleList();
-			},
-			props,
-			redirect,
-			request,
-			site: pipeline.site,
-			url,
-			get clientAddress() {
-				if (clientAddressSymbol in request) {
-					return Reflect.get(request, clientAddressSymbol) as string;
-				}
-				if (pipeline.adapterName) {
-					throw new AstroError({
-						...AstroErrorData.ClientAddressNotAvailable,
-						message: AstroErrorData.ClientAddressNotAvailable.message(pipeline.adapterName),
-					});
-				} else {
-					throw new AstroError(AstroErrorData.StaticClientAddressNotAvailable);
-				}
-			},
 			get locals() {
 				return renderContext.locals;
 			},
@@ -182,6 +160,18 @@ export class RenderContext {
 					Reflect.set(request, clientLocalsSymbol, val);
 				}
 			},
+			params,
+			get preferredLocale() {
+				return renderContext.computePreferredLocale();
+			},
+			get preferredLocaleList() {
+				return renderContext.computePreferredLocaleList();
+			},
+			props,
+			redirect,
+			request,
+			site: pipeline.site,
+			url,
 		};
 	}
 
@@ -247,7 +237,7 @@ export class RenderContext {
 		slotValues: Record<string, any> | null
 	): AstroGlobal {
 		const renderContext = this;
-		const { cookies, locals, params, pipeline, request, url } = this
+		const { cookies, locals, params, pipeline, request, url } = this;
 		const { response } = result;
 		const redirect = (path: string, status = 302) => {
 			// If the response is already sent, error as we cannot proceed with the redirect.
@@ -264,6 +254,9 @@ export class RenderContext {
 		const astroGlobalCombined: Omit<AstroGlobal, 'self'> = {
 			...astroGlobalPartial,
 			cookies,
+			get clientAddress() {
+				return renderContext.clientAddress()
+			},
 			get currentLocale() {
 				return renderContext.computeCurrentLocale();
 			},
@@ -282,22 +275,24 @@ export class RenderContext {
 			slots,
 			site: pipeline.site,
 			url,
-			get clientAddress() {
-				if (clientAddressSymbol in request) {
-					return Reflect.get(request, clientAddressSymbol) as string;
-				}
-				if (pipeline.adapterName) {
-					throw new AstroError({
-						...AstroErrorData.ClientAddressNotAvailable,
-						message: AstroErrorData.ClientAddressNotAvailable.message(pipeline.adapterName),
-					});
-				} else {
-					throw new AstroError(AstroErrorData.StaticClientAddressNotAvailable);
-				}
-			},
 		};
 		
 		return astroGlobalCombined as AstroGlobal
+	}
+
+	clientAddress() {
+		const { pipeline, request } = this;
+		if (clientAddressSymbol in request) {
+			return Reflect.get(request, clientAddressSymbol) as string;
+		}
+		if (pipeline.adapterName) {
+			throw new AstroError({
+				...AstroErrorData.ClientAddressNotAvailable,
+				message: AstroErrorData.ClientAddressNotAvailable.message(pipeline.adapterName),
+			});
+		} else {
+			throw new AstroError(AstroErrorData.StaticClientAddressNotAvailable);
+		}
 	}
 
 	/**

--- a/packages/astro/src/core/render/index.ts
+++ b/packages/astro/src/core/render/index.ts
@@ -3,7 +3,7 @@ import type { Pipeline } from '../base-pipeline.js';
 export { Pipeline } from '../base-pipeline.js';
 export { getParams, getProps } from './params-and-props.js';
 export { loadRenderer } from './renderer.js';
-export { createResult } from './result.js';
+export { Slots } from './result.js';
 
 export interface SSROptions {
 	/** The pipeline instance */

--- a/packages/astro/src/core/render/result.ts
+++ b/packages/astro/src/core/render/result.ts
@@ -1,60 +1,9 @@
-import type {
-	AstroGlobal,
-	AstroGlobalPartial,
-	Locales,
-	Params,
-	SSRElement,
-	SSRLoadedRenderer,
-	SSRResult,
-} from '../../@types/astro.js';
-import {
-	type RoutingStrategies,
-	computeCurrentLocale,
-	computePreferredLocale,
-	computePreferredLocaleList,
-} from '../../i18n/utils.js';
+import type { SSRResult } from '../../@types/astro.js';
 import { type ComponentSlots, renderSlotToString } from '../../runtime/server/index.js';
 import { renderJSX } from '../../runtime/server/jsx.js';
 import { chunkToString } from '../../runtime/server/render/index.js';
-import { clientAddressSymbol, responseSentSymbol } from '../constants.js';
-import { AstroCookies } from '../cookies/index.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 import type { Logger } from '../logger/core.js';
-
-export interface CreateResultArgs {
-	/**
-	 * Used to provide better error messages for `Astro.clientAddress`
-	 */
-	adapterName: string | undefined;
-	/**
-	 * Value of Astro config's `output` option, true if "server" or "hybrid"
-	 */
-	ssr: boolean;
-	logger: Logger;
-	params: Params;
-	pathname: string;
-	renderers: SSRLoadedRenderer[];
-	clientDirectives: Map<string, string>;
-	compressHTML: boolean;
-	partial: boolean;
-	resolve: (s: string) => Promise<string>;
-	/**
-	 * Used for `Astro.site`
-	 */
-	site: string | undefined;
-	links: Set<SSRElement>;
-	scripts: Set<SSRElement>;
-	styles: Set<SSRElement>;
-	componentMetadata: SSRResult['componentMetadata'];
-	request: Request;
-	status: number;
-	locals: App.Locals;
-	cookies: AstroCookies;
-	locales: Locales | undefined;
-	defaultLocale: string | undefined;
-	route: string;
-	strategy: RoutingStrategies | undefined;
-}
 
 function getFunctionExpression(slot: any) {
 	if (!slot) return;
@@ -62,7 +11,7 @@ function getFunctionExpression(slot: any) {
 	return slot.expressions[0] as (...args: any[]) => any;
 }
 
-class Slots {
+export class Slots {
 	#result: SSRResult;
 	#slots: ComponentSlots | null;
 	#logger: Logger;
@@ -130,158 +79,4 @@ class Slots {
 
 		return outHTML;
 	}
-}
-
-export function createResult(args: CreateResultArgs): SSRResult {
-	const { params, request, resolve, locals } = args;
-
-	const url = new URL(request.url);
-	const headers = new Headers();
-	headers.set('Content-Type', 'text/html');
-	const response: ResponseInit = {
-		status: args.status,
-		statusText: 'OK',
-		headers,
-	};
-
-	// Make headers be read-only
-	Object.defineProperty(response, 'headers', {
-		value: response.headers,
-		enumerable: true,
-		writable: false,
-	});
-
-	// Astro.cookies is defined lazily to avoid the cost on pages that do not use it.
-	let cookies: AstroCookies | undefined = args.cookies;
-	let preferredLocale: string | undefined = undefined;
-	let preferredLocaleList: string[] | undefined = undefined;
-	let currentLocale: string | undefined = undefined;
-
-	// Create the result object that will be passed into the render function.
-	// This object starts here as an empty shell (not yet the result) but then
-	// calling the render() function will populate the object with scripts, styles, etc.
-	const result: SSRResult = {
-		styles: args.styles ?? new Set<SSRElement>(),
-		scripts: args.scripts ?? new Set<SSRElement>(),
-		links: args.links ?? new Set<SSRElement>(),
-		componentMetadata: args.componentMetadata ?? new Map(),
-		renderers: args.renderers,
-		clientDirectives: args.clientDirectives,
-		compressHTML: args.compressHTML,
-		partial: args.partial,
-		pathname: args.pathname,
-		cookies,
-		/** This function returns the `Astro` faux-global */
-		createAstro(
-			astroGlobal: AstroGlobalPartial,
-			props: Record<string, any>,
-			slots: Record<string, any> | null
-		) {
-			const astroSlots = new Slots(result, slots, args.logger);
-
-			const Astro: AstroGlobal = {
-				// @ts-expect-error
-				__proto__: astroGlobal,
-				get clientAddress() {
-					if (!(clientAddressSymbol in request)) {
-						if (args.adapterName) {
-							throw new AstroError({
-								...AstroErrorData.ClientAddressNotAvailable,
-								message: AstroErrorData.ClientAddressNotAvailable.message(args.adapterName),
-							});
-						} else {
-							throw new AstroError(AstroErrorData.StaticClientAddressNotAvailable);
-						}
-					}
-
-					return Reflect.get(request, clientAddressSymbol) as string;
-				},
-				get cookies() {
-					if (cookies) {
-						return cookies;
-					}
-					cookies = new AstroCookies(request);
-					result.cookies = cookies;
-					return cookies;
-				},
-				get preferredLocale(): string | undefined {
-					if (preferredLocale) {
-						return preferredLocale;
-					}
-					if (args.locales) {
-						preferredLocale = computePreferredLocale(request, args.locales);
-						return preferredLocale;
-					}
-
-					return undefined;
-				},
-				get preferredLocaleList(): string[] | undefined {
-					if (preferredLocaleList) {
-						return preferredLocaleList;
-					}
-					if (args.locales) {
-						preferredLocaleList = computePreferredLocaleList(request, args.locales);
-						return preferredLocaleList;
-					}
-
-					return undefined;
-				},
-				get currentLocale(): string | undefined {
-					if (currentLocale) {
-						return currentLocale;
-					}
-					if (args.locales) {
-						currentLocale = computeCurrentLocale(
-							url.pathname,
-							args.locales,
-							args.strategy,
-							args.defaultLocale
-						);
-						if (currentLocale) {
-							return currentLocale;
-						}
-					}
-
-					return undefined;
-				},
-				params,
-				props,
-				locals,
-				request,
-				url,
-				redirect(path, status) {
-					// If the response is already sent, error as we cannot proceed with the redirect.
-					if ((request as any)[responseSentSymbol]) {
-						throw new AstroError({
-							...AstroErrorData.ResponseSentError,
-						});
-					}
-
-					return new Response(null, {
-						status: status || 302,
-						headers: {
-							Location: path,
-						},
-					});
-				},
-				response: response as AstroGlobal['response'],
-				slots: astroSlots as unknown as AstroGlobal['slots'],
-			};
-
-			return Astro;
-		},
-		resolve,
-		response,
-		_metadata: {
-			hasHydrationScript: false,
-			rendererSpecificHydrationScripts: new Set(),
-			hasRenderedHead: false,
-			hasDirectives: new Set(),
-			headInTree: false,
-			extraHead: [],
-			propagators: new Set(),
-		},
-	};
-
-	return result;
 }

--- a/packages/astro/src/i18n/utils.ts
+++ b/packages/astro/src/i18n/utils.ts
@@ -155,8 +155,6 @@ export function computePreferredLocaleList(request: Request, locales: Locales): 
 export function computeCurrentLocale(
 	pathname: string,
 	locales: Locales,
-	routingStrategy: RoutingStrategies | undefined,
-	defaultLocale: string | undefined
 ): undefined | string {
 	for (const segment of pathname.split('/')) {
 		for (const locale of locales) {
@@ -179,15 +177,7 @@ export function computeCurrentLocale(
 				}
 			}
 		}
-	}
-
-	if (
-		routingStrategy === 'pathname-prefix-other-locales' ||
-		routingStrategy === 'domains-prefix-other-locales'
-	) {
-		return defaultLocale;
-	}
-	return undefined;
+	};
 }
 
 export type RoutingStrategies =

--- a/packages/astro/src/runtime/server/astro-global.ts
+++ b/packages/astro/src/runtime/server/astro-global.ts
@@ -30,6 +30,8 @@ function createAstroGlobFn() {
 // inside of getStaticPaths. See the `astroGlobalArgs` option for parameter type.
 export function createAstro(site: string | undefined): AstroGlobalPartial {
 	return {
+		// TODO: this is no longer neccessary for `Astro.site`
+		// but it somehow allows working around caching issues in content collections for some tests
 		site: site ? new URL(site) : undefined,
 		generator: `Astro v${ASTRO_VERSION}`,
 		glob: createAstroGlobFn(),

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -136,9 +136,7 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 		renderers: [],
 		base: settings.config.base,
 		assetsPrefix: settings.config.build.assetsPrefix,
-		site: settings.config.site
-			? new URL(settings.config.base, settings.config.site).toString()
-			: settings.config.site,
+		site: settings.config.site,
 		componentMetadata: new Map(),
 		i18n: i18nManifest,
 		middleware(_, next) {

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -65,7 +65,7 @@ describe('Astro Global', () => {
 		it('Astro.site', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
-			assert.equal($('#site').attr('href'), 'https://mysite.dev/blog/');
+			assert.equal($('#site').attr('href'), 'https://mysite.dev/blog');
 		});
 
 		it('Astro.glob() correctly returns an array of all posts', async () => {

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
+import testAdapter from './test-adapter.js';
 
 describe('Astro Global', () => {
 	let fixture;
@@ -9,7 +10,7 @@ describe('Astro Global', () => {
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/astro-global/',
-			site: 'https://mysite.dev/blog/',
+			site: 'https://mysite.dev/subsite/',
 			base: '/blog',
 		});
 	});
@@ -65,7 +66,7 @@ describe('Astro Global', () => {
 		it('Astro.site', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
-			assert.equal($('#site').attr('href'), 'https://mysite.dev/blog/');
+			assert.equal($('#site').attr('href'), 'https://mysite.dev/subsite/');
 		});
 
 		it('Astro.glob() correctly returns an array of all posts', async () => {
@@ -79,6 +80,30 @@ describe('Astro Global', () => {
 			const $ = cheerio.load(html);
 			assert.equal($('[data-file]').length, 8);
 			assert.equal($('.post-url[href]').length, 8);
+		});
+	});
+
+	describe('app', () => {
+		/** @type {import('../dist/core/app/index.js').App} */
+		let app;
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/astro-global/',
+				site: 'https://mysite.dev/subsite/',
+				base: '/new',
+				output: "server",
+				adapter: testAdapter()
+			});
+			await fixture.build();
+			app = await fixture.loadTestAdapterApp();
+		});
+
+		it('Astro.site', async () => {
+			const response = await app.render(new Request("https://example.com/"));
+			const html = await response.text();
+			const $ = cheerio.load(html);
+			assert.equal($('#site').attr('href'), 'https://mysite.dev/subsite/');
 		});
 	});
 });

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -65,7 +65,7 @@ describe('Astro Global', () => {
 		it('Astro.site', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
-			assert.equal($('#site').attr('href'), 'https://mysite.dev/blog');
+			assert.equal($('#site').attr('href'), 'https://mysite.dev/blog/');
 		});
 
 		it('Astro.glob() correctly returns an array of all posts', async () => {

--- a/packages/astro/test/ssr-api-route.test.js
+++ b/packages/astro/test/ssr-api-route.test.js
@@ -4,20 +4,21 @@ import { after, before, describe, it } from 'node:test';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
 
-describe('API routes in SSR', async () => {
+describe('API routes in SSR', () => {
 
-	const fixture = await loadFixture({
+	const config = {
 		root: './fixtures/ssr-api-route/',
 		output: 'server',
 		site: 'https://mysite.dev/subsite/',
 		base: '/blog',
 		adapter: testAdapter(),
-	});
+	};
 
 	describe('Build', () => {
-		/** @type {Awaited<ReturnType<(typeof fixture)["loadTestAdapterApp"]>>} */
+		/** @type {import('./test-utils.js').App} */
 		let app;
 	before(async () => {
+		const fixture = await loadFixture(config);
 		await fixture.build();
 		app = await fixture.loadTestAdapterApp();
 	});
@@ -55,9 +56,12 @@ describe('API routes in SSR', async () => {
 	})
 
 	describe('Dev', () => {
-		/** @type {Awaited<ReturnType<(typeof fixture)["startDevServer"]>>} */
+		/** @type {import('./test-utils.js').DevServer} */
 		let devServer;
+		/** @type {import('./test-utils.js').Fixture} */
+		let fixture;
 		before(async () => {
+			fixture = await loadFixture(config);
 			devServer = await fixture.startDevServer();
 		});
 

--- a/packages/astro/test/ssr-api-route.test.js
+++ b/packages/astro/test/ssr-api-route.test.js
@@ -4,21 +4,25 @@ import { after, before, describe, it } from 'node:test';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
 
-describe('API routes in SSR', () => {
-	/** @type {import('./test-utils').Fixture} */
-	let fixture;
+describe('API routes in SSR', async () => {
 
+	const fixture = await loadFixture({
+		root: './fixtures/ssr-api-route/',
+		output: 'server',
+		site: 'https://mysite.dev/subsite/',
+		base: '/blog',
+		adapter: testAdapter(),
+	});
+
+	describe('Build', () => {
+		/** @type {Awaited<ReturnType<(typeof fixture)["loadTestAdapterApp"]>>} */
+		let app;
 	before(async () => {
-		fixture = await loadFixture({
-			root: './fixtures/ssr-api-route/',
-			output: 'server',
-			adapter: testAdapter(),
-		});
 		await fixture.build();
+		app = await fixture.loadTestAdapterApp();
 	});
 
 	it('Basic pages work', async () => {
-		const app = await fixture.loadTestAdapterApp();
 		const request = new Request('http://example.com/');
 		const response = await app.render(request);
 		const html = await response.text();
@@ -26,7 +30,6 @@ describe('API routes in SSR', () => {
 	});
 
 	it('Can load the API route too', async () => {
-		const app = await fixture.loadTestAdapterApp();
 		const request = new Request('http://example.com/food.json');
 		const response = await app.render(request);
 		assert.equal(response.status, 200);
@@ -35,7 +38,6 @@ describe('API routes in SSR', () => {
 	});
 
 	it('Has valid api context', async () => {
-		const app = await fixture.loadTestAdapterApp();
 		const request = new Request('http://example.com/context/any');
 		const response = await app.render(request);
 		assert.equal(response.status, 200);
@@ -48,9 +50,12 @@ describe('API routes in SSR', () => {
 		assert.match(data.generator, /^Astro v/);
 		assert.equal(data.url, 'http://example.com/context/any');
 		assert.equal(data.clientAddress, '0.0.0.0');
+		assert.equal(data.site, "https://mysite.dev/subsite/");
 	});
+	})
 
-	describe('API Routes - Dev', () => {
+	describe('Dev', () => {
+		/** @type {Awaited<ReturnType<(typeof fixture)["startDevServer"]>>} */
 		let devServer;
 		before(async () => {
 			devServer = await fixture.startDevServer();
@@ -115,6 +120,21 @@ describe('API routes in SSR', () => {
 			}
 
 			assert.equal(count, 2, 'Found two seperate set-cookie response headers');
+		});
+
+		it('Has valid api context', async () => {
+			const response = await fixture.fetch('/context/any');
+			assert.equal(response.status, 200);
+			const data = await response.json();
+			assert.equal(data.cookiesExist, true);
+			assert.equal(data.requestExist, true);
+			assert.equal(data.redirectExist, true);
+			assert.equal(data.propsExist, true);
+			assert.deepEqual(data.params, { param: 'any' });
+			assert.match(data.generator, /^Astro v/);
+			assert.equal(data.url, 'http://[::1]:4321/blog/context/any');
+			assert.equal(data.clientAddress, '::1');
+			assert.equal(data.site, "https://mysite.dev/subsite/");
 		});
 	});
 });

--- a/packages/astro/test/units/test-utils.js
+++ b/packages/astro/test/units/test-utils.js
@@ -203,7 +203,7 @@ export function createBasicPipeline(options = {}) {
 		options.site
 	);
 	pipeline.headElements = () => ({ scripts: new Set(), styles: new Set(), links: new Set() });
-	pipeline.componentMetadata = () => {};
+	pipeline.componentMetadata = () => new Map;
 	return pipeline;
 }
 


### PR DESCRIPTION
## Changes

- Fixes #10303
- Colocates code for the `Astro` global alongside that of `APIContext`.
- Removes `base` out of the picture while generating `manifest.site`.

## Testing
- Added to `astro-global.test.js` and `ssr-api-route.test.js`

## Docs
- Does not affect usage.