### PR TITLE
feat: log slow pages in red

### DIFF
--- a/.changeset/spotty-rice-shake.md
+++ b/.changeset/spotty-rice-shake.md
@@ -1,5 +1,5 @@
 ---
-'astro': patch
+'astro': minor
 ---
 
 During the build, pages that take more than 500 milliseconds to render, will have their time increased logged in red.

--- a/.changeset/spotty-rice-shake.md
+++ b/.changeset/spotty-rice-shake.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+During the build, pages that take more than 500 milliseconds to render, will have their time increased logged in red.

--- a/.changeset/spotty-rice-shake.md
+++ b/.changeset/spotty-rice-shake.md
@@ -2,4 +2,6 @@
 'astro': minor
 ---
 
-During the build, pages that take more than 500 milliseconds to render, will have their time increased logged in red.
+Adds color-coding to the console output during the build to highlight slow pages. 
+
+Pages that take more than 500 milliseconds to render will have their build time logged in red. This change can help you discover pages of your site that are not performant and may need attention.

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { bgGreen, black, blue, bold, dim, green, magenta } from 'kleur/colors';
+import { bgGreen, black, blue, bold, dim, green, magenta, red } from 'kleur/colors';
 import PQueue from 'p-queue';
 import type { OutputAsset, OutputChunk } from 'rollup';
 import type {
@@ -192,6 +192,8 @@ export async function generatePages(options: StaticBuildOptions, internals: Buil
 	await runHookBuildGenerated({ config, logger });
 }
 
+const THRESHOLD_SLOW_RENDER_TIME_MS = 500;
+
 async function generatePage(
 	pageData: PageBuildData,
 	ssrEntry: SinglePageBuiltModule,
@@ -199,7 +201,7 @@ async function generatePage(
 	pipeline: BuildPipeline
 ) {
 	// prepare information we need
-	const { config, internals, logger } = pipeline;
+	const { config, logger } = pipeline;
 	const pageModulePromise = ssrEntry.page;
 
 	// Calculate information of the page, like scripts, links and styles
@@ -244,7 +246,13 @@ async function generatePage(
 			const timeEnd = performance.now();
 			const timeChange = getTimeStat(prevTimeEnd, timeEnd);
 			const timeIncrease = `(+${timeChange})`;
-			logger.info('SKIP_FORMAT', ` ${dim(timeIncrease)}`);
+			let timeIncreaseLabel;
+			if (Math.round(timeEnd - prevTimeEnd) > THRESHOLD_SLOW_RENDER_TIME_MS) {
+				timeIncreaseLabel = red(timeIncrease);
+			} else {
+				timeIncreaseLabel = dim(timeIncrease);
+			}
+			logger.info('SKIP_FORMAT', ` ${timeIncreaseLabel}`);
 			prevTimeEnd = timeEnd;
 		}
 	}

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -247,7 +247,7 @@ async function generatePage(
 			const timeChange = getTimeStat(prevTimeEnd, timeEnd);
 			const timeIncrease = `(+${timeChange})`;
 			let timeIncreaseLabel;
-			if (Math.round(timeEnd - prevTimeEnd) > THRESHOLD_SLOW_RENDER_TIME_MS) {
+			if (timeEnd - prevTimeEnd > THRESHOLD_SLOW_RENDER_TIME_MS) {
 				timeIncreaseLabel = red(timeIncrease);
 			} else {
 				timeIncreaseLabel = dim(timeIncrease);


### PR DESCRIPTION
## Changes

A small change in DX that renders times that exceed the 500ms in red.

## Testing

Manually tested

<img width="396" alt="Screenshot 2024-07-19 at 13 40 54" src="https://github.com/user-attachments/assets/9b4117d2-a2da-4b52-83be-9f90517bdc31">


<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
