### PR TITLE
Add support for LibSQL remote

### DIFF
--- a/.changeset/healthy-boxes-poke.md
+++ b/.changeset/healthy-boxes-poke.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/db': minor
+---
+
+Adds support for self-hosted LibSQL

--- a/packages/db/src/runtime/db-client.ts
+++ b/packages/db/src/runtime/db-client.ts
@@ -1,5 +1,5 @@
 import type { InStatement } from '@libsql/client';
-import { createClient, type Config as LibSQLConfig } from '@libsql/client';
+import { type Config as LibSQLConfig, createClient } from '@libsql/client';
 import type { LibSQLDatabase } from 'drizzle-orm/libsql';
 import { drizzle as drizzleLibsql } from 'drizzle-orm/libsql';
 import { type SqliteRemoteDatabase, drizzle as drizzleProxy } from 'drizzle-orm/sqlite-proxy';
@@ -43,15 +43,16 @@ export function createRemoteDatabaseClient(appToken: string, remoteDbURL: string
 	switch (remoteUrl.protocol) {
 		case 'http:':
 		case 'https:':
-			return createStudioDatabaseClient(appToken, remoteUrl)
-    case 'libsql+http:':
-    	remoteUrl.protocol = 'http:';
-    case 'libsql+https:':
-    	remoteUrl.protocol = 'https:';
-    case 'ws:':
-    case 'wss:':
-    case 'file:':
-    case 'libsql:':
+			return createStudioDatabaseClient(appToken, remoteUrl);
+		case 'libsql+http:':
+			remoteUrl.protocol = 'http:';
+		case 'libsql+https:':
+			remoteUrl.protocol = 'https:';
+		case 'ws:':
+		case 'wss:':
+		case 'file:':
+		case 'memory:':
+		case 'libsql:':
 			return createRemoteLibSQLClient(appToken, remoteUrl);
 		default:
 			throw new Error(`Unsupported remote DB: ${remoteDbURL}`);
@@ -62,10 +63,10 @@ function createRemoteLibSQLClient(appToken: string, remoteDbURL: URL) {
 	const options: Partial<LibSQLConfig> = Object.fromEntries(remoteDbURL.searchParams.entries());
 	remoteDbURL.search = '';
 
-	const client = createClient({ 
+	const client = createClient({
 		...options,
 		authToken: appToken,
-		url: remoteDbURL.toString(),
+		url: remoteDbURL.protocol === 'memory:' ? ':memory:' : remoteDbURL.toString(),
 	});
 	const db = drizzleLibsql(client);
 

--- a/packages/db/test/static-remote.test.js
+++ b/packages/db/test/static-remote.test.js
@@ -39,4 +39,31 @@ describe('astro:db', () => {
 			assert.match($('#row').text(), /1/);
 		});
 	});
+
+	describe('static build --remote with custom LibSQL', () => {
+		let remoteDbServer;
+
+		before(async () => {
+			process.env.ASTRO_STUDIO_REMOTE_DB_URL = `memory:`;
+			await fixture.build();
+		});
+
+		after(async () => {
+			await remoteDbServer?.stop();
+		});
+
+		it('Can render page', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerioLoad(html);
+
+			assert.equal($('li').length, 1);
+		});
+
+		it('Returns correct shape from db.run()', async () => {
+			const html = await fixture.readFile('/run/index.html');
+			const $ = cheerioLoad(html);
+
+			assert.match($('#row').text(), /1/);
+		});
+	});
 });


### PR DESCRIPTION
## Changes

- Allows `ASTRO_STUDIO_REMOTE_DB_URL` to point to a LibSQL server instance (using any supported LibSQL protocols). This enables Astro DB to be used with self-hosting and air-gapped deployments.
- Accept extra LibSQL options as query parameters in the remote URL.
  - For example, `memory:?syncUrl=libsql%3A%2F%2Fdb-server.example.com` would create an in-memory embedded replica for the LibSQL DB on `libsql://db-server.example.com`.

## Testing

Replicated the test for Studio remote using the LibSQL remote

## Docs

I'll open the docs PR if this is of interest :)