### PR TITLE
fix a deprecated method in react integration using SSR: renderToStaticNodeStream

### DIFF
--- a/.changeset/twelve-bulldogs-raise.md
+++ b/.changeset/twelve-bulldogs-raise.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/react": patch
+---
+
+Removes using deprecated `ReactDOMServer.renderToStaticNodeStream` API

--- a/packages/integrations/react/server.js
+++ b/packages/integrations/react/server.js
@@ -106,18 +106,10 @@ async function renderToStaticMarkup(Component, props, { default: children, ...sl
 		identifierPrefix: prefix,
 	};
 	let html;
-	if (metadata?.hydrate) {
-		if ('renderToReadableStream' in ReactDOM) {
-			html = await renderToReadableStreamAsync(vnode, renderOptions);
-		} else {
-			html = await renderToPipeableStreamAsync(vnode, renderOptions);
-		}
+	if ('renderToReadableStream' in ReactDOM) {
+		html = await renderToReadableStreamAsync(vnode, renderOptions);
 	} else {
-		if ('renderToReadableStream' in ReactDOM) {
-			html = await renderToReadableStreamAsync(vnode, renderOptions);
-		} else {
-			html = await renderToStaticNodeStreamAsync(vnode, renderOptions);
-		}
+		html = await renderToPipeableStreamAsync(vnode, renderOptions);
 	}
 	return { html, attrs };
 }
@@ -147,28 +139,6 @@ async function renderToPipeableStreamAsync(vnode, options) {
 				);
 			},
 		});
-	});
-}
-
-async function renderToStaticNodeStreamAsync(vnode, options) {
-	const Writable = await getNodeWritable();
-	let html = '';
-	return new Promise((resolve, reject) => {
-		let stream = ReactDOM.renderToStaticNodeStream(vnode, options);
-		stream.on('error', (err) => {
-			reject(err);
-		});
-		stream.pipe(
-			new Writable({
-				write(chunk, _encoding, callback) {
-					html += chunk.toString('utf-8');
-					callback();
-				},
-				destroy() {
-					resolve(html);
-				},
-			})
-		);
 	});
 }
 


### PR DESCRIPTION
## Changes

ReactDOMServer.renderToStaticNodeStream() is deprecated. 
Use ReactDOMServer.renderToPipeableStream() and wait to `pipe` until the `onAllReady` callback has been called instead.

## Testing

Tested manually in a project


## Docs
