### PR TITLE
chore(db): move tests to node runner

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -66,8 +66,7 @@
     "build": "astro-scripts build \"src/**/*.ts\" && tsc && pnpm types:virtual",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "mocha --exit --timeout 20000 \"test/*.js\" \"test/unit/**/*.js\"",
-    "test:match": "mocha --timeout 20000 \"test/*.js\" \"test/unit/*.js\" -g"
+    "test": "astro-scripts test \"test/**/*.test.js\""
   },
   "dependencies": {
     "@astrojs/studio": "workspace:*",
@@ -90,14 +89,11 @@
     "@types/chai": "^4.3.16",
     "@types/deep-diff": "^1.0.5",
     "@types/diff": "^5.2.1",
-    "@types/mocha": "^10.0.6",
     "@types/prompts": "^2.4.9",
     "@types/yargs-parser": "^21.0.3",
     "astro": "workspace:*",
     "astro-scripts": "workspace:*",
-    "chai": "^5.1.1",
     "cheerio": "1.0.0-rc.12",
-    "mocha": "^10.4.0",
     "typescript": "^5.4.5",
     "vite": "^5.2.11"
   }

--- a/packages/db/test/basics.test.js
+++ b/packages/db/test/basics.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before, after } from "node:test";
+import assert from  "node:assert/strict";
 import { load as cheerioLoad } from 'cheerio';
 import testAdapter from '../../astro/test/test-adapter.js';
 import { loadFixture } from '../../astro/test/test-utils.js';
