### PR TITLE
Fix: Actions `accept` type completions

### DIFF
--- a/.changeset/swift-cows-walk.md
+++ b/.changeset/swift-cows-walk.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fix autocompletion for the Actions `accept` property.

--- a/.changeset/swift-cows-walk.md
+++ b/.changeset/swift-cows-walk.md
@@ -2,4 +2,4 @@
 "astro": patch
 ---
 
-Fix autocompletion for the Actions `accept` property.
+Fixes `astro:actions` autocompletion for the `defineAction` `accept` property

--- a/packages/astro/src/actions/runtime/virtual/server.ts
+++ b/packages/astro/src/actions/runtime/virtual/server.ts
@@ -11,7 +11,7 @@ export { z } from 'zod';
 export const getApiContext = _getApiContext;
 
 export type Accept = 'form' | 'json';
-export type InputSchema<T extends Accept> = T extends 'form'
+export type InputSchema<T extends Accept | undefined> = T extends 'form'
 	? z.AnyZodObject | z.ZodType<FormData>
 	: z.ZodType;
 
@@ -21,7 +21,7 @@ type Handler<TInputSchema, TOutput> = TInputSchema extends z.ZodType
 
 export type ActionClient<
 	TOutput,
-	TAccept extends Accept,
+	TAccept extends Accept | undefined,
 	TInputSchema extends InputSchema<TAccept> | undefined,
 > = TInputSchema extends z.ZodType
 	? ((
@@ -44,7 +44,7 @@ export type ActionClient<
 
 export function defineAction<
 	TOutput,
-	TAccept extends Accept = 'json',
+	TAccept extends Accept | undefined = undefined,
 	TInputSchema extends InputSchema<Accept> | undefined = TAccept extends 'form'
 		? // If `input` is omitted, default to `FormData` for forms and `any` for JSON.
 			z.ZodType<FormData>

--- a/packages/astro/test/types/define-action-accept.ts
+++ b/packages/astro/test/types/define-action-accept.ts
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import { expectTypeOf } from 'expect-type';
+import { defineAction } from '../../dist/actions/runtime/virtual/server.js';
+import { z } from '../../zod.mjs';
+
+describe('defineAction accept', () => {
+	it('accepts type `any` when input is omitted with accept json', async () => {
+		const action = defineAction({
+			handler: () => {},
+		});
+		expectTypeOf(action).parameter(0).toBeAny();
+		expectTypeOf(action).parameter(0).not.toEqualTypeOf<FormData>();
+
+		const jsonAction = defineAction({
+			accept: 'json',
+			handler: () => {},
+		});
+		expectTypeOf(jsonAction).parameter(0).toBeAny();
+		expectTypeOf(jsonAction).parameter(0).not.toEqualTypeOf<FormData>();
+	});
+	it('accepts type `FormData` when input is omitted with accept form', async () => {
+		const action = defineAction({
+			accept: 'form',
+			handler: () => {},
+		});
+		expectTypeOf(action).parameter(0).toEqualTypeOf<FormData>();
+	});
+
+	it('accept type safe values for input with accept json', async () => {
+		const action = defineAction({
+			input: z.object({ name: z.string() }),
+			handler: () => {},
+		});
+		expectTypeOf(action).parameter(0).toEqualTypeOf<{ name: string }>();
+	});
+
+	it('accepts type `FormData` for all inputs with accept form', async () => {
+		const action = defineAction({
+			accept: 'form',
+			input: z.object({ name: z.string() }),
+			handler: () => {},
+		});
+		expectTypeOf(action).parameter(0).toEqualTypeOf<FormData>();
+	});
+});


### PR DESCRIPTION
## Changes

Fixes the issue originally reported by https://github.com/withastro/astro/pull/11292

Default the `accept` property to `undefined` instead of `json`. This shows the correct string completions while preserving behavior when `accept` is omitted.

## Testing

Manual type testing

## Docs

N/A