### PR TITLE
Add Atom feed generator as a new package

### DIFF
--- a/packages/astro-atom/CHANGELOG.md
+++ b/packages/astro-atom/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @astrojs/atom

--- a/packages/astro-atom/README.md
+++ b/packages/astro-atom/README.md
@@ -1,0 +1,393 @@
+# @astrojs/atom 📖
+
+<!-- TODO: Update README -->
+
+This package brings fast RSS feed generation to blogs and other content sites built with [Astro](https://astro.build/). For more information about RSS feeds in general, see [aboutfeeds.com](https://aboutfeeds.com/).
+
+## Installation
+
+Install the `@astrojs/rss` package into any Astro project using your preferred package manager:
+
+```bash
+# npm
+npm i @astrojs/rss
+# yarn
+yarn add @astrojs/rss
+# pnpm
+pnpm i @astrojs/rss
+```
+
+## Example usage
+
+The `@astrojs/rss` package provides helpers for generating RSS feeds within [Astro endpoints][astro-endpoints]. This unlocks both static builds _and_ on-demand generation when using an [SSR adapter](https://docs.astro.build/en/guides/server-side-rendering/).
+
+For instance, say you need to generate an RSS feed for all posts under `src/content/blog/` using content collections.
+
+Start by [adding a `site` to your project's `astro.config` for link generation](https://docs.astro.build/en/reference/configuration-reference/#site). Then, create an `rss.xml.js` file under your project's `src/pages/` directory, and [use `getCollection()`](https://docs.astro.build/en/guides/content-collections/#getcollection) to generate a feed from all documents in the `blog` collection:
+
+```js
+// src/pages/rss.xml.js
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+
+export async function GET(context) {
+  const posts = await getCollection('blog');
+  return rss({
+    title: 'Buzz’s Blog',
+    description: 'A humble Astronaut’s guide to the stars',
+    // Pull in your project "site" from the endpoint context
+    // https://docs.astro.build/en/reference/api-reference/#contextsite
+    site: context.site,
+    items: posts.map((post) => ({
+      // Assumes all RSS feed item properties are in post frontmatter
+      ...post.data,
+      // Generate a `url` from each post `slug`
+      // This assumes all blog posts are rendered as `/blog/[slug]` routes
+      // https://docs.astro.build/en/guides/content-collections/#generating-pages-from-content-collections
+      link: `/blog/${post.slug}/`,
+    })),
+  });
+}
+```
+
+Read **[Astro's RSS docs][astro-rss]** for more on using content collections, and instructions for globbing entries in `/src/pages/`.
+
+## `rss()` configuration options
+
+The `rss` default export offers a number of configuration options. Here's a quick reference:
+
+```js
+export function GET(context) {
+  return rss({
+    // `<title>` field in output xml
+    title: 'Buzz’s Blog',
+    // `<description>` field in output xml
+    description: 'A humble Astronaut’s guide to the stars',
+    // provide a base URL for RSS <item> links
+    site: context.site,
+    // list of `<item>`s in output xml
+    items: [],
+    // (optional) absolute path to XSL stylesheet in your project
+    stylesheet: '/rss-styles.xsl',
+    // (optional) inject custom xml
+    customData: '<language>en-us</language>',
+    // (optional) add arbitrary metadata to opening <rss> tag
+    xmlns: { h: 'http://www.w3.org/TR/html4/' },
+    // (optional) add trailing slashes to URLs (default: true)
+    trailingSlash: false,
+  });
+}
+```
+
+### title
+
+Type: `string (required)`
+
+The `<title>` attribute of your RSS feed's output xml.
+
+### description
+
+Type: `string (required)`
+
+The `<description>` attribute of your RSS feed's output xml.
+
+### site
+
+Type: `string (required)`
+
+The base URL to use when generating RSS item links. We recommend using the [endpoint context object](https://docs.astro.build/en/reference/api-reference/#contextsite), which includes the `site` configured in your project's `astro.config.*`:
+
+```ts
+import rss from '@astrojs/rss';
+
+export const GET = (context) =>
+  rss({
+    site: context.site,
+    // ...
+  });
+```
+
+### items
+
+Type: `RSSFeedItem[] (required)`
+
+A list of formatted RSS feed items. See [Astro's RSS items documentation](https://docs.astro.build/en/guides/rss/#generating-items) for usage examples to choose the best option for you.
+
+When providing a formatted RSS item list, see the [`RSSFeedItem` type reference](#rssfeeditem).
+
+### stylesheet
+
+Type: `string (optional)`
+
+An absolute path to an XSL stylesheet in your project. If you don’t have an RSS stylesheet in mind, we recommend the [Pretty Feed v3 default stylesheet](https://github.com/genmon/aboutfeeds/blob/main/tools/pretty-feed-v3.xsl), which you can download from GitHub and save into your project's `public/` directory.
+
+### customData
+
+Type: `string (optional)`
+
+A string of valid XML to be injected between your feed's `<description>` and `<item>` tags. This is commonly used to set a language for your feed:
+
+```js
+import rss from '@astrojs/rss';
+
+export const GET = () => rss({
+    ...
+    customData: '<language>en-us</language>',
+  });
+```
+
+### xmlns
+
+Type: `Record<string, string> (optional)`
+
+An object mapping a set of `xmlns` suffixes to strings of metadata on the opening `<rss>` tag.
+
+For example, this object:
+
+```js
+rss({
+  ...
+  xmlns: { h: 'http://www.w3.org/TR/html4/' },
+})
+```
+
+Will inject the following XML:
+
+```xml
+<rss xmlns:h="http://www.w3.org/TR/html4/"...
+```
+
+### content
+
+The `content` key contains the full content of the post as HTML. This allows you to make your entire post content available to RSS feed readers.
+
+**Note:** Whenever you're using HTML content in XML, we suggest using a package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) in order to make sure that your content is properly sanitized, escaped, and encoded.
+
+[See our RSS documentation](https://docs.astro.build/en/guides/rss/#including-full-post-content) for examples using content collections and glob imports.
+
+### `trailingSlash`
+
+Type: `boolean (optional)`
+Default: `true`
+
+By default, the library will add trailing slashes to the emitted URLs. To prevent this behavior, add `trailingSlash: false` to the `rss` function.
+
+```js
+import rss from '@astrojs/rss';
+
+export const GET = () =>
+  rss({
+    trailingSlash: false,
+  });
+```
+
+## `RSSFeedItem`
+
+An `RSSFeedItem` is a single item in the list of items in your feed. It represents a story, with `link`, `title`, and `pubDate` fields. There are further optional fields defined below. You can also check the definitions for the fields in the [RSS spec](https://validator.w3.org/feed/docs/rss2.html#ltpubdategtSubelementOfLtitemgt).
+
+An example feed item might look like:
+
+```js
+const item = {
+  title: 'Alpha Centauri: so close you can touch it',
+  link: '/blog/alpha-centuari',
+  pubDate: new Date('2023-06-04'),
+  description:
+    'Alpha Centauri is a triple star system, containing Proxima Centauri, the closest star to our sun at only 4.24 light-years away.',
+  categories: ['stars', 'space'],
+};
+```
+
+### `title`
+
+Type: `string (required)`
+
+The title of the item in the feed.
+
+### `link`
+
+Type: `string (required)`
+
+The URL of the item on the web.
+
+### `pubDate`
+
+Type: `Date (required)`
+
+Indicates when the item was published.
+
+### `description`
+
+Type: `string (optional)`
+
+A synopsis of your item when you are publishing the full content of the item in the `content` field. The `description` may alternatively be the full content of the item in the feed if you are not using the `content` field (entity-coded HTML is permitted).
+
+### `content`
+
+Type: `string (optional)`
+
+The full text content of the item suitable for presentation as HTML. If used, you should also provide a short article summary in the `description` field.
+
+See the [recommendations from the RSS spec for how to use and differentiate between `description` and `content`](https://www.rssboard.org/rss-profile#namespace-elements-content-encoded).
+
+### `categories`
+
+Type: `string[] (optional)`
+
+A list of any tags or categories to categorize your content. They will be output as multiple `<category>` elements.
+
+### `author`
+
+Type: `string (optional)`
+
+The email address of the item author. This is useful for indicating the author of a post on multi-author blogs.
+
+### `commentsUrl`
+
+Type: `string (optional)`
+
+The URL of a web page that contains comments on the item.
+
+### `source`
+
+Type: `object (optional)`
+
+An object that defines the `title` and `url` of the original feed for items that have been republished from another source. Both are required properties of `source` for proper attribution.
+
+```js
+const item = {
+  title: 'Alpha Centauri: so close you can touch it',
+  link: '/blog/alpha-centuari',
+  pubDate: new Date('2023-06-04'),
+  description:
+    'Alpha Centauri is a triple star system, containing Proxima Centauri, the closest star to our sun at only 4.24 light-years away.',
+  source: {
+    title: 'The Galactic Times',
+    url: 'https://galactictimes.space/feed.xml',
+  },
+};
+```
+
+#### `source.title`
+
+Type: `string (required)`
+
+The name of the original feed in which the item was published. (Note that this is the feed's title, not the individual article title.)
+
+#### `source.url`
+
+Type: `string (required)`
+
+The URL of the original feed in which the item was published.
+
+### `enclosure`
+
+Type: `object (optional)`
+
+An object to specify properties for an included media source (e.g. a podcast) with three required values: `url`, `length`, and `type`.
+
+```js
+const item = {
+  title: 'Alpha Centauri: so close you can touch it',
+  link: '/blog/alpha-centuari',
+  pubDate: new Date('2023-06-04'),
+  description:
+    'Alpha Centauri is a triple star system, containing Proxima Centauri, the closest star to our sun at only 4.24 light-years away.',
+  enclosure: {
+    url: '/media/alpha-centauri.aac',
+    length: 124568,
+    type: 'audio/aac',
+  },
+};
+```
+
+#### `enclosure.url`
+
+Type: `string (required)`
+
+The URL where the media can be found. If the media is hosted outside of your own domain you must provide a full URL.
+
+#### `enclosure.length`
+
+Type: `number (required)`
+
+The size of the file found at the `url` in bytes.
+
+#### `enclosure.type`
+
+Type: `string (required)`
+
+The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) for the media item found at the `url`.
+
+## `rssSchema`
+
+When using content collections, you can configure your collection schema to enforce expected [`RSSFeedItem`](#items) properties. Import and apply `rssSchema` to ensure that each collection entry produces a valid RSS feed item:
+
+```ts "schema: rssSchema,"
+import { defineCollection } from 'astro:content';
+import { rssSchema } from '@astrojs/rss';
+
+const blog = defineCollection({
+  schema: rssSchema,
+});
+
+export const collections = { blog };
+```
+
+If you have an existing schema, you can merge extra properties using `extends()`:
+
+```ts ".extends({ extraProperty: z.string() }),"
+import { defineCollection } from 'astro:content';
+import { rssSchema } from '@astrojs/rss';
+
+const blog = defineCollection({
+  schema: rssSchema.extends({ extraProperty: z.string() }),
+});
+```
+
+## `pagesGlobToRssItems()`
+
+To create an RSS feed from documents in `src/pages/`, use the `pagesGlobToRssItems()` helper. This accepts an `import.meta.glob` result ([see Vite documentation](https://vitejs.dev/guide/features.html#glob-import)) and outputs an array of valid [`RSSFeedItem`s](#items).
+
+This function assumes, but does not verify, you are globbing for items inside `src/pages/`, and all necessary feed properties are present in each document's frontmatter. If you encounter errors, verify each page frontmatter manually.
+
+```ts "pagesGlobToRssItems"
+// src/pages/rss.xml.js
+import rss, { pagesGlobToRssItems } from '@astrojs/rss';
+
+export async function GET(context) {
+  return rss({
+    title: 'Buzz’s Blog',
+    description: 'A humble Astronaut’s guide to the stars',
+    site: context.site,
+    items: await pagesGlobToRssItems(import.meta.glob('./blog/*.{md,mdx}')),
+  });
+}
+```
+
+## `getRssString()`
+
+As `rss()` returns a `Response`, you can also use `getRssString()` to get the RSS string directly and use it in your own response:
+
+```ts "getRssString"
+// src/pages/rss.xml.js
+import { getRssString } from '@astrojs/rss';
+
+export async function GET(context) {
+  const rssString = await getRssString({
+    title: 'Buzz’s Blog',
+    ...
+  });
+
+  return new Response(rssString, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  });
+}
+```
+
+For more on building with Astro, [visit the Astro docs][astro-rss].
+
+[astro-rss]: https://docs.astro.build/en/guides/rss/#using-astrojsrss-recommended
+[astro-endpoints]: https://docs.astro.build/en/core-concepts/astro-pages/#non-html-pages

--- a/packages/astro-atom/package.json
+++ b/packages/astro-atom/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@astrojs/atom",
+  "description": "Add Atom feeds to your Astro projects",
+  "version": "0.1.0",
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "author": "withastro",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/withastro/astro.git",
+    "directory": "packages/astro-atom"
+  },
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://astro.build",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
+    "dev": "astro-scripts dev \"src/**/*.ts\"",
+    "test": "astro-scripts test \"test/**/*.test.js\""
+  },
+  "devDependencies": {
+    "@types/xml2js": "^0.4.14",
+    "astro": "workspace:*",
+    "astro-scripts": "workspace:*",
+    "xml2js": "0.6.2"
+  },
+  "dependencies": {
+    "fast-xml-parser": "^4.2.7",
+    "kleur": "^4.1.5"
+  }
+}

--- a/packages/astro-atom/src/index.ts
+++ b/packages/astro-atom/src/index.ts
@@ -185,27 +185,26 @@ async function generateAtom(atomOptions: ValidatedAtomOptions): Promise<string> 
 			...(isXSL && { '@_type': 'text/xsl' }),
 		};
 	}
-	root.feed = { '@_version': '2.0' };
 
 	// xmlns
 	const XMLNamespace = 'http://www.w3.org/2005/Atom';
-	root.feed['@_xmlns'] = XMLNamespace;
+	root.feed = { '@_xmlns': XMLNamespace };
 	if (atomOptions.xmlns) {
 		for (const [k, v] of Object.entries(atomOptions.xmlns)) {
-			root.rss[`@_xmlns:${k}`] = v;
+			root.feed[`@_xmlns:${k}`] = v;
 		}
 	}
 
 	// title, description, customData
-	(root.feed.title = atomOptions.title),
-		(root.feed.subtitle = atomOptions.subtitle),
-		(root.feed.link = {
-			'@_href': createCanonicalURL(site, atomOptions.trailingSlash, undefined).href,
-		});
+	root.feed.title = atomOptions.title;
+	root.feed.subtitle = atomOptions.subtitle;
+	root.feed.link = {
+		'@_href': createCanonicalURL(site, atomOptions.trailingSlash, undefined).href,
+	};
 	if (typeof atomOptions.customData === 'string')
-		Object.assign(root.rss.feed, parser.parse(`<feed>${atomOptions.customData}</feed>`).feed);
+		Object.assign(root.feed, parser.parse(`<feed>${atomOptions.customData}</feed>`).feed);
 	// entris
-	root.rss.channel.entry = entries.map((result) => {
+	root.feed.entry = entries.map((result) => {
 		const entry: Record<string, unknown> & { link: any[] } = { link: [] };
 
 		if (result.title) {
@@ -245,7 +244,7 @@ async function generateAtom(atomOptions: ValidatedAtomOptions): Promise<string> 
 		}
 		if (result.source) {
 			// TODO: Source object
-			entry.source = { title: result.source.title, link: { href: result.source.url } };
+			entry.source = { title: result.source.title, link: { '@_href': result.source.url } };
 		}
 		if (result.enclosure) {
 			const enclosureURL = isValidURL(result.enclosure.url)

--- a/packages/astro-atom/src/index.ts
+++ b/packages/astro-atom/src/index.ts
@@ -1,0 +1,264 @@
+import { z } from 'astro/zod';
+import { XMLBuilder, XMLParser } from 'fast-xml-parser';
+import { atomSchema } from './schema.js';
+import { createCanonicalURL, errorMap, isValidURL } from './util.js';
+
+// TODO: What is left that does not have a TODO:
+// - More validation for Atom Feed particularly
+// - Tests
+
+export { atomSchema };
+
+export type AtomOptions = {
+	/** Title of the Atom Feed */
+	title: z.infer<typeof atomOptionsValidator>['title'];
+	/** Description or subtitle of the Atom Feed */
+	subtitle: z.infer<typeof atomOptionsValidator>['subtitle'];
+	/**
+	 * Link to site. Formally speaking, the URL to an alternate version of the Atom Feed.
+	 * We recommend using the [endpoint context object](https://docs.astro.build/en/reference/api-reference/#contextsite),
+	 * which includes the `site` configured in your project's `astro.config.*`
+	 */
+	site: z.infer<typeof atomOptionsValidator>['site'] | URL;
+	/** List of Atom feed entries to render. */
+	entries: AtomFeedEntry[];
+	/** Specify arbitrary metadata on opening <xml> tag */
+	xmlns?: z.infer<typeof atomOptionsValidator>['xmlns'];
+	/** Specifies a local custom XSL stylesheet. Ex. '/public/custom-feed.xsl' */
+	stylesheet?: z.infer<typeof atomOptionsValidator>['stylesheet'];
+	/** Specify custom data in opening of file */
+	customData?: z.infer<typeof atomOptionsValidator>['customData'];
+	trailingSlash?: z.infer<typeof atomOptionsValidator>['trailingSlash'];
+};
+
+export type AtomFeedEntry = {
+	/**
+	 * Link to entry.
+	 * Formally speaking, the URL to an alternate version of the entry.
+	 */
+	link: z.infer<typeof atomSchema>['link'];
+	/** Full content of the item. Should be valid HTML */
+	content?: z.infer<typeof atomSchema>['content'];
+	/** Title of item */
+	title: z.infer<typeof atomSchema>['title'];
+	/**
+	 * The most recent date when the entry is modified in a way the publisher considers significant.
+	 * Not all modifications necessarily result in a change of the field.
+	 */
+	updated: z.infer<typeof atomSchema>['updated'];
+	/** Initial creation or first availability date of entry */
+	published: z.infer<typeof atomSchema>['published'];
+	/** Short summary, abstract, or excerpt of the entry */
+	summary?: z.infer<typeof atomSchema>['summary'];
+	/** Append some other XML-valid data to this entry */
+	customData?: z.infer<typeof atomSchema>['customData'];
+	/** Categories associated with the entry */
+	categories?: z.infer<typeof atomSchema>['categories'];
+	/** The entry author */
+	author?: z.infer<typeof atomSchema>['author'];
+	/** The Atom channel that the entry came from */
+	source?: z.infer<typeof atomSchema>['source'];
+	/** A media object that belongs to the entry */
+	enclosure?: z.infer<typeof atomSchema>['enclosure'];
+};
+
+type ValidatedAtomFeedItem = z.infer<typeof atomSchema>;
+type ValidatedAtomOptions = z.infer<typeof atomOptionsValidator>;
+type GlobResult = z.infer<typeof globResultValidator>;
+
+const globResultValidator = z.record(z.function().returns(z.promise(z.any())));
+
+const atomOptionsValidator = z.object({
+	title: z.string(),
+	subtitle: z.string().optional(),
+	site: z.preprocess((url) => (url instanceof URL ? url.href : url), z.string().url()),
+	entries: z.array(atomSchema).transform((items) => {
+		return items;
+	}),
+	xmlns: z.record(z.string()).optional(),
+	stylesheet: z.union([z.string(), z.boolean()]).optional(),
+	customData: z.string().optional(),
+	trailingSlash: z.boolean().default(true),
+});
+
+export default async function getAtomResponse(atomOptions: AtomOptions): Promise<Response> {
+	const atomString = await getAtomString(atomOptions);
+	return new Response(atomString, {
+		headers: {
+			// The RFC gives `application/atom+xml`, but no MAY, SHOULD, or MUST are used.
+			// We use this value like @astrojs/rss
+			'Content-Type': 'application/xml',
+		},
+	});
+}
+
+export async function getAtomString(atomOptions: AtomOptions): Promise<string> {
+	const validatedRssOptions = await validateAtomOptions(atomOptions);
+	return await generateAtom(validatedRssOptions);
+}
+
+async function validateAtomOptions(atomOptions: AtomOptions) {
+	const parsedResult = await atomOptionsValidator.safeParseAsync(atomOptions, { errorMap });
+	if (parsedResult.success) {
+		return parsedResult.data;
+	}
+	const formattedError = new Error(
+		[
+			`[Atom] Invalid or missing options:`,
+			...parsedResult.error.errors.map((zodError) => {
+				const path = zodError.path.join('.');
+				const message = `${zodError.message} (${path})`;
+				const code = zodError.code;
+
+				if (path === 'items' && code === 'invalid_union') {
+					return [
+						message,
+						`The \`entris\` property requires at least the \`summary\` or \`content\` key, and at least \`link\` or \`content\` key. They must be properly typed, as well as \`published\` and \`updated\` keys if provided.`,
+						`Check your collection's schema, and visit similar https://docs.astro.build/en/guides/rss/#generating-items for more info.`,
+					].join('\n');
+				}
+
+				return message;
+			}),
+		].join('\n')
+	);
+	throw formattedError;
+}
+
+// TODO: Frontmatter transformation helper
+export function pagesGlobToAtomItems(
+	entries: GlobResult,
+	frontmatterTransform: (frontmatter: any) => any
+): Promise<ValidatedAtomFeedItem[]> {
+	return Promise.all(
+		Object.entries(entries).map(async ([filePath, getInfo]) => {
+			const { url, frontmatter } = await getInfo();
+			if (url === undefined || url === null) {
+				throw new Error(
+					`[Atom] You can only glob entries within 'src/pages/' when passing import.meta.glob() directly. Consider mapping the result to an array of AtomFeedItems. See the similar RSS docs for usage examples: https://docs.astro.build/en/guides/rss/#2-list-of-rss-feed-objects`
+				);
+			}
+			const parsedResult = atomSchema
+				.refine((val) => val.title, {
+					message: 'Title must be provided.',
+					path: ['title'],
+				})
+				.refine((val) => val.summary || val.content, {
+					message: 'At least summary or content must be provided.',
+					path: ['title'],
+				})
+				.safeParse({ ...frontmatterTransform(frontmatter), link: url }, { errorMap });
+
+			if (parsedResult.success) {
+				return parsedResult.data;
+			}
+			const formattedError = new Error(
+				[
+					`[Atom] ${filePath} has invalid or missing frontmatter.\nFix the following properties:`,
+					...parsedResult.error.errors.map((zodError) => zodError.message),
+				].join('\n')
+			);
+			(formattedError as any).file = filePath;
+			throw formattedError;
+		})
+	);
+}
+
+/** Generate Atom 1.0 (RFC 4287) feed */
+async function generateAtom(atomOptions: ValidatedAtomOptions): Promise<string> {
+	const { entries, site } = atomOptions;
+
+	const xmlOptions = {
+		ignoreAttributes: false,
+		// Avoid correcting self-closing tags to standard tags
+		// when using `customData`
+		// https://github.com/withastro/astro/issues/5794
+		suppressEmptyNode: true,
+		suppressBooleanAttributes: false,
+	};
+	const parser = new XMLParser(xmlOptions);
+	const root: any = { '?xml': { '@_version': '1.0', '@_encoding': 'UTF-8' } };
+	if (typeof atomOptions.stylesheet === 'string') {
+		const isXSL = /\.xsl$/i.test(atomOptions.stylesheet);
+		root['?xml-stylesheet'] = {
+			'@_href': atomOptions.stylesheet,
+			...(isXSL && { '@_type': 'text/xsl' }),
+		};
+	}
+	root.feed = { '@_version': '2.0' };
+
+	// xmlns
+	const XMLNamespace = 'http://www.w3.org/2005/Atom';
+	root.feed['@_xmlns'] = XMLNamespace;
+	if (atomOptions.xmlns) {
+		for (const [k, v] of Object.entries(atomOptions.xmlns)) {
+			root.rss[`@_xmlns:${k}`] = v;
+		}
+	}
+
+	// title, description, customData
+	(root.feed.title = atomOptions.title),
+		(root.feed.subtitle = atomOptions.subtitle),
+		(root.feed.link = {
+			'@_href': createCanonicalURL(site, atomOptions.trailingSlash, undefined).href,
+		});
+	if (typeof atomOptions.customData === 'string')
+		Object.assign(root.rss.feed, parser.parse(`<feed>${atomOptions.customData}</feed>`).feed);
+	// entris
+	root.rss.channel.entry = entries.map((result) => {
+		const entry: Record<string, unknown> & { link: any[] } = { link: [] };
+
+		if (result.title) {
+			entry.title = result.title;
+		}
+		if (typeof result.link === 'string') {
+			// If the item's link is already a valid URL, don't mess with it.
+			const itemLink = isValidURL(result.link)
+				? result.link
+				: createCanonicalURL(result.link, atomOptions.trailingSlash, site).href;
+			entry.link.push({ '@_href': itemLink });
+			entry.id = itemLink;
+		}
+		if (result.summary) {
+			entry.summary = result.summary;
+		}
+		if (result.updated) {
+			entry.updated = result.updated.toUTCString();
+		}
+		if (result.published) {
+			entry.published = result.published.toUTCString();
+		}
+		// include the full content of the post if the user supplies it
+		if (typeof result.content === 'string') {
+			// TODO: Other types, e.g., XHTML
+			entry.content = { '@_type': 'html', '#text': result.content };
+		}
+		if (typeof result.customData === 'string') {
+			Object.assign(entry, parser.parse(`<entry>${result.customData}</entry>`).entry);
+		}
+		if (Array.isArray(result.categories)) {
+			// TODO: Category objects
+			entry.category = result.categories.map((category) => ({ '@_term': category }));
+		}
+		if (typeof result.author === 'object') {
+			entry.author = result.author;
+		}
+		if (result.source) {
+			// TODO: Source object
+			entry.source = { title: result.source.title, link: { href: result.source.url } };
+		}
+		if (result.enclosure) {
+			const enclosureURL = isValidURL(result.enclosure.url)
+				? result.enclosure.url
+				: createCanonicalURL(result.enclosure.url, atomOptions.trailingSlash, site).href;
+			entry.link.push(
+				parser.parse(
+					`<link rel="enclosure" href="${enclosureURL}" length="${result.enclosure.length}" type="${result.enclosure.type}"/>`
+				).link
+			);
+		}
+		return entry;
+	});
+
+	return new XMLBuilder(xmlOptions).build(root);
+}

--- a/packages/astro-atom/src/schema.ts
+++ b/packages/astro-atom/src/schema.ts
@@ -1,0 +1,35 @@
+import { z } from 'astro/zod';
+
+export const atomSchema = z.object({
+	title: z.string().optional(),
+	summary: z.string().optional(),
+	published: z
+		.union([z.string(), z.number(), z.date()])
+		.optional()
+		.transform((value) => (value === undefined ? value : new Date(value)))
+		.refine((value) => (value === undefined ? value : !isNaN(value.getTime()))),
+	updated: z
+		.union([z.string(), z.number(), z.date()])
+		.optional()
+		.transform((value) => (value === undefined ? value : new Date(value)))
+		.refine((value) => (value === undefined ? value : !isNaN(value.getTime()))),
+	customData: z.string().optional(),
+	categories: z.array(z.string()).optional(),
+	author: z
+		.object({
+			name: z.string(),
+			uri: z.string().url().optional(),
+			email: z.string().email().optional(),
+		})
+		.optional(),
+	source: z.object({ url: z.string().url(), title: z.string() }).optional(),
+	enclosure: z
+		.object({
+			url: z.string(),
+			length: z.number().nonnegative().int().finite(),
+			type: z.string(),
+		})
+		.optional(),
+	link: z.string().optional(),
+	content: z.string().optional(),
+});

--- a/packages/astro-atom/src/schema.ts
+++ b/packages/astro-atom/src/schema.ts
@@ -6,8 +6,8 @@ export const atomSchema = z.object({
 	published: z
 		.union([z.string(), z.number(), z.date()])
 		.optional()
-		.transform((value) => (value === undefined ? value : new Date(value)))
-		.refine((value) => (value === undefined ? value : !isNaN(value.getTime()))),
+		.transform((value) => (value !== undefined ? new Date(value) : undefined))
+		.refine((value) => (value ? !isNaN(value.getTime()) : true)),
 	updated: z
 		.union([z.string(), z.number(), z.date()])
 		.optional()

--- a/packages/astro-atom/src/util.ts
+++ b/packages/astro-atom/src/util.ts
@@ -1,0 +1,53 @@
+import type { z } from 'astro/zod';
+import type { AtomOptions } from './index.js';
+
+/** Normalize URL to its canonical form */
+export function createCanonicalURL(
+	url: string,
+	// TODO: The type is `boolean | undefined`, which is the same as the one in `src/utils.ts` in `@astrojs/rss`.
+	// Alternatively, we can import the utilities from `@astrojs/rss` other than copying them.
+	// But I am not sure whether this package should have `@astrojs/rss` as a dependency.
+	trailingSlash?: AtomOptions['trailingSlash'],
+	base?: string
+): URL {
+	let pathname = url.replace(/\/index.html$/, ''); // index.html is not canonical
+	if (trailingSlash === false) {
+		// remove the trailing slash
+		pathname = pathname.replace(/\/*$/, '');
+	} else if (!getUrlExtension(url)) {
+		// add trailing slash if there’s no extension or `trailingSlash` is true
+		pathname = pathname.replace(/\/*$/, '/');
+	}
+
+	pathname = pathname.replace(/\/+/g, '/'); // remove duplicate slashes (URL() won’t)
+	return new URL(pathname, base);
+}
+
+/** Check if a URL is already valid */
+export function isValidURL(url: string): boolean {
+	try {
+		new URL(url);
+		return true;
+	} catch (e) {}
+	return false;
+}
+
+function getUrlExtension(url: string) {
+	const lastDot = url.lastIndexOf('.');
+	const lastSlash = url.lastIndexOf('/');
+	return lastDot > lastSlash ? url.slice(lastDot + 1) : '';
+}
+
+const flattenErrorPath = (errorPath: (string | number)[]) => errorPath.join('.');
+
+export const errorMap: z.ZodErrorMap = (error, ctx) => {
+	if (error.code === 'invalid_type') {
+		const badKeyPath = JSON.stringify(flattenErrorPath(error.path));
+		if (error.received === 'undefined') {
+			return { message: `${badKeyPath} is required.` };
+		} else {
+			return { message: `${badKeyPath} should be ${error.expected}, not ${error.received}.` };
+		}
+	}
+	return { message: ctx.defaultError };
+};

--- a/packages/astro-atom/test/atom.test.js
+++ b/packages/astro-atom/test/atom.test.js
@@ -1,0 +1,270 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { z } from 'astro/zod';
+import atom, { getAtomString } from '../dist/index.js';
+import { atomSchema } from '../dist/schema.js';
+import {
+	subtitle,
+	parseXmlString,
+	phpFeedEntry,
+	phpFeedEntryWithContent,
+	phpFeedEntryWithCustomData,
+	site,
+	title,
+	web1FeedEntry,
+	web1FeedEntryWithAllData,
+	web1FeedEntryWithContent,
+} from './test-utils.js';
+
+// note: I spent 30 minutes looking for a nice node-based snapshot tool
+// ...and I gave up. Enjoy big strings!
+
+// biome-ignore format: keep in one line
+const validXmlResult = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.w3.org/2005/Atom"><title><![CDATA[${title}]]></title><subtitle><![CDATA[${subtitle}]]></subtitle><link href="${site}/" /><entry><title><![CDATA[${phpFeedEntry.title}]]></title><link href="${site}${phpFeedEntry.link}/" /><id>${site}${phpFeedEntry.link}/</id><summary><![CDATA[${phpFeedEntry.summary}]]></summary><updated>${new Date(phpFeedEntry.updated).toUTCString()}</updated></entry><entry><title><![CDATA[${web1FeedEntry.title}]]></title><link href="${site}${web1FeedEntry.link}/" /><id>${site}${web1FeedEntry.link}/</id><summary><![CDATA[${web1FeedEntry.summary}]]></summary><updated>${new Date(web1FeedEntry.updated).toUTCString()}</updated></entry></feed>`;
+// biome-ignore format: keep in one line
+const validXmlWithContentResult = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.w3.org/2005/Atom"><title><![CDATA[${title}]]></title><subtitle><![CDATA[${subtitle}]]></subtitle><link href="${site}/" /><entry><title><![CDATA[${phpFeedEntryWithContent.title}]]></title><link href="${site}${phpFeedEntryWithContent.link}/" /><id>${site}${phpFeedEntryWithContent.link}/</id><summary><![CDATA[${phpFeedEntryWithContent.summary}]]></summary><updated>${new Date(phpFeedEntryWithContent.updated).toUTCString()}</updated><content type="html"><![CDATA[${phpFeedEntryWithContent.content}]]></content></entry><entry><title><![CDATA[${web1FeedEntryWithContent.title}]]></title><link href="${site}${web1FeedEntryWithContent.link}/" /><id>${site}${web1FeedEntryWithContent.link}/</id><summary><![CDATA[${web1FeedEntryWithContent.summary}]]></summary><updated>${new Date(web1FeedEntryWithContent.updated).toUTCString()}</updated><content type="html"><![CDATA[${web1FeedEntryWithContent.content}]]></content></entry></feed>`;
+// biome-ignore format: keep in one line
+const validXmlResultWithAllData = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.w3.org/2005/Atom"><title><![CDATA[${title}]]></title><subtitle><![CDATA[${subtitle}]]></subtitle><link href="${site}/" /><entry><title><![CDATA[${phpFeedEntry.title}]]></title><link href="${site}${phpFeedEntry.link}/" /><id>${site}${phpFeedEntry.link}/</id><summary><![CDATA[${phpFeedEntry.summary}]]></summary><updated>${new Date(phpFeedEntry.updated).toUTCString()}</updated></entry><entry><title><![CDATA[${web1FeedEntryWithAllData.title}]]></title><link href="${site}${web1FeedEntryWithAllData.link}/" /><id>${site}${web1FeedEntryWithAllData.link}/</id><summary><![CDATA[${web1FeedEntryWithAllData.summary}]]></summary><updated>${new Date(web1FeedEntryWithAllData.updated).toUTCString()}</updated><category term="${web1FeedEntryWithAllData.categories[0]}" /><category term="${web1FeedEntryWithAllData.categories[1]}" /><author><name>${web1FeedEntryWithAllData.author.name}</name><email>${web1FeedEntryWithAllData.author.email}</email></author><source><title>${web1FeedEntryWithAllData.source.title}</title><link href="${web1FeedEntryWithAllData.source.url}" /></source><link rel="enclosure" href="${site}${web1FeedEntryWithAllData.enclosure.url}" length="${web1FeedEntryWithAllData.enclosure.length}" type="${web1FeedEntryWithAllData.enclosure.type}"/></entry></feed>`;
+// biome-ignore format: keep in one line
+const validXmlWithCustomDataResult = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/"><title><![CDATA[${title}]]></title><subtitle><![CDATA[${subtitle}]]></subtitle><link href="${site}/" /><entry><title><![CDATA[${phpFeedEntryWithCustomData.title}]]></title><link href="${site}${phpFeedEntryWithCustomData.link}/" /><id>${site}${phpFeedEntryWithCustomData.link}/</id><summary><![CDATA[${phpFeedEntryWithCustomData.summary}]]></summary><updated>${new Date(phpFeedEntryWithCustomData.updated).toUTCString()}</updated>${phpFeedEntryWithCustomData.customData}</entry><entry><title><![CDATA[${web1FeedEntryWithContent.title}]]></title><link href="${site}${web1FeedEntryWithContent.link}/" /><id>${site}${web1FeedEntryWithContent.link}/</id><summary><![CDATA[${web1FeedEntryWithContent.summary}]]></summary><updated>${new Date(web1FeedEntryWithContent.updated).toUTCString()}</updated><content type="html"><![CDATA[${web1FeedEntryWithContent.content}]]></content></entry></feed>`;
+// biome-ignore format: keep in one line
+const validXmlWithStylesheet = `<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet href="/feedstylesheet.css"?><feed xmlns="http://www.w3.org/2005/Atom"><title><![CDATA[${title}]]></title><subtitle><![CDATA[${subtitle}]]></subtitle><link href="${site}/" /></feed>`;
+// biome-ignore format: keep in one line
+const validXmlWithXSLStylesheet = `<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet href="/feedstylesheet.xsl" type="text/xsl"?><feed xmlns="http://www.w3.org/2005/Atom"><title><![CDATA[${title}]]></title><subtitle><![CDATA[${subtitle}]]></subtitle><link href="${site}/" /></feed>`;
+
+function assertXmlDeepEqual(a, b) {
+	const parsedA = parseXmlString(a);
+	const parsedB = parseXmlString(b);
+
+	assert.equal(parsedA.err, null);
+	assert.equal(parsedB.err, null);
+	assert.deepEqual(parsedA.result, parsedB.result);
+}
+
+describe('atom', () => {
+	it('should return a response', async () => {
+		const response = await atom({
+			title,
+			subtitle,
+			entries: [phpFeedEntry, web1FeedEntry],
+			site,
+		});
+
+		const str = await response.text();
+
+		// NOTE: Chai used the below parser to perform the tests, but I have omitted it for now.
+		// parser = new xml2js.Parser({ trim: flag(this, 'deep') });
+
+		assertXmlDeepEqual(str, validXmlResult);
+
+		const contentType = response.headers.get('Content-Type');
+		assert.equal(contentType, 'application/xml');
+	});
+
+	it('should be the same string as getAtomString', async () => {
+		const options = {
+			title,
+			subtitle,
+			entries: [phpFeedEntry, web1FeedEntry],
+			site,
+		};
+
+		const response = await atom(options);
+		const str1 = await response.text();
+		const str2 = await getAtomString(options);
+
+		assert.equal(str1, str2);
+	});
+});
+
+describe('getAtomString', () => {
+	it('should generate on valid AtomFeedEntry array', async () => {
+		const str = await getAtomString({
+			title,
+			subtitle,
+			entries: [phpFeedEntry, web1FeedEntry],
+			site,
+		});
+
+		assertXmlDeepEqual(str, validXmlResult);
+	});
+
+	it('should generate on valid AtomFeedEntry array with HTML content included', async () => {
+		const str = await getAtomString({
+			title,
+			subtitle,
+			entries: [phpFeedEntryWithContent, web1FeedEntryWithContent],
+			site,
+		});
+
+		assertXmlDeepEqual(str, validXmlWithContentResult);
+	});
+
+	it('should generate on valid AtomFeedEntry array with all Atom content included', async () => {
+		const str = await getAtomString({
+			title,
+			subtitle,
+			entries: [phpFeedEntry, web1FeedEntryWithAllData],
+			site,
+		});
+
+		assertXmlDeepEqual(str, validXmlResultWithAllData);
+	});
+
+	it('should generate on valid AtomFeedEntry array with custom data included', async () => {
+		const str = await getAtomString({
+			xmlns: {
+				dc: 'http://purl.org/dc/elements/1.1/',
+			},
+			title,
+			subtitle,
+			entries: [phpFeedEntryWithCustomData, web1FeedEntryWithContent],
+			site,
+		});
+
+		assertXmlDeepEqual(str, validXmlWithCustomDataResult);
+	});
+
+	it('should include xml-stylesheet instruction when stylesheet is defined', async () => {
+		const str = await getAtomString({
+			title,
+			subtitle,
+			entries: [],
+			site,
+			stylesheet: '/feedstylesheet.css',
+		});
+
+		assertXmlDeepEqual(str, validXmlWithStylesheet);
+	});
+
+	it('should include xml-stylesheet instruction with xsl type when stylesheet is set to xsl file', async () => {
+		const str = await getAtomString({
+			title,
+			subtitle,
+			entries: [],
+			site,
+			stylesheet: '/feedstylesheet.xsl',
+		});
+
+		assertXmlDeepEqual(str, validXmlWithXSLStylesheet);
+	});
+
+	it('should preserve self-closing tags on `customData`', async () => {
+		const customData =
+			'<atom:link href="https://example.com/feed.xml" rel="self" type="application/rss+xml"/>';
+		const str = await getAtomString({
+			title,
+			subtitle,
+			entries: [],
+			site,
+			xmlns: {
+				atom: 'http://www.w3.org/2005/Atom',
+			},
+			customData,
+		});
+
+		assert.ok(str.includes(customData));
+	});
+
+	it('should not append trailing slash to URLs with the given option', async () => {
+		const str = await getAtomString({
+			title,
+			subtitle,
+			entries: [phpFeedEntry],
+			site,
+			trailingSlash: false,
+		});
+
+		assert.ok(str.includes('https://example.com/"'));
+		assert.ok(str.includes('https://example.com/php"'));
+	});
+
+	// it('Deprecated import.meta.glob mapping still works', async () => {
+	// 	const globResult = {
+	// 		'./posts/php.md': () =>
+	// 			new Promise((resolve) =>
+	// 				resolve({
+	// 					url: phpFeedEntry.link,
+	// 					frontmatter: {
+	// 						title: phpFeedEntry.title,
+	// 						updated: phpFeedEntry.updated,
+	// 						summary: phpFeedEntry.summary,
+	// 					},
+	// 				})
+	// 			),
+	// 		'./posts/nested/web1.md': () =>
+	// 			new Promise((resolve) =>
+	// 				resolve({
+	// 					url: web1FeedEntry.link,
+	// 					frontmatter: {
+	// 						title: web1FeedEntry.title,
+	// 						updated: web1FeedEntry.updated,
+	// 						summary: web1FeedEntry.summary,
+	// 					},
+	// 				})
+	// 			),
+	// 	};
+
+	// 	const str = await getAtomString({
+	// 		title,
+	// 		summary,
+	// 		entries: globResult,
+	// 		site,
+	// 	});
+
+	// 	assertXmlDeepEqual(str, validXmlResult);
+	// });
+
+	it('should fail when an invalid date string is provided', async () => {
+		const res = atomSchema.safeParse({
+			title: phpFeedEntry.title,
+			updated: 'invalid date',
+			summary: phpFeedEntry.summary,
+			link: phpFeedEntry.link,
+		});
+
+		assert.equal(res.success, false);
+		assert.equal(res.error.issues[0].path[0], 'updated');
+	});
+
+	it('should be extendable', () => {
+		let error = null;
+		try {
+			atomSchema.extend({
+				category: z.string().optional(),
+			});
+		} catch (e) {
+			error = e.message;
+		}
+		assert.equal(error, null);
+	});
+
+	it('should not fail when an enclosure has a length of 0', async () => {
+		let error = null;
+		try {
+			await getAtomString({
+				title,
+				summary: subtitle,
+				entries: [
+					{
+						title: 'Title',
+						updated: new Date().toISOString(),
+						summary: 'Description',
+						link: '/link',
+						enclosure: {
+							url: '/enclosure',
+							length: 0,
+							type: 'audio/mpeg',
+						},
+					},
+				],
+				site,
+			});
+		} catch (e) {
+			error = e.message;
+		}
+
+		assert.equal(error, null);
+	});
+});

--- a/packages/astro-atom/test/test-utils.js
+++ b/packages/astro-atom/test/test-utils.js
@@ -1,0 +1,69 @@
+import xml2js from 'xml2js';
+
+export const title = 'My Atom feed';
+export const subtitle = 'This sure is a nice Atom feed';
+export const site = 'https://example.com';
+
+export const phpFeedEntry = {
+	link: '/php',
+	title: 'Remember PHP?',
+	updated: '1994-05-03',
+	summary:
+		'PHP is a general-purpose scripting language geared toward web development. It was originally created by Danish-Canadian programmer Rasmus Lerdorf in 1994.',
+};
+export const phpFeedEntryWithContent = {
+	...phpFeedEntry,
+	content: `<h1>${phpFeedEntry.title}</h1><p>${phpFeedEntry.summary}</p>`,
+};
+export const phpFeedEntryWithCustomData = {
+	...phpFeedEntry,
+	customData: '<dc:creator><![CDATA[Buster Bluth]]></dc:creator>',
+};
+
+export const web1FeedEntry = {
+	// Should support empty string as a URL (possible for homepage route)
+	link: '',
+	title: 'Web 1.0',
+	updated: '1997-05-03',
+	summary:
+		'Web 1.0 is the term used for the earliest version of the Internet as it emerged from its origins with Defense Advanced Research Projects Agency (DARPA) and became, for the first time, a global network representing the future of digital communications.',
+};
+export const web1FeedEntryWithContent = {
+	...web1FeedEntry,
+	content: `<h1>${web1FeedEntry.title}</h1><p>${web1FeedEntry.summary}</p>`,
+};
+export const web1FeedEntryWithAllData = {
+	...web1FeedEntry,
+	categories: ['web1', 'history'],
+	author: {
+		name: 'test',
+		email: 'test@example.com'
+	},
+	// commentsUrl: 'http://example.com/comments',
+	source: {
+		url: 'http://example.com/source',
+		title: 'The Web 1.0 blog',
+	},
+	enclosure: {
+		url: '/podcast.mp3',
+		length: 256,
+		type: 'audio/mpeg',
+	},
+};
+
+const parser = new xml2js.Parser({ trim: true });
+
+/**
+ *
+ * Utility function to parse an XML string into an object using `xml2js`.
+ *
+ * @param {string} xmlString - Stringified XML to parse.
+ * @return {{ err: Error, result: any }} Represents an option containing the parsed XML string or an Error.
+ */
+export function parseXmlString(xmlString) {
+	let res;
+	parser.parseString(xmlString, (err, result) => {
+		res = { err, result };
+	});
+	return res;
+}

--- a/packages/astro-atom/tsconfig.json
+++ b/packages/astro-atom/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -812,6 +812,28 @@ importers:
         specifier: ^11.0.4
         version: 11.0.4
 
+  packages/astro-atom:
+    dependencies:
+      fast-xml-parser:
+        specifier: ^4.2.7
+        version: 4.3.6
+      kleur:
+        specifier: ^4.1.5
+        version: 4.1.5
+    devDependencies:
+      '@types/xml2js':
+        specifier: ^0.4.14
+        version: 0.4.14
+      astro:
+        specifier: workspace:*
+        version: link:../astro
+      astro-scripts:
+        specifier: workspace:*
+        version: link:../../scripts
+      xml2js:
+        specifier: 0.6.2
+        version: 0.6.2
+
   packages/astro-prism:
     dependencies:
       prismjs:


### PR DESCRIPTION
## Changes

<!-- - What does this change? -->
<!-- - Be short and concise. Bullet points can help! -->
<!-- - Before/after screenshots can help as well. -->
<!-- - Don't forget a changeset! `pnpm exec changeset` -->

- Add a new package `astro-atom` that works like `astro-rss` to generate Atom 1.0 feed (aka. [RFC 4287])
- Deprecated "Passing a glob result directly" is not added
- Atom-specified attributes are not added, but the attribute names are changed to fit the ones in Atom feed. Maybe need to add a transformer for the two attribute sets.

[RFC 4287]: https://datatracker.ietf.org/doc/html/rfc4287

Related #1657, #1113, [proposals/0020-api-route-signature] (mentioned)

[proposals/0020-api-route-signature]: https://github.com/withastro/roadmap/blob/258ea61882e788ba4ad3edf0445053aec5910f1c/proposals/0020-api-route-signature.md?plain=1#L30

I am not sure if a new proposal is required for this new package, since it expands the code base to be managed.
Anyway, I will first finish the left parts shown below to make this a complete work.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

- Tests like the ones in `astro-rss` are added correspondingly, except the ones in `pagesGlobToRssItems.test.js`. To add the later ones soon.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

To be added soon, and it should be mostly similar to the one in `astro-rss`