### PR TITLE
feat: add postinstall sync script to examples

### DIFF
--- a/examples/basics/package.json
+++ b/examples/basics/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/container-with-vitest/package.json
+++ b/examples/container-with-vitest/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/framework-alpine/package.json
+++ b/examples/framework-alpine/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/framework-lit/package.json
+++ b/examples/framework-lit/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/framework-multiple/package.json
+++ b/examples/framework-multiple/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/framework-preact/package.json
+++ b/examples/framework-preact/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/framework-react/package.json
+++ b/examples/framework-react/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/framework-solid/package.json
+++ b/examples/framework-solid/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/framework-svelte/package.json
+++ b/examples/framework-svelte/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/framework-vue/package.json
+++ b/examples/framework-vue/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/hackernews/package.json
+++ b/examples/hackernews/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/middleware/package.json
+++ b/examples/middleware/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/non-html-pages/package.json
+++ b/examples/non-html-pages/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/portfolio/package.json
+++ b/examples/portfolio/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/server-islands/package.json
+++ b/examples/server-islands/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/ssr/package.json
+++ b/examples/ssr/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/starlog/package.json
+++ b/examples/starlog/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/view-transitions/package.json
+++ b/examples/view-transitions/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/with-markdoc/package.json
+++ b/examples/with-markdoc/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/with-markdown-plugins/package.json
+++ b/examples/with-markdown-plugins/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.2",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/with-markdown-shiki/package.json
+++ b/examples/with-markdown-shiki/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/with-mdx/package.json
+++ b/examples/with-mdx/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/with-nanostores/package.json
+++ b/examples/with-nanostores/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/examples/with-vitest/package.json
+++ b/examples/with-vitest/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "astro sync",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",


### PR DESCRIPTION
## Changes

- Now that some essential types rely on codegen (eg. `astro/client`), I think it's right to add `"postinstall": "astro sync"`

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
