### PR TITLE
Prevents inputs from changing ViewTransitions' form method or action

### DIFF
--- a/.changeset/tasty-swans-refuse.md
+++ b/.changeset/tasty-swans-refuse.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Prevents inputs with a name attribute of action or method to break ViewTransitions' form submission

--- a/packages/astro/components/ViewTransitions.astro
+++ b/packages/astro/components/ViewTransitions.astro
@@ -108,9 +108,16 @@ const { fallback = 'animate' } = Astro.props;
 			const form = el as HTMLFormElement;
 			const submitter = ev.submitter;
 			const formData = new FormData(form, submitter);
+			// form.action and form.method can point to an <input name="action"> or <input name="method">
+			// in which case should fallback to the form attribute
+			const formAction =
+				typeof form.action === 'string' ? form.action : form.getAttribute('action');
+			const formmethod =
+				typeof form.method === 'string' ? form.method : form.getAttribute('method');
 			// Use the form action, if defined, otherwise fallback to current path.
-			let action = submitter?.getAttribute('formaction') ?? form.action ?? location.pathname;
-			const method = submitter?.getAttribute('formmethod') ?? form.method;
+			let action = submitter?.getAttribute('formaction') ?? formAction ?? location.pathname;
+			// Use the form method, if defined, otherwise fallback to "get"
+			const method = submitter?.getAttribute('formmethod') ?? formmethod ?? 'get';
 
 			// the "dialog" method is a special keyword used within <dialog> elements
 			// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/form-seven.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/form-seven.astro
@@ -1,0 +1,11 @@
+---
+import Layout from '../components/Layout.astro';
+
+---
+<Layout>
+	<form>
+		<p>This form has an no method defined, but input with `name=method`</p>
+		<input type="text" name="method" value="POST" />
+		<button id="submit">Submit</button>
+	</form>
+</Layout>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/form-six.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/form-six.astro
@@ -1,0 +1,11 @@
+---
+import Layout from '../components/Layout.astro';
+
+---
+<Layout>
+	<form method="POST" action="bar">
+		<p>This form has an input with `name=action`</p>
+		<input type="text" name="action" value="foo" />
+		<button id="submit">Submit</button>
+	</form>
+</Layout>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -1168,6 +1168,25 @@ test.describe('View Transitions', () => {
 		).toEqual(['application/x-www-form-urlencoded']);
 	});
 
+
+	test('form POST that includes an input with name action should not override action', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/form-six'));
+		page.on('request', (request) => {
+			expect(request.url()).toContain('/bar')
+		});
+		// Submit the form
+		await page.click('#submit');
+	});
+
+	test('form without method that includes an input with name method should not override default method', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/form-seven'));
+		page.on('request', (request) => {
+			expect(request.method()).toBe('GET')
+		});
+		// Submit the form
+		await page.click('#submit');
+	});
+
 	test('Route announcer is invisible on page transition', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/no-directive-one'));
 


### PR DESCRIPTION

## Changes

Fixes #10849. Prevents inputs with a name attribute of action or method to break ViewTransitions' form submission

### Before
```html
<form action="foo">
 <input name="action" value="bar">
</form>
```
Submission would result in a broken route `GET /[object%20HTMLInputElement]` since `form.action` now points to an HTML element.

### After
Form submission handler tests action to be a string, and if not reads the action using `form.getAttribute`

## Testing

- Added two additional e2e tests of scenarios that would break without this fix.
- Existing tests enhanced my fix to have more rigorous checking of attributes
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

No docs changed needed

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
