### PR TITLE
Actions: include zod error in message for easier debugging

### DIFF
--- a/.changeset/modern-donkeys-taste.md
+++ b/.changeset/modern-donkeys-taste.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Actions: include validation error in thrown error message for debugging.

--- a/packages/astro/src/actions/runtime/virtual/shared.ts
+++ b/packages/astro/src/actions/runtime/virtual/shared.ts
@@ -109,7 +109,7 @@ export class ActionInputError<T extends ErrorInferenceObject> extends ActionErro
 	fields: z.ZodError<T>['formErrors']['fieldErrors'];
 
 	constructor(issues: z.ZodIssue[]) {
-		super({ message: 'Failed to validate', code: 'BAD_REQUEST' });
+		super({ message: `Failed to validate: ${JSON.stringify(issues, null, 2)}`, code: 'BAD_REQUEST' });
 		this.issues = issues;
 		this.fields = {};
 		for (const issue of issues) {


### PR DESCRIPTION
## Changes

Zod validation errors are hidden in the error message. This makes thrown validation errors tougher to debug. This stringifies the Zod object for easier debugging.

## Testing

Manual call

## Docs

N/A