### PR TITLE
Add `--remote` flag for remote connection

### DIFF
--- a/.changeset/healthy-taxis-applaud.md
+++ b/.changeset/healthy-taxis-applaud.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": minor
+---
+
+Introduce `astro build --remote` to build with a remote database connection. Running `astro build` plain will use a local database file, and `--remote` will authenticate with a studio app token.

--- a/packages/db/src/core/cli/commands/execute/index.ts
+++ b/packages/db/src/core/cli/commands/execute/index.ts
@@ -2,7 +2,10 @@ import { existsSync } from 'node:fs';
 import type { AstroConfig } from 'astro';
 import type { Arguments } from 'yargs-parser';
 import { FILE_NOT_FOUND_ERROR, MISSING_EXECUTE_PATH_ERROR } from '../../../errors.js';
-import { getStudioVirtualModContents } from '../../../integration/vite-plugin-db.js';
+import {
+	getLocalVirtualModContents,
+	getStudioVirtualModContents,
+} from '../../../integration/vite-plugin-db.js';
 import { bundleFile, importBundledFile } from '../../../load-file.js';
 import { getManagedAppTokenOrExit } from '../../../tokens.js';
 import { type DBConfig } from '../../../types.js';
@@ -28,12 +31,20 @@ export async function cmd({
 		process.exit(1);
 	}
 
-	const appToken = await getManagedAppTokenOrExit(flags.token);
-
-	const virtualModContents = getStudioVirtualModContents({
-		tables: dbConfig.tables ?? {},
-		appToken: appToken.token,
-	});
+	let virtualModContents: string;
+	if (flags.remote) {
+		const appToken = await getManagedAppTokenOrExit(flags.token);
+		virtualModContents = getStudioVirtualModContents({
+			tables: dbConfig.tables ?? {},
+			appToken: appToken.token,
+		});
+	} else {
+		virtualModContents = getLocalVirtualModContents({
+			tables: dbConfig.tables ?? {},
+			root: astroConfig.root,
+			shouldSeed: false,
+		});
+	}
 	const { code } = await bundleFile({ virtualModContents, root: astroConfig.root, fileUrl });
 	// Executable files use top-level await. Importing will run the file.
 	await importBundledFile({ code, root: astroConfig.root });

--- a/packages/db/src/core/cli/commands/shell/index.ts
+++ b/packages/db/src/core/cli/commands/shell/index.ts
@@ -1,23 +1,38 @@
 import type { AstroConfig } from 'astro';
 import { sql } from 'drizzle-orm';
 import type { Arguments } from 'yargs-parser';
-import { createRemoteDatabaseClient } from '../../../../runtime/db-client.js';
+import {
+	createRemoteDatabaseClient,
+	createLocalDatabaseClient,
+} from '../../../../runtime/db-client.js';
 import { getManagedAppTokenOrExit } from '../../../tokens.js';
 import type { DBConfigInput } from '../../../types.js';
 import { getRemoteDatabaseUrl } from '../../../utils.js';
+import { DB_PATH } from '../../../consts.js';
+import { SHELL_QUERY_MISSING_ERROR } from '../../../errors.js';
 
 export async function cmd({
 	flags,
+	astroConfig,
 }: {
 	dbConfig: DBConfigInput;
 	astroConfig: AstroConfig;
 	flags: Arguments;
 }) {
 	const query = flags.query;
-	const appToken = await getManagedAppTokenOrExit(flags.token);
-	const db = createRemoteDatabaseClient(appToken.token, getRemoteDatabaseUrl());
-	// Temporary: create the migration table just in case it doesn't exist
-	const result = await db.run(sql.raw(query));
-	await appToken.destroy();
-	console.log(result);
+	if (!query) {
+		console.error(SHELL_QUERY_MISSING_ERROR);
+		process.exit(1);
+	}
+	if (flags.remote) {
+		const appToken = await getManagedAppTokenOrExit(flags.token);
+		const db = createRemoteDatabaseClient(appToken.token, getRemoteDatabaseUrl());
+		const result = await db.run(sql.raw(query));
+		await appToken.destroy();
+		console.log(result);
+	} else {
+		const db = createLocalDatabaseClient({ dbUrl: new URL(DB_PATH, astroConfig.root).href });
+		const result = await db.run(sql.raw(query));
+		console.log(result);
+	}
 }

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 
 export const PACKAGE_NAME = JSON.parse(
@@ -11,7 +12,7 @@ export const DB_TYPES_FILE = 'db-types.d.ts';
 
 export const VIRTUAL_MODULE_ID = 'astro:db';
 
-export const DB_PATH = '.astro/content.db';
+export const DB_PATH = `.astro/${process.env.TEST_RANDOM_ID ? randomUUID() : 'content.db'}`;
 
 export const CONFIG_FILE_NAMES = ['config.ts', 'config.js', 'config.mts', 'config.mjs'];
 

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -12,7 +12,9 @@ export const DB_TYPES_FILE = 'db-types.d.ts';
 
 export const VIRTUAL_MODULE_ID = 'astro:db';
 
-export const DB_PATH = `.astro/${process.env.TEST_RANDOM_ID ? randomUUID() : 'content.db'}`;
+export const DB_PATH = `.astro/${
+	process.env.ASTRO_TEST_RANDOM_DB_ID ? randomUUID() : 'content.db'
+}`;
 
 export const CONFIG_FILE_NAMES = ['config.ts', 'config.js', 'config.mts', 'config.mjs'];
 

--- a/packages/db/src/core/errors.ts
+++ b/packages/db/src/core/errors.ts
@@ -1,4 +1,4 @@
-import { bold, cyan, green, red, yellow } from 'kleur/colors';
+import { bold, cyan, red } from 'kleur/colors';
 
 export const MISSING_SESSION_ID_ERROR = `${red('▶ Login required!')}
 

--- a/packages/db/src/core/errors.ts
+++ b/packages/db/src/core/errors.ts
@@ -33,6 +33,10 @@ export const RENAME_COLUMN_ERROR = (oldSelector: string, newSelector: string) =>
 export const FILE_NOT_FOUND_ERROR = (path: string) =>
 	`${red('▶ File not found:')} ${bold(path)}\n`;
 
+export const SHELL_QUERY_MISSING_ERROR = `${red(
+	'▶ Please provide a query to execute using the --query flag.'
+)}\n`;
+
 export const SEED_ERROR = (error: string) => {
 	return `${red(`Error while seeding database:`)}\n\n${error}`;
 };

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -42,7 +42,7 @@ function astroDBIntegration(): AstroIntegration {
 
 				let dbPlugin: VitePlugin | undefined = undefined;
 				const args = parseArgs(process.argv.slice(3));
-				connectToStudio = command === 'build' && args['remote'];
+				connectToStudio = args['remote'];
 
 				if (connectToStudio) {
 					appToken = await getManagedAppTokenOrExit();

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -82,7 +82,7 @@ function astroDBIntegration(): AstroIntegration {
 				// TODO: resolve integrations here?
 				tables.get = () => dbConfig.tables ?? {};
 
-				if (!connectToStudio && !process.env.TEST_IN_MEMORY_DB) {
+				if (!connectToStudio) {
 					const dbUrl = new URL(DB_PATH, config.root);
 					if (existsSync(dbUrl)) {
 						await rm(dbUrl);

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -14,6 +14,7 @@ import { fileURLIntegration } from './file-url.js';
 import { typegen } from './typegen.js';
 import { type LateTables, vitePluginDb } from './vite-plugin-db.js';
 import { vitePluginInjectEnvTs } from './vite-plugin-inject-env-ts.js';
+import parseArgs from 'yargs-parser';
 
 function astroDBIntegration(): AstroIntegration {
 	let connectToStudio = false;
@@ -40,7 +41,8 @@ function astroDBIntegration(): AstroIntegration {
 				if (command === 'preview') return;
 
 				let dbPlugin: VitePlugin | undefined = undefined;
-				connectToStudio = command === 'build' && process.argv[3] === '--remote';
+				const args = parseArgs(process.argv.slice(3));
+				connectToStudio = command === 'build' && args['remote'];
 
 				if (connectToStudio) {
 					appToken = await getManagedAppTokenOrExit();

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -5,15 +5,17 @@ import type { AstroIntegration } from 'astro';
 import { mkdir, rm, writeFile } from 'fs/promises';
 import { blue, yellow } from 'kleur/colors';
 import { CONFIG_FILE_NAMES, DB_PATH } from '../consts.js';
-import { loadDbConfigFile } from '../load-file.js';
+import { bundleFile, importBundledFile, loadDbConfigFile } from '../load-file.js';
 import { type ManagedAppToken, getManagedAppTokenOrExit } from '../tokens.js';
 import { type DBConfig, dbConfigSchema } from '../types.js';
 import { type VitePlugin, getDbDirectoryUrl } from '../utils.js';
 import { errorMap } from './error-map.js';
 import { fileURLIntegration } from './file-url.js';
 import { typegen } from './typegen.js';
-import { type LateTables, vitePluginDb } from './vite-plugin-db.js';
+import { type LateTables, vitePluginDb, getLocalVirtualModContents } from './vite-plugin-db.js';
 import { vitePluginInjectEnvTs } from './vite-plugin-inject-env-ts.js';
+import { createLocalDatabaseClient } from '../../runtime/db-client.js';
+import { SEED_FILE_NAMES, recreateTables } from '../../runtime/queries.js';
 
 function astroDBIntegration(): AstroIntegration {
 	let connectToStudio = false;
@@ -57,6 +59,7 @@ function astroDBIntegration(): AstroIntegration {
 						tables,
 						root: config.root,
 						srcDir: config.srcDir,
+						injectSeedImport: command === 'dev',
 					});
 				}
 
@@ -113,6 +116,30 @@ function astroDBIntegration(): AstroIntegration {
 			},
 			'astro:build:start': async ({ logger }) => {
 				logger.info('database: ' + (connectToStudio ? yellow('remote') : blue('local database.')));
+
+				// Load seed file manually for builds instead of bundling.
+				if (!connectToStudio) {
+					let seedFileUrl: URL | undefined;
+					for (const fileName of SEED_FILE_NAMES) {
+						const fileUrl = new URL(fileName, getDbDirectoryUrl(root));
+						if (existsSync(fileUrl)) {
+							seedFileUrl = fileUrl;
+							break;
+						}
+					}
+					if (!seedFileUrl) return;
+
+					await recreateTables({
+						db: createLocalDatabaseClient({ dbUrl: new URL(DB_PATH, root).href }),
+						tables: tables.get() ?? {},
+					});
+					const virtualModContents = getLocalVirtualModContents({
+						tables: tables.get() ?? {},
+						root,
+					});
+					const { code } = await bundleFile({ virtualModContents, root, fileUrl: seedFileUrl });
+					await importBundledFile({ code, root });
+				}
 			},
 			'astro:build:done': async ({}) => {
 				await appToken?.destroy();

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -40,7 +40,7 @@ function astroDBIntegration(): AstroIntegration {
 				if (command === 'preview') return;
 
 				let dbPlugin: VitePlugin | undefined = undefined;
-				connectToStudio = command === 'build';
+				connectToStudio = command === 'build' && process.argv[3] === '--remote';
 
 				if (connectToStudio) {
 					appToken = await getManagedAppTokenOrExit();
@@ -68,6 +68,8 @@ function astroDBIntegration(): AstroIntegration {
 				});
 			},
 			'astro:config:done': async ({ config }) => {
+				if (command === 'preview') return;
+
 				// TODO: refine where we load tables
 				// @matthewp: may want to load tables by path at runtime
 				const { mod, dependencies } = await loadDbConfigFile(config.root);

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -1,10 +1,17 @@
 import { fileURLToPath } from 'node:url';
 import { normalizePath } from 'vite';
-import { SEED_DEV_FILE_NAME, recreateTables } from '../../runtime/queries.js';
+import {
+	SEED_DEV_FILE_NAME,
+	getCreateIndexQueries,
+	getCreateTableQuery,
+} from '../../runtime/queries.js';
 import { DB_PATH, RUNTIME_CONFIG_IMPORT, RUNTIME_IMPORT, VIRTUAL_MODULE_ID } from '../consts.js';
 import type { DBTables } from '../types.js';
 import { type VitePlugin, getDbDirectoryUrl, getRemoteDatabaseUrl } from '../utils.js';
 import { createLocalDatabaseClient } from '../../runtime/db-client.js';
+import { type SQL, sql } from 'drizzle-orm';
+import type { SqliteDB } from '../../runtime/index.js';
+import { SQLiteAsyncDialect } from 'drizzle-orm/sqlite-core';
 
 const WITH_SEED_VIRTUAL_MODULE_ID = 'astro:db:seed';
 
@@ -143,4 +150,20 @@ function getStringifiedCollectionExports(tables: DBTables) {
 				)}, false)`
 		)
 		.join('\n');
+}
+
+const sqlite = new SQLiteAsyncDialect();
+
+async function recreateTables({ db, tables }: { db: SqliteDB; tables: DBTables }) {
+	const setupQueries: SQL[] = [];
+	for (const [name, table] of Object.entries(tables)) {
+		const dropQuery = sql.raw(`DROP TABLE IF EXISTS ${sqlite.escapeName(name)}`);
+		const createQuery = sql.raw(getCreateTableQuery(name, table));
+		const indexQueries = getCreateIndexQueries(name, table);
+		setupQueries.push(dropQuery, createQuery, ...indexQueries.map((s) => sql.raw(s)));
+	}
+	await db.batch([
+		db.run(sql`pragma defer_foreign_keys=true;`),
+		...setupQueries.map((q) => db.run(q)),
+	]);
 }

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -108,12 +108,19 @@ export function getLocalVirtualModContents({
 
 	const dbUrl = new URL(DB_PATH, root);
 	return `
-import { asDrizzleTable } from ${RUNTIME_IMPORT};
-import { createLocalDatabaseClient } from ${RUNTIME_IMPORT};
+import { asDrizzleTable, createLocalDatabaseClient } from ${RUNTIME_IMPORT};
+${shouldSeed ? `import { seedLocal } from ${RUNTIME_IMPORT};` : ''}
+
 const dbUrl = ${JSON.stringify(dbUrl)};
 export const db = createLocalDatabaseClient({ dbUrl });
 
-${shouldSeed ? `import.meta.glob(${JSON.stringify(seedFilePaths)}, { eager: true });` : ''}
+${
+	shouldSeed
+		? `await seedLocal({
+	fileGlob: import.meta.glob(${JSON.stringify(seedFilePaths)}, { eager: true }),
+});`
+		: ''
+}
 
 export * from ${RUNTIME_CONFIG_IMPORT};
 

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -1,10 +1,17 @@
 import { fileURLToPath } from 'node:url';
 import { normalizePath } from 'vite';
-import { SEED_DEV_FILE_NAME, recreateTables } from '../../runtime/queries.js';
+import {
+	SEED_DEV_FILE_NAME,
+	getCreateIndexQueries,
+	getCreateTableQuery,
+} from '../../runtime/queries.js';
 import { DB_PATH, RUNTIME_CONFIG_IMPORT, RUNTIME_IMPORT, VIRTUAL_MODULE_ID } from '../consts.js';
 import type { DBTables } from '../types.js';
 import { type VitePlugin, getDbDirectoryUrl, getRemoteDatabaseUrl } from '../utils.js';
 import { createLocalDatabaseClient } from '../../runtime/db-client.js';
+import type { SqliteDB } from '../../runtime/index.js';
+import { sql, type SQL } from 'drizzle-orm';
+import { SQLiteAsyncDialect } from 'drizzle-orm/sqlite-core';
 
 const LOCAL_DB_VIRTUAL_MODULE_ID = 'astro:local';
 const WITH_SEED_VIRTUAL_MODULE_ID = 'astro:db:seed';
@@ -152,4 +159,20 @@ function getStringifiedCollectionExports(tables: DBTables) {
 				)}, false)`
 		)
 		.join('\n');
+}
+
+const sqlite = new SQLiteAsyncDialect();
+
+async function recreateTables({ db, tables }: { db: SqliteDB; tables: DBTables }) {
+	const setupQueries: SQL[] = [];
+	for (const [name, table] of Object.entries(tables)) {
+		const dropQuery = sql.raw(`DROP TABLE IF EXISTS ${sqlite.escapeName(name)}`);
+		const createQuery = sql.raw(getCreateTableQuery(name, table));
+		const indexQueries = getCreateIndexQueries(name, table);
+		setupQueries.push(dropQuery, createQuery, ...indexQueries.map((s) => sql.raw(s)));
+	}
+	await db.batch([
+		db.run(sql`pragma defer_foreign_keys=true;`),
+		...setupQueries.map((q) => db.run(q)),
+	]);
 }

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -62,8 +62,15 @@ export function vitePluginDb(params: VitePluginDBParams): VitePlugin {
 				const dbUrl = new URL(DB_PATH, params.root);
 				return `import { createLocalDatabaseClient } from ${RUNTIME_IMPORT};
 				const dbUrl = ${JSON.stringify(dbUrl)};
-
-				export const db = createLocalDatabaseClient({ dbUrl });`;
+				export const db = createLocalDatabaseClient({ dbUrl });
+				${
+					// Recreate tables in-memory to access correct memory db
+					process.env.TEST_IN_MEMORY_DB
+						? `import { recreateTables } from ${RUNTIME_IMPORT};
+				console.log('in memory db')
+				await recreateTables({ db, tables: ${JSON.stringify(params.tables.get() ?? {})} })`
+						: ''
+				}`;
 			}
 
 			// Recreate tables whenever a seed file is loaded.

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -1,17 +1,10 @@
 import { fileURLToPath } from 'node:url';
 import { normalizePath } from 'vite';
-import {
-	SEED_DEV_FILE_NAME,
-	getCreateIndexQueries,
-	getCreateTableQuery,
-} from '../../runtime/queries.js';
+import { SEED_DEV_FILE_NAME, recreateTables } from '../../runtime/queries.js';
 import { DB_PATH, RUNTIME_CONFIG_IMPORT, RUNTIME_IMPORT, VIRTUAL_MODULE_ID } from '../consts.js';
 import type { DBTables } from '../types.js';
 import { type VitePlugin, getDbDirectoryUrl, getRemoteDatabaseUrl } from '../utils.js';
 import { createLocalDatabaseClient } from '../../runtime/db-client.js';
-import type { SqliteDB } from '../../runtime/index.js';
-import { sql, type SQL } from 'drizzle-orm';
-import { SQLiteAsyncDialect } from 'drizzle-orm/sqlite-core';
 
 const LOCAL_DB_VIRTUAL_MODULE_ID = 'astro:local';
 const WITH_SEED_VIRTUAL_MODULE_ID = 'astro:db:seed';
@@ -159,20 +152,4 @@ function getStringifiedCollectionExports(tables: DBTables) {
 				)}, false)`
 		)
 		.join('\n');
