### PR TITLE
Remove non-fatal errors from telemetry

### DIFF
--- a/.changeset/swift-ladybugs-sniff.md
+++ b/.changeset/swift-ladybugs-sniff.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Remove non-fatal errors from telemetry
+
+Previously we tracked non-fatal errors in telemetry to get a good idea of the types of errors that occur in `astro dev`. However this has become noisy over time and results in a lot of data that isn't particularly useful. This removes those non-fatal errors from being tracked.

--- a/packages/astro/src/vite-plugin-astro-server/error.ts
+++ b/packages/astro/src/vite-plugin-astro-server/error.ts
@@ -24,11 +24,6 @@ export function recordServerError(
 	// Our error should already be complete, but let's try to add a bit more through some guesswork
 	const errorWithMetadata = collectErrorMetadata(err, config.root);
 
-	// Ignore unhandled rejection errors as they appear A LOT and we cannot record the amount to telemetry
-	if (errorWithMetadata.name !== AstroErrorData.UnhandledRejection.name) {
-		telemetry.record(eventError({ cmd: 'dev', err: errorWithMetadata, isFatal: false }));
-	}
-
 	logger.error(null, formatErrorMessage(errorWithMetadata, logger.level() === 'debug'));
 
 	return {


### PR DESCRIPTION
## Changes

- Removes errors that occur during dev, such as code errors, as they result in a lot of telemetry data.

## Testing

N/A

## Docs

N/A