### PR TITLE
Fixes ASTRO_DATABASE_FILE interaction with relative paths

### DIFF
--- a/.changeset/olive-cars-run.md
+++ b/.changeset/olive-cars-run.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Fixes `ASTRO_DATABASE_FILE` not correctly resolving relative paths (e.g. `ASTRO_DATABASE_FILE=./api/database.db`

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -139,7 +139,8 @@ export function normalizeDatabaseUrl(envDbUrl: string | undefined, defaultDbUrl:
 		if (envDbUrl.startsWith('file://')) {
 			return envDbUrl;
 		}
-		return new URL(envDbUrl, pathToFileURL(process.cwd())).toString();
+
+		return new URL(envDbUrl, pathToFileURL(process.cwd()) + "/").toString();
 	} else {
 		// This is going to be a file URL always,
 		return defaultDbUrl;


### PR DESCRIPTION
## Changes

`process.cwd()` doesn't have a trailing slash, so you can't do relative paths with it in an URL

## Testing

Tested manually

## Docs

N/A
