### PR TITLE
Fix inline stylesheets in content collection cache

### DIFF
--- a/.changeset/tricky-cobras-mate.md
+++ b/.changeset/tricky-cobras-mate.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fix inline stylesheets with content collections cache
+Fixes inline stylesheets with content collections cache

--- a/.changeset/tricky-cobras-mate.md
+++ b/.changeset/tricky-cobras-mate.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix inline stylesheets with content collections cache

--- a/packages/astro/src/content/index.ts
+++ b/packages/astro/src/content/index.ts
@@ -2,7 +2,7 @@ export { CONTENT_FLAG, PROPAGATED_ASSET_FLAG } from './consts.js';
 export { errorMap } from './error-map.js';
 export { attachContentServerListeners } from './server-listeners.js';
 export { createContentTypesGenerator } from './types-generator.js';
-export { contentObservable, getContentPaths, getDotAstroTypeReference } from './utils.js';
+export { contentObservable, getContentPaths, getDotAstroTypeReference, hasAssetPropagationFlag } from './utils.js';
 export { astroContentAssetPropagationPlugin } from './vite-plugin-content-assets.js';
 export { astroContentImportPlugin } from './vite-plugin-content-imports.js';
 export { astroContentVirtualModPlugin } from './vite-plugin-content-virtual-mod.js';

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -16,7 +16,7 @@ import { AstroError, AstroErrorData } from '../core/errors/index.js';
 
 import { MarkdownError } from '../core/errors/index.js';
 import { isYAMLException } from '../core/errors/utils.js';
-import { CONTENT_FLAGS, CONTENT_TYPES_FILE } from './consts.js';
+import { CONTENT_FLAGS, CONTENT_TYPES_FILE, PROPAGATED_ASSET_FLAG } from './consts.js';
 import { errorMap } from './error-map.js';
 import { createImage } from './runtime-assets.js';
 
@@ -504,4 +504,12 @@ export function getExtGlob(exts: string[]) {
 		? // Wrapping {...} breaks when there is only one extension
 			exts[0]
 		: `{${exts.join(',')}}`;
+}
+
+export function hasAssetPropagationFlag(id: string): boolean {
+	try {
+		return new URL(id, 'file://').searchParams.has(PROPAGATED_ASSET_FLAG)
+	} catch {
+		return false;
+	}
 }

--- a/packages/astro/src/core/build/plugins/plugin-css.ts
+++ b/packages/astro/src/core/build/plugins/plugin-css.ts
@@ -101,13 +101,6 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 								// so they can be injected where needed
 								const chunkId = assetName.createNameHash(id, [id]);
 								internals.cssModuleToChunkIdMap.set(id, chunkId);
-								if (isContentCollectionCache) {
-									// TODO: Handle inlining?
-									const propagatedStyles =
-										internals.propagatedStylesMap.get(pageInfo.id) ?? new Set();
-									propagatedStyles.add({ type: 'external', src: chunkId });
-									internals.propagatedStylesMap.set(pageInfo.id, propagatedStyles);
-								}
 								return chunkId;
 							}
 						}
@@ -152,7 +145,8 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 						}
 					)) {
 						if (new URL(pageInfo.id, 'file://').searchParams.has(PROPAGATED_ASSET_FLAG)) {
-							for (const parentInfo of getParentModuleInfos(id, this)) {
+							const walkId = isContentCollectionCache ? ('\0' + 'astro:content') : id;
+							for (const parentInfo of getParentModuleInfos(walkId, this)) {
 								if (moduleIsTopLevelPage(parentInfo) === false) continue;
 
 								const pageViteID = parentInfo.id;

--- a/packages/astro/test/experimental-content-collections-css-inline-stylesheets.test.js
+++ b/packages/astro/test/experimental-content-collections-css-inline-stylesheets.test.js
@@ -92,7 +92,7 @@ describe('Experimental Content Collections cache - inlineStylesheets to never in
 	});
 });
 
-describe.skip('Experimental Content Collections cache - inlineStylesheets to auto in static output', () => {
+describe('Experimental Content Collections cache - inlineStylesheets to auto in static output', () => {
 	let fixture;
 
 	before(async () => {
@@ -120,7 +120,7 @@ describe.skip('Experimental Content Collections cache - inlineStylesheets to aut
 
 	after(async () => await fixture.clean());
 
-	it.skip(
+	it(
 		'Renders some <style> and some <link> tags',
 		{ todo: 'Styles have the wrong length' },
 		async () => {


### PR DESCRIPTION
## Changes

- Can't walk up the parent tree in propagation flag modules with CCC because `astro:content` is marked as external. So walk parents of that instead.

## Testing

- Unskipped most of the inline stylesheet tests, one remains.

## Docs

N/A, bug fix