### PR TITLE
Fix db for projects without a seed file or with integrations

### DIFF
--- a/.changeset/calm-roses-camp.md
+++ b/.changeset/calm-roses-camp.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Fixes support for integrations configuring `astro:db` and for projects that use `astro:db` but do not include a seed file.

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -1,13 +1,9 @@
 import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 
 export const PACKAGE_NAME = JSON.parse(
 	readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
 ).name;
 
-export const SEED_LOCAL_IMPORT = JSON.stringify(
-	fileURLToPath(new URL('../../dist/runtime/seed-local.js', import.meta.url))
-);
 export const RUNTIME_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime`);
 export const RUNTIME_CONFIG_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime/config`);
 

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -1,9 +1,13 @@
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 export const PACKAGE_NAME = JSON.parse(
 	readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
 ).name;
 
+export const SEED_LOCAL_IMPORT = JSON.stringify(
+	fileURLToPath(new URL('../../dist/runtime/seed-local.js', import.meta.url))
+);
 export const RUNTIME_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime`);
 export const RUNTIME_CONFIG_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime/config`);
 

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -1,13 +1,7 @@
 import { fileURLToPath } from 'node:url';
 import { normalizePath } from 'vite';
 import { SEED_DEV_FILE_NAME } from '../../runtime/queries.js';
-import {
-	DB_PATH,
-	RUNTIME_CONFIG_IMPORT,
-	RUNTIME_IMPORT,
-	SEED_LOCAL_IMPORT,
-	VIRTUAL_MODULE_ID,
-} from '../consts.js';
+import { DB_PATH, RUNTIME_CONFIG_IMPORT, RUNTIME_IMPORT, VIRTUAL_MODULE_ID } from '../consts.js';
 import type { DBTables } from '../types.js';
 import { type VitePlugin, getDbDirectoryUrl, getRemoteDatabaseUrl } from '../utils.js';
 
