### PR TITLE
chore: enable `useImportType` rule

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,21 @@
 {
   "[json]": {
-    "editor.defaultFormatter": "biomejs.biome",
+    "editor.defaultFormatter": "biomejs.biome"
   },
   "[javascript]": {
-    "editor.defaultFormatter": "biomejs.biome",
+    "editor.defaultFormatter": "biomejs.biome"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "biomejs.biome",
+    "editor.defaultFormatter": "biomejs.biome"
   },
   "[javascriptreact]": {
-    "editor.defaultFormatter": "biomejs.biome",
+    "editor.defaultFormatter": "biomejs.biome"
   },
   "[typescriptreact]": {
-    "editor.defaultFormatter": "biomejs.biome",
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "editor.codeActionsOnSave": {
+    "quickFix.biome": true,
+    "source.fixAll.biome": true
   }
 }

--- a/biome.json
+++ b/biome.json
@@ -31,7 +31,8 @@
     "rules": {
       "recommended": false,
       "style": {
-        "useNodejsImportProtocol": "error"
+        "useNodejsImportProtocol": "error",
+        "useImportType": "error"
       }
     }
   },

--- a/packages/astro/src/actions/utils.ts
+++ b/packages/astro/src/actions/utils.ts
@@ -1,6 +1,6 @@
 import type { APIContext } from '../@types/astro.js';
 import type { Locals } from './runtime/middleware.js';
