### PR TITLE
feat(next): add `Astro.routePattern`

### DIFF
--- a/.changeset/nasty-crabs-worry.md
+++ b/.changeset/nasty-crabs-worry.md
@@ -2,14 +2,14 @@
 'astro': minor
 ---
 
-Adds a new property to the globals `Astro` and `APIContext` called `route`. The `route` represents the current route (component)
-that is being rendered by Astro. It's usually a path that will look like this: `src/pages/blog/[slug].astro`:
+Adds a new property to the globals `Astro` and `APIContext` called `routePattern`. The `routePattern` represents the current route (component)
+that is being rendered by Astro. It's usually a path pattern will look like this: `blog/[slug]`:
 
 ```asto
 ---
-// src/pages/index.astro
-const route = Astro.route;
-console.log(route); // it will log src/pages/index.astro
+// src/pages/blog/[slug].astro
+const route = Astro.routePattern;
+console.log(route); // it will log "blog/[slug]"
 ---
 ```
 
@@ -17,7 +17,7 @@ console.log(route); // it will log src/pages/index.astro
 // src/pages/index.js
 
 export const GET = (ctx) => {
-  console.log(ctx.route) // it will log src/pages/index.js
+  console.log(ctx.routePattern) // it will log src/pages/index.js
   return new Response.json({ loreum: "ipsum" })
 }
 ```

--- a/.changeset/nasty-crabs-worry.md
+++ b/.changeset/nasty-crabs-worry.md
@@ -1,0 +1,25 @@
+---
+'astro': minor
+---
+
+Adds a new property to the globals `Astro` and `APIContext` called `route`. The `route` represents the current route (component)
+that is being rendered by Astro. It's usually a path that will look like this: `src/pages/blog/[slug].astro`:
+
+```asto
+---
+// src/pages/index.astro
+const route = Astro.route;
+console.log(route); // it will log src/pages/index.astro
+---
+```
+
+```js
+// src/pages/index.js
+
+export const GET = (ctx) => {
+  console.log(ctx.route) // it will log src/pages/index.js
+  return new Response.json({ loreum: "ipsum" })
+}
+```
+
+

--- a/packages/astro/src/core/middleware/index.ts
+++ b/packages/astro/src/core/middleware/index.ts
@@ -61,7 +61,7 @@ function createContext({
 		generator: `Astro v${ASTRO_VERSION}`,
 		props: {},
 		rewrite,
-		route: "",
+		routePattern: "",
 		redirect(path, status) {
 			return new Response(null, {
 				status: status || 302,

--- a/packages/astro/src/core/middleware/index.ts
+++ b/packages/astro/src/core/middleware/index.ts
@@ -61,6 +61,7 @@ function createContext({
 		generator: `Astro v${ASTRO_VERSION}`,
 		props: {},
 		rewrite,
+		route: "",
 		redirect(path, status) {
 			return new Response(null, {
 				status: status || 302,

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -37,6 +37,9 @@ import { type Pipeline, Slots, getParams, getProps } from './render/index.js';
 export class RenderContext {
 	// The first route that this instance of the context attempts to render
 	originalRoute: RouteData;
+	
+	// The component pattern to send to the users
+	astroRoute: string;
 
 	private constructor(
 		readonly pipeline: Pipeline,
@@ -52,6 +55,7 @@ export class RenderContext {
 		public props: Props = {},
 	) {
 		this.originalRoute = routeData;
+		this.astroRoute = getAstroRoute(routeData.component);
 	}
 
 	/**
@@ -234,6 +238,7 @@ export class RenderContext {
 		this.isRewriting = true;
 		// we found a route and a component, we can change the status code to 200
 		this.status = 200;
+		this.astroRoute = getAstroRoute(routeData.component);
 		return await this.render(component);
 	}
 
@@ -250,7 +255,7 @@ export class RenderContext {
 
 		return {
 			cookies,
-			route: this.routeData.component,
+			route: this.astroRoute,
 			get clientAddress() {
 				return renderContext.clientAddress();
 			},
@@ -436,7 +441,7 @@ export class RenderContext {
 		return {
 			generator: astroStaticPartial.generator,
 			glob: astroStaticPartial.glob,
-			route: this.routeData.component,
+			route: this.astroRoute,
 			cookies,
 			get clientAddress() {
 				return renderContext.clientAddress();
@@ -567,4 +572,32 @@ export class RenderContext {
 			duplex: 'half',
 		});
 	}
+}
+
+/**
+ * Return the component path without the `srcDir` and `pages`
+ * @param component
+ */
+function getAstroRoute(component: RouteData['component']): string {
+	let splitComponent = component.split("/");
+	while (true) {
+		const currentPart = splitComponent.shift();
+		if (!currentPart) {break}
+		
+		// "pages" isn't configurable, so it's safe to stop here
+		if (currentPart === "pages") {
+			break
+		}
+	}
+	
+	const pathWithoutPages = splitComponent.join("/");
+	// This covers cases where routes don't have extensions, so they can be: [slug] or [...slug]
+	if (pathWithoutPages.endsWith("]")) {
+		return pathWithoutPages;
+	}
+	splitComponent =  splitComponent.join("/").split(".");
+
+	// this should remove the extension
+	splitComponent.pop();
+	return splitComponent.join("/");
 }

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -599,5 +599,5 @@ function getAstroRoutePattern(component: RouteData['component']): string {
 
 	// this should remove the extension
 	splitComponent.pop();
-	return splitComponent.join("/");
+	return "/" + splitComponent.join("/");
 }

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -39,7 +39,7 @@ export class RenderContext {
 	originalRoute: RouteData;
 	
 	// The component pattern to send to the users
-	astroRoute: string;
+	routePattern: string;
 
 	private constructor(
 		readonly pipeline: Pipeline,
@@ -55,7 +55,7 @@ export class RenderContext {
 		public props: Props = {},
 	) {
 		this.originalRoute = routeData;
-		this.astroRoute = getAstroRoute(routeData.component);
+		this.routePattern = getAstroRoutePattern(routeData.component);
 	}
 
 	/**
@@ -238,7 +238,7 @@ export class RenderContext {
 		this.isRewriting = true;
 		// we found a route and a component, we can change the status code to 200
 		this.status = 200;
-		this.astroRoute = getAstroRoute(routeData.component);
+		this.routePattern = getAstroRoutePattern(routeData.component);
 		return await this.render(component);
 	}
 
@@ -255,7 +255,7 @@ export class RenderContext {
 
 		return {
 			cookies,
-			route: this.astroRoute,
+			routePattern: this.routePattern,
 			get clientAddress() {
 				return renderContext.clientAddress();
 			},
@@ -441,7 +441,7 @@ export class RenderContext {
 		return {
 			generator: astroStaticPartial.generator,
 			glob: astroStaticPartial.glob,
-			route: this.astroRoute,
+			routePattern: this.routePattern,
 			cookies,
 			get clientAddress() {
 				return renderContext.clientAddress();
@@ -578,7 +578,7 @@ export class RenderContext {
  * Return the component path without the `srcDir` and `pages`
  * @param component
  */
-function getAstroRoute(component: RouteData['component']): string {
+function getAstroRoutePattern(component: RouteData['component']): string {
 	let splitComponent = component.split("/");
 	while (true) {
 		const currentPart = splitComponent.shift();

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -250,6 +250,7 @@ export class RenderContext {
 
 		return {
 			cookies,
+			route: this.routeData.component,
 			get clientAddress() {
 				return renderContext.clientAddress();
 			},
@@ -435,6 +436,7 @@ export class RenderContext {
 		return {
 			generator: astroStaticPartial.generator,
 			glob: astroStaticPartial.glob,
+			route: this.routeData.component,
 			cookies,
 			get clientAddress() {
 				return renderContext.clientAddress();

--- a/packages/astro/src/types/public/context.ts
+++ b/packages/astro/src/types/public/context.ts
@@ -146,7 +146,7 @@ export interface AstroGlobal<
 	 * - The value when rendering `src/pages/blog/[slug].astro` will `blog/[slug]`.
 	 * - The value when rendering `src/pages/[...path].astro` will `[...path]`.
 	 */
-	route: string;
+	routePattern: string;
 	/**
 	 * The <Astro.self /> element allows a component to reference itself recursively.
 	 *
@@ -517,5 +517,5 @@ export interface APIContext<
 	 * - The value when rendering `src/pages/blog/[slug].astro` will `blog/[slug]`.
 	 * - The value when rendering `src/pages/[...path].astro` will `[...path]`.
 	 */
-	route: string
+	routePattern: string
 }

--- a/packages/astro/src/types/public/context.ts
+++ b/packages/astro/src/types/public/context.ts
@@ -137,6 +137,16 @@ export interface AstroGlobal<
 	 * ```
 	 */
 	rewrite: AstroSharedContext['rewrite'];
