### PR TITLE
Let web vitals route handle all requests under that path

### DIFF
--- a/.changeset/three-bikes-stare.md
+++ b/.changeset/three-bikes-stare.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/web-vitals": patch
+---
+
+Fixes requests to the web vitals endpoint in setups like Vercel’s `trailingSlash: true` that redirect from `/web-vitals` to `/web-vitals/`

--- a/packages/integrations/web-vitals/src/index.ts
+++ b/packages/integrations/web-vitals/src/index.ts
@@ -32,7 +32,7 @@ export default function webVitals({ deprecated }: { deprecated?: boolean } = {})
 				// Endpoint that collects metrics and inserts them in Astro DB.
 				injectRoute({
 					entrypoint: '@astrojs/web-vitals/endpoint',
-					pattern: WEB_VITALS_ENDPOINT_PATH,
+					pattern: WEB_VITALS_ENDPOINT_PATH + '/[...any]',
 					prerender: false,
 				});
 				// Client-side performance measurement script.


### PR DESCRIPTION
## Changes

- Fixes requests to the web vitals endpoint in setups like Vercel’s `trailingSlash: true` that redirect from `/web-vitals` to `/web-vitals/`
- I’m not 100% sure if this is a larger bug in Astro’s route handling (I’d kind of expect a route injected at `/web-vitals` to handle `/web-vitals/`), or just Vercel being fussy — I’ve definitely found their `trailingSlash` handling to be much more fragile than other platforms

## Testing

Applied as a patch in some repos using the current integration version.

## Docs

n/a — bug fix
