### PR TITLE
Only traverse children and handle mdxJsxTextElement when optimizing

### DIFF
--- a/.changeset/young-chicken-exercise.md
+++ b/.changeset/young-chicken-exercise.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/mdx": patch
+---
+
+Improves `optimize` handling for MDX components with attributes and inline MDX components


### PR DESCRIPTION
## Changes

`rehype-optimize-static.ts` wasn't working as intended in some cases. For example, if you have:

```mdx
<Card foo="bar">
  This is content
</Card>
```

Previously it compiles to:

```jsx
<Card foo="bar">
  <_components.p set:html="This is content" />
</Card>
```

But what it should be is 

```jsx
<Card foo="bar" set:html="<p>This is content</p>" />
```

This PR fixes it by adding `if (key != null && key !== 'children') return SKIP` because we accidentally visited `foo="bar"` (part of `node.attributes`), which de-optimizes the flow. The `key` check helps avoid the `attributes` key.

---

I also made a second change to add `mdxJsxTextElement` as a proper MDX node. It is kinda synonymous to `mdxJsxFlowElement`, but I forgot to add both of them.

## Testing

Sorry, I don't have tests for `rehype-optimize-static` 😅 This is all manually tested in the astro docs repo.

## Docs

n/a. internal change. Added a changeset
