### PR TITLE
fix: logic for printing warning

### DIFF
--- a/packages/astro/src/core/middleware/callMiddleware.ts
+++ b/packages/astro/src/core/middleware/callMiddleware.ts
@@ -56,13 +56,15 @@ export async function callMiddleware(
 	let responseFunctionPromise: Promise<Response> | Response | undefined = undefined;
 	const next: MiddlewareNext = async (payload) => {
 		nextCalled = true;
-		if (enableRerouting) {
-			responseFunctionPromise = responseFunction(apiContext, payload);
-		} else {
+		if (!enableRerouting && payload) {
 			logger.warn(
 				'router',
 				'The rewrite API is experimental. To use this feature, add the `rewriting` flag to the `experimental` object in your Astro config.'
 			);
+		}
+		if (enableRerouting) {
+			responseFunctionPromise = responseFunction(apiContext, payload);
+		} else {
 			responseFunctionPromise = responseFunction(apiContext);
 		}
 		// We need to pass the APIContext pass to `callMiddleware` because it can be mutated across middleware functions


### PR DESCRIPTION
## Changes

The logic for printing the warning wasn't correct

## Testing

I tested locally, and I don't see the warning

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
