### PR TITLE
Reduce prerender dynamic value warning false positives

### DIFF
--- a/.changeset/new-pillows-kick.md
+++ b/.changeset/new-pillows-kick.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prints prerender dynamic value usage warning only if it's used

--- a/packages/astro/src/vite-plugin-env/index.ts
+++ b/packages/astro/src/vite-plugin-env/index.ts
@@ -176,8 +176,8 @@ export default function envVitePlugin({ settings, logger }: EnvPluginOptions): v
 				// TODO: Remove in Astro 5
 				let exportConstPrerenderStr: string | undefined;
 				s.replace(exportConstPrerenderRe, (m, key) => {
-					exportConstPrerenderStr = m;
 					if (privateEnv[key] != null) {
+						exportConstPrerenderStr = m;
 						return `export const prerender = ${privateEnv[key]}`;
 					} else {
 						return m;


### PR DESCRIPTION
## Changes

cc @ascorbic 

The `export const prerender = import.meta.env....` warning should now only happen if the replacement actually happened. Previously even if there's no replacement, e.g. a false match of some docs/content, it will warn incorrectly.

## Testing

tested manually.

## Docs

n/a.