### PR TITLE
Generates missing popstate events for Firefox when navigating to hash targets on the same page

### DIFF
--- a/.changeset/loud-numbers-notice.md
+++ b/.changeset/loud-numbers-notice.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Generates missing popstate events for Firefox when navigating to hash targets on the same page.

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -205,7 +205,12 @@ const moveToLocation = (
 			history.scrollRestoration = 'auto';
 			const savedState = history.state;
 			location.href = to.href; // this kills the history state on Firefox
-			history.state || replaceState(savedState, ''); // this restores the history state
+			if (!history.state) {
+				replaceState(savedState, ''); // this restores the history state
+				if (intraPage){
+					window.dispatchEvent(new PopStateEvent('popstate' ));
+				}
+			}
 		} else {
 			if (!scrolledToTop) {
 				scrollTo({ left: 0, top: 0, behavior: 'instant' });


### PR DESCRIPTION
## Changes

Closes #10249

On view transitions, Firefox does not generate popstate events on same-page navigation to hash fragments.

We already have a special handling for Firefox when it loses state on current site updates. Dispatching the popstate event can be seen as additional compensation here.

## Testing

Manually tested.

## Docs

N.a./bug fix

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
