### PR TITLE
Only add framework component formats to Vite’s `optimizeDeps`

### DIFF
--- a/.changeset/chatty-spies-jog.md
+++ b/.changeset/chatty-spies-jog.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Avoids targetting all files in `src` directory for eager optimization by Vite. After this change, only JSX, Vue, Svelte, and Astro components get scanned for early optimization.
+Avoids targeting all files in the `src/` directory for eager optimization by Vite. After this change, only JSX, Vue, Svelte, and Astro components get scanned for early optimization.

--- a/.changeset/chatty-spies-jog.md
+++ b/.changeset/chatty-spies-jog.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Avoids targetting all files in `src` directory for eager optimization by Vite. After this change, only JSX, Vue, Svelte, and Astro components get scanned for early optimization.

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -121,7 +121,7 @@ export async function createVite(
 		appType: 'custom',
 		optimizeDeps: {
 			// Scan framework component code within `srcDir`
-			entries: [`${srcDirPattern}**/(*.jsx|*.tsx|*.vue|*.svelte)`],
+			entries: [`${srcDirPattern}**/*.{jsx,tsx,vue,svelte,html,astro}`],
 			exclude: ['astro', 'node-fetch'],
 		},
 		plugins: [

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -120,7 +120,7 @@ export async function createVite(
 		customLogger: createViteLogger(logger, settings.config.vite.logLevel),
 		appType: 'custom',
 		optimizeDeps: {
-			// Scan framework component code within `srcDir`
+			// Scan for component code within `srcDir`
 			entries: [`${srcDirPattern}**/*.{jsx,tsx,vue,svelte,html,astro}`],
 			exclude: ['astro', 'node-fetch'],
 		},

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -120,13 +120,8 @@ export async function createVite(
 		customLogger: createViteLogger(logger, settings.config.vite.logLevel),
 		appType: 'custom',
 		optimizeDeps: {
-			// Scan all files within `srcDir` except for known server-code (e.g endpoints)
-			entries: [
-				`${srcDirPattern}!(pages)/**/*`, // All files except for pages
-				`${srcDirPattern}pages/**/!(*.js|*.mjs|*.ts|*.mts)`, // All pages except for endpoints
-				`${srcDirPattern}pages/**/_*.{js,mjs,ts,mts}`, // Remaining JS/TS files prefixed with `_` (not endpoints)
-				`${srcDirPattern}pages/**/_*/**/*.{js,mjs,ts,mts}`, // Remaining JS/TS files within directories prefixed with `_` (not endpoints)
-			],
+			// Scan framework component code within `srcDir`
+			entries: [`${srcDirPattern}**/(*.jsx|*.tsx|*.vue|*.svelte)`],
 			exclude: ['astro', 'node-fetch'],
 		},
 		plugins: [


### PR DESCRIPTION
## Changes

- Astro currently tells Vite to scan most of `src/` (excluding endpoints in `src/pages/`)
- This PR makes that scan much more targeted at only known framework component formats
- The thinking is that the target for that scan is to optimize client-side code and this will catch most of it
- It avoids eagerly transforming code that is not intended for the client, which can include:
	- server utilities
	- documentation snippets only imported with `?raw`

## Testing

Tests should pass I think — would love feedback from @bluwy 

## Docs

n/a — internal change