### PR TITLE
Fix CSS handling for experimental.directRenderScript

### DIFF
--- a/.changeset/clever-ads-scream.md
+++ b/.changeset/clever-ads-scream.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Skips rendering script tags if it's inlined and empty when `experimental.directRenderScript` is enabled

--- a/.changeset/rich-melons-worry.md
+++ b/.changeset/rich-melons-worry.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes CSS handling if imported in a script tag in an Astro file when `experimental.directRenderScript` is enabled

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -58,6 +58,11 @@ export interface BuildInternals {
 	pagesByClientOnly: Map<string, Set<PageBuildData>>;
 
 	/**
+	 * A map for page-specific information by a script in an Astro file
+	 */
+	pagesByScriptId: Map<string, Set<PageBuildData>>;
+
+	/**
 	 * A map of hydrated components to export names that are discovered during the SSR build.
 	 * These will be used as the top-level entrypoints for the client build.
 	 *
@@ -133,6 +138,7 @@ export function createBuildInternals(): BuildInternals {
 		pageOptionsByPage: new Map(),
 		pagesByViteID: new Map(),
 		pagesByClientOnly: new Map(),
+		pagesByScriptId: new Map(),
 
 		propagatedStylesMap: new Map(),
 		propagatedScriptsMap: new Map(),
@@ -176,6 +182,26 @@ export function trackClientOnlyPageDatas(
 		} else {
 			pageDataSet = new Set<PageBuildData>();
 			internals.pagesByClientOnly.set(clientOnlyComponent, pageDataSet);
+		}
+		pageDataSet.add(pageData);
+	}
+}
+
+/**
+ * Tracks scripts to the pages they are associated with. (experimental.directRenderScript)
+ */
+export function trackScriptPageDatas(
+	internals: BuildInternals,
+	pageData: PageBuildData,
+	scriptIds: string[]
+) {
+	for (const scriptId of scriptIds) {
+		let pageDataSet: Set<PageBuildData>;
+		if (internals.pagesByScriptId.has(scriptId)) {
+			pageDataSet = internals.pagesByScriptId.get(scriptId)!;
+		} else {
+			pageDataSet = new Set<PageBuildData>();
+			internals.pagesByScriptId.set(scriptId, pageDataSet);
 		}
 		pageDataSet.add(pageData);
 	}

--- a/packages/astro/src/core/build/plugins/plugin-css.ts
+++ b/packages/astro/src/core/build/plugins/plugin-css.ts
@@ -145,12 +145,21 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 							if (pageData) {
 								appendCSSToPage(pageData, meta, pagesToCss, depth, order);
 							}
-						} else if (
-							options.target === 'client' &&
-							internals.hoistedScriptIdToPagesMap.has(pageInfo.id)
-						) {
-							for (const pageData of getPageDatasByHoistedScriptId(internals, pageInfo.id)) {
-								appendCSSToPage(pageData, meta, pagesToCss, -1, order);
+						} else if (options.target === 'client') {
+							// For scripts or hoisted scripts, walk parents until you find a page, and add the CSS to that page.
+							if (buildOptions.settings.config.experimental.directRenderScript) {
+								const pageDatas = internals.pagesByScriptId.get(pageInfo.id)!;
+								if (pageDatas) {
+									for (const pageData of pageDatas) {
+										appendCSSToPage(pageData, meta, pagesToCss, -1, order);
+									}
+								}
+							} else {
+								if (internals.hoistedScriptIdToPagesMap.has(pageInfo.id)) {
+									for (const pageData of getPageDatasByHoistedScriptId(internals, pageInfo.id)) {
+										appendCSSToPage(pageData, meta, pagesToCss, -1, order);
+									}
+								}
 							}
 						}
 					}

--- a/packages/astro/src/runtime/server/render/script.ts
+++ b/packages/astro/src/runtime/server/render/script.ts
@@ -10,8 +10,13 @@ export async function renderScript(result: SSRResult, id: string) {
 	result._metadata.renderedScripts.add(id);
 
 	const inlined = result.inlinedScripts.get(id);
-	if (inlined) {
-		return markHTMLString(`<script type="module">${inlined}</script>`);
+	if (inlined != null) {
+		// The inlined script may actually be empty, so skip rendering it altogether if so
+		if (inlined) {
+			return markHTMLString(`<script type="module">${inlined}</script>`);
+		} else {
+			return '';
+		}
 	}
 
 	const resolved = await result.resolve(id);

--- a/packages/astro/test/fixtures/hoisted-imports/src/pages/script-import-style.astro
+++ b/packages/astro/test/fixtures/hoisted-imports/src/pages/script-import-style.astro
@@ -1,0 +1,10 @@
+<html lang="en">
+	<head>
+		<script>
+			import "../styles/script-import-style.css";
+		</script>
+	</head>
+	<body>
+		<h1>Astro</h1>
+	</body>
+</html>

--- a/packages/astro/test/fixtures/hoisted-imports/src/styles/script-import-style.css
+++ b/packages/astro/test/fixtures/hoisted-imports/src/styles/script-import-style.css
@@ -1,0 +1,3 @@
+h1 {
+  background-color: tomato;
+}

--- a/packages/astro/test/hoisted-imports.test.js
+++ b/packages/astro/test/hoisted-imports.test.js
@@ -87,5 +87,15 @@ describe('Hoisted Imports', () => {
 			assert.ok(scripts[0].attribs.src);
 			assert.ok(scripts[1].attribs.src);
 		});
+
+		it('renders styles if imported from the script', async () => {
+			const html = await fixture.readFile('/script-import-style/index.html');
+			const $ = cheerio.load(html);
+			const styles = $('style');
+			assert.equal(styles.length, 1);
+			// There should be no script because it's empty (contains only CSS import)
+			const scripts = $('scripts');
+			assert.equal(scripts.length, 0);
+		});
 	});
 });


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/10998

When importing CSS in `<script>` with `experimental.directRenderScript` enabled, we need to track the pages that uses the scripts in order to inject the styles to the pages.

This unfortunately means that if the script is never rendered on a page, the CSS will still be included, but I think this is acceptable for now as CSS imports in Astro components also work this way.

I also fixed a bug where rendered script tags pointed to non-existent URLs.

## Testing

Added a new test

## Docs

n/a. bug fix.
