### PR TITLE
fix(astro): always return cloned content collection

### DIFF
--- a/.changeset/early-melons-thank.md
+++ b/.changeset/early-melons-thank.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Always return a cloned array from getCollection
+Updates `getCollection()` to always return a cloned array

--- a/.changeset/early-melons-thank.md
+++ b/.changeset/early-melons-thank.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Always return a cloned array from getCollection

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -79,8 +79,7 @@ export function createGetCollection({
 		// Cache `getCollection()` calls in production only
 		// prevents stale cache in development
 		if (!import.meta.env?.DEV && cacheEntriesByCollection.has(collection)) {
-			// Always return a new instance so consumers can safely mutate it
-			entries = [...cacheEntriesByCollection.get(collection)!];
+			entries = cacheEntriesByCollection.get(collection)!;
 		} else {
 			const limit = pLimit(10);
 			entries = await Promise.all(
@@ -115,7 +114,9 @@ export function createGetCollection({
 		if (typeof filter === 'function') {
 			return entries.filter(filter);
 		} else {
-			return entries;
+			// Clone the array so users can safely mutate it. 
+			// slice() is faster than ...spread for large arrays.
+			return entries.slice();
 		}
 	};
 }

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -370,4 +370,26 @@ describe('Content Collections', () => {
 			assert.equal($('script').attr('src').startsWith('/docs'), true);
 		});
 	});
+
+	describe('Mutation', () => {
+		let fixture;
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/content-collections-mutation/',
+			});
+			await fixture.build();
+		});
+
+		it('Does not mutate cached collection', async () => {
+			const html = await fixture.readFile('/index.html');
+			const index = cheerio.load(html)('h2:first').text();
+			const html2 = await fixture.readFile('/another_page/index.html');
+			const anotherPage = cheerio.load(html2)('h2:first').text();
+
+			assert.equal(index, anotherPage);
+		});
+
+	});
+
 });

--- a/packages/astro/test/fixtures/content-collections-mutation/astro.config.mjs
+++ b/packages/astro/test/fixtures/content-collections-mutation/astro.config.mjs
@@ -1,0 +1,6 @@
+import mdx from '@astrojs/mdx';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  integrations: [mdx()],
+});

--- a/packages/astro/test/fixtures/content-collections-mutation/package.json
+++ b/packages/astro/test/fixtures/content-collections-mutation/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/content-collections-mutation",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/mdx": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/content-collections-mutation/src/content/blog/first.md
+++ b/packages/astro/test/fixtures/content-collections-mutation/src/content/blog/first.md
@@ -1,0 +1,6 @@
+---
+title: "First Blog"
+date: 2024-04-05
+---
+
+First blog content.

--- a/packages/astro/test/fixtures/content-collections-mutation/src/content/blog/second.md
+++ b/packages/astro/test/fixtures/content-collections-mutation/src/content/blog/second.md
@@ -1,0 +1,6 @@
+---
+title: "Second Blog"
+date: 2024-04-06
+---
+
+Second blog content.

--- a/packages/astro/test/fixtures/content-collections-mutation/src/content/blog/third.md
+++ b/packages/astro/test/fixtures/content-collections-mutation/src/content/blog/third.md
@@ -1,0 +1,6 @@
+---
+title: "Third Blog"
+date: 2024-04-07
+---
+
+Third blog content.

--- a/packages/astro/test/fixtures/content-collections-mutation/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-collections-mutation/src/content/config.ts
@@ -1,0 +1,16 @@
+// 1. Import utilities from `astro:content`
+import { z, defineCollection } from "astro:content";
+
+// 2. Define a `type` and `schema` for each collection
+const blogCollection = defineCollection({
+  type: "content", // v2.5.0 and later
+  schema: z.object({
+    title: z.string(),
+    date: z.date(),
+  }),
+});
+
+// 3. Export a single `collections` object to register your collection(s)
+export const collections = {
+  blog: blogCollection,
+};

--- a/packages/astro/test/fixtures/content-collections-mutation/src/pages/another_page.astro
+++ b/packages/astro/test/fixtures/content-collections-mutation/src/pages/another_page.astro
@@ -1,0 +1,25 @@
+---
+import { getCollection } from "astro:content";
+const blogs = await getCollection("blog");
+blogs.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf()); // sort by date most recent first
+const latestBlog = blogs.splice(0, 1)[0]; // modifies the collection
+---
+
+<html>
+  <body>
+    <a href="/">home</a>
+    <h1>Latest Blog</h1>
+    <h2>{latestBlog.data.title}</h2>
+    <p>posted: {latestBlog.data.date.toLocaleString()}</p>
+    <br />
+    <h2>Older blogs</h2>
+    {
+      blogs.map((b) => (
+        <>
+          <h3>{b.data.title}</h3>
+          <p>posted: {b.data.date.toLocaleString()}</p>
+        </>
+      ))
+    }
+  </body>
+</html>

--- a/packages/astro/test/fixtures/content-collections-mutation/src/pages/index.astro
+++ b/packages/astro/test/fixtures/content-collections-mutation/src/pages/index.astro
@@ -1,0 +1,25 @@
+---
+import { getCollection } from "astro:content";
+const blogs = await getCollection("blog");
+blogs.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf()); // sort by date most recent first
+const latestBlog = blogs.splice(0, 1)[0]; // modifies the collection
+---
+
+<html>
+  <body>
+    <a href="/another_page">other page</a>
+    <h1>Latest Blog</h1>
+    <h2>{latestBlog.data.title}</h2>
+    <p>posted: {latestBlog.data.date.toLocaleString()}</p>
+    <br />
+    <h2>Older blogs</h2>
+    {
+      blogs.map((b) => (
+        <>
+          <h3>{b.data.title}</h3>
+          <p>posted: {b.data.date.toLocaleString()}</p>
+        </>
+      ))
+    }
+  </body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2599,6 +2599,15 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/content-collections-mutation:
+    dependencies:
+      '@astrojs/mdx':
+        specifier: workspace:*
+        version: link:../../../../integrations/mdx
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/content-collections-with-config-mjs:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

Currently, the first time `getCollection` is called in prod it returns the same array that is then cached, meaning that any mutations are applied to the cached value. Subsequent calls return a clone of the cached value (so these can be safely changed), but any changes made on the first call are still present. The original bug was fixed in #8022, but it missed the issue with the first invocation. This PR ensures that the array is always cloned before returning.

Fixes #10700

## Testing

Adds a test fixture based on the #10700 repro. Thanks @SStembridge.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
