### PR TITLE
fix(types): update Astro.redirect JSDoc comment

### DIFF
--- a/.changeset/mighty-mirrors-try.md
+++ b/.changeset/mighty-mirrors-try.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Remove "SSR Only" mention in `Astro.redirect` inline documentation and update reference link.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -262,7 +262,7 @@ export interface AstroGlobal<
 	 * ```
 	 */
 	getActionResult: AstroSharedContext['getActionResult'];
-	/** Redirect to another page (**SSR Only**)
+	/** Redirect to another page
 	 *
 	 * Example usage:
 	 * ```typescript
@@ -271,7 +271,7 @@ export interface AstroGlobal<
 	 * }
 	 * ```
 	 *
-	 * [Astro reference](https://docs.astro.build/en/guides/server-side-rendering/)
+	 * [Astro reference](https://docs.astro.build/en/reference/api-reference/#astroredirect)
 	 */
 	redirect: AstroSharedContext['redirect'];
 	/**


### PR DESCRIPTION
## Changes

Update the inline documentation (JSDoc comment) for `Astro.redirect`:
* Closes #11544

I haven't added a changeset since it is a small change. Should I?

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

No test. I only reworded a comment.

## Docs

No doc needed since it does not change the behavior. However it could be a nice addition to clarify the difference between `server` and `static` with `Astro.redirect` (I can post a suggestion on `astro/docs` separately of this PR).

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
