### PR TITLE
Adds missing readonly keyword

### DIFF
--- a/packages/astro/src/transitions/events.ts
+++ b/packages/astro/src/transitions/events.ts
@@ -25,7 +25,7 @@ class BeforeEvent extends Event {
 	readonly sourceElement: Element | undefined;
 	readonly info: any;
 	newDocument: Document;
-	signal: AbortSignal;
+	readonly signal: AbortSignal;
 
 	constructor(
 		type: string,


### PR DESCRIPTION
## Changes

I have just seen that the new property "signal" of the events "astro:before-preparation" and "astro:before-swap" is missing the keyword "readonly". Technically, it has already been set to "readonly" via Object.defineProperty(). This is therefore not a functional change, but rather an in-code documentation improvement.

## Testing

none.

## Docs

n.a.
