### PR TITLE
db: scaffold db files when using `astro add db`

### DIFF
--- a/.changeset/stupid-eagles-begin.md
+++ b/.changeset/stupid-eagles-begin.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Adds scaffolded files when running `astro add db`

--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -38,7 +38,7 @@ export async function getPackage<T>(
 		return packageImport as T;
 	} catch (e) {
 		logger.info(
-			null,
+			'SKIP_FORMAT',
 			`To continue, Astro requires the following dependency to be installed: ${bold(packageName)}.`
 		);
 		const result = await installPackage([packageName, ...otherDeps], options, logger);
@@ -108,7 +108,7 @@ async function installPackage(
 		borderStyle: 'round',
 	})}\n`;
 	logger.info(
-		null,
+		'SKIP_FORMAT',
 		`\n  ${magenta('Astro will run the following command:')}\n  ${dim(
 			'If you skip this step, you can always run it yourself later'
 		)}\n${message}`


### PR DESCRIPTION
## Changes

- Updates `astro add` CLI to scaffold out the `db/` directory
- Refactors the stub logic in `astro add` for improved maintainability
- We'll eventually want to expose scaffolding functionality for _any_ integration, but that will take some API design work. Right now, we just need to improve the `astro add db` experience. Baby steps!
- Bonus: removes default logger formatting when running any `astro add` command (AS INTENDED!)

## Testing

Tested manually because `astro add` isn't tested

## Docs

Will be documented in preparation for launch day
