### PR TITLE
Add indicator for inline code blocks

### DIFF
--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -84,6 +84,13 @@ const highlighter = await getCachedHighlighter({
 	],
 	theme,
 	themes,
+  transformers: [
+    {
+      code (node) {
+        this.addClassToHast(node, inline ? "inline-block" : "")
+      },
+    },
+  ]
 	wrap,
 });
 


### PR DESCRIPTION
## Changes

- currently there is no way to distinguish between inline and block-level code blocks.
- this results in inline code blocks getting styled in the same way as block-level ones.
- which may or may not be what you want.
- this change is non-breaking, the user is free to implement inline-code specific styles at their own pace

## Testing
no tests implemented. pretty simple change

## Docs
Developer can style inline code blocks on their own. just like what's done with other aspects of shiki. although if requested I can write documentation
