### PR TITLE
Fix markdown of `markdown-style-guide.md` in the blog example

### DIFF
--- a/examples/blog/src/content/blog/markdown-style-guide.md
+++ b/examples/blog/src/content/blog/markdown-style-guide.md
@@ -31,13 +31,13 @@ Itatur? Quiatae cullecum rem ent aut odis in re eossequodi nonsequ idebis ne sap
 
 ## Images
 
-#### Syntax
+### Syntax
 
 ```markdown
 ![Alt text](./full/or/relative/path/of/image)
 ```
 
-#### Output
+### Output
 
 ![blog placeholder](/blog-placeholder-about.jpg)
 
@@ -77,7 +77,7 @@ The blockquote element represents content that is quoted from another source, op
 
 ## Tables
 
-#### Syntax
+### Syntax
 
 ```markdown
 | Italics   | Bold     | Code   |
@@ -85,7 +85,7 @@ The blockquote element represents content that is quoted from another source, op
 | _italics_ | **bold** | `code` |
 ```
 
-#### Output
+### Output
 
 | Italics   | Bold     | Code   |
 | --------- | -------- | ------ |
@@ -93,7 +93,7 @@ The blockquote element represents content that is quoted from another source, op
 
 ## Code Blocks
 
-#### Syntax
+### Syntax
 
 we can use 3 backticks ``` in new line and write snippet and close with 3 backticks on new line and to highlight language specific syntax, write one word of language name after first 3 backticks, for eg. html, javascript, css, markdown, typescript, txt, bash
 
@@ -112,7 +112,7 @@ we can use 3 backticks ``` in new line and write snippet and close with 3 backti
 ```
 ````
 
-Output
+### Output
 
 ```html
 <!doctype html>
@@ -187,7 +187,7 @@ Output
 
 ## Other Elements — abbr, sub, sup, kbd, mark
 
-#### Syntax
+### Syntax
 
 ```markdown
 <abbr title="Graphics Interchange Format">GIF</abbr> is a bitmap image format.
@@ -196,12 +196,12 @@ H<sub>2</sub>O
 
 X<sup>n</sup> + Y<sup>n</sup> = Z<sup>n</sup>
 
-Press <kbd><kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>Delete</kbd></kbd> to end the session.
+Press <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>Delete</kbd> to end the session.
 
 Most <mark>salamanders</mark> are nocturnal, and hunt for insects, worms, and other small creatures.
 ```
 
-#### Output
+### Output
 
 <abbr title="Graphics Interchange Format">GIF</abbr> is a bitmap image format.
 
@@ -209,6 +209,6 @@ H<sub>2</sub>O
 
 X<sup>n</sup> + Y<sup>n</sup> = Z<sup>n</sup>
 
-Press <kbd><kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>Delete</kbd></kbd> to end the session.
+Press <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>Delete</kbd> to end the session.
 
 Most <mark>salamanders</mark> are nocturnal, and hunt for insects, worms, and other small creatures.


### PR DESCRIPTION
## Changes

Updates the markdown in the `markdown-style-guide.md` blog example file:

- Updates wrong/missing heading levels (on "Syntax" and "Output" sections where its missing or skipping a level);
- Updates the syntax of the `<kbd>` tag example, where there was an extra tag surrounding the whole example command and nos just individual keys, as expected.

## Testing

Heading changes were testes with the [Headings Map browser extension (Chrome)](https://chromewebstore.google.com/detail/headingsmap/flbjommegcjonpdmenkdiocclhjacmbi?hl=pt-BR&utm_source=ext_sidebar) for easier error detection.

Heading structure before:

![Headings structure before the change, with skipping heading levels](https://github.com/withastro/astro/assets/12275019/65e6462c-a846-45ad-93ee-ecac1ce61c0d)

Heading structure after:

![Headings structure after the change, with no erros](https://github.com/withastro/astro/assets/12275019/5e10e472-0347-4f8b-8396-82bce1128364)

## Docs

I believe no docs changes are needed, since its a syntax fix.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
