### PR TITLE
Consistent file hashes

### DIFF
--- a/.changeset/young-pillows-shave.md
+++ b/.changeset/young-pillows-shave.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Generated CSS chunk ids are now stable across different environments

--- a/.changeset/young-pillows-shave.md
+++ b/.changeset/young-pillows-shave.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Generated CSS chunk ids are now stable across different environments
+Ensures consistent CSS chunk hashes across different environments

--- a/packages/astro/src/core/build/css-asset-name.ts
+++ b/packages/astro/src/core/build/css-asset-name.ts
@@ -2,7 +2,6 @@ import type { GetModuleInfo, ModuleInfo } from 'rollup';
 
 import crypto from 'node:crypto';
 import npath from 'node:path';
-import process from 'node:process';
 import { normalizePath } from 'vite';
 import type { AstroSettings } from '../../@types/astro.js';
 import { viteID } from '../util.js';

--- a/packages/astro/src/core/build/css-asset-name.ts
+++ b/packages/astro/src/core/build/css-asset-name.ts
@@ -2,6 +2,7 @@ import type { GetModuleInfo, ModuleInfo } from 'rollup';
 
 import crypto from 'node:crypto';
 import npath from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { normalizePath } from 'vite';
 import type { AstroSettings } from '../../@types/astro.js';
 import { viteID } from '../util.js';
@@ -32,7 +33,7 @@ export function createNameHash(
 ): string {
 	const baseName = baseId ? prettifyBaseName(npath.parse(baseId).name) : 'index';
 	const hash = crypto.createHash('sha256');
-	const root = settings.config.root.pathname;
+	const root = fileURLToPath(settings.config.root);
 
 	for (const id of hashIds) {
 		// Strip the project directory from the paths before they are hashed, so that assets

--- a/packages/astro/src/core/build/plugins/plugin-css.ts
+++ b/packages/astro/src/core/build/plugins/plugin-css.ts
@@ -70,7 +70,7 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 			const assetFileNames = outputOptions.assetFileNames;
 			const namingIncludesHash = assetFileNames?.toString().includes('[hash]');
 			const createNameForParentPages = namingIncludesHash
-				? assetName.shortHashedName
+				? assetName.shortHashedName(settings)
 				: assetName.createSlugger(settings);
 
 			extendManualChunks(outputOptions, {
@@ -94,7 +94,7 @@ function rollupPluginAstroBuildCSS(options: PluginOptions): VitePlugin[] {
 							if (hasAssetPropagationFlag(pageInfo.id)) {
 								// Split delayed assets to separate modules
 								// so they can be injected where needed
-								const chunkId = assetName.createNameHash(id, [id]);
+								const chunkId = assetName.createNameHash(id, [id], settings);
 								internals.cssModuleToChunkIdMap.set(id, chunkId);
 								return chunkId;
 							}


### PR DESCRIPTION
## Changes

Astro's css plugin generates chunk ids that include a hash of all of the chunk's parent ids.  These ids are currently the absolute file paths of the parent files.  The generated chunk ids are then inserted into those pages as import statements.

Because these import statements include a hash based on these absolute file paths, this causes rollup to generate different hashes for those pages when a build is run in different environments.  The exact same project will produce identical assets with different filenames when built on different machines, or when built from different directories on the same machine, etc.

To fix this, I've stripped out the working directory of these file paths before they are added to the hash.  This means that the hash will still change if the files referencing it chacnge (which I believe is the intended behavior), but will be stable if the entire project is built in different environments.

## Testing

I tested this by manually patching the copy of astro in my project to include this change.  I did not include any new tests here, mostly because I'm not very familiar with astro's codebase and wasn't sure where/how to best add one, but it's also a fairly small change.

## Docs

I don't think this would need any additional docs; I think that either this behavior doesn't matter to most users, or they would expect it to already work this way.
