### PR TITLE
fix: resolve syntax errors in fixtures

### DIFF
--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/404.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/404.astro
@@ -4,4 +4,3 @@ import Layout from '../components/Layout.astro';
 <Layout>
 	<p id="FourOhFour">Page not found</p>
 </Layout>
-</script>

--- a/packages/astro/test/fixtures/astro-basic/src/pages/fileurl.astro
+++ b/packages/astro/test/fixtures/astro-basic/src/pages/fileurl.astro
@@ -5,6 +5,6 @@ import {capitalize} from 'file://../strings.js';
 <html>
 	<head><title>Testing</title></head>
 	<body>
-		<h1>{capitalize('works')</h1>
+		<h1>{capitalize('works')}</h1>
 	</body>
 </html>

--- a/packages/astro/test/fixtures/core-image-deletion/src/pages/index.astro
+++ b/packages/astro/test/fixtures/core-image-deletion/src/pages/index.astro
@@ -8,8 +8,8 @@ import twoFromURL_URL from "../assets/url.jpg?url";
 
 <Image src={onlyOne} alt="Only one of me exists at the end of the build" />
 
-<Image src={twoOfUs} alt="Two of us will exist, because I'm also used as a normal image" /></Image>
+<Image src={twoOfUs} alt="Two of us will exist, because I'm also used as a normal image" />
 <img src={twoOfUs.src} alt="Two of us will exist, because I'm also used as a normal image" />
 
-<Image src={twoFromURL} alt="Two of us will exist, because I'm also imported using ?url" /></Image>
+<Image src={twoFromURL} alt="Two of us will exist, because I'm also imported using ?url" />
 <img src={twoFromURL_URL} alt="Two of us will exist, because I'm also used as a normal image" />


### PR DESCRIPTION
I parsed every `.astro` file in the Astro repository (to check if [tree-sitter-astro](https://github.com/virchau13/tree-sitter-astro) had any bugs), and found three files with syntax errors that don't seem intentional.

## Changes

Fixes those syntax errors.

## Testing

Executed `pnpm run test` at top-level and all 17 tasks passed.

## Docs

It's a simple syntax error fix, so no docs are required.
