### PR TITLE
Batch instead of using p-limit

### DIFF
--- a/.changeset/fresh-plants-worry.md
+++ b/.changeset/fresh-plants-worry.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Batch imports rather than use `p-limit`


### PR DESCRIPTION
cc @jlarmstrongiv

## Changes

Potentially fix https://github.com/withastro/astro/pull/10708#issuecomment-2060010637. We use `p-limit` two other places that could probably use a similar strategy, if we want to remove a dependency.

## Testing

If possible, I would like to try installing this branch as a package to ensure it still works. I'm not familiar enough with package managers to know how to do that.

## Docs

Should just fix a potential import issue.