### PR TITLE
Remove fs read for MDX transform

### DIFF
--- a/.changeset/large-glasses-jam.md
+++ b/.changeset/large-glasses-jam.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/mdx": patch
+---
+
+Allows Vite plugins to transform `.mdx` files before the MDX plugin transforms it

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -70,7 +70,7 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 
 				updateConfig({
 					vite: {
-						plugins: [vitePluginMdx(config, mdxOptions), vitePluginMdxPostprocess(config)],
+						plugins: [vitePluginMdx(mdxOptions), vitePluginMdxPostprocess(config)],
 					},
 				});
 			},


### PR DESCRIPTION
## Changes

> Merges into `mdx-v3` branch

When transforming MDX, we can use the code from the `transform()` hook directly. The `import.meta.env` issue is no longer a problem as Vite and Astro had refactored how the replacements are done.

## Testing

Existing tests should pass.

## Docs

n/a. internal change.
