### PR TITLE
Improve e2e setup

### DIFF
--- a/packages/astro/e2e/actions-blog.test.js
+++ b/packages/astro/e2e/actions-blog.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
-import { testFactory } from './test-utils.js';
+import { testFactory, waitForHydrate } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/actions-blog/' });
+const test = testFactory(import.meta.url, { root: './fixtures/actions-blog/' });
 
 let devServer;
 
@@ -23,11 +23,10 @@ test.describe('Astro Actions - Blog', () => {
 		await page.goto(astro.resolveUrl('/blog/first-post/'));
 
 		const likeButton = page.getByLabel('Like');
+		await waitForHydrate(page, likeButton);
 		await expect(likeButton, 'like button starts with 10 likes').toContainText('10');
 		await likeButton.click();
-		await expect(likeButton, 'like button should increment likes').toContainText('11', {
-			timeout: 6_000,
-		});
+		await expect(likeButton, 'like button should increment likes').toContainText('11');
 	});
 
 	test('Like action - server-side', async ({ page, astro }) => {
@@ -38,9 +37,7 @@ test.describe('Astro Actions - Blog', () => {
 
 		await expect(likeCount, 'like button starts with 10 likes').toContainText('10');
 		await likeButton.click();
-		await expect(likeCount, 'like button should increment likes').toContainText('11', {
-			timeout: 6_000,
-		});
+		await expect(likeCount, 'like button should increment likes').toContainText('11');
 	});
 
 	test('Comment action - validation error', async ({ page, astro }) => {
@@ -134,7 +131,8 @@ test.describe('Astro Actions - Blog', () => {
 		await page.goto(astro.resolveUrl('/blog/first-post/'));
 
 		const logoutButton = page.getByTestId('logout-button');
+		await waitForHydrate(page, logoutButton);
 		await logoutButton.click();
-		await expect(page).toHaveURL(astro.resolveUrl('/blog/'), { timeout: 6_000 });
+		await expect(page).toHaveURL(astro.resolveUrl('/blog/'));
 	});
 });

--- a/packages/astro/e2e/actions-react-19.test.js
+++ b/packages/astro/e2e/actions-react-19.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
-import { testFactory } from './test-utils.js';
+import { testFactory, waitForHydrate } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/actions-react-19/' });
+const test = testFactory(import.meta.url, { root: './fixtures/actions-react-19/' });
 
 let devServer;
 
@@ -23,10 +23,12 @@ test.describe('Astro Actions - React 19', () => {
 		await page.goto(astro.resolveUrl('/blog/first-post/'));
 
 		const likeButton = page.getByLabel('likes-client');
+		await waitForHydrate(page, likeButton);
+
 		await expect(likeButton).toBeVisible();
 		await likeButton.click();
 		await expect(likeButton, 'like button should be disabled when pending').toBeDisabled();
-		await expect(likeButton).not.toBeDisabled({ timeout: 5000 });
+		await expect(likeButton).not.toBeDisabled();
 	});
 
 	test('Like action - server progressive enhancement', async ({ page, astro }) => {
@@ -43,6 +45,8 @@ test.describe('Astro Actions - React 19', () => {
 		await page.goto(astro.resolveUrl('/blog/first-post/'));
 
 		const likeButton = page.getByLabel('likes-action-client');
+		await waitForHydrate(page, likeButton);
+
 		await expect(likeButton).toBeVisible();
 		await likeButton.click();
 

--- a/packages/astro/e2e/astro-component.test.js
+++ b/packages/astro/e2e/astro-component.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/astro-component/' });
+const test = testFactory(import.meta.url, { root: './fixtures/astro-component/' });
 
 let devServer;
 

--- a/packages/astro/e2e/astro-envs.test.js
+++ b/packages/astro/e2e/astro-envs.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/astro-envs/',
 	devToolbar: {
 		enabled: false,

--- a/packages/astro/e2e/client-only.test.js
+++ b/packages/astro/e2e/client-only.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/client-only/' });
+const test = testFactory(import.meta.url, { root: './fixtures/client-only/' });
 
 let devServer;
 

--- a/packages/astro/e2e/content-collections.test.js
+++ b/packages/astro/e2e/content-collections.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/content-collections/' });
+const test = testFactory(import.meta.url, { root: './fixtures/content-collections/' });
 
 let devServer;
 

--- a/packages/astro/e2e/css.test.js
+++ b/packages/astro/e2e/css.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/css/',
 	devToolbar: {
 		enabled: false,

--- a/packages/astro/e2e/custom-client-directives.test.js
+++ b/packages/astro/e2e/custom-client-directives.test.js
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import testAdapter from '../test/test-adapter.js';
 import { testFactory, waitForHydrate } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/custom-client-directives/',
 });
 

--- a/packages/astro/e2e/dev-toolbar-audits.test.js
+++ b/packages/astro/e2e/dev-toolbar-audits.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/dev-toolbar/',
 });
 

--- a/packages/astro/e2e/dev-toolbar.test.js
+++ b/packages/astro/e2e/dev-toolbar.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/dev-toolbar/',
 });
 

--- a/packages/astro/e2e/error-cyclic.test.js
+++ b/packages/astro/e2e/error-cyclic.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { getErrorOverlayContent, testFactory } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/error-cyclic/',
 });
 

