### PR TITLE
fix: use astro cli command instead of astro db's

### DIFF
--- a/.changeset/metal-rocks-design.md
+++ b/.changeset/metal-rocks-design.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Fixes some error messages not using the proper command to login or sync the project

--- a/packages/db/src/core/cli/commands/link/index.ts
+++ b/packages/db/src/core/cli/commands/link/index.ts
@@ -68,7 +68,7 @@ async function getWorkspaceId(): Promise<string> {
 			if (res.status === 401) {
 				throw new Error(
 					`${bgRed('Unauthorized')}\n\n  Are you logged in?\n  Run ${cyan(
-						'astro db login'
+						'astro login'
 					)} to authenticate and then try linking again.\n\n`
 				);
 			}
@@ -116,7 +116,7 @@ export async function createNewProject({
 			if (res.status === 401) {
 				console.error(
 					`${bgRed('Unauthorized')}\n\n  Are you logged in?\n  Run ${cyan(
-						'astro db login'
+						'astro login'
 					)} to authenticate and then try linking again.\n\n`
 				);
 				process.exit(1);
@@ -150,7 +150,7 @@ export async function promptExistingProjectName({ workspaceId }: { workspaceId: 
 			if (res.status === 401) {
 				console.error(
 					`${bgRed('Unauthorized')}\n\n  Are you logged in?\n  Run ${cyan(
-						'astro db login'
+						'astro login'
 					)} to authenticate and then try linking again.\n\n`
 				);
 				process.exit(1);

--- a/packages/db/src/core/errors.ts
+++ b/packages/db/src/core/errors.ts
@@ -7,12 +7,12 @@ export const MISSING_SESSION_ID_CI_ERROR = `${red('▶ ASTRO_STUDIO_APP_TOKEN re
 export const MISSING_SESSION_ID_ERROR = `${red('▶ Login required!')}
 
   To authenticate with Astro Studio, run
-  ${cyan('astro db login')}\n`;
+  ${cyan('astro login')}\n`;
 
 export const MISSING_PROJECT_ID_ERROR = `${red('▶ Directory not linked.')}
 
   To link this directory to an Astro Studio project, run
-  ${cyan('astro db link')}\n`;
+  ${cyan('astro link')}\n`;
 
 export const MISSING_EXECUTE_PATH_ERROR = `${red(
 	'▶ No file path provided.'
@@ -26,7 +26,7 @@ export const RENAME_TABLE_ERROR = (oldTable: string, newTable: string) => {
 
   1. Use "deprecated: true" to deprecate a table before renaming.
   2. Use "--force-reset" to ignore this warning and reset the database (deleting all of your data).
-	
+
 	Visit https://docs.astro.build/en/guides/astro-db/#renaming-tables to learn more.`
 	);
 };


### PR DESCRIPTION
## Changes

Some of the error messages are using db-specific commands instead of the more general Astro ones, like our docs does. As Astro Studio become less specific to db, we orient people towards using `astro` commands instead.
 
## Testing

N/A

## Docs

Our docs already recommend the proper commands: https://docs.astro.build/en/reference/cli-reference/#astro-studio-cli
