### PR TITLE
Limit imports in flight for `getCollection`

### DIFF
--- a/.changeset/four-zoos-taste.md
+++ b/.changeset/four-zoos-taste.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Limits parallel imports within `getCollection()` to prevent EMFILE errors when accessing files


### PR DESCRIPTION
## Changes

This is like https://github.com/withastro/astro/pull/7125 but for another place accessing many files at once: `getCollection`. This might address some of https://github.com/withastro/astro/issues/7241 -- some of the errors don't look like they're from `getCollection` but I got `EMFILE` and this fixed my own project.

## Testing

I modified the distributed `runtime.ts` (well, `runtime.js` cause it's in `dist`) in my `node_modules` install of `astro` and my project stopped erroring. Then I did those same edits to the file here.

## Docs

I don't think this needs to be documented as it is a bugfix. Should I include a changelog? I did not for now.