### PR TITLE
Fix inconsistent results from raw SQL

### DIFF
--- a/.changeset/honest-shirts-sell.md
+++ b/.changeset/honest-shirts-sell.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/db": patch
+---
+
+Fix inconsistent result type using raw SQL

--- a/packages/db/src/runtime/db-client.ts
+++ b/packages/db/src/runtime/db-client.ts
@@ -71,7 +71,20 @@ export function createRemoteDatabaseClient(appToken: string, remoteDbURL: string
 				});
 			}
 
-			if (method === 'run') return remoteResult;
+			if (method === 'run') {
+				// Using `db.run()` drizzle massages the rows into an object.
+				// So in order to make dev/prod consistent, we need to do the same here.
+				// This creates an object and loops over each row replacing it with the object.
+				for(let i = 0; i < remoteResult.rows.length; i++) {
+          let row = remoteResult.rows[i];
+          let item: Record<string, any> = {};
+          remoteResult.columns.forEach((col, index) => {
+            item[col] = row[index];
+          });
+          (remoteResult as any).rows[i] = item;
+        }
+				return remoteResult;
+			}
 
 			// Drizzle expects each row as an array of its values
 			const rowValues: unknown[][] = [];

--- a/packages/db/test/fixtures/static-remote/src/pages/run.astro
+++ b/packages/db/test/fixtures/static-remote/src/pages/run.astro
@@ -1,0 +1,17 @@
+---
+import { User, db, sql } from 'astro:db';
+
+const results = await db.run(sql`SELECT 1 as value`);
+const row = results.rows[0];
+---
+
+<html>
+	<head>
+		<title>Testing</title>
+	</head>
+	<body>
+		<h1>Testing</h1>
+
+		<span id="row">{row.value}</span>
+	</body>
+</html>

--- a/packages/db/test/static-remote.test.js
+++ b/packages/db/test/static-remote.test.js
@@ -30,5 +30,12 @@ describe('astro:db', () => {
 
 			expect($('li').length).to.equal(1);
 		});
+
+		it.only('Returns correct shape from db.run()', async () => {
+			const html = await fixture.readFile('/run/index.html');
+			const $ = cheerioLoad(html);
+
+			expect($('#row').text()).to.equal('1');
+		});
 	});
 });


### PR DESCRIPTION
## Changes

- Locally drizzle turns each row into an object when creating the result. Remote, which runs regular SQL, does not.
- So this changes how remote deserializes the result, only for raw SQL, so that it is also an object.
- Fixes https://github.com/withastro/astro/issues/10970

## Testing

- New test case added

## Docs

N/A, bug fix