### PR TITLE
feat: add `sync` variant

### DIFF
--- a/.changeset/afraid-apricots-develop.md
+++ b/.changeset/afraid-apricots-develop.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+The hook `astro:config:setup` now provide a `"sync"` variant for the `command` property. This value is usually set when calling the command `astro sync`

--- a/.changeset/afraid-apricots-develop.md
+++ b/.changeset/afraid-apricots-develop.md
@@ -2,4 +2,6 @@
 'astro': minor
 ---
 
-The hook `astro:config:setup` now provide a `"sync"` variant for the `command` property. This value is usually set when calling the command `astro sync`
+Adds a new variant `sync` for the `astro:config:setup` hook's `command` property. This value is set when calling the command `astro sync`.
+
+If your integration previously relied on knowing how many variants existed for the `command` property, you must update your logic to account for this new option.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -3309,7 +3309,7 @@ declare global {
 		export interface IntegrationHooks {
 			'astro:config:setup': (options: {
 				config: AstroConfig;
-				command: 'dev' | 'build' | 'preview';
+				command: 'dev' | 'build' | 'preview' | 'sync';
 				isRestart: boolean;
 				updateConfig: (newConfig: DeepPartial<AstroConfig>) => AstroConfig;
 				addRenderer: (renderer: AstroRenderer) => void;

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -57,7 +57,7 @@ export default async function sync(
 	}
 	let settings = await createSettings(astroConfig, inlineConfig.root);
 	settings = await runHookConfigSetup({
-		command: 'build',
+		command: 'sync',
 		settings,
 		logger,
 	});

--- a/packages/astro/src/integrations/hooks.ts
+++ b/packages/astro/src/integrations/hooks.ts
@@ -121,7 +121,7 @@ export async function runHookConfigSetup({
 	fs = fsMod,
 }: {
 	settings: AstroSettings;
-	command: 'dev' | 'build' | 'preview';
+	command: 'dev' | 'build' | 'preview' | 'sync';
 	logger: Logger;
 	isRestart?: boolean;
 	fs?: typeof fsMod;

--- a/packages/db/src/core/integration/file-url.ts
+++ b/packages/db/src/core/integration/file-url.ts
@@ -12,7 +12,7 @@ async function copyFile(toDir: URL, fromUrl: URL, toUrl: URL) {
 export function fileURLIntegration(): AstroIntegration {
 	const fileNames: string[] = [];
 
-	function createVitePlugin(command: 'build' | 'preview' | 'dev'): VitePlugin {
+	function createVitePlugin(command: 'build' | 'preview' | 'dev' | 'sync'): VitePlugin {
 		let referenceIds: string[] = [];
 		return {
 			name: '@astrojs/db/file-url',

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -58,7 +58,7 @@ function astroDBIntegration(): AstroIntegration {
 		inProgress: false,
 	};
 
-	let command: 'dev' | 'build' | 'preview';
+	let command: 'dev' | 'build' | 'preview' | 'sync';
 	let output: AstroConfig['output'] = 'server';
 	return {
 		name: 'astro:db',


### PR DESCRIPTION
## Changes

Closes #10876 

I added a `"sync"` variant to the command. This will be useful to the extension too.

This is flagged as minor, because it adds new information. 

## Testing

Existing CI should pass. Should I create a test? 🤔 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs


https://github.com/withastro/docs/pull/9110

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
