### PR TITLE
Rename `defineDB` to `defineDb`

### DIFF
--- a/.changeset/wet-kiwis-laugh.md
+++ b/.changeset/wet-kiwis-laugh.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/db": minor
+"astro": patch
+---
+
+Renames the `defineDB()` helper to `defineDb()`

--- a/.changeset/wet-kiwis-laugh.md
+++ b/.changeset/wet-kiwis-laugh.md
@@ -3,4 +3,6 @@
 "astro": patch
 ---
 
-Renames the `defineDB()` helper to `defineDb()`
+Renames the Astro DB `defineDB()` helper to `defineDb()`
+
+⚠️ Breaking change: update your imports from `astro:db` to use `defineDb` with a lowercase “b”.

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -71,10 +71,10 @@ export default {
 public-hoist-pattern[]=*lit*
 `,
 	DB_CONFIG: `\
-import { defineDB } from 'astro:db';
+import { defineDb } from 'astro:db';
 
 // https://astro.build/db/config
-export default defineDB({
+export default defineDb({
   tables: {}
 });
 `,

--- a/packages/db/src/runtime/config.ts
+++ b/packages/db/src/runtime/config.ts
@@ -41,7 +41,7 @@ export function defineTable<TColumns extends ColumnsConfig>(userConfig: TableCon
 	return userConfig;
 }
 
-export function defineDB(userConfig: DBConfigInput) {
+export function defineDb(userConfig: DBConfigInput) {
 	return userConfig;
 }
 

--- a/packages/db/test/fixtures/basics/db/config.ts
+++ b/packages/db/test/fixtures/basics/db/config.ts
@@ -1,5 +1,5 @@
 import { Themes } from './theme';
-import { column, defineDB, defineTable } from 'astro:db';
+import { column, defineDb, defineTable } from 'astro:db';
 
 const Author = defineTable({
 	columns: {
@@ -8,6 +8,6 @@ const Author = defineTable({
 	},
 });
 
-export default defineDB({
+export default defineDb({
 	tables: { Author, Themes },
 });

--- a/packages/db/test/fixtures/integrations/db/config.ts
+++ b/packages/db/test/fixtures/integrations/db/config.ts
@@ -1,4 +1,4 @@
-import { column, defineDB, defineTable } from 'astro:db';
+import { column, defineDb, defineTable } from 'astro:db';
 
 const Author = defineTable({
 	columns: {
@@ -7,6 +7,6 @@ const Author = defineTable({
 	},
 });
 
-export default defineDB({
+export default defineDb({
 	tables: { Author },
 });

--- a/packages/db/test/fixtures/integrations/integration/config.ts
+++ b/packages/db/test/fixtures/integrations/integration/config.ts
@@ -1,7 +1,7 @@
 import { menu } from './shared';
-import { defineDB } from 'astro:db';
+import { defineDb } from 'astro:db';
 
-export default defineDB({
+export default defineDb({
 	tables: {
 		menu,
 	},

--- a/packages/db/test/fixtures/recipes/db/config.ts
+++ b/packages/db/test/fixtures/recipes/db/config.ts
@@ -1,4 +1,4 @@
-import { column, defineDB, defineTable } from 'astro:db';
+import { column, defineDb, defineTable } from 'astro:db';
 
 const Recipe = defineTable({
 	columns: {
@@ -21,6 +21,6 @@ const Ingredient = defineTable({
 	foreignKeys: [{ columns: 'recipeId', references: () => [Recipe.columns.id] }],
 });
 
-export default defineDB({
+export default defineDb({
 	tables: { Recipe, Ingredient },
 });

--- a/packages/db/test/fixtures/ticketing-example/db/config.ts
+++ b/packages/db/test/fixtures/ticketing-example/db/config.ts
@@ -1,4 +1,4 @@
-import { column, defineDB, defineTable } from 'astro:db';
+import { column, defineDb, defineTable } from 'astro:db';
 
 const Event = defineTable({
 	columns: {
@@ -24,4 +24,4 @@ const Ticket = defineTable({
 	},
 });
 
-export default defineDB({ tables: { Event, Ticket } });
+export default defineDb({ tables: { Event, Ticket } });

--- a/packages/db/virtual.d.ts
+++ b/packages/db/virtual.d.ts
@@ -4,6 +4,6 @@ declare module 'astro:db' {
 	export const TRUE: typeof import('./dist/runtime/config.js').TRUE;
 	export const FALSE: typeof import('./dist/runtime/config.js').FALSE;
 	export const column: typeof import('./dist/runtime/config.js').column;
-	export const defineDB: typeof import('./dist/runtime/config.js').defineDB;
+	export const defineDb: typeof import('./dist/runtime/config.js').defineDb;
 	export const defineTable: typeof import('./dist/runtime/config.js').defineTable;
 }


### PR DESCRIPTION
## Changes

- Renames the `defineDB()` helper to `defineDb()` to align with other APIs which use `Db` for better readability.

## Testing

- Existing tests should pass

## Docs

- Docs will need updating to use the new casing