### PR TITLE
fix: move db ambient types to separate module

### DIFF
--- a/.changeset/dry-pants-act.md
+++ b/.changeset/dry-pants-act.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Ensure `astro:db` types exist in your `db/config.ts` before running type generation.

--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -1,5 +1,3 @@
-export { default, cli } from './dist/index.js';
+import './virtual.js';
 
-declare module 'astro:db' {
-	export { defineTable, defineDB, column, sql, NOW, TRUE, FALSE } from './dist/index.js';
-}
+export { default, cli } from './dist/index.js';

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,3 @@
 export type { ResolvedCollectionConfig, TableConfig } from './core/types.js';
 export { cli } from './core/cli/index.js';
 export { integration as default } from './core/integration/index.js';
-export { sql, NOW, TRUE, FALSE, defineDB, defineTable, column } from './runtime/config.js';

--- a/packages/db/virtual.d.ts
+++ b/packages/db/virtual.d.ts
@@ -1,0 +1,9 @@
+declare module 'astro:db' {
+	export const sql: typeof import('./dist/runtime/config.js').sql;
+	export const NOW: typeof import('./dist/runtime/config.js').NOW;
+	export const TRUE: typeof import('./dist/runtime/config.js').TRUE;
+	export const FALSE: typeof import('./dist/runtime/config.js').FALSE;
+	export const column: typeof import('./dist/runtime/config.js').column;
+	export const defineDB: typeof import('./dist/runtime/config.js').defineDB;
+	export const defineTable: typeof import('./dist/runtime/config.js').defineTable;
+}


### PR DESCRIPTION
## Changes

Mixing a `declare module` statement within `index.d.ts` does not properly declare the type. This is because `index.d.ts` contains an `export` statement already.

- Move `astro:db` declaration to separate `virtual.d.ts`
- Refactor barrel export to individual exports. Barrel exports from a relative path are _not_ supported in virtual modules sadly

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
