### PR TITLE
fix(install-package): Automatically exit in CI instead of waiting for input

### DIFF
--- a/.changeset/neat-grapes-cry.md
+++ b/.changeset/neat-grapes-cry.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes Astro waiting infinitely in CI when a required package was not installed


### PR DESCRIPTION
## Changes

Rarely, someone run a project in CI that doesn't have `astro check` or `typescript` (or now, `@astrojs/db`) and the CLI stall infinitely waiting for someone, out there, to press a button. This PR makes it so it fails instantly now in CI.

## Testing

Tested manually by inverting the checks locally

## Docs

N/A
