### PR TITLE
Fix: allow `locals` access from actions

### DIFF
--- a/.changeset/popular-spiders-cough.md
+++ b/.changeset/popular-spiders-cough.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix `locals` access from action handlers

--- a/packages/astro/src/actions/index.ts
+++ b/packages/astro/src/actions/index.ts
@@ -29,7 +29,7 @@ export default function astroActions(): AstroIntegration {
 
 				params.addMiddleware({
 					entrypoint: 'astro/actions/runtime/middleware.js',
-					order: 'pre',
+					order: 'post',
 				});
 
 				await typegen({

--- a/packages/astro/test/actions.test.js
+++ b/packages/astro/test/actions.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
+import * as cheerio from 'cheerio';
 
 describe('Astro Actions', () => {
 	let fixture;
@@ -169,5 +170,20 @@ describe('Astro Actions', () => {
 			assert.equal(json.success, true);
 			assert.equal(json.isFormData, true, 'Should receive plain FormData');
 		});
+
+		it('Respects user middleware', async () => {
+			const formData = new FormData();
+			formData.append('_astroAction', '/_actions/getUser');
+			const req = new Request('http://example.com/middleware', {
+				method: 'POST',
+				body: formData,
+			});
+			const res = await app.render(req);
+			assert.equal(res.ok, true);
+
+			const html = await res.text();
+			let $ = cheerio.load(html);
+			assert.equal($('#user').text(), 'Houston');
+		})
 	});
 });

--- a/packages/astro/test/fixtures/actions/src/actions/index.ts
+++ b/packages/astro/test/fixtures/actions/src/actions/index.ts
@@ -1,4 +1,4 @@
-import { defineAction, z } from 'astro:actions';
+import { defineAction, getApiContext, z } from 'astro:actions';
 
 export const server = {
 	subscribe: defineAction({
@@ -29,4 +29,11 @@ export const server = {
 			};
 		},
 	}),
+	getUser: defineAction({
+		accept: 'form',
+		handler: async () => {
+			const { locals } = getApiContext();
+			return locals.user;
+		}
+	})
 };

--- a/packages/astro/test/fixtures/actions/src/middleware.ts
+++ b/packages/astro/test/fixtures/actions/src/middleware.ts
@@ -1,0 +1,8 @@
+import { defineMiddleware } from 'astro:middleware';
+
+export const onRequest = defineMiddleware((ctx, next) => {
+	ctx.locals.user = {
+		name: 'Houston',
+	};
+	return next();
+});

--- a/packages/astro/test/fixtures/actions/src/pages/middleware.astro
+++ b/packages/astro/test/fixtures/actions/src/pages/middleware.astro
@@ -1,0 +1,7 @@
+---
+import { actions } from 'astro:actions';
+
+const res = Astro.getActionResult(actions.getUser);
+---
+
+<h1 id="user">{res?.data?.name}</h1>


### PR DESCRIPTION
## Changes

Move actions middleware to run _after_ user middleware for `locals` access. This should unblock authwentication middleware for action handlers.

## Testing

Add integration test with user middleware.

## Docs

N/A: this feature is expected in the RFC already.