### PR TITLE
fix(svelte): update add_snippet_symbol import

### DIFF
--- a/.changeset/lovely-kids-knock.md
+++ b/.changeset/lovely-kids-knock.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/svelte": patch
+---
+
+Support internal breaking changes in svelte@5.0.0-next.134

--- a/packages/integrations/svelte/client-v5.js
+++ b/packages/integrations/svelte/client-v5.js
@@ -1,5 +1,5 @@
 import { hydrate, mount, unmount } from 'svelte';
-import { add_snippet_symbol } from 'svelte/internal/client';
+import { add_snippet_symbol } from 'svelte/internal/server';
 
 // Allow a slot to be rendered as a snippet (dev validation only)
 const tagSlotAsSnippet = import.meta.env.DEV ? add_snippet_symbol : (s) => s;


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

Fixes https://github.com/withastro/astro/issues/11149

[`svelte@5.0.0-next-134`](https://github.com/sveltejs/svelte/pull/10800) removed the `add_snippet_symbol` export in `svelte/internal/client`. This changes the import from  `svelte/internal/client` to `svelte/internal/server`.



 ---

Looking at the svelte source code, `add_snippet_symbol` from both [client](https://github.com/sveltejs/svelte/blob/4c0b723c177063e94ed6beecc7e6a9b5ef806749/packages/svelte/src/internal/client/index.js#L140) and [server](https://github.com/sveltejs/svelte/blob/4c0b723c177063e94ed6beecc7e6a9b5ef806749/packages/svelte/src/internal/server/index.js#L661) were simply re-exports of a [shared file](https://github.com/sveltejs/svelte/blob/4c0b723c177063e94ed6beecc7e6a9b5ef806749/packages/svelte/src/internal/shared/validate.js#L8-L11).

Though it feels wrong to import a server file into a client file, this might be acceptable since this is for dev validation only and the underlying function is the same.

The re-export from `svelte/internal/server` was originally added in [`svelte@5.0.0-next.88`](https://github.com/sveltejs/svelte/pull/10972). Since the minimum version required is already `svelte@5.0.0-next.90`, this should not be a breaking change.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Changing the import from `svelte/internal/client` to `svelte/internal/server` using `pnpm patch` in pre-existing projects allows build to complete. 

```diff
diff --git a/client-v5.js b/client-v5.js
index 755a6aa5381ee602ba8ece2f91f6439c8b19dd3f..896be0982ee3047cdc182345bad818733e06be92 100644
--- a/client-v5.js
+++ b/client-v5.js
@@ -1,5 +1,5 @@
 import { hydrate, mount, unmount } from 'svelte';
-import { add_snippet_symbol } from 'svelte/internal/client';
+import { add_snippet_symbol } from 'svelte/internal/server';
 
 // Allow a slot to be rendered as a snippet (dev validation only)
 const tagSlotAsSnippet = import.meta.env.DEV ? add_snippet_symbol : (s) => s;
```

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This fix requires no changes on the part of the user and shouldn't need to be documented.