### PR TITLE
actions: check result.data is not undefined instead of truthy

### DIFF
--- a/.changeset/tasty-rockets-jog.md
+++ b/.changeset/tasty-rockets-jog.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Let actions return falsy values without an error
+Allows actions to return falsy values without an error

--- a/.changeset/tasty-rockets-jog.md
+++ b/.changeset/tasty-rockets-jog.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Let actions return falsy values without an error

--- a/packages/astro/src/actions/runtime/route.ts
+++ b/packages/astro/src/actions/runtime/route.ts
@@ -40,7 +40,7 @@ export const POST: APIRoute = async (context) => {
 		);
 	}
 	return new Response(JSON.stringify(result.data), {
-		status: result.data ? 200 : 204,
+		status: result.data !== undefined ? 200 : 204,
 		headers: {
 			'Content-Type': 'application/json',
 		},

--- a/packages/astro/test/actions.test.js
+++ b/packages/astro/test/actions.test.js
@@ -228,5 +228,33 @@ describe('Astro Actions', () => {
 			assert.equal($('[data-url]').text(), '/subscribe');
 			assert.equal($('[data-channel]').text(), 'bholmesdev');
 		});
+
+		it('Returns content when the value is 0', async () => {
+			const req = new Request('http://example.com/_actions/zero', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Content-Length': '0',
+				},
+			});
+			const res = await app.render(req);
+			assert.equal(res.status, 200);
+			const value = await res.json();
+			assert.equal(value, 0);
+		});
+
+		it('Returns content when the value is false', async () => {
+			const req = new Request('http://example.com/_actions/false', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Content-Length': '0',
+				},
+			});
+			const res = await app.render(req);
+			assert.equal(res.status, 200);
+			const value = await res.json();
+			assert.equal(value, false);
+		});
 	});
 });

--- a/packages/astro/test/fixtures/actions/src/actions/index.ts
+++ b/packages/astro/test/fixtures/actions/src/actions/index.ts
@@ -64,4 +64,14 @@ export const server = {
 			return;
 		}
 	}),
+	zero: defineAction({
+		handler: async () => {
+			return 0;
+		}
+	}),
+	false: defineAction({
+		handler: async () => {
+			return false;
+		}
+	})
 };


### PR DESCRIPTION
## Changes

Allows actions to return falsy values by changing the result.data check to a strict inequality check for undefined. Fixes #11549

## Testing

- Added tests for 0 and false return values.

## Docs

I don't think this requires docs, reading them I'd expect returning a value of 0 or false to work.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
