### PR TITLE
fix(rewrite): correctly update the status code during a rewrite

### DIFF
--- a/.changeset/curvy-kids-call.md
+++ b/.changeset/curvy-kids-call.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where the rewrites didn't update the status code when using manual i18n routing.

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -92,6 +92,7 @@ export async function renderPage(
 	} else if (route?.route === '/500') {
 		status = 500;
 	}
+	console.log(status, init.status);
 	if (status) {
 		return new Response(body, { ...init, headers, status });
 	} else {

--- a/packages/astro/src/runtime/server/render/page.ts
+++ b/packages/astro/src/runtime/server/render/page.ts
@@ -92,7 +92,6 @@ export async function renderPage(
 	} else if (route?.route === '/500') {
 		status = 500;
 	}
-	console.log(status, init.status);
 	if (status) {
 		return new Response(body, { ...init, headers, status });
 	} else {

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -13,10 +13,9 @@ import { type SSROptions, getProps } from '../core/render/index.js';
 import { createRequest } from '../core/request.js';
 import { default404Page } from '../core/routing/astro-designed-error-pages.js';
 import { matchAllRoutes } from '../core/routing/index.js';
-import { normalizeTheLocale } from '../i18n/index.js';
 import { getSortedPreloadedMatches } from '../prerender/routing.js';
 import type { DevPipeline } from './pipeline.js';
-import { handle404Response, writeSSRResult, writeWebResponse } from './response.js';
+import { writeSSRResult, writeWebResponse } from './response.js';
 
 type AsyncReturnType<T extends (...args: any) => Promise<any>> = T extends (
 	...args: any

--- a/packages/astro/test/fixtures/rewrite-i18n-manual-routing/astro.config.mjs
+++ b/packages/astro/test/fixtures/rewrite-i18n-manual-routing/astro.config.mjs
@@ -1,0 +1,13 @@
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	experimental: {
+		rewriting: true
+	},
+	i18n: {
+		routing: "manual",
+		locales: ["en", "es"],
+		defaultLocale: "en"
+	}
+});

--- a/packages/astro/test/fixtures/rewrite-i18n-manual-routing/package.json
+++ b/packages/astro/test/fixtures/rewrite-i18n-manual-routing/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/rewrite-i18n-manual-routing",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/rewrite-i18n-manual-routing/src/middleware.js
+++ b/packages/astro/test/fixtures/rewrite-i18n-manual-routing/src/middleware.js
@@ -1,0 +1,5 @@
+export const onRequest = async (_ctx, next) => {
+	const response = await next('/');
+	console.log('expected response.status is', response.status);
+	return response;
+};

--- a/packages/astro/test/fixtures/rewrite-i18n-manual-routing/src/pages/index.astro
+++ b/packages/astro/test/fixtures/rewrite-i18n-manual-routing/src/pages/index.astro
@@ -1,0 +1,3 @@
+<html lang="en">
+	<body><h1>Expected http status of index page is 200</h1></body>
+</html>

--- a/packages/astro/test/rewrite.test.js
+++ b/packages/astro/test/rewrite.test.js
@@ -520,7 +520,7 @@ describe('Runtime error in SSR, custom 500', () => {
 	});
 });
 
-describe.only('Runtime error in SSR, custom 500', () => {
+describe('Runtime error in SSR, custom 500', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
 	let app;
@@ -535,7 +535,7 @@ describe.only('Runtime error in SSR, custom 500', () => {
 		app = await fixture.loadTestAdapterApp();
 	});
 
-	it.only('should return a status 200 when rewriting from the middleware to the homepage', async () => {
+	it('should return a status 200 when rewriting from the middleware to the homepage', async () => {
 		const request = new Request('http://example.com/foo');
 		const response = await app.render(request);
 		assert.equal(response.status, 200);

--- a/packages/astro/test/rewrite.test.js
+++ b/packages/astro/test/rewrite.test.js
@@ -519,3 +519,30 @@ describe('Runtime error in SSR, custom 500', () => {
 		assert.equal($('h1').text(), 'I am the custom 500');
 	});
 });
+
+describe.only('Runtime error in SSR, custom 500', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	let app;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/rewrite-i18n-manual-routing/',
+			output: 'server',
+			adapter: testAdapter(),
+		});
+		await fixture.build();
+		app = await fixture.loadTestAdapterApp();
+	});
+
+	it.only('should return a status 200 when rewriting from the middleware to the homepage', async () => {
+		const request = new Request('http://example.com/foo');
+		const response = await app.render(request);
+		assert.equal(response.status, 200);
+		const html = await response.text();
+
+		const $ = cheerioLoad(html);
+
+		assert.equal($('h1').text(), 'Expected http status of index page is 200');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3529,6 +3529,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/rewrite-i18n-manual-routing:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/rewrite-runtime-error:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/11306

The issue was caused by `this.status` inside the `RenderContext` class. This status code is then passed to the `SSResult` and used as initial status of `Response`. 

This status code was passed by `route.ts`. It was a 404 because `/foo` didn't match any route, however we still call the middleware because the user chose `routing: 'manual'`.

When we arrived to the middleware, we executed the rewrite, and we need update this status code in case we find a `RouteData` and a `ComponentInstance`.

I moved the shared logic inside a new, private, function called `#executeRewrite` as per @florian-lefebvre suggestion.

## Testing

Added a new test case

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
