### PR TITLE
fix(add): Fixes astro add modifying baseUrl by accident

### DIFF
--- a/.changeset/mean-candles-hammer.md
+++ b/.changeset/mean-candles-hammer.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes `astro add` sometimes modifying `baseUrl` unintentionally

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -968,16 +968,16 @@ async function updateTSConfig(
 		inputConfig = {
 			tsconfig: defaultTSConfig,
 			tsconfigFile: path.join(cwd, 'tsconfig.json'),
-			rawConfig: { tsconfig: defaultTSConfig, tsconfigFile: path.join(cwd, 'tsconfig.json') },
+			rawConfig: defaultTSConfig,
 		};
 	} else {
-		inputConfigText = JSON.stringify(inputConfig.rawConfig.tsconfig, null, 2);
+		inputConfigText = JSON.stringify(inputConfig.rawConfig, null, 2);
 	}
 
 	const configFileName = path.basename(inputConfig.tsconfigFile);
 
 	const outputConfig = updateTSConfigForFramework(
-		inputConfig.rawConfig.tsconfig,
+		inputConfig.rawConfig,
 		firstIntegrationWithTSSettings
 	);
 

--- a/packages/astro/src/core/config/tsconfig.ts
+++ b/packages/astro/src/core/config/tsconfig.ts
@@ -6,6 +6,7 @@ import {
 	type TSConfckParseResult,
 	find,
 	parse,
+	toJson
 } from 'tsconfck';
 import type { CompilerOptions, TypeAcquisition } from 'typescript';
 
@@ -88,7 +89,9 @@ export async function loadTSConfig(
 
 		// tsconfck does not return the original config, so we need to parse it ourselves
 		// https://github.com/dominikg/tsconfck/issues/138
-		const rawConfig = await readFile(tsconfig, 'utf-8').then((content) => JSON.parse(content) as TSConfig);
+		const rawConfig = await readFile(tsconfig, 'utf-8')
+			.then(toJson)
+			.then((content) => JSON.parse(content) as TSConfig);
 
 		return { ...parsedConfig, rawConfig };
 	}
@@ -100,7 +103,9 @@ export async function loadTSConfig(
 			return parsedConfig;
 		}
 
-		const rawConfig = await readFile(jsconfig, 'utf-8').then((content) => JSON.parse(content) as TSConfig);
+		const rawConfig = await readFile(jsconfig, 'utf-8')
+			.then(toJson)
+			.then((content) => JSON.parse(content) as TSConfig);
 
 		return { ...parsedConfig, rawConfig: rawConfig };
 	}

--- a/packages/astro/src/core/config/tsconfig.ts
+++ b/packages/astro/src/core/config/tsconfig.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import { readFile } from "node:fs/promises"
 import {
 	TSConfckParseError,
 	type TSConfckParseOptions,
@@ -64,7 +65,7 @@ type TSConfigResult<T = {}> = Promise<
 export async function loadTSConfig(
 	root: string | undefined,
 	findUp = false
-): Promise<TSConfigResult<{ rawConfig: TSConfckParseResult }>> {
+): Promise<TSConfigResult<{ rawConfig: TSConfig }>> {
 	const safeCwd = root ?? process.cwd();
 
 	const [jsconfig, tsconfig] = await Promise.all(
@@ -85,7 +86,11 @@ export async function loadTSConfig(
 			return parsedConfig;
 		}
 
-		return { ...parsedConfig, rawConfig: parsedConfig.extended?.[0] ?? parsedConfig.tsconfig };
+		// tsconfck does not return the original config, so we need to parse it ourselves
+		// https://github.com/dominikg/tsconfck/issues/138
+		const rawConfig = await readFile(tsconfig, 'utf-8').then((content) => JSON.parse(content) as TSConfig);
+
+		return { ...parsedConfig, rawConfig };
 	}
 
 	if (jsconfig) {
@@ -95,7 +100,9 @@ export async function loadTSConfig(
 			return parsedConfig;
 		}
 
-		return { ...parsedConfig, rawConfig: parsedConfig.extended?.[0] ?? parsedConfig.tsconfig };
+		const rawConfig = await readFile(jsconfig, 'utf-8').then((content) => JSON.parse(content) as TSConfig);
+
+		return { ...parsedConfig, rawConfig: rawConfig };
 	}
 
 	return 'missing-config';

--- a/packages/astro/test/fixtures/tsconfig-handling/baseUrl/tsconfig.json
+++ b/packages/astro/test/fixtures/tsconfig-handling/baseUrl/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "files": ["i-have-base-url'"],
+  "files": ["i-have-base-url"],
   "compilerOptions": {
     "baseUrl": ".",
   }

--- a/packages/astro/test/fixtures/tsconfig-handling/baseUrl/tsconfig.json
+++ b/packages/astro/test/fixtures/tsconfig-handling/baseUrl/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "files": ["i-have-base-url'"],
+  "compilerOptions": {
+    "baseUrl": ".",
+  }
+}

--- a/packages/astro/test/units/config/config-tsconfig.test.js
+++ b/packages/astro/test/units/config/config-tsconfig.test.js
@@ -3,7 +3,8 @@ import * as path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { loadTSConfig, updateTSConfigForFramework } from '../../../dist/core/config/index.js';
-import { readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { toJson } from 'tsconfck';
 
 const cwd = fileURLToPath(new URL('../../fixtures/tsconfig-handling/', import.meta.url));
 
@@ -41,7 +42,8 @@ describe('TSConfig handling', () => {
 
 		it('does not change baseUrl in raw config', async () => {
 			const loadedConfig = await loadTSConfig(path.join(cwd, 'baseUrl'));
-			const rawConfig = readFileSync(path.join(cwd, 'baseUrl', 'tsconfig.json'), 'utf-8');
+			const rawConfig = await readFile(path.join(cwd, 'baseUrl', 'tsconfig.json'), 'utf-8').then(toJson)
+			.then((content) => JSON.parse(content));
 
 			assert.deepEqual(loadedConfig.rawConfig, rawConfig);
 		});

--- a/packages/astro/test/units/config/config-tsconfig.test.js
+++ b/packages/astro/test/units/config/config-tsconfig.test.js
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { loadTSConfig, updateTSConfigForFramework } from '../../../dist/core/config/index.js';
+import { readFileSync } from 'node:fs';
 
 const cwd = fileURLToPath(new URL('../../fixtures/tsconfig-handling/', import.meta.url));
 
@@ -36,6 +37,13 @@ describe('TSConfig handling', () => {
 
 			assert.equal(invalidConfig, 'invalid-config');
 			assert.equal(missingConfig, 'missing-config');
+		});
+
+		it('does not change baseUrl in raw config', async () => {
+			const loadedConfig = await loadTSConfig(path.join(cwd, 'baseUrl'));
+			const rawConfig = readFileSync(path.join(cwd, 'baseUrl', 'tsconfig.json'), 'utf-8');
+
+			assert.deepEqual(loadedConfig.rawConfig, rawConfig);
 		});
 	});
 


### PR DESCRIPTION
## Changes

`tsconfck` apply some transformation to the parsed `tsconfig.json`, but we need the raw config to modify it for `astro add`. This changes how we get the raw config`

## Testing

Added a test

## Docs

N/A