### PR TITLE
feat: use devalue to serialize content layer data

### DIFF
--- a/packages/astro/src/content/consts.ts
+++ b/packages/astro/src/content/consts.ts
@@ -25,5 +25,5 @@ export const CONTENT_FLAGS = [
 
 export const CONTENT_TYPES_FILE = 'types.d.ts';
 
-export const DATA_STORE_FILE = 'data-store.json';
+export const DATA_STORE_FILE = 'data-store-module.mjs';
 export const ASSET_IMPORTS_FILE = 'assets.mjs';

--- a/packages/astro/src/content/consts.ts
+++ b/packages/astro/src/content/consts.ts
@@ -25,5 +25,5 @@ export const CONTENT_FLAGS = [
 
 export const CONTENT_TYPES_FILE = 'types.d.ts';
 
-export const DATA_STORE_FILE = 'data-store-module.mjs';
+export const DATA_STORE_FILE = 'data-store.json';
 export const ASSET_IMPORTS_FILE = 'assets.mjs';

--- a/packages/astro/src/content/data-store.ts
+++ b/packages/astro/src/content/data-store.ts
@@ -114,7 +114,7 @@ export class DataStore {
 				await fs.writeFile(filePath, 'export default new Map();');
 			} catch (err) {
 				throw new AstroError({
-					...(err as Error),
+					message: (err as Error).message,
 					...AstroErrorData.ContentLayerWriteError,
 				});
 			}
@@ -141,7 +141,7 @@ export default new Map([${exports.join(', ')}]);
 			await fs.writeFile(filePath, code);
 		} catch (err) {
 			throw new AstroError({
-				...(err as Error),
+				message: (err as Error).message,
 				...AstroErrorData.ContentLayerWriteError,
 			});
 		}
@@ -252,7 +252,7 @@ export default new Map([${exports.join(', ')}]);
 			this.#dirty = false;
 		} catch (err) {
 			throw new AstroError({
-				...(err as Error),
+				message: (err as Error).message,
 				...AstroErrorData.ContentLayerWriteError,
 			});
 		}

--- a/packages/astro/src/content/sync.ts
+++ b/packages/astro/src/content/sync.ts
@@ -6,12 +6,12 @@ import xxhash from 'xxhash-wasm';
 import type { AstroSettings } from '../@types/astro.js';
 import type { Logger } from '../core/logger/core.js';
 import { ASSET_IMPORTS_FILE, DATA_STORE_FILE } from './consts.js';
