### PR TITLE
fix(actions): save error stack trace in memory

### DIFF
--- a/.changeset/silver-horses-beam.md
+++ b/.changeset/silver-horses-beam.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue in the Astro actions, where the size of the generated cookie was exceeding the size permitted by the `Set-Cookie` header.  

--- a/packages/astro/src/actions/runtime/virtual/shared.ts
+++ b/packages/astro/src/actions/runtime/virtual/shared.ts
@@ -213,14 +213,16 @@ export type SerializedActionResult =
 
 export function serializeActionResult(res: SafeResult<any, any>): SerializedActionResult {
 	if (res.error) {
+		if (import.meta.env?.DEV) {
+			actionResultErrorStack.set(res.error.stack)
+		}
 		return {
 			type: 'error',
 			status: res.error.status,
 			contentType: 'application/json',
 			body: JSON.stringify({
 				...res.error,
-				message: res.error.message,
-				stack: import.meta.env.PROD ? undefined : res.error.stack,
+				message: res.error.message
 			}),
 		};
 	}
@@ -243,7 +245,15 @@ export function serializeActionResult(res: SafeResult<any, any>): SerializedActi
 
 export function deserializeActionResult(res: SerializedActionResult): SafeResult<any, any> {
 	if (res.type === 'error') {
-		return { error: ActionError.fromJson(JSON.parse(res.body)), data: undefined };
+		if (import.meta.env?.PROD) {
+			return { error: ActionError.fromJson(JSON.parse(res.body)), data: undefined };
+		} else {
+			const error = ActionError.fromJson(JSON.parse(res.body));
+			error.stack = actionResultErrorStack.get();
+			return {
+				error, data: undefined
+			}
+		}
 	}
 	if (res.type === 'empty') {
 		return { data: undefined, error: undefined };
@@ -255,3 +265,16 @@ export function deserializeActionResult(res: SerializedActionResult): SafeResult
 		error: undefined,
 	};
 }
+
+// in-memory singleton to save the stack trace 
+const actionResultErrorStack = function actionResultErrorStackFn() {
+	let errorStack: string | undefined;
+	return {
+		set(stack: string | undefined) {
+			errorStack = stack;
+		},
+		get() {
+			return errorStack;
+		}
+	}
+}();


### PR DESCRIPTION
## Changes

Closes #11675 

The stack trace of the error is saved in memory across submits. The stack trace is populated only in dev

## Testing

I tested it against the reproduction of the issue, and I can successfully see the errors. No warnings regarding the size of the cookie

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
