### PR TITLE
Use unified plugin only for MDX transform

### DIFF
--- a/.changeset/fresh-masks-agree.md
+++ b/.changeset/fresh-masks-agree.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/mdx": major
+---
+
+Refactors the MDX transformation to rely only on the unified pipeline. Babel and esbuild transformations are removed, which should result in faster build times. The refactor requires using Astro v4.8.0 but no other changes are necessary.

--- a/.changeset/friendly-plants-leave.md
+++ b/.changeset/friendly-plants-leave.md
@@ -1,0 +1,5 @@
+---
+"astro": minor
+---
+
+Exports `astro/jsx/rehype.js` with utilities to generate an Astro metadata object

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -208,6 +208,8 @@
     "astro-scripts": "workspace:*",
     "cheerio": "1.0.0-rc.12",
     "eol": "^0.9.1",
+    "mdast-util-mdx": "^3.0.0",
+    "mdast-util-mdx-jsx": "^3.1.2",
     "memfs": "^4.8.2",
     "node-mocks-http": "^1.14.1",
     "parse-srcset": "^1.0.2",

--- a/packages/astro/src/jsx/babel.ts
+++ b/packages/astro/src/jsx/babel.ts
@@ -134,6 +134,9 @@ function addClientOnlyMetadata(
 	}
 }
 
