### PR TITLE
Skip prerender chunk in static output

### DIFF
--- a/.changeset/plenty-bugs-hunt.md
+++ b/.changeset/plenty-bugs-hunt.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Skips prerender chunk if building with static output

--- a/packages/astro/src/core/build/plugins/plugin-prerender.ts
+++ b/packages/astro/src/core/build/plugins/plugin-prerender.ts
@@ -68,7 +68,6 @@ function vitePluginPrerender(opts: StaticBuildOptions, internals: BuildInternals
 								}
 							}
 
-							opts.allPages;
 							pageInfo.hasSharedModules = hasSharedModules;
 							pageInfo.route.prerender = true;
 							return 'prerender';
@@ -87,6 +86,11 @@ export function pluginPrerender(
 	opts: StaticBuildOptions,
 	internals: BuildInternals
 ): AstroBuildPlugin {
+	// Static output can skip prerender completely because we're already rendering all pages
+	if (opts.settings.config.output === 'static') {
+		return { targets: ['server'] };
+	}
+
 	return {
 		targets: ['server'],
 		hooks: {


### PR DESCRIPTION
## Changes

close https://github.com/withastro/astro/issues/10485 (This PR helps with the issue's repro, but fundamentally rendering >100k is not possible with Rollup)

This PR skips a prerender chunk edge case where if you put too many modules within a single chunk, Rollup has a hard time deconflicting the variable names. For example, all Markdown modules export `compiledContent`/`frontmatter`. Those exist as top-level variables in the prerender chunk, and Rollup has to deconflict the variables which proportionately gets slower when iterating over the variables.

The main bottleneck is [`getSafeName` in Rollup](https://github.com/rollup/rollup/blob/459bfe1b336814199b5c643e212390f6979de83d/src/utils/safeName.ts#L4-L16), which would be nice to fix directly, but I made this different fix within Astro for now. 

Before:

<img width="629" alt="image" src="https://github.com/withastro/astro/assets/34116392/02dc7b1e-fa05-4217-b24d-096afaf9c164">

After:

<img width="628" alt="image" src="https://github.com/withastro/astro/assets/34116392/a9151006-1204-4179-99af-6c7da9f94636">

(The execution time for `getSafeName` dropped from 36.7s to 0.033s)

For the astro docs, there's no significant time change as `getSafeName` wasn't the bottleneck)

## Testing

Existing tests should pass.

## Docs

n/a. internal change.
