### PR TITLE
fix: ensure outDir doesn't lead to bundlers bloating Lambda size

### DIFF
--- a/.changeset/thin-impalas-cry.md
+++ b/.changeset/thin-impalas-cry.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes bug where server builds would include unneeded assets in SSR Function, potentially leading to upload errors on Vercel, Netlify because of size limits

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -70,7 +70,7 @@ export default function assets({
 					export const imageConfig = ${JSON.stringify(settings.config.image)};
 					// This is used by the @astrojs/node integration to locate images.
 					// It's unused on other platforms, but on some platforms like Netlify (and presumably also Vercel)
-					// "new URL("dist/...") is interpreted by the bundler as a signal to include that directory
+					// new URL("dist/...") is interpreted by the bundler as a signal to include that directory
 					// in the Lambda bundle, which would bloat the bundle with images.
 					// To prevent this, we mark the URL construction as pure,
 					// so that it's tree-shaken away for all platforms that don't need it.

--- a/packages/astro/src/assets/vite-plugin-assets.ts
+++ b/packages/astro/src/assets/vite-plugin-assets.ts
@@ -68,14 +68,20 @@ export default function assets({
 					export { default as Picture } from "astro/components/Picture.astro";
 
 					export const imageConfig = ${JSON.stringify(settings.config.image)};
-					export const outDir = new URL(${JSON.stringify(
+					// This is used by the @astrojs/node integration to locate images.
+					// It's unused on other platforms, but on some platforms like Netlify (and presumably also Vercel)
+					// "new URL("dist/...") is interpreted by the bundler as a signal to include that directory
+					// in the Lambda bundle, which would bloat the bundle with images.
+					// To prevent this, we mark the URL construction as pure,
+					// so that it's tree-shaken away for all platforms that don't need it.
+					export const outDir = /* #__PURE__ */ new URL(${JSON.stringify(
 						new URL(
 							isServerLikeOutput(settings.config)
 								? settings.config.build.client
 								: settings.config.outDir
 						)
 					)});
-					export const assetsDir = new URL(${JSON.stringify(settings.config.build.assets)}, outDir);
+					export const assetsDir = /* #__PURE__ */ new URL(${JSON.stringify(settings.config.build.assets)}, outDir);
 					export const getImage = async (options) => await getImageInternal(options, imageConfig);
 				`;
 				}

--- a/packages/integrations/vercel/test/serverless-prerender.test.js
+++ b/packages/integrations/vercel/test/serverless-prerender.test.js
@@ -18,6 +18,18 @@ describe('Serverless prerender', () => {
 		assert.ok(await fixture.readFile('../.vercel/output/static/index.html'));
 	});
 
+	it('outDir is tree-shaken if not needed', async () => {
+		const [file] = await fixture.glob(
+			'../.vercel/output/functions/_render.func/packages/integrations/vercel/test/fixtures/serverless-prerender/.vercel/output/_functions/chunks/pages/generic_*.mjs'
+		);
+		const contents = await fixture.readFile(file);
+		console.log(contents)
+		assert.ok(
+			!contents.includes('const outDir ='),
+			"outDir is tree-shaken if it's not imported"
+		);
+	});
+
 	// TODO: The path here seems to be inconsistent?
 	it.skip('includeFiles work', async () => {
 		assert.ok(


### PR DESCRIPTION
## Changes

Fixes https://github.com/withastro/adapters/issues/185, which is a bug around Lambda bundles containing unneeded `dist` files on Netlify. This bug presumably also exists on Vercel, as they use the same tracer under the hood (`@vercel/nft`).

## Testing

Added a test to ensure this isn't introduced again to the Vercel integration test suite. I picked that test suite, since we know they also have their own image integration, and that it likely has the same bug as the Netlify adapter.

## Docs

It's a bug fix, I don't see a need to change docs.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
