### PR TITLE
ci: update check-merge.yml action

### DIFF
--- a/.github/workflows/check-merge.yml
+++ b/.github/workflows/check-merge.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Get changed files in the .changeset folder
         id: changed-files
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v44
         if: steps.blocked.outputs.result != 'true'
         with:
           files: |
@@ -49,12 +49,14 @@ jobs:
       - name: Check if any changesets contain minor or major changes
         id: check
         if: steps.blocked.outputs.result != 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           echo "Checking for changesets marked as minor or major"
           echo "found=false" >> $GITHUB_OUTPUT
 
           regex="[\"']astro[\"']: (minor|major)"
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+          for file in ${ALL_CHANGED_FILES}; do
               if [[ $(cat $file) =~ $regex ]]; then
                   version="${BASH_REMATCH[1]}"
                   echo "version=$version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Changes

The action that was assigning the minor label stopped working, and I'm not sure why.

This PR attempts to:
- update the action to `v44`
- align out usage with [how the docs explain](https://github.com/tj-actions/changed-files?tab=readme-ov-file#using-local-git-directory-): using an environment variable 

## Testing

Merge it and monitor it on another PR

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
