### PR TITLE
Increase log severity when a page's `getStaticPaths` fails

### DIFF
--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -335,7 +335,7 @@ async function getPathsForRoute(
 			logger,
 			ssr: serverLike,
 		}).catch((err) => {
-			logger.debug('build', `├── ${bold(red('✗'))} ${route.component}`);
+			logger.info(null, `├── ${bold(red('✗'))} ${route.component}`);
 			throw err;
 		});
 


### PR DESCRIPTION
## Changes

When investigating https://github.com/withastro/astro/issues/7241, I found that this is due to `getCollection` erroring (due to some weird import stuff I still need to investigate).

This would have been obvious to others -- the only reason I figured this out was because I ran `astro build --verbose`. Here's what `astro build` before looked like:

```
> astro build

08:17:45 [build] output: "static"
08:17:45 [build] directory: ...\classes\dist\
08:17:45 [build] Collecting build info...
08:17:45 [build] ✓ Completed in 41.38s.
08:17:50 [build] Building static entrypoints...
08:18:32 [vite] ✓ built in 42.31s
08:18:32 [build] ✓ Completed in 42.36s.

 generating static routes 
08:18:32 ▶ src/pages/[subject]/[code].astro
[Error: EMFILE: too many open files, open '...\classes\node_modules\astro\dist\cli\throw-and-exit.js'] {
  errno: -4066,
  code: 'EMFILE',
  syscall: 'open',
  path: '...\\classes\\node_modules\\astro\\dist\\cli\\throw-and-exit.js'
}
```

And here's after:

```
> astro build

08:13:42 [build] output: "static"
08:13:42 [build] directory: ...\classes\dist\
08:13:42 [build] Collecting build info...
08:13:42 [build] ✓ Completed in 45.02s.
08:13:46 [build] Building static entrypoints...
08:14:28 [vite] ✓ built in 41.85s
08:14:28 [build] ✓ Completed in 41.91s.

 generating static routes 
08:14:29 ▶ src/pages/[subject]/[code].astro
08:14:32 ├── ✗ src/pages/[subject]/[code].astro
[Error: EMFILE: too many open files, open '...\classes\node_modules\astro\dist\cli\throw-and-exit.js'] {
  errno: -4066,
  code: 'EMFILE',
  syscall: 'open',
  path: '...\\classes\\node_modules\\astro\\dist\\cli\\throw-and-exit.js'
}
```

## Testing

I didn't test because I don't see how this is to be tested.

## Docs

Unnecessary to document, I think.