### PR TITLE
Import Database type from correct file

### DIFF
--- a/.changeset/nice-pillows-teach.md
+++ b/.changeset/nice-pillows-teach.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/db': patch
+---
+
+Import type `Database` from correct file

--- a/packages/db/virtual.d.ts
+++ b/packages/db/virtual.d.ts
@@ -1,7 +1,7 @@
 declare module 'astro:db' {
 	type RuntimeConfig = typeof import('./dist/_internal/runtime/virtual.js');
 
-	export const db: import('./dist/_internal/runtime/virtual.js').Database;
+	export const db: import('./dist/runtime/index.js').Database;
 	export const dbUrl: string;
 
 	export const sql: RuntimeConfig['sql'];


### PR DESCRIPTION
## Changes
Following #11216 `Database` type was moved between files, but dts wasn't updated. In @astrojs/db 0.11.15 db is always type any as it can't be found in `'./dist/_internal/runtime/virtual.js'`

Sorry if there is anything wrong with the change, just started using the lib today.