@@ -30,8 +31,14 @@ describe('astro:db', () => {
 			const $ = cheerioLoad(html);
 
 			const ul = $('.authors-list');
-			expect(ul.children()).to.have.a.lengthOf(5);
-			expect(ul.children().eq(0).text()).to.equal('Ben');
+			assert.equal(
+				ul.children().length,
+				5
+			);
+			assert.match(
+				ul.children().eq(0).text(),
+				/Ben/
+			)
 		});
 
 		it('Allows expression defaults for date columns', async () => {
@@ -39,7 +46,7 @@ describe('astro:db', () => {
 			const $ = cheerioLoad(html);
 
 			const themeAdded = $($('.themes-list .theme-added')[0]).text();
-			expect(new Date(themeAdded).getTime()).to.not.be.NaN;
+		assert.equal(Number.isNaN(new Date(themeAdded).getTime()), false);
 		});
 
 		it('Defaults can be overridden for dates', async () => {
@@ -47,7 +54,7 @@ describe('astro:db', () => {
 			const $ = cheerioLoad(html);
 
 			const themeAdded = $($('.themes-list .theme-added')[1]).text();
-			expect(new Date(themeAdded).getTime()).to.not.be.NaN;
+			assert.equal(Number.isNaN(new Date(themeAdded).getTime()), false);
 		});
 
 		it('Allows expression defaults for text columns', async () => {
@@ -55,7 +62,7 @@ describe('astro:db', () => {
 			const $ = cheerioLoad(html);
 
 			const themeOwner = $($('.themes-list .theme-owner')[0]).text();
-			expect(themeOwner).to.equal('');
+			assert.equal(themeOwner, '');
 		});
 
 		it('Allows expression defaults for boolean columns', async () => {
@@ -63,20 +70,20 @@ describe('astro:db', () => {
 			const $ = cheerioLoad(html);
 
 			const themeDark = $($('.themes-list .theme-dark')[0]).text();
-			expect(themeDark).to.equal('dark mode');
+			assert.match(themeDark, /dark mode/);
 		});
 
 		it('text fields an be used as references', async () => {
 			const html = await fixture.fetch('/login').then((res) => res.text());
 			const $ = cheerioLoad(html);
 
-			expect($('.session-id').text()).to.equal('12345');
-			expect($('.username').text()).to.equal('Mario');
+			assert.match($('.session-id').text(), /12345/);
+			assert.match($('.username').text(), /Mario/);
 		});
 
 		it('Prints authors from raw sql call', async () => {
 			const json = await fixture.fetch('run.json').then((res) => res.json());
-			expect(json).to.deep.equal({
+			assert.deepEqual(json, {
 				columns: ['_id', 'name', 'age2'],
 				columnTypes: ['INTEGER', 'TEXT', 'INTEGER'],
 				rows: [
@@ -111,8 +118,14 @@ describe('astro:db', () => {
 			const $ = cheerioLoad(html);
 
 			const ul = $('.authors-list');
-			expect(ul.children()).to.have.a.lengthOf(5);
-			expect(ul.children().eq(0).text()).to.equal('Ben');
+			assert.equal(
+				ul.children().length,
+				5
+			);
+			assert.match(
+				ul.children().eq(0).text(),
+				/Ben/
+			)
 		});
 
 		it('Allows expression defaults for date columns', async () => {
@@ -120,7 +133,7 @@ describe('astro:db', () => {
 			const $ = cheerioLoad(html);
 
 			const themeAdded = $($('.themes-list .theme-added')[0]).text();
-			expect(new Date(themeAdded).getTime()).to.not.be.NaN;
+			assert.equal(Number.isNaN(new Date(themeAdded).getTime()), false);
 		});
 
 		it('Defaults can be overridden for dates', async () => {
@@ -128,7 +141,7 @@ describe('astro:db', () => {
 			const $ = cheerioLoad(html);
 
 			const themeAdded = $($('.themes-list .theme-added')[1]).text();
-			expect(new Date(themeAdded).getTime()).to.not.be.NaN;
+			assert.equal(Number.isNaN(new Date(themeAdded).getTime()), false);
 		});
 
 		it('Allows expression defaults for text columns', async () => {
@@ -136,7 +149,8 @@ describe('astro:db', () => {
 			const $ = cheerioLoad(html);
 
 			const themeOwner = $($('.themes-list .theme-owner')[0]).text();
-			expect(themeOwner).to.equal('');
+			assert.equal(themeOwner, '');
+
 		});
 
 		it('Allows expression defaults for boolean columns', async () => {
@@ -144,20 +158,21 @@ describe('astro:db', () => {
 			const $ = cheerioLoad(html);
 
 			const themeDark = $($('.themes-list .theme-dark')[0]).text();
-			expect(themeDark).to.equal('dark mode');
+			assert.match(themeDark, /dark mode/);
+
 		});
 
 		it('text fields an be used as references', async () => {
 			const html = await fixture.fetch('/login').then((res) => res.text());
 			const $ = cheerioLoad(html);
 
-			expect($('.session-id').text()).to.equal('12345');
-			expect($('.username').text()).to.equal('Mario');
+			assert.match($('.session-id').text(), /12345/);
+			assert.match($('.username').text(), /Mario/);
 		});
 
 		it('Prints authors from raw sql call', async () => {
 			const json = await fixture.fetch('run.json').then((res) => res.json());
-			expect(json).to.deep.equal({
+			assert.deepEqual(json, {
 				columns: ['_id', 'name', 'age2'],
 				columnTypes: ['INTEGER', 'TEXT', 'INTEGER'],
 				rows: [
@@ -195,7 +210,9 @@ describe('astro:db', () => {
 			const $ = cheerioLoad(html);
 
 			const ul = $('.authors-list');
-			expect(ul.children()).to.have.a.lengthOf(5);
+			assert.equal(
+				ul.children().length,5
+			)
 		});
 	});
 });

--- a/packages/db/test/db-in-src.test.js
+++ b/packages/db/test/db-in-src.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before, after } from "node:test";
+import assert from  "node:assert/strict";
 import { load as cheerioLoad } from 'cheerio';
 import testAdapter from '../../astro/test/test-adapter.js';
 import { loadFixture } from '../../astro/test/test-utils.js';
@@ -30,8 +31,14 @@ describe('astro:db', () => {
 			const $ = cheerioLoad(html);
 
 			const ul = $('.users-list');
-			expect(ul.children()).to.have.a.lengthOf(1);
-			expect($('.users-list li').text()).to.equal('Mario');
+			assert.equal(
+				ul.children().length,
+				1
+			);
+			assert.match(
+				$('.users-list li').text(),
+				/Mario/
+			)
 		});
 	});
 });

--- a/packages/db/test/error-handling.test.js
+++ b/packages/db/test/error-handling.test.js
@@ -1,6 +1,7 @@
-import { expect } from 'chai';
+import { describe, it, before, after } from "node:test";
 import { loadFixture } from '../../astro/test/test-utils.js';
 import { setupRemoteDbServer } from './test-utils.js';
+import assert from "node:assert/strict"
 
 const foreignKeyConstraintError =
 	'LibsqlError: SQLITE_CONSTRAINT_FOREIGNKEY: FOREIGN KEY constraint failed';
@@ -26,10 +27,10 @@ describe('astro:db - error handling', () => {
 
 		it('Raises foreign key constraint LibsqlError', async () => {
 			const json = await fixture.fetch('/foreign-key-constraint.json').then((res) => res.json());
-			expect(json).to.deep.equal({
+			assert.deepEqual(json, {
 				message: foreignKeyConstraintError,
 				code: 'SQLITE_CONSTRAINT_FOREIGNKEY',
-			});
+			})
 		});
 	});
 
@@ -47,10 +48,10 @@ describe('astro:db - error handling', () => {
 
 		it('Raises foreign key constraint LibsqlError', async () => {
 			const json = await fixture.readFile('/foreign-key-constraint.json');
-			expect(JSON.parse(json)).to.deep.equal({
+			assert.deepEqual(JSON.parse(json), {
 				message: foreignKeyConstraintError,
 				code: 'SQLITE_CONSTRAINT_FOREIGNKEY',
-			});
+			})
 		});
 	});
 });

--- a/packages/db/test/integration-only.test.js
+++ b/packages/db/test/integration-only.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before, after } from "node:test";
+import assert from  "node:assert/strict";
 import { load as cheerioLoad } from 'cheerio';
 import { loadFixture } from '../../astro/test/test-utils.js';
 
@@ -25,8 +26,14 @@ describe('astro:db with only integrations, no user db config', () => {
 			const $ = cheerioLoad(html);
 
 			const ul = $('ul.menu');
-			expect(ul.children()).to.have.a.lengthOf(4);
-			expect(ul.children().eq(0).text()).to.equal('Pancakes');
+			assert.equal(
+				ul.children().length,
+				4
+			);
+			assert.match(
+				ul.children().eq(0).text(),
+				/Pancakes/
+			)
 		});
 	});
 
@@ -40,8 +47,14 @@ describe('astro:db with only integrations, no user db config', () => {
 			const $ = cheerioLoad(html);
 
 			const ul = $('ul.menu');
-			expect(ul.children()).to.have.a.lengthOf(4);
-			expect(ul.children().eq(0).text()).to.equal('Pancakes');
+			assert.equal(
+				ul.children().length,
+				4
+			);
+			assert.match(
+				ul.children().eq(0).text(),
+				/Pancakes/
+			)
 		});
 	});
 });

--- a/packages/db/test/integrations.test.js
+++ b/packages/db/test/integrations.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before, after } from "node:test";
+import assert from  "node:assert/strict";
 import { load as cheerioLoad } from 'cheerio';
 import { loadFixture } from '../../astro/test/test-utils.js';
 
@@ -27,8 +28,14 @@ describe('astro:db with integrations', () => {
 			const $ = cheerioLoad(html);
 
 			const ul = $('.authors-list');
-			expect(ul.children()).to.have.a.lengthOf(5);
-			expect(ul.children().eq(0).text()).to.equal('Ben');
+			assert.equal(
+				ul.children().length,
+				5
+			);
+			assert.match(
+				ul.children().eq(0).text(),
+				/Ben/
+			)
 		});
 
 		it('Prints the list of menu items from integration-defined table', async () => {
@@ -36,8 +43,14 @@ describe('astro:db with integrations', () => {
 			const $ = cheerioLoad(html);
 
 			const ul = $('ul.menu');
-			expect(ul.children()).to.have.a.lengthOf(4);
-			expect(ul.children().eq(0).text()).to.equal('Pancakes');
+			assert.equal(
+				ul.children().length,
+				4
+			);
+			assert.match(
+				ul.children().eq(0).text(),
+				/Pancakes/
+			)
 		});
 	});
 
@@ -51,8 +64,14 @@ describe('astro:db with integrations', () => {
 			const $ = cheerioLoad(html);
 
 			const ul = $('.authors-list');
-			expect(ul.children()).to.have.a.lengthOf(5);
-			expect(ul.children().eq(0).text()).to.equal('Ben');
+			assert.equal(
+				ul.children().length,
+				5
+			);
+			assert.match(
+				ul.children().eq(0).text(),
+				/Ben/
+			)
 		});
 
 		it('Prints the list of menu items from integration-defined table', async () => {
@@ -60,8 +79,14 @@ describe('astro:db with integrations', () => {
 			const $ = cheerioLoad(html);
 
 			const ul = $('ul.menu');
-			expect(ul.children()).to.have.a.lengthOf(4);
-			expect(ul.children().eq(0).text()).to.equal('Pancakes');
+			assert.equal(
+				ul.children().length,
+				4
+			);
+			assert.match(
+				ul.children().eq(0).text(),
+				/Pancakes/
+			)
 		});
 	});
 });

--- a/packages/db/test/local-prod.test.js
+++ b/packages/db/test/local-prod.test.js
@@ -1,6 +1,7 @@
 import { relative } from 'path';
 import { fileURLToPath } from 'url';
-import { expect } from 'chai';
+import { describe, it, before, after } from "node:test";
+import assert from  "node:assert/strict";
 import testAdapter from '../../astro/test/test-adapter.js';
 import { loadFixture } from '../../astro/test/test-utils.js';
 
@@ -29,7 +30,7 @@ describe('astro:db local database', () => {
 			const app = await fixture.loadTestAdapterApp();
 			const request = new Request('http://example.com/');
 			const response = await app.render(request);
-			expect(response.status).to.equal(200);
+			assert.equal(response.status, 200);
 		});
 	});
 
@@ -50,7 +51,7 @@ describe('astro:db local database', () => {
 			const app = await fixture.loadTestAdapterApp();
 			const request = new Request('http://example.com/');
 			const response = await app.render(request);
-			expect(response.status).to.equal(200);
+			assert.equal(response.status, 200);
 		});
 	});
 
@@ -63,8 +64,8 @@ describe('astro:db local database', () => {
 			} catch (err) {
 				buildError = err;
 			}
-
-			expect(buildError).to.be.an('Error');
+			
+			assert.equal(buildError instanceof  Error, true)
 		});
 
 		it('should throw during the build for hybrid output', async () => {
@@ -81,8 +82,8 @@ describe('astro:db local database', () => {
 			} catch (err) {
 				buildError = err;
 			}
-
-			expect(buildError).to.be.an('Error');
+			
+			assert.equal(buildError instanceof  Error, true)
 		});
 	});
 });

--- a/packages/db/test/no-seed.test.js
+++ b/packages/db/test/no-seed.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before, after } from "node:test";
+import assert from  "node:assert/strict";
 import { load as cheerioLoad } from 'cheerio';
 import { loadFixture } from '../../astro/test/test-utils.js';
 
