### PR TITLE
feat(astro): address astro env rfc feedback

### DIFF
--- a/.changeset/clever-jars-trade.md
+++ b/.changeset/clever-jars-trade.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Removes the `PUBLIC_` prefix constraint for `astro:env` public variables

--- a/.changeset/dirty-rabbits-act.md
+++ b/.changeset/dirty-rabbits-act.md
@@ -4,7 +4,7 @@
 
 **BREAKING CHANGE to the experimental `astro:env` feature only**
 
-Server secrets specified in the schema must now be imported from `astro:env/server`. Using `getSecret()` with these keys no longer involves any special handling and the raw value will be returned.
+Server secrets specified in the schema must now be imported from `astro:env/server`. Using `getSecret()` is no longer required to use these environment variables in your schema:
 
 ```diff
 - import { getSecret } from 'astro:env/server'
@@ -12,4 +12,4 @@ Server secrets specified in the schema must now be imported from `astro:env/serv
 + import { API_SECRET } from 'astro:env/server'
 ```
 
-Note that `getSecret()` can still be used to retrieve secrets not specified in your schema.
+Note that using `getSecret()` with these keys no longer involves any special handling and the raw value will be returned, just like retrieving secrets not specified in your schema.

--- a/.changeset/dirty-rabbits-act.md
+++ b/.changeset/dirty-rabbits-act.md
@@ -8,10 +8,8 @@ Server secrets specified in the schema must now be imported from `astro:env/serv
 
 ```diff
 - import { getSecret } from 'astro:env/server'
-+ import { API_SECRET, getSecret } from 'astro:env/server'
-
 - const API_SECRET = getSecret("API_SECRET")
-const UNKNOWN = getSecret("UNKNOWN")
++ import { API_SECRET } from 'astro:env/server'
 ```
 
 Note that `getSecret()` can still be used to retrieve secrets not specified in your schema.

--- a/.changeset/dirty-rabbits-act.md
+++ b/.changeset/dirty-rabbits-act.md
@@ -1,0 +1,17 @@
+---
+'astro': patch
+---
+
+**BREAKING CHANGE to the experimental `astro:env` feature only**
+
+Server secrets specfied in the schema must now be imported from `astro:env/server`:
+
+```diff
+- import { getSecret } from 'astro:env/server'
++ import { FOO, getSecret } from 'astro:env/server'
+
+- const FOO = getSecret("FOO")
+const UNKNOWN = getSecret("UNKNOWN")
+```
+
+Note that `getSecret` can still be used to retrieve secrets not specified in your schema. If the key is also in the schema, no special handling will occur and the raw value will be returned.

--- a/.changeset/dirty-rabbits-act.md
+++ b/.changeset/dirty-rabbits-act.md
@@ -4,13 +4,13 @@
 
 **BREAKING CHANGE to the experimental `astro:env` feature only**
 
-Server secrets specfied in the schema must now be imported from `astro:env/server`:
+Server secrets specfied in the schema must now be imported from `astro:env/server` along with `getSecret()`:
 
 ```diff
 - import { getSecret } from 'astro:env/server'
-+ import { FOO, getSecret } from 'astro:env/server'
++ import { API_SECRET, getSecret } from 'astro:env/server'
 
-- const FOO = getSecret("FOO")
+- const API_SECRET = getSecret("API_SECRET")
 const UNKNOWN = getSecret("UNKNOWN")
 ```
 

--- a/.changeset/dirty-rabbits-act.md
+++ b/.changeset/dirty-rabbits-act.md
@@ -12,4 +12,4 @@ Server secrets specified in the schema must now be imported from `astro:env/serv
 + import { API_SECRET } from 'astro:env/server'
 ```
 
-Note that using `getSecret()` with these keys no longer involves any special handling and the raw value will be returned, just like retrieving secrets not specified in your schema.
+Note that using `getSecret()` with these keys is still possible, but no longer involves any special handling and the raw value will be returned, just like retrieving secrets not specified in your schema.

--- a/.changeset/dirty-rabbits-act.md
+++ b/.changeset/dirty-rabbits-act.md
@@ -4,7 +4,7 @@
 
 **BREAKING CHANGE to the experimental `astro:env` feature only**
 
