### PR TITLE
Remove MDX processor on buildEnd

### DIFF
--- a/.changeset/orange-ladybugs-nail.md
+++ b/.changeset/orange-ladybugs-nail.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/mdx": patch
+---
+
+Removes internal MDX processor on `buildEnd` to free up memory

--- a/benchmark/make-project/memory-default.js
+++ b/benchmark/make-project/memory-default.js
@@ -35,6 +35,17 @@ ${loremIpsum}
 		);
 	}
 
+	for (let i = 0; i < 100; i++) {
+		const content = `\
+# Post ${i}
+
+${loremIpsum}
+`;
+		promises.push(
+			fs.writeFile(new URL(`./src/content/blog/post-${i}.mdx`, projectDir), content, 'utf-8')
+		);
+	}
+
 	await fs.writeFile(
 		new URL(`./src/pages/blog/[...slug].astro`, projectDir),
 		`\
@@ -56,4 +67,16 @@ const { Content } = await entry.render();
 	);
 
 	await Promise.all(promises);
+
+	await fs.writeFile(
+		new URL('./astro.config.js', projectDir),
+		`\
+import { defineConfig } from 'astro/config';
+import mdx from '@astrojs/mdx';
+
+export default defineConfig({
+  integrations: [mdx()],
+});`,
+		'utf-8'
+	);
 }

--- a/packages/astro/src/vite-plugin-markdown/index.ts
+++ b/packages/astro/src/vite-plugin-markdown/index.ts
@@ -55,7 +55,15 @@ export default function markdown({ settings, logger }: AstroPluginOptions): Plug
 
 				const fileURL = pathToFileURL(fileId);
 
-				const renderResult = await processor!
+				// `processor` is initialized in `buildStart`, and removed in `buildEnd`. `load`
+				// should be called in between those two lifecycles, so this error should never happen
+				if (!processor) {
+					return this.error(
+						'MDX processor is not initialized. This is an internal error. Please file an issue.'
+					);
+				}
+
+				const renderResult = await processor
 					.render(raw.content, {
 						// @ts-expect-error passing internal prop
 						fileURL,

--- a/packages/markdown/remark/src/highlight.ts
+++ b/packages/markdown/remark/src/highlight.ts
@@ -73,6 +73,7 @@ export async function highlightCodeBlocks(tree: Root, highlighter: Highlighter) 
 	for (const { node, language, grandParent, parent } of nodes) {
 		const meta = (node.data as any)?.meta ?? node.properties.metastring ?? undefined;
 		const code = toText(node, { whitespace: 'pre' });
+		// TODO: In Astro 5, have `highlighter()` return hast directly to skip expensive HTML parsing and serialization.
 		const html = await highlighter(code, language, { meta });
 		// The replacement returns a root node with 1 child, the `<pr>` element replacement.
 		const replacement = fromHtml(html, { fragment: true }).children[0] as Element;


### PR DESCRIPTION
## Changes

Similar to [`ec02b09`](https://github.com/withastro/astro/pull/10618/commits/ec02b09c0c4b8a6237ec8aa5f40ff8ba4501db0e) (https://github.com/withastro/astro/pull/10618) but for `@astrojs/mdx`.

I also updated `vite-plugin-markdown` to provide a better error in case something odd happens.

## Testing

I updated the benchmark to include MDX files, but unfortunately I couldn't observe a significant difference. Likely because we're freeing up memory in the middle of a Rollup build, but the benchmark records only after the entire build ends.

Theoretically this PR should still be useful though 😅 

## Docs

n/a. internal refactor.
