### PR TITLE
Export type Database from db/runtime

### DIFF
--- a/.changeset/warm-pets-tap.md
+++ b/.changeset/warm-pets-tap.md
@@ -2,4 +2,4 @@
 '@astrojs/db': patch
 ---
 
-Export type Database from `@astrojs/db/runtime`
+Export type `Database` from `@astrojs/db/runtime`

--- a/.changeset/warm-pets-tap.md
+++ b/.changeset/warm-pets-tap.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/db': patch
+---
+
+Export type Database from `@astrojs/db/runtime`

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -11,7 +11,8 @@ import {
 import type { DBColumn, DBTable } from '../core/types.js';
 import { type SerializedSQL, isSerializedSQL } from './types.js';
 import { pathToFileURL } from './utils.js';
-
+import { type LibSQLDatabase } from 'drizzle-orm/libsql';
+export type Database = Omit<LibSQLDatabase, 'transaction'>;
 export type { Table } from './types.js';
 export { createRemoteDatabaseClient, createLocalDatabaseClient } from './db-client.js';
 

--- a/packages/db/src/runtime/virtual.ts
+++ b/packages/db/src/runtime/virtual.ts
@@ -11,10 +11,6 @@ import type {
 	TextColumnOpts,
 } from '../core/types.js';
 
-import type { LibSQLDatabase } from 'drizzle-orm/libsql';
-
-export type Database = Omit<LibSQLDatabase, 'transaction'>;
-
 function createColumn<S extends string, T extends Record<string, unknown>>(type: S, schema: T) {
 	return {
 		type,


### PR DESCRIPTION
This type used to be exported, was moved around a bit starting in https://github.com/withastro/astro/pull/10457 and ended up no longer being exported

This PR moves the import and export to runtime/index.ts to ensure it ends up exported from `@astrojs/db/runtime`