### PR TITLE
reset history title after push/replace but prior to assignment to location

### DIFF
--- a/.changeset/eighty-olives-destroy.md
+++ b/.changeset/eighty-olives-destroy.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue with outdated page titles in browser history when using text fragments in view transition navigation.

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -184,6 +184,7 @@ const moveToLocation = (
 			);
 		}
 	}
+	document.title = targetPageTitle;
 	// now we are on the new page for non-history navigations!
 	// (with history navigation page change happens before popstate is fired)
 	originalLocation = to;
@@ -212,7 +213,6 @@ const moveToLocation = (
 		}
 		history.scrollRestoration = 'manual';
 	}
-	document.title = targetPageTitle;
 };
 
 function preloadStyleLinks(newDocument: Document) {


### PR DESCRIPTION
## Changes

We change the history title while we push / replace the history during view transition.
It got changes back at the end of the function which turned out to be too late when using text fragments (`#:~:text=...`) as Chrome pushes another state.

## Testing

**Edit:** ~~n./a.~~ Tested manually.

## Docs

bug fix n./a.