### PR TITLE
:bug: removed deprecated items from lit integration

### DIFF
--- a/.changeset/gold-meals-march.md
+++ b/.changeset/gold-meals-march.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/lit": minor
+---
+
+Removes deprecated `template` attribute and replaces deprecated domparser function

--- a/packages/integrations/lit/client-shim.js
+++ b/packages/integrations/lit/client-shim.js
@@ -7,7 +7,7 @@ async function polyfill() {
 	});
 }
 
-const polyfillCheckEl = document
+const polyfillCheckEl = Document
 	.parseHTMLUnsafe(`<p><template shadowrootmode="open"></template></p>`)
 	.querySelector('p');
 

--- a/packages/integrations/lit/client-shim.js
+++ b/packages/integrations/lit/client-shim.js
@@ -7,14 +7,8 @@ async function polyfill() {
 	});
 }
 
-const polyfillCheckEl = new DOMParser()
-	.parseFromString(
-		`<p><template shadowroot="open" shadowrootmode="open"></template></p>`,
-		'text/html',
-		{
-			includeShadowRoots: true,
-		}
-	)
+const polyfillCheckEl = document
+	.parseHTMLUnsafe(`<p><template shadowrootmode="open"></template></p>`)
 	.querySelector('p');
 
 if (!polyfillCheckEl?.shadowRoot) {

--- a/packages/integrations/lit/client-shim.min.js
+++ b/packages/integrations/lit/client-shim.min.js
@@ -8,7 +8,7 @@ var b = (t, n) => {
 function s() {
 	if (d === void 0) {
 		let t = document.createElement('div');
-		(t.innerHTML = '<div><template shadowroot="open" shadowrootmode="open"></template></div>'),
+		(t.innerHTML = '<div><template shadowrootmode="open"></template></div>'),
 			(d = !!t.firstElementChild.shadowRoot);
 	}
 	return d;
@@ -79,13 +79,6 @@ async function g() {
 	let { hydrateShadowRoots: t } = await Promise.resolve().then(() => (S(), v));
 	window.addEventListener('DOMContentLoaded', () => t(document.body), { once: true });
 }
-var x = new DOMParser()
-	.parseFromString(
-		'<p><template shadowroot="open" shadowrootmode="open"></template></p>',
-		'text/html',
-		{
-			includeShadowRoots: !0,
-		}
-	)
+var x = document.parseHTMLUnsafe('<p><template shadowrootmode="open"></template></p>')
 	.querySelector('p');
 (!x || !x.shadowRoot) && g();

--- a/packages/integrations/lit/client-shim.min.js
+++ b/packages/integrations/lit/client-shim.min.js
@@ -79,6 +79,6 @@ async function g() {
 	let { hydrateShadowRoots: t } = await Promise.resolve().then(() => (S(), v));
 	window.addEventListener('DOMContentLoaded', () => t(document.body), { once: true });
 }
-var x = document.parseHTMLUnsafe('<p><template shadowrootmode="open"></template></p>')
+var x = Document.parseHTMLUnsafe('<p><template shadowrootmode="open"></template></p>')
 	.querySelector('p');
 (!x || !x.shadowRoot) && g();


### PR DESCRIPTION
## Changes

### Deprecated API
- Removes a deprecated API in lit plugin's client-shim which is causing a big hit to page insights.

Chrome's deprecation info:
https://chromestatus.com/feature/5116094370283520

Related story:
https://github.com/withastro/astro/issues/11160

### Deprecated Attribute

- Removes the `shadowroot` attribute which was deprecated by chrome and not needed by other browsers

Deprecation info:
https://chromestatus.com/feature/6239658726391808

## Testing

<!-- How was this change tested? -->
The original file did not include tests so I installed `client-shim` and client-shim-min` locally and tested them with the latest astro install I have, which has `lit` components in it

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
Should not change the user experience. Worked for me with both local dev server and build/preview
