### PR TITLE
Removing embedding appToken from CI

### DIFF
--- a/.changeset/lucky-brooms-help.md
+++ b/.changeset/lucky-brooms-help.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Remove embedded app token from CI

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -142,10 +142,7 @@ export function getStudioVirtualModContents({
 	return `
 import {asDrizzleTable, createRemoteDatabaseClient} from ${RUNTIME_IMPORT};
 
-export const db = await createRemoteDatabaseClient(process.env.ASTRO_STUDIO_APP_TOKEN ?? ${JSON.stringify(
-		appToken
-		// Respect runtime env for user overrides in SSR
-	)}, import.meta.env.ASTRO_STUDIO_REMOTE_DB_URL ?? ${JSON.stringify(getRemoteDatabaseUrl())});
+export const db = await createRemoteDatabaseClient(process.env.ASTRO_STUDIO_APP_TOKEN);
 
 export * from ${RUNTIME_CONFIG_IMPORT};
 


### PR DESCRIPTION
## Changes

- Removes fallbacks that grab the app token from the CI env. 
- This is because we require this token be set in your host env instead.

## Testing

N/A

## Docs

N/A