### PR TITLE
feat(preact): add support for devtools

### DIFF
--- a/.changeset/little-dryers-stare.md
+++ b/.changeset/little-dryers-stare.md
@@ -1,0 +1,18 @@
+---
+"@astrojs/preact": minor
+---
+
+Adds a `devtools` option
+
+Enabling `devtools` will enable the [official Preact Devtools](https://preactjs.github.io/preact-devtools/) in development:
+
+```js
+import { defineConfig } from "astro/config"
+import preact from "@astrojs/preact"
+
+export default defineConfig({
+    integrations: [
+        preact({ devtools: true })
+    ]
+})
+```

--- a/.changeset/little-dryers-stare.md
+++ b/.changeset/little-dryers-stare.md
@@ -4,7 +4,7 @@
 
 Adds a `devtools` option
 
-Enabling `devtools` will enable the [official Preact Devtools](https://preactjs.github.io/preact-devtools/) in development:
+You can enable [Preact devtools](https://preactjs.github.io/preact-devtools/) in development by setting `devtools: true` in your `preact()` integration config:
 
 ```js
 import { defineConfig } from "astro/config"

--- a/packages/integrations/preact/src/index.ts
+++ b/packages/integrations/preact/src/index.ts
@@ -12,13 +12,16 @@ function getRenderer(development: boolean): AstroRenderer {
 	};
 }
 
-export type Options = Pick<VitePreactPluginOptions, 'include' | 'exclude'> & { compat?: boolean };
+export interface Options extends Pick<VitePreactPluginOptions, 'include' | 'exclude'> {
+	compat?: boolean;
+	devtools?: boolean;
+}
 
-export default function ({ include, exclude, compat }: Options = {}): AstroIntegration {
+export default function ({ include, exclude, compat, devtools }: Options = {}): AstroIntegration {
 	return {
 		name: '@astrojs/preact',
 		hooks: {
-			'astro:config:setup': ({ addRenderer, updateConfig, command }) => {
+			'astro:config:setup': ({ addRenderer, updateConfig, command, injectScript }) => {
 				const preactPlugin = preact({
 					reactAliasesEnabled: compat ?? false,
 					include,
@@ -56,6 +59,10 @@ export default function ({ include, exclude, compat }: Options = {}): AstroInteg
 				updateConfig({
 					vite: viteConfig,
 				});
+
+				if (command === 'dev' && devtools) {
+					injectScript('page', 'import "preact/debug";');
+				}
 			},
 		},
 	};


### PR DESCRIPTION
## Changes

- Adds a flag to enable https://preactjs.github.io/preact-devtools/ in dev mode

## Testing

Manually in the preact example

## Docs

[TBD](https://github.com/withastro/docs/pull/8164)

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
