### PR TITLE
Disable streaming for SSG

### DIFF
--- a/.changeset/eight-hotels-try.md
+++ b/.changeset/eight-hotels-try.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Disables streaming when rendering site with `output: "static"`

--- a/packages/astro/src/core/build/pipeline.ts
+++ b/packages/astro/src/core/build/pipeline.ts
@@ -53,7 +53,8 @@ export class BuildPipeline extends Pipeline {
 			return assetLink;
 		}
 		const serverLike = isServerLikeOutput(config);
-		const streaming = true;
+		// We can skip streaming in SSG for performance as writing as strings are faster
+		const streaming = serverLike;
 		super(
 			options.logger,
 			manifest,

--- a/packages/astro/src/runtime/server/render/astro/render.ts
+++ b/packages/astro/src/runtime/server/render/astro/render.ts
@@ -31,6 +31,10 @@ export async function renderToString(
 	let str = '';
 	let renderedFirstPageChunk = false;
 
+	if (isPage) {
+		await bufferHeadContent(result);
+	}
+
 	const destination: RenderDestination = {
 		write(chunk) {
 			// Automatic doctype insertion for pages

--- a/packages/astro/test/content-collections-render.test.js
+++ b/packages/astro/test/content-collections-render.test.js
@@ -2,11 +2,7 @@ import * as assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
-import { isWindows, loadFixture } from './test-utils.js';
-
-if (!isWindows) {
-	describe();
-}
+import { loadFixture } from './test-utils.js';
 
 describe('Content Collections - render()', () => {
 	describe('Build - SSG', () => {


### PR DESCRIPTION
## Changes

Since we need the entire string before we can write to a file anyway, we don't need streaming. Streaming keeps the state in an array buffer, while non-streaming keeps it as a string. The latter is more performant as most of the input is already a string, preventing transformations.

Credits go to @delucis for the initial idea & benchmark. And @ematipico for the initial PR (https://github.com/withastro/astro/pull/9603)

---

Locally building the docs repo, the render time went from 56s to 44.3s.

I marked this as a patch because I wanted to get this out, but if anyone feels being more cautious, happy to mark this as a minor too 😄 

## Testing

Existing tests should pass

## Docs

n/a. internal change.
