### PR TITLE
chore: remove unused astro error

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1669,21 +1669,6 @@ export const ActionsWithoutServerOutputError = {
  * @see
  * - [Actions RFC](https://github.com/withastro/roadmap/blob/actions/proposals/0046-actions.md)
  * @description
- * Action was called from a form using a GET request, but only POST requests are supported. This often occurs if `method="POST"` is missing on the form.
- */
-export const ActionsUsedWithForGetError = {
-	name: 'ActionsUsedWithForGetError',
-	title: 'An invalid Action query string was passed by a form.',
-	message: (actionName: string) =>
-		`Action ${actionName} was called from a form using a GET request, but only POST requests are supported. This often occurs if \`method="POST"\` is missing on the form.`,
-	hint: 'Actions are experimental. Visit the RFC for usage instructions: https://github.com/withastro/roadmap/blob/actions/proposals/0046-actions.md',
-} satisfies ErrorData;
-
-/**
- * @docs
- * @see
- * - [Actions RFC](https://github.com/withastro/roadmap/blob/actions/proposals/0046-actions.md)
- * @description
  * The server received the query string `?_astroAction=name`, but could not find an action with that name. Use the action function's `.queryString` property to retrieve the form `action` URL.
  */
 export const ActionQueryStringInvalidError = {


### PR DESCRIPTION
## Changes

I noticed this error was removed due to a false positive in a previous PR. It was used to prevent users from applying an Action without the `method="POST"` property on a form.

However, this is no longer detectable since we moved to using a query param for the action URL. When using `method="GET"`, this query param will get ignored, so we can no longer detect from the server and raise an exception.

## Testing

N/A

## Docs

N/A