### PR TITLE
fix some i18n config docs

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1494,6 +1494,7 @@ export interface AstroUserConfig {
 		 * @description
 		 *
 		 * Controls the routing strategy to determine your site URLs. Set this based on your folder/URL path configuration for your default language.
+	   *
 		 */
 		// prettier-ignore
 		routing?: 
@@ -1501,12 +1502,25 @@ export interface AstroUserConfig {
 			 *
 			 * @docs
 			 * @name i18n.routing.manual
+		   * @kind h4
 			 * @type {string}
 			 * @version 4.6.0
 			 * @description
 			 * When this option is enabled, Astro will **disable** its i18n middleware so that you can implement your own custom logic. No other `routing` options (e.g. `prefixDefaultLocale`) may be configured with `routing: "manual"`.
 			 *
 			 * You will be responsible for writing your own routing logic, or executing Astro's i18n middleware manually alongside your own.
+		   *
+			 * ```js
+		   * export default defineConfig({
+		   * 	i18n: {
+		   * 		defaultLocale: "en",
+		   * 		locales: ["en", "fr", "pt-br", "es"],
+		   * 		routing: {
+		   * 			prefixDefaultLocale: true,
+		   * 		}
+		   * 	}
+		   * })
+		   * ```
 			 */
 		 	'manual'
 			| {
@@ -1526,6 +1540,18 @@ export interface AstroUserConfig {
 					 * When `true`, all URLs will display a language prefix.
 					 * URLs will be of the form `example.com/[locale]/content/` for every route, including the default language.
 					 * Localized folders are used for every language, including the default.
+			     *
+				   * ```js
+		       * export default defineConfig({
+		       * 	i18n: {
+		       * 		defaultLocale: "en",
+		       * 		locales: ["en", "fr", "pt-br", "es"],
+		       * 		routing: {
+		       * 			prefixDefaultLocale: true,
+		       * 		}
+		       * 	}
+		       * })
+		       * ```
 					 */
 					prefixDefaultLocale?: boolean;
 

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1498,32 +1498,7 @@ export interface AstroUserConfig {
 		 */
 		// prettier-ignore
 		routing?: 
-			/**
-			 *
-			 * @docs
-			 * @name i18n.routing.manual
-		   * @kind h4
-			 * @type {string}
-			 * @version 4.6.0
-			 * @description
-			 * When this option is enabled, Astro will **disable** its i18n middleware so that you can implement your own custom logic. No other `routing` options (e.g. `prefixDefaultLocale`) may be configured with `routing: "manual"`.
-			 *
-			 * You will be responsible for writing your own routing logic, or executing Astro's i18n middleware manually alongside your own.
-		   *
-			 * ```js
-		   * export default defineConfig({
-		   * 	i18n: {
-		   * 		defaultLocale: "en",
-		   * 		locales: ["en", "fr", "pt-br", "es"],
-		   * 		routing: {
-		   * 			prefixDefaultLocale: true,
-		   * 		}
-		   * 	}
-		   * })
-		   * ```
-			 */
-		 	'manual'
-			| {
+        {
 					/**
 					 * @docs
 					 * @name i18n.routing.prefixDefaultLocale
@@ -1594,7 +1569,32 @@ export interface AstroUserConfig {
 					 * - `"pathname": The strategy is applied to the pathname of the URLs
 					 */
 					strategy?: 'pathname';
-			  };
+			  } |
+        /**
+  			 *
+  			 * @docs
+  			 * @name i18n.routing.manual
+  		   * @kind h4
+  			 * @type {string}
+  			 * @version 4.6.0
+  			 * @description
+  			 * When this option is enabled, Astro will **disable** its i18n middleware so that you can implement your own custom logic. No other `routing` options (e.g. `prefixDefaultLocale`) may be configured with `routing: "manual"`.
+  			 *
+  			 * You will be responsible for writing your own routing logic, or executing Astro's i18n middleware manually alongside your own.
+  		   *
+  			 * ```js
+  		   * export default defineConfig({
+  		   * 	i18n: {
+  		   * 		defaultLocale: "en",
+  		   * 		locales: ["en", "fr", "pt-br", "es"],
+  		   * 		routing: {
+  		   * 			prefixDefaultLocale: true,
+  		   * 		}
+  		   * 	}
+  		   * })
+  		   * ```
+  			 */
+        'manual';
 
 		/**
 		 * @name i18n.domains


### PR DESCRIPTION
## Changes

Updates the config reference for docs for i18n

## Testing

no tests, just docs

## Docs

- adds the necessary`h4` tag to the new `routing.manual` entry
- improves some existing descriptions for other i18n by adding code examples (did not uniformly have these)

STILL TO FIX:

- currently, `manual` shows up BEFORE the other config options. This should appear last, as the "least common/most manual" option. I did not want to play around with the syntax to get the `|` just right by reversing the object and the manual entry.
