### PR TITLE
fix(renderer): omitting internal symbol from mdx props

### DIFF
--- a/.changeset/wild-mice-battle.md
+++ b/.changeset/wild-mice-battle.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/mdx": patch
+---
+
+Omitting compiler-internal symbol from user components to fix breaking error messages

--- a/packages/astro/src/runtime/server/jsx.ts
+++ b/packages/astro/src/runtime/server/jsx.ts
@@ -84,6 +84,8 @@ Did you forget to import the component or is it possible there is a typo?`);
 			}
 			if (typeof vnode.type === 'function') {
 				if (vnode.props[hasTriedRenderComponentSymbol]) {
+					// omitting compiler-internals from user components
+					delete vnode.props[hasTriedRenderComponentSymbol];
 					const output = await vnode.type(vnode.props ?? {});
 					if (output?.[AstroJSX] || !output) {
 						return await renderJSXVNode(result, output);

--- a/packages/integrations/mdx/test/fixtures/mdx-plus-react-errors/astro.config.mjs
+++ b/packages/integrations/mdx/test/fixtures/mdx-plus-react-errors/astro.config.mjs
@@ -1,0 +1,6 @@
+import mdx from '@astrojs/mdx';
+import react from '@astrojs/react';
+
+export default {
+	integrations: [mdx(), react()],
+}

--- a/packages/integrations/mdx/test/fixtures/mdx-plus-react-errors/package.json
+++ b/packages/integrations/mdx/test/fixtures/mdx-plus-react-errors/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@test/mdx-plus-react-errors",
+  "private": true,
+  "dependencies": {
+    "@astrojs/mdx": "workspace:*",
+    "@astrojs/react": "workspace:*",
+    "astro": "workspace:*",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  }
+}

--- a/packages/integrations/mdx/test/fixtures/mdx-plus-react-errors/src/components/BrokenComponent.jsx
+++ b/packages/integrations/mdx/test/fixtures/mdx-plus-react-errors/src/components/BrokenComponent.jsx
@@ -1,0 +1,8 @@
+import { useState } from "react";
+
+export default function BrokenComponent() {
+  useState(0);
+  a;
+
+  return <p>Whoops!</p>;
+};

--- a/packages/integrations/mdx/test/fixtures/mdx-plus-react-errors/src/content/config.js
+++ b/packages/integrations/mdx/test/fixtures/mdx-plus-react-errors/src/content/config.js
@@ -1,0 +1,12 @@
+import { z, defineCollection } from "astro:content";
+
+const filesSchema = () => {
+  return z.object({});
+};
+
+const filesCollection = defineCollection({
+  type: "content",
+  schema: filesSchema(),
+});
+
+export const collections = { files: filesCollection, };

--- a/packages/integrations/mdx/test/fixtures/mdx-plus-react-errors/src/content/files/file.mdx
+++ b/packages/integrations/mdx/test/fixtures/mdx-plus-react-errors/src/content/files/file.mdx
@@ -1,0 +1,4 @@
+
+import BrokenComponent from '../../components/BrokenComponent'
+
+<BrokenComponent {...props} />

--- a/packages/integrations/mdx/test/fixtures/mdx-plus-react-errors/src/pages/broken.astro
+++ b/packages/integrations/mdx/test/fixtures/mdx-plus-react-errors/src/pages/broken.astro
@@ -1,0 +1,9 @@
+---
+import { getCollection } from "astro:content";
+const files = await getCollection("files");
+
+const { Content } = await files[0].render();
+---
+
+<Content />
+

--- a/packages/integrations/mdx/test/mdx-plus-react-errors.test.js
+++ b/packages/integrations/mdx/test/mdx-plus-react-errors.test.js
@@ -1,0 +1,33 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { loadFixture } from '../../../astro/test/test-utils.js';
+
+function hookError() {
+	const error = console.error;
+	const errors = [];
+	console.error = function (...args) {
+		errors.push(args);
+	};
+	return () => {
+		console.error = error;
+		return errors;
+	};
+}
+
+describe('MDX and React with build errors', () => {
+	let fixture;
+	let unhook;
+
+	it('shows correct error messages on build error', async () => {
+		try {
+			fixture = await loadFixture({
+				root: new URL('./fixtures/mdx-plus-react-errors/', import.meta.url),
+			});
+			unhook = hookError();
+			await fixture.build();
+		} catch (err) {
+			assert.equal(err.message, 'a is not defined');
+		}
+		unhook();
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4679,6 +4679,24 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
 
+  packages/integrations/mdx/test/fixtures/mdx-plus-react-errors:
+    dependencies:
+      '@astrojs/mdx':
+        specifier: workspace:*
+        version: link:../../..
+      '@astrojs/react':
+        specifier: workspace:*
+        version: link:../../../../react
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+
   packages/integrations/mdx/test/fixtures/mdx-vite-env-vars:
     dependencies:
       '@astrojs/mdx':


### PR DESCRIPTION
I've noticed that when using the following code in an mdx file with a content collection, everything works fine if I have a properly compiling page
```ts
<MyComponent {...props} />
```

But if there's an error anywhere in the codebase _after_ a react dependency is being used, let's say

```ts
import { useState } from 'react';
export default function MyComponent() {
  useState(0);
  someKindOfRenderBreakingErrorHere;

  return <p>something</p>;
}
```

we're greeted with an error that makes no sense
```
Cannot read properties of null (reading 'useState')
```

But if the error happens earlier in the code like
```ts
import { useState } from 'react';
export default function MyComponent() {
  someKindOfRenderBreakingErrorHere;
  useState(0);

  return <p>something</p>;
}
```

then we get the expected error

```
someKindOfRenderBreakingErrorHere is not defined
```

Here's a minimal reproducible example: https://codesandbox.io/p/devbox/magical-hoover-phk2cv?file=%2Fastro.config.mjs%3A9%2C2

After some digging, I found that the problem happens because the symbol
```ts
const hasTriedRenderComponentSymbol = Symbol('hasTriedRenderComponent');
```
gets passed down to the user's component.

The weird error messages even go away if we manage to get rid of that symbol in the mdx outside the compiler before the react component is rendered, like:
```ts
{(function (props) {
  const [symbol] = Object.getOwnPropertySymbols(props)
  delete props[symbol]
}(props))}
```

While trying to unknowningly recreate the above example using an old astro version before v4.5.9, I realized that all react mdx components used to have this issue even without `{...props}` being spread.

```tsx
<MyComponent />
```

After updating astro to latest, I traced this problem getting partially fixed with this commit https://github.com/withastro/astro/commit/627e47d67af4846cea2acf26a96b4124001b26fc.

I'm guessing it has something to do with `Skip.symbol` always being passed in, but the new symbol is also always being passed in. I guess I'm not familiar enough with the astro compiler internals to know why that was always erroring and the above commit made it only break when props is spread. Oh well.

Here's the same problem happening with v4.5.8 without any props getting passed to the component in the mdx file in case you're curious https://codesandbox.io/p/devbox/compassionate-hypatia-glvdg5?file=%2Fastro.config.mjs

## Changes
I'm not 100% sure what part of the process `vnode.type()` exactly represents. Omitting the symbol here seems to magically solve the problem, but I can't really explain why a symbol being passed to a component would cause React to be null. Since this is a build error, I can't compare bundle outputs either to see what exactly is being changed either.

Since this function continues to recurse with the value of `vnode.props`, I had to spread the symbol out of it instead of mutating.

## Testing

I added a regression test for the user-facing part of the problem which is that error messages get messed up during build errors. I don't think it would be valuable to check for any specific symbol in the mdx here

## Docs

Shouldn't need a documentation change for a bug fix
