### PR TITLE
fix: skip glob files in content dir

### DIFF
--- a/packages/astro/src/content/loaders/glob.ts
+++ b/packages/astro/src/content/loaders/glob.ts
@@ -229,9 +229,9 @@ export function glob(globOptions: GlobOptions): Loader {
 			if (skipCount > 0) {
 				logger.warn(`The glob() loader cannot be used for files in ${bold('src/content')}.`);
 				if (skipCount > 10) {
-					logger.warn(`Skipped ${green(skippedFiles.length)} files.`);
+					logger.warn(`Skipped ${green(skippedFiles.length)} files that matched ${green(globOptions.pattern)}.`);
 				} else {
-					logger.warn(`Skipped:`);
+					logger.warn(`Skipped the following files that matched ${green(globOptions.pattern)}:`);
 					skippedFiles.forEach((file) => logger.warn(`• ${green(file)}`));
 				}
 			}


### PR DESCRIPTION
## Changes

Files in `src/content` are automatically processed by content collections, so the glob loader should not be used for these. This might not be immediately obvious, and it will be tempting to use that folder for data. This PR avoids that by skipping any globbed files in the content dir, and logging a warning.

Fixes PLT-2373

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
