### PR TITLE
Refactor content layer into shared instance

### DIFF
--- a/packages/astro/src/content/loaders/glob.ts
+++ b/packages/astro/src/content/loaders/glob.ts
@@ -229,7 +229,9 @@ export function glob(globOptions: GlobOptions): Loader {
 			if (skipCount > 0) {
 				logger.warn(`The glob() loader cannot be used for files in ${bold('src/content')}.`);
 				if (skipCount > 10) {
-					logger.warn(`Skipped ${green(skippedFiles.length)} files that matched ${green(globOptions.pattern)}.`);
+					logger.warn(
+						`Skipped ${green(skippedFiles.length)} files that matched ${green(globOptions.pattern)}.`
+					);
 				} else {
 					logger.warn(`Skipped the following files that matched ${green(globOptions.pattern)}:`);
 					skippedFiles.forEach((file) => logger.warn(`• ${green(file)}`));

--- a/packages/astro/src/content/sync.ts
+++ b/packages/astro/src/content/sync.ts
@@ -235,6 +235,10 @@ function contentLayerSingleton() {
 			}
 			return instance;
 		},
+		/** @internal */
+		dispose: () => {
+			instance = null;
+		},
 	};
 }
 

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -128,12 +128,10 @@ export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevS
 			logger,
 			watcher: restart.container.viteServer.watcher,
 			store,
-		})
+		});
 		contentLayer.watchContentConfig();
 		await contentLayer.sync();
 	}
-
-
 
 	logger.info(null, green('watching for file changes...'));
 

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -8,7 +8,7 @@ import { getPackage } from '../../cli/install-package.js';
 import { DATA_STORE_FILE } from '../../content/consts.js';
 import { DataStore, globalDataStore } from '../../content/data-store.js';
 import { createContentTypesGenerator } from '../../content/index.js';
-import { syncContentLayer } from '../../content/sync.js';
+import { globalContentLayer } from '../../content/sync.js';
 import { globalContentConfigObserver } from '../../content/utils.js';
 import { syncAstroEnv } from '../../env/sync.js';
 import { telemetry } from '../../events/index.js';
@@ -135,7 +135,12 @@ export async function syncInternal({
 				store = new DataStore();
 				globalDataStore.set(store);
 			}
-			await syncContentLayer({ settings, logger, store });
+			const contentLayer = globalContentLayer.init({
+				settings,
+				logger,
+				store,
+			});
+			await contentLayer.sync();
 			settings.timer.end('Sync content layer');
 		}
 		syncAstroEnv(settings, fs);

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -7,6 +7,7 @@ import fastGlob from 'fast-glob';
 import stripAnsi from 'strip-ansi';
 import { Agent } from 'undici';
 import { check } from '../dist/cli/check/index.js';
+import { globalContentLayer } from '../dist/content/sync.js';
 import build from '../dist/core/build/index.js';
 import { RESOLVED_SPLIT_MODULE_ID } from '../dist/core/build/plugins/plugin-ssr.js';
 import { getVirtualModulePageName } from '../dist/core/build/plugins/util.js';
@@ -158,6 +159,7 @@ export async function loadFixture(inlineConfig) {
 
 	return {
 		build: async (extraInlineConfig = {}, options = {}) => {
+			globalContentLayer.dispose();
 			process.env.NODE_ENV = 'production';
 			return build(mergeConfig(inlineConfig, extraInlineConfig), {
 				teardownCompiler: false,

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -171,6 +171,7 @@ export async function loadFixture(inlineConfig) {
 			return await check(opts);
 		},
 		startDevServer: async (extraInlineConfig = {}) => {
+			globalContentLayer.dispose();
 			process.env.NODE_ENV = 'development';
 			devServer = await dev(mergeConfig(inlineConfig, extraInlineConfig));
 			config.server.host = parseAddressToHost(devServer.address.address); // update host


### PR DESCRIPTION
## Changes

As suggested by @bluwy, this refactors content layer into a central location. This is most useful in dev, where variosu events can trigger a re-sync. Currently this includes the content config changing, but in future will also include hot keys and integrations.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
