### PR TITLE
feat: split config types to separate build

### DIFF
--- a/.changeset/beige-gorillas-warn.md
+++ b/.changeset/beige-gorillas-warn.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Fix astro:db configuration types returning `any`

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -55,7 +55,8 @@
     "astro-integration"
   ],
   "scripts": {
-    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "types:config": "tsc -p ./tsconfig.config-types.json",
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc && pnpm types:config",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
     "test": "mocha --exit --timeout 20000 \"test/*.js\" \"test/unit/**/*.js\"",

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -5,9 +5,12 @@ export const PACKAGE_NAME = JSON.parse(
 ).name;
 
 export const RUNTIME_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime`);
-// Exposed without type definitions
-// to avoid duplicate suggestions in Intellisense
+
 export const RUNTIME_CONFIG_IMPORT = JSON.stringify(`${PACKAGE_NAME}/dist/runtime/config.js`);
+
+export const RUNTIME_CONFIG_TYPES_IMPORT = JSON.stringify(
+	`${PACKAGE_NAME}/dist/_internal/runtime/config.js`
+);
 
 export const DB_TYPES_FILE = 'db-types.d.ts';
 

--- a/packages/db/src/core/consts.ts
+++ b/packages/db/src/core/consts.ts
@@ -8,10 +8,6 @@ export const RUNTIME_IMPORT = JSON.stringify(`${PACKAGE_NAME}/runtime`);
 
 export const RUNTIME_CONFIG_IMPORT = JSON.stringify(`${PACKAGE_NAME}/dist/runtime/config.js`);
 
-export const RUNTIME_CONFIG_TYPES_IMPORT = JSON.stringify(
-	`${PACKAGE_NAME}/dist/_internal/runtime/config.js`
-);
-
 export const DB_TYPES_FILE = 'db-types.d.ts';
 
 export const VIRTUAL_MODULE_ID = 'astro:db';

--- a/packages/db/src/core/integration/typegen.ts
+++ b/packages/db/src/core/integration/typegen.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
-import { DB_TYPES_FILE, RUNTIME_CONFIG_IMPORT, RUNTIME_IMPORT } from '../consts.js';
+import { DB_TYPES_FILE, RUNTIME_CONFIG_TYPES_IMPORT, RUNTIME_IMPORT } from '../consts.js';
 import type { DBTable, DBTables } from '../types.js';
 
 export async function typegen({ tables, root }: { tables: DBTables; root: URL }) {
@@ -8,7 +8,7 @@ export async function typegen({ tables, root }: { tables: DBTables; root: URL })
 declare module 'astro:db' {
 	export const db: import(${RUNTIME_IMPORT}).SqliteDB;
 	export const dbUrl: string;
-	export * from ${RUNTIME_CONFIG_IMPORT};
+	export * from ${RUNTIME_CONFIG_TYPES_IMPORT};
 
 ${Object.entries(tables)
 	.map(([name, collection]) => generateTableType(name, collection))

--- a/packages/db/src/core/integration/typegen.ts
+++ b/packages/db/src/core/integration/typegen.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
-import { DB_TYPES_FILE, RUNTIME_CONFIG_TYPES_IMPORT, RUNTIME_IMPORT } from '../consts.js';
+import { DB_TYPES_FILE, RUNTIME_IMPORT } from '../consts.js';
 import type { DBTable, DBTables } from '../types.js';
 
 export async function typegen({ tables, root }: { tables: DBTables; root: URL }) {
@@ -8,7 +8,6 @@ export async function typegen({ tables, root }: { tables: DBTables; root: URL })
 declare module 'astro:db' {
 	export const db: import(${RUNTIME_IMPORT}).SqliteDB;
 	export const dbUrl: string;
-	export * from ${RUNTIME_CONFIG_TYPES_IMPORT};
 
 ${Object.entries(tables)
 	.map(([name, collection]) => generateTableType(name, collection))

--- a/packages/db/tsconfig.config-types.json
+++ b/packages/db/tsconfig.config-types.json
@@ -1,0 +1,12 @@
+{
+  // We want to avoid defineTable() and defineDb() import hints
+  // from the runtime config export instead of astro:db.
+  // We exclude runtime/config from the base types,
+  // and generate to a separate _internal/ directory
+  // for our virtual module (virtual.d.ts) to reference.
+  "extends": "../../tsconfig.base.json",
+  "files": ["./src/runtime/config.ts"],
+  "compilerOptions": {
+    "outDir": "./dist/_internal"
+  }
+}

--- a/packages/db/virtual.d.ts
+++ b/packages/db/virtual.d.ts
@@ -1,9 +1,9 @@
 declare module 'astro:db' {
-	export const sql: typeof import('./dist/runtime/config.js').sql;
-	export const NOW: typeof import('./dist/runtime/config.js').NOW;
-	export const TRUE: typeof import('./dist/runtime/config.js').TRUE;
-	export const FALSE: typeof import('./dist/runtime/config.js').FALSE;
-	export const column: typeof import('./dist/runtime/config.js').column;
-	export const defineDb: typeof import('./dist/runtime/config.js').defineDb;
-	export const defineTable: typeof import('./dist/runtime/config.js').defineTable;
+	export const sql: typeof import('./dist/_internal/runtime/config.js').sql;
+	export const NOW: typeof import('./dist/_internal/runtime/config.js').NOW;
+	export const TRUE: typeof import('./dist/_internal/runtime/config.js').TRUE;
+	export const FALSE: typeof import('./dist/_internal/runtime/config.js').FALSE;
+	export const column: typeof import('./dist/_internal/runtime/config.js').column;
+	export const defineDb: typeof import('./dist/_internal/runtime/config.js').defineDb;
+	export const defineTable: typeof import('./dist/_internal/runtime/config.js').defineTable;
 }

--- a/packages/db/virtual.d.ts
+++ b/packages/db/virtual.d.ts
@@ -1,9 +1,33 @@
 declare module 'astro:db' {
-	export const sql: typeof import('./dist/_internal/runtime/config.js').sql;
-	export const NOW: typeof import('./dist/_internal/runtime/config.js').NOW;
-	export const TRUE: typeof import('./dist/_internal/runtime/config.js').TRUE;
-	export const FALSE: typeof import('./dist/_internal/runtime/config.js').FALSE;
-	export const column: typeof import('./dist/_internal/runtime/config.js').column;
-	export const defineDb: typeof import('./dist/_internal/runtime/config.js').defineDb;
-	export const defineTable: typeof import('./dist/_internal/runtime/config.js').defineTable;
+	type RuntimeConfig = typeof import('./dist/_internal/runtime/config.js');
+
+	export const sql: RuntimeConfig['sql'];
+	export const NOW: RuntimeConfig['NOW'];
+	export const TRUE: RuntimeConfig['TRUE'];
+	export const FALSE: RuntimeConfig['FALSE'];
+	export const column: RuntimeConfig['column'];
+	export const defineDb: RuntimeConfig['defineDb'];
+	export const defineTable: RuntimeConfig['defineTable'];
+
+	export const eq: RuntimeConfig['eq'];
+	export const gt: RuntimeConfig['gt'];
+	export const gte: RuntimeConfig['gte'];
+	export const lt: RuntimeConfig['lt'];
+	export const lte: RuntimeConfig['lte'];
+	export const ne: RuntimeConfig['ne'];
+	export const isNull: RuntimeConfig['isNull'];
+	export const isNotNull: RuntimeConfig['isNotNull'];
+	export const inArray: RuntimeConfig['inArray'];
+	export const notInArray: RuntimeConfig['notInArray'];
+	export const exists: RuntimeConfig['exists'];
+	export const notExists: RuntimeConfig['notExists'];
+	export const between: RuntimeConfig['between'];
+	export const notBetween: RuntimeConfig['notBetween'];
+	export const like: RuntimeConfig['like'];
+	export const notIlike: RuntimeConfig['notIlike'];
+	export const not: RuntimeConfig['not'];
+	export const asc: RuntimeConfig['asc'];
+	export const desc: RuntimeConfig['desc'];
+	export const and: RuntimeConfig['and'];
+	export const or: RuntimeConfig['or'];
 }


### PR DESCRIPTION
## Changes

Split config types to a separate `dist/_internal` to keep type inference while still masking types in your editor.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
