### PR TITLE
fix:  fix incorrect actions path on windows

### DIFF
--- a/.changeset/fluffy-zoos-hammer.md
+++ b/.changeset/fluffy-zoos-hammer.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+fix: remove actions path leading slash on windows

--- a/.changeset/fluffy-zoos-hammer.md
+++ b/.changeset/fluffy-zoos-hammer.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-fix: remove actions path leading slash on windows
+fix incorrect actions path on windows

--- a/packages/astro/src/actions/index.ts
+++ b/packages/astro/src/actions/index.ts
@@ -2,13 +2,15 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import type { Plugin as VitePlugin } from 'vite';
 import type { AstroIntegration } from '../@types/astro.js';
 import { ACTIONS_TYPES_FILE, RESOLVED_VIRTUAL_MODULE_ID, VIRTUAL_MODULE_ID } from './consts.js';
+import { viteID } from '../core/util.js';
+
 
 export default function astroActions(): AstroIntegration {
 	return {
 		name: VIRTUAL_MODULE_ID,
 		hooks: {
 			async 'astro:config:setup'(params) {
-				const stringifiedActionsImport = getActionsImportPath(params.config.srcDir)
+				const stringifiedActionsImport = JSON.stringify(viteID(new URL('./actions', params.config.srcDir)));
 				params.updateConfig({
 					vite: {
 						define: {
@@ -76,14 +78,4 @@ async function typegen({
 
 	await mkdir(dotAstroDir, { recursive: true });
 	await writeFile(new URL(ACTIONS_TYPES_FILE, dotAstroDir), content);
-}
-
-const isWindows = process.platform === 'win32';
-
-function getActionsImportPath(srcDir: URL) {
-	const urlPath = JSON.stringify(
-		new URL('actions', srcDir).pathname
-	);
-	// remove leading slash on windows
-	return isWindows ? urlPath.replace(/^\//, '') : urlPath;
 }

--- a/packages/astro/src/actions/index.ts
+++ b/packages/astro/src/actions/index.ts
@@ -8,9 +8,7 @@ export default function astroActions(): AstroIntegration {
 		name: VIRTUAL_MODULE_ID,
 		hooks: {
 			async 'astro:config:setup'(params) {
-				const stringifiedActionsImport = JSON.stringify(
-					new URL('actions', params.config.srcDir).pathname
-				);
+				const stringifiedActionsImport = getActionsImportPath(params.config.srcDir)
 				params.updateConfig({
 					vite: {
 						define: {
@@ -78,4 +76,14 @@ async function typegen({
 
 	await mkdir(dotAstroDir, { recursive: true });
 	await writeFile(new URL(ACTIONS_TYPES_FILE, dotAstroDir), content);
+}
+
+const isWindows = process.platform === 'win32';
+
+function getActionsImportPath(srcDir: URL) {
+	const urlPath = JSON.stringify(
+		new URL('actions', srcDir).pathname
+	);
+	// remove leading slash on windows
+	return isWindows ? urlPath.replace(/^\//, '') : urlPath;
 }


### PR DESCRIPTION
## Changes

On Windows, the path `stringifiedActionsImport` will get `/D:/XX/src/actions`, this cause the `Actions` type to be `any`.

![image](https://github.com/withastro/astro/assets/25167721/5487d9a8-709c-495d-b3f8-ab83df91edbf)



## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
