### PR TITLE
feat: make i18n domains stable

### DIFF
--- a/.changeset/five-crabs-rhyme.md
+++ b/.changeset/five-crabs-rhyme.md
@@ -1,0 +1,5 @@
+---
+"astro": minor
+---
+
+The i18n domains are out of experimental, and the relative flag has been removed.

--- a/.changeset/five-crabs-rhyme.md
+++ b/.changeset/five-crabs-rhyme.md
@@ -2,4 +2,22 @@
 "astro": minor
 ---
 
-The i18n domains are out of experimental, and the relative flag has been removed.
+The `i18nDomains` routing feature introduced behind a flag in [v3.4.0](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md#430) is no longer experimental and is available for general use.
+
+This routing option allows you to configure different domains for individual locales in entirely server-rendered projects using the [@astrojs/node](https://docs.astro.build/en/guides/integrations-guide/node/) or [@astrojs/vercel](https://docs.astro.build/en/guides/integrations-guide/vercel/) adapter with a `site` configured.
+
+If you were using this feature, please remove the experimental flag from your Astro config:
+
+```diff
+import { defineConfig } from 'astro'
+
+export default defineConfig({
+-  experimental: {
+-    i18nDomains: true,
+-  }
+})
+```
+
+If you have been waiting for stabilization before using this routing option, you can now do so. 
+
+Please see [the internationalization docs](https://docs.astro.build/en/guides/internationalization/#domains) for more about this feature.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1953,50 +1953,7 @@ export interface AstroUserConfig {
 		 * In the event of route collisions, where two routes of equal route priority attempt to build the same URL, Astro will log a warning identifying the conflicting routes.
 		 */
 		globalRoutePriority?: boolean;
-
-		/**
-		 * @docs
-		 * @name experimental.i18nDomains
-		 * @type {boolean}
-		 * @default `false`
-		 * @version 4.3.0
-		 * @description
-		 *
-		 * Enables domain support for the [experimental `domains` routing strategy](https://docs.astro.build/en/guides/internationalization/#domains-experimental) which allows you to configure the URL pattern of one or more supported languages to use a custom domain (or sub-domain).
-		 *
-		 * When a locale is mapped to a domain, a `/[locale]/` path prefix will not be used. However, localized folders within `src/pages/` are still required, including for your configured `defaultLocale`.
-		 *
-		 * Any other locale not configured will default to a localized path-based URL according to your `prefixDefaultLocale` strategy (e.g. `https://example.com/[locale]/blog`).
-		 *
-		 * ```js
-		 * //astro.config.mjs
-		 * export default defineConfig({
-		 * 	site: "https://example.com",
-		 * 	output: "server", // required, with no prerendered pages
-		 * 	adapter: node({
-		 * 		mode: 'standalone',
-		 * 	}),
-		 * 	i18n: {
-		 * 		defaultLocale: "en",
-		 * 		locales: ["en", "fr", "pt-br", "es"],
-		 * 		prefixDefaultLocale: false,
-		 * 		domains: {
-		 * 			fr: "https://fr.example.com",
-		 * 			es: "https://example.es",
-		 * 		},
-		 * 	},
-		 * 	experimental: {
-		 * 		i18nDomains: true,
-		 * 	},
-		 * });
-		 * ```
-		 *
-		 * Both page routes built and URLs returned by the `astro:i18n` helper functions [`getAbsoluteLocaleUrl()`](https://docs.astro.build/en/reference/api-reference/#getabsolutelocaleurl) and [`getAbsoluteLocaleUrlList()`](https://docs.astro.build/en/reference/api-reference/#getabsolutelocaleurllist) will use the options set in `i18n.domains`.
-		 *
-		 * See the [Internationalization Guide](https://docs.astro.build/en/guides/internationalization/#domains-experimental) for more details, including the limitations of this experimental feature.
-		 */
-		i18nDomains?: boolean;
-
+		
 		/**
 		 * @docs
 		 * @name experimental.security

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -129,8 +129,8 @@ export async function generatePages(options: StaticBuildOptions, internals: Buil
 	if (ssr) {
 		for (const [pageData, filePath] of pagesToGenerate) {
 			if (pageData.route.prerender) {
-				// i18n domains won't work with pre rendered routes at the moment, so we need to to throw an error
-				if (config.experimental.i18nDomains) {
+				// i18n domains won't work with pre rendered routes at the moment, so we need to throw an error
+				if (config.i18n?.domains && Object.keys(config.i18n.domains).length > 0) {
 					throw new AstroError({
 						...NoPrerenderedRoutesWithDomains,
 						message: NoPrerenderedRoutesWithDomains.message(pageData.component),
@@ -284,7 +284,7 @@ async function getPathsForRoute(
 		const label = staticPaths.length === 1 ? 'page' : 'pages';
 		logger.debug(
 			'build',
-			`├── ${bold(green('✔'))} ${route.component} → ${magenta(`[${staticPaths.length} ${label}]`)}`
+			`├── ${bold(green('√'))} ${route.component} → ${magenta(`[${staticPaths.length} ${label}]`)}`
 		);
 
 		paths = staticPaths

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -239,7 +239,7 @@ function buildManifest(
 	 * logic meant for i18n domain support, where we fill the lookup table
 	 */
 	const i18n = settings.config.i18n;
-	if (settings.config.experimental.i18nDomains && i18n && i18n.domains) {
+	if (i18n && i18n.domains) {
 		for (const [locale, domainValue] of Object.entries(i18n.domains)) {
 			domainLookupTable[domainValue] = normalizeTheLocale(locale);
 		}

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -86,7 +86,6 @@ const ASTRO_CONFIG_DEFAULTS = {
 		contentCollectionJsonSchema: false,
 		clientPrerender: false,
 		globalRoutePriority: false,
-		i18nDomains: false,
 		security: {},
 		rewriting: false,
 	},
@@ -527,7 +526,6 @@ export const AstroConfigSchema = z.object({
 				})
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.experimental.security),
-			i18nDomains: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.i18nDomains),
 			rewriting: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.rewriting),
 		})
 		.strict(
@@ -668,22 +666,20 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 		})
 		.superRefine((configuration, ctx) => {
 			const { site, experimental, i18n, output } = configuration;
-			if (experimental.i18nDomains) {
-				const hasDomains = i18n?.domains ? Object.keys(i18n.domains).length > 0 : false;
-				if (hasDomains) {
-					if (!site) {
-						ctx.addIssue({
-							code: z.ZodIssueCode.custom,
-							message:
-								"The option `site` isn't set. When using the 'domains' strategy for `i18n`, `site` is required to create absolute URLs for locales that aren't mapped to a domain.",
-						});
-					}
-					if (output !== 'server') {
-						ctx.addIssue({
-							code: z.ZodIssueCode.custom,
-							message: 'Domain support is only available when `output` is `"server"`.',
-						});
-					}
+			const hasDomains = i18n?.domains ? Object.keys(i18n.domains).length > 0 : false;
+			if (hasDomains) {
+				if (!site) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message:
+							"The option `site` isn't set. When using the 'domains' strategy for `i18n`, `site` is required to create absolute URLs for locales that aren't mapped to a domain.",
+					});
+				}
+				if (output !== 'server') {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: 'Domain support is only available when `output` is `"server"`.',
+					});
 				}
 			}
 		});

