### PR TITLE
Support scope styles for picture element in Picture component

### DIFF
--- a/.changeset/ten-needles-rescue.md
+++ b/.changeset/ten-needles-rescue.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Passes the scoped style attribute or class to the `<picture>` element in the `<Picture />` component so scoped styling can be applied to the `<picture>` element

--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -27,6 +27,21 @@ if (props.alt === undefined || props.alt === null) {
 	throw new AstroError(AstroErrorData.ImageMissingAlt);
 }
 
+// Picture attribute inherit scoped styles from class and attributes
+const scopedStyleClass = props.class?.match(/\bastro-\w{8}\b/)?.[0]
+if (scopedStyleClass) {
+	if (pictureAttributes.class) {
+		pictureAttributes.class = `${pictureAttributes.class} ${scopedStyleClass}`;
+	} else {
+		pictureAttributes.class = scopedStyleClass;
+	}
+}
+for (const key in props) {
+	if (key.startsWith('data-astro-')) {
+		pictureAttributes[key] = props[key];
+	}
+}
+
 const originalSrc = await resolveSrc(props.src);
 const optimizedImages: GetImageResult[] = await Promise.all(
 	formats.map(

--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -37,7 +37,7 @@ if (scopedStyleClass) {
 	}
 }
 for (const key in props) {
-	if (key.startsWith('data-astro-')) {
+	if (key.startsWith('data-astro-cid')) {
 		pictureAttributes[key] = props[key];
 	}
 }

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -246,6 +246,19 @@ describe('astro:image', () => {
 				);
 			});
 
+			it('Picture component scope styles work', async () => {
+				let res = await fixture.fetch('/picturecomponent');
+				let html = await res.text();
+				$ = cheerio.load(html);
+
+				// Should have scoped attribute
+				let $picture = $('#picture-attributes picture');
+				assert.ok(Object.keys($picture.attr()).find((a) => a.startsWith('data-astro-cid-')));
+
+				let $img = $('#picture-attributes img');
+				assert.ok(Object.keys($img.attr()).find((a) => a.startsWith('data-astro-cid-')));
+			});
+
 			it('properly deduplicate srcset images', async () => {
 				let res = await fixture.fetch('/srcset');
 				let html = await res.text();

--- a/packages/astro/test/fixtures/core-image/src/pages/picturecomponent.astro
+++ b/packages/astro/test/fixtures/core-image/src/pages/picturecomponent.astro
@@ -14,3 +14,18 @@ import myImage from "../assets/penguin1.jpg";
 <div id="picture-fallback">
 <Picture src={myImage} fallbackFormat="jpeg" alt="A penguin" />
 </div>
+
+<div id="picture-attributes">
+  <Picture src={myImage} fallbackFormat="jpeg" alt="A penguin" class="img-comp" pictureAttributes={{ class: 'picture-comp' }} />
+</div>
+
+<style>
+  .img-comp {
+    border: 5px solid blue;
+  }
+
+  .picture-comp {
+    border: 5px solid red;
+    display: inline-block;
+  }
+</style>


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/10307

The PR uses some tricks to get the scoped attributes or class to pass it to the `<picture>` element, instead of only to the `img` element.

The trick uses regexes for `astro-*` class and `data-astro-cid-*` attributes, which perhaps is not the most elegant, but I think it should be fine?

Question: Do we want to check for `data-astro-cid` specifically?

## Testing

Added test

## Docs

Added changeset