### PR TITLE
Fix cli package resolution for `@astrojs/db`

### DIFF
--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module';
 import { sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import boxen from 'boxen';
 import { execa } from 'execa';
 import { bold, cyan, dim, magenta } from 'kleur/colors';
@@ -8,7 +9,6 @@ import prompts from 'prompts';
 import resolvePackage from 'resolve';
 import whichPm from 'which-pm';
 import { type Logger } from '../core/logger/core.js';
-import { pathToFileURL } from 'node:url';
 const require = createRequire(import.meta.url);
 
 type GetPackageOptions = {

--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -8,6 +8,7 @@ import prompts from 'prompts';
 import resolvePackage from 'resolve';
 import whichPm from 'which-pm';
 import { type Logger } from '../core/logger/core.js';
+import { pathToFileURL } from 'node:url';
 const require = createRequire(import.meta.url);
 
 type GetPackageOptions = {
@@ -28,7 +29,7 @@ export async function getPackage<T>(
 			const packageJsonLoc = require.resolve(packageName + '/package.json', {
 				paths: [options.cwd ?? process.cwd()],
 			});
-			const packageLoc = packageJsonLoc.replace(`package.json`, 'dist/index.js');
+			const packageLoc = pathToFileURL(packageJsonLoc.replace(`package.json`, 'dist/index.js'));
 			const packageImport = await import(packageLoc);
 			return packageImport as T;
 		}

--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -30,7 +30,7 @@ export async function getPackage<T>(
 				paths: [options.cwd ?? process.cwd()],
 			});
 			const packageLoc = pathToFileURL(packageJsonLoc.replace(`package.json`, 'dist/index.js'));
-			const packageImport = await import(packageLoc);
+			const packageImport = await import(packageLoc.toString());
 			return packageImport as T;
 		}
 		await tryResolve(packageName, options.cwd ?? process.cwd());


### PR DESCRIPTION
## Changes

Fixes bug where every time a `astro db` command is used it prompts the user to add `@astrojs/db` even if it is already installed

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

No tests, it is a pretty small fix for an error that doesn't get surfaced because it is inside a try/catch

> Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'


## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No docs needed
