### PR TITLE
fix(config): prevent vite from loading config

### DIFF
--- a/.changeset/khaki-emus-wait.md
+++ b/.changeset/khaki-emus-wait.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Instruct vite to not look for an external vite config file when creating a server
+Fixes an issue where some CLI commands attempted to directly read vite config files.

--- a/.changeset/khaki-emus-wait.md
+++ b/.changeset/khaki-emus-wait.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Instruct vite to not look for an external vite config file when creating a server

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -6,6 +6,7 @@ import { debug } from '../logger/core.js';
 
 async function createViteServer(root: string, fs: typeof fsType): Promise<ViteDevServer> {
 	const viteServer = await createServer({
+		configFile: false /* prevent vite from trying to discover a vite conf file */,
 		server: { middlewareMode: true, hmr: false, watch: null },
 		optimizeDeps: { noDiscovery: true },
 		clearScreen: false,

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -6,7 +6,7 @@ import { debug } from '../logger/core.js';
 
 async function createViteServer(root: string, fs: typeof fsType): Promise<ViteDevServer> {
 	const viteServer = await createServer({
-		configFile: false /* prevent vite from trying to discover a vite conf file */,
+		configFile: false,
 		server: { middlewareMode: true, hmr: false, watch: null },
 		optimizeDeps: { noDiscovery: true },
 		clearScreen: false,


### PR DESCRIPTION
Fixes #10262

## Changes


This fixes an issue where creating a vite server (to e.g. load a TypeScript astro config) would trigger vite to look up and load an unrelated vite config (potentially going up directories).

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

This has not been tested because I'm not familiar with the astro testing setup...

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This fixes an unexpected side effect of loading a TypeScript config. Since this is the expected behavior, it might not require documentation.