### PR TITLE
fix: dont error on nullish prop values in jsx runtime

### DIFF
--- a/.changeset/forty-turkeys-tap.md
+++ b/.changeset/forty-turkeys-tap.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes a bug where JSX runtime would error on components with nullish prop values in certain conditions.

--- a/packages/astro/src/runtime/server/jsx.ts
+++ b/packages/astro/src/runtime/server/jsx.ts
@@ -116,7 +116,7 @@ Did you forget to import the component or is it possible there is a typo?`);
 			}
 			extractSlots(children);
 			for (const [key, value] of Object.entries(props)) {
-				if (value['$$slot']) {
+				if (value?.['$$slot']) {
 					_slots[key] = value;
 					delete props[key];
 				}


### PR DESCRIPTION
resolves #10575

## Changes

- jsx runtime no longer errors on non-`.astro` jsx function component instances represented as vnode objects with nullish prop values
    - only try property access on non-nullish prop values when checking if a prop is a slot

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

tested locally (ran dev server for `@examples/with-mdx` and added reproduction sample from linked issue)

not sure where a test file would best go or how to construct it, since particular reproduction from linked issue uses mdx, but don't think mdx is actually necessary, merely an environment where the issue could naturally occur.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

not needed, internal bugfix
