### PR TITLE
feat: `ActionReturnType`

### DIFF
--- a/.changeset/small-vans-own.md
+++ b/.changeset/small-vans-own.md
@@ -1,0 +1,29 @@
+---
+'astro': patch
+---
+
+Expose new `ActionReturnType` utility from `astro:actions`. This infers the return type of an action by passing `typeof actions.name` as a type argument. This example defines a `like` action that returns `likes` as an object:
+
+```ts
+// actions/index.ts
+import { defineAction } from 'astro:actions';
+
+export const server = {
+  like: defineAction({
+    handler: () => {
+      /* ... */
+      return { likes: 42 }
+    }
+  })
+}
+```
+
+In your client code, you can infer this handler return value with `ActionReturnType`:
+
+```ts
+// client.ts
+import { actions, ActionReturnType } from 'astro:actions';
+
+type LikesResult = ActionReturnType<typeof actions.like>;
+// -> { likes: number }
+```

--- a/packages/astro/src/actions/runtime/virtual/server.ts
+++ b/packages/astro/src/actions/runtime/virtual/server.ts
@@ -19,6 +19,8 @@ type Handler<TInputSchema, TOutput> = TInputSchema extends z.ZodType
 	? (input: z.infer<TInputSchema>, context: ActionAPIContext) => MaybePromise<TOutput>
 	: (input: any, context: ActionAPIContext) => MaybePromise<TOutput>;
 
+export type ActionReturnType<T extends Handler<any, any>> = Awaited<ReturnType<T>>;
+
 export type ActionClient<
 	TOutput,
 	TAccept extends Accept,

--- a/packages/astro/test/types/action-return-type.ts
+++ b/packages/astro/test/types/action-return-type.ts
@@ -1,0 +1,18 @@
+import { describe, it } from 'node:test';
+import { expectTypeOf } from 'expect-type';
+import { type ActionReturnType, defineAction } from '../../dist/actions/runtime/virtual/server.js';
+import { z } from '../../zod.mjs';
+
+describe('ActionReturnType', () => {
+	it('Infers action return type', async () => {
+		const action = defineAction({
+			input: z.object({
+				name: z.string(),
+			}),
+			handler: async ({ name }) => {
+				return { name };
+			},
+		});
+		expectTypeOf<ActionReturnType<typeof action>>().toEqualTypeOf<{ name: string }>();
+	});
+});


### PR DESCRIPTION
## Changes

Expose an `ActionReturnType` utility to infer the result of an action. This is simpler than the usual `Awaited<ReturnType<typeof action>>`.

## Testing

Added type test

## Docs

See changeset