### PR TITLE
For --force-reset use conditional drop table query

### DIFF
--- a/.changeset/ninety-islands-deny.md
+++ b/.changeset/ninety-islands-deny.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Conditionally drop table with --force-reset

--- a/packages/db/src/core/cli/migration-queries.ts
+++ b/packages/db/src/core/cli/migration-queries.ts
@@ -7,6 +7,7 @@ import { hasPrimaryKey } from '../../runtime/index.js';
 import {
 	getCreateIndexQueries,
 	getCreateTableQuery,
+	getDropTableIfExistsQuery,
 	getModifiers,
 	getReferencesConfig,
 	hasDefault,
@@ -455,7 +456,7 @@ export async function getProductionCurrentSnapshot({
 function getDropTableQueriesForSnapshot(snapshot: DBSnapshot) {
 	const queries = [];
 	for (const tableName of Object.keys(snapshot.schema)) {
-		const dropQuery = `DROP TABLE ${sqlite.escapeName(tableName)}`;
+		const dropQuery = getDropTableIfExistsQuery(tableName);
 		queries.unshift(dropQuery);
 	}
 	return queries;

--- a/packages/db/test/unit/reset-queries.test.js
+++ b/packages/db/test/unit/reset-queries.test.js
@@ -32,7 +32,7 @@ describe('force reset', () => {
 			});
 
 			expect(queries).to.deep.equal([
-				`DROP TABLE "${TABLE_NAME}"`,
+				`DROP TABLE IF EXISTS "${TABLE_NAME}"`,
 				`CREATE TABLE "${TABLE_NAME}" (_id INTEGER PRIMARY KEY, "name" text NOT NULL, "age" integer NOT NULL, "email" text NOT NULL UNIQUE, "mi" text)`,
 			]);
 		});


### PR DESCRIPTION
## Changes

- `--force-reset` should restore the database to the current schema, but it adds a DROP TABLE for all tables in the new schema. Since those might not exist, this should be conditional.

## Testing

- Updated existing tests

## Docs

N/A, bug fix