### PR TITLE
Actions: remove `request.clone()` to fix Bun issue

### DIFF
--- a/.changeset/nervous-mirrors-invite.md
+++ b/.changeset/nervous-mirrors-invite.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes "Unexpected end of JSON input" error when using Actions with the Bun runtime.

--- a/packages/astro/src/actions/runtime/route.ts
+++ b/packages/astro/src/actions/runtime/route.ts
@@ -15,9 +15,9 @@ export const POST: APIRoute = async (context) => {
 	if (contentLength === '0') {
 		args = undefined;
 	} else if (contentType && hasContentType(contentType, formContentTypes)) {
-		args = await request.clone().formData();
+		args = await request.formData();
 	} else if (contentType && hasContentType(contentType, ['application/json'])) {
-		args = await request.clone().json();
+		args = await request.json();
 	} else {
 		// 415: Unsupported media type
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/415


### PR DESCRIPTION
## Changes

- Resolves https://github.com/withastro/astro/issues/11423

This remove an unnecessary `request.clone()` on the Actions route handler. It seems the Bun runtime incorrectly loses the body when calling `.clone()` on a request.

I don't want to open PRs for bundlers we don't _officially_ support. Still, the `request.clone()` was unnecessary and could add additional latency, so it felt safe to remove.

## Testing

Manual testing on a sample app using `bun --bun dev`

## Docs

N/A