### PR TITLE
Revert "Removing embedding appToken from CI (#10497)"

### DIFF
--- a/.changeset/modern-roses-buy.md
+++ b/.changeset/modern-roses-buy.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Fix accessing remote database URL

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -142,7 +142,10 @@ export function getStudioVirtualModContents({
 	return `
 import {asDrizzleTable, createRemoteDatabaseClient} from ${RUNTIME_IMPORT};
 
-export const db = await createRemoteDatabaseClient(process.env.ASTRO_STUDIO_APP_TOKEN);
+export const db = await createRemoteDatabaseClient(process.env.ASTRO_STUDIO_APP_TOKEN ?? ${JSON.stringify(
+		appToken
+		// Respect runtime env for user overrides in SSR
+	)}, import.meta.env.ASTRO_STUDIO_REMOTE_DB_URL ?? ${JSON.stringify(getRemoteDatabaseUrl())});
 
 export * from ${RUNTIME_CONFIG_IMPORT};
 


### PR DESCRIPTION
This reverts commit 2fc7231df28e5a3425ee47b871ba3766e0856bd8.

## Changes

- This broken everything.
- Env is definitely needed locally, we should only be not including it during the build. Will follow up with a proper fix.
- Fixes https://github.com/withastro/astro/pull/10520

## Testing

- Manual for now

## Docs

N/A