### PR TITLE
Fixes a style issue of `client:only` components in DEV mode during view transitions.

### DIFF
--- a/.changeset/spotty-bats-nail.md
+++ b/.changeset/spotty-bats-nail.md
@@ -2,4 +2,5 @@
 "astro": patch
 ---
 
-Fix DEV-mode-only style issue of client:only components during view transitions.
+Fixes a style issue of "client:only" components in DEV mode during view transitions.
+

--- a/.changeset/spotty-bats-nail.md
+++ b/.changeset/spotty-bats-nail.md
@@ -2,5 +2,5 @@
 "astro": patch
 ---
 
-Fixes a style issue of "client:only" components in DEV mode during view transitions.
+Fixes a style issue of `client:only` components in DEV mode during view transitions.
 

--- a/.changeset/spotty-bats-nail.md
+++ b/.changeset/spotty-bats-nail.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix DEV-mode-only style issue of client:only components during view transitions.

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -696,18 +696,13 @@ async function prepareForClientOnlyComponents(newDocument: Document, toLocation:
 
 		const nextHead = nextPage.contentDocument?.head;
 		if (nextHead) {
-			// Clear former persist marks
-			document.head
-				.querySelectorAll(`style[${PERSIST_ATTR}=""]`)
-				.forEach((s) => s.removeAttribute(PERSIST_ATTR));
-
 			// Collect the vite ids of all styles present in the next head
 			const viteIds = [...nextHead.querySelectorAll(`style[${VITE_ID}]`)].map((style) =>
 				style.getAttribute(VITE_ID)
 			);
 			// Copy required styles to the new document if they are from hydration.
 			viteIds.forEach((id) => {
-				const style = document.head.querySelector(`style[${VITE_ID}="${id}"]`);
+				const style = nextHead.querySelector(`style[${VITE_ID}="${id}"]`);
 				if (style && !newDocument.head.querySelector(`style[${VITE_ID}="${id}"]`)) {
 					newDocument.head.appendChild(style.cloneNode(true));
 				}


### PR DESCRIPTION
## Changes

fixes #10466 

Originally fixed for client:only components that use transition:persist in #8840.
It turns out that the styles were also missing when navigating back to pages with non-persisted `client:only` components.

## Testing

e2e tests successful

## Docs

bug fix, n.a.