+
+	/**
+	 * The route currently rendered. It's stripped of the `srcDir` and the `pages` folder, and it doesn't contain the extension.
+	 * 
+	 * ## Example
+	 * - The value when rendering `src/pages/index.astro` will `index`.
+	 * - The value when rendering `src/pages/blog/[slug].astro` will `blog/[slug]`.
+	 * - The value when rendering `src/pages/[...path].astro` will `[...path]`.
+	 */
+	route: string;
 	/**
 	 * The <Astro.self /> element allows a component to reference itself recursively.
 	 *
@@ -498,4 +508,14 @@ export interface APIContext<
 	 * The current locale computed from the URL of the request. It matches the locales in `i18n.locales`, and returns `undefined` otherwise.
 	 */
 	currentLocale: string | undefined;
+
+	/**
+	 * The route currently rendered. It's stripped of the `srcDir` and the `pages` folder, and it doesn't contain the extension.
+	 *
+	 * ## Example
+	 * - The value when rendering `src/pages/index.astro` will `index`.
+	 * - The value when rendering `src/pages/blog/[slug].astro` will `blog/[slug]`.
+	 * - The value when rendering `src/pages/[...path].astro` will `[...path]`.
+	 */
+	route: string
 }

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -50,12 +50,12 @@ describe('Astro Global', () => {
 		it("Astro.route.pattern has the right value in pages and components", async () => {
 			let html = await fixture.fetch('/blog').then((res) => res.text());
 			let $ = cheerio.load(html);
-			assert.match($("#pattern").text(),  /Astro route pattern: index/);
-			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: index/);
+			assert.match($("#pattern").text(),  /Astro route pattern: \/index/);
+			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: \/index/);
 			html = await fixture.fetch('/blog/omit-markdown-extensions/').then((res) => res.text());
 			$ = cheerio.load(html);
-			assert.match($("#pattern").text(),  /Astro route pattern: omit-markdown-extensions/);
-			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: omit-markdown-extensions/);
+			assert.match($("#pattern").text(),  /Astro route pattern: \/omit-markdown-extensions/);
+			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: \/omit-markdown-extensions/);
 		})
 	});
 
