### PR TITLE
fix(starlog): Correct layout syntax.

### DIFF
--- a/examples/starlog/src/components/BaseHead.astro
+++ b/examples/starlog/src/components/BaseHead.astro
@@ -7,6 +7,7 @@ export type Props = Partial<SEOProps>;
 const { title = SiteTitle, name = SiteTitle, description = SiteDescription, ...seo } = Astro.props;
 ---
 
+<meta charset="utf-8" />
 <SEO {title} {description} {name} {...seo} />
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/examples/starlog/src/layouts/IndexLayout.astro
+++ b/examples/starlog/src/layouts/IndexLayout.astro
@@ -9,15 +9,14 @@ const { ...head } = Astro.props;
 ---
 
 <!doctype html>
-<meta charset="utf-8" />
 <html lang="en">
 	<head>
 		<BaseHead {...head} />
-		<body>
-			<div class="glow"></div>
-			<Header />
-			<slot />
-			<Footer />
-		</body>
 	</head>
+	<body>
+		<div class="glow"></div>
+		<Header />
+		<slot />
+		<Footer />
+	</body>
 </html>


### PR DESCRIPTION
## Changes

The `<meta charset="utf-8" />` and `</head>` tags are not in the correct place, so the `<head>` tag is not output at build time.
So I changed it to the correct place.

## Testing

Checked the output of the build.

## Docs

N/A