--- a/packages/astro/e2e/error-sass.test.js
+++ b/packages/astro/e2e/error-sass.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { getErrorOverlayContent, testFactory } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/error-sass/',
 });
 

--- a/packages/astro/e2e/errors.test.js
+++ b/packages/astro/e2e/errors.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { getErrorOverlayContent, testFactory } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/errors/',
 	// Only test the error overlay, don't print to console
 	vite: {

--- a/packages/astro/e2e/hmr.test.js
+++ b/packages/astro/e2e/hmr.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/hmr/',
 	devToolbar: {
 		enabled: false,

--- a/packages/astro/e2e/hydration-race.test.js
+++ b/packages/astro/e2e/hydration-race.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/hydration-race/',
 });
 

--- a/packages/astro/e2e/i18n.test.js
+++ b/packages/astro/e2e/i18n.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/i18n/',
 	devToolbar: {
 		enabled: false,

--- a/packages/astro/e2e/lit-component.test.js
+++ b/packages/astro/e2e/lit-component.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory, waitForHydrate } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/lit-component/',
 });
 

--- a/packages/astro/e2e/multiple-frameworks.test.js
+++ b/packages/astro/e2e/multiple-frameworks.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/multiple-frameworks/' });
+const test = testFactory(import.meta.url, { root: './fixtures/multiple-frameworks/' });
 
 let devServer;
 

--- a/packages/astro/e2e/namespaced-component.test.js
+++ b/packages/astro/e2e/namespaced-component.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory, waitForHydrate } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/namespaced-component/',
 });
 

--- a/packages/astro/e2e/nested-in-preact.test.js
+++ b/packages/astro/e2e/nested-in-preact.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory, waitForHydrate } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/nested-in-preact/' });
+const test = testFactory(import.meta.url, { root: './fixtures/nested-in-preact/' });
 
 let devServer;
 

--- a/packages/astro/e2e/nested-in-react.test.js
+++ b/packages/astro/e2e/nested-in-react.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory, waitForHydrate } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/nested-in-react/' });
+const test = testFactory(import.meta.url, { root: './fixtures/nested-in-react/' });
 
 let devServer;
 

--- a/packages/astro/e2e/nested-in-solid.test.js
+++ b/packages/astro/e2e/nested-in-solid.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory, waitForHydrate } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/nested-in-solid/' });
+const test = testFactory(import.meta.url, { root: './fixtures/nested-in-solid/' });
 
 let devServer;
 

--- a/packages/astro/e2e/nested-in-svelte.test.js
+++ b/packages/astro/e2e/nested-in-svelte.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory, waitForHydrate } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/nested-in-svelte/' });
+const test = testFactory(import.meta.url, { root: './fixtures/nested-in-svelte/' });
 
 let devServer;
 

--- a/packages/astro/e2e/nested-in-vue.test.js
+++ b/packages/astro/e2e/nested-in-vue.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory, waitForHydrate } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/nested-in-vue/' });
+const test = testFactory(import.meta.url, { root: './fixtures/nested-in-vue/' });
 
 let devServer;
 

--- a/packages/astro/e2e/nested-recursive.test.js
+++ b/packages/astro/e2e/nested-recursive.test.js
@@ -3,7 +3,7 @@ import { loadFixture, waitForHydrate } from './test-utils.js';
 
 const test = base.extend({
 	astro: async ({}, use) => {
-		const fixture = await loadFixture({ root: './fixtures/nested-recursive/' });
+		const fixture = await loadFixture(import.meta.url, { root: './fixtures/nested-recursive/' });
 		await use(fixture);
 	},
 });

