### PR TITLE
fix: better isPromise check for proxy objects

### DIFF
--- a/.changeset/green-moose-fetch.md
+++ b/.changeset/green-moose-fetch.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves `isPromise` utility to check the presence of `then` on an object before trying to access it - which can cause undesired side-effects on Proxy objects

--- a/packages/astro/src/runtime/server/util.ts
+++ b/packages/astro/src/runtime/server/util.ts
@@ -1,5 +1,5 @@
 export function isPromise<T = any>(value: any): value is Promise<T> {
-	return !!value && typeof value === 'object' && typeof value.then === 'function';
+	return !!value && typeof value === 'object' && 'then' in value && typeof value.then === 'function';
 }
 
 export async function* streamAsyncIterator(stream: ReadableStream) {


### PR DESCRIPTION
## Changes

Adjusts the `isPromise` utility to first check for the presence of the `'then'` key before accessing it to check the type.

The absence of this check on a Proxy object was causing an error to be thrown  - as my Proxy object throws on access of an unknown keys.

## Testing

This should be a totally transparent change, and not quite worth setting up a test IMO.
Note that a few tests were failing for me locally, but they are failing on main as well, so seem to be unrelated.

## Docs

N/A - This should hopefully be a totally transparent change that affects nothing other than this very specific error scenario.