### PR TITLE
chore: updates the supported features of test adapter

### DIFF
--- a/packages/astro/test/test-adapter.js
+++ b/packages/astro/test/test-adapter.js
@@ -108,6 +108,10 @@ export default function ({
 					supportedAstroFeatures: {
 						serverOutput: 'stable',
 						envGetSecret: 'experimental',
+						staticOutput: 'stable',
+						hybridOutput: 'stable',
+						assets: 'stable',
+						i18nDomains: 'stable',
 					},
 					...extendAdapter,
 				});


### PR DESCRIPTION
## Changes

Chore PR, it doesn't change any functionality, but it removes some annoying errors we get in CI e.g.:

```
Error: 6 [ERROR] [config] The feature "assets" is not supported (used by test).
Error: 6 [ERROR] [config] The feature "hybridOutput" is not supported (used by test).
```

## Testing

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
