### PR TITLE
test: fix regression upon import sorting

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,14 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.6.4/schema.json",
   "files": {
-    "ignore": ["vendor", "dist/**"],
+    "ignore": [
+      "vendor",
+      "**/dist/**",
+      "**/smoke/**",
+      "**/fixtures/**",
+      "**/vendor/**",
+      "**/.vercel/**"
+    ],
     "include": ["test/**", "e2e/**", "packages/**"]
   },
   "formatter": {
@@ -11,18 +18,15 @@
     "ignore": [
       "benchmark/projects/",
       "benchmark/results/",
-      "**/dist/**",
-      "**/smoke/**",
-      "**/fixtures/**",
-      "**/vendor/**",
-      "**/.vercel/**",
       ".changeset",
       "pnpm-lock.yaml",
       "package.json",
       "*.astro"
     ]
   },
-  "organizeImports": { "enabled": true },
+  "organizeImports": {
+    "enabled": true
+  },
   "linter": { "enabled": false },
   "javascript": {
     "formatter": {

--- a/packages/astro/test/fixtures/css-order-layout/src/layouts/Main.astro
+++ b/packages/astro/test/fixtures/css-order-layout/src/layouts/Main.astro
@@ -1,6 +1,6 @@
 ---
-import BlueButton from "../components/BlueButton.astro";
 import MainHead from "../components/MainHead.astro";
+import BlueButton from "../components/BlueButton.astro";
 ---
 
 <html lang="en">


### PR DESCRIPTION
## Changes

This PR fixes a regression happened in here:   https://github.com/withastro/astro/actions/runs/8719929820/job/23920426920

Biome flipped a couple of imports and the test failed, because the order of imports matters in this case.

I moved some ignored files inside `files.ignore`


## Testing

The CI should pass now. I also verified locally that `format:imports` doesn't flip the imports anymore

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
