### PR TITLE
Performance improvement in createAstro function

### DIFF
--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -264,7 +264,8 @@ export class RenderContext {
 
 		// `Astro.self` is added by the compiler
 		const astroGlobalCombined: Omit<AstroGlobal, 'self'> = {
-			...astroGlobalPartial,
+			generator: astroGlobalPartial.generator,
+			glob: astroGlobalPartial.glob,
 			cookies,
 			get clientAddress() {
 				return renderContext.clientAddress();


### PR DESCRIPTION

## Changes

- I ran a cpu profile and noticed the createAstro function was taking up a lot of time. For some reason the object spreading is very slow.
- this change improves the server stress latency when running `pnpm run benchmark` by about 25%

### Before:
#### Server stress


|         |        Avg |     Stdev |     Max |
| :------ | ---------: | --------: | ------: |
| Latency | 2401.63 ms | 529.43 ms | 5495 ms |

|           |     Avg |   Stdev |     Min |   Total in 30s |
| :-------- | ------: | ------: | ------: | -------------: |
| Req/Sec   |   400.8 |  171.83 |     300 | 12.0k requests |
| Bytes/Sec | 70.6 MB | 30.2 MB | 52.8 MB |   2.12 GB read |

### After:
#### Server stress


|         |       Avg |     Stdev |     Max |
| :------ | --------: | --------: | ------: |
| Latency | 1908.7 ms | 383.24 ms | 3237 ms |

|           |     Avg |   Stdev |     Min |   Total in 30s |
| :-------- | ------: | ------: | ------: | -------------: |
| Req/Sec   |  508.77 |  160.08 |     398 | 15.3k requests |
| Bytes/Sec | 89.6 MB | 28.2 MB | 70.1 MB |   2.69 GB read |
## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
This PR doesn't change any behaviour so no tests are needed.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This PR doesn't change any behaviour so no docs are needed.