### PR TITLE
Fix redirect logic to be able to handle dynamic parts in target paths

### DIFF
--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -1,4 +1,3 @@
-import { posix } from 'node:path';
 import type {
 	AstroRenderer,
 	AstroUserConfig,
@@ -15,9 +14,8 @@ import { validateConfig } from '../core/config/config.js';
 import { ASTRO_CONFIG_DEFAULTS } from '../core/config/schema.js';
 import { Logger } from '../core/logger/core.js';
 import { nodeLogDestination } from '../core/logger/node.js';
-import { removeLeadingForwardSlash } from '../core/path.js';
 import { RenderContext } from '../core/render-context.js';
-import { getParts, getPattern, validateSegment } from '../core/routing/manifest/create.js';
+import { getSegmentsFromRoutePath, getPattern } from '../core/routing/manifest/create.js';
 import type { AstroComponentFactory } from '../runtime/server/index.js';
 import { ContainerPipeline } from './pipeline.js';
 
@@ -387,13 +385,7 @@ export class experimental_AstroContainer {
 	}
 
 	#createRoute(url: URL, params: Record<string, string | undefined>, type: RouteType): RouteData {
-		const segments = removeLeadingForwardSlash(url.pathname)
-			.split(posix.sep)
-			.filter(Boolean)
-			.map((s: string) => {
-				validateSegment(s);
-				return getParts(s, url.pathname);
-			});
+		const segments = getSegmentsFromRoutePath(url.pathname);
 		return {
 			route: url.pathname,
 			component: '',

--- a/packages/astro/src/core/app/common.ts
+++ b/packages/astro/src/core/app/common.ts
@@ -1,5 +1,6 @@
 import { deserializeRouteData } from '../routing/manifest/serialization.js';
 import type { RouteInfo, SSRManifest, SerializedSSRManifest } from './types.js';
+export { getSegmentsFromRoutePath } from '../routing/manifest/create.js'
 
 export function deserializeManifest(serializedManifest: SerializedSSRManifest): SSRManifest {
 	const routes: RouteInfo[] = [];

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -25,7 +25,7 @@ import { ensure404Route } from '../routing/astro-designed-error-pages.js';
 import { matchRoute } from '../routing/match.js';
 import { createOriginCheckMiddleware } from './middlewares.js';
 import { AppPipeline } from './pipeline.js';
-export { deserializeManifest } from './common.js';
+export { deserializeManifest, getSegmentsFromRoutePath } from './common.js';
 
 export interface RenderOptions {
 	/**

--- a/packages/astro/src/core/routing/index.ts
+++ b/packages/astro/src/core/routing/index.ts
@@ -1,4 +1,4 @@
-export { createRouteManifest } from './manifest/create.js';
+export { createRouteManifest, getSegmentsFromRoutePath } from './manifest/create.js';
 export { deserializeRouteData, serializeRouteData } from './manifest/serialization.js';
 export { matchAllRoutes, matchRoute } from './match.js';
 export { validateDynamicRouteModule, validateGetStaticPathsResult } from './validation.js';

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -140,6 +140,16 @@ export function validateSegment(segment: string, file = '') {
 	}
 }
 
+export function getSegmentsFromRoutePath(routePath: string, file = routePath) {
+	return removeLeadingForwardSlash(routePath)
+		.split(path.posix.sep)
+		.filter(Boolean)
+		.map((s: string) => {
+			validateSegment(s);
+			return getParts(s, file);
+		});
+}
+
 /**
  * Checks whether two route segments are semantically equivalent.
  *
@@ -350,13 +360,7 @@ function createInjectedRoutes({ settings, cwd }: CreateRouteManifestParams): Pri
 		}
 		const component = slash(path.relative(cwd || fileURLToPath(config.root), resolved));
 
-		const segments = removeLeadingForwardSlash(name)
-			.split(path.posix.sep)
-			.filter(Boolean)
-			.map((s: string) => {
-				validateSegment(s);
-				return getParts(s, component);
-			});
+		const segments = getSegmentsFromRoutePath(name, component);
 
 		const type = resolved.endsWith('.astro') ? 'page' : 'endpoint';
 		const isPage = type === 'page';
@@ -410,14 +414,7 @@ function createRedirectRoutes(
 
 	const priority = computeRoutePriority(settings.config);
 	for (const [from, to] of Object.entries(settings.config.redirects)) {
-		const segments = removeLeadingForwardSlash(from)
-			.split(path.posix.sep)
-			.filter(Boolean)
-			.map((s: string) => {
-				validateSegment(s);
-				return getParts(s, from);
-			});
-
+		const segments = getSegmentsFromRoutePath(from);
 		const pattern = getPattern(segments, settings.config.base, trailingSlash);
 		const generate = getRouteGenerator(segments, trailingSlash);
 		const pathname = segments.every((segment) => segment.length === 1 && !segment[0].dynamic)
@@ -443,6 +440,16 @@ function createRedirectRoutes(
 			);
 		}
 
+		const redirectRoute =
+			routeMap.get(destination) ??
+			[...routeMap.values()]
+				.sort(routeComparator)
+				.find(
+					(route) =>
+						route.pattern.test(destination) ||
+						route.fallbackRoutes.some((fallbackRoute) => fallbackRoute.pattern.test(destination))
+				);
+
 		routes[priority].push({
 			type: 'redirect',
 			// For backwards compatibility, a redirect is never considered an index route.
@@ -456,7 +463,7 @@ function createRedirectRoutes(
 			pathname: pathname || void 0,
 			prerender: false,
 			redirect: to,
-			redirectRoute: routeMap.get(destination),
+			redirectRoute,
 			fallbackRoutes: [],
 		});
 	}
@@ -673,14 +680,7 @@ export function createRouteManifest(
 					const pathname = '/';
 					const route = '/';
 
-					const segments = removeLeadingForwardSlash(route)
-						.split(path.posix.sep)
-						.filter(Boolean)
-						.map((s: string) => {
-							validateSegment(s);
-							return getParts(s, route);
-						});
-
+					const segments = getSegmentsFromRoutePath(route);
 					routes.push({
 						...indexDefaultRoute,
 						pathname,
@@ -747,13 +747,7 @@ export function createRouteManifest(
 									.replace(`/${fallbackToLocale}`, `/${fallbackFromLocale}`)
 									.replace(`/${fallbackToLocale}/`, `/${fallbackFromLocale}/`);
 							}
-							const segments = removeLeadingForwardSlash(route)
-								.split(path.posix.sep)
-								.filter(Boolean)
-								.map((s: string) => {
-									validateSegment(s);
-									return getParts(s, route);
-								});
+							const segments = getSegmentsFromRoutePath(route);
 							const generate = getRouteGenerator(segments, config.trailingSlash);
 							const index = routes.findIndex((r) => r === fallbackToRoute);
 							if (index >= 0) {

--- a/packages/astro/test/units/routing/manifest.test.js
+++ b/packages/astro/test/units/routing/manifest.test.js
@@ -527,6 +527,102 @@ describe('routing - createRouteManifest', () => {
 		]);
 	});
 
+	it('redirect routes target params should exist in old route', async () => {
+		const fs = createFs(
+			{
+				'/src/pages/[category]/page/[page].astro': `<h1>test</h1>`,
+				'/src/pages/[category]/[...slug].astro': `<h1>test</h1>`,
+			},
+			root
+		);
+		async function createWithRedirect(redirects) {
+			const settings = await createBasicSettings({
+				root: fileURLToPath(root),
+				output: 'server',
+				base: '/blog',
+				trailingSlash: 'never',
+				redirects,
+				integrations: [],
+				experimental: {
+					globalRoutePriority: true,
+				},
+			});
+			return createRouteManifest({
+				cwd: fileURLToPath(root),
+				settings,
+				fsMod: fs,
+			});
+		}
+
+		await assert.rejects(
+			async () =>
+				await createWithRedirect({
+					'/[category]': '/[category]/page/[page]',
+				}),
+			(err) => {
+				assert.match(err.message, /Parameter \[page\] must also be present in the old route/);
+				return true;
+			}
+		);
+
+		await assert.rejects(
+			async () =>
+				await createWithRedirect({
+					'/[category]': '/[category]/page/[...slug]',
+				}),
+			(err) => {
+				assert.match(err.message, /Parameter \[\.{3}slug\] must also be present in the old route/);
+				return true;
+			}
+		);
+
+		const omitDynamicManifest = await createWithRedirect({
+			'/[category]/old/[omit]': '/[category]/page/1',
+		});
+
+		assert.deepEqual(getManifestRoutes(omitDynamicManifest, true), [
+			{
+				route: '/[category]/old/[omit]',
+				type: 'redirect',
+				redirectRoute: omitDynamicManifest.routes.find(
+					(route) => route.route === '/[category]/page/[page]'
+				),
+			},
+			{
+				redirectRoute: undefined,
+				route: '/[category]/page/[page]',
+				type: 'page',
+			},
+			{
+				redirectRoute: undefined,
+				route: '/[category]/[...slug]',
+				type: 'page',
+			},
+		]);
+
+		const omitSlug = await createWithRedirect({
+			'/[category]/old/[...omit]': '/[category]/page/1',
+		});
+
+		assert.deepEqual(getManifestRoutes(omitSlug, true), [
+			{
+				route: '/[category]/old/[...omit]',
+				type: 'redirect',
+				redirectRoute: omitSlug.routes.find((route) => route.route === '/[category]/page/[page]'),
+			},
+			{
+				redirectRoute: undefined,
+				route: '/[category]/page/[page]',
+				type: 'page',
+			},
+			{
+				redirectRoute: undefined,
+				route: '/[category]/[...slug]',
+				type: 'page',
+			},
+		]);
+	});
+
 	it('report colliding static routes', async () => {
 		const fs = createFs(
 			{

--- a/packages/underscore-redirects/test/astro.test.js
+++ b/packages/underscore-redirects/test/astro.test.js
@@ -29,4 +29,282 @@ describe('Astro', () => {
 
 		assert.equal(_redirects.definitions.length, 2);
 	});
+
+	describe('Supports dynamic routes', () => {
+		it('Supports renaming static parts: /old/[foo] -> /new/[foo]', () => {
+			const routeToDynamicTargetMap = new Map(
+				Array.from([
+					[
+						{
+							
+							route: '/old/[foo]',
+							segments: [
+								[{ content: 'old', dynamic: false, spread: false }],
+								[{ content: 'foo', dynamic: true, spread: false }],
+							],
+							redirect: '/new/[foo]',
+							redirectRoute: {
+								distURL: new URL('./index.html', import.meta.url),
+								segments: [
+									[{ content: 'new', dynamic: false, spread: false }],
+									[{ content: 'foo', dynamic: true, spread: false }],
+								],
+							},
+						},
+						'./.adapter/dist/entry.mjs',
+					],
+				])
+			);
+			const _redirects = createRedirectsFromAstroRoutes({
+				config: serverConfig,
+				routeToDynamicTargetMap,
+				dir: new URL(import.meta.url),
+			});
+			assert.deepEqual(_redirects.definitions,[
+				{
+					dynamic: true,
+					input: '/old/:foo',
+					target: '/new/:foo/index.html',
+					status: 200,
+					weight: 1
+				}
+			]);
+		});
+
+		it('Supports removing dynamic params: /old/[omit] -> /new', () => {
+			const routeToDynamicTargetMap = new Map(
+				Array.from([
+					[
+						{
+							route: '/old/[omit]',
+							segments: [[{ content: 'old', dynamic: false, spread: false }],
+							[{ content: 'omit', dynamic: true, spread: false }]],
+							redirect: '/new',
+							
+							redirectRoute: {
+								distURL: new URL('./index.html', import.meta.url),
+								segments: [[{ content: 'new', dynamic: false, spread: false }]],
+							},
+							
+						},
+						'./.adapter/dist/entry.mjs',
+					],
+				])
+			);
+			const _redirects = createRedirectsFromAstroRoutes({
+				config: serverConfig,
+				routeToDynamicTargetMap,
+				dir: new URL(import.meta.url),
+			});
+
+			assert.deepEqual(_redirects.definitions,[
+				{
+					dynamic: true,
+					input: '/old/:omit',
+					target: '/new/index.html',
+					status: 200,
+					weight: 1
+				}
+			]);
+		});
+
+		it('Supports mapping dynamic params to a static value: /old/[foo]/ -> /new/1', () => {
+			const routeToDynamicTargetMap = new Map(
+				Array.from([
+					[
+						{
+							route: '/old/[foo]',
+							segments: [
+								[{ content: 'old', dynamic: false, spread: false }],
+								[{ content: 'foo', dynamic: true, spread: false }],
+							],
+							redirect: '/foo/1',
+							redirectRoute: {
+								distURL: new URL('./index.html', import.meta.url),
+								segments: [
+									[{ content: 'new', dynamic: false, spread: false }],
+									[{ content: 'foo', dynamic: true, spread: false }],
+								],
+							},
+						},
+						'./.adapter/dist/entry.mjs',
+					],
+				])
+			);
+			const _redirects = createRedirectsFromAstroRoutes({
+				config: serverConfig,
+				routeToDynamicTargetMap,
+				dir: new URL(import.meta.url),
+			});
+
+			assert.deepEqual(_redirects.definitions,[
+				{
+					dynamic: true,
+					input: '/old/:foo',
+					target: '/foo/1/index.html',
+					status: 200,
+					weight: 1
+				}
+			]);
+		});
+
+
+	});
+
+	describe('Supports spread routes', () => {
+		it('Supports renaming static parts: /old/[...bar] -> /new/[...bar]', () => {
+			const routeToDynamicTargetMap = new Map(
+				Array.from([
+					[
+						{
+							route: '/old/[...bar]',
+							segments: [
+								[{ content: 'old', dynamic: false, spread: false }],
+								[{ content: 'bar', dynamic: true, spread: true }],
+							],
+							redirect: '/new/[...bar]',
+							redirectRoute: {
+								distURL: new URL('./index.html', import.meta.url),
+								segments: [
+									[{ content: 'new', dynamic: false, spread: false }],
+									[{ content: 'bar', dynamic: true, spread: true }],
+								],
+							},
+						},
+						'./.adapter/dist/entry.mjs',
+					],
+				])
+			);
+			const _redirects = createRedirectsFromAstroRoutes({
+				config: serverConfig,
+				routeToDynamicTargetMap,
+				dir: new URL(import.meta.url),
+			});
+
+
+			assert.deepEqual(_redirects.definitions, [
+				{
+					dynamic: true,
+					input: '/old/*',
+					target: '/new/:splat/index.html',
+					status: 200,
+					weight: 1
+				}
+			]);
+		});
+
+		it('Supports removing spread params: /old/[...bar] -> /new', () => {
+			const routeToDynamicTargetMap = new Map(
+				Array.from([
+					[
+						{
+							route: '/old/[...bar]',
+							segments: [
+								[{ content: 'old', dynamic: false, spread: false }],
+								[{ content: 'bar', dynamic: true, spread: true }],
+							],
+							redirect: '/new',
+							redirectRoute: {
+								distURL: new URL('./index.html', import.meta.url),
+								segments: [
+									[{ content: 'new', dynamic: false, spread: false }],
+								],
+							},
+						},
+						'./.adapter/dist/entry.mjs',
+					],
+				])
+			);
+			const _redirects = createRedirectsFromAstroRoutes({
+				config: serverConfig,
+				routeToDynamicTargetMap,
+				dir: new URL(import.meta.url),
+			});
+
+
+			assert.deepEqual(_redirects.definitions, [{
+				dynamic: true,
+				input: '/old/*',
+				target: '/new/index.html',
+				status: 200,
+				weight: 1
+			}]);
+		});
+
+		it('Supports mapping spread params to a static value: /old/[...bar] -> /new/1', () => {
+			const routeToDynamicTargetMap = new Map(
+				Array.from([
+					[
+						{
+							route: '/old/[...bar]',
+							segments: [
+								[{ content: 'old', dynamic: false, spread: false }],
+								[{ content: 'bar', dynamic: true, spread: true }],
+							],
+							redirect: '/new/1',
+							redirectRoute: {
+								distURL: new URL('./index.html', import.meta.url),
+								segments: [
+									[{ content: 'new', dynamic: false, spread: false }],
+									[{ content: 'bar', dynamic: true, spread: true }],
+								],
+							},
+						},
+						'./.adapter/dist/entry.mjs',
+					],
+				])
+			);
+			const _redirects = createRedirectsFromAstroRoutes({
+				config: serverConfig,
+				routeToDynamicTargetMap,
+				dir: new URL(import.meta.url),
+			});
+
+			assert.deepEqual(_redirects.definitions, [{
+				dynamic: true,
+				input: '/old/*',
+				target: '/new/1/index.html',
+				status: 200,
+				weight: 1
+			}]);
+		});
+
+		it('Supports appending spread params with a static value: /old/[...bar] -> /new/[...bar]/1', () => {
+			const routeToDynamicTargetMap = new Map(
+				Array.from([
+					[
+						{
+							route: '/old/[...bar]',
+							segments: [
+								[{ content: 'old', dynamic: false, spread: false }],
+								[{ content: 'bar', dynamic: true, spread: true }],
+							],
+							redirect: '/new/[...bar]/1',
+							redirectRoute: {
+								distURL: new URL('./index.html', import.meta.url),
+								segments: [
+									[{ content: 'new', dynamic: false, spread: false }],
+									[{ content: 'bar', dynamic: true, spread: true }],
+								],
+							},
+						},
+						'./.adapter/dist/entry.mjs',
+					],
+				])
+			);
+			const _redirects = createRedirectsFromAstroRoutes({
+				config: serverConfig,
+				routeToDynamicTargetMap,
+				dir: new URL(import.meta.url),
+			});
+
+			assert.deepEqual(_redirects.definitions, [{
+				dynamic: true,
+				input: '/old/*',
+				target: '/new/:splat/1/index.html',
+				status: 200,
+				weight: 1
+			}]);
+		})
+	})
 });


### PR DESCRIPTION
## Context
There are a few related changes in this PR, but this was the use case I was trying to fix:
`[category]/page/[page].astro` is the route handler for `myCategory/page/1`.
 
I'm trying to redirect from `/[category]` to `/[category]/page/1`. Right now, since there's no RouteData with key `/[category]/page/1` in the manifest, my redirect target falls back to the server-rendered path, which in my case for cloudflare, is the [empty string ''](https://github.com/withastro/adapters/blob/be0b27de38418330898205d506fad87b7da563be/packages/cloudflare/src/index.ts#L378), causing the entry in `_redirect` to be invalid. The line that gets generated is `/:category   301`

There *is* however, a RouteData in the manifest that's able to handle this path, so it should resolve that route at the key `/[category]/page/[page]`.

## Changes
1. Adds validation for the target such that target params should also be in source params, as per the current docs
2. Resolve partially static redirect target paths to their route handler during manifest creation
3. Fix `underscore-redirect` to generate the right _redirect for targets with dynamic parts

This should allow [this comment](https://github.com/withastro/adapters/blob/be0b27de38418330898205d506fad87b7da563be/packages/netlify/src/index.ts#L198) and hack to be removed 

## Questions
Are there edge cases that I'm missing? Its not clear to me if this is actually a backwards compatible change. It feels like my changes align with what the code is *supposed* to do, but this might break some folks?

## Testing

Added test for each of the 3 cases above that did not exist before.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs Not sure if we need to add more docs around what is permissible in the redirect config, but this really threw me off guard that I couldn't do what I thought I was able to do. 


<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
