### PR TITLE
Tag MDX component for faster checks when rendering

### DIFF
--- a/.changeset/chilly-items-help.md
+++ b/.changeset/chilly-items-help.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Improves the error message when failed to render MDX components

--- a/.changeset/tame-avocados-relax.md
+++ b/.changeset/tame-avocados-relax.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/mdx": patch
+---
+
+Tags the MDX component export for quicker component checks while rendering

--- a/packages/integrations/mdx/src/vite-plugin-mdx-postprocess.ts
+++ b/packages/integrations/mdx/src/vite-plugin-mdx-postprocess.ts
@@ -8,11 +8,14 @@ import {
 } from './remark-images-to-component.js';
 import { type FileInfo, getFileInfo } from './utils.js';
 
+const fragmentImportRegex = /[\s,{]Fragment[\s,}]/;
+const astroTagComponentImportRegex = /[\s,{]__astro_tag_component__[\s,}]/;
+
 // These transforms must happen *after* JSX runtime transformations
 export function vitePluginMdxPostprocess(astroConfig: AstroConfig): Plugin {
 	return {
 		name: '@astrojs/mdx-postprocess',
-		transform(code, id) {
+		transform(code, id, opts) {
 			if (!id.endsWith('.mdx')) return;
 
 			const fileInfo = getFileInfo(id, astroConfig);
@@ -22,7 +25,7 @@ export function vitePluginMdxPostprocess(astroConfig: AstroConfig): Plugin {
 			code = injectFragmentImport(code, imports);
 			code = injectMetadataExports(code, exports, fileInfo);
 			code = transformContentExport(code, exports);
-			code = annotateContentExport(code, id);
+			code = annotateContentExport(code, id, !!opts?.ssr, imports);
 
 			// The code transformations above are append-only, so the line/column mappings are the same
 			// and we can omit the sourcemap for performance.
@@ -31,23 +34,12 @@ export function vitePluginMdxPostprocess(astroConfig: AstroConfig): Plugin {
 	};
 }
 
-const fragmentImportRegex = /[\s,{](?:Fragment,|Fragment\s*\})/;
-
 /**
- * Inject `Fragment` identifier import if not already present. It should already be injected,
- * but check just to be safe.
- *
- * TODO: Double-check if we no longer need this function.
+ * Inject `Fragment` identifier import if not already present.
  */
 function injectFragmentImport(code: string, imports: readonly ImportSpecifier[]) {
-	const importsFromJSXRuntime = imports
-		.filter(({ n }) => n === 'astro/jsx-runtime')
-		.map(({ ss, se }) => code.substring(ss, se));
-	const hasFragmentImport = importsFromJSXRuntime.some((statement) =>
-		fragmentImportRegex.test(statement)
-	);
-	if (!hasFragmentImport) {
-		code = `import { Fragment } from "astro/jsx-runtime"\n` + code;
+	if (!isSpecifierImported(code, imports, fragmentImportRegex, 'astro/jsx-runtime')) {
+		code += `\nimport { Fragment } from 'astro/jsx-runtime';`;
 	}
 	return code;
 }
@@ -103,7 +95,12 @@ export default Content;`;
 /**
  * Add properties to the `Content` export.
  */
-function annotateContentExport(code: string, id: string) {
+function annotateContentExport(
+	code: string,
+	id: string,
+	ssr: boolean,
+	imports: readonly ImportSpecifier[]
+) {
 	// Mark `Content` as MDX component
 	code += `\nContent[Symbol.for('mdx-component')] = true`;
 	// Ensure styles and scripts are injected into a `<head>` when a layout is not applied
@@ -111,5 +108,39 @@ function annotateContentExport(code: string, id: string) {
 	// Assign the `moduleId` metadata to `Content`
 	code += `\nContent.moduleId = ${JSON.stringify(id)};`;
 
+	// Tag the `Content` export as "astro:jsx" so it's quicker to identify how to render this component
+	if (ssr) {
+		if (
+			!isSpecifierImported(
+				code,
+				imports,
+				astroTagComponentImportRegex,
+				'astro/runtime/server/index.js'
+			)
+		) {
+			code += `\nimport { __astro_tag_component__ } from 'astro/runtime/server/index.js';`;
+		}
+		code += `\n__astro_tag_component__(Content, 'astro:jsx');`;
+	}
+
 	return code;
+}
+
+/**
+ * Check whether the `specifierRegex` matches for an import of `source` in the `code`.
+ */
+function isSpecifierImported(
+	code: string,
+	imports: readonly ImportSpecifier[],
+	specifierRegex: RegExp,
+	source: string
+) {
+	for (const imp of imports) {
+		if (imp.n !== source) continue;
+
+		const importStatement = code.slice(imp.ss, imp.se);
+		if (specifierRegex.test(importStatement)) return true;
+	}
+
+	return false;
 }


### PR DESCRIPTION
## Changes

> Merges into the `mdx-v3` branch. Technically this is non-breaking, but it's easier to merge here to prevent new releases for `@astrojs/mdx`.

This PR does two things:
1. Inject `__astro_tag_component__(Content, 'astro:jsx')` so that we can render MDX components faster. No need to call `check()` to test if it's `astro:jsx` as we already tagged it.
2. Add enhanced error handling for `astro:jsx` `renderToStaticMarkup()`. Because of the above, `check()` wasn't enhancing the error anymore, which failed [a test](https://github.com/withastro/astro/blob/f513ba602c9d9bc2f1984bf994381d30cdea6a0d/packages/integrations/mdx/test/invalid-mdx-component.test.js#L31-L37).

Performance:

I tested this in the docs repo but there isn't any significant improvements nor regressions, so this would be harmless. Part of the reason I added this is to port a faster version of https://github.com/withastro/astro/blob/main/packages/astro/src/vite-plugin-mdx/tag.ts.

## Testing

Existing tests should pass. 

## Docs

Added changesets about the improved error message, but otherwise this shouldn't have a significant impact on normal usage.
