### PR TITLE
fix: check before writing to errors

### DIFF
--- a/.changeset/violet-drinks-film.md
+++ b/.changeset/violet-drinks-film.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes DomException errors not being handled properly

--- a/packages/astro/e2e/errors.test.js
+++ b/packages/astro/e2e/errors.test.js
@@ -125,4 +125,10 @@ test.describe('Error display', () => {
 		const message = (await getErrorOverlayContent(page)).message;
 		expect(message).toMatch('can only be used in');
 	});
+
+	test('can handle DomException errors zzz', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/dom-exception'), { waitUntil: 'networkidle' });
+		const message = (await getErrorOverlayContent(page)).message;
+		expect(message).toMatch('The operation was aborted due to timeout');
+	});
 });

--- a/packages/astro/e2e/errors.test.js
+++ b/packages/astro/e2e/errors.test.js
@@ -126,7 +126,7 @@ test.describe('Error display', () => {
 		expect(message).toMatch('can only be used in');
 	});
 
-	test('can handle DomException errors zzz', async ({ page, astro }) => {
+	test('can handle DomException errors', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/dom-exception'), { waitUntil: 'networkidle' });
 		const message = (await getErrorOverlayContent(page)).message;
 		expect(message).toMatch('The operation was aborted due to timeout');

--- a/packages/astro/e2e/fixtures/errors/src/pages/dom-exception.astro
+++ b/packages/astro/e2e/fixtures/errors/src/pages/dom-exception.astro
@@ -1,0 +1,3 @@
+---
+await fetch("https://example.com/", {signal: AbortSignal.timeout(5)})
+---

--- a/packages/astro/src/core/errors/dev/utils.ts
+++ b/packages/astro/src/core/errors/dev/utils.ts
@@ -24,7 +24,7 @@ export function collectErrorMetadata(e: any, rootFolder?: URL | undefined): Erro
 		AggregateError.is(e) || Array.isArray(e.errors) ? (e.errors as SSRError[]) : [e as SSRError];
 
 	err.forEach((error) => {
-		if (e.stack) {
+		if (e.stack && isWritable(error, 'stack')) {
 			const stackInfo = collectInfoFromStacktrace(e);
 			error.stack = stripAnsi(stackInfo.stack);
 			error.loc = stackInfo.loc;
@@ -71,7 +71,8 @@ export function collectErrorMetadata(e: any, rootFolder?: URL | undefined): Erro
 
 		// Strip ANSI for `message` property. Note that ESBuild errors may not have the property,
 		// but it will be handled and added below, which is already ANSI-free
-		if (error.message) {
+		// We need to check if it's writable because, unusually, some errors, like DomException, have a read-only message property
+		if (error.message && isWritable(error, 'message')) {
 			error.message = stripAnsi(error.message);
 		}
 	});
@@ -83,7 +84,7 @@ export function collectErrorMetadata(e: any, rootFolder?: URL | undefined): Erro
 			const { location, pluginName, text } = buildError;
 
 			// ESBuild can give us a slightly better error message than the one in the error, so let's use it
-			if (text) {
+			if (text && isWritable(err[i], 'message')) {
 				err[i].message = text;
 			}
 
@@ -254,4 +255,12 @@ export function renderErrorMarkdown(markdown: string, target: 'html' | 'cli') {
 			.replace(urlRegex, (fullMatch) => ` ${underline(fullMatch.trim())}`)
 			.replace(boldRegex, (_, m1) => `${bold(m1)}`);
 	}
+}
+
+function isWritable<T extends object>(obj: T, key: keyof T) {
+	const desc =
+		Object.getOwnPropertyDescriptor(obj, key) ||
+		Object.getOwnPropertyDescriptor(Object.getPrototypeOf(obj), key) ||
+		{};
+	return Boolean(desc?.writable);
 }


### PR DESCRIPTION
## Changes

Unusually, some errors have some of their properties read-only. Since this has only happened once in the history of Astro, I figure it wasn't worth it to shield *everything*, but just adding checks for the common properties should be enough

Fixes https://github.com/withastro/astro/issues/11538

## Testing

Added a test

## Docs

N/A
