### PR TITLE
Enable `allowJs` for `strictest.json`

### DIFF
--- a/.changeset/thirty-poems-chew.md
+++ b/.changeset/thirty-poems-chew.md
@@ -2,4 +2,6 @@
 "astro": minor
 ---
 
-Enable type checking for JavaScript files for the `strictest` TS config. This ensures consistency with Astro's other TS configs, and fixes type checking for integrations like Astro DB when using an `astro.config.mjs`.
+Enables type checking for JavaScript files when using the `strictest` TS config. This ensures consistency with Astro's other TS configs, and fixes type checking for integrations like Astro DB when using an `astro.config.mjs`.
+
+If you are currently using the `strictest` preset and would like to still disable `.js` files, set `allowJS: false` in your `tsconfig.json`.

--- a/.changeset/thirty-poems-chew.md
+++ b/.changeset/thirty-poems-chew.md
@@ -1,0 +1,5 @@
+---
+"astro": minor
+---
+
+Enable type checking for JavaScript files for the `strictest` TS config. This ensures consistency with Astro's other TS configs, and fixes type checking for integrations like Astro DB when using an `astro.config.mjs`.

--- a/packages/astro/tsconfigs/strictest.json
+++ b/packages/astro/tsconfigs/strictest.json
@@ -19,8 +19,6 @@
     // Report an error for unreachable code instead of just a warning.
     "allowUnreachableCode": false,
     // Report an error for unused labels instead of just a warning.
-    "allowUnusedLabels": false,
-    // Disallow JavaScript files from being imported
-    "allowJs": false
+    "allowUnusedLabels": false
   }
 }


### PR DESCRIPTION
## Changes

Resolves #10507

This allows typechecking for JS files when using the `strictest` TS config. This is consistent with our other TS configs, and fixes virtual module types provided by integrations like Astro DB (https://github.com/withastro/astro/issues/10507)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