--- a/packages/astro/e2e/nested-styles.test.js
+++ b/packages/astro/e2e/nested-styles.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/nested-styles/',
 	devToolbar: {
 		enabled: false,

--- a/packages/astro/e2e/pass-js.test.js
+++ b/packages/astro/e2e/pass-js.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/pass-js/',
 });
 

--- a/packages/astro/e2e/preact-compat-component.test.js
+++ b/packages/astro/e2e/preact-compat-component.test.js
@@ -1,6 +1,8 @@
 import { prepareTestFactory } from './shared-component-tests.js';
 
-const { test, createTests } = prepareTestFactory({ root: './fixtures/preact-compat-component/' });
+const { test, createTests } = prepareTestFactory(import.meta.url, {
+	root: './fixtures/preact-compat-component/',
+});
 
 const config = {
 	counterComponentFilePath: './src/components/Counter.jsx',

--- a/packages/astro/e2e/preact-component.test.js
+++ b/packages/astro/e2e/preact-component.test.js
@@ -1,6 +1,8 @@
 import { prepareTestFactory } from './shared-component-tests.js';
 
-const { test, createTests } = prepareTestFactory({ root: './fixtures/preact-component/' });
+const { test, createTests } = prepareTestFactory(import.meta.url, {
+	root: './fixtures/preact-component/',
+});
 
 const config = {
 	counterComponentFilePath: './src/components/Counter.jsx',

--- a/packages/astro/e2e/preact-lazy-component.test.js
+++ b/packages/astro/e2e/preact-lazy-component.test.js
@@ -1,6 +1,8 @@
 import { prepareTestFactory } from './shared-component-tests.js';
 
-const { test, createTests } = prepareTestFactory({ root: './fixtures/preact-lazy-component/' });
+const { test, createTests } = prepareTestFactory(import.meta.url, {
+	root: './fixtures/preact-lazy-component/',
+});
 
 const config = {
 	counterComponentFilePath: './src/components/Counter.jsx',

--- a/packages/astro/e2e/prefetch.test.js
+++ b/packages/astro/e2e/prefetch.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({
+const test = testFactory(import.meta.url, {
 	root: './fixtures/prefetch/',
 });
 

--- a/packages/astro/e2e/react-component.test.js
+++ b/packages/astro/e2e/react-component.test.js
@@ -1,7 +1,9 @@
 import { expect } from '@playwright/test';
 import { prepareTestFactory } from './shared-component-tests.js';
 
-const { test, createTests } = prepareTestFactory({ root: './fixtures/react-component/' });
+const { test, createTests } = prepareTestFactory(import.meta.url, {
+	root: './fixtures/react-component/',
+});
 
 const config = {
 	counterComponentFilePath: './src/components/Counter.jsx',

--- a/packages/astro/e2e/server-islands.test.js
+++ b/packages/astro/e2e/server-islands.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/server-islands/' });
+const test = testFactory(import.meta.url, { root: './fixtures/server-islands/' });
 
 test.describe('Server islands', () => {
 	test.describe('Development', () => {

--- a/packages/astro/e2e/shared-component-tests.js
+++ b/packages/astro/e2e/shared-component-tests.js
@@ -1,8 +1,8 @@
 import { expect } from '@playwright/test';
 import { scrollToElement, testFactory, waitForHydrate } from './test-utils.js';
 
-export function prepareTestFactory(opts, { canReplayClicks = false } = {}) {
-	const test = testFactory(opts);
+export function prepareTestFactory(testFile, opts, { canReplayClicks = false } = {}) {
+	const test = testFactory(testFile, opts);
 
 	let devServer;
 
@@ -120,6 +120,7 @@ export function prepareTestFactory(opts, { canReplayClicks = false } = {}) {
 			await page.goto(astro.resolveUrl(pageUrl));
 
 			const label = page.locator('#client-only');
+			await waitForHydrate(page, label);
 			await expect(label, 'component is visible').toBeVisible();
 
 			await expect(label, 'slot text is visible').toHaveText('Framework client:only component');

--- a/packages/astro/e2e/solid-circular.test.js
+++ b/packages/astro/e2e/solid-circular.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/solid-circular/' });
+const test = testFactory(import.meta.url, { root: './fixtures/solid-circular/' });
 
 let devServer;
 

--- a/packages/astro/e2e/solid-component.test.js
+++ b/packages/astro/e2e/solid-component.test.js
@@ -1,6 +1,7 @@
 import { prepareTestFactory } from './shared-component-tests.js';
 
 const { test, createTests } = prepareTestFactory(
+	import.meta.url,
 	{ root: './fixtures/solid-component/' },
 	{
 		canReplayClicks: true,

--- a/packages/astro/e2e/solid-recurse.test.js
+++ b/packages/astro/e2e/solid-recurse.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory, waitForHydrate } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/solid-recurse/' });
+const test = testFactory(import.meta.url, { root: './fixtures/solid-recurse/' });
 
 let devServer;
 

--- a/packages/astro/e2e/svelte-component.test.js
+++ b/packages/astro/e2e/svelte-component.test.js
@@ -2,7 +2,9 @@ import { expect } from '@playwright/test';
 import { prepareTestFactory } from './shared-component-tests.js';
 import { waitForHydrate } from './test-utils.js';
 
-const { test, createTests } = prepareTestFactory({ root: './fixtures/svelte-component/' });
+const { test, createTests } = prepareTestFactory(import.meta.url, {
+	root: './fixtures/svelte-component/',
+});
 
 const config = {
 	componentFilePath: './src/components/SvelteComponent.svelte',

--- a/packages/astro/e2e/tailwindcss.test.js
+++ b/packages/astro/e2e/tailwindcss.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/tailwindcss/' });
+const test = testFactory(import.meta.url, { root: './fixtures/tailwindcss/' });
 
 let devServer;
 

--- a/packages/astro/e2e/test-utils.js
+++ b/packages/astro/e2e/test-utils.js
@@ -14,12 +14,14 @@ const testFileToPort = new Map();
 for (let i = 0; i < testFiles.length; i++) {
 	const file = testFiles[i];
 	if (file.endsWith('.test.js')) {
-		testFileToPort.set(file.slice(0, -8), 4000 + i);
+		testFileToPort.set(file, 4000 + i);
 	}
 }
 
-export function loadFixture(inlineConfig) {
+export function loadFixture(testFile, inlineConfig) {
 	if (!inlineConfig?.root) throw new Error("Must provide { root: './fixtures/...' }");
+
+	const port = testFileToPort.get(path.basename(testFile));
 
 	// resolve the relative root (i.e. "./fixtures/tailwindcss") to a full filepath
 	// without this, the main `loadFixture` helper will resolve relative to `packages/astro/test`
@@ -27,17 +29,25 @@ export function loadFixture(inlineConfig) {
 		...inlineConfig,
 		root: fileURLToPath(new URL(inlineConfig.root, import.meta.url)),
 		server: {
-			port: testFileToPort.get(path.basename(inlineConfig.root)),
+			...inlineConfig?.server,
+			port,
+		},
+		vite: {
+			...inlineConfig?.vite,
+			server: {
+				...inlineConfig?.vite?.server,
+				strictPort: true,
+			},
 		},
 	});
 }
 
-export function testFactory(inlineConfig) {
+export function testFactory(testFile, inlineConfig) {
 	let fixture;
 
 	const test = testBase.extend({
 		astro: async ({}, use) => {
-			fixture = fixture || (await loadFixture(inlineConfig));
+			fixture = fixture || (await loadFixture(testFile, inlineConfig));
 			await use(fixture);
 		},
 	});

--- a/packages/astro/e2e/ts-resolution.test.js
+++ b/packages/astro/e2e/ts-resolution.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory, waitForHydrate } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/ts-resolution/' });
+const test = testFactory(import.meta.url, { root: './fixtures/ts-resolution/' });
 
 function runTest(it) {
 	it('client:idle', async ({ page, astro }) => {

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { testFactory, waitForHydrate } from './test-utils.js';
 
-const test = testFactory({ root: './fixtures/view-transitions/' });
+const test = testFactory(import.meta.url, { root: './fixtures/view-transitions/' });
 
 let devServer;
 
@@ -447,7 +447,9 @@ test.describe('View Transitions', () => {
 		expect(consoleCount).toEqual(1);
 
 		// forward '' to 'hash' (no transition)
-		await page.goForward();
+		// NOTE: the networkidle below is needed for Firefox to consistently
+		// pass the `#longpage` viewport check below
+		await page.goForward({ waitUntil: 'networkidle' });
 		locator = page.locator('#click-one-again');
 		await expect(locator).toBeInViewport();
 		expect(consoleCount).toEqual(1);

--- a/packages/astro/e2e/vue-component.test.js
+++ b/packages/astro/e2e/vue-component.test.js
@@ -1,6 +1,8 @@
 import { expect } from '@playwright/test';
 import { prepareTestFactory } from './shared-component-tests.js';
-const { test, createTests } = prepareTestFactory({ root: './fixtures/vue-component/' });
+const { test, createTests } = prepareTestFactory(import.meta.url, {
+	root: './fixtures/vue-component/',
+});
 
 const config = {
 	componentFilePath: './src/components/VueComponent.vue',

--- a/packages/astro/playwright.config.js
+++ b/packages/astro/playwright.config.js
@@ -1,4 +1,5 @@
 import { defineConfig } from '@playwright/test';
+
 // NOTE: Sometimes, tests fail with `TypeError: process.stdout.clearLine is not a function`
 // for some reason. This comes from Vite, and is conditionally called based on `isTTY`.
 // We set it to false here to skip this odd behavior.
@@ -6,35 +7,16 @@ process.stdout.isTTY = false;
 
 export default defineConfig({
 	testMatch: 'e2e/*.test.js',
-	/* Maximum time one test can run for. */
-	timeout: 40 * 1000,
-	expect: {
-		/**
-		 * Maximum time expect() should wait for the condition to be met.
-		 * For example in `await expect(locator).toHaveText();`
-		 */
-		timeout: 6 * 1000,
-	},
-	/* Fail the build on CI if you accidentally left test in the source code. */
+	timeout: 40000,
 	forbidOnly: !!process.env.CI,
-	/* Retry on CI only */
-	retries: process.env.CI ? 3 : 0,
-	/* Opt out of parallel tests on CI. */
-	workers: 1,
-	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
-	use: {
-		/* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-		actionTimeout: 0,
-		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-		trace: 'on-first-retry',
-	},
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
 	projects: [
 		{
 			name: 'Chrome Stable',
 			use: {
 				browserName: 'chromium',
 				channel: 'chrome',
-				args: ['--use-gl=egl'],
 			},
 		},
 	],

--- a/packages/astro/playwright.firefox.config.js
+++ b/packages/astro/playwright.firefox.config.js
@@ -1,43 +1,24 @@
+import { defineConfig } from '@playwright/test';
+
 // NOTE: Sometimes, tests fail with `TypeError: process.stdout.clearLine is not a function`
 // for some reason. This comes from Vite, and is conditionally called based on `isTTY`.
 // We set it to false here to skip this odd behavior.
 process.stdout.isTTY = false;
 
-const config = {
+export default defineConfig({
 	// TODO: add more tests like view transitions and audits, and fix them. Some of them are failing.
 	testMatch: ['e2e/css.test.js', 'e2e/prefetch.test.js', 'e2e/view-transitions.test.js'],
-	/* Maximum time one test can run for. */
-	timeout: 40 * 1000,
-	expect: {
-		/**
-		 * Maximum time expect() should wait for the condition to be met.
-		 * For example in `await expect(locator).toHaveText();`
-		 */
-		timeout: 6 * 1000,
-	},
-	/* Fail the build on CI if you accidentally left test in the source code. */
+	timeout: 40000,
 	forbidOnly: !!process.env.CI,
-	/* Retry on CI only */
-	retries: process.env.CI ? 3 : 0,
-	/* Opt out of parallel tests on CI. */
-	workers: 1,
-	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
-	use: {
-		/* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-		actionTimeout: 0,
-		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-		trace: 'on-first-retry',
-	},
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
 	projects: [
 		{
 			name: 'Firefox Stable',
 			use: {
 				browserName: 'firefox',
 				channel: 'firefox',
-				args: ['--use-gl=egl'],
 			},
 		},
 	],
-};
-
-export default config;
+});


### PR DESCRIPTION
## Changes

- Simplify playwright config setup (removed comments as they intellisense can provide better explanation on hover)
- Reduce retries from 3 to 2, since we already run the test once, and then retry 3 times again, this makes a total of 4 runs, which I think is a bit too many, and could cause the CI to cut off after 20min and unable to show what failed for debugging
- Update e2e to each use its own port, and enable Vite's strictPort to prevent possible sharing. (this required some `import.meta.url` refactoring to ensure the right ports are used)
- Enable multiple workers locally so it runs faster
- Fix flaky tests in `actions-blog.test.js` and `actions-react-19.test.js` by waiting for the islands to hydrate first.

## Testing

CI should pass

## Docs

n/a
