### PR TITLE
Add Zod as an optional peer dependency of Astro

### DIFF
--- a/.changeset/warm-carrots-remember.md
+++ b/.changeset/warm-carrots-remember.md
@@ -1,5 +1,5 @@
 ---
-'astro': major
+'astro': minor
 ---
 
 Adds Zod as an optional peer dependency of Astro. This reduces the risk of incompatibility between manual `zod` installations and Astro's features that rely on Zod. Namely, Content Collections and Actions.

--- a/.changeset/warm-carrots-remember.md
+++ b/.changeset/warm-carrots-remember.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+Adds Zod as an optional peer dependency of Astro. This reduces the risk of incompatibility betweena manual `zod` installation and Astro's features that rely on Zod. Namely, Content Collections and Actions.

--- a/.changeset/warm-carrots-remember.md
+++ b/.changeset/warm-carrots-remember.md
@@ -2,4 +2,4 @@
 'astro': major
 ---
 
-Adds Zod as an optional peer dependency of Astro. This reduces the risk of incompatibility betweena manual `zod` installation and Astro's features that rely on Zod. Namely, Content Collections and Actions.
+Adds Zod as an optional peer dependency of Astro. This reduces the risk of incompatibility between manual `zod` installations and Astro's features that rely on Zod. Namely, Content Collections and Actions.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -191,6 +191,14 @@
   "optionalDependencies": {
     "sharp": "^0.33.3"
   },
+  "peerDependencies": {
+    "zod": "^3.23.8"
+  },
+  "peerDependenciesMeta": {
+    "zod": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@astrojs/check": "^0.8.2",
     "@playwright/test": "^1.45.2",


### PR DESCRIPTION
## Changes

We've found a number of users reach for a manual installation of Zod in their Astro project. This may be to consolidate content validators in a separate package, or to reach for zod-compatable libraries like `react-hook-form`.

Adding `zod` as an optional peer dependency should ensure the user's version of zod is _at least as_ recent as the version Astro uses internally. This lowers the risk of incompatibility between user code and Astro code that relies on Zod, like Content Collections or Actions.

Note: Since we use the carat `^` on our peer dependency, the user may still install a _more_ recent version of Zod than Astro uses internally. This can cause compatibility issues. The only solution to this problem is making `zod` a _required_ peer dependency of Astro. Given this would be required for every Astro project, it feels a step too far.

## Testing

Manually tested installation with and without the optional peer dependency. Adding the peer dependency adds one point of security: a warning message when the user's installation of `zod` is an older version than what Astro expects.

## Docs

N/A