### PR TITLE
In Vercel Edge, include cookies set by Astro.cookies.set

### DIFF
--- a/.changeset/shaggy-camels-dream.md
+++ b/.changeset/shaggy-camels-dream.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+In Vercel Edge, include cookies set by Astro.cookies.set

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -47,7 +47,7 @@
     "build": "astro-scripts build \"src/**/*.ts\" && tsc",
     "build:ci": "astro-scripts build \"src/**/*.ts\"",
     "dev": "astro-scripts dev \"src/**/*.ts\"",
-    "test": "astro-scripts test --timeout 50000 \"test/**/!(hosted|edge-middleware).test.js\"",
+    "test": "astro-scripts test --timeout 50000 \"test/**/!(hosted).test.js\"",
     "test:hosted": "astro-scripts test --timeout 30000 \"test/hosted/*.test.js\""
   },
   "dependencies": {

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -508,6 +508,7 @@ class VercelBuilder {
 
 		await generateEdgeMiddleware(
 			entry,
+			this.config.root,
 			new URL(VERCEL_EDGE_MIDDLEWARE_FILE, this.config.srcDir),
 			new URL('./middleware.mjs', functionFolder),
 			middlewareSecret,

--- a/packages/integrations/vercel/test/edge-middleware.test.js
+++ b/packages/integrations/vercel/test/edge-middleware.test.js
@@ -30,6 +30,15 @@ describe('Vercel edge middleware', () => {
 		);
 	});
 
+	it('edge sets Set-Cookie headers', async () => {
+		let entry = new URL('../.vercel/output/functions/_middleware.func/middleware.mjs', build.config.outDir);
+		const module = await import(entry);
+		const request = new Request('http://example.com/foo');
+		const response = await module.default(request, {});
+		assert.equal(response.headers.get('set-cookie'), 'foo=bar');
+		assert.ok((await response.text()).length, 'Body is included');
+	});
+
 	// TODO: The path here seems to be inconsistent?
 	it.skip('with edge handle file, should successfully build the middleware', async () => {
 		const fixture = await loadFixture({

--- a/packages/integrations/vercel/test/fixtures/middleware-with-edge-file/src/middleware.js
+++ b/packages/integrations/vercel/test/fixtures/middleware-with-edge-file/src/middleware.js
@@ -3,6 +3,7 @@
  */
 export const onRequest = async (context, next) => {
 	const test = 'something';
+	context.cookies.set('foo', 'bar');
 	const response = await next();
 	return response;
 };


### PR DESCRIPTION
## Changes

- Vercel Edge Middleware does a fetch call to the remote, but Astro.cookies need to be set on the response.
- Addes the cookies similar to what happens inside of SSR.

## Testing

- New test added. Also re-enables a test that was previously skipped.

## Docs

N/A, bug fix