### PR TITLE
feat(vercel): allow external redirects

### DIFF
--- a/.changeset/clean-cows-draw.md
+++ b/.changeset/clean-cows-draw.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': minor
+---
+
+Allow external redirects to be configured through Astro config

--- a/packages/integrations/vercel/src/lib/redirects.ts
+++ b/packages/integrations/vercel/src/lib/redirects.ts
@@ -85,15 +85,29 @@ function getReplacePattern(segments: RoutePart[][]) {
 }
 
 function getRedirectLocation(route: RouteData, config: AstroConfig): string {
+	let redirectPath: string;
+	let forceTrailingSlash = false;
+
 	if (route.redirectRoute) {
-		const pattern = getReplacePattern(route.redirectRoute.segments);
-		const path = config.trailingSlash === 'always' ? appendForwardSlash(pattern) : pattern;
-		return pathJoin(config.base, path);
+		redirectPath = getReplacePattern(route.redirectRoute.segments);
+		if (config.trailingSlash === 'always') forceTrailingSlash = true;
 	} else if (typeof route.redirect === 'object') {
-		return pathJoin(config.base, route.redirect.destination);
+		redirectPath = route.redirect.destination;
 	} else {
-		return pathJoin(config.base, route.redirect || '');
+		redirectPath = route.redirect || '';
 	}
+
+	// Is external link - do not transform
+	const hasProtocol = redirectPath.includes('://');
+	if (hasProtocol) {
+		return redirectPath;
+	}
+
+	if (forceTrailingSlash) {
+		redirectPath = appendForwardSlash(redirectPath);
+	}
+
+	return pathJoin(config.base, redirectPath);
 }
 
 function getRedirectStatus(route: RouteData): number {

--- a/packages/integrations/vercel/test/redirects.test.js
+++ b/packages/integrations/vercel/test/redirects.test.js
@@ -18,6 +18,7 @@ describe('Redirects', () => {
 				},
 				'/blog/[...slug]': '/team/articles/[...slug]',
 				'/Basic/http-2-0.html': '/posts/http2',
+				'/google': 'https://google.com'
 			},
 			trailingSlash: 'always',
 		});
@@ -54,6 +55,14 @@ describe('Redirects', () => {
 		assert.notEqual(staticRoute, undefined);
 		assert.equal(staticRoute.headers.Location, '/posts/http2');
 		assert.equal(staticRoute.status, 301);
+	});
+
+	it('define external redirects', async () => {
+		const config = await getConfig();
+
+		const route = config.routes.find((r) => r.src === '/google');
+		assert.equal(route.headers.Location, 'https://google.com');
+		assert.equal(route.status, 301);
 	});
 
 	it('defines dynamic routes', async () => {


### PR DESCRIPTION
Based on issue #11313

## Changes

**Before:**

Redirects with schema defined in `astro.config.mjs` were converted into paths on the same site: `https://google.com` -> `/https://google.com`

**After:**

External redirects are detected and don't have the project `base` path prepended.

## Testing

The output (esp. `.vercel/output/config.json`) of building a project with the updated integration was manually inspected.

A test was added

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

The Astro docs generally state that supporting external links configured through `astro.config.mjs` isn't a goal. While the Cloudflare adapter already supports external redirects, the Vercel adapter handled external redirects differently so far. Therefore this could potentially be considered a _breaking change_.

/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
