### PR TITLE
feat(container): provide a virtual module to load renderers

### DIFF
--- a/.changeset/fair-singers-reflect.md
+++ b/.changeset/fair-singers-reflect.md
@@ -1,12 +1,24 @@
+---
+"@astrojs/preact": minor
+"@astrojs/svelte": minor
+"@astrojs/react": minor
+"@astrojs/solid-js": minor
+"@astrojs/lit": minor
+"@astrojs/mdx": minor
+"@astrojs/vue": minor
+"astro": patch
+---
+
+The integration now exposes a function called `getContainerRenderer`, that can be used inside the Container APIs to load the relative renderer.
+
+```js
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
-import { expect, test } from 'vitest';
 import ReactWrapper from '../src/components/ReactWrapper.astro';
 import { loadRenderers} from "astro:container";
 import { getContainerRenderer } from "@astrojs/react";
 
 test('ReactWrapper with react renderer', async () => {
 	const renderers = await loadRenderers([getContainerRenderer(19)])
-	
 	const container = await AstroContainer.create({
 		renderers,
 	});
@@ -15,3 +27,4 @@ test('ReactWrapper with react renderer', async () => {
 	expect(result).toContain('Counter');
 	expect(result).toContain('Count: <!-- -->5');
 });
+```

--- a/.changeset/fair-singers-reflect.md
+++ b/.changeset/fair-singers-reflect.md
@@ -14,11 +14,11 @@ The integration now exposes a function called `getContainerRenderer`, that can b
 ```js
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import ReactWrapper from '../src/components/ReactWrapper.astro';
-import { loadRenderers} from "astro:container";
+import { loadRenderers } from "astro:container";
 import { getContainerRenderer } from "@astrojs/react";
 
 test('ReactWrapper with react renderer', async () => {
-	const renderers = await loadRenderers([getContainerRenderer(19)])
+	const renderers = await loadRenderers([getContainerRenderer()])
 	const container = await AstroContainer.create({
 		renderers,
 	});

--- a/.changeset/fair-singers-reflect.md
+++ b/.changeset/fair-singers-reflect.md
@@ -11,14 +11,21 @@
 
 The integration now exposes a function called `getContainerRenderer`, that can be used inside the Container APIs to load the relative renderer.
 
-```js
+```diff
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import ReactWrapper from '../src/components/ReactWrapper.astro';
 import { loadRenderers } from "astro:container";
 import { getContainerRenderer } from "@astrojs/react";
 
 test('ReactWrapper with react renderer', async () => {
-	const renderers = await loadRenderers([getContainerRenderer()])
++	const renderers = await loadRenderers([getContainerRenderer()])
+-  const renderers = [
+-    {
+-      name: '@astrojs/react',
+-      clientEntrypoint: '@astrojs/react/client.js',
+-      serverEntrypoint: '@astrojs/react/server.js',
+-    },
+-  ];
 	const container = await AstroContainer.create({
 		renderers,
 	});

--- a/.changeset/fair-singers-reflect.md
+++ b/.changeset/fair-singers-reflect.md
@@ -11,27 +11,20 @@
 
 The integration now exposes a function called `getContainerRenderer`, that can be used inside the Container APIs to load the relative renderer.
 
-```diff
+```js
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import ReactWrapper from '../src/components/ReactWrapper.astro';
 import { loadRenderers } from "astro:container";
 import { getContainerRenderer } from "@astrojs/react";
 
 test('ReactWrapper with react renderer', async () => {
-+	const renderers = await loadRenderers([getContainerRenderer()])
--  const renderers = [
--    {
--      name: '@astrojs/react',
--      clientEntrypoint: '@astrojs/react/client.js',
--      serverEntrypoint: '@astrojs/react/server.js',
--    },
--  ];
-	const container = await AstroContainer.create({
-		renderers,
-	});
-	const result = await container.renderToString(ReactWrapper);
+  const renderers = await loadRenderers([getContainerRenderer()])
+  const container = await AstroContainer.create({
+    renderers,
+  });
+  const result = await container.renderToString(ReactWrapper);
 
-	expect(result).toContain('Counter');
-	expect(result).toContain('Count: <!-- -->5');
+  expect(result).toContain('Counter');
+  expect(result).toContain('Count: <!-- -->5');
 });
 ```

