### PR TITLE
fix(astro): newer navigation aborts existing one

### DIFF
--- a/.changeset/curly-spoons-pull.md
+++ b/.changeset/curly-spoons-pull.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Detects overlapping navigations and view transitions and automatically aborts all but the most recent one.

--- a/.changeset/curly-spoons-pull.md
+++ b/.changeset/curly-spoons-pull.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Detects overlapping navigations and view transitions and automatically aborts all but the most recent one.
+Detects overlapping navigation and view transitions and automatically aborts all but the most recent one.

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/abort.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/abort.astro
@@ -1,0 +1,25 @@
+---
+import { ViewTransitions } from 'astro:transitions';
+---
+<html>
+	<head>
+		<ViewTransitions />
+	</head>
+	<body>
+		<h1>Abort</h1>
+	</body>
+</html>
+<script>
+	import {navigate } from 'astro:transitions/client';
+	document.addEventListener('astro:before-preparation', (e) => {
+		const originalLoader = e.loader;
+		e.loader = async () => {
+			const result = await originalLoader();
+			if (e.to.href.endsWith("/two")) {
+				await new Promise((resolve) => setTimeout(resolve, 1100));
+			}
+		}
+	});
+	setTimeout(()=>navigate("/one"), 400);
+	navigate("/two");
+</script>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/abort.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/abort.astro
@@ -11,15 +11,19 @@ import { ViewTransitions } from 'astro:transitions';
 </html>
 <script>
 	import {navigate } from 'astro:transitions/client';
+
 	document.addEventListener('astro:before-preparation', (e) => {
 		const originalLoader = e.loader;
 		e.loader = async () => {
 			const result = await originalLoader();
 			if (e.to.href.endsWith("/two")) {
+				// delay loading of /two
 				await new Promise((resolve) => setTimeout(resolve, 1100));
 			}
 		}
 	});
+	// starts later, but is faster and overtakes the slower navigation
 	setTimeout(()=>navigate("/one"), 400);
+	// starts now, but is to slow to keep its lead
 	navigate("/two");
 </script>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/abort2.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/abort2.astro
@@ -15,9 +15,11 @@ import { ViewTransitions, fade } from 'astro:transitions';
 	import {navigate } from 'astro:transitions/client';
 
 	setTimeout(()=>{
-		[...document.getAnimations()].forEach((a) => a.addEventListener('cancel', (e) => console.log('canceled', a.animationName)));
+		[...document.getAnimations()].forEach((a) => a.addEventListener('cancel',
+		(e) => console.log("[test]",e.type, a.animationName)));
+	console.log("[test] navigate to /one")
 		navigate("/one");
 	}, 1000);
-
+	console.log('[test] navigate to "."')
 	navigate("/abort2");
 </script>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/abort2.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/abort2.astro
@@ -1,0 +1,23 @@
+---
+import { ViewTransitions, fade } from 'astro:transitions';
+---
+<html transition:animate="none">
+	<head>
+		<ViewTransitions />
+	</head>
+	<body>
+		<h1 transition:name="h1" transition:animate={fade({duration:10000})}>Abort</h1>
+	</body>
+</html>
+
+<style is:global>::view-transition-group(h1){animation:none}</style>
+<script>
+	import {navigate } from 'astro:transitions/client';
+
+	setTimeout(()=>{
+		[...document.getAnimations()].forEach((a) => a.addEventListener('cancel', (e) => console.log('canceled', a.animationName)));
+		navigate("/one");
+	}, 1000);
+
+	navigate("/abort2");
+</script>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -1,6 +1,4 @@
-import exp from 'constants';
 import { expect } from '@playwright/test';
-import { maxSatisfying } from 'semver';
 import { testFactory, waitForHydrate } from './test-utils.js';
 
 const test = testFactory({ root: './fixtures/view-transitions/' });
