### PR TITLE
[error docs] adds section heading for Actions

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1620,6 +1620,12 @@ export const UnsupportedConfigTransformError = {
 
 /**
  * @docs
+ * @kind heading
+ * @name Action Errors
+ */
+// Action Errors
+/**
+ * @docs
  * @see
  * - [On-demand rendering](https://docs.astro.build/en/basics/rendering-modes/#on-demand-rendered)
  * @description


### PR DESCRIPTION
## Changes

Adds a new heading in `errors-data.ts` so that Action errors don't show up under Content Collection errors on the Docs Error reference index page.

Note: We'll probably add more headings/organization in the future so that "Astro Errors" isn't a dumping ground, but this clears up an actual problem with errors being in the wrong section!

## Testing

No tests, only docs

## Docs

Only updates the docs site!