-import { type ActionAPIContext } from './runtime/utils.js';
+import type { ActionAPIContext } from './runtime/utils.js';
 import { deserializeActionResult, getActionQueryString } from './runtime/virtual/shared.js';
 
 export function hasActionPayload(locals: APIContext['locals']): locals is Locals {

--- a/packages/astro/src/core/build/plugins/plugin-content.ts
+++ b/packages/astro/src/core/build/plugins/plugin-content.ts
@@ -22,7 +22,7 @@ import {
 import { isContentCollectionsCacheEnabled } from '../../util.js';
 import { addRollupInput } from '../add-rollup-input.js';
 import { CHUNKS_PATH, CONTENT_PATH } from '../consts.js';
-import { type BuildInternals } from '../internal.js';
+import type { BuildInternals } from '../internal.js';
 import type { AstroBuildPlugin } from '../plugin.js';
 import { copyFiles } from '../static-build.js';
 import type { StaticBuildOptions } from '../types.js';

--- a/packages/astro/src/core/build/plugins/plugin-pages.ts
+++ b/packages/astro/src/core/build/plugins/plugin-pages.ts
@@ -1,7 +1,7 @@
 import type { Plugin as VitePlugin } from 'vite';
 import { routeIsRedirect } from '../../redirects/index.js';
 import { addRollupInput } from '../add-rollup-input.js';
-import { type BuildInternals } from '../internal.js';
+import type { BuildInternals } from '../internal.js';
 import type { AstroBuildPlugin } from '../plugin.js';
 import type { StaticBuildOptions } from '../types.js';
 import { RENDERERS_MODULE_ID } from './plugin-renderers.js';

--- a/packages/astro/src/runtime/client/dev-toolbar/toolbar.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/toolbar.ts
@@ -3,7 +3,7 @@ import type { ResolvedDevToolbarApp as DevToolbarAppDefinition } from '../../../
 import { type ToolbarAppEventTarget, serverHelpers } from './helpers.js';
 import { settings } from './settings.js';
 import { type Icon, getIconElement, isDefinedIcon } from './ui-library/icons.js';
-import { type Placement } from './ui-library/window.js';
+import type { Placement } from './ui-library/window.js';
 
 export type DevToolbarApp = DevToolbarAppDefinition & {
 	builtIn: boolean;

--- a/packages/astro/src/vite-plugin-astro-server/pipeline.ts
+++ b/packages/astro/src/vite-plugin-astro-server/pipeline.ts
@@ -11,7 +11,7 @@ import type {
 	SSRManifest,
 } from '../@types/astro.js';
 import { getInfoOutput } from '../cli/info/index.js';
-import { type HeadElements } from '../core/base-pipeline.js';
+import type { HeadElements } from '../core/base-pipeline.js';
 import { ASTRO_VERSION } from '../core/constants.js';
 import { enhanceViteSSRError } from '../core/errors/dev/index.js';
 import { AggregateError, CSSError, MarkdownError } from '../core/errors/index.js';

--- a/packages/astro/src/vite-plugin-scanner/index.ts
+++ b/packages/astro/src/vite-plugin-scanner/index.ts
@@ -3,7 +3,7 @@ import { bold } from 'kleur/colors';
 import type { Plugin as VitePlugin } from 'vite';
 import { normalizePath } from 'vite';
 import type { AstroSettings, RouteOptions } from '../@types/astro.js';
-import { type Logger } from '../core/logger/core.js';
+import type { Logger } from '../core/logger/core.js';
 import { isEndpoint, isPage, isServerLikeOutput } from '../core/util.js';
 import { rootRelativePath } from '../core/viteUtils.js';
 import { runHookRouteSetup } from '../integrations/hooks.js';

--- a/packages/db/src/core/cli/commands/link/index.ts
+++ b/packages/db/src/core/cli/commands/link/index.ts
@@ -12,7 +12,7 @@ import { bgRed, cyan } from 'kleur/colors';
 import ora from 'ora';
 import prompts from 'prompts';
 import { safeFetch } from '../../../../runtime/utils.js';
-import { type Result } from '../../../utils.js';
+import type { Result } from '../../../utils.js';
 
 export async function cmd() {
 	const sessionToken = await getSessionIdFromFile();

--- a/packages/db/src/core/cli/commands/push/index.ts
+++ b/packages/db/src/core/cli/commands/push/index.ts
@@ -4,7 +4,7 @@ import prompts from 'prompts';
 import type { Arguments } from 'yargs-parser';
 import { safeFetch } from '../../../../runtime/utils.js';
 import { MIGRATION_VERSION } from '../../../consts.js';
-import { type DBConfig, type DBSnapshot } from '../../../types.js';
+import type { DBConfig, DBSnapshot } from '../../../types.js';
 import { type Result, getRemoteDatabaseUrl } from '../../../utils.js';
 import {
 	createCurrentSnapshot,

--- a/packages/db/src/core/cli/migration-queries.ts
+++ b/packages/db/src/core/cli/migration-queries.ts
@@ -18,20 +18,20 @@ import {
 	schemaTypeToSqlType,
 } from '../queries.js';
 import { columnSchema } from '../schemas.js';
-import {
-	type BooleanColumn,
-	type ColumnType,
-	type DBColumn,
-	type DBColumns,
-	type DBConfig,
-	type DBSnapshot,
-	type DateColumn,
-	type JsonColumn,
-	type NumberColumn,
-	type ResolvedDBTable,
-	type ResolvedDBTables,
-	type ResolvedIndexes,
-	type TextColumn,
+import type {
+	BooleanColumn,
+	ColumnType,
+	DBColumn,
+	DBColumns,
+	DBConfig,
+	DBSnapshot,
+	DateColumn,
+	JsonColumn,
+	NumberColumn,
+	ResolvedDBTable,
+	ResolvedDBTables,
+	ResolvedIndexes,
+	TextColumn,
 } from '../types.js';
 import { type Result, getRemoteDatabaseUrl } from '../utils.js';
 

--- a/packages/db/src/core/queries.ts
+++ b/packages/db/src/core/queries.ts
@@ -1,4 +1,4 @@
-import { type SQL } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
 import { SQLiteAsyncDialect } from 'drizzle-orm/sqlite-core';
 import { bold } from 'kleur/colors';
 import {

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -1,5 +1,5 @@
 import { type ColumnBuilderBaseConfig, type ColumnDataType, sql } from 'drizzle-orm';
-import { type LibSQLDatabase } from 'drizzle-orm/libsql';
+import type { LibSQLDatabase } from 'drizzle-orm/libsql';
 import {
 	type IndexBuilder,
 	type SQLiteColumnBuilderBase,

--- a/packages/integrations/markdoc/src/runtime.ts
+++ b/packages/integrations/markdoc/src/runtime.ts
@@ -7,7 +7,7 @@ import Markdoc, {
 } from '@markdoc/markdoc';
 import type { AstroInstance } from 'astro';
 import { createComponent, renderComponent } from 'astro/runtime/server/index.js';
-import { type AstroMarkdocConfig } from './config.js';
+import type { AstroMarkdocConfig } from './config.js';
 import { setupHeadingConfig } from './heading-ids.js';
 import { htmlTag } from './html/tagdefs/html.tag.js';
 import type { MarkdocIntegrationOptions } from './options.js';


### PR DESCRIPTION
## Changes

This rule enables `useImportType` from Biome: https://biomejs.dev/linter/rules/use-import-type/

We've had issues where the syntax `import { type Something }` broke our build and downstream adapters.

This rule should prevent that.

Also, I updated the `settings.json` to apply safe fixes on save. 

## Testing

Current CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
