### PR TITLE
fix: add missing href to canonicalURL

### DIFF
--- a/examples/blog/src/components/BaseHead.astro
+++ b/examples/blog/src/components/BaseHead.astro
@@ -25,7 +25,7 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <link rel="preload" href="/fonts/atkinson-bold.woff" as="font" type="font/woff" crossorigin />
 
 <!-- Canonical URL -->
-<link rel="canonical" href={canonicalURL} />
+<link rel="canonical" href={canonicalURL.href} />
 
 <!-- Primary Meta Tags -->
 <title>{title}</title>

--- a/examples/starlog/src/components/SEO.astro
+++ b/examples/starlog/src/components/SEO.astro
@@ -34,7 +34,7 @@ const {
 	description,
 	image,
 	locale = 'en',
-	canonicalURL = new URL(Astro.url.pathname, Astro.site),
+	canonicalURL = new URL(Astro.url.pathname, Astro.site).href,
 } = Astro.props;
 
 const og = {

--- a/packages/astro/e2e/fixtures/actions-blog/src/components/BaseHead.astro
+++ b/packages/astro/e2e/fixtures/actions-blog/src/components/BaseHead.astro
@@ -21,7 +21,7 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <meta name="generator" content={Astro.generator} />
 
 <!-- Canonical URL -->
-<link rel="canonical" href={canonicalURL} />
+<link rel="canonical" href={canonicalURL.href} />
 
 <!-- Primary Meta Tags -->
 <title>{title}</title>

--- a/packages/astro/e2e/fixtures/actions-react-19/src/components/BaseHead.astro
+++ b/packages/astro/e2e/fixtures/actions-react-19/src/components/BaseHead.astro
@@ -21,7 +21,7 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <meta name="generator" content={Astro.generator} />
 
 <!-- Canonical URL -->
-<link rel="canonical" href={canonicalURL} />
+<link rel="canonical" href={canonicalURL.href} />
 
 <!-- Primary Meta Tags -->
 <title>{title}</title>


### PR DESCRIPTION
the `new URL(Astro.url.pathname, Astro.site)` return `URL`, only the `href` is needed
```
<!-- Canonical URL -->
<link rel="canonical" href={canonicalURL.href} />
```
## Changes

- add `.href`to `canonicalURL`

## Testing

## Docs

https://docs.astro.build/en/reference/api-reference/#astrocanonicalurl