### PR TITLE
Prevent Partytown integration from inserting a 'null' string into the body

### DIFF
--- a/.changeset/eight-rice-tap.md
+++ b/.changeset/eight-rice-tap.md
@@ -2,4 +2,4 @@
 '@astrojs/partytown': patch
 ---
 
-Prevent Partytown from inserting a 'null' string into the body
+Prevent Partytown integration from inserting a 'null' string into the body

--- a/.changeset/eight-rice-tap.md
+++ b/.changeset/eight-rice-tap.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/partytown': patch
+---
+
+Prevent Partytown from inserting a 'null' string into the body

--- a/packages/integrations/partytown/src/index.ts
+++ b/packages/integrations/partytown/src/index.ts
@@ -26,7 +26,7 @@ export default function createPlugin(options?: PartytownOptions): AstroIntegrati
 		hooks: {
 			'astro:config:setup': ({ config: _config, command, injectScript }) => {
 				const lib = `${appendForwardSlash(_config.base)}~partytown/`;
-				const recreateIFrameScript = `;(e=>{e.addEventListener("astro:before-swap",e=>{let r=document.body.querySelector("iframe[src*='${lib}']");e.newDocument.body.append(r)})})(document);`;
+				const recreateIFrameScript = `;(e=>{e.addEventListener("astro:before-swap",e=>{let r=document.body.querySelector("iframe[src*='${lib}']");if(r)e.newDocument.body.append(r)})})(document);`;
 				const partytownConfig = {
 					lib,
 					...options?.config,


### PR DESCRIPTION
## Changes

When using astro/partytown with astro:transitions, if partytown failed to load, it inserts "null" string into the page during transition. This mainly occurs in non-Secure Context where Service Worker that partytown needs can't be install. For example, if you're accessing it via an IP address on a LAN during development, it isn't served over HTTPS or on localhost so it's not Secure Context.

This PR prevent that by append a element only if found.

![image](https://github.com/user-attachments/assets/52cea71d-0999-46d3-ad02-07179272be68)
― The script going to append "null"

![image](https://github.com/user-attachments/assets/2bed4850-8c93-4514-944d-b305f8afdd39)
― The added "null" string node

## Testing

Building @astrojs/partytown, linking it to my project, and confirming no "null" were inserted during page transitions.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This should be a minor bug fix affecting only special cases, so no docs will be required.