### PR TITLE
Fix component defined in `extends` not rendered as Markdoc tags/nodes

### DIFF
--- a/.changeset/good-adults-punch.md
+++ b/.changeset/good-adults-punch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': patch
+---
+
+Fixes an issue preventing to use Astro components as Markdoc tags and nodes when configured using the `extends` property.

--- a/packages/integrations/markdoc/src/content-entry-type.ts
+++ b/packages/integrations/markdoc/src/content-entry-type.ts
@@ -78,13 +78,13 @@ export async function getContentEntryType({
 			// Only include component imports for tags used in the document.
 			// Avoids style and script bleed.
 			for (const tag of usedTags) {
-				const render = userMarkdocConfig.tags?.[tag]?.render;
+				const render = markdocConfig.tags?.[tag]?.render;
 				if (isComponentConfig(render)) {
 					componentConfigByTagMap[tag] = render;
 				}
 			}
 			let componentConfigByNodeMap: Record<string, ComponentConfig> = {};
-			for (const [nodeType, schema] of Object.entries(userMarkdocConfig.nodes ?? {})) {
+			for (const [nodeType, schema] of Object.entries(markdocConfig.nodes ?? {})) {
 				const render = schema?.render;
 				if (isComponentConfig(render)) {
 					componentConfigByNodeMap[nodeType] = render;

--- a/packages/integrations/markdoc/test/fixtures/render-with-extends-components/astro.config.mjs
+++ b/packages/integrations/markdoc/test/fixtures/render-with-extends-components/astro.config.mjs
@@ -1,0 +1,7 @@
+import markdoc from '@astrojs/markdoc';
+import { defineConfig } from 'astro/config';
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [markdoc()],
+});

--- a/packages/integrations/markdoc/test/fixtures/render-with-extends-components/markdoc.config.ts
+++ b/packages/integrations/markdoc/test/fixtures/render-with-extends-components/markdoc.config.ts
@@ -1,0 +1,31 @@
+import { component, defineMarkdocConfig } from '@astrojs/markdoc/config';
+
+export default defineMarkdocConfig({
+	extends: [preset()],
+});
+
+function preset() {
+	return {
+		nodes: {
+			fence: {
+				render: component('./src/components/Code.astro'),
+				attributes: {
+					language: { type: String },
+					content: { type: String },
+				},
+			},
+		},
+		tags: {
+			'marquee-element': {
+				render: component('./src/components/CustomMarquee.astro'),
+				attributes: {
+					direction: {
+						type: String,
+						default: 'left',
+						matches: ['left', 'right', 'up', 'down'],
+					},
+				},
+			},
+		},
+	}
+}

--- a/packages/integrations/markdoc/test/fixtures/render-with-extends-components/package.json
+++ b/packages/integrations/markdoc/test/fixtures/render-with-extends-components/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/markdoc-render-with-extends-components",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/markdoc": "workspace:*",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/integrations/markdoc/test/fixtures/render-with-extends-components/src/components/Code.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-extends-components/src/components/Code.astro
@@ -1,0 +1,12 @@
+---
+import { Code } from 'astro/components';
+
+type Props = {
+	content: string;
+	language: string;
+}
+
+const { content, language } = Astro.props as Props;
+---
+
+<Code lang={language} code={content} />

--- a/packages/integrations/markdoc/test/fixtures/render-with-extends-components/src/components/CustomMarquee.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-extends-components/src/components/CustomMarquee.astro
@@ -1,0 +1,1 @@
+<marquee data-custom-marquee {...Astro.props}><slot /></marquee>

--- a/packages/integrations/markdoc/test/fixtures/render-with-extends-components/src/content/blog/with-components.mdoc
+++ b/packages/integrations/markdoc/test/fixtures/render-with-extends-components/src/content/blog/with-components.mdoc
@@ -1,0 +1,17 @@
+---
+title: Post with components
+---
+
+## Post with components
+
+This uses a custom marquee component with a shortcode:
+
+{% marquee-element direction="right" %}
+I'm a marquee too!
+{% /marquee-element %}
+
+And a code component for code blocks:
+
+```js
+const isRenderedWithShiki = true;
+```

--- a/packages/integrations/markdoc/test/fixtures/render-with-extends-components/src/pages/index.astro
+++ b/packages/integrations/markdoc/test/fixtures/render-with-extends-components/src/pages/index.astro
@@ -1,0 +1,19 @@
+---
+import { getEntryBySlug } from "astro:content";
+
+const post = await getEntryBySlug('blog', 'with-components');
+const { Content } = await post.render();
+---
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Content</title>
+</head>
+<body>
+	<Content />	
+</body>
+</html>

--- a/packages/integrations/markdoc/test/render-extends-components.test.js
+++ b/packages/integrations/markdoc/test/render-extends-components.test.js
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { parseHTML } from 'linkedom';
+import { loadFixture } from '../../../astro/test/test-utils.js';
+
+const root = new URL('./fixtures/render-with-extends-components/', import.meta.url);
+
+describe('Markdoc - render components defined in `extends`', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root,
+		});
+	});
+
+	describe('dev', () => {
+		let devServer;
+
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('renders content - with components', async () => {
+			const res = await fixture.fetch('/');
+			const html = await res.text();
+
+			renderComponentsChecks(html);
+		});
+	});
+
+	describe('build', () => {
+		before(async () => {
+			await fixture.build();
+		});
+
+		it('renders content - with components', async () => {
+			const html = await fixture.readFile('/index.html');
+
+			renderComponentsChecks(html);
+		});
+	});
+});
+
+/** @param {string} html */
+function renderComponentsChecks(html) {
+	const { document } = parseHTML(html);
+	const h2 = document.querySelector('h2');
+	assert.equal(h2.textContent, 'Post with components');
+
+	// Renders custom shortcode component
+	const marquee = document.querySelector('marquee');
+	assert.notEqual(marquee, null);
+	assert.equal(marquee.hasAttribute('data-custom-marquee'), true);
+
+	// Renders Astro Code component
+	const pre = document.querySelector('pre');
+	assert.notEqual(pre, null);
+	assert.equal(pre.className, 'astro-code github-dark');
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4744,6 +4744,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../../astro
 
+  packages/integrations/markdoc/test/fixtures/render-with-extends-components:
+    dependencies:
+      '@astrojs/markdoc':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: workspace:*
+        version: link:../../../../../astro
+
   packages/integrations/markdoc/test/fixtures/render-with-indented-components:
     dependencies:
       '@astrojs/markdoc':


### PR DESCRIPTION
## Changes

This PR fixes an issue where rendering Astro components as Markdoc tags and nodes when configured using the `extends` property would lead to an error (`Unable to render [object Object]. No valid renderer was found for this file extension.`).

This would prevent for example Starlight users to have a configuration like this:

```ts
export default defineMarkdocConfig({
  extends: [starlightMarkdoc()]
  tags: {
    custom: { render: component('./src/components/Custom.astro') },
  },
});
```

The issue was that when creating the component configs for used tags and nodes, the user-defined Markdoc config was used instead of the computed one that also contains the merged configurations from the `extends` property.

## Testing

I mostly duplicated the existing `test/fixtures/render-with-components` fixture and its associated `test/render-components.test.js` tests and created a fixture where the configuration is done using `extends`.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

This is a bug fix for a feature that does not have a specific documentation or example.