### PR TITLE
db: dev --remote test fixture

### DIFF
--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -44,7 +44,7 @@ function astroDBIntegration(): AstroIntegration {
 
 				let dbPlugin: VitePlugin | undefined = undefined;
 				const args = parseArgs(process.argv.slice(3));
-				connectToStudio = args['remote'];
+				connectToStudio = process.env.ASTRO_INTERNAL_TEST_REMOTE || args['remote'];
 
 				if (connectToStudio) {
 					appToken = await getManagedAppTokenOrExit();

--- a/packages/db/src/core/tokens.ts
+++ b/packages/db/src/core/tokens.ts
@@ -173,6 +173,9 @@ export async function getManagedAppTokenOrExit(token?: string): Promise<ManagedA
 	if (token) {
 		return new ManagedLocalAppToken(token);
 	}
+	if (process.env.ASTRO_INTERNAL_TEST_REMOTE) {
+		return new ManagedLocalAppToken('fake' /* token ignored in test */);
+	}
 	const { ASTRO_STUDIO_APP_TOKEN } = getAstroStudioEnv();
 	if (ASTRO_STUDIO_APP_TOKEN) {
 		return new ManagedLocalAppToken(ASTRO_STUDIO_APP_TOKEN);

--- a/packages/db/test/basics.test.js
+++ b/packages/db/test/basics.test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { load as cheerioLoad } from 'cheerio';
 import testAdapter from '../../astro/test/test-adapter.js';
 import { loadFixture } from '../../astro/test/test-utils.js';
+import { setupRemoteDbServer } from './test-utils.js';
 
 describe('astro:db', () => {
 	let fixture;
@@ -22,6 +23,70 @@ describe('astro:db', () => {
 
 		after(async () => {
 			await devServer.stop();
+		});
+
+		it('Prints the list of authors', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			const $ = cheerioLoad(html);
+
+			const ul = $('.authors-list');
+			expect(ul.children()).to.have.a.lengthOf(5);
+			expect(ul.children().eq(0).text()).to.equal('Ben');
+		});
+
+		it('Allows expression defaults for date columns', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			const $ = cheerioLoad(html);
+
+			const themeAdded = $($('.themes-list .theme-added')[0]).text();
+			expect(new Date(themeAdded).getTime()).to.not.be.NaN;
+		});
+
+		it('Defaults can be overridden for dates', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			const $ = cheerioLoad(html);
+
+			const themeAdded = $($('.themes-list .theme-added')[1]).text();
+			expect(new Date(themeAdded).getTime()).to.not.be.NaN;
+		});
+
+		it('Allows expression defaults for text columns', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			const $ = cheerioLoad(html);
+
+			const themeOwner = $($('.themes-list .theme-owner')[0]).text();
+			expect(themeOwner).to.equal('');
+		});
+
+		it('Allows expression defaults for boolean columns', async () => {
+			const html = await fixture.fetch('/').then((res) => res.text());
+			const $ = cheerioLoad(html);
+
+			const themeDark = $($('.themes-list .theme-dark')[0]).text();
+			expect(themeDark).to.equal('dark mode');
+		});
+
+		it('text fields an be used as references', async () => {
+			const html = await fixture.fetch('/login').then((res) => res.text());
+			const $ = cheerioLoad(html);
+
+			expect($('.session-id').text()).to.equal('12345');
+			expect($('.username').text()).to.equal('Mario');
+		});
+	});
+
+	describe('development --remote', () => {
+		let devServer;
+		let remoteDbServer;
+
+		before(async () => {
+			remoteDbServer = await setupRemoteDbServer(fixture.config);
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer?.stop();
+			await remoteDbServer?.stop();
 		});
 
 		it('Prints the list of authors', async () => {

--- a/packages/db/test/test-utils.js
+++ b/packages/db/test/test-utils.js
@@ -1,0 +1,78 @@
+import { createClient } from '@libsql/client';
+import { createServer } from 'node:http';
+import { z } from 'zod';
+
+const singleQuerySchema = z.object({
+	sql: z.string(),
+	args: z.array(z.any()).or(z.record(z.string(), z.any())),
+});
+
+const querySchema = singleQuerySchema.or(z.array(singleQuerySchema));
+
+export function createProxyServer() {
+	const client = createClient({
+		url: ':memory:',
+	});
+	const server = createServer((req, res) => {
+		if (
+			!req.url.startsWith('/db/query') ||
+			req.method !== 'POST' ||
+			req.headers['content-type'] !== 'application/json'
+		) {
+			res.writeHead(404, { 'Content-Type': 'application/json' });
+			res.end(
+				JSON.stringify({
+					success: false,
+				})
+			);
+			return;
+		}
+		const rawBody = [];
+		req.on('data', (chunk) => {
+			rawBody.push(chunk);
+		});
+		req.on('end', async () => {
+			let json;
+			try {
+				json = JSON.parse(Buffer.concat(rawBody).toString());
+			} catch (e) {
+				applyParseError(res);
+				return;
+			}
+			const parsed = querySchema.safeParse(json);
+			if (parsed.success === false) {
+				applyParseError(res);
+				return;
+			}
+			const body = parsed.data;
+			try {
+				const result = Array.isArray(body) ? await client.batch(body) : await client.execute(body);
+				res.writeHead(200, { 'Content-Type': 'application/json' });
+				res.end(JSON.stringify(result));
+			} catch (e) {
+				res.writeHead(500, { 'Content-Type': 'application/json' });
+				res.statusMessage = e.message;
+				res.end(
+					JSON.stringify({
+						success: false,
+						message: e.message,
+					})
+				);
+			}
+		});
+	});
+
+	return server;
+}
+
+function applyParseError(res) {
+	res.writeHead(400, { 'Content-Type': 'application/json' });
+	res.statusMessage = 'Invalid request body';
+	res.end(
+		JSON.stringify({
+			// Use JSON response with `success: boolean` property
+			// to match remote error responses.
+			success: false,
+		})
+	);
+}

--- a/packages/db/test/test-utils.js
+++ b/packages/db/test/test-utils.js
@@ -12,11 +12,14 @@ const singleQuerySchema = z.object({
 
 const querySchema = singleQuerySchema.or(z.array(singleQuerySchema));
 
+let portIncrementer = 8081;
+
 /**
  * @param {import('astro').AstroConfig} astroConfig
  * @param {number | undefined} port
  */
-export async function setupRemoteDbServer(astroConfig, port = 8081) {
+export async function setupRemoteDbServer(astroConfig) {
+	const port = portIncrementer++;
 	process.env.ASTRO_STUDIO_REMOTE_DB_URL = `http://localhost:${port}`;
 	process.env.ASTRO_INTERNAL_TEST_REMOTE = true;
 	const server = createRemoteDbServer().listen(port);


### PR DESCRIPTION
## Changes

Introduce a mock remote db server for testing the `--remote` flag and the remote database adapter.

- Add a `test-utils` file with `setupRemoteDbServer()`
- Add basics test for `dev --remote`

## Testing

Basics test for `dev --remote`

## Docs

N/A