### PR TITLE
fix: regression for astro attributes escaping

### DIFF
--- a/.changeset/large-knives-confess.md
+++ b/.changeset/large-knives-confess.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes a regression where some very **specific** code rendered using `expressive-code` was not escaped properly.

--- a/packages/astro/src/runtime/server/render/util.ts
+++ b/packages/astro/src/runtime/server/render/util.ts
@@ -105,7 +105,7 @@ Make sure to use the static attribute syntax (\`${key}={value}\`) instead of the
 	}
 
 	// Prevents URLs in attributes from being escaped in static builds
-	if (typeof value === 'string' && value.includes('&') && urlCanParse(value)) {
+	if (typeof value === 'string' && value.includes('&') && isHttpUrl(value)) {
 		return markHTMLString(` ${key}="${toAttributeString(value, false)}"`);
 	}
 
@@ -247,10 +247,11 @@ export function promiseWithResolvers<T = any>(): PromiseWithResolvers<T> {
 	};
 }
 
-function urlCanParse(url: string) {
+const VALID_PROTOCOLS = ['http:', 'https:'];
+function isHttpUrl(url: string) {
 	try {
-		new URL(url);
-		return true;
+		const parsedUrl = new URL(url);
+		return VALID_PROTOCOLS.includes(parsedUrl.protocol);
 	} catch {
 		return false;
 	}

--- a/packages/astro/test/astro-attrs.test.js
+++ b/packages/astro/test/astro-attrs.test.js
@@ -37,6 +37,12 @@ describe('Attributes', async () => {
 			true
 		);
 
+		// cheerio will unescape the values, so checking that the url rendered unescaped to begin with has to be done manually
+		assert.equal(
+			html.includes('cmd: echo &#34;foo&#34; &#38;&#38; echo &#34;bar&#34; > /tmp/hello.txt'),
+			true
+		);
+
 		for (const id of Object.keys(attrs)) {
 			const { attribute, value } = attrs[id];
 			const attr = $(`#${id}`).attr(attribute);

--- a/packages/astro/test/fixtures/astro-attrs/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-attrs/src/pages/index.astro
@@ -6,6 +6,7 @@
 <span id="null" attr={null} />
 <span id="undefined" attr={undefined} />
 <span id="url" attr={"https://example.com/api/og?title=hello&description=somedescription"}/>
+<span id="code" attr={"cmd: echo \"foo\" && echo \"bar\" > /tmp/hello.txt"} />
 <!--
     Per HTML spec, some attributes should be treated as booleans
     These should always render <span async /> or <span /> (without a string value)


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/10726

Fixes a regression where some specific code could trigger some false positive. In particular, a string like the following is a valid URL:

```js
new URL("cmd: echo \"foo\" && echo \"bar\" > /tmp/hello.txt")
```
```
URL {
  href: 'cmd: echo "foo" && echo "bar" > /tmp/hello.txt',
  origin: 'null',
  protocol: 'cmd:',
  username: '',
  password: '',
  host: '',
  hostname: '',
  port: '',
  pathname: ' echo "foo" && echo "bar" > /tmp/hello.txt',
  search: '',
  searchParams: URLSearchParams {},
  hash: ''
}
```

I made the check a bit stricter by strictly checking the protocol to be `http:` or `https:`. 

## Testing

Added a new test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
