### PR TITLE
Remove build.format: 'file'

### DIFF
--- a/.changeset/hot-needles-flash.md
+++ b/.changeset/hot-needles-flash.md
@@ -1,0 +1,21 @@
+---
+'astro': major
+'@astrojs/sitemap': minor
+---
+
+Removes build.format: 'file'
+
+This removes the config option `build.format: 'file'`. This option would remove directory structures in SSG output and instead make all input pages into directory-less HTML files. The use-case has been superceded by `build.format: 'preserve'`.
+
+```diff
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  build: {
+-    format: 'file'
++    format: 'preserve'
+  }
+})
+```
+
+Note that there is one key difference between `'file'` and `'preserve'`: The `'file'` option would remove directories defined as `about/index.astro`. The `'preserve'` option matches the input structure exactly.

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -49,7 +49,7 @@ export type SSRManifest = {
 	site?: string;
 	base: string;
 	trailingSlash: 'always' | 'never' | 'ignore';
-	buildFormat: 'file' | 'directory' | 'preserve';
+	buildFormat: 'directory' | 'preserve';
 	compressHTML: boolean;
 	assetsPrefix?: AssetsPrefix;
 	renderers: SSRLoadedRenderer[];

--- a/packages/astro/src/core/build/common.ts
+++ b/packages/astro/src/core/build/common.ts
@@ -37,10 +37,6 @@ export function getOutFolder(
 					}
 					return new URL('.' + appendForwardSlash(pathname), outRoot);
 				}
