### PR TITLE
fix typo in CHANGELOG

### DIFF
--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -119,7 +119,7 @@
   export default defineConfig({
     output: 'hybrid',
     adapter: netlify(),
-    experimental {
+    experimental: {
       serverIslands: true,
     },
   });


### PR DESCRIPTION
## Changes

Updates a code sample to fix a missing `:` in the CHANGELOG

## Testing

 no tests

## Docs

only docs.