### PR TITLE
actions: Throw error on missing server output

### DIFF
--- a/.changeset/many-news-rescue.md
+++ b/.changeset/many-news-rescue.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Throw on missing server output when using Astro Actions.

--- a/packages/astro/src/actions/index.ts
+++ b/packages/astro/src/actions/index.ts
@@ -1,18 +1,16 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import type { Plugin as VitePlugin } from 'vite';
 import type { AstroIntegration } from '../@types/astro.js';
-import { viteID } from '../core/util.js';
+import { viteID, isServerLikeOutput } from '../core/util.js';
 import { ACTIONS_TYPES_FILE, RESOLVED_VIRTUAL_MODULE_ID, VIRTUAL_MODULE_ID } from './consts.js';
 import { AstroUserError } from '../core/errors/errors.js';
-
-const serverOutputs = ['server', 'hybrid'];
 
 export default function astroActions(): AstroIntegration {
 	return {
 		name: VIRTUAL_MODULE_ID,
 		hooks: {
 			async 'astro:config:setup'(params) {
-				if (!serverOutputs.includes(params.config.output)) {
+				if (!isServerLikeOutput(params.config)) {
 					const error = new AstroUserError(
 						'Actions require a server output. Set the \`output\` property in your Astro config.',
 						'Learn about on-demand rendering: https://docs.astro.build/en/basics/rendering-modes/#on-demand-rendered'

--- a/packages/astro/src/actions/index.ts
+++ b/packages/astro/src/actions/index.ts
@@ -3,12 +3,24 @@ import type { Plugin as VitePlugin } from 'vite';
 import type { AstroIntegration } from '../@types/astro.js';
 import { viteID } from '../core/util.js';
 import { ACTIONS_TYPES_FILE, RESOLVED_VIRTUAL_MODULE_ID, VIRTUAL_MODULE_ID } from './consts.js';
+import { AstroUserError } from '../core/errors/errors.js';
+
+const serverOutputs = ['server', 'hybrid'];
 
 export default function astroActions(): AstroIntegration {
 	return {
 		name: VIRTUAL_MODULE_ID,
 		hooks: {
 			async 'astro:config:setup'(params) {
+				if (!serverOutputs.includes(params.config.output)) {
+					const error = new AstroUserError(
+						'Actions require a server output. Set the \`output\` property in your Astro config.',
+						'Learn about on-demand rendering: https://docs.astro.build/en/basics/rendering-modes/#on-demand-rendered'
+					);
+					error.stack = undefined;
+					throw error;
+				}
+
 				const stringifiedActionsImport = JSON.stringify(
 					viteID(new URL('./actions', params.config.srcDir))
 				);

--- a/packages/astro/src/actions/index.ts
+++ b/packages/astro/src/actions/index.ts
@@ -3,7 +3,8 @@ import type { Plugin as VitePlugin } from 'vite';
 import type { AstroIntegration } from '../@types/astro.js';
 import { viteID, isServerLikeOutput } from '../core/util.js';
 import { ACTIONS_TYPES_FILE, RESOLVED_VIRTUAL_MODULE_ID, VIRTUAL_MODULE_ID } from './consts.js';
-import { AstroUserError } from '../core/errors/errors.js';
+import { AstroError } from '../core/errors/errors.js';
+import { ActionsWithoutServerOutputError } from '../core/errors/errors-data.js';
 
 export default function astroActions(): AstroIntegration {
 	return {
@@ -11,10 +12,7 @@ export default function astroActions(): AstroIntegration {
 		hooks: {
 			async 'astro:config:setup'(params) {
 				if (!isServerLikeOutput(params.config)) {
-					const error = new AstroUserError(
-						'Actions require a server output. Set the \`output\` property in your Astro config.',
-						'Learn about on-demand rendering: https://docs.astro.build/en/basics/rendering-modes/#on-demand-rendered'
-					);
+					const error = new AstroError(ActionsWithoutServerOutputError);
 					error.stack = undefined;
 					throw error;
 				}

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1493,10 +1493,18 @@ export const DuplicateContentEntrySlugError = {
 	},
 } satisfies ErrorData;
 
+/**
+ * @docs
+ * @see
+ * - [On-demand rendering](https://docs.astro.build/en/basics/rendering-modes/#on-demand-rendered)
+ * @description
+ * Your project must have a server output to create backend functions with Actions.
+ */
 export const ActionsWithoutServerOutputError = {
 	name: 'ActionsWithoutServerOutputError',
 	title: 'Actions must be used with server output.',
-	message: 'Actions enabled without setting a server build output. A server is required to create callable backend functions. To deploy routes to a server, add a server adapter to your astro config.',
+	message:
+		'Actions enabled without setting a server build output. A server is required to create callable backend functions. To deploy routes to a server, add a server adapter to your astro config.',
 	hint: 'Learn about on-demand rendering: https://docs.astro.build/en/basics/rendering-modes/#on-demand-rendered',
 } satisfies ErrorData;
 

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1493,6 +1493,13 @@ export const DuplicateContentEntrySlugError = {
 	},
 } satisfies ErrorData;
 
+export const ActionsWithoutServerOutputError = {
+	name: 'ActionsWithoutServerOutputError',
+	title: 'Actions must be used with server output.',
+	message: 'Actions enabled without setting a server build output. A server is required to create callable backend functions. To deploy routes to a server, add a server adapter to your astro config.',
+	hint: 'Learn about on-demand rendering: https://docs.astro.build/en/basics/rendering-modes/#on-demand-rendered',
+} satisfies ErrorData;
+
 /**
  * @docs
  * @see


### PR DESCRIPTION
## Changes

Throw error when `output` is missing when using actions.

## Testing

Manual testing

## Docs

Already documented!