### PR TITLE
Fix server islands with trailingSlash: always

### DIFF
--- a/.changeset/wicked-books-sip.md
+++ b/.changeset/wicked-books-sip.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix server islands with trailingSlash: always

--- a/packages/astro/e2e/fixtures/server-islands/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/server-islands/astro.config.mjs
@@ -8,6 +8,7 @@ export default defineConfig({
 	output: 'hybrid',
 	adapter: nodejs({ mode: 'standalone' }),
 	integrations: [react(), mdx()],
+	trailingSlash: 'always',
 	experimental: {
 		serverIslands: true,
 	}

--- a/packages/astro/e2e/fixtures/server-islands/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/server-islands/astro.config.mjs
@@ -5,6 +5,7 @@ import nodejs from '@astrojs/node';
 
 // https://astro.build/config
 export default defineConfig({
+	base: '/base',
 	output: 'hybrid',
 	adapter: nodejs({ mode: 'standalone' }),
 	integrations: [react(), mdx()],

--- a/packages/astro/e2e/server-islands.test.js
+++ b/packages/astro/e2e/server-islands.test.js
@@ -24,7 +24,7 @@ test.describe('Server islands', () => {
 		});
 
 		test('Can be in an MDX file', async ({ page, astro }) => {
-			await page.goto(astro.resolveUrl('/mdx'));
+			await page.goto(astro.resolveUrl('/mdx/'));
 			let el = page.locator('#island');
 
 			await expect(el, 'element rendered').toBeVisible();

--- a/packages/astro/e2e/server-islands.test.js
+++ b/packages/astro/e2e/server-islands.test.js
@@ -16,7 +16,7 @@ test.describe('Server islands', () => {
 		});
 
 		test('Load content from the server', async ({ page, astro }) => {
-			await page.goto(astro.resolveUrl('/'));
+			await page.goto(astro.resolveUrl('/base/'));
 			let el = page.locator('#island');
 
 			await expect(el, 'element rendered').toBeVisible();
@@ -24,7 +24,7 @@ test.describe('Server islands', () => {
 		});
 
 		test('Can be in an MDX file', async ({ page, astro }) => {
-			await page.goto(astro.resolveUrl('/mdx/'));
+			await page.goto(astro.resolveUrl('/base/mdx/'));
 			let el = page.locator('#island');
 
 			await expect(el, 'element rendered').toBeVisible();
@@ -32,7 +32,7 @@ test.describe('Server islands', () => {
 		});
 
 		test('Slots are provided back to the server islands', async ({ page, astro }) => {
-			await page.goto(astro.resolveUrl('/'));
+			await page.goto(astro.resolveUrl('/base/'));
 			let el = page.locator('#children');
 
 			await expect(el, 'element rendered').toBeVisible();
@@ -55,7 +55,7 @@ test.describe('Server islands', () => {
 		});
 
 		test('Only one component in prod', async ({ page, astro }) => {
-			await page.goto(astro.resolveUrl('/'));
+			await page.goto(astro.resolveUrl('/base/'));
 
 			let el = page.locator('#island');
 

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -3324,6 +3324,7 @@ export interface SSRResult {
 	 * Whether the page has failed with a non-recoverable error, or the client disconnected.
 	 */
 	cancelled: boolean;
+	base: string;
 	styles: Set<SSRElement>;
 	scripts: Set<SSRElement>;
 	links: Set<SSRElement>;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -3352,6 +3352,7 @@ export interface SSRResult {
 	pathname: string;
 	cookies: AstroCookies | undefined;
 	serverIslandNameMap: Map<string, string>;
+	trailingSlash: AstroConfig['trailingSlash'];
 	_metadata: SSRMetadata;
 }
 

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -368,6 +368,7 @@ export class RenderContext {
 			styles,
 			actionResult,
 			serverIslandNameMap: manifest.serverIslandNameMap ?? new Map(),
+			trailingSlash: manifest.trailingSlash,
 			_metadata: {
 				hasHydrationScript: false,
 				rendererSpecificHydrationScripts: new Set(),

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -347,6 +347,7 @@ export class RenderContext {
 		// This object starts here as an empty shell (not yet the result) but then
 		// calling the render() function will populate the object with scripts, styles, etc.
 		const result: SSRResult = {
+			base: manifest.base,
 			cancelled: false,
 			clientDirectives,
 			inlinedScripts,

--- a/packages/astro/src/runtime/server/render/server-islands.ts
+++ b/packages/astro/src/runtime/server/render/server-islands.ts
@@ -71,7 +71,7 @@ let data = {
 	slots: ${safeJsonStringify(renderedSlots)},
 };
 
-let response = await fetch('/_server-islands/${componentId}', {
+let response = await fetch('/_server-islands/${componentId}${result.trailingSlash === 'always' ? '/' : ''}', {
 	method: 'POST',
 	body: JSON.stringify(data),
 });

--- a/packages/astro/src/runtime/server/render/server-islands.ts
+++ b/packages/astro/src/runtime/server/render/server-islands.ts
@@ -60,6 +60,7 @@ export function renderServerIsland(
 			}
 
 			const hostId = crypto.randomUUID();
+			const serverIslandUrl = `${result.base}_server-islands/${componentId}${result.trailingSlash === 'always' ? '/' : ''}`;
 
 			destination.write(`<script async type="module" data-island-id="${hostId}">
 let componentId = ${safeJsonStringify(componentId)};
@@ -71,7 +72,7 @@ let data = {
 	slots: ${safeJsonStringify(renderedSlots)},
 };
 
-let response = await fetch('/_server-islands/${componentId}${result.trailingSlash === 'always' ? '/' : ''}', {
+let response = await fetch('${serverIslandUrl}'), {
 	method: 'POST',
 	body: JSON.stringify(data),
 });

--- a/packages/astro/src/runtime/server/render/server-islands.ts
+++ b/packages/astro/src/runtime/server/render/server-islands.ts
@@ -72,7 +72,7 @@ let data = {
 	slots: ${safeJsonStringify(renderedSlots)},
 };
 
-let response = await fetch('${serverIslandUrl}'), {
+let response = await fetch('${serverIslandUrl}', {
 	method: 'POST',
 	body: JSON.stringify(data),
 });


### PR DESCRIPTION
## Changes

- Uses `trailingSlash` config in order to append a trailing slash to the island request. Only done when set to `always`.

## Testing

- Test updated

## Docs

N/A, bug fix