### PR TITLE
fix(node): handle offshoot promise rejections

### DIFF
--- a/.changeset/sharp-flowers-ring.md
+++ b/.changeset/sharp-flowers-ring.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/node": patch
+---
+
+Prevents crashes caused by rejections of offshoot promises.

--- a/packages/integrations/node/test/errors.test.js
+++ b/packages/integrations/node/test/errors.test.js
@@ -1,11 +1,16 @@
+import { spawn } from 'node:child_process';
+import { Worker } from 'node:worker_threads';
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import nodejs from '../dist/index.js';
 import { loadFixture } from './test-utils.js';
+import { fileURLToPath } from 'node:url';
 
 describe('Errors', () => {
+	/** @type {import('./test-utils.js').Fixture} */
 	let fixture;
+
 	before(async () => {
 		fixture = await loadFixture({
 			root: './fixtures/errors/',
@@ -17,10 +22,30 @@ describe('Errors', () => {
 	let devPreview;
 
 	before(async () => {
-		devPreview = await fixture.preview();
+		// devPreview = await fixture.preview();
 	});
 	after(async () => {
-		await devPreview.stop();
+		await devPreview?.stop();
+	});
+
+	it('stays alive after offshoot promise rejections', async () => {
+		// this test needs to happen in a worker because node test runner adds a listener for unhandled rejections in the main thread
+		const worker = new Worker('./test/fixtures/errors/dist/server/entry.mjs', {
+			type: 'module',
+			env: { ASTRO_NODE_LOGGING: 'enabled' }
+		});
+		
+		await new Promise((resolve, reject) => {
+			worker.stdout.on('data', data => {
+				setTimeout(() => reject("Server took too long to start"), 1000);
+				if (data.toString().includes('Server listening on http://localhost:4321')) resolve();
+			});
+		});
+		
+		await fetch("http://localhost:4321/offshoot-promise-rejection");
+
+		// if there was a crash, it becomes an error here
+		await worker.terminate();
 	});
 
 	it(

--- a/packages/integrations/node/test/errors.test.js
+++ b/packages/integrations/node/test/errors.test.js
@@ -22,6 +22,7 @@ describe('Errors', () => {
 	let devPreview;
 
 	before(async () => {
+		// The two tests that need the server to run are skipped
 		// devPreview = await fixture.preview();
 	});
 	after(async () => {

--- a/packages/integrations/node/test/fixtures/errors/src/pages/offshoot-promise-rejection.astro
+++ b/packages/integrations/node/test/fixtures/errors/src/pages/offshoot-promise-rejection.astro
@@ -1,0 +1,2 @@
+{new Promise(async _ => (await {}, Astro.props.undefined.alsoAPropertyOfUndefined))}
+{Astro.props.undefined.propertyOfUndefined}


### PR DESCRIPTION
## Changes
- Fixes #10367 thoroughly but only for the node adapter.

## Testing
- Added

## Docs
- Does not affect usage.