### PR TITLE
[docs] fix typos in config reference

### DIFF
--- a/.changeset/empty-onions-buy.md
+++ b/.changeset/empty-onions-buy.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes typo in documenting the `slot="fallback"` attribute for Server Islands experimental feature.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2236,7 +2236,7 @@ export interface AstroUserConfig {
 		 * <Avatar server:defer />
 		 * ```
 		 *
-		 * The outer page will be rendered, either at build-time (`hybrid`) or at runtime (`server`) with the island content omitted and a `<script>` tag included in its place.
+		 * The outer page will be rendered, either at build time (`hybrid`) or at runtime (`server`) with the island content omitted and a `<script>` tag included in its place.
 		 *
 		 * After the page loads in the browser, the script tag will replace itself with the the contents of the island by making a request.
 		 *
@@ -2255,7 +2255,7 @@ export interface AstroUserConfig {
 		 *
 		 * Since your component will not render with the rest of the page, you may want to add generic content (e.g. a loading message) to temporarily show in its place. This content will be displayed when the page first renders but before the island has loaded.
 		 *
-		 * Add placeholder content as a child of your Astro component with the `slot="fallback:` attribute. When your island content is available, the fallback content will be replaced.
+		 * Add placeholder content as a child of your Astro component with the `slot="fallback"` attribute. When your island content is available, the fallback content will be replaced.
 		 *
 		 * The example below displays a generic avatar as fallback content, then animates into a personalized avatar using view transitions:
 		 *


### PR DESCRIPTION
## Changes

Just fixes two typos in the Server Islands config reference

## Testing

no tests

## Docs

only docs
