### PR TITLE
fix: Fixed errorOverlay theme toggle bug.

### DIFF
--- a/.changeset/short-flies-itch.md
+++ b/.changeset/short-flies-itch.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-save `localStorage.astroErrorOverlayTheme` when detected dark mode
+Fixed errorOverlay theme toggle bug.

--- a/.changeset/short-flies-itch.md
+++ b/.changeset/short-flies-itch.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+save `localStorage.astroErrorOverlayTheme` when detected dark mode

--- a/packages/astro/src/core/errors/overlay.ts
+++ b/packages/astro/src/core/errors/overlay.ts
@@ -600,7 +600,7 @@ class ErrorOverlay extends HTMLElement {
 			themeToggle!.checked = false;
 		}
 		themeToggle?.addEventListener('click', () => {
-			const isDark = localStorage.astroErrorOverlayTheme === 'dark';
+			const isDark = localStorage.astroErrorOverlayTheme === 'dark' || this?.classList.contains('astro-dark');
 			this?.classList.toggle('astro-dark', !isDark);
 			localStorage.astroErrorOverlayTheme = isDark ? 'light' : 'dark';
 		});

--- a/packages/astro/src/core/errors/overlay.ts
+++ b/packages/astro/src/core/errors/overlay.ts
@@ -593,6 +593,7 @@ class ErrorOverlay extends HTMLElement {
 				window.matchMedia('(prefers-color-scheme: dark)').matches)
 		) {
 			this?.classList.add('astro-dark');
+			localStorage.astroErrorOverlayTheme = 'dark';
 			themeToggle!.checked = true;
 		} else {
 			this?.classList.remove('astro-dark');


### PR DESCRIPTION
## Changes

Close https://github.com/withastro/astro/issues/10715

- Save `localStorage.astroErrorOverlayTheme` when detected system dark mode
- Update `isDark`
```ts
const isDark = localStorage.astroErrorOverlayTheme === 'dark' || this?.classList.contains('astro-dark');
```



## Testing

null

## Docs

null