### PR TITLE
fix(cli): call path.replace only if it is a function

### DIFF
--- a/.changeset/late-spoons-knock.md
+++ b/.changeset/late-spoons-knock.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where CLI commands could not report the reason for failure before exiting.

--- a/packages/astro/src/core/errors/dev/utils.ts
+++ b/packages/astro/src/core/errors/dev/utils.ts
@@ -174,7 +174,7 @@ function collectInfoFromStacktrace(error: SSRError & { stack: string }): StackIn
 			stackText.split('\n').find((ln) => ln.includes('src') || ln.includes('node_modules'));
 		// Disable eslint as we're not sure how to improve this regex yet
 		// eslint-disable-next-line regexp/no-super-linear-backtracking
-		const source = possibleFilePath?.replace(/^[^(]+\(([^)]+).*$/, '$1').replace(/^\s+at\s+/, '');
+		const source = possibleFilePath?.replace?.(/^[^(]+\(([^)]+).*$/, '$1').replace(/^\s+at\s+/, '');
 
 		let file = source?.replace(/:\d+/g, '');
 		const location = /:(\d+):(\d+)/.exec(source!) ?? [];


### PR DESCRIPTION
## Changes

- Fixes #10741 

## Testing
- Minor change. Existing tests should pass.

## Docs
- Does not affect usage.