### PR TITLE
Close iterator after rendering is complete and no more chunks remain

### DIFF
--- a/.changeset/purple-pianos-greet.md
+++ b/.changeset/purple-pianos-greet.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Close the iterator only after rendering is complete

--- a/packages/astro/src/runtime/server/render/astro/render.ts
+++ b/packages/astro/src/runtime/server/render/astro/render.ts
@@ -239,6 +239,11 @@ export async function renderToAsyncIterable(
 			if (next !== null) {
 				await next.promise;
 			}
+			// Buffer is empty so there's nothing to receive, wait for the next resolve.
+			else if(!renderingComplete && !buffer.length) {
+				next = promiseWithResolvers();
+				await next.promise;
+			}
 
 			// Only create a new promise if rendering is still ongoing. Otherwise
 			// there will be a dangling promises that breaks tests (probably not an actual app)
@@ -305,6 +310,8 @@ export async function renderToAsyncIterable(
 				// Push the chunks into the buffer and resolve the promise so that next()
 				// will run.
 				buffer.push(bytes);
+				next?.resolve();
+			} else if(buffer.length > 0) {
 				next?.resolve();
 			}
 		},

--- a/packages/astro/src/runtime/server/render/astro/render.ts
+++ b/packages/astro/src/runtime/server/render/astro/render.ts
@@ -270,8 +270,9 @@ export async function renderToAsyncIterable(
 			buffer.length = 0;
 
 			const returnValue = {
-				// The iterator is done if there are no chunks to return.
-				done: length === 0,
+				// The iterator is done when rendering has finished
+				// and there are no more chunks to return.
+				done: length === 0 && renderingComplete,
 				value: mergedArray,
 			};
 

--- a/packages/astro/test/fixtures/partials/src/pages/partials/nested-conditional.astro
+++ b/packages/astro/test/fixtures/partials/src/pages/partials/nested-conditional.astro
@@ -1,0 +1,12 @@
+---
+export const partial = true
+---
+
+{
+  true && (
+    <>
+      {true && <div id="true">test</div>}
+      {false && <div>test</div>}
+    </>
+  )
+}

--- a/packages/astro/test/partials.test.js
+++ b/packages/astro/test/partials.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
 describe('Partials', () => {
@@ -27,6 +28,12 @@ describe('Partials', () => {
 		it('is only the written HTML', async () => {
 			const html = await fixture.fetch('/partials/item/').then((res) => res.text());
 			assert.equal(html.startsWith('<li'), true);
+		});
+
+		it('Nested conditionals render', async () => {
+			const html = await fixture.fetch('/partials/nested-conditional/').then((res) => res.text());
+			const $ = cheerio.load(html);
+			assert.equal($('#true').text(), 'test');
 		});
 	});
 


### PR DESCRIPTION
## Changes

- Our async iterable was closing too fast because with partials we skip the head parts. So there would be a pull of chunks that were empty even though rendering was still ongoing. The fix is to only end the iterator after both rendering is done and there are no more chunks to flush out.
- Closes https://github.com/withastro/astro/issues/11103

## Testing

- Test case added

## Docs

N/A, bug fix