### PR TITLE
Fix action form parsing for .nullish

### DIFF
--- a/.changeset/new-mails-prove.md
+++ b/.changeset/new-mails-prove.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where using .nullish() in a formdata Astro action would always parse as a string

--- a/packages/astro/src/actions/runtime/virtual/server.ts
+++ b/packages/astro/src/actions/runtime/virtual/server.ts
@@ -124,8 +124,8 @@ export function formDataToObject<T extends z.AnyZodObject>(
 	const obj: Record<string, unknown> = {};
 	for (const [key, baseValidator] of Object.entries(schema.shape)) {
 		let validator = baseValidator;
-		if (baseValidator instanceof z.ZodOptional || baseValidator instanceof z.ZodNullable) {
-			validator = baseValidator._def.innerType;
+		while (validator instanceof z.ZodOptional || validator instanceof z.ZodNullable) {
+			validator = validator._def.innerType;
 		}
 		if (validator instanceof z.ZodBoolean) {
 			obj[key] = formData.has(key);


### PR DESCRIPTION
## Changes

In the experimental Astro actions, users can provide an input schema using zod and parse formdata natively with `accept: 'form'`. However, if a user uses the `.nullish()` zod modifier, it will always treat the field as a string, regardless of the intended type.

This is because zod's `.nullish()` is equivalent to `.nullable().optional()` and returns `z.ZodOptional<z.ZodNullable<ActualType>>` and must be double-unwrapped to get the underlying type.

This change swaps from a single-unwrap of `ZodOptional` and `ZodNullable` to a loop that can go as deep as needed.

## Testing

This change was not tested.

## Docs

No docs were written or changed as this is a bugfix.
