### PR TITLE
docs: fix indentation in experimental.actions code examples

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1734,7 +1734,7 @@ export interface AstroUserConfig {
 		 *
 		 * ```js
 		 * {
-		 * 	 output: 'hybrid', // or 'server'
+		 *   output: 'hybrid', // or 'server'
 		 *   experimental: {
 		 *     actions: true,
 		 *   },
@@ -1761,7 +1761,7 @@ export interface AstroUserConfig {
 		 *     },
 		 *   }),
 		 *   comment: defineAction({
-		 * 		 accept: 'form',
+		 *     accept: 'form',
 		 *     input: z.object({
 		 *       postId: z.string(),
 		 *       author: z.string(),


### PR DESCRIPTION
## Changes

- This PR fixes the mixed tabs and spaces in the [experimental.actions](https://docs.astro.build/en/reference/configuration-reference/#experimentalactions) code examples to ensure consistent indentation.
  - Screenshots of the current document:
    - ![Screenshot 2024-05-10 at 23 06 50](https://github.com/withastro/astro/assets/7889778/78d2e345-4b88-4501-8108-d51618cbf67e)
    - ![Screenshot 2024-05-10 at 23 07 13](https://github.com/withastro/astro/assets/7889778/8e6dc510-b0f2-4544-960a-b5aa4bda5814)


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
