### PR TITLE
fix(audit): remove false positive warnings on elements with `tabpanel` role

### DIFF
--- a/.changeset/calm-beans-jam.md
+++ b/.changeset/calm-beans-jam.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes false positive audit warnings on elements with the role "tabpanel".

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -101,6 +101,7 @@ const aria_non_interactive_roles = [
 	'rowheader',
 	'search',
 	'status',
+	'tabpanel',
 	'term',
 	'timer',
 	'toolbar',

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -504,7 +504,7 @@ export const a11y: AuditRuleWithSelector[] = [
 		description:
 			'The `tabindex` attribute should only be used on interactive elements, as it can be confusing for keyboard-only users to navigate through non-interactive elements. If your element is only conditionally interactive, consider using `tabindex="-1"` to make it focusable only when it is actually interactive.',
 		message: (element) => `${element.localName} elements should not have \`tabindex\` attribute`,
-		selector: '[tabindex]',
+		selector: '[tabindex]:not([role="tabpanel"])',
 		match(element) {
 			// Scrollable elements are considered interactive
 			// See: https://www.w3.org/WAI/standards-guidelines/act/rules/0ssw9k/proposed/


### PR DESCRIPTION
## Changes

- Adds `tabpanel` to [`aria_non_interactive_roles`](https://github.com/withastro/astro/blob/88e2b43305c07ef8b489081a5a580584cbd7f342/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts#L67)
- Allows `tabIndex` on elements with `tabpanel` role
- Closes #11239

| Before | After |
| ------ | ----- |
| ![before](https://github.com/user-attachments/assets/92eb8507-e784-4efc-90d3-4a3b398f7607) | ![after](https://github.com/user-attachments/assets/9543d61e-b2bd-4e1c-917b-1cb65b213e7e) |

## Testing

- Manually tested with a minimal Starlight project containing the built-in `Tabs` and `TabItem` components

## Docs

- N/A