### PR TITLE
Move format option from LocalImageProps to ImageSharedProps

### DIFF
--- a/.changeset/lovely-trees-wait.md
+++ b/.changeset/lovely-trees-wait.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Moves format option from LocalImageProps to ImageSharedProps to solve type error when using format with remote images

--- a/.changeset/lovely-trees-wait.md
+++ b/.changeset/lovely-trees-wait.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Moves format option from LocalImageProps to ImageSharedProps to solve type error when using format with remote images
+Fixes typing issues when using `format` and `quality` options with remote images

--- a/packages/astro/src/assets/types.ts
+++ b/packages/astro/src/assets/types.ts
@@ -118,6 +118,15 @@ type ImageSharedProps<T> = T & {
 	 * ```
 	 */
 	height?: number | `${number}`;
+	/**
+	 * Desired output format for the image. Defaults to `webp`.
+	 *
+	 * **Example**:
+	 * ```astro
+	 * <Image src={...} format="avif" alt="..." />
+	 * ```
+	 */
+	format?: ImageOutputFormat;
 } & (
 		| {
 				/**
@@ -153,15 +162,6 @@ export type LocalImageProps<T> = ImageSharedProps<T> & {
 	 * ```
 	 */
 	src: ImageMetadata | Promise<{ default: ImageMetadata }>;
-	/**
-	 * Desired output format for the image. Defaults to `webp`.
-	 *
-	 * **Example**:
-	 * ```astro
-	 * <Image src={...} format="avif" alt="..." />
-	 * ```
-	 */
-	format?: ImageOutputFormat;
 	/**
 	 * Desired quality for the image. Value can either be a preset such as `low` or `high`, or a numeric value from 0 to 100.
 	 *

--- a/packages/astro/src/assets/types.ts
+++ b/packages/astro/src/assets/types.ts
@@ -127,6 +127,19 @@ type ImageSharedProps<T> = T & {
 	 * ```
 	 */
 	format?: ImageOutputFormat;
+	/**
+	 * Desired quality for the image. Value can either be a preset such as `low` or `high`, or a numeric value from 0 to 100.
+	 *
+	 * The perceptual quality of the output image is service-specific.
+	 * For instance, a certain service might decide that `high` results in a very beautiful image, but another could choose for it to be at best passable.
+	 *
+	 * **Example**:
+	 * ```astro
+	 * <Image src={...} quality='high' alt="..." />
+	 * <Image src={...} quality={300} alt="..." />
+	 * ```
+	 */
+	quality?: ImageQuality;
 } & (
 		| {
 				/**
@@ -162,19 +175,6 @@ export type LocalImageProps<T> = ImageSharedProps<T> & {
 	 * ```
 	 */
 	src: ImageMetadata | Promise<{ default: ImageMetadata }>;
-	/**
-	 * Desired quality for the image. Value can either be a preset such as `low` or `high`, or a numeric value from 0 to 100.
-	 *
-	 * The perceptual quality of the output image is service-specific.
-	 * For instance, a certain service might decide that `high` results in a very beautiful image, but another could choose for it to be at best passable.
-	 *
-	 * **Example**:
-	 * ```astro
-	 * <Image src={...} quality='high' alt="..." />
-	 * <Image src={...} quality={300} alt="..." />
-	 * ```
-	 */
-	quality?: ImageQuality;
 };
 
 export type RemoteImageProps<T> =


### PR DESCRIPTION
## What does this change?

Moves format and quality options from `LocalImageProps` to `ImageSharedProps` so it doesn't cause a type error when used with remote images, these always should have been shared

