### PR TITLE
fix(overlay): adjust the color of punctuations

### DIFF
--- a/.changeset/fair-wolves-move.md
+++ b/.changeset/fair-wolves-move.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adjusts the color of punctuations in error overlay.

--- a/packages/astro/src/core/errors/overlay.ts
+++ b/packages/astro/src/core/errors/overlay.ts
@@ -76,7 +76,7 @@ const style = /* css */ `
   --astro-code-token-parameter: #aa0000;
   --astro-code-token-function: #4ca48f;
   --astro-code-token-string-expression: #9f722a;
-  --astro-code-token-punctuation: #ffffff;
+  --astro-code-token-punctuation: #000000;
   --astro-code-token-link: #9f722a;
 }
 


### PR DESCRIPTION
## Changes

- This PR adjusts the color of punctuations in error layout, aiming to improve the contrast in light mode
- Closes #11373

| Before | After |
| ------ | ----- |
| ![before](https://github.com/withastro/astro/assets/40516784/07ec3c71-3016-40a6-b9f4-1ae68a840c88) | ![after](https://github.com/withastro/astro/assets/40516784/a72186ab-fe8b-448a-92c7-c9086100bed1) |

## Testing

- Manually tested

## Docs

- N/A
