### PR TITLE
fix: warn for missing head

### DIFF
--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -199,8 +199,18 @@ async function generatePage(
 	pipeline: BuildPipeline
 ) {
 	// prepare information we need
-	const { config, internals, logger } = pipeline;
+	const { config, logger, internals } = pipeline;
+	
 	const pageModulePromise = ssrEntry.page;
+	const viteId = internals.viteIdsByPage.get(pageData.key)
+	const hasStyles = pageData.styles.length > 0;
+	const hasScripts = Boolean(pageData.hoistedScript);
+	if(viteId && !internals.componentMetadata.get(viteId)?.containsHead && (hasScripts || hasStyles)) {
+		const reason = [hasScripts ? 'scripts' : '', hasStyles ? 'styles' : ''].filter(Boolean).join(' and ')
+		logger.warn(null, `${blue(pageData.component)} does not contain a ${green('<head>')} element, but has hoisted ${reason}. This is probably a mistake and can cause unexpected behavior.`)
+	}
+
+
 
 	// Calculate information of the page, like scripts, links and styles
 	const styles = pageData.styles

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -53,6 +53,11 @@ export interface BuildInternals {
 	pagesByViteID: Map<ViteID, PageBuildData>;
 
 	/**
+	 * A map for Vite module IDs by page key
+	 */
+	viteIdsByPage: Map<string, string>;
+
+	/**
 	 * A map for page-specific information by a client:only component
 	 */
 	pagesByClientOnly: Map<string, Set<PageBuildData>>;
@@ -142,6 +147,7 @@ export function createBuildInternals(): BuildInternals {
 		pagesByKeys: new Map(),
 		pageOptionsByPage: new Map(),
 		pagesByViteID: new Map(),
+		viteIdsByPage: new Map(),
 		pagesByClientOnly: new Map(),
 		pagesByScriptId: new Map(),
 
@@ -169,7 +175,9 @@ export function trackPageData(
 ): void {
 	pageData.moduleSpecifier = componentModuleId;
 	internals.pagesByKeys.set(pageData.key, pageData);
-	internals.pagesByViteID.set(viteID(componentURL), pageData);
+	const id = viteID(componentURL)
+	internals.pagesByViteID.set(id, pageData);
+	internals.viteIdsByPage.set(pageData.key, id);
 }
 
 /**

--- a/packages/astro/test/fixtures/ssr-hoisted-script/src/components/button.astro
+++ b/packages/astro/test/fixtures/ssr-hoisted-script/src/components/button.astro
@@ -1,0 +1,11 @@
+<button>Hello</button>
+<script>
+		document.querySelector('button')!.addEventListener('click', function() {
+				alert('Hello');
+		});
+</script>
+<style>
+		button {
+				background-color: red;
+		}
+</style>

--- a/packages/astro/test/fixtures/ssr-hoisted-script/src/pages/no-head.astro
+++ b/packages/astro/test/fixtures/ssr-hoisted-script/src/pages/no-head.astro
@@ -1,0 +1,22 @@
+---
+import Button from '../components/button.astro'
+---
+<html>
+	<meta charset="UTF-8">
+	<meta name="description" content="Astro description">
+	<meta name="viewport" content="width=device-width">
+	<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+	<meta name="generator" content="Astro v4.10.3">
+	<title>Welcome to Astro.</title>
+	<body>
+		<h1>Testing</h1>
+		<Button />
+		<script>console.log('hello world');</script>
+		<style>
+			h1 {
+				color: #111;
+			}
+		</style>
+	</body>
+	
+</html>


### PR DESCRIPTION
## Changes

This PR warns if a page has either hoisted scripts or inline styles, but does not have a head element. This can cause bugs and is probably a mistake.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
