### PR TITLE
feat(db): `execute` command logs

### DIFF
--- a/.changeset/hip-mugs-know.md
+++ b/.changeset/hip-mugs-know.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Add success and error logs to `astro db execute` command

--- a/packages/db/src/core/errors.ts
+++ b/packages/db/src/core/errors.ts
@@ -41,11 +41,16 @@ export const SEED_ERROR = (error: string) => {
 	return `${red(`Error while seeding database:`)}\n\n${error}`;
 };
 
+export const EXEC_ERROR = (error: string) => {
+	return `${red(`Error while executing file:`)}\n\n${error}`;
+};
+
 export const SEED_DEFAULT_EXPORT_ERROR = (fileName: string) => {
-	return (
-		red('Error while seeding database:') +
-		`\n\nMissing default function export in ${bold(fileName)}`
-	);
+	return SEED_ERROR(`Missing default function export in ${bold(fileName)}`);
+};
+
+export const EXEC_DEFAULT_EXPORT_ERROR = (fileName: string) => {
+	return EXEC_ERROR(`Missing default function export in ${bold(fileName)}`);
 };
 
 export const REFERENCE_DNE_ERROR = (columnName: string) => {


### PR DESCRIPTION
## Changes

Add formatted success and error logs to `db execute.
- Add LibSQL error formatting to match seed error messages
- Add success log

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
