### PR TITLE
Fix getPackage resolve path

### DIFF
--- a/.changeset/famous-maps-notice.md
+++ b/.changeset/famous-maps-notice.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes installed packages detection when running `astro check`

--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -9,6 +9,8 @@ import prompts from 'prompts';
 import whichPm from 'which-pm';
 import type { Logger } from '../core/logger/core.js';
 
+const require = createRequire(import.meta.url);
+
 type GetPackageOptions = {
 	skipAsk?: boolean;
 	optional?: boolean;
@@ -24,7 +26,7 @@ export async function getPackage<T>(
 	try {
 		// Try to resolve with `createRequire` first to prevent ESM caching of the package
 		// if it errors and fails here
-		createRequire(options.cwd ?? process.cwd()).resolve(packageName);
+		require.resolve(packageName, { paths: [options.cwd ?? process.cwd()] });
 		const packageImport = await import(packageName);
 		return packageImport as T;
 	} catch (e) {


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/11344

Refactor the way `require.resolve` is called. It failed before because the `process.cwd()` didn't have a trailing slash, so it wasn't resolve from the project directory, but its parent, which doesn't contain the `node_modules` to check packages for.

I refactored it to use the `paths` option because it's simpler and we also had a similar code like this.

https://github.com/withastro/astro/blob/dc95d674af8792773693d491a1f7520d0260e20b/packages/astro/src/core/routing/manifest/create.ts#L347

## Testing

Tested manually by editing the node_modules. I wasn't testing this correctly before because I linked the package, which resolves differently.

## Docs

n/a. bug fix.
