### PR TITLE
fix: make semicolon optional when detecting `prerender` option

### DIFF
--- a/.changeset/good-birds-clap.md
+++ b/.changeset/good-birds-clap.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes a case where omitting a semicolon in the `prerender` option could throw an error.
+Fixes a case where omitting a semicolon and line ending with carriage return - CRLF - in the `prerender` option could throw an error.

--- a/.changeset/good-birds-clap.md
+++ b/.changeset/good-birds-clap.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where omitting a semicolon in the `prerender` option could throw an error.

--- a/packages/astro/src/vite-plugin-scanner/scan.ts
+++ b/packages/astro/src/vite-plugin-scanner/scan.ts
@@ -65,7 +65,7 @@ export async function scan(
 				.trim();
 			// For a given export, check the value of the first non-whitespace token.
 			// Basically extract the `true` from the statement `export const prerender = true`
-			const suffix = code.slice(endOfLocalName).trim().replace(/=/, '').trim().split(/[;?(\n|\r)]/)[0].trim();
+			const suffix = code.slice(endOfLocalName).trim().replace(/=/, '').trim().split(/[;\n\r]/)[0].trim();
 			if (prefix !== 'const' || !(isTruthy(suffix) || isFalsy(suffix))) {
 				throw new AstroError({
 					...AstroErrorData.InvalidPrerenderExport,

--- a/packages/astro/src/vite-plugin-scanner/scan.ts
+++ b/packages/astro/src/vite-plugin-scanner/scan.ts
@@ -65,7 +65,7 @@ export async function scan(
 				.trim();
 			// For a given export, check the value of the first non-whitespace token.
 			// Basically extract the `true` from the statement `export const prerender = true`
-			const suffix = code.slice(endOfLocalName).trim().replace(/=/, '').trim().split(/[;?\n]/)[0];
+			const suffix = code.slice(endOfLocalName).trim().replace(/=/, '').trim().split(/[;?(\n|\r)]/)[0].trim();
 			if (prefix !== 'const' || !(isTruthy(suffix) || isFalsy(suffix))) {
 				throw new AstroError({
 					...AstroErrorData.InvalidPrerenderExport,

--- a/packages/astro/src/vite-plugin-scanner/scan.ts
+++ b/packages/astro/src/vite-plugin-scanner/scan.ts
@@ -65,7 +65,7 @@ export async function scan(
 				.trim();
 			// For a given export, check the value of the first non-whitespace token.
 			// Basically extract the `true` from the statement `export const prerender = true`
-			const suffix = code.slice(endOfLocalName).trim().replace(/=/, '').trim().split(/[;\n]/)[0];
+			const suffix = code.slice(endOfLocalName).trim().replace(/=/, '').trim().split(/[;?\n]/)[0];
 			if (prefix !== 'const' || !(isTruthy(suffix) || isFalsy(suffix))) {
 				throw new AstroError({
 					...AstroErrorData.InvalidPrerenderExport,


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/11283

## Testing

I tested it locally in a project of mine and it worked.

Existing CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
