### PR TITLE
Retain client scripts in content cache

### DIFF
--- a/.changeset/wicked-dragons-draw.md
+++ b/.changeset/wicked-dragons-draw.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Retain client scripts in content cache

--- a/packages/astro/src/core/build/plugins/plugin-content.ts
+++ b/packages/astro/src/core/build/plugins/plugin-content.ts
@@ -255,6 +255,7 @@ function vitePluginContent(
 				...oldManifest.clientEntries,
 				...internals.discoveredHydratedComponents.keys(),
 				...internals.discoveredClientOnlyComponents.keys(),
+				...internals.discoveredScripts
 			]);
 			// Likewise, these are server modules that might not be referenced
 			// once the cached items are excluded from the build process

--- a/packages/astro/test/experimental-content-collections-render.test.js
+++ b/packages/astro/test/experimental-content-collections-render.test.js
@@ -136,6 +136,21 @@ if (!isWindows) {
 					const files = await fixture.readdir('');
 					assert.equal(files.includes('chunks'), false, 'chunks folder removed');
 				});
+
+				it('hoisted script is built', async () => {
+					const html = await fixture.readFile('/launch-week-component-scripts/index.html');
+					const $ = cheerio.load(html);
+
+					const allScripts = $('head > script[type="module"]');
+					assert.ok(allScripts.length > 0);
+
+					// Includes hoisted script
+					assert.notEqual(
+						[...allScripts].find((script) => $(script).attr('src')?.includes('/_astro/WithScripts')),
+						undefined,
+						'hoisted script missing from head.'
+					);
+				});
 			});
 		});
 	});


### PR DESCRIPTION
## Changes

- We keep track of client input in order to know what to build in future builds, but were not keeping client scripts (aka hydrated scripts) as part of that.

## Testing

- Not yet, trying a preview release first

## Docs

N/A, bug fix