### PR TITLE
fix: audit incorrectly flagging images as above the fold (#10891)

### DIFF
--- a/.changeset/shy-bees-look.md
+++ b/.changeset/shy-bees-look.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix toolbar audit incorrectly flagging images as above the fold.

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/perf.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/perf.ts
@@ -36,7 +36,8 @@ export const perf: AuditRuleWithSelector[] = [
 		match(element) {
 			const htmlElement = element as HTMLImageElement | HTMLIFrameElement;
 			// Ignore elements that are above the fold, they should be loaded eagerly
-			if (htmlElement.offsetTop < window.innerHeight) return false;
+			const elementYPosition = htmlElement.getBoundingClientRect().y + window.scrollY 
+			if (elementYPosition < window.innerHeight) return false;
 
 			// Ignore elements using `data:` URI, the `loading` attribute doesn't do anything for these
 			if (htmlElement.src.startsWith('data:')) return false;
@@ -54,7 +55,8 @@ export const perf: AuditRuleWithSelector[] = [
 			const htmlElement = element as HTMLImageElement | HTMLIFrameElement;
 
 			// Ignore elements that are below the fold, they should be loaded lazily
-			if (htmlElement.offsetTop > window.innerHeight) return false;
+			const elementYPosition = htmlElement.getBoundingClientRect().y + window.scrollY 
+			if (elementYPosition > window.innerHeight) return false;
 
 			// Ignore elements using `data:` URI, the `loading` attribute doesn't do anything for these
 			if (htmlElement.src.startsWith('data:')) return false;


### PR DESCRIPTION
## Changes

- Fixes #10891

- Previously used `element.offsetTop` to find the y position of the image, which does not work when the element parent has a position: relative property. 

- Instead, this uses `element.getBoundingClientRect().y` to get the real y position of the image. 

- There's one issue though. `getBoundingClientRect` returns the position relative to the user's viewport, not the absolute position. 

- So, add window.scrollY to the value, and you have the element's absolute position.

## Testing

No new tests were added as this is a trivial fix.

## Docs

No docs needed for this fix.
