### PR TITLE
Provide better messaging when renaming a table

### DIFF
--- a/.changeset/old-planes-walk.md
+++ b/.changeset/old-planes-walk.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Provide better messaging when renaming a table

--- a/packages/db/src/core/cli/commands/push/index.ts
+++ b/packages/db/src/core/cli/commands/push/index.ts
@@ -12,6 +12,7 @@ import {
 	getMigrationQueries,
 	getProductionCurrentSnapshot,
 } from '../../migration-queries.js';
+import prompts from 'prompts';
 
 export async function cmd({
 	dbConfig,
@@ -41,6 +42,18 @@ export async function cmd({
 	}
 
 	if (isForceReset) {
+    const { begin } = await prompts({
+      type: "confirm",
+      name: "begin",
+      message: `Reset your database? All of your data will be erased and your schema created from scratch.`,
+      initial: false
+    });
+
+    if(!begin) {
+      console.log("Canceled.");
+      process.exit(0);
+    }
+
 		console.log(`Force-pushing to the database. All existing data will be erased.`);
 	} else if (confirmations.length > 0) {
 		console.log('\n' + formatDataLossMessage(confirmations) + '\n');

--- a/packages/db/src/core/cli/migration-queries.ts
+++ b/packages/db/src/core/cli/migration-queries.ts
@@ -64,9 +64,9 @@ export async function getMigrationQueries({
 		Object.entries(droppedTables).filter(([, table]) => !table.deprecated)
 	);
 	if (!isEmpty(addedTables) && !isEmpty(notDeprecatedDroppedTables)) {
-		throw new Error(
-			RENAME_TABLE_ERROR(Object.keys(addedTables)[0], Object.keys(notDeprecatedDroppedTables)[0])
-		);
+		const oldTable = Object.keys(notDeprecatedDroppedTables)[0];
+		const newTable = Object.keys(addedTables)[0];
+		throw new Error(RENAME_TABLE_ERROR(oldTable, newTable));
 	}
 
 	for (const [tableName, table] of Object.entries(addedTables)) {

--- a/packages/db/src/core/errors.ts
+++ b/packages/db/src/core/errors.ts
@@ -19,22 +19,10 @@ export const RENAME_TABLE_ERROR = (oldTable: string, newTable: string) => {
 		red("\u25B6 Potential table rename detected: " + oldTable + " -> " + newTable) + `
   You cannot add and remove tables in the same schema update batch.
 
-  To rename a table you need to push twice. Follow these steps:
-
-  1. Keep the ${oldTable} schema in your config and add a 'deprecated: true' flag instead.
-  
-    const ${oldTable} = defineTable({
-      deprecated: true 
-      // ...
-    });
-
-    Also, do include in the ${newTable} schema as well.
-
-    Then run \`astro db push --remote\` again.
-
-  2. Remove the ${oldTable} schema from the config.
-  
-    Run \`astro db push --remote\`. You should now have only your renamed table.`
+  1. Use "deprecated: true" to deprecate a table before renaming.
+  2. Use "--force-reset" to ignore this warning and reset the database (deleting all of your data).
+	
+	Visit https://docs.astro.build/en/guides/astro-db/#renaming-tables to learn more.`
 	);
 };
 

--- a/packages/db/src/core/errors.ts
+++ b/packages/db/src/core/errors.ts
@@ -16,9 +16,25 @@ export const MISSING_EXECUTE_PATH_ERROR = `${red(
 
 export const RENAME_TABLE_ERROR = (oldTable: string, newTable: string) => {
 	return (
-		red('▶ Potential table rename detected: ' + oldTable + ', ' + newTable) +
-		`\n  You cannot add and remove tables in the same schema update batch.` +
-		`\n  To resolve, add a 'deprecated: true' flag to '${oldTable}' instead.`
+		red("\u25B6 Potential table rename detected: " + oldTable + " -> " + newTable) + `
+  You cannot add and remove tables in the same schema update batch.
+
+  To rename a table you need to push twice. Follow these steps:
+
+  1. Keep the ${oldTable} schema in your config and add a 'deprecated: true' flag instead.
+  
+    const ${oldTable} = defineTable({
+      deprecated: true 
+      // ...
+    });
+
+    Also, do include in the ${newTable} schema as well.
+
+    Then run \`astro db push --remote\` again.
+
+  2. Remove the ${oldTable} schema from the config.
+  
+    Run \`astro db push --remote\`. You should now have only your renamed table.`
 	);
 };
 


### PR DESCRIPTION
## Changes

- Instructs on the steps required
- Fixes issue where we were telling them to add `deprecated: true` to the new table.
- Closes https://github.com/withastro/astro/issues/10510

### Push

<img width="808" alt="Screen Shot 2024-03-29 at 3 20 15 PM" src="https://github.com/withastro/astro/assets/361671/58f8977c-21f6-40d7-85c6-aa899c5e0159">

### `--force-reset`

<img width="797" alt="Screen Shot 2024-03-29 at 3 20 51 PM" src="https://github.com/withastro/astro/assets/361671/0ab03264-69cb-4c32-9e05-9fe9d322de20">


## Testing

N/A

## Docs

- https://github.com/withastro/docs/pull/7655. Docs must be merged first