### PR TITLE
Ensure --force-reset drops previous tables

### DIFF
--- a/.changeset/large-trees-give.md
+++ b/.changeset/large-trees-give.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Ensure --force-reset drops previous tables

--- a/packages/db/src/core/cli/commands/push/index.ts
+++ b/packages/db/src/core/cli/commands/push/index.ts
@@ -9,7 +9,6 @@ import {
 	createCurrentSnapshot,
 	createEmptySnapshot,
 	formatDataLossMessage,
-	getDropTableQueriesForSnapshot,
 	getMigrationQueries,
 	getProductionCurrentSnapshot,
 } from '../../migration-queries.js';

--- a/packages/db/src/core/cli/commands/push/index.ts
+++ b/packages/db/src/core/cli/commands/push/index.ts
@@ -9,6 +9,7 @@ import {
 	createCurrentSnapshot,
 	createEmptySnapshot,
 	formatDataLossMessage,
+	getDropTableQueriesForSnapshot,
 	getMigrationQueries,
 	getProductionCurrentSnapshot,
 } from '../../migration-queries.js';
@@ -26,10 +27,11 @@ export async function cmd({
 	const appToken = await getManagedAppTokenOrExit(flags.token);
 	const productionSnapshot = await getProductionCurrentSnapshot({ appToken: appToken.token });
 	const currentSnapshot = createCurrentSnapshot(dbConfig);
-	const isFromScratch = isForceReset || !productionSnapshot;
+	const isFromScratch = !productionSnapshot;
 	const { queries: migrationQueries, confirmations } = await getMigrationQueries({
 		oldSnapshot: isFromScratch ? createEmptySnapshot() : productionSnapshot,
 		newSnapshot: currentSnapshot,
+		reset: isForceReset
 	});
 
 	// // push the database schema

--- a/packages/db/src/core/cli/migration-queries.ts
+++ b/packages/db/src/core/cli/migration-queries.ts
@@ -46,15 +46,15 @@ export async function getMigrationQueries({
 	newSnapshot: DBSnapshot;
 	reset?: boolean;
 }): Promise<{ queries: string[]; confirmations: string[] }> {
-	let queries: string[] = [];
+	const queries: string[] = [];
 	const confirmations: string[] = [];
 
 	// When doing a reset, first create DROP TABLE statements, then treat everything
 	// else as creation.
 	if(reset) {
-		const curSnapshot = oldSnapshot;
+		const currentSnapshot = oldSnapshot;
 		oldSnapshot = createEmptySnapshot();
-		queries = getDropTableQueriesForSnapshot(curSnapshot);
+		queries.push(...getDropTableQueriesForSnapshot(currentSnapshot));
 	}
 
 	const addedCollections = getAddedCollections(oldSnapshot, newSnapshot);

--- a/packages/db/test/unit/reset-queries.test.js
+++ b/packages/db/test/unit/reset-queries.test.js
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import {
+	getMigrationQueries,
+} from '../../dist/core/cli/migration-queries.js';
+import { MIGRATION_VERSION } from '../../dist/core/consts.js';
+import { tableSchema } from '../../dist/core/schemas.js';
+import { column, defineTable } from '../../dist/runtime/config.js';
+
+const TABLE_NAME = 'Users';
+
+// `parse` to resolve schema transformations
+// ex. convert column.date() to ISO strings
+const userInitial = tableSchema.parse(
+	defineTable({
+		columns: {
+			name: column.text(),
+			age: column.number(),
+			email: column.text({ unique: true }),
+			mi: column.text({ optional: true }),
+		},
+	})
+);
+
+describe('force reset', () => {
+	describe('getMigrationQueries', () => {
+		it('should drop table and create new version', async () => {
+			const oldCollections = { [TABLE_NAME]: userInitial };
+			const newCollections = { [TABLE_NAME]: userInitial };
+			const { queries } = await getMigrationQueries({
+				oldSnapshot: { schema: oldCollections, version: MIGRATION_VERSION },
+				newSnapshot: { schema: newCollections, version: MIGRATION_VERSION },
+				reset: true,
+			});
+
+			expect(queries).to.deep.equal([
+				`DROP TABLE "${TABLE_NAME}"`,
+				`CREATE TABLE "${TABLE_NAME}" (_id INTEGER PRIMARY KEY, "name" text NOT NULL, "age" integer NOT NULL, "email" text NOT NULL UNIQUE, "mi" text)`,
+			]);
+		});
+
+		it('should not drop table when previous snapshot did not have it', async () => {
+			const oldCollections = {};
+			const newCollections = { [TABLE_NAME]: userInitial };
+			const { queries } = await getMigrationQueries({
+				oldSnapshot: { schema: oldCollections, version: MIGRATION_VERSION },
+				newSnapshot: { schema: newCollections, version: MIGRATION_VERSION },
+				reset: true,
+			});
+
+			expect(queries).to.deep.equal([
+				`CREATE TABLE "${TABLE_NAME}" (_id INTEGER PRIMARY KEY, "name" text NOT NULL, "age" integer NOT NULL, "email" text NOT NULL UNIQUE, "mi" text)`,
+			]);
+		});
+	});
+});


### PR DESCRIPTION
## Changes

- Previously `--force-reset` did not include DROP TABLE statements
- Now it does, and they are prepended before creation statements.
- Fixes https://github.com/withastro/astro/issues/10451

## Testing

- Added new unit tests for this.

## Docs

N/A, bug fix