### PR TITLE
Add disableremoteplayback attribute to VideoHTMLAttributes interface

### DIFF
--- a/.changeset/olive-camels-greet.md
+++ b/.changeset/olive-camels-greet.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Adds the `disableremoteplayback` attribute to MediaHTMLAttributes interface

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -873,7 +873,8 @@ declare namespace astroHTML.JSX {
 		playsinline?: boolean | string | undefined | null;
 		preload?: string | undefined | null;
 		src?: string | undefined | null;
-		disableremoteplayback?: boolean | string | undefined | null;
+		// https://www.w3.org/TR/remote-playback/#the-disableremoteplayback-attribute
+		disableRemotePlayback?: boolean | string | undefined | null;
 	}
 
 	interface MetaHTMLAttributes extends HTMLAttributes {

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -1057,6 +1057,7 @@ declare namespace astroHTML.JSX {
 		poster?: string | undefined | null;
 		width?: number | string | undefined | null;
 		disablepictureinpicture?: boolean | string | undefined | null;
+		disableremoteplayback?: boolean | string | undefined | null;
 	}
 
 	// this list is "complete" in that it contains every SVG attribute

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -873,6 +873,7 @@ declare namespace astroHTML.JSX {
 		playsinline?: boolean | string | undefined | null;
 		preload?: string | undefined | null;
 		src?: string | undefined | null;
+		disableremoteplayback?: boolean | string | undefined | null;
 	}
 
 	interface MetaHTMLAttributes extends HTMLAttributes {
@@ -1057,7 +1058,6 @@ declare namespace astroHTML.JSX {
 		poster?: string | undefined | null;
 		width?: number | string | undefined | null;
 		disablepictureinpicture?: boolean | string | undefined | null;
-		disableremoteplayback?: boolean | string | undefined | null;
 	}
 
 	// this list is "complete" in that it contains every SVG attribute


### PR DESCRIPTION
## Changes

Addition of `disableremoteplayback` to the `VideoHTMLAttributes` interface for TypeScript support.
No code changes needed as it's already handled by the regex in `packages/astro/src/runtime/server/render/util.ts`

## Testing

N/A - Type change only

## Docs

N/A - Type change only

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
