### PR TITLE
Hide the dev toolbar on print

### DIFF
--- a/.changeset/orange-boats-trade.md
+++ b/.changeset/orange-boats-trade.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Hide the dev toolbar on `window.print()` (CTRL + P)

--- a/packages/astro/e2e/dev-toolbar.test.js
+++ b/packages/astro/e2e/dev-toolbar.test.js
@@ -413,4 +413,28 @@ test.describe('Dev Toolbar', () => {
 			}
 		}
 	});
+
+	test('hidden on print media', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/'));
+
+		const toolbar = page.locator('astro-dev-toolbar');
+
+		const settingsAppButton = toolbar.locator('button[data-app-id="astro:settings"]');
+		await settingsAppButton.click();
+
+		const settingsAppCanvas = toolbar.locator(
+			'astro-dev-toolbar-app-canvas[data-app-id="astro:settings"]'
+		);
+		const settingsWindow = settingsAppCanvas.locator('astro-dev-toolbar-window');
+		await expect(settingsWindow).toBeVisible();
+
+		await page.emulateMedia({ media: 'print' });
+		await expect(settingsWindow).not.toBeVisible();
+
+		await page.emulateMedia({ media: 'screen' });
+		await expect(settingsWindow).toBeVisible();
+
+		await settingsAppButton.click();
+		await expect(settingsWindow).not.toBeVisible();
+	});
 });

--- a/packages/astro/src/runtime/client/dev-toolbar/toolbar.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/toolbar.ts
@@ -49,6 +49,11 @@ export class AstroDevToolbar extends HTMLElement {
 				z-index: 999999;
 				view-transition-name: astro-dev-toolbar;
 				display: contents;
+
+				/* Hide the dev toolbar on window.print() (CTRL + P) */
+				@media print {
+					display: none;
+				}
 			}
 
 			::view-transition-old(astro-dev-toolbar),


### PR DESCRIPTION
## Changes

The dev toolbar shows in every page when running `window.print()` (<kbd>CTRL</kbd> + <kbd>P</kbd>), which is useless and disturbing when working on styling a page for printing. This change hides the dev toolbar on printing.

If you see a point in having it on each page when printing, then I suggest adding a settings option to hide it.

Before:
![image](https://github.com/user-attachments/assets/c762773f-f71c-4d22-9be4-75d21a548cc7)


After:
![image](https://github.com/user-attachments/assets/98e60ba7-a64b-4da4-bb82-9042e1247485)


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Tested by emulating media print and checking visibility with Playwright.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
No usage instructions or important details to be mentioned.

