### PR TITLE
Make `@astrojs/markdown-remark` a dep in `@astrojs/markdoc`

### DIFF
--- a/.changeset/selfish-spies-end.md
+++ b/.changeset/selfish-spies-end.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/markdoc": patch
+---
+
+Moves `@astrojs/markdown-remark` as a dependency

--- a/packages/integrations/markdoc/package.json
+++ b/packages/integrations/markdoc/package.json
@@ -63,6 +63,7 @@
   },
   "dependencies": {
     "@astrojs/internal-helpers": "workspace:*",
+    "@astrojs/markdown-remark": "workspace:*",
     "@astrojs/prism": "workspace:*",
     "@markdoc/markdoc": "^0.3.5",
     "esbuild": "^0.19.6",
@@ -76,7 +77,6 @@
     "astro": "^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
-    "@astrojs/markdown-remark": "workspace:*",
     "@types/html-escaper": "^3.0.2",
     "@types/markdown-it": "^13.0.6",
     "astro": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4136,6 +4136,9 @@ importers:
       '@astrojs/internal-helpers':
         specifier: workspace:*
         version: link:../../internal-helpers
+      '@astrojs/markdown-remark':
+        specifier: workspace:*
+        version: link:../../markdown/remark
       '@astrojs/prism':
         specifier: workspace:*
         version: link:../../astro-prism
@@ -4161,9 +4164,6 @@ importers:
         specifier: ^3.22.4
         version: 3.22.4
     devDependencies:
-      '@astrojs/markdown-remark':
-        specifier: workspace:*
-        version: link:../../markdown/remark
       '@types/html-escaper':
         specifier: ^3.0.2
         version: 3.0.2


### PR DESCRIPTION
## Changes

I noticed that after bumping `@astrojs/markdown-remark`, it didn't bump `@astrojs/markdoc` too. Turns out  `@astrojs/markdown-remark` was a dev dep, which is strange because `@astrojs/markdoc/shiki` uses it in runtime.

This PR should fix it.

## Testing

Existing tests should pass.

## Docs

n/a
