### PR TITLE
[docs] formatting for astro:env

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2104,9 +2104,9 @@ export interface AstroUserConfig {
 		 * })
 		 * ```
 		 *
-		 * There are currently 3 data types supported: strings, numbers and booleans.
+		 * There are currently three data types supported: strings, numbers and booleans.
 		 *
-		 * There are three kinds of variables, determined by the combination of `context` (`client` or `server`) and `access` (`private` or `public`) settings defined in your [`env.schema`](#experimentalenvschema):
+		 * There are three kinds of environment variables, determined by the combination of `context` (client or server) and `access` (private or public) settings defined in your [`env.schema`](#experimentalenvschema):
 		 *
 		 * - **Public client variables**: These variables end up in both your final client and server bundles, and can be accessed from both client and server through the `astro:env/client` module:
 		 *
@@ -2137,6 +2137,7 @@ export interface AstroUserConfig {
 			/**
 			 * @docs
 			 * @name experimental.env.schema
+		   * @kind h4
 			 * @type {EnvSchema}
 			 * @default `undefined`
 			 * @version 4.10.0


### PR DESCRIPTION
## Changes

Updates some formatting for the `astro:env` experimental docs in config reference

## Testing

no tests, docs.

## Docs

just docs!
