### PR TITLE
chore(lint): enable no-floating-promises rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,6 +70,12 @@ export default [
 					ignoreRestSiblings: true,
 				},
 			],
+			'@typescript-eslint/no-floating-promises': [
+				'error',
+				{
+					ignoreIIFE: true
+				}
+			],
 			'no-only-tests/no-only-tests': 'error',
 			'@typescript-eslint/no-shadow': 'error',
 			'no-console': 'warn',
@@ -83,7 +89,6 @@ export default [
 			'@typescript-eslint/dot-notation': 'off',
 			'@typescript-eslint/no-base-to-string': 'off',
 			'@typescript-eslint/no-empty-function': 'off',
-			'@typescript-eslint/no-floating-promises': 'off',
 			'@typescript-eslint/no-misused-promises': 'off',
 			'@typescript-eslint/no-redundant-type-constituents': 'off',
 			'@typescript-eslint/no-this-alias': 'off',
@@ -200,4 +205,13 @@ export default [
 			],
 		},
 	},
+
+	// Disable no-floating-promises for tests using the node:test api
+	// See https://github.com/nodejs/node/issues/51292 for a discussion on why this is necessary right now
+	{
+		files: ['packages/**/*.test.ts', 'packages/**/*.test.js'],
+		rules: {
+			'@typescript-eslint/no-floating-promises': 'off',
+		}
+	}
 ];


### PR DESCRIPTION
## Changes

This PR enables the eslint [`no-floating-promises` rule](https://typescript-eslint.io/rules/no-floating-promises/).

I noticed that #10991 fixed a bug from a missing `await` statement. Bugs caused by missing `await` statements can be very hard to track down! So, I find that this eslint rule is very helpful in identifying subtle bugs.

## Current Failures

This PR is currently work-in-progress. I didn't want to spend the time fixing issues if the team doesn't want to enable this rule for some other reason. For your convenience, here's a list of the current failures:

```
/private/tmp/astro/packages/astro/src/assets/services/vendor/squoosh/utils/workerPool.ts
  27:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  55:6  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  75:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  77:3  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  81:3  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  88:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/cli/add/index.ts
  104:2  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/core/build/index.ts
  69:2  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/core/config/config.ts
  43:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/core/create-vite.ts
  251:3  error  An array of Promises may be unintentional. Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/core/dev/restart.ts
  117:2  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  156:5  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/core/errors/overlay.ts
  655:6  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/core/preview/index.ts
  28:2  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/core/sync/index.ts
  61:2  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/prefetch/index.ts
  242:3  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/runtime/client/dev-toolbar/apps/astro.ts
   55:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  383:5  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/runtime/client/dev-toolbar/apps/audit/index.ts
  59:8   error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  60:24  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  68:7   error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  69:23  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  82:4   error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  96:5   error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/runtime/client/dev-toolbar/entrypoint.ts
  239:7  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/runtime/client/dev-toolbar/toolbar.ts
  311:6  error  An array of Promises may be unintentional. Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  317:5  error  An array of Promises may be unintentional. Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  376:5  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator                                         @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/runtime/client/media.ts
  15:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/runtime/client/visible.ts
  26:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/runtime/server/astro-island.ts
   64:5  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
   72:6  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
   95:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  205:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/toolbar/vite-plugin-dev-toolbar.ts
  51:6  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/transitions/router.ts
  314:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  524:2  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  531:2  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  590:2  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/vite-plugin-astro-server/error.ts
  29:3  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/vite-plugin-astro-server/plugin.ts
  92:7  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/vite-plugin-astro-server/request.ts
  73:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/astro/src/vite-plugin-mdx/transform-jsx.ts
  67:2  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/create-astro/create-astro.mjs
  15:1  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/create-astro/src/actions/dependencies.ts
  32:5  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  33:5  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/create-astro/src/actions/git.ts
  37:6  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/create-astro/src/actions/template.ts
  42:7  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  45:7  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/create-astro/src/actions/typescript.ts
  53:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  76:6  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/create-astro/src/actions/verify.ts
  16:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  26:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/db/src/core/cli/commands/login/index.ts
  50:3  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/db/src/core/integration/index.ts
   80:6  error  An array of Promises may be unintentional. Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator  @typescript-eslint/no-floating-promises
   90:6  error  An array of Promises may be unintentional. Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  138:7  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator                                         @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/db/src/core/load-file.ts
  37:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/integrations/lit/client-shim.js
  21:2  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a
rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/integrations/markdoc/src/index.ts
  43:7  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/integrations/node/src/preview.ts
  52:2  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/integrations/node/src/standalone.ts
  27:3  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/integrations/vercel/src/speed-insights.ts
  32:3  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/integrations/web-vitals/src/client-script.ts
  25:7  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/upgrade/src/actions/install.ts
  164:5  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/upgrade/src/actions/verify.ts
  22:4  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  33:3  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/private/tmp/astro/packages/upgrade/upgrade.mjs
  15:1  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

✖ 68 problems (68 errors, 0 warnings)
```

Does it seem worth fixing these issues and enabling the rule? cc @matthewp who reviewed #10991.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
