### PR TITLE
Add useful links to `@astrojs/db` package.json

### DIFF
--- a/.changeset/grumpy-moose-pretend.md
+++ b/.changeset/grumpy-moose-pretend.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Improves `package.json` metadata fields

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@astrojs/db",
   "version": "0.10.3",
-  "description": "Add libSQL and Astro Studio support to your Astro site.",
+  "description": "Add libSQL and Astro Studio support to your Astro site",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@astrojs/db",
   "version": "0.10.3",
-  "description": "Add SQLite and Astro Studio support to your Astro site.",
+  "description": "Add libSQL and Astro Studio support to your Astro site.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@astrojs/db",
   "version": "0.10.3",
-  "description": "",
+  "description": "Add SQLite and Astro Studio support to your Astro site.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,6 +3,13 @@
   "version": "0.10.3",
   "description": "",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/withastro/astro.git",
+    "directory": "packages/db"
+  },
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://docs.astro.build/en/guides/integrations-guide/db/",
   "type": "module",
   "author": "withastro",
   "types": "./index.d.ts",


### PR DESCRIPTION
## Changes

- Adds repo, homepage, and issues links to the DB package.json
- These are surfaced on npm but also in places like editor tooltips
- Adds a `description` field to package.json too. Currently this is an empty string causing the first link of the README to be used in places, e.g.
   npm:  
   <img width="814" alt="image" src="https://github.com/withastro/astro/assets/357379/5a63b7d7-4d9f-45ce-9235-d81243614272">
   VS Code:  
   <img width="548" alt="image" src="https://github.com/withastro/astro/assets/357379/c57372d8-c6a5-4b82-8c34-767cb1b0e6e0">


## Testing

n/a — copied the format used in other integrations

## Docs

n/a
