### PR TITLE
db: Seed on dev server startup

### DIFF
--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -58,6 +58,9 @@ export function vitePluginDb(params: VitePluginDBParams): VitePlugin {
 			}
 			return resolved.virtual;
 		},
+		configureServer(server) {
+			server.ssrLoadModule(resolved.seedVirtual);
+		},
 		async load(id) {
 			if (id !== resolved.virtual && id !== resolved.seedVirtual) return;
 

--- a/packages/db/src/core/integration/vite-plugin-db.ts
+++ b/packages/db/src/core/integration/vite-plugin-db.ts
@@ -7,7 +7,7 @@ import { type VitePlugin, getDbDirectoryUrl, getRemoteDatabaseUrl } from '../uti
 
 const WITH_SEED_VIRTUAL_MODULE_ID = 'astro:db:seed';
 
-const resolved = {
+export const resolved = {
 	virtual: '\0' + VIRTUAL_MODULE_ID,
 	seedVirtual: '\0' + WITH_SEED_VIRTUAL_MODULE_ID,
 };
@@ -57,9 +57,6 @@ export function vitePluginDb(params: VitePluginDBParams): VitePlugin {
 				return resolved.seedVirtual;
 			}
 			return resolved.virtual;
-		},
-		configureServer(server) {
-			server.ssrLoadModule(resolved.seedVirtual);
 		},
 		async load(id) {
 			if (id !== resolved.virtual && id !== resolved.seedVirtual) return;


### PR DESCRIPTION
## Changes

This PR loads your seed file whenever the dev server startups. To make it unblocking and preserve HMR on file changes, we use `vite.ssrLoadModule()`.
- Add a `ssrLoadModule()` call for the `astro:db:seed` module on server startup
- Add a file watcher to `ssrLoadModule()` again whenever a seed file changes. This does **not** cause duplicate runs in the Vite server; it eagerly loads and allows us to track the promise to log another "seeded database" message. This gives user feedback when your seed file changes and keeps your db up-to-date even when your browser is closed.

## Testing

Manual testing to ensure logs fire and the seed file is only loaded/reloaded once.

## Docs

N/A