### PR TITLE
fix: support filters in content layer `getCollection`

### DIFF
--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -71,6 +71,7 @@ export function createGetCollection({
 	cacheEntriesByCollection: Map<string, any[]>;
 }) {
 	return async function getCollection(collection: string, filter?: (entry: any) => unknown) {
+		const hasFilter = typeof filter === 'function';
 		const store = await globalDataStore.get();
 		let type: 'content' | 'data';
 		if (collection in contentCollectionToEntryMap) {
@@ -82,15 +83,19 @@ export function createGetCollection({
 			const { default: imageAssetMap } = await import('astro:asset-imports');
 
 			const result = [];
-			for (const entry of store.values<DataEntry>(collection)) {
-				const data = entry.filePath
-					? updateImageReferencesInData(entry.data, entry.filePath, imageAssetMap)
-					: entry.data;
-				result.push({
-					...entry,
+			for (const rawEntry of store.values<DataEntry>(collection)) {
+				const data = rawEntry.filePath
+					? updateImageReferencesInData(rawEntry.data, rawEntry.filePath, imageAssetMap)
+					: rawEntry.data;
+				const entry = {
+					...rawEntry,
 					data,
 					collection,
-				});
+				};
+				if(hasFilter && !filter(entry)) {
+					continue;
+				}
+				result.push(entry);
 			}
 			return result;
 		} else {
@@ -143,7 +148,7 @@ export function createGetCollection({
 			);
 			cacheEntriesByCollection.set(collection, entries);
 		}
-		if (typeof filter === 'function') {
+		if (hasFilter) {
 			return entries.filter(filter);
 		} else {
 			// Clone the array so users can safely mutate it.

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -42,6 +42,12 @@ describe('Content Layer', () => {
 			});
 		});
 
+		it('filters collection items', async () => {
+			assert.ok(json.hasOwnProperty('customLoader'));
+			assert.ok(Array.isArray(json.customLoader));
+			assert.equal(json.customLoader.length, 5);
+		});
+
 		it('Returns `file()` loader collection', async () => {
 			assert.ok(json.hasOwnProperty('fileLoader'));
 			assert.ok(Array.isArray(json.fileLoader));

--- a/packages/astro/test/fixtures/content-layer/src/loaders/post-loader.ts
+++ b/packages/astro/test/fixtures/content-layer/src/loaders/post-loader.ts
@@ -26,7 +26,7 @@ export function loader(config:PostLoaderConfig): Loader {
 
 			store.clear();
 
-			for (const data of posts.slice(0, 10)) {
+			for (const data of posts) {
 				store.set({id: data.id, data});
 			}
 			meta.set('lastSynced', String(Date.now()));

--- a/packages/astro/test/fixtures/content-layer/src/pages/collections.json.js
+++ b/packages/astro/test/fixtures/content-layer/src/pages/collections.json.js
@@ -1,19 +1,20 @@
 import { getCollection, getEntry } from 'astro:content';
 import * as devalue from 'devalue';
-import { stripAllRenderFn, stripRenderFn } from '../utils';
 
 export async function GET() {
-	const customLoader = stripAllRenderFn((await getCollection('blog')).slice(0, 10));
-	const fileLoader = stripAllRenderFn(await getCollection('dogs'));
+	const customLoader = await getCollection('blog', (entry) => {
+		return entry.data.id < 6;
+	});
+	const fileLoader = await getCollection('dogs');
 
-	const dataEntry = stripRenderFn(await getEntry('dogs', 'beagle'));
+	const dataEntry = await getEntry('dogs', 'beagle');
 
-	const simpleLoader = stripAllRenderFn(await getCollection('cats'));
+	const simpleLoader = await getCollection('cats');
 
-	const entryWithReference = stripRenderFn(await getEntry('spacecraft', 'columbia-copy'));
-	const referencedEntry = stripRenderFn(await getEntry(entryWithReference.data.cat));
+	const entryWithReference = await getEntry('spacecraft', 'columbia-copy');
+	const referencedEntry = await getEntry(entryWithReference.data.cat);
 
-	const increment = stripRenderFn(await getEntry('increment', 'value'));
+	const increment = await getEntry('increment', 'value');
 
 	return new Response(
 		devalue.stringify({

--- a/packages/astro/test/fixtures/content-layer/src/utils.js
+++ b/packages/astro/test/fixtures/content-layer/src/utils.js
@@ -1,8 +1,0 @@
-export function stripRenderFn(entryWithRender) {
-	const { render, ...entry } = entryWithRender;
-	return entry;
-}
-
-export function stripAllRenderFn(collection = []) {
-	return collection.map(stripRenderFn);
-}


### PR DESCRIPTION
## Changes
Adds support for the `filter` arg in `getCollection`

## Testing

Updated fixtures to use the filter. 

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
