### PR TITLE
Allow overriding vite mode from astro config

### DIFF
--- a/.changeset/nine-crabs-jog.md
+++ b/.changeset/nine-crabs-jog.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allow overriding vite mode from astro config

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -3477,7 +3477,7 @@ export type SerializedRouteData = Omit<
 	};
 };
 
-export type RuntimeMode = 'development' | 'production';
+export type RuntimeMode = 'development' | 'production' | string;
 
 export type SSRError = Error & vite.ErrorPayload['err'];
 

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -78,7 +78,7 @@ export default async function build(
 	const builder = new AstroBuilder(settings, {
 		...options,
 		logger,
-		mode: inlineConfig.mode,
+		mode: inlineConfig.mode ?? userConfig.vite?.mode,
 	});
 	await builder.run();
 }


### PR DESCRIPTION
## Changes

Currently, the mode property of the vite block of user config is ignored.  I've updated it to pass this value through to AstroBuilder if it's not defined on inlineConfig.  I've also updated the type of `RuntimeMode` to allow arbitrary strings, as those are valid to use for custom environments.

## Testing

I tested this locally in my project by just writing this change into my local astro.

## Docs

I don't think the docs need to be updated; my reading of the docs implies you would be able to override this setting already.
