### PR TITLE
Update to new shiki token names

### DIFF
--- a/.changeset/quick-ads-exercise.md
+++ b/.changeset/quick-ads-exercise.md
@@ -1,0 +1,10 @@
+---
+'@astrojs/markdown-remark': major
+---
+
+Renames the CSS variables theme color token names to better align with the Shiki v1 defaults:
+
+- `--astro-code-color-text` => `--astro-code-foreground`
+- `--astro-code-color-background` => `--astro-code-background`
+
+You can perform a global find and replace in your project to migrate to the new token names.

--- a/.changeset/quick-ads-exercise.md
+++ b/.changeset/quick-ads-exercise.md
@@ -2,7 +2,7 @@
 '@astrojs/markdown-remark': major
 ---
 
-Renames the CSS variables theme color token names to better align with the Shiki v1 defaults:
+Renames the following CSS variables theme color token names to better align with the Shiki v1 defaults:
 
 - `--astro-code-color-text` => `--astro-code-foreground`
 - `--astro-code-color-background` => `--astro-code-background`

--- a/packages/astro/test/astro-component-code.test.js
+++ b/packages/astro/test/astro-component-code.test.js
@@ -88,12 +88,12 @@ describe('<Code>', () => {
 				.map((i, f) => (f.attribs ? f.attribs.style : 'no style found'))
 				.toArray(),
 			[
-				'background-color:var(--astro-code-color-background);color:var(--astro-code-color-text); overflow-x: auto;',
+				'background-color:var(--astro-code-background);color:var(--astro-code-foreground); overflow-x: auto;',
 				'color:var(--astro-code-token-constant)',
 				'color:var(--astro-code-token-function)',
-				'color:var(--astro-code-color-text)',
+				'color:var(--astro-code-foreground)',
 				'color:var(--astro-code-token-string-expression)',
-				'color:var(--astro-code-color-text)',
+				'color:var(--astro-code-foreground)',
 			]
 		);
 	});


### PR DESCRIPTION
## Changes

Originally planned in https://github.com/withastro/astro/pull/9643#discussion_r1446083665

The new token names follow Shiki v1's defaults and allows us to remove the compat replacements before.

## Testing

Updated test

## Docs

It doesn't look like docs document this particular usecase with css-variables shiki theme, so it doesn't need an update there, but it'll need an entry for the migration guide for sure.
