### PR TITLE
Update `test:vite-ci` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:smoke:example": "turbo run build --concurrency=100% --filter=\"@example/*\"",
     "test:smoke:docs": "turbo run build --filter=docs",
     "test:check-examples": "node ./scripts/smoke/check.js",
-    "test:vite-ci": "turbo run test --filter=astro",
+    "test:vite-ci": "cd packages/astro && pnpm run test:node",
     "test:e2e": "cd packages/astro && pnpm playwright install chromium firefox && pnpm run test:e2e",
     "test:e2e:match": "cd packages/astro && pnpm playwright install chromium firefox && pnpm run test:e2e:match",
     "test:e2e:hosts": "turbo run test:hosted",


### PR DESCRIPTION
## Changes

In vite-ecosystem-ci, Astro has been failing for a long time and seems to relate to the `test:types` fail: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/10414902461/job/28844581429#step:8:8664

I'm not sure why this happens as the errors imply that the built types were missing, but anyways we don't test Vite specific stuff in the types tests for now, so I figured to skip it.

If anyone has any ideas why the `test:types` test fails though, that'd also be great.

## Testing

Will re-run vite-ecosystem-ci for Astro after merge

## Docs

n/a
