### PR TITLE
feat: astro:env allow schema keys to include numbers

### DIFF
--- a/.changeset/loud-socks-doubt.md
+++ b/.changeset/loud-socks-doubt.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Allow env schema variables to include numbers, except as a first character
+Fixes a case where Astro's config `experimental.env.schema` keys did not allow numbers. Numbers are still not allowed as the first character to be able to generate valid JavaScript identifiers

--- a/.changeset/loud-socks-doubt.md
+++ b/.changeset/loud-socks-doubt.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow env schema variables to include numbers, except as a first character

--- a/packages/astro/src/env/schema.ts
+++ b/packages/astro/src/env/schema.ts
@@ -81,18 +81,18 @@ const EnvFieldMetadata = z.union([
 	SecretServerEnvFieldMetadata,
 ]);
 
-const KEY_REGEX = /^[A-Z0-9_]+$/;
+const EnvSchemaKey = z
+	.string()
+	.min(1)
+	.refine(([firstChar]) => isNaN(Number.parseInt(firstChar)), {
+		message: 'A valid variable name cannot start with a number.',
+	})
+	.refine((str) => /^[A-Z0-9_]+$/.test(str), {
+		message: 'A valid variable name can only contain uppercase letters, numbers and underscores.',
+	});
 
 export const EnvSchema = z.record(
-	z
-		.string()
-		.min(1)
-		.refine(([firstChar]) => isNaN(Number.parseInt(firstChar)), {
-			message: 'A valid variable name cannot start with a number.',
-		})
-		.refine((str) => KEY_REGEX.test(str), {
-			message: 'A valid variable name can only contain uppercase letters, numbers and underscores.',
-		}),
+	EnvSchemaKey
 	z.intersection(EnvFieldMetadata, EnvFieldType)
 );
 

--- a/packages/astro/src/env/schema.ts
+++ b/packages/astro/src/env/schema.ts
@@ -92,7 +92,7 @@ const EnvSchemaKey = z
 	});
 
 export const EnvSchema = z.record(
-	EnvSchemaKey
+	EnvSchemaKey,
 	z.intersection(EnvFieldMetadata, EnvFieldType)
 );
 

--- a/packages/astro/src/env/schema.ts
+++ b/packages/astro/src/env/schema.ts
@@ -81,12 +81,18 @@ const EnvFieldMetadata = z.union([
 	SecretServerEnvFieldMetadata,
 ]);
 
-const KEY_REGEX = /^[A-Z_]+$/;
+const KEY_REGEX = /^[A-Z0-9_]+$/;
 
 export const EnvSchema = z.record(
-	z.string().regex(KEY_REGEX, {
-		message: 'A valid variable name can only contain uppercase letters and underscores.',
-	}),
+	z
+		.string()
+		.min(1)
+		.refine(([firstChar]) => isNaN(Number.parseInt(firstChar)), {
+			message: 'A valid variable name cannot start with a number.',
+		})
+		.refine((str) => KEY_REGEX.test(str), {
+			message: 'A valid variable name can only contain uppercase letters, numbers and underscores.',
+		}),
 	z.intersection(EnvFieldMetadata, EnvFieldType)
 );
 

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 import stripAnsi from 'strip-ansi';
 import { z } from 'zod';
 import { validateConfig } from '../../../dist/core/config/validate.js';
+import { envField } from '../../../dist/env/config.js';
 import { formatConfigErrorMessage } from '../../../dist/core/messages.js';
 
 describe('Config Validation', () => {
@@ -360,6 +361,23 @@ describe('Config Validation', () => {
 						experimental: {
 							env: {
 								schema: undefined,
+							},
+						},
+					},
+					process.cwd()
+				).catch((err) => err)
+			);
+		});
+
+		it('Should allow schema variables with numbers', () => {
+			assert.doesNotThrow(() =>
+				validateConfig(
+					{
+						experimental: {
+							env: {
+								schema: {
+									ABC123: envField.string({ access: 'public', context: 'server' }),
+								},
 							},
 						},
 					},

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -385,5 +385,25 @@ describe('Config Validation', () => {
 				).catch((err) => err)
 			);
 		});
+
+		it('Should not allow schema variables starting with a number', async () => {
+			const configError = await validateConfig(
+				{
+					experimental: {
+						env: {
+							schema: {
+								"123ABC": envField.string({ access: 'public', context: 'server' }),
+							},
+						},
+					},
+				},
+				process.cwd()
+			).catch((err) => err);
+			assert.equal(configError instanceof z.ZodError, true);
+			assert.equal(
+				configError.errors[0].message,
+				'A valid variable name cannot start with a number.'
+			);
+		});
 	});
 });


### PR DESCRIPTION
This PR closes & fixes the bug reported in #11430 

## Changes

- Updated the `EnvSchema` validators regex pattern to also allow for numbers
- Updated the `EnvSchema` validator to reject if the first character is a number (Not a valid identifier)

## Testing

 - Added 2 new unit tests to account for the above changes
	 - `Should allow schema variables with numbers`
	 - `Should not allow schema variables starting with a number`

## Docs

Added changeset & did not update any docs as currently there is no documentation to modify informing users that numbers were not previously allowed.

Though I am unsure if it is worth adding a comment for users to be aware of this, or just let the edge case error message inform them?