### PR TITLE
fix(astro): ignore query params when matching .astro extension

### DIFF
--- a/.changeset/pink-experts-count.md
+++ b/.changeset/pink-experts-count.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Ignores query strings in module identifiers when matching ".astro" file extensions in Vite plugin

--- a/packages/astro/src/vite-plugin-astro/index.ts
+++ b/packages/astro/src/vite-plugin-astro/index.ts
@@ -202,7 +202,7 @@ export default function astro({ settings, logger }: AstroPluginOptions): vite.Pl
 		async transform(source, id) {
 			const parsedId = parseAstroRequest(id);
 			// ignore astro file sub-requests, e.g. Foo.astro?astro&type=script&index=0&lang.ts
-			if (!id.endsWith('.astro') || parsedId.query.astro) {
+			if (!parsedId.filename.endsWith('.astro') || parsedId.query.astro) {
 				return;
 			}
 

--- a/packages/astro/test/extension-matching.test.js
+++ b/packages/astro/test/extension-matching.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('Matching .astro modules', () => {
+	let fixture;
+	/** @type {string} */
+	let output;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/extension-matching/',
+		});
+		await fixture.build();
+		output = await fixture.readFile('./index.html');
+	});
+
+	it('loads virtual modules with .astro in query string', async () => {
+		const $ = cheerio.load(output);
+		const title = $('h1').text();
+		assert.strictEqual(title, 'true');
+	});
+});

--- a/packages/astro/test/fixtures/extension-matching/astro.config.mjs
+++ b/packages/astro/test/fixtures/extension-matching/astro.config.mjs
@@ -1,0 +1,38 @@
+import { defineConfig } from 'astro/config';
+
+const MODULE_ID = 'virtual:test';
+const RESOLVED_MODULE_ID = '\0virtual:test';
+
+export default defineConfig({
+  integrations: [
+    {
+      name: 'astro-test-invalid-transform',
+      hooks: {
+        'astro:config:setup': ({ updateConfig }) => {
+          updateConfig({
+            vite: {
+              plugins: [
+                // -----------------------------------
+                {
+                  name: 'vite-test-invalid-transform',
+                  resolveId(id) {
+                    if (id === MODULE_ID) {
+                      // Astro tries to transform this import because the query params can end with '.astro'
+                      return `${RESOLVED_MODULE_ID}?importer=index.astro`;
+                    }
+                  },
+                  load(id) {
+                    if (id.startsWith(RESOLVED_MODULE_ID)) {
+                      return `export default 'true';`;
+                    }
+                  },
+                },
+                // -----------------------------------
+              ],
+            },
+          });
+        },
+      },
+    },
+  ],
+});

--- a/packages/astro/test/fixtures/extension-matching/package.json
+++ b/packages/astro/test/fixtures/extension-matching/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@test/extension-matching",
+  "type": "module",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/extension-matching/src/pages/index.astro
+++ b/packages/astro/test/fixtures/extension-matching/src/pages/index.astro
@@ -1,0 +1,12 @@
+---
+let success =  'false'
+
+try {
+	success = (await import('virtual:test')).default
+} catch (e) {
+	console.error('Failed to load virtual module:', e)
+}
+
+console.log('Loaded virtual module:', success)
+---
+<h1>{String(success)}</h1>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2946,6 +2946,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/extension-matching:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/fetch:
     dependencies:
       '@astrojs/preact':
@@ -9575,7 +9581,6 @@ packages:
 
   libsql@0.3.12:
     resolution: {integrity: sha512-to30hj8O3DjS97wpbKN6ERZ8k66MN1IaOfFLR6oHqd25GMiPJ/ZX0VaZ7w+TsPmxcFS3p71qArj/hiedCyvXCg==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@2.1.0:


### PR DESCRIPTION
## Changes

Checks the filename for the `.astro`, rather than the full ID. Fixes #11230, where a query that ended in the string `.astro` would incorrectly match.

## Testing

I wasn't able to find a place where there were tests of this part of the code. If anyone has suggestions for a good place to test it then that would be welcome.

## Docs
Nothing changed
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