+/**
+ * @deprecated This plugin is no longer used. Remove in Astro 5.0
+ */
 export default function astroJSX(): PluginObj {
 	return {
 		visitor: {

--- a/packages/astro/src/jsx/rehype.ts
+++ b/packages/astro/src/jsx/rehype.ts
@@ -1,0 +1,237 @@
+import type { RehypePlugin } from '@astrojs/markdown-remark';
+import type { RootContent } from 'hast';
+import type { MdxJsxFlowElementHast, MdxJsxTextElementHast } from 'mdast-util-mdx-jsx';
+import { visit } from 'unist-util-visit';
+import type { VFile } from 'vfile';
+import { AstroError } from '../core/errors/errors.js';
+import { AstroErrorData } from '../core/errors/index.js';
+import { resolvePath } from '../core/util.js';
+import type { PluginMetadata } from '../vite-plugin-astro/types.js';
+
+// This import includes ambient types for hast to include mdx nodes
+import type {} from 'mdast-util-mdx';
+
+const ClientOnlyPlaceholder = 'astro-client-only';
+
+export const rehypeAnalyzeAstroMetadata: RehypePlugin = () => {
+	return (tree, file) => {
+		// Initial metadata for this MDX file, it will be mutated as we traverse the tree
+		const metadata: PluginMetadata['astro'] = {
+			clientOnlyComponents: [],
+			hydratedComponents: [],
+			scripts: [],
+			containsHead: false,
+			propagation: 'none',
+			pageOptions: {},
+		};
+
+		// Parse imports in this file. This is used to match components with their import source
+		const imports = parseImports(tree.children);
+
+		visit(tree, (node) => {
+			if (node.type !== 'mdxJsxFlowElement' && node.type !== 'mdxJsxTextElement') return;
+
+			const tagName = node.name;
+			if (!tagName || !isComponent(tagName) || !hasClientDirective(node)) return;
+
+			// From this point onwards, `node` is confirmed to be an island component
+
+			// Match this component with its import source
+			const matchedImport = findMatchingImport(tagName, imports);
+			if (!matchedImport) {
+				throw new AstroError({
+					...AstroErrorData.NoMatchingImport,
+					message: AstroErrorData.NoMatchingImport.message(node.name!),
+				});
+			}
+
+			const resolvedPath = resolvePath(matchedImport.path, file.path);
+
+			if (hasClientOnlyDirective(node)) {
+				// Add this component to the metadata
+				metadata.clientOnlyComponents.push({
+					exportName: matchedImport.name,
+					specifier: tagName,
+					resolvedPath,
+				});
+				// Mutate node with additional island attributes
+				addClientOnlyMetadata(node, matchedImport, resolvedPath);
+			} else {
+				// Add this component to the metadata
+				metadata.hydratedComponents.push({
+					exportName: '*',
+					specifier: tagName,
+					resolvedPath,
+				});
+				// Mutate node with additional island attributes
+				addClientMetadata(node, matchedImport, resolvedPath);
+			}
+		});
+
+		file.data.__astroMetadata = metadata;
+	};
+};
+
+export function getAstroMetadata(file: VFile) {
+	return file.data.__astroMetadata as PluginMetadata['astro'] | undefined;
+}
+
+type ImportSpecifier = { local: string; imported: string };
+
+function parseImports(children: RootContent[]) {
+	// Map of import source to its imported specifiers
+	const imports = new Map<string, Set<ImportSpecifier>>();
+
+	for (const child of children) {
+		if (child.type !== 'mdxjsEsm') continue;
+
+		const body = child.data?.estree?.body;
+		if (!body) continue;
+
+		for (const ast of body) {
+			if (ast.type !== 'ImportDeclaration') continue;
+
+			const source = ast.source.value as string;
+			const specs: ImportSpecifier[] = ast.specifiers.map((spec) => {
+				switch (spec.type) {
+					case 'ImportDefaultSpecifier':
+						return { local: spec.local.name, imported: 'default' };
+					case 'ImportNamespaceSpecifier':
+						return { local: spec.local.name, imported: '*' };
+					case 'ImportSpecifier':
+						return { local: spec.local.name, imported: spec.imported.name };
+					default:
+						throw new Error('Unknown import declaration specifier: ' + spec);
+				}
+			});
+
+			// Get specifiers set from source or initialize a new one
+			let specSet = imports.get(source);
+			if (!specSet) {
+				specSet = new Set();
+				imports.set(source, specSet);
+			}
+
+			for (const spec of specs) {
+				specSet.add(spec);
+			}
+		}
+	}
+
+	return imports;
+}
+
+function isComponent(tagName: string) {
+	return (
+		(tagName[0] && tagName[0].toLowerCase() !== tagName[0]) ||
+		tagName.includes('.') ||
+		/[^a-zA-Z]/.test(tagName[0])
+	);
+}
+
+function hasClientDirective(node: MdxJsxFlowElementHast | MdxJsxTextElementHast) {
+	return node.attributes.some(
+		(attr) => attr.type === 'mdxJsxAttribute' && attr.name.startsWith('client:')
+	);
+}
+
+function hasClientOnlyDirective(node: MdxJsxFlowElementHast | MdxJsxTextElementHast) {
+	return node.attributes.some(
+		(attr) => attr.type === 'mdxJsxAttribute' && attr.name === 'client:only'
+	);
+}
+
+type MatchedImport = { name: string; path: string };
+
+function findMatchingImport(
+	tagName: string,
+	imports: Map<string, Set<ImportSpecifier>>
+): MatchedImport | undefined {
+	const tagSpecifier = tagName.split('.')[0];
+	for (const [source, specs] of imports) {
+		for (const { imported, local } of specs) {
+			if (local === tagSpecifier) {
+				return { name: imported === '*' ? imported : tagName, path: source };
+			}
+		}
+	}
+}
+
+function addClientMetadata(
+	node: MdxJsxFlowElementHast | MdxJsxTextElementHast,
+	meta: MatchedImport,
+	resolvedPath: string
+) {
+	const attributeNames = node.attributes
+		.map((attr) => (attr.type === 'mdxJsxAttribute' ? attr.name : null))
+		.filter(Boolean);
+
+	if (!attributeNames.includes('client:component-path')) {
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'client:component-path',
+			value: resolvedPath,
+		});
+	}
+	if (!attributeNames.includes('client:component-export')) {
+		if (meta.name === '*') {
+			meta.name = node.name!.split('.').slice(1).join('.')!;
+		}
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'client:component-export',
+			value: meta.name,
+		});
+	}
+	if (!attributeNames.includes('client:component-hydration')) {
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'client:component-hydration',
+			value: null,
+		});
+	}
+}
+
+function addClientOnlyMetadata(
+	node: MdxJsxFlowElementHast | MdxJsxTextElementHast,
+	meta: { path: string; name: string },
+	resolvedPath: string
+) {
+	const attributeNames = node.attributes
+		.map((attr) => (attr.type === 'mdxJsxAttribute' ? attr.name : null))
+		.filter(Boolean);
+
+	if (!attributeNames.includes('client:display-name')) {
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'client:display-name',
+			value: node.name,
+		});
+	}
+	if (!attributeNames.includes('client:component-hydpathation')) {
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'client:component-path',
+			value: resolvedPath,
+		});
+	}
+	if (!attributeNames.includes('client:component-export')) {
+		if (meta.name === '*') {
+			meta.name = node.name!.split('.').slice(1).join('.')!;
+		}
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'client:component-export',
+			value: meta.name,
+		});
+	}
+	if (!attributeNames.includes('client:component-hydration')) {
+		node.attributes.push({
+			type: 'mdxJsxAttribute',
+			name: 'client:component-hydration',
+			value: null,
+		});
+	}
+
+	node.name = ClientOnlyPlaceholder;
+}

