### PR TITLE
Update security flow to report on GitHub

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,11 @@
 
 ## Reporting a Vulnerability
 
-To report a security issue, please email security@astro.build with a detailed description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+To report a security issue, please [open a security advisory](https://github.com/withastro/astro/security/advisories/new) on GitHub with a detailed description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
 
 Please remember to include everything required for us to reproduce the issue, including but not limited to a publicly accessible git repository and/or StackBlitz repository. All code samples shared with our Security team will only be used to verify and diagnose the issue and will not be publicly shared with anyone outside of Astro's teams. Astro's Security Team members may share information only within the Astro teams on a need-to-know basis to fix the related issue in Astro.
 
-Our Security team will acknowledge receiving your email within 3 working days.
+Our Security team will respond to the security advisory within 3 working days.
 
 <ins>**If you think you've found a security issue, please DO NOT report, discuss, or describe it on Discord, GitHub, or any other public forum; without prior contact and acknowledgment of Astro's Security team.**<ins>
 


### PR DESCRIPTION
## Changes

Update `SECURITY.md` to use GitHub to report vulnerabilties. This is only for this repo, for other repos it'll fallback to the default in https://github.com/withastro/.github/blob/main/SECURITY.md (via email).

Starting this PR as a point of discussion, we could decide whether we want to do this or not. From Discord, this new flow will look like:

1. First, we need to enable the feature at https://github.com/withastro/astro/settings/security_analysis
2. When creating a bug report, users can choose to submit a security report instead, e.g. [vite](https://github.com/vitejs/vite/issues/new/choose)
3. Users can fill in the form to describe the severity and explain in private. Only repo admins can see unless they invite others.
4. We can triage them (comment, close, update descriptions/severity, etc similar to GH issues), and if it's real, we can work on a fix.
5. After a fix is done, we can update the report to describe the versions fixed, add extra explanation, etc, then accept the report.
6. Someone from GitHub will then publish the CVE for us.

Compared to the email approach, this allows us to easily publish CVE, credit the folks who found the vulnerability, and is easier to discover (`npm audit`).

## Testing

n/a

## Docs

n/a
