### PR TITLE
fix: allow redoc to render on react components

### DIFF
--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -82,7 +82,6 @@ function getViteConfiguration({
 				'@mui/material',
 				'@mui/base',
 				'@babel/runtime',
-				'redoc',
 				'use-immer',
 				'@material-tailwind/react',
 			],


### PR DESCRIPTION
## Changes

Removed `redoc` from `noExternal`. Closes https://github.com/withastro/astro/issues/10815.

## Testing

Exisiting should pass

## Docs

N/A
