### PR TITLE
refactor: enforce node prefix

### DIFF
--- a/.changeset/hungry-monkeys-talk.md
+++ b/.changeset/hungry-monkeys-talk.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an incompatibility issue with Cloudflare caused by the Content Layer

--- a/.changeset/hungry-monkeys-talk.md
+++ b/.changeset/hungry-monkeys-talk.md
@@ -1,5 +1,0 @@
----
-'astro': patch
----
-
-Fixes an incompatibility issue with Cloudflare caused by the Content Layer

--- a/biome.json
+++ b/biome.json
@@ -29,7 +29,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "all": false,
+      "recommended": false,
       "style": {
         "useNodejsImportProtocol": "error"
       }

--- a/biome.json
+++ b/biome.json
@@ -26,7 +26,15 @@
   "organizeImports": {
     "enabled": true
   },
-  "linter": { "enabled": false },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "all": false,
+      "style": {
+        "useNodejsImportProtocol": "error"
+      }
+    }
+  },
   "javascript": {
     "formatter": {
       "trailingCommas": "all",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:e2e:match": "cd packages/astro && pnpm playwright install chromium firefox && pnpm run test:e2e:match",
     "test:e2e:hosts": "turbo run test:hosted",
     "benchmark": "astro-benchmark",
-    "lint": "eslint . --report-unused-disable-directives && biome lint",
+    "lint": "biome lint && eslint . --report-unused-disable-directives",
     "version": "changeset version && node ./scripts/deps/update-example-versions.js && pnpm install --no-frozen-lockfile && pnpm run format",
     "preinstall": "npx only-allow pnpm"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:e2e:match": "cd packages/astro && pnpm playwright install chromium firefox && pnpm run test:e2e:match",
     "test:e2e:hosts": "turbo run test:hosted",
     "benchmark": "astro-benchmark",
-    "lint": "eslint . --report-unused-disable-directives",
+    "lint": "eslint . --report-unused-disable-directives && biome lint",
     "version": "changeset version && node ./scripts/deps/update-example-versions.js && pnpm install --no-frozen-lockfile && pnpm run format",
     "preinstall": "npx only-allow pnpm"
   },

--- a/packages/astro/src/assets/endpoint/node.ts
+++ b/packages/astro/src/assets/endpoint/node.ts
@@ -5,7 +5,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 // @ts-expect-error
 import { assetsDir, imageConfig, outDir } from 'astro:assets';
 import { isRemotePath, removeQueryString } from '@astrojs/internal-helpers/path';
-import { readFile } from 'fs/promises';
+import { readFile } from 'node:fs/promises';
 import * as mime from 'mrmime';
 import type { APIRoute } from '../../@types/astro.js';
 import { getConfiguredImageService } from '../internal.js';

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -2,7 +2,7 @@ import fs, { existsSync } from 'node:fs';
 import type http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { green } from 'kleur/colors';
-import { performance } from 'perf_hooks';
+import { performance } from 'node:perf_hooks';
 import { gt, major, minor, patch } from 'semver';
 import type * as vite from 'vite';
 import type { AstroInlineConfig } from '../../@types/astro.js';

--- a/packages/astro/src/core/logger/vite.ts
+++ b/packages/astro/src/core/logger/vite.ts
@@ -1,4 +1,4 @@
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import stripAnsi from 'strip-ansi';
 import type { LogLevel, Rollup, Logger as ViteLogger } from 'vite';
 import { isAstroError } from '../errors/errors.js';

--- a/packages/astro/src/core/preview/static-preview-server.ts
+++ b/packages/astro/src/core/preview/static-preview-server.ts
@@ -1,6 +1,6 @@
 import type http from 'node:http';
 import { fileURLToPath } from 'node:url';
-import { performance } from 'perf_hooks';
+import { performance } from 'node:perf_hooks';
 import { type PreviewServer as VitePreviewServer, preview } from 'vite';
 import type { AstroSettings } from '../../@types/astro.js';
 import type { Logger } from '../logger/core.js';

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../../@types/astro.js';
 import type { Logger } from '../../logger/core.js';
 
-import { createRequire } from 'module';
+import { createRequire } from 'node:module';
 import nodeFs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/packages/astro/src/vite-plugin-astro-server/response.ts
+++ b/packages/astro/src/vite-plugin-astro-server/response.ts
@@ -2,7 +2,7 @@ import type http from 'node:http';
 import type { ErrorWithMetadata } from '../core/errors/index.js';
 import type { ModuleLoader } from '../core/module-loader/index.js';
 
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { getSetCookiesFromResponse } from '../core/cookies/index.js';
 import { getViteErrorPayload } from '../core/errors/dev/index.js';
 import notFoundTemplate from '../template/4xx.js';

--- a/packages/astro/test/build-readonly-file.test.js
+++ b/packages/astro/test/build-readonly-file.test.js
@@ -1,5 +1,5 @@
 import { after, before, describe, it } from 'node:test';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
 

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -1,11 +1,11 @@
-import { existsSync } from 'fs';
+import { existsSync } from 'node:fs';
 import { parseArgs } from 'node:util';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { type ManagedAppToken, getManagedAppTokenOrExit } from '@astrojs/studio';
 import { LibsqlError } from '@libsql/client';
 import type { AstroConfig, AstroIntegration } from 'astro';
-import { mkdir, writeFile } from 'fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { blue, yellow } from 'kleur/colors';
 import {
 	type HMRPayload,

--- a/packages/db/test/local-prod.test.js
+++ b/packages/db/test/local-prod.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
-import { relative } from 'path';
-import { fileURLToPath } from 'url';
+import { relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import testAdapter from '../../astro/test/test-adapter.js';
 import { loadFixture } from '../../astro/test/test-utils.js';
 

--- a/packages/integrations/node/src/standalone.ts
+++ b/packages/integrations/node/src/standalone.ts
@@ -1,4 +1,4 @@
-import https from 'https';
+import https from 'node:https';
 import fs from 'node:fs';
 import http from 'node:http';
 import type { PreviewServer } from 'astro';

--- a/packages/integrations/partytown/src/index.ts
+++ b/packages/integrations/partytown/src/index.ts
@@ -1,4 +1,4 @@
-import { createRequire } from 'module';
+import { createRequire } from 'node:module';
 import * as fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/packages/integrations/sitemap/src/write-sitemap.ts
+++ b/packages/integrations/sitemap/src/write-sitemap.ts
@@ -1,8 +1,8 @@
-import { type WriteStream, createWriteStream } from 'fs';
-import { normalize, resolve } from 'path';
-import { Readable, pipeline } from 'stream';
-import { promisify } from 'util';
-import { mkdir } from 'fs/promises';
+import { type WriteStream, createWriteStream } from 'node:fs';
+import { normalize, resolve } from 'node:path';
+import { Readable, pipeline } from 'node:stream';
+import { promisify } from 'node:util';
+import { mkdir } from 'node:fs/promises';
 import replace from 'stream-replace-string';
 
 import { SitemapAndIndexStream, SitemapStream } from 'sitemap';


### PR DESCRIPTION
## Changes

- Updates fs import with prefix
- enable biome rule to catch such thing in the future
- depends on #11725

## Testing

should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A, no changeset since internal only

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
