### PR TITLE
chore: test with latest minor versions of node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           - os: macos-14
             NODE_VERSION: 18
           - os: windows-latest
-            NODE_VERSION: 18.17.1
+            NODE_VERSION: 18
       fail-fast: false
     env:
       NODE_VERSION: ${{ matrix.NODE_VERSION }}
@@ -147,7 +147,7 @@ jobs:
     strategy:
       matrix:
         OS: [ubuntu-latest, windows-latest]
-        NODE_VERSION: [18.17.1]
+        NODE_VERSION: [18]
       fail-fast: false
     env:
       NODE_VERSION: ${{ matrix.NODE_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix:
         OS: [ubuntu-latest]
-        NODE_VERSION: [18, 20.5.1]
+        NODE_VERSION: [18, 20]
         include:
           - os: macos-14
             NODE_VERSION: 18


### PR DESCRIPTION
## Changes
- we pinned node versions twice because of regressions introduced in node, both are no longer necessary

## Testing
- does not affect behavior

## Docs
- does not affect usage