### PR TITLE
fix: do not append trailing slash to subresource urls

### DIFF
--- a/.changeset/tender-snails-accept.md
+++ b/.changeset/tender-snails-accept.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/node": patch
+---
+
+fix: do not append traling slash to subresource urls

--- a/.changeset/tender-snails-accept.md
+++ b/.changeset/tender-snails-accept.md
@@ -2,4 +2,4 @@
 "@astrojs/node": patch
 ---
 
-fix: do not append traling slash to subresource urls
+Fixes a bug where the preview server wrongly appends trailing slashes to subresource URLs.

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -6,6 +6,8 @@ import type { NodeApp } from 'astro/app/node';
 import send from 'send';
 import type { Options } from './types.js';
 
+const isSubresourceRegex = /.+\.[a-z]+$/i
+
 /**
  * Creates a Node.js http listener for static files and prerendered pages.
  * In standalone mode, the static handler is queried first for the static files.
@@ -49,7 +51,7 @@ export function createStaticHandler(app: NodeApp, options: Options) {
 					break;
 				case 'always':
 					// trailing slash is not added to "subresources"
-					if (!hasSlash && !urlPath.match(/.+\.[a-z]+$/i)) {
+					if (!hasSlash && !urlPath.match(isSubresourceRegex)) {
 						pathname = urlPath + '/' + (urlQuery ? '?' + urlQuery : '');
 						res.statusCode = 301;
 						res.setHeader('Location', pathname);

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -48,7 +48,8 @@ export function createStaticHandler(app: NodeApp, options: Options) {
 					}
 					break;
 				case 'always':
-					if (!hasSlash) {
+					// trailing slash is not added to "subresources"
+					if (!hasSlash && !urlPath.match(/.+\.[a-z]+$/i)) {
 						pathname = urlPath + '/' + (urlQuery ? '?' + urlQuery : '');
 						res.statusCode = 301;
 						res.setHeader('Location', pathname);

--- a/packages/integrations/node/src/serve-static.ts
+++ b/packages/integrations/node/src/serve-static.ts
@@ -6,6 +6,7 @@ import type { NodeApp } from 'astro/app/node';
 import send from 'send';
 import type { Options } from './types.js';
 
+// check for a dot followed by a extension made up of lowercase characters
 const isSubresourceRegex = /.+\.[a-z]+$/i
 
 /**

--- a/packages/integrations/node/test/fixtures/trailing-slash/public/one.css
+++ b/packages/integrations/node/test/fixtures/trailing-slash/public/one.css
@@ -1,0 +1,1 @@
+h1 { color: red; }

--- a/packages/integrations/node/test/trailing-slash.test.js
+++ b/packages/integrations/node/test/trailing-slash.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { after, before, describe, it, expect } from 'node:test';
 import * as cheerio from 'cheerio';
 import nodejs from '../dist/index.js';
 import { loadFixture } from './test-utils.js';
@@ -76,6 +76,14 @@ describe('Trailing slash', () => {
 				expect(res.status).to.equal(200);
 				expect($('h1').text()).to.equal('One');
 			});
+
+			it('Does not add trailing slash to subresource urls', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/some-base/one.css`);
+				const css = await res.text();
+
+				expect(res.status).to.equal(200);
+				expect(css).to.equal('h1 { color: red; }\n');
+			})
 		});
 		describe('Without base', async () => {
 			before(async () => {
@@ -133,6 +141,14 @@ describe('Trailing slash', () => {
 				expect(res.status).to.equal(200);
 				expect($('h1').text()).to.equal('One');
 			});
+
+			it('Does not add trailing slash to subresource urls', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/one.css`);
+				const css = await res.text();
+
+				expect(res.status).to.equal(200);
+				expect(css).to.equal('h1 { color: red; }\n');
+			})
 		});
 	});
 	describe('Never', async () => {

--- a/packages/integrations/node/test/trailing-slash.test.js
+++ b/packages/integrations/node/test/trailing-slash.test.js
@@ -1,4 +1,5 @@
-import { after, before, describe, it, expect } from 'node:test';
+import { after, before, describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
 import * as cheerio from 'cheerio';
 import nodejs from '../dist/index.js';
 import { loadFixture } from './test-utils.js';
@@ -48,24 +49,24 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('Index');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'Index');
 			});
 
 			it('Can render prerendered route with redirect', async () => {
 				const res = await fetch(`http://${server.host}:${server.port}/some-base/one`, {
 					redirect: 'manual',
 				});
-				expect(res.status).to.equal(301);
-				expect(res.headers.get('location')).to.equal('/some-base/one/');
+				assert.equal(res.status, 301);
+				assert.equal(res.headers.get('location'), '/some-base/one/');
 			});
 
 			it('Can render prerendered route with redirect and query params', async () => {
 				const res = await fetch(`http://${server.host}:${server.port}/some-base/one?foo=bar`, {
 					redirect: 'manual',
 				});
-				expect(res.status).to.equal(301);
-				expect(res.headers.get('location')).to.equal('/some-base/one/?foo=bar');
+				assert.equal(res.status, 301);
+				assert.equal(res.headers.get('location'), '/some-base/one/?foo=bar');
 			});
 
 			it('Can render prerendered route with query params', async () => {
@@ -73,16 +74,16 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('One');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'One');
 			});
 
 			it('Does not add trailing slash to subresource urls', async () => {
 				const res = await fetch(`http://${server.host}:${server.port}/some-base/one.css`);
 				const css = await res.text();
 
-				expect(res.status).to.equal(200);
-				expect(css).to.equal('h1 { color: red; }\n');
+				assert.equal(res.status, 200);
+				assert.equal(css, 'h1 { color: red; }\n');
 			})
 		});
 		describe('Without base', async () => {
@@ -113,24 +114,24 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('Index');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'Index');
 			});
 
 			it('Can render prerendered route with redirect', async () => {
 				const res = await fetch(`http://${server.host}:${server.port}/one`, {
 					redirect: 'manual',
 				});
-				expect(res.status).to.equal(301);
-				expect(res.headers.get('location')).to.equal('/one/');
+				assert.equal(res.status, 301);
+				assert.equal(res.headers.get('location'), '/one/');
 			});
 
 			it('Can render prerendered route with redirect and query params', async () => {
 				const res = await fetch(`http://${server.host}:${server.port}/one?foo=bar`, {
 					redirect: 'manual',
 				});
-				expect(res.status).to.equal(301);
-				expect(res.headers.get('location')).to.equal('/one/?foo=bar');
+				assert.equal(res.status, 301);
+				assert.equal(res.headers.get('location'), '/one/?foo=bar');
 			});
 
 			it('Can render prerendered route with query params', async () => {
@@ -138,16 +139,16 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('One');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'One');
 			});
 
 			it('Does not add trailing slash to subresource urls', async () => {
 				const res = await fetch(`http://${server.host}:${server.port}/one.css`);
 				const css = await res.text();
 
-				expect(res.status).to.equal(200);
-				expect(css).to.equal('h1 { color: red; }\n');
+				assert.equal(res.status, 200);
+				assert.equal(css, 'h1 { color: red; }\n');
 			})
 		});
 	});
@@ -181,16 +182,16 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('Index');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'Index');
 			});
 
 			it('Can render prerendered route with redirect', async () => {
 				const res = await fetch(`http://${server.host}:${server.port}/some-base/one/`, {
 					redirect: 'manual',
 				});
-				expect(res.status).to.equal(301);
-				expect(res.headers.get('location')).to.equal('/some-base/one');
+				assert.equal(res.status, 301);
+				assert.equal(res.headers.get('location'), '/some-base/one');
 			});
 
 			it('Can render prerendered route with redirect and query params', async () => {
@@ -198,8 +199,8 @@ describe('Trailing slash', () => {
 					redirect: 'manual',
 				});
 
-				expect(res.status).to.equal(301);
-				expect(res.headers.get('location')).to.equal('/some-base/one?foo=bar');
+				assert.equal(res.status, 301);
+				assert.equal(res.headers.get('location'), '/some-base/one?foo=bar');
 			});
 
 			it('Can render prerendered route with query params', async () => {
@@ -207,8 +208,8 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('One');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'One');
 			});
 		});
 		describe('Without base', async () => {
@@ -239,16 +240,16 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('Index');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'Index');
 			});
 
 			it('Can render prerendered route with redirect', async () => {
 				const res = await fetch(`http://${server.host}:${server.port}/one/`, {
 					redirect: 'manual',
 				});
-				expect(res.status).to.equal(301);
-				expect(res.headers.get('location')).to.equal('/one');
+				assert.equal(res.status, 301);
+				assert.equal(res.headers.get('location'), '/one');
 			});
 
 			it('Can render prerendered route with redirect and query params', async () => {
@@ -256,8 +257,8 @@ describe('Trailing slash', () => {
 					redirect: 'manual',
 				});
 
-				expect(res.status).to.equal(301);
-				expect(res.headers.get('location')).to.equal('/one?foo=bar');
+				assert.equal(res.status, 301);
+				assert.equal(res.headers.get('location'), '/one?foo=bar');
 			});
 
 			it('Can render prerendered route and query params', async () => {
@@ -265,8 +266,8 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('One');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'One');
 			});
 		});
 	});
@@ -300,8 +301,8 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('Index');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'Index');
 			});
 
 			it('Can render prerendered route with slash', async () => {
@@ -311,8 +312,8 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('One');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'One');
 			});
 
 			it('Can render prerendered route without slash', async () => {
@@ -322,8 +323,8 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('One');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'One');
 			});
 
 			it('Can render prerendered route with slash and query params', async () => {
@@ -333,8 +334,8 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('One');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'One');
 			});
 
 			it('Can render prerendered route without slash and with query params', async () => {
@@ -344,8 +345,8 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('One');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'One');
 			});
 		});
 		describe('Without base', async () => {
@@ -376,8 +377,8 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('Index');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'Index');
 			});
 
 			it('Can render prerendered route with slash', async () => {
@@ -385,8 +386,8 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('One');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'One');
 			});
 
 			it('Can render prerendered route without slash', async () => {
@@ -394,8 +395,8 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('One');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'One');
 			});
 
 			it('Can render prerendered route with slash and query params', async () => {
@@ -405,8 +406,8 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('One');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'One');
 			});
 
 			it('Can render prerendered route without slash and with query params', async () => {
@@ -414,8 +415,8 @@ describe('Trailing slash', () => {
 				const html = await res.text();
 				const $ = cheerio.load(html);
 
-				expect(res.status).to.equal(200);
-				expect($('h1').text()).to.equal('One');
+				assert.equal(res.status, 200);
+				assert.equal($('h1').text(), 'One');
 			});
 		});
 	});


### PR DESCRIPTION
## Changes

- What does this change? It fixes #10481 .
- How: By not appending a trailing slash to subresource urls

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

- Added a new couple of tests to ensure that subresources such as .css files are properly served with a 200 status response.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This change is a bugfix, no documentation changes are needed.
