### PR TITLE
Make Biome formatting work out-of-the-box in VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,6 @@ package-lock.json
 .eslintcache
 .pnpm-store
 
-# ignore top-level vscode settings
-/.vscode/settings.json
-
 # do not commit .env files or any files that end with `.env`
 *.env
 
@@ -37,3 +34,8 @@ packages/**/e2e/**/fixtures/**/.astro/
 packages/**/e2e/**/fixtures/**/env.d.ts
 examples/**/.astro/
 examples/**/env.d.ts
+
+# make it easy for people to add project-specific Astro settings that they don't
+# want to share with others (see
+# https://github.com/withastro/astro/pull/11759#discussion_r1721444711)
+*.code-workspace

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,8 @@
     "astro-build.astro-vscode",
     "esbenp.prettier-vscode",
     "editorconfig.editorconfig",
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "biomejs.biome"
   ],
   "unwantedRecommendations": []
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome",
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome",
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome",
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome",
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome",
+  }
+}


### PR DESCRIPTION
Right now, if you open Astro you don't get format-on-save code formatting without manually configuring it yourself. This PR makes it work with zero configuration!

## Changes

- Add Biome VS Code extension to recommendations
- Set Biome as the default formatter for the appropriate file types (the same ones in the .prettierignore)

These changes have two good consequences:
- New contributors will get Biome's format-on-save in VS Code out-of-the-box with zero configuration. It'll just work.
- For people that work in some projects that use Prettier side-by-side with Astro (which uses Biome) this will allow automatic enabling of Biome as the default formatter in Astro, without interfering with the user's settings or other projects they work on with different configuration. When you open a project using Prettier (or whatever it is configured with) it'll continue using that formatting, and when you open Astro it'll switch to Biome only within Astro.

NOTE: I'm removing `.vscode/settings.json` from the .gitignore file, which was added 2 years ago, albeit with no discussion of that line: https://github.com/withastro/astro/pull/2844. This file isn't meant to be gitignored: it's where you put project-specific workspace settings. VS Code user settings go elsewhere. Without this file you put the burden on the user, having to manually switch between Biome and Prettier as they switch between projects in VS Code.

## Testing

automated testing: none, only changing project config
manual testing: Open a .js test file, add a new test with formatting mistakes. Press cmd-s to save and watch file get formatted.

## Docs

n/a, only changing project config
