### PR TITLE
chore: don't log more than 100 pages per route

### DIFF
--- a/.changeset/red-crabs-breathe.md
+++ b/.changeset/red-crabs-breathe.md
@@ -1,0 +1,17 @@
+---
+'astro': patch
+---
+
+Limits the number of pages logged by default to 100 per route.
+
+If there are more than 100 pages it will log the first 100 pages and then log a summary of the total number of pages.
+
+For example:
+
+```sh
+10:08:26   ├─ /blog/article-98/index.html (+0ms)
+10:08:26   ├─ /blog/article-99/index.html (+1ms)
+10:08:26   └─ ...rendering 100 more paths. Done. (+63ms)
+```
+
+To see the full list of pages rendered, enable debug logging using the `--verbose` flag.

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -234,18 +234,29 @@ async function generatePage(
 		const paths = await getPathsForRoute(route, pageModule, pipeline, builtPaths);
 		let timeStart = performance.now();
 		let prevTimeEnd = timeStart;
+		const maxPathsToLog = 100;
 		for (let i = 0; i < paths.length; i++) {
 			const path = paths[i];
 			pipeline.logger.debug('build', `Generating: ${path}`);
-			const filePath = getOutputFilename(config, path, pageData.route.type);
-			const lineIcon = i === paths.length - 1 ? '└─' : '├─';
-			logger.info(null, `  ${blue(lineIcon)} ${dim(filePath)}`, false);
+			if (i < maxPathsToLog) {
+				const filePath = getOutputFilename(config, path, pageData.route.type);
+				const lineIcon = i === paths.length - 1 ? '└─' : '├─';
+				logger.info(null, `  ${blue(lineIcon)} ${dim(filePath)}`, false);
+			}
 			await generatePath(path, pipeline, generationOptions, route);
-			const timeEnd = performance.now();
-			const timeChange = getTimeStat(prevTimeEnd, timeEnd);
-			const timeIncrease = `(+${timeChange})`;
-			logger.info('SKIP_FORMAT', ` ${dim(timeIncrease)}`);
-			prevTimeEnd = timeEnd;
+			if (i < maxPathsToLog) {
+				const timeEnd = performance.now();
+				const timeChange = getTimeStat(prevTimeEnd, timeEnd);
+				const timeIncrease = `(+${timeChange})`;
+				logger.info('SKIP_FORMAT', ` ${dim(timeIncrease)}`);
+				prevTimeEnd = timeEnd;
+			}
+			if (i === maxPathsToLog && paths.length > maxPathsToLog) {
+				logger.info(null, `  ${blue('└─')} ${dim(`...`)}`, false);
+			}
+		}
+		if (paths.length > maxPathsToLog) {
+			logger.info('SKIP_FORMAT', `${dim(`${paths.length - maxPathsToLog} more paths.`)}`);
 		}
 	}
 }


### PR DESCRIPTION
## Changes

Currently we log every page generated, which is fine in most cases, but for very large sites is useless, makes the logs hard to use and can affect performance. This PR caps this to 100 pages per route, after which it displays a summary instead.

## Testing

Most easily tested with the benchmark scripts.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
