### PR TITLE
astro/cli/install-package.ts: whichPm may return null if ran in an empty directory

### DIFF
--- a/.changeset/many-hairs-jump.md
+++ b/.changeset/many-hairs-jump.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Handles possible null value when calling `which-pm` during dynamic package installation

--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -101,7 +101,7 @@ async function installPackage(
 	logger: Logger
 ): Promise<boolean> {
 	const cwd = options.cwd ?? process.cwd();
-	const packageManager = (await whichPm(cwd)).name ?? 'npm';
+	const packageManager = (await whichPm(cwd))?.name ?? 'npm';
 	const installCommand = getInstallCommand(packageNames, packageManager);
 
 	if (!installCommand) {


### PR DESCRIPTION
## Changes

- If `whichPm` is unable to determine the package manager it will return `null`, not `{ name: null }`.
- This patch allows the null coalescing already added to work.

## Testing

before

```
❯ npx astro init
Need to install the following packages:
astro@4.6.1
Ok to proceed? (y) y
To continue, Astro requires the following dependency to be installed: @astrojs/db.
Cannot read properties of null (reading 'name')
  Stack trace:
    at installPackage (file:///Users/meghandenny/.npm/_npx/aa98e6899c6baff3/node_modules/astro/dist/cli/install-package.js:79:47)
    at async db (file:///Users/meghandenny/.npm/_npx/aa98e6899c6baff3/node_modules/astro/dist/cli/db/index.js:9:21)
    at async cli (file:///Users/meghandenny/.npm/_npx/aa98e6899c6baff3/node_modules/astro/dist/cli/index.js:169:5)
```

after change made locally

```
❯ npx astro init
To continue, Astro requires the following dependency to be installed: @astrojs/db.

  Astro will run the following command:
  If you skip this step, you can always run it yourself later

 ╭──────────────────────────╮
 │ npm install @astrojs/db  │
 ╰──────────────────────────╯

✔ Continue? … no
20:50:22 [ERROR] [check] The `@astrojs/db` package is required for this command to work. Please manually install it in your project and try again.
````

(I manually selected no, it loaded successfully.)

## Docs

this should not require a docs change
