### PR TITLE
fix(upgrade): use preferred-pm instead of which-pm-runs

### DIFF
--- a/.changeset/rich-singers-accept.md
+++ b/.changeset/rich-singers-accept.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/upgrade": patch
+---
+
+Fixes @astrojs/upgrade not using the package manager that was used to install the project to install dependencies

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -22,21 +22,18 @@
     "dev": "astro-scripts dev \"src/**/*.ts\"",
     "test": "astro-scripts test \"test/**/*.test.js\""
   },
-  "files": [
-    "dist",
-    "upgrade.js"
-  ],
+  "files": ["dist", "upgrade.js"],
   "//a": "MOST PACKAGES SHOULD GO IN DEV_DEPENDENCIES! THEY WILL BE BUNDLED.",
   "//b": "DEPENDENCIES IS FOR UNBUNDLED PACKAGES",
   "dependencies": {
     "@astrojs/cli-kit": "^0.4.1",
     "semver": "^7.6.2",
-    "which-pm-runs": "^1.1.0",
+    "preferred-pm": "^3.1.3",
     "terminal-link": "^3.0.0"
   },
   "devDependencies": {
     "@types/semver": "^7.5.8",
-    "@types/which-pm-runs": "^1.0.2",
+    "@types/preferred-pm": "^3.0.0",
     "arg": "^5.0.2",
     "astro-scripts": "workspace:*",
     "strip-ansi": "^7.1.0"

--- a/packages/upgrade/src/actions/context.ts
+++ b/packages/upgrade/src/actions/context.ts
@@ -1,7 +1,7 @@
 import { pathToFileURL } from 'node:url';
 import { prompt } from '@astrojs/cli-kit';
 import arg from 'arg';
-import detectPackageManager from 'which-pm-runs';
+import detectPackageManager from 'preferred-pm';
 
 export interface Context {
 	help: boolean;
@@ -38,7 +38,7 @@ export async function getContext(argv: string[]): Promise<Context> {
 		{ argv, permissive: true }
 	);
 
-	const packageManager = detectPackageManager()?.name ?? 'npm';
+	const packageManager = (await detectPackageManager(process.cwd()))?.name ?? 'npm';
 	const {
 		_: [version = 'latest'] = [],
 		'--help': help = false,

--- a/packages/upgrade/src/messages.ts
+++ b/packages/upgrade/src/messages.ts
@@ -1,8 +1,8 @@
 /* eslint no-console: 'off' */
 import { color, label, spinner as load } from '@astrojs/cli-kit';
 import { align } from '@astrojs/cli-kit/utils';
+import detectPackageManager from 'preferred-pm';
 import terminalLink from 'terminal-link';
-import detectPackageManager from 'which-pm-runs';
 import type { PackageInfo } from './actions/context.js';
 import { shell } from './shell.js';
 
@@ -14,7 +14,7 @@ let _registry: string;
 export async function getRegistry(): Promise<string> {
 	if (_registry) return _registry;
 	const fallback = 'https://registry.npmjs.org';
-	const packageManager = detectPackageManager()?.name || 'npm';
+	const packageManager = (await detectPackageManager(process.cwd()))?.name || 'npm';
 	try {
 		const { stdout } = await shell(packageManager, ['config', 'get', 'registry']);
 		_registry = stdout?.trim()?.replace(/\/$/, '') || fallback;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5691,22 +5691,22 @@ importers:
       '@astrojs/cli-kit':
         specifier: ^0.4.1
         version: 0.4.1
+      preferred-pm:
+        specifier: ^3.1.3
+        version: 3.1.3
       semver:
         specifier: ^7.6.2
         version: 7.6.2
       terminal-link:
         specifier: ^3.0.0
         version: 3.0.0
-      which-pm-runs:
-        specifier: ^1.1.0
-        version: 1.1.0
     devDependencies:
+      '@types/preferred-pm':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
-      '@types/which-pm-runs':
-        specifier: ^1.0.2
-        version: 1.0.2
       arg:
         specifier: ^5.0.2
         version: 5.0.2
@@ -8769,6 +8769,13 @@ packages:
 
   /@types/normalize-package-data@2.4.4:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+    dev: true
+
+  /@types/preferred-pm@3.0.0:
+    resolution: {integrity: sha512-Ub1de7EkdavsyM1KNrTb1K1QL+ISepEELELh2QWccyDcVEcyUDiGoYzzOJfonpGNwpymYXY13oRFpXQluGOC5w==}
+    deprecated: This is a stub types definition. preferred-pm provides its own type definitions, so you do not need this installed.
+    dependencies:
+      preferred-pm: 3.1.3
     dev: true
 
   /@types/prismjs@1.26.4:


### PR DESCRIPTION
## Changes

@astrojs/upgrade wrongfully used the current package manager used to run the command instead of the package manager used to install the project its run in. This normally would be fine, however many people uses `npx` even when using pnpm and other package managers, so using the package manager of the project ends up working better

<img width="313" alt="image" src="https://github.com/withastro/astro/assets/3019731/cf29ba15-b067-4bb9-ba7c-532737d7e313">

Notice it now using pnpm despite using npx in this screenshot.

## Testing

Tested manually, see screenshot

## Docs

N/A
