### PR TITLE
fix: code component was missing support for meta string

### DIFF
--- a/.changeset/odd-buttons-pay.md
+++ b/.changeset/odd-buttons-pay.md
@@ -2,7 +2,7 @@
 "astro": minor
 ---
 
-Adds a new property `meta` to Astro's built-in `<Code />` component.
+Adds a new property `meta` to Astro's [built-in `<Code />` component](https://docs.astro.build/en/reference/api-reference/#code-).
 
 This allows you to provide a value for [Shiki's `meta` attribute](https://shiki.style/guide/transformers#meta) to pass options to transformers.
 

--- a/.changeset/odd-buttons-pay.md
+++ b/.changeset/odd-buttons-pay.md
@@ -1,0 +1,15 @@
+---
+"astro": minor
+---
+
+Adds support for passing a metastring when using the Code component.
+
+The following code is equivalent to doing `` ```js astro=cool `` in Markdown.
+
+```astro
+---
+import { Code } from "astro:components";
+---
+
+<Code code="console.log('Hello, Astro!')" lang={"js"} meta="astro=cool" />
+```

--- a/.changeset/odd-buttons-pay.md
+++ b/.changeset/odd-buttons-pay.md
@@ -2,14 +2,21 @@
 "astro": minor
 ---
 
-Adds support for passing a metastring when using the Code component.
+Adds a new property `meta` to Astro's built-in `<Code />` component.
 
-The following code is equivalent to doing `` ```js astro=cool `` in Markdown.
+This allows you to provide a value for [Shiki's `meta` attribute](https://shiki.style/guide/transformers#meta) to pass options to transformers.
+
+The following example passes an option to highlight lines 1 and 3 to Shiki's `tranformerMetaHighlight`:
 
 ```astro
+// src/pages/index.astro
 ---
 import { Code } from "astro:components";
+import { transformerMetaHighlight } from '@shikijs/transformers';
 ---
-
-<Code code="console.log('Hello, Astro!')" lang={"js"} meta="astro=cool" />
+<Code
+  code={code}
+  lang="js"
+  transformers={[transformerMetaHighlight()]}
+  meta="{1,3}" />
 ```

--- a/.changeset/odd-buttons-pay.md
+++ b/.changeset/odd-buttons-pay.md
@@ -9,8 +9,8 @@ This allows you to provide a value for [Shiki's `meta` attribute](https://shiki.
 The following example passes an option to highlight lines 1 and 3 to Shiki's `tranformerMetaHighlight`:
 
 ```astro
-// src/pages/index.astro
 ---
+// src/components/Card.astro
 import { Code } from "astro:components";
 import { transformerMetaHighlight } from '@shikijs/transformers';
 ---

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -24,6 +24,12 @@ interface Props extends Omit<HTMLAttributes<'pre'>, 'lang'> {
 	 */
 	lang?: BuiltinLanguage | SpecialLanguage | LanguageRegistration;
 	/**
+	 * A metastring to pass to the highlighter.
+	 * 
+	 * @default undefined
+	 */
+	meta?: string;
+	/**
 	 * The styling theme.
 	 * Supports all themes listed here: https://shiki.style/themes
 	 * Instructions for loading a custom theme: https://shiki.style/guide/load-theme
@@ -72,6 +78,7 @@ interface Props extends Omit<HTMLAttributes<'pre'>, 'lang'> {
 const {
 	code,
 	lang = 'plaintext',
+	meta,
 	theme = 'github-dark',
 	themes = {},
 	defaultColor = 'light',
@@ -110,6 +117,7 @@ const highlighter = await getCachedHighlighter({
 
 const html = await highlighter.highlight(code, typeof lang === 'string' ? lang : lang.name, {
 	inline,
+	meta,
 	attributes: rest as any,
 });
 ---

--- a/packages/astro/components/Code.astro
+++ b/packages/astro/components/Code.astro
@@ -25,6 +25,7 @@ interface Props extends Omit<HTMLAttributes<'pre'>, 'lang'> {
 	lang?: BuiltinLanguage | SpecialLanguage | LanguageRegistration;
 	/**
 	 * A metastring to pass to the highlighter.
+	 * Allows passing information to transformers: https://shiki.style/guide/transformers#meta
 	 * 
 	 * @default undefined
 	 */


### PR DESCRIPTION
Fixes withastro/roadmap#990

## Changes

This fixes `Code.astro` so that passing the `meta` option to the shiki highlighter is supported.

## Testing

The change is just a new prop and passing it to Shiki. Tests are implemented in Shiki.

## Docs

The jsdoc is up-to-date.

/cc @withastro/maintainers-docs for feedback!

docs pr: https://github.com/withastro/docs/pull/9054
