### PR TITLE
Provide guidance when --remote is omitted

### DIFF
--- a/.changeset/neat-stingrays-judge.md
+++ b/.changeset/neat-stingrays-judge.md
@@ -1,0 +1,7 @@
+---
+"@astrojs/db": patch
+---
+
+Provide guidance when --remote is missing
+
+When running the build `astro build` without the `--remote`, either require a `DATABASE_FILE` variable be defined, which means you are going expert-mode and having your own database, or error suggesting to use the `--remote` flag.

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'fs';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import type { AstroConfig, AstroIntegration } from 'astro';
+import { AstroError } from 'astro/errors';
 import { mkdir, writeFile } from 'fs/promises';
 import { blue, yellow } from 'kleur/colors';
 import parseArgs from 'yargs-parser';
@@ -114,8 +115,10 @@ function astroDBIntegration(): AstroIntegration {
 				});
 			},
 			'astro:build:start': async ({ logger }) => {
-				if(!connectToStudio && !databaseFileEnvDefined() && output === 'server') {
-					throw new Error(`Attempting to build without the --remote flag or the DATABASE_FILE environment variable defined. You probably want to pass --remote to astro build.`)
+				if(!connectToStudio && !databaseFileEnvDefined() && (output === 'server' || output === 'hybrid')) {
+					const message = `Attempting to build without the --remote flag or the DATABASE_FILE environment variable defined. You probably want to pass --remote to astro build.`;
+					const hint = 'Learn more connecting to Studio: https://docs.astro.build/en/guides/astro-db/#connect-to-astro-studio';
+					throw new AstroError(message, hint);
 				}
 
 				logger.info('database: ' + (connectToStudio ? yellow('remote') : blue('local database.')));
@@ -129,7 +132,7 @@ function astroDBIntegration(): AstroIntegration {
 
 function databaseFileEnvDefined() {
 	const env = loadEnv('', process.cwd());
-	return env.DATABASE_FILE != null || process.env.DATABASE_FILE != null;
+	return env.ASTRO_DATABASE_FILE != null || process.env.ASTRO_DATABASE_FILE != null;
 }
 
 export function integration(): AstroIntegration[] {

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
-import type { AstroIntegration } from 'astro';
+import type { AstroConfig, AstroIntegration } from 'astro';
 import { mkdir, writeFile } from 'fs/promises';
 import { blue, yellow } from 'kleur/colors';
 import parseArgs from 'yargs-parser';
@@ -34,12 +34,14 @@ function astroDBIntegration(): AstroIntegration {
 		},
 	};
 	let command: 'dev' | 'build' | 'preview';
+	let output: AstroConfig['output'] = 'server';
 	return {
 		name: 'astro:db',
 		hooks: {
 			'astro:config:setup': async ({ updateConfig, config, command: _command, logger }) => {
 				command = _command;
 				root = config.root;
+				output = config.output;
 
 				if (command === 'preview') return;
 
@@ -112,7 +114,7 @@ function astroDBIntegration(): AstroIntegration {
 				});
 			},
 			'astro:build:start': async ({ logger }) => {
-				if(!connectToStudio && !databaseFileEnvDefined()) {
+				if(!connectToStudio && !databaseFileEnvDefined() && output === 'server') {
 					throw new Error(`Attempting to build without the --remote flag or the DATABASE_FILE environment variable defined. You probably want to pass --remote to astro build.`)
 				}
 

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -116,7 +116,7 @@ function astroDBIntegration(): AstroIntegration {
 			},
 			'astro:build:start': async ({ logger }) => {
 				if(!connectToStudio && !databaseFileEnvDefined() && (output === 'server' || output === 'hybrid')) {
-					const message = `Attempting to build without the --remote flag or the DATABASE_FILE environment variable defined. You probably want to pass --remote to astro build.`;
+					const message = `Attempting to build without the --remote flag or the ASTRO_DATABASE_FILE environment variable defined. You probably want to pass --remote to astro build.`;
 					const hint = 'Learn more connecting to Studio: https://docs.astro.build/en/guides/astro-db/#connect-to-astro-studio';
 					throw new AstroError(message, hint);
 				}

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -13,6 +13,7 @@ import { fileURLIntegration } from './file-url.js';
 import { typegenInternal } from './typegen.js';
 import { type LateSeedFiles, type LateTables, vitePluginDb } from './vite-plugin-db.js';
 import { vitePluginInjectEnvTs } from './vite-plugin-inject-env-ts.js';
+import { loadEnv } from 'vite';
 
 function astroDBIntegration(): AstroIntegration {
 	let connectToStudio = false;
@@ -111,6 +112,10 @@ function astroDBIntegration(): AstroIntegration {
 				});
 			},
 			'astro:build:start': async ({ logger }) => {
+				if(!connectToStudio && !databaseFileEnvDefined()) {
+					throw new Error(`Attempting to build without the --remote flag or the DATABASE_FILE environment variable defined. You probably want to pass --remote to astro build.`)
+				}
+
 				logger.info('database: ' + (connectToStudio ? yellow('remote') : blue('local database.')));
 			},
 			'astro:build:done': async ({}) => {
@@ -118,6 +123,11 @@ function astroDBIntegration(): AstroIntegration {
 			},
 		},
 	};
+}
+
+function databaseFileEnvDefined() {
+	const env = loadEnv('', process.cwd());
+	return env.DATABASE_FILE != null || process.env.DATABASE_FILE != null;
 }
 
 export function integration(): AstroIntegration[] {

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -118,7 +118,7 @@ import { asDrizzleTable, createLocalDatabaseClient } from ${RUNTIME_IMPORT};
 ${shouldSeed ? `import { seedLocal } from ${RUNTIME_IMPORT};` : ''}
 ${shouldSeed ? integrationSeedImportStatements.join('\n') : ''}
 
-const dbUrl = import.meta.env.DATABASE_FILE ?? ${JSON.stringify(dbUrl)};
+const dbUrl = import.meta.env.ASTRO_DATABASE_FILE ?? ${JSON.stringify(dbUrl)};
 
 export const db = createLocalDatabaseClient({ dbUrl });
 

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -118,7 +118,8 @@ import { asDrizzleTable, createLocalDatabaseClient } from ${RUNTIME_IMPORT};
 ${shouldSeed ? `import { seedLocal } from ${RUNTIME_IMPORT};` : ''}
 ${shouldSeed ? integrationSeedImportStatements.join('\n') : ''}
 
-const dbUrl = ${JSON.stringify(dbUrl)};
+const dbUrl = import.meta.env.DATABASE_FILE ?? ${JSON.stringify(dbUrl)};
+
 export const db = createLocalDatabaseClient({ dbUrl });
 
 ${

--- a/packages/db/test/basics.test.js
+++ b/packages/db/test/basics.test.js
@@ -183,6 +183,7 @@ describe('astro:db', () => {
 		});
 
 		after(async () => {
+			process.env.ASTRO_STUDIO_APP_TOKEN = '';
 			await remoteDbServer?.stop();
 		});
 

--- a/packages/db/test/fixtures/local-prod/astro.config.ts
+++ b/packages/db/test/fixtures/local-prod/astro.config.ts
@@ -1,0 +1,10 @@
+import db from '@astrojs/db';
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [db()],
+	devToolbar: {
+		enabled: false,
+	},
+});

--- a/packages/db/test/fixtures/local-prod/db/config.ts
+++ b/packages/db/test/fixtures/local-prod/db/config.ts
@@ -1,0 +1,13 @@
+import { column, defineDb, defineTable } from 'astro:db';
+
+const User = defineTable({
+	columns: {
+		id: column.text({ primaryKey: true, optional: false }),
+		username: column.text({ optional: false, unique: true }),
+		password: column.text({ optional: false }),
+	},
+});
+
+export default defineDb({
+	tables: { User },
+});

--- a/packages/db/test/fixtures/local-prod/db/seed.ts
+++ b/packages/db/test/fixtures/local-prod/db/seed.ts
@@ -1,0 +1,8 @@
+import { asDrizzleTable } from '@astrojs/db/utils';
+import { User, db } from 'astro:db';
+
+export default async function () {
+	await db.batch([
+		db.insert(User).values([{ id: 'mario', username: 'Mario', password: 'itsame' }]),
+	]);
+}

--- a/packages/db/test/fixtures/local-prod/package.json
+++ b/packages/db/test/fixtures/local-prod/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@test/db-local-prod",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "@astrojs/db": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/db/test/fixtures/local-prod/src/pages/index.astro
+++ b/packages/db/test/fixtures/local-prod/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+/// <reference path="../../.astro/db-types.d.ts" />
+import { db, User } from 'astro:db';
+
+const users = await db.select().from(User);
+---
+
+<h2>Users</h2>
+<ul class="users-list">
+	{users.map((user) => <li>{user.name}</li>)}
+</ul>

--- a/packages/db/test/local-prod.test.js
+++ b/packages/db/test/local-prod.test.js
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+import testAdapter from '../../astro/test/test-adapter.js';
+import { loadFixture } from '../../astro/test/test-utils.js';
+
+describe('astro:db local database', () => {
+	let fixture;
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/local-prod/', import.meta.url),
+			output: 'server',
+			adapter: testAdapter(),
+		});
+	});
+
+	describe('build (not remote) with DATABASE_FILE env', () => {
+		const prodDbPath = new URL('./fixtures/basics/dist/astro.db', import.meta.url).toString();
+		before(async () => {
+			process.env.DATABASE_FILE = prodDbPath;
+			await fixture.build();
+		});
+
+		after(async () => {
+			delete process.env.DATABASE_FILE;
+		});
+
+		it('Can render page', async () => {
+			const app = await fixture.loadTestAdapterApp();
+			const request = new Request('http://example.com/');
+			const response = await app.render(request);
+			expect(response.status).to.equal(200);
+		});
+	});
+
+	describe('build (not remote)', () => {
+		it('should throw during the build', async () => {
+			delete process.env.DATABASE_FILE;
+			let buildError = null;
+			try {
+				await fixture.build();
+			} catch(err) {
+				buildError = err;
+			}
+
+			expect(buildError).to.be.an('Error');
+		});
+	});
+});

