### PR TITLE
[Actions] Fix middleware warning static mode

### DIFF
--- a/.changeset/chatty-cups-sleep.md
+++ b/.changeset/chatty-cups-sleep.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes unexpected warning log when using Actions on "hybrid" rendered projects.

--- a/packages/astro/e2e/fixtures/actions-blog/src/pages/blog/[...slug].astro
+++ b/packages/astro/e2e/fixtures/actions-blog/src/pages/blog/[...slug].astro
@@ -17,14 +17,13 @@ export async function getStaticPaths() {
 	}));
 }
 
-
 type Props = CollectionEntry<'blog'>;
 
 const post = await getEntry('blog', Astro.params.slug)!;
 const { Content } = await post.render();
 
 if (Astro.url.searchParams.has('like')) {
-	await Astro.callAction(actions.blog.like.orThrow, {postId: post.id});
+	await Astro.callAction(actions.blog.like.orThrow, { postId: post.id });
 }
 
 const comment = Astro.getActionResult(actions.blog.comment);
@@ -57,17 +56,17 @@ const commentPostIdOverride = Astro.url.searchParams.get('commentPostIdOverride'
 	/>
 	<form method="POST" data-testid="progressive-fallback" action={actions.blog.comment.queryString}>
 		<input type="hidden" name="postId" value={post.id} />
-		<label for="fallback-author">
-			Author
-		</label>
-			<input id="fallback-author" type="text" name="author" required />
-		<label for="fallback-body" class="sr-only">
-			Comment
-		</label>
+		<label for="fallback-author"> Author </label>
+		<input id="fallback-author" type="text" name="author" required />
+		<label for="fallback-body" class="sr-only"> Comment </label>
 		<textarea id="fallback-body" rows={10} name="body" required></textarea>
-		{isInputError(comment?.error) && comment.error.fields.body && (
-			<p class="error" data-error="body">{comment.error.fields.body.toString()}</p>
-		)}
+		{
+			isInputError(comment?.error) && comment.error.fields.body && (
+				<p class="error" data-error="body">
+					{comment.error.fields.body.toString()}
+				</p>
+			)
+		}
 		<button type="submit">Post Comment</button>
 	</form>
 	<div data-testid="server-comments">

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -22,8 +22,20 @@ export type Locals = {
 };
 
 export const onRequest = defineMiddleware(async (context, next) => {
-	const locals = context.locals as Locals;
 	const { request } = context;
+
+	if ((context as any)._isPrerendered) {
+		if (request.method === 'POST') {
+			// eslint-disable-next-line no-console
+			console.warn(
+				yellow('[astro:actions]'),
+				'POST requests should not be sent to prerendered pages. If you\'re using Actions, disable prerendering with `export const prerender = "false".',
+			);
+		}
+		return next();
+	}
+
+	const locals = context.locals as Locals;
 	// Actions middleware may have run already after a path rewrite.
 	// See https://github.com/withastro/roadmap/blob/feat/reroute/proposals/0047-rerouting.md#ctxrewrite
 	// `_actionPayload` is the same for every page,
@@ -36,16 +48,6 @@ export const onRequest = defineMiddleware(async (context, next) => {
 			throw new Error('Internal: Invalid action payload in cookie.');
 		}
 		return renderResult({ context, next, ...actionPayload });
-	}
-
-	// Heuristic: If body is null, Astro might've reset this for prerendering.
-	if (import.meta.env.DEV && request.method === 'POST' && request.body === null) {
-		// eslint-disable-next-line no-console
-		console.warn(
-			yellow('[astro:actions]'),
-			'POST requests should not be sent to prerendered pages. If you\'re using Actions, disable prerendering with `export const prerender = "false".',
-		);
-		return next();
 	}
 
 	const actionName = context.url.searchParams.get(ACTION_QUERY_PARAMS.actionName);
@@ -92,7 +94,11 @@ async function handlePost({
 	context,
 	next,
 	actionName,
-}: { context: APIContext; next: MiddlewareNext; actionName: string }) {
+}: {
+	context: APIContext;
+	next: MiddlewareNext;
+	actionName: string;
+}) {
 	const { request } = context;
 
 	const baseAction = await getAction(actionName);

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -22,10 +22,8 @@ export type Locals = {
 };
 
 export const onRequest = defineMiddleware(async (context, next) => {
-	const { request } = context;
-
 	if ((context as any)._isPrerendered) {
-		if (request.method === 'POST') {
+		if (context.request.method === 'POST') {
 			// eslint-disable-next-line no-console
 			console.warn(
 				yellow('[astro:actions]'),

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -114,6 +114,8 @@ export class RenderContext {
 		const { cookies, middleware, pipeline } = this;
 		const { logger, serverLike, streaming } = pipeline;
 
+		const isPrerendered = !serverLike || this.routeData.prerender;
+
 		const props =
 			Object.keys(this.props).length > 0
 				? this.props
@@ -125,7 +127,7 @@ export class RenderContext {
 						logger,
 						serverLike,
 					});
-		const apiContext = this.createAPIContext(props);
+		const apiContext = this.createAPIContext(props, isPrerendered);
 
 		this.counter++;
 		if (this.counter === 4) {
@@ -212,12 +214,17 @@ export class RenderContext {
 		return response;
 	}
 
-	createAPIContext(props: APIContext['props']): APIContext {
+	createAPIContext(props: APIContext['props'], isPrerendered: boolean): APIContext {
 		const context = this.createActionAPIContext();
 		return Object.assign(context, {
 			props,
 			getActionResult: createGetActionResult(context.locals),
 			callAction: createCallAction(context),
+			// Used internally by Actions middleware.
+			// TODO: discuss exposing this information from APIContext.
+			// middleware runs on prerendered routes in the dev server,
+			// so this is useful information to have.
+			_isPrerendered: isPrerendered,
 		});
 	}
 

--- a/packages/astro/test/fixtures/actions/src/pages/subscribe-prerendered.astro
+++ b/packages/astro/test/fixtures/actions/src/pages/subscribe-prerendered.astro
@@ -1,0 +1,17 @@
+---
+import { actions } from 'astro:actions';
+
+export const prerender = true;
+
+const result = Astro.getActionResult(actions.subscribe);
+---
+
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Document</title>
+	</head>
+	<body>{result?.data?.subscribeButtonState ?? 'No cookie found.'}</body>
+</html>


### PR DESCRIPTION
## Changes

This adds a check for whether a route is prerendered before running actions middleware.
- Resolves #11751
- Expose `isPrerendered` as untyped variable on `APIContext`. This is hidden from user-facing types for now to unblock actions, similar to our hidden `addContentEntryType()` when releasing content collections. Still, it sounds like integration authors will also benefit from this feature. It's worth discussing what a user-facing version would look like for the future.

## Testing

- Assert  that cookies are ignored when rendering a prerendered route in dev.

## Docs

N/A