### PR TITLE
[docs] updates security.checkOrigin config reference

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -803,10 +803,11 @@ export interface AstroUserConfig {
 	 */
 	security?: {
 		/**
+	   * @docs
 		 * @name security.checkOrigin
 		 * @type {boolean}
 		 * @default 'false'
-		 * @version 4.6.0
+		 * @version 4.9.0
 		 * @description
 		 *
 		 * When enabled, performs a check that the "origin" header, automatically passed by all modern browsers, matches the URL sent by each `Request`. This is used to provide Cross-Site Request Forgery (CSRF) protection.


### PR DESCRIPTION
## Changes

Adds missing `@docs` field for config reference entry for `security.checkOrigin` and corrects the version number.

## Testing

No tests. Just docs.

## Docs

Updates for inclusion in docs.
