### PR TITLE
fix: picture fallback check

### DIFF
--- a/.changeset/modern-mugs-raise.md
+++ b/.changeset/modern-mugs-raise.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix Picture component specialFormatsFallback fallback check

--- a/.changeset/modern-mugs-raise.md
+++ b/.changeset/modern-mugs-raise.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fix Picture component specialFormatsFallback fallback check
+Fixes Picture component specialFormatsFallback fallback check

--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -45,7 +45,7 @@ let resultFallbackFormat = fallbackFormat ?? defaultFallbackFormat;
 if (
 	!fallbackFormat &&
 	isESMImportedImage(originalSrc) &&
-	originalSrc.format in specialFormatsFallback
+	(specialFormatsFallback as ReadonlyArray<string>).includes(originalSrc.format)
 ) {
 	resultFallbackFormat = originalSrc.format;
 }


### PR DESCRIPTION
## Changes

Fixes match condition for specialFormatsFallback formats.

## Testing

Tested locally.

## Docs

[Current docs](https://docs.astro.build/en/guides/images/#fallbackformat) matches with the fix.
