### PR TITLE
Make Astro.url in format: 'preserve' match dev

### DIFF
--- a/.changeset/sweet-trainers-eat.md
+++ b/.changeset/sweet-trainers-eat.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes a case where `Astro.url` would be incorrect when having `build.format` set to `'preserve'` in the Astro config

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -381,7 +381,19 @@ function getUrlForPath(
 	 * pathname: /, /foo
 	 * base: /
 	 */
-	const ending = format === 'directory' ? (trailingSlash === 'never' ? '' : '/') : '.html';
+
+	let ending: string;
+	switch(format) {
+		case 'directory':
+		case 'preserve': {
+			ending = trailingSlash === 'never' ? '' : '/';
+			break;
+		}
+		default: {
+			ending = '.html';
+			break;
+		}
+	}
 	let buildPathname: string;
 	if (pathname === '/' || pathname === '') {
 		buildPathname = base;

--- a/packages/astro/test/fixtures/page-format/src/pages/nested/index.astro
+++ b/packages/astro/test/fixtures/page-format/src/pages/nested/index.astro
@@ -1,8 +1,12 @@
+---
+const url = Astro.url;
+---
 <html>
 	<head>
 		<title>Testing</title>
 	</head>
 	<body>
 		<h1>Testing</h1>
+		<h2>{url.pathname}</h2>
 	</body>
 </html>

--- a/packages/astro/test/page-format.test.js
+++ b/packages/astro/test/page-format.test.js
@@ -51,7 +51,35 @@ describe('build.format', () => {
 		});
 	});
 
-	describe('preserve', () => {
+	describe('preserve - i18n', () => {
+		/** @type {import('./test-utils').Fixture} */
+		let fixture;
+		before(async () => {
+			fixture = await loadFixture({
+				base: '/test',
+				root: './fixtures/page-format/',
+				trailingSlash: 'always',
+				build: {
+					format: 'preserve',
+				},
+			});
+		});
+
+		describe('Build', () => {
+			before(async () => {
+				await fixture.build();
+			});
+
+			it('Astro.url points to right file', async () => {
+				let html = await fixture.readFile('/nested/index.html');
+				let $ = cheerio.load(html);
+				console.log(html);
+				assert.equal($('h2').text(), '/test/nested/');
+			});
+		});
+	});
+
+	describe('preserve - i18n', () => {
 		/** @type {import('./test-utils').Fixture} */
 		let fixture;
 		before(async () => {
@@ -81,7 +109,7 @@ describe('build.format', () => {
 			it('relative urls created point to sibling folders', async () => {
 				let html = await fixture.readFile('/en/nested/page.html');
 				let $ = cheerio.load(html);
-				assert.equal($('#another').attr('href'), '/test/en/nested/another/');
+				assert.equal($('#another').attr('href'), '/test/en/nested/page/another/');
 			});
 
 			it('index files are written as index.html', async () => {


### PR DESCRIPTION
## Changes

- Updates `Astro.url` in generated pages with `format: 'preserve'` so that it is *not* treated like format: file which removes `index`. Instead it behaves like `format: 'directory'`, directories exist and get the same trailingSlash behavior.
- Fixes https://github.com/withastro/astro/issues/11107

## Testing

- Added a test
- Updated an old one with wrong assumption

## Docs

N/A, bug fix