### PR TITLE
[db] wait for token to propagate

### DIFF
--- a/.changeset/breezy-dancers-give.md
+++ b/.changeset/breezy-dancers-give.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Add wait time for the db token to propagate

--- a/packages/db/src/core/tokens.ts
+++ b/packages/db/src/core/tokens.ts
@@ -3,7 +3,9 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { MISSING_PROJECT_ID_ERROR, MISSING_SESSION_ID_ERROR } from './errors.js';
-import { getAstroStudioEnv, getAstroStudioUrl, getRemoteDatabaseUrl, safeFetch } from './utils.js';
+import { getAstroStudioEnv, getAstroStudioUrl, safeFetch } from './utils.js';
+import ora from 'ora';
+import { green } from 'kleur/colors';
 
 export const SESSION_LOGIN_FILE = pathToFileURL(join(homedir(), '.astro', 'session-token'));
 export const PROJECT_ID_FILE = pathToFileURL(join(process.cwd(), '.astro', 'link'));
@@ -26,19 +28,12 @@ class ManagedLocalAppToken implements ManagedAppToken {
 class ManagedRemoteAppToken implements ManagedAppToken {
 	token: string;
 	session: string;
-	region: string | undefined;
 	projectId: string;
 	ttl: number;
 	renewTimer: NodeJS.Timeout | undefined;
 
-	static async getRegionCode(): Promise<string | undefined> {
-		const pingResponse = await safeFetch(new URL(`${getRemoteDatabaseUrl()}/ping`));
-		const pingResult = (await pingResponse.json()) as { success: true; data: { region: string } };
-		return pingResult.data.region;
-	}
-
 	static async create(sessionToken: string, projectId: string) {
-		const region = await ManagedRemoteAppToken.getRegionCode();
+		const spinner = ora('Connecting to remote database...').start();
 		const response = await safeFetch(
 			new URL(`${getAstroStudioUrl()}/auth/cli/token-create`),
 			{
@@ -46,18 +41,22 @@ class ManagedRemoteAppToken implements ManagedAppToken {
 				headers: new Headers({
 					Authorization: `Bearer ${sessionToken}`,
 				}),
-				body: JSON.stringify({ projectId, region }),
+				body: JSON.stringify({ projectId }),
 			},
 			(res) => {
 				throw new Error(`Failed to create token: ${res.status} ${res.statusText}`);
 			}
 		);
+		// Wait for 2 seconds! This is the maximum time we would reasonably expect a token
+		// to be created and propagate to all the necessary DB services. Without this, you
+		// risk a token being created, used immediately, and failing to authenticate.
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+		spinner.succeed(green('Connected to remote database.'));
 
 		const { token: shortLivedAppToken, ttl } = await response.json();
 		return new ManagedRemoteAppToken({
 			token: shortLivedAppToken,
 			session: sessionToken,
-			region,
 			projectId,
 			ttl,
 		});
@@ -66,13 +65,11 @@ class ManagedRemoteAppToken implements ManagedAppToken {
 	constructor(options: {
 		token: string;
 		session: string;
-		region: string | undefined;
 		projectId: string;
 		ttl: number;
 	}) {
 		this.token = options.token;
 		this.session = options.session;
-		this.region = options.region;
 		this.projectId = options.projectId;
 		this.ttl = options.ttl;
 		this.renewTimer = setTimeout(() => this.renew(), (1000 * 60 * 5) / 2);
@@ -87,7 +84,7 @@ class ManagedRemoteAppToken implements ManagedAppToken {
 					Authorization: `Bearer ${this.session}`,
 					'Content-Type': 'application/json',
 				},
-				body: JSON.stringify({ ...body, region: this.region }),
+				body: JSON.stringify(body),
 			},
 			() => {
 				throw new Error(`Failed to fetch ${url}.`);


### PR DESCRIPTION
## Changes

- A new attempt to solve this problem: https://github.com/withastro/astro/pull/10428
- That PR did solve the problem when each region had a single machine running, but failed to account for replication across multiple machines in the same region. 
- In practice, Machine A in region `sjc` could create your token and Machine B (also in region `sjc`) could attempt to use it before it's been propagated. Pinning to region `sjc` did not solve the problem in that case.
- The new solution removes the complexity of the original one, and now just embraces replication as something to wait for vs. trying to build around and solve for. It adds a delay on token creation greater than the maximum time our tokens take to propagate (2sec of wait vs. 1600ms of maximum token propagation). In the near future, we should be able to get this down closer to 1sec of wait time. 

https://github.com/withastro/astro/assets/622227/fa16bcad-3396-4617-8edf-009344202c5c


## Testing

- Tested manually

## Docs

- N/A