@@ -1460,7 +1458,7 @@ test.describe('View Transitions', () => {
 	test('animation get canceled when view transition is interrupted', async ({ page, astro }) => {
 		let lines = [];
 		page.on('console', (msg) => {
-			msg.text().startsWith("[test]") && lines.push(msg.text());
+			msg.text().startsWith('[test]') && lines.push(msg.text());
 		});
 		await page.goto(astro.resolveUrl('/abort2'));
 		// implemented in /abort2:
@@ -1475,6 +1473,8 @@ test.describe('View Transitions', () => {
 		// as those do not have automatic cancelation of transitions.
 		// For simulated view transitions, the last line would be missing as enter and exit animations
 		// don't run in parallel.
-		expect(lines.join("\n")).toBe('[test] navigate to "."\n[test] navigate to /one\n[test] cancel astroFadeOut\n[test] cancel astroFadeIn');
+		expect(lines.join('\n')).toBe(
+			'[test] navigate to "."\n[test] navigate to /one\n[test] cancel astroFadeOut\n[test] cancel astroFadeIn'
+		);
 	});
 });

--- a/packages/astro/src/transitions/events.ts
+++ b/packages/astro/src/transitions/events.ts
@@ -25,6 +25,7 @@ class BeforeEvent extends Event {
 	readonly sourceElement: Element | undefined;
 	readonly info: any;
 	newDocument: Document;
+	signal: AbortSignal;
 
 	constructor(
 		type: string,
@@ -35,7 +36,8 @@ class BeforeEvent extends Event {
 		navigationType: NavigationTypeString,
 		sourceElement: Element | undefined,
 		info: any,
-		newDocument: Document
+		newDocument: Document,
+		signal: AbortSignal
 	) {
 		super(type, eventInitDict);
 		this.from = from;
@@ -45,6 +47,7 @@ class BeforeEvent extends Event {
 		this.sourceElement = sourceElement;
 		this.info = info;
 		this.newDocument = newDocument;
+		this.signal = signal;
 
 		Object.defineProperties(this, {
 			from: { enumerable: true },
@@ -54,6 +57,7 @@ class BeforeEvent extends Event {
 			sourceElement: { enumerable: true },
 			info: { enumerable: true },
 			newDocument: { enumerable: true, writable: true },
+			signal: { enumerable: true },
 		});
 	}
 }
@@ -76,6 +80,7 @@ export class TransitionBeforePreparationEvent extends BeforeEvent {
 		sourceElement: Element | undefined,
 		info: any,
 		newDocument: Document,
+		signal: AbortSignal,
 		formData: FormData | undefined,
 		loader: (event: TransitionBeforePreparationEvent) => Promise<void>
 	) {
@@ -88,7 +93,8 @@ export class TransitionBeforePreparationEvent extends BeforeEvent {
 			navigationType,
 			sourceElement,
 			info,
-			newDocument
+			newDocument,
+			signal
 		);
 		this.formData = formData;
 		this.loader = loader.bind(this, this);
@@ -124,7 +130,8 @@ export class TransitionBeforeSwapEvent extends BeforeEvent {
 			afterPreparation.navigationType,
 			afterPreparation.sourceElement,
 			afterPreparation.info,
-			afterPreparation.newDocument
+			afterPreparation.newDocument,
+			afterPreparation.signal
 		);
 		this.direction = afterPreparation.direction;
 		this.viewTransition = viewTransition;
@@ -145,6 +152,7 @@ export async function doPreparation(
 	navigationType: NavigationTypeString,
 	sourceElement: Element | undefined,
 	info: any,
+	signal: AbortSignal,
 	formData: FormData | undefined,
 	defaultLoader: (event: TransitionBeforePreparationEvent) => Promise<void>
 ) {
@@ -156,6 +164,7 @@ export async function doPreparation(
 		sourceElement,
 		info,
 		window.document,
+		signal,
 		formData,
 		defaultLoader
 	);
@@ -172,7 +181,7 @@ export async function doPreparation(
 	return event;
 }
 
-export async function doSwap(
+export function doSwap(
 	afterPreparation: BeforeEvent,
 	viewTransition: ViewTransition,
 	defaultSwap: (event: TransitionBeforeSwapEvent) => void

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -92,7 +92,7 @@ if (inBrowser) {
 		currentHistoryIndex = history.state.index;
 		scrollTo({ left: history.state.scrollX, top: history.state.scrollY });
 	} else if (transitionEnabledOnThisPage()) {
-		// This page is loaded from the browser addressbar or via a link from extern,
+		// This page is loaded from the browser address bar or via a link from extern,
 		// it needs a state in the history
 		replaceState({ index: currentHistoryIndex, scrollX, scrollY }, '');
 		history.scrollRestoration = 'manual';
@@ -157,7 +157,7 @@ function runScripts() {
 	return wait;
 }
 
-// Add a new entry to the browser history. This also sets the new page in the browser addressbar.
+// Add a new entry to the browser history. This also sets the new page in the browser address bar.
 // Sets the scroll position according to the hash fragment of the new location.
 const moveToLocation = (
 	to: URL,
@@ -194,7 +194,7 @@ const moveToLocation = (
 		}
 	}
 	document.title = targetPageTitle;
-	// now we are on the new page for non-history navigations!
+	// now we are on the new page for non-history navigation!
 	// (with history navigation page change happens before popstate is fired)
 	originalLocation = to;
 

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -656,6 +656,7 @@ async function transition(
 	currentTransition.viewTransition.finished.finally(() => {
 		currentTransition.viewTransition = undefined;
 		if (currentTransition === mostRecentTransition) mostRecentTransition = undefined;
+		if (currentNavigation === mostRecentNavigation) mostRecentNavigation = undefined;
 		document.documentElement.removeAttribute(DIRECTION_ATTR);
 		document.documentElement.removeAttribute(OLD_NEW_ATTR);
 	});

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -794,7 +794,7 @@ async function prepareForClientOnlyComponents(
 			acc[key] = () => {};
 			return acc;
 		}, {});
-		await hydrationDone(nextPage, signal);
+		await hydrationDone(nextPage);
 
 		const nextHead = nextPage.contentDocument?.head;
 		if (nextHead) {
@@ -812,7 +812,7 @@ async function prepareForClientOnlyComponents(
 		}
 
 		// return a promise that resolves when all astro-islands are hydrated
-		async function hydrationDone(loadingPage: HTMLIFrameElement, signal: AbortSignal) {
+		async function hydrationDone(loadingPage: HTMLIFrameElement) {
 			if (!signal.aborted) {
 				await new Promise((r) =>
 					loadingPage.contentWindow?.addEventListener('load', r, { once: true })


### PR DESCRIPTION
## Changes

Closes #10807
 
Detects when navigate() is called while another instance is still executing.
Uses an AbortController to abort running fetch operations and signal at various points in the implementation that the current navigation should be abandoned.
For simulation mode, adds the ability to prevent/cancel running animations of view transitions (for native view transitions this is automatic)
Made the handling of asynchronous parts in the existing implementation more robust for cases where something really goes wrong.

## Testing

Two new e2e test that test for canceling of earlier requests and canceling of ongoing animations.

## Docs

n.a. / Bug Fix 