### PR TITLE
db: rename experimentalVersion to version

### DIFF
--- a/.changeset/fluffy-bobcats-arrive.md
+++ b/.changeset/fluffy-bobcats-arrive.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Rename experimentalVersion to version

--- a/.changeset/fluffy-bobcats-arrive.md
+++ b/.changeset/fluffy-bobcats-arrive.md
@@ -2,4 +2,4 @@
 "@astrojs/db": patch
 ---
 
-Rename experimentalVersion to version
+Rename `experimentalVersion` to `version`

--- a/packages/db/src/core/cli/commands/push/index.ts
+++ b/packages/db/src/core/cli/commands/push/index.ts
@@ -1,5 +1,4 @@
 import type { AstroConfig } from 'astro';
-import { red } from 'kleur/colors';
 import type { Arguments } from 'yargs-parser';
 import { getManagedAppTokenOrExit } from '../../../tokens.js';
 import { type DBConfig, type DBSnapshot } from '../../../types.js';
@@ -11,6 +10,7 @@ import {
 	getMigrationQueries,
 	getProductionCurrentSnapshot,
 } from '../../migration-queries.js';
+import { MIGRATION_VERSION } from '../../../consts.js';
 
 export async function cmd({
 	dbConfig,
@@ -75,7 +75,7 @@ async function pushSchema({
 	const requestBody = {
 		snapshot: currentSnapshot,
 		sql: statements,
-		experimentalVersion: 1,
+		version: MIGRATION_VERSION,
 	};
 	if (isDryRun) {
 		console.info('[DRY RUN] Batch query:', JSON.stringify(requestBody, null, 2));

--- a/packages/db/src/core/cli/migration-queries.ts
+++ b/packages/db/src/core/cli/migration-queries.ts
@@ -32,6 +32,7 @@ import {
 	columnSchema,
 } from '../types.js';
 import { getRemoteDatabaseUrl } from '../utils.js';
+import { MIGRATION_VERSION } from '../consts.js';
 
 const sqlite = new SQLiteAsyncDialect();
 const genTempTableName = customAlphabet('abcdefghijklmnopqrstuvwxyz', 10);
@@ -437,11 +438,11 @@ export async function getProductionCurrentSnapshot({
 
 export function createCurrentSnapshot({ tables = {} }: DBConfig): DBSnapshot {
 	const schema = JSON.parse(JSON.stringify(tables));
-	return { experimentalVersion: 1, schema };
+	return { version: MIGRATION_VERSION, schema };
 }
 
 export function createEmptySnapshot(): DBSnapshot {
-	return { experimentalVersion: 1, schema: {} };
+	return { version: MIGRATION_VERSION, schema: {} };
 }
 
 export function formatDataLossMessage(confirmations: string[], isColor = true): string {

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -15,3 +15,5 @@ export const VIRTUAL_MODULE_ID = 'astro:db';
 export const DB_PATH = '.astro/content.db';
 
 export const CONFIG_FILE_NAMES = ['config.ts', 'config.js', 'config.mts', 'config.mjs'];
+
+export const MIGRATION_VERSION = "2024-03-12";

--- a/packages/db/src/core/types.ts
+++ b/packages/db/src/core/types.ts
@@ -233,11 +233,7 @@ export type DBTable = z.infer<typeof tableSchema>;
 export type DBTables = Record<string, DBTable>;
 export type DBSnapshot = {
 	schema: Record<string, DBTable>;
-	/**
-	 * Snapshot version. Breaking changes to the snapshot format increment this number.
-	 * @todo Rename to "version" once closer to release.
-	 */
-	experimentalVersion: number;
+	version: string;
 };
 
 export const dbConfigSchema = z.object({

--- a/packages/db/test/unit/column-queries.test.js
+++ b/packages/db/test/unit/column-queries.test.js
@@ -7,7 +7,7 @@ import {
 import { tableSchema } from '../../dist/core/types.js';
 import { column, defineTable } from '../../dist/runtime/config.js';
 import { NOW } from '../../dist/runtime/index.js';
-import { getCreateTableQuery } from '../../dist/runtime/queries.js';
+import { MIGRATE_VERSION } from '../../dist/core/consts.js';
 
 const TABLE_NAME = 'Users';
 
@@ -34,8 +34,8 @@ function userChangeQueries(oldTable, newTable) {
 
 function configChangeQueries(oldCollections, newCollections) {
 	return getMigrationQueries({
-		oldSnapshot: { schema: oldCollections, experimentalVersion: 1 },
-		newSnapshot: { schema: newCollections, experimentalVersion: 1 },
+		oldSnapshot: { schema: oldCollections, version: MIGRATE_VERSION },
+		newSnapshot: { schema: newCollections, version: MIGRATE_VERSION },
 	});
 }
 

--- a/packages/db/test/unit/column-queries.test.js
+++ b/packages/db/test/unit/column-queries.test.js
@@ -7,7 +7,7 @@ import {
 import { tableSchema } from '../../dist/core/types.js';
 import { column, defineTable } from '../../dist/runtime/config.js';
 import { NOW } from '../../dist/runtime/index.js';
-import { MIGRATE_VERSION } from '../../dist/core/consts.js';
+import { MIGRATION_VERSION } from '../../dist/core/consts.js';
 
 const TABLE_NAME = 'Users';
 
@@ -34,8 +34,8 @@ function userChangeQueries(oldTable, newTable) {
 
 function configChangeQueries(oldCollections, newCollections) {
 	return getMigrationQueries({
-		oldSnapshot: { schema: oldCollections, version: MIGRATE_VERSION },
-		newSnapshot: { schema: newCollections, version: MIGRATE_VERSION },
+		oldSnapshot: { schema: oldCollections, version: MIGRATION_VERSION },
+		newSnapshot: { schema: newCollections, version: MIGRATION_VERSION },
 	});
 }
 


### PR DESCRIPTION
## Changes

- Removed `experimentalVersion` on migration schemas.
- Added `version`, a date string that starts with the package's release date.

## Testing

- Updated tests

## Docs

N/A