### PR TITLE
Update generator.ts to allow %23 (#) in dynamic urls

### DIFF
--- a/.changeset/mean-geckos-sell.md
+++ b/.changeset/mean-geckos-sell.md
@@ -1,5 +1,5 @@
 ---
-"astro": minor
+"astro": patch
 ---
 
 Update generator.ts to allow %23 (#) in dynamic urls

--- a/.changeset/mean-geckos-sell.md
+++ b/.changeset/mean-geckos-sell.md
@@ -1,0 +1,5 @@
+---
+"astro": minor
+---
+
+Update generator.ts to allow %23 (#) in dynamic urls

--- a/packages/astro/src/core/routing/manifest/generator.ts
+++ b/packages/astro/src/core/routing/manifest/generator.ts
@@ -2,6 +2,11 @@ import type { AstroConfig, RoutePart } from '../../../@types/astro.js';
 
 import { compile } from 'path-to-regexp';
 
+/**
+ * Sanitizes the parameters object by normalizing string values and replacing certain characters with their URL-encoded equivalents.
+ * @param {Record<string, string | number | undefined>} params - The parameters object to be sanitized.
+ * @returns {Record<string, string | number | undefined>} The sanitized parameters object.
+ */
 function sanitizeParams(params: Record<string, string | number | undefined>): Record<string, string | number | undefined> {
 	return Object.fromEntries(
 		Object.entries(params).map(([key, value]) => {

--- a/packages/astro/src/core/routing/manifest/generator.ts
+++ b/packages/astro/src/core/routing/manifest/generator.ts
@@ -3,17 +3,17 @@ import type { AstroConfig, RoutePart } from '../../../@types/astro.js';
 import { compile } from 'path-to-regexp';
 
 function sanitizeParams(params: Record<string, string | number | undefined>): Record<string, string | number | undefined> {
-	return Object.entries(params).reduce((acc, [key, value]) => {
-		if (typeof value === 'string') {
-			acc[key] = value
-				.normalize()
-				.replace(/#/g, '%23')
-				.replace(/\?/g, '%3F')
-		} else {
-			acc[key] = value;
-		}
-		return acc;
-	}, {} as Record<string, string | number | undefined>);
+	return Object.fromEntries(
+		Object.entries(params).map(([key, value]) => {
+			if (typeof value === 'string') {
+				return [key, value
+					.normalize()
+					.replace(/#/g, '%23')
+					.replace(/\?/g, '%3F')]
+			}
+			return [key, value];
+		})
+	)
 }
 
 export function getRouteGenerator(

--- a/packages/astro/src/core/routing/manifest/generator.ts
+++ b/packages/astro/src/core/routing/manifest/generator.ts
@@ -2,19 +2,13 @@ import type { AstroConfig, RoutePart } from '../../../@types/astro.js';
 
 import { compile } from 'path-to-regexp';
 
-function sanitizePath(path: string) {
-	return path.normalize()
-		.replace(/\?/g, "%3F")
-		.replace(/#/g, "%23")
-		.replace(/%5B/g, "[")
-		.replace(/%5D/g, "]")
-		.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function sanitizeParams(params: Record<string, string | number | undefined>): Record<string, string | number | undefined> {
 	return Object.entries(params).reduce((acc, [key, value]) => {
-		if (typeof value === "string") {
-			acc[key] = sanitizePath(value);
+		if (typeof value === 'string') {
+			acc[key] = value
+				.normalize()
+				.replace(/#/g, '%23')
+				.replace(/\?/g, '%3F')
 		} else {
 			acc[key] = value;
 		}
@@ -37,7 +31,13 @@ export function getRouteGenerator(
 						} else if (part.dynamic) {
 							return `:${part.content}`;
 						} else {
-							return sanitizePath(part.content)
+							return part.content
+								.normalize()
+								.replace(/\?/g, '%3F')
+								.replace(/#/g, '%23')
+								.replace(/%5B/g, '[')
+								.replace(/%5D/g, ']')
+								.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 						}
 					})
 					.join('')

--- a/packages/astro/src/core/routing/manifest/generator.ts
+++ b/packages/astro/src/core/routing/manifest/generator.ts
@@ -50,7 +50,7 @@ export function getRouteGenerator(
 	if (addTrailingSlash === 'always' && segments.length) {
 		trailing = '/';
 	}
-	const toPath = compile(template + trailing, { delimiter: "/?" });
+	const toPath = compile(template + trailing);
 	return (params: Record<string, string | number | undefined>): string => {
 		const sanitizedParams = sanitizeParams(params);
 		const path = toPath(sanitizedParams);

--- a/packages/astro/src/core/routing/manifest/generator.ts
+++ b/packages/astro/src/core/routing/manifest/generator.ts
@@ -11,12 +11,16 @@ function sanitizePath(path: string) {
 		.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function sanitizeParams(params: Record<string, string>): Record<string, string> {
-	return Object.keys(params).reduce((acc: Record<string, string>, key: string) => {
-		acc[key] = sanitizePath(params[key]);
-		return acc;
-	}, {});
-};
+function sanitizeParams(params: Record<string, string | number | undefined>): Record<string, string | number | undefined> {
+	return Object.entries(params).reduce((acc, [key, value]) => {
+	  if (typeof value === "string") {
+		acc[key] = sanitizePath(value);
+	  } else {
+		acc[key] = value;
+	  }
+	  return acc;
+	}, {} as Record<string, string | number | undefined>);
+  }
 
 export function getRouteGenerator(
 	segments: RoutePart[][],
@@ -47,7 +51,7 @@ export function getRouteGenerator(
 		trailing = '/';
 	}
 	const toPath = compile(template + trailing, { delimiter: "/?" });
-	return (params: Record<string, string>): string => {
+	return (params: Record<string, string | number | undefined>): string => {
 		const sanitizedParams = sanitizeParams(params);
 		const path = toPath(sanitizedParams);
 

--- a/packages/astro/src/core/routing/manifest/generator.ts
+++ b/packages/astro/src/core/routing/manifest/generator.ts
@@ -36,7 +36,7 @@ export function getRouteGenerator(
 	if (addTrailingSlash === 'always' && segments.length) {
 		trailing = '/';
 	}
-	const toPath = compile(template + trailing);
+	const toPath = compile(template + trailing, { delimiter: "/?" });
 	return (params: object): string => {
 		const path = toPath(params);
 

--- a/packages/astro/src/core/routing/manifest/generator.ts
+++ b/packages/astro/src/core/routing/manifest/generator.ts
@@ -13,14 +13,14 @@ function sanitizePath(path: string) {
 
 function sanitizeParams(params: Record<string, string | number | undefined>): Record<string, string | number | undefined> {
 	return Object.entries(params).reduce((acc, [key, value]) => {
-	  if (typeof value === "string") {
-		acc[key] = sanitizePath(value);
-	  } else {
-		acc[key] = value;
-	  }
-	  return acc;
+		if (typeof value === "string") {
+			acc[key] = sanitizePath(value);
+		} else {
+			acc[key] = value;
+		}
+		return acc;
 	}, {} as Record<string, string | number | undefined>);
-  }
+}
 
 export function getRouteGenerator(
 	segments: RoutePart[][],

--- a/packages/astro/test/ssr-params.test.js
+++ b/packages/astro/test/ssr-params.test.js
@@ -42,11 +42,11 @@ describe('Astro.params in SSR', () => {
 
 	it('No double URL decoding', async () => {
 		const app = await fixture.loadTestAdapterApp();
-		const request = new Request('http://example.com/users/houston/%25');
+		const request = new Request('http://example.com/users/houston/%25%23%3F');
 		const response = await app.render(request);
 		assert.equal(response.status, 200);
 		const html = await response.text();
 		const $ = cheerio.load(html);
-		assert.equal($('.category').text(), '%');
+		assert.equal($('.category').text(), '%#?');
 	});
 });


### PR DESCRIPTION
## Changes

- Allows the server to retrive # in dynamic paths (will need to be %23 on client to be recived)
- I do have a case in my project where this makes sense.

## Testing

- Tested locally and seems to be fine. I dont know why these checks are in place well enough.
- Didnt see this beeing a problem in my older project where I used react.

## Docs

- Dont think this need any new doc changes
/cc @withastro/maintainers-docs for feedback! 