### PR TITLE
Prefer getting app token from runtime env

### DIFF
--- a/.changeset/dry-rivers-switch.md
+++ b/.changeset/dry-rivers-switch.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Prefer getting the app token from the runtime env

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -142,7 +142,7 @@ export function getStudioVirtualModContents({
 	return `
 import {asDrizzleTable, createRemoteDatabaseClient} from ${RUNTIME_IMPORT};
 
-export const db = await createRemoteDatabaseClient(${JSON.stringify(
+export const db = await createRemoteDatabaseClient(process.env.ASTRO_STUDIO_APP_TOKEN ?? ${JSON.stringify(
 		appToken
 		// Respect runtime env for user overrides in SSR
 	)}, import.meta.env.ASTRO_STUDIO_REMOTE_DB_URL ?? ${JSON.stringify(getRemoteDatabaseUrl())});


### PR DESCRIPTION
## Changes

- Use the runtime `process.env.ASTRO_STUDIO_APP_TOKEN` before falling back to one that's in CI.

## Testing

- manually

## Docs

N/A, bug fix