### PR TITLE
chore: remove duplicate astro:db log

### DIFF
--- a/.changeset/eleven-lobsters-doubt.md
+++ b/.changeset/eleven-lobsters-doubt.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Remove duplicate astro:db log during type generation

--- a/packages/db/src/core/integration/vite-plugin-inject-env-ts.ts
+++ b/packages/db/src/core/integration/vite-plugin-inject-env-ts.ts
@@ -46,7 +46,7 @@ export async function setUpEnvTs({
 		if (!typesEnvContents.includes(dbTypeReference)) {
 			typesEnvContents = `${dbTypeReference}\n${typesEnvContents}`;
 			await writeFile(envTsPath, typesEnvContents, 'utf-8');
-			logger.info(`${cyan(bold('[astro:db]'))} Added ${bold(envTsPathRelativetoRoot)} types`);
+			logger.info(`Added ${bold(envTsPathRelativetoRoot)} types`);
 		}
 	}
 }


### PR DESCRIPTION
## Changes

Remove duplicate `astro:db` prefix on env type update

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
