### PR TITLE
Prevent importing db core from db runtime

### DIFF
--- a/.changeset/sixty-eels-camp.md
+++ b/.changeset/sixty-eels-camp.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Prevent runtime from importing core code

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -136,5 +136,23 @@ module.exports = {
         'arrow-body-style': ['error', 'never'],
       },
     },
+
+    {
+      files: ['packages/db/src/runtime/**/*.ts'],
+      rules: {
+        'no-restricted-imports': 'off',
+        '@typescript-eslint/no-restricted-imports': [
+          'error',
+          {
+            patterns: [
+              {
+                group: ['../core/*'],
+                allowTypeImports: true,
+              }
+            ]
+          }
+        ]
+      }
+    }
   ],
 };

--- a/packages/db/src/core/errors.ts
+++ b/packages/db/src/core/errors.ts
@@ -37,44 +37,12 @@ export const SHELL_QUERY_MISSING_ERROR = `${red(
 	'▶ Please provide a query to execute using the --query flag.'
 )}\n`;
 
-export const SEED_ERROR = (error: string) => {
-	return `${red(`Error while seeding database:`)}\n\n${error}`;
-};
-
 export const EXEC_ERROR = (error: string) => {
 	return `${red(`Error while executing file:`)}\n\n${error}`;
 };
 
-export const SEED_DEFAULT_EXPORT_ERROR = (fileName: string) => {
-	return SEED_ERROR(`Missing default function export in ${bold(fileName)}`);
-};
-
 export const EXEC_DEFAULT_EXPORT_ERROR = (fileName: string) => {
 	return EXEC_ERROR(`Missing default function export in ${bold(fileName)}`);
-};
-
-export const REFERENCE_DNE_ERROR = (columnName: string) => {
-	return `Column ${bold(
-		columnName
-	)} references a table that does not exist. Did you apply the referenced table to the \`tables\` object in your db config?`;
-};
-
-export const FOREIGN_KEY_DNE_ERROR = (tableName: string) => {
-	return `Table ${bold(
-		tableName
-	)} references a table that does not exist. Did you apply the referenced table to the \`tables\` object in your db config?`;
-};
-
-export const FOREIGN_KEY_REFERENCES_LENGTH_ERROR = (tableName: string) => {
-	return `Foreign key on ${bold(
-		tableName
-	)} is misconfigured. \`columns\` and \`references\` must be the same length.`;
-};
-
-export const FOREIGN_KEY_REFERENCES_EMPTY_ERROR = (tableName: string) => {
-	return `Foreign key on ${bold(
-		tableName
-	)} is misconfigured. \`references\` array cannot be empty.`;
 };
 
 export const INTEGRATION_TABLE_CONFLICT_ERROR = (

--- a/packages/db/src/runtime/errors.ts
+++ b/packages/db/src/runtime/errors.ts
@@ -1,0 +1,33 @@
+import { bold, red } from 'kleur/colors';
+
+export const FOREIGN_KEY_DNE_ERROR = (tableName: string) => {
+	return `Table ${bold(
+		tableName
+	)} references a table that does not exist. Did you apply the referenced table to the \`tables\` object in your db config?`;
+};
+
+export const FOREIGN_KEY_REFERENCES_LENGTH_ERROR = (tableName: string) => {
+	return `Foreign key on ${bold(
+		tableName
+	)} is misconfigured. \`columns\` and \`references\` must be the same length.`;
+};
+
+export const FOREIGN_KEY_REFERENCES_EMPTY_ERROR = (tableName: string) => {
+	return `Foreign key on ${bold(
+		tableName
+	)} is misconfigured. \`references\` array cannot be empty.`;
+};
+
+export const REFERENCE_DNE_ERROR = (columnName: string) => {
+	return `Column ${bold(
+		columnName
+	)} references a table that does not exist. Did you apply the referenced table to the \`tables\` object in your db config?`;
+};
+
+export const SEED_ERROR = (error: string) => {
+	return `${red(`Error while seeding database:`)}\n\n${error}`;
+};
+
+export const SEED_DEFAULT_EXPORT_ERROR = (fileName: string) => {
+	return SEED_ERROR(`Missing default function export in ${bold(fileName)}`);
+};

--- a/packages/db/src/runtime/queries.ts
+++ b/packages/db/src/runtime/queries.ts
@@ -6,7 +6,7 @@ import {
 	FOREIGN_KEY_REFERENCES_EMPTY_ERROR,
 	FOREIGN_KEY_REFERENCES_LENGTH_ERROR,
 	REFERENCE_DNE_ERROR,
-} from '../core/errors.js';
+} from './errors.js';
 import type {
 	BooleanColumn,
 	ColumnType,

--- a/packages/db/src/runtime/seed-local.ts
+++ b/packages/db/src/runtime/seed-local.ts
@@ -2,7 +2,7 @@ import { LibsqlError } from '@libsql/client';
 import { type SQL, sql } from 'drizzle-orm';
 import type { LibSQLDatabase } from 'drizzle-orm/libsql';
 import { SQLiteAsyncDialect } from 'drizzle-orm/sqlite-core';
-import { SEED_DEFAULT_EXPORT_ERROR, SEED_ERROR } from '../core/errors.js';
+import { SEED_DEFAULT_EXPORT_ERROR, SEED_ERROR } from './errors.js';
 import { type DBTables } from '../core/types.js';
 import { getCreateIndexQueries, getCreateTableQuery } from './queries.js';
 


### PR DESCRIPTION
## Changes

- Importing things in `src/core` from `src/runtime` will cause production to include rollup, vite and other unwanted things.
- This eslint rule will error if you do this. 

## Testing

- Verified locally

## Docs

N/A, bug fix