### PR TITLE
fixed the path to checkout existing blog posts on the home page of the blog starter template

### DIFF
--- a/examples/blog/src/pages/index.astro
+++ b/examples/blog/src/pages/index.astro
@@ -30,7 +30,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 				<li>Edit this page in <code>src/pages/index.astro</code></li>
 				<li>Edit the site header items in <code>src/components/Header.astro</code></li>
 				<li>Add your name to the footer in <code>src/components/Footer.astro</code></li>
-				<li>Check out the included blog posts in <code>src/pages/blog/</code></li>
+				<li>Check out the included blog posts in <code>src/content/blog/</code></li>
 				<li>Customize the blog post page layout in <code>src/layouts/BlogPost.astro</code></li>
 			</ul>
 			<p>


### PR DESCRIPTION
## Changes
In blog starter template, currently the 4th point on the home page says: "Check out the included blog posts in src/pages/blog/". The path here should be "src/content/blog/".

## Testing
No test added as its only a text change.

## Docs
No doc changes or addition required as its only a text change.
