### PR TITLE
feat: add option to parse `.md` files as mdx

### DIFF
--- a/.changeset/hip-worms-marry.md
+++ b/.changeset/hip-worms-marry.md
@@ -1,0 +1,8 @@
+---
+"astro": minor
+"@astrojs/mdx": minor
+---
+
+Add `allowMd` boolean option, which makes `.md` files parsed as MDX as well.
+
+vite-plugin-mdx no longer early returns on `.md` files, as they may need to be parsed as JSX.

--- a/packages/astro/src/vite-plugin-mdx/index.ts
+++ b/packages/astro/src/vite-plugin-mdx/index.ts
@@ -102,7 +102,8 @@ export default function mdxVitePlugin({ settings }: AstroPluginJSXOptions): Plug
 			}
 			id = removeQueryString(id);
 			// Shortcut: only use Astro renderer for MD and MDX files
-			if (!id.endsWith('.mdx')) {
+			const markdownExtensions = ['.md', '.mdx'];
+			if (markdownExtensions.every((ext) => !id.endsWith(ext))) {
 				return null;
 			}
 			const { code: jsxCode } = await transformWithEsbuild(code, id, {

--- a/packages/integrations/mdx/test/fixtures/md-file/src/pages/index.md
+++ b/packages/integrations/mdx/test/fixtures/md-file/src/pages/index.md
@@ -1,0 +1,5 @@
+---
+title: 'Using JSX expressions in MDX'
+---
+
+# {frontmatter.title}

--- a/packages/integrations/mdx/test/md-file.test.js
+++ b/packages/integrations/mdx/test/md-file.test.js
@@ -1,0 +1,66 @@
+import mdx from '@astrojs/mdx';
+
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { parseHTML } from 'linkedom';
+import { loadFixture } from '../../../astro/test/test-utils.js';
+
+const FIXTURE_ROOT = new URL('./fixtures/md-file/', import.meta.url);
+
+describe('MD file', () => {
+	it('parses as MDX when allowMd = true', async () => {
+		const fixture = await buildFixture({
+			integrations: [
+				mdx({
+					allowMd: true,
+				}),
+			],
+		});
+
+		const html = await fixture.readFile('/index.html');
+		const { document } = parseHTML(html);
+
+		const title = document.querySelector('h1');
+
+		assert.equal(title.textContent, 'Using JSX expressions in MDX');
+	});
+	it('parses as plain Markdown when allowMd = false', async () => {
+		const fixture = await buildFixture({
+			integrations: [
+				mdx({
+					allowMd: false,
+				}),
+			],
+		});
+
+		const html = await fixture.readFile('/index.html');
+		const { document } = parseHTML(html);
+
+		const title = document.querySelector('h1');
+
+		assert.equal(title.textContent, '{frontmatter.title}');
+	});
+	it('parses as plain Markdown when allowMd is undefined', async () => {
+		const fixture = await buildFixture({
+			integrations: [
+				mdx(),
+			],
+		});
+
+		const html = await fixture.readFile('/index.html');
+		const { document } = parseHTML(html);
+
+		const title = document.querySelector('h1');
+
+		assert.equal(title.textContent, '{frontmatter.title}');
+	});
+});
+
+async function buildFixture(config) {
+	const fixture = await loadFixture({
+		root: FIXTURE_ROOT,
+		...config,
+	});
+	await fixture.build();
+	return fixture;
+}


### PR DESCRIPTION
## Motivation

Some people don't like having to change their file extensions to `.mdx` to make use of MDX.

For a sample use case, I personally mostly use mdx/astro as an IR of sorts, using directives for anything complex, and plugins to basically transform the directives into JSX. This way the content is technically valid plain markdown with directives as opposed to MDX, and in turn I find the `.md` extension more appropriate.

One user's feedback from the discord:
> I also am a .md purist so the concept sounds very cool

## Changes

- adds an `allowMd` boolean option to `@astrojs/mdx`, which if true makes `.md` files parsed as mdx
- updates `astro/vite-plugin-mdx` to run the transform on `.md` files as well. previously it would only run on `.mdx` files, but the associated comment with the check for this mentions both MD and MDX anyway

### Points of discussion

- open to feedback regarding what the option name should be, if another name is preferred
- currently only applies to `.md` files. `astro/src/core` has a `SUPPORTED_MARKDOWN_FILE_EXTENSIONS` and `isMarkdownFile()` but those are not exported and so aren't accessible to `@astrojs/mdx`. not sure how this should be best resolved
- I'm not too familiar with how the dataflow goes for markdown and `.mdx` files. I'm aware of `astro/vite-plugin-markdown` which appears to do some processing on markdown files already during the vite `load` step, but from what I can tell the data is the same going into the `transform` step between `.md` and `.mdx` files anyway? not too familiar with vite plugins either though so don't too much about it, but not sure if there's some behavior I'm overlooking due to whatever other processing plain markdown files typically go through that `.mdx` files don't.

## Testing

- added test fixtures to `@astrojs/mdx`, using substitution of MDX expressions as a proxy for parsing as MDX

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!
will probably submit docs pr once accepted and discussion is mostly settled

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
