### PR TITLE
Actions: support empty args and empty response

### DIFF
--- a/.changeset/many-guests-yell.md
+++ b/.changeset/many-guests-yell.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Actions: fix 500 errors when sending empty params or returning an empty response from an action.

--- a/.changeset/many-guests-yell.md
+++ b/.changeset/many-guests-yell.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Actions: fix 500 errors when sending empty params or returning an empty response from an action.
+Fixes 500 errors when sending empty params or returning an empty response from an action.

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -27,6 +27,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
 	const actionPathKeys = actionPath.replace('/_actions/', '').split('.');
 	const action = await getAction(actionPathKeys);
+	if (!action) return nextWithLocalsStub(next, locals);
+
 	const result = await ApiContextStorage.run(context, () => callSafely(() => action(formData)));
 
 	const actionsInternal: Locals['_actionsInternal'] = {

--- a/packages/astro/src/actions/runtime/route.ts
+++ b/packages/astro/src/actions/runtime/route.ts
@@ -7,9 +7,15 @@ export const POST: APIRoute = async (context) => {
 	const { request, url } = context;
 	const actionPathKeys = url.pathname.replace('/_actions/', '').split('.');
 	const action = await getAction(actionPathKeys);
+	if (!action) {
+		return new Response(null, { status: 404 });
+	}
 	const contentType = request.headers.get('Content-Type');
+	const contentLength = request.headers.get('Content-Length');
 	let args: unknown;
-	if (contentType && hasContentType(contentType, formContentTypes)) {
+	if (contentLength === '0') {
+		args = undefined;
+	} else if (contentType && hasContentType(contentType, formContentTypes)) {
 		args = await request.clone().formData();
 	} else if (contentType && hasContentType(contentType, ['application/json'])) {
 		args = await request.clone().json();
@@ -35,6 +41,7 @@ export const POST: APIRoute = async (context) => {
 		);
 	}
 	return new Response(JSON.stringify(result.data), {
+		status: result.data ? 200 : 204,
 		headers: {
 			'Content-Type': 'application/json',
 		},

--- a/packages/astro/src/actions/runtime/utils.ts
+++ b/packages/astro/src/actions/runtime/utils.ts
@@ -12,16 +12,16 @@ export type MaybePromise<T> = T | Promise<T>;
 
 export async function getAction(
 	pathKeys: string[]
-): Promise<(param: unknown) => MaybePromise<unknown>> {
+): Promise<((param: unknown) => MaybePromise<unknown>) | undefined> {
 	let { server: actionLookup } = await import(import.meta.env.ACTIONS_PATH);
 	for (const key of pathKeys) {
 		if (!(key in actionLookup)) {
-			throw new Error('Action not found');
+			return undefined;
 		}
 		actionLookup = actionLookup[key];
 	}
 	if (typeof actionLookup !== 'function') {
-		throw new Error('Action not found');
+		return undefined;
 	}
 	return actionLookup;
 }

--- a/packages/astro/templates/actions.mjs
+++ b/packages/astro/templates/actions.mjs
@@ -45,6 +45,7 @@ async function actionHandler(clientParam, path) {
 			});
 		}
 		headers.set('Content-Type', 'application/json');
+		headers.set('Content-Length', body?.length.toString() ?? '0');
 	}
 	const res = await fetch(path, {
 		method: 'POST',
@@ -54,6 +55,9 @@ async function actionHandler(clientParam, path) {
 	if (!res.ok) {
 		throw await ActionError.fromResponse(res);
 	}
+	// Check if response body is empty before parsing.
+	if (res.status === 204) return;
+
 	const json = await res.json();
 	return json;
 }

--- a/packages/astro/test/actions.test.js
+++ b/packages/astro/test/actions.test.js
@@ -202,5 +202,17 @@ describe('Astro Actions', () => {
 			assert.equal($('#error-message').text(), 'Not logged in');
 			assert.equal($('#error-code').text(), 'UNAUTHORIZED');
 		});
+
+		it('Sets status to 204 when no content', async () => {
+			const req = new Request('http://example.com/_actions/fireAndForget', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Content-Length': '0',
+				},
+			});
+			const res = await app.render(req);
+			assert.equal(res.status, 204);
+		});
 	});
 });

--- a/packages/astro/test/fixtures/actions/src/actions/index.ts
+++ b/packages/astro/test/fixtures/actions/src/actions/index.ts
@@ -50,4 +50,9 @@ export const server = {
 			return locals.user;
 		}
 	}),
+	fireAndForget: defineAction({
+		handler: async () => {
+			return;
+		}
+	}),
 };


### PR DESCRIPTION
## Changes

We raised a 500 when an action's arguments or return value were `undefined`. This follows the HTTP spec to respect these cases.
- Return a 204 when the response is empty.
- Include the `Content-Length` on JSON args to check for a length of zero.
- Misc: return a 404 instead of a 500 when requesting an action that doesn't exist.

## Testing

Add test for 204 status.

## Docs

N/A