-}
-
-const sqlite = new SQLiteAsyncDialect();
-
-async function recreateTables({ db, tables }: { db: SqliteDB; tables: DBTables }) {
-	const setupQueries: SQL[] = [];
-	for (const [name, table] of Object.entries(tables)) {
-		const dropQuery = sql.raw(`DROP TABLE IF EXISTS ${sqlite.escapeName(name)}`);
-		const createQuery = sql.raw(getCreateTableQuery(name, table));
-		const indexQueries = getCreateIndexQueries(name, table);
-		setupQueries.push(dropQuery, createQuery, ...indexQueries.map((s) => sql.raw(s)));
-	}
-	await db.batch([
-		db.run(sql`pragma defer_foreign_keys=true;`),
-		...setupQueries.map((q) => db.run(q)),
-	]);
 }

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -1,15 +1,19 @@
 import { fileURLToPath } from 'node:url';
 import { normalizePath } from 'vite';
-import { SEED_DEV_FILE_NAME } from '../../runtime/queries.js';
+import { SEED_DEV_FILE_NAME, recreateTables } from '../../runtime/queries.js';
 import { DB_PATH, RUNTIME_CONFIG_IMPORT, RUNTIME_IMPORT, VIRTUAL_MODULE_ID } from '../consts.js';
 import type { DBTables } from '../types.js';
 import { type VitePlugin, getDbDirectoryUrl, getRemoteDatabaseUrl } from '../utils.js';
