### PR TITLE
ci: use `issue_comment`

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -2,7 +2,7 @@ name: Preview release
 
 on:
   workflow_dispatch:
-  pull_request_review_comment:
+  issue_comment:
     types: [created] 
         
 permissions:


### PR DESCRIPTION
## Changes

The `pull_request_issue_comment` wasn't the event I needed. `issue_comment` is fine. 

## Testing

[I worked before,](https://github.com/withastro/astro/actions/runs/10490295437) so I will merge this PR.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
