### PR TITLE
Simplify plain MDX nodes in optimize option

### DIFF
--- a/.changeset/blue-geese-visit.md
+++ b/.changeset/blue-geese-visit.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/mdx": patch
+---
+
+Simplifies plain MDX components as hast element nodes to further improve HTML string inlining for the `optimize` option

--- a/packages/integrations/mdx/src/rehype-optimize-static.ts
+++ b/packages/integrations/mdx/src/rehype-optimize-static.ts
@@ -76,7 +76,7 @@ export const rehypeOptimizeStatic: RehypePlugin<[OptimizeOptions?]> = (options) 
 				if (key != null && key !== 'children') return SKIP;
 
 				// Mutate `node` as a normal hast element node if it's a plain MDX node, e.g. `<kbd>something</kbd>`
-				simplifyPlainMdxComponentNode(node);
+				simplifyPlainMdxComponentNode(node, ignoreElementNames);
 
 				// For nodes that are not static, eliminate all elements in the `elementStack` from the
 				// `allPossibleElements` set.
@@ -269,13 +269,15 @@ function getExportConstComponentObjectKeys(node: RootContentMap['mdxjsEsm']) {
  * Some MDX nodes are simply `<kbd>something</kbd>` which isn't needed to be completely treated
  * as an MDX node. This function tries to mutate this node as a simple hast element node if so.
  */
-function simplifyPlainMdxComponentNode(node: Node) {
+function simplifyPlainMdxComponentNode(node: Node, ignoreElementNames: Set<string>) {
 	if (
 		!isMdxComponentNode(node) ||
 		// Attributes could be dynamic, so bail if so.
 		node.attributes.length > 0 ||
 		// Fragments are also dynamic
 		!node.name ||
+		// Ignore if the node name is in the ignore list
+		ignoreElementNames.has(node.name) ||
 		// If the node name has uppercase characters, it's likely an actual MDX component
 		node.name.toLowerCase() !== node.name
 	) {

--- a/packages/integrations/mdx/test/units/rehype-optimize-static.test.js
+++ b/packages/integrations/mdx/test/units/rehype-optimize-static.test.js
@@ -69,4 +69,21 @@ This is a <Comp />
 " /><_components.p>{"This is a "}<Comp /></_components.p></>`
 		);
 	});
+
+	it('optimizes explicit html elements', async () => {
+		const jsx = await compile(`\
+# hello
+
+foo <strong>bar</strong> baz
+
+<strong>qux</strong>
+`);
+		assert.equal(
+			jsx,
+			`\
+<Fragment set:html="<h1>hello</h1>
+<p>foo <strong>bar</strong> baz</p>
+<strong>qux</strong>" />`
+		);
+	});
 });


### PR DESCRIPTION
## Changes

Some MDX nodes are simply `<kbd>something</kbd>` which the optimizer bails out because it thinks that it's non-static. However, it works like a plain HTML element and should be static.

This PR tries to simplify these MDX nodes as normal hast `element` nodes so we can further optimize the strings.

## Testing

Added a new test

## Docs

Added a changeset
