### PR TITLE
fix: server islands regression in bundling

### DIFF
--- a/.changeset/young-tigers-fry.md
+++ b/.changeset/young-tigers-fry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a regression where an emitted hashed file contained characters that aren't allowed in some hosting platforms

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -27,11 +27,6 @@ function vitePluginSSR(
 	return {
 		name: '@astrojs/vite-plugin-astro-ssr-server',
 		enforce: 'post',
-		augmentChunkHash(chunkInfo) {
-			if (chunkInfo.facadeModuleId === options.settings.adapter?.serverEntrypoint) {
-				return Date.now().toString();
-			}
-		},
 		options(opts) {
 			const inputs = new Set<string>();
 
@@ -40,6 +35,11 @@ function vitePluginSSR(
 					continue;
 				}
 				inputs.add(getVirtualModulePageName(ASTRO_PAGE_MODULE_ID, pageData.component));
+			}
+
+			const adapterServerEntrypoint = options.settings.adapter?.serverEntrypoint;
+			if (adapterServerEntrypoint && options.settings.config.experimental.serverIslands) {
+				inputs.add(adapterServerEntrypoint);
 			}
 
 			inputs.add(SSR_VIRTUAL_MODULE_ID);
@@ -170,11 +170,6 @@ function vitePluginSSRSplit(
 			}
 
 			return addRollupInput(opts, Array.from(inputs));
-		},
-		augmentChunkHash(chunkInfo) {
-			if (chunkInfo.facadeModuleId === options.settings.adapter?.serverEntrypoint) {
-				return Date.now().toString();
-			}
 		},
 		resolveId(id) {
 			if (id.startsWith(SPLIT_MODULE_ID)) {

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -27,6 +27,11 @@ function vitePluginSSR(
 	return {
 		name: '@astrojs/vite-plugin-astro-ssr-server',
 		enforce: 'post',
+		augmentChunkHash(chunkInfo) {
+			if (chunkInfo.facadeModuleId === options.settings.adapter?.serverEntrypoint) {
+				return Date.now().toString();
+			}
+		},
 		options(opts) {
 			const inputs = new Set<string>();
 
@@ -170,6 +175,11 @@ function vitePluginSSRSplit(
 			}
 
 			return addRollupInput(opts, Array.from(inputs));
+		},
+		augmentChunkHash(chunkInfo) {
+			if (chunkInfo.facadeModuleId === options.settings.adapter?.serverEntrypoint) {
+				return Date.now().toString();
+			}
 		},
 		resolveId(id) {
 			if (id.startsWith(SPLIT_MODULE_ID)) {

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -42,11 +42,6 @@ function vitePluginSSR(
 				inputs.add(getVirtualModulePageName(ASTRO_PAGE_MODULE_ID, pageData.component));
 			}
 
-			const adapterServerEntrypoint = options.settings.adapter?.serverEntrypoint;
-			if (adapterServerEntrypoint) {
-				inputs.add(adapterServerEntrypoint);
-			}
-
 			inputs.add(SSR_VIRTUAL_MODULE_ID);
 			return addRollupInput(opts, Array.from(inputs));
 		},

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -255,7 +255,7 @@ async function ssrBuild(
 							return 'renderers.mjs';
 						} else if (chunkInfo.facadeModuleId === RESOLVED_SSR_MANIFEST_VIRTUAL_MODULE_ID) {
 							return 'manifest_[hash].mjs';
-						} else if (chunkInfo.facadeModuleId === settings.adapter?.serverEntrypoint) {
+						} else if (chunkInfo.facadeModuleId === settings.adapter?.serverEntrypoint && settings.config.experimental.serverIslands) {
 							return 'adapter_[hash].mjs';
 						} else if (
 							settings.config.experimental.contentCollectionCache &&

--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -108,6 +108,9 @@ export default function ({
 					supportedAstroFeatures: {
 						serverOutput: 'stable',
 						envGetSecret: 'experimental',
+						hybridOutput: 'stable',
+						assets: 'stable',
+						i18nDomains: 'stable',
 					},
 					...extendAdapter,
 				});


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/11700

I changed the condition that adds the server entrypoint to the rollup inputs, to only so when the server islands are enabled. 

## Testing

I will create a preview release and ask the user to test it.

The CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
