### PR TITLE
db: Expose aggregation helpers

### DIFF
--- a/.changeset/clever-glasses-rest.md
+++ b/.changeset/clever-glasses-rest.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": minor
+---
+
+Expose Drizzle aggregation helpers including `count()` from the `astro:db` module.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -66,7 +66,7 @@
     "@libsql/client": "^0.5.5",
     "async-listen": "^3.0.1",
     "deep-diff": "^1.0.2",
-    "drizzle-orm": "^0.29.5",
+    "drizzle-orm": "^0.30.2",
     "kleur": "^4.1.5",
     "nanoid": "^5.0.1",
     "open": "^10.0.3",

--- a/packages/db/src/runtime/config.ts
+++ b/packages/db/src/runtime/config.ts
@@ -76,4 +76,12 @@ export {
 	desc,
 	and,
 	or,
+	count,
+	countDistinct,
+	avg,
+	avgDistinct,
+	sum,
+	sumDistinct,
+	max,
+	min,
 } from 'drizzle-orm';

--- a/packages/db/virtual.d.ts
+++ b/packages/db/virtual.d.ts
@@ -33,4 +33,12 @@ declare module 'astro:db' {
 	export const desc: RuntimeConfig['desc'];
 	export const and: RuntimeConfig['and'];
 	export const or: RuntimeConfig['or'];
+	export const count: RuntimeConfig['count'];
+	export const countDistinct: RuntimeConfig['countDistinct'];
+	export const avg: RuntimeConfig['avg'];
+	export const avgDistinct: RuntimeConfig['avgDistinct'];
+	export const sum: RuntimeConfig['sum'];
+	export const sumDistinct: RuntimeConfig['sumDistinct'];
+	export const max: RuntimeConfig['max'];
+	export const min: RuntimeConfig['min'];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3842,8 +3842,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       drizzle-orm:
-        specifier: ^0.29.5
-        version: 0.29.5(@libsql/client@0.5.6)
+        specifier: ^0.30.2
+        version: 0.30.2(@libsql/client@0.5.6)
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
@@ -10058,13 +10058,14 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /drizzle-orm@0.29.5(@libsql/client@0.5.6):
-    resolution: {integrity: sha512-jS3+uyzTz4P0Y2CICx8FmRQ1eplURPaIMWDn/yq6k4ShRFj9V7vlJk67lSf2kyYPzQ60GkkNGXcJcwrxZ6QCRw==}
+  /drizzle-orm@0.30.2(@libsql/client@0.5.6):
+    resolution: {integrity: sha512-DNd3djg03o+WxZX3pGD8YD+qrWT8gbrbhaZ2W0PVb6yH4rtM/VTB92cTGvumcRh7SSd2KfV0NWYDB70BHIXQTg==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=3'
       '@libsql/client': '*'
       '@neondatabase/serverless': '>=0.1'
+      '@op-engineering/op-sqlite': '>=2'
       '@opentelemetry/api': ^1.4.1
       '@planetscale/database': '>=1'
       '@types/better-sqlite3': '*'
@@ -10091,6 +10092,8 @@ packages:
       '@libsql/client':
         optional: true
       '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
         optional: true
       '@opentelemetry/api':
         optional: true


### PR DESCRIPTION
## Changes

Expose drizzle aggregation helpers like `count()`. This includes a minor version bump to Drizzle ORM.

## Testing

Manual testing to ensure exports exist.

## Docs

It was documented even though it was not exposed 🙈 