@@ -135,7 +129,7 @@ export function getLocalVirtualModContents({
 	const dbUrl = new URL(DB_PATH, root);
 	return `
 import { asDrizzleTable, createLocalDatabaseClient } from ${RUNTIME_IMPORT};
-${shouldSeed ? `import { seedLocal } from ${SEED_LOCAL_IMPORT};` : ''}
+${shouldSeed ? `import { seedLocal } from ${RUNTIME_IMPORT};` : ''}
 ${shouldSeed ? integrationSeedImportStatements.join('\n') : ''}
 
 const dbUrl = ${JSON.stringify(dbUrl)};

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -16,6 +16,7 @@ export { sql };
 export type SqliteDB = LibSQLDatabase;
 export type { Table } from './types.js';
 export { createRemoteDatabaseClient, createLocalDatabaseClient } from './db-client.js';
+export { seedLocal } from './seed-local.js';
 
 export function hasPrimaryKey(column: DBColumn) {
 	return 'primaryKey' in column.schema && !!column.schema.primaryKey;

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -1,4 +1,3 @@
-import { LibsqlError } from '@libsql/client';
 import { type ColumnBuilderBaseConfig, type ColumnDataType, sql } from 'drizzle-orm';
 import type { LibSQLDatabase } from 'drizzle-orm/libsql';
 import {
@@ -10,7 +9,6 @@ import {
 	sqliteTable,
 	text,
 } from 'drizzle-orm/sqlite-core';
-import { SEED_DEFAULT_EXPORT_ERROR, SEED_ERROR } from '../core/errors.js';
 import { type DBColumn, type DBTable } from '../core/types.js';
 import { type SerializedSQL, isSerializedSQL } from './types.js';
 
@@ -18,36 +16,6 @@ export { sql };
 export type SqliteDB = LibSQLDatabase;
 export type { Table } from './types.js';
 export { createRemoteDatabaseClient, createLocalDatabaseClient } from './db-client.js';
-
-export async function seedLocal({
-	// Glob all potential seed files to catch renames and deletions.
-	userSeedGlob,
-	integrationSeedFunctions,
-}: {
-	userSeedGlob: Record<string, { default?: () => Promise<void> }>;
-	integrationSeedFunctions: Array<() => Promise<void>>;
-}) {
-	const seedFunctions: Array<() => Promise<void>> = [];
-	const seedFilePath = Object.keys(userSeedGlob)[0];
-	if (seedFilePath) {
-		const mod = userSeedGlob[seedFilePath];
-		if (!mod.default) throw new Error(SEED_DEFAULT_EXPORT_ERROR(seedFilePath));
-		seedFunctions.push(mod.default);
-	}
-	for (const seedFn of integrationSeedFunctions) {
-		seedFunctions.push(seedFn);
-	}
-	for (const seed of seedFunctions) {
-		try {
-			await seed();
-		} catch (e) {
-			if (e instanceof LibsqlError) {
-				throw new Error(SEED_ERROR(e.message));
-			}
-			throw e;
-		}
-	}
-}
 
 export function hasPrimaryKey(column: DBColumn) {
 	return 'primaryKey' in column.schema && !!column.schema.primaryKey;

--- a/packages/db/src/runtime/seed-local.ts
+++ b/packages/db/src/runtime/seed-local.ts
@@ -41,6 +41,7 @@ export async function seedLocal({
 			throw e;
 		}
 	}
+}
 
 async function recreateTables({ db, tables }: { db: LibSQLDatabase; tables: DBTables }) {
 	const setupQueries: SQL[] = [];

--- a/packages/db/src/runtime/seed-local.ts
+++ b/packages/db/src/runtime/seed-local.ts
@@ -1,0 +1,57 @@
+import { LibsqlError } from '@libsql/client';
+import { sql, type SQL } from 'drizzle-orm';
+import type { LibSQLDatabase } from 'drizzle-orm/libsql';
+import { SQLiteAsyncDialect } from 'drizzle-orm/sqlite-core';
+import { SEED_DEFAULT_EXPORT_ERROR, SEED_ERROR } from '../core/errors.js';
+import { type DBTables } from '../core/types.js';
+import { getCreateIndexQueries, getCreateTableQuery } from './queries.js';
+
+const sqlite = new SQLiteAsyncDialect();
+
+export async function seedLocal({
+	db,
+	tables,
+	// Glob all potential seed files to catch renames and deletions.
+	userSeedGlob,
+	integrationSeedFunctions,
+}: {
+	db: LibSQLDatabase;
+	tables: DBTables;
+	userSeedGlob: Record<string, { default?: () => Promise<void> }>;
+	integrationSeedFunctions: Array<() => Promise<void>>;
+}) {
+	await recreateTables({ db, tables });
+	const seedFunctions: Array<() => Promise<void>> = [];
+	const seedFilePath = Object.keys(userSeedGlob)[0];
+	if (seedFilePath) {
+		const mod = userSeedGlob[seedFilePath];
+		if (!mod.default) throw new Error(SEED_DEFAULT_EXPORT_ERROR(seedFilePath));
+		seedFunctions.push(mod.default);
+	}
+	for (const seedFn of integrationSeedFunctions) {
+		seedFunctions.push(seedFn);
+	}
+	for (const seed of seedFunctions) {
+		try {
+			await seed();
+		} catch (e) {
+			if (e instanceof LibsqlError) {
+				throw new Error(SEED_ERROR(e.message));
+			}
+			throw e;
+		}
+	}
+
+async function recreateTables({ db, tables }: { db: LibSQLDatabase; tables: DBTables }) {
+	const setupQueries: SQL[] = [];
+	for (const [name, table] of Object.entries(tables)) {
+		const dropQuery = sql.raw(`DROP TABLE IF EXISTS ${sqlite.escapeName(name)}`);
+		const createQuery = sql.raw(getCreateTableQuery(name, table));
+		const indexQueries = getCreateIndexQueries(name, table);
+		setupQueries.push(dropQuery, createQuery, ...indexQueries.map((s) => sql.raw(s)));
+	}
+	await db.batch([
+		db.run(sql`pragma defer_foreign_keys=true;`),
+		...setupQueries.map((q) => db.run(q)),
+	]);
+}

--- a/packages/db/test/fixtures/integration-only/astro.config.mjs
+++ b/packages/db/test/fixtures/integration-only/astro.config.mjs
@@ -1,0 +1,8 @@
+import db from '@astrojs/db';
+import { defineConfig } from 'astro/config';
+import testIntegration from './integration';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [db(), testIntegration()],
+});

--- a/packages/db/test/fixtures/integration-only/integration/config.ts
+++ b/packages/db/test/fixtures/integration-only/integration/config.ts
@@ -1,0 +1,8 @@
+import { menu } from './shared';
+import { defineDb } from 'astro:db';
+
+export default defineDb({
+	tables: {
+		menu,
+	},
+});

--- a/packages/db/test/fixtures/integration-only/integration/index.ts
+++ b/packages/db/test/fixtures/integration-only/integration/index.ts
@@ -1,0 +1,15 @@
+import { defineDbIntegration } from '@astrojs/db/utils';
+
+export default function testIntegration() {
+	return defineDbIntegration({
+		name: 'db-test-integration',
+		hooks: {
+			'astro:db:setup'({ extendDb }) {
+				extendDb({
+					configEntrypoint: './integration/config.ts',
+					seedEntrypoint: './integration/seed.ts',
+				});
+			},
+		},
+	});
+}

--- a/packages/db/test/fixtures/integration-only/integration/seed.ts
+++ b/packages/db/test/fixtures/integration-only/integration/seed.ts
@@ -1,0 +1,14 @@
+import { asDrizzleTable } from '@astrojs/db/utils';
+import { menu } from './shared';
+import { db } from 'astro:db';
+
+export default async function () {
+	const table = asDrizzleTable('menu', menu);
+
+	await db.insert(table).values([
+		{ name: 'Pancakes', price: 9.5, type: 'Breakfast' },
+		{ name: 'French Toast', price: 11.25, type: 'Breakfast' },
+		{ name: 'Coffee', price: 3, type: 'Beverages' },
+		{ name: 'Cappuccino', price: 4.5, type: 'Beverages' },
+	]);
+}

--- a/packages/db/test/fixtures/integration-only/integration/shared.ts
+++ b/packages/db/test/fixtures/integration-only/integration/shared.ts
@@ -1,0 +1,9 @@
+import { column, defineTable } from 'astro:db';
+
+export const menu = defineTable({
+	columns: {
+		name: column.text(),
+		type: column.text(),
+		price: column.number(),
+	},
+});

--- a/packages/db/test/fixtures/integration-only/package.json
+++ b/packages/db/test/fixtures/integration-only/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@test/db-integration",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "@astrojs/db": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/db/test/fixtures/integration-only/package.json
+++ b/packages/db/test/fixtures/integration-only/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/db-integration",
+  "name": "@test/db-integration-only",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/packages/db/test/fixtures/integration-only/src/pages/index.astro
+++ b/packages/db/test/fixtures/integration-only/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+/// <reference path="../../.astro/db-types.d.ts" />
+import { db, menu } from 'astro:db';
+
+const menuItems = await db.select().from(menu);
+---
+
+<h2>Menu</h2>
+<ul class="menu">
+	{menuItems.map((item) => <li>{item.name}</li>)}
+</ul>

--- a/packages/db/test/fixtures/no-seed/astro.config.ts
+++ b/packages/db/test/fixtures/no-seed/astro.config.ts
@@ -1,0 +1,7 @@
+import db from '@astrojs/db';
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [db()],
+});

--- a/packages/db/test/fixtures/no-seed/db/config.ts
+++ b/packages/db/test/fixtures/no-seed/db/config.ts
@@ -1,0 +1,12 @@
+import { column, defineDb, defineTable } from 'astro:db';
+
+const Author = defineTable({
+	columns: {
+		name: column.text(),
+		age2: column.number({ optional: true }),
+	},
+});
+
+export default defineDb({
+	tables: { Author },
+});

--- a/packages/db/test/fixtures/no-seed/package.json
+++ b/packages/db/test/fixtures/no-seed/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@test/db-no-seed",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "@astrojs/db": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/db/test/fixtures/no-seed/src/pages/index.astro
+++ b/packages/db/test/fixtures/no-seed/src/pages/index.astro
@@ -1,0 +1,21 @@
+---
+/// <reference path="../../.astro/db-types.d.ts" />
+import { Author, db } from 'astro:db';
+
+await db
+	.insert(Author)
+	.values([
+		{ name: 'Ben' },
+		{ name: 'Nate' },
+		{ name: 'Erika' },
+		{ name: 'Bjorn' },
+		{ name: 'Sarah' },
+	]);
+
+const authors = await db.select().from(Author);
+---
+
+<h2>Authors</h2>
+<ul class="authors-list">
+	{authors.map((author) => <li>{author.name}</li>)}
+</ul>

--- a/packages/db/test/integration-only.test.js
+++ b/packages/db/test/integration-only.test.js
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+import { load as cheerioLoad } from 'cheerio';
+import { loadFixture } from '../../astro/test/test-utils.js';
+
+describe('astro:db with only integrations, no user db config', () => {
+	let fixture;
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/integration-only/', import.meta.url),
+		});
+	});
+
+	// Note(bholmesdev): Use in-memory db to avoid
+	// Multiple dev servers trying to unlink and remount
+	// the same database file.
+	process.env.TEST_IN_MEMORY_DB = 'true';
+	describe('development', () => {
+		let devServer;
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+			process.env.TEST_IN_MEMORY_DB = undefined;
+		});
+
+		it('Prints the list of menu items from integration-defined table', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			const $ = cheerioLoad(html);
+
+			const ul = $('ul.menu');
+			expect(ul.children()).to.have.a.lengthOf(4);
+			expect(ul.children().eq(0).text()).to.equal('Pancakes');
+		});
+	});
+});

--- a/packages/db/test/integration-only.test.js
+++ b/packages/db/test/integration-only.test.js
@@ -29,4 +29,19 @@ describe('astro:db with only integrations, no user db config', () => {
 			expect(ul.children().eq(0).text()).to.equal('Pancakes');
 		});
 	});
+
+	describe('build', () => {
+		before(async () => {
+			await fixture.build();
+		});
+
+		it('Prints the list of menu items from integration-defined table', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerioLoad(html);
+
+			const ul = $('ul.menu');
+			expect(ul.children()).to.have.a.lengthOf(4);
+			expect(ul.children().eq(0).text()).to.equal('Pancakes');
+		});
+	});
 });

--- a/packages/db/test/integration-only.test.js
+++ b/packages/db/test/integration-only.test.js
@@ -10,10 +10,6 @@ describe('astro:db with only integrations, no user db config', () => {
 		});
 	});
 
-	// Note(bholmesdev): Use in-memory db to avoid
-	// Multiple dev servers trying to unlink and remount
-	// the same database file.
-	process.env.TEST_IN_MEMORY_DB = 'true';
 	describe('development', () => {
 		let devServer;
 		before(async () => {
@@ -22,7 +18,6 @@ describe('astro:db with only integrations, no user db config', () => {
 
 		after(async () => {
 			await devServer.stop();
-			process.env.TEST_IN_MEMORY_DB = undefined;
 		});
 
 		it('Prints the list of menu items from integration-defined table', async () => {

--- a/packages/db/test/no-seed.test.js
+++ b/packages/db/test/no-seed.test.js
@@ -10,10 +10,6 @@ describe('astro:db with no seed file', () => {
 		});
 	});
 
-	// Note(bholmesdev): Use in-memory db to avoid
-	// Multiple dev servers trying to unlink and remount
-	// the same database file.
-	process.env.TEST_IN_MEMORY_DB = 'true';
 	describe('development', () => {
 		let devServer;
 		before(async () => {
@@ -22,7 +18,6 @@ describe('astro:db with no seed file', () => {
 
 		after(async () => {
 			await devServer.stop();
-			process.env.TEST_IN_MEMORY_DB = undefined;
 		});
 
 		it('Prints the list of authors', async () => {

--- a/packages/db/test/no-seed.test.js
+++ b/packages/db/test/no-seed.test.js
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+import { load as cheerioLoad } from 'cheerio';
+import { loadFixture } from '../../astro/test/test-utils.js';
+
+describe('astro:db with no seed file', () => {
+	let fixture;
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/no-seed/', import.meta.url),
+		});
+	});
+
+	// Note(bholmesdev): Use in-memory db to avoid
+	// Multiple dev servers trying to unlink and remount
+	// the same database file.
+	process.env.TEST_IN_MEMORY_DB = 'true';
+	describe('development', () => {
+		let devServer;
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+			process.env.TEST_IN_MEMORY_DB = undefined;
+		});
+
+		it('Prints the list of authors', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			const $ = cheerioLoad(html);
+
+			const ul = $('.authors-list');
+			expect(ul.children()).to.have.a.lengthOf(5);
+			expect(ul.children().eq(0).text()).to.equal('Ben');
+		});
+	});
+});

--- a/packages/db/test/no-seed.test.js
+++ b/packages/db/test/no-seed.test.js
@@ -29,4 +29,19 @@ describe('astro:db with no seed file', () => {
 			expect(ul.children().eq(0).text()).to.equal('Ben');
 		});
 	});
+
+	describe('build', () => {
+		before(async () => {
+			await fixture.build();
+		});
+
+		it('Prints the list of authors', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerioLoad(html);
+
+			const ul = $('.authors-list');
+			expect(ul.children()).to.have.a.lengthOf(5);
+			expect(ul.children().eq(0).text()).to.equal('Ben');
+		});
+	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3909,7 +3909,25 @@ importers:
         specifier: workspace:*
         version: link:../../../../astro
 
+  packages/db/test/fixtures/integration-only:
+    dependencies:
+      '@astrojs/db':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../astro
+
   packages/db/test/fixtures/integrations:
+    dependencies:
+      '@astrojs/db':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../astro
+
+  packages/db/test/fixtures/no-seed:
     dependencies:
       '@astrojs/db':
         specifier: workspace:*


### PR DESCRIPTION
## Changes

- Fixes `astro:db` integration support when an Astro project doesn’t include a user-defined seed file.
- Source of the bug was this change: https://github.com/withastro/astro/pull/10352/files#diff-4d4325b62adab978b9a1910a7ae9742c5269220b88f3b4372ff1a2a7d7fc9704R64-R70
- This moved the table creation to be triggered when a user’s seed file is loaded. This meant in the absence of a user seed file, tables are never created.
- The fix is moving `recreateTables()` back to runtime, called each time we `seedLocal()`. @bholmesdev had some concerns about this initially but I think these were resolved in #10381.
- To help keep things organised, I’ve split `seedLocal()` into its own file.

## Testing

- Added a fixture where an integration configures and seeds tables and no user config is present.
- Added a fixture where there is no seed file at all.
- Both tests include testing the build output.

## Docs

N/A — bug fix.
