### PR TITLE
Prevent cache content from being left in dist folder

### DIFF
--- a/.changeset/brown-pens-type.md
+++ b/.changeset/brown-pens-type.md
@@ -1,0 +1,7 @@
+---
+"astro": patch
+---
+
+Prevent cache content from being left in dist folder
+
+When `contentCollectionsCache` is enabled temporary cached content is copied into the `outDir` for processing. This fixes it so that this content is cleaned out, along with the rest of the temporary build JS.

--- a/packages/astro/src/core/build/consts.ts
+++ b/packages/astro/src/core/build/consts.ts
@@ -1,1 +1,2 @@
 export const CHUNKS_PATH = 'chunks/';
+export const CONTENT_PATH = 'content/';

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -195,8 +195,8 @@ class AstroBuilder {
 			viteConfig,
 		};
 
-		const { internals, ssrOutputChunkNames } = await viteBuild(opts);
-		await staticBuild(opts, internals, ssrOutputChunkNames);
+		const { internals, ssrOutputChunkNames, contentFileNames } = await viteBuild(opts);
+		await staticBuild(opts, internals, ssrOutputChunkNames, contentFileNames);
 
 		// Write any additionally generated assets to disk.
 		this.timer.assetsStart = performance.now();

--- a/packages/astro/src/core/build/plugins/plugin-content.ts
+++ b/packages/astro/src/core/build/plugins/plugin-content.ts
@@ -20,15 +20,16 @@ import {
 } from '../../path.js';
 import { isContentCollectionsCacheEnabled } from '../../util.js';
 import { addRollupInput } from '../add-rollup-input.js';
-import { CHUNKS_PATH } from '../consts.js';
+import { CHUNKS_PATH, CONTENT_PATH } from '../consts.js';
 import { type BuildInternals } from '../internal.js';
 import type { AstroBuildPlugin } from '../plugin.js';
 import { copyFiles } from '../static-build.js';
 import type { StaticBuildOptions } from '../types.js';
 import { encodeName } from '../util.js';
 import { extendManualChunks } from './util.js';
+import glob from 'fast-glob';
 
-const CONTENT_CACHE_DIR = './content/';
+const CONTENT_CACHE_DIR = './' + CONTENT_PATH;
 const CONTENT_MANIFEST_FILE = './manifest.json';
 // IMPORTANT: Update this version when making significant changes to the manifest format.
 // Only manifests generated with the same version number can be compared.
@@ -454,9 +455,24 @@ export async function copyContentToCache(opts: StaticBuildOptions) {
 
 	await fsMod.promises.mkdir(cacheTmp, { recursive: true });
 	await copyFiles(distContentRoot, cacheTmp, true);
-
 	await copyFiles(cacheTmp, contentCacheDir);
+
+	// Read the files from `dist/content/*` and `dist/chunks/*` so that
+	// we can clean them out of the dist folder
+	let files: string[] = [];
+	await Promise.all([
+		glob(`**/*.{mjs,json}`,{
+			cwd: fileURLToPath(cacheTmp)
+		}).then(f => files.push(...f.map(file => CONTENT_PATH + file))),
+		glob(`**/*.{mjs,json}`,{
+			cwd: fileURLToPath(new URL('./' + CHUNKS_PATH, config.outDir)),
+		}).then(f => files.push(...f.map(file => CHUNKS_PATH + file))),
+	]);
+
+	// Remove the tmp folder that's no longer needed.
 	await fsMod.promises.rm(cacheTmp, { recursive: true, force: true });
+
+	return files;
 }
 
 export function pluginContent(

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -107,8 +107,9 @@ export async function viteBuild(opts: StaticBuildOptions) {
 	const ssrOutputs = viteBuildReturnToRollupOutputs(ssrOutput);
 	const clientOutputs = viteBuildReturnToRollupOutputs(clientOutput ?? []);
 	await runPostBuildHooks(container, ssrOutputs, clientOutputs);
+	let contentFileNames: string[] | undefined = undefined;
 	if (opts.settings.config.experimental.contentCollectionCache) {
-		await copyContentToCache(opts);
+		contentFileNames = await copyContentToCache(opts);
 	}
 	settings.timer.end('Client build');
 
@@ -129,20 +130,21 @@ export async function viteBuild(opts: StaticBuildOptions) {
 		}
 	}
 
-	return { internals, ssrOutputChunkNames };
+	return { internals, ssrOutputChunkNames, contentFileNames };
 }
 
 export async function staticBuild(
 	opts: StaticBuildOptions,
 	internals: BuildInternals,
-	ssrOutputChunkNames: string[]
+	ssrOutputChunkNames: string[],
+	contentFileNames?: string[]
 ) {
 	const { settings } = opts;
 	switch (true) {
 		case settings.config.output === 'static': {
 			settings.timer.start('Static generate');
 			await generatePages(opts, internals);
-			await cleanServerOutput(opts, ssrOutputChunkNames, internals);
+			await cleanServerOutput(opts, ssrOutputChunkNames, contentFileNames, internals);
 			settings.timer.end('Static generate');
 			return;
 		}
@@ -431,11 +433,13 @@ async function cleanStaticOutput(
 async function cleanServerOutput(
 	opts: StaticBuildOptions,
 	ssrOutputChunkNames: string[],
+	contentFileNames: string[] | undefined,
 	internals: BuildInternals
 ) {
 	const out = getOutDirWithinCwd(opts.settings.config.outDir);
 	// The SSR output chunks for Astro are all .mjs files
-	const files = ssrOutputChunkNames.filter((f) => f.endsWith('.mjs'));
+	const files = ssrOutputChunkNames.filter((f) => f.endsWith('.mjs'))
+		.concat(contentFileNames ?? []);
 	if (internals.manifestFileName) {
 		files.push(internals.manifestFileName);
 	}

--- a/packages/astro/test/experimental-content-collections-render.test.js
+++ b/packages/astro/test/experimental-content-collections-render.test.js
@@ -121,6 +121,21 @@ if (!isWindows) {
 					// Includes styles
 					assert.equal($('link[rel=stylesheet]').length, 1);
 				});
+
+				it('content folder is cleaned', async () => {
+					let found = true;
+					try {
+						await fixture.readFile('content/manifest.json');
+					} catch {
+						found = false;
+					}
+					assert.equal(found, false, 'manifest not in dist folder');
+				});
+
+				it('chunks folder is cleaned', async () => {
+					const files = await fixture.readdir('');
+					assert.equal(files.includes('chunks'), false, 'chunks folder removed');
+				});
 			});
 		});
 	});


### PR DESCRIPTION
## Changes

- When `contentCollectionsCache` is enabled temporary cached content is copied into the `outDir` for processing. This fixes it so that this content is cleaned out, along with the rest of the temporary build JS.

## Testing

- New test case added for both the `content` and `chunks` folder.

## Docs

N/A, bug fix