### PR TITLE
Changelog: Fix typo

### DIFF
--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -7,7 +7,7 @@
 - [#11138](https://github.com/withastro/astro/pull/11138) [`98e0372`](https://github.com/withastro/astro/commit/98e0372cfd47a3e025be2ac68d1e9ebf06cf548b) Thanks [@ematipico](https://github.com/ematipico)! - You can now pass `props` when rendering a component using the Container APIs:
 
   ```js
-  import { experimental_AstroContainer as AstroContainer } from 'astro/contaienr';
+  import { experimental_AstroContainer as AstroContainer } from 'astro/container';
   import Card from '../src/components/Card.astro';
 
   const container = await AstroContainer.create();


### PR DESCRIPTION
Fix typo in `container`