### PR TITLE
fix(astro): getSecret in dev and build

### DIFF
--- a/.changeset/metal-onions-hope.md
+++ b/.changeset/metal-onions-hope.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes a case where `astro:env` `getSecret` would not retrieve envirnonment variables properly in dev and build modes
+Fixes a case where `astro:env` `getSecret` would not retrieve environment variables properly in dev and build modes

--- a/.changeset/metal-onions-hope.md
+++ b/.changeset/metal-onions-hope.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where `astro:env` `getSecret` would not retrieve envirnonment variables properly in dev and build modes

--- a/packages/astro/src/env/vite-plugin-env.ts
+++ b/packages/astro/src/env/vite-plugin-env.ts
@@ -47,6 +47,12 @@ export function astroEnv({
 				fileURLToPath(settings.config.root),
 				''
 			);
+			for (const [key, value] of Object.entries(loadedEnv)) {
+				if (value !== undefined) {
+					process.env[key] = value;
+				}
+			}
+
 			const validatedVariables = validatePublicVariables({ schema, loadedEnv });
 
 			const clientTemplates = getClientTemplates({ validatedVariables });

--- a/packages/astro/test/env-secret.test.js
+++ b/packages/astro/test/env-secret.test.js
@@ -1,17 +1,38 @@
 import assert from 'node:assert/strict';
-import { before, describe, it } from 'node:test';
+import { after, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
+import { writeFileSync } from 'node:fs';
 
 describe('astro:env public variables', () => {
 	/** @type {Awaited<ReturnType<typeof loadFixture>>} */
 	let fixture;
 	/** @type {Awaited<ReturnType<(typeof fixture)["loadTestAdapterApp"]>>} */
 	let app;
+	/** @type {Awaited<ReturnType<(typeof fixture)["startDevServer"]>>} */
+	let devServer = undefined;
 
 	describe('Server variables', () => {
-		before(async () => {
+		after(async () => {
+			await devServer?.stop();
+		});
+
+		it('works in dev', async () => {
+			writeFileSync(
+				new URL('./fixtures/astro-env-server-secret/.env', import.meta.url),
+				'KNOWN_SECRET=5',
+				'utf-8'
+			);
+			fixture = await loadFixture({
+				root: './fixtures/astro-env-server-secret/',
+			});
+			devServer = await fixture.startDevServer();
+			const response = await fixture.fetch('/');
+			assert.equal(response.status, 200);
+		});
+
+		it('builds without throwing', async () => {
 			fixture = await loadFixture({
 				root: './fixtures/astro-env-server-secret/',
 				output: 'server',
@@ -24,13 +45,22 @@ describe('astro:env public variables', () => {
 			});
 			await fixture.build();
 			app = await fixture.loadTestAdapterApp();
-		});
-
-		it('builds without throwing', async () => {
 			assert.equal(true, true);
 		});
 
 		it('adapter can set how env is retrieved', async () => {
+			fixture = await loadFixture({
+				root: './fixtures/astro-env-server-secret/',
+				output: 'server',
+				adapter: testAdapter({
+					env: {
+						KNOWN_SECRET: '123456',
+						UNKNOWN_SECRET: 'abc',
+					},
+				}),
+			});
+			await fixture.build();
+			app = await fixture.loadTestAdapterApp();
 			const request = new Request('http://example.com/');
 			const response = await app.render(request);
 			assert.equal(response.status, 200);

--- a/packages/astro/test/fixtures/astro-env-server-secret/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-env-server-secret/astro.config.mjs
@@ -5,7 +5,7 @@ export default defineConfig({
 	experimental: {
 		env: {
 			schema: {
-				KNOWN_SECRET: envField.number({ context: "server", access: "secret", optional: true })
+				KNOWN_SECRET: envField.number({ context: "server", access: "secret" })
 			}
 		}
 	}


### PR DESCRIPTION
## Changes

- `process.env` was not populated

## Testing

Added a test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
