### PR TITLE
Require the experimental flag to use server islands

### DIFF
--- a/examples/server-islands/astro.config.mjs
+++ b/examples/server-islands/astro.config.mjs
@@ -12,4 +12,7 @@ export default defineConfig({
 		tailwind({ applyBaseStyles: false })
 	],
 	devToolbar: { enabled: false },
+	experimental: {
+		serverIslands: true,
+	}
 });

--- a/packages/astro/e2e/fixtures/server-islands/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/server-islands/astro.config.mjs
@@ -8,4 +8,7 @@ export default defineConfig({
 	output: 'hybrid',
 	adapter: nodejs({ mode: 'standalone' }),
 	integrations: [react(), mdx()],
+	experimental: {
+		serverIslands: true,
+	}
 });

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2163,6 +2163,34 @@ export interface AstroUserConfig {
 			 */
 			schema?: EnvSchema;
 		};
+
+		/**
+		 * @docs
+		 * @name experimental.serverIslands
+		 * @type {boolean}
+		 * @default `false`
+		 * @version 4.12.0
+		 * @description
+		 *
+		 * Enables Server Islands, the ability to defer a component to render asynchronously after the page has already rendered.
+		 *
+		 * ```js
+		 * {
+		 *   experimental: {
+		 *     serverIslands: true,
+		 *   },
+		 * }
+		 * ```
+		 * 
+		 * Use the `server:defer` directive on any component, Astro or framework, and the component will not render initially.
+		 *
+		 * ```astro "server:defer"
+		 * <Avatar server:defer />
+		 * ```
+		 *
+		 * For a complete overview, and to give feedback on this experimental API, see the [Server Islands RFC](https://github.com/withastro/roadmap/pull/963).
+		 */
+		serverIslands?: boolean;
 	};
 }
 

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -89,6 +89,7 @@ export const ASTRO_CONFIG_DEFAULTS = {
 		clientPrerender: false,
 		globalRoutePriority: false,
 		rewriting: false,
+		serverIslands: false,
 	},
 } satisfies AstroUserConfig & { server: { open: boolean } };
 
@@ -529,6 +530,7 @@ export const AstroConfigSchema = z.object({
 				})
 				.strict()
 				.optional(),
+			serverIslands: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.experimental.serverIslands),
 		})
 		.strict(
 			`Invalid or outdated experimental feature.\nCheck for incorrect spelling or outdated Astro version.\nSee https://docs.astro.build/en/reference/configuration-reference/#experimental-flags for a list of all current experiments.`
@@ -667,7 +669,7 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 				'The value of `outDir` must not point to a path within the folder set as `publicDir`, this will cause an infinite loop',
 		})
 		.superRefine((configuration, ctx) => {
-			const { site, experimental, i18n, output } = configuration;
+			const { site, i18n, output } = configuration;
 			const hasDomains = i18n?.domains ? Object.keys(i18n.domains).length > 0 : false;
 			if (hasDomains) {
 				if (!site) {

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -159,7 +159,7 @@ export async function createVite(
 			astroDevToolbar({ settings, logger }),
 			vitePluginFileURL({}),
 			astroInternationalization({ settings }),
-			vitePluginServerIslands({ settings }),
+			settings.config.experimental.serverIslands && vitePluginServerIslands({ settings }),
 			astroContainer(),
 		],
 		publicDir: fileURLToPath(settings.config.publicDir),

--- a/packages/astro/test/fixtures/server-islands/hybrid/astro.config.mjs
+++ b/packages/astro/test/fixtures/server-islands/hybrid/astro.config.mjs
@@ -5,6 +5,9 @@ export default defineConfig({
   output: 'hybrid',
   integrations: [
     svelte()
-  ]
+  ],
+  experimental: {
+    serverIslands: true,
+  }
 });
 

--- a/packages/astro/test/fixtures/server-islands/ssr/astro.config.mjs
+++ b/packages/astro/test/fixtures/server-islands/ssr/astro.config.mjs
@@ -5,6 +5,9 @@ export default defineConfig({
   output: 'server',
   integrations: [
     svelte()
-  ]
+  ],
+  experimental: {
+    serverIslands: true,
+  }
 });
 


### PR DESCRIPTION
## Changes

- Create the experimental flag and only enable the vite plugin when its used.

## Testing

- Updated tests

## Docs

N/A