### PR TITLE
fix(vercel): Fix srcset generation not working on Vercel

### DIFF
--- a/.changeset/nine-radios-peel.md
+++ b/.changeset/nine-radios-peel.md
@@ -2,4 +2,6 @@
 "@astrojs/vercel": patch
 ---
 
-Fixes `srcset` not working when using <Image />
+Fixes `widths` and `densities` not working when using Vercel's Image Optimization.
+
+Note that you still need to make sure that the widths you're outputting are enabled in [the `imageConfig` property of the Vercel adapter](https://docs.astro.build/en/guides/integrations-guide/vercel/#imagesconfig) in order for these properties to work.

--- a/.changeset/nine-radios-peel.md
+++ b/.changeset/nine-radios-peel.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/vercel": patch
+---
+
+Fixes `srcset` not working when using <Image />

--- a/packages/integrations/vercel/src/image/build-service.ts
+++ b/packages/integrations/vercel/src/image/build-service.ts
@@ -1,7 +1,9 @@
 import type { ExternalImageService } from 'astro';
 import { isESMImportedImage, sharedValidateOptions } from './shared.js';
+import { baseService } from 'astro/assets';
 
 const service: ExternalImageService = {
+	...baseService,
 	validateOptions: (options, serviceOptions) =>
 		sharedValidateOptions(options, serviceOptions.service.config, 'production'),
 	getHTMLAttributes(options) {

--- a/packages/integrations/vercel/src/image/build-service.ts
+++ b/packages/integrations/vercel/src/image/build-service.ts
@@ -31,7 +31,7 @@ const service: ExternalImageService = {
 			}
 		}
 
-		const { src, width, height, format, quality, densities, widths, ...attributes } = props;
+		const { src, width, height, format, quality, densities, widths, formats, ...attributes } = options;
 
 		return {
 			...attributes,

--- a/packages/integrations/vercel/src/image/build-service.ts
+++ b/packages/integrations/vercel/src/image/build-service.ts
@@ -31,7 +31,7 @@ const service: ExternalImageService = {
 			}
 		}
 
-		const { src, width, height, format, quality, ...attributes } = props;
+		const { src, width, height, format, quality, densities, widths, ...attributes } = props;
 
 		return {
 			...attributes,

--- a/packages/integrations/vercel/src/image/shared-dev-service.ts
+++ b/packages/integrations/vercel/src/image/shared-dev-service.ts
@@ -1,7 +1,9 @@
 import type { LocalImageService } from 'astro';
+import { baseService } from 'astro/assets';
 import { sharedValidateOptions } from './shared.js';
 
 export const baseDevService: Omit<LocalImageService, 'transform'> = {
+	...baseService,
 	validateOptions: (options, serviceOptions) =>
 		sharedValidateOptions(options, serviceOptions.service.config, 'development'),
 	getURL(options) {


### PR DESCRIPTION
## Changes

We were wrongfully not including the hooks for srcset generation in the Vercel service. This fixes that. I'll note that it's still a little bit wonky on the user side, because they need to make sure that the dimensions they're outputting are part of their Vercel config, but that's normal for Vercel.

Fixes https://github.com/withastro/astro/issues/10623

## Testing

Tested manually by deploying to Vercel.

## Docs

N/A