### PR TITLE
fix(astro): refine assets prefix typing

### DIFF
--- a/.changeset/seven-crabs-burn.md
+++ b/.changeset/seven-crabs-burn.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Add type declarations for `import.meta.env.ASSETS_PREFIX` when defined as an object for handling different file types.

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -12,7 +12,7 @@ interface ImportMetaEnv {
 	/**
 	 * The prefix for Astro-generated asset links if the build.assetsPrefix config option is set. This can be used to create asset links not handled by Astro.
 	 */
-	readonly ASSETS_PREFIX: string;
+	readonly ASSETS_PREFIX: string | Record<string, string>;
 	/**
 	 * This is set to the site option specified in your project’s Astro config file.
 	 */


### PR DESCRIPTION
## Changes

Add type declarations for `import.meta.env.ASSETS_PREFIX` when defined as an object for handling different file types.

## Testing

No tests should be required, but tests are running OK locally.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This was already documented [here](https://docs.astro.build/en/reference/configuration-reference/#buildassetsprefix), it just seems to have been missed in the actual codebase.