### PR TITLE
Fix building static sites with Astro DB

### DIFF
--- a/.changeset/serious-elephants-push.md
+++ b/.changeset/serious-elephants-push.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Pass through appToken on static sites with Astro DB

--- a/packages/db/src/core/cli/commands/execute/index.ts
+++ b/packages/db/src/core/cli/commands/execute/index.ts
@@ -45,6 +45,7 @@ export async function cmd({
 			tables: dbConfig.tables ?? {},
 			appToken: appToken.token,
 			isBuild: false,
+			output: 'server',
 		});
 	} else {
 		virtualModContents = getLocalVirtualModContents({

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -59,6 +59,7 @@ function astroDBIntegration(): AstroIntegration {
 						tables,
 						root: config.root,
 						srcDir: config.srcDir,
+						output: config.output,
 					});
 				} else {
 					dbPlugin = vitePluginDb({
@@ -67,6 +68,7 @@ function astroDBIntegration(): AstroIntegration {
 						seedFiles,
 						root: config.root,
 						srcDir: config.srcDir,
+						output: config.output,
 					});
 				}
 

--- a/packages/db/test/fixtures/static-remote/astro.config.ts
+++ b/packages/db/test/fixtures/static-remote/astro.config.ts
@@ -1,0 +1,6 @@
+import astroDb from '@astrojs/db';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	integrations: [astroDb()],
+});

--- a/packages/db/test/fixtures/static-remote/db/config.ts
+++ b/packages/db/test/fixtures/static-remote/db/config.ts
@@ -1,0 +1,12 @@
+import { column, defineDb, defineTable } from 'astro:db';
+
+const User = defineTable({
+	columns: {
+		id: column.number({ primaryKey: true }),
+		name: column.text(),
+	},
+});
+
+export default defineDb({
+	tables: { User },
+});

--- a/packages/db/test/fixtures/static-remote/db/seed.ts
+++ b/packages/db/test/fixtures/static-remote/db/seed.ts
@@ -1,0 +1,9 @@
+import { User, db } from 'astro:db';
+
+export default async function () {
+	await db.insert(User).values([
+		{
+			name: 'Houston'
+		}
+	]);
+}

--- a/packages/db/test/fixtures/static-remote/package.json
+++ b/packages/db/test/fixtures/static-remote/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@test/db-static-remote",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@astrojs/db": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/db/test/fixtures/static-remote/src/pages/index.astro
+++ b/packages/db/test/fixtures/static-remote/src/pages/index.astro
@@ -1,0 +1,20 @@
+---
+import { User, db } from 'astro:db';
+
+const users = await db.select().from(User);
+---
+<html>
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<h1>Testing</h1>
+
+		<h2>Users</h2>
+		<ul>
+			{users.map(user => (
+				<li>{user.name}</li>
+			))}
+		</ul>
+	</body>
+</html>

--- a/packages/db/test/static-remote.test.js
+++ b/packages/db/test/static-remote.test.js
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import { load as cheerioLoad } from 'cheerio';
+import { loadFixture } from '../../astro/test/test-utils.js';
+import { setupRemoteDbServer } from './test-utils.js';
+
+describe('astro:db', () => {
+	let fixture;
+	before(async () => {
+		fixture = await loadFixture({
+			root: new URL('./fixtures/static-remote/', import.meta.url),
+			output: 'static',
+		});
+	});
+
+	describe('static build --remote', () => {
+		let remoteDbServer;
+
+		before(async () => {
+			remoteDbServer = await setupRemoteDbServer(fixture.config);
+			await fixture.build();
+		});
+
+		after(async () => {
+			await remoteDbServer?.stop();
+		});
+
+		it('Can render page', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerioLoad(html);
+
+			expect($('li').length).to.equal(1);
+		});
+	});
+});

--- a/packages/db/test/test-utils.js
+++ b/packages/db/test/test-utils.js
@@ -12,7 +12,7 @@ const singleQuerySchema = z.object({
 
 const querySchema = singleQuerySchema.or(z.array(singleQuerySchema));
 
-let portIncrementer = 8081;
+let portIncrementer = 8030;
 
 /**
  * @param {import('astro').AstroConfig} astroConfig

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3996,6 +3996,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../astro
 
+  packages/db/test/fixtures/static-remote:
+    dependencies:
+      '@astrojs/db':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../astro
+
   packages/db/test/fixtures/ticketing-example:
     dependencies:
       '@astrojs/check':


### PR DESCRIPTION
## Changes

- When building a site with `output: 'static'` (or hybrid), the temporary app token is needed to build pages.
- Pass through in this condition so this is used if the env doesn't exist (which won't most of the time).

## Testing

- New test fixture added.

## Docs

N/A, bug fix