### PR TITLE
fix(astro): remove github slugger in content utils

### DIFF
--- a/.changeset/big-rules-jam.md
+++ b/.changeset/big-rules-jam.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Remove github slugger in content slug util

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -159,7 +159,6 @@
     "execa": "^8.0.1",
     "fast-glob": "^3.3.2",
     "flattie": "^1.1.1",
-    "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "html-escaper": "^3.0.3",
     "http-cache-semantics": "^4.1.1",

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -1,7 +1,6 @@
 import fsMod from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { slug as githubSlug } from 'github-slugger';
 import matter from 'gray-matter';
 import type { PluginContext } from 'rollup';
 import { type ViteDevServer, normalizePath } from 'vite';
@@ -272,9 +271,7 @@ export function getContentEntryIdAndSlug({
 	const rawSlugSegments = withoutFileExt.split(path.sep);
 
 	const slug = rawSlugSegments
-		// Slugify each route segment to handle capitalization and spaces.
-		// Note: using `slug` instead of `new Slugger()` means no slug deduping.
-		.map((segment) => githubSlug(segment))
+		.map((segment) => segment.toLowerCase().replace(/ /g, '-'))
 		.join('/')
 		.replace(/\/index$/, '');
 

--- a/packages/astro/test/units/content-collections/get-entry-info.test.js
+++ b/packages/astro/test/units/content-collections/get-entry-info.test.js
@@ -44,4 +44,11 @@ describe('Content Collections - entry info', () => {
 		const info = getContentEntryIdAndSlug({ entry, contentDir, collection });
 		assert.equal(info.slug, '2021/01/01');
 	});
+
+	it('Returns correct slug when when use special character', () => {
+		const collection = 'blog';
+		const entry = new URL(`${collection}/tutorial-c++`, contentDir);
+		const info = getContentEntryIdAndSlug({ entry, contentDir, collection });
+		assert.equal(info.slug, 'tutorial-c++');
+	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -669,9 +669,6 @@ importers:
       flattie:
         specifier: ^1.1.1
         version: 1.1.1
-      github-slugger:
-        specifier: ^2.0.0
-        version: 2.0.0
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3


### PR DESCRIPTION
## Changes
I removed the github slugger from content utils and astro, leaving only the behavior left in the comment.

## Testing
I tested whether getContentEntryIdAndSlug does not delete special characters.

## Docs
I don't know if this is something I should understand from a user's point of view. So I don't add docs.

/cc @withastro/maintainers-docs for feedback!

Fix: #11458