### PR TITLE
Disable server.ws vite config for loading config files

### DIFF
--- a/.changeset/weak-masks-do.md
+++ b/.changeset/weak-masks-do.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+'@astrojs/db': patch
+---
+
+Disables the WebSocket server when creating a Vite server for loading config files

--- a/packages/astro/src/core/config/vite-load.ts
+++ b/packages/astro/src/core/config/vite-load.ts
@@ -7,7 +7,7 @@ import { debug } from '../logger/core.js';
 async function createViteServer(root: string, fs: typeof fsType): Promise<ViteDevServer> {
 	const viteServer = await createServer({
 		configFile: false,
-		server: { middlewareMode: true, hmr: false, watch: null },
+		server: { middlewareMode: true, hmr: false, watch: null, ws: false },
 		optimizeDeps: { noDiscovery: true },
 		clearScreen: false,
 		appType: 'custom',

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -169,7 +169,7 @@ async function syncContentCollections(
 	const tempViteServer = await createServer(
 		await createVite(
 			{
-				server: { middlewareMode: true, hmr: false, watch: null },
+				server: { middlewareMode: true, hmr: false, watch: null, ws: false },
 				optimizeDeps: { noDiscovery: true },
 				ssr: { external: [] },
 				logLevel: 'silent',

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -222,7 +222,7 @@ async function executeSeedFile({
 async function getTempViteServer({ viteConfig }: { viteConfig: UserConfig }) {
 	const tempViteServer = await createServer(
 		mergeConfig(viteConfig, {
-			server: { middlewareMode: true, hmr: false, watch: null },
+			server: { middlewareMode: true, hmr: false, watch: null, ws: false },
 			optimizeDeps: { noDiscovery: true },
 			ssr: { external: [] },
 			logLevel: 'silent',


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/11003

The option was added at https://github.com/vitejs/vite/pull/16219 which is experimental, but it should be stable enough for us to use as its main usecase when the Vite team discussed was for Vitest and Astro specifically.

Disabling `server.ws` should disable Vite from creating a websocket server in the first place.

## Testing

Existing tests should pass

## Docs
n/a. bug fix.