### PR TITLE
fix: don't include port twice from x-forwarded-host and x-forwarded-port headers

### DIFF
--- a/.changeset/forty-wolves-turn.md
+++ b/.changeset/forty-wolves-turn.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix internal server error when bot `X-Forwarded-Host: hostname:8080` and `X-Forwarded-Port: 8080` are set

--- a/.changeset/forty-wolves-turn.md
+++ b/.changeset/forty-wolves-turn.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fix internal server error when bot `X-Forwarded-Host: hostname:8080` and `X-Forwarded-Port: 8080` are set
+Fixes a case where the local server would crash when the host also contained the port, eg. with `X-Forwarded-Host: hostname:8080` and `X-Forwarded-Port: 8080` headers

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -66,7 +66,11 @@ export class NodeApp extends App {
 		const hostname =
 			req.headers['x-forwarded-host'] ?? req.headers.host ?? req.headers[':authority'];
 		const port = req.headers['x-forwarded-port'];
-		const url = `${protocol}://${hostname}${port ? `:${port}` : ''}${req.url}`;
+
+		const portInHostname = typeof hostname === "string" && typeof port === "string" && hostname.endsWith(port);
+		const hostnamePort = portInHostname ? hostname : `${hostname}:${port}`;
+
+		const url = `${protocol}://${hostnamePort}${req.url}`;
 		const options: RequestInit = {
 			method: req.method || 'GET',
 			headers: makeRequestHeaders(req),

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -67,8 +67,9 @@ export class NodeApp extends App {
 			req.headers['x-forwarded-host'] ?? req.headers.host ?? req.headers[':authority'];
 		const port = req.headers['x-forwarded-port'];
 
-		const portInHostname = typeof hostname === "string" && typeof port === "string" && hostname.endsWith(port);
-		const hostnamePort = portInHostname ? hostname : `${hostname}:${port}`;
+		const portInHostname =
+			typeof hostname === 'string' && typeof port === 'string' && hostname.endsWith(port);
+		const hostnamePort = portInHostname ? hostname : hostname + (port ? `:${port}` : '');
 
 		const url = `${protocol}://${hostnamePort}${req.url}`;
 		const options: RequestInit = {

--- a/packages/integrations/node/test/url.test.js
+++ b/packages/integrations/node/test/url.test.js
@@ -92,4 +92,25 @@ describe('URL', () => {
 
 		assert.equal($('body').text(), 'https://abc.xyz:444/');
 	});
+
+
+	it('accepts port in forwarded host and forwarded port', async () => {
+		const { handler } = await import('./fixtures/url/dist/server/entry.mjs');
+		let { req, res, text } = createRequestAndResponse({
+			headers: {
+				'X-Forwarded-Proto': 'https',
+				'X-Forwarded-Host': 'abc.xyz:444',
+				'X-Forwarded-Port': '444',
+			},
+			url: '/',
+		});
+
+		handler(req, res);
+		req.send();
+
+		const html = await text();
+		const $ = cheerio.load(html);
+
+		assert.equal($('body').text(), 'https://abc.xyz:444/');
+	});
 });

--- a/packages/integrations/node/test/url.test.js
+++ b/packages/integrations/node/test/url.test.js
@@ -93,7 +93,6 @@ describe('URL', () => {
 		assert.equal($('body').text(), 'https://abc.xyz:444/');
 	});
 
-
 	it('accepts port in forwarded host and forwarded port', async () => {
 		const { handler } = await import('./fixtures/url/dist/server/entry.mjs');
 		let { req, res, text } = createRequestAndResponse({


### PR DESCRIPTION
fixes #10916 

## Changes

- Fix internal server error when bot `X-Forwarded-Host: hostname:8080` and `X-Forwarded-Port: 8080` are set

## Testing

add another test next to the existing URL tests for `X-Forwarded-*`

## Docs

The docs shouldn't need to be changed since this is just a bugfix and now works as expected.