### PR TITLE
fix(redirects): escape `Location` header

### DIFF
--- a/.changeset/khaki-bears-enjoy.md
+++ b/.changeset/khaki-bears-enjoy.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where configured redirects could not include certain characters in the target path.

--- a/packages/astro/src/core/redirects/render.ts
+++ b/packages/astro/src/core/redirects/render.ts
@@ -8,7 +8,7 @@ export async function renderRedirect(renderContext: RenderContext) {
 	const { redirect, redirectRoute } = routeData;
 	const status =
 		redirectRoute && typeof redirect === 'object' ? redirect.status : method === 'GET' ? 301 : 308;
-	const headers = { location: redirectRouteGenerate(renderContext) };
+	const headers = { location: encodeURI(redirectRouteGenerate(renderContext)) };
 	return new Response(null, { status, headers });
 }
 

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -232,7 +232,15 @@ describe('Astro.redirect', () => {
 
 			it('performs dynamic redirects', async () => {
 				const response = await fixture.fetch('/more/old/hello', { redirect: 'manual' });
+				assert.equal(response.status, 301);
 				assert.equal(response.headers.get('Location'), '/more/hello');
+			});
+
+			it.only('performs dynamic redirects with special characters', async () => {
+				// encodeURI("/more/old/’")
+				const response = await fixture.fetch("/more/old/%E2%80%99", { redirect: 'manual' });
+				assert.equal(response.status, 301);
+				assert.equal(response.headers.get('Location'), "/more/%E2%80%99");
 			});
 
 			it('performs dynamic redirects with multiple params', async () => {

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -98,6 +98,16 @@ describe('Astro.redirect', () => {
 				const response = await app.render(request);
 				assert.equal(response.headers.get('Location'), '/not-verbatim/target3/x/y/z');
 			});
+
+			it('Forwards params to the target path - special characters', async () => {
+				const app = await fixture.loadTestAdapterApp();
+				const request = new Request('http://example.com/source/Las Vegas’');
+				const response = await app.render(request);
+				assert.equal(
+					response.headers.get('Location'),
+					'/not-verbatim/target1/Las%20Vegas%E2%80%99'
+				);
+			});
 		});
 	});
 

--- a/packages/astro/test/redirects.test.js
+++ b/packages/astro/test/redirects.test.js
@@ -246,7 +246,7 @@ describe('Astro.redirect', () => {
 				assert.equal(response.headers.get('Location'), '/more/hello');
 			});
 
-			it.only('performs dynamic redirects with special characters', async () => {
+			it('performs dynamic redirects with special characters', async () => {
 				// encodeURI("/more/old/’")
 				const response = await fixture.fetch("/more/old/%E2%80%99", { redirect: 'manual' });
 				assert.equal(response.status, 301);


### PR DESCRIPTION
## Changes
- Fixes #10404

## Testing
- https://github.com/withastro/astro/pull/10410/files
- Another test copied from https://github.com/withastro/astro/pull/10411, where @mingjunlu independently came up with the same solution!

## Docs
- Does not affect usage.