### PR TITLE
feat: add origin check for CSRF protection

### DIFF
--- a/.changeset/fair-jars-behave.md
+++ b/.changeset/fair-jars-behave.md
@@ -2,7 +2,7 @@
 "astro": minor
 ---
 
-Adds a new security - and experimental - option to prevent CSRF attacks. This feature is available only for on-demand pages:
+Adds a new experimental security option to prevent [Cross-Site Request Forgery (CSRF) attacks](https://owasp.org/www-community/attacks/csrf). This feature is available only for pages rendered on demand:
 
 ```js
 import { defineConfig } from "astro/config"
@@ -17,9 +17,8 @@ export default defineConfig({
 })
 ```
 
-When enabled, it checks that the "origin" header, automatically passed by all modern browsers, matches the URL sent by each `Request`.
+Enabling this setting performs a check that the "origin" header, automatically passed by all modern browsers, matches the URL sent by each `Request`.
 
-The "origin" check is executed only on-demand pages, and only for the requests `POST, `PATCH`, `DELETE` and `PUT`, only for those requests that
-the followin `content-type` header: 'application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain'.
+This experimental "origin" check is executed only for pages rendered on demand, and only for the requests `POST, `PATCH`, `DELETE` and `PUT` with one of the following `content-type` headers: 'application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain'.
 
 It the "origin" header doesn't match the pathname of the request, Astro will return a 403 status code and won't render the page.

--- a/.changeset/fair-jars-behave.md
+++ b/.changeset/fair-jars-behave.md
@@ -1,0 +1,26 @@
+---
+"astro": minor
+---
+
+Adds a new security - and experimental - option to prevent CSRF attacks. This feature is available only for on-demand pages:
+
+```js
+import { defineConfig } from "astro/config"
+export default defineConfig({
+  security: {
+    csrfProtection: {
+      origin: true
+    }
+  },
+  experimental: {
+    csrfProtection: true
+  }
+})
+```
+
+When enabled, it checks that the "origin" header, automatically passed by all modern browsers, matches the URL sent by each `Request`.
+
+The "origin" check is executed only on-demand pages, and only for the requests `POST, `PATCH`, `DELETE` and `PUT`, only for those requests that
+the followin `content-type` header: 'application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain'.
+
+It the "origin" header doesn't match the pathname of the request, Astro will return a 403 status code and won't render the page.

--- a/.changeset/fair-jars-behave.md
+++ b/.changeset/fair-jars-behave.md
@@ -7,13 +7,12 @@ Adds a new security - and experimental - option to prevent CSRF attacks. This fe
 ```js
 import { defineConfig } from "astro/config"
 export default defineConfig({
-  security: {
-    csrfProtection: {
-      origin: true
-    }
-  },
   experimental: {
-    csrfProtection: true
+    security: {
+      csrfProtection: {
+        origin: true
+      }
+    }
   }
 })
 ```

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1611,6 +1611,49 @@ export interface AstroUserConfig {
 	legacy?: object;
 
 	/**
+	 * @name security
+	 * @type {object}
+	 * @version 4.6.0
+	 * @type {object}
+	 * @description
+	 *
+	 * It allows to opt-in various security measures for Astro applications.
+	 */
+	security?: {
+		/**
+		 * @name security.csrfProtection
+		 * @type {object}
+		 * @default '{}'
+		 * @version 4.6.0
+		 * @description
+		 */
+
+		csrfProtection?: {
+			/**
+			 * @name security.csrfProtection.origin
+			 * @type {boolean}
+			 * @default 'false'
+			 * @version 4.6.0
+			 * @description
+			 *
+			 * Something
+			 */
+			origin?: boolean;
+
+			/**
+			 * @name security.csrfProtection.token
+			 * @type {boolean}
+			 * @default 'false'
+			 * @version 4.6.0
+			 * @description
+			 *
+			 * Something
+			 */
+			token?: boolean | string;
+		};
+	};
+
+	/**
 	 * @docs
 	 * @kind heading
 	 * @name Experimental Flags
@@ -1821,6 +1864,29 @@ export interface AstroUserConfig {
 		 * See the [Internationalization Guide](https://docs.astro.build/en/guides/internationalization/#domains-experimental) for more details, including the limitations of this experimental feature.
 		 */
 		i18nDomains?: boolean;
+
+		/**
+		 * @docs
+		 * @name experimental.csrfProtection
+		 * @type {boolean}
+		 * @default `false`
+		 * @version 4.6.0
+		 * @description
+		 *
+		 * It enables the CSRF protection for Astro websites.
+		 *
+		 * The CSRF protection works only for on-demand pages (SSR) and hybrid pages where prerendering is opted out.
+		 *
+		 * ```js
+		 * // astro.config.mjs
+		 * export default defineConfig({
+		 *   experimental: {
+		 *     csrfProtection: true,
+		 *   },
+		 * })
+		 * ```
+		 */
+		csrfProtection?: boolean;
 	};
 }
 

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1830,9 +1830,9 @@ export interface AstroUserConfig {
 		 * @version 4.6.0
 		 * @description
 		 *
-		 * It enables the CSRF protection for Astro websites.
+		 * Enables CSRF protection for Astro websites.
 		 *
-		 * The CSRF protection works only for on-demand pages (SSR) and hybrid pages where prerendering is opted out.
+		 * The CSRF protection works only for pages rendered on demand (SSR) using `server` or `hybrid` mode. The pages must opt out of prerendering in `hybrid` mode.
 		 *
 		 * ```js
 		 * // astro.config.mjs
@@ -1867,12 +1867,12 @@ export interface AstroUserConfig {
 				 * @version 4.6.0
 				 * @description
 				 *
-				 * When enabled, it checks that the "origin" header, automatically passed by all modern browsers, matches the URL sent by each `Request`.
+				 * When enabled, performs a check that the "origin" header, automatically passed by all modern browsers, matches the URL sent by each `Request`.
 				 *
-				 * The "origin" check is executed only on-demand pages, and only for the requests `POST, `PATCH`, `DELETE` and `PUT`, only for those requests that
-				 * the followin `content-type` header: 'application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain'.
+				 * The "origin" check is executed only for pages rendered on demand, and only for the requests `POST, `PATCH`, `DELETE` and `PUT` with
+				 * the following `content-type` header: 'application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain'.
 				 *
-				 * It the "origin" header doesn't match the pathname of the request, Astro will return a 403 status code and won't render the page.
+				 * If the "origin" header doesn't match the `pathname` of the request, Astro will return a 403 status code and will not render the page.
 				 */
 				origin?: boolean;
 			};

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1877,12 +1877,12 @@ export interface AstroUserConfig {
 		 * // astro.config.mjs
 		 * export default defineConfig({
 		 *   experimental: {
-		 *     csrfProtection: true,
+		 *     security: true,
 		 *   },
 		 * })
 		 * ```
 		 */
-		csrfProtection?: boolean;
+		security?: boolean;
 	};
 }
 

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1856,7 +1856,7 @@ export interface AstroUserConfig {
 			 * @version 4.6.0
 			 * @description
 			 *
-			 * It enables some security measures to prevent CSRF attacks: https://owasp.org/www-community/attacks/csrf
+			 * Allows you to enable security measures to prevent CSRF attacks: https://owasp.org/www-community/attacks/csrf
 			 */
 
 			csrfProtection?: {

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1638,7 +1638,7 @@ export interface AstroUserConfig {
 			 * @version 4.6.0
 			 * @description
 			 *
-			 * When enabled, it enables a strict check on the "origin" header. This is header it that is passed by the browsers on each request.
+			 * When enabled, it checks that the "origin" header, automatically passed by all modern browsers, matches the URL sent by each `Request`.
 			 *
 			 * The "origin" check is executed only on-demand pages, and only for the requests `POST, `PATCH`, `DELETE` and `PUT`, only for those requests that
 			 * the followin `content-type` header: 'application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain'.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1617,7 +1617,7 @@ export interface AstroUserConfig {
 	 * @type {object}
 	 * @description
 	 *
-	 * It allows to opt-in various security measures for Astro applications.
+	 * It allows to opt-in various security features.
 	 */
 	security?: {
 		/**
@@ -1626,6 +1626,8 @@ export interface AstroUserConfig {
 		 * @default '{}'
 		 * @version 4.6.0
 		 * @description
+		 *
+		 * It enables some security measures to prevent CSRF attacks: https://owasp.org/www-community/attacks/csrf
 		 */
 
 		csrfProtection?: {
@@ -1636,20 +1638,14 @@ export interface AstroUserConfig {
 			 * @version 4.6.0
 			 * @description
 			 *
-			 * Something
+			 * When enabled, it enables a strict check on the "origin" header. This is header it that is passed by the browsers on each request.
+			 *
+			 * The "origin" check is executed only on-demand pages, and only for the requests `POST, `PATCH`, `DELETE` and `PUT`, only for those requests that
+			 * the followin `content-type` header: 'application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain'.
+			 *
+			 * It the "origin" header doesn't match the pathname of the request, Astro will return a 403 status code and won't render the page.
 			 */
 			origin?: boolean;
-
-			/**
-			 * @name security.csrfProtection.token
-			 * @type {boolean}
-			 * @default 'false'
-			 * @version 4.6.0
-			 * @description
-			 *
-			 * Something
-			 */
-			token?: boolean | string;
 		};
 	};
 

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1611,45 +1611,6 @@ export interface AstroUserConfig {
 	legacy?: object;
 
 	/**
-	 * @name security
-	 * @type {object}
-	 * @version 4.6.0
-	 * @type {object}
-	 * @description
-	 *
-	 * It allows to opt-in various security features.
-	 */
-	security?: {
-		/**
-		 * @name security.csrfProtection
-		 * @type {object}
-		 * @default '{}'
-		 * @version 4.6.0
-		 * @description
-		 *
-		 * It enables some security measures to prevent CSRF attacks: https://owasp.org/www-community/attacks/csrf
-		 */
-
-		csrfProtection?: {
-			/**
-			 * @name security.csrfProtection.origin
-			 * @type {boolean}
-			 * @default 'false'
-			 * @version 4.6.0
-			 * @description
-			 *
-			 * When enabled, it checks that the "origin" header, automatically passed by all modern browsers, matches the URL sent by each `Request`.
-			 *
-			 * The "origin" check is executed only on-demand pages, and only for the requests `POST, `PATCH`, `DELETE` and `PUT`, only for those requests that
-			 * the followin `content-type` header: 'application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain'.
-			 *
-			 * It the "origin" header doesn't match the pathname of the request, Astro will return a 403 status code and won't render the page.
-			 */
-			origin?: boolean;
-		};
-	};
-
-	/**
 	 * @docs
 	 * @kind heading
 	 * @name Experimental Flags
@@ -1863,7 +1824,7 @@ export interface AstroUserConfig {
 
 		/**
 		 * @docs
-		 * @name experimental.csrfProtection
+		 * @name experimental.security
 		 * @type {boolean}
 		 * @default `false`
 		 * @version 4.6.0
@@ -1876,13 +1837,46 @@ export interface AstroUserConfig {
 		 * ```js
 		 * // astro.config.mjs
 		 * export default defineConfig({
+		 *   output: "server",
 		 *   experimental: {
-		 *     security: true,
-		 *   },
+		 *     security: {
+		 *       csrfProtection: {
+		 *         origin: true
+		 *       }
+		 *     }
+		 *   }
 		 * })
 		 * ```
 		 */
-		security?: boolean;
+		security?: {
+			/**
+			 * @name security.csrfProtection
+			 * @type {object}
+			 * @default '{}'
+			 * @version 4.6.0
+			 * @description
+			 *
+			 * It enables some security measures to prevent CSRF attacks: https://owasp.org/www-community/attacks/csrf
+			 */
+
+			csrfProtection?: {
+				/**
+				 * @name security.csrfProtection.origin
+				 * @type {boolean}
+				 * @default 'false'
+				 * @version 4.6.0
+				 * @description
+				 *
+				 * When enabled, it checks that the "origin" header, automatically passed by all modern browsers, matches the URL sent by each `Request`.
+				 *
+				 * The "origin" check is executed only on-demand pages, and only for the requests `POST, `PATCH`, `DELETE` and `PUT`, only for those requests that
+				 * the followin `content-type` header: 'application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain'.
+				 *
+				 * It the "origin" header doesn't match the pathname of the request, Astro will return a 403 status code and won't render the page.
+				 */
+				origin?: boolean;
+			};
+		};
 	};
 }
 

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -114,7 +114,8 @@ export class App {
 	 * @private
 	 */
 	#createPipeline(streaming = false) {
-		if (this.#manifest.csrfProtection) {
+		console.log(this.#manifest);
+		if (this.#manifest.csrfProtection?.origin === true) {
 			this.#manifest.middleware = sequence(
 				this.#createOriginCheckMiddleware(),
 				this.#manifest.middleware

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -114,7 +114,6 @@ export class App {
 	 * @private
 	 */
 	#createPipeline(streaming = false) {
-		console.log(this.#manifest);
 		if (this.#manifest.csrfProtection?.origin === true) {
 			this.#manifest.middleware = sequence(
 				this.#createOriginCheckMiddleware(),

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -164,7 +164,7 @@ export class App {
 			const { request, url } = context;
 			const contentType = request.headers.get('content-type');
 			if (contentType) {
-				if (this.#formContentTypes.includes(contentType)) {
+				if (this.#formContentTypes.includes(contentType.toLowerCase())) {
 					const forbidden =
 						(request.method === 'POST' ||
 							request.method === 'PUT' ||

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -114,7 +114,7 @@ export class App {
 	 * @private
 	 */
 	#createPipeline(streaming = false) {
-		if (this.#manifest.csrfProtection?.origin === true) {
+		if (this.#manifest.checkOrigin) {
 			this.#manifest.middleware = sequence(
 				createOriginCheckMiddleware(),
 				this.#manifest.middleware

--- a/packages/astro/src/core/app/middlewares.ts
+++ b/packages/astro/src/core/app/middlewares.ts
@@ -1,0 +1,42 @@
+import type { MiddlewareHandler } from '../../@types/astro.js';
+import { defineMiddleware } from '../middleware/index.js';
+
+/**
+ * Content types that can be passed when sending a request via a form
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/enctype
+ * @private
+ */
+const FORM_CONTENT_TYPES = [
+	'application/x-www-form-urlencoded',
+	'multipart/form-data',
+	'text/plain',
+];
+
+/**
+ * Returns a middleware function in charge to check the `origin` header.
+ *
+ * @private
+ */
+export function createOriginCheckMiddleware(): MiddlewareHandler {
+	return defineMiddleware((context, next) => {
+		const { request, url } = context;
+		const contentType = request.headers.get('content-type');
+		if (contentType) {
+			if (FORM_CONTENT_TYPES.includes(contentType.toLowerCase())) {
+				const forbidden =
+					(request.method === 'POST' ||
+						request.method === 'PUT' ||
+						request.method === 'PATCH' ||
+						request.method === 'DELETE') &&
+					request.headers.get('origin') !== url.origin;
+				if (forbidden) {
+					return new Response(`Cross-site ${request.method} form submissions are forbidden`, {
+						status: 403,
+					});
+				}
+			}
+		}
+		return next();
+	});
+}

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -64,6 +64,7 @@ export type SSRManifest = {
 	pageMap?: Map<ComponentPath, ImportComponentInstance>;
 	i18n: SSRManifestI18n | undefined;
 	middleware: MiddlewareHandler;
+	csrfProtection: SSRCsrfProtection | undefined;
 };
 
 export type SSRManifestI18n = {
@@ -72,6 +73,10 @@ export type SSRManifestI18n = {
 	locales: Locales;
 	defaultLocale: string;
 	domainLookupTable: Record<string, string>;
+};
+
+export type SSRCsrfProtection = {
+	origin: boolean;
 };
 
 export type SerializedSSRManifest = Omit<

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -64,7 +64,7 @@ export type SSRManifest = {
 	pageMap?: Map<ComponentPath, ImportComponentInstance>;
 	i18n: SSRManifestI18n | undefined;
 	middleware: MiddlewareHandler;
-	csrfProtection: SSRCsrfProtection | undefined;
+	checkOrigin: boolean;
 };
 
 export type SSRManifestI18n = {

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -75,10 +75,6 @@ export type SSRManifestI18n = {
 	domainLookupTable: Record<string, string>;
 };
 
-export type SSRCsrfProtection = {
-	origin: boolean;
-};
-
 export type SerializedSSRManifest = Omit<
 	SSRManifest,
 	'middleware' | 'routes' | 'assets' | 'componentMetadata' | 'inlinedScripts' | 'clientDirectives'

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -615,5 +615,8 @@ function createBuildManifest(
 		i18n: i18nManifest,
 		buildFormat: settings.config.build.format,
 		middleware,
+		csrfProtection: settings.config.experimental.csrfProtection
+			? settings.config.security?.csrfProtection
+			: undefined,
 	};
 }

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -615,8 +615,6 @@ function createBuildManifest(
 		i18n: i18nManifest,
 		buildFormat: settings.config.build.format,
 		middleware,
-		checkOrigin: settings.config.experimental.security
-			? settings.config.security?.csrfProtection?.origin ?? false
-			: false,
+		checkOrigin: settings.config.experimental.security?.csrfProtection?.origin ?? false,
 	};
 }

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -615,8 +615,8 @@ function createBuildManifest(
 		i18n: i18nManifest,
 		buildFormat: settings.config.build.format,
 		middleware,
-		csrfProtection: settings.config.experimental.csrfProtection
-			? settings.config.security?.csrfProtection
-			: undefined,
+		checkOrigin: settings.config.experimental.security
+			? settings.config.security?.csrfProtection?.origin ?? false
+			: false,
 	};
 }

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -276,5 +276,8 @@ function buildManifest(
 		assets: staticFiles.map(prefixAssetPath),
 		i18n: i18nManifest,
 		buildFormat: settings.config.build.format,
+		csrfProtection: settings.config.experimental.csrfProtection
+			? settings.config.security?.csrfProtection
+			: undefined,
 	};
 }

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -276,8 +276,8 @@ function buildManifest(
 		assets: staticFiles.map(prefixAssetPath),
 		i18n: i18nManifest,
 		buildFormat: settings.config.build.format,
-		csrfProtection: settings.config.experimental.csrfProtection
-			? settings.config.security?.csrfProtection
-			: undefined,
+		checkOrigin: settings.config.experimental.security
+			? settings.config.security?.csrfProtection?.origin ?? false
+			: false,
 	};
 }

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -276,8 +276,6 @@ function buildManifest(
 		assets: staticFiles.map(prefixAssetPath),
 		i18n: i18nManifest,
 		buildFormat: settings.config.build.format,
-		checkOrigin: settings.config.experimental.security
-			? settings.config.security?.csrfProtection?.origin ?? false
-			: false,
+		checkOrigin: settings.config.experimental.security?.csrfProtection?.origin ?? false,
 	};
 }

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -86,6 +86,7 @@ const ASTRO_CONFIG_DEFAULTS = {
 		clientPrerender: false,
 		globalRoutePriority: false,
 		i18nDomains: false,
+		csrfProtection: false,
 	},
 } satisfies AstroUserConfig & { server: { open: boolean } };
 
@@ -139,6 +140,15 @@ export const AstroConfigSchema = z.object({
 			.array(z.object({ name: z.string(), hooks: z.object({}).passthrough().default({}) }))
 			.default(ASTRO_CONFIG_DEFAULTS.integrations)
 	),
+	security: z
+		.object({
+			csrfProtection: z
+				.object({
+					origin: z.boolean().default(false),
+				})
+				.optional(),
+		})
+		.optional(),
 	build: z
 		.object({
 			format: z
@@ -508,6 +518,10 @@ export const AstroConfigSchema = z.object({
 				.boolean()
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.experimental.globalRoutePriority),
+			csrfProtection: z
+				.boolean()
+				.optional()
+				.default(ASTRO_CONFIG_DEFAULTS.experimental.csrfProtection),
 			i18nDomains: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.i18nDomains),
 		})
 		.strict(

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -86,7 +86,7 @@ const ASTRO_CONFIG_DEFAULTS = {
 		clientPrerender: false,
 		globalRoutePriority: false,
 		i18nDomains: false,
-		csrfProtection: false,
+		security: false,
 	},
 } satisfies AstroUserConfig & { server: { open: boolean } };
 
@@ -518,10 +518,7 @@ export const AstroConfigSchema = z.object({
 				.boolean()
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.experimental.globalRoutePriority),
-			csrfProtection: z
-				.boolean()
-				.optional()
-				.default(ASTRO_CONFIG_DEFAULTS.experimental.csrfProtection),
+			security: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.security),
 			i18nDomains: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.i18nDomains),
 		})
 		.strict(

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -86,7 +86,7 @@ const ASTRO_CONFIG_DEFAULTS = {
 		clientPrerender: false,
 		globalRoutePriority: false,
 		i18nDomains: false,
-		security: false,
+		security: {},
 	},
 } satisfies AstroUserConfig & { server: { open: boolean } };
 
@@ -140,15 +140,6 @@ export const AstroConfigSchema = z.object({
 			.array(z.object({ name: z.string(), hooks: z.object({}).passthrough().default({}) }))
 			.default(ASTRO_CONFIG_DEFAULTS.integrations)
 	),
-	security: z
-		.object({
-			csrfProtection: z
-				.object({
-					origin: z.boolean().default(false),
-				})
-				.optional(),
-		})
-		.optional(),
 	build: z
 		.object({
 			format: z
@@ -518,7 +509,17 @@ export const AstroConfigSchema = z.object({
 				.boolean()
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.experimental.globalRoutePriority),
-			security: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.security),
+			security: z
+				.object({
+					csrfProtection: z
+						.object({
+							origin: z.boolean().default(false),
+						})
+						.optional()
+						.default({}),
+				})
+				.optional()
+				.default(ASTRO_CONFIG_DEFAULTS.experimental.security),
 			i18nDomains: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.i18nDomains),
 		})
 		.strict(

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -143,6 +143,9 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 		componentMetadata: new Map(),
 		inlinedScripts: new Map(),
 		i18n: i18nManifest,
+		csrfProtection: settings.config.experimental.csrfProtection
+			? settings.config.security?.csrfProtection
+			: undefined,
 		middleware(_, next) {
 			return next();
 		},

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -143,9 +143,9 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 		componentMetadata: new Map(),
 		inlinedScripts: new Map(),
 		i18n: i18nManifest,
-		csrfProtection: settings.config.experimental.csrfProtection
-			? settings.config.security?.csrfProtection
-			: undefined,
+		checkOrigin: settings.config.experimental.security
+			? settings.config.security?.csrfProtection?.origin ?? false
+			: false,
 		middleware(_, next) {
 			return next();
 		},

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -143,9 +143,7 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 		componentMetadata: new Map(),
 		inlinedScripts: new Map(),
 		i18n: i18nManifest,
-		checkOrigin: settings.config.experimental.security
-			? settings.config.security?.csrfProtection?.origin ?? false
-			: false,
+		checkOrigin: settings.config.experimental.security?.csrfProtection?.origin ?? false,
 		middleware(_, next) {
 			return next();
 		},

--- a/packages/astro/test/csrf-protection.test.js
+++ b/packages/astro/test/csrf-protection.test.js
@@ -1,0 +1,188 @@
+import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
+import testAdapter from './test-adapter.js';
+import assert from 'node:assert/strict';
+
+describe('CSRF origin check', () => {
+	let app;
+
+	before(async () => {
+		const fixture = await loadFixture({
+			root: './fixtures/csrf-check-origin/',
+			adapter: testAdapter(),
+		});
+		await fixture.build();
+		app = await fixture.loadTestAdapterApp();
+	});
+
+	it("return 403 when the origin doesn't match and calling a POST", async () => {
+		let request;
+		let response;
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'multipart/form-data' },
+			method: 'POST',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 403);
+
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'application/x-www-form-urlencoded' },
+			method: 'POST',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 403);
+
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'text/plain' },
+			method: 'POST',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 403);
+	});
+
+	it("return 403 when the origin doesn't match and calling a PUT", async () => {
+		let request;
+		let response;
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'multipart/form-data' },
+			method: 'PUT',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 403);
+
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'application/x-www-form-urlencoded' },
+			method: 'PUT',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 403);
+
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'text/plain' },
+			method: 'PUT',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 403);
+	});
+
+	it("return 403 when the origin doesn't match and calling a DELETE", async () => {
+		let request;
+		let response;
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'multipart/form-data' },
+			method: 'DELETE',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 403);
+
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'application/x-www-form-urlencoded' },
+			method: 'DELETE',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 403);
+
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'text/plain' },
+			method: 'DELETE',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 403);
+	});
+
+	it("return 403 when the origin doesn't match and calling a PATCH", async () => {
+		let request;
+		let response;
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'multipart/form-data' },
+			method: 'PATCH',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 403);
+
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'application/x-www-form-urlencoded' },
+			method: 'PATCH',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 403);
+
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'text/plain' },
+			method: 'PATCH',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 403);
+	});
+
+	it("return a 200 when the origin doesn't match but calling a GET", async () => {
+		let request;
+		let response;
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'multipart/form-data' },
+			method: 'GET',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 200);
+		assert.deepEqual(await response.json(), {
+			something: 'true',
+		});
+
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'application/x-www-form-urlencoded' },
+			method: 'GET',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 200);
+		assert.deepEqual(await response.json(), {
+			something: 'true',
+		});
+
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'text/plain' },
+			method: 'GET',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 200);
+		assert.deepEqual(await response.json(), {
+			something: 'true',
+		});
+	});
+
+	it('return 200 when calling POST/PUT/DELETE/PATCH with the correct origin', async () => {
+		let request;
+		let response;
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://example.com', 'content-type': 'multipart/form-data' },
+			method: 'POST',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 200);
+		assert.deepEqual(await response.json(), {
+			something: 'true',
+		});
+
+		request = new Request('http://example.com/api/', {
+			headers: {
+				origin: 'http://example.com',
+				'content-type': 'application/x-www-form-urlencoded',
+			},
+			method: 'PUT',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 200);
+		assert.deepEqual(await response.json(), {
+			something: 'true',
+		});
+
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://example.com', 'content-type': 'text/plain' },
+			method: 'PATCH',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 200);
+		assert.deepEqual(await response.json(), {
+			something: 'true',
+		});
+	});
+});

