### PR TITLE
chore: extract fs helpers into shared internal-helpers package

### DIFF
--- a/.changeset/lovely-parents-attend.md
+++ b/.changeset/lovely-parents-attend.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/vercel': patch
+'@astrojs/internal-helpers': patch
+---
+
+Extracts fs helpers into shared internal-helpers module

--- a/packages/integrations/vercel/src/lib/nft.ts
+++ b/packages/integrations/vercel/src/lib/nft.ts
@@ -1,7 +1,7 @@
 import { relative as relativePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { AstroIntegrationLogger } from 'astro';
-import { copyFilesToFunction } from './fs.js';
+import { copyFilesToFolder } from '@astrojs/internal-helpers/fs';
 
 export async function copyDependenciesToFunction(
 	{
@@ -72,7 +72,7 @@ export async function copyDependenciesToFunction(
 		}
 	}
 
-	const commonAncestor = await copyFilesToFunction(
+	const commonAncestor = await copyFilesToFolder(
 		[...result.fileList].map((file) => new URL(file, base)).concat(includeFiles),
 		outDir,
 		excludeFiles

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -16,7 +16,7 @@ import {
 	getAstroImageConfig,
 	getDefaultImageConfig,
 } from '../image/shared.js';
-import { removeDir, writeJson } from '../lib/fs.js';
+import { removeDir, writeJson } from '@astrojs/internal-helpers/fs';
 import { copyDependenciesToFunction } from '../lib/nft.js';
 import { escapeRegex, getRedirects } from '../lib/redirects.js';
 import {

--- a/packages/integrations/vercel/src/static/adapter.ts
+++ b/packages/integrations/vercel/src/static/adapter.ts
@@ -6,7 +6,7 @@ import {
 	getAstroImageConfig,
 	getDefaultImageConfig,
 } from '../image/shared.js';
-import { emptyDir, writeJson } from '../lib/fs.js';
+import { emptyDir, writeJson } from '@astrojs/internal-helpers/fs';
 import { isServerLikeOutput } from '../lib/prerender.js';
 import { getRedirects } from '../lib/redirects.js';
 import {

--- a/packages/internal-helpers/package.json
+++ b/packages/internal-helpers/package.json
@@ -12,12 +12,16 @@
   },
   "bugs": "https://github.com/withastro/astro/issues",
   "exports": {
-    "./path": "./dist/path.js"
+    "./path": "./dist/path.js",
+    "./fs": "./dist/fs.js"
   },
   "typesVersions": {
     "*": {
       "path": [
         "./dist/path.d.ts"
+      ],
+      "fs": [
+        "./dist/fs.d.ts"
       ]
     }
   },

--- a/packages/internal-helpers/src/fs.ts
+++ b/packages/internal-helpers/src/fs.ts
@@ -40,7 +40,7 @@ export async function getFilesFromFolder(dir: URL) {
  * @param {URL[]} [exclude] A list of files to exclude (absolute path).
  * @returns {Promise<string>} The common ancestor of the copied files.
  */
-export async function copyFilesToFunction(
+export async function copyFilesToFolder(
 	files: URL[],
 	outDir: URL,
 	exclude: URL[] = []
@@ -48,7 +48,7 @@ export async function copyFilesToFunction(
 	const excludeList = exclude.map(fileURLToPath);
 	const fileList = files.map(fileURLToPath).filter((f) => !excludeList.includes(f));
 
-	if (files.length === 0) throw new Error('[@astrojs/vercel] No files found to copy');
+	if (files.length === 0) throw new Error('No files found to copy');
 
 	let commonAncestor = nodePath.dirname(fileList[0]);
 	for (const file of fileList.slice(1)) {
@@ -86,8 +86,4 @@ export async function copyFilesToFunction(
 	}
 
 	return commonAncestor;
-}
-
-export async function writeFile(path: PathLike, content: string) {
-	await fs.writeFile(path, content, { encoding: 'utf-8' });
 }


### PR DESCRIPTION
## Changes

The `@astrojs/vercel` package includes some filesystem helpers that would be useful in other packages. This PR moves them into the `internal-helpers` package.

## Testing

There should be no change in behaviour

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
