### PR TITLE
fix: clear content layer cache if config has changed

### DIFF
--- a/packages/astro/src/content/data-store.ts
+++ b/packages/astro/src/content/data-store.ts
@@ -75,6 +75,11 @@ export class DataStore {
 		this.#saveToDiskDebounced();
 	}
 
+	clearAll() {
+		this.#collections.clear();
+		this.#saveToDiskDebounced();
+	}
+
 	has(collectionName: string, key: string) {
 		const collection = this.#collections.get(collectionName);
 		if (collection) {
@@ -227,8 +232,10 @@ export default new Map([${exports.join(', ')}]);
 				this.addAssetImports(assets, fileName),
 		};
 	}
-
-	metaStore(collectionName: string): MetaStore {
+	/**
+	 * Returns a MetaStore for a given collection, or if no collection is provided, the default meta collection.
+	 */
+	metaStore(collectionName = ':meta'): MetaStore {
 		const collectionKey = `meta:${collectionName}`;
 		return {
 			get: (key: string) => this.get(collectionKey, key),

--- a/packages/astro/src/content/sync.ts
+++ b/packages/astro/src/content/sync.ts
@@ -38,6 +38,15 @@ export async function syncContentLayer({
 		logger.debug('Content config not loaded, skipping sync');
 		return;
 	}
+
+	const previousConfigDigest = await store.metaStore().get('config-digest');
+	const { digest: currentConfigDigest } = contentConfig.config;
+	if (currentConfigDigest && previousConfigDigest !== currentConfigDigest) {
+		logger.info('Content config changed, clearing cache');
+		store.clearAll();
+		await store.metaStore().set('config-digest', currentConfigDigest);
+	}
+
 	// xxhash is a very fast non-cryptographic hash function that is used to generate a content digest
 	// It uses wasm, so we need to load it asynchronously.
 	const { h64ToString } = await xxhash();

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -5,6 +5,7 @@ import { slug as githubSlug } from 'github-slugger';
 import matter from 'gray-matter';
 import type { PluginContext } from 'rollup';
 import { type ViteDevServer, normalizePath } from 'vite';
+import xxhash from 'xxhash-wasm';
 import { z } from 'zod';
 import type {
 	AstroConfig,
@@ -22,7 +23,6 @@ import {
 	PROPAGATED_ASSET_FLAG,
 } from './consts.js';
 import { createImage } from './runtime-assets.js';
-import xxhash from 'xxhash-wasm';
 /**
  * Amap from a collection + slug to the local file path.
  * This is used internally to resolve entry imports when using `getEntry()`.

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -156,8 +156,12 @@ export const _internal = {
 						const entryType = getEntryType(entry, contentPaths, contentEntryExts, dataEntryExts);
 						if (!COLLECTION_TYPES_TO_INVALIDATE_ON.includes(entryType)) return;
 
+						// The content config could depend on collection entries via `reference()`.
 						// Reload the config in case of changes.
-						await reloadContentConfigObserver({ fs, settings, viteServer });
+						// Changes to the config file itself are handled in types-generator.ts, so we skip them here
+						if (entryType === 'content' || entryType === 'data') {
+							await reloadContentConfigObserver({ fs, settings, viteServer });
+						}
 
 						// Invalidate all content imports and `render()` modules.
 						// TODO: trace `reference()` calls for fine-grained invalidation.

--- a/packages/astro/src/content/vite-plugin-content-imports.ts
+++ b/packages/astro/src/content/vite-plugin-content-imports.ts
@@ -156,11 +156,8 @@ export const _internal = {
 						const entryType = getEntryType(entry, contentPaths, contentEntryExts, dataEntryExts);
 						if (!COLLECTION_TYPES_TO_INVALIDATE_ON.includes(entryType)) return;
 
-						// The content config could depend on collection entries via `reference()`.
 						// Reload the config in case of changes.
-						if (entryType === 'content' || entryType === 'data') {
-							await reloadContentConfigObserver({ fs, settings, viteServer });
-						}
+						await reloadContentConfigObserver({ fs, settings, viteServer });
 
 						// Invalidate all content imports and `render()` modules.
 						// TODO: trace `reference()` calls for fine-grained invalidation.

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -28,12 +28,12 @@ import { levels, timerMessage } from '../logger/core.js';
 import { apply as applyPolyfill } from '../polyfill.js';
 import { createRouteManifest } from '../routing/index.js';
 import { getServerIslandRouteData } from '../server-islands/endpoint.js';
+import { clearContentLayerCache } from '../sync/index.js';
 import { ensureProcessNodeEnv, isServerLikeOutput } from '../util.js';
 import { collectPagesData } from './page-data.js';
 import { staticBuild, viteBuild } from './static-build.js';
 import type { StaticBuildOptions } from './types.js';
 import { getTimeStat } from './util.js';
-import { clearContentLayerCache } from '../sync/index.js';
 export interface BuildOptions {
 	/**
 	 * Teardown the compiler WASM instance after build. This can improve performance when
@@ -43,7 +43,6 @@ export interface BuildOptions {
 	 * @default true
 	 */
 	teardownCompiler?: boolean;
-
 }
 
 /**

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -73,7 +73,11 @@ export default async function sync({
 /**
  * Clears the content layer and content collection cache, forcing a full rebuild.
  */
-export async function clearContentLayerCache({ astroConfig, logger, fs = fsMod }: { astroConfig: AstroConfig; logger: Logger, fs?: typeof fsMod }) {
+export async function clearContentLayerCache({
+	astroConfig,
+	logger,
+	fs = fsMod,
+}: { astroConfig: AstroConfig; logger: Logger; fs?: typeof fsMod }) {
 	const dataStore = new URL(DATA_STORE_FILE, astroConfig.cacheDir);
 	if (fs.existsSync(dataStore)) {
 		logger.debug('content', 'clearing data store');
@@ -93,9 +97,8 @@ export async function syncInternal({
 	fs = fsMod,
 	settings,
 	skip,
-	force
+	force,
 }: SyncOptions): Promise<void> {
-
 	if (force) {
 		await clearContentLayerCache({ astroConfig: settings.config, logger, fs });
 	}

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -152,6 +152,17 @@ describe('Content Layer', () => {
 			newJson = devalue.parse(await fixture.readFile('/collections.json'));
 			assert.equal(newJson.increment.data.lastValue, 1);
 		});
+
+		it('clears the store on new build if the config has changed', async () => {
+			let newJson = devalue.parse(await fixture.readFile('/collections.json'));
+			assert.equal(newJson.increment.data.lastValue, 1);
+			await fixture.editFile('src/content/config.ts', (prev) => {
+				return `${prev}\nexport const foo = 'bar';`;
+			});
+			await fixture.build();
+			newJson = devalue.parse(await fixture.readFile('/collections.json'));
+			assert.equal(newJson.increment.data.lastValue, 1);
+		});
 	});
 
 	describe('Dev', () => {

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -278,7 +278,7 @@ export async function loadFixture(inlineConfig) {
 				typeof newContentsOrCallback === 'function'
 					? newContentsOrCallback(contents)
 					: newContentsOrCallback;
-			const nextChange = onNextChange();
+			const nextChange = devServer ? onNextChange() : Promise.resolve();
 			await fs.promises.writeFile(fileUrl, newContents);
 			await nextChange;
 			return reset;


### PR DESCRIPTION
## Changes

- calculates a digest of the content config file and adds it to the config object
- when the data store is instantiated, checks if the value has changed, and if it has then it clears the data store
- stores the new digest value in the meta store

Fixes PLT-2372
Fixes PLT-2374

## Testing

Added a test

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
