### PR TITLE
fix: watch for content layer changes

### DIFF
--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -50,6 +50,7 @@ export const collectionConfigParser = z.union([
 							logger: z.any(),
 							settings: z.any(),
 							parseData: z.any(),
+							watcher: z.any().optional(),
 						}),
 					],
 					z.unknown()

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -103,7 +103,11 @@ export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevS
 
 	await attachContentServerListeners(restart.container);
 
-	await syncContentLayer({ settings: restart.container.settings, logger: logger });
+	await syncContentLayer({
+		settings: restart.container.settings,
+		logger,
+		watcher: restart.container.viteServer.watcher,
+	});
 
 	logger.info(null, green('watching for file changes...'));
 

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -1,83 +1,192 @@
 import assert from 'node:assert/strict';
-import { before, describe, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('Content Layer', () => {
+	/** @type {import("./test-utils.js").Fixture} */
 	let fixture;
-	let json;
 
 	before(async () => {
 		fixture = await loadFixture({ root: './fixtures/content-layer/' });
-		await fixture.build();
-		const rawJson = await fixture.readFile('/collections.json');
-		json = JSON.parse(rawJson);
 	});
 
-	it('Returns custom loader collection', async () => {
-		assert.ok(json.hasOwnProperty('customLoader'));
-		assert.ok(Array.isArray(json.customLoader));
+	describe('Build', () => {
+		let json;
+		before(async () => {
+			fixture = await loadFixture({ root: './fixtures/content-layer/' });
+			await fixture.build();
+			const rawJson = await fixture.readFile('/collections.json');
+			json = JSON.parse(rawJson);
+		});
 
-		const item = json.customLoader[0];
-		assert.deepEqual(item, {
-			id: '1',
-			collection: 'blog',
-			data: {
-				userId: 1,
-				id: 1,
-				title: 'sunt aut facere repellat provident occaecati excepturi optio reprehenderit',
-				body: 'quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto',
-			},
-			type: 'experimental_data',
+		it('Returns custom loader collection', async () => {
+			assert.ok(json.hasOwnProperty('customLoader'));
+			assert.ok(Array.isArray(json.customLoader));
+
+			const item = json.customLoader[0];
+			assert.deepEqual(item, {
+				id: '1',
+				collection: 'blog',
+				data: {
+					userId: 1,
+					id: 1,
+					title: 'sunt aut facere repellat provident occaecati excepturi optio reprehenderit',
+					body: 'quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto',
+				},
+				type: 'experimental_data',
+			});
+		});
+
+		it('Returns `file()` loader collection', async () => {
+			assert.ok(json.hasOwnProperty('fileLoader'));
+			assert.ok(Array.isArray(json.fileLoader));
+
+			const ids = json.fileLoader.map((item) => item.data.id);
+			assert.deepEqual(ids, [
+				'labrador-retriever',
+				'german-shepherd',
+				'golden-retriever',
+				'french-bulldog',
+				'bulldog',
+				'beagle',
+				'poodle',
+				'rottweiler',
+				'german-shorthaired-pointer',
+				'yorkshire-terrier',
+				'boxer',
+				'dachshund',
+				'siberian-husky',
+				'great-dane',
+				'doberman-pinscher',
+				'australian-shepherd',
+				'miniature-schnauzer',
+				'cavalier-king-charles-spaniel',
+				'shih-tzu',
+				'boston-terrier',
+				'bernese-mountain-dog',
+				'pomeranian',
+				'havanese',
+				'english-springer-spaniel',
+				'shetland-sheepdog',
+			]);
+		});
+
+		it('Returns data entry by id', async () => {
+			assert.ok(json.hasOwnProperty('dataEntryById'));
+			assert.deepEqual(json.dataEntryById, {
+				id: 'beagle',
+				collection: 'dogs',
+				data: {
+					breed: 'Beagle',
+					id: 'beagle',
+					size: 'Small to Medium',
+					origin: 'England',
+					lifespan: '12-15 years',
+					temperament: ['Friendly', 'Curious', 'Merry'],
+				},
+			});
 		});
 	});
 
-	it('Returns `file()` loader collection', async () => {
-		assert.ok(json.hasOwnProperty('fileLoader'));
-		assert.ok(Array.isArray(json.fileLoader));
+	describe('Dev', () => {
+		let devServer;
+		let json;
+		before(async () => {
+			devServer = await fixture.startDevServer();
+			const rawJsonResponse = await fixture.fetch('/collections.json');
+			const rawJson = await rawJsonResponse.text();
+			json = JSON.parse(rawJson);
+		});
 
-		const ids = json.fileLoader.map((item) => item.data.id);
-		assert.deepEqual(ids, [
-			'labrador-retriever',
-			'german-shepherd',
-			'golden-retriever',
-			'french-bulldog',
-			'bulldog',
-			'beagle',
-			'poodle',
-			'rottweiler',
-			'german-shorthaired-pointer',
-			'yorkshire-terrier',
-			'boxer',
-			'dachshund',
-			'siberian-husky',
-			'great-dane',
-			'doberman-pinscher',
-			'australian-shepherd',
-			'miniature-schnauzer',
-			'cavalier-king-charles-spaniel',
-			'shih-tzu',
-			'boston-terrier',
-			'bernese-mountain-dog',
-			'pomeranian',
-			'havanese',
-			'english-springer-spaniel',
-			'shetland-sheepdog',
-		]);
-	});
+		after(async () => {
+			devServer?.stop();
+		});
 
-	it('Returns data entry by id', async () => {
-		assert.ok(json.hasOwnProperty('dataEntryById'));
-		assert.deepEqual(json.dataEntryById, {
-			id: 'beagle',
-			collection: 'dogs',
-			data: {
-				breed: 'Beagle',
+		it('Returns custom loader collection', async () => {
+			assert.ok(json.hasOwnProperty('customLoader'));
+			assert.ok(Array.isArray(json.customLoader));
+
+			const item = json.customLoader[0];
+			assert.deepEqual(item, {
+				id: '1',
+				collection: 'blog',
+				data: {
+					userId: 1,
+					id: 1,
+					title: 'sunt aut facere repellat provident occaecati excepturi optio reprehenderit',
+					body: 'quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto',
+				},
+				type: 'experimental_data',
+			});
+		});
+
+		it('Returns `file()` loader collection', async () => {
+			assert.ok(json.hasOwnProperty('fileLoader'));
+			assert.ok(Array.isArray(json.fileLoader));
+
+			const ids = json.fileLoader.map((item) => item.data.id);
+			assert.deepEqual(ids, [
+				'labrador-retriever',
+				'german-shepherd',
+				'golden-retriever',
+				'french-bulldog',
+				'bulldog',
+				'beagle',
+				'poodle',
+				'rottweiler',
+				'german-shorthaired-pointer',
+				'yorkshire-terrier',
+				'boxer',
+				'dachshund',
+				'siberian-husky',
+				'great-dane',
+				'doberman-pinscher',
+				'australian-shepherd',
+				'miniature-schnauzer',
+				'cavalier-king-charles-spaniel',
+				'shih-tzu',
+				'boston-terrier',
+				'bernese-mountain-dog',
+				'pomeranian',
+				'havanese',
+				'english-springer-spaniel',
+				'shetland-sheepdog',
+			]);
+		});
+
+		it('Returns data entry by id', async () => {
+			assert.ok(json.hasOwnProperty('dataEntryById'));
+			assert.deepEqual(json.dataEntryById, {
 				id: 'beagle',
-				size: 'Small to Medium',
-				origin: 'England',
-				lifespan: '12-15 years',
-				temperament: ['Friendly', 'Curious', 'Merry'],
-			},
+				collection: 'dogs',
+				data: {
+					breed: 'Beagle',
+					id: 'beagle',
+					size: 'Small to Medium',
+					origin: 'England',
+					lifespan: '12-15 years',
+					temperament: ['Friendly', 'Curious', 'Merry'],
+				},
+			});
+		});
+
+		it('updates collection when data file is changed', async () => {
+			const rawJsonResponse = await fixture.fetch('/collections.json');
+			const initialJson = await rawJsonResponse.json();
+			assert.equal(initialJson.fileLoader[0].data.temperament.includes('Bouncy'), false);
+
+			await fixture.editFile('/src/content/_data/dogs.json', (prev) => {
+				const data = JSON.parse(prev);
+				data[0].temperament.push('Bouncy');
+				return JSON.stringify(data, null, 2);
+			});
+
+			// Writes are debounced to 500ms
+			await new Promise((r) => setTimeout(r, 700));
+
+			const updatedJsonResponse = await fixture.fetch('/collections.json');
+			const updated = await updatedJsonResponse.json();
+			assert.ok(updated.fileLoader[0].data.temperament.includes('Bouncy'));
 		});
 	});
 });

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -36,7 +36,7 @@ process.env.ASTRO_TELEMETRY_DISABLED = true;
  * @property {(path: string) => Promise<boolean>} pathExists
  * @property {(url: string, opts: Parameters<typeof fetch>[1]) => Promise<Response>} fetch
  * @property {(path: string) => Promise<string>} readFile
- * @property {(path: string, updater: (content: string) => string) => Promise<void>} writeFile
+ * @property {(path: string, updater: (content: string) => string) => Promise<void>} editFile
  * @property {(path: string) => Promise<string[]>} readdir
  * @property {(pattern: string) => Promise<string[]>} glob
  * @property {typeof dev} startDevServer

--- a/packages/astro/types/content.d.ts
+++ b/packages/astro/types/content.d.ts
@@ -54,6 +54,8 @@ declare module 'astro:content' {
 		parseData<T extends Record<string, unknown> = Record<string, unknown>>(
 			props: ParseDataOptions
 		): T;
+		/** When running in dev, this is a filesystem watcher that can be used to trigger updates */
+		watcher?: import('vite').FSWatcher;
 	}
 	export interface Loader {
 		/** Unique name of the loader, e.g. the npm package name */


### PR DESCRIPTION
## Changes

- adds a `watcher` to the loader props, which can be used to update data. I've not tried to do anythign with scoping the watcher, because I think it's best to allow flexibility there
- uses this watcher in the `file()` loader to reload data when the file changes
- because we now can change data in the store outside of the main lifecycle, I've needed to add support for automatically saving changes to disk. I did this with a debounced save function that's automatically called whenever the store is changed. This will save to disk 500ms after the last data change
- during dev, it watches the data store file and invalidates the virtual module when it changes

## Testing

Adds `dev` tests, including one that edits the data file

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
