### PR TITLE
Actions: fix missing orThrow type when input is omitted

### DIFF
--- a/.changeset/gold-seas-crash.md
+++ b/.changeset/gold-seas-crash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `orThrow()` type when calling an Action without an `input` validator.

--- a/packages/astro/src/actions/runtime/virtual/server.ts
+++ b/packages/astro/src/actions/runtime/virtual/server.ts
@@ -39,7 +39,7 @@ export type ActionClient<
 				input: TAccept extends 'form' ? FormData : z.input<TInputSchema>,
 			) => Promise<Awaited<TOutput>>;
 		}
-	: (input?: any) => Promise<SafeResult<never, Awaited<TOutput>>> & {
+	: ((input?: any) => Promise<SafeResult<never, Awaited<TOutput>>>) & {
 			orThrow: (input?: any) => Promise<Awaited<TOutput>>;
 		};
 

--- a/packages/astro/test/types/action-return-type.ts
+++ b/packages/astro/test/types/action-return-type.ts
@@ -9,8 +9,7 @@ import { z } from '../../zod.mjs';
 
 describe('ActionReturnType', () => {
 	it('Infers action return type', async () => {
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const action = defineAction({
+		const _action = defineAction({
 			input: z.object({
 				name: z.string(),
 			}),
@@ -18,9 +17,21 @@ describe('ActionReturnType', () => {
 				return { name };
 			},
 		});
-		expectTypeOf<ActionReturnType<typeof action>>().toEqualTypeOf<
+		expectTypeOf<ActionReturnType<typeof _action>>().toEqualTypeOf<
 			SafeResult<any, { name: string }>
 		>();
-		expectTypeOf<ActionReturnType<typeof action.orThrow>>().toEqualTypeOf<{ name: string }>();
+		expectTypeOf<ActionReturnType<typeof _action.orThrow>>().toEqualTypeOf<{ name: string }>();
+	});
+
+	it('Infers action return type when input is omitted', async () => {
+		const _action = defineAction({
+			handler: async () => {
+				return { name: 'Ben' };
+			},
+		});
+		expectTypeOf<ActionReturnType<typeof _action>>().toEqualTypeOf<
+			SafeResult<any, { name: string }>
+		>();
+		expectTypeOf<ActionReturnType<typeof _action.orThrow>>().toEqualTypeOf<{ name: string }>();
 	});
 });


### PR DESCRIPTION
## Changes

Resolves [RFC comment](https://github.com/withastro/roadmap/pull/912#issuecomment-2275277245) reporting that `orThrow()` is missing when `input` is omitted.

This was uncaught due to type casting in the handler assignment code. A fix isn't simple in the near term, so a type test has been added.

## Testing

- Add return type test when `input` is omittted.

## Docs

N/A