### PR TITLE
Fix an issue where `astro build` writes type declaration files to `outDir`

### DIFF
--- a/.changeset/curvy-humans-judge.md
+++ b/.changeset/curvy-humans-judge.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes an issue where `astro build` writes type declaration files to `outDir` when it's outside of root directory.

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -442,6 +442,13 @@ async function cleanServerOutput(
 
 	// Clean out directly if the outDir is outside of root
 	if (out.toString() !== opts.settings.config.outDir.toString()) {
+		// Remove .d.ts files
+		const fileNames = await fs.promises.readdir(out);
+		await Promise.all(
+			fileNames
+				.filter((fileName) => fileName.endsWith('.d.ts'))
+				.map((fileName) => fs.promises.rm(new URL(fileName, out)))
+		);
 		// Copy assets before cleaning directory if outside root
 		await copyFiles(out, opts.settings.config.outDir, true);
 		await fs.promises.rm(out, { recursive: true });


### PR DESCRIPTION
## Changes

- Fixes an issue where `astro build` writes type declaration files to `outDir` when it's outside of root directory
- Closes #10610

## Testing

- Manually tested with the [minimal reproduction repo](https://github.com/m-radzikowski/astro-issue-10610)

## Docs

- N/A