### PR TITLE
feat: add an internal for now studio package

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -83,7 +83,8 @@
     "prompts": "^2.4.2",
     "strip-ansi": "^7.1.0",
     "yargs-parser": "^21.1.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@astrojs/studio": "^0.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.16",

--- a/packages/db/src/core/cli/commands/execute/index.ts
+++ b/packages/db/src/core/cli/commands/execute/index.ts
@@ -14,7 +14,7 @@ import {
 	getStudioVirtualModContents,
 } from '../../../integration/vite-plugin-db.js';
 import { bundleFile, importBundledFile } from '../../../load-file.js';
-import { getManagedAppTokenOrExit } from '../../../tokens.js';
+import { getManagedAppTokenOrExit } from '@astrojs/studio';
 import type { DBConfig } from '../../../types.js';
 
 export async function cmd({

--- a/packages/db/src/core/cli/commands/link/index.ts
+++ b/packages/db/src/core/cli/commands/link/index.ts
@@ -7,7 +7,7 @@ import ora from 'ora';
 import prompts from 'prompts';
 import { safeFetch } from '../../../../runtime/utils.js';
 import { MISSING_SESSION_ID_ERROR } from '../../../errors.js';
-import { PROJECT_ID_FILE, getSessionIdFromFile } from '../../../tokens.js';
+import { PROJECT_ID_FILE, getSessionIdFromFile } from '@astrojs/studio';
 import { type Result, getAstroStudioUrl } from '../../../utils.js';
 
 export async function cmd() {

--- a/packages/db/src/core/cli/commands/login/index.ts
+++ b/packages/db/src/core/cli/commands/login/index.ts
@@ -7,7 +7,7 @@ import open from 'open';
 import ora from 'ora';
 import prompt from 'prompts';
 import type { Arguments } from 'yargs-parser';
-import { SESSION_LOGIN_FILE } from '../../../tokens.js';
+import { SESSION_LOGIN_FILE } from '@astrojs/studio';
 import type { DBConfig } from '../../../types.js';
 import { getAstroStudioUrl } from '../../../utils.js';
 

--- a/packages/db/src/core/cli/commands/logout/index.ts
+++ b/packages/db/src/core/cli/commands/logout/index.ts
@@ -1,5 +1,5 @@
 import { unlink } from 'node:fs/promises';
-import { SESSION_LOGIN_FILE } from '../../../tokens.js';
+import { SESSION_LOGIN_FILE } from '@astrojs/studio'
 
 export async function cmd() {
 	await unlink(SESSION_LOGIN_FILE);

--- a/packages/db/src/core/cli/commands/push/index.ts
+++ b/packages/db/src/core/cli/commands/push/index.ts
@@ -3,7 +3,7 @@ import prompts from 'prompts';
 import type { Arguments } from 'yargs-parser';
 import { safeFetch } from '../../../../runtime/utils.js';
 import { MIGRATION_VERSION } from '../../../consts.js';
-import { getManagedAppTokenOrExit } from '../../../tokens.js';
+import { getManagedAppTokenOrExit } from '@astrojs/studio';
 import { type DBConfig, type DBSnapshot } from '../../../types.js';
 import { type Result, getRemoteDatabaseUrl } from '../../../utils.js';
 import {

--- a/packages/db/src/core/cli/commands/shell/index.ts
+++ b/packages/db/src/core/cli/commands/shell/index.ts
@@ -8,7 +8,7 @@ import {
 import { normalizeDatabaseUrl } from '../../../../runtime/index.js';
 import { DB_PATH } from '../../../consts.js';
 import { SHELL_QUERY_MISSING_ERROR } from '../../../errors.js';
-import { getManagedAppTokenOrExit } from '../../../tokens.js';
+import { getManagedAppTokenOrExit } from '@astrojs/studio';
 import type { DBConfigInput } from '../../../types.js';
 import { getAstroEnv, getRemoteDatabaseUrl } from '../../../utils.js';
 

--- a/packages/db/src/core/cli/commands/verify/index.ts
+++ b/packages/db/src/core/cli/commands/verify/index.ts
@@ -1,6 +1,6 @@
 import type { AstroConfig } from 'astro';
 import type { Arguments } from 'yargs-parser';
-import { getManagedAppTokenOrExit } from '../../../tokens.js';
+import { getManagedAppTokenOrExit } from '@astrojs/studio';
 import type { DBConfig } from '../../../types.js';
 import {
 	createCurrentSnapshot,

--- a/packages/db/src/core/errors.ts
+++ b/packages/db/src/core/errors.ts
@@ -1,18 +1,9 @@
 import { bold, cyan, red } from 'kleur/colors';
 
-export const MISSING_SESSION_ID_CI_ERROR = `${red('▶ ASTRO_STUDIO_APP_TOKEN required')}
-
-	To authenticate with Astro Studio add the token to your CI's environment variables.\n`;
-
 export const MISSING_SESSION_ID_ERROR = `${red('▶ Login required!')}
 
   To authenticate with Astro Studio, run
   ${cyan('astro db login')}\n`;
-
-export const MISSING_PROJECT_ID_ERROR = `${red('▶ Directory not linked.')}
-
-  To link this directory to an Astro Studio project, run
-  ${cyan('astro db link')}\n`;
 
 export const MISSING_EXECUTE_PATH_ERROR = `${red(
 	'▶ No file path provided.'
@@ -26,7 +17,7 @@ export const RENAME_TABLE_ERROR = (oldTable: string, newTable: string) => {
 
   1. Use "deprecated: true" to deprecate a table before renaming.
   2. Use "--force-reset" to ignore this warning and reset the database (deleting all of your data).
-	
+
 	Visit https://docs.astro.build/en/guides/astro-db/#renaming-tables to learn more.`
 	);
 };

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -19,7 +19,7 @@ import { CONFIG_FILE_NAMES, DB_PATH } from '../consts.js';
 import { EXEC_DEFAULT_EXPORT_ERROR, EXEC_ERROR } from '../errors.js';
 import { resolveDbConfig } from '../load-file.js';
 import { SEED_DEV_FILE_NAME } from '../queries.js';
-import { type ManagedAppToken, getManagedAppTokenOrExit } from '../tokens.js';
+import { type ManagedAppToken, getManagedAppTokenOrExit } from '@astrojs/studio';
 import { type VitePlugin, getDbDirectoryUrl } from '../utils.js';
 import { fileURLIntegration } from './file-url.js';
 import { typegenInternal } from './typegen.js';

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -1,0 +1,34 @@
+# @astrojs/studio
+
+This package manages the connection between a local Astro project and [Astro Studio](studio). At this time, this package is not intended for direct use by end users, but rather as a dependency of other Astro packages.
+
+## Support
+
+- Get help in the [Astro Discord][discord]. Post questions in our `#support` forum, or visit our dedicated `#dev` channel to discuss current development and more!
+
+- Check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
+- Submit bug reports and feature requests as [GitHub issues][issues].
+
+## Contributing
+
+This package is maintained by Astro's Core team. You're welcome to submit an issue or PR! These links will help you get started:
+
+- [Contributor Manual][contributing]
+- [Code of Conduct][coc]
+- [Community Guide][community]
+
+## License
+
+MIT
+
+Copyright (c) 2023–present [Astro][astro]
+
+[astro]: https://astro.build/
+[contributing]: https://github.com/withastro/astro/blob/main/CONTRIBUTING.md
+[coc]: https://github.com/withastro/.github/blob/main/CODE_OF_CONDUCT.md
+[community]: https://github.com/withastro/.github/blob/main/COMMUNITY_GUIDE.md
+[discord]: https://astro.build/chat/
+[issues]: https://github.com/withastro/astro/issues
+[astro-integration]: https://docs.astro.build/en/guides/integrations-guide/
+[studio]: https://studio.astro.build/

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@astrojs/studio",
+  "version": "0.1.0",
+  "description": "Add libSQL and Astro Studio support to your Astro site",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/withastro/astro.git",
+    "directory": "packages/studio"
+  },
+  "bugs": "https://github.com/withastro/astro/issues",
+  "homepage": "https://docs.astro.build/en/guides/integrations-guide/studio/",
+  "type": "module",
+  "author": "withastro",
+  "types": "./index.d.ts",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "withastro",
+    "astro-integration"
+  ],
+  "scripts": {
+    "build": "astro-scripts build \"src/**/*.ts\" && tsc",
+    "build:ci": "astro-scripts build \"src/**/*.ts\"",
+    "dev": "astro-scripts dev \"src/**/*.ts\"",
+    "test": "mocha --exit --timeout 20000 \"test/*.js\" \"test/unit/**/*.js\"",
+    "test:match": "mocha --timeout 20000 \"test/*.js\" \"test/unit/*.js\" -g"
+  },
+  "dependencies": {
+    "ci-info": "^4.0.0",
+    "kleur": "^4.1.5",
+    "ora": "^8.0.1"
+  },
+  "devDependencies": {
+    "astro": "workspace:*",
+    "astro-scripts": "workspace:*",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.11"
+  }
+}

--- a/packages/studio/src/core/errors.ts
+++ b/packages/studio/src/core/errors.ts
@@ -1,0 +1,15 @@
+import { cyan, red } from 'kleur/colors';
+
+export const MISSING_SESSION_ID_CI_ERROR = `${red('▶ ASTRO_STUDIO_APP_TOKEN required')}
+
+	To authenticate with Astro Studio add the token to your CI's environment variables.\n`;
+
+export const MISSING_SESSION_ID_ERROR = `${red('▶ Login required!')}
+
+  To authenticate with Astro Studio, run
+  ${cyan('astro db login')}\n`;
+
+export const MISSING_PROJECT_ID_ERROR = `${red('▶ Directory not linked.')}
+
+  To link this directory to an Astro Studio project, run
+  ${cyan('astro db link')}\n`;

--- a/packages/studio/src/core/tokens.ts
+++ b/packages/studio/src/core/tokens.ts
@@ -5,13 +5,12 @@ import { pathToFileURL } from 'node:url';
 import ci from 'ci-info';
 import { green } from 'kleur/colors';
 import ora from 'ora';
-import { safeFetch } from '../runtime/utils.js';
 import {
 	MISSING_PROJECT_ID_ERROR,
 	MISSING_SESSION_ID_CI_ERROR,
 	MISSING_SESSION_ID_ERROR,
 } from './errors.js';
-import { getAstroStudioEnv, getAstroStudioUrl } from './utils.js';
+import { getAstroStudioEnv, getAstroStudioUrl, safeFetch } from './utils.js';
 
 export const SESSION_LOGIN_FILE = pathToFileURL(join(homedir(), '.astro', 'session-token'));
 export const PROJECT_ID_FILE = pathToFileURL(join(process.cwd(), '.astro', 'link'));

--- a/packages/studio/src/core/utils.ts
+++ b/packages/studio/src/core/utils.ts
@@ -1,0 +1,30 @@
+import { loadEnv } from 'vite';
+
+export function getAstroStudioEnv(envMode = ''): Record<`ASTRO_STUDIO_${string}`, string> {
+	const env = loadEnv(envMode, process.cwd(), 'ASTRO_STUDIO_');
+	return env;
+}
+
+export function getAstroStudioUrl(): string {
+	const env = getAstroStudioEnv();
+	return env.ASTRO_STUDIO_URL || 'https://studio.astro.build';
+}
+
+/**
+ * Small wrapper around fetch that throws an error if the response is not OK. Allows for custom error handling as well through the onNotOK callback.
+ */
+export async function safeFetch(
+	url: Parameters<typeof fetch>[0],
+	options: Parameters<typeof fetch>[1] = {},
+	onNotOK: (response: Response) => void | Promise<void> = () => {
+		throw new Error(`Request to ${url} returned a non-OK status code.`);
+	}
+): Promise<Response> {
+	const response = await fetch(url, options);
+
+	if (!response.ok) {
+		await onNotOK(response);
+	}
+
+	return response;
+}

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -1,0 +1,2 @@
+export * from './core/tokens.js';
+export * from './core/utils.js';

--- a/packages/studio/tsconfig.json
+++ b/packages/studio/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3943,6 +3943,9 @@ importers:
 
   packages/db:
     dependencies:
+      '@astrojs/studio':
+        specifier: ^0.1.0
+        version: link:../studio
       '@libsql/client':
         specifier: ^0.6.0
         version: 0.6.0
@@ -5532,6 +5535,31 @@ importers:
       mdast-util-mdx-expression:
         specifier: ^2.0.0
         version: 2.0.0
+
+  packages/studio:
+    dependencies:
+      ci-info:
+        specifier: ^4.0.0
+        version: 4.0.0
+      kleur:
+        specifier: ^4.1.5
+        version: 4.1.5
+      ora:
+        specifier: ^8.0.1
+        version: 8.0.1
+    devDependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../astro
+      astro-scripts:
+        specifier: workspace:*
+        version: link:../../scripts
+      typescript:
+        specifier: ^5.4.5
+        version: 5.4.5
+      vite:
+        specifier: ^5.2.11
+        version: 5.2.11(@types/node@18.19.31)(sass@1.77.1)
 
   packages/telemetry:
     dependencies:


### PR DESCRIPTION
## Changes

In the future, Astro Studio will include more features than just DB, as such some of the more internal parts around handling tokens and env need to be elsewhere than the DB package. This PR adds a new `@astrojs/studio` package that only contains those parts.

In the future, this package could become the "core" Studio package and then we'll have a `astro studio` command and stuff, but for now, it's just code moved around
  
## Testing

DB tests should still pass!

## Docs

N/A for now.