### PR TITLE
feat: make 3rd party integration warning less scary

### DIFF
--- a/.changeset/light-bikes-study.md
+++ b/.changeset/light-bikes-study.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+"astro": patch
 ---
 
 Makes the warning less scary when adding 3rd-party integrations using `astro add`

--- a/.changeset/light-bikes-study.md
+++ b/.changeset/light-bikes-study.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Makes the warning less scary when adding 3rd-party integrations using `astro add`

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -860,7 +860,7 @@ export async function validateIntegrations(integrations: string[]): Promise<Inte
 							spinner.warn(yellow(firstPartyPkgCheck.message));
 						}
 						spinner.warn(
-							yellow(`${bold(integration)} is not an official Astro package. Use at your own risk!`)
+							yellow(`${bold(integration)} is not an official Astro package.`)
 						);
 						const response = await prompts({
 							type: 'confirm',


### PR DESCRIPTION
## Changes

- Removes "Use at your own risk!" when using `astro add` with a 3rd party integration. It does not remove any check

## Testing

N/A
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