-				case 'file': {
-					const d = pathname === '' ? pathname : npath.dirname(pathname);
-					return new URL('.' + appendForwardSlash(d), outRoot);
-				}
 				case 'preserve': {
 					let dir;
 					// If the pathname is '' then this is the root index.html
@@ -76,10 +72,6 @@ export function getOutFile(
 						return new URL('./' + (baseName || 'index') + '.html', outFolder);
 					}
 					return new URL('./index.html', outFolder);
-				}
-				case 'file': {
-					const baseName = npath.basename(pathname);
-					return new URL('./' + (baseName || 'index') + '.html', outFolder);
 				}
 				case 'preserve': {
 					let baseName = npath.basename(pathname);

--- a/packages/astro/src/core/build/util.ts
+++ b/packages/astro/src/core/build/util.ts
@@ -24,7 +24,6 @@ export function shouldAppendForwardSlash(
 				case 'directory':
 					return true;
 				case 'preserve':
-				case 'file':
 					return false;
 			}
 		}

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -150,7 +150,7 @@ export const AstroConfigSchema = z.object({
 	build: z
 		.object({
 			format: z
-				.union([z.literal('file'), z.literal('directory'), z.literal('preserve')])
+				.union([z.literal('directory'), z.literal('preserve')])
 				.optional()
 				.default(ASTRO_CONFIG_DEFAULTS.build.format),
 			client: z
@@ -583,7 +583,7 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 		build: z
 			.object({
 				format: z
-					.union([z.literal('file'), z.literal('directory'), z.literal('preserve')])
+					.union([z.literal('directory'), z.literal('preserve')])
 					.optional()
 					.default(ASTRO_CONFIG_DEFAULTS.build.format),
 				client: z

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -49,7 +49,7 @@ export function getOutputFilename(astroConfig: AstroConfig, name: string, type: 
 	if (name === '/' || name === '') {
 		return path.posix.join(name, 'index.html');
 	}
-	if (astroConfig.build.format === 'file' || STATUS_CODE_PAGES.has(name)) {
+	if (STATUS_CODE_PAGES.has(name)) {
 		return `${removeTrailingForwardSlash(name || 'index')}.html`;
 	}
 	return path.posix.join(name, 'index.html');

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -526,19 +526,18 @@ export interface AstroUserConfig {
 		/**
 		 * @docs
 		 * @name build.format
-		 * @typeraw {('file' | 'directory' | 'preserve')}
+		 * @typeraw {('directory' | 'preserve')}
 		 * @default `'directory'`
 		 * @description
 		 * Control the output file format of each page. This value may be set by an adapter for you.
-		 *   - `'file'`: Astro will generate an HTML file named for each page route. (e.g. `src/pages/about.astro` and `src/pages/about/index.astro` both build the file `/about.html`)
 		 *   - `'directory'`: Astro will generate a directory with a nested `index.html` file for each page. (e.g. `src/pages/about.astro` and `src/pages/about/index.astro` both build the file `/about/index.html`)
 		 *   - `'preserve'`: Astro will generate HTML files exactly as they appear in your source folder. (e.g. `src/pages/about.astro` builds `/about.html` and `src/pages/about/index.astro` builds the file `/about/index.html`)
 		 *
 		 * ```js
 		 * {
 		 *   build: {
-		 *     // Example: Generate `page.html` instead of `page/index.html` during build.
-		 *     format: 'file'
+		 *     // Example: Generate `page.astro` as `page.html` instead of `page/index.html` during build.
+		 *     format: 'preserve'
 		 *   }
 		 * }
 		 * ```
@@ -548,15 +547,15 @@ export interface AstroUserConfig {
 		 * #### Effect on Astro.url
 		 * Setting `build.format` controls what `Astro.url` is set to during the build. When it is:
 		 * - `directory` - The `Astro.url.pathname` will include a trailing slash to mimic folder behavior; ie `/foo/`.
-		 * - `file` - The `Astro.url.pathname` will include `.html`; ie `/foo.html`.
+		 * - `perserve` - The `Astro.url.pathname` will include `.html`; ie `/foo.html`.
 		 *
 		 * This means that when you create relative URLs using `new URL('./relative', Astro.url)`, you will get consistent behavior between dev and build.
 		 *
 		 * To prevent inconsistencies with trailing slash behaviour in dev, you can restrict the [`trailingSlash` option](#trailingslash) to `'always'` or `'never'` depending on your build format:
 		 * - `directory` - Set `trailingSlash: 'always'`
-		 * - `file` - Set `trailingSlash: 'never'`
+		 * - `preserve` - Set `trailingSlash: 'never'`
 		 */
-		format?: 'file' | 'directory' | 'preserve';
+		format?: 'directory' | 'preserve';
 		/**
 		 * @docs
 		 * @name build.client

--- a/packages/astro/src/vite-plugin-utils/index.ts
+++ b/packages/astro/src/vite-plugin-utils/index.ts
@@ -1,7 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import ancestor from 'common-ancestor-path';
 import {
-	appendExtension,
 	appendForwardSlash,
 	removeLeadingForwardSlashWindows,
 } from '../core/path.js';

--- a/packages/astro/src/vite-plugin-utils/index.ts
+++ b/packages/astro/src/vite-plugin-utils/index.ts
@@ -22,9 +22,6 @@ export function getFileInfo(id: string, config: AstroConfig) {
 	if (fileUrl && config.trailingSlash === 'always') {
 		fileUrl = appendForwardSlash(fileUrl);
 	}
-	if (fileUrl && config.build.format === 'file') {
-		fileUrl = appendExtension(fileUrl, 'html');
-	}
 	return { fileId, fileUrl };
 }
 

--- a/packages/astro/test/astro-pageDirectoryUrl.test.js
+++ b/packages/astro/test/astro-pageDirectoryUrl.test.js
@@ -19,27 +19,6 @@ describe('build format', () => {
 
 		it('outputs', async () => {
 			assert.ok(await fixture.readFile('/client.html'));
-			assert.ok(await fixture.readFile('/nested-md.html'));
-			assert.ok(await fixture.readFile('/nested-astro.html'));
-		});
-	});
-
-	describe('build.format: preserve', () => {
-		/** @type {import('./test-utils.js').Fixture} */
-		let fixture;
-
-		before(async () => {
-			fixture = await loadFixture({
-				root: './fixtures/astro-page-directory-url',
-				build: {
-					format: 'preserve',
-				},
-			});
-			await fixture.build();
-		});
-
-		it('outputs', async () => {
-			assert.ok(await fixture.readFile('/client.html'));
 			assert.ok(await fixture.readFile('/nested-md/index.html'));
 			assert.ok(await fixture.readFile('/nested-astro/index.html'));
 		});

--- a/packages/astro/test/astro-pageDirectoryUrl.test.js
+++ b/packages/astro/test/astro-pageDirectoryUrl.test.js
@@ -3,7 +3,7 @@ import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
 describe('build format', () => {
-	describe('build.format: file', () => {
+	describe('build.format: preserve', () => {
 		/** @type {import('./test-utils.js').Fixture} */
 		let fixture;
 
@@ -11,7 +11,7 @@ describe('build format', () => {
 			fixture = await loadFixture({
 				root: './fixtures/astro-page-directory-url',
 				build: {
-					format: 'file',
+					format: 'preserve',
 				},
 			});
 			await fixture.build();

--- a/packages/astro/test/dev-routing.test.js
+++ b/packages/astro/test/dev-routing.test.js
@@ -295,7 +295,7 @@ describe('Development Routing', () => {
 		});
 	});
 
-	describe('file format routing', () => {
+	describe('preserve format routing', () => {
 		/** @type {import('./test-utils').Fixture} */
 		let fixture;
 		/** @type {import('./test-utils').DevServer} */
@@ -304,7 +304,7 @@ describe('Development Routing', () => {
 		before(async () => {
 			fixture = await loadFixture({
 				build: {
-					format: 'file',
+					format: 'preserve',
 				},
 				root: './fixtures/without-site-config/',
 				site: 'http://example.com/',

--- a/packages/astro/test/dynamic-route-build-file.test.js
+++ b/packages/astro/test/dynamic-route-build-file.test.js
@@ -3,7 +3,7 @@ import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
 
-describe('build.format=file with dynamic routes', () => {
+describe('build.format=preserve with dynamic routes', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
 
@@ -11,7 +11,7 @@ describe('build.format=file with dynamic routes', () => {
 		fixture = await loadFixture({
 			root: './fixtures/dynamic-route-build-file',
 			build: {
-				format: 'file',
+				format: 'perserve',
 			},
 		});
 		await fixture.build();

--- a/packages/astro/test/events.test.js
+++ b/packages/astro/test/events.test.js
@@ -10,7 +10,7 @@ describe('Events', () => {
 			const config = {
 				srcDir: 1,
 				build: {
-					format: 'file',
+					format: 'preserve',
 				},
 			};
 			const [{ payload }] = events.eventCliSession(
@@ -19,7 +19,7 @@ describe('Events', () => {
 				},
 				config,
 			);
-			assert.equal(payload.config.build.format, 'file');
+			assert.equal(payload.config.build.format, 'preserve');
 		});
 
 		it('string literal "markdown.syntaxHighlight" is included', () => {

--- a/packages/astro/test/fixtures/static-build-page-url-format/astro.config.mjs
+++ b/packages/astro/test/fixtures/static-build-page-url-format/astro.config.mjs
@@ -5,6 +5,6 @@ export default defineConfig({
 	site: 'http://example.com/',
 	base: '/subpath',
 	build: {
-		format: 'file',
+		format: 'preserve',
 	},
 });

--- a/packages/astro/test/page-format.test.js
+++ b/packages/astro/test/page-format.test.js
@@ -26,31 +26,6 @@ describe('build.format', () => {
 		});
 	});
 
-	describe('file', () => {
-		/** @type {import('./test-utils').Fixture} */
-		let fixture;
-		before(async () => {
-			fixture = await loadFixture({
-				root: './fixtures/page-format/',
-				build: {
-					format: 'file',
-				},
-			});
-		});
-
-		describe('Build', () => {
-			before(async () => {
-				await fixture.build();
-			});
-
-			it('relative urls created point to sibling folders', async () => {
-				let html = await fixture.readFile('/nested/page.html');
-				let $ = cheerio.load(html);
-				assert.equal($('#another').attr('href'), '/nested/another/');
-			});
-		});
-	});
-
 	describe('preserve - i18n', () => {
 		/** @type {import('./test-utils').Fixture} */
 		let fixture;

--- a/packages/astro/test/preview-routing.test.js
+++ b/packages/astro/test/preview-routing.test.js
@@ -221,7 +221,7 @@ describe('Preview Routing', () => {
 		});
 	});
 
-	describe('build format: file', () => {
+	describe('build format: preserve', () => {
 		describe('Subpath without trailing slash and trailingSlash: never', () => {
 			/** @type {import('./test-utils').Fixture} */
 			let fixture;
@@ -234,7 +234,7 @@ describe('Preview Routing', () => {
 					base: '/blog',
 					outDir: './dist-4003',
 					build: {
-						format: 'file',
+						format: 'preserve',
 					},
 					trailingSlash: 'never',
 					server: {
@@ -294,7 +294,7 @@ describe('Preview Routing', () => {
 					base: '/blog',
 					outDir: './dist-4004',
 					build: {
-						format: 'file',
+						format: 'preserve',
 					},
 					trailingSlash: 'always',
 					server: {
@@ -357,7 +357,7 @@ describe('Preview Routing', () => {
 					base: '/blog',
 					outDir: './dist-4005',
 					build: {
-						format: 'file',
+						format: 'preserve',
 					},
 					trailingSlash: 'ignore',
 					server: {
@@ -420,7 +420,7 @@ describe('Preview Routing', () => {
 					base: '/blog',
 					outDir: './dist-4006',
 					build: {
-						format: 'file',
+						format: 'preserve',
 					},
 					trailingSlash: 'ignore',
 					server: {
@@ -473,7 +473,7 @@ describe('Preview Routing', () => {
 				fixture = await loadFixture({
 					root: './fixtures/custom-404-html/',
 					build: {
-						format: 'file',
+						format: 'preserve',
 					},
 					server: {
 						port: 4008,

--- a/packages/astro/test/static-build-page-url-format.test.js
+++ b/packages/astro/test/static-build-page-url-format.test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 import { loadFixture } from './test-utils.js';
 
-describe("Static build - format: 'file'", () => {
+describe("Static build - format: 'preserve'", () => {
 	let fixture;
 
 	before(async () => {

--- a/packages/astro/test/units/i18n/astro_i18n.test.js
+++ b/packages/astro/test/units/i18n/astro_i18n.test.js
@@ -58,14 +58,14 @@ describe('getLocaleRelativeUrl', () => {
 			'/blog/es/',
 		);
 
-		// file format
+		// preserve format
 		assert.equal(
 			getLocaleRelativeUrl({
 				locale: 'en',
 				base: '/blog/',
 				...config.experimental.i18n,
 				trailingSlash: 'always',
-				format: 'file',
+				format: 'preserve',
 			}),
 			'/blog/',
 		);
@@ -75,7 +75,7 @@ describe('getLocaleRelativeUrl', () => {
 				base: '/blog/',
 				...config.experimental.i18n,
 				trailingSlash: 'always',
-				format: 'file',
+				format: 'preserve',
 			}),
 			'/blog/es/',
 		);
@@ -86,7 +86,7 @@ describe('getLocaleRelativeUrl', () => {
 				base: '/blog/',
 				...config.experimental.i18n,
 				trailingSlash: 'always',
-				format: 'file',
+				format: 'preserve',
 			}),
 			'/blog/italiano/',
 		);
@@ -174,7 +174,7 @@ describe('getLocaleRelativeUrl', () => {
 				base: '/blog/',
 				...config.i18n,
 				trailingSlash: 'always',
-				format: 'file',
+				format: 'preserve',
 			}),
 			'/blog/italiano/',
 		);
@@ -197,7 +197,7 @@ describe('getLocaleRelativeUrl', () => {
 				base: '/blog',
 				...config.i18n,
 				trailingSlash: 'never',
-				format: 'file',
+				format: 'preserve',
 			}),
 			'/blog',
 		);
@@ -207,7 +207,7 @@ describe('getLocaleRelativeUrl', () => {
 				base: '/blog/',
 				...config.i18n,
 				trailingSlash: 'always',
-				format: 'file',
+				format: 'preserve',
 			}),
 			'/blog/es/',
 		);
@@ -219,7 +219,7 @@ describe('getLocaleRelativeUrl', () => {
 				base: '/blog',
 				...config.i18n,
 				trailingSlash: 'ignore',
-				format: 'file',
+				format: 'preserve',
 			}),
 			'/blog',
 		);
@@ -316,14 +316,14 @@ describe('getLocaleRelativeUrl', () => {
 			'/blog/es/',
 		);
 
-		// file format
+		// preserve format
 		assert.equal(
 			getLocaleRelativeUrl({
 				locale: 'en',
 				base: '/blog/',
 				...config.i18n,
 				trailingSlash: 'always',
-				format: 'file',
+				format: 'preserve',
 				strategy: toRoutingStrategy(config.i18n.routing, {}),
 			}),
 			'/blog/en/',
@@ -334,7 +334,7 @@ describe('getLocaleRelativeUrl', () => {
 				base: '/blog/',
 				...config.i18n,
 				trailingSlash: 'always',
-				format: 'file',
+				format: 'preserve',
 				strategy: toRoutingStrategy(config.i18n.routing, {}),
 			}),
 			'/blog/es/',
@@ -382,14 +382,14 @@ describe('getLocaleRelativeUrl', () => {
 			'/blog/es/',
 		);
 
-		// file format
+		// preserve format
 		assert.equal(
 			getLocaleRelativeUrl({
 				locale: 'en',
 				base: '/blog/',
 				...config.i18n,
 				trailingSlash: 'always',
-				format: 'file',
+				format: 'preserve',
 				strategy: toRoutingStrategy(config.i18n.routing, {}),
 			}),
 			'/blog/en/',
@@ -400,7 +400,7 @@ describe('getLocaleRelativeUrl', () => {
 				base: '/blog/',
 				...config.i18n,
 				trailingSlash: 'always',
-				format: 'file',
+				format: 'preserve',
 				strategy: toRoutingStrategy(config.i18n.routing, {}),
 			}),
 			'/blog/es/',
@@ -477,7 +477,7 @@ describe('getLocaleRelativeUrlList', () => {
 		);
 	});
 
-	it('should retrieve the correct list of base URL with locales [format: file, trailingSlash: always]', () => {
+	it('should retrieve the correct list of base URL with locales [format: preserve, trailingSlash: always]', () => {
 		/**
 		 *
 		 * @type {import("../../../dist/@types").AstroUserConfig}
@@ -497,13 +497,13 @@ describe('getLocaleRelativeUrlList', () => {
 				base: '/blog/',
 				...config.experimental.i18n,
 				trailingSlash: 'always',
-				format: 'file',
+				format: 'preserve',
 			}),
 			['/blog/', '/blog/en-us/', '/blog/es/'],
 		);
 	});
 
-	it('should retrieve the correct list of base URL with locales [format: file, trailingSlash: never]', () => {
+	it('should retrieve the correct list of base URL with locales [format: preserve, trailingSlash: never]', () => {
 		/**
 		 *
 		 * @type {import("../../../dist/@types").AstroUserConfig}
@@ -523,13 +523,13 @@ describe('getLocaleRelativeUrlList', () => {
 				base: '/blog',
 				...config.experimental.i18n,
 				trailingSlash: 'never',
-				format: 'file',
+				format: 'preserve',
 			}),
 			['/blog', '/blog/en-us', '/blog/es'],
 		);
 	});
 
-	it('should retrieve the correct list of base URL with locales [format: file, trailingSlash: ignore]', () => {
+	it('should retrieve the correct list of base URL with locales [format: preserve, trailingSlash: ignore]', () => {
 		/**
 		 *
 		 * @type {import("../../../dist/@types").AstroUserConfig}
@@ -549,7 +549,7 @@ describe('getLocaleRelativeUrlList', () => {
 				base: '/blog',
 				...config.experimental.i18n,
 				trailingSlash: 'ignore',
-				format: 'file',
+				format: 'preserve',
 			}),
 			['/blog', '/blog/en-us', '/blog/es'],
 		);
@@ -720,14 +720,14 @@ describe('getLocaleAbsoluteUrl', () => {
 				}),
 			);
 
-			// file format
+			// preserve format
 			assert.equal(
 				getLocaleAbsoluteUrl({
 					locale: 'en',
 					base: '/blog/',
 					...config.i18n,
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 				}),
 				'https://example.com/blog/',
@@ -738,7 +738,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					base: '/blog/',
 					...config.i18n,
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 				}),
 				'https://example.com/blog/es/',
@@ -750,7 +750,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					base: '/blog/',
 					...config.i18n,
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 				}),
 				'https://example.com/blog/italiano/',
@@ -762,7 +762,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					base: '/blog/',
 					...config.i18n,
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 					isBuild: true,
 				}),
@@ -776,7 +776,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					prependWith: 'some-name',
 					...config.i18n,
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 					path: 'first-post',
 					isBuild: true,
@@ -792,7 +792,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					prependWith: 'some-name',
 					...config.i18n,
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 					path: 'first-post',
 					isBuild: true,
@@ -848,14 +848,14 @@ describe('getLocaleAbsoluteUrl', () => {
 				'https://example.com/blog/es/',
 			);
 
-			// file format
+			// preserve format
 			assert.equal(
 				getLocaleAbsoluteUrl({
 					locale: 'en',
 					base: '/blog/',
 					...config.i18n,
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 					strategy: toRoutingStrategy(config.i18n.routing, {}),
 				}),
@@ -867,7 +867,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					base: '/blog/',
 					...config.i18n,
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 					strategy: toRoutingStrategy(config.i18n.routing, {}),
 				}),
@@ -880,7 +880,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					base: '/blog/',
 					...config.i18n,
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 					isBuild: true,
 					strategy: toRoutingStrategy(config.i18n.routing, {}),
@@ -895,7 +895,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					prependWith: 'some-name',
 					...config.i18n,
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 					path: 'first-post',
 					isBuild: true,
@@ -998,14 +998,14 @@ describe('getLocaleAbsoluteUrl', () => {
 				'https://example.com/blog/en/',
 			);
 
-			// directory file
+			// format preserve
 			assert.equal(
 				getLocaleAbsoluteUrl({
 					locale: 'en',
 					base: '/blog',
 					...config.i18n,
 					trailingSlash: 'never',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 					strategy: toRoutingStrategy(config.i18n.routing, {}),
 				}),
@@ -1017,7 +1017,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					base: '/blog/',
 					...config.i18n,
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 					strategy: toRoutingStrategy(config.i18n.routing, {}),
 				}),
@@ -1031,7 +1031,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					base: '/blog',
 					...config.i18n,
 					trailingSlash: 'ignore',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 					strategy: toRoutingStrategy(config.i18n.routing, {}),
 				}),
@@ -1132,7 +1132,7 @@ describe('getLocaleAbsoluteUrl', () => {
 				'https://example.com/blog/es/',
 			);
 
-			// file format
+			// preserve format
 			assert.equal(
 				getLocaleAbsoluteUrl({
 					locale: 'en',
@@ -1140,7 +1140,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					...config.i18n,
 					site: 'https://example.com',
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					strategy: toRoutingStrategy(config.i18n.routing, {}),
 				}),
 				'https://example.com/blog/en/',
@@ -1152,7 +1152,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					...config.i18n,
 					site: 'https://example.com',
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					strategy: toRoutingStrategy(config.i18n.routing, {}),
 				}),
 				'https://example.com/blog/es/',
@@ -1202,7 +1202,7 @@ describe('getLocaleAbsoluteUrl', () => {
 				'https://example.com/blog/es/',
 			);
 
-			// file format
+			// preserve format
 			assert.equal(
 				getLocaleAbsoluteUrl({
 					locale: 'en',
@@ -1210,7 +1210,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					...config.i18n,
 					site: 'https://example.com',
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					strategy: toRoutingStrategy(config.i18n.routing, {}),
 				}),
 				'https://example.com/blog/en/',
@@ -1222,7 +1222,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					...config.i18n,
 					site: 'https://example.com',
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					strategy: toRoutingStrategy(config.i18n.routing, {}),
 				}),
 				'https://example.com/blog/es/',
@@ -1342,7 +1342,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					base: '/blog',
 					...config.experimental.i18n,
 					trailingSlash: 'never',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 				}),
 				'https://example.com/blog',
@@ -1353,7 +1353,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					base: '/blog/',
 					...config.experimental.i18n,
 					trailingSlash: 'always',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 				}),
 				'https://example.com/blog/es/',
@@ -1366,7 +1366,7 @@ describe('getLocaleAbsoluteUrl', () => {
 					base: '/blog',
 					...config.experimental.i18n,
 					trailingSlash: 'ignore',
-					format: 'file',
+					format: 'preserve',
 					site: 'https://example.com',
 				}),
 				'https://example.com/blog',
@@ -1582,7 +1582,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 		);
 	});
 
-	it('should retrieve the correct list of base URL with locales [format: file, trailingSlash: always]', () => {
+	it('should retrieve the correct list of base URL with locales [format: preserve, trailingSlash: always]', () => {
 		/**
 		 *
 		 * @type {import("../../../dist/@types").AstroUserConfig}
@@ -1608,7 +1608,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 				base: '/blog/',
 				...config.i18n,
 				trailingSlash: 'always',
-				format: 'file',
+				format: 'preserve',
 				site: 'https://example.com',
 			}),
 			[
@@ -1620,7 +1620,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 		);
 	});
 
-	it('should retrieve the correct list of base URL with locales [format: file, trailingSlash: never]', () => {
+	it('should retrieve the correct list of base URL with locales [format: preserve, trailingSlash: never]', () => {
 		/**
 		 *
 		 * @type {import("../../../dist/@types").AstroUserConfig}
@@ -1640,14 +1640,14 @@ describe('getLocaleAbsoluteUrlList', () => {
 				base: '/blog',
 				...config.experimental.i18n,
 				trailingSlash: 'never',
-				format: 'file',
+				format: 'preserve',
 				site: 'https://example.com',
 			}),
 			['https://example.com/blog', 'https://example.com/blog/en-us', 'https://example.com/blog/es'],
 		);
 	});
 
-	it('should retrieve the correct list of base URL with locales [format: file, trailingSlash: ignore]', () => {
+	it('should retrieve the correct list of base URL with locales [format: preserve, trailingSlash: ignore]', () => {
 		/**
 		 *
 		 * @type {import("../../../dist/@types").AstroUserConfig}
@@ -1667,7 +1667,7 @@ describe('getLocaleAbsoluteUrlList', () => {
 				base: '/blog',
 				...config.experimental.i18n,
 				trailingSlash: 'ignore',
-				format: 'file',
+				format: 'preserve',
 				site: 'https://example.com',
 			}),
 			['https://example.com/blog', 'https://example.com/blog/en-us', 'https://example.com/blog/es'],

--- a/packages/integrations/sitemap/src/write-sitemap.ts
+++ b/packages/integrations/sitemap/src/write-sitemap.ts
@@ -47,7 +47,7 @@ export async function writeSitemap(
 			const publicPath = normalize(publicBasePath + path);
 
 			let stream: WriteStream;
-			if (astroConfig.trailingSlash === 'never' || astroConfig.build.format === 'file') {
+			if (astroConfig.trailingSlash === 'never') {
 				// workaround for trailing slash issue in sitemap.js: https://github.com/ekalinin/sitemap.js/issues/403
 				const host = hostname.endsWith('/') ? hostname.slice(0, -1) : hostname;
 				const searchStr = `<loc>${host}/</loc>`;

--- a/packages/integrations/sitemap/test/trailing-slash.test.js
+++ b/packages/integrations/sitemap/test/trailing-slash.test.js
@@ -29,13 +29,13 @@ describe('Trailing slash', () => {
 			});
 		});
 
-		describe('build.format: file', () => {
+		describe('build.format: preserve', () => {
 			before(async () => {
 				fixture = await loadFixture({
 					root: './fixtures/trailing-slash/',
 					trailingSlash: 'ignore',
 					build: {
-						format: 'file',
+						format: 'preserve',
 					},
 				});
 				await fixture.build();


### PR DESCRIPTION
## Changes

- Removes `build: { format: 'file' }`. Using `preserve` is encouraged instead.

## Testing

- Updates tests that used file to use preserve instead.

## Docs

- v5 guide updated
- Config docs updated
