### PR TITLE
fix(types): Fixes HTMLAttribute extend to allow everything

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,7 @@ on:
       - "scripts/smoke/check.js"
       - "packages/astro/src/@types/astro.ts"
       - "pnpm-lock.yaml"
+      - "packages/astro/types.d.ts"
 
 env:
   ASTRO_TELEMETRY_DISABLED: true

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -526,7 +526,7 @@ declare namespace astroHTML.JSX {
 			| 'search'
 			| 'send'
 			| undefined
-		| null;
+			| null;
 		exportparts?: string | undefined | null;
 		hidden?: boolean | string | undefined | null;
 		id?: string | undefined | null;
@@ -584,6 +584,9 @@ declare namespace astroHTML.JSX {
 		results?: number | string | undefined | null;
 		security?: string | undefined | null;
 		unselectable?: 'on' | 'off' | undefined | null; // Internet Explorer
+
+		// Allow data- attribute
+		[key: `data-${string}`]: any;
 	}
 
 	type HTMLAttributeReferrerPolicy =
@@ -1344,6 +1347,9 @@ declare namespace astroHTML.JSX {
 		yChannelSelector?: string | undefined | null;
 		z?: number | string | undefined | null;
 		zoomAndPan?: string | undefined | null;
+
+		// Allow data- attribute
+		[key: `data-${string}`]: any;
 	}
 
 	interface DefinedIntrinsicElements {

--- a/packages/astro/types.d.ts
+++ b/packages/astro/types.d.ts
@@ -10,7 +10,8 @@ export type HTMLAttributes<Tag extends HTMLTag> = Omit<
 	astroHTML.JSX.IntrinsicElements[Tag],
 	keyof Omit<AstroBuiltinAttributes, 'class:list'>
 > & {
-	[key: string]: string | number | boolean | null | undefined;
+	// This is not needed in the actual JSX definitions, because TypeScript implicitly adds it in JSX, however we need it here in case someone is using HTMLAttributes directly
+	[key: `${string}-${string}`]: any;
 };
 
 /**

--- a/packages/astro/types.d.ts
+++ b/packages/astro/types.d.ts
@@ -9,19 +9,17 @@ export type HTMLTag = keyof astroHTML.JSX.DefinedIntrinsicElements;
 export type HTMLAttributes<Tag extends HTMLTag> = Omit<
 	astroHTML.JSX.IntrinsicElements[Tag],
 	keyof Omit<AstroBuiltinAttributes, 'class:list'>
-> & {
-	// This is not needed in the actual JSX definitions, because TypeScript implicitly adds it in JSX, however we need it here in case someone is using HTMLAttributes directly
-	[key: `${string}-${string}`]: any;
-};
+>;
 
 /**
  * All the CSS properties available, as defined by the CSS specification
  */
 export type CSSProperty = keyof astroHTML.JSX.KebabCSSDOMProperties;
 
-type PolymorphicAttributes<P extends { as: HTMLTag }> = Omit<P & HTMLAttributes<P['as']>, 'as'> & {
+type PolymorphicAttributes<P extends { as: HTMLTag }> = Omit<P, 'as'> & {
 	as?: P['as'];
-};
+} & HTMLAttributes<P['as']>;
+
 export type Polymorphic<P extends { as: HTMLTag }> = PolymorphicAttributes<
 	Omit<P, 'as'> & { as: NonNullable<P['as']> }
 >;


### PR DESCRIPTION
## Changes

The type in https://github.com/withastro/astro/pull/10549 didn't allow enough stuff and the key was too wide. This fixes that

## Testing

Tested manually + astro check should pass

## Docs

N/A