--- a/.changeset/gold-mayflies-beam.md
+++ b/.changeset/gold-mayflies-beam.md
@@ -9,11 +9,11 @@ The **type** of the `renderers` option of the `AstroContainer::create` function 
 ```js
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import ReactWrapper from '../src/components/ReactWrapper.astro';
-import { loadRenderers} from "astro:container";
+import { loadRenderers } from "astro:container";
 import { getContainerRenderer } from "@astrojs/react";
 
 test('ReactWrapper with react renderer', async () => {
-	const renderers = await loadRenderers([getContainerRenderer(19)])
+	const renderers = await loadRenderers([getContainerRenderer()])
 	const container = await AstroContainer.create({
 		renderers,
 	});

--- a/.changeset/gold-mayflies-beam.md
+++ b/.changeset/gold-mayflies-beam.md
@@ -1,12 +1,19 @@
+---
+"astro": patch
+---
+
+**BREAKING CHANGE** 
+
+The **type** of the `renderers` option of the `AstroContainer::create` function has been changed. Now, in order to load the renderer, you can use a dedicated function:
+
+```js
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
-import { expect, test } from 'vitest';
 import ReactWrapper from '../src/components/ReactWrapper.astro';
 import { loadRenderers} from "astro:container";
 import { getContainerRenderer } from "@astrojs/react";
 
 test('ReactWrapper with react renderer', async () => {
 	const renderers = await loadRenderers([getContainerRenderer(19)])
-	
 	const container = await AstroContainer.create({
 		renderers,
 	});
@@ -15,3 +22,6 @@ test('ReactWrapper with react renderer', async () => {
 	expect(result).toContain('Counter');
 	expect(result).toContain('Count: <!-- -->5');
 });
+```
+
+The `astro:container` is a virtual module that can be used when running the Astro container inside `vite`.

--- a/.changeset/gold-mayflies-beam.md
+++ b/.changeset/gold-mayflies-beam.md
@@ -8,21 +8,28 @@ Changes the **type** of the `renderers` option of the `AstroContainer::create` f
 
 You no longer need to know the individual, direct file paths to the client and server rendering scripts for each renderer integration package. Now, there is a dedicated function to load the renderer from each package, which is available from `getContainerRenderer()`:
 
-```js
+```diff
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import ReactWrapper from '../src/components/ReactWrapper.astro';
 import { loadRenderers } from "astro:container";
 import { getContainerRenderer } from "@astrojs/react";
 
 test('ReactWrapper with react renderer', async () => {
-	const renderers = await loadRenderers([getContainerRenderer()])
-	const container = await AstroContainer.create({
-		renderers,
-	});
-	const result = await container.renderToString(ReactWrapper);
++ const renderers = await loadRenderers([getContainerRenderer()])
+- const renderers = [
+- {
+-  name: '@astrojs/react',
+-   clientEntrypoint: '@astrojs/react/client.js',
+-   serverEntrypoint: '@astrojs/react/server.js',
+-  },
+- ];
+  const container = await AstroContainer.create({
+    renderers,
+  });
+  const result = await container.renderToString(ReactWrapper);
 
-	expect(result).toContain('Counter');
-	expect(result).toContain('Count: <!-- -->5');
+  expect(result).toContain('Counter');
+  expect(result).toContain('Count: <!-- -->5');
 });
 ```
 

--- a/.changeset/gold-mayflies-beam.md
+++ b/.changeset/gold-mayflies-beam.md
@@ -2,9 +2,11 @@
 "astro": patch
 ---
 
-**BREAKING CHANGE** 
+**BREAKING CHANGE to the experimental Container API only** 
 
-The **type** of the `renderers` option of the `AstroContainer::create` function has been changed. Now, in order to load the renderer, you can use a dedicated function:
+Changes the **type** of the `renderers` option of the `AstroContainer::create` function and adds a dedicated function `loadRenderers()` to load the rendering scripts from renderer integration packages (`@astrojs/react`, `@astrojs/preact`, `@astrojs/solid-js`, `@astrojs/svelte`, `@astrojs/vue`, `@astrojs/lit`, and `@astrojs/mdx`).
+
+You no longer need to know the individual, direct file paths to the client and server rendering scripts for each renderer integration package. Now, there is a dedicated function to load the renderer from each package, which is available from `getContainerRenderer()`:
 
 ```js
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
@@ -24,4 +26,4 @@ test('ReactWrapper with react renderer', async () => {
 });
 ```
 
-The `astro:container` is a virtual module that can be used when running the Astro container inside `vite`.
+The new `loadRenderers()` helper function is available from `astro:container`,  a virtual module that can be used when running the Astro container inside `vite`.

--- a/examples/container-with-vitest/package.json
+++ b/examples/container-with-vitest/package.json
@@ -12,8 +12,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "astro": "^4.9.3",
-    "@astrojs/react": "^3.4.0",
+    "astro": "experimental--container",
+    "@astrojs/react": "experimental--container",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "vitest": "^1.6.0"

--- a/examples/container-with-vitest/test/ReactWrapper.test.ts
+++ b/examples/container-with-vitest/test/ReactWrapper.test.ts
@@ -1,17 +1,15 @@
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import { expect, test } from 'vitest';
 import ReactWrapper from '../src/components/ReactWrapper.astro';
-import { loadRenderers} from "astro:container";
-import { getContainerRenderer } from "@astrojs/react";
+import { loadRenderers } from 'astro:container';
+import { getContainerRenderer } from '@astrojs/react';
 
-const renderers = await loadRenderers([getContainerRenderer()])
+const renderers = await loadRenderers([getContainerRenderer()]);
 const container = await AstroContainer.create({
 	renderers,
 });
 
-
 test('ReactWrapper with react renderer', async () => {
-	
 	const result = await container.renderToString(ReactWrapper);
 
 	expect(result).toContain('Counter');

--- a/examples/container-with-vitest/test/ReactWrapper.test.ts
+++ b/examples/container-with-vitest/test/ReactWrapper.test.ts
@@ -4,12 +4,14 @@ import ReactWrapper from '../src/components/ReactWrapper.astro';
 import { loadRenderers} from "astro:container";
 import { getContainerRenderer } from "@astrojs/react";
 
+const renderers = await loadRenderers([getContainerRenderer()])
+const container = await AstroContainer.create({
+	renderers,
+});
+
+
 test('ReactWrapper with react renderer', async () => {
-	const renderers = await loadRenderers([getContainerRenderer(19)])
 	
-	const container = await AstroContainer.create({
-		renderers,
-	});
 	const result = await container.renderToString(ReactWrapper);
 
 	expect(result).toContain('Counter');

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -152,8 +152,8 @@ declare module 'astro:i18n' {
 	export * from 'astro/virtual-modules/i18n.js';
 }
 
-declare module "astro:container" {
-	export * from "astro/virtual-modules/container.js";
+declare module 'astro:container' {
+	export * from 'astro/virtual-modules/container.js';
 }
 
 declare module 'astro:middleware' {

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -152,6 +152,10 @@ declare module 'astro:i18n' {
 	export * from 'astro/virtual-modules/i18n.js';
 }
 
+declare module "astro:container" {
+	export * from "astro/virtual-modules/container.js";
+}
+
 declare module 'astro:middleware' {
 	export * from 'astro/virtual-modules/middleware.js';
 }

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -3290,3 +3290,17 @@ declare global {
 		'astro:page-load': Event;
 	}
 }
+
+// Container types
+export type ContainerImportRendererFn = (containerRenderer: ContainerRenderer) => Promise<SSRLoadedRenderer>;
+
+export type ContainerRenderer = {
+	/**
+	 * The name of the renderer.
+	 */
+	name: string,
+	/**
+	 * The entrypoint that is used to render a component on the server
+	 */
+	serverEntrypoint: string,
+}

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -3292,15 +3292,17 @@ declare global {
 }
 
 // Container types
-export type ContainerImportRendererFn = (containerRenderer: ContainerRenderer) => Promise<SSRLoadedRenderer>;
+export type ContainerImportRendererFn = (
+	containerRenderer: ContainerRenderer
+) => Promise<SSRLoadedRenderer>;
 
 export type ContainerRenderer = {
 	/**
 	 * The name of the renderer.
 	 */
-	name: string,
+	name: string;
 	/**
 	 * The entrypoint that is used to render a component on the server
 	 */
-	serverEntrypoint: string,
-}
+	serverEntrypoint: string;
+};

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -260,7 +260,7 @@ export class experimental_AstroContainer {
 	): Promise<experimental_AstroContainer> {
 		const { streaming = false, manifest, renderers = [], resolve } = containerOptions;
 		const astroConfig = await validateConfig(ASTRO_CONFIG_DEFAULTS, process.cwd(), 'container');
-		return new experimental_AstroContainer({ streaming, renderers, astroConfig, resolve });
+		return new experimental_AstroContainer({ streaming, manifest, renderers, astroConfig, resolve });
 	}
 
 	// NOTE: we keep this private via TS instead via `#` so it's still available on the surface, so we can play with it.

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -164,6 +164,14 @@ export type AstroContainerOptions = {
 
 	// TODO: document out of experimental
 	resolve?: SSRResult['resolve'];
+
+	/**
+	 * @default {}
+	 * @description
+	 * 
+	 * The raw manifest from the build output.
+	 */
+	manifest?: SSRManifest;
 };
 
 type AstroContainerManifest = Pick<
@@ -222,7 +230,7 @@ export class experimental_AstroContainer {
 			manifest: createManifest(manifest, renderers),
 			streaming,
 			serverLike: true,
-			renderers: [],
+			renderers: renderers ?? manifest?.renderers ?? [],
 			resolve: async (specifier: string) => {
 				if (this.#withManifest) {
 					return this.#containerResolve(specifier, astroConfig);
@@ -250,7 +258,7 @@ export class experimental_AstroContainer {
 	public static async create(
 		containerOptions: AstroContainerOptions = {}
 	): Promise<experimental_AstroContainer> {
-		const { streaming = false, renderers = [], resolve } = containerOptions;
+		const { streaming = false, manifest, renderers = [], resolve } = containerOptions;
 		const astroConfig = await validateConfig(ASTRO_CONFIG_DEFAULTS, process.cwd(), 'container');
 		return new experimental_AstroContainer({ streaming, renderers, astroConfig, resolve });
 	}

--- a/packages/astro/src/virtual-modules/container.ts
+++ b/packages/astro/src/virtual-modules/container.ts
@@ -1,16 +1,16 @@
-import type {AstroRenderer, SSRLoadedRenderer} from "../@types/astro.js";
+import type { AstroRenderer, SSRLoadedRenderer } from '../@types/astro.js';
 
 /**
  * Use this function to provide renderers to the `AstroContainer`:
- * 
+ *
  * ```js
  * import { getContainerRenderer } from "@astrojs/react";
  * import { experimental_AstroContainer as AstroContainer } from "astro/container";
  * import { loadRenderers } from "astro:container"; // use this only when using vite/vitest
- * 
+ *
  * const renderers = await loadRenderers([ getContainerRenderer ]);
  * const container = await AstroContainer.create({ renderers });
- * 
+ *
  * ```
  * @param renderers
  */
@@ -29,5 +29,4 @@ export async function loadRenderers(renderers: AstroRenderer[]) {
 	);
 
 	return loadedRenderers.filter((r): r is SSRLoadedRenderer => Boolean(r));
-
 }

--- a/packages/astro/src/virtual-modules/container.ts
+++ b/packages/astro/src/virtual-modules/container.ts
@@ -1,0 +1,33 @@
+import type {AstroRenderer, SSRLoadedRenderer} from "../@types/astro.js";
+
+/**
+ * Use this function to provide renderers to the `AstroContainer`:
+ * 
+ * ```js
+ * import { getContainerRenderer } from "@astrojs/react";
+ * import { experimental_AstroContainer as AstroContainer } from "astro/container";
+ * import { loadRenderers } from "astro:content"; // use this only when using vite/vitest
+ * 
+ * const renderers = await loadRenderers([ getContainerRenderer ]);
+ * const container = await AstroContainer.create({ renderers });
+ * 
+ * ```
+ * @param renderers
+ */
+export async function loadRenderers(renderers: AstroRenderer[]) {
+	const loadedRenderers = await Promise.all(
+		renderers.map(async (renderer) => {
+			const mod = await import(renderer.serverEntrypoint);
+			if (typeof mod.default !== 'undefined') {
+				return {
+					...renderer,
+					ssr: mod.default,
+				} as SSRLoadedRenderer;
+			}
+			return undefined;
+		})
+	);
+
+	return loadedRenderers.filter((r): r is SSRLoadedRenderer => Boolean(r));
+
+}

--- a/packages/astro/src/virtual-modules/container.ts
+++ b/packages/astro/src/virtual-modules/container.ts
@@ -6,7 +6,7 @@ import type {AstroRenderer, SSRLoadedRenderer} from "../@types/astro.js";
  * ```js
  * import { getContainerRenderer } from "@astrojs/react";
  * import { experimental_AstroContainer as AstroContainer } from "astro/container";
- * import { loadRenderers } from "astro:content"; // use this only when using vite/vitest
+ * import { loadRenderers } from "astro:container"; // use this only when using vite/vitest
  * 
  * const renderers = await loadRenderers([ getContainerRenderer ]);
  * const container = await AstroContainer.create({ renderers });

--- a/packages/integrations/lit/src/index.ts
+++ b/packages/integrations/lit/src/index.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import type {AstroIntegration, ContainerRenderer} from 'astro';
+import type { AstroIntegration, ContainerRenderer } from 'astro';
 
 function getViteConfiguration() {
 	return {
@@ -21,11 +21,10 @@ function getViteConfiguration() {
 
 export function getContainerRenderer(): ContainerRenderer {
 	return {
-		name: "@astrojs/lit",
+		name: '@astrojs/lit',
 		serverEntrypoint: '@astrojs/lit/server.js',
-	}
+	};
 }
-
 
 export default function (): AstroIntegration {
 	return {

--- a/packages/integrations/lit/src/index.ts
+++ b/packages/integrations/lit/src/index.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import type { AstroIntegration } from 'astro';
+import type {AstroIntegration, ContainerRenderer} from 'astro';
 
 function getViteConfiguration() {
 	return {
@@ -18,6 +18,14 @@ function getViteConfiguration() {
 		},
 	};
 }
+
+export function getContainerRenderer(): ContainerRenderer {
+	return {
+		name: "@astrojs/lit",
+		serverEntrypoint: '@astrojs/lit/server.js',
+	}
+}
+
 
 export default function (): AstroIntegration {
 	return {

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { markdownConfigDefaults } from '@astrojs/markdown-remark';
-import type { AstroIntegration, ContentEntryType, HookParameters } from 'astro';
+import type {AstroIntegration, ContainerRenderer, ContentEntryType, HookParameters} from 'astro';
 import astroJSXRenderer from 'astro/jsx/renderer.js';
 import type { Options as RemarkRehypeOptions } from 'remark-rehype';
 import type { PluggableList } from 'unified';
@@ -27,6 +27,14 @@ type SetupHookParams = HookParameters<'astro:config:setup'> & {
 	addPageExtension: (extension: string) => void;
 	addContentEntryType: (contentEntryType: ContentEntryType) => void;
 };
+
+export function getContainerRenderer(): ContainerRenderer {
+	return {
+		name: "astro:jsx",
+		serverEntrypoint: 'astro/jsx/server.js',
+	}
+}
+
 
 export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroIntegration {
 	// @ts-expect-error Temporarily assign an empty object here, which will be re-assigned by the

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { markdownConfigDefaults } from '@astrojs/markdown-remark';
-import type {AstroIntegration, ContainerRenderer, ContentEntryType, HookParameters} from 'astro';
+import type { AstroIntegration, ContainerRenderer, ContentEntryType, HookParameters } from 'astro';
 import astroJSXRenderer from 'astro/jsx/renderer.js';
 import type { Options as RemarkRehypeOptions } from 'remark-rehype';
 import type { PluggableList } from 'unified';
@@ -30,11 +30,10 @@ type SetupHookParams = HookParameters<'astro:config:setup'> & {
 
 export function getContainerRenderer(): ContainerRenderer {
 	return {
-		name: "astro:jsx",
+		name: 'astro:jsx',
 		serverEntrypoint: 'astro/jsx/server.js',
-	}
+	};
 }
-
 
 export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroIntegration {
 	// @ts-expect-error Temporarily assign an empty object here, which will be re-assigned by the

--- a/packages/integrations/preact/src/index.ts
+++ b/packages/integrations/preact/src/index.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { type PreactPluginOptions as VitePreactPluginOptions, preact } from '@preact/preset-vite';
-import type { AstroIntegration, AstroRenderer, ViteUserConfig } from 'astro';
+import type {AstroIntegration, AstroRenderer, ContainerRenderer, ViteUserConfig} from 'astro';
 
 const babelCwd = new URL('../', import.meta.url);
 
@@ -10,6 +10,13 @@ function getRenderer(development: boolean): AstroRenderer {
 		clientEntrypoint: development ? '@astrojs/preact/client-dev.js' : '@astrojs/preact/client.js',
 		serverEntrypoint: '@astrojs/preact/server.js',
 	};
+}
+
+export function getContainerRenderer(): ContainerRenderer {
+	return {
+		name: "@astrojs/preact",
+		serverEntrypoint: '@astrojs/preact/server.js',
+	}
 }
 
 export interface Options extends Pick<VitePreactPluginOptions, 'include' | 'exclude'> {

--- a/packages/integrations/preact/src/index.ts
+++ b/packages/integrations/preact/src/index.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { type PreactPluginOptions as VitePreactPluginOptions, preact } from '@preact/preset-vite';
-import type {AstroIntegration, AstroRenderer, ContainerRenderer, ViteUserConfig} from 'astro';
+import type { AstroIntegration, AstroRenderer, ContainerRenderer, ViteUserConfig } from 'astro';
 
 const babelCwd = new URL('../', import.meta.url);
 
@@ -14,9 +14,9 @@ function getRenderer(development: boolean): AstroRenderer {
 
 export function getContainerRenderer(): ContainerRenderer {
 	return {
-		name: "@astrojs/preact",
+		name: '@astrojs/preact',
 		serverEntrypoint: '@astrojs/preact/server.js',
-	}
+	};
 }
 
 export interface Options extends Pick<VitePreactPluginOptions, 'include' | 'exclude'> {

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -53,10 +53,16 @@ function getRenderer(reactConfig: ReactVersionConfig) {
 	};
 }
 
-export function getContainerRenderer(reactVersion: ReactVersionConfig): ContainerRenderer {
+export function getContainerRenderer(): ContainerRenderer {
+	const majorVersion = getReactMajorVersion();
+	if (isUnsupportedVersion(majorVersion)) {
+		throw new Error(`Unsupported React version: ${majorVersion}.`);
+	}
+	const versionConfig = versionsConfig[majorVersion as SupportedReactVersion];
+	
 	return {
 		name: "@astrojs/react",
-		serverEntrypoint: reactVersion.server,
+		serverEntrypoint: versionConfig.server,
 	}
 }
 

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -59,11 +59,11 @@ export function getContainerRenderer(): ContainerRenderer {
 		throw new Error(`Unsupported React version: ${majorVersion}.`);
 	}
 	const versionConfig = versionsConfig[majorVersion as SupportedReactVersion];
-	
+
 	return {
-		name: "@astrojs/react",
+		name: '@astrojs/react',
 		serverEntrypoint: versionConfig.server,
-	}
+	};
 }
 
 function optionsPlugin(experimentalReactChildren: boolean): vite.Plugin {

--- a/packages/integrations/react/src/index.ts
+++ b/packages/integrations/react/src/index.ts
@@ -1,5 +1,5 @@
 import react, { type Options as ViteReactPluginOptions } from '@vitejs/plugin-react';
-import type { AstroIntegration } from 'astro';
+import type { AstroIntegration, ContainerRenderer } from 'astro';
 import { version as ReactVersion } from 'react-dom';
 import type * as vite from 'vite';
 
@@ -51,6 +51,13 @@ function getRenderer(reactConfig: ReactVersionConfig) {
 		clientEntrypoint: reactConfig.client,
 		serverEntrypoint: reactConfig.server,
 	};
+}
+
+export function getContainerRenderer(reactVersion: ReactVersionConfig): ContainerRenderer {
+	return {
+		name: "@astrojs/react",
+		serverEntrypoint: reactVersion.server,
+	}
 }
 
 function optionsPlugin(experimentalReactChildren: boolean): vite.Plugin {

--- a/packages/integrations/solid/src/index.ts
+++ b/packages/integrations/solid/src/index.ts
@@ -1,4 +1,9 @@
-import type {AstroIntegration, AstroIntegrationLogger, AstroRenderer, ContainerRenderer} from 'astro';
+import type {
+	AstroIntegration,
+	AstroIntegrationLogger,
+	AstroRenderer,
+	ContainerRenderer,
+} from 'astro';
 import type { PluginOption, UserConfig } from 'vite';
 import solid, { type Options as ViteSolidPluginOptions } from 'vite-plugin-solid';
 
@@ -94,14 +99,12 @@ function getRenderer(): AstroRenderer {
 	};
 }
 
-
 export function getContainerRenderer(): ContainerRenderer {
 	return {
-		name: "@astrojs/solid",
+		name: '@astrojs/solid',
 		serverEntrypoint: '@astrojs/solid-js/server.js',
-	}
+	};
 }
-
 
 export interface Options extends Pick<ViteSolidPluginOptions, 'include' | 'exclude'> {
 	devtools?: boolean;

--- a/packages/integrations/solid/src/index.ts
+++ b/packages/integrations/solid/src/index.ts
@@ -1,4 +1,4 @@
-import type { AstroIntegration, AstroIntegrationLogger, AstroRenderer } from 'astro';
+import type {AstroIntegration, AstroIntegrationLogger, AstroRenderer, ContainerRenderer} from 'astro';
 import type { PluginOption, UserConfig } from 'vite';
 import solid, { type Options as ViteSolidPluginOptions } from 'vite-plugin-solid';
 
@@ -93,6 +93,15 @@ function getRenderer(): AstroRenderer {
 		serverEntrypoint: '@astrojs/solid-js/server.js',
 	};
 }
+
+
+export function getContainerRenderer(): ContainerRenderer {
+	return {
+		name: "@astrojs/solid",
+		serverEntrypoint: '@astrojs/solid-js/server.js',
+	}
+}
+
 
 export interface Options extends Pick<ViteSolidPluginOptions, 'include' | 'exclude'> {
 	devtools?: boolean;

--- a/packages/integrations/svelte/src/index.ts
+++ b/packages/integrations/svelte/src/index.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url';
 import type { Options } from '@sveltejs/vite-plugin-svelte';
 import { svelte, vitePreprocess } from '@sveltejs/vite-plugin-svelte';
-import type { AstroIntegration, AstroRenderer } from 'astro';
+import type {AstroIntegration, AstroRenderer, ContainerRenderer} from 'astro';
 import { VERSION } from 'svelte/compiler';
 import type { UserConfig } from 'vite';
 
@@ -13,6 +13,13 @@ function getRenderer(): AstroRenderer {
 		clientEntrypoint: isSvelte5 ? '@astrojs/svelte/client-v5.js' : '@astrojs/svelte/client.js',
 		serverEntrypoint: isSvelte5 ? '@astrojs/svelte/server-v5.js' : '@astrojs/svelte/server.js',
 	};
+}
+
+export function getContainerRenderer(): ContainerRenderer {
+	return {
+		name: "@astrojs/svelte",
+		serverEntrypoint: isSvelte5 ? '@astrojs/svelte/server-v5.js' : '@astrojs/svelte/server.js',
+	}
 }
 
 async function svelteConfigHasPreprocess(root: URL) {

--- a/packages/integrations/svelte/src/index.ts
+++ b/packages/integrations/svelte/src/index.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url';
 import type { Options } from '@sveltejs/vite-plugin-svelte';
 import { svelte, vitePreprocess } from '@sveltejs/vite-plugin-svelte';
-import type {AstroIntegration, AstroRenderer, ContainerRenderer} from 'astro';
+import type { AstroIntegration, AstroRenderer, ContainerRenderer } from 'astro';
 import { VERSION } from 'svelte/compiler';
 import type { UserConfig } from 'vite';
 
@@ -17,9 +17,9 @@ function getRenderer(): AstroRenderer {
 
 export function getContainerRenderer(): ContainerRenderer {
 	return {
-		name: "@astrojs/svelte",
+		name: '@astrojs/svelte',
 		serverEntrypoint: isSvelte5 ? '@astrojs/svelte/server-v5.js' : '@astrojs/svelte/server.js',
-	}
+	};
 }
 
 async function svelteConfigHasPreprocess(root: URL) {

--- a/packages/integrations/vue/src/index.ts
+++ b/packages/integrations/vue/src/index.ts
@@ -3,7 +3,7 @@ import type { Options as VueOptions } from '@vitejs/plugin-vue';
 import vue from '@vitejs/plugin-vue';
 import type { Options as VueJsxOptions } from '@vitejs/plugin-vue-jsx';
 import { MagicString } from '@vue/compiler-sfc';
-import type { AstroIntegration, AstroRenderer, HookParameters } from 'astro';
+import type {AstroIntegration, AstroRenderer, ContainerRenderer, HookParameters} from 'astro';
 import type { Plugin, UserConfig } from 'vite';
 import type { VitePluginVueDevToolsOptions } from 'vite-plugin-vue-devtools';
 
@@ -30,6 +30,13 @@ function getJsxRenderer(): AstroRenderer {
 		clientEntrypoint: '@astrojs/vue/client.js',
 		serverEntrypoint: '@astrojs/vue/server.js',
 	};
+}
+
+export function getContainerRenderer(): ContainerRenderer {
+	return {
+		name: "@astrojs/vue",
+		serverEntrypoint: '@astrojs/vue/server.js'
+	}
 }
 
 function virtualAppEntrypoint(options?: Options): Plugin {

--- a/packages/integrations/vue/src/index.ts
+++ b/packages/integrations/vue/src/index.ts
@@ -3,7 +3,7 @@ import type { Options as VueOptions } from '@vitejs/plugin-vue';
 import vue from '@vitejs/plugin-vue';
 import type { Options as VueJsxOptions } from '@vitejs/plugin-vue-jsx';
 import { MagicString } from '@vue/compiler-sfc';
-import type {AstroIntegration, AstroRenderer, ContainerRenderer, HookParameters} from 'astro';
+import type { AstroIntegration, AstroRenderer, ContainerRenderer, HookParameters } from 'astro';
 import type { Plugin, UserConfig } from 'vite';
 import type { VitePluginVueDevToolsOptions } from 'vite-plugin-vue-devtools';
 
@@ -34,9 +34,9 @@ function getJsxRenderer(): AstroRenderer {
 
 export function getContainerRenderer(): ContainerRenderer {
 	return {
-		name: "@astrojs/vue",
-		serverEntrypoint: '@astrojs/vue/server.js'
-	}
+		name: '@astrojs/vue',
+		serverEntrypoint: '@astrojs/vue/server.js',
+	};
 }
 
 function virtualAppEntrypoint(options?: Options): Plugin {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,10 +155,10 @@ importers:
   examples/container-with-vitest:
     dependencies:
       '@astrojs/react':
-        specifier: ^3.4.0
+        specifier: experimental--container
         version: link:../../packages/integrations/react
       astro:
-        specifier: ^4.9.3
+        specifier: experimental--container
         version: link:../../packages/astro
       react:
         specifier: ^18.3.1


### PR DESCRIPTION
## Changes

This PR does the following:
- updates our client-side integrations to expose a new function called `getContainerRenderer`. This function will be used by the consumers of a vite-full environment
- creates a new virtual module, `astro:container`, that exposes a utility function that loads the renderers when people are in a vite-full environment
- rollbacks the types of the `renderers`; this change should allow vite-less environments to load the renderer modules manually and pass them

## Testing

I updated the example with the new code

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

We will probably need to update the docs for that

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

https://github.com/withastro/docs/pull/8428