-import { DataStore, globalDataStore } from './data-store.js';
+import type { DataStore } from './data-store.js';
 import type { LoaderContext } from './loaders/types.js';
 import { getEntryDataAndImages, globalContentConfigObserver, posixRelative } from './utils.js';
 
 export interface SyncContentLayerOptions {
-	store?: DataStore;
+	store: DataStore;
 	settings: AstroSettings;
 	logger: Logger;
 	watcher?: FSWatcher;
@@ -33,10 +33,6 @@ export async function syncContentLayer({
 
 	const logger = globalLogger.forkIntegrationLogger('content');
 	logger.info('Syncing content');
-	if (!store) {
-		store = await DataStore.fromDisk(new URL(DATA_STORE_FILE, settings.config.cacheDir));
-		globalDataStore.set(store);
-	}
 	const contentConfig = globalContentConfigObserver.get();
 	if (contentConfig?.status !== 'loaded') {
 		logger.debug('Content config not loaded, skipping sync');

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -1,7 +1,6 @@
 import nodeFs from 'node:fs';
 import { extname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { dataToEsm } from '@rollup/pluginutils';
 import glob from 'fast-glob';
 import pLimit from 'p-limit';
 import type { Plugin } from 'vite';
@@ -107,16 +106,13 @@ export function astroContentVirtualModPlugin({
 			}
 			if (id === RESOLVED_DATA_STORE_VIRTUAL_ID) {
 				if (!fs.existsSync(dataStoreFile)) {
-					return 'export default {}';
+					return 'export default new Map()';
 				}
-				const jsonData = await fs.promises.readFile(dataStoreFile, 'utf-8');
+				const code = await fs.promises.readFile(dataStoreFile, 'utf-8');
 
 				try {
-					const parsed = JSON.parse(jsonData);
 					return {
-						code: dataToEsm(parsed, {
-							compact: true,
-						}),
+						code,
 						map: { mappings: '' },
 					};
 				} catch (err) {

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -1,6 +1,7 @@
 import nodeFs from 'node:fs';
 import { extname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dataToEsm } from '@rollup/pluginutils';
 import glob from 'fast-glob';
 import pLimit from 'p-limit';
 import type { Plugin } from 'vite';
@@ -108,11 +109,14 @@ export function astroContentVirtualModPlugin({
 				if (!fs.existsSync(dataStoreFile)) {
 					return 'export default new Map()';
 				}
-				const code = await fs.promises.readFile(dataStoreFile, 'utf-8');
+				const jsonData = await fs.promises.readFile(dataStoreFile, 'utf-8');
 
 				try {
+					const parsed = JSON.parse(jsonData);
 					return {
-						code,
+						code: dataToEsm(parsed, {
+							compact: true,
+						}),
 						map: { mappings: '' },
 					};
 				} catch (err) {

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -20,7 +20,6 @@ import {
 	shouldCheckForUpdates,
 } from './update-check.js';
 import { DATA_STORE_FILE } from '../../content/consts.js';
-import { fileURLToPath } from 'node:url';
 
 export interface DevServer {
 	address: AddressInfo;

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -19,7 +19,7 @@ import {
 	fetchLatestAstroVersion,
 	shouldCheckForUpdates,
 } from './update-check.js';
-import { DATA_STORE_FILE } from '#astro/content/consts';
+import { DATA_STORE_FILE } from '../../content/consts.js';
 import { fileURLToPath } from 'node:url';
 
 export interface DevServer {

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -108,11 +108,9 @@ export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevS
 
 	let store: DataStore | undefined;
 	try {
-		const dataStoreFile = fileURLToPath(
-			new URL(DATA_STORE_FILE, restart.container.settings.config.cacheDir)
-		);
+		const dataStoreFile = new URL(DATA_STORE_FILE, restart.container.settings.config.cacheDir);
 		if (existsSync(dataStoreFile)) {
-			store = await DataStore.fromModuleFile(dataStoreFile);
+			store = await DataStore.fromFile(dataStoreFile);
 			globalDataStore.set(store);
 		}
 	} catch (err: any) {

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -1,4 +1,4 @@
-import fsMod from 'node:fs';
+import fsMod, { existsSync } from 'node:fs';
 import { performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';
 import { dim } from 'kleur/colors';
@@ -30,6 +30,7 @@ import type { Logger } from '../logger/core.js';
 import { formatErrorMessage } from '../messages.js';
 import { ensureProcessNodeEnv } from '../util.js';
 import { setUpEnvTs } from './setup-env-ts.js';
+import { DATA_STORE_FILE } from '../../content/consts.js';
 
 export type SyncOptions = {
 	/**
@@ -98,9 +99,21 @@ export async function syncInternal({
 		if (!skip?.content) {
 			await syncContentCollections(settings, { fs, logger });
 			settings.timer.start('Sync content layer');
-			const dataStore = await DataStore.fromModule();
-			globalDataStore.set(dataStore);
-			await syncContentLayer({ settings, logger });
+			let store: DataStore | undefined;
+			try {
+				const dataStoreFile = fileURLToPath(new URL(DATA_STORE_FILE, settings.config.cacheDir));
+				if (existsSync(dataStoreFile)) {
+					store = await DataStore.fromModuleFile(dataStoreFile);
+					globalDataStore.set(store);
+				}
+			} catch (err: any) {
+				logger.error('content', err.message);
+			}
+			if (!store) {
+				store = new DataStore();
+				globalDataStore.set(store);
+			}
+			await syncContentLayer({ settings, logger, store });
 			settings.timer.end('Sync content layer');
 		}
 		syncAstroEnv(settings, fs);

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -101,9 +101,9 @@ export async function syncInternal({
 			settings.timer.start('Sync content layer');
 			let store: DataStore | undefined;
 			try {
-				const dataStoreFile = fileURLToPath(new URL(DATA_STORE_FILE, settings.config.cacheDir));
+				const dataStoreFile = new URL(DATA_STORE_FILE, settings.config.cacheDir);
 				if (existsSync(dataStoreFile)) {
-					store = await DataStore.fromModuleFile(dataStoreFile);
+					store = await DataStore.fromFile(dataStoreFile);
 					globalDataStore.set(store);
 				}
 			} catch (err: any) {

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -4,7 +4,7 @@ import { sep } from 'node:path';
 import { sep as posixSep } from 'node:path/posix';
 import { after, before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
-
+import * as devalue from 'devalue';
 describe('Content Layer', () => {
 	/** @type {import("./test-utils.js").Fixture} */
 	let fixture;
@@ -18,11 +18,11 @@ describe('Content Layer', () => {
 		before(async () => {
 			fixture = await loadFixture({ root: './fixtures/content-layer/' });
 			await fs
-				.unlink(new URL('./node_modules/.astro/data-store.json', fixture.config.root))
+				.unlink(new URL('./node_modules/.astro/data-store-module.mjs', fixture.config.root))
 				.catch(() => {});
 			await fixture.build();
 			const rawJson = await fixture.readFile('/collections.json');
-			json = JSON.parse(rawJson);
+			json = devalue.parse(rawJson);
 		});
 
 		it('Returns custom loader collection', async () => {
@@ -118,6 +118,10 @@ describe('Content Layer', () => {
 			assert.deepEqual(json.entryWithReference.data.cat, { collection: 'cats', id: 'tabby' });
 		});
 
+		it('can store Date objects', async () => {
+			assert.ok(json.entryWithReference.data.publishedDate instanceof Date);
+		});
+
 		it('returns a referenced entry', async () => {
 			assert.ok(json.hasOwnProperty('referencedEntry'));
 			assert.deepEqual(json.referencedEntry, {
@@ -137,15 +141,15 @@ describe('Content Layer', () => {
 		it('updates the store on new builds', async () => {
 			assert.equal(json.increment.data.lastValue, 1);
 			await fixture.build();
-			const newJson = JSON.parse(await fixture.readFile('/collections.json'));
+			const newJson = devalue.parse(await fixture.readFile('/collections.json'));
 			assert.equal(newJson.increment.data.lastValue, 2);
 		});
 
 		it('clears the store on new build with force flag', async () => {
-			let newJson = JSON.parse(await fixture.readFile('/collections.json'));
+			let newJson = devalue.parse(await fixture.readFile('/collections.json'));
 			assert.equal(newJson.increment.data.lastValue, 2);
 			await fixture.build({}, { force: true });
-			newJson = JSON.parse(await fixture.readFile('/collections.json'));
+			newJson = devalue.parse(await fixture.readFile('/collections.json'));
 			assert.equal(newJson.increment.data.lastValue, 1);
 		});
 	});
@@ -157,7 +161,7 @@ describe('Content Layer', () => {
 			devServer = await fixture.startDevServer();
 			const rawJsonResponse = await fixture.fetch('/collections.json');
 			const rawJson = await rawJsonResponse.text();
-			json = JSON.parse(rawJson);
+			json = devalue.parse(rawJson);
 		});
 
 		after(async () => {
@@ -235,7 +239,7 @@ describe('Content Layer', () => {
 
 		it('updates collection when data file is changed', async () => {
 			const rawJsonResponse = await fixture.fetch('/collections.json');
-			const initialJson = await rawJsonResponse.json();
+			const initialJson = devalue.parse(await rawJsonResponse.text());
 			assert.equal(initialJson.fileLoader[0].data.temperament.includes('Bouncy'), false);
 
 			await fixture.editFile('/src/data/dogs.json', (prev) => {
@@ -248,7 +252,7 @@ describe('Content Layer', () => {
 			await new Promise((r) => setTimeout(r, 700));
 
 			const updatedJsonResponse = await fixture.fetch('/collections.json');
-			const updated = await updatedJsonResponse.json();
+			const updated = devalue.parse(await updatedJsonResponse.text());
 			assert.ok(updated.fileLoader[0].data.temperament.includes('Bouncy'));
 		});
 	});

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -18,7 +18,7 @@ describe('Content Layer', () => {
 		before(async () => {
 			fixture = await loadFixture({ root: './fixtures/content-layer/' });
 			await fs
-				.unlink(new URL('./node_modules/.astro/data-store-module.mjs', fixture.config.root))
+				.unlink(new URL('./node_modules/.astro/data-store.json', fixture.config.root))
 				.catch(() => {});
 			await fixture.build();
 			const rawJson = await fixture.readFile('/collections.json');

--- a/packages/astro/test/fixtures/content-layer/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-layer/src/content/config.ts
@@ -79,7 +79,7 @@ const spacecraft = defineCollection({
 		z.object({
 			title: z.string(),
 			description: z.string(),
-			publishedDate: z.string(),
+			publishedDate: z.coerce.date(),
 			tags: z.array(z.string()),
 			heroImage: image().optional(),
 			cat: reference('cats').optional(),

--- a/packages/astro/test/fixtures/content-layer/src/pages/collections.json.js
+++ b/packages/astro/test/fixtures/content-layer/src/pages/collections.json.js
@@ -1,17 +1,29 @@
 import { getCollection, getEntry } from 'astro:content';
+import * as devalue from 'devalue';
+import { stripAllRenderFn, stripRenderFn } from '../utils';
 
 export async function GET() {
-	const customLoader = (await getCollection('blog')).slice(0, 10);
-	const fileLoader = await getCollection('dogs');
+	const customLoader = stripAllRenderFn((await getCollection('blog')).slice(0, 10));
+	const fileLoader = stripAllRenderFn(await getCollection('dogs'));
 
-	const dataEntry = await getEntry('dogs', 'beagle');
+	const dataEntry = stripRenderFn(await getEntry('dogs', 'beagle'));
 
-	const simpleLoader = await getCollection('cats');
+	const simpleLoader = stripAllRenderFn(await getCollection('cats'));
 
-	const entryWithReference = await getEntry('spacecraft', 'columbia-copy')
-	const referencedEntry = await getEntry(entryWithReference.data.cat)
+	const entryWithReference = stripRenderFn(await getEntry('spacecraft', 'columbia-copy'));
+	const referencedEntry = stripRenderFn(await getEntry(entryWithReference.data.cat));
 
-	const increment = await getEntry('increment', 'value')
+	const increment = stripRenderFn(await getEntry('increment', 'value'));
 
-	return Response.json({ customLoader, fileLoader, dataEntry, simpleLoader, entryWithReference, referencedEntry, increment });
+	return new Response(
+		devalue.stringify({
+			customLoader,
+			fileLoader,
+			dataEntry,
+			simpleLoader,
+			entryWithReference,
+			referencedEntry,
+			increment,
+		})
+	);
 }

--- a/packages/astro/test/fixtures/content-layer/src/utils.js
+++ b/packages/astro/test/fixtures/content-layer/src/utils.js
@@ -1,0 +1,8 @@
+export function stripRenderFn(entryWithRender) {
+	const { render, ...entry } = entryWithRender;
+	return entry;
+}
+
+export function stripAllRenderFn(collection = []) {
+	return collection.map(stripRenderFn);
+}


### PR DESCRIPTION
## Changes

Switches content layer to use devalue for the data store serialization, so it supports Dates etc

## Testing
Added a test

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
