### PR TITLE
fix: new version message when running astro dev

### DIFF
--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -67,7 +67,7 @@ export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevS
 
 						logger.warn(
 							'SKIP_FORMAT',
-							msg.newVersionAvailable({
+							await msg.newVersionAvailable({
 								latestVersion: version,
 							})
 						);

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -105,10 +105,10 @@ export function serverShortcuts({ key, label }: { key: string; label: string }):
 	return [dim('  Press'), key, dim('to'), label].join(' ');
 }
 
-export function newVersionAvailable({ latestVersion }: { latestVersion: string }) {
+export async function newVersionAvailable({ latestVersion }: { latestVersion: string }) {
 	const badge = bgYellow(black(` update `));
 	const headline = yellow(`▶ New version of Astro available: ${latestVersion}`);
-	const execCommand = getExecCommand();
+	const execCommand = await getExecCommand();
 
 	const details = `  Run ${cyan(`${execCommand} @astrojs/upgrade`)} to update`;
 	return ['', `${badge} ${headline}`, details, ''].join('\n');


### PR DESCRIPTION
The `getExecCommand` is an async function but it wasn't awaited in the `newVersionAvailable` function so the message in the console was:

```
Run [object Promise] @astrojs/upgrade to update
```

Instead of (for example):

```
Run pnpx @astrojs/upgrade to update
```

## Changes

I transformed `newVersionAvailable` to an async function and added two `await`:
* one for `getExecCommand()`
* another where `newVersionAvailable` was called

Should I add a changeset for this?

## Testing

Not sure how to test. If I use `pnpm link` on a project, it will use the latest version so the message will not be displayed. But I'm not sure a test is necessary.

I also run `pnpm test` and everything was ok.

## Docs

No new behavior, only a minor fix so no need to update the doc.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
