### PR TITLE
Fix vue-jsx change

### DIFF
--- a/packages/integrations/vue/src/index.ts
+++ b/packages/integrations/vue/src/index.ts
@@ -19,6 +19,14 @@ function getRenderer(): AstroRenderer {
 	};
 }
 
+function getJsxRenderer(): AstroRenderer {
+	return {
+		name: '@astrojs/vue (jsx)',
+		clientEntrypoint: '@astrojs/vue/client.js',
+		serverEntrypoint: '@astrojs/vue/server.js',
+	};
+}
+
 function virtualAppEntrypoint(options?: Options): Plugin {
 	const virtualModuleId = 'virtual:@astrojs/vue/app';
 	const resolvedVirtualModuleId = '\0' + virtualModuleId;
@@ -120,6 +128,9 @@ export default function (options?: Options): AstroIntegration {
 		hooks: {
 			'astro:config:setup': async ({ addRenderer, updateConfig }) => {
 				addRenderer(getRenderer());
+				if (options?.jsx) {
+					addRenderer(getJsxRenderer());
+				}
 				updateConfig({ vite: await getViteConfiguration(options) });
 			},
 		},


### PR DESCRIPTION
## Changes

The tests wasn't running correctly in https://github.com/withastro/astro/pull/10687, this PR should fix the current CI fail. It looks like we had hardcoded `@astrojs/vue (jsx)` at https://github.com/withastro/astro/blob/799f6f3f29a3ef4f76347870a209ffa89651adfa/packages/astro/src/runtime/server/render/component.ts#L46 so we have to keep the name for now.

## Testing

Ran the test locally.

## Docs

n/a. no changeset as https://github.com/withastro/astro/pull/10687 it not published yet.