### PR TITLE
chore: enable @typescript-eslint/no-unused-vars internally

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,7 +62,7 @@ export default [
 			// These off/configured-differently-by-default rules fit well for us
 			'@typescript-eslint/switch-exhaustiveness-check': 'error',
 			'@typescript-eslint/no-unused-vars': [
-				'warn',
+				'error',
 				{
 					argsIgnorePattern: '^_',
 					varsIgnorePattern: '^_',

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -168,8 +168,6 @@ test.describe('View Transitions', () => {
 	});
 
 	test('Moving from a page without ViewTransitions w/ back button', async ({ page, astro }) => {
-		const loads = collectLoads(page);
-
 		// Go to page 1
 		await page.goto(astro.resolveUrl('/one'));
 		let p = page.locator('#one');

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -45,7 +45,7 @@ import type {
 	TransitionBeforePreparationEvent,
 	TransitionBeforeSwapEvent,
 } from '../transitions/events.js';
-import type { DeepPartial, OmitIndexSignature, Simplify, WithRequired } from '../type-utils.js';
+import type { DeepPartial, OmitIndexSignature, Simplify } from '../type-utils.js';
 import type { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from './../core/constants.js';
 
 export type { AstroIntegrationLogger, ToolbarServerHelpers };

--- a/packages/astro/src/actions/runtime/virtual/server.ts
+++ b/packages/astro/src/actions/runtime/virtual/server.ts
@@ -4,7 +4,6 @@ import { type MaybePromise } from '../utils.js';
 import {
 	ActionError,
 	ActionInputError,
-	type ErrorInferenceObject,
 	type SafeResult,
 	callSafely,
 } from './shared.js';
@@ -37,15 +36,12 @@ export type ActionClient<
 				input: TAccept extends 'form' ? FormData : z.input<TInputSchema>
 			) => Promise<
 				SafeResult<
-					z.input<TInputSchema> extends ErrorInferenceObject
-						? z.input<TInputSchema>
-						: ErrorInferenceObject,
 					Awaited<TOutput>
 				>
 			>;
 		}
 	: ((input?: any) => Promise<Awaited<TOutput>>) & {
-			safe: (input?: any) => Promise<SafeResult<never, Awaited<TOutput>>>;
+			safe: (input?: any) => Promise<SafeResult<Awaited<TOutput>>>;
 		};
 
 export function defineAction<

--- a/packages/astro/src/actions/runtime/virtual/shared.ts
+++ b/packages/astro/src/actions/runtime/virtual/shared.ts
@@ -42,7 +42,7 @@ const statusToCodeMap: Record<number, ActionErrorCode> = Object.entries(codeToSt
 
 export type ErrorInferenceObject = Record<string, any>;
 
-export class ActionError<T extends ErrorInferenceObject = ErrorInferenceObject> extends Error {
+export class ActionError extends Error {
 	type = 'AstroActionError';
 	code: ActionErrorCode = 'INTERNAL_SERVER_ERROR';
 	status = 500;
@@ -84,19 +84,19 @@ export class ActionError<T extends ErrorInferenceObject = ErrorInferenceObject> 
 }
 
 export function isInputError<T extends ErrorInferenceObject>(
-	error?: ActionError<T>
+	error?: ActionError
 ): error is ActionInputError<T> {
 	return error instanceof ActionInputError;
 }
 
-export type SafeResult<TInput extends ErrorInferenceObject, TOutput> =
+export type SafeResult<TOutput> =
 	| {
 			data: TOutput;
 			error: undefined;
 	  }
 	| {
 			data: undefined;
-			error: ActionError<TInput>;
+			error: ActionError;
 	  };
 
 export class ActionInputError<T extends ErrorInferenceObject> extends ActionError {
@@ -128,7 +128,7 @@ export class ActionInputError<T extends ErrorInferenceObject> extends ActionErro
 
 export async function callSafely<TOutput>(
 	handler: () => MaybePromise<TOutput>
-): Promise<SafeResult<z.ZodType, TOutput>> {
+): Promise<SafeResult<TOutput>> {
 	try {
 		const data = await handler();
 		return { data, error: undefined };

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -271,7 +271,7 @@ export class experimental_AstroContainer {
 	private static async createFromManifest(
 		manifest: SSRManifest
 	): Promise<experimental_AstroContainer> {
-		const config = await validateConfig(ASTRO_CONFIG_DEFAULTS, process.cwd(), 'container');
+		await validateConfig(ASTRO_CONFIG_DEFAULTS, process.cwd(), 'container');
 		const container = new experimental_AstroContainer({
 			manifest,
 		});

--- a/packages/astro/src/content/vite-plugin-content-assets.ts
+++ b/packages/astro/src/content/vite-plugin-content-assets.ts
@@ -1,6 +1,6 @@
 import { extname } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import type { Plugin, Rollup } from 'vite';
+import type { Plugin } from 'vite';
 import type { AstroSettings, SSRElement } from '../@types/astro.js';
 import { getAssetsPrefix } from '../assets/utils/getAssetsPrefix.js';
 import type { BuildInternals } from '../core/build/internal.js';
@@ -129,22 +129,9 @@ export function astroConfigBuildPlugin(
 	options: StaticBuildOptions,
 	internals: BuildInternals
 ): AstroBuildPlugin {
-	let ssrPluginContext: Rollup.PluginContext | undefined = undefined;
 	return {
 		targets: ['server'],
 		hooks: {
-			'build:before': ({ target }) => {
-				return {
-					vitePlugin: {
-						name: 'astro:content-build-plugin',
-						generateBundle() {
-							if (target === 'server') {
-								ssrPluginContext = this;
-							}
-						},
-					},
-				};
-			},
 			'build:post': ({ ssrOutputs, clientOutputs, mutate }) => {
 				const outputs = ssrOutputs.flatMap((o) => o.output);
 				const prependBase = (src: string) => {
@@ -232,8 +219,6 @@ export function astroConfigBuildPlugin(
 						mutate(chunk, ['server'], newCode);
 					}
 				}
-
-				ssrPluginContext = undefined;
 			},
 		},
 	};

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -44,8 +44,6 @@ import { getOutputFilename, isServerLikeOutput } from '../util.js';
 import { getOutDirWithinCwd, getOutFile, getOutFolder } from './common.js';
 import { cssOrder, mergeInlineCss } from './internal.js';
 import { BuildPipeline } from './pipeline.js';
-import { ASTRO_PAGE_MODULE_ID } from './plugins/plugin-pages.js';
-import { getVirtualModulePageName } from './plugins/util.js';
 import type {
 	PageBuildData,
 	SinglePageBuiltModule,
@@ -200,7 +198,7 @@ async function generatePage(
 	pipeline: BuildPipeline
 ) {
 	// prepare information we need
-	const { config, internals, logger } = pipeline;
+	const { config, logger } = pipeline;
 	const pageModulePromise = ssrEntry.page;
 
 	// Calculate information of the page, like scripts, links and styles

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -660,7 +660,7 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 				'The value of `outDir` must not point to a path within the folder set as `publicDir`, this will cause an infinite loop',
 		})
 		.superRefine((configuration, ctx) => {
-			const { site, experimental, i18n, output } = configuration;
+			const { site, i18n, output } = configuration;
 			const hasDomains = i18n?.domains ? Object.keys(i18n.domains).length > 0 : false;
 			if (hasDomains) {
 				if (!site) {

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -125,12 +125,6 @@ const a11y_required_content = [
 
 const a11y_distracting_elements = ['blink', 'marquee'];
 
-// Unused for now
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const a11y_nested_implicit_semantics = new Map([
-	['header', 'banner'],
-	['footer', 'contentinfo'],
-]);
 const a11y_implicit_semantics = new Map([
 	['a', 'link'],
 	['area', 'link'],
@@ -621,19 +615,6 @@ export const a11y: AuditRuleWithSelector[] = [
 			if (!ariaRoles.has(role)) return true;
 		},
 	},
-];
-
-// Unused for now
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const a11y_labelable = [
-	'button',
-	'input',
-	'keygen',
-	'meter',
-	'output',
-	'progress',
-	'select',
-	'textarea',
 ];
 
 /**

--- a/packages/astro/src/runtime/server/render/astro/instance.ts
+++ b/packages/astro/src/runtime/server/render/astro/instance.ts
@@ -1,6 +1,6 @@
 import type { SSRResult } from '../../../../@types/astro.js';
 import type { ComponentSlots } from '../slot.js';
-import type { AstroComponentFactory, AstroFactoryReturnValue } from './factory.js';
+import type { AstroComponentFactory } from './factory.js';
 
 import { isPromise } from '../../util.js';
 import { renderChild } from '../any.js';

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -1,13 +1,5 @@
-import type { TransitionBeforePreparationEvent, TransitionBeforeSwapEvent } from './events.js';
+import type { TransitionBeforePreparationEvent } from './events.js';
 import { TRANSITION_AFTER_SWAP, doPreparation, doSwap } from './events.js';
-import {
-	deselectScripts,
-	restoreFocus,
-	saveFocus,
-	swapBodyElement,
-	swapHeadElements,
-	swapRootAttributes,
-} from './swap-functions.js';
 import type { Direction, Fallback, Options } from './types.js';
 
 type State = {

--- a/packages/astro/test/reuse-injected-entrypoint.test.js
+++ b/packages/astro/test/reuse-injected-entrypoint.test.js
@@ -106,8 +106,6 @@ describe('Reuse injected entrypoint', () => {
 		});
 
 		routes.forEach(({ description, url, fourOhFour, h1, p, htmlMatch }) => {
-			const isEndpoint = htmlMatch && !h1 && !p;
-
 			// checks URLs as written above
 			it(description, async () => {
 				const html = await fixture.fetch(url).then((res) => res.text());

--- a/packages/astro/test/rewrite.test.js
+++ b/packages/astro/test/rewrite.test.js
@@ -112,7 +112,7 @@ describe('Build reroute', () => {
 
 	it('should render the 404 built-in page', async () => {
 		try {
-			const html = await fixture.readFile('/spread/oops/index.html');
+			await fixture.readFile('/spread/oops/index.html');
 			assert.fail('Not found');
 		} catch {
 			assert.ok;

--- a/packages/integrations/sitemap/src/utils/is-valid-url.ts
+++ b/packages/integrations/sitemap/src/utils/is-valid-url.ts
@@ -4,8 +4,7 @@ export const isValidUrl = (s: any) => {
 		return false;
 	}
 	try {
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const dummy = new URL(s);
+		new URL(s);
 		return true;
 	} catch {
 		return false;


### PR DESCRIPTION
## Changes

> _(please forgive me for wiping the template for this internal-only chore)_

Upgrades `@typescript-eslint/no-unused-vars` from `'warn'` to `'error'` in the ESLint config, then resolves the roughly 20 complaints that were hanging around from it. It's a nice amount of deletions, I think. 🙂 

I don't believe any of the changed types impact users. But just to be safe, added comments inline.