-Server secrets specfied in the schema must now be imported from `astro:env/server` along with `getSecret()`:
+Server secrets specified in the schema must now be imported from `astro:env/server`. Using `getSecret()` with these keys no longer involves any special handling and the raw value will be returned.
 
 ```diff
 - import { getSecret } from 'astro:env/server'
@@ -14,4 +14,4 @@ Server secrets specfied in the schema must now be imported from `astro:env/serve
 const UNKNOWN = getSecret("UNKNOWN")
 ```
 
-Note that `getSecret` can still be used to retrieve secrets not specified in your schema. If the key is also in the schema, no special handling will occur and the raw value will be returned.
+Note that `getSecret()` can still be used to retrieve secrets not specified in your schema.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2070,17 +2070,17 @@ export interface AstroUserConfig {
 		 *
 		 * ```astro
 		 * ---
-		 * import { PUBLIC_APP_ID } from "astro:env/client"
-		 * import { PUBLIC_API_URL, getSecret } from "astro:env/server"
-		 * const API_TOKEN = getSecret("API_TOKEN")
+		 * import { APP_ID } from "astro:env/client"
+		 * import { API_URL, API_TOKEN, getSecret } from "astro:env/server"
+		 * const NODE_ENV = getSecret("NODE_ENV")
 		 *
