### PR TITLE
Rename to `optimize.ignoreComponentNames` in MDX

### DIFF
--- a/.changeset/small-oranges-report.md
+++ b/.changeset/small-oranges-report.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/mdx": major
+---
+
+Renames the `optimize.customComponentNames` option to `optimize.ignoreComponentNames` to better reflect its usecase. Its behaviour is not changed and should continue to work as before.

--- a/packages/integrations/mdx/test/fixtures/mdx-optimize/astro.config.mjs
+++ b/packages/integrations/mdx/test/fixtures/mdx-optimize/astro.config.mjs
@@ -3,7 +3,7 @@ import mdx from '@astrojs/mdx';
 export default {
 	integrations: [mdx({
 		optimize: {
-			customComponentNames: ['strong']
+			ignoreComponentNames: ['strong']
 		}
 	})]
 }


### PR DESCRIPTION
## Changes

@delucis suggested to rename the `optimize.customComponentNames` option to `optimize.ignoreComponentNames`, which I agree better reflect its usecase. Since this is an advanced option, I assume this shouldn't affect many projects and wouldn't be cumbersome to rename.

## Testing

Existing tests should work

## Docs

I added a changeset describing the breaking change. The docs for `@astrojs/mdx` should also be updated, but I'll send a single PR about all the breaking changes later to the docs repo.
