### PR TITLE
ci: enable preview and repo dispatch

### DIFF
--- a/.github/workflows/dispatch-event.yml
+++ b/.github/workflows/dispatch-event.yml
@@ -1,0 +1,61 @@
+name: Dispatch event
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - '!**'
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
+env:
+  ASTRO_ADAPTERS_REPO: withastro/adapters
+  ASTRO_STARLIGHT_REPO: withastro/starlight
+  ASTRO_PUSH_MAIN_EVENT: biome-push-main-event
+    
+jobs:
+  repository-dispatch:
+    name: Repository dispatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch event on push - adapters
+        if: ${{ github.event_name == 'push' }}
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+        with:
+          token: ${{ secrets.ASTRO_REPOSITORY_DISPATCH }}
+          repository: ${{ env.ASTRO_ADAPTERS_REPO }}
+          event-type: ${{ env.ASTRO_PUSH_MAIN_EVENT }}
+          client-payload: '{"event": ${{ toJson(github.event) }}}'
+      - name: Dispatch event on push - starlight
+        if: ${{ github.event_name == 'push' }}
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+        with:
+          token: ${{ secrets.ASTRO_REPOSITORY_DISPATCH }}
+          repository: ${{ env.ASTRO_STARLIGHT_REPO }}
+          event-type: ${{ env.ASTRO_PUSH_MAIN_EVENT }}
+          client-payload: '{"event": ${{ toJson(github.event) }}}'
+      # For testing only, the payload is mocked
+      - name: Dispatch event on workflow dispatch - adapters
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+        with:
+          token: ${{ secrets.ASTRO_REPOSITORY_DISPATCH }}
+          repository: ${{ env.ASTRO_ADAPTERS_REPO }}
+          event-type: ${{ env.ASTRO_PUSH_MAIN_EVENT }}
+          client-payload: '{"event": {"head_commit": {"id": "${{ env.GITHUB_SHA }}"}}}'
+      - name: Dispatch event on workflow dispatch - starlight
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+        with:
+          token: ${{ secrets.ASTRO_REPOSITORY_DISPATCH }}
+          repository: ${{ env.ASTRO_STARLIGHT_REPO }}
+          event-type: ${{ env.ASTRO_PUSH_MAIN_EVENT }}
+          client-payload: '{"event": {"head_commit": {"id": "${{ env.GITHUB_SHA }}"}}}'          

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,62 @@
+name: Preview release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - '!**' 
+  merge_group:
+  pull_request:
+    paths-ignore:
+      - ".vscode/**"
+      - "**/*.md"
+      - ".github/ISSUE_TEMPLATE/**"
+        
+permissions:
+  contents: read
+  actions: write
+  
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  FORCE_COLOR: true
+  ASTRO_TELEMETRY_DISABLED: true
+  # 7 GiB by default on GitHub, setting to 6 GiB
+  # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+  NODE_OPTIONS: --max-old-space-size=6144
+
+jobs:
+  preview:
+    name: Publish preview release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Disable git crlf
+        run: git config --global core.autocrlf false
+  
+      - name: Checkout
+        uses: actions/checkout@v4
+  
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v3
+  
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: "pnpm"
+  
+      - name: Install dependencies
+        run: pnpm install
+  
+      - name: Build Packages
+        run: pnpm run build
+  
+      - name: Publish packages
+        run: pnpx pkg-pr-new publish --compact './packages/**/*'

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -59,4 +59,4 @@ jobs:
         run: pnpm run build
   
       - name: Publish packages
-        run: pnpx pkg-pr-new publish './packages/*'
+        run: pnpx pkg-pr-new publish --pnpm './packages/*'

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -59,4 +59,4 @@ jobs:
         run: pnpm run build
   
       - name: Publish packages
-        run: pnpx pkg-pr-new publish --pnpm './packages/**/*'
+        run: pnpx pkg-pr-new publish --pnpm './packages/*' './packages/integrations/*'

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -59,4 +59,4 @@ jobs:
         run: pnpm run build
   
       - name: Publish packages
-        run: pnpx pkg-pr-new publish --pnpm './packages/*'
+        run: pnpx pkg-pr-new publish --pnpm './packages/**/*'

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -59,4 +59,4 @@ jobs:
         run: pnpm run build
   
       - name: Publish packages
-        run: pnpx pkg-pr-new publish --compact './packages/**/*'
+        run: pnpx pkg-pr-new publish './packages/*'


### PR DESCRIPTION
## Changes

This PR creates two new workflows:
- one to create a preview release when a PR is open, a PR is merged into `main`, and there's a workflow dispatch (manually triggered). It uses `pkg.pr.new`
- one to dispatch an event when a PR is merged to `main`. This event is dispatched to `withastro/starlight` and `withastro/adapters`. These two repositories can subscribe to this event and enable continuous testing whenever we merge a PR. 

The reason why I enabled the dispatch event only on `push` to `main`, is that it's not sustainable to trigger a test in other repositories at each commit.

## Testing

This PR won't work until:
- ~~we enable `pkg.pr.new` as application for this repository (ideally for the entire org, I will sync with Matthew)~~
- ~~we create a [PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) for dispatching the event~~

The usage of the PAT needs to be nested on `main`, so I will have to merge the PR.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
