### PR TITLE
db: export 'alias' from drizzle-orm/sqlite-core

### DIFF
--- a/.changeset/few-pets-relax.md
+++ b/.changeset/few-pets-relax.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+"@astrojs/db": patch
 ---
 
 Expose the Drizzle `alias` utility from `astro:db` to enable self-joins on a table.

--- a/.changeset/few-pets-relax.md
+++ b/.changeset/few-pets-relax.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Expose the Drizzle `alias` utility from `astro:db` to enable self-joins on a table.

--- a/packages/db/src/runtime/virtual.ts
+++ b/packages/db/src/runtime/virtual.ts
@@ -92,3 +92,5 @@ export {
 	max,
 	min,
 } from 'drizzle-orm';
+
+export { alias } from 'drizzle-orm/sqlite-core';

--- a/packages/db/virtual.d.ts
+++ b/packages/db/virtual.d.ts
@@ -42,4 +42,5 @@ declare module 'astro:db' {
 	export const sumDistinct: RuntimeConfig['sumDistinct'];
 	export const max: RuntimeConfig['max'];
 	export const min: RuntimeConfig['min'];
+	export const alias: RuntimeConfig['alias'];
 }


### PR DESCRIPTION
## Changes

For convenience, expose drizzle's `alias` in `astro:db` exports. This slightly narrows the set of situations where devs need to add drizzle itself.

This `alias` helper is needed when you are joining on the same table multiple times, or joining a table on itself. For example, I have a sports-themed app where a `Game` can have a `HomeTeam` and an `AwayTeam` (which both reference a `Team` entity).

## Testing

I ran `pnpm build` locally and verified `dist/_internal/runtime/virtual.d.ts` includes the new export.

## Docs

It could be worth adding this to the "Drizzle utilities" section of the astrodb docs, but might be unnecessary. Let me know if you want me to add it (as a fourth bullet point, after "the sql helper...")
