### PR TITLE
Fix a performance issue with JSON schema generation

### DIFF
--- a/.changeset/early-spies-bow.md
+++ b/.changeset/early-spies-bow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a performance issue with JSON schema generation

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -449,41 +449,42 @@ async function writeContentFiles({
 				for (const entryKey of Object.keys(collection.entries).sort()) {
 					const dataType = collectionConfig?.schema ? `InferEntrySchema<${collectionKey}>` : 'any';
 					dataTypesStr += `${entryKey}: {\n	id: ${entryKey};\n  collection: ${collectionKey};\n  data: ${dataType}\n};\n`;
-					if (
-						settings.config.experimental.contentCollectionJsonSchema &&
-						collectionConfig?.schema
-					) {
-						let zodSchemaForJson =
-							typeof collectionConfig.schema === 'function'
-								? collectionConfig.schema({ image: () => z.string() })
-								: collectionConfig.schema;
-						if (zodSchemaForJson instanceof z.ZodObject) {
-							zodSchemaForJson = zodSchemaForJson.extend({
-								$schema: z.string().optional(),
-							});
-						}
-						try {
-							await fs.promises.writeFile(
-								new URL(`./${collectionKey.replace(/"/g, '')}.schema.json`, collectionSchemasDir),
-								JSON.stringify(
-									zodToJsonSchema(zodSchemaForJson, {
-										name: collectionKey.replace(/"/g, ''),
-										markdownDescription: true,
-										errorMessages: true,
-									}),
-									null,
-									2
-								)
-							);
-						} catch (err) {
-							logger.warn(
-								'content',
-								`An error was encountered while creating the JSON schema for the ${entryKey} entry in ${collectionKey} collection. Proceeding without it. Error: ${err}`
-							);
-						}
+					dataTypesStr += `};\n`;
+				}
+
+				if (
+					settings.config.experimental.contentCollectionJsonSchema &&
+					collectionConfig?.schema
+				) {
+					let zodSchemaForJson =
+						typeof collectionConfig.schema === 'function'
+							? collectionConfig.schema({ image: () => z.string() })
+							: collectionConfig.schema;
+					if (zodSchemaForJson instanceof z.ZodObject) {
+						zodSchemaForJson = zodSchemaForJson.extend({
+							$schema: z.string().optional(),
+						});
+					}
+					try {
+						await fs.promises.writeFile(
+							new URL(`./${collectionKey.replace(/"/g, '')}.schema.json`, collectionSchemasDir),
+							JSON.stringify(
+								zodToJsonSchema(zodSchemaForJson, {
+									name: collectionKey.replace(/"/g, ''),
+									markdownDescription: true,
+									errorMessages: true,
+								}),
+								null,
+								2
+							)
+						);
+					} catch (err) {
+						logger.warn(
+							'content',
+						`An error was encountered while creating the JSON schema for the ${collectionKey} collection. Proceeding without it. Error: ${err}`
+						);
 					}
 				}
-				dataTypesStr += `};\n`;
 				break;
 		}
 	}


### PR DESCRIPTION
## Changes

I have a large number of items in my content collections and I've noticed a considerable slowness when starting the dev server, having looked into it (with `--verbose`), I noticed that the JSON schema files were being changed repeatedly which made the HMR spend approximately 90ms reloading it. With a lot of content files, this quickly adds up and made my startup times approach a minute in some cases 🙈 

This PR changes the behaviour so that the JSON schema is only generated once rather than in the `for` loop like it was before, I can't think of any reason that it needed to be in that `for` loop but other people may know better than me!

## Testing

I've tested this change in the project that was having the performance issue and it only generates the JSON schemas once and the dev server starts instantly, as it did before.

I also ran the unit tests locally and they still generate the same JSON schema files

I haven't added a test for this scenario, as it could be quite difficult to prove that it was slow but isn't now but I'm happy to look into it, if it's of value!

If nothing else, I could throw together a StackBlitz example that shows the issue, if needs be 🙂 

## Docs

Nothing changes for the end user, so no new docs required
