### PR TITLE
fix: guard asset global usage

### DIFF
--- a/.changeset/gentle-moose-provide.md
+++ b/.changeset/gentle-moose-provide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Guard globalThis.astroAsset usage in proxy code to avoid errors in wonky situations

--- a/packages/astro/src/assets/utils/proxy.ts
+++ b/packages/astro/src/assets/utils/proxy.ts
@@ -13,7 +13,7 @@ export function getProxyCode(options: ImageMetadata, isSSR: boolean): string {
 							}
 							${
 								!isSSR
-									? `if (target[name] !== undefined) globalThis.astroAsset.referencedImages.add(${stringifiedFSPath});`
+									? `if (target[name] !== undefined && globalThis.astroAsset) globalThis.astroAsset?.referencedImages.add(${stringifiedFSPath});`
 									: ''
 							}
 							return target[name];


### PR DESCRIPTION
## Changes

The global is never supposed to be undefined here, but in some cases where you use code intended for the server on the client, or in some weird setups it can be. This doesn't *really* fix the issue, because well, you're still using the wrong code at the wrong place, but at least it won't fail on this cryptic error.

Does not exactly fix, but in my opinion, closes https://github.com/withastro/astro/issues/11042

## Testing

Tested manually

## Docs

N/A
