### PR TITLE
Improve `asDrizzleTable()` types

### DIFF
--- a/.changeset/angry-lemons-tie.md
+++ b/.changeset/angry-lemons-tie.md
@@ -1,0 +1,7 @@
+---
+"@astrojs/db": patch
+---
+
+Improves the typing of the `asDrizzleTable()` utility
+
+Fixes a type error when passing the output of `defineTable()` to the utility and returns a more detailed type inferred from the columns of the passed table config.

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -8,10 +8,15 @@ import {
 	sqliteTable,
 	text,
 } from 'drizzle-orm/sqlite-core';
-import { type ColumnsConfig, type DBColumn, type DBTable, type TableConfig } from '../core/types.js';
-import { type SerializedSQL, isSerializedSQL, type Table } from './types.js';
-import { pathToFileURL } from './utils.js';
 import { tableSchema } from '../core/schemas.js';
+import {
+	type ColumnsConfig,
+	type DBColumn,
+	type DBTable,
+	type TableConfig,
+} from '../core/types.js';
+import { type SerializedSQL, type Table, isSerializedSQL } from './types.js';
+import { pathToFileURL } from './utils.js';
 
 export type { Table } from './types.js';
 export { createRemoteDatabaseClient, createLocalDatabaseClient } from './db-client.js';
@@ -49,7 +54,10 @@ type D1ColumnBuilder = SQLiteColumnBuilderBase<
 	ColumnBuilderBaseConfig<ColumnDataType, string> & { data: unknown }
 >;
 
-export function asDrizzleTable<TableName extends string = string, TColumns extends ColumnsConfig = ColumnsConfig>(name: TableName, tbl: TableConfig<TColumns>): Table<TableName, TColumns> {
+export function asDrizzleTable<
+	TableName extends string = string,
+	TColumns extends ColumnsConfig = ColumnsConfig,
+>(name: TableName, tbl: TableConfig<TColumns>): Table<TableName, TColumns> {
 	const table = tableSchema.parse(tbl);
 	const columns: Record<string, D1ColumnBuilder> = {};
 	if (!Object.entries(table.columns).some(([, column]) => hasPrimaryKey(column))) {

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -8,14 +8,8 @@ import {
 	sqliteTable,
 	text,
 } from 'drizzle-orm/sqlite-core';
-import { tableSchema } from '../core/schemas.js';
-import {
-	type ColumnsConfig,
-	type DBColumn,
-	type DBTable,
-	type TableConfig,
-} from '../core/types.js';
-import { type SerializedSQL, type Table, isSerializedSQL } from './types.js';
+import type { DBColumn, DBTable } from '../core/types.js';
+import { type SerializedSQL, isSerializedSQL } from './types.js';
 import { pathToFileURL } from './utils.js';
 
 export type { Table } from './types.js';
@@ -54,11 +48,7 @@ type D1ColumnBuilder = SQLiteColumnBuilderBase<
 	ColumnBuilderBaseConfig<ColumnDataType, string> & { data: unknown }
 >;
 
-export function asDrizzleTable<
-	TableName extends string = string,
-	TColumns extends ColumnsConfig = ColumnsConfig,
->(name: TableName, tbl: TableConfig<TColumns>): Table<TableName, TColumns> {
-	const table = tableSchema.parse(tbl);
+export function asDrizzleTable(name: string, table: DBTable) {
 	const columns: Record<string, D1ColumnBuilder> = {};
 	if (!Object.entries(table.columns).some(([, column]) => hasPrimaryKey(column))) {
 		columns['_id'] = integer('_id').primaryKey();
@@ -77,7 +67,7 @@ export function asDrizzleTable<
 		}
 		return indexes;
 	});
-	return drizzleTable as Table<TableName, TColumns>;
+	return drizzleTable;
 }
 
 function atLeastOne<T>(arr: T[]): arr is [T, ...T[]] {

--- a/packages/db/src/utils.ts
+++ b/packages/db/src/utils.ts
@@ -1,2 +1,11 @@
 export { defineDbIntegration } from './core/utils.js';
-export { asDrizzleTable } from './runtime/index.js';
+import { tableSchema } from './core/schemas.js';
+import type { ColumnsConfig, TableConfig } from './core/types.js';
+import { type Table, asDrizzleTable as internal_asDrizzleTable } from './runtime/index.js';
+
+export function asDrizzleTable<
+	TableName extends string = string,
+	TColumns extends ColumnsConfig = ColumnsConfig,
+>(name: TableName, tableConfig: TableConfig<TColumns>) {
+	return internal_asDrizzleTable(name, tableSchema.parse(tableConfig)) as Table<TableName, TColumns>;
+}


### PR DESCRIPTION
## Changes

- Improves the typing of the `asDrizzleTable()` utility

- Fixes a type error when passing the output of `defineTable()` to the utility and returns a more detailed type inferred from the columns of the passed table config.


## Testing

Tested manually in an integration

## Docs

n/a — bug fix
