### PR TITLE
Patch for Astro VS Code Plugin type errors

### DIFF
--- a/.changeset/breezy-peaches-agree.md
+++ b/.changeset/breezy-peaches-agree.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes minor type issues inside the built-in components of Astro

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -80,7 +80,7 @@ const highlighter = await getCachedHighlighter({
 			? Object.keys(bundledLanguages).includes(lang)
 				? lang
 				: 'plaintext'
-			: lang as any,
+			: (lang as any),
 	],
 	theme,
 	themes,

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -80,7 +80,7 @@ const highlighter = await getCachedHighlighter({
 			? Object.keys(bundledLanguages).includes(lang)
 				? lang
 				: 'plaintext'
-			: lang,
+			: lang as any,
 	],
 	theme,
 	themes,
@@ -89,7 +89,7 @@ const highlighter = await getCachedHighlighter({
 
 const html = highlighter.highlight(code, typeof lang === 'string' ? lang : lang.name, {
 	inline,
-	attributes: rest,
+	attributes: rest as any,
 });
 ---
 

--- a/packages/astro/components/Image.astro
+++ b/packages/astro/components/Image.astro
@@ -31,7 +31,7 @@ if (image.srcSet.values.length > 0) {
 }
 
 if (import.meta.env.DEV) {
-	additionalAttributes['data-image-component'] = 'true';
+	(additionalAttributes as Record<string, string>)['data-image-component'] = 'true';
 }
 ---
 

--- a/packages/astro/components/Image.astro
+++ b/packages/astro/components/Image.astro
@@ -31,7 +31,7 @@ if (image.srcSet.values.length > 0) {
 }
 
 if (import.meta.env.DEV) {
-	(additionalAttributes as Record<string, string>)['data-image-component'] = 'true';
+	additionalAttributes['data-image-component'] = 'true';
 }
 ---
 

--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -63,7 +63,7 @@ if (fallbackImage.srcSet.values.length > 0) {
 }
 
 if (import.meta.env.DEV) {
-	imgAdditionalAttributes['data-image-component'] = 'true';
+	(imgAdditionalAttributes as Record<string, string>)['data-image-component'] = 'true';
 }
 ---
 

--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -1,7 +1,7 @@
 ---
 import { getImage, type LocalImageProps, type RemoteImageProps } from 'astro:assets';
 import type { GetImageResult, ImageOutputFormat } from '../dist/@types/astro';
-import { isESMImportedImage } from '../dist/assets/utils/imageKind';
+import { isESMImportedImage, resolveSrc } from '../dist/assets/utils/imageKind';
 import { AstroError, AstroErrorData } from '../dist/core/errors/index.js';
 import type { HTMLAttributes } from '../types';
 
@@ -27,20 +27,27 @@ if (props.alt === undefined || props.alt === null) {
 	throw new AstroError(AstroErrorData.ImageMissingAlt);
 }
 
+const originalSrc = await resolveSrc(props.src);
 const optimizedImages: GetImageResult[] = await Promise.all(
 	formats.map(
 		async (format) =>
-			await getImage({ ...props, format: format, widths: props.widths, densities: props.densities })
+			await getImage({
+				...props,
+				src: originalSrc,
+				format: format,
+				widths: props.widths,
+				densities: props.densities,
+			})
 	)
 );
 
 let resultFallbackFormat = fallbackFormat ?? defaultFallbackFormat;
 if (
 	!fallbackFormat &&
-	isESMImportedImage(props.src as string | ImageMetadata) &&
-	specialFormatsFallback.includes((props.src as ImageMetadata).format as typeof specialFormatsFallback[number])
+	isESMImportedImage(originalSrc) &&
+	originalSrc.format in specialFormatsFallback
 ) {
-	resultFallbackFormat = (props.src as ImageMetadata).format;
+	resultFallbackFormat = originalSrc.format;
 }
 
 const fallbackImage = await getImage({
@@ -63,7 +70,7 @@ if (fallbackImage.srcSet.values.length > 0) {
 }
 
 if (import.meta.env.DEV) {
-	(imgAdditionalAttributes as Record<string, string>)['data-image-component'] = 'true';
+	imgAdditionalAttributes['data-image-component'] = 'true';
 }
 ---
 

--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -37,10 +37,10 @@ const optimizedImages: GetImageResult[] = await Promise.all(
 let resultFallbackFormat = fallbackFormat ?? defaultFallbackFormat;
 if (
 	!fallbackFormat &&
-	isESMImportedImage(props.src) &&
-	specialFormatsFallback.includes(props.src.format)
+	isESMImportedImage(props.src as string | ImageMetadata) &&
+	specialFormatsFallback.includes((props.src as ImageMetadata).format as typeof specialFormatsFallback[number])
 ) {
-	resultFallbackFormat = props.src.format;
+	resultFallbackFormat = (props.src as ImageMetadata).format;
 }
 
 const fallbackImage = await getImage({

--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -8,7 +8,7 @@ import type {
 	SrcSetValue,
 	UnresolvedImageTransform,
 } from './types.js';
-import { isESMImportedImage, isRemoteImage } from './utils/imageKind.js';
+import { isESMImportedImage, isRemoteImage, resolveSrc } from './utils/imageKind.js';
 import { probe } from './utils/remoteProbe.js';
 
 export async function getConfiguredImageService(): Promise<ImageService> {
@@ -56,10 +56,7 @@ export async function getImage(
 	// If the user inlined an import, something fairly common especially in MDX, or passed a function that returns an Image, await it for them
 	const resolvedOptions: ImageTransform = {
 		...options,
-		src:
-			typeof options.src === 'object' && 'then' in options.src
-				? (await options.src).default ?? (await options.src)
-				: options.src,
+		src: await resolveSrc(options.src),
 	};
 
 	// Infer size for remote images if inferSize is true

--- a/packages/astro/src/assets/utils/imageKind.ts
+++ b/packages/astro/src/assets/utils/imageKind.ts
@@ -1,4 +1,4 @@
-import type { ImageMetadata } from '../types.js';
+import type { ImageMetadata, UnresolvedImageTransform } from '../types.js';
 
 export function isESMImportedImage(src: ImageMetadata | string): src is ImageMetadata {
 	return typeof src === 'object';
@@ -6,4 +6,8 @@ export function isESMImportedImage(src: ImageMetadata | string): src is ImageMet
 
 export function isRemoteImage(src: ImageMetadata | string): src is string {
 	return typeof src === 'string';
+}
+
+export async function resolveSrc(src: UnresolvedImageTransform['src']) {
+	return typeof src === 'object' && 'then' in src ? (await src).default ?? (await src) : src;
 }


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/10560

Suggestive changes to typing that seems to silence the errors generated by the Astro VS Code plugin in a fresh project setup with the `/examples/framework-react` example as outlined in #10560 

## Testing

Tested in project, type annotation changes only

## Docs

N/A
