### PR TITLE
Fix file loader for JSON object files

### DIFF
--- a/.changeset/four-rats-fail.md
+++ b/.changeset/four-rats-fail.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where the `filePath` property was not available on content collection entries when using the content layer `file()` loader with a JSON file that contained an object instead of an array. This was breaking use of the `image()` schema utility among other things.

--- a/packages/astro/src/content/loaders/file.ts
+++ b/packages/astro/src/content/loaders/file.ts
@@ -26,6 +26,8 @@ export function file(fileName: string): Loader {
 			return;
 		}
 
+		const normalizedFilePath = posixRelative(fileURLToPath(settings.config.root), filePath);
+
 		if (Array.isArray(json)) {
 			if (json.length === 0) {
 				logger.warn(`No items found in ${fileName}`);
@@ -39,11 +41,7 @@ export function file(fileName: string): Loader {
 					continue;
 				}
 				const data = await parseData({ id, data: rawItem, filePath });
-				store.set({
-					id,
-					data,
-					filePath: posixRelative(fileURLToPath(settings.config.root), filePath),
-				});
+				store.set({ id, data, filePath: normalizedFilePath });
 			}
 		} else if (typeof json === 'object') {
 			const entries = Object.entries<Record<string, unknown>>(json);
@@ -51,7 +49,7 @@ export function file(fileName: string): Loader {
 			store.clear();
 			for (const [id, rawItem] of entries) {
 				const data = await parseData({ id, data: rawItem, filePath });
-				store.set({ id, data });
+				store.set({ id, data, filePath: normalizedFilePath });
 			}
 		} else {
 			logger.error(`Invalid data in ${fileName}. Must be an array or object.`);


### PR DESCRIPTION
## Changes

- Sets `filePath`  on collection entries in the `file()` loader when the loaded JSON is an object not array
- There was an inconsistency in the two code paths that meant that objects had been overlooked
- Amongst other things this fixes use of the `image()` schema utility which depends on `filePath`
- There’s probably an argument for refactoring the loader to first normalize the data, then run the other logic to avoid inconsistencies in the future, but I took the quick fix path for now.

## Testing

Used as a patch in some work in the `astro.build` repo and working as expected

## Docs

n/a — bug fix only