### PR TITLE
fix: improve logging for on-demand pages

### DIFF
--- a/.changeset/silly-parents-repair.md
+++ b/.changeset/silly-parents-repair.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Improves debug logging for on-demand pages

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -280,6 +280,10 @@ export class App {
 				this.#logRenderOptionsDeprecationWarning();
 			}
 		}
+		if (routeData) {
+			this.#logger.debug("router", "The adapter " + this.#manifest.adapterName + " provided a custom RouteData for ", request.url);
+			this.#logger.debug("router", "RouteData:\n" + routeData);
+		}
 		if (locals) {
 			if (typeof locals !== 'object') {
 				this.#logger.error(null, new AstroError(AstroErrorData.LocalsNotAnObject).stack!);
@@ -296,8 +300,12 @@ export class App {
 		}
 		if (!routeData) {
 			routeData = this.match(request);
+			this.#logger.debug("router", "Astro matched the following route for "+ request.url);
+			this.#logger.debug("router", "RouteData:\n" + routeData);
 		}
 		if (!routeData) {
+			this.#logger.debug("router", "Astro hasn't found routes that match " + request.url);
+			this.#logger.debug("router", "Here's the available routes:\n", this.#manifestData);
 			return this.#renderError(request, { locals, status: 404 });
 		}
 		const pathname = this.#getPathnameFromRequest(request);


### PR DESCRIPTION
## Changes

This PR improves debug logging for on-demand pages.

I was chatting with a person on Discord, trying to debug some issue they were having, and realised we don't have any logging that could help the debug.

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
