### PR TITLE
Fix hoisted scripts propagation

### DIFF
--- a/.changeset/hungry-phones-melt.md
+++ b/.changeset/hungry-phones-melt.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes regression when handling hoisted scripts from content collections

--- a/packages/astro/src/core/build/plugins/plugin-analyzer.ts
+++ b/packages/astro/src/core/build/plugins/plugin-analyzer.ts
@@ -56,7 +56,7 @@ export function vitePluginAnalyzer(
 						if (isPropagatedAsset(parentInfo.id)) {
 							for (const hid of hoistedScripts) {
 								if (!internals.propagatedScriptsMap.has(parentInfo.id)) {
-									internals.propagatedScriptsMap.set(parentInfo.id, new Set())
+									internals.propagatedScriptsMap.set(parentInfo.id, new Set());
 								}
 								internals.propagatedScriptsMap.get(parentInfo.id)?.add(hid);
 							}

--- a/packages/astro/src/core/build/plugins/plugin-analyzer.ts
+++ b/packages/astro/src/core/build/plugins/plugin-analyzer.ts
@@ -54,7 +54,12 @@ export function vitePluginAnalyzer(
 				if (hoistedScripts.size) {
 					for (const parentInfo of getParentModuleInfos(from, this, isPropagatedAsset)) {
 						if (isPropagatedAsset(parentInfo.id)) {
-							internals.propagatedScriptsMap.set(parentInfo.id, hoistedScripts);
+							for (const hid of hoistedScripts) {
+								if (!internals.propagatedScriptsMap.has(parentInfo.id)) {
+									internals.propagatedScriptsMap.set(parentInfo.id, new Set())
+								}
+								internals.propagatedScriptsMap.get(parentInfo.id)?.add(hid);
+							}
 						} else if (moduleIsTopLevelPage(parentInfo)) {
 							for (const hid of hoistedScripts) {
 								if (!pageScripts.has(parentInfo.id)) {

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -154,12 +154,16 @@ describe('Content Collections', () => {
 				// `experimental.directRenderScript` so this optimization isn't a priority at the moment.
 				assert.equal($('script').length, 2);
 				// Read the scripts' content
-				const scripts = $('script').map((_, el) => $(el).attr('src')).toArray()
-				const scriptsCode = (await Promise.all(scripts.map(async (src) => await fixture.readFile(src)))).join('\n')
-				assert.match(scriptsCode,/ScriptCompA/)
-				assert.match(scriptsCode,/ScriptCompB/)
-			})
-		})
+				const scripts = $('script')
+					.map((_, el) => $(el).attr('src'))
+					.toArray();
+				const scriptsCode = (
+					await Promise.all(scripts.map(async (src) => await fixture.readFile(src)))
+				).join('\n');
+				assert.match(scriptsCode, /ScriptCompA/);
+				assert.match(scriptsCode, /ScriptCompB/);
+			});
+		});
 	});
 
 	const blogSlugToContents = {

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -145,6 +145,21 @@ describe('Content Collections', () => {
 				});
 			});
 		});
+
+		describe('Hoisted scripts', () => {
+			it('Contains all the scripts imported by components', async () => {
+				const html = await fixture.readFile('/with-scripts/one/index.html');
+				const $ = cheerio.load(html);
+				// NOTE: Hoisted scripts have two tags currently but could be optimized as one. However, we're moving towards
+				// `experimental.directRenderScript` so this optimization isn't a priority at the moment.
+				assert.equal($('script').length, 2);
+				// Read the scripts' content
+				const scripts = $('script').map((_, el) => $(el).attr('src')).toArray()
+				const scriptsCode = (await Promise.all(scripts.map(async (src) => await fixture.readFile(src)))).join('\n')
+				assert.match(scriptsCode,/ScriptCompA/)
+				assert.match(scriptsCode,/ScriptCompB/)
+			})
+		})
 	});
 
 	const blogSlugToContents = {

--- a/packages/astro/test/fixtures/content-collections/src/components/ScriptCompA.astro
+++ b/packages/astro/test/fixtures/content-collections/src/components/ScriptCompA.astro
@@ -1,0 +1,1 @@
+<script>console.log('ScriptCompA')</script>

--- a/packages/astro/test/fixtures/content-collections/src/components/ScriptCompB.astro
+++ b/packages/astro/test/fixtures/content-collections/src/components/ScriptCompB.astro
@@ -1,0 +1,1 @@
+<script>console.log('ScriptCompB')</script>

--- a/packages/astro/test/fixtures/content-collections/src/content/with-scripts/one.mdx
+++ b/packages/astro/test/fixtures/content-collections/src/content/with-scripts/one.mdx
@@ -1,0 +1,7 @@
+import ScriptCompA from '../../components/ScriptCompA.astro'
+import ScriptCompB from '../../components/ScriptCompB.astro'
+
+Both scripts should exist.
+
+<ScriptCompA />
+<ScriptCompB />

--- a/packages/astro/test/fixtures/content-collections/src/pages/with-scripts/[...slug].astro
+++ b/packages/astro/test/fixtures/content-collections/src/pages/with-scripts/[...slug].astro
@@ -1,0 +1,21 @@
+---
+import { getCollection } from 'astro:content';
+
+export async function getStaticPaths() {
+  const blogEntries = await getCollection('with-scripts');
+  return blogEntries.map(entry => ({
+    params: { slug: entry.slug }, props: { entry },
+  }));
+}
+
+const { entry } = Astro.props;
+
+const { Content } = await entry.render();
+const { title } = entry.data;
+---
+
+<article>
+  <h1>This is a content collection post</h1>
+  <h2>{title}</h2>
+  <Content />
+</article>


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/11063

regression from https://github.com/withastro/astro/pull/10959. When there's two hoisted scripts for a propagated asset (eg mdx file in content collection), there's two sets and I was incorrectly replacing the older with the new one. This PR fixes it and combines the set instead.

## Testing

Added a new test

## Docs

n/a. bug fix.