### PR TITLE
Fix an issue where `getCollection` might return `undefined`

### DIFF
--- a/.changeset/polite-bats-smile.md
+++ b/.changeset/polite-bats-smile.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where `getCollection` might return `undefined` when content collection is empty

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -66,7 +66,7 @@ export function createGetCollection({
 					collection
 				)} does not exist or is empty. Ensure a collection directory with this name exists.`
 			);
-			return;
+			return [];
 		}
 		const lazyImports = Object.values(
 			type === 'content'

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -261,7 +261,7 @@ describe('Content Collections', () => {
 	});
 
 	describe('With empty collections directory', () => {
-		it('Handles the empty directory correclty', async () => {
+		it('Handles the empty directory correctly', async () => {
 			const fixture = await loadFixture({
 				root: './fixtures/content-collections-empty-dir/',
 			});
@@ -272,7 +272,12 @@ describe('Content Collections', () => {
 				error = e.message;
 			}
 			assert.equal(error, undefined);
-			// TODO: try to render a page
+
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			const h1 = $('h1');
+			assert.equal(h1.text(), 'Entries length: 0');
+			assert.equal(h1.attr('data-entries'), '[]');
 		});
 	});
 

--- a/packages/astro/test/fixtures/content-collections-empty-dir/src/pages/index.astro
+++ b/packages/astro/test/fixtures/content-collections-empty-dir/src/pages/index.astro
@@ -1,8 +1,7 @@
 ---
 import { getCollection } from 'astro:content'
 
-const blogs =  await getCollection("blogs")
-// console.log(blogs)
+const entries = await getCollection('blogs');
 ---
 
-<p>This should still render</p>
+<h1 data-entries={JSON.stringify(entries)}>Entries length: {entries.length}</h1>


### PR DESCRIPTION
## Changes

- Fixes an issue where `getCollection` might return `undefined` when content collection is empty
- Closes #8999

## Testing

- A related test case in `packages/astro/test/content-collections.test.js` is updated

## Docs

- N/A