### PR TITLE
Fix prerendering with unused dynamic chunks

### DIFF
--- a/.changeset/giant-lies-taste.md
+++ b/.changeset/giant-lies-taste.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes prerendering not removing unused dynamic imported chunks

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -314,10 +314,12 @@ export class App {
 		}
 		const pathname = this.#getPathnameFromRequest(request);
 		const defaultStatus = this.#getDefaultStatusCode(routeData, pathname);
-		const mod = await this.#pipeline.getModuleForRoute(routeData);
 
 		let response;
 		try {
+			// Load route module. We also catch its error here if it fails on initialization
+			const mod = await this.#pipeline.getModuleForRoute(routeData);
+
 			const renderContext = RenderContext.create({
 				pipeline: this.#pipeline,
 				locals,

--- a/packages/astro/src/core/build/plugins/plugin-pages.ts
+++ b/packages/astro/src/core/build/plugins/plugin-pages.ts
@@ -44,8 +44,8 @@ function vitePluginPages(opts: StaticBuildOptions, internals: BuildInternals): V
 				for (const pageData of pageDatas) {
 					const resolvedPage = await this.resolve(pageData.moduleSpecifier);
 					if (resolvedPage) {
-						imports.push(`const page = () => import(${JSON.stringify(pageData.moduleSpecifier)});`);
-						exports.push(`export { page }`);
+						imports.push(`import * as _page from ${JSON.stringify(pageData.moduleSpecifier)};`);
+						exports.push(`export const page = () => _page`);
 
 						imports.push(`import { renderers } from "${RENDERERS_MODULE_ID}";`);
 						exports.push(`export { renderers };`);

--- a/packages/astro/src/core/build/plugins/plugin-prerender.ts
+++ b/packages/astro/src/core/build/plugins/plugin-prerender.ts
@@ -40,7 +40,7 @@ function getNonPrerenderOnlyChunks(bundle: Rollup.OutputBundle, internals: Build
 	const prerenderOnlyEntryChunks = new Set<Rollup.OutputChunk>();
 	const nonPrerenderOnlyEntryChunks = new Set<Rollup.OutputChunk>();
 	for (const chunk of chunks) {
-		if (chunk.type === 'chunk' && (chunk.isEntry || chunk.isDynamicEntry)) {
+		if (chunk.type === 'chunk' && chunk.isEntry) {
 			// See if this entry chunk is prerendered, if so, skip it
 			if (chunk.facadeModuleId?.startsWith(ASTRO_PAGE_RESOLVED_MODULE_ID)) {
 				const pageDatas = getPagesFromVirtualModulePageName(

--- a/packages/astro/test/fixtures/ssr-prerender-chunks/src/pages/index.astro
+++ b/packages/astro/test/fixtures/ssr-prerender-chunks/src/pages/index.astro
@@ -5,7 +5,7 @@
 
  <html>
  <head>
- 	<title>Static Page</title>
+ 	<title>Static Page should not exist in chunks</title>
  </head>
  	<body>
  		<Counter client:load />

--- a/packages/astro/test/ssr-prerender-chunks.test.js
+++ b/packages/astro/test/ssr-prerender-chunks.test.js
@@ -18,4 +18,15 @@ describe('Chunks', () => {
 		const hasImportFromPrerender = !content.includes(`React } from './chunks/prerender`);
 		assert.ok(hasImportFromPrerender);
 	});
+
+	it('does not have prerender code', async () => {
+		const files = await fixture.readdir('/_worker.js/chunks');
+		assert.ok(files.length > 0);
+		for (const file of files) {
+			// Skip astro folder
+			if (file === 'astro') continue
+			const content = await fixture.readFile(`/_worker.js/chunks/${file}`);
+			assert.doesNotMatch(content, /Static Page should not exist in chunks/);
+		}
+	});
 });


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/11377

re-implements the idea from https://github.com/withastro/astro/pull/11245#discussion_r1636593458

I also additionally tweaked `plugin-prerender.ts` line 43 to further remove unused dynamic imports. I didn't do it before as I thought it might incorrectly get deleted if it's via `this.emitFile`, but that API actually marks the entrypoints as `isEntry` instead.

## Testing

Updated test

## Docs

n/a. bug fix.