### PR TITLE
fix(packages/create-astro): wait for writeFile to complete in updateFiles

### DIFF
--- a/.changeset/light-falcons-battle.md
+++ b/.changeset/light-falcons-battle.md
@@ -1,0 +1,5 @@
+---
+"create-astro": patch
+---
+
+Fixes a case where a promise wasn't awaited, causing an issue in Deno.

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -59,7 +59,7 @@ const FILES_TO_UPDATE = {
 		fs.promises.readFile(file, 'utf-8').then((value) => {
 			// Match first indent in the file or fallback to `\t`
 			const indent = /(^\s+)/m.exec(value)?.[1] ?? '\t';
-			fs.promises.writeFile(
+			return fs.promises.writeFile(
 				file,
 				JSON.stringify(
 					Object.assign(JSON.parse(value), Object.assign(overrides, { private: undefined })),


### PR DESCRIPTION
This fix helps create-astro to work with Deno when using the typescript template.
```
deno run -A npm:create-astro@latest
```

Ref https://github.com/denoland/deno/issues/22537#issuecomment-2006165841