-		 * const data = await fetch(`${PUBLIC_API_URL}/users`, {
+		 * const data = await fetch(`${API_URL}/users`, {
 		 * 	method: "POST",
 		 * 	headers: {
 		 * 		"Content-Type": "application/json",
 		 * 		"Authorization": `Bearer ${API_TOKEN}`
 		 * 	},
-		 * 	body: JSON.stringify({ appId: PUBLIC_APP_ID })
+		 * 	body: JSON.stringify({ appId: APP_ID, nodeEnv: NODE_ENV })
 		 * })
 		 * ---
 		 * ```
@@ -2095,8 +2095,8 @@ export interface AstroUserConfig {
 		 *     experimental: {
 		 *         env: {
 		 *             schema: {
-		 *                 PUBLIC_API_URL: envField.string({ context: "client", access: "public", optional: true }),
-		 *                 PUBLIC_PORT: envField.number({ context: "server", access: "public", default: 4321 }),
+		 *                 API_URL: envField.string({ context: "client", access: "public", optional: true }),
+		 *                 PORT: envField.number({ context: "server", access: "public", default: 4321 }),
 		 *                 API_SECRET: envField.string({ context: "server", access: "secret" }),
 		 *             }
 		 *         }
@@ -2104,28 +2104,27 @@ export interface AstroUserConfig {
 		 * })
 		 * ```
 		 *
-		 * There are currently three data types supported: strings, numbers and booleans.
+		 * There are currently four data types supported: strings, numbers, booleans and enums.
 		 *
 		 * There are three kinds of environment variables, determined by the combination of `context` (client or server) and `access` (secret or public) settings defined in your [`env.schema`](#experimentalenvschema):
 		 *
 		 * - **Public client variables**: These variables end up in both your final client and server bundles, and can be accessed from both client and server through the `astro:env/client` module:
 		 *
 		 *     ```js
-		 *     import { PUBLIC_API_URL } from "astro:env/client"
+		 *     import { API_URL } from "astro:env/client"
 		 *     ```
 		 *
 		 * - **Public server variables**: These variables end up in your final server bundle and can be accessed on the server through the `astro:env/server` module:
 		 *
 		 *     ```js
-		 *     import { PUBLIC_PORT } from "astro:env/server"
+		 *     import { PORT } from "astro:env/server"
 		 *     ```
 		 *
-		 * - **Secret server variables**: These variables are not part of your final bundle and can be accessed on the server through the `getSecret()` helper function available from the `astro:env/server` module:
+		 * - **Secret server variables**: These variables are not part of your final bundle and can be accessed on the server through the `astro:env/server` module. The `getSecret()` helper function can be used to retrieve secrets not specified in the schema:
 		 *
 		 *     ```js
-		 *     import { getSecret } from "astro:env/server"
+		 *     import { API_SECRET, getSecret } from "astro:env/server"
 		 *
-		 *     const API_SECRET = getSecret("API_SECRET") // typed
 		 *     const SECRET_NOT_IN_SCHEMA = getSecret("SECRET_NOT_IN_SCHEMA") // string | undefined
 		 *     ```
 		 *
@@ -2152,8 +2151,8 @@ export interface AstroUserConfig {
 			 *   experimental: {
 			 *     env: {
 			 *       schema: {
-			 *         PUBLIC_API_URL: envField.string({ context: "client", access: "public", optional: true }),
-			 *         PUBLIC_PORT: envField.number({ context: "server", access: "public", default: 4321 }),
+			 *         API_URL: envField.string({ context: "client", access: "public", optional: true }),
+			 *         PORT: envField.number({ context: "server", access: "public", default: 4321 }),
 			 *         API_SECRET: envField.string({ context: "server", access: "secret" }),
 			 *       }
 			 *     }

--- a/packages/astro/src/core/base-pipeline.ts
+++ b/packages/astro/src/core/base-pipeline.ts
@@ -66,7 +66,7 @@ export abstract class Pipeline {
 		if (callSetGetEnv && manifest.experimentalEnvGetSecretEnabled) {
 			setGetEnv(() => {
 				throw new AstroError(AstroErrorData.EnvUnsupportedGetSecret);
-			});
+			}, true);
 		}
 	}
 

--- a/packages/astro/src/env/constants.ts
+++ b/packages/astro/src/env/constants.ts
@@ -5,7 +5,6 @@ export const VIRTUAL_MODULES_IDS = {
 };
 export const VIRTUAL_MODULES_IDS_VALUES = new Set(Object.values(VIRTUAL_MODULES_IDS));
 
-export const PUBLIC_PREFIX = 'PUBLIC_';
 export const ENV_TYPES_FILE = 'env.d.ts';
 
 const PKG_BASE = new URL('../../', import.meta.url);

--- a/packages/astro/src/env/runtime.ts
+++ b/packages/astro/src/env/runtime.ts
@@ -1,6 +1,5 @@
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 export { validateEnvVariable } from './validators.js';
-import { EventEmitter } from 'node:events'
 
 export type GetEnv = (key: string) => string | undefined;
 
@@ -9,7 +8,13 @@ let _getEnv: GetEnv = (key) => process.env[key];
 export function setGetEnv(fn: GetEnv, reset = false) {
 	_getEnv = fn;
 
-	eventEmitter.emit('setGetEnv', reset);
+	_onSetGetEnv(reset);
+}
+
+let _onSetGetEnv = (reset: boolean) => {};
+
+export function setOnSetGetEnv(fn: typeof _onSetGetEnv) {
+	_onSetGetEnv = fn;
 }
 
 export function getEnv(...args: Parameters<GetEnv>) {
@@ -24,5 +29,3 @@ export function createInvalidVariableError(
 		message: AstroErrorData.EnvInvalidVariable.message(...args),
 	});
 }
-
-export const eventEmitter = new EventEmitter();

--- a/packages/astro/src/env/runtime.ts
+++ b/packages/astro/src/env/runtime.ts
@@ -1,5 +1,6 @@
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 export { validateEnvVariable } from './validators.js';
+import { EventEmitter } from 'node:events'
 
 export type GetEnv = (key: string) => string | undefined;
 
@@ -8,7 +9,7 @@ let _getEnv: GetEnv = (key) => process.env[key];
 export function setGetEnv(fn: GetEnv, reset = false) {
 	_getEnv = fn;
 
-	eventEmitter.publish(reset);
+	eventEmitter.emit('setGetEnv', reset);
 }
 
 export function getEnv(...args: Parameters<GetEnv>) {
@@ -22,15 +23,6 @@ export function createInvalidVariableError(
 		...AstroErrorData.EnvInvalidVariable,
 		message: AstroErrorData.EnvInvalidVariable.message(...args),
 	});
-}
-
-class EventEmitter extends EventTarget {
-	publish(reset: boolean) {
-		this.dispatchEvent(new CustomEvent('update', { detail: { reset } }));
-	}
-	subscribe(cb: (reset: boolean) => void) {
-		this.addEventListener('update', (e) => cb((e as any).detail.reset));
-	}
 }
 
 export const eventEmitter = new EventEmitter();

--- a/packages/astro/src/env/runtime.ts
+++ b/packages/astro/src/env/runtime.ts
@@ -5,8 +5,10 @@ export type GetEnv = (key: string) => string | undefined;
 
 let _getEnv: GetEnv = (key) => process.env[key];
 
-export function setGetEnv(fn: GetEnv) {
+export function setGetEnv(fn: GetEnv, reset = false) {
 	_getEnv = fn;
+
+	eventEmitter.publish(reset);
 }
 
 export function getEnv(...args: Parameters<GetEnv>) {
@@ -21,3 +23,14 @@ export function createInvalidVariableError(
 		message: AstroErrorData.EnvInvalidVariable.message(...args),
 	});
 }
+
+class EventEmitter extends EventTarget {
+	publish(reset: boolean) {
+		this.dispatchEvent(new CustomEvent('update', { detail: { reset } }));
+	}
+	subscribe(cb: (reset: boolean) => void) {
+		this.addEventListener('update', (e) => cb((e as any).detail.reset));
+	}
+}
+
+export const eventEmitter = new EventEmitter();

--- a/packages/astro/src/env/schema.ts
+++ b/packages/astro/src/env/schema.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { PUBLIC_PREFIX } from './constants.js';
 
 const StringSchema = z.object({
 	type: z.literal('string'),
@@ -35,36 +34,19 @@ const SecretServerEnvFieldMetadata = z.object({
 
 const KEY_REGEX = /^[A-Z_]+$/;
 
-export const EnvSchema = z
-	.record(
-		z.string().regex(KEY_REGEX, {
-			message: 'A valid variable name can only contain uppercase letters and underscores.',
-		}),
-		z.intersection(
-			z.union([
-				PublicClientEnvFieldMetadata,
-				PublicServerEnvFieldMetadata,
-				SecretServerEnvFieldMetadata,
-			]),
-			EnvFieldType
-		)
+export const EnvSchema = z.record(
+	z.string().regex(KEY_REGEX, {
+		message: 'A valid variable name can only contain uppercase letters and underscores.',
+	}),
+	z.intersection(
+		z.union([
+			PublicClientEnvFieldMetadata,
+			PublicServerEnvFieldMetadata,
+			SecretServerEnvFieldMetadata,
+		]),
+		EnvFieldType
 	)
-	.superRefine((schema, ctx) => {
-		for (const [key, value] of Object.entries(schema)) {
-			if (key.startsWith(PUBLIC_PREFIX) && value.access !== 'public') {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					message: `An environment variable whose name is prefixed by "${PUBLIC_PREFIX}" must be public.`,
-				});
-			}
-			if (value.access === 'public' && !key.startsWith(PUBLIC_PREFIX)) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					message: `An environment variable that is public must have a name prefixed by "${PUBLIC_PREFIX}".`,
-				});
-			}
-		}
-	});
+);
 
 export type EnvSchema = z.infer<typeof EnvSchema>;
 

--- a/packages/astro/src/env/vite-plugin-env.ts
+++ b/packages/astro/src/env/vite-plugin-env.ts
@@ -67,9 +67,8 @@ export function astroEnv({
 				fs,
 				content: getDts({
 					fs,
-					clientPublic: clientTemplates.types,
-					serverPublic: serverTemplates.types.public,
-					serverSecret: serverTemplates.types.secret,
+					client: clientTemplates.types,
+					server: serverTemplates.types,
 				}),
 			});
 		},
