### PR TITLE
fix(astro): Prevent prefetching of same urls with different hashes

### DIFF
--- a/.changeset/nasty-ladybugs-whisper.md
+++ b/.changeset/nasty-ladybugs-whisper.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Prevents prefetching of the same urls with different hahes.
+Prevents prefetching of the same urls with different hashes.

--- a/.changeset/nasty-ladybugs-whisper.md
+++ b/.changeset/nasty-ladybugs-whisper.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevents prefetching of the same urls with different hahes.

--- a/packages/astro/src/prefetch/index.ts
+++ b/packages/astro/src/prefetch/index.ts
@@ -215,6 +215,11 @@ export interface PrefetchOptions {
  * @param opts Additional options for prefetching.
  */
 export function prefetch(url: string, opts?: PrefetchOptions) {
+	// Remove url hash to avoid prefetching the same URL multiple times
+	const urlObj = new URL(url, location.href);
+	urlObj.hash = '';
+	url = urlObj.toString();
+
 	const ignoreSlowConnection = opts?.ignoreSlowConnection ?? false;
 	if (!canPrefetchUrl(url, ignoreSlowConnection)) return;
 	prefetchedUrls.add(url);

--- a/packages/astro/src/prefetch/index.ts
+++ b/packages/astro/src/prefetch/index.ts
@@ -216,9 +216,7 @@ export interface PrefetchOptions {
  */
 export function prefetch(url: string, opts?: PrefetchOptions) {
 	// Remove url hash to avoid prefetching the same URL multiple times
-	const urlObj = new URL(url, location.href);
-	urlObj.hash = '';
-	url = urlObj.toString();
+	url = url.replace(/#.*/, '');
 
 	const ignoreSlowConnection = opts?.ignoreSlowConnection ?? false;
 	if (!canPrefetchUrl(url, ignoreSlowConnection)) return;


### PR DESCRIPTION
## Changes

Prevents prefetching of same urls with different hashes.
This should not matter if cache works as expected but is annoying, especially in dev.

Before: ![image](https://github.com/user-attachments/assets/41491287-2b65-4893-a98d-81a59daf25bd)

## Testing

Tested locally, not sure if this needs a test at all.

## Docs

This should not need any documentation.
