### PR TITLE
fix: remove runtime/config suggestion for db config exports

### DIFF
--- a/.changeset/breezy-seals-begin.md
+++ b/.changeset/breezy-seals-begin.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Remove @astrojs/runtime/config suggestion for astro:db configuration helpers.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -20,8 +20,7 @@
       "types": "./dist/runtime/index.d.ts",
       "import": "./dist/runtime/index.js"
     },
-    "./runtime/config": {
-      "types": null,
+    "./dist/runtime/config.js": {
       "import": "./dist/runtime/config.js"
     },
     "./package.json": "./package.json"
@@ -36,9 +35,6 @@
       ],
       "runtime": [
         "./dist/runtime/index.d.ts"
-      ],
-      "runtime/config": [
-        "./dist/runtime/config.d.ts"
       ]
     }
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -20,10 +20,6 @@
       "types": "./dist/runtime/index.d.ts",
       "import": "./dist/runtime/index.js"
     },
-    "./runtime/config": {
-      "types": "./dist/runtime/config.d.ts",
-      "import": "./dist/runtime/config.js"
-    },
     "./package.json": "./package.json"
   },
   "typesVersions": {
@@ -36,9 +32,6 @@
       ],
       "runtime": [
         "./dist/runtime/index.d.ts"
-      ],
-      "runtime/config": [
-        "./dist/runtime/config.d.ts"
       ]
     }
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -21,7 +21,7 @@
       "import": "./dist/runtime/index.js"
     },
     "./runtime/config": {
-      "types": "./dist/runtime/config.d.ts",
+      "types": null,
       "import": "./dist/runtime/config.js"
     },
     "./package.json": "./package.json"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -20,6 +20,10 @@
       "types": "./dist/runtime/index.d.ts",
       "import": "./dist/runtime/index.js"
     },
+    "./runtime/config": {
+      "types": "./dist/runtime/config.d.ts",
+      "import": "./dist/runtime/config.js"
+    },
     "./package.json": "./package.json"
   },
   "typesVersions": {
@@ -32,6 +36,9 @@
       ],
       "runtime": [
         "./dist/runtime/index.d.ts"
+      ],
+      "runtime/config": [
+        "./dist/runtime/config.d.ts"
       ]
     }
   },

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -5,7 +5,8 @@ export const PACKAGE_NAME = JSON.parse(
 ).name;
 
 export const RUNTIME_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime`);
-export const RUNTIME_CONFIG_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime/config`);
+// Use `dist` path. Not exposed as a public API.
+export const RUNTIME_CONFIG_IMPORT = JSON.stringify(`${PACKAGE_NAME}/dist/runtime/config.js`);
 
 export const DB_TYPES_FILE = 'db-types.d.ts';
 

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -5,8 +5,7 @@ export const PACKAGE_NAME = JSON.parse(
 ).name;
 
 export const RUNTIME_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime`);
-// Use `dist` path. Not exposed as a public API.
-export const RUNTIME_CONFIG_IMPORT = JSON.stringify(`${PACKAGE_NAME}/dist/runtime/config.js`);
+export const RUNTIME_CONFIG_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime/config`);
 
 export const DB_TYPES_FILE = 'db-types.d.ts';
 

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -5,11 +5,8 @@ export const PACKAGE_NAME = JSON.parse(
 ).name;
 
 export const RUNTIME_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime`);
-
-// Use `dist` path for config helpers. Not exposed as a public API.
-const RUNTIME_DIR = new URL('../../dist/runtime/', import.meta.url);
-
-export const RUNTIME_CONFIG_IMPORT = JSON.stringify(new URL('./config.js', RUNTIME_DIR));
+// Use `dist` path. Not exposed as a public API.
+export const RUNTIME_CONFIG_IMPORT = JSON.stringify(`${PACKAGE_NAME}/dist/runtime/config.js`);
 
 export const DB_TYPES_FILE = 'db-types.d.ts';
 

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -5,8 +5,11 @@ export const PACKAGE_NAME = JSON.parse(
 ).name;
 
 export const RUNTIME_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime`);
-// Use `dist` path. Not exposed as a public API.
-export const RUNTIME_CONFIG_IMPORT = JSON.stringify(`${PACKAGE_NAME}/dist/runtime/config.js`);
+
+// Use `dist` path for config helpers. Not exposed as a public API.
+const RUNTIME_DIR = new URL('../../dist/runtime/', import.meta.url);
+
+export const RUNTIME_CONFIG_IMPORT = JSON.stringify(new URL('./config.js', RUNTIME_DIR));
 
 export const DB_TYPES_FILE = 'db-types.d.ts';
 

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -5,7 +5,7 @@ export const PACKAGE_NAME = JSON.parse(
 ).name;
 
 export const RUNTIME_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime`);
-export const RUNTIME_CONFIG_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime/config`);
+export const RUNTIME_CONFIG_IMPORT = JSON.stringify(`${PACKAGE_NAME}/dist/runtime/config.js`);
 
 export const DB_TYPES_FILE = 'db-types.d.ts';
 

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -5,6 +5,8 @@ export const PACKAGE_NAME = JSON.parse(
 ).name;
 
 export const RUNTIME_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime`);
+// Exposed without type definitions
+// to avoid duplicate suggestions in Intellisense
 export const RUNTIME_CONFIG_IMPORT = JSON.stringify(`${PACKAGE_NAME}/dist/runtime/config.js`);
 
 export const DB_TYPES_FILE = 'db-types.d.ts';

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
+  "exclude": ["src/runtime/config.ts"],
   "compilerOptions": {
     "outDir": "./dist"
   }


### PR DESCRIPTION
## Changes

Before, your LSP would recommend importing `defineDb()` from `@astrojs/runtime/config` before recommending `astro:db`. This change removes `runtime/config` from public types to only surface `astro:db`

## Testing

Manual `pnpm link` to check intellisense

## Docs

N/A