### PR TITLE
Avoid importing vite in db utils

### DIFF
--- a/.changeset/twenty-lizards-tan.md
+++ b/.changeset/twenty-lizards-tan.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Fixes issue where Vite ended up being imported by code using the `'@astrojs/db/utils'` module

--- a/packages/db/src/core/schemas.ts
+++ b/packages/db/src/core/schemas.ts
@@ -4,7 +4,6 @@ import { type ZodTypeDef, z } from 'zod';
 import { SERIALIZED_SQL_KEY, type SerializedSQL } from '../runtime/types.js';
 import { errorMap } from './integration/error-map.js';
 import type { NumberColumn, TextColumn } from './types.js';
-import { mapObject } from './utils.js';
 
 export type MaybeArray<T> = T | T[];
 
@@ -245,3 +244,17 @@ export const dbConfigSchema = z
 			}),
 		};
 	});
+
+
+/**
+ * Map an object's values to a new set of values
+ * while preserving types.
+ */
+function mapObject<T, U = T>(
+	item: Record<string, T>,
+	callback: (key: string, value: T) => U
+): Record<string, U> {
+	return Object.fromEntries(
+		Object.entries(item).map(([key, value]) => [key, callback(key, value)])
+	);
+}

--- a/packages/db/src/core/utils.ts
+++ b/packages/db/src/core/utils.ts
@@ -1,6 +1,5 @@
-import type { AstroConfig, AstroIntegration } from 'astro';
+import type { AstroConfig } from 'astro';
 import { loadEnv } from 'vite';
-import type { AstroDbIntegration } from './types.js';
 
 export type VitePlugin = Required<AstroConfig['vite']>['plugins'][number];
 
@@ -28,21 +27,4 @@ export function getDbDirectoryUrl(root: URL | string) {
 	return new URL('db/', root);
 }
 
-export function defineDbIntegration(integration: AstroDbIntegration): AstroIntegration {
-	return integration;
-}
-
 export type Result<T> = { success: true; data: T } | { success: false; data: unknown };
-
-/**
- * Map an object's values to a new set of values
- * while preserving types.
- */
-export function mapObject<T, U = T>(
-	item: Record<string, T>,
-	callback: (key: string, value: T) => U
-): Record<string, U> {
-	return Object.fromEntries(
-		Object.entries(item).map(([key, value]) => [key, callback(key, value)])
-	);
-}

--- a/packages/db/src/utils.ts
+++ b/packages/db/src/utils.ts
@@ -1,7 +1,11 @@
-export { defineDbIntegration } from './core/utils.js';
+import type { AstroIntegration } from 'astro';
 import { tableSchema } from './core/schemas.js';
-import type { ColumnsConfig, TableConfig } from './core/types.js';
+import type { AstroDbIntegration, ColumnsConfig, TableConfig } from './core/types.js';
 import { type Table, asDrizzleTable as internal_asDrizzleTable } from './runtime/index.js';
+
+export function defineDbIntegration(integration: AstroDbIntegration): AstroIntegration {
+	return integration;
+}
 
 export function asDrizzleTable<
 	TableName extends string = string,


### PR DESCRIPTION
## Changes

- Reorganises some Astro DB code to avoid Vite being imported by `@astrojs/db/utils`

## Testing

- Existing tests should pass
- Is there a way we can enforce or check Vite is not imported?

## Docs

n/a — bug fix