### PR TITLE
optimization(runtime): create smaller objects for each Astro global

### DIFF
--- a/.changeset/lazy-rats-beam.md
+++ b/.changeset/lazy-rats-beam.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Improves performance for frequent use of small components.


### PR DESCRIPTION
## Changes

- Piggybanking on the bottleneck identified by @LeanderG in #10765

## Testing
- Existing tests should pass.

## Docs
- Does not affect behavior.