### PR TITLE
Make viewTransition.finished wait for animations triggered by viewTransition.ready

### DIFF
--- a/.changeset/stupid-countries-warn.md
+++ b/.changeset/stupid-countries-warn.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes a timing issue in the view transition simulation.

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -396,8 +396,10 @@ async function updateDOM(
 			const style = window.getComputedStyle(effect.target, effect.pseudoElement);
 			return style.animationIterationCount === 'infinite';
 		}
-		// Trigger the animations
 		const currentAnimations = document.getAnimations();
+		// allow animations triggered by viewTransition.ready to start
+		await new Promise<void>((r)=>setTimeout(r));
+		// Trigger view transition animations waiting for data-astro-transition-fallback
 		document.documentElement.setAttribute(OLD_NEW_ATTR, phase);
 		const nextAnimations = document.getAnimations();
 		const newAnimations = nextAnimations.filter(


### PR DESCRIPTION
## Changes

Ensures that the `finished` promise of view transition simulation not only waits for animations triggered by the data-astro-transition-fallback attribute, but also waits for JavaScript animations triggered by the viewTransition.ready promise.


## Testing

Manually tested

## Docs

n.a./bug fix

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
