### PR TITLE
fix: inferRemoteSize not being exported in the type

### DIFF
--- a/.changeset/cold-ravens-dream.md
+++ b/.changeset/cold-ravens-dream.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes inferRemoteSize type not working

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -70,7 +70,14 @@ declare module 'astro:assets' {
 	export type RemoteImageProps = import('./dist/type-utils.js').Simplify<
 		import('./dist/assets/types.js').RemoteImageProps<ImgAttributes>
 	>;
-	export const { getImage, getConfiguredImageService, imageConfig, Image, Picture }: AstroAssets;
+	export const {
+		getImage,
+		getConfiguredImageService,
+		imageConfig,
+		Image,
+		Picture,
+		inferRemoteSize,
+	}: AstroAssets;
 }
 
 type ImageMetadata = import('./dist/assets/types.js').ImageMetadata;


### PR DESCRIPTION
## Changes

My initial PR added it to the type, but not to the exports of said type. oops

## Testing

Tested manually

## Docs

N/A
