### PR TITLE
fix(tsconfigs): Add `jsx: 'preserve'` to the base template

### DIFF
--- a/.changeset/slimy-avocados-sniff.md
+++ b/.changeset/slimy-avocados-sniff.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Updates the base `tsconfig.json` preset with `jsx: 'preserve'` in order to fix errors when importing Astro files inside `.js` and `.ts` files.

--- a/packages/astro/tsconfigs/base.json
+++ b/packages/astro/tsconfigs/base.json
@@ -24,6 +24,8 @@
     // Skip typechecking libraries and .d.ts files
     "skipLibCheck": true,
     // Allow JavaScript files to be imported
-    "allowJs": true
+    "allowJs": true,
+    // Allow JSX files (or files that are internally considered JSX, like Astro files) to be imported inside `.js` and `.ts` files.
+    "jsx": "preserve"
   }
 }


### PR DESCRIPTION
## Changes

Despite being supposed to only affect emitting, the `jsx` setting is required to import JSX and internally considered to be JSX files, or you get an error. This adds `jsx: 'preserve'`, the safest setting to our base preset. 

This shouldn't affect anything, for two reasons:
- We don't use TypeScript to emit JSX code
- Using `astro add JSX_FRAMEWORK` already changes the `tsconfig.json` to something else for frameworks that need it (most of which are in fact, using `preserve` already)

Fix https://github.com/withastro/language-tools/issues/787

## Testing

Tests should pass!

## Docs

N/A