### PR TITLE
Actions: fix Bun support with a `request.clone()` workaround

### DIFF
--- a/.changeset/metal-forks-retire.md
+++ b/.changeset/metal-forks-retire.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes Actions when using the Bun adapter.
+Fixes "unexpected end of JSON input" error when using Actions with Bun.

--- a/.changeset/metal-forks-retire.md
+++ b/.changeset/metal-forks-retire.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes Actions when using the Bun adapter.

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -4,7 +4,7 @@ import { ActionQueryStringInvalidError } from '../../core/errors/errors-data.js'
 import { AstroError } from '../../core/errors/errors.js';
 import { defineMiddleware } from '../../core/middleware/index.js';
 import { ACTION_QUERY_PARAMS } from '../consts.js';
-import { formContentTypes, hasContentType } from './utils.js';
+import { cloneRequestFromConsumedBody, formContentTypes, hasContentType } from './utils.js';
 import { getAction } from './virtual/get-action.js';
 import {
 	type SafeResult,
@@ -110,7 +110,8 @@ async function handlePost({
 	const contentType = request.headers.get('content-type');
 	let formData: FormData | undefined;
 	if (contentType && hasContentType(contentType, formContentTypes)) {
-		formData = await request.clone().formData();
+		formData = await request.formData();
+		Object.assign(context, { request: cloneRequestFromConsumedBody(request, formData) });
 	}
 	const action = baseAction.bind(context);
 	const actionResult = await action(formData);

--- a/packages/astro/src/actions/runtime/utils.ts
+++ b/packages/astro/src/actions/runtime/utils.ts
@@ -29,7 +29,8 @@ export type ErrorInferenceObject = Record<string, any>;
 
 /**
  * Clone a request from an already consumed body.
- * This avoids the cost of cloning of a readable stream with `request.clone()`.
+ * This is used instead of `request.clone()` due to an upstream issue in Bun.
+ * https://github.com/oven-sh/bun/issues/6348
  */
 export function cloneRequestFromConsumedBody(request: Request, consumedBody?: BodyInit) {
 	if (consumedBody instanceof FormData) {

--- a/packages/astro/src/actions/runtime/utils.ts
+++ b/packages/astro/src/actions/runtime/utils.ts
@@ -26,3 +26,26 @@ export type MaybePromise<T> = T | Promise<T>;
  * `result.error.fields` will be typed with the `name` field.
  */
 export type ErrorInferenceObject = Record<string, any>;
+
+/**
+ * Clone a request from an already consumed body.
+ * This avoids the cost of cloning of a readable stream with `request.clone()`.
+ */
+export function cloneRequestFromConsumedBody(request: Request, consumedBody?: BodyInit) {
+	if (consumedBody instanceof FormData) {
+		// Consuming the body of a urlencoded form request will create a FormData object.
+		// Reset the Content-Type header to 'multipart/form-data' to match this.
+		request.headers.delete('Content-Type');
+	}
+	return new Request(request.url, {
+		method: request.method,
+		headers: request.headers,
+		body: consumedBody,
+		mode: request.mode,
+		credentials: request.credentials,
+		cache: request.cache,
+		redirect: request.redirect,
+		referrer: request.referrer,
+		integrity: request.integrity,
+	});
+}


### PR DESCRIPTION
## Changes

There's an upstream issue in Bun that causes `request.clone()` to return an empty body: https://github.com/oven-sh/bun/issues/6348 We have a few users shipping Astro Actions + Bun in production, and this fix get things working for them.

- Introduce a request clone function to create a new request object from an already consumed body
- Update the route and middleware handlers to use this utility

## Testing

Ensure existing tests pass. Verified manually that Bun is working as expected using a preview release outside of the monorepo (couldn't replicate within the monorepo for some reason). To reproduce:
- Create an Astro project that uses actions
- Run `bunx --bun astro dev`
- Notice "unexpected end of JSON output" submitting an action

## Docs

N/A