### PR TITLE
[db] Add success=false handling to API entrypoints

### DIFF
--- a/.changeset/soft-foxes-grin.md
+++ b/.changeset/soft-foxes-grin.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+handle success=false response on api endpoints

--- a/packages/db/src/core/cli/commands/push/index.ts
+++ b/packages/db/src/core/cli/commands/push/index.ts
@@ -82,11 +82,24 @@ async function pushSchema({
 		return new Response(null, { status: 200 });
 	}
 	const url = new URL('/db/push', getRemoteDatabaseUrl());
-	return await fetch(url, {
+	const response = await fetch(url, {
 		method: 'POST',
 		headers: new Headers({
 			Authorization: `Bearer ${appToken}`,
 		}),
 		body: JSON.stringify(requestBody),
 	});
+	if (!response.ok) {
+		console.error(`${url.toString()} failed: ${response.status} ${response.statusText}`);
+		console.error(await response.text());
+		throw new Error(`/db/push fetch failed: ${response.status} ${response.statusText}`);
+	}
+	const result = (await response.json()) as
+		| { success: false; }
+		| { success: true; };
+	if (!result.success) {
+		console.error(`${url.toString()} unsuccessful`);
+		console.error(await response.text());
+		throw new Error(`/db/push fetch unsuccessful`);
+	}
 }

--- a/packages/db/src/core/cli/migration-queries.ts
+++ b/packages/db/src/core/cli/migration-queries.ts
@@ -432,7 +432,19 @@ export async function getProductionCurrentSnapshot({
 			Authorization: `Bearer ${appToken}`,
 		}),
 	});
-	const result = await response.json();
+	if (!response.ok) {
+		console.error(`${url.toString()} failed: ${response.status} ${response.statusText}`);
+		console.error(await response.text());
+		throw new Error(`/db/schema fetch failed: ${response.status} ${response.statusText}`);
+	}
+	const result = (await response.json()) as
+		| { success: false; data: undefined }
+		| { success: true; data: DBSnapshot };
+	if (!result.success) {
+		console.error(`${url.toString()} unsuccessful`);
+		console.error(await response.text());
+		throw new Error(`/db/schema fetch unsuccessful`);
+	}
 	return result.data;
 }
 


### PR DESCRIPTION
## Changes

- We had an issue where the server was incorrectly returning a `200` on error responses.
- This is a bit redundant if everything is working well, but a good line of defense in case anything isn't.

## Testing

- n/a

## Docs

- n/a