@@ -96,18 +96,18 @@ describe('Astro Global', () => {
 		it("Astro.route.pattern has the right value in pages and components", async () => {
 			let html = await fixture.readFile('/index.html');
 			let $ = cheerio.load(html);
-			assert.match($("#pattern").text(),  /Astro route pattern: index/);
-			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: index/);
+			assert.match($("#pattern").text(),  /Astro route pattern: \/index/);
+			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: \/index/);
 
 			html =await fixture.readFile('/omit-markdown-extensions/index.html');
 			$ = cheerio.load(html);
-			assert.match($("#pattern").text(),  /Astro route pattern: omit-markdown-extensions/);
-			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: omit-markdown-extensions/);
+			assert.match($("#pattern").text(),  /Astro route pattern: \/omit-markdown-extensions/);
+			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: \/omit-markdown-extensions/);
 
 			html = await fixture.readFile('/posts/1/index.html');
 			$ = cheerio.load(html);
-			assert.equal($("#pattern").text(),  "Astro route pattern: posts/[page]");
-			assert.equal($("#pattern-middleware").text(),  "Astro route pattern middleware: posts/[page]");
+			assert.equal($("#pattern").text(),  "Astro route pattern: /posts/[page]");
+			assert.equal($("#pattern-middleware").text(),  "Astro route pattern middleware: /posts/[page]");
 
 		})
 	});
