### PR TITLE
feat: add first and last to the Page interface

### DIFF
--- a/.changeset/twenty-maps-glow.md
+++ b/.changeset/twenty-maps-glow.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+feat: Add urls to the first and the last page in the Page interface

--- a/.changeset/twenty-maps-glow.md
+++ b/.changeset/twenty-maps-glow.md
@@ -2,4 +2,4 @@
 'astro': minor
 ---
 
-feat: Add urls to the first and the last page in the Page interface
+Adds two new values to the [pagination `page` prop](https://docs.astro.build/en/reference/api-reference/#the-pagination-page-prop): `page.first` and `page.last` for accessing the URLs of the first and last pages.

--- a/.changeset/twenty-maps-glow.md
+++ b/.changeset/twenty-maps-glow.md
@@ -1,5 +1,5 @@
 ---
-'astro': major
+'astro': minor
 ---
 
 feat: Add urls to the first and the last page in the Page interface

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2498,6 +2498,10 @@ export interface Page<T = any> {
 		prev: string | undefined;
 		/** url of the next page (if there is one) */
 		next: string | undefined;
+		/** url of the first page (if the current page is not the first page) */
+		first: string | undefined;
+		/** url of the next page (if the current page in not the last page) */
+		last: string | undefined;
 	};
 }
 

--- a/packages/astro/src/core/render/paginate.ts
+++ b/packages/astro/src/core/render/paginate.ts
@@ -56,6 +56,19 @@ export function generatePaginateFunction(
 									!includesFirstPageNumber && pageNum - 1 === 1 ? undefined : String(pageNum - 1),
 							})
 						);
+			const first =
+				pageNum === 1
+					? undefined
+					: correctIndexRoute(
+							routeMatch.generate({
+								...params,
+								page: includesFirstPageNumber? "1": undefined,
+							})
+					);
+			const last =
+					pageNum === lastPage
+					? undefined
+					: correctIndexRoute(routeMatch.generate({ ...params, page: String(lastPage)}));
 			return {
 				params,
 				props: {
@@ -68,7 +81,7 @@ export function generatePaginateFunction(
 						total: data.length,
 						currentPage: pageNum,
 						lastPage: lastPage,
-						url: { current, next, prev },
+						url: { current, next, prev, first, last },
 					} as Page,
 				},
 			};


### PR DESCRIPTION
## Changes

Add `page.url.first`, `page.url.last` to the Page interface.
Closes https://github.com/withastro/roadmap/discussions/862

## Testing
I couldn't find relevant tests for `page.url`. Let me know if there is one already.

## Docs
This needs to be updated
https://github.com/withastro/docs/blob/main/src/content/docs/en/guides/routing.mdx#complete-api-reference

/cc @withastro/maintainers-docs for feedback!

