### PR TITLE
Support deprecating Web Vitals table

### DIFF
--- a/.changeset/good-turtles-guess.md
+++ b/.changeset/good-turtles-guess.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/web-vitals": patch
+---
+
+Adds support for deprecating the web vitals DB table, so the integration can be removed if desired

--- a/packages/integrations/web-vitals/README.md
+++ b/packages/integrations/web-vitals/README.md
@@ -27,6 +27,55 @@ This **[Astro integration][astro-integration]** enables tracking real-world webs
 
 Learn more about [Astro DB](https://docs.astro.build/en/guides/astro-db/) and [deploying with Astro Studio](https://docs.astro.build/en/guides/astro-db/#astro-studio) in the Astro docs.
 
+## Uninstalling
+
+To remove the Web Vitals integration, follow the Astro DB deprecation process:
+
+1. Mark the integration as deprecated in `astro.config.mjs`, by setting the `deprecated` option to `true`:
+
+   ```js
+   import db from '@astrojs/db';
+   import webVitals from '@astrojs/web-vitals';
+   import { defineConfig } from 'astro/config';
+
+   export default defineConfig({
+     integrations: [
+       db(),
+       // Mark the web vitals integration as deprecated:
+       webVitals({ deprecated: true }),
+     ],
+     // ...
+   });
+   ```
+
+2. Push the deprecation to Astro Studio:
+
+   ```sh
+   npx astro db push
+   ```
+
+3. Remove the web vitals integration in `astro.config.mjs`:
+
+   ```diff
+   import db from '@astrojs/db';
+   - import webVitals from '@astrojs/web-vitals';
+   import { defineConfig } from 'astro/config';
+
+   export default defineConfig({
+     integrations: [
+       db(),
+   -   webVitals({ deprecated: true }),
+     ],
+     // ...
+   });
+   ```
+
+4. Push the table deletion to Astro Studio:
+
+   ```sh
+   npx astro db push
+   ```
+
 ## Support
 
 - Get help in the [Astro Discord][discord]. Post questions in our `#support` forum, or visit our dedicated `#dev` channel to discuss current development and more!

--- a/packages/integrations/web-vitals/src/db-config.ts
+++ b/packages/integrations/web-vitals/src/db-config.ts
@@ -11,6 +11,7 @@ const Metric = defineTable({
 		rating: column.text(),
 		timestamp: column.date(),
 	},
+	deprecated: Boolean(process.env.DEPRECATE_WEB_VITALS) ?? false,
 });
 
 // export const AstrojsWebVitals_Metric = asDrizzleTable('AstrojsWebVitals_Metric', Metric);

--- a/packages/integrations/web-vitals/src/index.ts
+++ b/packages/integrations/web-vitals/src/index.ts
@@ -2,7 +2,8 @@ import { defineDbIntegration } from '@astrojs/db/utils';
 import { AstroError } from 'astro/errors';
 import { WEB_VITALS_ENDPOINT_PATH } from './constants.js';
 
-export default function webVitals() {
+export default function webVitals({ deprecated }: { deprecated?: boolean } = {}) {
+	process.env.DEPRECATE_WEB_VITALS = deprecated ? 'true' : undefined;
 	return defineDbIntegration({
 		name: '@astrojs/web-vitals',
 		hooks: {


### PR DESCRIPTION
## Changes

- Adds an option to the web vitals integration that allows users to “deprecate” the Astro DB tables web vitals adds.
- Currently, Astro DB requires a user to set `deprecated: true` on a table and push that before it will allow you to remove it completely. Because integrations control the tables themselves this is not something users can do themselves, so this PR reflects that up to the integration options.
- See the README changes in this PR for a full description of the “uninstall” process. (It’s not amazing, might be something for us to be aware of/think about.)
 
## Testing

Tested manually that the `deprecated` property is being set properly on the table config.

## Docs

/cc @withastro/maintainers-docs for feedback on the README changes!
