### PR TITLE
fix: astro:env sync error in content config

### DIFF
--- a/.changeset/tiny-lamps-lick.md
+++ b/.changeset/tiny-lamps-lick.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an error thrown by `astro sync` when an `astro:env` virtual module is imported inside the Content Collections config

--- a/packages/astro/src/env/vite-plugin-env.ts
+++ b/packages/astro/src/env/vite-plugin-env.ts
@@ -31,7 +31,7 @@ export function astroEnv({
 	fs,
 	sync,
 }: AstroEnvVirtualModPluginParams): Plugin | undefined {
-	if (!settings.config.experimental.env || sync) {
+	if (!settings.config.experimental.env) {
 		return;
 	}
 	const schema = settings.config.experimental.env.schema ?? {};
@@ -57,6 +57,7 @@ export function astroEnv({
 				schema,
 				loadedEnv,
 				validateSecrets: settings.config.experimental.env?.validateSecrets ?? false,
+				sync,
 			});
 
 			templates = {
@@ -100,10 +101,12 @@ function validatePublicVariables({
 	schema,
 	loadedEnv,
 	validateSecrets,
+	sync,
 }: {
 	schema: EnvSchema;
 	loadedEnv: Record<string, string>;
 	validateSecrets: boolean;
+	sync: boolean;
 }) {
 	const valid: Array<{ key: string; value: any; type: string; context: 'server' | 'client' }> = [];
 	const invalid: Array<InvalidVariable> = [];
@@ -125,7 +128,7 @@ function validatePublicVariables({
 		}
 	}
 
-	if (invalid.length > 0) {
+	if (invalid.length > 0 && !sync) {
 		throw new AstroError({
 			...AstroErrorData.EnvInvalidVariables,
 			message: AstroErrorData.EnvInvalidVariables.message(invalidVariablesToError(invalid)),

--- a/packages/astro/test/astro-sync.test.js
+++ b/packages/astro/test/astro-sync.test.js
@@ -219,6 +219,16 @@ describe('astro sync', () => {
 				assert.fail();
 			}
 		});
+		it('Does not throw if a virtual module is imported in content/config.ts', async () => {
+			try {
+				await fixture.load('./fixtures/astro-env-content-collections/');
+				fixture.clean();
+				await fixture.whenSyncing();
+				assert.ok(true);
+			} catch {
+				assert.fail();
+			}
+		});
 	});
 
 	describe('astro:actions', () => {

--- a/packages/astro/test/fixtures/astro-env-content-collections/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-env-content-collections/astro.config.mjs
@@ -1,0 +1,12 @@
+import { defineConfig, envField } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	experimental: {
+		env: {
+			schema: {
+				FOO: envField.string({ context: "client", access: "public", optional: true, default: "ABC" }),
+			}
+		}
+	}
+});

--- a/packages/astro/test/fixtures/astro-env-content-collections/package.json
+++ b/packages/astro/test/fixtures/astro-env-content-collections/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/astro-env-content-collections",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/astro-env-content-collections/src/content/config.ts
+++ b/packages/astro/test/fixtures/astro-env-content-collections/src/content/config.ts
@@ -1,0 +1,13 @@
+import { defineCollection, z } from "astro:content";
+import { FOO } from "astro:env/client"
+
+console.log({ FOO })
+
+export const collections = {
+    foo: defineCollection({
+        type: "data",
+        schema: z.object({
+            title: z.string()
+        })
+    })
+}

--- a/packages/astro/test/fixtures/astro-env-content-collections/tsconfig.json
+++ b/packages/astro/test/fixtures/astro-env-content-collections/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/base"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2163,6 +2163,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/astro-env-content-collections:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/astro-env-required-public:
     dependencies:
       astro:
@@ -9457,12 +9463,10 @@ packages:
 
   libsql@0.3.19:
     resolution: {integrity: sha512-Aj5cQ5uk/6fHdmeW0TiXK42FqUlwx7ytmMLPSaUQPin5HKKKuUPD62MAbN4OEweGBBI7q1BekoEN4gPUEL6MZA==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   libsql@0.4.1:
     resolution: {integrity: sha512-qZlR9Yu1zMBeLChzkE/cKfoKV3Esp9cn9Vx5Zirn4AVhDWPcjYhKwbtJcMuHehgk3mH+fJr9qW+3vesBWbQpBg==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@2.1.0:


### PR DESCRIPTION
## Changes

- Closes #11754
- Keeps creating the virtual module in sync and only prevents validation error from being thrown

## Testing

Adds a test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