@@ -25,8 +26,14 @@ describe('astro:db with no seed file', () => {
 			const $ = cheerioLoad(html);
 
 			const ul = $('.authors-list');
-			expect(ul.children()).to.have.a.lengthOf(5);
-			expect(ul.children().eq(0).text()).to.equal('Ben');
+			assert.equal(
+				ul.children().length,
+				5
+			);
+			assert.match(
+				ul.children().eq(0).text(),
+				/Ben/
+			)
 		});
 	});
 
@@ -40,8 +47,14 @@ describe('astro:db with no seed file', () => {
 			const $ = cheerioLoad(html);
 
 			const ul = $('.authors-list');
-			expect(ul.children()).to.have.a.lengthOf(5);
-			expect(ul.children().eq(0).text()).to.equal('Ben');
+			assert.equal(
+				ul.children().length,
+				5
+			);
+			assert.match(
+				ul.children().eq(0).text(),
+				/Ben/
+			)
 		});
 	});
 });

--- a/packages/db/test/ssr-no-apptoken.test.js
+++ b/packages/db/test/ssr-no-apptoken.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before, after } from "node:test";
+import assert from  "node:assert/strict";
 import testAdapter from '../../astro/test/test-adapter.js';
 import { loadFixture } from '../../astro/test/test-utils.js';
 import { setupRemoteDbServer } from './test-utils.js';
@@ -26,11 +27,11 @@ describe('missing app token', () => {
 	it('Errors as runtime', async () => {
 		const app = await fixture.loadTestAdapterApp();
 		const request = new Request('http://example.com/');
+		const response = await app.render(request);
 		try {
-			const response = await app.render(request);
 			await response.text();
 		} catch {
-			expect(response.status).to.equal(501);
+			assert.equal(response.status, 501)
 		}
 	});
 });

--- a/packages/db/test/static-remote.test.js
+++ b/packages/db/test/static-remote.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { describe, it, before, after } from "node:test";
+import assert from  "node:assert/strict";
 import { load as cheerioLoad } from 'cheerio';
 import { loadFixture } from '../../astro/test/test-utils.js';
 import { setupRemoteDbServer } from './test-utils.js';
@@ -28,7 +29,7 @@ describe('astro:db', () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerioLoad(html);
 
-			expect($('li').length).to.equal(1);
+			assert.equal($('li').length, 1)
 		});
 	});
 });

