### PR TITLE
fix(rss): fix an issue where trailing slash is not removed even if `trailingSlash` is set to `false`

### DIFF
--- a/.changeset/tame-otters-destroy.md
+++ b/.changeset/tame-otters-destroy.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/rss": patch
+---
+
+Fixes an issue where trailing slash is not removed even if the `trailingSlash` option is set to `false`.

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -202,7 +202,7 @@ async function generateRSS(rssOptions: ValidatedRSSOptions): Promise<string> {
 	root.rss.channel = {
 		title: rssOptions.title,
 		description: rssOptions.description,
-		link: createCanonicalURL(site, rssOptions.trailingSlash, undefined).href,
+		link: createCanonicalURL(site, rssOptions.trailingSlash, undefined),
 	};
 	if (typeof rssOptions.customData === 'string')
 		Object.assign(
@@ -220,7 +220,7 @@ async function generateRSS(rssOptions: ValidatedRSSOptions): Promise<string> {
 			// If the item's link is already a valid URL, don't mess with it.
 			const itemLink = isValidURL(result.link)
 				? result.link
-				: createCanonicalURL(result.link, rssOptions.trailingSlash, site).href;
+					: createCanonicalURL(result.link, rssOptions.trailingSlash, site);
 			item.link = itemLink;
 			item.guid = { '#text': itemLink, '@_isPermaLink': 'true' };
 		}
@@ -246,7 +246,7 @@ async function generateRSS(rssOptions: ValidatedRSSOptions): Promise<string> {
 		if (typeof result.commentsUrl === 'string') {
 			item.comments = isValidURL(result.commentsUrl)
 				? result.commentsUrl
-				: createCanonicalURL(result.commentsUrl, rssOptions.trailingSlash, site).href;
+				: createCanonicalURL(result.commentsUrl, rssOptions.trailingSlash, site);
 		}
 		if (result.source) {
 			item.source = parser.parse(
@@ -256,7 +256,7 @@ async function generateRSS(rssOptions: ValidatedRSSOptions): Promise<string> {
 		if (result.enclosure) {
 			const enclosureURL = isValidURL(result.enclosure.url)
 				? result.enclosure.url
-				: createCanonicalURL(result.enclosure.url, rssOptions.trailingSlash, site).href;
+				: createCanonicalURL(result.enclosure.url, rssOptions.trailingSlash, site);
 			item.enclosure = parser.parse(
 				`<enclosure url="${enclosureURL}" length="${result.enclosure.length}" type="${result.enclosure.type}"/>`
 			).enclosure;

--- a/packages/astro-rss/src/util.ts
+++ b/packages/astro-rss/src/util.ts
@@ -8,16 +8,19 @@ export function createCanonicalURL(
 	base?: string
 ): string {
 	let pathname = url.replace(/\/index.html$/, ''); // index.html is not canonical
-	if (trailingSlash === false) {
-		// remove the trailing slash
-		pathname = pathname.replace(/\/*$/, '');
-	} else if (!getUrlExtension(url)) {
+	if (!getUrlExtension(url)) {
 		// add trailing slash if there’s no extension or `trailingSlash` is true
 		pathname = pathname.replace(/\/*$/, '/');
 	}
 
 	pathname = pathname.replace(/\/+/g, '/'); // remove duplicate slashes (URL() won’t)
-	return new URL(pathname, base).href;
+
+	const canonicalUrl = new URL(pathname, base).href;
+	if (trailingSlash === false) {
+		// remove the trailing slash
+		return canonicalUrl.replace(/\/*$/, '');
+	}
+	return canonicalUrl;
 }
 
 /** Check if a URL is already valid */

--- a/packages/astro-rss/src/util.ts
+++ b/packages/astro-rss/src/util.ts
@@ -6,7 +6,7 @@ export function createCanonicalURL(
 	url: string,
 	trailingSlash?: RSSOptions['trailingSlash'],
 	base?: string
-): URL {
+): string {
 	let pathname = url.replace(/\/index.html$/, ''); // index.html is not canonical
 	if (trailingSlash === false) {
 		// remove the trailing slash
@@ -17,7 +17,7 @@ export function createCanonicalURL(
 	}
 
 	pathname = pathname.replace(/\/+/g, '/'); // remove duplicate slashes (URL() won’t)
-	return new URL(pathname, base);
+	return new URL(pathname, base).href;
 }
 
 /** Check if a URL is already valid */

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -176,7 +176,7 @@ describe('getRssString', () => {
 			trailingSlash: false,
 		});
 
-		assert.ok(str.includes('https://example.com/<'));
+		assert.ok(str.includes('https://example.com<'));
 		assert.ok(str.includes('https://example.com/php<'));
 	});
 


### PR DESCRIPTION
## Changes

- Makes `createCanonicalURL` function return string instead of URL object
- Fixes an issue where trailing slash is not removed even if `trailingSlash` option is set to `false` when generating RSS string
- Closes #10994

## Testing

- Related test case updated
- `pnpm --filter @astrojs/rss run test`

## Docs

- N/A