@@ -154,22 +153,17 @@ function validatePublicVariables({
 }
 
 function getDts({
-	clientPublic,
-	serverPublic,
-	serverSecret,
+	client,
+	server,
 	fs,
 }: {
-	clientPublic: string;
-	serverPublic: string;
-	serverSecret: string;
+	client: string;
+	server: string;
 	fs: typeof fsMod;
 }) {
 	const template = fs.readFileSync(TYPES_TEMPLATE_URL, 'utf-8');
 
-	return template
-		.replace('// @@CLIENT@@', clientPublic)
-		.replace('// @@SERVER@@', serverPublic)
-		.replace('// @@SECRET_VALUES@@', serverSecret);
+	return template.replace('// @@CLIENT@@', client).replace('// @@SERVER@@', server);
 }
 
 function getClientTemplates({
@@ -201,12 +195,12 @@ function getServerTemplates({
 	fs: typeof fsMod;
 }) {
 	let module = fs.readFileSync(MODULE_TEMPLATE_URL, 'utf-8');
-	let publicTypes = '';
-	let secretTypes = '';
+	let types = '';
+	let onSetGetEnv = '';
 
 	for (const { key, type, value } of validatedVariables.filter((e) => e.context === 'server')) {
 		module += `export const ${key} = ${JSON.stringify(value)};`;
-		publicTypes += `export const ${key}: ${type};	\n`;
+		types += `export const ${key}: ${type};	\n`;
 	}
 
 	for (const [key, options] of Object.entries(schema)) {
@@ -214,14 +208,15 @@ function getServerTemplates({
 			continue;
 		}
 
-		secretTypes += `${key}: ${getEnvFieldType(options)};		\n`;
+		types += `export const ${key}: ${getEnvFieldType(options)};		\n`;
+		module += `export let ${key} = _internalGetSecret(${JSON.stringify(key)});\n`;
+		onSetGetEnv += `${key} = reset ? undefined : _internalGetSecret(${JSON.stringify(key)});\n`;
 	}
+
+	module = module.replace('// @@ON_SET_GET_ENV@@', onSetGetEnv);
 
 	return {
 		module,
-		types: {
-			public: publicTypes,
-			secret: secretTypes,
-		},
+		types,
 	};
 }

--- a/packages/astro/src/env/vite-plugin-env.ts
+++ b/packages/astro/src/env/vite-plugin-env.ts
@@ -12,6 +12,10 @@ import {
 } from './constants.js';
 import type { EnvSchema } from './schema.js';
 import { getEnvFieldType, validateEnvVariable } from './validators.js';
+import { parse } from 'acorn';
+import type { Node as ESTreeNode } from 'estree-walker';
+import { walk } from 'estree-walker';
+import MagicString from 'magic-string';
 
 // TODO: reminders for when astro:env comes out of experimental
 // Types should always be generated (like in types/content.d.ts). That means the client module will be empty
@@ -68,8 +72,7 @@ export function astroEnv({
 				content: getDts({
 					fs,
 					clientPublic: clientTemplates.types,
-					serverPublic: serverTemplates.types.public,
-					serverSecret: serverTemplates.types.secret,
+					server: serverTemplates.types,
 				}),
 			});
 		},
@@ -98,7 +101,136 @@ export function astroEnv({
 				return templates!.internal;
 			}
 		},
+		transform(code, id) {
+			if (!isValidExtension(id)) {
+				return null;
+			}
+			console.log({ id, code });
+
+			let s: MagicString | undefined;
+			const ast = parse(code, {
+				ecmaVersion: 'latest',
+				sourceType: 'module',
+			});
+
+			// TODO: get
+			const secretsKeys = ['KNOWN_SECRET'];
+			const usedSecrets: Array<string> = [];
+			const protectedNodes: Array<ESTreeNode> = [];
+
+			function updateAST(node: ESTreeNode, content: string) {
+				s ??= new MagicString(code);
+				s.overwrite((node as any).start, (node as any).end, content);
+			}
+
+			function isNodeProtected(node: ESTreeNode) {
+				for (const n of protectedNodes) {
+					if ((node as any).start === (n as any).start && (node as any).end === (n as any).end) {
+						return true;
+					}
+				}
+				return false;
+			}
+
+			// TODO: support import * as X; X.FOO
+			// TODO: support const X = await import(); X.FOO
+			// TODO: support object
+			walk(ast as ESTreeNode, {
+				enter(node, parent) {
+					// imports
+					if (node.type === 'ImportDeclaration' && node.source.value === 'astro:env/server') {
+						for (const specifier of node.specifiers) {
+							if (
+								specifier.type === 'ImportSpecifier' &&
+								secretsKeys.includes(specifier.imported.name)
+							) {
+								// accounts for imports aliases
+								usedSecrets.push(specifier.local.name);
+								protectedNodes.push(specifier);
+							}
+						}
+					}
+
+					// await import
+					if (
+						node.type === 'VariableDeclarator' &&
+						node.init &&
+						node.init.type === 'AwaitExpression' &&
+						node.init.argument.type === 'ImportExpression' &&
+						node.init.argument.source.type === 'Literal' &&
+						node.init.argument.source.value === 'astro:env/server' &&
+						node.id.type === 'ObjectPattern'
+					) {
+						for (const property of node.id.properties) {
+							if (
+								property.type === 'Property' &&
+								property.key.type === 'Identifier' &&
+								property.value.type === 'Identifier'
+							) {
+								if (
+									secretsKeys.includes(property.key.name) ||
+									secretsKeys.includes(property.value.name)
+								) {
+									if (property.key.name === property.value.name) {
+										usedSecrets.push(property.value.name);
+									} else {
+										usedSecrets.push(property.key.name);
+									}
+									protectedNodes.push(property.key);
+									protectedNodes.push(property.value);
+								}
+							}
+						}
+					}
+
+					// calls
+					if (
+						node.type === 'Identifier' &&
+						!isNodeProtected(node) &&
+						usedSecrets.includes(node.name)
+					) {
+						const shouldUpdateNode = !parent || parent.type !== 'ImportSpecifier';
+
+						if (shouldUpdateNode) {
+							if (
+								parent &&
+								parent.type === 'Property' &&
+								parent.key.type === 'Identifier' &&
+								parent.value.type === 'Identifier' &&
+								parent.key.name === parent.value.name
+							) {
+								// object shorthand
+								updateAST(parent.value, `${node.name}: ${node.name}()`);
+							} else {
+								updateAST(node, `${node.name}()`);
+							}
+						}
+					}
+				},
+			});
+
+			if (s) {
+				const code = s.toString();
+				console.log({ code });
+				return {
+					code,
+					map: s.generateMap({ hires: 'boundary' }),
+				};
+			}
+		},
 	};
+}
+
+// TODO: restore
+// const EXTENSIONS = ['.astro', '.ts', '.mts', '.tsx', '.js', '.mjs', '.jsx'];
+const EXTENSIONS = ['.astro'];
+function isValidExtension(id: string) {
+	for (const ext of EXTENSIONS) {
+		if (id.endsWith(ext)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 function resolveVirtualModuleId<T extends string>(id: T): `\0${T}` {
@@ -155,21 +287,16 @@ function validatePublicVariables({
 
 function getDts({
 	clientPublic,
-	serverPublic,
-	serverSecret,
+	server,
 	fs,
 }: {
 	clientPublic: string;
-	serverPublic: string;
-	serverSecret: string;
+	server: string;
 	fs: typeof fsMod;
 }) {
 	const template = fs.readFileSync(TYPES_TEMPLATE_URL, 'utf-8');
 
-	return template
-		.replace('// @@CLIENT@@', clientPublic)
-		.replace('// @@SERVER@@', serverPublic)
-		.replace('// @@SECRET_VALUES@@', serverSecret);
+	return template.replace('// @@CLIENT@@', clientPublic).replace('// @@SERVER@@', server);
 }
 
 function getClientTemplates({
@@ -201,12 +328,11 @@ function getServerTemplates({
 	fs: typeof fsMod;
 }) {
 	let module = fs.readFileSync(MODULE_TEMPLATE_URL, 'utf-8');
-	let publicTypes = '';
-	let secretTypes = '';
+	let types = '';
 
 	for (const { key, type, value } of validatedVariables.filter((e) => e.context === 'server')) {
 		module += `export const ${key} = ${JSON.stringify(value)};`;
-		publicTypes += `export const ${key}: ${type};	\n`;
+		types += `export const ${key}: ${type};	\n`;
 	}
 
 	for (const [key, options] of Object.entries(schema)) {
@@ -214,14 +340,12 @@ function getServerTemplates({
 			continue;
 		}
 
-		secretTypes += `${key}: ${getEnvFieldType(options)};		\n`;
+		module += `export const ${key} = () => _internalGetSecret(${JSON.stringify(key)})`;
+		types += `export const ${key}: ${getEnvFieldType(options)};	\n`;
 	}
 
 	return {
 		module,
-		types: {
-			public: publicTypes,
-			secret: secretTypes,
-		},
+		types,
 	};
 }

--- a/packages/astro/templates/env/module.mjs
+++ b/packages/astro/templates/env/module.mjs
@@ -1,5 +1,10 @@
 import { schema } from 'virtual:astro:env/internal';
-import { createInvalidVariableError, getEnv, validateEnvVariable } from 'astro/env/runtime';
+import {
+	createInvalidVariableError,
+	getEnv,
+	validateEnvVariable,
+	eventEmitter,
+} from 'astro/env/runtime';
 
 export const getSecret = (key) => {
 	return getEnv(key);
@@ -16,3 +21,7 @@ const _internalGetSecret = (key) => {
 	}
 	throw createInvalidVariableError(key, result.type);
 };
+
+eventEmitter.subscribe((reset) => {
+	// @@ON_SET_GET_ENV@@
+});

--- a/packages/astro/templates/env/module.mjs
+++ b/packages/astro/templates/env/module.mjs
@@ -3,7 +3,7 @@ import {
 	createInvalidVariableError,
 	getEnv,
 	validateEnvVariable,
-	eventEmitter,
+	setOnSetGetEnv,
 } from 'astro/env/runtime';
 
 export const getSecret = (key) => {
@@ -22,6 +22,6 @@ const _internalGetSecret = (key) => {
 	throw createInvalidVariableError(key, result.type);
 };
 
-eventEmitter.on('setGetEnv', (reset) => {
+setOnSetGetEnv((reset) => {
 	// @@ON_SET_GET_ENV@@
 });

--- a/packages/astro/templates/env/module.mjs
+++ b/packages/astro/templates/env/module.mjs
@@ -22,6 +22,6 @@ const _internalGetSecret = (key) => {
 	throw createInvalidVariableError(key, result.type);
 };
 
-eventEmitter.subscribe((reset) => {
+eventEmitter.on('setGetEnv', (reset) => {
 	// @@ON_SET_GET_ENV@@
 });

--- a/packages/astro/templates/env/module.mjs
+++ b/packages/astro/templates/env/module.mjs
@@ -2,13 +2,13 @@ import { schema } from 'virtual:astro:env/internal';
 import { createInvalidVariableError, getEnv, validateEnvVariable } from 'astro/env/runtime';
 
 export const getSecret = (key) => {
+	return getEnv(key);
+};
+
+const _internalGetSecret = (key) => {
 	const rawVariable = getEnv(key);
 	const variable = rawVariable === '' ? undefined : rawVariable;
 	const options = schema[key];
-
-	if (!options) {
-		return variable;
-	}
 
 	const result = validateEnvVariable(variable, options);
 	if (result.ok) {

--- a/packages/astro/templates/env/types.d.ts
+++ b/packages/astro/templates/env/types.d.ts
@@ -5,16 +5,5 @@ declare module 'astro:env/client' {
 declare module 'astro:env/server' {
 	// @@SERVER@@
 
-	type SecretValues = {
-		// @@SECRET_VALUES@@
-	};
-
-	type SecretValue = keyof SecretValues;
-
-	type Loose<T> = T | (string & {});
-	type Strictify<T extends string> = T extends `${infer _}` ? T : never;
-
-	export const getSecret: <TKey extends Loose<SecretValue>>(
-		key: TKey
-	) => TKey extends Strictify<SecretValue> ? SecretValues[TKey] : string | undefined;
+	export const getSecret: (key: string) => string | undefined;
 }

--- a/packages/astro/test/fixtures/astro-env-server-fail/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-env-server-fail/astro.config.mjs
@@ -5,7 +5,7 @@ export default defineConfig({
 	experimental: {
 		env: {
 			schema: {
-				PUBLIC_FOO: envField.string({ context: "server", access: "public", optional: true, default: "ABC" }),
+				FOO: envField.string({ context: "server", access: "public", optional: true, default: "ABC" }),
 			}
 		}
 	}

--- a/packages/astro/test/fixtures/astro-env-server-fail/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-env-server-fail/src/pages/index.astro
@@ -1,3 +1,3 @@
 <script>
-    import { PUBLIC_FOO } from "astro:env/server"
+    import { FOO } from "astro:env/server"
 </script>

--- a/packages/astro/test/fixtures/astro-env-server-secret/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-env-server-secret/src/pages/index.astro
@@ -1,8 +1,20 @@
 ---
-import { getSecret } from "astro:env/server"
+import { getSecret, KNOWN_SECRET } from "astro:env/server"
 
-const KNOWN_SECRET = getSecret("KNOWN_SECRET")
+// const { getSecret, KNOWN_SECRET } = await import("astro:env/server")
+
+const X = KNOWN_SECRET
+console.log({ X })
+console.log(KNOWN_SECRET)
+console.log(`abc ${KNOWN_SECRET}`)
+
 const UNKNOWN_SECRET = getSecret("UNKNOWN_SECRET")
+
+const fn = (KNOWN_SECRET) => {
+    console.log(KNOWN_SECRET)
+}
+
+fn(`${KNOWN_SECRET} augf`)
 ---
 
 <pre id="data">{JSON.stringify({ KNOWN_SECRET, UNKNOWN_SECRET })}</pre>

--- a/packages/astro/test/fixtures/astro-env-server-secret/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-env-server-secret/src/pages/index.astro
@@ -1,20 +1,7 @@
 ---
 import { getSecret, KNOWN_SECRET } from "astro:env/server"
 
-// const { getSecret, KNOWN_SECRET } = await import("astro:env/server")
-
-const X = KNOWN_SECRET
-console.log({ X })
-console.log(KNOWN_SECRET)
-console.log(`abc ${KNOWN_SECRET}`)
-
 const UNKNOWN_SECRET = getSecret("UNKNOWN_SECRET")
-
-const fn = (KNOWN_SECRET) => {
-    console.log(KNOWN_SECRET)
-}
-
-fn(`${KNOWN_SECRET} augf`)
 ---
 
 <pre id="data">{JSON.stringify({ KNOWN_SECRET, UNKNOWN_SECRET })}</pre>

--- a/packages/astro/test/fixtures/astro-env/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-env/astro.config.mjs
@@ -5,9 +5,9 @@ export default defineConfig({
 	experimental: {
 		env: {
 			schema: {
-				PUBLIC_FOO: envField.string({ context: "client", access: "public", optional: true, default: "ABC" }),
-				PUBLIC_BAR: envField.string({ context: "client", access: "public", optional: true, default: "DEF" }),
-				PUBLIC_BAZ: envField.string({ context: "server", access: "public", optional: true, default: "GHI" }),
+				FOO: envField.string({ context: "client", access: "public", optional: true, default: "ABC" }),
+				BAR: envField.string({ context: "client", access: "public", optional: true, default: "DEF" }),
+				BAZ: envField.string({ context: "server", access: "public", optional: true, default: "GHI" }),
 			}
 		}
 	}

--- a/packages/astro/test/fixtures/astro-env/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-env/src/pages/index.astro
@@ -1,15 +1,15 @@
 ---
-import { PUBLIC_FOO } from "astro:env/client"
-import { PUBLIC_BAZ } from "astro:env/server"
+import { FOO } from "astro:env/client"
+import { BAZ } from "astro:env/server"
 
-console.log({ PUBLIC_BAZ })
+console.log({ BAZ })
 ---
 
-<div id="server-rendered">{PUBLIC_FOO}</div>
+<div id="server-rendered">{FOO}</div>
 <div id="client-rendered"></div>
 
 <script>
-    import { PUBLIC_BAR } from "astro:env/client"
+    import { BAR } from "astro:env/client"
 
-    document.getElementById("client-rendered").innerText = PUBLIC_BAR
+    document.getElementById("client-rendered").innerText = BAR
 </script>

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -4,7 +4,6 @@ import stripAnsi from 'strip-ansi';
 import { z } from 'zod';
 import { validateConfig } from '../../../dist/core/config/config.js';
 import { formatConfigErrorMessage } from '../../../dist/core/messages.js';
-import { envField } from '../../../dist/env/config.js';
 
 describe('Config Validation', () => {
 	it('empty user config is valid', async () => {
@@ -366,47 +365,6 @@ describe('Config Validation', () => {
 					},
 					process.cwd()
 				).catch((err) => err)
-			);
-		});
-
-		it('Should not allow client variables without a PUBLIC_ prefix', async () => {
-			const configError = await validateConfig(
-				{
-					experimental: {
-						env: {
-							schema: {
-								FOO: envField.string({ context: 'client', access: 'public' }),
-							},
-						},
-					},
-				},
-				process.cwd()
-			).catch((err) => err);
-			assert.equal(configError instanceof z.ZodError, true);
-			assert.equal(
-				configError.errors[0].message,
-				'An environment variable that is public must have a name prefixed by "PUBLIC_".'
-			);
-		});
-
-		it('Should not allow non client variables with a PUBLIC_ prefix', async () => {
-			const configError = await validateConfig(
-				{
-					experimental: {
-						env: {
-							schema: {
-								FOO: envField.string({ context: 'server', access: 'public' }),
-							},
-						},
-					},
-				},
-				process.cwd()
-			).catch((err) => err);
-			assert.equal(configError instanceof z.ZodError, true);
-			console.log(configError);
-			assert.equal(
-				configError.errors[0].message,
-				'An environment variable that is public must have a name prefixed by "PUBLIC_".'
 			);
 		});
 	});


### PR DESCRIPTION
## Todo

- [x] Update fixtures
	- [x] remove prefix
	- [x] check getSecret usage
- [x] Update documentation
- [x] changesets
	- [x] public
	- [x] secrets

## Changes

- Removes the `PUBLIC_` prefix constraint
- Allows importing secrets from `astro:env/server` directly

## Testing

Tests should still pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Config reference updated

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
