### PR TITLE
Deprecate the Squoosh image service

### DIFF
--- a/.changeset/fair-rats-fail.md
+++ b/.changeset/fair-rats-fail.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Deprecates the Squoosh image service, to be removed in Astro 5.0. We recommend migrating to the default Sharp service.

--- a/packages/astro/config.d.ts
+++ b/packages/astro/config.d.ts
@@ -26,6 +26,9 @@ export function getViteConfig(
 export function sharpImageService(config?: SharpImageServiceConfig): ImageServiceConfig;
 
 /**
+ * @deprecated The Squoosh image service is deprecated and will be removed in Astro 5.x.
+ * We suggest migrating to the default Sharp image service instead, as it is faster, more powerful and better maintained.
+ *
  * Return the configuration needed to use the Squoosh-based image service
  * See: https://docs.astro.build/en/guides/images/#configure-squoosh
  */

--- a/packages/astro/src/assets/services/squoosh.ts
+++ b/packages/astro/src/assets/services/squoosh.ts
@@ -1,5 +1,4 @@
-// TODO: Investigate removing this service once sharp lands WASM support, as libsquoosh is deprecated
-
+import { yellow } from 'kleur/colors';
 import type { ImageOutputFormat, ImageQualityPreset } from '../types.js';
 import { imageMetadata } from '../utils/metadata.js';
 import {
@@ -10,6 +9,13 @@ import {
 } from './service.js';
 import { processBuffer } from './vendor/squoosh/image-pool.js';
 import type { Operation } from './vendor/squoosh/image.js';
+
+// eslint-disable-next-line no-console
+console.warn(
+	yellow(
+		'The Squoosh image service is deprecated and will be removed in Astro 5.x. We suggest migrating to the default Sharp image service instead, as it is faster, more powerful and better maintained.',
+	),
+);
 
 const baseQuality = { low: 25, mid: 50, high: 80, max: 100 };
 const qualityTable: Record<


### PR DESCRIPTION
## Changes

Astro 5.x removes the service completely see https://github.com/withastro/astro/pull/11770

## Testing

Tested manually that the message works

## Docs

Some of it is docs!
