### PR TITLE
[db] remove token creation wait time

### DIFF
--- a/.changeset/small-crabs-look.md
+++ b/.changeset/small-crabs-look.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Remove redundant wait time on token creation

--- a/packages/db/src/core/tokens.ts
+++ b/packages/db/src/core/tokens.ts
@@ -62,10 +62,6 @@ class ManagedRemoteAppToken implements ManagedAppToken {
 				throw new Error(`Failed to create token: ${res.status} ${res.statusText}`);
 			}
 		);
-		// Wait for 2 seconds! This is the maximum time we would reasonably expect a token
-		// to be created and propagate to all the necessary DB services. Without this, you
-		// risk a token being created, used immediately, and failing to authenticate.
-		await new Promise((resolve) => setTimeout(resolve, 2000));
 		spinner.succeed(green('Connected to remote database.'));
 
 		const { token, ttl } = await response.json();


### PR DESCRIPTION
## Changes

- The `/auth/cli/token-create` endpoint is being updated to handle the propagation itself, meaning that the client-side wait is no longer needed. 
- This means that older versions of this code will run ~2sec longer than actually needed. We can also add a query-param to opt-in to the server-side handling to avoid this, but ultimately it didn't feel worth it to me. Happy to revisit if others disagree.
- For older versions of this code, there will be no change to the user experience, just a shifting of responsibility out of the client.

## Testing

- N/A

## Docs

- N/A