### PR TITLE
db: add login flow for web containers

### DIFF
--- a/.changeset/spotty-dots-beg.md
+++ b/.changeset/spotty-dots-beg.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Add `astro login` support from online editors like Stackblitz and GitHub Codespaces

--- a/packages/db/src/core/cli/commands/login/index.ts
+++ b/packages/db/src/core/cli/commands/login/index.ts
@@ -50,22 +50,6 @@ export async function cmd({
 	await writeFile(SESSION_LOGIN_FILE, `${session}`);
 }
 
-export async function web() {
-	console.log(`Please visit the following URL in your web browser:`);
-	console.log(cyan(`${getAstroStudioUrl()}/auth/cli/login`));
-	console.log(`After login in complete, enter the verification code displayed:`);
-	const { session } = await prompt({
-		type: 'text',
-		name: 'session',
-		message: 'Verification code:',
-	});
-	if (!session) {
-		console.error('Cancelling login.');
-		process.exit(0);
-	}
-	return session;
-}
-
 // NOTE(fks): How the Astro CLI login process works:
 // 1. The Astro CLI creates a temporary server to listen for the session token
 // 2. The user is directed to studio.astro.build/ to login

--- a/packages/db/src/core/cli/commands/login/index.ts
+++ b/packages/db/src/core/cli/commands/login/index.ts
@@ -40,6 +40,7 @@ export async function cmd({
 			process.exit(0);
 		}
 		session = response.session;
+		console.log('Successfully logged in');
 	} else if (!session) {
 		const { url, promise } = await createServer();
 		const loginUrl = getAstroStudioUrl() + '/auth/cli/login?returnTo=' + encodeURIComponent(url);
@@ -49,7 +50,7 @@ export async function cmd({
 		open(loginUrl);
 		const spinner = ora('Waiting for confirmation...');
 		session = await promise;
-		spinner.succeed('Successfully logged in!');
+		spinner.succeed('Successfully logged in');
 	}
 
 	await mkdir(new URL('.', SESSION_LOGIN_FILE), { recursive: true });

--- a/packages/db/src/core/cli/commands/login/index.ts
+++ b/packages/db/src/core/cli/commands/login/index.ts
@@ -43,7 +43,8 @@ export async function cmd({
 		console.log('Successfully logged in');
 	} else if (!session) {
 		const { url, promise } = await createServer();
-		const loginUrl = getAstroStudioUrl() + '/auth/cli/login?returnTo=' + encodeURIComponent(url);
+		const loginUrl = new URL('/auth/cli/login', getAstroStudioUrl());
+		loginUrl.searchParams.set('returnTo', url);
 		console.log(`Opening the following URL in your browser...`);
 		console.log(cyan(loginUrl));
 		console.log(`If something goes wrong, copy-and-paste the URL into your browser.`);

--- a/packages/db/src/core/cli/commands/login/index.ts
+++ b/packages/db/src/core/cli/commands/login/index.ts
@@ -46,9 +46,9 @@ export async function cmd({
 		const loginUrl = new URL('/auth/cli/login', getAstroStudioUrl());
 		loginUrl.searchParams.set('returnTo', url);
 		console.log(`Opening the following URL in your browser...`);
-		console.log(cyan(loginUrl));
+		console.log(cyan(loginUrl.href));
 		console.log(`If something goes wrong, copy-and-paste the URL into your browser.`);
-		open(loginUrl);
+		open(loginUrl.href);
 		const spinner = ora('Waiting for confirmation...');
 		session = await promise;
 		spinner.succeed('Successfully logged in');

--- a/packages/db/src/core/cli/commands/login/index.ts
+++ b/packages/db/src/core/cli/commands/login/index.ts
@@ -11,6 +11,12 @@ import { SESSION_LOGIN_FILE } from '../../../tokens.js';
 import type { DBConfig } from '../../../types.js';
 import { getAstroStudioUrl } from '../../../utils.js';
 
+const isWebContainer =
+	// Stackblitz heuristic
+	process.versions?.webcontainer ??
+	// Github Codespaces heuristic
+	process.env.CODESPACE_NAME;
+
 export async function cmd({
 	flags,
 }: {
@@ -20,7 +26,7 @@ export async function cmd({
 }) {
 	let session = flags.session;
 
-	if (!session && process.versions?.webcontainer) {
+	if (!session && isWebContainer) {
 		console.log(`Please visit the following URL in your web browser:`);
 		console.log(cyan(`${getAstroStudioUrl()}/auth/cli/login`));
 		console.log(`After login in complete, enter the verification code displayed:`);


### PR DESCRIPTION
## Changes

Add a check to `astro login` for your environment. When in Codespaces or Stackblitz, use a manual login flow that lets you enter your session ID rather than using redirects.

Related Studio PR: https://github.com/withastro/studio/pull/589

https://github.com/withastro/astro/assets/51384119/5bd68a79-de14-49d4-8a8f-c865f96888f3

## Testing

Manual testing for the preview package on Stackblitz and Codespaces, connecting to a local Studio instance with a tunnel.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
