### PR TITLE
fix(app): provide adapter locals to error pages

### DIFF
--- a/.changeset/thin-deers-sin.md
+++ b/.changeset/thin-deers-sin.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where error pages did not have access to the `Astro.locals` fields provided by the adapter.

--- a/packages/astro/test/fixtures/ssr-locals/src/pages/404.astro
+++ b/packages/astro/test/fixtures/ssr-locals/src/pages/404.astro
@@ -1,0 +1,4 @@
+---
+const { foo } = Astro.locals;
+---
+<h1 id="foo">{ foo }</h1>

--- a/packages/astro/test/fixtures/ssr-locals/src/pages/500.astro
+++ b/packages/astro/test/fixtures/ssr-locals/src/pages/500.astro
@@ -1,0 +1,4 @@
+---
+const { foo } = Astro.locals;
+---
+<h1 id="foo">{ foo }</h1>

--- a/packages/astro/test/fixtures/ssr-locals/src/pages/go-to-error-page.astro
+++ b/packages/astro/test/fixtures/ssr-locals/src/pages/go-to-error-page.astro
@@ -1,0 +1,3 @@
+---
+throw new Error
+---


### PR DESCRIPTION
## Changes
- Fixes #10421 

## Testing
- Added to `ssr-locals` fixture.

## Docs
- Does not affect usage.