### PR TITLE
fix(rss): correct types for `RSSFeedItem`

### DIFF
--- a/.changeset/tricky-mirrors-carry.md
+++ b/.changeset/tricky-mirrors-carry.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': patch
+---
+
+Fixes an issue where the `pagesGlobToRssItems` returned an incorrect type for `items`

--- a/packages/astro-rss/src/index.ts
+++ b/packages/astro-rss/src/index.ts
@@ -32,13 +32,13 @@ export type RSSOptions = {
 
 export type RSSFeedItem = {
 	/** Link to item */
-	link: z.infer<typeof rssSchema>['link'];
+	link?: z.infer<typeof rssSchema>['link'];
 	/** Full content of the item. Should be valid HTML */
 	content?: z.infer<typeof rssSchema>['content'];
 	/** Title of item */
-	title: z.infer<typeof rssSchema>['title'];
+	title?: z.infer<typeof rssSchema>['title'];
 	/** Publication date of item */
-	pubDate: z.infer<typeof rssSchema>['pubDate'];
+	pubDate?: z.infer<typeof rssSchema>['pubDate'];
 	/** Item description */
 	description?: z.infer<typeof rssSchema>['description'];
 	/** Append some other XML-valid data to this item */


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/11287

The types between type `RSSFeedItem` and the `rssSchema` were not aligned

## Testing

I locally tested the change, and type error is now gone

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
