### PR TITLE
Set action input default values from zod if FormData key is not present

### DIFF
--- a/.changeset/nervous-garlics-beam.md
+++ b/.changeset/nervous-garlics-beam.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes Astro Actions `input` validation when using `default` values with a form input.

--- a/packages/astro/src/actions/runtime/virtual/server.ts
+++ b/packages/astro/src/actions/runtime/virtual/server.ts
@@ -134,11 +134,21 @@ export function formDataToObject<T extends z.AnyZodObject>(
 	const obj: Record<string, unknown> = {};
 	for (const [key, baseValidator] of Object.entries(schema.shape)) {
 		let validator = baseValidator;
-		while (validator instanceof z.ZodOptional || validator instanceof z.ZodNullable) {
+
+		while (validator instanceof z.ZodOptional || validator instanceof z.ZodNullable || validator instanceof z.ZodDefault) {
+			// use default value when key is undefined
+			if(validator instanceof z.ZodDefault && !formData.has(key)) {
+				obj[key] = validator._def.defaultValue();				
+			}
 			validator = validator._def.innerType;
 		}
-		if (validator instanceof z.ZodBoolean) {
-			obj[key] = formData.has(key);
+
+    if (!formData.has(key) && key in obj) {
+			// continue loop if form input is not found and default value is set
+      continue;
+    } else if (validator instanceof z.ZodBoolean) {	
+			const val = formData.get(key);		
+			obj[key] = val === 'true' ? true : val === 'false' ? false : formData.has(key)
 		} else if (validator instanceof z.ZodArray) {
 			obj[key] = handleFormDataGetAll(key, formData, validator);
 		} else {

--- a/packages/astro/test/units/actions/form-data-to-object.test.js
+++ b/packages/astro/test/units/actions/form-data-to-object.test.js
@@ -46,15 +46,24 @@ describe('formDataToObject', () => {
 	it('should handle boolean checks', () => {
 		const formData = new FormData();
 		formData.set('isCool', 'yes');
+		formData.set('isTrue', true)
+		formData.set("isFalse", false);
+		formData.set("falseString", 'false')
 
 		const input = z.object({
 			isCool: z.boolean(),
 			isNotCool: z.boolean(),
+			isTrue: z.boolean(),
+			isFalse: z.boolean(),
+			falseString: z.boolean(),
 		});
 
 		const res = formDataToObject(formData, input);
 		assert.equal(res.isCool, true);
 		assert.equal(res.isNotCool, false);
+		assert.equal(res.isTrue, true);
+		assert.equal(res.isFalse, false);
+		assert.equal(res.falseString, false)
 	});
 
 	it('should handle optional values', () => {
@@ -90,6 +99,37 @@ describe('formDataToObject', () => {
 		assert.equal(res.email, null);
 		assert.equal(res.age, null);
 	});
+
+	it('should handle zod default values', () => {
+		const formData = new FormData();
+		
+		const input = z.object({
+			name: z.string().default("test"),
+			email: z.string().default('test@test.test'),
+			favoriteNumbers: z.array(z.number()).default([1,2])
+		});
+
+		const res = formDataToObject(formData, input);
+		assert.equal(res.name, 'test');
+		assert.equal(res.email, 'test@test.test');
+		assert.deepEqual(res.favoriteNumbers, [1, 2]);
+	})
+
+	it('should handle zod chaining of optional, default, and nullish values', () => {
+		const formData = new FormData();
+		formData.set('email', 'test@test.test')
+		
+		const input = z.object({
+			name: z.string().default("test").optional(),
+			email: z.string().optional().nullish(),
+			favoriteNumbers: z.array(z.number()).default([1,2]).nullish().optional()
+		});
+
+		const res = formDataToObject(formData, input);
+		assert.equal(res.name, 'test');
+		assert.equal(res.email, 'test@test.test');
+		assert.deepEqual(res.favoriteNumbers, [1, 2])
+	})
 
 	it('should handle File objects', () => {
 		const formData = new FormData();
@@ -134,5 +174,22 @@ describe('formDataToObject', () => {
 
 		assert.ok(Array.isArray(res.age), 'age is not an array');
 		assert.deepEqual(res.age.sort(), [25, 30, 35]);
+	});
+
+	it('should handle an array of File objects', () => {
+		const formData = new FormData();
+		const file1 = new File([''], 'test1.txt');
+		const file2 = new File([''], 'test2.txt')
+		formData.append('files', file1);
+		formData.append('files', file2);
+
+		const input = z.object({
+			files: z.array(z.instanceof(File))
+		});
+
+		const res = formDataToObject(formData, input);
+
+		assert.equal(res.files instanceof Array, true);
+		assert.deepEqual(res.files, [file1, file2])
 	});
 });


### PR DESCRIPTION
## Changes

- What does this change?

Resolves #11659

This changes `formDataToObject` to allow default values to be set from zod.

## Testing

<!-- How was this change tested? -->
Add tests to capture changes. I ran unit tests for this specific change and it passes. Not sure if the whole project tests are working correctly since I was getting some failures.
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
