### PR TITLE
Prevent errors from adapters when i18n domains is not used

### DIFF
--- a/.changeset/shy-pets-lie.md
+++ b/.changeset/shy-pets-lie.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Prevent errors from adapters when i18n domains is not used

--- a/packages/astro/src/integrations/features-validation.ts
+++ b/packages/astro/src/integrations/features-validation.ts
@@ -70,7 +70,7 @@ export function validateSupportedFeatures(
 	);
 	validationResult.assets = validateAssetsFeature(assets, adapterName, config, logger);
 
-	if (!config.i18n?.domains) {
+	if (config.i18n?.domains) {
 		validationResult.i18nDomains = validateSupportKind(
 			i18nDomains,
 			adapterName,


### PR DESCRIPTION
## Changes

- Previously any adapter that didn't support the `i18nDomains` feature would cause an error. Even if this feature was not used by the app.

## Testing

This actually happens in the test adapter, but since it's just logging there's no way to assert. Otherwise tested manually.

## Docs

N/A, bug fix