### PR TITLE
fix: allow cookies to be set in rewritten responses

### DIFF
--- a/.changeset/big-eyes-share.md
+++ b/.changeset/big-eyes-share.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that prevented cookies from being set when using experimental rewrites

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -347,9 +347,6 @@ export class App {
 			for (const setCookieHeaderValue of App.getSetCookieFromResponse(response)) {
 				response.headers.append('set-cookie', setCookieHeaderValue);
 			}
-		} else {
-			// It may have been set already in a rewrite
-			response.headers.delete('set-cookie');
 		}
 
 		Reflect.set(response, responseSentSymbol, true);

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -347,6 +347,9 @@ export class App {
 			for (const setCookieHeaderValue of App.getSetCookieFromResponse(response)) {
 				response.headers.append('set-cookie', setCookieHeaderValue);
 			}
+		} else {
+			// It may have been set already in a rewrite
+			response.headers.delete('set-cookie');
 		}
 
 		Reflect.set(response, responseSentSymbol, true);

--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -192,6 +192,19 @@ class AstroCookies implements AstroCookiesInterface {
 	}
 
 	/**
+	 * Merges a new AstroCookies instance into the current instance. Any new cookies
+	 * will be added to the current instance, overwriting any existing cookies with the same name.
+	 */
+	merge(cookies: AstroCookies) {
+		const outgoing = cookies.#outgoing;
+		if (outgoing) {
+			for (const [key, value] of outgoing) {
+				this.#ensureOutgoingMap().set(key, value);
+			}
+		}
+	}
+
+	/**
 	 * Astro.cookies.header() returns an iterator for the cookies that have previously
 	 * been set by either Astro.cookies.set() or Astro.cookies.delete().
 	 * This method is primarily used by adapters to set the header on outgoing responses.

--- a/packages/astro/src/core/cookies/response.ts
+++ b/packages/astro/src/core/cookies/response.ts
@@ -10,7 +10,7 @@ export function responseHasCookies(response: Response): boolean {
 	return Reflect.has(response, astroCookiesSymbol);
 }
 
-function getFromResponse(response: Response): AstroCookies | undefined {
+export function getFromResponse(response: Response): AstroCookies | undefined {
 	let cookies = Reflect.get(response, astroCookiesSymbol);
 	if (cookies != null) {
 		return cookies as AstroCookies;

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -27,6 +27,7 @@ import {
 	responseSentSymbol,
 } from './constants.js';
 import { AstroCookies, attachCookiesToResponse } from './cookies/index.js';
+import { getFromResponse } from './cookies/response.js';
 import { AstroError, AstroErrorData } from './errors/index.js';
 import { callMiddleware } from './middleware/callMiddleware.js';
 import { sequence } from './middleware/index.js';
@@ -164,10 +165,9 @@ export class RenderContext {
 							this.routeData
 						);
 
-						if (result.cookies) {
-							for (const cookie of AstroCookies.consume(result.cookies)) {
-								response.headers.append('Set-Cookie', cookie);
-							}
+						const responseCookies = getFromResponse(response);
+						if (result.cookies && responseCookies) {
+							result.cookies?.merge(responseCookies);
 						}
 					} catch (e) {
 						// If there is an error in the page's frontmatter or instantiation of the RenderTemplate fails midway,

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -163,6 +163,12 @@ export class RenderContext {
 							streaming,
 							this.routeData
 						);
+
+						if (result.cookies) {
+							for (const cookie of AstroCookies.consume(result.cookies)) {
+								response.headers.append('Set-Cookie', cookie);
+							}
+						}
 					} catch (e) {
 						// If there is an error in the page's frontmatter or instantiation of the RenderTemplate fails midway,
 						// we signal to the rest of the internals that we can ignore the results of existing renders and avoid kicking off more of them.

--- a/packages/astro/test/astro-cookies.test.js
+++ b/packages/astro/test/astro-cookies.test.js
@@ -53,11 +53,29 @@ describe('Astro.cookies', () => {
 			}
 		});
 
-		it('can set cookies in a rewritten request', async () => {
+		it('can set cookies in a rewritten page request', async () => {
 			const response = await fixture.fetch('/from');
 			assert.equal(response.status, 200);
 
-			assert.equal(response.headers.get('set-cookie'), 'my_cookie=value');
+			assert.match(response.headers.get('set-cookie'), /my_cookie=value/);
+		});
+
+		it('overwrites cookie values set in the source page with values from the target page', async () => {
+			const response = await fixture.fetch('/from');
+			assert.equal(response.status, 200);
+			assert.match(response.headers.get('set-cookie'), /another=set-in-target/);
+		});
+
+		it('allows cookies to be set in the source page', async () => {
+			const response = await fixture.fetch('/from');
+			assert.equal(response.status, 200);
+			assert.match(response.headers.get('set-cookie'), /set-in-from=yes/);
+		});
+
+		it('can set cookies in a rewritten endpoint request', async () => {
+			const response = await fixture.fetch('/from-endpoint');
+			assert.equal(response.status, 200);
+			assert.match(response.headers.get('set-cookie'), /test=value/);
 		});
 	});
 
@@ -146,6 +164,35 @@ describe('Astro.cookies', () => {
 			let data = JSON.parse(decodeURIComponent(raw));
 			assert.equal(typeof data, 'object');
 			assert.equal(data.mode, 'dark');
+		});
+
+		it('can set cookies in a rewritten page request', async () => {
+			const request = new Request('http://example.com/from');
+			const response = await app.render(request, { addCookieHeader: true });
+			assert.equal(response.status, 200);
+
+			assert.match(response.headers.get('Set-Cookie'), /my_cookie=value/);
+		});
+
+		it('overwrites cookie values set in the source page with values from the target page', async () => {
+			const request = new Request('http://example.com/from');
+			const response = await app.render(request, { addCookieHeader: true });
+			assert.equal(response.status, 200);
+			assert.match(response.headers.get('Set-Cookie'), /another=set-in-target/);
+		});
+
+		it('allows cookies to be set in the source page', async () => {
+			const request = new Request('http://example.com/from');
+			const response = await app.render(request, { addCookieHeader: true });
+			assert.equal(response.status, 200);
+			assert.match(response.headers.get('Set-Cookie'), /set-in-from=yes/);
+		});
+
+		it('can set cookies in a rewritten endpoint request', async () => {
+			const request = new Request('http://example.com/from-endpoint');
+			const response = await app.render(request, { addCookieHeader: true });
+			assert.equal(response.status, 200);
+			assert.match(response.headers.get('Set-Cookie'), /test=value/);
 		});
 	});
 });

--- a/packages/astro/test/astro-cookies.test.js
+++ b/packages/astro/test/astro-cookies.test.js
@@ -52,6 +52,13 @@ describe('Astro.cookies', () => {
 				assert.equal(response.headers.has('set-cookie'), true);
 			}
 		});
+
+		it('can set cookies in a rewritten request', async () => {
+			const response = await fixture.fetch('/from');
+			assert.equal(response.status, 200);
+
+			assert.equal(response.headers.get('set-cookie'), 'my_cookie=value');
+		});
 	});
 
 	describe('Production', () => {

--- a/packages/astro/test/fixtures/astro-cookies/src/pages/from-endpoint.ts
+++ b/packages/astro/test/fixtures/astro-cookies/src/pages/from-endpoint.ts
@@ -1,0 +1,3 @@
+export async function GET(context) {
+	return context.rewrite('/to-endpoint');
+}

--- a/packages/astro/test/fixtures/astro-cookies/src/pages/from.astro
+++ b/packages/astro/test/fixtures/astro-cookies/src/pages/from.astro
@@ -1,4 +1,5 @@
 ---
-console.log('cookie value: ', Astro.cookies.get('my_cookie')?.value); 
+Astro.cookies.set('another','set-in-from');
+Astro.cookies.set('set-in-from','yes');
 return Astro.rewrite('/rewrite-target');
 ---

--- a/packages/astro/test/fixtures/astro-cookies/src/pages/from.astro
+++ b/packages/astro/test/fixtures/astro-cookies/src/pages/from.astro
@@ -1,0 +1,4 @@
+---
+console.log('cookie value: ', Astro.cookies.get('my_cookie')?.value); 
+return Astro.rewrite('/rewrite-target');
+---

--- a/packages/astro/test/fixtures/astro-cookies/src/pages/rewrite-target.astro
+++ b/packages/astro/test/fixtures/astro-cookies/src/pages/rewrite-target.astro
@@ -1,0 +1,16 @@
+---
+Astro.cookies.set('my_cookie', 'value')
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={Astro.generator} />
+		<title>Page 2</title>
+	</head>
+  <body>
+    <h1>Page 2</h1>
+  </body>
+</html>

--- a/packages/astro/test/fixtures/astro-cookies/src/pages/rewrite-target.astro
+++ b/packages/astro/test/fixtures/astro-cookies/src/pages/rewrite-target.astro
@@ -1,5 +1,7 @@
 ---
 Astro.cookies.set('my_cookie', 'value')
+Astro.cookies.set('another','set-in-target');
+
 ---
 
 <html lang="en">

--- a/packages/astro/test/fixtures/astro-cookies/src/pages/to-endpoint.ts
+++ b/packages/astro/test/fixtures/astro-cookies/src/pages/to-endpoint.ts
@@ -1,0 +1,4 @@
+export async function GET(context) {
+	context.cookies.set('test', 'value');
+	return Response.json({hi: "world"})
+}


### PR DESCRIPTION
## Changes

Ensures that `set-cookie` headers are set when rewriting a request.

Fixes #11265

## Testing

Adds a test case for a rewritten request

## Docs
Just a bugfix
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
