### PR TITLE
Make vite-plugin-fileurl a pre plugin

### DIFF
--- a/.changeset/fuzzy-falcons-tan.md
+++ b/.changeset/fuzzy-falcons-tan.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Marks internal `vite-plugin-fileurl` plugin with `enforce: 'pre'`

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -151,7 +151,7 @@ export async function createVite(
 			astroPrefetch({ settings }),
 			astroTransitions({ settings }),
 			astroDevToolbar({ settings, logger }),
-			vitePluginFileURL({}),
+			vitePluginFileURL(),
 			astroInternationalization({ settings }),
 			settings.config.experimental.serverIslands && vitePluginServerIslands({ settings }),
 			astroContainer(),

--- a/packages/astro/src/vite-plugin-fileurl/index.ts
+++ b/packages/astro/src/vite-plugin-fileurl/index.ts
@@ -1,8 +1,9 @@
 import type { Plugin as VitePlugin } from 'vite';
 
-export default function vitePluginFileURL({}): VitePlugin {
+export default function vitePluginFileURL(): VitePlugin {
 	return {
 		name: 'astro:vite-plugin-file-url',
+		enforce: 'pre',
 		resolveId(source, importer) {
 			if (source.startsWith('file://')) {
 				const rest = source.slice(7);


### PR DESCRIPTION
## Changes

In the next Vite major with https://github.com/vitejs/vite/pull/17369, `file://` imports will be automatically externalized by Vite's resolver plugin, which causes problem with our `vite-plugin-fileurl` plugin because it's after vite's resolver plugin.

This PR marks it as `enforce: 'pre'` so that it runs before Vite's resolver plugin. In practice with this change now, it shouldn't break other plugins unless they also handle `file://` and with `enforce: 'pre'`, but I don't think that's a common case.

## Testing

Existing should pass.

## Docs

Added a changeset in case I'm wrong that this shouldn't break people.