### PR TITLE
Normalize content layer render function return value

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -124,7 +124,7 @@ export type TransitionAnimationValue =
 	| TransitionDirectionalAnimations;
 
 // Allow users to extend this for astro-jsx.d.ts
- 
+
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface AstroClientDirectives {}
 

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -449,7 +449,12 @@ export async function renderEntry(
 			// @ts-expect-error	virtual module
 			const { default: contentModules } = await import('astro:content-module-imports');
 			const module = contentModules.get(entry.filePath);
-			return await module();
+			const deferredMod = await module();
+			return {
+				Content: deferredMod.Content,
+				headings: deferredMod.getHeadings?.() ?? [],
+				remarkPluginFrontmatter: deferredMod.frontmatter ?? {},
+			};
 		} catch (e) {
 			// eslint-disable-next-line
 			console.error(e);
@@ -462,7 +467,11 @@ export async function renderEntry(
 			: entry?.rendered?.html;
 
 	const Content = createComponent(() => serverRender`${unescapeHTML(html)}`);
-	return { Content };
+	return {
+		Content,
+		headings: entry?.rendered?.metadata?.headings ?? [],
+		remarkPluginFrontmatter: entry?.rendered?.metadata?.frontmatter ?? {},
+	};
 }
 
 async function render({

--- a/packages/astro/templates/content/types.d.ts
+++ b/packages/astro/templates/content/types.d.ts
@@ -1,14 +1,14 @@
 declare module 'astro:content' {
-	interface Render {
-		'.md': Promise<{
-			Content: import('astro').MarkdownInstance<{}>['Content'];
-			headings: import('astro').MarkdownHeading[];
-			remarkPluginFrontmatter: Record<string, any>;
-		}>;
-	}
-	interface ContentLayerRenderResult {
+
+	interface RenderResult {
 		Content: import('astro/runtime/server/index.js').AstroComponentFactory;
+		headings: import('astro').MarkdownHeading[];
+		remarkPluginFrontmatter: Record<string, any>;
 	}
+	interface Render {
+		'.md': Promise<RenderResult>;
+	}
+
 
 	export interface RenderedContent {
 		html: string;
@@ -113,7 +113,7 @@ declare module 'astro:content' {
 
 	export function render<C extends keyof AnyEntryMap>(
 		entry: AnyEntryMap[C][string],
-	): Promise<ContentLayerRenderResult>;
+	): Promise<RenderResult>;
 
 	export function reference<C extends keyof AnyEntryMap>(
 		collection: C,

--- a/packages/astro/test/fixtures/content-layer-rendering/content-outside-src-mdx/iguana.mdx
+++ b/packages/astro/test/fixtures/content-layer-rendering/content-outside-src-mdx/iguana.mdx
@@ -9,6 +9,8 @@ import H2 from "../src/components/H2.astro";
 
 <H2>Iguana</H2>
 
+### Iguana
+
 This is a rendered entry
 
 ![file](./shuttle.jpg)

--- a/packages/astro/test/fixtures/content-layer/src/pages/spacecraft/[slug].astro
+++ b/packages/astro/test/fixtures/content-layer/src/pages/spacecraft/[slug].astro
@@ -22,12 +22,14 @@ export const getStaticPaths = (async () => {
 const { craft } = Astro.props as any
 
 let cat = craft.data.cat ? await getEntry(craft.data.cat) : undefined
-const { Content } = await render(craft)
+const { Content, headings } = await render(craft)
 
 ---
 <meta charset="utf-8">
 <h1>{craft.data.title}</h1>
+<ul>
+{headings.map((heading) => <li><a href={`#${heading.slug}`}>{heading.text}</a></li>)}
+</ul>
 {cat? <p>🐈: {cat.data.breed}</p> : undefined}
 {craft.data.heroImage ? <Image src={craft.data.heroImage} alt={craft.data.title} width="100" height="100"/> : undefined}
 <Content />
-</ul>


### PR DESCRIPTION
## Changes

This PR updates the `render(entry)` function so that it returns the same values as `entry.render()` for all entry types. We will document this as the preferred way to access headings for markdown too.

## Testing
Updated fixtures
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
I will update the RFC and other docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