@@ -139,13 +139,13 @@ describe('Astro Global', () => {
 			let response = await app.render(new Request('https://example.com/'));
 			let html = await response.text();
 			let $ = cheerio.load(html);
-			assert.match($("#pattern").text(),  /Astro route pattern: index/);
-			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: index/);
+			assert.match($("#pattern").text(),  /Astro route pattern: \/index/);
+			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: \/index/);
 			response = await app.render(new Request('https://example.com/omit-markdown-extensions'));
 			html = await response.text();
 			$ = cheerio.load(html);
-			assert.match($("#pattern").text(),  /Astro route pattern: omit-markdown-extensions/);
-			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: omit-markdown-extensions/);
+			assert.match($("#pattern").text(),  /Astro route pattern: \/omit-markdown-extensions/);
+			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: \/omit-markdown-extensions/);
 		})
 	});
 });

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -50,10 +50,10 @@ describe('Astro Global', () => {
 		it("Astro.route has the right value in pages and components", async () => {
 			let html = await fixture.fetch('/blog').then((res) => res.text());
 			let $ = cheerio.load(html);
-			assert.match($("#route").text(),  /Astro route: src\/pages\/index.astro/);
+			assert.match($("#route").text(),  /Astro route: index/);
 			html = await fixture.fetch('/blog/omit-markdown-extensions/').then((res) => res.text());
 			$ = cheerio.load(html);
-			assert.match($("#route").text(),  /Astro route: src\/pages\/omit-markdown-extensions.astro/);
+			assert.match($("#route").text(),  /Astro route: omit-markdown-extensions/);
 		})
 	});
 
@@ -94,10 +94,13 @@ describe('Astro Global', () => {
 		it("Astro.route has the right value in pages and components", async () => {
 			let html = await fixture.readFile('/index.html');
 			let $ = cheerio.load(html);
-			assert.match($("#route").text(),  /Astro route: src\/pages\/index.astro/);
+			assert.match($("#route").text(),  /Astro route: index/);
 			html =await fixture.readFile('/omit-markdown-extensions/index.html');
 			$ = cheerio.load(html);
-			assert.match($("#route").text(),  /Astro route: src\/pages\/omit-markdown-extensions.astro/);
+			assert.match($("#route").text(),  /Astro route: omit-markdown-extensions/);
+			html = await fixture.readFile('/posts/1/index.html');
+			$ = cheerio.load(html);
+			assert.equal($("#route").text(),  "Astro route: posts/[page]");
 		})
 	});
 
@@ -128,11 +131,11 @@ describe('Astro Global', () => {
 			let response = await app.render(new Request('https://example.com/'));
 			let html = await response.text();
 			let $ = cheerio.load(html);
-			assert.match($("#route").text(),  /Astro route: src\/pages\/index.astro/);
+			assert.match($("#route").text(),  /Astro route: index/);
 			response = await app.render(new Request('https://example.com/omit-markdown-extensions'));
 			html = await response.text();
 			$ = cheerio.load(html);
-			assert.match($("#route").text(),  /Astro route: src\/pages\/omit-markdown-extensions.astro/);
+			assert.match($("#route").text(),  /Astro route: omit-markdown-extensions/);
 		})
 	});
 });

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -46,6 +46,15 @@ describe('Astro Global', () => {
 				false,
 			);
 		});