--- a/packages/astro/src/integrations/features-validation.ts
+++ b/packages/astro/src/integrations/features-validation.ts
@@ -70,7 +70,7 @@ export function validateSupportedFeatures(
 	);
 	validationResult.assets = validateAssetsFeature(assets, adapterName, config, logger);
 
-	if (i18nDomains && config?.experimental?.i18nDomains === true && !config.i18n?.domains) {
+	if (!config.i18n?.domains) {
 		validationResult.i18nDomains = validateSupportKind(
 			i18nDomains,
 			adapterName,

--- a/packages/astro/test/fixtures/i18n-routing-subdomain/astro.config.mjs
+++ b/packages/astro/test/fixtures/i18n-routing-subdomain/astro.config.mjs
@@ -17,8 +17,5 @@ export default defineConfig({
 			redirectToDefaultLocale: false
 		}
 	},
-	experimental: {
-		i18nDomains: true
-	},
 	site: "https://example.com",
 })

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -319,9 +319,6 @@ describe('Config Validation', () => {
 							en: 'https://www.example.com/',
 						},
 					},
-					experimental: {
-						i18nDomains: true,
-					},
 				},
 				process.cwd()
 			).catch((err) => err);
@@ -342,9 +339,6 @@ describe('Config Validation', () => {
 						domains: {
 							en: 'https://www.example.com/',
 						},
-					},
-					experimental: {
-						i18nDomains: true,
 					},
 					site: 'https://foo.org',
 				},

--- a/packages/astro/test/units/i18n/astro_i18n.test.js
+++ b/packages/astro/test/units/i18n/astro_i18n.test.js
@@ -1548,6 +1548,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 		const config = await validateConfig(
 			{
 				format: 'directory',
+				output: "server",
 				site: 'https://example.com/',
 				trailingSlash: 'always',
 				i18n: {
@@ -1587,7 +1588,6 @@ describe('getLocaleAbsoluteUrlList', () => {
 		 * @type {import("../../../dist/@types").AstroUserConfig}
 		 */
 		const config = {
-			experimental: {
 				i18n: {
 					defaultLocale: 'en',
 					locales: [
@@ -1599,7 +1599,6 @@ describe('getLocaleAbsoluteUrlList', () => {
 							codes: ['it', 'it-VA'],
 						},
 					],
-				},
 			},
 		};
 		// directory format
@@ -1607,7 +1606,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 			getLocaleAbsoluteUrlList({
 				locale: 'en',
 				base: '/blog/',
-				...config.experimental.i18n,
+				...config.i18n,
 				trailingSlash: 'always',
 				format: 'file',
 				site: 'https://example.com',


### PR DESCRIPTION
## Changes

This PR removes the experimental flag `experimental.i18nDomains`

## Testing

Current tests should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback! 

https://github.com/withastro/docs/pull/8285

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
