### PR TITLE
@astrojs/react - Expose Babel config.

### DIFF
--- a/.changeset/tall-wombats-clap.md
+++ b/.changeset/tall-wombats-clap.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/react": minor
+---
+
+Expose Babel config for @astro/react.

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -3,7 +3,7 @@ import type { AstroIntegration } from 'astro';
 import { version as ReactVersion } from 'react-dom';
 import type * as vite from 'vite';
 
-export type ReactIntegrationOptions = Pick<ViteReactPluginOptions, 'include' | 'exclude'> & {
+export type ReactIntegrationOptions = Pick<ViteReactPluginOptions, 'include' | 'exclude' | 'babel'> & {
 	experimentalReactChildren?: boolean;
 };
 
@@ -46,6 +46,7 @@ function optionsPlugin(experimentalReactChildren: boolean): vite.Plugin {
 function getViteConfiguration({
 	include,
 	exclude,
+	babel,
 	experimentalReactChildren,
 }: ReactIntegrationOptions = {}) {
 	return {
@@ -65,7 +66,7 @@ function getViteConfiguration({
 					: '@astrojs/react/server-v17.js',
 			],
 		},
-		plugins: [react({ include, exclude }), optionsPlugin(!!experimentalReactChildren)],
+		plugins: [react({ include, exclude, babel }), optionsPlugin(!!experimentalReactChildren)],
 		resolve: {
 			dedupe: ['react', 'react-dom', 'react-dom/server'],
 		},
@@ -89,6 +90,7 @@ function getViteConfiguration({
 export default function ({
 	include,
 	exclude,
+	babel,
 	experimentalReactChildren,
 }: ReactIntegrationOptions = {}): AstroIntegration {
 	return {
@@ -97,7 +99,7 @@ export default function ({
 			'astro:config:setup': ({ command, addRenderer, updateConfig, injectScript }) => {
 				addRenderer(getRenderer());
 				updateConfig({
-					vite: getViteConfiguration({ include, exclude, experimentalReactChildren }),
+					vite: getViteConfiguration({ include, exclude, babel, experimentalReactChildren }),
 				});
 				if (command === 'dev') {
 					const preamble = FAST_REFRESH_PREAMBLE.replace(`__BASE__`, '/');


### PR DESCRIPTION
## Changes

- Expose Babel config for @astro/react, as it was expected to be a "very high priority" in [this proposal](https://github.com/withastro/roadmap/discussions/202).

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
It should not break the current tests.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
It wasn't specifically mentioned before.