### PR TITLE
fix: add missing attribute popovertargetaction

### DIFF
--- a/.changeset/witty-cougars-allow.md
+++ b/.changeset/witty-cougars-allow.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Add `popovertargetaction` to the attribute that can be passed to the `button` and `input` element

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -649,6 +649,7 @@ declare namespace astroHTML.JSX {
 		type?: 'submit' | 'reset' | 'button' | undefined | null;
 		value?: string | string[] | number | undefined | null;
 		popovertarget?: string | undefined | null;
+		popovertargetaction?: "hide" | "show" | "toggle" | undefined | null;
 	}
 
 	interface CanvasHTMLAttributes extends HTMLAttributes {
@@ -815,6 +816,7 @@ declare namespace astroHTML.JSX {
 		value?: string | string[] | number | undefined | null;
 		width?: number | string | undefined | null;
 		popovertarget?: string | undefined | null;
+		popovertargetaction?: "hide" | "show" | "toggle" | undefined | null;
 	}
 
 	interface KeygenHTMLAttributes extends HTMLAttributes {


### PR DESCRIPTION
## Changes

- add popovertargetaction into ButtonHTMLAttributes and InputHTMLAttributes

## Testing

I manually tested the change in a local project

## Docs

N/A
