### PR TITLE
fix: use Shiki's `isSpecialLang` to allow `ansi` codeblocks

### DIFF
--- a/.changeset/eighty-pumpkins-float.md
+++ b/.changeset/eighty-pumpkins-float.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/markdown-remark": patch
+---
+
+This patch allows Shiki to use all of its reserved languages instead of the
+previous behavior of forcing unknown languages to plaintext.

--- a/packages/markdown/remark/src/shiki.ts
+++ b/packages/markdown/remark/src/shiki.ts
@@ -1,5 +1,5 @@
 import type { Properties } from 'hast';
-import { bundledLanguages, createCssVariablesTheme, getHighlighter } from 'shiki';
+import { bundledLanguages, createCssVariablesTheme, getHighlighter, isSpecialLang } from 'shiki';
 import { visit } from 'unist-util-visit';
 import type { ShikiConfig } from './types.js';
 
@@ -51,7 +51,7 @@ export async function createShikiHighlighter({
 
 	return {
 		highlight(code, lang = 'plaintext', options) {
-			if (lang !== 'plaintext' && !loadedLanguages.includes(lang)) {
+			if (!isSpecialLang(lang) && !loadedLanguages.includes(lang)) {
 				// eslint-disable-next-line no-console
 				console.warn(`[Shiki] The language "${lang}" doesn't exist, falling back to "plaintext".`);
 				lang = 'plaintext';


### PR DESCRIPTION
Previously, there was a hardcoded if condition which detected unknown languages and replaced them with `plaintext` for codeblocks. Hardcoding this value makes it impossible to use Shiki's `ansi` feature. Changed the code from using the hard coded value over to using a library function, fixing #10539.

## Changes

- Instead of using the hard-coded check for an invalid language, use the built in function to do so.
- Enables using the `ansi` language (as well as `txt`, `text`, etc.)

Before and after photos:

![image](https://github.com/withastro/astro/assets/13318546/063e7795-4434-4183-b76a-6da89266b66c)
![image](https://github.com/withastro/astro/assets/13318546/087ed2e2-539d-4829-812c-0c6f4725dbf4)


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
This change was tested by modifying the blog example locally (not tracked). Unit tests may not be necessary for change.

## Docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

As this is a bug fix that only enables wrongly suppressed behavior, no documentation needs to be altered.
