### PR TITLE
fix: set status on error with progressive fallback

### DIFF
--- a/.changeset/gorgeous-dancers-return.md
+++ b/.changeset/gorgeous-dancers-return.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Respect error status when handling Actions with a progressive fallback.

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -51,7 +51,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	if (result.error) {
 		return new Response(response.body, {
 			status: result.error.status,
-			statusText: result.error.message,
+			statusText: import.meta.env.DEV ? result.error.message : 'Action error',
 			headers: response.headers,
 		})
 	}

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -51,7 +51,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	if (result.error) {
 		return new Response(response.body, {
 			status: result.error.status,
-			statusText: import.meta.env.DEV ? result.error.message : 'Action error',
+			statusText: result.error.name,
 			headers: response.headers,
 		})
 	}

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -47,7 +47,15 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		},
 	};
 	Object.defineProperty(locals, '_actionsInternal', { writable: false, value: actionsInternal });
-	return next();
+	const response = await next();
+	if (result.error) {
+		return new Response(response.body, {
+			status: result.error.status,
+			statusText: result.error.message,
+			headers: response.headers,
+		})
+	}
+	return response;
 });
 
 function nextWithLocalsStub(next: MiddlewareNext, locals: Locals) {


### PR DESCRIPTION
## Changes

Respect error status when using a progressive fallback. This will overwrite any `status` set from Astro frontmatter with `response.status`. Curious if we think this makes sense?

## Testing

Already have e2e test for progressive fallback validation errors. It doesn't check the status, but this is difficult to assert.

## Docs

N/A