### PR TITLE
fix(cli): Suggest `pnpm dlx` instead of `pnpx`

### DIFF
--- a/.changeset/purple-pears-divide.md
+++ b/.changeset/purple-pears-divide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Suggest `pnpm dlx` instead of `pnpx` in update check.

--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -99,7 +99,7 @@ function getInstallCommand(packages: string[], packageManager: string) {
 }
 
 /**
- * Get the command to execute and download a package (e.g. `npx`, `yarn dlx`, `pnpx`, etc.)
+ * Get the command to execute and download a package (e.g. `npx`, `yarn dlx`, `pnpm dlx`, etc.)
  * @param packageManager - Optional package manager to use. If not provided, Astro will attempt to detect the preferred package manager.
  * @returns The command to execute and download a package
  */
@@ -114,7 +114,7 @@ export async function getExecCommand(packageManager?: string): Promise<string> {
 		case 'yarn':
 			return 'yarn dlx';
 		case 'pnpm':
-			return 'pnpx';
+			return 'pnpm dlx';
 		case 'bun':
 			return 'bunx';
 		default:


### PR DESCRIPTION

## Changes

- pnpx was removed in pnpm v7 and replaced by pnpm exec and pnpm dlx. (pnpm/pnpm#3652)
- pnpm dlx works the same as yarn dlx.
- Astro update check's command sample should suggest `pnpm dlx`

Before:
```
 update  ▶ New version of Astro available: 4.9.2
  Run pnpx @astrojs/upgrade to update
```

After:
```
 update  ▶ New version of Astro available: 4.9.2
  Run pnpm dlx @astrojs/upgrade to update
```

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
N/A

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A