--- a/packages/astro/src/jsx/transform-options.ts
+++ b/packages/astro/src/jsx/transform-options.ts
@@ -1,5 +1,8 @@
 import type { JSXTransformConfig } from '../@types/astro.js';
 
+/**
+ * @deprecated This function is no longer used. Remove in Astro 5.0
+ */
 export async function jsxTransformOptions(): Promise<JSXTransformConfig> {
 	// @ts-expect-error types not found
 	const plugin = await import('@babel/plugin-transform-react-jsx');

--- a/packages/astro/src/vite-plugin-mdx/index.ts
+++ b/packages/astro/src/vite-plugin-mdx/index.ts
@@ -9,7 +9,9 @@ const SPECIAL_QUERY_REGEX = new RegExp(
 	`[?&](?:worker|sharedworker|raw|url|${CONTENT_FLAG}|${PROPAGATED_ASSET_FLAG})\\b`
 );
 
-// TODO: Move this Vite plugin into `@astrojs/mdx` in Astro 5
+/**
+ * @deprecated This plugin is no longer used. Remove in Astro 5.0
+ */
 export default function mdxVitePlugin(): Plugin {
 	return {
 		name: 'astro:jsx',

--- a/packages/astro/src/vite-plugin-mdx/tag.ts
+++ b/packages/astro/src/vite-plugin-mdx/tag.ts
@@ -11,6 +11,8 @@ const rendererName = astroJsxRenderer.name;
  *
  * This plugin crawls each export in the file and "tags" each export with a given `rendererName`.
  * This allows us to automatically match a component to a renderer and skip the usual `check()` calls.
+ * 
+ * @deprecated This plugin is no longer used. Remove in Astro 5.0
  */
 export const tagExportsPlugin: PluginObj = {
 	visitor: {

--- a/packages/astro/src/vite-plugin-mdx/transform-jsx.ts
+++ b/packages/astro/src/vite-plugin-mdx/transform-jsx.ts
@@ -5,6 +5,9 @@ import { jsxTransformOptions } from '../jsx/transform-options.js';
 import type { PluginMetadata } from '../vite-plugin-astro/types.js';
 import { tagExportsPlugin } from './tag.js';
 
+/**
+ * @deprecated This function is no longer used. Remove in Astro 5.0
+ */
 export async function transformJSX(
 	code: string,
 	id: string,

--- a/packages/astro/test/units/dev/collections-renderentry.test.js
+++ b/packages/astro/test/units/dev/collections-renderentry.test.js
@@ -84,18 +84,6 @@ _describe('Content Collections - render()', () => {
 	it('can be used in a layout component', async () => {
 		const fs = createFsWithFallback(
 			{
-				// Loading the content config with `astro:content` oddly
-				// causes this test to fail. Spoof a different src/content entry
-				// to ensure `existsSync` checks pass.
-				// TODO: revisit after addressing this issue
-				// https://github.com/withastro/astro/issues/6121
-				'/src/content/blog/promo/launch-week.mdx': `---
-title: Launch Week
-description: Astro is launching this week!
----
-# Launch Week
-- [x] Launch Astro
-- [ ] Celebrate`,
 				'/src/components/Layout.astro': `
 					---
 					import { getCollection } from 'astro:content';

--- a/packages/integrations/mdx/src/plugins.ts
+++ b/packages/integrations/mdx/src/plugins.ts
@@ -5,6 +5,7 @@ import {
 	remarkCollectImages,
 } from '@astrojs/markdown-remark';
 import { createProcessor, nodeTypes } from '@mdx-js/mdx';
+import { rehypeAnalyzeAstroMetadata } from 'astro/jsx/rehype.js';
 import rehypeRaw from 'rehype-raw';
 import remarkGfm from 'remark-gfm';
 import remarkSmartypants from 'remark-smartypants';
@@ -13,9 +14,9 @@ import type { PluggableList } from 'unified';
 import type { MdxOptions } from './index.js';
 import { rehypeApplyFrontmatterExport } from './rehype-apply-frontmatter-export.js';
 import { rehypeInjectHeadingsExport } from './rehype-collect-headings.js';
+import { rehypeImageToComponent } from './rehype-images-to-component.js';
 import rehypeMetaString from './rehype-meta-string.js';
 import { rehypeOptimizeStatic } from './rehype-optimize-static.js';
-import { rehypeImageToComponent } from './rehype-images-to-component.js';
 
 // Skip nonessential plugins during performance benchmark runs
 const isPerformanceBenchmark = Boolean(process.env.ASTRO_PERFORMANCE_BENCHMARK);
@@ -30,7 +31,6 @@ export function createMdxProcessor(mdxOptions: MdxOptions, extraOptions: MdxProc
 		rehypePlugins: getRehypePlugins(mdxOptions),
 		recmaPlugins: mdxOptions.recmaPlugins,
 		remarkRehypeOptions: mdxOptions.remarkRehype,
-		jsx: true,
 		jsxImportSource: 'astro',
 		// Note: disable `.md` (and other alternative extensions for markdown files like `.markdown`) support
 		format: 'mdx',
@@ -82,8 +82,12 @@ function getRehypePlugins(mdxOptions: MdxOptions): PluggableList {
 		rehypePlugins.push(rehypeHeadingIds, rehypeInjectHeadingsExport);
 	}
 
-	// computed from `astro.data.frontmatter` in VFile data
-	rehypePlugins.push(rehypeApplyFrontmatterExport);
+	rehypePlugins.push(
+		// Render info from `vfile.data.astro.data.frontmatter` as JS
+		rehypeApplyFrontmatterExport,
+		// Analyze MDX nodes and attach to `vfile.data.__astroMetadata`
+		rehypeAnalyzeAstroMetadata
+	);
 
 	if (mdxOptions.optimize) {
 		// Convert user `optimize` option to compatible `rehypeOptimizeStatic` option

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -775,6 +775,12 @@ importers:
       eol:
         specifier: ^0.9.1
         version: 0.9.1
+      mdast-util-mdx:
+        specifier: ^3.0.0
+        version: 3.0.0
+      mdast-util-mdx-jsx:
+        specifier: ^3.1.2
+        version: 3.1.2
       memfs:
         specifier: ^4.8.2
         version: 4.8.2


### PR DESCRIPTION
## Changes

- Port `jsx/babel.ts` to `jsx/rehype.ts`. The file logic are essentially the same thing but written as a rehype plugin.
- The builtin `vite-plugin-mdx` plugin is deleted by `@astrojs/mdx`, the integration will takeover MDX transformation instead, using the rehype plugin.

Performance:

Rollup build time of Astro docs dropped from **108s to 96s (12s or 11% faster)**

How this perf improvement works is by removing the hoops needed to compile MDX as JS:
- Before: MDX string -> mdast -> hast -> esast -> JSX string -> esbuild -> babel ast -> JS string
- After: MDX string -> mdast -> hast -> esast -> JS string

## Testing

Existing tests should pass, we have extensive coverage for MDX usecases and edgecases.

## Docs

This is a breaking change. I've added a changeset explaning the change, but the only change needed is to upgrade to Astro v4.8.0 (to be released together)