### PR TITLE
Fix backwards compat with Astro <= 4.9 in Node and Vercel adapters

### DIFF
--- a/.changeset/serious-humans-obey.md
+++ b/.changeset/serious-humans-obey.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/vercel': patch
+'@astrojs/node': patch
+---
+
+Fix backwards compat with Astro <= 4.9

--- a/packages/integrations/node/src/server.ts
+++ b/packages/integrations/node/src/server.ts
@@ -5,10 +5,13 @@ import { createStandaloneHandler } from './standalone.js';
 import startServer from './standalone.js';
 import type { Options } from './types.js';
 
+type EnvSetupModule = typeof import('astro/env/setup');
+
 // Won't throw if the virtual module is not available because it's not supported in
 // the users's astro version or if astro:env is not enabled in the project
-await import('astro/env/setup')
-	.then((mod) => mod.setGetEnv((key) => process.env[key]))
+const setupModule = 'astro/env/setup';
+await import(/* @vite-ignore */setupModule)
+	.then((mod: EnvSetupModule) => mod.setGetEnv((key) => process.env[key]))
 	.catch(() => {});
 
 applyPolyfills();

--- a/packages/integrations/vercel/src/serverless/entrypoint.ts
+++ b/packages/integrations/vercel/src/serverless/entrypoint.ts
@@ -8,10 +8,13 @@ import {
 	ASTRO_PATH_PARAM,
 } from './adapter.js';
 
+type EnvSetupModule = typeof import('astro/env/setup');
+
 // Won't throw if the virtual module is not available because it's not supported in
 // the users's astro version or if astro:env is not enabled in the project
-await import('astro/env/setup')
-	.then((mod) => mod.setGetEnv((key) => process.env[key]))
+const setupModule = 'astro/env/setup';
+await import(/* @vite-ignore */setupModule)
+	.then((mod: EnvSetupModule) => mod.setGetEnv((key) => process.env[key]))
 	.catch(() => {});
 
 applyPolyfills();


### PR DESCRIPTION
## Changes

- Even though the code uses a dynamic import with a catch, this still breaks in the build because Rollup tries to build that import.
- Moving the import specifier to a variable lets us hide from Rollup, while still dynamically importing this module at runtime.

## Testing

- Can't create unit tests for this since it requires Astro <= 4.9. Tested manually.

## Docs

N/A, bug fix