### PR TITLE
chore: reorder issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: 💁 Support
+    url: https://astro.build/chat
+    about: 'This issue tracker is not for support questions. Join us on Discord for assistance!'
   - name: 📘 Documentation
     url: https://github.com/withastro/docs
     about: File an issue or make an improvement to the docs website.
@@ -9,6 +12,3 @@ contact_links:
   - name: 👾 Chat
     url: https://astro.build/chat
     about: Our Discord server is active, come join us!
-  - name: 💁 Support
-    url: https://astro.build/chat
-    about: 'This issue tracker is not for support questions. Join us on Discord for assistance!'


### PR DESCRIPTION
## Changes

- Puts Support 3rd instead of last to try avoid getting support in issues

