### PR TITLE
Fix: remove `db.transaction()` from types until supported

### DIFF
--- a/.changeset/grumpy-years-lick.md
+++ b/.changeset/grumpy-years-lick.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Remove `db.transaction()` from type definitions until it is supported by our remote database adapter.

--- a/packages/db/src/runtime/config.ts
+++ b/packages/db/src/runtime/config.ts
@@ -10,7 +10,9 @@ import type {
 	TextColumnOpts,
 } from '../core/types.js';
 
-export type { LibSQLDatabase } from 'drizzle-orm/libsql';
+import type { LibSQLDatabase } from 'drizzle-orm/libsql';
+
+export type Database = Omit<LibSQLDatabase, 'transaction'>;
 
 function createColumn<S extends string, T extends Record<string, unknown>>(type: S, schema: T) {
 	return {

--- a/packages/db/virtual.d.ts
+++ b/packages/db/virtual.d.ts
@@ -1,7 +1,7 @@
 declare module 'astro:db' {
 	type RuntimeConfig = typeof import('./dist/_internal/runtime/config.js');
 
-	export const db: import('./dist/_internal/runtime/config.js').LibSQLDatabase;
+	export const db: import('./dist/_internal/runtime/config.js').Database;
 	export const dbUrl: string;
 
 	export const sql: RuntimeConfig['sql'];


### PR DESCRIPTION
## Changes

Users can call `db.transaction()` today, even though it is not supported by our remote DB adapter. This removes `db.transaction()` from our type definitions until this is supported, and raises a runtime error if called.

## Testing

Manual `pnpm pack` to ensure types work.

## Docs

N/A