### PR TITLE
fix: incorrect type for experimental option

### DIFF
--- a/.changeset/lemon-otters-rest.md
+++ b/.changeset/lemon-otters-rest.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix a regression where the flag `experimental.rewriting` was marked mandatory. Is is now optional.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2107,7 +2107,7 @@ export interface AstroUserConfig {
 		 *
 		 * For a complete overview, and to give feedback on this experimental API, see the [Rerouting RFC](https://github.com/withastro/roadmap/blob/feat/reroute/proposals/0047-rerouting.md).
 		 */
-		rewriting: boolean;
+		rewriting?: boolean;
 	};
 }
 


### PR DESCRIPTION
## Changes

Fixes the type for `experimental.rewriting`

## Testing

Checked locally

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
