### PR TITLE
bug: removes type override from defineAction

### DIFF
--- a/.changeset/quiet-doors-eat.md
+++ b/.changeset/quiet-doors-eat.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Removes type override from defineAction accept paramter
+Fixes a case where `defineAction` autocomplete for the `accept` prop would not show `"form"` as a possible value

--- a/.changeset/quiet-doors-eat.md
+++ b/.changeset/quiet-doors-eat.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Removes type override from defineAction accept paramter

--- a/packages/astro/src/actions/runtime/virtual/server.ts
+++ b/packages/astro/src/actions/runtime/virtual/server.ts
@@ -50,7 +50,7 @@ export type ActionClient<
 
 export function defineAction<
 	TOutput,
-	TAccept extends Accept = 'json',
+	TAccept extends Accept,
 	TInputSchema extends InputSchema<Accept> | undefined = TAccept extends 'form'
 		? // If `input` is omitted, default to `FormData` for forms and `any` for JSON.
 			z.ZodType<FormData>


### PR DESCRIPTION
## Changes

This PR removes the type override for the `accept` parameter in the `defineAction` Actions function.

Fernando Herrera pointed out earlier that the `accept` param for `defineAction` only suggested `json` in the intellisense instead of both `json` and `form`.

Now I'm not going to pretend I understand _everything_ going on in the typing for the `accept` param here. But I'm pretty sure the `= 'json'` here is redundant.

https://discord.com/channels/830184174198718474/1252972140161142816/1252996832238506056

Before:
![image](https://github.com/withastro/astro/assets/7649031/0589ffac-2ce5-41fa-ada2-0eb1efb03853)

After:
![image](https://github.com/withastro/astro/assets/7649031/3e454f83-9c4d-4ae6-9740-cd945396716d)

## Testing

No tests are necessary here I think?

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

No docs are necessary as I think this is a bug fix?

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
