### PR TITLE
fix: content types sync in dev

### DIFF
--- a/.changeset/angry-plants-guess.md
+++ b/.changeset/angry-plants-guess.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes content types sync in dev

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -3,11 +3,11 @@ import { performance } from 'node:perf_hooks';
 import { dim } from 'kleur/colors';
 import { type HMRPayload, createServer } from 'vite';
 import type { AstroConfig, AstroInlineConfig, AstroSettings } from '../../@types/astro.js';
-import { DATA_STORE_FILE } from '../../content/consts.js';
+import { CONTENT_TYPES_FILE, DATA_STORE_FILE } from '../../content/consts.js';
 import { globalContentLayer } from '../../content/content-layer.js';
 import { DataStore, globalDataStore } from '../../content/data-store.js';
 import { createContentTypesGenerator } from '../../content/index.js';
-import { globalContentConfigObserver } from '../../content/utils.js';
+import { getContentPaths, globalContentConfigObserver } from '../../content/utils.js';
 import { syncAstroEnv } from '../../env/sync.js';
 import { telemetry } from '../../events/index.js';
 import { eventCliSession } from '../../events/session.js';
@@ -124,6 +124,14 @@ export async function syncInternal({
 			});
 			await contentLayer.sync();
 			settings.timer.end('Sync content layer');
+		} else if (fs.existsSync(getContentPaths(settings.config, fs).contentDir)) {
+			// Content is synced after writeFiles. That means references are not created
+			// To work around it, we create a stub so the reference is created and content
+			// sync will override the empty file
+			settings.injectedTypes.push({
+				filename: CONTENT_TYPES_FILE,
+				content: '',
+			});
 		}
 		syncAstroEnv(settings, fs);
 


### PR DESCRIPTION
## Changes

- Content is synced after writeFiles. That means references are not created. To work around it, we create a stub so the reference is created and content sync will override the empty file

## Testing

Should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
