### PR TITLE
Update a11y-no-noninteractive-tabindex rule for dev tool bar

### DIFF
--- a/.changeset/few-mails-kiss.md
+++ b/.changeset/few-mails-kiss.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes a false positive for "Invalid `tabindex` on non-interactive element" rule for roleless elements ( `div` and `span` ).

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -513,7 +513,11 @@ export const a11y: AuditRuleWithSelector[] = [
 
 			if (!isInteractive(element)) return false;
 
-			if (!interactiveElements.includes(element.localName)) return true;
+			if (
+				!interactiveElements.includes(element.localName) &&
+				!roleless_elements.includes(element.localName)
+			)
+				return true;
 		},
 	},
 	{


### PR DESCRIPTION
## What

Make `a11y-no-noninteractive-tabindex` rule not apply to the roleless elements list that was added in https://github.com/withastro/astro/pull/10719 

## Why

Need to add `tabindex` for https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-automatic/
