### PR TITLE
feat: allow dynamic route segments in isr.exclude array

### DIFF
--- a/.changeset/angry-lamps-cheer.md
+++ b/.changeset/angry-lamps-cheer.md
@@ -2,4 +2,16 @@
 "@astrojs/vercel": minor
 ---
 
-Allow dynamic route segments in isr.exclude array
+The `isr.exclude` configuration can now include routes with dynamic and spread parameters.
+```ts
+export default defineConfig({
+    adapter: vercel({
+        isr: {
+            exclude: [
+                "/blog/[title]"
+                "/api/[...slug]",
+            ]
+        }
+    })
+})
+```

--- a/.changeset/angry-lamps-cheer.md
+++ b/.changeset/angry-lamps-cheer.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vercel": minor
+---
+
+Allow dynamic route segments in isr.exclude array

--- a/packages/integrations/vercel/src/lib/redirects.ts
+++ b/packages/integrations/vercel/src/lib/redirects.ts
@@ -15,6 +15,8 @@ interface VercelRoute {
 }
 
 // Copied from astro/packages/astro/src/core/routing/manifest/create.ts
+// Disable eslint as we're not sure how to improve this regex yet
+// eslint-disable-next-line regexp/no-super-linear-backtracking
 const ROUTE_DYNAMIC_SPLIT = /\[(.+?\(.+?\)|.+?)\]/;
 const ROUTE_SPREAD = /^\.{3}.+$/;
 function getParts(part: string, file: string) {

--- a/packages/integrations/vercel/src/lib/redirects.ts
+++ b/packages/integrations/vercel/src/lib/redirects.ts
@@ -1,5 +1,5 @@
 import nodePath from 'node:path';
-import { appendForwardSlash } from '@astrojs/internal-helpers/path';
+import { appendForwardSlash, removeLeadingForwardSlash } from '@astrojs/internal-helpers/path';
 import type { AstroConfig, RouteData, RoutePart } from 'astro';
 
 const pathJoin = nodePath.posix.join;
@@ -12,6 +12,31 @@ interface VercelRoute {
 	headers?: Record<string, string>;
 	status?: number;
 	continue?: boolean;
+}
+
+// Copied from astro/packages/astro/src/core/routing/manifest/create.ts
+const ROUTE_DYNAMIC_SPLIT = /\[(.+?\(.+?\)|.+?)\]/;
+const ROUTE_SPREAD = /^\.{3}.+$/;
+function getParts(part: string, file: string) {
+	const result: RoutePart[] = [];
+	part.split(ROUTE_DYNAMIC_SPLIT).map((str, i) => {
+		if (!str) return;
+		const dynamic = i % 2 === 1;
+
+		const [, content] = dynamic ? /([^(]+)$/.exec(str) || [null, null] : [null, str];
+
+		if (!content || (dynamic && !/^(?:\.\.\.)?[\w$]+$/.test(content))) {
+			throw new Error(`Invalid route ${file} — parameter name must match /^[a-zA-Z0-9_$]+$/`);
+		}
+
+		result.push({
+			content,
+			dynamic,
+			spread: dynamic && ROUTE_SPREAD.test(content),
+		});
+	});
+
+	return result;
 }
 
 // Copied from /home/juanm04/dev/misc/astro/packages/astro/src/core/routing/manifest/create.ts
@@ -77,7 +102,13 @@ function getRedirectStatus(route: RouteData): number {
 }
 
 export function escapeRegex(content: string) {
-	return `^${getMatchPattern([[{ content, dynamic: false, spread: false }]])}$`;
+	const segments = removeLeadingForwardSlash(content)
+		.split(nodePath.posix.sep)
+		.filter(Boolean)
+		.map((s: string) => {
+			return getParts(s, content);
+		});
+	return `^/${getMatchPattern(segments)}$`;
 }
 
 export function getRedirects(routes: RouteData[], config: AstroConfig): VercelRoute[] {

--- a/packages/integrations/vercel/test/fixtures/isr/astro.config.mjs
+++ b/packages/integrations/vercel/test/fixtures/isr/astro.config.mjs
@@ -7,7 +7,7 @@ export default defineConfig({
 		isr: {
 			bypassToken: "1c9e601d-9943-4e7c-9575-005556d774a8",
 			expiration: 120,
-			exclude: ["/two"]
+			exclude: ["/two", "/excluded/[dynamic]"]
 		}
 	})
 });

--- a/packages/integrations/vercel/test/fixtures/isr/src/pages/excluded/[dynamic].astro
+++ b/packages/integrations/vercel/test/fixtures/isr/src/pages/excluded/[dynamic].astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>Dynamic</title>
+	</head>
+	<body>
+		<h1>Dynamic</h1>
+	</body>
+</html>

--- a/packages/integrations/vercel/test/isr.test.js
+++ b/packages/integrations/vercel/test/isr.test.js
@@ -34,8 +34,16 @@ describe('ISR', () => {
 				dest: '_render',
 			},
 			{
+				src: '^\\/excluded\\/([^/]+?)$',
+				dest: '_render'
+		    },
+			{
 				src: '^\\/_image$',
 				dest: '_render',
+			},
+			{
+				src: '^\\/excluded\\/([^/]+?)\\/?$',
+				dest: '/_isr?x_astro_path=$0',
 			},
 			{
 				src: '^\\/one\\/?$',

--- a/packages/integrations/vercel/test/isr.test.js
+++ b/packages/integrations/vercel/test/isr.test.js
@@ -34,7 +34,7 @@ describe('ISR', () => {
 				dest: '_render',
 			},
 			{
-				src: '^\\/excluded\\/([^/]+?)$',
+				src: '^/excluded/([^/]+?)$',
 				dest: '_render'
 		    },
 			{


### PR DESCRIPTION
## Changes
Adds support for dynamic route segments in the isr.exclude array. See #10492

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Manually tested: the implementation transforms the route segments similar to how redirects are transformed.
## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A