### PR TITLE
ci: add ref when checking out the repository

### DIFF
--- a/.github/workflows/check-merge.yml
+++ b/.github/workflows/check-merge.yml
@@ -36,6 +36,7 @@ jobs:
         if: steps.blocked.outputs.result != 'true'
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Get changed files in the .changeset folder


### PR DESCRIPTION
## Changes

Adds the `ref`, which should allow to checkout the actual branch and not the `HEAD` of the repository

## Testing

Merge and check it on other PRs

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
N/A
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
