### PR TITLE
fix type definition of IntrinsicAttributes's slot attribute

### DIFF
--- a/.changeset/new-mice-occur.md
+++ b/.changeset/new-mice-occur.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Change `slot` attribute of `IntrinsicAttributes` to match the definition of `HTMLAttributes`'s own `slot` attribute of type `string | undefined | null`

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -22,7 +22,7 @@ declare namespace astroHTML.JSX {
 		extends AstroBuiltinProps,
 			AstroBuiltinAttributes,
 			AstroClientDirectives {
-		slot?: string;
+		slot?: string | undefined | null;
 		children?: Children;
 	}
 


### PR DESCRIPTION
## Changes

Closes #11072 
- What does this change?
Changed IntrinsicAttributes's slot attribute type, adding `null` as a possible type
 ```
interface IntrinsicAttributes {
....
slot?: string | undefined | null
....
}
```
Now `slot` is consistent in IntrinsicAttributes and HTMLAttributes

## Testing

None, since I only widened the type choice

## Docs

None, change doesn't affect docs