### PR TITLE
Fix `db.run()` type signature in production

### DIFF
--- a/.changeset/wild-nails-call.md
+++ b/.changeset/wild-nails-call.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Fix `db.run()` type signature in production.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -66,7 +66,7 @@
     "@libsql/client": "^0.5.5",
     "async-listen": "^3.0.1",
     "deep-diff": "^1.0.2",
-    "drizzle-orm": "^0.30.2",
+    "drizzle-orm": "^0.30.4",
     "github-slugger": "^2.0.0",
     "kleur": "^4.1.5",
     "nanoid": "^5.0.1",

--- a/packages/db/test/basics.test.js
+++ b/packages/db/test/basics.test.js
@@ -73,6 +73,23 @@ describe('astro:db', () => {
 			expect($('.session-id').text()).to.equal('12345');
 			expect($('.username').text()).to.equal('Mario');
 		});
+
+		it('Prints authors from raw sql call', async () => {
+			const json = await fixture.fetch('run.json').then((res) => res.json());
+			expect(json).to.deep.equal({
+				columns: ['_id', 'name', 'age2'],
+				columnTypes: ['INTEGER', 'TEXT', 'INTEGER'],
+				rows: [
+					[1, 'Ben', null],
+					[2, 'Nate', null],
+					[3, 'Erika', null],
+					[4, 'Bjorn', null],
+					[5, 'Sarah', null],
+				],
+				rowsAffected: 0,
+				lastInsertRowid: null,
+			});
+		});
 	});
 
 	describe('development --remote', () => {
@@ -136,6 +153,23 @@ describe('astro:db', () => {
 
 			expect($('.session-id').text()).to.equal('12345');
 			expect($('.username').text()).to.equal('Mario');
+		});
+
+		it('Prints authors from raw sql call', async () => {
+			const json = await fixture.fetch('run.json').then((res) => res.json());
+			expect(json).to.deep.equal({
+				columns: ['_id', 'name', 'age2'],
+				columnTypes: ['INTEGER', 'TEXT', 'INTEGER'],
+				rows: [
+					[1, 'Ben', null],
+					[2, 'Nate', null],
+					[3, 'Erika', null],
+					[4, 'Bjorn', null],
+					[5, 'Sarah', null],
+				],
+				rowsAffected: 0,
+				lastInsertRowid: null,
+			});
 		});
 	});
 

--- a/packages/db/test/fixtures/basics/src/pages/run.json.ts
+++ b/packages/db/test/fixtures/basics/src/pages/run.json.ts
@@ -1,0 +1,12 @@
+/// <reference types="@astrojs/db" />
+import type { APIRoute } from 'astro';
+import { db, sql } from 'astro:db';
+
+export const GET: APIRoute = async () => {
+	const authors = await db.run(sql`SELECT * FROM Author`);
+	return new Response(JSON.stringify(authors), {
+		headers: {
+			'content-type': 'application/json',
+		},
+	});
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3842,8 +3842,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       drizzle-orm:
-        specifier: ^0.30.2
-        version: 0.30.2(@libsql/client@0.5.6)
+        specifier: ^0.30.4
+        version: 0.30.4(@libsql/client@0.5.6)
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -10133,8 +10133,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /drizzle-orm@0.30.2(@libsql/client@0.5.6):
-    resolution: {integrity: sha512-DNd3djg03o+WxZX3pGD8YD+qrWT8gbrbhaZ2W0PVb6yH4rtM/VTB92cTGvumcRh7SSd2KfV0NWYDB70BHIXQTg==}
+  /drizzle-orm@0.30.4(@libsql/client@0.5.6):
+    resolution: {integrity: sha512-kWoSMGbrOFkmkAweLTFtHJMpN+nwhx89q0mLELqT2aEU+1szNV8jrnBmJwZ0WGNp7J7yQn/ezEtxBI/qzTSElQ==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=3'
@@ -10148,6 +10148,7 @@ packages:
       '@types/react': '>=18'
       '@types/sql.js': '*'
       '@vercel/postgres': '*'
+      '@xata.io/client': '*'
       better-sqlite3: '>=7'
       bun-types: '*'
       expo-sqlite: '>=13.2.0'
@@ -10183,6 +10184,8 @@ packages:
       '@types/sql.js':
         optional: true
       '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
         optional: true
       better-sqlite3:
         optional: true


### PR DESCRIPTION
## Changes

Bump to latest Drizzle release to fix `db.run()` types.

## Testing

Test `db.run()` output for the development and production database clients.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
