### PR TITLE
Remove resolve package and refactor db & studio exports

### DIFF
--- a/.changeset/selfish-impalas-cough.md
+++ b/.changeset/selfish-impalas-cough.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/studio': patch
+'@astrojs/db': patch
+---
+
+Relaxes exports condition to allow importing ESM from CJS

--- a/.changeset/strong-news-yawn.md
+++ b/.changeset/strong-news-yawn.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Removes `resolve` package and simplify internal resolve check

--- a/.npmrc
+++ b/.npmrc
@@ -4,11 +4,11 @@ link-workspace-packages=true
 save-workspace-protocol=false # This prevents the examples to have the `workspace:` prefix
 auto-install-peers=false
 
-# `github-slugger` is used by `vite-plugin-markdown-legacy`.
-# Temporarily hoist this until we remove the feature.
-public-hoist-pattern[]=github-slugger
 # Vite's esbuild optimizer has trouble optimizing `@astrojs/lit/client-shim.js`
 # which imports this dependency.
 public-hoist-pattern[]=@webcomponents/template-shadowroot
 # There's a lit dependency duplication somewhere causing multiple Lit versions error.
 public-hoist-pattern[]=*lit*
+# `astro sync` could try to import `@astrojs/db` but could fail due to linked dependencies in the monorepo.
+# We hoist it here so that it can easily resolve `@astrojs/db` without hardcoded handling.
+public-hoist-pattern[]=@astrojs/db

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -191,7 +191,6 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.7.0",
-    "@astrojs/db": "workspace:*",
     "@playwright/test": "^1.44.1",
     "@types/aria-query": "^5.0.4",
     "@types/babel__generator": "^7.6.8",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -208,7 +208,6 @@
     "@types/js-yaml": "^4.0.9",
     "@types/probe-image-size": "^7.2.4",
     "@types/prompts": "^2.4.9",
-    "@types/resolve": "^1.20.6",
     "@types/semver": "^7.5.8",
     "@types/send": "^0.17.4",
     "@types/unist": "^3.0.2",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -172,7 +172,6 @@
     "preferred-pm": "^3.1.3",
     "prompts": "^2.4.2",
     "rehype": "^13.0.1",
-    "resolve": "^1.22.8",
     "semver": "^7.6.2",
     "shiki": "^1.9.0",
     "string-width": "^7.1.0",
@@ -192,6 +191,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.7.0",
+    "@astrojs/db": "workspace:*",
     "@playwright/test": "^1.44.1",
     "@types/aria-query": "^5.0.4",
     "@types/babel__generator": "^7.6.8",

--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -1,5 +1,4 @@
 import { createRequire } from 'node:module';
-import { pathToFileURL } from 'node:url';
 import boxen from 'boxen';
 import ci from 'ci-info';
 import { execa } from 'execa';
@@ -7,10 +6,8 @@ import { bold, cyan, dim, magenta } from 'kleur/colors';
 import ora from 'ora';
 import preferredPM from 'preferred-pm';
 import prompts from 'prompts';
-import resolvePackage from 'resolve';
 import whichPm from 'which-pm';
-import { type Logger } from '../core/logger/core.js';
-const require = createRequire(import.meta.url);
+import type { Logger } from '../core/logger/core.js';
 
 type GetPackageOptions = {
 	skipAsk?: boolean;
@@ -25,17 +22,9 @@ export async function getPackage<T>(
 	otherDeps: string[] = []
 ): Promise<T | undefined> {
 	try {
-		// Custom resolution logic for @astrojs/db. Since it lives in our monorepo,
-		// the generic tryResolve() method doesn't work.
-		if (packageName === '@astrojs/db') {
-			const packageJsonLoc = require.resolve(packageName + '/package.json', {
-				paths: [options.cwd ?? process.cwd()],
-			});
-			const packageLoc = pathToFileURL(packageJsonLoc.replace(`package.json`, 'dist/index.js'));
-			const packageImport = await import(packageLoc.toString());
-			return packageImport as T;
-		}
-		await tryResolve(packageName, options.cwd ?? process.cwd());
+		// Try to resolve with `createRequire` first to prevent ESM caching of the package
+		// if it errors and fails here
+		createRequire(options.cwd ?? process.cwd()).resolve(packageName);
 		const packageImport = await import(packageName);
 		return packageImport as T;
 	} catch (e) {
@@ -63,24 +52,6 @@ export async function getPackage<T>(
 			return undefined;
 		}
 	}
-}
-
-function tryResolve(packageName: string, cwd: string) {
-	return new Promise((resolve, reject) => {
-		resolvePackage(
-			packageName,
-			{
-				basedir: cwd,
-			},
-			(err) => {
-				if (err) {
-					reject(err);
-				} else {
-					resolve(0);
-				}
-			}
-		);
-	});
 }
 
 function getInstallCommand(packages: string[], packageManager: string) {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,22 +17,22 @@
   "exports": {
     ".": {
       "types": "./index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./utils": {
       "types": "./dist/utils.d.ts",
-      "import": "./dist/utils.js"
+      "default": "./dist/utils.js"
     },
     "./runtime": {
       "types": "./dist/runtime/index.d.ts",
-      "import": "./dist/runtime/index.js"
+      "default": "./dist/runtime/index.js"
     },
     "./dist/runtime/virtual.js": {
-      "import": "./dist/runtime/virtual.js"
+      "default": "./dist/runtime/virtual.js"
     },
     "./types": {
       "types": "./dist/core/types.d.ts",
-      "import": "./dist/core/types.js"
+      "default": "./dist/core/types.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -17,7 +17,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -722,9 +722,6 @@ importers:
       '@astrojs/check':
         specifier: ^0.7.0
         version: 0.7.0(prettier-plugin-astro@0.14.0)(prettier@3.3.2)(typescript@5.5.2)
-      '@astrojs/db':
-        specifier: workspace:*
-        version: link:../db
       '@playwright/test':
         specifier: ^1.44.1
         version: 1.44.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -773,9 +773,6 @@ importers:
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
-      '@types/resolve':
-        specifier: ^1.20.6
-        version: 1.20.6
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -675,9 +675,6 @@ importers:
       rehype:
         specifier: ^13.0.1
         version: 13.0.1
-      resolve:
-        specifier: ^1.22.8
-        version: 1.22.8
       semver:
         specifier: ^7.6.2
         version: 7.6.2
@@ -725,6 +722,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.7.0
         version: 0.7.0(prettier-plugin-astro@0.14.0)(prettier@3.3.2)(typescript@5.5.2)
+      '@astrojs/db':
+        specifier: workspace:*
+        version: link:../db
       '@playwright/test':
         specifier: ^1.44.1
         version: 1.44.1


### PR DESCRIPTION
## Changes

We can use `require.resolve()` instead of the `resolve` package for resolving.

Also simplifies the resolving of `@astrojs/db` by hoisting it up so it can be resolved from `packages/astro/dist/cli/install-package.js`. While we could also install `@astrojs/db` as a devdep in `packages/astro/package.json` to fix it, it would however create a cyclic workspace dependency between `astro`, `@astrojs/db`, and `@astrojs/studio`.

In order to simplify the code, I had to tweak the exports condition of `@astrojs/db` and `@astrojs/studio` to allow importing ESM from CJS (by `require.resolve`). This would also unblock a future Node.js feature where you could import ESM from CJS as long as there's no top-level await. In practice, I also find that it's best practice to use the `import` condition only if you have a corresponding `require` condition.

## Testing

Tested manually in an external project and in one of the fixtures.

## Docs

n/a. refactor only. I added a changeset as it removes a dependency (and would like to document this for users)
