### PR TITLE
fix: highlight line with error in the error overlay

### DIFF
--- a/.changeset/old-bats-travel.md
+++ b/.changeset/old-bats-travel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes line with the error not being properly highlighted in the error overlay

--- a/packages/astro/e2e/errors.test.js
+++ b/packages/astro/e2e/errors.test.js
@@ -131,4 +131,12 @@ test.describe('Error display', () => {
 		const message = (await getErrorOverlayContent(page)).message;
 		expect(message).toMatch('The operation was aborted due to timeout');
 	});
+
+	test('properly highlight the line with the error zzz', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/import-not-found'), { waitUntil: 'networkidle' });
+
+		const { codeFrame } = await getErrorOverlayContent(page);
+		const codeFrameContent = await codeFrame.innerHTML();
+		expect(codeFrameContent).toContain('error-line');
+	});
 });

--- a/packages/astro/e2e/errors.test.js
+++ b/packages/astro/e2e/errors.test.js
@@ -132,7 +132,7 @@ test.describe('Error display', () => {
 		expect(message).toMatch('The operation was aborted due to timeout');
 	});
 
-	test('properly highlight the line with the error zzz', async ({ page, astro }) => {
+	test('properly highlight the line with the error', async ({ page, astro }) => {
 		await page.goto(astro.resolveUrl('/import-not-found'), { waitUntil: 'networkidle' });
 
 		const { codeFrame } = await getErrorOverlayContent(page);

--- a/packages/astro/e2e/test-utils.js
+++ b/packages/astro/e2e/test-utils.js
@@ -51,8 +51,8 @@ export function testFactory(inlineConfig) {
 
 /**
  *
- * @param {string} page
- * @returns {Promise<{message: string, hint: string, absoluteFileLocation: string, fileLocation: string}>}
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<{message: string, hint: string, absoluteFileLocation: string, fileLocation: string, codeFrame: import('@playwright/test').ElementHandle}>}
  */
 export async function getErrorOverlayContent(page) {
 	const overlay = await page.waitForSelector('vite-error-overlay', {
@@ -68,7 +68,10 @@ export async function getErrorOverlayContent(page) {
 		m[0].title,
 		m[0].textContent,
 	]);
-	return { message, hint, absoluteFileLocation, fileLocation };
+
+	const codeFrame = await overlay.$('#code pre code');
+
+	return { message, hint, absoluteFileLocation, fileLocation, codeFrame };
 }
 
 /**


### PR DESCRIPTION
## Changes

Shiki 1.0 removed the `lineOptions` property, so our line highlighting stopped working. For some reason, this didn't cause a type error.

## Testing

Added a test

## Docs

N/A
