### PR TITLE
[docs] update JSDoc for API Reference links

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -285,7 +285,7 @@ export interface AstroGlobal<
 	/**
 	 * The <Astro.self /> element allows a component to reference itself recursively.
 	 *
-	 * [Astro reference](https://docs.astro.build/en/guides/api-reference/#astroself)
+	 * [Astro reference](https://docs.astro.build/en/reference/api-reference/#astroself)
 	 */
 	self: Self;
 	/** Utility functions for modifying an Astro component’s slotted children
@@ -2857,7 +2857,7 @@ export interface APIContext<
 	 * }
 	 * ```
 	 *
-	 * [Reference](https://docs.astro.build/en/guides/api-reference/#contextprops)
+	 * [Reference](https://docs.astro.build/en/reference/api-reference/#contextprops)
 	 */
 	props: AstroSharedContext<Props, APIParams>['props'];
 	/**


### PR DESCRIPTION
## Changes

* There were two incorrect links for the `reference/api-reference` in JSDoc that now point to the right place.

## Testing

Tried links before and after. Updated links work. 

## Docs

These are JSDocs.