### PR TITLE
fix: throw error if rewrite is attempted after body is used

### DIFF
--- a/.changeset/healthy-oranges-report.md
+++ b/.changeset/healthy-oranges-report.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Throws an error if Astro.rewrite is used after the request body has been used
+Adds a new error `RewriteWithBodyUsed` that throws when `Astro.rewrite` is used after the request body has already been read.

--- a/.changeset/healthy-oranges-report.md
+++ b/.changeset/healthy-oranges-report.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Throws an error if Astro.rewrite is used after the request body has been used

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1270,7 +1270,7 @@ export const ServerOnlyModule = {
 /**
  * @docs
  * @description
- * `Astro.rewrite()` cannot be used if the request body has already been read. If you need to read the body you should first clone the request. For example:
+ * `Astro.rewrite()` cannot be used if the request body has already been read. If you need to read the body, first clone the request. For example:
  * 
  * ```js
  * const data = await Astro.request.clone().formData();
@@ -1286,7 +1286,7 @@ export const ServerOnlyModule = {
 export const RewriteWithBodyUsed = {
 	name: 'RewriteWithBodyUsed',
 	title: 'Cannot use Astro.rewrite after the request body has been read',
-	message: 'Astro.rewrite() cannot be used if the request body has already been read. If you need to read the body you should first clone the request.',
+	message: 'Astro.rewrite() cannot be used if the request body has already been read. If you need to read the body, first clone the request.',
 } satisfies ErrorData;
 
 /**

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1266,6 +1266,29 @@ export const ServerOnlyModule = {
 	message: (name: string) => `The "${name}" module is only available server-side.`,
 } satisfies ErrorData;
 
+
+/**
+ * @docs
+ * @description
+ * `Astro.rewrite()` cannot be used if the request body has already been read. If you need to read the body you should first clone the request. For example:
+ * 
+ * ```js
+ * const data = await Astro.request.clone().formData();
+ * 
+ * Astro.rewrite("/target")
+ * ```
+ * 
+ * @see
+ * - [Request.clone()](https://developer.mozilla.org/en-US/docs/Web/API/Request/clone)
+ * - [Astro.rewrite](https://docs.astro.build/en/reference/configuration-reference/#experimentalrewriting)
+ */
+
+export const RewriteWithBodyUsed = {
+	name: 'RewriteWithBodyUsed',
+	title: 'Cannot use Astro.rewrite after the request body has been read',
+	message: 'Astro.rewrite() cannot be used if the request body has already been read. If you need to read the body you should first clone the request.',
+} satisfies ErrorData;
+
 /**
  * @docs
  * @kind heading

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -542,6 +542,9 @@ export class RenderContext {
 	 * @param oldRequest The old `Request`
 	 */
 	#copyRequest(newUrl: URL, oldRequest: Request): Request {
+		if(oldRequest.bodyUsed) {
+			throw new AstroError(AstroErrorData.RewriteWithBodyUsed);
+		}
 		return new Request(newUrl, {
 			method: oldRequest.method,
 			headers: oldRequest.headers,

--- a/packages/astro/test/fixtures/rewrite-server/src/pages/post/index.astro
+++ b/packages/astro/test/fixtures/rewrite-server/src/pages/post/index.astro
@@ -1,0 +1,7 @@
+---
+---
+
+<form method="post" action="/post/post-body-used">
+	<input type="text" name="email" value="example@example.com" />
+	<input type="submit" />
+</form>

--- a/packages/astro/test/fixtures/rewrite-server/src/pages/post/post-b.astro
+++ b/packages/astro/test/fixtures/rewrite-server/src/pages/post/post-b.astro
@@ -1,0 +1,15 @@
+---
+let email = ''
+if (Astro.request.method === 'POST') {
+	try {
+		const data = await Astro.request.formData();
+		email = data.get('email');
+	} catch (e) {
+		console.log(e)
+	}
+}
+---
+
+<h1>Post B</h1>
+
+<h2>{email}</h2>

--- a/packages/astro/test/fixtures/rewrite-server/src/pages/post/post-body-used.astro
+++ b/packages/astro/test/fixtures/rewrite-server/src/pages/post/post-body-used.astro
@@ -1,0 +1,17 @@
+---
+let data
+if (Astro.request.method === 'POST') {
+	try {
+		data = await Astro.request.text();
+	} catch (e) {
+		console.log(e)
+	}
+}
+
+return Astro.rewrite('/post/post-b')
+
+---
+
+<h1>Post body used</h1>
+
+<h2>{data}</h2>

--- a/packages/astro/test/rewrite.test.js
+++ b/packages/astro/test/rewrite.test.js
@@ -85,6 +85,21 @@ describe('Dev rewrite, hybrid/server', () => {
 		assert.match($('h1').text(), /Title/);
 		assert.match($('p').text(), /some-slug/);
 	});
+
+	it('should display an error if a rewrite is attempted after the body has been consumed', async () => {
+		const formData = new FormData();
+		formData.append('email', 'example@example.com');
+
+		const request = new Request('http://example.com/post/post-body-used', {
+			method: 'POST',
+			body: formData,
+		});
+		const response = await fixture.fetch('/post/post-body-used', request);
+		const html = await response.text();
+		const $ = cheerioLoad(html);
+
+		assert.equal($('title').text(), 'RewriteWithBodyUsed');
+	});
 });
 
 describe('Build reroute', () => {
@@ -271,6 +286,18 @@ describe('SSR rewrite, hybrid/server', () => {
 
 		assert.match($('h1').text(), /Title/);
 		assert.match($('p').text(), /some-slug/);
+	});
+
+	it('should return a 500 if a rewrite is attempted after the body has been read', async () => {
+		const formData = new FormData();
+		formData.append('email', 'example@example.com');
+
+		const request = new Request('http://example.com/post/post-body-used', {
+			method: 'POST',
+			body: formData,
+		});
+		const response = await app.render(request);
+		assert.equal(response.status, 500);
 	});
 });
 


### PR DESCRIPTION
## Changes

Experimental `Astro.rewrite()` clones the request, which throws a confusing error if the body has already been consumed. This PR detects this and throws a more helpful error instead.

Fixes #11247

## Testing

Adds tests

## Docs

@withastro/maintainers-docs This adds a new Astro error 

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
