### PR TITLE
Prevent externalized adapters from breaking build

### DIFF
--- a/.changeset/new-boats-flash.md
+++ b/.changeset/new-boats-flash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix adapter causing Netlify to break

--- a/packages/astro/test/ssr-split-manifest.test.js
+++ b/packages/astro/test/ssr-split-manifest.test.js
@@ -62,12 +62,10 @@ describe('astro:ssr-manifest, split', () => {
 	});
 
 	it('should correctly emit the the pre render page', async () => {
-		const text = readFileSync(
-			resolve('./test/fixtures/ssr-split-manifest/dist/client/prerender/index.html'),
-			{
-				encoding: 'utf8',
-			},
-		);
+		const indexUrl = new URL('./fixtures/ssr-split-manifest/dist/client/prerender/index.html', import.meta.url);
+		const text = readFileSync(indexUrl, {
+			encoding: 'utf8',
+		});
 		assert.equal(text.includes('<title>Pre render me</title>'), true);
 	});
 

--- a/packages/astro/test/ssr-split-manifest.test.js
+++ b/packages/astro/test/ssr-split-manifest.test.js
@@ -1,6 +1,5 @@
 import assert from 'node:assert/strict';
 import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { before, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import * as cheerio from 'cheerio';


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/astro/issues/11700
- A different approach than https://github.com/withastro/astro/pull/11702, makes a virtual module that can be imported even if the adapter is external.

## Testing

Preview release

## Docs

N/A, bug fix