### PR TITLE
Provide a better error for when the app token is missing in CI

### DIFF
--- a/.changeset/happy-pumpkins-rescue.md
+++ b/.changeset/happy-pumpkins-rescue.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Provide a better error message when app token is missing in CI

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -72,6 +72,7 @@
   "dependencies": {
     "@libsql/client": "^0.6.0",
     "async-listen": "^3.0.1",
+    "ci-info": "^4.0.0",
     "deep-diff": "^1.0.2",
     "drizzle-orm": "^0.30.9",
     "github-slugger": "^2.0.0",

--- a/packages/db/src/core/errors.ts
+++ b/packages/db/src/core/errors.ts
@@ -1,5 +1,9 @@
 import { bold, cyan, red } from 'kleur/colors';
 
+export const MISSING_SESSION_ID_CI_ERROR = `${red('▶ ASTRO_STUDIO_APP_TOKEN required')}
+
+	To authenticate with Astro Studio add the token to your CI's environment variables.\n`;
+
 export const MISSING_SESSION_ID_ERROR = `${red('▶ Login required!')}
 
   To authenticate with Astro Studio, run

--- a/packages/db/src/core/tokens.ts
+++ b/packages/db/src/core/tokens.ts
@@ -5,8 +5,9 @@ import { pathToFileURL } from 'node:url';
 import { green } from 'kleur/colors';
 import ora from 'ora';
 import { safeFetch } from '../runtime/utils.js';
-import { MISSING_PROJECT_ID_ERROR, MISSING_SESSION_ID_ERROR } from './errors.js';
+import { MISSING_PROJECT_ID_ERROR, MISSING_SESSION_ID_CI_ERROR, MISSING_SESSION_ID_ERROR } from './errors.js';
 import { getAstroStudioEnv, getAstroStudioUrl } from './utils.js';
+import ci from 'ci-info';
 
 export const SESSION_LOGIN_FILE = pathToFileURL(join(homedir(), '.astro', 'session-token'));
 export const PROJECT_ID_FILE = pathToFileURL(join(process.cwd(), '.astro', 'link'));
@@ -182,12 +183,17 @@ export async function getManagedAppTokenOrExit(token?: string): Promise<ManagedA
 	}
 	const sessionToken = await getSessionIdFromFile();
 	if (!sessionToken) {
-		// eslint-disable-next-line no-console
-		console.error(MISSING_SESSION_ID_ERROR);
+		if(ci.isCI) {
+			// eslint-disable-next-line no-console
+			console.error(MISSING_SESSION_ID_CI_ERROR);
+		} else {
+			// eslint-disable-next-line no-console
+			console.error(MISSING_SESSION_ID_ERROR);
+		}
 		process.exit(1);
 	}
 	const projectId = await getProjectIdFromFile();
-	if (!sessionToken || !projectId) {
+	if (!projectId) {
 		// eslint-disable-next-line no-console
 		console.error(MISSING_PROJECT_ID_ERROR);
 		process.exit(1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3874,6 +3874,9 @@ importers:
       async-listen:
         specifier: ^3.0.1
         version: 3.0.1
+      ci-info:
+        specifier: ^4.0.0
+        version: 4.0.0
       deep-diff:
         specifier: ^1.0.2
         version: 1.0.2


### PR DESCRIPTION
## Changes

- Uses `ci-info` which seems to be the most popular library for detecting CI environments.
- Provide a message about add the ASTRO_STUDIO_APP_TOKEN, rather than the previous message which said to run `astro login`.

## Testing

- None yet

## Docs

N/A, bug fix