### PR TITLE
Pass slots to server islands

### DIFF
--- a/packages/astro/e2e/fixtures/server-islands/src/components/Island.astro
+++ b/packages/astro/e2e/fixtures/server-islands/src/components/Island.astro
@@ -1,3 +1,4 @@
 ---
 ---
 <h2 id="island">I am an island</h2>
+<slot />

--- a/packages/astro/e2e/fixtures/server-islands/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/server-islands/src/pages/index.astro
@@ -7,6 +7,8 @@ import Island from '../components/Island.astro';
 		<!-- Head Stuff -->
 	</head>
 	<body>
-		<Island server:defer />		
+		<Island server:defer>
+			<h3 id="children">children</h3>
+		</Island>
 	</body>
 </html>

--- a/packages/astro/e2e/server-islands.test.js
+++ b/packages/astro/e2e/server-islands.test.js
@@ -30,6 +30,13 @@ test.describe('Server islands', () => {
 			await expect(el, 'element rendered').toBeVisible();
 			await expect(el, 'should have content').toHaveText('I am an island');
 		});
+
+		test('Slots are provided back to the server islands', async ({ page, astro }) => {
+			await page.goto(astro.resolveUrl('/'));
+			let el = page.locator('#children');
+
+			await expect(el, 'element rendered').toBeVisible();
+		});
 	});
 
 	test.describe('Production', () => {

--- a/packages/astro/src/core/server-islands/endpoint.ts
+++ b/packages/astro/src/core/server-islands/endpoint.ts
@@ -1,6 +1,6 @@
-import { renderComponent, renderTemplate, type AstroComponentFactory } from '../../runtime/server/index.js';
-import type { APIRoute, ComponentInstance, ManifestData, RouteData, SSRManifest } from '../../@types/astro.js';
-import type { ModuleLoader } from '../module-loader/loader.js';
+import { renderComponent, renderTemplate, type AstroComponentFactory, type ComponentSlots } from '../../runtime/server/index.js';
+import type { ComponentInstance, ManifestData, RouteData, SSRManifest } from '../../@types/astro.js';
+import { createSlotValueFromString } from '../../runtime/server/render/slot.js';
 
 export const SERVER_ISLAND_ROUTE = '/_server-islands/[name]';
 export const SERVER_ISLAND_COMPONENT = '_server-islands.astro';
@@ -33,7 +33,7 @@ export function ensureServerIslandRoute(manifest: ManifestData) {
 type RenderOptions = {
 	componentExport: string;
 	props: Record<string, any>;
-	slots: Record<string, any>;
+	slots: Record<string, string>;
 }
 
 export function createEndpoint(manifest: SSRManifest) {
@@ -59,9 +59,13 @@ export function createEndpoint(manifest: SSRManifest) {
 		}
 
 		const props = data.props;
-		const slots = data.slots;
 		const componentModule = await imp();
 		const Component = (componentModule as any)[data.componentExport];
+
+		const slots: ComponentSlots = {};
+		for(const prop in data.slots) {
+			slots[prop] = createSlotValueFromString(data.slots[prop]);
+		}
 
 		return renderTemplate`${renderComponent(result, 'Component', Component, props, slots)}`;
 	}

--- a/packages/astro/src/runtime/server/render/component.ts
+++ b/packages/astro/src/runtime/server/render/component.ts
@@ -494,7 +494,7 @@ export async function renderComponent(
 	displayName: string,
 	Component: unknown,
 	props: Record<string | number, any>,
-	slots: any = {}
+	slots: ComponentSlots = {}
 ): Promise<RenderInstance> {
 	if (isPromise(Component)) {
 		Component = await Component.catch(handleCancellation);

--- a/packages/astro/src/runtime/server/render/slot.ts
+++ b/packages/astro/src/runtime/server/render/slot.ts
@@ -1,8 +1,8 @@
 import type { SSRResult } from '../../../@types/astro.js';
-import type { renderTemplate } from './astro/render-template.js';
+import { renderTemplate } from './astro/render-template.js';
 import type { RenderInstruction } from './instruction.js';
 
-import { HTMLString, markHTMLString } from '../escape.js';
+import { HTMLString, markHTMLString, unescapeHTML } from '../escape.js';
 import { renderChild } from './any.js';
 import { type RenderDestination, type RenderInstance, chunkToString } from './common.js';
 
@@ -102,4 +102,10 @@ export async function renderSlots(
 		);
 	}
 	return { slotInstructions, children };
+}
+
+export function createSlotValueFromString(content: string): ComponentSlotValue {
+	return function() {
+		return renderTemplate`${unescapeHTML(content)}`;
+	};
 }


### PR DESCRIPTION
## Changes

- Slots are statically rendered into a string and included in the original HTML.
- When an island posts back it includes those slots to the server environment so that it can use them.

## Testing

- E2E test added to verify the full flow works.

## Docs

N/A