### PR TITLE
fix(@astrojs/partytown): prevent crashes when View Transitions are enabled

### DIFF
--- a/.changeset/friendly-eagles-arrive.md
+++ b/.changeset/friendly-eagles-arrive.md
@@ -1,0 +1,9 @@
+---
+"@astrojs/partytown": patch
+---
+
+Prevent Partytown from crashing when View Transitions are enabled
+
+When View Transitions are turned on, Partytown executes on every transition.
+It's not meant to be like that, and therefore it breaks the integration completely.
+Starting from now, Partytown will be executed only once.

--- a/packages/integrations/partytown/src/index.ts
+++ b/packages/integrations/partytown/src/index.ts
@@ -21,19 +21,19 @@ export default function createPlugin(options?: PartytownOptions): AstroIntegrati
 	let partytownSnippetHtml: string;
 	const partytownEntrypoint = resolve('@builder.io/partytown/package.json');
 	const partytownLibDirectory = path.resolve(partytownEntrypoint, '../lib');
-	const SELF_DESTRUCT_ON_VIEW_TRANSITION = `;((d,s)=>(s=d.currentScript,d.addEventListener('astro:before-swap',()=>s.remove(),{once:true})))(document);`;
 	return {
 		name: '@astrojs/partytown',
 		hooks: {
 			'astro:config:setup': ({ config: _config, command, injectScript }) => {
 				const lib = `${appendForwardSlash(_config.base)}~partytown/`;
+				const recreateIFrameScript = `;(e=>{e.addEventListener("astro:before-swap",e=>{let r=document.body.querySelector("iframe[src*='${lib}']");e.newDocument.body.append(r)})})(document);`;
 				const partytownConfig = {
 					lib,
 					...options?.config,
 					debug: options?.config?.debug ?? command === 'dev',
 				};
 				partytownSnippetHtml = partytownSnippet(partytownConfig);
-				partytownSnippetHtml += SELF_DESTRUCT_ON_VIEW_TRANSITION;
+				partytownSnippetHtml += recreateIFrameScript;
 				injectScript('head-inline', partytownSnippetHtml);
 			},
 			'astro:server:setup': ({ server }) => {


### PR DESCRIPTION
## Changes

This pull request intend to resolve the incompatibility of Partytown integration and View Transitions.

The Partytown snippet is supposed to be loaded only once, but when the View Transitions API gets activated, the <script> element containing this snippet is recreated on every transition. It has been changed and now it's executed only once.

Under certain conditions, Partytown may need an <iframe> element to be present on the page. When a view transition happens, this <iframe> is removed from the DOM. There has been a change added, which will move `<iframe>` element from the old document to the new one. The side-effect is all Partytown scripts will get re-executed. That behavior is aligned with other frameworks like Nuxt.

Closes https://github.com/withastro/astro/issues/11033

## Testing

There is no testing suite present for Partytown. I believe we should work on implementing one, but that's probably out of scope for this pull request.

## Docs

I'm not sure if docs update is needed, because Partytown never really worked with View Transitions 😅 On the other hand, it's worth mentioning that scripts will get re-executed on each transition.

/cc @withastro/maintainers-docs for feedback!