### PR TITLE
refactor: Drop Preact compat hack, remove incorrect alias

### DIFF
--- a/.changeset/proud-books-hope.md
+++ b/.changeset/proud-books-hope.md
@@ -2,4 +2,4 @@
 "@astrojs/preact": patch
 ---
 
-Fix (theoretical) edge case in Preact integration's JSX aliases
+Fixes (theoretical) edge case in Preact integration's JSX aliases

--- a/.changeset/proud-books-hope.md
+++ b/.changeset/proud-books-hope.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/preact": patch
+---
+
+Fix (theoretical) edge case in Preact integration's JSX aliases

--- a/packages/integrations/preact/src/index.ts
+++ b/packages/integrations/preact/src/index.ts
@@ -20,6 +20,7 @@ export default function ({ include, exclude, compat }: Options = {}): AstroInteg
 		hooks: {
 			'astro:config:setup': ({ addRenderer, updateConfig, command }) => {
 				const preactPlugin = preact({
+					reactAliasesEnabled: compat,
 					include,
 					exclude,
 					babel: {
@@ -34,20 +35,13 @@ export default function ({ include, exclude, compat }: Options = {}): AstroInteg
 					},
 				};
 
-				// If not compat, delete the plugin that does it
-				if (!compat) {
-					const pIndex = preactPlugin.findIndex((p) => p.name == 'preact:config');
-					if (pIndex >= 0) {
-						preactPlugin.splice(pIndex, 1);
-					}
-				} else {
+				if (compat) {
 					viteConfig.optimizeDeps!.include!.push(
 						'preact/compat',
 						'preact/test-utils',
 						'preact/compat/jsx-runtime'
 					);
 					viteConfig.resolve = {
-						alias: [{ find: 'react/jsx-runtime', replacement: 'preact/jsx-runtime' }],
 						dedupe: ['preact/compat', 'preact'],
 					};
 					// noExternal React entrypoints to be bundled, resolved, and aliased by Vite

--- a/packages/integrations/preact/src/index.ts
+++ b/packages/integrations/preact/src/index.ts
@@ -20,7 +20,7 @@ export default function ({ include, exclude, compat }: Options = {}): AstroInteg
 		hooks: {
 			'astro:config:setup': ({ addRenderer, updateConfig, command }) => {
 				const preactPlugin = preact({
-					reactAliasesEnabled: compat,
+					reactAliasesEnabled: compat ?? false,
 					include,
 					exclude,
 					babel: {


### PR DESCRIPTION
## Changes

- Swaps out the config to disable `preact/compat` aliases now that `@preact/preset-vite` supports this natively (https://github.com/preactjs/preset-vite/pull/79)
- Disables incorrect `react/jsx-runtime` -> `preact/jsx-runtime` alias. `@preact/preset-vite` already covers this (correctly) and so it did not need a replacement here.

## Testing

No functional changes, beyond fixing a theoretical edge case with the `jsx-runtime` alias. I don't think it's worth adding a test here, this is pretty unlikely behavior to run across and is addressed by `@preact/preset-vite` already.

## Docs

N/A, not user facing.

## Misc

Some of the other config bits looks to be something we can upstream, so I'll take a look soon-ish and see if we can't reduce the config here further.