### PR TITLE
Fix: drizzle vs. config runtime export conflict

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -20,10 +20,6 @@
       "types": "./dist/runtime/index.d.ts",
       "import": "./dist/runtime/index.js"
     },
-    "./runtime/drizzle": {
-      "types": "./dist/runtime/drizzle.d.ts",
-      "import": "./dist/runtime/drizzle.js"
-    },
     "./runtime/config": {
       "types": "./dist/runtime/config.d.ts",
       "import": "./dist/runtime/config.js"
@@ -40,9 +36,6 @@
       ],
       "runtime": [
         "./dist/runtime/index.d.ts"
-      ],
-      "runtime/drizzle": [
-        "./dist/runtime/drizzle.d.ts"
       ],
       "runtime/config": [
         "./dist/runtime/config.d.ts"

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -5,7 +5,6 @@ export const PACKAGE_NAME = JSON.parse(
 ).name;
 
 export const RUNTIME_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime`);
-export const RUNTIME_DRIZZLE_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime/drizzle`);
 export const RUNTIME_CONFIG_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime/config`);
 
 export const DB_TYPES_FILE = 'db-types.d.ts';

--- a/packages/db/src/core/integration/typegen.ts
+++ b/packages/db/src/core/integration/typegen.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
-import { DB_TYPES_FILE, RUNTIME_DRIZZLE_IMPORT, RUNTIME_IMPORT } from '../consts.js';
+import { DB_TYPES_FILE, RUNTIME_CONFIG_IMPORT, RUNTIME_IMPORT } from '../consts.js';
 import type { DBTable, DBTables } from '../types.js';
 
 export async function typegen({ tables, root }: { tables: DBTables; root: URL }) {
@@ -8,7 +8,7 @@ export async function typegen({ tables, root }: { tables: DBTables; root: URL })
 declare module 'astro:db' {
 	export const db: import(${RUNTIME_IMPORT}).SqliteDB;
 	export const dbUrl: string;
-	export * from ${RUNTIME_DRIZZLE_IMPORT};
+	export * from ${RUNTIME_CONFIG_IMPORT};
 
 ${Object.entries(tables)
 	.map(([name, collection]) => generateTableType(name, collection))

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -1,13 +1,7 @@
 import { fileURLToPath } from 'node:url';
 import { normalizePath } from 'vite';
 import { SEED_DEV_FILE_NAME } from '../../runtime/queries.js';
-import {
-	DB_PATH,
-	RUNTIME_CONFIG_IMPORT,
-	RUNTIME_DRIZZLE_IMPORT,
-	RUNTIME_IMPORT,
-	VIRTUAL_MODULE_ID,
-} from '../consts.js';
+import { DB_PATH, RUNTIME_CONFIG_IMPORT, RUNTIME_IMPORT, VIRTUAL_MODULE_ID } from '../consts.js';
 import type { DBTables } from '../types.js';
 import { type VitePlugin, getDbDirectoryUrl, getRemoteDatabaseUrl } from '../utils.js';
 
@@ -116,7 +110,6 @@ ${
 		: ''
 }
 
-export * from ${RUNTIME_DRIZZLE_IMPORT};
 export * from ${RUNTIME_CONFIG_IMPORT};
 
 ${getStringifiedCollectionExports(tables)}`;
@@ -136,7 +129,7 @@ export const db = await createRemoteDatabaseClient(${JSON.stringify(
 		appToken
 		// Respect runtime env for user overrides in SSR
 	)}, import.meta.env.ASTRO_STUDIO_REMOTE_DB_URL ?? ${JSON.stringify(getRemoteDatabaseUrl())});
-export * from ${RUNTIME_DRIZZLE_IMPORT};
+
 export * from ${RUNTIME_CONFIG_IMPORT};
 
 ${getStringifiedCollectionExports(tables)}

--- a/packages/db/src/runtime/config.ts
+++ b/packages/db/src/runtime/config.ts
@@ -45,4 +45,29 @@ export function defineDB(userConfig: DBConfigInput) {
 	return userConfig;
 }
 
-export { sql, NOW, TRUE, FALSE } from './index.js';
+export { NOW, TRUE, FALSE } from './index.js';
+
+export {
+	sql,
+	eq,
+	gt,
+	gte,
+	lt,
+	lte,
+	ne,
+	isNull,
+	isNotNull,
+	inArray,
+	notInArray,
+	exists,
+	notExists,
+	between,
+	notBetween,
+	like,
+	notIlike,
+	not,
+	asc,
+	desc,
+	and,
+	or,
+} from 'drizzle-orm';


### PR DESCRIPTION
## Changes

@ElianCodes found a bundling issue where `sql` is exported by both the `drizzle` and `config` files. This causes an ambiguity error during production builds.
- Flatten to a single `config` export
- Remove `drizzle` export

## Testing

Tested on Elian (private) repo to ensure build issue is resolved

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
