### PR TITLE
Move nft warnings behind verbose logging

### DIFF
--- a/.changeset/unlucky-shoes-vanish.md
+++ b/.changeset/unlucky-shoes-vanish.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vercel": patch
+---
+
+Move nft warnings behind verbose logging

--- a/packages/integrations/vercel/src/lib/nft.ts
+++ b/packages/integrations/vercel/src/lib/nft.ts
@@ -53,11 +53,11 @@ export async function copyDependenciesToFunction(
 			if (module === 'sharp') continue;
 
 			if (entryPath === file) {
-				console.warn(
+				logger.info(
 					`[@astrojs/vercel] The module "${module}" couldn't be resolved. This may not be a problem, but it's worth checking.`
 				);
 			} else {
-				console.warn(
+				logger.info(
 					`[@astrojs/vercel] The module "${module}" inside the file "${file}" couldn't be resolved. This may not be a problem, but it's worth checking.`
 				);
 			}


### PR DESCRIPTION
## Changes

- These warnings are almost always false-positives. They happen when Vercel scans your source code looking for files to move over.
- Keep the warnings but put them behind the Astro logger so they respect the `--verbose` flag and aren't seen normally.

## Testing

Tested against example project

## Docs

N/A, bug fix