### PR TITLE
fix(assets): Forward headers from the original request to the internal request to the image

### DIFF
--- a/.changeset/rich-spoons-fold.md
+++ b/.changeset/rich-spoons-fold.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes assets endpoint in serverless returning 404 in certain situations where the website might be under a protected route

--- a/packages/astro/src/assets/endpoint/generic.ts
+++ b/packages/astro/src/assets/endpoint/generic.ts
@@ -10,10 +10,8 @@ import { imageConfig } from 'astro:assets';
 async function loadRemoteImage(src: URL, headers: Headers) {
 	try {
 		const res = await fetch(src, {
-			headers: {
-				// Forward all headers from the original request
-				...Object.fromEntries(headers.entries()),
-			},
+			// Forward all headers from the original request
+			headers,
 		});
 
 		if (!res.ok) {
@@ -47,7 +45,6 @@ export const GET: APIRoute = async ({ request }) => {
 		let inputBuffer: ArrayBuffer | undefined = undefined;
 
 		const isRemoteImage = isRemotePath(transform.src);
-
 		const sourceUrl = isRemoteImage
 			? new URL(transform.src)
 			: new URL(transform.src, url.origin);

--- a/packages/astro/src/assets/endpoint/generic.ts
+++ b/packages/astro/src/assets/endpoint/generic.ts
@@ -7,9 +7,14 @@ import { isRemoteAllowed } from '../utils/remotePattern.js';
 // @ts-expect-error
 import { imageConfig } from 'astro:assets';
 
-async function loadRemoteImage(src: URL) {
+async function loadRemoteImage(src: URL, request: Request) {
 	try {
-		const res = await fetch(src);
+		const res = await fetch(src, {
+			headers: {
+				// Forward all headers from the original request
+				...Object.fromEntries(request.headers.entries()),
+			},
+		});
 
 		if (!res.ok) {
 			return undefined;
@@ -49,7 +54,7 @@ export const GET: APIRoute = async ({ request }) => {
 			return new Response('Forbidden', { status: 403 });
 		}
 
-		inputBuffer = await loadRemoteImage(sourceUrl);
+		inputBuffer = await loadRemoteImage(sourceUrl, request);
 
 		if (!inputBuffer) {
 			return new Response('Not Found', { status: 404 });


### PR DESCRIPTION
## Changes

This is similar to something we do in our edge middleware thingy where we forward the headers from the original request to the self-request (is that a thing) so that it works properly when the website is protected. For instance, this fixes image requests in preview website on Vercel that have their preview behind a auth.

Fixes https://github.com/withastro/astro/issues/10752

## Testing

Tested manually

## Docs

N/A