### PR TITLE
Convert saved non-UTC dates to UTC

### DIFF
--- a/.changeset/tiny-gifts-fry.md
+++ b/.changeset/tiny-gifts-fry.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Convert non-ISO date to UTC time


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/10964
- Using the `NOW` helper saves dates as the `CURRENT_TIMESTAMP`, a UTC date that is unfortunately formated as `2024-05-07 17:53:37` (no timezone).
- The change is to check if the date string is ISO when we read from the database. If its not, append the UTC timezone to the end so that its treated as a UTC time and not local time.

## Testing

- Tried really hard to write a test, but because the database is running locally the date's already in the "correct" time zone. Would love a suggestion here if anyone can think of one.

## Docs

N/A, bug fix