### PR TITLE
Fall back to page reload when redirected to a cross origin URL

### DIFF
--- a/.changeset/small-badgers-juggle.md
+++ b/.changeset/small-badgers-juggle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue with the view transition router when redirecting to an URL with different origin.

--- a/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
@@ -11,8 +11,7 @@ export default defineConfig({
 	integrations: [react(),vue(),svelte()],
 	redirects: {
 		'/redirect-two': '/two',
-		'/redirect-external': 'http://example.com/',
-		'/redirect-cross-origin': 'http://127.0.0.1:4321/two',
+		'/redirect-external': 'http://example.com/'
 	},
 	devToolbar: {
 		enabled: false,

--- a/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
@@ -11,7 +11,7 @@ export default defineConfig({
 	integrations: [react(),vue(),svelte()],
 	redirects: {
 		'/redirect-two': '/two',
-		'/redirect-external': 'http://example.com/'
+		'/redirect-external': 'http://example.com/',
 	},
 	devToolbar: {
 		enabled: false,

--- a/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
@@ -12,6 +12,7 @@ export default defineConfig({
 	redirects: {
 		'/redirect-two': '/two',
 		'/redirect-external': 'http://example.com/',
+		'/redirect-cross-origin': 'http://127.0.0.1:4321/two',
 	},
 	devToolbar: {
 		enabled: false,

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
@@ -11,6 +11,7 @@ import Layout from '../components/Layout.astro';
 	<a id="click-self" href="">go to top</a>
 	<a id="click-redirect-two" href="/redirect-two">go to redirect 2</a>
 	<a id="click-redirect-external" href="/redirect-external">go to a redirect external</a>
+	<a id="click-redirect-cross-origin" href="/redirect-cross-origin">go cross origin</a>
 	<a id="click-404" href="/undefined-page">go to undefined page</a>
 	<custom-a id="custom-click-two">
 		<template shadowrootmode="open">

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/one.astro
@@ -11,7 +11,7 @@ import Layout from '../components/Layout.astro';
 	<a id="click-self" href="">go to top</a>
 	<a id="click-redirect-two" href="/redirect-two">go to redirect 2</a>
 	<a id="click-redirect-external" href="/redirect-external">go to a redirect external</a>
-	<a id="click-redirect-cross-origin" href="/redirect-cross-origin">go cross origin</a>
+	<a id="click-redirect" href="/redirect">redirect cross-origin</a>
 	<a id="click-404" href="/undefined-page">go to undefined page</a>
 	<custom-a id="custom-click-two">
 		<template shadowrootmode="open">

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/redirect.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/redirect.astro
@@ -1,0 +1,10 @@
+---
+const myURL = Astro.request.url;
+const redirectTo = (myURL.startsWith("http://localhost")
+? myURL.replace("http://localhost","http://127.0.0.1")
+: myURL.replace("http://127.0.0.1", "http://localhost"))
+.replace("redirect","two");
+return Astro.redirect(redirectTo);
+---
+
+<h1>Should not see this</h1>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -788,25 +788,23 @@ test.describe('View Transitions', () => {
 		expect(loads.length, 'There should be 2 page loads').toEqual(2);
 	});
 
-	test('Cross origin loads do not raise errors', async ({ page, astro }) => {
+	test('Cross origin redirects do not raise errors', async ({ page, astro }) => {
+
 		let consoleErrors = [];
 		page.on('console', (msg) => {
 			if (msg.type() === 'error') {
 				consoleErrors.push(msg.text());
 			}
 		});
-
 		// Go to page 1
 		await page.goto(astro.resolveUrl('/one'));
 		let p = page.locator('#one');
 		await expect(p, 'should have content').toHaveText('Page 1');
 
-		// go to external page
-		await page.click('#click-redirect-cross-origin');
-		// doesn't work for playwright when we are too fast
+		await page.click('#click-redirect');
+		p = page.locator('#two');
+		await expect(p, 'should have content').toHaveText('Page 2');
 
-		let pageTwo = page.locator('#two');
-		await expect(pageTwo, 'should have content').toHaveText('Page 2');
 		expect(consoleErrors.length, 'There should be no errors').toEqual(0);
 	});
 

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -788,6 +788,28 @@ test.describe('View Transitions', () => {
 		expect(loads.length, 'There should be 2 page loads').toEqual(2);
 	});
 
+	test('Cross origin loads do not raise errors', async ({ page, astro }) => {
+		let consoleErrors = [];
+		page.on('console', (msg) => {
+			if (msg.type() === 'error') {
+				consoleErrors.push(msg.text());
+			}
+		});
+
+		// Go to page 1
+		await page.goto(astro.resolveUrl('/one'));
+		let p = page.locator('#one');
+		await expect(p, 'should have content').toHaveText('Page 1');
+
+		// go to external page
+		await page.click('#click-redirect-cross-origin');
+		// doesn't work for playwright when we are too fast
+
+		let pageTwo = page.locator('#two');
+		await expect(pageTwo, 'should have content').toHaveText('Page 2');
+		expect(consoleErrors.length, 'There should be no errors').toEqual(0);
+	});
+
 	test('client:only styles are retained on transition (1/2)', async ({ page, astro }) => {
 		const totalExpectedStyles = 9;
 

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -418,7 +418,13 @@ async function transition(
 		}
 		// if there was a redirection, show the final URL in the browser's address bar
 		if (response.redirected) {
-			preparationEvent.to = new URL(response.redirected);
+			const redirectedTo = new URL(response.redirected);
+			// but do not redirect cross origin
+			if (redirectedTo.origin !== preparationEvent.to.origin) {
+				preparationEvent.preventDefault();
+				return;
+			}
+			preparationEvent.to = redirectedTo;
 		}
 
 		parser ??= new DOMParser();


### PR DESCRIPTION
## Changes

Fixes #11301 
when redirected to a different origin, interrupt loading and do a full page reload the redirected URL 

## Testing

Added new e2e testcase

## Docs

n.a.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
