### PR TITLE
fix(astro): do not open new tab when saving config files

### DIFF
--- a/.changeset/proud-singers-call.md
+++ b/.changeset/proud-singers-call.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `astro dev --open` unexpected behavior that spawns a new tab every time a config file is saved

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -56,9 +56,23 @@ export async function createContainer({
 		base,
 		server: { host, headers, open: serverOpen },
 	} = settings.config;
+
+	// serverOpen = true, isRestart = false
+	// when astro dev --open command is run the first time
+	// expected behavior: spawn a new tab
+	// ------------------------------------------------------
+	// serverOpen = true, isRestart = true
+	// when config file is saved
+	// expected behavior: do not spawn a new tab
+	// ------------------------------------------------------
+	// Non-config files don't reach this point
+	const isServerOpenURL = typeof serverOpen == 'string' && !isRestart;
+	const isServerOpenBoolean = serverOpen && !isRestart;
+
 	// Open server to the correct path. We pass the `base` here as we didn't pass the
 	// base to the initial Vite config
-	const open = typeof serverOpen == 'string' ? serverOpen : serverOpen ? base : false;
+	const open = isServerOpenURL ? serverOpen
+		: isServerOpenBoolean ? base : false;
 
 	// The client entrypoint for renderers. Since these are imported dynamically
 	// we need to tell Vite to preoptimize them.


### PR DESCRIPTION
## Changes

- Fixes #11374
- Running `astro dev --open` will no longer spawn extra tabs when saving config files

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
To reproduce the manual test locally:

Run build with changes
```
pnpm run build
```

Run astro dev
```
pnpm --filter astro dev
```

Test the changes using the following example:
```
pnpm --filter @example/minimal dev --open
```

**Expected behavior:**
- Open new tab on first run of dev command, then update the same tab on each file save
- Saving config files shouldn't spawn new tabs

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

Unexpected behavior has been fixed, no additional docs needed
