### PR TITLE
fix(container): breakdown files to avoid importing `vite`

### DIFF
--- a/.changeset/happy-boxes-collect.md
+++ b/.changeset/happy-boxes-collect.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue with the container APIs where a runtime error was thrown during the build, when using `pnpm` as package manager.

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -329,10 +329,10 @@ export class experimental_AstroContainer {
 	private static async createFromManifest(
 		manifest: SSRManifest
 	): Promise<experimental_AstroContainer> {
-		// const astroConfig = await validateConfig(ASTRO_CONFIG_DEFAULTS, process.cwd(), 'container');
+		const astroConfig = await validateConfig(ASTRO_CONFIG_DEFAULTS, process.cwd(), 'container');
 		const container = new experimental_AstroContainer({
 			manifest,
-			// astroConfig,
+			astroConfig,
 		});
 		container.#withManifest = true;
 		return container;

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -14,8 +14,8 @@ import type {
 	SSRManifest,
 	SSRResult,
 } from '../@types/astro.js';
-import { validateConfig } from '../core/config/validate.js';
 import { ASTRO_CONFIG_DEFAULTS } from '../core/config/schema.js';
+import { validateConfig } from '../core/config/validate.js';
 import { Logger } from '../core/logger/core.js';
 import { nodeLogDestination } from '../core/logger/node.js';
 import { removeLeadingForwardSlash } from '../core/path.js';

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -14,7 +14,7 @@ import type {
 	SSRManifest,
 	SSRResult,
 } from '../@types/astro.js';
-import { validateConfig } from '../core/config/config.js';
+import { validateConfig } from '../core/config/validate.js';
 import { ASTRO_CONFIG_DEFAULTS } from '../core/config/schema.js';
 import { Logger } from '../core/logger/core.js';
 import { nodeLogDestination } from '../core/logger/node.js';
@@ -208,7 +208,7 @@ type AstroContainerConstructor = {
 	renderers?: SSRLoadedRenderer[];
 	manifest?: AstroContainerManifest;
 	resolve?: SSRResult['resolve'];
-	astroConfig: AstroConfig;
+	astroConfig?: AstroConfig;
 };
 
 export class experimental_AstroContainer {
@@ -253,10 +253,10 @@ export class experimental_AstroContainer {
 		});
 	}
 
-	async #containerResolve(specifier: string, astroConfig: AstroConfig): Promise<string> {
+	async #containerResolve(specifier: string, astroConfig?: AstroConfig): Promise<string> {
 		const found = this.#pipeline.manifest.entryModules[specifier];
 		if (found) {
-			return new URL(found, astroConfig.build.client).toString();
+			return new URL(found, astroConfig?.build.client).toString();
 		}
 		return found;
 	}
