### PR TITLE
revert handling of JavaScript animations during view transitions

### DIFF
--- a/.changeset/weak-swans-sparkle.md
+++ b/.changeset/weak-swans-sparkle.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Due to regression on mobile webkit browsers, reverts a change made for JavaScript animations during view transitions.
+Due to regression on mobile WebKit browsers, reverts a change made for JavaScript animations during view transitions.

--- a/.changeset/weak-swans-sparkle.md
+++ b/.changeset/weak-swans-sparkle.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Due to regression on mobile webkit browsers, reverts a change made for JavaScript animations during view transitions.

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -397,8 +397,6 @@ async function updateDOM(
 			return style.animationIterationCount === 'infinite';
 		}
 		const currentAnimations = document.getAnimations();
-		// allow animations triggered by viewTransition.ready to start
-		await new Promise<void>((r) => setTimeout(r));
 		// Trigger view transition animations waiting for data-astro-transition-fallback
 		document.documentElement.setAttribute(OLD_NEW_ATTR, phase);
 		const nextAnimations = document.getAnimations();


### PR DESCRIPTION
## Changes

This is edge-case-land of Astro's view transition simulation when you do not use CSS only but also want to combine it with JavaScript animations.
 
While #10787 worked fine for Firefox on desktops, it introduced a regression on mobile WebKit browsers. 

https://github.com/withastro/astro/assets/94928215/afc58325-3fde-48a7-9581-5f53f625924f

The blinking screen in the middle of the animation is a result of un-animated rendering before the animation kicks in. Reverting #10787 fixes this.

As an afterthought, it would have been better to switch micro tasks instead of yielding to the tasks queue. But after consulting the spec again (https://drafts.csswg.org/css-view-transitions-1/), I'm not sure whether this goes into the right direction. In browsers with native view transition support 
`viewTransition.finished` would not wait for arbitrary animations triggered by `viewTransition.ready`.

It would only include animations that depend on the view transition pseudo elements. Translated to Astro that would mean only animations that depend on `data-astro-transition*` attributes. This thinking leads to a straight forward solution for JavaScript animations:
If you want to delay `finished` in Astro's view transition simulation for a JavaScript animation triggered by ready, add a noop animation that is triggered by `data-astro-transition-fallback="new"`. This will automatically be covered by `fallback="animate"`. 

```
<style is:global>
    /* Example: For Astro's view transition simulation, 
       ensure that `viewTransition.finished` happens 
       at least 1.5s after `viewTransition.ready` */ 
    @keyframes noop {}
    :root[data-astro-transition-fallback="new"] {animation: noop 0s 1.5s}
</style>
```

## Testing

No automated tests as this only shows on browsers which we do not include in our e2e tests.

After removing the round trip through the task queue, the transition looks smooth again. The noop CSS animation shown above was used to fix the original issue faced in #10787 

https://github.com/withastro/astro/assets/94928215/bccc8cf7-f2ac-4e83-90a4-d772a6c66375


## Docs

n.a. / Bug fix
