### PR TITLE
Actions: Allow effect chaining on form input validators

### DIFF
--- a/.changeset/pink-kids-taste.md
+++ b/.changeset/pink-kids-taste.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes usage of `.transform()`, `.refine()`, `.passthrough()`, and other effects on Action form inputs.

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1,4 +1,5 @@
 import type { OutgoingHttpHeaders } from 'node:http';
+import type { z } from 'zod';
 import type { AddressInfo } from 'node:net';
 import type {
 	MarkdownHeading,
@@ -14,7 +15,6 @@ import type * as vite from 'vite';
 import type {
 	ActionAccept,
 	ActionClient,
-	ActionInputSchema,
 	ActionReturnType,
 } from '../actions/runtime/virtual/server.js';
 import type { RemotePattern } from '../assets/utils/remotePattern.js';
@@ -3010,7 +3010,7 @@ interface AstroSharedContext<
 	 */
 	getActionResult: <
 		TAccept extends ActionAccept,
-		TInputSchema extends ActionInputSchema<TAccept>,
+		TInputSchema extends z.ZodType,
 		TAction extends ActionClient<unknown, TAccept, TInputSchema>,
 	>(
 		action: TAction,
@@ -3020,7 +3020,7 @@ interface AstroSharedContext<
 	 */
 	callAction: <
 		TAccept extends ActionAccept,
-		TInputSchema extends ActionInputSchema<TAccept>,
+		TInputSchema extends z.ZodType,
 		TOutput,
 		TAction extends
 			| ActionClient<TOutput, TAccept, TInputSchema>

--- a/packages/astro/src/actions/runtime/virtual/server.ts
+++ b/packages/astro/src/actions/runtime/virtual/server.ts
@@ -194,8 +194,13 @@ function handleFormDataGet(
 }
 
 function unwrapSchemaEffects(schema: z.ZodType) {
-	while (schema instanceof z.ZodEffects) {
-		schema = schema._def.schema;
+	while (schema instanceof z.ZodEffects || schema instanceof z.ZodPipeline) {
+		if (schema instanceof z.ZodEffects) {
+			schema = schema._def.schema;
+		}
+		if (schema instanceof z.ZodPipeline) {
+			schema = schema._def.in;
+		}
 	}
 	return schema;
 }

--- a/packages/astro/src/actions/runtime/virtual/server.ts
+++ b/packages/astro/src/actions/runtime/virtual/server.ts
@@ -136,7 +136,8 @@ export function formDataToObject<T extends z.AnyZodObject>(
 	formData: FormData,
 	schema: T,
 ): Record<string, unknown> {
-	const obj: Record<string, unknown> = {};
+	const obj: Record<string, unknown> =
+		schema._def.unknownKeys === 'passthrough' ? Object.fromEntries(formData.entries()) : {};
 	for (const [key, baseValidator] of Object.entries(schema.shape)) {
 		let validator = baseValidator;
 

--- a/packages/astro/test/actions.test.js
+++ b/packages/astro/test/actions.test.js
@@ -261,6 +261,30 @@ describe('Astro Actions', () => {
 			assert.equal(data.issues?.[0]?.message, 'Passwords do not match');
 		});
 
+		it('Supports complex chained effects on form input validators', async () => {
+			const formData = new FormData();
+			formData.set('currentPassword', 'benisboring');
+			formData.set('newPassword', 'benisawesome');
+			formData.set('confirmNewPassword', 'benisawesome');
+
+			const req = new Request('http://example.com/_actions/validatePasswordComplex', {
+				method: 'POST',
+				body: formData,
+			});
+
+			const res = await app.render(req);
+
+			assert.equal(res.ok, true);
+			assert.equal(res.headers.get('Content-Type'), 'application/json+devalue');
+
+			const data = devalue.parse(await res.text());
+			assert.equal(Object.keys(data).length, 2, 'More keys than expected');
+			assert.deepEqual(data, {
+				currentPassword: 'benisboring',
+				newPassword: 'benisawesome',
+			});
+		});
+
 		it('Supports input form data transforms', async () => {
 			const formData = new FormData();
 			formData.set('name', 'ben');

--- a/packages/astro/test/actions.test.js
+++ b/packages/astro/test/actions.test.js
@@ -261,6 +261,26 @@ describe('Astro Actions', () => {
 			assert.equal(data.issues?.[0]?.message, 'Passwords do not match');
 		});
 
+		it('Supports input form data transforms', async () => {
+			const formData = new FormData();
+			formData.set('name', 'ben');
+			formData.set('age', '42');
+
+			const req = new Request('http://example.com/_actions/transformFormInput', {
+				method: 'POST',
+				body: formData,
+			});
+
+			const res = await app.render(req);
+
+			assert.equal(res.ok, true);
+			assert.equal(res.headers.get('Content-Type'), 'application/json+devalue');
+
+			const data = devalue.parse(await res.text());
+			assert.equal(data?.name, 'ben');
+			assert.equal(data?.age, '42');
+		});
+
 		describe('legacy', () => {
 			it('Response middleware fallback', async () => {
 				const formData = new FormData();

--- a/packages/astro/test/actions.test.js
+++ b/packages/astro/test/actions.test.js
@@ -240,6 +240,27 @@ describe('Astro Actions', () => {
 			assert.ok($('#user'));
 		});
 
+		it('Supports effects on form input validators', async () => {
+			const formData = new FormData();
+			formData.set('password', 'benisawesome');
+			formData.set('confirmPassword', 'benisveryawesome');
+
+			const req = new Request('http://example.com/_actions/validatePassword', {
+				method: 'POST',
+				body: formData,
+			});
+
+			const res = await app.render(req);
+
+			assert.equal(res.ok, false);
+			assert.equal(res.status, 400);
+			assert.equal(res.headers.get('Content-Type'), 'application/json');
+
+			const data = await res.json();
+			assert.equal(data.type, 'AstroActionInputError');
+			assert.equal(data.issues?.[0]?.message, 'Passwords do not match');
+		});
+
 		describe('legacy', () => {
 			it('Response middleware fallback', async () => {
 				const formData = new FormData();

--- a/packages/astro/test/fixtures/actions/src/actions/index.ts
+++ b/packages/astro/test/fixtures/actions/src/actions/index.ts
@@ -57,6 +57,13 @@ export const server = {
 			return password;
 		},
 	}),
+	transformFormInput: defineAction({
+		accept: 'form',
+		input: z.instanceof(FormData).transform((formData) => Object.fromEntries(formData.entries())),
+		handler: async (data) => {
+			return data;
+		},
+	}),
 	getUserOrThrow: defineAction({
 		accept: 'form',
 		handler: async (_, { locals }) => {

--- a/packages/astro/test/fixtures/actions/src/actions/index.ts
+++ b/packages/astro/test/fixtures/actions/src/actions/index.ts
@@ -44,7 +44,18 @@ export const server = {
 		accept: 'form',
 		handler: async (_, { locals }) => {
 			return locals.user;
-		}
+		},
+	}),
+	validatePassword: defineAction({
+		accept: 'form',
+		input: z
+			.object({ password: z.string(), confirmPassword: z.string() })
+			.refine((data) => data.password === data.confirmPassword, {
+				message: 'Passwords do not match',
+			}),
+		handler: async ({ password }) => {
+			return password;
+		},
 	}),
 	getUserOrThrow: defineAction({
 		accept: 'form',
@@ -57,22 +68,22 @@ export const server = {
 				});
 			}
 			return locals.user;
-		}
+		},
 	}),
 	fireAndForget: defineAction({
 		handler: async () => {
 			return;
-		}
+		},
 	}),
 	zero: defineAction({
 		handler: async () => {
 			return 0;
-		}
+		},
 	}),
 	false: defineAction({
 		handler: async () => {
 			return false;
-		}
+		},
 	}),
 	complexValues: defineAction({
 		handler: async () => {
@@ -80,7 +91,7 @@ export const server = {
 				date: new Date(),
 				set: new Set(),
 				url: new URL('https://example.com'),
-			}
-		}
-	})
+			};
+		},
+	}),
 };

--- a/packages/astro/test/units/actions/form-data-to-object.test.js
+++ b/packages/astro/test/units/actions/form-data-to-object.test.js
@@ -192,4 +192,22 @@ describe('formDataToObject', () => {
 		assert.equal(res.files instanceof Array, true);
 		assert.deepEqual(res.files, [file1, file2]);
 	});
+
+	it('should allow object passthrough when chaining .passthrough() on root object', () => {
+		const formData = new FormData();
+		formData.set('expected', '42');
+		formData.set('unexpected', '42');
+
+		const input = z
+			.object({
+				expected: z.number(),
+			})
+			.passthrough();
+
+		const res = formDataToObject(formData, input);
+		assert.deepEqual(res, {
+			expected: 42,
+			unexpected: '42',
+		});
+	});
 });


### PR DESCRIPTION
## Changes

Allow chaining utilities on `z.object()` when validating forms. This includes `.refine()`, `.transform()`, and `.passthrough()`.

- Resolves #11641
- Resolves #11693
- Unwrap nested effects to get basic Zod object
- Add check for the `passthrough` property. If present, pass unknown form data values as object keys
- Simplify Zod schema type for forms to `z.ZodType`. We originally tried to restrict this type, but it would grow quite complex to support infinitely nested `z.ZodEffect` objects. So, we relaxed the type and relaxed the handler. If we find a ZodObject in your validator, we massage `FormData`. Otherwise, we run your schema as-is.

## Testing

- Add unit test for passthrough
- Add integration tests for refine and transform

## Docs

N/A