### PR TITLE
Fix astro add for prerelease packages

### DIFF
--- a/.changeset/violet-coats-fail.md
+++ b/.changeset/violet-coats-fail.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix `astro add` for packages with only prerelease versions.

--- a/.changeset/violet-coats-fail.md
+++ b/.changeset/violet-coats-fail.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fix `astro add` for packages with only prerelease versions.
+Fixes `astro add` for packages with only prerelease versions

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -691,9 +691,9 @@ async function convertIntegrationsToInstallSpecifiers(
 async function resolveRangeToInstallSpecifier(name: string, range: string): Promise<string> {
 	const versions = await fetchPackageVersions(name);
 	if (versions instanceof Error) return name;
-	// Filter out any prerelease versions
-	const stableVersions = versions.filter((v) => !v.includes('-'));
-	const maxStable = maxSatisfying(stableVersions, range);
+	// Filter out any prerelease versions, but fallback if there are no stable versions
+	let stableVersions = versions.filter((v) => !v.includes('-'));
+	const maxStable = maxSatisfying(stableVersions.length !== 0 ? stableVersions : versions, range);
 	return `${name}@^${maxStable}`;
 }
 

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -692,7 +692,7 @@ async function resolveRangeToInstallSpecifier(name: string, range: string): Prom
 	const versions = await fetchPackageVersions(name);
 	if (versions instanceof Error) return name;
 	// Filter out any prerelease versions, but fallback if there are no stable versions
-	let stableVersions = versions.filter((v) => !v.includes('-'));
+	const stableVersions = versions.filter((v) => !v.includes('-'));
 	const maxStable = maxSatisfying(stableVersions.length !== 0 ? stableVersions : versions, range);
 	return `${name}@^${maxStable}`;
 }


### PR DESCRIPTION
## Changes

- Fix how `astro add` handles packages with only prerelease versions.

## Testing

No tests exist for `astro add`. Should we add some?

## Docs

Not something that is documented or needs new documentation.
