### PR TITLE
fix(devtool): do not trigger interaction check for `div` and `span`

### DIFF
--- a/.changeset/swift-coats-teach.md
+++ b/.changeset/swift-coats-teach.md
@@ -2,9 +2,9 @@
 "astro": patch
 ---
 
-Fixes a false positive for the elements `div` and `span`. `div` and `span` are special elements that don't have an interaction assigned, instead it is assigned based on the role assigned via attributes.
+Fixes a false positive for `div` and `span` elements when running the Dev Toolbar accessibility audits.
 
-This means that cases like the following are deemed correct by the a11y audits:
+Those are special elements that don't have an interaction assigned by default. Instead, it is assigned through the `role` attribute. This means that cases like the following are now deemed correct:
 
 ```html
 <div role="tablist"></div>

--- a/.changeset/swift-coats-teach.md
+++ b/.changeset/swift-coats-teach.md
@@ -2,4 +2,11 @@
 "astro": patch
 ---
 
-The devtool bar doesn't report `div` and `span` when check their role. `div` and `span` are special elements that don't have an interaction assigned, instead it is assigned based on the role assigned via attributes.
+Fixes a false positive for the elements `div` and `span`. `div` and `span` are special elements that don't have an interaction assigned, instead it is assigned based on the role assigned via attributes.
+
+This means that cases like the following are deemed correct by the a11y audits:
+
+```html
+<div role="tablist"></div>
+<span role="button" onclick="" onkeydown=""></span>
+```

--- a/.changeset/swift-coats-teach.md
+++ b/.changeset/swift-coats-teach.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+The devtool bar doesn't report `div` and `span` when check their role. `div` and `span` are special elements that don't have an interaction assigned, instead it is assigned based on the role assigned via attributes.

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-exceptions.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-exceptions.astro
@@ -4,3 +4,5 @@
 
 
 <input role="button" aria-label="Label"/>
+<div role="grid"></div>
+<span role="button"></span>

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-exceptions.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-exceptions.astro
@@ -5,4 +5,4 @@
 
 <input role="button" aria-label="Label"/>
 <div role="grid"></div>
-<span role="button"></span>
+<span role="button" onclick="" onfocus=""></span>

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/index.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/index.ts
@@ -140,8 +140,6 @@ export default {
 				hasCreatedUI = false;
 			}
 
-			console.log('AUDITS', audits);
-
 			const selectorCache = new Map<string, NodeListOf<Element>>();
 			for (const ruleCategory of rulesCategories) {
 				for (const rule of ruleCategory.rules) {

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/index.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/index.ts
@@ -140,6 +140,8 @@ export default {
 				hasCreatedUI = false;
 			}
 
+			console.log('AUDITS', audits);
+
 			const selectorCache = new Map<string, NodeListOf<Element>>();
 			for (const ruleCategory of rulesCategories) {
 				for (const rule of ruleCategory.rules) {

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -470,7 +470,7 @@ export const a11y: AuditRuleWithSelector[] = [
 			const role = element.getAttribute('role');
 			if (!role) return false;
 			if (!ariaRoles.has(role)) return false;
-			if (roleless_elements.includes(role)) return false;
+			if (roleless_elements.includes(element.localName)) return false;
 
 			if (aria_non_interactive_roles.includes(role)) return true;
 		},
@@ -491,6 +491,7 @@ export const a11y: AuditRuleWithSelector[] = [
 					element.localName as keyof typeof a11y_non_interactive_element_to_interactive_role_exceptions
 				];
 			if (exceptions?.includes(role)) return false;
+			if (roleless_elements.includes(element.localName)) return false;
 
 			if (!aria_non_interactive_roles.includes(role)) return true;
 		},

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -108,6 +108,7 @@ const aria_non_interactive_roles = [
 ];
 
 // These elements aren't interactive and aren't non-interactive. Their interaction changes based on the role assigned to them
+// https://www.w3.org/TR/html-aria/#docconformance -> look at the table, specification for the `div` and `span` elements.
 const roleless_elements = ['div', 'span'];
 
 const a11y_required_content = [

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -107,6 +107,9 @@ const aria_non_interactive_roles = [
 	'tooltip',
 ];
 
+// These elements aren't interactive and aren't non-interactive. Their interaction changes based on the role assigned to them
+const roleless_elements = ['div', 'span'];
+
 const a11y_required_content = [
 	// anchor-has-content
 	'a',
@@ -467,6 +470,7 @@ export const a11y: AuditRuleWithSelector[] = [
 			const role = element.getAttribute('role');
 			if (!role) return false;
 			if (!ariaRoles.has(role)) return false;
+			if (roleless_elements.includes(role)) return false;
 
 			if (aria_non_interactive_roles.includes(role)) return true;
 		},


### PR DESCRIPTION
## Changes

This PR fixes the interaction check by bypassing `div` and `span` elements, which don't have a real interaction role.

## Testing

I added a new test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
