### PR TITLE
Add `pkg: db` to labelling automation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,6 +12,9 @@
 'pkg: create-astro':
 - packages/create-astro/**
 
+'pkg: db':
+- packages/integrations/db/**
+
 'feat: markdown':
 - packages/markdown/**
 


### PR DESCRIPTION
## Changes

- Adds labelling automation for PRs changing `@astrojs/db`.
- I’ve found myself wanting a quick way to see open PRs for the package.

## Testing

n/a

## Docs

n/a