### PR TITLE
Actions: fix 500 on empty object for Vercel serverless

### DIFF
--- a/.changeset/tiny-poems-battle.md
+++ b/.changeset/tiny-poems-battle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes internal server error when calling an Astro Action without arguments on Vercel.

--- a/packages/astro/src/actions/runtime/route.ts
+++ b/packages/astro/src/actions/runtime/route.ts
@@ -12,7 +12,7 @@ export const POST: APIRoute = async (context) => {
 	const contentType = request.headers.get('Content-Type');
 	const contentLength = request.headers.get('Content-Length');
 	let args: unknown;
-	if (contentLength === '0') {
+	if (!contentType || contentLength === '0') {
 		args = undefined;
 	} else if (contentType && hasContentType(contentType, formContentTypes)) {
 		args = await request.clone().formData();

--- a/packages/astro/templates/actions.mjs
+++ b/packages/astro/templates/actions.mjs
@@ -65,15 +65,18 @@ async function handleAction(param, path, context) {
 	let body = param;
 	if (!(body instanceof FormData)) {
 		try {
-			body = param ? JSON.stringify(param) : undefined;
+			body = JSON.stringify(param);
 		} catch (e) {
 			throw new ActionError({
 				code: 'BAD_REQUEST',
 				message: `Failed to serialize request body to JSON. Full error: ${e.message}`,
 			});
 		}
-		headers.set('Content-Type', 'application/json');
-		headers.set('Content-Length', body?.length.toString() ?? '0');
+		if (body) {
+			headers.set('Content-Type', 'application/json');
+		} else {
+			headers.set('Content-Length', '0');
+		}
 	}
 	const rawResult = await fetch(`/_actions/${path}`, {
 		method: 'POST',

--- a/packages/astro/test/actions.test.js
+++ b/packages/astro/test/actions.test.js
@@ -234,16 +234,35 @@ describe('Astro Actions', () => {
 			});
 		});
 
-		it('Sets status to 204 when no content', async () => {
+		it('Sets status to 204 when content-length is 0', async () => {
 			const req = new Request('http://example.com/_actions/fireAndForget', {
 				method: 'POST',
 				headers: {
-					'Content-Type': 'application/json',
 					'Content-Length': '0',
 				},
 			});
 			const res = await app.render(req);
 			assert.equal(res.status, 204);
+		});
+
+		it('Sets status to 204 when content-type is omitted', async () => {
+			const req = new Request('http://example.com/_actions/fireAndForget', {
+				method: 'POST',
+			});
+			const res = await app.render(req);
+			assert.equal(res.status, 204);
+		});
+
+		it('Sets status to 415 when content-type is unexpected', async () => {
+			const req = new Request('http://example.com/_actions/fireAndForget', {
+				method: 'POST',
+				body: 'hey',
+				headers: {
+					'Content-Type': 'text/plain',
+				},
+			});
+			const res = await app.render(req);
+			assert.equal(res.status, 415);
 		});
 
 		it('Is callable from the server with rewrite', async () => {


### PR DESCRIPTION
## Changes

Resolves #11515. We discovered that Actions sets the `content-type` to `application/json` even when the body is `undefined`. We set `content-length` to `0` for this case, but it seems some deployment platforms (Vercel) may remove this header if it detects an empty body.

This fix removes the `content-type` when no body is present.

## Testing

- Add test for empty content type
- Add test for unexpected content type

## Docs

N/A