--- a/packages/astro/test/csrf-protection.test.js
+++ b/packages/astro/test/csrf-protection.test.js
@@ -25,6 +25,14 @@ describe('CSRF origin check', () => {
 		response = await app.render(request);
 		assert.equal(response.status, 403);
 
+		// case where content-type has different casing
+		request = new Request('http://example.com/api/', {
+			headers: { origin: 'http://loreum.com', 'content-type': 'MULTIPART/FORM-DATA' },
+			method: 'POST',
+		});
+		response = await app.render(request);
+		assert.equal(response.status, 403);
+
 		request = new Request('http://example.com/api/', {
 			headers: { origin: 'http://loreum.com', 'content-type': 'application/x-www-form-urlencoded' },
 			method: 'POST',

--- a/packages/astro/test/fixtures/csrf-check-origin/astro.config.mjs
+++ b/packages/astro/test/fixtures/csrf-check-origin/astro.config.mjs
@@ -1,0 +1,15 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	output: "server",
+	security: {
+		csrfProtection: {
+			origin: true
+		}
+	},
+	experimental: {
+		csrfProtection: true
+	}
+});
+

--- a/packages/astro/test/fixtures/csrf-check-origin/astro.config.mjs
+++ b/packages/astro/test/fixtures/csrf-check-origin/astro.config.mjs
@@ -3,13 +3,12 @@ import { defineConfig } from 'astro/config';
 // https://astro.build/config
 export default defineConfig({
 	output: "server",
-	security: {
-		csrfProtection: {
-			origin: true
-		}
-	},
 	experimental: {
-		csrfProtection: true
+		security: {
+			csrfProtection: {
+				origin: true
+			}
+		}
 	}
 });
 

--- a/packages/astro/test/fixtures/csrf-check-origin/package.json
+++ b/packages/astro/test/fixtures/csrf-check-origin/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/csrf",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/csrf-check-origin/src/pages/api.ts
+++ b/packages/astro/test/fixtures/csrf-check-origin/src/pages/api.ts
@@ -1,0 +1,29 @@
+export const GET = () => {
+	return Response.json({
+		something: 'true',
+	});
+};
+
+export const POST = () => {
+	return Response.json({
+		something: 'true',
+	});
+};
+
+export const PUT = () => {
+	return Response.json({
+		something: 'true',
+	});
+};
+
+export const DELETE = () => {
+	return Response.json({
+		something: 'true',
+	});
+};
+
+export const PATCH = () => {
+	return Response.json({
+		something: 'true',
+	});
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2559,6 +2559,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/csrf-check-origin:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/css-assets:
     dependencies:
       '@test/astro-font-awesome-package':


### PR DESCRIPTION
## Changes

This PR adds the **origin header check** for the CSRF protection.

Closes PLT-1872

Here's the RFC for more details: https://github.com/withastro/roadmap/pull/879

This is a feature that is supposed to work only for on-demand pages. It should not work during the build. To enable the feature, I **had** considered some generic way to change the `internalMiddleware` that is present in the `BasePipeline` class, but after having a chat with @lilnasy, we decided that it felt a bit premature and decided to go for a more custom way.

The `manifest` inside the pipeline contains the middleware, and if the feature is enabled, the `App` class (the one that all adapters use) will modify the middleware to add the origin check middleware function.

The logic of the origin check is heavily inspired from SvelteKit, and adapted to match Astro.

## Testing

I added new test cases 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

I documented new options. I am not sure about the creation of a new page. We can still create a new page later on, considering that the RFC is still open.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
