### PR TITLE
Actions: expose ActionAPIContext

### DIFF
--- a/.changeset/poor-olives-battle.md
+++ b/.changeset/poor-olives-battle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Exposes `ActionAPIContext` type from the `astro:actions` module.

--- a/packages/astro/src/actions/runtime/virtual/shared.ts
+++ b/packages/astro/src/actions/runtime/virtual/shared.ts
@@ -1,8 +1,13 @@
 import { parse as devalueParse, stringify as devalueStringify } from 'devalue';
 import type { z } from 'zod';
 import { ACTION_QUERY_PARAMS as _ACTION_QUERY_PARAMS } from '../../consts.js';
-import type { ErrorInferenceObject, MaybePromise } from '../utils.js';
+import type {
+	ErrorInferenceObject,
+	MaybePromise,
+	ActionAPIContext as _ActionAPIContext,
+} from '../utils.js';
 
+export type ActionAPIContext = _ActionAPIContext;
 export const ACTION_QUERY_PARAMS = _ACTION_QUERY_PARAMS;
 
 export const ACTION_ERROR_CODES = [


### PR DESCRIPTION
## Changes

- Resolves #11764
- Exposes `ActionAPIContext` utility type for integration authors.

## Testing

N/A

## Docs

N/A