### PR TITLE
WIP adds POC for injectAssets

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1864,6 +1864,14 @@ export interface ResolvedInjectedRoute extends InjectedRoute {
 	resolvedEntryPoint?: URL;
 }
 
+export interface InjectedAsset {
+	entrypoint: string;
+}
+
+export interface ResolvedInjectedAsset extends InjectedAsset {
+	resolvedEntryPoint: URL;
+}
+
 /**
  * Resolved Astro Config
  * Config with user settings along with all defaults filled in.
@@ -1995,6 +2003,8 @@ export interface AstroSettings {
 	preferences: AstroPreferences;
 	injectedRoutes: InjectedRoute[];
 	resolvedInjectedRoutes: ResolvedInjectedRoute[];
+	injectedAssets: InjectedAsset[];
+	resolvedInjectedAssets: ResolvedInjectedAsset[];
 	pageExtensions: string[];
 	contentEntryTypes: ContentEntryType[];
 	dataEntryTypes: DataEntryType[];
@@ -2595,6 +2605,7 @@ export interface AstroIntegration {
 			addWatchFile: (path: URL | string) => void;
 			injectScript: (stage: InjectedScriptStage, content: string) => void;
 			injectRoute: (injectRoute: InjectedRoute) => void;
+			injectAsset: (injectAsset: InjectedAsset) => void;
 			addClientDirective: (directive: ClientDirectiveConfig) => void;
 			/**
 			 * @deprecated Use `addDevToolbarApp` instead.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1866,6 +1866,9 @@ export interface ResolvedInjectedRoute extends InjectedRoute {
 
 export interface InjectedAsset {
 	entrypoint: string;
+	outName?: string;
+	outDir?: string;
+	hash?: string;
 }
 
 export interface ResolvedInjectedAsset extends InjectedAsset {

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -33,8 +33,6 @@ import { collectPagesData } from './page-data.js';
 import { staticBuild, viteBuild } from './static-build.js';
 import type { StaticBuildOptions } from './types.js';
 import { getTimeStat } from './util.js';
-import { basename } from 'node:path';
-import { appendForwardSlash } from '../path.js';
 
 export interface BuildOptions {
 	/**
@@ -169,6 +167,7 @@ class AstroBuilder {
 		}
 
 		this.manifest = createRouteManifest({ settings: this.settings }, this.logger);
+		createInjectedAssets({ settings: this.settings }, this.logger);
 
 		const viteConfig = await createVite(
 			{
@@ -248,20 +247,6 @@ class AstroBuilder {
 		});
 		this.logger.debug('build', timerMessage('Additional assets copied', this.timer.assetsStart));
 
-		createInjectedAssets({ settings: this.settings }, this.logger);
-		// console.log('DEBUG', this.settings.resolvedInjectedAssets);
-		this.logger.info('assets', 'Injecting assets...');
-		const assetsPath = this.settings.config.build.assets;
-		for (const resolvedAsset of this.settings.resolvedInjectedAssets) {
-			const assetURL = new URL(
-				`./${assetsPath}/${basename(fileURLToPath(resolvedAsset.resolvedEntryPoint))}`,
-				appendForwardSlash(opts.settings.config.outDir.toString())
-			);
-			// console.log(assetURL);
-			try {
-				fs.promises.copyFile(fileURLToPath(resolvedAsset.resolvedEntryPoint), assetURL);
-			} catch (error) {}
-		}
 		// You're done! Time to clean up.
 		await runHookBuildDone({
 			config: this.settings.config,

--- a/packages/astro/src/core/build/plugins/index.ts
+++ b/packages/astro/src/core/build/plugins/index.ts
@@ -15,6 +15,7 @@ import { pluginPrerender } from './plugin-prerender.js';
 import { pluginRenderers } from './plugin-renderers.js';
 import { pluginScripts } from './plugin-scripts.js';
 import { pluginSSR, pluginSSRSplit } from './plugin-ssr.js';
+import { pluginInjectAssets } from './plugin-inject-assets.js';
 
 export function registerAllPlugins({ internals, options, register }: AstroBuildPluginContainer) {
 	register(pluginComponentEntry(internals));
@@ -37,4 +38,5 @@ export function registerAllPlugins({ internals, options, register }: AstroBuildP
 	register(pluginSSR(options, internals));
 	register(pluginSSRSplit(options, internals));
 	register(pluginChunks());
+	register(pluginInjectAssets(options, internals));
 }

--- a/packages/astro/src/core/build/plugins/plugin-inject-assets.ts
+++ b/packages/astro/src/core/build/plugins/plugin-inject-assets.ts
@@ -1,0 +1,54 @@
+import { type Plugin as VitePlugin } from 'vite';
+import { type BuildInternals } from '../internal.js';
+import type { AstroBuildPlugin } from '../plugin.js';
+import type { StaticBuildOptions } from '../types.js';
+
+function vitePluginContent(
+	opts: StaticBuildOptions,
+	internals: BuildInternals
+): VitePlugin {
+	const { config } = opts.settings;
+	const distRoot = config.outDir;
+	console.log("DEBUG", distRoot)
+	console.log("DEBUG", internals)
+
+	// // console.log('DEBUG', this.settings.resolvedInjectedAssets);
+	// this.logger.info('assets', 'Injecting assets...');
+	// for (const resolvedAsset of this.settings.resolvedInjectedAssets) {
+	// 	const assetsPath = resolvedAsset.outDir ?? this.settings.config.build.assets;
+	// 	let assetName = resolvedAsset.outName ?? resolvedAsset.resolvedEntryPoint.pathname.substring(resolvedAsset.resolvedEntryPoint.pathname.lastIndexOf('/') + 1)
+	// 	if (resolvedAsset.addHash) {
+	// 		assetName = `${assetName.split('.')}.${resolvedAsset.hash}`;
+	// 	}
+	// 	const assetURL = new URL(
+	// 		`./${assetsPath}/${assetName}`,
+	// 		appendForwardSlash(opts.settings.config.outDir.toString())
+	// 	);
+	// 	// console.log(assetURL);
+	// 	try {
+	// 		fs.promises.copyFile(fileURLToPath(resolvedAsset.resolvedEntryPoint), assetURL);
+	// 	} catch (error) { }
+	// }
+	return {
+		name: '@astro/plugin-inject-assets',
+	};
+}
+
+export function pluginInjectAssets(
+	opts: StaticBuildOptions,
+	internals: BuildInternals
+): AstroBuildPlugin {
+
+	return {
+		targets: ['server'],
+		hooks: {
+			async 'build:before'() {
+				console.log("DEBUG BEFORE", opts.settings.resolvedInjectedAssets)
+
+				return {
+					vitePlugin: vitePluginContent(opts, internals),
+				};
+			},
+		},
+	};
+}

--- a/packages/astro/src/core/config/settings.ts
+++ b/packages/astro/src/core/config/settings.ts
@@ -22,7 +22,9 @@ export function createBaseSettings(config: AstroConfig): AstroSettings {
 		tsConfigPath: undefined,
 		adapter: undefined,
 		injectedRoutes: [],
+		injectedAssets: [],
 		resolvedInjectedRoutes: [],
+		resolvedInjectedAssets: [],
 		pageExtensions: ['.astro', '.html', ...SUPPORTED_MARKDOWN_FILE_EXTENSIONS],
 		contentEntryTypes: [markdownContentEntryType],
 		dataEntryTypes: [

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -137,6 +137,9 @@ export async function runHookConfigSetup({
 					}
 					updatedSettings.injectedRoutes.push(injectRoute);
 				},
+				injectAsset: (injectAsset) => {
+					updatedSettings.injectedAssets.push(injectAsset);
+				},
 				addWatchFile: (path) => {
 					updatedSettings.watchFiles.push(path instanceof URL ? fileURLToPath(path) : path);
 				},

--- a/packages/astro/src/integrations/index.ts
+++ b/packages/astro/src/integrations/index.ts
@@ -21,6 +21,7 @@ import { mergeConfig } from '../core/config/index.js';
 import type { AstroIntegrationLogger, Logger } from '../core/logger/core.js';
 import { isServerLikeOutput } from '../prerender/utils.js';
 import { validateSupportedFeatures } from './astroFeaturesValidation.js';
+import { createHash } from 'node:crypto';
 
 async function withTakingALongTimeMsg<T>({
 	name,
@@ -138,7 +139,11 @@ export async function runHookConfigSetup({
 					updatedSettings.injectedRoutes.push(injectRoute);
 				},
 				injectAsset: (injectAsset) => {
+					const hash = createHash('sha256').update(injectAsset.entrypoint, 'utf-8').digest('hex').slice(0, 10);
+					injectAsset.hash = hash;
 					updatedSettings.injectedAssets.push(injectAsset);
+					const fileName = injectAsset.entrypoint.substring(injectAsset.entrypoint.lastIndexOf('/') + 1)
+					return `${injectAsset.outDir ?? updatedConfig.build.assets}/${injectAsset.outName ?? fileName.split('.')[0]}.${injectAsset.hash}${fileName.split('.').length > 1 ? '.' + fileName.split('.').slice(1).join('.') : ''}`;
 				},
 				addWatchFile: (path) => {
 					updatedSettings.watchFiles.push(path instanceof URL ? fileURLToPath(path) : path);

--- a/packages/astro/test/custom-assets-injected-from-dep.test.js
+++ b/packages/astro/test/custom-assets-injected-from-dep.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
+
+describe('Custom 404 with injectRoute from dependency', () => {
+	describe('build', () => {
+		/** @type {import('./test-utils.js').Fixture} */
+		let fixture;
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/custom-404-injected-from-dep/',
+				site: 'http://example.com',
+			});
+			await fixture.build();
+		});
+
+		it('Build succeeds', async () => {
+			const html = await fixture.readFile('/404.html');
+			assert.equal(html.includes('<!DOCTYPE html>'), true);
+		});
+	});
+});

