### PR TITLE
fix: ensure vite is not imported by runtime utils

### DIFF
--- a/.changeset/eleven-papayas-rhyme.md
+++ b/.changeset/eleven-papayas-rhyme.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where Vite would be imported by the SSR runtime, causing bundling errors and bloat.

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -4,7 +4,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { slug as githubSlug } from 'github-slugger';
 import matter from 'gray-matter';
 import type { PluginContext } from 'rollup';
-import { type ViteDevServer, normalizePath } from 'vite';
+import type { ViteDevServer } from 'vite';
 import xxhash from 'xxhash-wasm';
 import { z } from 'zod';
 import type {
@@ -25,6 +25,7 @@ import {
 	PROPAGATED_ASSET_FLAG,
 } from './consts.js';
 import { createImage } from './runtime-assets.js';
+import { normalizePath } from '../core/viteUtils.js';
 /**
  * Amap from a collection + slug to the local file path.
  * This is used internally to resolve entry imports when using `getEntry()`.

--- a/packages/astro/src/core/viteUtils.ts
+++ b/packages/astro/src/core/viteUtils.ts
@@ -1,9 +1,17 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { normalizePath } from 'vite';
-import { prependForwardSlash } from '../core/path.js';
+import { prependForwardSlash, slash } from '../core/path.js';
 import type { ModuleLoader } from './module-loader/index.js';
 import { VALID_ID_PREFIX, resolveJsToTs, unwrapId, viteID } from './util.js';
+
+const isWindows = typeof process !== 'undefined' && process.platform === 'win32';
+
+/**
+ * Re-implementation of Vite's normalizePath that can be used without Vite
+ */
+export function normalizePath(id: string) {
+	return path.posix.normalize(isWindows ? slash(id) : id);
+}
 
 /**
  * Resolve the hydration paths so that it can be imported in the client


### PR DESCRIPTION
## Changes

The content utils use `normalizePath` imported from vite. This was causing problems because it was making vite a dependency of SSR chunks, causing bundling errors and bloated bundles. This was encountered in https://github.com/withastro/astro.build/pull/1225

This fixes the issue by re-implementing `normalizePath` (it's quite simple), so it can be used elsewhere.

## Testing

Tested with https://github.com/withastro/astro.build/pull/1225

## Docs
Bugfix
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
