### PR TITLE
Use static imports for integration seed files in `astro:db`

### DIFF
--- a/.changeset/perfect-experts-attend.md
+++ b/.changeset/perfect-experts-attend.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Fixes builds for projects using integration seed files

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 
 export const PACKAGE_NAME = JSON.parse(
@@ -12,10 +11,7 @@ export const DB_TYPES_FILE = 'db-types.d.ts';
 
 export const VIRTUAL_MODULE_ID = 'astro:db';
 
-console.log('###env', process.env.ASTRO_TEST_RANDOM_DB_ID);
-export const DB_PATH = `.astro/${
-	process.env.ASTRO_TEST_RANDOM_DB_ID ? randomUUID() : 'content.db'
-}`;
+export const DB_PATH = '.astro/content.db';
 
 export const CONFIG_FILE_NAMES = ['config.ts', 'config.js', 'config.mts', 'config.mjs'];
 

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -12,6 +12,7 @@ export const DB_TYPES_FILE = 'db-types.d.ts';
 
 export const VIRTUAL_MODULE_ID = 'astro:db';
 
+console.log('###env', process.env.ASTRO_TEST_RANDOM_DB_ID);
 export const DB_PATH = `.astro/${
 	process.env.ASTRO_TEST_RANDOM_DB_ID ? randomUUID() : 'content.db'
 }`;

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -82,13 +82,10 @@ function astroDBIntegration(): AstroIntegration {
 				seedFiles.get = () => integrationSeedPaths;
 				configFileDependencies = dependencies;
 
-				if (!connectToStudio) {
-					const dbUrl = new URL(DB_PATH, config.root);
-					if (existsSync(dbUrl)) {
-						await rm(dbUrl);
-					}
-					await mkdir(dirname(fileURLToPath(dbUrl)), { recursive: true });
-					await writeFile(dbUrl, '');
+				const localDbUrl = new URL(DB_PATH, config.root);
+				if (!connectToStudio && !existsSync(localDbUrl)) {
+					await mkdir(dirname(fileURLToPath(localDbUrl)), { recursive: true });
+					await writeFile(localDbUrl, '');
 				}
 
 				await typegen({ tables: tables.get() ?? {}, root: config.root });

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -114,6 +114,9 @@ export function getLocalVirtualModContents({
 		(name) => new URL(name, getDbDirectoryUrl('file:///')).pathname
 	);
 	const resolveId = (id: string) => (id.startsWith('.') ? resolve(fileURLToPath(root), id) : id);
+	// Use top-level imports to correctly resolve `astro:db` within seed files.
+	// Dynamic imports cause a silent build failure,
+	// potentially because of circular module references.
 	const integrationSeedImportStatements: string[] = [];
 	const integrationSeedImportNames: string[] = [];
 	seedFiles.forEach((pathOrUrl, index) => {

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -114,17 +114,20 @@ export function getLocalVirtualModContents({
 		(name) => new URL(name, getDbDirectoryUrl('file:///')).pathname
 	);
 	const resolveId = (id: string) => (id.startsWith('.') ? resolve(fileURLToPath(root), id) : id);
-	const integrationSeedFilePaths = seedFiles.map((pathOrUrl) =>
-		typeof pathOrUrl === 'string' ? resolveId(pathOrUrl) : pathOrUrl.pathname
-	);
-	const integrationSeedImports = integrationSeedFilePaths.map(
-		(filePath) => `() => import(${JSON.stringify(filePath)})`
-	);
+	const integrationSeedImportStatements: string[] = [];
+	const integrationSeedImportNames: string[] = [];
+	seedFiles.forEach((pathOrUrl, index) => {
+		const path = typeof pathOrUrl === 'string' ? resolveId(pathOrUrl) : pathOrUrl.pathname;
+		const importName = 'integration_seed_' + index;
+		integrationSeedImportStatements.push(`import ${importName} from ${JSON.stringify(path)};`);
+		integrationSeedImportNames.push(importName);
+	});
 
 	const dbUrl = new URL(DB_PATH, root);
 	return `
 import { asDrizzleTable, createLocalDatabaseClient } from ${RUNTIME_IMPORT};
 ${shouldSeed ? `import { seedLocal } from ${RUNTIME_IMPORT};` : ''}
+${shouldSeed ? integrationSeedImportStatements.join('\n') : ''}
 
 const dbUrl = ${JSON.stringify(dbUrl)};
 export const db = createLocalDatabaseClient({ dbUrl });
@@ -133,7 +136,7 @@ ${
 	shouldSeed
 		? `await seedLocal({
 	userSeedGlob: import.meta.glob(${JSON.stringify(userSeedFilePaths)}, { eager: true }),
-	integrationSeedImports: [${integrationSeedImports.join(',')}],
+	integrationSeedFunctions: [${integrationSeedImportNames.join(',')}],
 });`
 		: ''
 }

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -22,10 +22,10 @@ export { createRemoteDatabaseClient, createLocalDatabaseClient } from './db-clie
 export async function seedLocal({
 	// Glob all potential seed files to catch renames and deletions.
 	userSeedGlob,
-	integrationSeedImports,
+	integrationSeedFunctions: integrationSeedFunctions,
 }: {
 	userSeedGlob: Record<string, { default?: () => Promise<void> }>;
-	integrationSeedImports: Array<() => Promise<{ default: () => Promise<void> }>>;
+	integrationSeedFunctions: Array<() => Promise<void>>;
 }) {
 	const seedFilePath = Object.keys(userSeedGlob)[0];
 	if (seedFilePath) {
@@ -43,9 +43,8 @@ export async function seedLocal({
 			throw e;
 		}
 	}
-	for (const importModule of integrationSeedImports) {
-		const mod = await importModule();
-		await mod.default().catch((e) => {
+	for (const seedFn of integrationSeedFunctions) {
+		await seedFn().catch((e) => {
 			if (e instanceof LibsqlError) {
 				throw new Error(SEED_ERROR(e.message));
 			}

--- a/packages/db/test/basics.test.js
+++ b/packages/db/test/basics.test.js
@@ -3,6 +3,10 @@ import { load as cheerioLoad } from 'cheerio';
 import testAdapter from '../../astro/test/test-adapter.js';
 import { loadFixture } from '../../astro/test/test-utils.js';
 
+// Note (@bholmesdev) generate a random database id on startup.
+// Ensures database connections don't conflict
+// when multiple dev servers are run in parallel on the same project.
+process.env.ASTRO_TEST_RANDOM_DB_ID = 'true';
 describe('astro:db', () => {
 	let fixture;
 	before(async () => {
@@ -13,10 +17,6 @@ describe('astro:db', () => {
 		});
 	});
 
-	// Note (@bholmesdev) generate a random database id on startup.
-	// Ensures database connections don't conflict
-	// when multiple dev servers are run in parallel on the same project.
-	process.env.ASTRO_TEST_RANDOM_DB_ID = 'true';
 	describe('development', () => {
 		let devServer;
 

--- a/packages/db/test/basics.test.js
+++ b/packages/db/test/basics.test.js
@@ -26,7 +26,6 @@ describe('astro:db', () => {
 
 		after(async () => {
 			await devServer.stop();
-			process.env.ASTRO_TEST_RANDOM_DB_ID = undefined;
 		});
 
 		it('Prints the list of authors', async () => {

--- a/packages/db/test/basics.test.js
+++ b/packages/db/test/basics.test.js
@@ -3,10 +3,6 @@ import { load as cheerioLoad } from 'cheerio';
 import testAdapter from '../../astro/test/test-adapter.js';
 import { loadFixture } from '../../astro/test/test-utils.js';
 
-// Note (@bholmesdev) generate a random database id on startup.
-// Ensures database connections don't conflict
-// when multiple dev servers are run in parallel on the same project.
-process.env.ASTRO_TEST_RANDOM_DB_ID = 'true';
 describe('astro:db', () => {
 	let fixture;
 	before(async () => {

--- a/packages/db/test/integrations.test.js
+++ b/packages/db/test/integrations.test.js
@@ -45,4 +45,28 @@ describe('astro:db with integrations', () => {
 			expect(ul.children().eq(0).text()).to.equal('Pancakes');
 		});
 	});
+
+	describe('build', () => {
+		before(async () => {
+			await fixture.build();
+		});
+
+		it('Prints the list of authors from user-defined table', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerioLoad(html);
+
+			const ul = $('.authors-list');
+			expect(ul.children()).to.have.a.lengthOf(5);
+			expect(ul.children().eq(0).text()).to.equal('Ben');
+		});
+
+		it('Prints the list of menu items from integration-defined table', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerioLoad(html);
+
+			const ul = $('ul.menu');
+			expect(ul.children()).to.have.a.lengthOf(4);
+			expect(ul.children().eq(0).text()).to.equal('Pancakes');
+		});
+	});
 });

--- a/packages/db/test/integrations.test.js
+++ b/packages/db/test/integrations.test.js
@@ -48,6 +48,7 @@ describe('astro:db with integrations', () => {
 
 	describe('build', () => {
 		before(async () => {
+			process.env.ASTRO_TEST_RANDOM_DB_ID = 'true';
 			await fixture.build();
 		});
 

--- a/packages/db/test/integrations.test.js
+++ b/packages/db/test/integrations.test.js
@@ -10,10 +10,10 @@ describe('astro:db with integrations', () => {
 		});
 	});
 
-	// Note(bholmesdev): Use in-memory db to avoid
-	// Multiple dev servers trying to unlink and remount
-	// the same database file.
-	process.env.TEST_IN_MEMORY_DB = 'true';
+	// Note (@bholmesdev) generate a random database id on startup.
+	// Ensures database connections don't conflict
+	// when multiple dev servers are run in parallel on the same project.
+	process.env.ASTRO_TEST_RANDOM_DB_ID = 'true';
 	describe('development', () => {
 		let devServer;
 

--- a/packages/db/test/integrations.test.js
+++ b/packages/db/test/integrations.test.js
@@ -2,6 +2,10 @@ import { expect } from 'chai';
 import { load as cheerioLoad } from 'cheerio';
 import { loadFixture } from '../../astro/test/test-utils.js';
 
+// Note (@bholmesdev) generate a random database id on startup.
+// Ensures database connections don't conflict
+// when multiple dev servers are run in parallel on the same project.
+process.env.ASTRO_TEST_RANDOM_DB_ID = 'true';
 describe('astro:db with integrations', () => {
 	let fixture;
 	before(async () => {
@@ -10,10 +14,6 @@ describe('astro:db with integrations', () => {
 		});
 	});
 
-	// Note (@bholmesdev) generate a random database id on startup.
-	// Ensures database connections don't conflict
-	// when multiple dev servers are run in parallel on the same project.
-	process.env.ASTRO_TEST_RANDOM_DB_ID = 'true';
 	describe('development', () => {
 		let devServer;
 

--- a/packages/db/test/integrations.test.js
+++ b/packages/db/test/integrations.test.js
@@ -2,10 +2,6 @@ import { expect } from 'chai';
 import { load as cheerioLoad } from 'cheerio';
 import { loadFixture } from '../../astro/test/test-utils.js';
 
-// Note (@bholmesdev) generate a random database id on startup.
-// Ensures database connections don't conflict
-// when multiple dev servers are run in parallel on the same project.
-process.env.ASTRO_TEST_RANDOM_DB_ID = 'true';
 describe('astro:db with integrations', () => {
 	let fixture;
 	before(async () => {
@@ -47,7 +43,6 @@ describe('astro:db with integrations', () => {
 
 	describe('build', () => {
 		before(async () => {
-			process.env.ASTRO_TEST_RANDOM_DB_ID = 'true';
 			await fixture.build();
 		});
 

--- a/packages/db/test/integrations.test.js
+++ b/packages/db/test/integrations.test.js
@@ -24,7 +24,6 @@ describe('astro:db with integrations', () => {
 
 		after(async () => {
 			await devServer.stop();
-			process.env.TEST_IN_MEMORY_DB = undefined;
 		});
 
 		it('Prints the list of authors from user-defined table', async () => {


### PR DESCRIPTION
## Changes

- Switches from dynamic to static imports for integration seed files in the `astro:db` virtual module.
- Fixes a bug where builds would fail silently when using integrations.

## Testing

Added a simple test with build output for the integrations fixture and also tested `astro build` manually locally.

## Docs

N/A — bug fix