### PR TITLE
Verify you can use server:defer on self-imported module

### DIFF
--- a/packages/astro/e2e/fixtures/server-islands/src/components/Self.astro
+++ b/packages/astro/e2e/fixtures/server-islands/src/components/Self.astro
@@ -1,0 +1,8 @@
+---
+import Self from './Self.astro';
+
+const now = Date();
+---
+
+<p class="now">{now}</p>
+{!Astro.props.stop && <Self stop server:defer />}

--- a/packages/astro/e2e/fixtures/server-islands/src/pages/index.astro
+++ b/packages/astro/e2e/fixtures/server-islands/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Island from '../components/Island.astro';
+import Self from '../components/Self.astro';
 ---
 
 <html>
@@ -10,5 +11,6 @@ import Island from '../components/Island.astro';
 		<Island server:defer>
 			<h3 id="children">children</h3>
 		</Island>
+		<Self server:defer />
 	</body>
 </html>

--- a/packages/astro/e2e/server-islands.test.js
+++ b/packages/astro/e2e/server-islands.test.js
@@ -37,6 +37,13 @@ test.describe('Server islands', () => {
 
 			await expect(el, 'element rendered').toBeVisible();
 		});
+
+		test('Self imported module can server defer', async ({ page, astro }) => {
+			await page.goto(astro.resolveUrl('/base/'));
+			let el = page.locator('.now');
+
+			await expect(el).toHaveCount(2);
+		});
 	});
 
 	test.describe('Production', () => {


### PR DESCRIPTION
## Changes

- No code changes, this already works, just adding a test.

## Testing

- Imports self, sets server:defer, verifies it adds itself once.

## Docs

N/A