### PR TITLE
Fix `getViteConfig()` type definition

### DIFF
--- a/.changeset/popular-colts-happen.md
+++ b/.changeset/popular-colts-happen.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes `getViteConfig()` type definition to allow passing an inline Astro configuration as second argument

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -1,6 +1,7 @@
 type ViteUserConfig = import('vite').UserConfig;
 type ViteUserConfigFn = import('vite').UserConfigFn;
 type AstroUserConfig = import('./dist/@types/astro.js').AstroUserConfig;
+type AstroInlineConfig = import('./dist/@types/astro.js').AstroInlineConfig;
 type ImageServiceConfig = import('./dist/@types/astro.js').ImageServiceConfig;
 type SharpImageServiceConfig = import('./dist/assets/services/sharp.js').SharpImageServiceConfig;
 
@@ -13,7 +14,10 @@ export function defineConfig(config: AstroUserConfig): AstroUserConfig;
 /**
  * Use Astro to generate a fully resolved Vite config
  */
-export function getViteConfig(config: ViteUserConfig): ViteUserConfigFn;
+export function getViteConfig(
+	config: ViteUserConfig,
+	inlineAstroConfig?: AstroInlineConfig
+): ViteUserConfigFn;
 
 /**
  * Return the configuration needed to use the Sharp-based image service


### PR DESCRIPTION
## Changes

This PR fixes the type definition of `getViteConfig()` following the [change](https://github.com/withastro/astro/pull/10963) to allow for a second argument to specify an inline Astro configuration.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Tested by checking the type definition of `getViteConfig()` in `examples/with-vitest/vitest.config.ts`.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This PR only fixes the type definition, the [feature docs PR](https://github.com/withastro/docs/pull/8192) has been merged and does not need to be updated.