### PR TITLE
Mark @material-tailwind/react as noExternal

### DIFF
--- a/.changeset/tall-apples-turn.md
+++ b/.changeset/tall-apples-turn.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/react": patch
+---
+
+Mark @material-tailwind/react as noExternal

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -80,6 +80,7 @@ function getViteConfiguration({
 				'@babel/runtime',
 				'redoc',
 				'use-immer',
+				'@material-tailwind/react'
 			],
 		},
 	};


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/astro/issues/10644
- Fairly popular library with 42k weekly downloads: https://www.npmjs.com/package/@material-tailwind/react
- Easily automatically fixed by adding it as a built-in noExternal fixes it

## Testing

Manually

## Docs

N/A, bug fix