### PR TITLE
fix: void elements

### DIFF
--- a/.changeset/thick-games-thank.md
+++ b/.changeset/thick-games-thank.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fix void elements
+`<link>` tags created by astro for optimized stylesheets now do not include the closing forward slash. This slash is optional for void elements such as link, but made some html validation fail.

--- a/.changeset/thick-games-thank.md
+++ b/.changeset/thick-games-thank.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix void elements

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -144,7 +144,7 @@ export function renderElement(
 		}
 	}
 	if ((children == null || children == '') && voidElementNames.test(name)) {
-		return `<${name}${internalSpreadAttributes(props, shouldEscape)} />`;
+		return `<${name}${internalSpreadAttributes(props, shouldEscape)}>`;
 	}
 	return `<${name}${internalSpreadAttributes(props, shouldEscape)}>${children}</${name}>`;
 }


### PR DESCRIPTION
## Changes

- What does this change?
	HTML is not XML. It doesn't have self-closing tags, it has void element tags that don't need closing slashes.

	Generated void elements (e.g. `link` with path to style file) do not pass validation, which can be easily fixed by simply removing two characters.
- FYI: https://jakearchibald.com/2023/against-self-closing-tags-in-html/
- Before/after screenshots can help as well.
	![Screenshot from 2024-03-19 16-14-53](https://github.com/withastro/astro/assets/3382798/7173d1df-fde6-4231-b0a3-8466443d265e)
	![Screenshot from 2024-03-19 16-17-11](https://github.com/withastro/astro/assets/3382798/dfc3fd1f-fcdf-41d7-8f8c-098efe1120e5)
- Don't forget a changeset! `pnpm exec changeset`
	I'm not sure, but I hope I did it right.



## Testing

I tested this change in my astro-project — it fixed the validity of the markup.
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Correcting the documentation is most likely not necessary.
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
