### PR TITLE
Update errors-data.ts for Astro.rewrite release in 4.13

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1280,7 +1280,7 @@ export const ServerOnlyModule = {
  *
  * @see
  * - [Request.clone()](https://developer.mozilla.org/en-US/docs/Web/API/Request/clone)
- * - [Astro.rewrite](https://docs.astro.build/en/reference/configuration-reference/#experimentalrewriting)
+ * - [Astro.rewrite](https://docs.astro.build/en/reference/api-reference/#astrorewrite)
  */
 
 export const RewriteWithBodyUsed = {

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1143,21 +1143,6 @@ export const MissingMiddlewareForInternationalization = {
 /**
  * @docs
  * @description
- * The user tried to rewrite using a route that doesn't exist, or it emitted a runtime error during its rendering phase.
- */
-export const RewriteEncounteredAnError = {
-	name: 'RewriteEncounteredAnError',
-	title:
-		"Astro couldn't find the route to rewrite, or if was found but it emitted an error during the rendering phase.",
-	message: (route: string, stack?: string) =>
-		`The route ${route} that you tried to render doesn't exist, or it emitted an error during the rendering phase. ${
-			stack ? stack : ''
-		}.`,
-} satisfies ErrorData;
-
-/**
- * @docs
- * @description
  * Astro could not find an associated file with content while trying to render the route. This is an Astro error and not a user error. If restarting the dev server does not fix the problem, please file an issue.
  */
 export const CantRenderPage = {

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1141,6 +1141,22 @@ export const MissingMiddlewareForInternationalization = {
 } satisfies ErrorData;
 
 /**
+ * @deprecated
+ * @docs
+ * @description
+ * The user tried to rewrite using a route that doesn't exist, or it emitted a runtime error during its rendering phase.
+ */
+export const RewriteEncounteredAnError = {
+	name: 'RewriteEncounteredAnError',
+	title:
+		"Astro couldn't find the route to rewrite, or if was found but it emitted an error during the rendering phase.",
+	message: (route: string, stack?: string) =>
+		`The route ${route} that you tried to render doesn't exist, or it emitted an error during the rendering phase. ${
+			stack ? stack : ''
+		}.`,
+} satisfies ErrorData;
+
+/**
  * @docs
  * @description
  * Astro could not find an associated file with content while trying to render the route. This is an Astro error and not a user error. If restarting the dev server does not fix the problem, please file an issue.


### PR DESCRIPTION
## Changes

This updates a link in an error message to point to the new docs for `Astro.rewrite()`, as part of 4.13 docs.

## Testing

no tests!

## Docs

all docs!
