### PR TITLE
fix(types): manually Pick and Omit from `CookieSerializeOptions` interface

### DIFF
--- a/.changeset/fast-planets-doubt.md
+++ b/.changeset/fast-planets-doubt.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where all options of `Astro.cookies.set` and `Astro.cookies.delete` were incorrectly reported as required.

--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -2,16 +2,155 @@ import type { CookieSerializeOptions } from 'cookie';
 import { parse, serialize } from 'cookie';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 
-export type AstroCookieSetOptions = Pick<
-	CookieSerializeOptions,
-	'domain' | 'path' | 'expires' | 'maxAge' | 'httpOnly' | 'sameSite' | 'secure' | 'encode'
->;
+// `AstroCookieSetOptions` and `AstroCookieDeleteOptions` are manually copied subsections of `CookieSerializeOptions` because `Omit` and `Pick` result in all fields being required.
+
+export interface AstroCookieSetOptions {
+	/**
+     * Specifies the value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.3|Domain Set-Cookie attribute}. By default, no
+     * domain is set, and most clients will consider the cookie to apply to only
+     * the current domain.
+     */
+	domain?: string | undefined;
+
+	/**
+	 * Specifies a function that will be used to encode a cookie's value. Since
+	 * value of a cookie has a limited character set (and must be a simple
+	 * string), this function can be used to encode a value into a string suited
+	 * for a cookie's value.
+	 *
+	 * The default function is the global `encodeURIComponent`, which will
+	 * encode a JavaScript string into UTF-8 byte sequences and then URL-encode
+	 * any that fall outside of the cookie range.
+	 */
+	encode?(value: string): string;
+
+	/**
+	 * Specifies the `Date` object to be the value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.1|`Expires` `Set-Cookie` attribute}. By default,
+	 * no expiration is set, and most clients will consider this a "non-persistent cookie" and will delete
+	 * it on a condition like exiting a web browser application.
+	 *
+	 * *Note* the {@link https://tools.ietf.org/html/rfc6265#section-5.3|cookie storage model specification}
+	 * states that if both `expires` and `maxAge` are set, then `maxAge` takes precedence, but it is
+	 * possible not all clients by obey this, so if both are set, they should
+	 * point to the same date and time.
+	 */
+	expires?: Date | undefined;
+
+	/**
+	 * Specifies the boolean value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.6|`HttpOnly` `Set-Cookie` attribute}.
+	 * When truthy, the `HttpOnly` attribute is set, otherwise it is not. By
+	 * default, the `HttpOnly` attribute is not set.
+	 *
+	 * *Note* be careful when setting this to true, as compliant clients will
+	 * not allow client-side JavaScript to see the cookie in `document.cookie`.
+	 */
+	httpOnly?: boolean | undefined;
+
+	/**
+	 * Specifies the number (in seconds) to be the value for the `Max-Age`
+	 * `Set-Cookie` attribute. The given number will be converted to an integer
+	 * by rounding down. By default, no maximum age is set.
+	 *
+	 * *Note* the {@link https://tools.ietf.org/html/rfc6265#section-5.3|cookie storage model specification}
+	 * states that if both `expires` and `maxAge` are set, then `maxAge` takes precedence, but it is
+	 * possible not all clients by obey this, so if both are set, they should
+	 * point to the same date and time.
+	 */
+	maxAge?: number | undefined;
+
+	/**
+	 * Specifies the value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.4|`Path` `Set-Cookie` attribute}.
+	 * By default, the path is considered the "default path".
+	 */
+	path?: string | undefined;
+
+	/**
+	 * Specifies the boolean or string to be the value for the {@link https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7|`SameSite` `Set-Cookie` attribute}.
+	 *
+	 * - `true` will set the `SameSite` attribute to `Strict` for strict same
+	 * site enforcement.
+	 * - `false` will not set the `SameSite` attribute.
+	 * - `'lax'` will set the `SameSite` attribute to Lax for lax same site
+	 * enforcement.
+	 * - `'strict'` will set the `SameSite` attribute to Strict for strict same
+	 * site enforcement.
+	 *  - `'none'` will set the SameSite attribute to None for an explicit
+	 *  cross-site cookie.
+	 *
+	 * More information about the different enforcement levels can be found in {@link https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7|the specification}.
+	 *
+	 * *note* This is an attribute that has not yet been fully standardized, and may change in the future. This also means many clients may ignore this attribute until they understand it.
+	 */
+	sameSite?: true | false | "lax" | "strict" | "none" | undefined;
+
+	/**
+	 * Specifies the boolean value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.5|`Secure` `Set-Cookie` attribute}. When truthy, the
+	 * `Secure` attribute is set, otherwise it is not. By default, the `Secure` attribute is not set.
+	 *
+	 * *Note* be careful when setting this to `true`, as compliant clients will
+	 * not send the cookie back to the server in the future if the browser does
+	 * not have an HTTPS connection.
+	 */
+	secure?: boolean | undefined;
+}
+
+export interface AstroCookieDeleteOptions {
+	/**
+     * Specifies the value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.3|Domain Set-Cookie attribute}. By default, no
+     * domain is set, and most clients will consider the cookie to apply to only
+     * the current domain.
+     */
+	domain?: string | undefined;
+
+	/**
+	 * Specifies the boolean value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.6|`HttpOnly` `Set-Cookie` attribute}.
+	 * When truthy, the `HttpOnly` attribute is set, otherwise it is not. By
+	 * default, the `HttpOnly` attribute is not set.
+	 *
+	 * *Note* be careful when setting this to true, as compliant clients will
+	 * not allow client-side JavaScript to see the cookie in `document.cookie`.
+	 */
+	httpOnly?: boolean | undefined;
+
+	/**
+	 * Specifies the value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.4|`Path` `Set-Cookie` attribute}.
+	 * By default, the path is considered the "default path".
+	 */
+	path?: string | undefined;
+
+	/**
+	 * Specifies the boolean or string to be the value for the {@link https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7|`SameSite` `Set-Cookie` attribute}.
+	 *
+	 * - `true` will set the `SameSite` attribute to `Strict` for strict same
+	 * site enforcement.
+	 * - `false` will not set the `SameSite` attribute.
+	 * - `'lax'` will set the `SameSite` attribute to Lax for lax same site
+	 * enforcement.
+	 * - `'strict'` will set the `SameSite` attribute to Strict for strict same
+	 * site enforcement.
+	 *  - `'none'` will set the SameSite attribute to None for an explicit
+	 *  cross-site cookie.
+	 *
+	 * More information about the different enforcement levels can be found in {@link https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7|the specification}.
+	 *
+	 * *note* This is an attribute that has not yet been fully standardized, and may change in the future. This also means many clients may ignore this attribute until they understand it.
+	 */
+	sameSite?: true | false | "lax" | "strict" | "none" | undefined;
+
+	/**
+	 * Specifies the boolean value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.5|`Secure` `Set-Cookie` attribute}. When truthy, the
+	 * `Secure` attribute is set, otherwise it is not. By default, the `Secure` attribute is not set.
+	 *
+	 * *Note* be careful when setting this to `true`, as compliant clients will
+	 * not send the cookie back to the server in the future if the browser does
+	 * not have an HTTPS connection.
+	 */
+	secure?: boolean | undefined;
+}
 
 export interface AstroCookieGetOptions {
 	decode?: (value: string) => string;
 }
-
-type AstroCookieDeleteOptions = Omit<AstroCookieSetOptions, 'expires' | 'maxAge' | 'encode'>;
 
 interface AstroCookieInterface {
 	value: string;


### PR DESCRIPTION
## Changes

- Fixes an issue where all options of `Astro.cookies.set` and `Astro.cookies.delete` were incorrectly reported as required.

## Testing
- Existing tests should pass.

## Docs
- Does not affect usage.