### PR TITLE
Avoid generators in render head API

### DIFF
--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -516,9 +516,7 @@ export async function renderComponentToString(
 	// we can ensure getting a value for `head`.
 	let head = '';
 	if (isPage && !result.partial && nonAstroPageNeedsHeadInjection(Component)) {
-		for (const headChunk of maybeRenderHead()) {
-			head += chunkToString(result, headChunk);
-		}
+		head += chunkToString(result, maybeRenderHead());
 	}
 
 	try {

--- a/packages/astro/src/runtime/server/render/head.ts
+++ b/packages/astro/src/runtime/server/render/head.ts
@@ -51,16 +51,16 @@ export function renderAllHeadContent(result: SSRResult) {
 	return markHTMLString(content);
 }
 
-export function* renderHead(): Generator<RenderHeadInstruction> {
-	yield createRenderInstruction({ type: 'head' });
+export function renderHead(): RenderHeadInstruction {
+	return createRenderInstruction({ type: 'head' });
 }
 
 // This function is called by Astro components that do not contain a <head> component
 // This accommodates the fact that using a <head> is optional in Astro, so this
 // is called before a component's first non-head HTML element. If the head was
 // already injected it is a noop.
-export function* maybeRenderHead(): Generator<MaybeRenderHeadInstruction> {
+export function maybeRenderHead(): MaybeRenderHeadInstruction {
 	// This is an instruction informing the page rendering that head might need rendering.
 	// This allows the page to deduplicate head injections.
-	yield createRenderInstruction({ type: 'maybe-head' });
+	return createRenderInstruction({ type: 'maybe-head' });
 }

--- a/packages/astro/test/streaming.test.js
+++ b/packages/astro/test/streaming.test.js
@@ -47,7 +47,7 @@ describe('Streaming', () => {
 				let chunk = decoder.decode(bytes);
 				chunks.push(chunk);
 			}
-			assert.equal(chunks.length, 3);
+			assert.ok(chunks.length >= 2);
 		});
 	});
 


### PR DESCRIPTION
## Changes

Return the render instruction directly instead of using generators. This should slightly improve performance.

## Testing

Existing tests should pass.

## Docs

n/a. internal refactor. I didn't add a changeset as it doesn't affect any user-facing features.
