### PR TITLE
[docs] format error messages

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1234,18 +1234,18 @@ export const EnvInvalidVariable = {
 /**
  * @docs
  * @description
- * "astro:env/server" exported function "getSecret" is not supported by your adapter..
+ * The `astro:env/server` exported function `getSecret()` is not supported by your adapter.
  */
 export const EnvUnsupportedGetSecret = {
 	name: 'EnvUnsupportedGetSecret',
 	title: 'Unsupported astro:env getSecret',
-	message: '"astro:env/server" exported function "getSecret" is not supported by your adapter.',
+	message: '\`astro:env/server\` exported function \`getSecret\` is not supported by your adapter.',
 } satisfies ErrorData;
 
 /**
  * @docs
  * @description
- * Module is only available server-side
+ * This module is only available server-side.
  */
 export const ServerOnlyModule = {
 	name: 'ServerOnlyModule',


### PR DESCRIPTION
## Changes

This fixes a typo and some formatting for astro:env error messages

## Testing

no tests, docs.

## Docs

only docs!
