### PR TITLE
Fix check example CI fail

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,6 +12,7 @@ on:
       - ".github/workflows/check.yml"
       - "scripts/smoke/check.js"
       - "packages/astro/src/@types/astro.ts"
+      - "pnpm-lock.yaml"
 
 env:
   ASTRO_TELEMETRY_DISABLED: true

--- a/examples/framework-multiple/package.json
+++ b/examples/framework-multiple/package.json
@@ -16,6 +16,8 @@
     "@astrojs/solid-js": "^4.0.1",
     "@astrojs/svelte": "^5.2.0",
     "@astrojs/vue": "^4.0.8",
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
     "astro": "^4.5.2",
     "preact": "^10.19.2",
     "react": "^18.2.0",

--- a/examples/framework-multiple/src/components/preact/PreactCounter.tsx
+++ b/examples/framework-multiple/src/components/preact/PreactCounter.tsx
@@ -1,9 +1,10 @@
 /** @jsxImportSource preact */
 
 import { useState } from 'preact/hooks';
+import type { ComponentChildren } from 'preact';
 
 /** A counter written with Preact */
-export function PreactCounter({ children }) {
+export function PreactCounter({ children }: { children?: ComponentChildren }) {
 	const [count, setCount] = useState(0);
 	const add = () => setCount((i) => i + 1);
 	const subtract = () => setCount((i) => i - 1);

--- a/examples/framework-multiple/src/components/react/ReactCounter.tsx
+++ b/examples/framework-multiple/src/components/react/ReactCounter.tsx
@@ -1,7 +1,9 @@
-import { useState } from 'react';
+/** @jsxImportSource react */
+
+import { useState, type ReactNode } from 'react';
 
 /** A counter written with React */
-export function Counter({ children }) {
+export function Counter({ children }: { children?: ReactNode }) {
 	const [count, setCount] = useState(0);
 	const add = () => setCount((i) => i + 1);
 	const subtract = () => setCount((i) => i - 1);

--- a/examples/framework-multiple/src/components/solid/SolidCounter.tsx
+++ b/examples/framework-multiple/src/components/solid/SolidCounter.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource solid-js */
 
-import { createSignal } from 'solid-js';
+import { createSignal, type JSX } from 'solid-js';
 
 /** A counter written with Solid */
-export default function SolidCounter({ children }) {
+export default function SolidCounter(props: { children?: JSX.Element }) {
 	const [count, setCount] = createSignal(0);
 	const add = () => setCount(count() + 1);
 	const subtract = () => setCount(count() - 1);
@@ -15,7 +15,7 @@ export default function SolidCounter({ children }) {
 				<pre>{count()}</pre>
 				<button onClick={add}>+</button>
 			</div>
-			<div class="counter-message">{children}</div>
+			<div class="counter-message">{props.children}</div>
 		</>
 	);
 }

--- a/examples/framework-preact/src/components/Counter.tsx
+++ b/examples/framework-preact/src/components/Counter.tsx
@@ -1,11 +1,17 @@
-import { h, Fragment } from 'preact';
+import type { ComponentChildren } from 'preact';
+import type { Signal } from '@preact/signals';
 import { lazy, Suspense } from 'preact/compat';
 import './Counter.css';
 
 const Message = lazy(async () => import('./Message'));
 const Fallback = () => <p>Loading...</p>;
 
-export default function Counter({ children, count }) {
+type Props = {
+	children: ComponentChildren;
+	count: Signal<number>;
+};
+
+export default function Counter({ children, count }: Props) {
 	const add = () => count.value++;
 	const subtract = () => count.value--;
 

--- a/examples/framework-preact/src/components/Message.tsx
+++ b/examples/framework-preact/src/components/Message.tsx
@@ -1,5 +1,6 @@
+import type { ComponentChildren } from 'preact';
 import './Message.css';
 
-export default function Message({ children }) {
+export default function Message({ children }: { children: ComponentChildren }) {
 	return <div class="message">{children}</div>;
 }

--- a/examples/framework-solid/src/components/Counter.tsx
+++ b/examples/framework-solid/src/components/Counter.tsx
@@ -1,7 +1,7 @@
-import { createSignal } from 'solid-js';
+import { createSignal, type JSX } from 'solid-js';
 import './Counter.css';
 
-export default function Counter(props) {
+export default function Counter(props: { children?: JSX.Element }) {
 	const [count, setCount] = createSignal(0);
 	const add = () => setCount(count() + 1);
 	const subtract = () => setCount(count() - 1);

--- a/examples/with-nanostores/src/cartStore.ts
+++ b/examples/with-nanostores/src/cartStore.ts
@@ -13,7 +13,7 @@ export type CartItemDisplayInfo = Pick<CartItem, 'id' | 'name' | 'imageSrc'>;
 
 export const cartItems = map<Record<string, CartItem>>({});
 
-export function addCartItem({ id, name, imageSrc }: CartItem) {
+export function addCartItem({ id, name, imageSrc }: CartItemDisplayInfo) {
 	const existingEntry = cartItems.get()[id];
 	if (existingEntry) {
 		cartItems.setKey(id, {

--- a/examples/with-nanostores/tsconfig.json
+++ b/examples/with-nanostores/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "astro/tsconfigs/base"
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    // Preact specific settings
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "astro-benchmark": "workspace:*"
   },
   "devDependencies": {
-    "@astrojs/check": "^0.3.1",
+    "@astrojs/check": "^0.5.8",
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.2",
     "@types/node": "^18.17.8",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -181,7 +181,7 @@
     "sharp": "^0.32.6"
   },
   "devDependencies": {
-    "@astrojs/check": "^0.3.1",
+    "@astrojs/check": "^0.5.8",
     "@playwright/test": "1.40.0",
     "@types/aria-query": "^5.0.4",
     "@types/babel__generator": "^7.6.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         version: link:benchmark
     devDependencies:
       '@astrojs/check':
-        specifier: ^0.3.1
-        version: 0.3.4(prettier-plugin-astro@0.12.3)(prettier@3.2.5)(typescript@5.2.2)
+        specifier: ^0.5.8
+        version: 0.5.8(prettier-plugin-astro@0.12.3)(prettier@3.2.5)(typescript@5.2.2)
       '@changesets/changelog-github':
         specifier: ^0.4.8
         version: 0.4.8
@@ -205,6 +205,12 @@ importers:
       '@astrojs/vue':
         specifier: ^4.0.8
         version: link:../../packages/integrations/vue
+      '@types/react':
+        specifier: ^18.2.37
+        version: 18.2.64
+      '@types/react-dom':
+        specifier: ^18.2.15
+        version: 18.2.21
       astro:
         specifier: ^4.5.2
         version: link:../../packages/astro
@@ -689,8 +695,8 @@ importers:
         version: 0.32.6
     devDependencies:
       '@astrojs/check':
-        specifier: ^0.3.1
-        version: 0.3.4(prettier-plugin-astro@0.12.3)(prettier@3.2.5)(typescript@5.2.2)
+        specifier: ^0.5.8
+        version: 0.5.8(prettier-plugin-astro@0.12.3)(prettier@3.2.5)(typescript@5.2.2)
       '@playwright/test':
         specifier: 1.40.0
         version: 1.40.0
@@ -5496,23 +5502,6 @@ packages:
       lite-youtube-embed: 0.2.0
     dev: false
 
-  /@astrojs/check@0.3.4(prettier-plugin-astro@0.12.3)(prettier@3.2.5)(typescript@5.2.2):
-    resolution: {integrity: sha512-Wi4KwW38J3GCd/U6LH2UuU4uc4P/K1WYaqhoKm2o7rVoGhQfO+RWrSO26rUPRXYbmae8JugAgpCmsHC8bt5RlA==}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    dependencies:
-      '@astrojs/language-server': 2.7.6(prettier-plugin-astro@0.12.3)(prettier@3.2.5)(typescript@5.2.2)
-      chokidar: 3.6.0
-      fast-glob: 3.3.2
-      kleur: 4.1.5
-      typescript: 5.2.2
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - prettier
-      - prettier-plugin-astro
-    dev: true
-
   /@astrojs/check@0.5.6(prettier-plugin-astro@0.12.3)(prettier@3.2.5)(typescript@5.4.2):
     resolution: {integrity: sha512-i7j5ogoSg/Bu2NV5zVvwCo9R4kGWXWsJDejxpCu9F7iNNlR333u8EwpP4bpeKASDtjOA1rXKo9ogUTEVlIAHqA==}
     hasBin: true
@@ -5529,6 +5518,23 @@ packages:
       - prettier
       - prettier-plugin-astro
     dev: false
+
+  /@astrojs/check@0.5.8(prettier-plugin-astro@0.12.3)(prettier@3.2.5)(typescript@5.2.2):
+    resolution: {integrity: sha512-O3lPUIwhlRtya8KcUDfB0+vBPgj/qVoNvTUhYTTDx0uEsHBbssO5RSFezw6KVBxps6zIR8+YAyOoRKPBhMB7KQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    dependencies:
+      '@astrojs/language-server': 2.8.0(prettier-plugin-astro@0.12.3)(prettier@3.2.5)(typescript@5.2.2)
+      chokidar: 3.6.0
+      fast-glob: 3.3.2
+      kleur: 4.1.5
+      typescript: 5.2.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - prettier
+      - prettier-plugin-astro
+    dev: true
 
   /@astrojs/cli-kit@0.2.5:
     resolution: {integrity: sha512-j6zpNUjtHJGEIKkTrTPvQD3G/sJUKyseJty42iVR3HqytzqHwLK165vptdT4NZKfZ082yLnUtsOXxRyIdfm/AQ==}
@@ -5552,40 +5558,6 @@ packages:
 
   /@astrojs/compiler@2.7.0:
     resolution: {integrity: sha512-XpC8MAaWjD1ff6/IfkRq/5k1EFj6zhCNqXRd5J43SVJEBj/Bsmizkm8N0xOYscGcDFQkRgEw6/eKnI5x/1l6aA==}
-
-  /@astrojs/language-server@2.7.6(prettier-plugin-astro@0.12.3)(prettier@3.2.5)(typescript@5.2.2):
-    resolution: {integrity: sha512-NhMSmMAuKBMXnvpfn9eYPR7R6zOasAjRb+ta8L+rCHHuKzUc0lBgAF5M6rx01FJqlpGqeqao13eYt4287Ze49g==}
-    hasBin: true
-    peerDependencies:
-      prettier: ^3.0.0
-      prettier-plugin-astro: '>=0.11.0'
-    peerDependenciesMeta:
-      prettier:
-        optional: true
-      prettier-plugin-astro:
-        optional: true
-    dependencies:
-      '@astrojs/compiler': 2.7.0
-      '@jridgewell/sourcemap-codec': 1.4.15
-      '@volar/kit': 2.0.4(typescript@5.2.2)
-      '@volar/language-core': 2.0.4
-      '@volar/language-server': 2.0.4
-      '@volar/language-service': 2.0.4
-      '@volar/typescript': 2.0.4
-      fast-glob: 3.3.2
-      prettier: 3.2.5
-      prettier-plugin-astro: 0.12.3
-      volar-service-css: 0.0.30(@volar/language-service@2.0.4)
-      volar-service-emmet: 0.0.30(@volar/language-service@2.0.4)
-      volar-service-html: 0.0.30(@volar/language-service@2.0.4)
-      volar-service-prettier: 0.0.30(@volar/language-service@2.0.4)(prettier@3.2.5)
-      volar-service-typescript: 0.0.30(@volar/language-service@2.0.4)(@volar/typescript@2.0.4)
-      volar-service-typescript-twoslash-queries: 0.0.30(@volar/language-service@2.0.4)
-      vscode-html-languageservice: 5.1.2
-      vscode-uri: 3.0.8
-    transitivePeerDependencies:
-      - typescript
-    dev: true
 
   /@astrojs/language-server@2.7.6(prettier-plugin-astro@0.12.3)(prettier@3.2.5)(typescript@5.4.2):
     resolution: {integrity: sha512-NhMSmMAuKBMXnvpfn9eYPR7R6zOasAjRb+ta8L+rCHHuKzUc0lBgAF5M6rx01FJqlpGqeqao13eYt4287Ze49g==}
@@ -5620,6 +5592,40 @@ packages:
     transitivePeerDependencies:
       - typescript
     dev: false
+
+  /@astrojs/language-server@2.8.0(prettier-plugin-astro@0.12.3)(prettier@3.2.5)(typescript@5.2.2):
+    resolution: {integrity: sha512-WFRwvsWNCQ2I+DEJzRkF/uX0LeJN/oGabr0hnwec8alQzHbzyoqogHmE+i+cU8Mb34ouwsLXa/LlqjEqFbkSZw==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^3.0.0
+      prettier-plugin-astro: '>=0.11.0'
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+    dependencies:
+      '@astrojs/compiler': 2.7.0
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@volar/kit': 2.1.2(typescript@5.2.2)
+      '@volar/language-core': 2.1.2
+      '@volar/language-server': 2.1.2
+      '@volar/language-service': 2.1.2
+      '@volar/typescript': 2.1.2
+      fast-glob: 3.3.2
+      prettier: 3.2.5
+      prettier-plugin-astro: 0.12.3
+      volar-service-css: 0.0.31(@volar/language-service@2.1.2)
+      volar-service-emmet: 0.0.31(@volar/language-service@2.1.2)
+      volar-service-html: 0.0.31(@volar/language-service@2.1.2)
+      volar-service-prettier: 0.0.31-patch.1(@volar/language-service@2.1.2)(prettier@3.2.5)
+      volar-service-typescript: 0.0.31(@volar/language-service@2.1.2)(@volar/typescript@2.1.2)
+      volar-service-typescript-twoslash-queries: 0.0.31(@volar/language-service@2.1.2)
+      vscode-html-languageservice: 5.1.2
+      vscode-uri: 3.0.8
+    transitivePeerDependencies:
+      - typescript
+    dev: true
 
   /@babel/code-frame@7.23.5:
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
@@ -8390,19 +8396,6 @@ packages:
       pretty-format: 29.7.0
     dev: false
 
-  /@volar/kit@2.0.4(typescript@5.2.2):
-    resolution: {integrity: sha512-USRx/o0jKz7o8+lEKWMxWqbqvC46XFrf3IE6CZBYzRo9kM7RERQLwUYaoT2bOcHt5DQWublpnTgdgHMm37Gysg==}
-    peerDependencies:
-      typescript: '*'
-    dependencies:
-      '@volar/language-service': 2.0.4
-      '@volar/typescript': 2.0.4
-      typesafe-path: 0.2.2
-      typescript: 5.2.2
-      vscode-languageserver-textdocument: 1.0.11
-      vscode-uri: 3.0.8
-    dev: true
-
   /@volar/kit@2.0.4(typescript@5.4.2):
     resolution: {integrity: sha512-USRx/o0jKz7o8+lEKWMxWqbqvC46XFrf3IE6CZBYzRo9kM7RERQLwUYaoT2bOcHt5DQWublpnTgdgHMm37Gysg==}
     peerDependencies:
@@ -8416,10 +8409,30 @@ packages:
       vscode-uri: 3.0.8
     dev: false
 
+  /@volar/kit@2.1.2(typescript@5.2.2):
+    resolution: {integrity: sha512-u20R1lCWCgFYBCHC+FR/e9J+P61vUNQpyWt4keAY+zpVHEHsSXVA2xWMJV1l1Iq5Dd0jBUSqrb1zsEya455AzA==}
+    peerDependencies:
+      typescript: '*'
+    dependencies:
+      '@volar/language-service': 2.1.2
+      '@volar/typescript': 2.1.2
+      typesafe-path: 0.2.2
+      typescript: 5.2.2
+      vscode-languageserver-textdocument: 1.0.11
+      vscode-uri: 3.0.8
+    dev: true
+
   /@volar/language-core@2.0.4:
     resolution: {integrity: sha512-VhC8i03P0x9LKGLTBi81xNTNWm40yxQ/Iba8IpH+LFr+Yb7c/D7fF90Cvf31MzPDM4G5rjIOlCfs+eQKPBkwQw==}
     dependencies:
       '@volar/source-map': 2.0.4
+    dev: false
+
+  /@volar/language-core@2.1.2:
+    resolution: {integrity: sha512-5qsDp0Gf6fE09UWCeK7bkVn6NxMwC9OqFWQkMMkeej8h8XjyABPdRygC2RCrqDrfVdGijqlMQeXs6yRS+vfZYA==}
+    dependencies:
+      '@volar/source-map': 2.1.2
+    dev: true
 
   /@volar/language-server@2.0.4:
     resolution: {integrity: sha512-VnljhooQjT6RhmvwwJK9+3YYs2ovFmav4IVNHiQgnTMfiOiyABzcghwvJrJrI39rJDI6LNOWF7BYUJq7K07BKQ==}
@@ -8435,6 +8448,23 @@ packages:
       vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
+    dev: false
+
+  /@volar/language-server@2.1.2:
+    resolution: {integrity: sha512-5NR5Ztg+OxvDI4oRrjS0/4ZVPumWwhVq5acuK2BJbakG1kJXViYI9NOWiWITMjnliPvf12TEcSrVDBmIq54DOg==}
+    dependencies:
+      '@volar/language-core': 2.1.2
+      '@volar/language-service': 2.1.2
+      '@volar/snapshot-document': 2.1.2
+      '@volar/typescript': 2.1.2
+      '@vscode/l10n': 0.0.16
+      path-browserify: 1.0.1
+      request-light: 0.7.0
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.11
+      vscode-uri: 3.0.8
+    dev: true
 
   /@volar/language-service@2.0.4:
     resolution: {integrity: sha512-DoanyU9I9Nl85lUytDl8jgyk+nrUDR5CFNVMrxWXGXclP4WTqBayBgSFAeF1L/5AwP3MywmWoK4GLAEVvl8D+Q==}
@@ -8443,23 +8473,56 @@ packages:
       vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
+    dev: false
+
+  /@volar/language-service@2.1.2:
+    resolution: {integrity: sha512-CmVbbKdqzVq+0FT67hfELdHpboqXhKXh6EjypypuFX5ptIRftHZdkaq3/lCCa46EHxS5tvE44jn+s7faN4iRDA==}
+    dependencies:
+      '@volar/language-core': 2.1.2
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.11
+      vscode-uri: 3.0.8
+    dev: true
 
   /@volar/snapshot-document@2.0.4:
     resolution: {integrity: sha512-YzgdmvpdRFxiBFCOVWga67naAtbPtKmPaFtGnmxWx+KXrjGkpUXT/2tzeKn5FLdtoYV+DRTdpMdP/45ArnVwZQ==}
     dependencies:
       vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.11
+    dev: false
+
+  /@volar/snapshot-document@2.1.2:
+    resolution: {integrity: sha512-ZpJIBZrdm/Gx4jC/zn8H+O6H5vZZwY7B5CMTxl9y8HvcqlePOyDi+VkX8pjQz1VFG9Z5Z+Bau/RL6exqkoVDDA==}
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.11
+    dev: true
 
   /@volar/source-map@2.0.4:
     resolution: {integrity: sha512-BbxUinEMoJZqrHsSj1aBa0boCBnN3BoXnf7j9IBwjxosxGXOhCvqmH2L9raJemadaKjeVR8ZQLhV7AOhyoHt/Q==}
     dependencies:
       muggle-string: 0.4.1
+    dev: false
+
+  /@volar/source-map@2.1.2:
+    resolution: {integrity: sha512-yFJqsuLm1OaWrsz9E3yd3bJcYIlHqdZ8MbmIoZLrAzMYQDcoF26/INIhgziEXSdyHc8xd7rd/tJdSnUyh0gH4Q==}
+    dependencies:
+      muggle-string: 0.4.1
+    dev: true
 
   /@volar/typescript@2.0.4:
     resolution: {integrity: sha512-KF7yh7GIo4iWuAQOKf/ONeFHdQA+wFriitW8LtGZB4iOOT6MdlRlYNsRL8do7XxmXvsBKcs4jTMtGn+uZRwlWg==}
     dependencies:
       '@volar/language-core': 2.0.4
       path-browserify: 1.0.1
+    dev: false
+
+  /@volar/typescript@2.1.2:
+    resolution: {integrity: sha512-lhTancZqamvaLvoz0u/uth8dpudENNt2LFZOWCw9JZiX14xRFhdhfzmphiCRb7am9E6qAJSbdS/gMt1utXAoHQ==}
+    dependencies:
+      '@volar/language-core': 2.1.2
+      path-browserify: 1.0.1
+    dev: true
 
   /@vscode/emmet-helper@2.9.2:
     resolution: {integrity: sha512-MaGuyW+fa13q3aYsluKqclmh62Hgp0BpKIqS66fCxfOaBcVQ1OnMQxRRgQUYnCkxFISAQlkJ0qWWPyXjro1Qrg==}
@@ -16415,6 +16478,21 @@ packages:
       '@volar/language-service': 2.0.4
       vscode-css-languageservice: 6.2.12
       vscode-uri: 3.0.8
+    dev: false
+
+  /volar-service-css@0.0.31(@volar/language-service@2.1.2):
+    resolution: {integrity: sha512-YDY+qwqYipkXVwh63f9Lk7x/48j9lsxVeXj9lsj5Fp1VAwpPoVpWQhAq3oNp3my9gyS8lEbdIPl0rJzBcJCuUA==}
+    peerDependencies:
+      '@volar/language-service': ~2.1.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+    dependencies:
+      '@volar/language-service': 2.1.2
+      vscode-css-languageservice: 6.2.12
+      vscode-languageserver-textdocument: 1.0.11
+      vscode-uri: 3.0.8
+    dev: true
 
   /volar-service-emmet@0.0.30(@volar/language-service@2.0.4):
     resolution: {integrity: sha512-HEeIrmqQ/DTfuQDI9ER5+YReXXjE9f7W6MlBmn5biUuPyizVTGfuILN8pJhmYvmPHCA7qHhU7CJqwE9DAh9AJg==}
@@ -16427,6 +16505,20 @@ packages:
       '@volar/language-service': 2.0.4
       '@vscode/emmet-helper': 2.9.2
       volar-service-html: 0.0.30(@volar/language-service@2.0.4)
+    dev: false
+
+  /volar-service-emmet@0.0.31(@volar/language-service@2.1.2):
+    resolution: {integrity: sha512-d+KfC0axTB6Ku4v70So3GEqsEzrE9zifDvwnqHUrg+Bts05kCFlRgDCLziXmddKhtaaJJ6oSizHr7WcFUyesww==}
+    peerDependencies:
+      '@volar/language-service': ~2.1.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+    dependencies:
+      '@volar/language-service': 2.1.2
+      '@vscode/emmet-helper': 2.9.2
+      vscode-html-languageservice: 5.1.2
+    dev: true
 
   /volar-service-html@0.0.30(@volar/language-service@2.0.4):
     resolution: {integrity: sha512-wW3TEeRTeHv/3mC8Ik6T62SwewMWFungb8ydyEK/2GDHEntBEG/J9wtuh01/J0kYqPerhlT9zhdGB6PGYHAGuA==}
@@ -16439,6 +16531,21 @@ packages:
       '@volar/language-service': 2.0.4
       vscode-html-languageservice: 5.1.2
       vscode-uri: 3.0.8
+    dev: false
+
+  /volar-service-html@0.0.31(@volar/language-service@2.1.2):
+    resolution: {integrity: sha512-duMjl/VLvPWtmYsIAUtwYw/esFY3FWnVmH7537UpnfY9ncYTX/G43xmoVd+oQJPWh7xi8zwFeUQgZAA6T45Bhg==}
+    peerDependencies:
+      '@volar/language-service': ~2.1.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+    dependencies:
+      '@volar/language-service': 2.1.2
+      vscode-html-languageservice: 5.1.2
+      vscode-languageserver-textdocument: 1.0.11
+      vscode-uri: 3.0.8
+    dev: true
 
   /volar-service-prettier@0.0.30(@volar/language-service@2.0.4)(prettier@3.2.5):
     resolution: {integrity: sha512-Qdc5Zc0y4hJmJbpIQ52cSDjs0uvVug/e2nuL/XZWPJM6Cr5/3RjjoRVKtDQbKItFYlGk+JH+LSXvwQeD5TXZqg==}
@@ -16454,6 +16561,23 @@ packages:
       '@volar/language-service': 2.0.4
       prettier: 3.2.5
       vscode-uri: 3.0.8
+    dev: false
+
+  /volar-service-prettier@0.0.31-patch.1(@volar/language-service@2.1.2)(prettier@3.2.5):
+    resolution: {integrity: sha512-jj6cKOFhOEgMUUKwdx0QUX5f7gsS0SXNqF/9LWcWslnf4C1i8GkOH+lba2yVhPMwHzltJLQOhOL5QKKB1PvKUg==}
+    peerDependencies:
+      '@volar/language-service': ~2.1.0
+      prettier: ^2.2 || ^3.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+      prettier:
+        optional: true
+    dependencies:
+      '@volar/language-service': 2.1.2
+      prettier: 3.2.5
+      vscode-uri: 3.0.8
+    dev: true
 
   /volar-service-typescript-twoslash-queries@0.0.30(@volar/language-service@2.0.4):
     resolution: {integrity: sha512-ahj6woBxhkZu7icQR58x5TnUaS8ZRKn7a+UvY+andmiTWsOaSu85zj36+LPZgZQi1MG+BtjNwUjKoxtZiN51PA==}
@@ -16464,6 +16588,18 @@ packages:
         optional: true
     dependencies:
       '@volar/language-service': 2.0.4
+    dev: false
+
+  /volar-service-typescript-twoslash-queries@0.0.31(@volar/language-service@2.1.2):
+    resolution: {integrity: sha512-NsI1izFST7H6GN7WQow/GEPykPLGt0zlIJl+05bX9W6pXY8kD6PUSz7U+v5TSbUMMmjFFn8IkAAHopbH11OWrA==}
+    peerDependencies:
+      '@volar/language-service': ~2.1.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+    dependencies:
+      '@volar/language-service': 2.1.2
+    dev: true
 
   /volar-service-typescript@0.0.30(@volar/language-service@2.0.4)(@volar/typescript@2.0.4):
     resolution: {integrity: sha512-jA8c0Mhy9rgAsrgtwocK95Smws1M2E0MxlQ/SVo/rmOGH32cX9UGgI0IENWKa3yagp/khfoemOIQDz/KNhI3zg==}
@@ -16482,6 +16618,25 @@ packages:
       vscode-languageserver-textdocument: 1.0.11
       vscode-nls: 5.2.0
       vscode-uri: 3.0.8
+    dev: false
+
+  /volar-service-typescript@0.0.31(@volar/language-service@2.1.2)(@volar/typescript@2.1.2):
+    resolution: {integrity: sha512-gaSsX0NmWgENPx6KrHcj+Xru4iQWDpt1kLJcWYNJZ5XaMawYFlVXjWGX/lCO6P7AoLoc2NQnTYUpgTfTjbqdaQ==}
+    peerDependencies:
+      '@volar/language-service': ~2.1.0
+      '@volar/typescript': ~2.1.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+    dependencies:
+      '@volar/language-service': 2.1.2
+      '@volar/typescript': 2.1.2
+      path-browserify: 1.0.1
+      semver: 7.6.0
+      typescript-auto-import-cache: 0.3.2
+      vscode-languageserver-textdocument: 1.0.11
+      vscode-nls: 5.2.0
+    dev: true
 
   /vscode-css-languageservice@6.2.12:
     resolution: {integrity: sha512-PS9r7HgNjqzRl3v91sXpCyZPc8UDotNo6gntFNtGCKPhGA9Frk7g/VjX1Mbv3F00pn56D+rxrFzR9ep4cawOgA==}


### PR DESCRIPTION
## Changes

`main` is currently failing on the examples check fail. Seems like `@astrojs/check` after the lockfile upgrade is able to properly typecheck `.tsx` files now. This PR improves the typings so it passes.

- I also updated `@astrojs/check` to latest (0.5.8) from 0.3.1 (this updates our version only and not a breaking change)
- I tweaked the `check.yml` workflow so it'll run whenever we do deps upgrades again. 

## Testing

Ran `pnpm test:check-examples` locally.

## Docs

n/a
