### PR TITLE
chore: logging cleanup

### DIFF
--- a/.changeset/thin-icons-yell.md
+++ b/.changeset/thin-icons-yell.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/sitemap': patch
+'@astrojs/node': patch
+'@astrojs/mdx': patch
+---
+
+Refactor to use Astro's integration logger for logging

--- a/packages/integrations/mdx/src/utils.ts
+++ b/packages/integrations/mdx/src/utils.ts
@@ -1,8 +1,8 @@
 import type { Options as AcornOpts } from 'acorn';
 import { parse } from 'acorn';
-import type { AstroConfig, SSRError } from 'astro';
+import type { AstroConfig, AstroIntegrationLogger, SSRError } from 'astro';
 import matter from 'gray-matter';
-import { bold, yellow } from 'kleur/colors';
+import { bold } from 'kleur/colors';
 import type { MdxjsEsm } from 'mdast-util-mdx';
 import type { PluggableList } from 'unified';
 
@@ -85,22 +85,22 @@ export function jsToTreeNode(
 	};
 }
 
-export function ignoreStringPlugins(plugins: any[]): PluggableList {
+export function ignoreStringPlugins(plugins: any[], logger: AstroIntegrationLogger): PluggableList {
 	let validPlugins: PluggableList = [];
 	let hasInvalidPlugin = false;
 	for (const plugin of plugins) {
 		if (typeof plugin === 'string') {
-			console.warn(yellow(`[MDX] ${bold(plugin)} not applied.`));
+			logger.warn(`${bold(plugin)} not applied.`);
 			hasInvalidPlugin = true;
 		} else if (Array.isArray(plugin) && typeof plugin[0] === 'string') {
-			console.warn(yellow(`[MDX] ${bold(plugin[0])} not applied.`));
+			logger.warn(`${bold(plugin[0])} not applied.`);
 			hasInvalidPlugin = true;
 		} else {
 			validPlugins.push(plugin);
 		}
 	}
 	if (hasInvalidPlugin) {
-		console.warn(
+		logger.warn(
 			`To inherit Markdown plugins in MDX, please use explicit imports in your config instead of "strings." See Markdown docs: https://docs.astro.build/en/guides/markdown-content/#markdown-plugins`
 		);
 	}

--- a/packages/integrations/node/src/index.ts
+++ b/packages/integrations/node/src/index.ts
@@ -45,7 +45,7 @@ export default function createIntegration(userOptions: UserOptions): AstroIntegr
 					},
 				});
 			},
-			'astro:config:done': ({ setAdapter, config }) => {
+			'astro:config:done': ({ setAdapter, config, logger }) => {
 				_options = {
 					...userOptions,
 					client: config.build.client?.toString(),
@@ -57,8 +57,8 @@ export default function createIntegration(userOptions: UserOptions): AstroIntegr
 				setAdapter(getAdapter(_options));
 
 				if (config.output === 'static') {
-					console.warn(
-						`[@astrojs/node] \`output: "server"\` or  \`output: "hybrid"\` is required to use this adapter.`
+					logger.warn(
+						`\`output: "server"\` or  \`output: "hybrid"\` is required to use this adapter.`
 					);
 				}
 			},

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -88,15 +88,7 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 
 					const { filter, customPages, serialize, entryLimit } = opts;
 
-					let finalSiteUrl: URL;
-					if (config.site) {
-						finalSiteUrl = new URL(config.base, config.site);
-					} else {
-						console.warn(
-							'The Sitemap integration requires the `site` astro.config option. Skipping.'
-						);
-						return;
-					}
+					let finalSiteUrl = new URL(config.base, config.site);
 					const shouldIgnoreStatus = isStatusCodePage(Object.keys(opts.i18n?.locales ?? {}));
 					let pageUrls = pages
 						.filter((p) => !shouldIgnoreStatus(p.pathname))


### PR DESCRIPTION
## Changes

- Use the logger provided by Astro more consistently in integrations.
- Remove an old duplicate check in the sitemap integration.

## Testing

No tests added because there are no integration log tests (to my knowledge).

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

No docs added because this is strictly stylistic.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
