### PR TITLE
Fix error when accessing `clientAddress` on prerendered routes

### DIFF
--- a/.changeset/breezy-lies-sparkle.md
+++ b/.changeset/breezy-lies-sparkle.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fix error when accessing `clientAddress` on prerendered routes
+Improve error message when accessing `clientAddress` on prerendered routes

--- a/.changeset/breezy-lies-sparkle.md
+++ b/.changeset/breezy-lies-sparkle.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix error when accessing `clientAddress` on prerendered routes

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -69,15 +69,15 @@ export const ClientAddressNotAvailable = {
 /**
  * @docs
  * @see
- * - [Official integrations](https://docs.astro.build/en/guides/integrations-guide/#official-integrations)
+ * - [Opting-in to pre-rendering](https://docs.astro.build/en/guides/server-side-rendering/#opting-in-to-pre-rendering-in-server-mode)
  * - [Astro.clientAddress](https://docs.astro.build/en/reference/api-reference/#astroclientaddress)
  * @description
- * The `Astro.clientAddress` property cannot be used on prerendered pages.
+ * The `Astro.clientAddress` property cannot be used inside prerendered routes.
  */
 export const PrerenderClientAddressNotAvailable = {
 	name: 'PrerenderClientAddressNotAvailable',
-	title: '`Astro.clientAddress` cannot be used on prerendered pages.',
-	message: `\`Astro.clientAddress\` cannot be used on prerendered pages`,
+	title: '`Astro.clientAddress` cannot be used inside prerendered routes.',
+	message: `\`Astro.clientAddress\` cannot be used inside prerendered routes`,
 } satisfies ErrorData;
 /**
  * @docs

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -69,6 +69,19 @@ export const ClientAddressNotAvailable = {
 /**
  * @docs
  * @see
+ * - [Official integrations](https://docs.astro.build/en/guides/integrations-guide/#official-integrations)
+ * - [Astro.clientAddress](https://docs.astro.build/en/reference/api-reference/#astroclientaddress)
+ * @description
+ * The `Astro.clientAddress` property cannot be used on prerendered pages.
+ */
+export const PrerenderClientAddressNotAvailable = {
+	name: 'PrerenderClientAddressNotAvailable',
+	title: '`Astro.clientAddress` cannot be used on prerendered pages.',
+	message: `\`Astro.clientAddress\` cannot be used on prerendered pages`,
+} satisfies ErrorData;
+/**
+ * @docs
+ * @see
  * - [Enabling SSR in Your Project](https://docs.astro.build/en/guides/server-side-rendering/)
  * - [Astro.clientAddress](https://docs.astro.build/en/reference/api-reference/#astroclientaddress)
  * @description

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -455,19 +455,21 @@ export class RenderContext {
 		if (clientAddressSymbol in request) {
 			return Reflect.get(request, clientAddressSymbol) as string;
 		}
+		
 		if (pipeline.serverLike) {
 			if (request.body === null) {
 				throw new AstroError(AstroErrorData.PrerenderClientAddressNotAvailable);
 			}
+
 			if (pipeline.adapterName) {
 				throw new AstroError({
 					...AstroErrorData.ClientAddressNotAvailable,
 					message: AstroErrorData.ClientAddressNotAvailable.message(pipeline.adapterName),
 				});
 			}
-		} else {
-			throw new AstroError(AstroErrorData.StaticClientAddressNotAvailable);
 		}
+
+		throw new AstroError(AstroErrorData.StaticClientAddressNotAvailable);
 	}
 
 	/**

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -455,11 +455,16 @@ export class RenderContext {
 		if (clientAddressSymbol in request) {
 			return Reflect.get(request, clientAddressSymbol) as string;
 		}
-		if (pipeline.adapterName) {
-			throw new AstroError({
-				...AstroErrorData.ClientAddressNotAvailable,
-				message: AstroErrorData.ClientAddressNotAvailable.message(pipeline.adapterName),
-			});
+		if (pipeline.serverLike) {
+			if (request.body === null) {
+				throw new AstroError(AstroErrorData.PrerenderClientAddressNotAvailable);
+			}
+			if (pipeline.adapterName) {
+				throw new AstroError({
+					...AstroErrorData.ClientAddressNotAvailable,
+					message: AstroErrorData.ClientAddressNotAvailable.message(pipeline.adapterName),
+				});
+			}
 		} else {
 			throw new AstroError(AstroErrorData.StaticClientAddressNotAvailable);
 		}

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -135,7 +135,7 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 		assets: new Set(),
 		entryModules: {},
 		routes: [],
-		adapterName: '',
+		adapterName: settings?.adapter?.name || '',
 		clientDirectives: settings.clientDirectives,
 		renderers: [],
 		base: settings.config.base,


### PR DESCRIPTION
## Changes

- What does this change?

Closes: https://github.com/withastro/astro/issues/10972

- Add adapter name to dev manifest
- Add error message for accessing `clientAddress` on prerendered routes
- Fix/Throw error when accessing `clientAddress` on prerendered routes

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I am not sure how to test this, I tested it manually. If someone could point me to an example, that would be great!

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

Does not change behavior, just throws a different error
