### PR TITLE
Actions: stop warning about `headers` usage on prerendered routes

### DIFF
--- a/.changeset/wild-hounds-repair.md
+++ b/.changeset/wild-hounds-repair.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix unexpected `headers` warning on prerendered routes when using Astro Actions.

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -3,6 +3,7 @@ import { defineMiddleware } from '../../core/middleware/index.js';
 import { ApiContextStorage } from './store.js';
 import { formContentTypes, getAction, hasContentType } from './utils.js';
 import { callSafely } from './virtual/shared.js';
+import { yellow } from 'kleur/colors';
 
 export type Locals = {
 	_actionsInternal: {
@@ -12,6 +13,16 @@ export type Locals = {
 
 export const onRequest = defineMiddleware(async (context, next) => {
 	const locals = context.locals as Locals;
+	if (context.request.method === 'GET') {
+		return nextWithLocalsStub(next, locals);
+	}
+
+	// Heuristic: If body is null, Astro might've reset this for prerendering.
+	// Stub with warning when `getActionResult()` is used.
+	if (context.request.method === 'POST' && context.request.body === null) {
+		return nextWithStaticStub(next, locals);
+	}
+
 	// Actions middleware may have run already after a path rewrite.
 	// See https://github.com/withastro/roadmap/blob/feat/reroute/proposals/0047-rerouting.md#ctxrewrite
 	// `_actionsInternal` is the same for every page,
@@ -57,6 +68,22 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	}
 	return response;
 });
+
+function nextWithStaticStub(next: MiddlewareNext, locals: Locals) {
+	Object.defineProperty(locals, '_actionsInternal', {
+		writable: false,
+		value: {
+			getActionResult: () => {
+				console.warn(
+					yellow('[astro:actions]'),
+					'`getActionResult()` should not be called on prerendered pages. Astro can only handle actions for pages rendered on-demand.'
+				);
+				return undefined;
+			},
+		},
+	});
+	return next();
+}
 
 function nextWithLocalsStub(next: MiddlewareNext, locals: Locals) {
 	Object.defineProperty(locals, '_actionsInternal', {


### PR DESCRIPTION
## Changes

Fixes unexpected warning that `headers` were accessed on prerendered routes: 
![image](https://github.com/withastro/astro/assets/51384119/da8dcad2-1ff9-454e-957a-38c71abba7fc)


- Short circuit on `GET` requests
- Add warning when `getActionResult()` is used for POST requests with a `null` body

## Testing

Manual testing that the log does not fire.

## Docs

N/A