### PR TITLE
Fixes an TypeError when using astro:transitions/client without <ViewTransitions>

### DIFF
--- a/.changeset/thirty-dancers-wink.md
+++ b/.changeset/thirty-dancers-wink.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an error when using `astro:transtions/client` without `<ViewTransitions/>`

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -622,7 +622,7 @@ const onScrollEnd = () => {
 	// "scrollend" events. To avoid redundant work and expensive calls to
 	// `replaceState()`, we simply check that the values are different before
 	// updating.
-	if (scrollX !== history.state.scrollX || scrollY !== history.state.scrollY) {
+	if (history.state && (scrollX !== history.state.scrollX || scrollY !== history.state.scrollY)) {
 		updateScrollPosition({ scrollX, scrollY });
 	}
 };


### PR DESCRIPTION
## Changes

prevents access of null object, see #10235  

## Testing

Manual tested

## Docs

n.a.