### PR TITLE
add missing regions to link command

### DIFF
--- a/.changeset/empty-ants-crash.md
+++ b/.changeset/empty-ants-crash.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Add all regions to the link command

--- a/packages/db/src/core/cli/commands/link/index.ts
+++ b/packages/db/src/core/cli/commands/link/index.ts
@@ -238,6 +238,10 @@ export async function promptNewProjectRegion(): Promise<string> {
 		choices: [
 			{ title: 'North America (East)', value: 'NorthAmericaEast' },
 			{ title: 'North America (West)', value: 'NorthAmericaWest' },
+			{ title: 'Europe (Amsterdam)', value: 'EuropeCentral' },
+			{ title: 'South America (Brazil)', value: 'SouthAmericaEast' },
+			{ title: 'Asia (India)', value: 'AsiaSouth' },
+			{ title: 'Asia (Japan)', value: 'AsiaNorthEast' },
 		],
 		initial: 0,
 	});


### PR DESCRIPTION
## Changes

- Only `us-east` and `us-west` were available, this adds back the missing 4 other regions!

## Testing

- N/A

## Docs

- N/A