### PR TITLE
fix(markdown-remark): mark prism package as an internal dependency

### DIFF
--- a/.changeset/few-beans-tickle.md
+++ b/.changeset/few-beans-tickle.md
@@ -1,0 +1,9 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Mark @astrojs/prism as an internal dependency
+
+
+This package wasn't marked as an internal dependency correctly, which introduced a race condition in the build process.
+Starting from now, @astrojs/prism will always be built first.

--- a/.changeset/few-beans-tickle.md
+++ b/.changeset/few-beans-tickle.md
@@ -1,9 +1,0 @@
----
-'@astrojs/markdown-remark': patch
----
-
-Mark @astrojs/prism as an internal dependency
-
-
-This package wasn't marked as an internal dependency correctly, which introduced a race condition in the build process.
-Starting from now, @astrojs/prism will always be built first.

--- a/packages/markdown/remark/package.json
+++ b/packages/markdown/remark/package.json
@@ -34,7 +34,7 @@
     "test": "astro-scripts test \"test/**/*.test.js\""
   },
   "dependencies": {
-    "@astrojs/prism": "^3.1.0",
+    "@astrojs/prism": "workspace:*",
     "github-slugger": "^2.0.0",
     "hast-util-from-html": "^2.0.1",
     "hast-util-to-text": "^4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5587,7 +5587,7 @@ importers:
   packages/markdown/remark:
     dependencies:
       '@astrojs/prism':
-        specifier: ^3.1.0
+        specifier: workspace:*
         version: link:../../astro-prism
       github-slugger:
         specifier: ^2.0.0


### PR DESCRIPTION
## Changes

This package wasn't marked as an internal dependency correctly, which introduced a race condition in the build process. Starting from now, `@astrojs/prism` will always be built first.

See discussion on Discord (contribute) for details.

## Testing

Clear Turborepo cache, try building `@astrojs/markdown-remark` - you will see an error regarding `@astrojs/prism`.

Checkout to this branch, do the same steps - you will see no error, `@astrojs/prism` will be built first.

## Docs

No changes needed