### PR TITLE
chore: fix content layer types

### DIFF
--- a/packages/astro/src/content/data-store.ts
+++ b/packages/astro/src/content/data-store.ts
@@ -12,9 +12,9 @@ export interface RenderedContent {
 	};
 }
 
-export interface DataEntry {
+export interface DataEntry<TData extends Record<string, unknown> = Record<string, unknown>> {
 	id: string;
-	data: Record<string, unknown>;
+	data: TData;
 	filePath?: string;
 	body?: string;
 	digest?: number | string;
@@ -174,7 +174,8 @@ export default new Map([${exports.join(', ')}]);
 
 	scopedStore(collectionName: string): ScopedDataStore {
 		return {
-			get: (key: string) => this.get<DataEntry>(collectionName, key),
+			get: <TData extends Record<string, unknown> = Record<string, unknown>>(key: string) =>
+				this.get<DataEntry<TData>>(collectionName, key),
 			entries: () => this.entries(collectionName),
 			values: () => this.values(collectionName),
 			keys: () => this.keys(collectionName),
@@ -292,7 +293,9 @@ export default new Map([${exports.join(', ')}]);
 }
 
 export interface ScopedDataStore {
-	get: (key: string) => DataEntry | undefined;
+	get: <TData extends Record<string, unknown> = Record<string, unknown>>(
+		key: string
+	) => DataEntry<TData> | undefined;
 	entries: () => Array<[id: string, DataEntry]>;
 	/**
 	 * Adds a new entry to the store. If an entry with the same ID already exists,
@@ -306,9 +309,9 @@ export interface ScopedDataStore {
 	 * @param opts.rendered The rendered content, if applicable.
 	 * @returns `true` if the entry was added or updated, `false` if the entry was not changed. This will be the case if the provided digest matches the one in the store.
 	 */
-	set: (opts: {
+	set: <TData extends Record<string, unknown>>(opts: {
 		id: string;
-		data: Record<string, unknown>;
+		data: TData;
 		body?: string;
 		filePath?: string;
 		digest?: number | string;

--- a/packages/astro/src/content/loaders/glob.ts
+++ b/packages/astro/src/content/loaders/glob.ts
@@ -4,10 +4,10 @@ import fastGlob from 'fast-glob';
 import { green } from 'kleur/colors';
 import micromatch from 'micromatch';
 import pLimit from 'p-limit';
-import type { ContentEntryType, ContentEntryRenderFuction } from '../../@types/astro.js';
+import type { ContentEntryRenderFuction, ContentEntryType } from '../../@types/astro.js';
+import type { RenderedContent } from '../data-store.js';
 import { getContentEntryIdAndSlug, getEntryConfigByExtMap, posixRelative } from '../utils.js';
 import type { Loader } from './types.js';
-import type { RenderedContent } from '../data-store.js';
 
 export interface GenerateIdOptions {
 	/** The path to the entry file, relative to the base directory. */

--- a/packages/astro/src/content/loaders/types.ts
+++ b/packages/astro/src/content/loaders/types.ts
@@ -3,19 +3,14 @@ import type { ZodSchema } from 'zod';
 import type { AstroIntegrationLogger, AstroSettings } from '../../@types/astro.js';
 import type { MetaStore, ScopedDataStore } from '../data-store.js';
 
-export interface ParseDataOptions {
+export interface ParseDataOptions<TData extends Record<string, unknown>> {
 	/** The ID of the entry. Unique per collection */
 	id: string;
 	/** The raw, unvalidated data of the entry */
-	data: Record<string, unknown>;
+	data: TData;
 	/** An optional file path, where the entry represents a local file. */
 	filePath?: string;
 }
-
-export type DataWithId = {
-	id: string;
-	[key: string]: unknown;
-};
 
 export interface LoaderContext {
 	/** The unique name of the collection */
@@ -29,7 +24,7 @@ export interface LoaderContext {
 	settings: AstroSettings;
 
 	/** Validates and parses the data according to the collection schema */
-	parseData(props: ParseDataOptions): Promise<DataWithId>;
+	parseData<TData extends Record<string, unknown>>(props: ParseDataOptions<TData>): Promise<TData>;
 
 	/** Generates a non-cryptographic content digest. This can be used to check if the data has changed */
 	generateDigest(data: Record<string, unknown> | string): string;

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -62,7 +62,7 @@ export function createGetCollection({
 }) {
 	return async function getCollection(collection: string, filter?: (entry: any) => unknown) {
 		const store = await globalDataStore.get();
-		let type: 'content' | 'data' | 'experimental_data';
+		let type: 'content' | 'data' | 'experimental_data' | 'experimental_content';
 		if (collection in contentCollectionToEntryMap) {
 			type = 'content';
 		} else if (collection in dataCollectionToEntryMap) {

--- a/packages/astro/src/content/sync.ts
+++ b/packages/astro/src/content/sync.ts
@@ -1,4 +1,5 @@
 import { promises as fs, existsSync } from 'node:fs';
+import { isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { FSWatcher } from 'vite';
 import xxhash from 'xxhash-wasm';
@@ -8,7 +9,6 @@ import { ASSET_IMPORTS_FILE, DATA_STORE_FILE } from './consts.js';
 import { DataStore, globalDataStore } from './data-store.js';
 import type { DataWithId, LoaderContext } from './loaders/types.js';
 import { getEntryDataAndImages, globalContentConfigObserver, posixRelative } from './utils.js';
-import { isAbsolute } from 'node:path';
 
 export interface SyncContentLayerOptions {
 	store?: DataStore;
@@ -53,7 +53,7 @@ export async function syncContentLayer({
 
 	await Promise.all(
 		Object.entries(contentConfig.config.collections).map(async ([name, collection]) => {
-			if (collection.type !== 'experimental_data') {
+			if (collection.type !== 'experimental_data' && collection.type !== 'experimental_content') {
 				return;
 			}
 

--- a/packages/astro/src/content/sync.ts
+++ b/packages/astro/src/content/sync.ts
@@ -7,7 +7,7 @@ import type { AstroSettings } from '../@types/astro.js';
 import type { Logger } from '../core/logger/core.js';
 import { ASSET_IMPORTS_FILE, DATA_STORE_FILE } from './consts.js';
 import { DataStore, globalDataStore } from './data-store.js';
-import type { DataWithId, LoaderContext } from './loaders/types.js';
+import type { LoaderContext } from './loaders/types.js';
 import { getEntryDataAndImages, globalContentConfigObserver, posixRelative } from './utils.js';
 
 export interface SyncContentLayerOptions {
@@ -73,7 +73,7 @@ export async function syncContentLayer({
 					{
 						id,
 						collection: name,
-						unvalidatedData: data as DataWithId,
+						unvalidatedData: data,
 						_internal: {
 							rawData: undefined,
 							filePath,
@@ -130,8 +130,8 @@ export async function syncContentLayer({
 	logger.info('Synced content');
 }
 
-export async function simpleLoader(
-	handler: () => Array<DataWithId> | Promise<Array<DataWithId>>,
+export async function simpleLoader<TData extends { id: string }>(
+	handler: () => Array<TData> | Promise<Array<TData>>,
 	context: LoaderContext
 ) {
 	const data = await handler();

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -36,7 +36,7 @@ export const collectionConfigParser = z.union([
 		schema: z.any().optional(),
 	}),
 	z.object({
-		type: z.literal('experimental_data'),
+		type: z.union([z.literal('experimental_data'), z.literal('experimental_content')]),
 		schema: z.any().optional(),
 		loader: z.union([
 			z.function().returns(
@@ -135,7 +135,11 @@ export async function getEntryDataAndImages<
 	pluginContext?: PluginContext
 ): Promise<{ data: TOutputData; imageImports: Array<string> }> {
 	let data: TOutputData;
-	if (collectionConfig.type === 'data' || collectionConfig.type === 'experimental_data') {
+	if (
+		collectionConfig.type === 'data' ||
+		collectionConfig.type === 'experimental_data' ||
+		collectionConfig.type === 'experimental_content'
+	) {
 		data = entry.unvalidatedData as TOutputData;
 	} else {
 		const { slug, ...unvalidatedData } = entry.unvalidatedData;
@@ -151,7 +155,10 @@ export async function getEntryDataAndImages<
 			schema = schema({
 				image: createImage(pluginContext, shouldEmitFile, entry._internal.filePath),
 			});
-		} else if (collectionConfig.type === 'experimental_data') {
+		} else if (
+			collectionConfig.type === 'experimental_data' ||
+			collectionConfig.type === 'experimental_content'
+		) {
 			schema = schema({
 				image: () =>
 					z.string().transform((val) => {

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -6,6 +6,7 @@ import { performance } from 'perf_hooks';
 import { gt, major, minor, patch } from 'semver';
 import type * as vite from 'vite';
 import type { AstroInlineConfig } from '../../@types/astro.js';
+import { DataStore, globalDataStore } from '../../content/data-store.js';
 import { attachContentServerListeners } from '../../content/index.js';
 import { syncContentLayer } from '../../content/sync.js';
 import { telemetry } from '../../events/index.js';
@@ -18,7 +19,6 @@ import {
 	fetchLatestAstroVersion,
 	shouldCheckForUpdates,
 } from './update-check.js';
-import { DataStore, globalDataStore } from '../../content/data-store.js';
 
 export interface DevServer {
 	address: AddressInfo;

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -5,6 +5,7 @@ import { dim } from 'kleur/colors';
 import { type HMRPayload, createServer } from 'vite';
 import type { AstroConfig, AstroInlineConfig, AstroSettings } from '../../@types/astro.js';
 import { getPackage } from '../../cli/install-package.js';
+import { DataStore, globalDataStore } from '../../content/data-store.js';
 import { createContentTypesGenerator } from '../../content/index.js';
 import { syncContentLayer } from '../../content/sync.js';
 import { globalContentConfigObserver } from '../../content/utils.js';
@@ -29,7 +30,6 @@ import type { Logger } from '../logger/core.js';
 import { formatErrorMessage } from '../messages.js';
 import { ensureProcessNodeEnv } from '../util.js';
 import { setUpEnvTs } from './setup-env-ts.js';
-import { DataStore, globalDataStore } from '../../content/data-store.js';
 
 export type SyncOptions = {
 	/**

--- a/packages/astro/templates/content/types.d.ts
+++ b/packages/astro/templates/content/types.d.ts
@@ -6,6 +6,17 @@ declare module 'astro:content' {
 			remarkPluginFrontmatter: Record<string, any>;
 		}>;
 	}
+	interface ContentLayerRenderer {
+		Content: import('astro/runtime/server').AstroComponentFactory;
+	}
+
+	export interface RenderedContent {
+		html: string;
+		metadata?: {
+			imagePaths: Array<string>;
+			[key: string]: unknown;
+		};
+	}
 }
 
 declare module 'astro:content' {

--- a/packages/astro/templates/content/types.d.ts
+++ b/packages/astro/templates/content/types.d.ts
@@ -7,7 +7,7 @@ declare module 'astro:content' {
 		}>;
 	}
 	interface ContentLayerRenderer {
-		Content: import('astro/runtime/server').AstroComponentFactory;
+		Content: import('astro/runtime/server/index.js').AstroComponentFactory;
 	}
 
 	export interface RenderedContent {

--- a/packages/astro/test/fixtures/content-layer/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-layer/src/content/config.ts
@@ -74,7 +74,7 @@ const cats = defineCollection({
 const absoluteRoot = new URL('../../content-outside-src', import.meta.url);
 
 const spacecraft = defineCollection({
-	type: 'experimental_data',
+	type: 'experimental_content',
 	loader: glob({ pattern: '*.md', base: absoluteRoot }),
 	schema: ({ image }) => z.object({
 		title: z.string(),
@@ -87,7 +87,7 @@ const spacecraft = defineCollection({
 });
 
 const numbers = defineCollection({
-	type: 'experimental_data',
+	type: 'experimental_content',
 	loader: glob({ pattern: 'src/data/glob-data/*', base: '.' }),
 });
 

--- a/packages/astro/types/content.d.ts
+++ b/packages/astro/types/content.d.ts
@@ -57,17 +57,10 @@ declare module 'astro:content' {
 
 	export type SchemaContext = { image: ImageFunction };
 
-	export interface DataWithId {
-		id: string;
-		[key: string]: unknown;
-	}
-
-	type ContentLayerConfig<S extends BaseSchema> = {
+	type ContentLayerConfig<S extends BaseSchema, TData extends { id: string } = { id: string }> = {
 		type: 'experimental_data' | 'experimental_content';
 		schema?: S | ((context: SchemaContext) => S);
-		loader:
-			| import('astro/loader/types').Loader
-			| (() => Array<DataWithId> | Promise<Array<DataWithId>>);
+		loader: import('astro/loaders').Loader | (() => Array<TData> | Promise<Array<TData>>);
 	};
 
 	type DataCollectionConfig<S extends BaseSchema> = {

--- a/packages/astro/types/content.d.ts
+++ b/packages/astro/types/content.d.ts
@@ -62,8 +62,8 @@ declare module 'astro:content' {
 		[key: string]: unknown;
 	}
 
-	type ContentCollectionV2Config<S extends BaseSchema> = {
-		type: 'experimental_data';
+	type ContentLayerConfig<S extends BaseSchema> = {
+		type: 'experimental_data' | 'experimental_content';
 		schema?: S | ((context: SchemaContext) => S);
 		loader:
 			| import('astro/loader/types').Loader
@@ -83,7 +83,7 @@ declare module 'astro:content' {
 	export type CollectionConfig<S extends BaseSchema> =
 		| ContentCollectionConfig<S>
 		| DataCollectionConfig<S>
-		| ContentCollectionV2Config<S>;
+		| ContentLayerConfig<S>;
 
 	export function defineCollection<S extends BaseSchema>(
 		input: CollectionConfig<S>


### PR DESCRIPTION
Creates a separate `experimental_content` type alongside `experimental_data` to allow the `render()` and `rendered` properties to be added to the types. Makes the data store types generic and fixes the collection definition types so that types are enforced better for manually-defined loaders.