### PR TITLE
fix(create-astro): log fetch errors

### DIFF
--- a/.changeset/gorgeous-timers-tease.md
+++ b/.changeset/gorgeous-timers-tease.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Logs underlying error when a template cannot be downloaded

--- a/packages/create-astro/src/actions/template.ts
+++ b/packages/create-astro/src/actions/template.ts
@@ -83,7 +83,6 @@ export function getTemplateTarget(tmpl: string, ref = 'latest') {
 
 export default async function copyTemplate(tmpl: string, ctx: Context) {
 	const templateTarget = getTemplateTarget(tmpl, ctx.ref);
-
 	// Copy
 	if (!ctx.dryRun) {
 		try {
@@ -104,11 +103,26 @@ export default async function copyTemplate(tmpl: string, ctx: Context) {
 				}
 			}
 
-			if (err.message.includes('404')) {
+			if (err.message?.includes('404')) {
 				throw new Error(`Template ${color.reset(tmpl)} ${color.dim('does not exist!')}`);
-			} else {
-				throw new Error(err.message);
 			}
+
+			if (err.message) {
+				error('error', err.message);
+			}
+			try {
+				// The underlying error is often buried deep in the `cause` property
+				// This is in a try/catch block in case of weirdnesses in accessing the `cause` property
+				if ('cause' in err) {
+					// This is probably included in err.message, but we can log it just in case it has extra info
+					error('error', err.cause);
+					if ('cause' in err.cause) {
+						// Hopefully the actual fetch error message
+						error('error', err.cause?.cause);
+					}
+				}
+			} catch {}
+			throw new Error(`Unable to download template ${color.reset(tmpl)}`);
 		}
 
 		// It's possible the repo exists (ex. `withastro/astro`),


### PR DESCRIPTION
## Changes

If create-astro fails when downloading a template, it currently only logs something unhelpful like "fetch error". This leads to reports like #11396, which is probably mutliple different issues. This PR changes it to traverse into `err.cause` to find the underlying error from undici.

Fixes #11396

## Testing

Tested by disabling the network after starting the command, which gave "Error: getaddrinfo ENOTFOUND api.github.com"

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
