### PR TITLE
chore: Remove unnecessary CSS in basic example

### DIFF
--- a/examples/basics/src/layouts/Layout.astro
+++ b/examples/basics/src/layouts/Layout.astro
@@ -35,7 +35,6 @@ const { title } = Astro.props;
 	html {
 		font-family: system-ui, sans-serif;
 		background: #13151a;
-		background-size: 224px;
 	}
 	code {
 		font-family:


### PR DESCRIPTION
## Changes

While modifying my landing page I stumble on a `background-size` property on html tag doing nothing. 

Probably author of this [PR](https://github.com/withastro/astro/pull/7760) forgot to remove that line while adding requested changes.

## Testing

<!-- How was this change tested? -->
I toggled that property in browser devtools.

<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
