### PR TITLE
[ui] fix margin around devtool tooltip icon in `rtl`

### DIFF
--- a/.changeset/rare-singers-try.md
+++ b/.changeset/rare-singers-try.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-- Fix svg icon margin in devtool tooltip title to look coherent in `rtl` and `ltr` layouts
+Fixes svg icon margin in devtool tooltip title to look coherent in `rtl` and `ltr` layouts

--- a/.changeset/rare-singers-try.md
+++ b/.changeset/rare-singers-try.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+- Fix svg icon margin in devtool tooltip title to look coherent in `rtl` and `ltr` layouts

--- a/packages/astro/src/runtime/client/dev-toolbar/ui-library/tooltip.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/ui-library/tooltip.ts
@@ -45,7 +45,7 @@ export class DevToolbarTooltip extends HTMLElement {
 
 			svg {
 				vertical-align: bottom;
-				margin-right: 4px;
+				margin-inline-end: 4px;
 			}
 
 			hr {


### PR DESCRIPTION
## Changes

Fixes the margin in the tooltip title SVG icon to work in both RTL and LTR layouts

### Before
![image](https://github.com/withastro/astro/assets/46135573/19b88bdf-1e17-42d1-a475-3330c434049a)


### After
![image](https://github.com/withastro/astro/assets/46135573/538924f9-b131-4c93-a1c1-d616716fbd1f)


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I didn't add a test because I think the change I made is extremely small. Plus I only found a test for [tooltip-positon](https://github.com/withastro/astro/blob/16af927e14b443eaf2722b51ab1d5c43e64812d1/packages/astro/e2e/fixtures/dev-toolbar/src/pages/tooltip-position.astro)

## Docs

Nothing changed or needs to be changed in the docs.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