--- a/packages/astro/test/fixtures/custom-assets-injected-from-dep/astro.config.mjs
+++ b/packages/astro/test/fixtures/custom-assets-injected-from-dep/astro.config.mjs
@@ -1,0 +1,28 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [
+		{
+			name: '404-integration',
+			hooks: {
+				'astro:config:setup': ({ injectAsset }) => {
+					const urlPathOne = injectAsset({
+						entrypoint: '@test/custom-404-pkg/404.astro',
+					});
+					console.log("DEBUG", urlPathOne);
+					const urlPathTwo = injectAsset({
+						entrypoint: '@test/custom-404-pkg/404.astro',
+						outDir: './my-assets'
+					});
+					console.log("DEBUG", urlPathTwo);
+					const urlPathThree = injectAsset({
+						entrypoint: '@test/custom-404-pkg/testy',
+						outDir: './my-assets'
+					});
+					console.log("DEBUG", urlPathThree);
+				},
+			},
+		},
+	],
+});

--- a/packages/astro/test/fixtures/custom-assets-injected-from-dep/package.json
+++ b/packages/astro/test/fixtures/custom-assets-injected-from-dep/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/custom-assets-injected-from-dep",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@test/custom-404-pkg": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/custom-assets-injected-from-dep/src/pages/index.astro
+++ b/packages/astro/test/fixtures/custom-assets-injected-from-dep/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+---
+
+<html lang="en">
+<head>
+  <title>Custom 404</title>
+</head>
+<body>
+  <h1>Home</h1>
+</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2690,6 +2690,15 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/custom-assets-injected-from-dep:
+    dependencies:
+      '@test/custom-404-pkg':
+        specifier: workspace:*
+        version: link:../custom-404-pkg
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/custom-assets-name:
     dependencies:
       '@astrojs/node':


### PR DESCRIPTION
**:warning: Looking for Guadiance / Feedback, before investing more time into this! https://discord.com/channels/830184174198718474/845430950191038464/1216122199518482662**


## Changes

- this is a POC for `injectAssets` inside the `astro:config:setup` hook
- goal is to allow integrations define entrypoints which are copied as is to the `build.assets` folder
- `injectRoute` & `injectScripts` are not suficient for such use-case
- see Discord #integration channel for some more reference and at least 3-4 people being in favor of this feature
- **it won't be a good assumption to say all assets should be injected into _astro, he final solution should have a config to allow configurable target folders for each injected asset**
- **the final solution should also have some opt-in hashing mechanism**
- **the final solution should also be able to return the URL / path for the injected asset**

some quote from Discord: 
 
> hey, I'm an integration, and this asset here will be a part of the site that I'll need to be able to access from the content I generate - can you let me know the URL this will be accessible under from the client side?

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
