### PR TITLE
chore: remove console.log from test

### DIFF
--- a/packages/integrations/vercel/test/serverless-prerender.test.js
+++ b/packages/integrations/vercel/test/serverless-prerender.test.js
@@ -23,7 +23,6 @@ describe('Serverless prerender', () => {
 			'../.vercel/output/functions/_render.func/packages/integrations/vercel/test/fixtures/serverless-prerender/.vercel/output/_functions/chunks/pages/generic_*.mjs'
 		);
 		const contents = await fixture.readFile(file);
-		console.log(contents);
 		assert.ok(!contents.includes('const outDir ='), "outDir is tree-shaken if it's not imported");
 	});
 


### PR DESCRIPTION
## Changes
- Removes a (really long) console.log from a test
- [sample](https://github.com/withastro/astro/actions/runs/8527589611/job/23359440318?pr=10652#step:8:5368) (over a thousand lines)
- originally added in https://github.com/withastro/astro/pull/10550

## Testing
- Does not affect behavior

## Docs
- Does not affect usage