### PR TITLE
Fix create-astro initial git commit

### DIFF
--- a/.changeset/smart-comics-doubt.md
+++ b/.changeset/smart-comics-doubt.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Fixes initial git commit when initializing git

--- a/packages/create-astro/src/actions/git.ts
+++ b/packages/create-astro/src/actions/git.ts
@@ -55,7 +55,7 @@ async function init({ cwd }: { cwd: string }) {
 			[
 				'commit',
 				'-m',
-				'Initial commit from Astro',
+				'"Initial commit from Astro"',
 				'--author="houston[bot] <astrobot-houston@users.noreply.github.com>"',
 			],
 			{ cwd, stdio: 'ignore' },


### PR DESCRIPTION
## Changes

I noticed that when initializing git, the initial git commit silently fails because the commit message wasn't wrapped in quotes.

## Testing

tested manually with npm and pnpm

## Docs

n/a, bug fix.