### PR TITLE
Actions: restore api context param

### DIFF
--- a/.changeset/six-icons-pump.md
+++ b/.changeset/six-icons-pump.md
@@ -16,7 +16,7 @@ export const server = {
   login: defineAction({
     input: z.object({ id: z.string }),
 +    handler(input, context) {
-      const user = apiContext.locals.auth(input.id);
+      const user = context.locals.auth(input.id);
       return user;
     }
   }),

--- a/.changeset/six-icons-pump.md
+++ b/.changeset/six-icons-pump.md
@@ -1,0 +1,24 @@
+---
+"astro": minor
+---
+
+Deprecate the `getApiContext()` function. API Context can now be accessed from the second parameter to your Action `handler()`:
+
+```diff
+// src/actions/index.ts
+import {
+  defineAction,
+  z,
+-  getApiContext,
+} from 'astro:actions';
+
+export const server = {
+  login: defineAction({
+    input: z.object({ id: z.string }),
++    handler(input, apiContext) {
+      const user = apiContext.locals.auth(input.id);
+      return user;
+    }
+  }),
+}
+```

--- a/.changeset/six-icons-pump.md
+++ b/.changeset/six-icons-pump.md
@@ -1,5 +1,5 @@
 ---
-"astro": minor
+"astro": patch
 ---
 
 Deprecate the `getApiContext()` function. API Context can now be accessed from the second parameter to your Action `handler()`:

--- a/.changeset/six-icons-pump.md
+++ b/.changeset/six-icons-pump.md
@@ -15,7 +15,7 @@ import {
 export const server = {
   login: defineAction({
     input: z.object({ id: z.string }),
-+    handler(input, apiContext) {
++    handler(input, context) {
       const user = apiContext.locals.auth(input.id);
       return user;
     }

--- a/packages/astro/src/actions/runtime/virtual/server.ts
+++ b/packages/astro/src/actions/runtime/virtual/server.ts
@@ -22,8 +22,8 @@ export type InputSchema<T extends Accept> = T extends 'form'
 	: z.ZodType;
 
 type Handler<TInputSchema, TOutput> = TInputSchema extends z.ZodType
-	? (input: z.infer<TInputSchema>, apiContext: ActionAPIContext) => MaybePromise<TOutput>
-	: (input: any, apiContext: ActionAPIContext) => MaybePromise<TOutput>;
+	? (input: z.infer<TInputSchema>, context: ActionAPIContext) => MaybePromise<TOutput>
+	: (input: any, context: ActionAPIContext) => MaybePromise<TOutput>;
 
 export type ActionClient<
 	TOutput,

--- a/packages/astro/test/fixtures/actions/src/actions/index.ts
+++ b/packages/astro/test/fixtures/actions/src/actions/index.ts
@@ -1,4 +1,4 @@
-import { defineAction, getApiContext, ActionError, z } from 'astro:actions';
+import { defineAction, ActionError, z } from 'astro:actions';
 
 export const server = {
 	subscribe: defineAction({
@@ -31,15 +31,13 @@ export const server = {
 	}),
 	getUser: defineAction({
 		accept: 'form',
-		handler: async () => {
-			const { locals } = getApiContext();
+		handler: async (_, { locals }) => {
 			return locals.user;
 		}
 	}),
 	getUserOrThrow: defineAction({
 		accept: 'form',
-		handler: async () => {
-			const { locals } = getApiContext();
+		handler: async (_, { locals }) => {
 			if (locals.user?.name !== 'admin') {
 				// Expected to throw
 				throw new ActionError({


### PR DESCRIPTION
## Changes

- Go back to accessing API Context from the second `handler()` param
- Add `@deprecated` note to the `getApiContext()` function

## Testing

Update fixture to use second param

## Docs

Updated RFC