--- a/packages/db/test/unit/column-queries.test.js
+++ b/packages/db/test/unit/column-queries.test.js
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
-import { describe, it } from 'mocha';
+import { describe, it } from "node:test";
+import assert from  "node:assert/strict";
 import {
 	getMigrationQueries,
 	getTableChangeQueries,
@@ -44,14 +44,14 @@ describe('column queries', () => {
 			const oldTables = { [TABLE_NAME]: userInitial };
 			const newTables = { [TABLE_NAME]: userInitial };
 			const { queries } = await configChangeQueries(oldTables, newTables);
-			expect(queries).to.deep.equal([]);
+			assert.deepEqual(queries, []);
 		});
 
 		it('should create table for new tables', async () => {
 			const oldTables = {};
 			const newTables = { [TABLE_NAME]: userInitial };
 			const { queries } = await configChangeQueries(oldTables, newTables);
-			expect(queries).to.deep.equal([
+			assert.deepEqual(queries, [
 				`CREATE TABLE "${TABLE_NAME}" (_id INTEGER PRIMARY KEY, "name" text NOT NULL, "age" integer NOT NULL, "email" text NOT NULL UNIQUE, "mi" text)`,
 			]);
 		});
@@ -60,7 +60,7 @@ describe('column queries', () => {
 			const oldTables = { [TABLE_NAME]: userInitial };
 			const newTables = {};
 			const { queries } = await configChangeQueries(oldTables, newTables);
-			expect(queries).to.deep.equal([`DROP TABLE "${TABLE_NAME}"`]);
+			assert.deepEqual(queries, [`DROP TABLE "${TABLE_NAME}"`]);
 		});
 
 		it('should error if possible table rename is detected', async () => {
@@ -73,7 +73,7 @@ describe('column queries', () => {
 			} catch (e) {
 				error = e.message;
 			}
-			expect(error).to.include.string('Potential table rename detected');
+			assert.match(error, /Potential table rename detected/);
 		});
 
 		it('should error if possible column rename is detected', async () => {
@@ -93,14 +93,14 @@ describe('column queries', () => {
 			} catch (e) {
 				error = e.message;
 			}
-			expect(error).to.include.string('Potential column rename detected');
+			assert.match(error, /Potential column rename detected/);
 		});
 	});
 
 	describe('getTableChangeQueries', () => {
 		it('should be empty when tables are the same', async () => {
 			const { queries } = await userChangeQueries(userInitial, userInitial);
-			expect(queries).to.deep.equal([]);
+			assert.deepEqual(queries, []);
 		});
 
 		it('should return warning if column type change introduces data loss', async () => {
@@ -117,11 +117,11 @@ describe('column queries', () => {
 				},
 			});
 			const { queries, confirmations } = await userChangeQueries(blogInitial, blogFinal);
-			expect(queries).to.deep.equal([
+			assert.deepEqual(queries, [
 				'DROP TABLE "Users"',
 				'CREATE TABLE "Users" (_id INTEGER PRIMARY KEY, "date" text NOT NULL)',
 			]);
-			expect(confirmations.length).to.equal(1);
+			assert.equal(confirmations.length, 1)
 		});
 
 		it('should return warning if new required column added', async () => {
@@ -136,11 +136,11 @@ describe('column queries', () => {
 				},
 			});
 			const { queries, confirmations } = await userChangeQueries(blogInitial, blogFinal);
-			expect(queries).to.deep.equal([
+			assert.deepEqual(queries, [
 				'DROP TABLE "Users"',
 				'CREATE TABLE "Users" (_id INTEGER PRIMARY KEY, "date" text NOT NULL)',
 			]);
-			expect(confirmations.length).to.equal(1);
+			assert.equal(confirmations.length, 1)
 		});
 
 		it('should return warning if non-number primary key with no default added', async () => {
@@ -155,11 +155,11 @@ describe('column queries', () => {
 				},
 			});
 			const { queries, confirmations } = await userChangeQueries(blogInitial, blogFinal);
-			expect(queries).to.deep.equal([
+			assert.deepEqual(queries, [
 				'DROP TABLE "Users"',
 				'CREATE TABLE "Users" ("id" text PRIMARY KEY)',
 			]);
-			expect(confirmations.length).to.equal(1);
+			assert.equal(confirmations.length, 1)
 		});
 
 		it('should be empty when type updated to same underlying SQL type', async () => {
@@ -178,7 +178,7 @@ describe('column queries', () => {
 				},
 			});
 			const { queries } = await userChangeQueries(blogInitial, blogFinal);
-			expect(queries).to.deep.equal([]);
+			assert.deepEqual(queries, []);
 		});
 
 		it('should respect user primary key without adding a hidden id', async () => {
@@ -199,10 +199,10 @@ describe('column queries', () => {
 			});
 
 			const { queries } = await userChangeQueries(user, userFinal);
-			expect(queries[0]).to.not.be.undefined;
+			assert.equal(queries[0] !== undefined, true);
 			const tempTableName = getTempTableName(queries[0]);
 
-			expect(queries).to.deep.equal([
+			assert.deepEqual(queries, [
 				`CREATE TABLE \"${tempTableName}\" (\"name\" text UNIQUE, \"age\" integer NOT NULL, \"email\" text NOT NULL UNIQUE, \"mi\" text, \"id\" integer PRIMARY KEY)`,
 				`INSERT INTO \"${tempTableName}\" (\"name\", \"age\", \"email\", \"mi\", \"id\") SELECT \"name\", \"age\", \"email\", \"mi\", \"id\" FROM \"Users\"`,
 				'DROP TABLE "Users"',
@@ -222,7 +222,7 @@ describe('column queries', () => {
 
 				const { queries } = await userChangeQueries(userInitial, userFinal);
 
-				expect(queries).to.deep.equal([
+				assert.deepEqual(queries, [
 					'DROP TABLE "Users"',
 					`CREATE TABLE "Users" (_id INTEGER PRIMARY KEY, "name" text NOT NULL, "age" text NOT NULL, "email" text NOT NULL UNIQUE, "mi" text)`,
 				]);
@@ -239,7 +239,7 @@ describe('column queries', () => {
 
 				const { queries } = await userChangeQueries(userInitial, userFinal);
 
-				expect(queries).to.deep.equal([
+				assert.deepEqual(queries, [
 					'DROP TABLE "Users"',
 					`CREATE TABLE "Users" (_id INTEGER PRIMARY KEY, "name" text NOT NULL, "age" integer NOT NULL, "email" text NOT NULL UNIQUE, "mi" text, "phoneNumber" text NOT NULL)`,
 				]);
@@ -257,10 +257,10 @@ describe('column queries', () => {
 				};
 
 				const { queries } = await userChangeQueries(userInitial, userFinal);
-				expect(queries[0]).to.not.be.undefined;
+				assert.equal(queries[0] !== undefined, true);
 
 				const tempTableName = getTempTableName(queries[0]);
-				expect(queries).to.deep.equal([
+				assert.deepEqual(queries, [
 					`CREATE TABLE \"${tempTableName}\" (\"name\" text NOT NULL, \"age\" integer NOT NULL, \"email\" text NOT NULL UNIQUE, \"mi\" text, \"id\" integer PRIMARY KEY)`,
 					`INSERT INTO \"${tempTableName}\" (\"name\", \"age\", \"email\", \"mi\") SELECT \"name\", \"age\", \"email\", \"mi\" FROM \"Users\"`,
 					'DROP TABLE "Users"',
@@ -278,10 +278,10 @@ describe('column queries', () => {
 				};
 
 				const { queries } = await userChangeQueries(user, userInitial);
-				expect(queries[0]).to.not.be.undefined;
+				assert.equal(queries[0] !== undefined, true);
 
 				const tempTableName = getTempTableName(queries[0]);
-				expect(queries).to.deep.equal([
+				assert.deepEqual(queries, [
 					`CREATE TABLE \"${tempTableName}\" (_id INTEGER PRIMARY KEY, \"name\" text NOT NULL, \"age\" integer NOT NULL, \"email\" text NOT NULL UNIQUE, \"mi\" text)`,
 					`INSERT INTO \"${tempTableName}\" (\"name\", \"age\", \"email\", \"mi\") SELECT \"name\", \"age\", \"email\", \"mi\" FROM \"Users\"`,
 					'DROP TABLE "Users"',
@@ -299,11 +299,11 @@ describe('column queries', () => {
 				};
 
 				const { queries } = await userChangeQueries(userInitial, userFinal);
-				expect(queries).to.have.lengthOf(4);
+				assert.equal(queries.length, 4)
 
 				const tempTableName = getTempTableName(queries[0]);
-				expect(tempTableName).to.be.a('string');
-				expect(queries).to.deep.equal([
+				assert.equal(typeof tempTableName, "string");
+				assert.deepEqual(queries, [
 					`CREATE TABLE "${tempTableName}" (_id INTEGER PRIMARY KEY, "name" text NOT NULL, "age" integer NOT NULL, "email" text NOT NULL UNIQUE, "mi" text, "phoneNumber" text UNIQUE)`,
 					`INSERT INTO "${tempTableName}" ("_id", "name", "age", "email", "mi") SELECT "_id", "name", "age", "email", "mi" FROM "Users"`,
 					'DROP TABLE "Users"',
@@ -321,11 +321,12 @@ describe('column queries', () => {
 				delete userFinal.columns.email;
 
 				const { queries } = await userChangeQueries(userInitial, userFinal);
-				expect(queries).to.have.lengthOf(4);
+				assert.equal(queries.length, 4)
+				assert.equal(queries.length, 4)
 
 				const tempTableName = getTempTableName(queries[0]);
-				expect(tempTableName).to.be.a('string');
-				expect(queries).to.deep.equal([
+				assert.equal(typeof tempTableName, "string");
+				assert.deepEqual(queries, [
 					`CREATE TABLE "${tempTableName}" (_id INTEGER PRIMARY KEY, "name" text NOT NULL, "age" integer NOT NULL, "mi" text)`,
 					`INSERT INTO "${tempTableName}" ("_id", "name", "age", "mi") SELECT "_id", "name", "age", "mi" FROM "Users"`,
 					'DROP TABLE "Users"',
@@ -351,11 +352,11 @@ describe('column queries', () => {
 				});
 
 				const { queries } = await userChangeQueries(initial, userFinal);
-				expect(queries).to.have.lengthOf(4);
+				assert.equal(queries.length, 4)
 
 				const tempTableName = getTempTableName(queries[0]);
-				expect(tempTableName).to.be.a('string');
-				expect(queries).to.deep.equal([
+				assert.equal(typeof tempTableName, "string");
+				assert.deepEqual(queries, [
 					`CREATE TABLE "${tempTableName}" (_id INTEGER PRIMARY KEY, "name" text NOT NULL, "age" text NOT NULL DEFAULT CURRENT_TIMESTAMP, "email" text NOT NULL UNIQUE, "mi" text)`,
 					`INSERT INTO "${tempTableName}" ("_id", "name", "age", "email", "mi") SELECT "_id", "name", "age", "email", "mi" FROM "Users"`,
 					'DROP TABLE "Users"',
@@ -373,11 +374,11 @@ describe('column queries', () => {
 				});
 
 				const { queries } = await userChangeQueries(userInitial, userFinal);
-				expect(queries).to.have.lengthOf(4);
+				assert.equal(queries.length, 4)
 
 				const tempTableName = getTempTableName(queries[0]);
-				expect(tempTableName).to.be.a('string');
-				expect(queries).to.deep.equal([
+				assert.equal(typeof tempTableName, "string");
+				assert.deepEqual(queries, [
 					`CREATE TABLE "${tempTableName}" (_id INTEGER PRIMARY KEY, "name" text NOT NULL, "age" integer NOT NULL, "email" text NOT NULL UNIQUE, "mi" text, "birthday" text NOT NULL DEFAULT CURRENT_TIMESTAMP)`,
 					`INSERT INTO "${tempTableName}" ("_id", "name", "age", "email", "mi") SELECT "_id", "name", "age", "email", "mi" FROM "Users"`,
 					'DROP TABLE "Users"',
@@ -403,11 +404,11 @@ describe('column queries', () => {
 
 				const { queries } = await userChangeQueries(userInitial, userFinal);
 
-				expect(queries).to.have.lengthOf(4);
+				assert.equal(queries.length, 4)
 
 				const tempTableName = getTempTableName(queries[0]);
-				expect(tempTableName).to.be.a('string');
-				expect(queries).to.deep.equal([
+				assert.equal(typeof tempTableName, "string");
+				assert.deepEqual(queries, [
 					`CREATE TABLE "${tempTableName}" (_id INTEGER PRIMARY KEY, "name" text NOT NULL, "age" integer NOT NULL, "email" text NOT NULL UNIQUE, "mi" text NOT NULL)`,
 					`INSERT INTO "${tempTableName}" ("_id", "name", "age", "email", "mi") SELECT "_id", "name", "age", "email", "mi" FROM "Users"`,
 					'DROP TABLE "Users"',
@@ -425,11 +426,11 @@ describe('column queries', () => {
 				};
 
 				const { queries } = await userChangeQueries(userInitial, userFinal);
-				expect(queries).to.have.lengthOf(4);
+				assert.equal(queries.length, 4)
 
 				const tempTableName = getTempTableName(queries[0]);
-				expect(tempTableName).to.be.a('string');
-				expect(queries).to.deep.equal([
+				assert.equal(typeof tempTableName, "string");
+				assert.deepEqual(queries, [
 					`CREATE TABLE "${tempTableName}" (_id INTEGER PRIMARY KEY, "name" text NOT NULL, "age" integer NOT NULL UNIQUE, "email" text NOT NULL UNIQUE, "mi" text)`,
 					`INSERT INTO "${tempTableName}" ("_id", "name", "age", "email", "mi") SELECT "_id", "name", "age", "email", "mi" FROM "Users"`,
 					'DROP TABLE "Users"',
@@ -449,7 +450,7 @@ describe('column queries', () => {
 				};
 
 				const { queries } = await userChangeQueries(userInitial, userFinal);
-				expect(queries).to.deep.equal(['ALTER TABLE "Users" ADD COLUMN "birthday" text']);
+				assert.deepEqual(queries, ['ALTER TABLE "Users" ADD COLUMN "birthday" text']);
 			});
 
 			it('when adding a required column with default', async () => {
@@ -463,7 +464,7 @@ describe('column queries', () => {
 				});
 
 				const { queries } = await userChangeQueries(userInitial, userFinal);
-				expect(queries).to.deep.equal([
+				assert.deepEqual(queries, [
 					`ALTER TABLE "Users" ADD COLUMN "birthday" text NOT NULL DEFAULT '${defaultDate.toISOString()}'`,
 				]);
 			});
@@ -480,7 +481,7 @@ describe('column queries', () => {
 				};
 
 				const { queries } = await userChangeQueries(userInitial, userFinal);
-				expect(queries).to.deep.equal([
+				assert.deepEqual(queries, [
 					'ALTER TABLE "Users" DROP COLUMN "age"',
 					'ALTER TABLE "Users" DROP COLUMN "mi"',
 				]);

--- a/packages/db/test/unit/index-queries.test.js
+++ b/packages/db/test/unit/index-queries.test.js
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
-import { describe, it } from 'mocha';
+import { describe, it } from "node:test";
+import assert from  "node:assert/strict";
 import { getTableChangeQueries } from '../../dist/core/cli/migration-queries.js';
 import { dbConfigSchema, tableSchema } from '../../dist/core/schemas.js';
 import { column } from '../../dist/runtime/virtual.js';
@@ -37,7 +37,7 @@ describe('index queries', () => {
 			newTable: dbConfig.tables.newTable,
 		});
 
-		expect(queries).to.deep.equal([
+		assert.deepEqual(queries, [
 			'CREATE INDEX "newTable_age_name_idx" ON "user" ("age", "name")',
 			'CREATE UNIQUE INDEX "newTable_email_idx" ON "user" ("email")',
 		]);
@@ -76,7 +76,7 @@ describe('index queries', () => {
 			newTable: final.tables.user,
 		});
 
-		expect(queries).to.be.empty;
+		assert.equal(queries.length, 0)
 	});
 
 	it('does not trigger queries when changing from legacy to new format', async () => {
@@ -110,7 +110,7 @@ describe('index queries', () => {
 			newTable: final.tables.user,
 		});
 
-		expect(queries).to.be.empty;
+		assert.equal(queries.length, 0)
 	});
 
 	it('adds indexes', async () => {
@@ -133,7 +133,7 @@ describe('index queries', () => {
 			newTable: dbConfig.tables.newTable,
 		});
 
-		expect(queries).to.deep.equal([
+		assert.deepEqual(queries, [
 			'CREATE INDEX "nameIdx" ON "user" ("name")',
 			'CREATE UNIQUE INDEX "emailIdx" ON "user" ("email")',
 		]);
@@ -162,7 +162,7 @@ describe('index queries', () => {
 			newTable: dbConfig.tables.newTable,
 		});
 
-		expect(queries).to.deep.equal(['DROP INDEX "nameIdx"', 'DROP INDEX "emailIdx"']);
+		assert.deepEqual(queries, ['DROP INDEX "nameIdx"', 'DROP INDEX "emailIdx"']);
 	});
 
 	it('drops and recreates modified indexes', async () => {
@@ -191,7 +191,7 @@ describe('index queries', () => {
 			newTable: dbConfig.tables.newTable,
 		});
 
-		expect(queries).to.deep.equal([
+		assert.deepEqual(queries, [
 			'DROP INDEX "nameIdx"',
 			'DROP INDEX "emailIdx"',
 			'CREATE UNIQUE INDEX "nameIdx" ON "user" ("name")',
@@ -216,7 +216,7 @@ describe('index queries', () => {
 				newTable: userFinal,
 			});
 
-			expect(queries).to.deep.equal([
+			assert.deepEqual(queries, [
 				'CREATE INDEX "nameIdx" ON "user" ("name")',
 				'CREATE UNIQUE INDEX "emailIdx" ON "user" ("email")',
 			]);
@@ -244,7 +244,7 @@ describe('index queries', () => {
 				newTable: final,
 			});
 
-			expect(queries).to.deep.equal(['DROP INDEX "nameIdx"', 'DROP INDEX "emailIdx"']);
+			assert.deepEqual(queries, ['DROP INDEX "nameIdx"', 'DROP INDEX "emailIdx"']);
 		});
 
 		it('drops and recreates modified indexes', async () => {
@@ -272,7 +272,7 @@ describe('index queries', () => {
 				newTable: final,
 			});
 
-			expect(queries).to.deep.equal([
+			assert.deepEqual(queries, [
 				'DROP INDEX "nameIdx"',
 				'DROP INDEX "emailIdx"',
 				'CREATE UNIQUE INDEX "nameIdx" ON "user" ("name")',

--- a/packages/db/test/unit/reference-queries.test.js
+++ b/packages/db/test/unit/reference-queries.test.js
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
-import { describe, it } from 'mocha';
+import { describe, it } from "node:test";
+import assert from  "node:assert/strict";
 import { getTableChangeQueries } from '../../dist/core/cli/migration-queries.js';
 import { tablesSchema } from '../../dist/core/schemas.js';
 import { column, defineTable } from '../../dist/runtime/virtual.js';
@@ -59,11 +59,11 @@ describe('reference queries', () => {
 
 		const { queries } = await userChangeQueries(Initial, Final);
 
-		expect(queries[0]).to.not.be.undefined;
+		assert.equal(queries[0] !== undefined, true);
 		const tempTableName = getTempTableName(queries[0]);
-		expect(tempTableName).to.not.be.undefined;
+		assert.notEqual(typeof tempTableName, "undefined");
 
-		expect(queries).to.deep.equal([
+		assert.deepEqual(queries, [
 			`CREATE TABLE \"${tempTableName}\" (_id INTEGER PRIMARY KEY, \"to\" integer NOT NULL REFERENCES \"User\" (\"id\"), \"toName\" text NOT NULL, \"subject\" text NOT NULL, \"body\" text NOT NULL)`,
 			`INSERT INTO \"${tempTableName}\" (\"_id\", \"to\", \"toName\", \"subject\", \"body\") SELECT \"_id\", \"to\", \"toName\", \"subject\", \"body\" FROM \"User\"`,
 			'DROP TABLE "User"',
@@ -84,11 +84,11 @@ describe('reference queries', () => {
 
 		const { queries } = await userChangeQueries(Initial, Final);
 
-		expect(queries[0]).to.not.be.undefined;
+		assert.equal(queries[0] !== undefined, true);
 		const tempTableName = getTempTableName(queries[0]);
-		expect(tempTableName).to.not.be.undefined;
+		assert.notEqual(typeof tempTableName, "undefined");
 
-		expect(queries).to.deep.equal([
+		assert.deepEqual(queries, [
 			`CREATE TABLE \"${tempTableName}\" (_id INTEGER PRIMARY KEY, \"to\" integer NOT NULL, \"toName\" text NOT NULL, \"subject\" text NOT NULL, \"body\" text NOT NULL)`,
 			`INSERT INTO \"${tempTableName}\" (\"_id\", \"to\", \"toName\", \"subject\", \"body\") SELECT \"_id\", \"to\", \"toName\", \"subject\", \"body\" FROM \"User\"`,
 			'DROP TABLE "User"',
@@ -108,10 +108,10 @@ describe('reference queries', () => {
 		});
 
 		const { queries } = await userChangeQueries(Initial, Final);
-		expect(queries[0]).to.not.be.undefined;
+		assert.equal(queries[0] !== undefined, true);
 		const tempTableName = getTempTableName(queries[0]);
 
-		expect(queries).to.deep.equal([
+		assert.deepEqual(queries, [
 			`CREATE TABLE \"${tempTableName}\" (_id INTEGER PRIMARY KEY, \"to\" integer NOT NULL, \"toName\" text NOT NULL, \"subject\" text NOT NULL, \"body\" text NOT NULL, \"from\" integer REFERENCES \"User\" (\"id\"))`,
 			`INSERT INTO \"${tempTableName}\" (\"_id\", \"to\", \"toName\", \"subject\", \"body\") SELECT \"_id\", \"to\", \"toName\", \"subject\", \"body\" FROM \"User\"`,
 			'DROP TABLE "User"',
@@ -149,14 +149,13 @@ describe('reference queries', () => {
 		const addedForeignKey = await userChangeQueries(InitialWithoutFK, Final);
 		const updatedForeignKey = await userChangeQueries(InitialWithDifferentFK, Final);
 
-		expect(addedForeignKey.queries[0]).to.not.be.undefined;
-		expect(updatedForeignKey.queries[0]).to.not.be.undefined;
-
-		expect(addedForeignKey.queries).to.deep.equal(
+		assert.notEqual(typeof addedForeignKey.queries[0], "undefined");
+		assert.notEqual(typeof updatedForeignKey.queries[0], "undefined");
+		assert.deepEqual(addedForeignKey.queries,
 			expected(getTempTableName(addedForeignKey.queries[0]))
 		);
 
-		expect(updatedForeignKey.queries).to.deep.equal(
+		assert.deepEqual(updatedForeignKey.queries,
 			expected(getTempTableName(updatedForeignKey.queries[0]))
 		);
 	});

--- a/packages/db/test/unit/reset-queries.test.js
+++ b/packages/db/test/unit/reset-queries.test.js
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
-import { describe, it } from 'mocha';
+import { describe, it } from "node:test";
+import assert from  "node:assert/strict";
 import { getMigrationQueries } from '../../dist/core/cli/migration-queries.js';
 import { MIGRATION_VERSION } from '../../dist/core/consts.js';
 import { tableSchema } from '../../dist/core/schemas.js';
@@ -31,7 +31,7 @@ describe('force reset', () => {
 				reset: true,
 			});
 
-			expect(queries).to.deep.equal([
+			assert.deepEqual(queries, [
 				`DROP TABLE IF EXISTS "${TABLE_NAME}"`,
 				`CREATE TABLE "${TABLE_NAME}" (_id INTEGER PRIMARY KEY, "name" text NOT NULL, "age" integer NOT NULL, "email" text NOT NULL UNIQUE, "mi" text)`,
 			]);
@@ -46,7 +46,7 @@ describe('force reset', () => {
 				reset: true,
 			});
 
-			expect(queries).to.deep.equal([
+			assert.deepEqual(queries, [
 				`CREATE TABLE "${TABLE_NAME}" (_id INTEGER PRIMARY KEY, "name" text NOT NULL, "age" integer NOT NULL, "email" text NOT NULL UNIQUE, "mi" text)`,
 			]);
 		});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,7 +571,7 @@ importers:
         version: 3.0.0
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.4
       deterministic-object-hash:
         specifier: ^2.0.2
         version: 2.0.2
@@ -3998,9 +3998,6 @@ importers:
       '@types/diff':
         specifier: ^5.2.1
         version: 5.2.1
-      '@types/mocha':
-        specifier: ^10.0.6
-        version: 10.0.6
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
@@ -4013,15 +4010,9 @@ importers:
       astro-scripts:
         specifier: workspace:*
         version: link:../../scripts
-      chai:
-        specifier: ^5.1.1
-        version: 5.1.1
       cheerio:
         specifier: 1.0.0-rc.12
         version: 1.0.0-rc.12
-      mocha:
-        specifier: ^10.4.0
-        version: 10.4.0
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
@@ -5568,7 +5559,7 @@ importers:
         version: 4.0.0
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.4
       dlv:
         specifier: ^1.1.3
         version: 1.1.3
@@ -5860,7 +5851,7 @@ packages:
       '@babel/traverse': 7.24.5
       '@babel/types': 7.24.5
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -6255,7 +6246,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.24.5
       '@babel/parser': 7.24.5
       '@babel/types': 7.24.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7423,7 +7414,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       espree: 10.0.1
       globals: 14.0.0
       ignore: 5.3.1
@@ -7453,7 +7444,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8164,7 +8155,7 @@ packages:
       '@prefresh/vite': 2.4.5(preact@10.21.0)
       '@rollup/pluginutils': 4.2.1
       babel-plugin-transform-hook-names: 1.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       kolorist: 1.8.0
       magic-string: 0.30.5
       node-html-parser: 6.1.13
@@ -8390,7 +8381,7 @@ packages:
         optional: true
     dependencies:
       '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.16)(vite@5.2.11)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       svelte: 4.2.16
       vite: 5.2.11(@types/node@18.19.31)(sass@1.77.1)
     transitivePeerDependencies:
@@ -8408,7 +8399,7 @@ packages:
         optional: true
     dependencies:
       '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.2.16)(vite@5.2.11)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.10
@@ -8660,10 +8651,6 @@ packages:
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
     dev: true
 
-  /@types/mocha@10.0.6:
-    resolution: {integrity: sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==}
-    dev: true
-
   /@types/ms@0.7.34:
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
@@ -8855,7 +8842,7 @@ packages:
       '@typescript-eslint/type-utils': 7.8.0(eslint@9.2.0)(typescript@5.4.5)
       '@typescript-eslint/utils': 7.8.0(eslint@9.2.0)(typescript@5.4.5)
       '@typescript-eslint/visitor-keys': 7.8.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 9.2.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -8881,7 +8868,7 @@ packages:
       '@typescript-eslint/types': 7.8.0
       '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.4.5)
       '@typescript-eslint/visitor-keys': 7.8.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 9.2.0
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -8908,7 +8895,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.4.5)
       '@typescript-eslint/utils': 7.8.0(eslint@9.2.0)(typescript@5.4.5)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 9.2.0
       ts-api-utils: 1.3.0(typescript@5.4.5)
       typescript: 5.4.5
@@ -8932,7 +8919,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 7.8.0
       '@typescript-eslint/visitor-keys': 7.8.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -8974,7 +8961,7 @@ packages:
     resolution: {integrity: sha512-kTwMUQ8xtAZaC4wb2XuLkPqFVBj2dNBueMQ89NWEuw87k2nLBbuafeG5cob/QEr6YduxIdTVUjix0MtC7mPlmg==}
     dependencies:
       '@typescript/vfs': 1.3.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       lz-string: 1.5.0
     transitivePeerDependencies:
       - supports-color
@@ -8983,7 +8970,7 @@ packages:
   /@typescript/vfs@1.3.4:
     resolution: {integrity: sha512-RbyJiaAGQPIcAGWFa3jAXSuAexU4BFiDRF1g3hy7LmRqfNpYlTQWGXjcrOaVZjJ8YkkpuwG0FcsYvtWQpd9igQ==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8991,7 +8978,7 @@ packages:
   /@typescript/vfs@1.3.5:
     resolution: {integrity: sha512-pI8Saqjupf9MfLw7w2+og+fmb0fZS0J6vsKXXrp4/PDXEFvntgzXmChCXC/KefZZS0YGS6AT8e0hGAJcTsdJlg==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9398,7 +9385,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -9407,7 +9394,7 @@ packages:
     resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9440,11 +9427,6 @@ packages:
     dependencies:
       string-width: 4.2.3
     dev: false
-
-  /ansi-colors@4.1.1:
-    resolution: {integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==}
-    engines: {node: '>=6'}
-    dev: true
 
   /ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -9578,11 +9560,6 @@ packages:
   /assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: false
-
-  /assertion-error@2.0.1:
-    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
-    engines: {node: '>=12'}
-    dev: true
 
   /astring@1.8.6:
     resolution: {integrity: sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg==}
@@ -9835,10 +9812,6 @@ packages:
       wcwidth: 1.0.1
     dev: true
 
-  /browser-stdout@1.3.1:
-    resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
-    dev: true
-
   /browserslist@4.23.0:
     resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -9918,6 +9891,7 @@ packages:
   /camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+    dev: false
 
   /camelcase@7.0.1:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
@@ -9946,17 +9920,6 @@ packages:
       pathval: 1.1.1
       type-detect: 4.0.8
     dev: false
-
-  /chai@5.1.1:
-    resolution: {integrity: sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==}
-    engines: {node: '>=12'}
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.1
-      deep-eql: 5.0.1
-      loupe: 3.1.0
-      pathval: 2.0.0
-    dev: true
 
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -10004,11 +9967,6 @@ packages:
       get-func-name: 2.0.2
     dev: false
 
-  /check-error@2.1.1:
-    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
-    engines: {node: '>= 16'}
-    dev: true
-
   /cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
     dependencies:
@@ -10031,21 +9989,6 @@ packages:
       htmlparser2: 8.0.2
       parse5: 7.1.2
       parse5-htmlparser2-tree-adapter: 7.0.0
-    dev: true
-
-  /chokidar@3.5.3:
-    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
-    engines: {node: '>= 8.10.0'}
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.2
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
     dev: true
 
   /chokidar@3.6.0:
@@ -10134,14 +10077,6 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
-    dev: true
-
-  /cliui@7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
     dev: true
 
   /cliui@8.0.1:
@@ -10487,7 +10422,7 @@ packages:
     dependencies:
       ms: 2.0.0
 
-  /debug@4.3.4(supports-color@8.1.1):
+  /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -10497,7 +10432,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-      supports-color: 8.1.1
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -10510,11 +10444,6 @@ packages:
   /decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /decamelize@4.0.0:
-    resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
-    engines: {node: '>=10'}
     dev: true
 
   /decimal.js@10.4.3:
@@ -10540,11 +10469,6 @@ packages:
     dependencies:
       type-detect: 4.0.8
     dev: false
-
-  /deep-eql@5.0.1:
-    resolution: {integrity: sha512-nwQCf6ne2gez3o1MxWifqkciwt0zhl0LO1/UwVu4uMBuPmflWM4oQ70XMqHqnBJA+nhzncaqL9HVL6KkHJ28lw==}
-    engines: {node: '>=6'}
-    dev: true
 
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -10678,11 +10602,6 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: false
-
-  /diff@5.0.0:
-    resolution: {integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==}
-    engines: {node: '>=0.3.1'}
-    dev: true
 
   /diff@5.2.0:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
@@ -11139,7 +11058,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       escape-string-regexp: 4.0.0
       eslint-scope: 8.0.1
       eslint-visitor-keys: 4.0.0
@@ -11442,11 +11361,6 @@ packages:
       keyv: 4.5.4
     dev: true
 
-  /flat@5.0.2:
-    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
-    hasBin: true
-    dev: true
-
   /flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
     dev: true
@@ -11605,6 +11519,7 @@ packages:
 
   /get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+    dev: false
 
   /get-intrinsic@1.2.4:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
@@ -11679,17 +11594,6 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
-
-  /glob@8.1.0:
-    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 5.0.1
-      once: 1.4.0
-    dev: true
 
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -12039,6 +11943,7 @@ packages:
   /he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+    dev: false
 
   /hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -12124,7 +12029,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12134,7 +12039,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -12144,7 +12049,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12410,11 +12315,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /is-plain-obj@2.1.0:
-    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
-    engines: {node: '>=8'}
-    dev: true
-
   /is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
@@ -12473,11 +12373,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       which-typed-array: 1.1.15
-    dev: true
-
-  /is-unicode-supported@0.1.0:
-    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
-    engines: {node: '>=10'}
     dev: true
 
   /is-unicode-supported@1.3.0:
@@ -12807,14 +12702,6 @@ packages:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
     dev: true
 
-  /log-symbols@4.1.0:
-    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
-    engines: {node: '>=10'}
-    dependencies:
-      chalk: 4.1.2
-      is-unicode-supported: 0.1.0
-    dev: true
-
   /log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
@@ -12848,12 +12735,6 @@ packages:
     dependencies:
       get-func-name: 2.0.2
     dev: false
-
-  /loupe@3.1.0:
-    resolution: {integrity: sha512-qKl+FrLXUhFuHUoDJG7f8P8gEMHq9NFS0c6ghXG1J0rldmZFQZoNVv/vyirE9qwCIhWZDsvEFd1sbFu3GvRQFg==}
-    dependencies:
-      get-func-name: 2.0.2
-    dev: true
 
   /lower-case@1.1.4:
     resolution: {integrity: sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==}
@@ -13563,7 +13444,7 @@ packages:
     resolution: {integrity: sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
@@ -13622,13 +13503,6 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
-
-  /minimatch@5.0.1:
-    resolution: {integrity: sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==}
-    engines: {node: '>=10'}
-    dependencies:
-      brace-expansion: 2.0.1
-    dev: true
 
   /minimatch@7.4.6:
     resolution: {integrity: sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==}
@@ -13728,33 +13602,6 @@ packages:
       pkg-types: 1.0.3
       ufo: 1.5.3
     dev: false
-
-  /mocha@10.4.0:
-    resolution: {integrity: sha512-eqhGB8JKapEYcC4ytX/xrzKforgEc3j1pGlAXVy3eRwrtAy5/nIfT1SvgGzfN0XZZxeLq0aQWkOUAmqIJiv+bA==}
-    engines: {node: '>= 14.0.0'}
-    hasBin: true
-    dependencies:
-      ansi-colors: 4.1.1
-      browser-stdout: 1.3.1
-      chokidar: 3.5.3
-      debug: 4.3.4(supports-color@8.1.1)
-      diff: 5.0.0
-      escape-string-regexp: 4.0.0
-      find-up: 5.0.0
-      glob: 8.1.0
-      he: 1.2.0
-      js-yaml: 4.1.0
-      log-symbols: 4.1.0
-      minimatch: 5.0.1
-      ms: 2.1.3
-      serialize-javascript: 6.0.0
-      strip-json-comments: 3.1.1
-      supports-color: 8.1.1
-      workerpool: 6.2.1
-      yargs: 16.2.0
-      yargs-parser: 20.2.4
-      yargs-unparser: 2.0.0
-    dev: true
 
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -14282,11 +14129,6 @@ packages:
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: false
-
-  /pathval@2.0.0:
-    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
-    engines: {node: '>= 14.16'}
-    dev: true
 
   /perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -14893,12 +14735,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: true
-
   /range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -15497,12 +15333,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /serialize-javascript@6.0.0:
-    resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
-    dependencies:
-      randombytes: 2.1.0
-    dev: true
-
   /seroval-plugins@1.0.5(seroval@1.0.5):
     resolution: {integrity: sha512-8+pDC1vOedPXjKG7oz8o+iiHrtF2WswaMQJ7CKFpccvSYfrzmvKY9zOJWCg+881722wIHfwkdnRmiiDm9ym+zQ==}
     engines: {node: '>=10'}
@@ -16060,12 +15890,6 @@ packages:
   /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
-    dependencies:
-      has-flag: 4.0.0
-
-  /supports-color@8.1.1:
-    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
-    engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
 
@@ -16865,7 +16689,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
       vite: 5.2.11(@types/node@18.19.31)(sass@1.77.1)
@@ -16894,7 +16718,7 @@ packages:
     dependencies:
       '@antfu/utils': 0.7.8
       '@rollup/pluginutils': 5.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
       open: 10.1.0
@@ -17080,7 +16904,7 @@ packages:
       '@vitest/utils': 1.6.0
       acorn-walk: 8.3.2
       chai: 4.4.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       execa: 8.0.1
       local-pkg: 0.5.0
       magic-string: 0.30.10
@@ -17398,10 +17222,6 @@ packages:
       string-width: 5.1.2
     dev: false
 
-  /workerpool@6.2.1:
-    resolution: {integrity: sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==}
-    dev: true
-
   /wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -17507,24 +17327,9 @@ packages:
       decamelize: 1.2.0
     dev: true
 
-  /yargs-parser@20.2.4:
-    resolution: {integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==}
-    engines: {node: '>=10'}
-    dev: true
-
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
-
-  /yargs-unparser@2.0.0:
-    resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
-    engines: {node: '>=10'}
-    dependencies:
-      camelcase: 6.3.0
-      decamelize: 4.0.0
-      flat: 5.0.2
-      is-plain-obj: 2.1.0
-    dev: true
 
   /yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
@@ -17541,19 +17346,6 @@ packages:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
-    dev: true
-
-  /yargs@16.2.0:
-    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
-    engines: {node: '>=10'}
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.1.2
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 20.2.4
     dev: true
 
   /yargs@17.7.2:


### PR DESCRIPTION
## Changes

This PR moves the tests of the `@astrojs/db` integration to use `node:test`

## Testing

For some reason, `error-handling.test.js` -> `build --remote` is failing, and it doesn't raise any errors. Not sure why.

Current CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
