### PR TITLE
docs: fix grammatical mix-up

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1743,7 +1743,7 @@ export interface AstroUserConfig {
 		 *
 		 * Declare all your actions in `src/actions/index.ts`. This file is the global actions handler.
 		 *
-		 * Define an action using the `defineAction()` utility from the `astro:actions` module. These accept the `handler` property to define your server-side request handler. If your action accepts arguments, apply the `input` property to validate parameters with Zod.
+		 * Define an action using the `defineAction()` utility from the `astro:actions` module. An action accepts the `handler` property to define your server-side request handler. If your action accepts arguments, apply the `input` property to validate parameters with Zod.
 		 *
 		 * This example defines two actions: `like` and `comment`. The `like` action accepts a JSON object with a `postId` string, while the `comment` action accepts [FormData](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest_API/Using_FormData_Objects) with `postId`, `author`, and `body` strings. Each `handler` updates your database and return a type-safe response.
 		 *


### PR DESCRIPTION
## Changes

Noticed a small grammatical mix-up here:

```diff
// before
Define an action using the `defineAction()` utility from the `astro:actions` module.
- These accept
the `handler` property to define your server-side request handler.

// after
Define an action using the `defineAction()` utility from the `astro:actions` module.
+ An action accepts
the `handler` property to define your server-side request handler.
```

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
