### PR TITLE
chore: remove drop table check for added table

### DIFF
--- a/.changeset/lazy-tools-reply.md
+++ b/.changeset/lazy-tools-reply.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Remove risk of data loss when pushing an out-of-date table schema.

--- a/packages/db/src/core/cli/migration-queries.ts
+++ b/packages/db/src/core/cli/migration-queries.ts
@@ -61,7 +61,6 @@ export async function getMigrationQueries({
 	}
 
 	for (const [collectionName, collection] of Object.entries(addedCollections)) {
-		queries.push(getDropTableIfExistsQuery(collectionName));
 		queries.push(getCreateTableQuery(collectionName, collection));
 		queries.push(...getCreateIndexQueries(collectionName, collection));
 	}

--- a/packages/db/test/unit/column-queries.test.js
+++ b/packages/db/test/unit/column-queries.test.js
@@ -53,7 +53,6 @@ describe('column queries', () => {
 			const newCollections = { [TABLE_NAME]: userInitial };
 			const { queries } = await configChangeQueries(oldCollections, newCollections);
 			expect(queries).to.deep.equal([
-				`DROP TABLE IF EXISTS "${TABLE_NAME}"`,
 				`CREATE TABLE "${TABLE_NAME}" (_id INTEGER PRIMARY KEY, "name" text NOT NULL, "age" integer NOT NULL, "email" text NOT NULL UNIQUE, "mi" text)`,
 			]);
 		});


### PR DESCRIPTION
## Changes

Remove call to "drop table if exists" when adding a table. This allowed tables to be dropped unexpectedly on a bad migration merge. This was an unexpected bug, and should raise a SQL error instead of dropping user data.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
