### PR TITLE
Adds missing export

### DIFF
--- a/.changeset/spotty-camels-joke.md
+++ b/.changeset/spotty-camels-joke.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds the missing export for accessing the `getFallback()` function of the client site router.

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -132,7 +132,7 @@ async function fetchHTML(
 	}
 }
 
-function getFallback(): Fallback {
+export function getFallback(): Fallback {
 	const el = document.querySelector('[name="astro-view-transitions-fallback"]');
 	if (el) {
 		return el.getAttribute('content') as Fallback;


### PR DESCRIPTION
## Changes

Adds a missing export for the `getFallback()` function of the client side router.

## Testing
makes this go away:
![image](https://github.com/user-attachments/assets/40eae7b7-3c10-4895-becc-1e42b578a4f5)

## Docs

n.a. / bugfix

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
