### PR TITLE
Add Shiki's `defaultColor` option to `<Code />` component

### DIFF
--- a/.changeset/thin-dodos-serve.md
+++ b/.changeset/thin-dodos-serve.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Adds Shiki's [`defaultColor`](https://shiki.style/guide/dual-themes#without-default-color) option to the `<Code />` component, giving you more control in applying multiple themes

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -37,6 +37,16 @@ interface Props extends Omit<HTMLAttributes<'pre'>, 'lang'> {
 	 */
 	themes?: Record<string, ThemePresets | ThemeRegistration | ThemeRegistrationRaw>;
 	/**
+	 * Chooses a theme from the "themes" option that you've defined as the default styling theme.
+	 *  - <string>: one of the keys defined in the "themes" option. Will throw an error if the key is not defined.
+	 *  - false: disabled. You'll have to apply the styling theme yourself. No effect if the "themes" option is not set.
+	 *
+	 * See https://shiki.style/guide/dual-themes#without-default-color for more information.
+	 *
+	 * @default "light"
+	 */
+	defaultColor?: 'light' | 'dark' | string | false
+	/**
 	 * Enable word wrapping.
 	 *  - true: enabled.
 	 *  - false: disabled.
@@ -64,6 +74,7 @@ const {
 	lang = 'plaintext',
 	theme = 'github-dark',
 	themes = {},
+	defaultColor = 'light',
 	wrap = false,
 	inline = false,
 	transformers = [],
@@ -92,6 +103,7 @@ const highlighter = await getCachedHighlighter({
 	],
 	theme,
 	themes,
+	defaultColor,
 	wrap,
 	transformers,
 });


### PR DESCRIPTION
## Changes

<!-- - What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset` -->

Adds Shiki's `defaultColor` option to the `<Code />` component

## Note

Because most of the work has been done by #11341, this PR is a partial implementation and depends on #11341 to work properly. Therefore this PR should be merged together with #11341, or alternatively let #11341 inherit this PR's changes and close this PR. (Pinging @madcampos for the heads up)

This PR comes from withastro/roadmap#897

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Not sure how to make automated tests

I've published a [testing branch](https://github.com/ARipeAppleByYoursTruly/astro/tree/pr/11341). The tests are located at [examples/component-code](https://github.com/ARipeAppleByYoursTruly/astro/tree/pr/11341/examples/component-code). They test all possible values of `defaultColor`

How to run the example:
1. `pnpm install`
2. `pnpm run dev`
3. `pnpm --filter @example/component-code run dev` in a new shell

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->

/cc @withastro/maintainers-docs for feedback!

The docs certainly needs to be updated as this exposes a new option of `<Code />` component for users to play with.

I also would like some feedback on the overall tone and structure of JSDocs on the `defaultColor` option in `<Code />` component

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
