### PR TITLE
Remove unused config in Vue JSX integration

### DIFF
--- a/.changeset/few-forks-taste.md
+++ b/.changeset/few-forks-taste.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vue": patch
+---
+
+Removes unused `jsxTransformOptions` and `jsxImportSource` options from the renderer config

--- a/packages/integrations/vue/package.json
+++ b/packages/integrations/vue/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
     "@vitejs/plugin-vue-jsx": "^3.1.0",
-    "@vue/babel-plugin-jsx": "^1.1.5",
     "@vue/compiler-sfc": "^3.3.8"
   },
   "devDependencies": {

--- a/packages/integrations/vue/src/index.ts
+++ b/packages/integrations/vue/src/index.ts
@@ -19,21 +19,6 @@ function getRenderer(): AstroRenderer {
 	};
 }
 
-function getJsxRenderer(): AstroRenderer {
-	return {
-		name: '@astrojs/vue (jsx)',
-		clientEntrypoint: '@astrojs/vue/client.js',
-		serverEntrypoint: '@astrojs/vue/server.js',
-		jsxImportSource: 'vue',
-		jsxTransformOptions: async () => {
-			const jsxPlugin = (await import('@vue/babel-plugin-jsx')).default;
-			return {
-				plugins: [jsxPlugin],
-			};
-		},
-	};
-}
-
 function virtualAppEntrypoint(options?: Options): Plugin {
 	const virtualModuleId = 'virtual:@astrojs/vue/app';
 	const resolvedVirtualModuleId = '\0' + virtualModuleId;
@@ -135,9 +120,6 @@ export default function (options?: Options): AstroIntegration {
 		hooks: {
 			'astro:config:setup': async ({ addRenderer, updateConfig }) => {
 				addRenderer(getRenderer());
-				if (options?.jsx) {
-					addRenderer(getJsxRenderer());
-				}
 				updateConfig({ vite: await getViteConfiguration(options) });
 			},
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5199,9 +5199,6 @@ importers:
       '@vitejs/plugin-vue-jsx':
         specifier: ^3.1.0
         version: 3.1.0(vite@5.2.7)(vue@3.4.21)
-      '@vue/babel-plugin-jsx':
-        specifier: ^1.1.5
-        version: 1.2.2(@babel/core@7.24.3)
       '@vue/compiler-sfc':
         specifier: ^3.3.8
         version: 3.4.21


### PR DESCRIPTION
## Changes

Removes unused `jsxTransformOptions` and `jsxImportSource` options from the renderer config. Those two is no longer useful since https://github.com/withastro/astro/pull/7924 (Astro 3). The fields should be marked deprecated, but I'll do so in a separate PR along with other refactors.

## Testing

There's an existing `vue-jsx` test that should still pass.

## Docs

n/a. internal refactor.