+		
+		it("Astro.route has the right value in pages and components", async () => {
+			let html = await fixture.fetch('/blog').then((res) => res.text());
+			let $ = cheerio.load(html);
+			assert.match($("#route").text(),  /Astro route: src\/pages\/index.astro/);
+			html = await fixture.fetch('/blog/omit-markdown-extensions/').then((res) => res.text());
+			$ = cheerio.load(html);
+			assert.match($("#route").text(),  /Astro route: src\/pages\/omit-markdown-extensions.astro/);
+		})
 	});
 
 	describe('build', () => {
@@ -81,6 +90,15 @@ describe('Astro Global', () => {
 			assert.equal($('[data-file]').length, 8);
 			assert.equal($('.post-url[href]').length, 8);
 		});
+
+		it("Astro.route has the right value in pages and components", async () => {
+			let html = await fixture.readFile('/index.html');
+			let $ = cheerio.load(html);
+			assert.match($("#route").text(),  /Astro route: src\/pages\/index.astro/);
+			html =await fixture.readFile('/omit-markdown-extensions/index.html');
+			$ = cheerio.load(html);
+			assert.match($("#route").text(),  /Astro route: src\/pages\/omit-markdown-extensions.astro/);
+		})
 	});
 
 	describe('app', () => {
@@ -105,6 +123,17 @@ describe('Astro Global', () => {
 			const $ = cheerio.load(html);
 			assert.equal($('#site').attr('href'), 'https://mysite.dev/subsite/');
 		});
+
+		it("Astro.route has the right value in pages and components", async () => {
+			let response = await app.render(new Request('https://example.com/'));
+			let html = await response.text();
+			let $ = cheerio.load(html);
+			assert.match($("#route").text(),  /Astro route: src\/pages\/index.astro/);
+			response = await app.render(new Request('https://example.com/omit-markdown-extensions'));
+			html = await response.text();
+			$ = cheerio.load(html);
+			assert.match($("#route").text(),  /Astro route: src\/pages\/omit-markdown-extensions.astro/);
+		})
 	});
 });
 

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -47,13 +47,15 @@ describe('Astro Global', () => {
 			);
 		});
 		
-		it("Astro.route has the right value in pages and components", async () => {
+		it("Astro.route.pattern has the right value in pages and components", async () => {
 			let html = await fixture.fetch('/blog').then((res) => res.text());
 			let $ = cheerio.load(html);
-			assert.match($("#route").text(),  /Astro route: index/);
+			assert.match($("#pattern").text(),  /Astro route pattern: index/);
+			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: index/);
 			html = await fixture.fetch('/blog/omit-markdown-extensions/').then((res) => res.text());
 			$ = cheerio.load(html);
-			assert.match($("#route").text(),  /Astro route: omit-markdown-extensions/);
+			assert.match($("#pattern").text(),  /Astro route pattern: omit-markdown-extensions/);
+			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: omit-markdown-extensions/);
 		})
 	});
 
@@ -91,16 +93,22 @@ describe('Astro Global', () => {
 			assert.equal($('.post-url[href]').length, 8);
 		});
 
-		it("Astro.route has the right value in pages and components", async () => {
+		it("Astro.route.pattern has the right value in pages and components", async () => {
 			let html = await fixture.readFile('/index.html');
 			let $ = cheerio.load(html);
-			assert.match($("#route").text(),  /Astro route: index/);
+			assert.match($("#pattern").text(),  /Astro route pattern: index/);
+			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: index/);
+
 			html =await fixture.readFile('/omit-markdown-extensions/index.html');
 			$ = cheerio.load(html);
-			assert.match($("#route").text(),  /Astro route: omit-markdown-extensions/);
+			assert.match($("#pattern").text(),  /Astro route pattern: omit-markdown-extensions/);
+			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: omit-markdown-extensions/);
+
 			html = await fixture.readFile('/posts/1/index.html');
 			$ = cheerio.load(html);
-			assert.equal($("#route").text(),  "Astro route: posts/[page]");
+			assert.equal($("#pattern").text(),  "Astro route pattern: posts/[page]");
+			assert.equal($("#pattern-middleware").text(),  "Astro route pattern middleware: posts/[page]");
+
 		})
 	});
 
@@ -127,15 +135,17 @@ describe('Astro Global', () => {
 			assert.equal($('#site').attr('href'), 'https://mysite.dev/subsite/');
 		});
 
-		it("Astro.route has the right value in pages and components", async () => {
+		it("Astro.route.pattern has the right value in pages and components", async () => {
 			let response = await app.render(new Request('https://example.com/'));
 			let html = await response.text();
 			let $ = cheerio.load(html);
-			assert.match($("#route").text(),  /Astro route: index/);
+			assert.match($("#pattern").text(),  /Astro route pattern: index/);
+			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: index/);
 			response = await app.render(new Request('https://example.com/omit-markdown-extensions'));
 			html = await response.text();
 			$ = cheerio.load(html);
-			assert.match($("#route").text(),  /Astro route: omit-markdown-extensions/);
+			assert.match($("#pattern").text(),  /Astro route pattern: omit-markdown-extensions/);
+			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: omit-markdown-extensions/);
 		})
 	});
 });

