### PR TITLE
Remove `#astro/*` subpath imports

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -83,9 +83,6 @@
     },
     "./virtual-modules/*": "./dist/virtual-modules/*"
   },
-  "imports": {
-    "#astro/*": "./dist/*.js"
-  },
   "bin": {
     "astro": "astro.js"
   },

--- a/packages/astro/test/units/i18n/astro_i18n.test.js
+++ b/packages/astro/test/units/i18n/astro_i18n.test.js
@@ -1,8 +1,8 @@
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { MissingLocale } from '#astro/core/errors/errors-data';
-import { AstroError } from '#astro/core/errors/index';
-import { toRoutingStrategy } from '#astro/i18n/utils';
+import { MissingLocale } from '../../../dist/core/errors/errors-data.js';
+import { AstroError } from '../../../dist/core/errors/index.js';
+import { toRoutingStrategy } from '../../../dist/i18n/utils.js';
 import { validateConfig } from '../../../dist/core/config/validate.js';
 import {
 	getLocaleAbsoluteUrl,


### PR DESCRIPTION
## Changes

The `#astro/*` subpath imports was added in https://github.com/withastro/astro/pull/161 but it doesn't look like we're using it much today. I'm not sure if we still want to continue pushing to use the subpath imports, we can discuss here if so!

If not, I figured to remove it so it doesn't interfere with the auto-imports path completion so we always stick with relative paths.

## Testing

n/a

## Docs

n/a
