### PR TITLE
Fix typo in error message for IncorrectStrategyForI18n

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1079,7 +1079,7 @@ export const IncorrectStrategyForI18n = {
 	name: 'IncorrectStrategyForI18n',
 	title: "You can't use the current function with the current strategy",
 	message: (functionName: string) =>
-		`The function \`${functionName}\' can only be used when the \`i18n.routing.strategy\` is set to \`"manual"\`.`,
+		`The function \`${functionName}\` can only be used when the \`i18n.routing.strategy\` is set to \`"manual"\`.`,
 } satisfies ErrorData;
 
 /**


### PR DESCRIPTION
## Changes

Fix typo in error message for IncorrectStrategyForI18n

![image](https://github.com/withastro/astro/assets/25167721/b3055872-82f8-4e3c-945b-2b29f6c5bf4d)

https://docs.astro.build/en/reference/errors/incorrect-strategy-for-i18n/


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
