### PR TITLE
Fix an XSS in Server Islands.

### DIFF
--- a/.changeset/smart-snakes-promise.md
+++ b/.changeset/smart-snakes-promise.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Escapes HTML in serialized props

--- a/packages/astro/src/runtime/server/render/server-islands.ts
+++ b/packages/astro/src/runtime/server/render/server-islands.ts
@@ -2,6 +2,7 @@ import type { SSRResult } from '../../../@types/astro.js';
 import { renderChild } from './any.js';
 import type { RenderInstance } from './common.js';
 import { type ComponentSlots, renderSlotToString } from './slot.js';
+import {escape} from 'html-escaper';
 
 const internalProps = new Set([
 	'server:component-path',
@@ -12,6 +13,10 @@ const internalProps = new Set([
 
 export function containsServerDirective(props: Record<string | number, any>) {
 	return 'server:component-directive' in props;
+}
+
+function safeJsonStringify(obj: any) {
+	return escape(JSON.stringify(obj));
 }
 
 export function renderServerIsland(
@@ -53,13 +58,13 @@ export function renderServerIsland(
 			const hostId = crypto.randomUUID();
 
 			destination.write(`<script async type="module" data-island-id="${hostId}">
-let componentId = ${JSON.stringify(componentId)};
-let componentExport = ${JSON.stringify(componentExport)};
+let componentId = ${safeJsonStringify(componentId)};
+let componentExport = ${safeJsonStringify(componentExport)};
 let script = document.querySelector('script[data-island-id="${hostId}"]');
 let data = {
 	componentExport,
-	props: ${JSON.stringify(props)},
-	slots: ${JSON.stringify(renderedSlots)},
+	props: ${safeJsonStringify(props)},
+	slots: ${safeJsonStringify(renderedSlots)},
 };
 
 let response = await fetch('/_server-islands/${componentId}', {

--- a/packages/astro/src/runtime/server/render/server-islands.ts
+++ b/packages/astro/src/runtime/server/render/server-islands.ts
@@ -1,8 +1,8 @@
+import { escape } from 'html-escaper';
 import type { SSRResult } from '../../../@types/astro.js';
 import { renderChild } from './any.js';
 import type { RenderInstance } from './common.js';
 import { type ComponentSlots, renderSlotToString } from './slot.js';
-import {escape} from 'html-escaper';
 
 const internalProps = new Set([
 	'server:component-path',

--- a/packages/astro/src/runtime/server/render/server-islands.ts
+++ b/packages/astro/src/runtime/server/render/server-islands.ts
@@ -1,4 +1,3 @@
-import { escape } from 'html-escaper';
 import type { SSRResult } from '../../../@types/astro.js';
 import { renderChild } from './any.js';
 import type { RenderInstance } from './common.js';
@@ -16,7 +15,12 @@ export function containsServerDirective(props: Record<string | number, any>) {
 }
 
 function safeJsonStringify(obj: any) {
-	return escape(JSON.stringify(obj));
+	return JSON.stringify(obj)
+		.replace(/\u2028/g, '\\u2028')
+		.replace(/\u2029/g, '\\u2029')
+		.replace(/</g, '\\u003c')
+		.replace(/>/g, '\\u003e')
+		.replace(/\//g, '\\u002f');
 }
 
 export function renderServerIsland(


### PR DESCRIPTION
Discussed with @FredKSchott that this is OK to disclose since Server Islands are still experimental.

It's generally not safe to use `JSON.stringify` to interpolate potentially attacker controlled data into `<script>` tags as JSON doesn't escape `<>"'` and so one can use it to break out of the script tag and e.g. make a new one with controlled content.

See https://pragmaticwebsecurity.com/articles/spasecurity/json-stringify-xss

## Changes

No behavior change expected. All tests should still pass unless they trigger the encoding change.

## Testing

Not at all. I couldn't get tests to run.
