### PR TITLE
fix(i18n): update strategy when defining manually astro i18n middleware

### DIFF
--- a/.changeset/brave-mayflies-share.md
+++ b/.changeset/brave-mayflies-share.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where creating manually the i18n middleware could break the logic of the functions of the virtual module `astro:i18n`

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -24,6 +24,7 @@ export function requestIs404Or500(request: Request, base = '') {
 
 	return url.pathname.startsWith(`${base}/404`) || url.pathname.startsWith(`${base}/500`);
 }
+
 // Checks if the pathname has any locale
 export function pathHasLocale(path: string, locales: Locales): boolean {
 	const segments = path.split('/');
@@ -70,6 +71,7 @@ type GetLocaleAbsoluteUrl = GetLocaleRelativeUrl & {
 	site: AstroConfig['site'];
 	isBuild: boolean;
 };
+
 /**
  * The base URL
  */

--- a/packages/astro/src/virtual-modules/i18n.ts
+++ b/packages/astro/src/virtual-modules/i18n.ts
@@ -11,6 +11,7 @@ import * as I18nInternals from '../i18n/index.js';
 import type { RedirectToFallback } from '../i18n/index.js';
 import { toRoutingStrategy } from '../i18n/utils.js';
 import type { I18nInternalConfig } from '../i18n/vite-plugin-i18n.js';
+
 export { normalizeTheLocale, toCodes, toPaths } from '../i18n/index.js';
 
 const { trailingSlash, format, site, i18n, isBuild } =
@@ -19,7 +20,7 @@ const { trailingSlash, format, site, i18n, isBuild } =
 const { defaultLocale, locales, domains, fallback, routing } = i18n!;
 const base = import.meta.env.BASE_URL;
 
-const strategy = toRoutingStrategy(routing, domains);
+let strategy = toRoutingStrategy(routing, domains);
 
 export type GetLocaleOptions = I18nInternals.GetLocaleOptions;
 
@@ -372,10 +373,11 @@ export let middleware: (customOptions: NewAstroRoutingConfigWithoutManual) => Mi
 
 if (i18n?.routing === 'manual') {
 	middleware = (customOptions: NewAstroRoutingConfigWithoutManual) => {
+		strategy = toRoutingStrategy(customOptions, {});
 		const manifest: SSRManifest['i18n'] = {
 			...i18n,
 			fallback: undefined,
-			strategy: toRoutingStrategy(customOptions, {}),
+			strategy,
 			domainLookupTable: {},
 		};
 		return I18nInternals.createMiddleware(manifest, base, trailingSlash, format);

--- a/packages/astro/test/fixtures/i18n-routing-manual-with-default-middleware/src/pages/en/start.astro
+++ b/packages/astro/test/fixtures/i18n-routing-manual-with-default-middleware/src/pages/en/start.astro
@@ -1,8 +1,13 @@
+---
+import {getRelativeLocaleUrl} from "astro:i18n";
+
+const customUrl = getRelativeLocaleUrl("en", "/blog/title")
+---
 <html>
 <head>
 	<title>Astro</title>
 </head>
 <body>
-Hello
+Hello <p>{customUrl}</p>
 </body>
 </html>

--- a/packages/astro/test/i18n-routing-manual-with-default-middleware.test.js
+++ b/packages/astro/test/i18n-routing-manual-with-default-middleware.test.js
@@ -35,6 +35,14 @@ describe('Dev server manual routing', () => {
 		const text = await response.text();
 		assert.equal(text.includes('ABOUT ME'), true);
 	});
+
+	it('should correctly print the relative locale url', async () => {
+		const response = await fixture.fetch('/en/start');
+		assert.equal(response.status, 200);
+		const html = await response.text();
+		const $ = cheerio.load(html);
+		assert.equal($('p').text(), '/en/blog/title/');
+	});
 });
 //
 // // SSG
@@ -60,6 +68,12 @@ describe('SSG manual routing', () => {
 		let html = await fixture.readFile('/about/index.html');
 		let $ = cheerio.load(html);
 		assert.equal($('body').text().includes('ABOUT ME'), true);
+	});
+
+	it('should correctly print the relative locale url', async () => {
+		const html = await fixture.readFile('/en/start/index.html');
+		const $ = cheerio.load(html);
+		assert.equal($('p').text(), '/en/blog/title/');
 	});
 });
 
@@ -93,5 +107,14 @@ describe('SSR manual routing', () => {
 		assert.equal(response.status, 200);
 		const text = await response.text();
 		assert.equal(text.includes('ABOUT ME'), true);
+	});
+
+	it('should correctly print the relative locale url', async () => {
+		let request = new Request('http://example.com/en/start');
+		let response = await app.render(request);
+		assert.equal(response.status, 200);
+		const html = await response.text();
+		const $ = cheerio.load(html);
+		assert.equal($('p').text(), '/en/blog/title/');
 	});
 });


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/11355

The utility functions were still using the `strategy = "manual"`. The fix updates `strategy` to the new value.

## Testing

Added new test cases.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
