### PR TITLE
Fix check-merge workflow on PRs from forks

### DIFF
--- a/.github/workflows/check-merge.yml
+++ b/.github/workflows/check-merge.yml
@@ -1,6 +1,6 @@
 name: Check mergeability
 
-on: pull_request
+on: pull_request_target
 
 permissions:
   pull-requests: write
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/checkout@v4
         if: steps.blocked.outputs.result != 'true'
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
       - name: Get changed files in the .changeset folder


### PR DESCRIPTION
## Changes

Noticed that the `check-marge` workflow was failing for https://github.com/withastro/astro/pull/10189. As noted in the [GH docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token), `GITHUB_TOKEN` has a hard permission limit for PRs from forks. The way to elevate the permissions and "trust" this PR is to use the [`pull_request_target` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target).

However, when using that event, `actions/checkout` will only operate on the base branch of the PR. I needed to update `actions/checkout` to checkout the head of the PR instead to fix this. This means we can "trust" the code coming from the PR with the elevated `GITHUB_TOKEN` permissions, but the workflow isn't executing code from the PR so this is safe. `tj-actions/changed-files` also have a [helpful note](https://github.com/tj-actions/changed-files/blob/fe6c3ea0ca88f25e4ba51fa00c27bb5dd06cb08a/src/commitSha.ts#L601-L607) about it.

## Testing

_Should work_

## Docs

n/a
