### PR TITLE
Deprecate the functionPerRoute option

### DIFF
--- a/.changeset/weak-dancers-beam.md
+++ b/.changeset/weak-dancers-beam.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': minor
+---
+
+Deprecate the functionPerRoute option

--- a/.changeset/weak-dancers-beam.md
+++ b/.changeset/weak-dancers-beam.md
@@ -2,4 +2,19 @@
 '@astrojs/vercel': minor
 ---
 
-Deprecate the functionPerRoute option
+Deprecates the `functionPerRoute` option
+
+This option is now deprecated, and will be removed entirely in Astro v5.0. We suggest removing this option from your configuration as soon as you are able to:
+
+```diff
+import { defineConfig } from 'astro/config';
+import vercel from '@astrojs/vercel/serverless';
+
+export default defineConfig({
+  // ...
+  output: 'server',
+  adapter: vercel({
+-     functionPerRoute: true,
+  }),
+});
+```

--- a/packages/integrations/vercel/src/serverless/adapter.ts
+++ b/packages/integrations/vercel/src/serverless/adapter.ts
@@ -134,7 +134,10 @@ export interface VercelServerlessConfig {
 	/** Whether to create the Vercel Edge middleware from an Astro middleware in your code base. */
 	edgeMiddleware?: boolean;
 
-	/** Whether to split builds into a separate function for each route. */
+	/**
+	 * Whether to split builds into a separate function for each route.
+	 * @deprecated `functionPerRoute` is deprecated and will be removed in the next major release of the adapter.
+	 */
 	functionPerRoute?: boolean;
 
 	/** The maximum duration (in seconds) that Serverless Functions can run before timing out. See the [Vercel documentation](https://vercel.com/docs/functions/serverless-functions/runtimes#maxduration) for the default and maximum limit for your account plan. */
@@ -285,6 +288,11 @@ export default function vercelServerless({
 							`\tVercel's hosting plans might have limits to the number of functions you can create.\n` +
 							`\tMake sure to check your plan carefully to avoid incurring additional costs.\n` +
 							`\tYou can set functionPerRoute: false to prevent surpassing the limit.\n`,
+					);
+
+					logger.warn(
+						`\n` +
+							`\t\`functionPerRoute\` is deprecated and will be removed in a future version of the adapter.\n`
 					);
 				}
 


### PR DESCRIPTION
## Changes

- Marks `functionPerRoute` as deprecated in the Vercel adapter and warns against usage.

## Testing

- N/A

## Docs

- https://github.com/withastro/docs/pull/9108