### PR TITLE
Remove unused code

### DIFF
--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -166,7 +166,7 @@ class AstroBuilder {
 		}
 		this.logger.info('build', 'Collecting build info...');
 		this.timer.loadStart = performance.now();
-		const { assets, allPages } = await collectPagesData({
+		const { assets, allPages } = collectPagesData({
 			settings: this.settings,
 			logger: this.logger,
 			manifest: this.manifest,

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -33,19 +33,9 @@ export interface BuildInternals {
 	entrySpecifierToBundleMap: Map<string, string>;
 
 	/**
-	 * A map to get a specific page's bundled output file.
-	 */
-	pageToBundleMap: Map<string, string>;
-
-	/**
 	 * A map for page-specific information.
 	 */
 	pagesByKeys: Map<string, PageBuildData>;
-
-	/**
-	 * A map for page-specific output.
-	 */
-	pageOptionsByPage: Map<string, PageOptions>;
 
 	/**
 	 * A map for page-specific information by Vite ID (a path-like string)
@@ -110,7 +100,6 @@ export interface BuildInternals {
 	manifestEntryChunk?: Rollup.OutputChunk;
 	manifestFileName?: string;
 	entryPoints: Map<RouteData, URL>;
-	ssrSplitEntryChunks: Map<string, Rollup.OutputChunk>;
 	componentMetadata: SSRResult['componentMetadata'];
 	middlewareEntryPoint?: URL;
 
@@ -138,9 +127,7 @@ export function createBuildInternals(): BuildInternals {
 		hoistedScriptIdToPagesMap,
 		inlinedScripts: new Map(),
 		entrySpecifierToBundleMap: new Map<string, string>(),
-		pageToBundleMap: new Map<string, string>(),
 		pagesByKeys: new Map(),
-		pageOptionsByPage: new Map(),
 		pagesByViteID: new Map(),
 		pagesByClientOnly: new Map(),
 		pagesByScriptId: new Map(),
@@ -153,7 +140,6 @@ export function createBuildInternals(): BuildInternals {
 		discoveredScripts: new Set(),
 		staticFiles: new Set(),
 		componentMetadata: new Map(),
-		ssrSplitEntryChunks: new Map(),
 		entryPoints: new Map(),
 		cacheManifestUsed: false,
 		prerenderOnlyChunks: [],

--- a/packages/astro/src/core/build/internal.ts
+++ b/packages/astro/src/core/build/internal.ts
@@ -1,6 +1,5 @@
 import type { Rollup } from 'vite';
 import type { RouteData, SSRResult } from '../../@types/astro.js';
-import type { PageOptions } from '../../vite-plugin-astro/types.js';
 import { prependForwardSlash, removeFileExtension } from '../path.js';
 import { viteID } from '../util.js';
 import { makePageDataKey } from './plugins/util.js';

--- a/packages/astro/src/core/build/page-data.ts
+++ b/packages/astro/src/core/build/page-data.ts
@@ -18,18 +18,11 @@ export interface CollectPagesDataResult {
 }
 
 // Examines the routes and returns a collection of information about each page.
-export async function collectPagesData(
-	opts: CollectPagesDataOptions
-): Promise<CollectPagesDataResult> {
+export function collectPagesData(opts: CollectPagesDataOptions): CollectPagesDataResult {
 	const { settings, manifest } = opts;
 
 	const assets: Record<string, string> = {};
 	const allPages: AllPagesData = {};
-	const builtPaths = new Set<string>();
-	const dataCollectionLogTimeout = setInterval(() => {
-		opts.logger.info('build', 'The data collection step may take longer for larger projects...');
-		clearInterval(dataCollectionLogTimeout);
-	}, 30000);
 
 	// Collect all routes ahead-of-time, before we start the build.
 	// NOTE: This enforces that `getStaticPaths()` is only called once per route,
@@ -40,16 +33,6 @@ export async function collectPagesData(
 		const key = makePageDataKey(route.route, route.component);
 		// static route:
 		if (route.pathname) {
-			const routeCollectionLogTimeout = setInterval(() => {
-				opts.logger.info(
-					'build',
-					`${colors.bold(
-						route.component
-					)} is taking a bit longer to import. This is common for larger "Astro.glob(...)" or "import.meta.glob(...)" calls, for instance. Hang tight!`
-				);
-				clearInterval(routeCollectionLogTimeout);
-			}, 10000);
-			builtPaths.add(route.pathname);
 			allPages[key] = {
 				key: key,
 				component: route.component,
@@ -59,7 +42,6 @@ export async function collectPagesData(
 				hoistedScript: undefined,
 			};
 
-			clearInterval(routeCollectionLogTimeout);
 			if (settings.config.output === 'static') {
 				const html = `${route.pathname}`.replace(/\/?$/, '/index.html');
 				debug(
@@ -82,6 +64,5 @@ export async function collectPagesData(
 		};
 	}
 
-	clearInterval(dataCollectionLogTimeout);
 	return { assets, allPages };
 }

--- a/packages/astro/src/core/build/plugins/plugin-analyzer.ts
+++ b/packages/astro/src/core/build/plugins/plugin-analyzer.ts
@@ -133,11 +133,6 @@ export function vitePluginAnalyzer(
 
 				const astro = info.meta.astro as AstroPluginMetadata['astro'];
 
-				const pageData = getPageDataByViteID(internals, id);
-				if (pageData) {
-					internals.pageOptionsByPage.set(id, astro.pageOptions);
-				}
-
 				for (const c of astro.hydratedComponents) {
 					const rid = c.resolvedPath ? decodeURI(c.resolvedPath) : c.specifier;
 					if (internals.discoveredHydratedComponents.has(rid)) {

--- a/packages/astro/src/core/build/plugins/plugin-internals.ts
+++ b/packages/astro/src/core/build/plugins/plugin-internals.ts
@@ -46,13 +46,6 @@ export function vitePluginInternals(input: Set<string>, internals: BuildInternal
 					for (const specifier of specifiers) {
 						internals.entrySpecifierToBundleMap.set(normalizeEntryId(specifier), chunk.fileName);
 					}
-				} else if (chunk.type === 'chunk') {
-					for (const id of Object.keys(chunk.modules)) {
-						const pageData = internals.pagesByViteID.get(id);
-						if (pageData) {
-							internals.pageToBundleMap.set(pageData.moduleSpecifier, chunk.fileName);
-						}
-					}
 				}
 			}
 		},

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -207,7 +207,6 @@ function vitePluginSSRSplit(
 				}
 				for (const moduleKey of Object.keys(chunk.modules)) {
 					if (moduleKey.startsWith(RESOLVED_SPLIT_MODULE_ID)) {
-						internals.ssrSplitEntryChunks.set(moduleKey, chunk);
 						storeEntryPoint(moduleKey, options, internals, chunk.fileName);
 					}
 				}


### PR DESCRIPTION
## Changes

While working on the prerender refactor, I found some code that weren't used and can be removed. Some state were called with `.set()` but never again with `.get()`.

## Testing

Existing tests should pass.

## Docs

n/a. internal change.
