### PR TITLE
fix(svelte): update import statements and bump peer dependency for v5

### DIFF
--- a/.changeset/calm-spiders-listen.md
+++ b/.changeset/calm-spiders-listen.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/svelte": minor
+---
+
+Bumps Svelte 5 peer dependency to `^5.0.0-next.90` and support its latest breaking changes

--- a/packages/integrations/svelte/client-v5.js
+++ b/packages/integrations/svelte/client-v5.js
@@ -1,5 +1,5 @@
 import { hydrate, mount, unmount } from 'svelte';
-import { add_snippet_symbol } from 'svelte/internal';
+import { add_snippet_symbol } from 'svelte/internal/client';
 
 // Allow a slot to be rendered as a snippet (dev validation only)
 const tagSlotAsSnippet = import.meta.env.DEV ? add_snippet_symbol : (s) => s;

--- a/packages/integrations/svelte/package.json
+++ b/packages/integrations/svelte/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "astro": "^4.0.0",
-    "svelte": "^4.0.0 || ^5.0.0-next.56",
+    "svelte": "^4.0.0 || ^5.0.0-next.90",
     "typescript": "^5.3.3"
   },
   "engines": {

--- a/packages/integrations/svelte/server-v5.js
+++ b/packages/integrations/svelte/server-v5.js
@@ -1,4 +1,4 @@
-import { add_snippet_symbol } from 'svelte/internal';
+import { add_snippet_symbol } from 'svelte/internal/server';
 import { render } from 'svelte/server';
 
 // Allow a slot to be rendered as a snippet (dev validation only)


### PR DESCRIPTION
## Changes

- Updates import statements for Svelte v5
- Bumps peer dependency `svelte` to `5.0.0-next.90`
- Closes #10637

## Testing

- Manually tested with [astro/examples/framework-svelte](https://astro.new/framework-svelte?on=github)

## Docs

- N/A
