### PR TITLE
Accept common cookie attributes when deleting a cookie

### DIFF
--- a/.changeset/shaggy-cats-film.md
+++ b/.changeset/shaggy-cats-film.md
@@ -1,5 +1,11 @@
 ---
-"astro": patch
+"astro": minor
 ---
 
-Accept standard cookie attributes when deleting a cookie
+Extends the acceptable cookie options when deleting a cookie, to the following attribute:
+
+- `domain`
+- `path`
+- `httpOnly` *(Added)*
+- `sameSite` *(Added)*
+- `secure` *(Added)*

--- a/.changeset/shaggy-cats-film.md
+++ b/.changeset/shaggy-cats-film.md
@@ -2,10 +2,4 @@
 "astro": minor
 ---
 
-Extends the acceptable cookie options when deleting a cookie, to the following attribute:
-
-- `domain`
-- `path`
-- `httpOnly` *(Added)*
-- `sameSite` *(Added)*
-- `secure` *(Added)*
+Adds the `httpOnly`, `sameSite`, and `secure` options when deleting a cookie

--- a/.changeset/shaggy-cats-film.md
+++ b/.changeset/shaggy-cats-film.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Accept standard cookie attributes when deleting a cookie

--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -11,7 +11,7 @@ export interface AstroCookieGetOptions {
 	decode?: (value: string) => string;
 }
 
-type AstroCookieDeleteOptions = Omit<CookieSerializeOptions, 'expires' | 'maxAge'>;
+type AstroCookieDeleteOptions = Omit<AstroCookieSetOptions, 'expires' | 'maxAge' | 'encode'>;
 
 interface AstroCookieInterface {
 	value: string;

--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -2,16 +2,10 @@ import type { CookieSerializeOptions } from 'cookie';
 import { parse, serialize } from 'cookie';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 
-export interface AstroCookieSetOptions {
-	domain?: string;
-	expires?: Date;
-	httpOnly?: boolean;
-	maxAge?: number;
-	path?: string;
-	sameSite?: boolean | 'lax' | 'none' | 'strict';
-	secure?: boolean;
-	encode?: (value: string) => string;
-}
+export type AstroCookieSetOptions = Pick<
+	CookieSerializeOptions,
+	'domain' | 'path' | 'expires' | 'maxAge' | 'httpOnly' | 'sameSite' | 'secure' | 'encode'
+>;
 
 export interface AstroCookieGetOptions {
 	decode?: (value: string) => string;

--- a/packages/astro/test/units/cookies/delete.test.js
+++ b/packages/astro/test/units/cookies/delete.test.js
@@ -47,26 +47,57 @@ describe('astro/src/core/cookies', () => {
 			assert.equal(cookies.has('foo'), false);
 		});
 
-		it('can provide a path', () => {
+		it('deletes a cookie with attributes', () => {
 			let req = new Request('http://example.com/');
 			let cookies = new AstroCookies(req);
+
 			cookies.delete('foo', {
+				domain: 'example.com',
 				path: '/subpath/',
+				priority: 'high',
+				secure: true,
+				httpOnly: true,
+				sameSite: 'strict',
 			});
+
 			let headers = Array.from(cookies.headers());
 			assert.equal(headers.length, 1);
+			assert.equal(/foo=deleted/.test(headers[0]), true);
+			assert.equal(/Expires=Thu, 01 Jan 1970 00:00:00 GMT/.test(headers[0]), true);
+			assert.equal(/Domain=example.com/.test(headers[0]), true);
 			assert.equal(/Path=\/subpath\//.test(headers[0]), true);
+			assert.equal(/Priority=High/.test(headers[0]), true);
+			assert.equal(/Secure/.test(headers[0]), true);
+			assert.equal(/HttpOnly/.test(headers[0]), true);
+			assert.equal(/SameSite=Strict/.test(headers[0]), true);
 		});
 
-		it('can provide a domain', () => {
+		it('ignores expires option', () => {
 			let req = new Request('http://example.com/');
 			let cookies = new AstroCookies(req);
+
 			cookies.delete('foo', {
-				domain: '.example.com',
+				expires: new Date(),
 			});
+
 			let headers = Array.from(cookies.headers());
 			assert.equal(headers.length, 1);
-			assert.equal(/Domain=\.example\.com/.test(headers[0]), true);
+			assert.equal(/foo=deleted/.test(headers[0]), true);
+			assert.equal(/Expires=Thu, 01 Jan 1970 00:00:00 GMT/.test(headers[0]), true);
+		});
+
+		it('ignores maxAge option', () => {
+			let req = new Request('http://example.com/');
+			let cookies = new AstroCookies(req);
+
+			cookies.delete('foo', {
+				maxAge: 60,
+			});
+
+			let headers = Array.from(cookies.headers());
+			assert.equal(headers.length, 1);
+			assert.equal(/foo=deleted/.test(headers[0]), true);
+			assert.equal(/Expires=Thu, 01 Jan 1970 00:00:00 GMT/.test(headers[0]), true);
 		});
 	});
 });


### PR DESCRIPTION
## Changes

Allows cookie attributes to be specified when deleting a cookie. The attributes were limited to `domain` and `path`.

See #10480 for context.

Closes #10480

## Testing

The changes are validated by unit tests.

## Docs

The [Astro.Cookie.delete API reference](https://docs.astro.build/en/reference/api-reference/#delete) must be updated, since following statement will no longer be true:

>Options allow setting the domain and path of the cookie to delete.