### PR TITLE
fix(types): change page.size to 10 in JSDoc comment

### DIFF
--- a/.changeset/good-bats-add.md
+++ b/.changeset/good-bats-add.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Use the correct pageSize default in `page.size` JSDoc comment

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2704,7 +2704,7 @@ export interface Page<T = any> {
 	total: number;
 	/** the current page number, starting from 1 */
 	currentPage: number;
-	/** number of items per page (default: 25) */
+	/** number of items per page (default: 10) */
 	size: number;
 	/** number of last page */
 	lastPage: number;


### PR DESCRIPTION
## Changes

- Update the JSDoc comment for `page.size` to use the accurate `pageSize` default (`10` and not `25`).
- Closes #11560

## Testing

No test needed, it's just a comment update. You can check the [reproduction](https://stackblitz.com/edit/astro-paginate-pagesize?file=src%2Fpages%2Fpokemon%2F[page].astro&on=stackblitz) to see that `10` is the correct number.

## Docs

An update to the [Routing guide](https://docs.astro.build/en/guides/routing/#complete-api-reference) will be needed since it reuse the `Page` interface (and maybe also an update to API reference). This is already reported in https://github.com/withastro/docs/issues/8929.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
