### PR TITLE
fix: merge userConfig inside `getViteConfig`

### DIFF
--- a/.changeset/tidy-days-decide.md
+++ b/.changeset/tidy-days-decide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where the function `getViteConfig` wasn't returning the correct merged Astro configuration

--- a/packages/astro/src/config/index.ts
+++ b/packages/astro/src/config/index.ts
@@ -34,7 +34,7 @@ export function getViteConfig(inlineConfig: UserConfig, inlineAstroConfig: Astro
 			dest: nodeLogDestination,
 			level: 'info',
 		});
-		const { astroConfig: config } = await resolveConfig(inlineAstroConfig, cmd);
+		const { astroConfig: config, userConfig } = await resolveConfig(inlineAstroConfig, cmd);
 		let settings = await createSettings(config, inlineConfig.root);
 		settings = await runHookConfigSetup({ settings, command: cmd, logger });
 		const viteConfig = await createVite(
@@ -48,6 +48,6 @@ export function getViteConfig(inlineConfig: UserConfig, inlineAstroConfig: Astro
 			{ settings, logger, mode }
 		);
 		await runHookConfigDone({ settings, logger });
-		return mergeConfig(viteConfig, inlineConfig);
+		return mergeConfig(viteConfig, userConfig);
 	};
 }

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -199,5 +199,5 @@ export async function resolveConfig(
 	const mergedConfig = mergeConfig(userConfig, inlineUserConfig);
 	const astroConfig = await validateConfig(mergedConfig, root, command);
 
-	return { userConfig, astroConfig };
+	return { userConfig: mergedConfig, astroConfig };
 }


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/11175

The were a bug where we were merging `inlineConfig` and `userConfig`, but at end we were not using the merged config anymore other than creating the `AstroConfig`.

That `AstroConfig` is used to create `AstroSettings`, but when returning the vite config, we only use `inlineConfig`. Instead, we should use the merged configuration mentioned before.

## Testing

Tested it against reproduction, it now returns the correct URL.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