--- a/packages/astro/test/fixtures/astro-global/src/components/Route.astro
+++ b/packages/astro/test/fixtures/astro-global/src/components/Route.astro
@@ -1,0 +1,4 @@
+---
+const route = Astro.route;
+---
+<p id="route">Astro route: {route}</p>

--- a/packages/astro/test/fixtures/astro-global/src/components/Route.astro
+++ b/packages/astro/test/fixtures/astro-global/src/components/Route.astro
@@ -1,4 +1,4 @@
 ---
-const route = Astro.route;
+const route = Astro.routePattern;
 ---
 <p id="route">Astro route: {route}</p>

--- a/packages/astro/test/fixtures/astro-global/src/components/Route.astro
+++ b/packages/astro/test/fixtures/astro-global/src/components/Route.astro
@@ -1,4 +1,6 @@
 ---
-const route = Astro.routePattern;
+const pattern = Astro.routePattern;
+const localsPattern = Astro.locals.localsPattern;
 ---
-<p id="route">Astro route: {route}</p>
+<p id="pattern">Astro route pattern: {pattern}</p>
+<p id="pattern-middleware">Astro route pattern middleware: {localsPattern}</p>

--- a/packages/astro/test/fixtures/astro-global/src/middleware.js
+++ b/packages/astro/test/fixtures/astro-global/src/middleware.js
@@ -1,0 +1,8 @@
+
+
+export function onRequest(ctx, next) {
+	ctx.locals = {
+		localsPattern: ctx.route.pattern
+	};
+	return next()
+}

--- a/packages/astro/test/fixtures/astro-global/src/middleware.js
+++ b/packages/astro/test/fixtures/astro-global/src/middleware.js
@@ -2,7 +2,7 @@
 
 export function onRequest(ctx, next) {
 	ctx.locals = {
-		localsPattern: ctx.route.pattern
+		localsPattern: ctx.routePattern
 	};
 	return next()
 }

--- a/packages/astro/test/fixtures/astro-global/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-global/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Child from '../components/Child.astro';
+import Route from '../components/Route.astro';
 const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? `http://example.com`);
 ---
 <html>
@@ -13,5 +14,6 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? `http://example.c
   <a id="site" href={Astro.site}>Home</a>
 
   <Child />
+	<Route />
 </body>
 </html>

--- a/packages/astro/test/fixtures/astro-global/src/pages/omit-markdown-extensions.astro
+++ b/packages/astro/test/fixtures/astro-global/src/pages/omit-markdown-extensions.astro
@@ -1,4 +1,6 @@
 ---
+import Route from "../components/Route.astro";
+
 const markdownPosts = await Astro.glob('./post/**/*.{markdown,mdown,mkdn,mkd,mdwn,md}');
 const markdownExtensions = /(\.(markdown|mdown|mkdn|mkd|mdwn|md))$/g
 const aUrlContainsExtension = markdownPosts.some((page:any)=> {
@@ -12,5 +14,6 @@ const aUrlContainsExtension = markdownPosts.some((page:any)=> {
   </head>
   <body>
     <p data-any-url-contains-extension={JSON.stringify(aUrlContainsExtension)}>Placeholder</p>
+		<Route />
   </body>
 </html>

--- a/packages/astro/test/fixtures/astro-global/src/pages/posts/[page].astro
+++ b/packages/astro/test/fixtures/astro-global/src/pages/posts/[page].astro
@@ -1,4 +1,6 @@
 ---
+import Route from "../../components/Route.astro";
+
 export async function getStaticPaths({paginate}) {
   const data = await Astro.glob('../post/*.md');
   return paginate(data, {pageSize: 1});
@@ -19,5 +21,6 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? `http://example.c
         <a class="post-url" href={data.url}>Read</a>
       </div>
     ))}
+		<Route />
   </body>
 </html>


### PR DESCRIPTION
## Changes

**For Astro 5.0**
Closes PLT-2339

It adds a new field to the `Astro` global called `routePattern`.

`route` is `RouteData.component` without `srcDir` and `pages`:

- `src/pages/index.astro` -> `index`
- `src/pages/blog/[post].astro` -> `blog/[post]`

## Testing

I added new tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

https://github.com/withastro/docs/pull/9180

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
 /cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
