### PR TITLE
chore: add `test:citgm` command that would run tests without caching and `build:ci:no-cache` to skip caching for build as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "release": "pnpm run build && changeset publish",
     "build": "turbo run build --filter=astro --filter=create-astro --filter=\"@astrojs/*\" --filter=\"@benchmark/*\"",
     "build:ci": "turbo run build:ci --filter=astro --filter=create-astro --filter=\"@astrojs/*\" --filter=\"@benchmark/*\"",
+    "build:ci:no-cache": "pnpm run build:ci -- --force",
     "build:examples": "turbo run build --filter=\"@example/*\"",
     "dev": "turbo run dev --concurrency=40 --parallel --filter=astro --filter=create-astro --filter=\"@astrojs/*\" --filter=\"@benchmark/*\"",
     "format": "pnpm run format:code && pnpm run format:imports",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "format:imports": "biome check --apply .",
     "format:imports:ci": "biome ci .",
     "test": "turbo run test --concurrency=1 --filter=astro --filter=create-astro --filter=\"@astrojs/*\"",
+    "test:citgm": "pnpm run test -- --force",
     "test:match": "cd packages/astro && pnpm run test:match",
     "test:unit": "cd packages/astro && pnpm run test:unit",
     "test:unit:match": "cd packages/astro && pnpm run test:unit:match",


### PR DESCRIPTION
## Changes
I'm pushing adding Astro to the citgm tests, so added this script that should be VERY SIMILAR to the original test script but avoid caching as it make no sense for citgm

Ref: https://github.com/nodejs/citgm/pull/1055

**Q:** Why not have a generic name for the test command?
**A:** I thought about doing `test:no-cache` but sometimes if we find that we only care about a subset of tests we wanna change the command

