### PR TITLE
fix(sitemap): fix missing base path in `sitemap-index.xml`

### DIFF
--- a/.changeset/fluffy-cups-invent.md
+++ b/.changeset/fluffy-cups-invent.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/sitemap": patch
+---
+
+Fixes an issue where the base path is missing in `sitemap-index.xml`.

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -170,6 +170,7 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 					await simpleSitemapAndIndex({
 						hostname: finalSiteUrl.href,
 						destinationDir: destDir,
+						publicBasePath: config.base,
 						sourceData: urlData,
 						limit: entryLimit,
 						gzip: false,

--- a/packages/integrations/sitemap/test/base-path.test.js
+++ b/packages/integrations/sitemap/test/base-path.test.js
@@ -16,9 +16,15 @@ describe('URLs with base path', () => {
 		});
 
 		it('Base path is concatenated correctly', async () => {
-			const data = await readXML(fixture.readFile('/client/sitemap-0.xml'));
-			const urls = data.urlset.url;
-			assert.equal(urls[0].loc[0], 'http://example.com/base/one/');
+			const [sitemapZero, sitemapIndex] = await Promise.all([
+				readXML(fixture.readFile('/client/sitemap-0.xml')),
+				readXML(fixture.readFile('/client/sitemap-index.xml')),
+			]);
+			assert.equal(sitemapZero.urlset.url[0].loc[0], 'http://example.com/base/one/');
+			assert.equal(
+				sitemapIndex.sitemapindex.sitemap[0].loc[0],
+				'http://example.com/base/sitemap-0.xml'
+			);
 		});
 	});
 
@@ -32,9 +38,15 @@ describe('URLs with base path', () => {
 		});
 
 		it('Base path is concatenated correctly', async () => {
-			const data = await readXML(fixture.readFile('/sitemap-0.xml'));
-			const urls = data.urlset.url;
-			assert.equal(urls[0].loc[0], 'http://example.com/base/123/');
+			const [sitemapZero, sitemapIndex] = await Promise.all([
+				readXML(fixture.readFile('/sitemap-0.xml')),
+				readXML(fixture.readFile('/sitemap-index.xml')),
+			]);
+			assert.equal(sitemapZero.urlset.url[0].loc[0], 'http://example.com/base/123/');
+			assert.equal(
+				sitemapIndex.sitemapindex.sitemap[0].loc[0],
+				'http://example.com/base/sitemap-0.xml'
+			);
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- Fixes an issue where the base path is missing in `sitemap-index.xml`
- Related upstream issue: https://github.com/ekalinin/sitemap.js/issues/359)
- Closes #10555

## Testing

- Test cases updated
- `pnpm --filter @astrojs/sitemap run test`

## Docs

- Probably not needed to update because:
  - The base path is not specifically mentioned in [the docs](https://docs.astro.build/en/guides/integrations-guide/sitemap/)
  - The [examples](https://docs.astro.build/en/guides/integrations-guide/sitemap/#example-of-generated-files-for-a-two-page-website) do not use the base config either