--- a/packages/db/test/local-prod.test.js
+++ b/packages/db/test/local-prod.test.js
@@ -15,12 +15,12 @@ describe('astro:db local database', () => {
 	describe('build (not remote) with DATABASE_FILE env', () => {
 		const prodDbPath = new URL('./fixtures/basics/dist/astro.db', import.meta.url).toString();
 		before(async () => {
-			process.env.DATABASE_FILE = prodDbPath;
+			process.env.ASTRO_DATABASE_FILE = prodDbPath;
 			await fixture.build();
 		});
 
 		after(async () => {
-			delete process.env.DATABASE_FILE;
+			delete process.env.ASTRO_DATABASE_FILE;
 		});
 
 		it('Can render page', async () => {
@@ -32,11 +32,29 @@ describe('astro:db local database', () => {
 	});
 
 	describe('build (not remote)', () => {
-		it('should throw during the build', async () => {
-			delete process.env.DATABASE_FILE;
+		it('should throw during the build for server output', async () => {
+			delete process.env.ASTRO_DATABASE_FILE;
 			let buildError = null;
 			try {
 				await fixture.build();
+			} catch(err) {
+				buildError = err;
+			}
+
+			expect(buildError).to.be.an('Error');
+		});
+
+		it('should throw during the build for hybrid output', async () => {
+			let fixture2 = await loadFixture({
+				root: new URL('./fixtures/local-prod/', import.meta.url),
+				output: 'hybrid',
+				adapter: testAdapter(),
+			});
+
+			delete process.env.ASTRO_DATABASE_FILE;
+			let buildError = null;
+			try {
+				await fixture2.build();
 			} catch(err) {
 				buildError = err;
 			}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3948,6 +3948,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../astro
 
+  packages/db/test/fixtures/local-prod:
+    dependencies:
+      '@astrojs/db':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../astro
+
   packages/db/test/fixtures/no-apptoken:
     dependencies:
       '@astrojs/db':


### PR DESCRIPTION
## Changes

- Expect a `DATABASE_FILE` during the build, which points to the production database, or error and explain that they probably wanted `--remote`.
- Note that this restriction does not apply to static mode.

## Testing

- New tests added, testing both cases.

## Docs

N/A, bug fix