### PR TITLE
fix(astro): duplicated brackets are generated in data collections.

### DIFF
--- a/.changeset/duplicated-brackets-generation.md
+++ b/.changeset/duplicated-brackets-generation.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Drop duplicated brackets in data collections schema generation.

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -449,7 +449,6 @@ async function writeContentFiles({
 				for (const entryKey of Object.keys(collection.entries).sort()) {
 					const dataType = collectionConfig?.schema ? `InferEntrySchema<${collectionKey}>` : 'any';
 					dataTypesStr += `${entryKey}: {\n	id: ${entryKey};\n  collection: ${collectionKey};\n  data: ${dataType}\n};\n`;
-					dataTypesStr += `};\n`;
 				}
 
 				if (settings.config.experimental.contentCollectionJsonSchema && collectionConfig?.schema) {
@@ -482,6 +481,7 @@ async function writeContentFiles({
 						);
 					}
 				}
+				dataTypesStr += `};\n`;
 				break;
 		}
 	}


### PR DESCRIPTION
## Changes

This PR fixed #11274

## Testing

This is a minor patch fix which doesn't need test.

## Docs

This doesn't introduce any new feature nor break changes. No doc is provided.