### PR TITLE
[docs] revert link to astro:env RFC

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2057,7 +2057,7 @@ export interface AstroUserConfig {
 		 *
 		 * **Note:** Secret client variables are not supported because there is no safe way to send this data to the client. Therefore, it is not possible to configure both `context: "client"` and `access: "secret"` in your schema.
 		 *
-		 * For a complete overview, and to give feedback on this experimental API, see the [Astro Env RFC](https://github.com/withastro/roadmap/blob/feat/astro-env-rfc/proposals/0046-astro-env.md).
+		 * For a complete overview, and to give feedback on this experimental API, see the [Astro Env RFC](https://github.com/withastro/roadmap/blob/main/proposals/0049-astro-env.md).
 		 */
 		env?: {
 			/**


### PR DESCRIPTION
## Changes

I looks like the link to the `astro:env` RFC was updated in error. This reverts the link.

## Testing

I asked @florian-lefebvre to verify the link!

## Docs

Live docs, and the latest released version of Astro are correct. No patch/update needed to make this correction.
