### PR TITLE
Actions: remove "action used with get" error

### DIFF
--- a/.changeset/big-tables-pump.md
+++ b/.changeset/big-tables-pump.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes unexpected error when refreshing a POST request from a form using Actions.

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -1,9 +1,6 @@
 import { yellow } from 'kleur/colors';
 import type { APIContext, MiddlewareNext } from '../../@types/astro.js';
-import {
-	ActionQueryStringInvalidError,
-	ActionsUsedWithForGetError,
-} from '../../core/errors/errors-data.js';
+import { ActionQueryStringInvalidError } from '../../core/errors/errors-data.js';
 import { AstroError } from '../../core/errors/errors.js';
 import { defineMiddleware } from '../../core/middleware/index.js';
 import { formContentTypes, hasContentType } from './utils.js';

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -46,13 +46,6 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		return handlePost({ context, next, actionName });
 	}
 
-	if (context.request.method === 'GET' && actionName) {
-		throw new AstroError({
-			...ActionsUsedWithForGetError,
-			message: ActionsUsedWithForGetError.message(actionName),
-		});
-	}
-
 	if (context.request.method === 'POST') {
 		return handlePostLegacy({ context, next });
 	}

--- a/packages/astro/test/actions.test.js
+++ b/packages/astro/test/actions.test.js
@@ -200,6 +200,18 @@ describe('Astro Actions', () => {
 			assert.equal($('#error-code').text(), 'UNAUTHORIZED');
 		});
 
+		it('Ignores `_astroAction` name for GET requests', async () => {
+			const req = new Request('http://example.com/user-or-throw?_astroAction=getUserOrThrow', {
+				method: 'GET',
+			});
+			const res = await app.render(req);
+			assert.equal(res.ok, true);
+
+			const html = await res.text();
+			let $ = cheerio.load(html);
+			assert.ok($('#user'));
+		});
+
 		describe('legacy', () => {
 			it('Response middleware fallback', async () => {
 				const formData = new FormData();


### PR DESCRIPTION
## Changes

We currently raise an error when `_astroAction` is present on a GET request. This breaks page refreshes when viewing a POST result. We should remove the error for now, and reimplement if the redirect PR is accepted: https://github.com/withastro/astro/pull/11603

## Testing



## Docs
