### PR TITLE
Minor cleanup in the content types generator

### DIFF
--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -121,16 +121,14 @@ export async function createContentTypesGenerator({
 
 			switch (event.name) {
 				case 'addDir':
-					collectionEntryMap[JSON.stringify(collection)] = {
+					collectionEntryMap[collectionKey] = {
 						type: 'unknown',
 						entries: {},
 					};
 					logger.debug('content', `${cyan(collection)} collection added`);
 					break;
 				case 'unlinkDir':
-					if (collectionKey in collectionEntryMap) {
-						delete collectionEntryMap[JSON.stringify(collection)];
-					}
+					delete collectionEntryMap[collectionKey];
 					break;
 			}
 			return { shouldGenerateTypes: true };


### PR DESCRIPTION
## Changes

- No functional change.
- Use an existing `collectionKey` variable defined at line 117 containing the `collectionEntryMap` key, rather than recalculate it.
- Don't check for an entry before deleting it, just delete it. Deleting a non-existing property in an Array will always succeed. Slightly reduces cyclomatic complexity.

## Testing

The behavior of deleting a non-existent key was checked via the `node` REPL and the [MDN docs for `delete`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete).

The change was otherwise not tested.

## Docs

Not necessary.
