### PR TITLE
Fix MDX stack trace location with frontmatter

### DIFF
--- a/.changeset/mighty-trees-teach.md
+++ b/.changeset/mighty-trees-teach.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Fixes stack trace location when failed to parse an MDX file with frontmatter

--- a/packages/integrations/mdx/src/vite-plugin-mdx.ts
+++ b/packages/integrations/mdx/src/vite-plugin-mdx.ts
@@ -44,9 +44,10 @@ export function vitePluginMdx(mdxOptions: MdxOptions): Plugin {
 		async transform(code, id) {
 			if (!id.endsWith('.mdx')) return;
 
-			const { data: frontmatter, content: pageContent } = parseFrontmatter(code, id);
+			const { data: frontmatter, content: pageContent, matter } = parseFrontmatter(code, id);
+			const frontmatterLines = matter ? matter.match(/\n/g)?.join('') + '\n\n' : '';
 
-			const vfile = new VFile({ value: pageContent, path: id });
+			const vfile = new VFile({ value: frontmatterLines + pageContent, path: id });
 			// Ensure `data.astro` is available to all remark plugins
 			setVfileFrontmatter(vfile, frontmatter);
 


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/11707

When we extract the frontmatter with `gray-matter` and it returns the `content`, it doesn't include the new lines from the stripped frontmatter, causing the MDX parser to incorrectly pinpoint the location of the error.

This PR manually adds the new lines to preserve the location.

## Testing

Tested manually. The location is now correct: 
<img width="1310" alt="image" src="https://github.com/user-attachments/assets/cd9f9724-be15-4652-874d-3bf0e6281360">


## Docs

n/a. bug fix.