@@ -329,10 +329,10 @@ export class experimental_AstroContainer {
 	private static async createFromManifest(
 		manifest: SSRManifest
 	): Promise<experimental_AstroContainer> {
-		const astroConfig = await validateConfig(ASTRO_CONFIG_DEFAULTS, process.cwd(), 'container');
+		// const astroConfig = await validateConfig(ASTRO_CONFIG_DEFAULTS, process.cwd(), 'container');
 		const container = new experimental_AstroContainer({
 			manifest,
-			astroConfig,
+			// astroConfig,
 		});
 		container.#withManifest = true;
 		return container;

--- a/packages/astro/src/container/pipeline.ts
+++ b/packages/astro/src/container/pipeline.ts
@@ -7,13 +7,10 @@ import type {
 } from '../@types/astro.js';
 import { type HeadElements, Pipeline } from '../core/base-pipeline.js';
 import type { SinglePageBuiltModule } from '../core/build/types.js';
-import { RouteNotFound } from '../core/errors/errors-data.js';
-import { AstroError } from '../core/errors/index.js';
 import {
 	createModuleScriptElement,
 	createStylesheetElementSet,
 } from '../core/render/ssr-element.js';
-import { DEFAULT_404_ROUTE } from '../core/routing/astro-designed-error-pages.js';
 import { findRouteToRewrite } from '../core/routing/rewrite.js';
 
 export class ContainerPipeline extends Pipeline {

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -3,12 +3,13 @@ import { extname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import glob from 'fast-glob';
 import pLimit from 'p-limit';
-import { type Plugin } from 'vite';
+import type { Plugin } from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
 import { encodeName } from '../core/build/util.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { appendForwardSlash, removeFileExtension } from '../core/path.js';
-import { isServerLikeOutput, rootRelativePath } from '../core/util.js';
+import {  rootRelativePath } from '../core/viteUtils.js';
+import { isServerLikeOutput } from "../core/util.js";
 import type { AstroPluginMetadata } from '../vite-plugin-astro/index.js';
 import {
 	CONTENT_FLAG,

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -8,8 +8,8 @@ import type { AstroSettings } from '../@types/astro.js';
 import { encodeName } from '../core/build/util.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { appendForwardSlash, removeFileExtension } from '../core/path.js';
-import {  rootRelativePath } from '../core/viteUtils.js';
-import { isServerLikeOutput } from "../core/util.js";
+import { isServerLikeOutput } from '../core/util.js';
+import { rootRelativePath } from '../core/viteUtils.js';
 import type { AstroPluginMetadata } from '../vite-plugin-astro/index.js';
 import {
 	CONTENT_FLAG,

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url';
 import glob from 'fast-glob';
 import type { OutputChunk } from 'rollup';
-import { type Plugin as VitePlugin } from 'vite';
+import type { Plugin as VitePlugin } from 'vite';
 import { getAssetsPrefix } from '../../../assets/utils/getAssetsPrefix.js';
 import { normalizeTheLocale } from '../../../i18n/index.js';
 import { toRoutingStrategy } from '../../../i18n/utils.js';

--- a/packages/astro/src/core/compile/compile.ts
+++ b/packages/astro/src/core/compile/compile.ts
@@ -9,7 +9,7 @@ import type { AstroPreferences } from '../../preferences/index.js';
 import type { AstroError } from '../errors/errors.js';
 import { AggregateError, CompilerError } from '../errors/errors.js';
 import { AstroErrorData } from '../errors/index.js';
-import { resolvePath } from '../util.js';
+import { resolvePath } from '../viteUtils.js';
 import { type PartialCompileCssResult, createStylePreprocessor } from './style.js';
 import type { CompileCssResult } from './types.js';
 

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -6,48 +6,18 @@ import type {
 	AstroUserConfig,
 	CLIFlags,
 } from '../../@types/astro.js';
-
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as colors from 'kleur/colors';
-import { ZodError } from 'zod';
-import { eventConfigError, telemetry } from '../../events/index.js';
-import { trackAstroConfigZodError } from '../errors/errors.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
-import { formatConfigErrorMessage } from '../messages.js';
 import { mergeConfig } from './merge.js';
-import { createRelativeSchema } from './schema.js';
 import { loadConfigWithVite } from './vite-load.js';
-
-/** Turn raw config values into normalized values */
-export async function validateConfig(
-	userConfig: any,
-	root: string,
-	cmd: string
-): Promise<AstroConfig> {
-	const AstroConfigRelativeSchema = createRelativeSchema(cmd, root);
-
-	// First-Pass Validation
-	let result: AstroConfig;
-	try {
-		result = await AstroConfigRelativeSchema.parseAsync(userConfig);
-	} catch (e) {
-		// Improve config zod error messages
-		if (e instanceof ZodError) {
-			// Mark this error so the callee can decide to suppress Zod's error if needed.
-			// We still want to throw the error to signal an error in validation.
-			trackAstroConfigZodError(e);
-			// eslint-disable-next-line no-console
-			console.error(formatConfigErrorMessage(e) + '\n');
-			telemetry.record(eventConfigError({ cmd, err: e, isFatal: true }));
-		}
-		throw e;
-	}
-
-	// If successful, return the result as a verified AstroConfig object.
-	return result;
-}
+import {validateConfig} from "./validate.js";
+import {ZodError} from "zod";
+import {trackAstroConfigZodError} from "../errors/errors.js";
+import {formatConfigErrorMessage} from "../messages.js";
+import {eventConfigError, telemetry} from "../../events/index.js";
 
 /** Convert the generic "yargs" flag object into our own, custom TypeScript object. */
 // NOTE: This function will be removed in a later PR. Use `flagsToAstroInlineConfig` instead.
@@ -197,7 +167,23 @@ export async function resolveConfig(
 
 	const userConfig = await loadConfig(root, inlineOnlyConfig.configFile, fsMod);
 	const mergedConfig = mergeConfig(userConfig, inlineUserConfig);
-	const astroConfig = await validateConfig(mergedConfig, root, command);
+	// First-Pass Validation
+	let astroConfig: AstroConfig;
+	try {
+		astroConfig = await validateConfig(mergedConfig, root, command);
+		
+	} catch (e) {
+		// Improve config zod error messages
+		if (e instanceof ZodError) {
+			// Mark this error so the callee can decide to suppress Zod's error if needed.
+			// We still want to throw the error to signal an error in validation.
+			trackAstroConfigZodError(e);
+			// eslint-disable-next-line no-console
+			console.error(formatConfigErrorMessage(e) + '\n');
+			telemetry.record(eventConfigError({ cmd: command, err: e, isFatal: true }));
+		}
+		throw e;
+	}
 
 	return { userConfig: mergedConfig, astroConfig };
 }

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -1,4 +1,9 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as colors from 'kleur/colors';
 import type { Arguments as Flags } from 'yargs-parser';
+import { ZodError } from 'zod';
 import type {
 	AstroConfig,
 	AstroInlineConfig,
@@ -6,18 +11,13 @@ import type {
 	AstroUserConfig,
 	CLIFlags,
 } from '../../@types/astro.js';
-import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import * as colors from 'kleur/colors';
+import { eventConfigError, telemetry } from '../../events/index.js';
+import { trackAstroConfigZodError } from '../errors/errors.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
+import { formatConfigErrorMessage } from '../messages.js';
 import { mergeConfig } from './merge.js';
+import { validateConfig } from './validate.js';
 import { loadConfigWithVite } from './vite-load.js';
-import {validateConfig} from "./validate.js";
-import {ZodError} from "zod";
-import {trackAstroConfigZodError} from "../errors/errors.js";
-import {formatConfigErrorMessage} from "../messages.js";
-import {eventConfigError, telemetry} from "../../events/index.js";
 
 /** Convert the generic "yargs" flag object into our own, custom TypeScript object. */
 // NOTE: This function will be removed in a later PR. Use `flagsToAstroInlineConfig` instead.
@@ -171,7 +171,6 @@ export async function resolveConfig(
 	let astroConfig: AstroConfig;
 	try {
 		astroConfig = await validateConfig(mergedConfig, root, command);
-		
 	} catch (e) {
 		// Improve config zod error messages
 		if (e instanceof ZodError) {

--- a/packages/astro/src/core/config/validate.ts
+++ b/packages/astro/src/core/config/validate.ts
@@ -1,0 +1,14 @@
+import type {AstroConfig} from "../../@types/astro.js";
+import {createRelativeSchema} from "./schema.js";
+
+/** Turn raw config values into normalized values */
+export async function validateConfig(
+	userConfig: any,
+	root: string,
+	cmd: string
+): Promise<AstroConfig> {
+	const AstroConfigRelativeSchema = createRelativeSchema(cmd, root);
+
+	// First-Pass Validation
+	return await AstroConfigRelativeSchema.parseAsync(userConfig);
+}

--- a/packages/astro/src/core/config/validate.ts
+++ b/packages/astro/src/core/config/validate.ts
@@ -1,5 +1,5 @@
-import type {AstroConfig} from "../../@types/astro.js";
-import {createRelativeSchema} from "./schema.js";
+import type { AstroConfig } from '../../@types/astro.js';
+import { createRelativeSchema } from './schema.js';
 
 /** Turn raw config values into normalized values */
 export async function validateConfig(

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -1,11 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { normalizePath } from 'vite';
 import type { AstroConfig, AstroSettings, RouteType } from '../@types/astro.js';
 import { SUPPORTED_MARKDOWN_FILE_EXTENSIONS } from './constants.js';
-import type { ModuleLoader } from './module-loader/index.js';
-import { prependForwardSlash, removeTrailingForwardSlash, slash } from './path.js';
+import { removeTrailingForwardSlash, slash } from './path.js';
 
 /** Returns true if argument is an object of any prototype/class (but not null). */
 export function isObject(value: unknown): value is Record<string, any> {
@@ -184,52 +182,9 @@ export function relativeToSrcDir(config: AstroConfig, idOrUrl: URL | string) {
 	return id.slice(slash(fileURLToPath(config.srcDir)).length);
 }
 
-export function rootRelativePath(
-	root: URL,
-	idOrUrl: URL | string,
-	shouldPrependForwardSlash = true
-) {
-	let id: string;
-	if (typeof idOrUrl !== 'string') {
-		id = unwrapId(viteID(idOrUrl));
-	} else {
-		id = idOrUrl;
-	}
-	const normalizedRoot = normalizePath(fileURLToPath(root));
-	if (id.startsWith(normalizedRoot)) {
-		id = id.slice(normalizedRoot.length);
-	}
-	return shouldPrependForwardSlash ? prependForwardSlash(id) : id;
-}
 
 export function emoji(char: string, fallback: string) {
 	return process.platform !== 'win32' ? char : fallback;
-}
-
-/**
- * Simulate Vite's resolve and import analysis so we can import the id as an URL
- * through a script tag or a dynamic import as-is.
- */
-// NOTE: `/@id/` should only be used when the id is fully resolved
-export async function resolveIdToUrl(loader: ModuleLoader, id: string, root?: URL) {
-	let resultId = await loader.resolveId(id, undefined);
-	// Try resolve jsx to tsx
-	if (!resultId && id.endsWith('.jsx')) {
-		resultId = await loader.resolveId(id.slice(0, -4), undefined);
-	}
-	if (!resultId) {
-		return VALID_ID_PREFIX + id;
-	}
-	if (path.isAbsolute(resultId)) {
-		const normalizedRoot = root && normalizePath(fileURLToPath(root));
-		// Convert to root-relative path if path is inside root
-		if (normalizedRoot && resultId.startsWith(normalizedRoot)) {
-			return resultId.slice(normalizedRoot.length - 1);
-		} else {
-			return '/@fs' + prependForwardSlash(resultId);
-		}
-	}
-	return VALID_ID_PREFIX + resultId;
 }
 
 export function resolveJsToTs(filePath: string) {
@@ -242,17 +197,7 @@ export function resolveJsToTs(filePath: string) {
 	return filePath;
 }
 
-/**
- * Resolve the hydration paths so that it can be imported in the client
- */
-export function resolvePath(specifier: string, importer: string) {
-	if (specifier.startsWith('.')) {
-		const absoluteSpecifier = path.resolve(path.dirname(importer), specifier);
-		return resolveJsToTs(normalizePath(absoluteSpecifier));
-	} else {
-		return specifier;
-	}
-}
+
 
 /**
  * Set a default NODE_ENV so Vite doesn't set an incorrect default when loading the Astro config

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -182,7 +182,6 @@ export function relativeToSrcDir(config: AstroConfig, idOrUrl: URL | string) {
 	return id.slice(slash(fileURLToPath(config.srcDir)).length);
 }
 
-
 export function emoji(char: string, fallback: string) {
 	return process.platform !== 'win32' ? char : fallback;
 }
@@ -196,8 +195,6 @@ export function resolveJsToTs(filePath: string) {
 	}
 	return filePath;
 }
-
-
 
 /**
  * Set a default NODE_ENV so Vite doesn't set an incorrect default when loading the Astro config

--- a/packages/astro/src/core/viteUtils.ts
+++ b/packages/astro/src/core/viteUtils.ts
@@ -1,10 +1,9 @@
-import type {ModuleLoader} from "./module-loader/index.js";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
-import {prependForwardSlash} from "../core/path.js";
-import {resolveJsToTs, unwrapId, VALID_ID_PREFIX, viteID} from "./util.js";
-import {normalizePath} from "vite";
-
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { normalizePath } from 'vite';
+import { prependForwardSlash } from '../core/path.js';
+import type { ModuleLoader } from './module-loader/index.js';
+import { VALID_ID_PREFIX, resolveJsToTs, unwrapId, viteID } from './util.js';
 
 /**
  * Resolve the hydration paths so that it can be imported in the client
@@ -17,7 +16,6 @@ export function resolvePath(specifier: string, importer: string) {
 		return specifier;
 	}
 }
-
 
 export function rootRelativePath(
 	root: URL,
@@ -36,7 +34,6 @@ export function rootRelativePath(
 	}
 	return shouldPrependForwardSlash ? prependForwardSlash(id) : id;
 }
-
 
 /**
  * Simulate Vite's resolve and import analysis so we can import the id as an URL

--- a/packages/astro/src/core/viteUtils.ts
+++ b/packages/astro/src/core/viteUtils.ts
@@ -1,0 +1,65 @@
+import type {ModuleLoader} from "./module-loader/index.js";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+import {prependForwardSlash} from "../core/path.js";
+import {resolveJsToTs, unwrapId, VALID_ID_PREFIX, viteID} from "./util.js";
+import {normalizePath} from "vite";
+
+
+/**
+ * Resolve the hydration paths so that it can be imported in the client
+ */
+export function resolvePath(specifier: string, importer: string) {
+	if (specifier.startsWith('.')) {
+		const absoluteSpecifier = path.resolve(path.dirname(importer), specifier);
+		return resolveJsToTs(normalizePath(absoluteSpecifier));
+	} else {
+		return specifier;
+	}
+}
+
+
+export function rootRelativePath(
+	root: URL,
+	idOrUrl: URL | string,
+	shouldPrependForwardSlash = true
+) {
+	let id: string;
+	if (typeof idOrUrl !== 'string') {
+		id = unwrapId(viteID(idOrUrl));
+	} else {
+		id = idOrUrl;
+	}
+	const normalizedRoot = normalizePath(fileURLToPath(root));
+	if (id.startsWith(normalizedRoot)) {
+		id = id.slice(normalizedRoot.length);
+	}
+	return shouldPrependForwardSlash ? prependForwardSlash(id) : id;
+}
+
+
+/**
+ * Simulate Vite's resolve and import analysis so we can import the id as an URL
+ * through a script tag or a dynamic import as-is.
+ */
+// NOTE: `/@id/` should only be used when the id is fully resolved
+export async function resolveIdToUrl(loader: ModuleLoader, id: string, root?: URL) {
+	let resultId = await loader.resolveId(id, undefined);
+	// Try resolve jsx to tsx
+	if (!resultId && id.endsWith('.jsx')) {
+		resultId = await loader.resolveId(id.slice(0, -4), undefined);
+	}
+	if (!resultId) {
+		return VALID_ID_PREFIX + id;
+	}
+	if (path.isAbsolute(resultId)) {
+		const normalizedRoot = root && normalizePath(fileURLToPath(root));
+		// Convert to root-relative path if path is inside root
+		if (normalizedRoot && resultId.startsWith(normalizedRoot)) {
+			return resultId.slice(normalizedRoot.length - 1);
+		} else {
+			return '/@fs' + prependForwardSlash(resultId);
+		}
+	}
+	return VALID_ID_PREFIX + resultId;
+}

--- a/packages/astro/src/jsx/babel.ts
+++ b/packages/astro/src/jsx/babel.ts
@@ -2,7 +2,7 @@ import type { PluginObj } from '@babel/core';
 import * as t from '@babel/types';
 import { AstroError } from '../core/errors/errors.js';
 import { AstroErrorData } from '../core/errors/index.js';
-import { resolvePath } from '../core/util.js';
+import { resolvePath } from '../core/viteUtils.js';
 import type { PluginMetadata } from '../vite-plugin-astro/types.js';
 
 const ClientOnlyPlaceholder = 'astro-client-only';

--- a/packages/astro/src/jsx/rehype.ts
+++ b/packages/astro/src/jsx/rehype.ts
@@ -9,7 +9,7 @@ import { visit } from 'unist-util-visit';
 import type { VFile } from 'vfile';
 import { AstroError } from '../core/errors/errors.js';
 import { AstroErrorData } from '../core/errors/index.js';
-import { resolvePath } from '../core/util.js';
+import { resolvePath } from '../core/viteUtils.js';
 import type { PluginMetadata } from '../vite-plugin-astro/types.js';
 
 // This import includes ambient types for hast to include mdx nodes

--- a/packages/astro/src/vite-plugin-astro-server/pipeline.ts
+++ b/packages/astro/src/vite-plugin-astro-server/pipeline.ts
@@ -12,18 +12,16 @@ import type {
 } from '../@types/astro.js';
 import { getInfoOutput } from '../cli/info/index.js';
 import { type HeadElements } from '../core/base-pipeline.js';
-import { shouldAppendForwardSlash } from '../core/build/util.js';
 import { ASTRO_VERSION, DEFAULT_404_COMPONENT } from '../core/constants.js';
 import { enhanceViteSSRError } from '../core/errors/dev/index.js';
-import { RewriteEncounteredAnError } from '../core/errors/errors-data.js';
-import { AggregateError, AstroError, CSSError, MarkdownError } from '../core/errors/index.js';
+import { AggregateError,  CSSError, MarkdownError } from '../core/errors/index.js';
 import type { Logger } from '../core/logger/core.js';
 import type { ModuleLoader } from '../core/module-loader/index.js';
-import { prependForwardSlash, removeTrailingForwardSlash } from '../core/path.js';
 import { Pipeline, loadRenderer } from '../core/render/index.js';
-import { DEFAULT_404_ROUTE, default404Page } from '../core/routing/astro-designed-error-pages.js';
+import {  default404Page } from '../core/routing/astro-designed-error-pages.js';
 import { findRouteToRewrite } from '../core/routing/rewrite.js';
-import { isPage, isServerLikeOutput, resolveIdToUrl, viteID } from '../core/util.js';
+import { isPage, isServerLikeOutput, viteID } from '../core/util.js';
+import { resolveIdToUrl } from "../core/viteUtils.js"
 import { PAGE_SCRIPT_ID } from '../vite-plugin-scripts/index.js';
 import { getStylesForURL } from './css.js';
 import { getComponentMetadata } from './metadata.js';

--- a/packages/astro/src/vite-plugin-astro-server/pipeline.ts
+++ b/packages/astro/src/vite-plugin-astro-server/pipeline.ts
@@ -14,14 +14,14 @@ import { getInfoOutput } from '../cli/info/index.js';
 import { type HeadElements } from '../core/base-pipeline.js';
 import { ASTRO_VERSION, DEFAULT_404_COMPONENT } from '../core/constants.js';
 import { enhanceViteSSRError } from '../core/errors/dev/index.js';
-import { AggregateError,  CSSError, MarkdownError } from '../core/errors/index.js';
+import { AggregateError, CSSError, MarkdownError } from '../core/errors/index.js';
 import type { Logger } from '../core/logger/core.js';
 import type { ModuleLoader } from '../core/module-loader/index.js';
 import { Pipeline, loadRenderer } from '../core/render/index.js';
-import {  default404Page } from '../core/routing/astro-designed-error-pages.js';
+import { default404Page } from '../core/routing/astro-designed-error-pages.js';
 import { findRouteToRewrite } from '../core/routing/rewrite.js';
 import { isPage, isServerLikeOutput, viteID } from '../core/util.js';
-import { resolveIdToUrl } from "../core/viteUtils.js"
+import { resolveIdToUrl } from '../core/viteUtils.js';
 import { PAGE_SCRIPT_ID } from '../vite-plugin-scripts/index.js';
 import { getStylesForURL } from './css.js';
 import { getComponentMetadata } from './metadata.js';

--- a/packages/astro/src/vite-plugin-astro-server/resolve.ts
+++ b/packages/astro/src/vite-plugin-astro-server/resolve.ts
@@ -1,5 +1,5 @@
 import type { ModuleLoader } from '../core/module-loader/index.js';
-import { resolveIdToUrl } from '../core/util.js';
+import { resolveIdToUrl } from '../core/viteUtils.js';
 
 export function createResolve(loader: ModuleLoader, root: URL) {
 	// Resolves specifiers in the inline hydrated scripts, such as:

--- a/packages/astro/src/vite-plugin-astro-server/scripts.ts
+++ b/packages/astro/src/vite-plugin-astro-server/scripts.ts
@@ -1,8 +1,8 @@
 import type { SSRElement } from '../@types/astro.js';
 import type { ModuleInfo, ModuleLoader } from '../core/module-loader/index.js';
 import { createModuleScriptElementWithSrc } from '../core/render/ssr-element.js';
+import { viteID } from '../core/util.js';
 import { rootRelativePath } from '../core/viteUtils.js';
-import { viteID} from "../core/util.js"
 import type { PluginMetadata as AstroPluginMetadata } from '../vite-plugin-astro/types.js';
 import { crawlGraph } from './vite.js';
 

--- a/packages/astro/src/vite-plugin-astro-server/scripts.ts
+++ b/packages/astro/src/vite-plugin-astro-server/scripts.ts
@@ -1,7 +1,8 @@
 import type { SSRElement } from '../@types/astro.js';
 import type { ModuleInfo, ModuleLoader } from '../core/module-loader/index.js';
 import { createModuleScriptElementWithSrc } from '../core/render/ssr-element.js';
-import { rootRelativePath, viteID } from '../core/util.js';
+import { rootRelativePath } from '../core/viteUtils.js';
+import { viteID} from "../core/util.js"
 import type { PluginMetadata as AstroPluginMetadata } from '../vite-plugin-astro/types.js';
 import { crawlGraph } from './vite.js';
 

--- a/packages/astro/src/vite-plugin-scanner/index.ts
+++ b/packages/astro/src/vite-plugin-scanner/index.ts
@@ -4,7 +4,8 @@ import type { Plugin as VitePlugin } from 'vite';
 import { normalizePath } from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
 import { type Logger } from '../core/logger/core.js';
-import { isEndpoint, isPage, isServerLikeOutput, rootRelativePath } from '../core/util.js';
+import { isEndpoint, isPage, isServerLikeOutput } from '../core/util.js';
+import { rootRelativePath } from "../core/viteUtils.js"
 import { getPrerenderDefault } from '../prerender/utils.js';
 import { scan } from './scan.js';
 

--- a/packages/astro/src/vite-plugin-scanner/index.ts
+++ b/packages/astro/src/vite-plugin-scanner/index.ts
@@ -5,7 +5,7 @@ import { normalizePath } from 'vite';
 import type { AstroSettings } from '../@types/astro.js';
 import { type Logger } from '../core/logger/core.js';
 import { isEndpoint, isPage, isServerLikeOutput } from '../core/util.js';
-import { rootRelativePath } from "../core/viteUtils.js"
+import { rootRelativePath } from '../core/viteUtils.js';
 import { getPrerenderDefault } from '../prerender/utils.js';
 import { scan } from './scan.js';
 

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -2,7 +2,7 @@ import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import stripAnsi from 'strip-ansi';
 import { z } from 'zod';
-import { validateConfig } from '../../../dist/core/config/config.js';
+import { validateConfig } from '../../../dist/core/config/validate.js';
 import { formatConfigErrorMessage } from '../../../dist/core/messages.js';
 
 describe('Config Validation', () => {

--- a/packages/astro/test/units/i18n/astro_i18n.test.js
+++ b/packages/astro/test/units/i18n/astro_i18n.test.js
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test';
 import { MissingLocale } from '#astro/core/errors/errors-data';
 import { AstroError } from '#astro/core/errors/index';
 import { toRoutingStrategy } from '#astro/i18n/utils';
-import { validateConfig } from '../../../dist/core/config/config.js';
+import { validateConfig } from '../../../dist/core/config/validate.js';
 import {
 	getLocaleAbsoluteUrl,
 	getLocaleAbsoluteUrlList,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9518,7 +9518,6 @@ packages:
 
   libsql@0.3.12:
     resolution: {integrity: sha512-to30hj8O3DjS97wpbKN6ERZ8k66MN1IaOfFLR6oHqd25GMiPJ/ZX0VaZ7w+TsPmxcFS3p71qArj/hiedCyvXCg==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@2.1.0:


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/11128

The container was indirectly pulling and importing some modules that were importing `vite`.

This PR attempts to breakdown the files in order to not import `vite` inside `astro/container`

## Testing

I tested locally the reproduction provided.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
