### PR TITLE
Allow remark/rehype plugins added after mdx to work

### DIFF
--- a/.changeset/slimy-cobras-end.md
+++ b/.changeset/slimy-cobras-end.md
@@ -1,0 +1,7 @@
+---
+"@astrojs/mdx": major
+---
+
+Allows integrations after the MDX integration to update `markdown.remarkPlugins` and `markdown.rehypePlugins`, and have the plugins work in MDX too.
+
+If you rely on the ordering before to not add remark/rehype plugins for MDX, you need to configure `@astrojs/mdx` with `extendMarkdownConfig: false` and explicitly specify the `remarkPlugins` and `rehypePlugins` options instead.

--- a/packages/astro/test/units/dev/collections-renderentry.test.js
+++ b/packages/astro/test/units/dev/collections-renderentry.test.js
@@ -84,6 +84,24 @@ _describe('Content Collections - render()', () => {
 	it('can be used in a layout component', async () => {
 		const fs = createFsWithFallback(
 			{
+				'/src/components/Layout.astro': `
+					---
+					import { getCollection } from 'astro:content';
+					const blog = await getCollection('blog');
+					const launchWeekEntry = blog.find(post => post.id === 'promo/launch-week.mdx');
+					const { Content } = await launchWeekEntry.render();
+					---
+					<html>
+						<head></head>
+						<body>
+							<slot name="title"></slot>
+							<article>
+								<Content />
+							</article>
+						</body>
+					</html>
+
+				`,
 				'/src/pages/index.astro': `
 					---
 					import Layout from '../components/Layout.astro';

--- a/packages/astro/test/units/dev/collections-renderentry.test.js
+++ b/packages/astro/test/units/dev/collections-renderentry.test.js
@@ -84,36 +84,6 @@ _describe('Content Collections - render()', () => {
 	it('can be used in a layout component', async () => {
 		const fs = createFsWithFallback(
 			{
-				// Loading the content config with `astro:content` oddly
-				// causes this test to fail. Spoof a different src/content entry
-				// to ensure `existsSync` checks pass.
-				// TODO: revisit after addressing this issue
-				// https://github.com/withastro/astro/issues/6121
-				'/src/content/blog/promo/launch-week.mdx': `---
-title: Launch Week
-description: Astro is launching this week!
----
-# Launch Week
-- [x] Launch Astro
-- [ ] Celebrate`,
-				'/src/components/Layout.astro': `
-					---
-					import { getCollection } from 'astro:content';
-					const blog = await getCollection('blog');
-					const launchWeekEntry = blog.find(post => post.id === 'promo/launch-week.mdx');
-					const { Content } = await launchWeekEntry.render();
-					---
-					<html>
-						<head></head>
-						<body>
-							<slot name="title"></slot>
-							<article>
-								<Content />
-							</article>
-						</body>
-					</html>
-
-				`,
 				'/src/pages/index.astro': `
 					---
 					import Layout from '../components/Layout.astro';

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -29,6 +29,10 @@ type SetupHookParams = HookParameters<'astro:config:setup'> & {
 };
 
 export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroIntegration {
+	// @ts-expect-error Temporarily assign an empty object here, which will be re-assigned by the
+	// `astro:config:done` hook later. This is so that `vitePluginMdx` can get hold of a reference earlier.
+	const mdxOptions: MdxOptions = {};
+
 	return {
 		name: '@astrojs/mdx',
 		hooks: {
@@ -58,21 +62,27 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 					handlePropagation: true,
 				});
 
+				updateConfig({
+					vite: {
+						plugins: [vitePluginMdx(mdxOptions), vitePluginMdxPostprocess(config)],
+					},
+				});
+			},
+			'astro:config:done': ({ config }) => {
+				// We resolve the final MDX options here so that other integrations have a chance to modify
+				// `config.markdown` before we access it
 				const extendMarkdownConfig =
 					partialMdxOptions.extendMarkdownConfig ?? defaultMdxOptions.extendMarkdownConfig;
 
-				const mdxOptions = applyDefaultOptions({
+				const resolvedMdxOptions = applyDefaultOptions({
 					options: partialMdxOptions,
 					defaults: markdownConfigToMdxOptions(
 						extendMarkdownConfig ? config.markdown : markdownConfigDefaults
 					),
 				});
 
-				updateConfig({
-					vite: {
-						plugins: [vitePluginMdx(mdxOptions), vitePluginMdxPostprocess(config)],
-					},
-				});
+				// Mutate `mdxOptions` so that `vitePluginMdx` can reference the actual options
+				Object.assign(mdxOptions, resolvedMdxOptions);
 			},
 		},
 	};
@@ -81,7 +91,8 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 const defaultMdxOptions = {
 	extendMarkdownConfig: true,
 	recmaPlugins: [],
-};
+	optimize: false,
+} satisfies Partial<MdxOptions>;
 
 function markdownConfigToMdxOptions(markdownConfig: typeof markdownConfigDefaults): MdxOptions {
 	return {
@@ -90,7 +101,6 @@ function markdownConfigToMdxOptions(markdownConfig: typeof markdownConfigDefault
 		remarkPlugins: ignoreStringPlugins(markdownConfig.remarkPlugins),
 		rehypePlugins: ignoreStringPlugins(markdownConfig.rehypePlugins),
 		remarkRehype: (markdownConfig.remarkRehype as any) ?? {},
-		optimize: false,
 	};
 }
 

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -31,7 +31,7 @@ type SetupHookParams = HookParameters<'astro:config:setup'> & {
 export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroIntegration {
 	// @ts-expect-error Temporarily assign an empty object here, which will be re-assigned by the
 	// `astro:config:done` hook later. This is so that `vitePluginMdx` can get hold of a reference earlier.
-	const mdxOptions: MdxOptions = {};
+	let mdxOptions: MdxOptions = {};
 
 	return {
 		name: '@astrojs/mdx',
@@ -83,6 +83,9 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 
 				// Mutate `mdxOptions` so that `vitePluginMdx` can reference the actual options
 				Object.assign(mdxOptions, resolvedMdxOptions);
+				// @ts-expect-error After we assign, we don't need to reference `mdxOptions` in this context anymore.
+				// Re-assign it so that the garbage can be collected later.
+				mdxOptions = {};
 			},
 		},
 	};

--- a/packages/integrations/mdx/src/vite-plugin-mdx.ts
+++ b/packages/integrations/mdx/src/vite-plugin-mdx.ts
@@ -16,12 +16,9 @@ export function vitePluginMdx(mdxOptions: MdxOptions): Plugin {
 			processor = undefined;
 		},
 		configResolved(resolved) {
-			// The first time we access `mdxOptions`, make sure it's populated (just in case)
-			if (Object.keys(mdxOptions).length === 0) {
-				throw new Error(
-					'`mdxOptions` is not populated. This is an internal error. Please file an issue.'
-				);
-			}
+			// `mdxOptions` should be populated at this point, but `astro sync` doesn't call `astro:config:done` :(
+			// Workaround this for now by skipping here. `astro sync` shouldn't call the `transform()` hook here anyways.
+			if (Object.keys(mdxOptions).length === 0) return;
 
 			processor = createMdxProcessor(mdxOptions, {
 				sourcemap: !!resolved.build.sourcemap,

--- a/packages/integrations/mdx/src/vite-plugin-mdx.ts
+++ b/packages/integrations/mdx/src/vite-plugin-mdx.ts
@@ -16,6 +16,13 @@ export function vitePluginMdx(mdxOptions: MdxOptions): Plugin {
 			processor = undefined;
 		},
 		configResolved(resolved) {
+			// The first time we access `mdxOptions`, make sure it's populated (just in case)
+			if (Object.keys(mdxOptions).length === 0) {
+				throw new Error(
+					'`mdxOptions` is not populated. This is an internal error. Please file an issue.'
+				);
+			}
+
 			processor = createMdxProcessor(mdxOptions, {
 				sourcemap: !!resolved.build.sourcemap,
 			});

--- a/packages/integrations/mdx/test/mdx-plugins.test.js
+++ b/packages/integrations/mdx/test/mdx-plugins.test.js
@@ -64,6 +64,30 @@ describe('MDX plugins', () => {
 		assert.notEqual(selectRehypeExample(document), null);
 	});
 
+	it('supports custom rehype plugins from integrations', async () => {
+		const fixture = await buildFixture({
+			integrations: [
+				mdx(),
+				{
+					name: 'test',
+					hooks: {
+						'astro:config:setup': ({ updateConfig }) => {
+							updateConfig({
+								markdown: {
+									rehypePlugins: [rehypeExamplePlugin],
+								}
+							});
+						}
+					}
+				}
+			],
+		});
+		const html = await fixture.readFile(FILE);
+		const { document } = parseHTML(html);
+
+		assert.notEqual(selectRehypeExample(document), null);
+	});
+
 	it('supports custom rehype plugins with namespaced attributes', async () => {
 		const fixture = await buildFixture({
 			integrations: [


### PR DESCRIPTION
## Changes

This PR moves the markdown options generation to the `astro:config:done` hook so that remark/rehype plugins added by integrations after `@astrojs/mdx` during `astro:config:setup` hook works.

This should unblock `astro-expressive-code` needing `@astrojs/mdx` in a specific order to work, which should remove the hack in https://github.com/withastro/docs/pull/7972

cc @hippotastic does this work for you?
cc @delucis 

---

NOTE: The implementation would be simpler if I added the Vite plugin in the `astro:config:done`, but other integrations also add Vite plugins in `astro:config:setup`. I figured it's more predictable if we also do so.

## Testing

Added a new test.

## Docs

I don't think this will affect many projects in practice, but I added a changeset explaining the migration path if so.
