### PR TITLE
Throw when using deprecated `getEntryByX` functions with content layer

### DIFF
--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -92,7 +92,7 @@ export function createGetCollection({
 					data,
 					collection,
 				};
-				if(hasFilter && !filter(entry)) {
+				if (hasFilter && !filter(entry)) {
 					continue;
 				}
 				result.push(entry);
@@ -170,20 +170,13 @@ export function createGetEntryBySlug({
 	return async function getEntryBySlug(collection: string, slug: string) {
 		const store = await globalDataStore.get();
 
-		if (store.hasCollection(collection)) {
-			const data = store.get(collection, slug);
-			if (!data) {
-				throw new Error(`Entry ${collection} → ${slug} was not found.`);
-			}
-
-			const entry = store.get<DataEntry>(collection, slug);
-
-			return {
-				...entry,
-				collection,
-			};
-		}
 		if (!collectionNames.has(collection)) {
+			if (store.hasCollection(collection)) {
+				throw new AstroError({
+					...AstroErrorData.GetEntryDeprecationError,
+					message: AstroErrorData.GetEntryDeprecationError.message(collection, 'getEntryBySlug'),
+				});
+			}
 			// eslint-disable-next-line no-console
 			console.warn(`The collection ${JSON.stringify(collection)} does not exist.`);
 			return undefined;
@@ -221,20 +214,13 @@ export function createGetDataEntryById({
 	return async function getDataEntryById(collection: string, id: string) {
 		const store = await globalDataStore.get();
 
-		if (store.hasCollection(collection)) {
-			const data = store.get(collection, id);
-			if (!data) {
-				throw new Error(`Entry ${collection} → ${id} was not found.`);
-			}
-
-			const entry = store.get<DataEntry>(collection, id);
-
-			return {
-				...entry,
-				collection,
-			};
-		}
 		if (!collectionNames.has(collection)) {
+			if (store.hasCollection(collection)) {
+				throw new AstroError({
+					...AstroErrorData.GetEntryDeprecationError,
+					message: AstroErrorData.GetEntryDeprecationError.message(collection, 'getDataEntryById'),
+				});
+			}
 			// eslint-disable-next-line no-console
 			console.warn(`The collection ${JSON.stringify(collection)} does not exist.`);
 			return undefined;

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1484,6 +1484,18 @@ export const ContentLayerWriteError = {
 
 /**
  * @docs
+ * @description
+ * The `getDataEntryById` and `getEntryBySlug` functions are deprecated and cannot be used with content layer collections. Use the `getEntry` function instead.
+ */
+export const GetEntryDeprecationError = {
+	name: 'GetEntryDeprecationError',
+	title: 'Invalid use of `getDataEntryById` or `getEntryBySlug` function.',
+	message: (collection: string, method: string) => `The \`${method}\` function is deprecated and cannot be used to query the "${collection}" collection. Use \`getEntry\` instead.`,
+	hint: 'Use the `getEntry` or `getCollection` functions to query content layer collections.',
+} satisfies ErrorData;
+
+/**
+ * @docs
  * @message
  * **Example error message:**<br/>
  * **blog** → **post.md** frontmatter does not match collection schema.<br/>

--- a/packages/astro/test/fixtures/content-layer/src/pages/index.astro
+++ b/packages/astro/test/fixtures/content-layer/src/pages/index.astro
@@ -1,8 +1,8 @@
 ---
-import { getCollection, getDataEntryById } from 'astro:content';
+import { getCollection, getEntry } from 'astro:content';
 
 const blog = await getCollection('blog');
-const first = await getDataEntryById('blog', 1);
+const first = await getEntry('blog', 1);
 const dogs = await getCollection('dogs');
 ---
 <html>


### PR DESCRIPTION
## Changes

The `getEntryBySlug` and `getDataEntryById` functions are deprecated. Previously they were implemented in content layer, but as they'll already be marked as deprecated once it is stable, we can safely not implement them for content layer collections. This PR adds a new AstroError that is thrown if a user attempts to call either of them with a content layer collection.

## Testing

Tested manually

## Docs

Adds a new AstroError

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
