### PR TITLE
ci: trigger using review comment instead

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -2,14 +2,8 @@ name: Preview release
 
 on:
   workflow_dispatch:
-  issue_comment:
+  pull_request_review_comment:
     types: [created] 
-  merge_group:
-  pull_request:
-    paths-ignore:
-      - ".vscode/**"
-      - "**/*.md"
-      - ".github/ISSUE_TEMPLATE/**"
         
 permissions:
   contents: read


### PR DESCRIPTION
## Changes

I want to try to use `pull_request_review_comment` instead. It's not the same as `issue_comment`, but maybe `pkg.pr.new` will understand it and it will add a comment to the PR

## Testing

Merge it and use another PR to trigger the event

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
