### PR TITLE
Allow setting vite mode

### DIFF
--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -8,7 +8,6 @@ import type {
 	AstroInlineConfig,
 	AstroSettings,
 	ManifestData,
-	RuntimeMode,
 } from '../../@types/astro.js';
 import { injectImageEndpoint } from '../../assets/endpoint/config.js';
 import { telemetry } from '../../events/index.js';
@@ -78,20 +77,20 @@ export default async function build(
 	const builder = new AstroBuilder(settings, {
 		...options,
 		logger,
-		mode: inlineConfig.mode,
+		mode: inlineConfig.mode ?? userConfig.vite?.mode,
 	});
 	await builder.run();
 }
 
 interface AstroBuilderOptions extends BuildOptions {
 	logger: Logger;
-	mode?: RuntimeMode;
+	mode?: string;
 }
 
 class AstroBuilder {
 	private settings: AstroSettings;
 	private logger: Logger;
-	private mode: RuntimeMode = 'production';
+	private mode: string = 'production';
 	private origin: string;
 	private manifest: ManifestData;
 	private timer: Record<string, number>;

--- a/packages/astro/src/core/build/types.ts
+++ b/packages/astro/src/core/build/types.ts
@@ -37,7 +37,7 @@ export interface StaticBuildOptions {
 	settings: AstroSettings;
 	logger: Logger;
 	manifest: ManifestData;
-	mode: RuntimeMode;
+	mode: string;
 	origin: string;
 	pageNames: string[];
 	viteConfig: InlineConfig;


### PR DESCRIPTION
## Changes

Currently, the mode property of the vite block of user config is ignored.  I've updated it to pass this value through to AstroBuilder if it's not defined on inlineConfig.  I've also updated some typing for mode to be a plain string, as it's valid to use any arbitrary string for mode for custom environments

## Testing

I tested this locally in my project by just writing this change into my local astro.

## Docs

I don't think the docs need to be updated; my reading of the docs implies you would be able to override this setting already.
