### PR TITLE
Fix(mark doc)/relative image pathing

### DIFF
--- a/.changeset/tasty-mayflies-clap.md
+++ b/.changeset/tasty-mayflies-clap.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': minor
+---
+
+when overriding markdoc's default image node relative image paths will work

--- a/packages/integrations/markdoc/src/content-entry-type.ts
+++ b/packages/integrations/markdoc/src/content-entry-type.ts
@@ -333,12 +333,14 @@ async function emitOptimizedImages(
 								globalThis.astroAsset.referencedImages.add(fsPath);
 						}
 
-						const pathToImg = prependForwardSlash(path.relative(
+						const pathToImg = prependForwardSlash(
+							path.relative(
 								ctx.astroConfig.root.pathname,
-								path.join(path.dirname(ctx.filePath), node.attributes.src)
-						));
+								path.join(path.dirname(ctx.filePath), node.attributes.src),
+							),
+						);
 						node.attributes[attributeName] = { ...src, fsPath };
-    				node.attributes.src = pathToImg;
+						node.attributes.src = pathToImg;
 					}
 				} else {
 					throw new MarkdocError({

--- a/packages/integrations/markdoc/src/content-entry-type.ts
+++ b/packages/integrations/markdoc/src/content-entry-type.ts
@@ -333,9 +333,12 @@ async function emitOptimizedImages(
 								globalThis.astroAsset.referencedImages.add(fsPath);
 						}
 
+						const pathToImg = prependForwardSlash(path.relative(
+								ctx.astroConfig.root.pathname,
+								path.join(path.dirname(ctx.filePath), node.attributes.src)
+						));
 						node.attributes[attributeName] = { ...src, fsPath };
-						// Serve optimizedSrc as src
-						node.attributes.src = src.src;
+    				node.attributes.src = pathToImg;
 					}
 				} else {
 					throw new MarkdocError({

--- a/packages/integrations/markdoc/src/content-entry-type.ts
+++ b/packages/integrations/markdoc/src/content-entry-type.ts
@@ -334,6 +334,8 @@ async function emitOptimizedImages(
 						}
 
 						node.attributes[attributeName] = { ...src, fsPath };
+						// Serve optimizedSrc as src
+						node.attributes.src = src.src;
 					}
 				} else {
 					throw new MarkdocError({

--- a/packages/integrations/markdoc/src/content-entry-type.ts
+++ b/packages/integrations/markdoc/src/content-entry-type.ts
@@ -310,7 +310,7 @@ async function emitOptimizedImages(
 		if ((node.type === 'image' || isComponent) && typeof node.attributes.src === 'string') {
 			let attributeName = isComponent ? 'src' : '__optimizedSrc';
 
-			if (node.attributes.src.startsWith('./')) {
+			if (node.attributes.src.startsWith('./') || node.attributes.src.startsWith('../')) {
 				node.attributes.src = prependForwardSlash(
 					path.relative(
 						ctx.astroConfig.root.pathname,
@@ -341,7 +341,6 @@ async function emitOptimizedImages(
 								globalThis.astroAsset.referencedImages.add(fsPath);
 						}
 						node.attributes[attributeName] = { ...src, fsPath };
-						node.attributes.src = src.src;
 					}
 				} else {
 					throw new MarkdocError({
@@ -361,7 +360,7 @@ async function emitOptimizedImages(
 }
 
 function shouldOptimizeImage(src: string, rootPath: string) {
-	// Optimize anything that is NOT external or a true absolute path to `public/`.
+	// Optimize anything that is NOT external or an absolute path to `public/`
 	if (isValidUrl(src)) return false;
 	const normPath = path.normalize(src);
 	if (normPath.startsWith(rootPath) || normPath.startsWith('/')) {

--- a/packages/integrations/markdoc/src/content-entry-type.ts
+++ b/packages/integrations/markdoc/src/content-entry-type.ts
@@ -341,6 +341,8 @@ async function emitOptimizedImages(
 								globalThis.astroAsset.referencedImages.add(fsPath);
 						}
 						node.attributes[attributeName] = { ...src, fsPath };
+						node.attributes.src = src.src;
+
 					}
 				} else {
 					throw new MarkdocError({


### PR DESCRIPTION
## Changes

closes #10546

- While using markdoc custom image node if a relative url is passed as src, the image wasn't rendered on webpage. This was fixed by repathing the relative.

## Testing

<!-- How was this change tested? -->
 - I tested this by modifying examples/blog to override markdoc’s default image node and then test relative paths, public and http links.
 
 - Different src paths all render correctly on webpage:
```
![test](./test.png)
![test](../test.jpg)
![test](/test.jpg)
![test](../../../test.jpg)
![test](https://imageIfound.jpg)
```
 

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->
- this fix is already reflected the current docs and removes the need for a work around https://github.com/withastro/astro/issues/10546#issuecomment-2017784213
 - https://docs.astro.build/en/guides/integrations-guide/markdoc/#override-markdocs-default-image-node

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
