### PR TITLE
ci: run preview release on demand

### DIFF
--- a/.github/workflows/dispatch-event.yml
+++ b/.github/workflows/dispatch-event.yml
@@ -19,7 +19,7 @@ concurrency:
 env:
   ASTRO_ADAPTERS_REPO: withastro/adapters
   ASTRO_STARLIGHT_REPO: withastro/starlight
-  ASTRO_PUSH_MAIN_EVENT: biome-push-main-event
+  ASTRO_PUSH_MAIN_EVENT: astro-push-main-event
     
 jobs:
   repository-dispatch:

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -33,8 +33,14 @@ env:
 
 jobs:
   preview:
-    name: Publish preview release
+    if: ${{ github.repository_owner == 'withastro' && github.event.issue.pull_request && (contains(github.event.comment.body, '!preview')) }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    name: Publish preview release
     timeout-minutes: 5
     steps:
       - name: Disable git crlf


### PR DESCRIPTION
## Changes

- it updates the preview release workflow to run only when there's a comment that contains `!preview`. 
- it updates the name of the dispatched event, it had the `biome-` prefix (copy-paste)

## Testing

I'll comment here and see if it works

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
