### PR TITLE
fix(rewrite): purge old data when rewriting

### DIFF
--- a/.changeset/fuzzy-eggs-kneel.md
+++ b/.changeset/fuzzy-eggs-kneel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue in the rewriting logic, where old data weren't puged during the rewrite flow, causing some false positiving during the rendering phase.

--- a/.changeset/fuzzy-eggs-kneel.md
+++ b/.changeset/fuzzy-eggs-kneel.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes an issue in the rewriting logic, where old data weren't puged during the rewrite flow, causing some false positiving during the rendering phase.
+Fixes an issue in the rewriting logic where old data was not purged during the rewrite flow. This caused some false positives when checking the validity of URL path names during the rendering phase.

--- a/packages/astro/src/container/pipeline.ts
+++ b/packages/astro/src/container/pipeline.ts
@@ -13,7 +13,7 @@ import {
 	createModuleScriptElement,
 	createStylesheetElementSet,
 } from '../core/render/ssr-element.js';
-import { default404Page } from '../core/routing/astro-designed-error-pages.js';
+import {default404Page, DEFAULT_404_ROUTE} from '../core/routing/astro-designed-error-pages.js';
 
 export class ContainerPipeline extends Pipeline {
 	/**
@@ -70,30 +70,29 @@ export class ContainerPipeline extends Pipeline {
 		return { links, styles, scripts };
 	}
 
-	async tryRewrite(rewritePayload: RewritePayload): Promise<[RouteData, ComponentInstance]> {
+	async tryRewrite(payload: RewritePayload, request: Request): Promise<[RouteData, ComponentInstance, URL]> {
 		let foundRoute: RouteData | undefined;
 		// options.manifest is the actual type that contains the information
+		let finalUrl: URL | undefined = undefined;
 		for (const route of this.manifest.routes) {
-			const routeData = route.routeData;
-			if (rewritePayload instanceof URL) {
-				if (routeData.pattern.test(rewritePayload.pathname)) {
-					foundRoute = routeData;
-					break;
-				}
-			} else if (rewritePayload instanceof Request) {
-				const url = new URL(rewritePayload.url);
-				if (routeData.pattern.test(url.pathname)) {
-					foundRoute = routeData;
-					break;
-				}
-			} else if (routeData.pattern.test(decodeURI(rewritePayload))) {
-				foundRoute = routeData;
+			if (payload instanceof URL) {
+				finalUrl = payload;
+			} else if (payload instanceof Request) {
+				finalUrl = new URL(payload.url);
+			} else {
+				finalUrl = new URL(payload, new URL(request.url).origin);
+			}
+			if (route.routeData.pattern.test(decodeURI(finalUrl.pathname))) {
+				foundRoute = route.routeData;
+				break;
+			} else if (finalUrl.pathname === '/404') {
+				foundRoute = DEFAULT_404_ROUTE;
 				break;
 			}
 		}
-		if (foundRoute) {
+		if (foundRoute && finalUrl) {
 			const componentInstance = await this.getComponentByRoute(foundRoute);
-			return [foundRoute, componentInstance];
+			return [foundRoute, componentInstance, finalUrl];
 		} else {
 			throw new AstroError(RouteNotFound);
 		}

--- a/packages/astro/src/core/app/pipeline.ts
+++ b/packages/astro/src/core/app/pipeline.ts
@@ -87,12 +87,11 @@ export class AppPipeline extends Pipeline {
 		payload: RewritePayload,
 		request: Request,
 		sourceRoute: RouteData
-	): Promise<[RouteData, ComponentInstance]> {
+	): Promise<[RouteData, ComponentInstance, URL]> {
 		let foundRoute;
 
+		let finalUrl: URL | undefined = undefined;
 		for (const route of this.#manifestData!.routes) {
-			let finalUrl: URL | undefined = undefined;
-
 			if (payload instanceof URL) {
 				finalUrl = payload;
 			} else if (payload instanceof Request) {
@@ -110,13 +109,13 @@ export class AppPipeline extends Pipeline {
 			}
 		}
 
-		if (foundRoute) {
+		if (foundRoute && finalUrl) {
 			if (foundRoute.pathname === '/404') {
 				const componentInstance = this.rewriteKnownRoute(foundRoute.pathname, sourceRoute);
-				return [foundRoute, componentInstance];
+				return [foundRoute, componentInstance, finalUrl];
 			} else {
 				const componentInstance = await this.getComponentByRoute(foundRoute);
-				return [foundRoute, componentInstance];
+				return [foundRoute, componentInstance, finalUrl];
 			}
 		}
 		throw new AstroError({

--- a/packages/astro/src/core/base-pipeline.ts
+++ b/packages/astro/src/core/base-pipeline.ts
@@ -88,7 +88,7 @@ export abstract class Pipeline {
 		rewritePayload: RewritePayload,
 		request: Request,
 		sourceRoute: RouteData
-	): Promise<[RouteData, ComponentInstance]>;
+	): Promise<[RouteData, ComponentInstance, URL]>;
 
 	/**
 	 * Tells the pipeline how to retrieve a component give a `RouteData`

--- a/packages/astro/src/core/build/pipeline.ts
+++ b/packages/astro/src/core/build/pipeline.ts
@@ -281,12 +281,11 @@ export class BuildPipeline extends Pipeline {
 		payload: RewritePayload,
 		request: Request,
 		sourceRoute: RouteData
-	): Promise<[RouteData, ComponentInstance]> {
+	): Promise<[RouteData, ComponentInstance, URL]> {
 		let foundRoute: RouteData | undefined;
 		// options.manifest is the actual type that contains the information
+		let finalUrl: URL | undefined = undefined;
 		for (const route of this.options.manifest.routes) {
-			let finalUrl: URL | undefined = undefined;
-
 			if (payload instanceof URL) {
 				finalUrl = payload;
 			} else if (payload instanceof Request) {
@@ -303,13 +302,13 @@ export class BuildPipeline extends Pipeline {
 				break;
 			}
 		}
-		if (foundRoute) {
+		if (foundRoute && finalUrl) {
 			if (foundRoute.pathname === '/404') {
 				const componentInstance = await this.rewriteKnownRoute(foundRoute.pathname, sourceRoute);
-				return [foundRoute, componentInstance];
+				return [foundRoute, componentInstance, finalUrl];
 			} else {
 				const componentInstance = await this.getComponentByRoute(foundRoute);
-				return [foundRoute, componentInstance];
+				return [foundRoute, componentInstance, finalUrl];
 			}
 		} else {
 			throw new AstroError({

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -392,7 +392,6 @@ export class RenderContext {
 			},
 		});
 
-		console.log('Astro.params', Astro.params);
 		return Astro as AstroGlobal;
 	}
 
@@ -420,7 +419,6 @@ export class RenderContext {
 				this.request,
 				this.originalRoute
 			);
-			console.log(routeData);
 			this.routeData = routeData;
 			if (reroutePayload instanceof Request) {
 				this.request = reroutePayload;

--- a/packages/astro/src/vite-plugin-astro-server/pipeline.ts
+++ b/packages/astro/src/vite-plugin-astro-server/pipeline.ts
@@ -195,15 +195,14 @@ export class DevPipeline extends Pipeline {
 		payload: RewritePayload,
 		request: Request,
 		sourceRoute: RouteData
-	): Promise<[RouteData, ComponentInstance]> {
+	): Promise<[RouteData, ComponentInstance, URL]> {
 		let foundRoute;
 		if (!this.manifestData) {
 			throw new Error('Missing manifest data. This is an internal error, please file an issue.');
 		}
 
+		let finalUrl: URL | undefined = undefined;
 		for (const route of this.manifestData.routes) {
-			let finalUrl: URL | undefined = undefined;
-
 			if (payload instanceof URL) {
 				finalUrl = payload;
 			} else if (payload instanceof Request) {
@@ -221,13 +220,13 @@ export class DevPipeline extends Pipeline {
 			}
 		}
 
-		if (foundRoute) {
+		if (foundRoute && finalUrl) {
 			if (foundRoute.pathname === '/404') {
 				const componentInstance = this.rewriteKnownRoute(foundRoute.pathname, sourceRoute);
-				return [foundRoute, componentInstance];
+				return [foundRoute, componentInstance, finalUrl];
 			} else {
 				const componentInstance = await this.getComponentByRoute(foundRoute);
-				return [foundRoute, componentInstance];
+				return [foundRoute, componentInstance, finalUrl];
 			}
 		} else {
 			throw new AstroError({

--- a/packages/astro/test/fixtures/rewrite-server/astro.config.mjs
+++ b/packages/astro/test/fixtures/rewrite-server/astro.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	output: "server",
+	experimental: {
+		rewriting: true
+	},
+	site: "https://example.com"
+});

--- a/packages/astro/test/fixtures/rewrite-server/package.json
+++ b/packages/astro/test/fixtures/rewrite-server/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/reroute-server",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/rewrite-server/src/pages/[slug]/title.astro
+++ b/packages/astro/test/fixtures/rewrite-server/src/pages/[slug]/title.astro
@@ -1,0 +1,14 @@
+---
+const { slug } = Astro.params;
+console.log("is it here???", Astro.params)
+export const prerender = false;
+---
+<html>
+<head>
+	<title>Title</title>
+</head>
+<body>
+<h1>Title</h1>
+<p>{slug}</p>
+</body>
+</html>

--- a/packages/astro/test/fixtures/rewrite-server/src/pages/index.astro
+++ b/packages/astro/test/fixtures/rewrite-server/src/pages/index.astro
@@ -1,0 +1,13 @@
+---
+return Astro.rewrite('/some-slug/title')
+
+export const prerender = false
+---
+<html>
+<head>
+	<title>Index</title>
+</head>
+<body>
+<h1>Index</h1>
+</body>
+</html>

--- a/packages/astro/test/rewrite.test.js
+++ b/packages/astro/test/rewrite.test.js
@@ -62,6 +62,31 @@ describe('Dev reroute', () => {
 	});
 });
 
+describe('Dev rewrite, hybrid/server', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	let devServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/rewrite-server/',
+		});
+		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer.stop();
+	});
+
+	it('should rewrite the [slug]/title ', async () => {
+		const html = await fixture.fetch('/').then((res) => res.text());
+		const $ = cheerioLoad(html);
+
+		assert.match($('h1').text(), /Title/);
+		assert.match($('p').text(), /some slug/);
+	});
+});
+
 describe('Build reroute', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
@@ -217,6 +242,35 @@ describe('SSR reroute', () => {
 
 		assert.equal($('h1').text(), 'Post B');
 		assert.match($('h2').text(), /example@example.com/);
+	});
+});
+
+describe('SSR rewrite, hybrid/server', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	let app;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/rewrite-server/',
+			output: 'server',
+			adapter: testAdapter(),
+		});
+
+		await fixture.build();
+		app = await fixture.loadTestAdapterApp();
+	});
+
+	it('should rewrite the [slug]/title ', async () => {
+		const request = new Request('http://example.com/');
+		const response = await app.render(request);
+		const html = await response.text();
+		const $ = cheerioLoad(html);
+
+		console.log(html);
+
+		assert.match($('h1').text(), /Title/);
+		assert.match($('p').text(), /some-slug/);
 	});
 });
 

--- a/packages/astro/test/rewrite.test.js
+++ b/packages/astro/test/rewrite.test.js
@@ -83,7 +83,7 @@ describe('Dev rewrite, hybrid/server', () => {
 		const $ = cheerioLoad(html);
 
 		assert.match($('h1').text(), /Title/);
-		assert.match($('p').text(), /some slug/);
+		assert.match($('p').text(), /some-slug/);
 	});
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3478,6 +3478,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/rewrite-server:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/root-srcdir-css:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/11204

This PR fixes two issues:
- Inside `RenderContext`, `pathname` is now updated during the rewriting. To correctly infer the correct pathname (`RouteData.pathame` sometimes is undefined, and `RouteData.route` **ins't** correct e.g. `/some-slug/title` VS `/[slug]/title`, and we need the former)
- The `tryRewrite` now returns the new `URL`, since we had the logic here in all the pipelines
- We recompute the `AstroPartial` object when rewriting because during rewriting, we were sending old information, such as `params`

## Testing

Added two new test cases

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
