### PR TITLE
feat: rework child rendering to use class

### DIFF
--- a/packages/astro/src/runtime/server/render/any.ts
+++ b/packages/astro/src/runtime/server/render/any.ts
@@ -1,11 +1,14 @@
 import { escapeHTML, isHTMLString, markHTMLString } from '../escape.js';
+import { isPromise } from '../util.js';
 import { isAstroComponentInstance, isRenderTemplateResult } from './astro/index.js';
 import { type RenderDestination, isRenderInstance } from './common.js';
 import { SlotString } from './slot.js';
 import { renderToBufferDestination } from './util.js';
 
 export async function renderChild(destination: RenderDestination, child: any) {
-	child = await child;
+	if (isPromise(child)) {
+		child = await child;
+	}
 	if (child instanceof SlotString) {
 		destination.write(child);
 	} else if (isHTMLString(child)) {

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -181,7 +181,7 @@ class BufferedRenderer implements RenderDestination {
 			destination.write(chunk);
 		}
 
-		// NOTE: We don't empty `bufferChunks` after it's written as benchmarks show
+		// NOTE: We don't empty `this.chunks` after it's written as benchmarks show
 		// that it causes poorer performance, likely due to forced memory re-allocation,
 		// instead of letting the garbage collector handle it automatically.
 		// (Unsure how this affects on limited memory machines)


### PR DESCRIPTION
Quite a lot of garbage collection happens when rendering due to the fact we create anonymous functions when buffering writes (the `catch`, the destination/write function, etc).

By extracting this logic into a class, we can instead rely on prototype methods which exist once in memory.

## Testing

Existing tests should cover this.

Manual testing has happened via the benchmark script to see if any benefit was gained.

Before:

| Page   | Avg (ms) | Stdev (ms) | Max (ms) |
| :----- | -------: | ---------: | -------: |
| /astro |   203.76 |      38.25 |   315.99 |
| /md    |     2.73 |       1.99 |    22.16 |
| /mdx   |   118.25 |      17.55 |   220.04 |


After:

| Page   | Avg (ms) | Stdev (ms) | Max (ms) |
| :----- | -------: | ---------: | -------: |
| /astro |   133.88 |      25.51 |   313.56 |
| /md    |     2.44 |       1.99 |    22.00 |
| /mdx   |   113.79 |      17.49 |   206.58 |


## Docs

N/A

## Notes to reviewers

This isn't a huge gain so i'm happy to throw it away if you think the numbers are lying, or the code is worse.

the whole `renderChild` buffering is interesting. thanks to the buffering, we do a _lot_ of garbage collection (which slows execution). however, its probably still faster than doing them in serial.

i do wonder if we can rework to avoid allocating/processing individual buffers per child