### PR TITLE
fix(astro): handle AstroUserError during sync and exports types

### DIFF
--- a/.changeset/strong-peaches-learn.md
+++ b/.changeset/strong-peaches-learn.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Handles `AstroUserError`s thrown while syncing content collections and exports `BaseSchema` and `CollectionConfig` types

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -17,7 +17,7 @@ import { createNodeLogger } from '../config/logging.js';
 import { createSettings } from '../config/settings.js';
 import { createVite } from '../create-vite.js';
 import { collectErrorMetadata } from '../errors/dev/utils.js';
-import { AstroError, AstroErrorData, createSafeError, isAstroError } from '../errors/index.js';
+import { AstroError, AstroErrorData, AstroUserError, createSafeError, isAstroError } from '../errors/index.js';
 import type { Logger } from '../logger/core.js';
 import { formatErrorMessage } from '../messages.js';
 import { ensureProcessNodeEnv } from '../util.js';
@@ -159,9 +159,11 @@ export async function syncContentCollections(
 		if (isAstroError(e)) {
 			throw e;
 		}
+		const hint = AstroUserError.is(e) ? e.hint : undefined
 		throw new AstroError(
 			{
 				...AstroErrorData.GenerateContentTypesError,
+				hint,
 				message: AstroErrorData.GenerateContentTypesError.message(safeError.message),
 			},
 			{ cause: e }

--- a/packages/astro/types/content.d.ts
+++ b/packages/astro/types/content.d.ts
@@ -26,7 +26,7 @@ declare module 'astro:content' {
 		| import('astro/zod').ZodDiscriminatedUnion<string, import('astro/zod').AnyZodObject[]>
 		| import('astro/zod').ZodIntersection<BaseSchemaWithoutEffects, BaseSchemaWithoutEffects>;
 
-	type BaseSchema =
+	export type BaseSchema =
 		| BaseSchemaWithoutEffects
 		| import('astro/zod').ZodEffects<BaseSchemaWithoutEffects>;
 
@@ -42,7 +42,7 @@ declare module 'astro:content' {
 		schema?: S | ((context: SchemaContext) => S);
 	};
 
-	type CollectionConfig<S extends BaseSchema> =
+	export type CollectionConfig<S extends BaseSchema> =
 		| ContentCollectionConfig<S>
 		| DataCollectionConfig<S>;
 


### PR DESCRIPTION
## Changes

- Handles `AstroUserError` hint during CC syncing
- Exports a few content types

## Testing

N/A

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
