### PR TITLE
fix: better logging for rewrites

### DIFF
--- a/.changeset/blue-jars-hang.md
+++ b/.changeset/blue-jars-hang.md
@@ -1,0 +1,12 @@
+---
+'astro': patch
+---
+
+Enhances the dev server logging when rewrites occur during the lifecycle or rendering.
+
+The dev server will log the status code **before** and **after** a rewrite:
+
+```shell
+08:16:48 [404 → rewrite → 200] /foo/about 200ms
+08:22:13 [200 → rewrite → 404] /about 23ms
+```

--- a/.changeset/blue-jars-hang.md
+++ b/.changeset/blue-jars-hang.md
@@ -7,6 +7,6 @@ Enhances the dev server logging when rewrites occur during the lifecycle or rend
 The dev server will log the status code **before** and **after** a rewrite:
 
 ```shell
-08:16:48 [404 → rewrite → 200] /foo/about 200ms
-08:22:13 [200 → rewrite → 404] /about 23ms
+08:16:48 [404] (rewrite) /foo/about 200ms
+08:22:13 [200] (rewrite) /about 23ms
 ```

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -36,24 +36,19 @@ export function req({
 	method,
 	statusCode,
 	reqTime,
-	formerStatusCode,
+	isRewrite,
 }: {
 	url: string;
 	statusCode: number;
 	method?: string;
 	reqTime?: number;
-	formerStatusCode?: number;
+	isRewrite?: boolean;
 }): string {
 	const color = statusCode >= 500 ? red : statusCode >= 300 ? yellow : blue;
-	let statusCodeLabel;
-	if (formerStatusCode) {
-		statusCodeLabel = color(`[${formerStatusCode} → rewrite → ${statusCode}]`);
-	} else {
-		statusCodeLabel = color(`[${statusCode}]`);
-	}
 	return (
-		statusCodeLabel +
+		color(`[${statusCode}]`) +
 		` ` +
+		`${isRewrite ? color('(rewrite) ') : ''}` +
 		(method && method !== 'GET' ? color(method) + ' ' : '') +
 		url +
 		` ` +

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -47,9 +47,7 @@ export function req({
 	const color = statusCode >= 500 ? red : statusCode >= 300 ? yellow : blue;
 	let statusCodeLabel;
 	if (formerStatusCode) {
-		const colorFormerStatusCode =
-			formerStatusCode >= 500 ? red : formerStatusCode >= 300 ? yellow : blue;
-		statusCodeLabel = `[${colorFormerStatusCode(formerStatusCode)} ${green('→ rewrite →')} ${color(statusCode)}]`;
+		statusCodeLabel = color(`[${formerStatusCode} → rewrite → ${statusCode}]`);
 	} else {
 		statusCodeLabel = color(`[${statusCode}]`);
 	}

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -36,15 +36,25 @@ export function req({
 	method,
 	statusCode,
 	reqTime,
+	formerStatusCode,
 }: {
 	url: string;
 	statusCode: number;
 	method?: string;
 	reqTime?: number;
+	formerStatusCode?: number;
 }): string {
 	const color = statusCode >= 500 ? red : statusCode >= 300 ? yellow : blue;
+	let statusCodeLabel;
+	if (formerStatusCode) {
+		const colorFormerStatusCode =
+			formerStatusCode >= 500 ? red : formerStatusCode >= 300 ? yellow : blue;
+		statusCodeLabel = `[${colorFormerStatusCode(formerStatusCode)} ${green('→ rewrite →')} ${color(statusCode)}]`;
+	} else {
+		statusCodeLabel = color(`[${statusCode}]`);
+	}
 	return (
-		color(`[${statusCode}]`) +
+		statusCodeLabel +
 		` ` +
 		(method && method !== 'GET' ? color(method) + ' ' : '') +
 		url +
@@ -240,6 +250,7 @@ export function formatConfigErrorMessage(err: ZodError) {
 // a regex to match the first line of a stack trace
 const STACK_LINE_REGEXP = /^\s+at /g;
 const IRRELEVANT_STACK_REGEXP = /node_modules|astro[/\\]dist/g;
+
 function formatErrorStackTrace(
 	err: Error | ErrorWithMetadata,
 	showFullStacktrace: boolean
@@ -364,6 +375,7 @@ export function printHelp({
 		function calculateTablePadding(rows: [string, string][]) {
 			return rows.reduce((val, [first]) => Math.max(val, first.length), 0) + 2;
 		}
+
 		const tableEntries = Object.entries(tables);
 		const padding = Math.max(...tableEntries.map(([, rows]) => calculateTablePadding(rows)));
 		for (const [tableTitle, tableRows] of tableEntries) {

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -130,7 +130,7 @@ type HandleRoute = {
 	manifestData: ManifestData;
 	incomingRequest: http.IncomingMessage;
 	incomingResponse: http.ServerResponse;
-	status?: 404 | 500;
+	status?: 404 | 500 | 200;
 	pipeline: DevPipeline;
 };
 
@@ -296,8 +296,9 @@ export async function handleRoute({
 	await writeSSRResult(request, response, incomingResponse);
 }
 
-function getStatus(matchedRoute?: MatchedRoute): 404 | 500 | undefined {
+function getStatus(matchedRoute?: MatchedRoute): 404 | 500 | 200 {
 	if (!matchedRoute) return 404;
 	if (matchedRoute.route.route === '/404') return 404;
 	if (matchedRoute.route.route === '/500') return 500;
+	return 200;
 }

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -232,7 +232,8 @@ export async function handleRoute({
 			req({
 				url: pathname,
 				method: incomingRequest.method,
-				statusCode: status ?? response.status,
+				statusCode: isRewrite ? response.status : (status ?? response.status),
+				formerStatusCode: isRewrite ? status : undefined,
 				reqTime: timeEnd - timeStart,
 			})
 		);

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -233,7 +233,7 @@ export async function handleRoute({
 				url: pathname,
 				method: incomingRequest.method,
 				statusCode: isRewrite ? response.status : (status ?? response.status),
-				formerStatusCode: isRewrite ? status : undefined,
+				isRewrite,
 				reqTime: timeEnd - timeStart,
 			})
 		);


### PR DESCRIPTION
## Changes

This PR enhances the logging of the dev server when there's a rewrite

## Testing

I tested locally

<img width="411" alt="Screenshot 2024-07-19 at 08 27 39" src="https://github.com/user-attachments/assets/4349be04-db40-4a0b-8c28-355482672de8">

The logic of the colours stays the same, which means the colour reflects the **final** status code.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
