### PR TITLE
Fix MDX layout style ordering

### DIFF
--- a/.changeset/tiny-suns-sit.md
+++ b/.changeset/tiny-suns-sit.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Fixes CSS in the layout component to be ordered first before any other components in the MDX file


### PR DESCRIPTION
## Changes

fixes https://github.com/withastro/astro/issues/11040

we can revert the workaround made in https://github.com/withastro/astro/pull/4428 as Vite is able to handle circular imports invalidation better now. I tested manually and can confirm that when one `.mdx` file (that's part of a `Astro.glob` of the layout file) is edited, only that `.mdx` file gets re-transformed. The rest `.mdx` file will reuse the transform result from the cache. (Checked with `DEBUG="vite:cache,vite:plugin-transform" pnpm dev`)

## Testing

Existing tests should pass. Also explained some manual testing method above.

## Docs

n/a. bug fix.
