### PR TITLE
Support --force flag in sync and dev

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2351,6 +2351,10 @@ export interface AstroInlineOnlyConfig {
 	 */
 	logLevel?: LoggerLevel;
 	/**
+	 * Clear the content layer cache, forcing a rebuild of all content entries.
+	 */
+	force?: boolean;
+	/**
 	 * @internal for testing only, use `logLevel` instead.
 	 */
 	logger?: Logger;

--- a/packages/astro/src/cli/build/index.ts
+++ b/packages/astro/src/cli/build/index.ts
@@ -29,5 +29,5 @@ export async function build({ flags }: BuildOptions) {
 
 	const inlineConfig = flagsToAstroInlineConfig(flags);
 
-	await _build(inlineConfig, { force: flags.force ?? false });
+	await _build(inlineConfig);
 }

--- a/packages/astro/src/cli/dev/index.ts
+++ b/packages/astro/src/cli/dev/index.ts
@@ -19,6 +19,7 @@ export async function dev({ flags }: DevOptions) {
 					['--host', `Listen on all addresses, including LAN and public addresses.`],
 					['--host <custom-address>', `Expose on a network IP address at <custom-address>`],
 					['--open', 'Automatically open the app in the browser on server start'],
+					['--force', 'Clear the content layer cache, forcing a full rebuild.'],
 					['--help (-h)', 'See all available flags.'],
 				],
 			},

--- a/packages/astro/src/cli/flags.ts
+++ b/packages/astro/src/cli/flags.ts
@@ -9,6 +9,7 @@ export function flagsToAstroInlineConfig(flags: Flags): AstroInlineConfig {
 		configFile: typeof flags.config === 'string' ? flags.config : undefined,
 		mode: typeof flags.mode === 'string' ? (flags.mode as AstroInlineConfig['mode']) : undefined,
 		logLevel: flags.verbose ? 'debug' : flags.silent ? 'silent' : undefined,
+		force: flags.force ? true : undefined,
 
 		// Astro user configs
 		root: typeof flags.root === 'string' ? flags.root : undefined,

--- a/packages/astro/src/cli/sync/index.ts
+++ b/packages/astro/src/cli/sync/index.ts
@@ -13,7 +13,10 @@ export async function sync({ flags }: SyncOptions) {
 			commandName: 'astro sync',
 			usage: '[...flags]',
 			tables: {
-				Flags: [['--help (-h)', 'See all available flags.']],
+				Flags: [
+					['--force', 'Clear the content layer cache, forcing a full rebuild.'],
+					['--help (-h)', 'See all available flags.'],
+				],
 			},
 			description: `Generates TypeScript types for all Astro modules.`,
 		});
@@ -21,7 +24,10 @@ export async function sync({ flags }: SyncOptions) {
 	}
 
 	try {
-		await _sync({ inlineConfig: flagsToAstroInlineConfig(flags), telemetry: true });
+		await _sync({
+			inlineConfig: flagsToAstroInlineConfig(flags),
+			telemetry: true,
+		});
 		return 0;
 	} catch (_) {
 		return 1;

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -11,7 +11,6 @@ import type {
 	RuntimeMode,
 } from '../../@types/astro.js';
 import { injectImageEndpoint } from '../../assets/endpoint/config.js';
-import { DATA_STORE_FILE } from '../../content/consts.js';
 import { telemetry } from '../../events/index.js';
 import { eventCliSession } from '../../events/session.js';
 import {

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -97,6 +97,7 @@ export async function createContainer({
 		skip: {
 			content: true,
 		},
+		force: inlineConfig?.force,
 	});
 
 	const viteServer = await vite.createServer(viteConfig);

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -148,7 +148,7 @@ describe('Content Layer', () => {
 		it('clears the store on new build with force flag', async () => {
 			let newJson = devalue.parse(await fixture.readFile('/collections.json'));
 			assert.equal(newJson.increment.data.lastValue, 2);
-			await fixture.build({}, { force: true });
+			await fixture.build({ force: true }, {});
 			newJson = devalue.parse(await fixture.readFile('/collections.json'));
 			assert.equal(newJson.increment.data.lastValue, 1);
 		});


### PR DESCRIPTION
## Changes

Adds support for the `--force` flag to `dev` and `sync`. It was already supported in `build`. 

Fixes PLT-2369

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
