### PR TITLE
Fix loading of non-index routes that end with `index.html`

### DIFF
--- a/.changeset/tiny-dodos-melt.md
+++ b/.changeset/tiny-dodos-melt.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix loading of non-index routes that end with `index.html`

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -81,7 +81,10 @@ export async function matchRoute(
 	// Try without `.html` extensions or `index.html` in request URLs to mimic
 	// routing behavior in production builds. This supports both file and directory
 	// build formats, and is necessary based on how the manifest tracks build targets.
-	const altPathname = pathname.replace(/(?:index)?\.html$/, '');
+	const altPathname = pathname
+		.replace(/\/index\.html$/, '/')
+		.replace(/\.html$/, '');
+
 	if (altPathname !== pathname) {
 		return await matchRoute(altPathname, manifestData, pipeline);
 	}

--- a/packages/astro/test/dev-routing.test.js
+++ b/packages/astro/test/dev-routing.test.js
@@ -321,6 +321,11 @@ describe('Development Routing', () => {
 			assert.equal(response.status, 200);
 		});
 
+		it('200 when loading /base-index.html', async () => {
+			const response = await fixture.fetch('/base-index.html');
+			assert.equal(response.status, 200);
+		});
+
 		it('200 when loading /', async () => {
 			const response = await fixture.fetch('/');
 			assert.equal(response.status, 200);

--- a/packages/astro/test/fixtures/without-site-config/src/pages/base-index.astro
+++ b/packages/astro/test/fixtures/without-site-config/src/pages/base-index.astro
@@ -1,0 +1,1 @@
+<div>testing</div>


### PR DESCRIPTION
## Changes

- What does this change?

Closes: https://github.com/withastro/astro/issues/10850

- Fix loading of non-index routes that end with `index.html`



## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Test included

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No behavior change, just aligning with expectations
