### PR TITLE
Actions: auto-redirect action response to avoid "confirm form resubmission" dialog

### DIFF
--- a/.changeset/rotten-months-report.md
+++ b/.changeset/rotten-months-report.md
@@ -9,7 +9,6 @@ Improves user experience when render an Action result from a form POST request:
 
 Also improves the DX of directing to a new route on success. Actions will now redirect to the route specified in your `action` string on success, and redirect back to the previous page on error.
 
-
 For example, say you want to redirect to a `/success` route when `actions.signup` succeeds. You can add `/success` to your `action` string like so:
 
 ```astro

--- a/.changeset/rotten-months-report.md
+++ b/.changeset/rotten-months-report.md
@@ -7,7 +7,7 @@ Improves user experience when render an Action result from a form POST request:
 - Removes "Confirm post resubmission?" dialog when refreshing a result.
 - Removes the `?_astroAction=NAME` flag when a result is rendered.
 
-Also improves the DX of directing to a new route on success. Actions will now redirect to the route specified in your `action` string on success, and redirect back to the previous page on error.
+Also improves the DX of directing to a new route on success. Actions will now redirect to the route specified in your `action` string on success, and redirect back to the previous page on error. This follows the routing convention of established backend frameworks like Laravel.
 
 For example, say you want to redirect to a `/success` route when `actions.signup` succeeds. You can add `/success` to your `action` string like so:
 

--- a/.changeset/rotten-months-report.md
+++ b/.changeset/rotten-months-report.md
@@ -1,0 +1,28 @@
+---
+'astro': patch
+---
+
+Improves user experience when render an Action result from a form POST request:
+
+- Removes "Confirm post resubmission?" dialog when refreshing a result.
+- Removes the `?_astroAction=NAME` flag when a result is rendered.
+
+Also improves the DX of directing to a new route on success. Actions will now redirect to the route specified in your `action` string on success, and redirect back to the previous page on error.
+
+
+For example, say you want to redirect to a `/success` route when `actions.signup` succeeds. You can add `/success` to your `action` string like so:
+
+```astro
+<form method="POST" action={"/success" + actions.signup}>
+```
+
+- On success, Astro will redirect to `/success`. 
+- On error, Astro will redirect back to the current page.
+
+You can retrieve the action result from either page using the `Astro.getActionResult()` function.
+
+### Note on security
+
+This uses a temporary cookie to forward the action result to the next page. The cookie will be deleted when that page is rendered.
+
+⚠ **The action result is not encrypted.** In general, we recommend returning minimal data from an action handler to a) avoid leaking sensitive information, and b) avoid unexpected render issues once the temporary cookie is deleted. For example, a `login` function may return a user's session id to retrieve from your Astro frontmatter, rather than the entire user object.

--- a/packages/astro/src/actions/consts.ts
+++ b/packages/astro/src/actions/consts.ts
@@ -8,4 +8,5 @@ export const NOOP_ACTIONS = '\0noop-actions';
 export const ACTION_QUERY_PARAMS = {
 	actionName: '_astroAction',
 	actionPayload: '_astroActionPayload',
+	actionRedirect: '_astroActionRedirect',
 };

--- a/packages/astro/src/actions/consts.ts
+++ b/packages/astro/src/actions/consts.ts
@@ -4,3 +4,8 @@ export const ACTIONS_TYPES_FILE = 'actions.d.ts';
 export const VIRTUAL_INTERNAL_MODULE_ID = 'astro:internal-actions';
 export const RESOLVED_VIRTUAL_INTERNAL_MODULE_ID = '\0astro:internal-actions';
 export const NOOP_ACTIONS = '\0noop-actions';
+
+export const ACTION_QUERY_PARAMS = {
+	actionName: '_astroAction',
+	actionPayload: '_astroActionPayload',
+};

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -114,17 +114,15 @@ async function handlePost({
 		});
 	}
 
-	return redirectWithResult({ context, next, actionName, actionResult });
+	return redirectWithResult({ context, actionName, actionResult });
 }
 
 async function redirectWithResult({
 	context,
-	next,
 	actionName,
 	actionResult,
 }: {
 	context: APIContext;
-	next: MiddlewareNext;
 	actionName: string;
 	actionResult: SafeResult<any, any>;
 }) {
@@ -136,7 +134,9 @@ async function redirectWithResult({
 
 	if (actionResult.error) {
 		const referer = context.request.headers.get('Referer');
-		if (!referer) return next();
+		if (!referer) {
+			throw new Error('Internal: Referer unexpectedly missing from Action POST request.');
+		}
 
 		return context.redirect(referer);
 	}
@@ -173,5 +173,5 @@ async function handlePostLegacy({ context, next }: { context: APIContext; next: 
 
 	const action = baseAction.bind(context);
 	const actionResult = await action(formData);
-	return redirectWithResult({ context, next, actionName, actionResult });
+	return redirectWithResult({ context, actionName, actionResult });
 }

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -30,14 +30,6 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	// so short circuit if already defined.
 	if (locals._actionPayload) return next();
 
-	const actionPayload = context.cookies.get(ACTION_QUERY_PARAMS.actionPayload)?.json();
-	if (actionPayload) {
-		if (!isActionPayload(actionPayload)) {
-			throw new Error('Internal: Invalid action payload in cookie.');
-		}
-		return renderResult({ context, next, ...actionPayload });
-	}
-
 	// Heuristic: If body is null, Astro might've reset this for prerendering.
 	if (import.meta.env.DEV && request.method === 'POST' && request.body === null) {
 		// eslint-disable-next-line no-console
@@ -56,6 +48,14 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
 	if (context.request.method === 'POST') {
 		return handlePostLegacy({ context, next });
+	}
+
+	const actionPayload = context.cookies.get(ACTION_QUERY_PARAMS.actionPayload)?.json();
+	if (context.request.method === 'GET' && actionPayload) {
+		if (!isActionPayload(actionPayload)) {
+			throw new Error('Internal: Invalid action payload in cookie.');
+		}
+		return renderResult({ context, next, ...actionPayload });
 	}
 
 	return next();

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -76,13 +76,9 @@ async function renderResult({
 
 	locals._actionPayload = { actionResult, actionName };
 	const response = await next();
+	context.cookies.delete(ACTION_QUERY_PARAMS.actionPayload);
 
 	if (actionResult.type === 'error') {
-		// Clear the cookie after rendering the error state.
-		// Otherwise, errors will reappear when revisiting a stale form.
-		// This is based on Laravel's implementation.
-		context.cookies.delete(ACTION_QUERY_PARAMS.actionPayload);
-
 		return new Response(response.body, {
 			status: actionResult.status,
 			statusText: actionResult.type,

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -111,7 +111,7 @@ async function handlePost({
 	const action = baseAction.bind(context);
 	const actionResult = await action(formData);
 
-	if (context.url.searchParams.has('_astroActionDisableRedirect')) {
+	if (context.url.searchParams.get(ACTION_QUERY_PARAMS.actionRedirect) === 'false') {
 		return renderResult({
 			context,
 			next,

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -78,10 +78,10 @@ async function renderResult({
 	const response = await next();
 	context.cookies.delete(ACTION_QUERY_PARAMS.actionPayload);
 
-	if (locals._actionPayload.actionResult.type === 'error') {
+	if (actionResult.type === 'error') {
 		return new Response(response.body, {
-			status: locals._actionPayload.actionResult.status,
-			statusText: locals._actionPayload.actionResult.type,
+			status: actionResult.status,
+			statusText: actionResult.type,
 			headers: response.headers,
 		});
 	}

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -10,7 +10,6 @@ import {
 	type SerializedActionResult,
 	serializeActionResult,
 } from './virtual/shared.js';
-import type { AstroCookie } from '../../core/cookies/cookies.js';
 
 export type Locals = {
 	_actionsInternal: {
@@ -30,7 +29,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
 	const actionResultCookie = context.cookies.get('_actionResult');
 	if (actionResultCookie) {
-		return renderResult({ context, next, actionResultCookie });
+		return renderResult({ context, next, ...actionResultCookie.json() });
 	}
 
 	// Heuristic: If body is null, Astro might've reset this for prerendering.
@@ -59,11 +58,17 @@ export const onRequest = defineMiddleware(async (context, next) => {
 async function renderResult({
 	context,
 	next,
-	actionResultCookie,
-}: { context: APIContext; next: MiddlewareNext; actionResultCookie: AstroCookie }) {
+	actionResult,
+	actionName,
+}: {
+	context: APIContext;
+	next: MiddlewareNext;
+	actionResult: SerializedActionResult;
+	actionName: string;
+}) {
 	const locals = context.locals as Locals;
 
-	locals._actionsInternal = actionResultCookie.json();
+	locals._actionsInternal = { actionResult, actionName };
 	const response = await next();
 	context.cookies.delete('_actionResult');
 
@@ -99,6 +104,15 @@ async function handlePost({
 	}
 	const action = baseAction.bind(context);
 	const actionResult = await action(formData);
+
+	if (context.url.searchParams.get('_actionResultBehavior') === 'none') {
+		return renderResult({
+			context,
+			next,
+			actionName,
+			actionResult: serializeActionResult(actionResult),
+		});
+	}
 
 	return redirectWithResult({ context, next, actionName, actionResult });
 }

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -126,7 +126,6 @@ async function redirectWithResult({
 	actionName: string;
 	actionResult: SafeResult<any, any>;
 }) {
-	// TODO: encrypt the action result
 	context.cookies.set('_actionResult', {
 		actionName,
 		actionResult: serializeActionResult(actionResult),

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -30,6 +30,14 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	// so short circuit if already defined.
 	if (locals._actionPayload) return next();
 
+	const actionPayload = context.cookies.get(ACTION_QUERY_PARAMS.actionPayload)?.json();
+	if (actionPayload) {
+		if (!isActionPayload(actionPayload)) {
+			throw new Error('Internal: Invalid action payload in cookie.');
+		}
+		return renderResult({ context, next, ...actionPayload });
+	}
+
 	// Heuristic: If body is null, Astro might've reset this for prerendering.
 	if (import.meta.env.DEV && request.method === 'POST' && request.body === null) {
 		// eslint-disable-next-line no-console
@@ -48,14 +56,6 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
 	if (context.request.method === 'POST') {
 		return handlePostLegacy({ context, next });
-	}
-
-	const actionPayload = context.cookies.get(ACTION_QUERY_PARAMS.actionPayload)?.json();
-	if (context.request.method === 'GET' && actionPayload) {
-		if (!isActionPayload(actionPayload)) {
-			throw new Error('Internal: Invalid action payload in cookie.');
-		}
-		return renderResult({ context, next, ...actionPayload });
 	}
 
 	return next();

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -76,9 +76,13 @@ async function renderResult({
 
 	locals._actionPayload = { actionResult, actionName };
 	const response = await next();
-	context.cookies.delete(ACTION_QUERY_PARAMS.actionPayload);
 
 	if (actionResult.type === 'error') {
+		// Clear the cookie after rendering the error state.
+		// Otherwise, errors will reappear when revisiting a stale form.
+		// This is based on Laravel's implementation.
+		context.cookies.delete(ACTION_QUERY_PARAMS.actionPayload);
+
 		return new Response(response.body, {
 			status: actionResult.status,
 			statusText: actionResult.type,

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -48,7 +48,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		return next();
 	}
 
-	const actionName = context.url.searchParams.get('_astroAction');
+	const actionName = context.url.searchParams.get(ACTION_QUERY_PARAMS.actionName);
 
 	if (context.request.method === 'POST' && actionName) {
 		return handlePost({ context, next, actionName });
@@ -165,7 +165,7 @@ async function handlePostLegacy({ context, next }: { context: APIContext; next: 
 
 	if (!formData) return next();
 
-	const actionName = formData.get('_astroAction') as string;
+	const actionName = formData.get(ACTION_QUERY_PARAMS.actionName) as string;
 	if (!actionName) return next();
 
 	const baseAction = await getAction(actionName);

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -105,7 +105,7 @@ async function handlePost({
 	const action = baseAction.bind(context);
 	const actionResult = await action(formData);
 
-	if (context.url.searchParams.get('_actionResultBehavior') === 'none') {
+	if (context.url.searchParams.has('_astroActionDisableRedirect')) {
 		return renderResult({
 			context,
 			next,

--- a/packages/astro/src/actions/runtime/virtual/shared.ts
+++ b/packages/astro/src/actions/runtime/virtual/shared.ts
@@ -1,7 +1,9 @@
 import { parse as devalueParse, stringify as devalueStringify } from 'devalue';
 import type { z } from 'zod';
 import type { ErrorInferenceObject, MaybePromise } from '../utils.js';
-import { ACTION_QUERY_PARAMS } from '../../consts.js';
+import { ACTION_QUERY_PARAMS as _ACTION_QUERY_PARAMS } from '../../consts.js';
+
+export const ACTION_QUERY_PARAMS = _ACTION_QUERY_PARAMS;
 
 export const ACTION_ERROR_CODES = [
 	'BAD_REQUEST',
@@ -167,7 +169,7 @@ export async function callSafely<TOutput>(
 }
 
 export function getActionQueryString(name: string) {
-	const searchParams = new URLSearchParams({ [ACTION_QUERY_PARAMS.actionName]: name });
+	const searchParams = new URLSearchParams({ [_ACTION_QUERY_PARAMS.actionName]: name });
 	return `?${searchParams.toString()}`;
 }
 

--- a/packages/astro/src/actions/runtime/virtual/shared.ts
+++ b/packages/astro/src/actions/runtime/virtual/shared.ts
@@ -1,6 +1,7 @@
 import { parse as devalueParse, stringify as devalueStringify } from 'devalue';
 import type { z } from 'zod';
 import type { ErrorInferenceObject, MaybePromise } from '../utils.js';
+import { ACTION_QUERY_PARAMS } from '../../consts.js';
 
 export const ACTION_ERROR_CODES = [
 	'BAD_REQUEST',
@@ -166,7 +167,7 @@ export async function callSafely<TOutput>(
 }
 
 export function getActionQueryString(name: string) {
-	const searchParams = new URLSearchParams({ _astroAction: name });
+	const searchParams = new URLSearchParams({ [ACTION_QUERY_PARAMS.actionName]: name });
 	return `?${searchParams.toString()}`;
 }
 

--- a/packages/astro/src/actions/utils.ts
+++ b/packages/astro/src/actions/utils.ts
@@ -3,19 +3,19 @@ import type { Locals } from './runtime/middleware.js';
 import { type ActionAPIContext } from './runtime/utils.js';
 import { deserializeActionResult, getActionQueryString } from './runtime/virtual/shared.js';
 
-export function hasActionsInternal(locals: APIContext['locals']): locals is Locals {
-	return '_actionsInternal' in locals;
+export function hasActionPayload(locals: APIContext['locals']): locals is Locals {
+	return '_actionPayload' in locals;
 }
 
 export function createGetActionResult(locals: APIContext['locals']): APIContext['getActionResult'] {
 	return (actionFn): any => {
 		if (
-			!hasActionsInternal(locals) ||
-			actionFn.toString() !== getActionQueryString(locals._actionsInternal.actionName)
+			!hasActionPayload(locals) ||
+			actionFn.toString() !== getActionQueryString(locals._actionPayload.actionName)
 		) {
 			return undefined;
 		}
-		return deserializeActionResult(locals._actionsInternal.actionResult);
+		return deserializeActionResult(locals._actionPayload.actionResult);
 	};
 }
 

--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -35,7 +35,7 @@ const DELETED_EXPIRATION = new Date(0);
 const DELETED_VALUE = 'deleted';
 const responseSentSymbol = Symbol.for('astro.responseSent');
 
-class AstroCookie implements AstroCookieInterface {
+export class AstroCookie implements AstroCookieInterface {
 	constructor(public value: string) {}
 	json() {
 		if (this.value === undefined) {

--- a/packages/astro/src/core/cookies/cookies.ts
+++ b/packages/astro/src/core/cookies/cookies.ts
@@ -35,7 +35,7 @@ const DELETED_EXPIRATION = new Date(0);
 const DELETED_VALUE = 'deleted';
 const responseSentSymbol = Symbol.for('astro.responseSent');
 
-export class AstroCookie implements AstroCookieInterface {
+class AstroCookie implements AstroCookieInterface {
 	constructor(public value: string) {}
 	json() {
 		if (this.value === undefined) {

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -11,7 +11,7 @@ import type {
 } from '../@types/astro.js';
 import type { ActionAPIContext } from '../actions/runtime/utils.js';
 import { deserializeActionResult } from '../actions/runtime/virtual/shared.js';
-import { createCallAction, createGetActionResult, hasActionsInternal } from '../actions/utils.js';
+import { createCallAction, createGetActionResult, hasActionPayload } from '../actions/utils.js';
 import {
 	computeCurrentLocale,
 	computePreferredLocale,
@@ -314,8 +314,8 @@ export class RenderContext {
 			},
 		} satisfies AstroGlobal['response'];
 
-		const actionResult = hasActionsInternal(this.locals)
-			? deserializeActionResult(this.locals._actionsInternal.actionResult)
+		const actionResult = hasActionPayload(this.locals)
+			? deserializeActionResult(this.locals._actionPayload.actionResult)
 			: undefined;
 
 		// Create the result object that will be passed into the renderPage function.

--- a/packages/astro/templates/actions.mjs
+++ b/packages/astro/templates/actions.mjs
@@ -16,13 +16,18 @@ function toActionProxy(actionCallback = {}, aggregatedPath = '') {
 				toString: () => action.queryString,
 				// Progressive enhancement info for React.
 				$$FORM_ACTION: function () {
+					const searchParams = new URLSearchParams(action.toString());
+					// Astro will redirect with a GET request by default.
+					// Disable this behavior to preserve form state
+					// for React's progressive enhancement.
+					searchParams.set('_actionResultBehavior', 'none');
 					return {
 						method: 'POST',
 						// `name` creates a hidden input.
 						// It's unused by Astro, but we can't turn this off.
 						// At least use a name that won't conflict with a user's formData.
 						name: '_astroAction',
-						action: action.toString(),
+						action: '?' + searchParams.toString(),
 					};
 				},
 				// Note: `orThrow` does not have progressive enhancement info.

--- a/packages/astro/templates/actions.mjs
+++ b/packages/astro/templates/actions.mjs
@@ -20,7 +20,7 @@ function toActionProxy(actionCallback = {}, aggregatedPath = '') {
 					// Astro will redirect with a GET request by default.
 					// Disable this behavior to preserve form state
 					// for React's progressive enhancement.
-					searchParams.set('_actionResultBehavior', 'none');
+					searchParams.set('_astroActionDisableRedirect', 'true');
 					return {
 						method: 'POST',
 						// `name` creates a hidden input.

--- a/packages/astro/templates/actions.mjs
+++ b/packages/astro/templates/actions.mjs
@@ -1,4 +1,9 @@
-import { ActionError, deserializeActionResult, getActionQueryString } from 'astro:actions';
+import {
+	ActionError,
+	deserializeActionResult,
+	getActionQueryString,
+	ACTION_QUERY_PARAMS,
+} from 'astro:actions';
 
 function toActionProxy(actionCallback = {}, aggregatedPath = '') {
 	return new Proxy(actionCallback, {
@@ -20,7 +25,7 @@ function toActionProxy(actionCallback = {}, aggregatedPath = '') {
 					// Astro will redirect with a GET request by default.
 					// Disable this behavior to preserve form state
 					// for React's progressive enhancement.
-					searchParams.set('_astroActionDisableRedirect', 'true');
+					searchParams.set(ACTION_QUERY_PARAMS.actionRedirect, 'false');
 					return {
 						method: 'POST',
 						// `name` creates a hidden input.

--- a/packages/astro/test/actions.test.js
+++ b/packages/astro/test/actions.test.js
@@ -200,7 +200,6 @@ describe('Astro Actions', () => {
 			assert.equal(res.status, 401);
 
 			const html = await res.text();
-			console.log({ html });
 			let $ = cheerio.load(html);
 			assert.equal($('#error-message').text(), 'Not logged in');
 			assert.equal($('#error-code').text(), 'UNAUTHORIZED');
@@ -362,7 +361,7 @@ async function followExpectedRedirect(req, app) {
 	const redirect = await app.render(req, { addCookieHeader: true });
 	assert.ok(
 		validRedirectStatuses.has(redirect.status),
-		`Expected redirect status, got ${redirect.status}`
+		`Expected redirect status, got ${redirect.status}`,
 	);
 
 	const redirectUrl = new URL(redirect.headers.get('Location'), req.url);

--- a/packages/astro/test/actions.test.js
+++ b/packages/astro/test/actions.test.js
@@ -180,7 +180,7 @@ describe('Astro Actions', () => {
 					Referer: 'http://example.com/user',
 				},
 			});
-			const res = await followRedirect(req, app);
+			const res = await followExpectedRedirect(req, app);
 			assert.equal(res.ok, true);
 
 			const html = await res.text();
@@ -196,7 +196,7 @@ describe('Astro Actions', () => {
 					Referer: 'http://example.com/user-or-throw',
 				},
 			});
-			const res = await followRedirect(req, app);
+			const res = await followExpectedRedirect(req, app);
 			assert.equal(res.status, 401);
 
 			const html = await res.text();
@@ -229,7 +229,7 @@ describe('Astro Actions', () => {
 						Referer: 'http://example.com/user',
 					},
 				});
-				const res = await followRedirect(req, app);
+				const res = await followExpectedRedirect(req, app);
 				assert.equal(res.ok, true);
 
 				const html = await res.text();
@@ -247,7 +247,7 @@ describe('Astro Actions', () => {
 						Referer: 'http://example.com/user-or-throw',
 					},
 				});
-				const res = await followRedirect(req, app);
+				const res = await followExpectedRedirect(req, app);
 				assert.equal(res.status, 401);
 
 				const html = await res.text();
@@ -358,7 +358,7 @@ const validRedirectStatuses = new Set([301, 302, 303, 304, 307, 308]);
  * @param {*} app
  * @returns {Promise<Response>}
  */
-async function followRedirect(req, app) {
+async function followExpectedRedirect(req, app) {
 	const redirect = await app.render(req, { addCookieHeader: true });
 	assert.ok(
 		validRedirectStatuses.has(redirect.status),

--- a/packages/astro/test/actions.test.js
+++ b/packages/astro/test/actions.test.js
@@ -244,7 +244,7 @@ describe('Astro Actions', () => {
 					method: 'POST',
 					body: formData,
 					headers: {
-						Referer: 'http://example.com/user',
+						Referer: 'http://example.com/user-or-throw',
 					},
 				});
 				const res = await followRedirect(req, app);


### PR DESCRIPTION
## Changes

This change adds automatic redirects when an action is called. This follows Laravel's POST/redirect/GET pattern to avoid a "confirm form resubmission" dialog and remove the `?_astroAction` param from the rendered result.

[See the changeset](https://github.com/withastro/astro/blob/d3ba81a8a6d990dd0411dd18cb60d3383fdec7c9/.changeset/rotten-months-report.md) for usage instructions.

- Persist action data in a cookie. **This cookie is not encrypted.** We are investigating a general encryption strategy for Astro as part of Astro Islands: #11535. If Astro adopts an encryption key as part of the runtime, we will revisit encryption of the action result cookie.
- Redirect to referrer on error, and the `url.pathname` on success.
- If an action cookie is present, populate `getActionResult` with the cookie JSON. Delete after the request has been fulfilled.

## Testing

Update integration tests to follow an expected redirect.

## Docs

Updated RFC docs with new guide: https://github.com/withastro/roadmap/blob/actions/proposals/0046-actions.md#call-actions-from-an-html-form