### PR TITLE
Content Layer API Example small fix

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2308,7 +2308,7 @@ export interface AstroUserConfig {
 		 *
 		 * const post = await getEntry('blog', Astro.params.slug);
 		 *
-		 * const { Content, headings } = await render(entry);
+		 * const { Content, headings } = await render(post);
 		 * ---
 		 *
 		 * <Content />


### PR DESCRIPTION
#### Description

It's a small error in an example of content-collections on page

https://docs.astro.build/en/reference/configuration-reference/

I'm fixing it here because after diving into the docs repo it seems the data comes canonically from these comments.

```diff
---
import { getEntry, render } from 'astro:content';

const post = await getEntry('blog', Astro.params.slug);

- const { Content, headings } = await render(entry);
+ const { Content, headings } = await render(post); 
---

<Content />
```


## Changes

A single comment string change to fix an example that uses the wrong variable.

## Testing

None. Only changes to doc strings

## Docs

We're fixing docs here, no docs needed.