+import { createLocalDatabaseClient } from '../../runtime/db-client.js';
 
 const LOCAL_DB_VIRTUAL_MODULE_ID = 'astro:local';
+const WITH_SEED_VIRTUAL_MODULE_ID = 'astro:db:seed';
 
-const resolvedVirtualModuleId = '\0' + VIRTUAL_MODULE_ID;
-const resolvedLocalDbVirtualModuleId = LOCAL_DB_VIRTUAL_MODULE_ID + '/local-db';
-const resolvedSeedVirtualModuleId = '\0' + VIRTUAL_MODULE_ID + '?shouldSeed';
+const resolved = {
+	localDb: '\0' + LOCAL_DB_VIRTUAL_MODULE_ID,
+	virtual: '\0' + VIRTUAL_MODULE_ID,
+	seedVirtual: '\0' + WITH_SEED_VIRTUAL_MODULE_ID,
+};
 
 export type LateTables = {
 	get: () => DBTables;
@@ -32,26 +36,29 @@ type VitePluginDBParams =
 
 export function vitePluginDb(params: VitePluginDBParams): VitePlugin {
 	const srcDirPath = normalizePath(fileURLToPath(params.srcDir));
+	const seedFilePaths = SEED_DEV_FILE_NAME.map((name) =>
+		normalizePath(fileURLToPath(new URL(name, getDbDirectoryUrl(params.root))))
+	);
 	return {
 		name: 'astro:db',
 		enforce: 'pre',
 		async resolveId(id, rawImporter) {
-			if (id === LOCAL_DB_VIRTUAL_MODULE_ID) return resolvedLocalDbVirtualModuleId;
+			if (id === LOCAL_DB_VIRTUAL_MODULE_ID) return resolved.localDb;
 			if (id !== VIRTUAL_MODULE_ID) return;
-			if (params.connectToStudio) return resolvedVirtualModuleId;
+			if (params.connectToStudio) return resolved.virtual;
 
 			const importer = rawImporter ? await this.resolve(rawImporter) : null;
-			if (!importer) return resolvedVirtualModuleId;
+			if (!importer) return resolved.virtual;
 
 			if (importer.id.startsWith(srcDirPath)) {
 				// Seed only if the importer is in the src directory.
 				// Otherwise, we may get recursive seed calls (ex. import from db/seed.ts).
-				return resolvedSeedVirtualModuleId;
+				return resolved.seedVirtual;
 			}
-			return resolvedVirtualModuleId;
+			return resolved.virtual;
 		},
-		load(id) {
-			if (id === resolvedLocalDbVirtualModuleId) {
+		async load(id) {
+			if (id === resolved.localDb) {
 				const dbUrl = new URL(DB_PATH, params.root);
 				return `import { createLocalDatabaseClient } from ${RUNTIME_IMPORT};
 				const dbUrl = ${JSON.stringify(dbUrl)};
@@ -59,7 +66,15 @@ export function vitePluginDb(params: VitePluginDBParams): VitePlugin {
 				export const db = createLocalDatabaseClient({ dbUrl });`;
 			}
 
-			if (id !== resolvedVirtualModuleId && id !== resolvedSeedVirtualModuleId) return;
+			// Recreate tables whenever a seed file is loaded.
+			if (seedFilePaths.some((f) => id === f)) {
+				await recreateTables({
+					db: createLocalDatabaseClient({ dbUrl: new URL(DB_PATH, params.root).href }),
+					tables: params.tables.get(),
+				});
+			}
+
+			if (id !== resolved.virtual && id !== resolved.seedVirtual) return;
 
 			if (params.connectToStudio) {
 				return getStudioVirtualModContents({
@@ -70,7 +85,7 @@ export function vitePluginDb(params: VitePluginDBParams): VitePlugin {
 			return getLocalVirtualModContents({
 				root: params.root,
 				tables: params.tables.get(),
-				shouldSeed: id === resolvedSeedVirtualModuleId,
+				shouldSeed: id === resolved.seedVirtual,
 			});
 		},
 	};
@@ -95,20 +110,12 @@ export function getLocalVirtualModContents({
 	);
 
 	return `
-import { asDrizzleTable, seedLocal } from ${RUNTIME_IMPORT};
+import { asDrizzleTable } from ${RUNTIME_IMPORT};
 import { db as _db } from ${JSON.stringify(LOCAL_DB_VIRTUAL_MODULE_ID)};
 
 export const db = _db;
 
-${
-	shouldSeed
-		? `await seedLocal({
-	db: _db,
-	tables: ${JSON.stringify(tables)},
-	fileGlob: import.meta.glob(${JSON.stringify(seedFilePaths)}),
-})`
-		: ''
-}
+${shouldSeed ? `import.meta.glob(${JSON.stringify(seedFilePaths)}, { eager: true });` : ''}
 
 export * from ${RUNTIME_CONFIG_IMPORT};
 

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -59,18 +59,12 @@ export function vitePluginDb(params: VitePluginDBParams): VitePlugin {
 		},
 		async load(id) {
 			if (id === resolved.localDb) {
+				// Split db creation to a separate module to
+				// share a connection across modules (namely astro:db and astro:db:seed)
 				const dbUrl = new URL(DB_PATH, params.root);
 				return `import { createLocalDatabaseClient } from ${RUNTIME_IMPORT};
 				const dbUrl = ${JSON.stringify(dbUrl)};
-				export const db = createLocalDatabaseClient({ dbUrl });
-				${
-					// Recreate tables in-memory to access correct memory db
-					process.env.TEST_IN_MEMORY_DB
-						? `import { recreateTables } from ${RUNTIME_IMPORT};
-				console.log('in memory db')
-				await recreateTables({ db, tables: ${JSON.stringify(params.tables.get() ?? {})} })`
-						: ''
-				}`;
+				export const db = createLocalDatabaseClient({ dbUrl });`;
 			}
 
 			// Recreate tables whenever a seed file is loaded.

--- a/packages/db/src/runtime/db-client.ts
+++ b/packages/db/src/runtime/db-client.ts
@@ -9,7 +9,7 @@ const isWebContainer = !!process.versions?.webcontainer;
 
 export function createLocalDatabaseClient({ dbUrl }: { dbUrl: string }): LibSQLDatabase {
 	const url = isWebContainer ? 'file:content.db' : dbUrl;
-	const client = createClient({ url: process.env.TEST_IN_MEMORY_DB ? ':memory:' : url });
+	const client = createClient({ url });
 	const db = drizzleLibsql(client);
 
 	return db;

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -16,7 +16,6 @@ export { sql };
 export type SqliteDB = LibSQLDatabase;
 export type { Table } from './types.js';
 export { createRemoteDatabaseClient, createLocalDatabaseClient } from './db-client.js';
-export { seedLocal } from './queries.js';
 
 export function hasPrimaryKey(column: DBColumn) {
 	return 'primaryKey' in column.schema && !!column.schema.primaryKey;

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -11,11 +11,36 @@ import {
 } from 'drizzle-orm/sqlite-core';
 import { type DBColumn, type DBTable } from '../core/types.js';
 import { type SerializedSQL, isSerializedSQL } from './types.js';
+import { SEED_DEFAULT_EXPORT_ERROR, SEED_ERROR } from '../core/errors.js';
+import { LibsqlError } from '@libsql/client';
 
 export { sql };
 export type SqliteDB = LibSQLDatabase;
 export type { Table } from './types.js';
 export { createRemoteDatabaseClient, createLocalDatabaseClient } from './db-client.js';
+
+export async function seedLocal({
+	// Glob all potential seed files to catch renames and deletions.
+	fileGlob,
+}: {
+	fileGlob: Record<string, { default?: () => Promise<void> }>;
+}) {
+	const seedFilePath = Object.keys(fileGlob)[0];
+	if (!seedFilePath) return;
+	const mod = fileGlob[seedFilePath];
+
+	if (!mod.default) {
+		throw new Error(SEED_DEFAULT_EXPORT_ERROR(seedFilePath));
+	}
+	try {
+		await mod.default();
+	} catch (e) {
+		if (e instanceof LibsqlError) {
+			throw new Error(SEED_ERROR(e.message));
+		}
+		throw e;
+	}
+}
 
 export function hasPrimaryKey(column: DBColumn) {
 	return 'primaryKey' in column.schema && !!column.schema.primaryKey;

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -16,6 +16,8 @@ export { sql };
 export type SqliteDB = LibSQLDatabase;
 export type { Table } from './types.js';
 export { createRemoteDatabaseClient, createLocalDatabaseClient } from './db-client.js';
+// only used for in-memory db in test fixtures
+export { recreateTables } from './queries.js';
 
 export function hasPrimaryKey(column: DBColumn) {
 	return 'primaryKey' in column.schema && !!column.schema.primaryKey;

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -16,8 +16,6 @@ export { sql };
 export type SqliteDB = LibSQLDatabase;
 export type { Table } from './types.js';
 export { createRemoteDatabaseClient, createLocalDatabaseClient } from './db-client.js';
-// only used for in-memory db in test fixtures
-export { recreateTables } from './queries.js';
 
 export function hasPrimaryKey(column: DBColumn) {
 	return 'primaryKey' in column.schema && !!column.schema.primaryKey;

--- a/packages/db/src/runtime/queries.ts
+++ b/packages/db/src/runtime/queries.ts
@@ -6,8 +6,6 @@ import {
 	FOREIGN_KEY_REFERENCES_EMPTY_ERROR,
 	FOREIGN_KEY_REFERENCES_LENGTH_ERROR,
 	REFERENCE_DNE_ERROR,
-	SEED_DEFAULT_EXPORT_ERROR,
-	SEED_ERROR,
 } from '../core/errors.js';
 import type {
 	BooleanColumn,
@@ -21,36 +19,10 @@ import type {
 } from '../core/types.js';
 import { hasPrimaryKey } from './index.js';
 import { isSerializedSQL } from './types.js';
-import { LibsqlError } from '@libsql/client';
 
 const sqlite = new SQLiteAsyncDialect();
 
 export const SEED_DEV_FILE_NAME = ['seed.ts', 'seed.js', 'seed.mjs', 'seed.mts'];
-
-export async function seedLocal({
-	// Glob all potential seed files to catch renames and deletions.
-	fileGlob,
-}: {
-	fileGlob: Record<string, () => Promise<{ default?: () => Promise<void> }>>;
-}) {
-	for (const fileName of SEED_DEV_FILE_NAME) {
-		const key = Object.keys(fileGlob).find((f) => f.endsWith(fileName));
-		if (key) {
-			try {
-				const mod = await fileGlob[key]();
-				if (!mod.default) {
-					throw new Error(SEED_DEFAULT_EXPORT_ERROR(key));
-				}
-				await mod.default();
-			} catch (e) {
-				if (e instanceof LibsqlError) {
-					throw new Error(SEED_ERROR(e.message));
-				}
-				throw e;
-			}
-			break;
-		}
-	}
 
 export function getDropTableIfExistsQuery(tableName: string) {
 	return `DROP TABLE IF EXISTS ${sqlite.escapeName(tableName)}`;

--- a/packages/db/src/runtime/queries.ts
+++ b/packages/db/src/runtime/queries.ts
@@ -26,7 +26,7 @@ import { isSerializedSQL } from './types.js';
 
 const sqlite = new SQLiteAsyncDialect();
 
-export const SEED_FILE_NAMES = ['seed.ts', 'seed.js', 'seed.mjs', 'seed.mts'];
+export const SEED_DEV_FILE_NAME = ['seed.ts', 'seed.js', 'seed.mjs', 'seed.mts'];
 
 export async function seedLocal({
 	db,
@@ -39,7 +39,7 @@ export async function seedLocal({
 	fileGlob: Record<string, () => Promise<{ default?: () => Promise<void> }>>;
 }) {
 	await recreateTables({ db, tables });
-	for (const fileName of SEED_FILE_NAMES) {
+	for (const fileName of SEED_DEV_FILE_NAME) {
 		const key = Object.keys(fileGlob).find((f) => f.endsWith(fileName));
 		if (key) {
 			try {

--- a/packages/db/src/runtime/queries.ts
+++ b/packages/db/src/runtime/queries.ts
@@ -1,4 +1,3 @@
-import { LibsqlError } from '@libsql/client';
 import { type SQL, sql } from 'drizzle-orm';
 import { SQLiteAsyncDialect } from 'drizzle-orm/sqlite-core';
 import { bold } from 'kleur/colors';
@@ -23,6 +22,7 @@ import type {
 } from '../core/types.js';
 import { type SqliteDB, hasPrimaryKey } from './index.js';
 import { isSerializedSQL } from './types.js';
+import { LibsqlError } from '@libsql/client';
 
 const sqlite = new SQLiteAsyncDialect();
 

--- a/packages/db/src/runtime/queries.ts
+++ b/packages/db/src/runtime/queries.ts
@@ -26,7 +26,7 @@ import { isSerializedSQL } from './types.js';
 
 const sqlite = new SQLiteAsyncDialect();
 
-export const SEED_DEV_FILE_NAME = ['seed.ts', 'seed.js', 'seed.mjs', 'seed.mts'];
+export const SEED_FILE_NAMES = ['seed.ts', 'seed.js', 'seed.mjs', 'seed.mts'];
 
 export async function seedLocal({
 	db,
@@ -39,7 +39,7 @@ export async function seedLocal({
 	fileGlob: Record<string, () => Promise<{ default?: () => Promise<void> }>>;
 }) {
 	await recreateTables({ db, tables });
-	for (const fileName of SEED_DEV_FILE_NAME) {
+	for (const fileName of SEED_FILE_NAMES) {
 		const key = Object.keys(fileGlob).find((f) => f.endsWith(fileName));
 		if (key) {
 			try {

--- a/packages/db/test/basics.test.js
+++ b/packages/db/test/basics.test.js
@@ -21,7 +21,6 @@ describe('astro:db', () => {
 		let devServer;
 
 		before(async () => {
-			console.log('starting dev server');
 			devServer = await fixture.startDevServer();
 		});
 

--- a/packages/db/test/basics.test.js
+++ b/packages/db/test/basics.test.js
@@ -16,7 +16,7 @@ describe('astro:db', () => {
 	// Note(bholmesdev): Use in-memory db to avoid
 	// Multiple dev servers trying to unlink and remount
 	// the same database file.
-	process.env.TEST_IN_MEMORY_DB = 'true';
+	process.env.TEST_RANDOM_ID = 'true';
 	describe('development', () => {
 		let devServer;
 
@@ -27,7 +27,7 @@ describe('astro:db', () => {
 
 		after(async () => {
 			await devServer.stop();
-			process.env.TEST_IN_MEMORY_DB = undefined;
+			process.env.TEST_RANDOM_ID = undefined;
 		});
 
 		it('Prints the list of authors', async () => {

--- a/packages/db/test/basics.test.js
+++ b/packages/db/test/basics.test.js
@@ -13,10 +13,10 @@ describe('astro:db', () => {
 		});
 	});
 
-	// Note(bholmesdev): Use in-memory db to avoid
-	// Multiple dev servers trying to unlink and remount
-	// the same database file.
-	process.env.TEST_RANDOM_ID = 'true';
+	// Note (@bholmesdev) generate a random database id on startup.
+	// Ensures database connections don't conflict
+	// when multiple dev servers are run in parallel on the same project.
+	process.env.ASTRO_TEST_RANDOM_DB_ID = 'true';
 	describe('development', () => {
 		let devServer;
 
@@ -27,7 +27,7 @@ describe('astro:db', () => {
 
 		after(async () => {
 			await devServer.stop();
-			process.env.TEST_RANDOM_ID = undefined;
+			process.env.ASTRO_TEST_RANDOM_DB_ID = undefined;
 		});
 
 		it('Prints the list of authors', async () => {

--- a/packages/db/test/fixtures/ticketing-example/db/config.ts
+++ b/packages/db/test/fixtures/ticketing-example/db/config.ts
@@ -10,8 +10,6 @@ const Event = defineTable({
 		ticketPrice: column.number(),
 		date: column.date(),
 		location: column.text(),
-		author3: column.text(),
-		author4: column.text(),
 	},
 });
 


### PR DESCRIPTION
## Changes

Require the `--remote` flag to dev or build with a studio connection. Use a local db with local seeding for standard `astro build` call.

- Add `--remote` check to dev and build
- Add `--remote` support to `shell` and `execute`
- Move table recreation from runtime to buildtime. Prevents build hanging failure and unblocks SSR app usage
- Refactor in-memory databases to a generate db hash. Solves the clobbering problem and remove all special logic for in-memory data
- Misc: remove bad `author3` and `author4` config in ticketing example

## Testing

- Add in-memory db patch for seeding to ensure tests still run

## Docs

https://docs-git-sarah-patch-6-astrodotbuild.vercel.app/en/guides/astro-db/#production-builds