### PR TITLE
refactor: `Astro.routePattern` is `RouteData.route`

### DIFF
--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -38,9 +38,6 @@ export class RenderContext {
 	// The first route that this instance of the context attempts to render
 	originalRoute: RouteData;
 
-	// The component pattern to send to the users
-	routePattern: string;
-
 	private constructor(
 		readonly pipeline: Pipeline,
 		public locals: App.Locals,
@@ -55,7 +52,6 @@ export class RenderContext {
 		public props: Props = {},
 	) {
 		this.originalRoute = routeData;
-		this.routePattern = getAstroRoutePattern(routeData.component);
 	}
 
 	/**
@@ -264,7 +260,7 @@ export class RenderContext {
 
 		return {
 			cookies,
-			routePattern: this.routePattern,
+			routePattern: this.routeData.route,
 			get clientAddress() {
 				return renderContext.clientAddress();
 			},
@@ -449,7 +445,7 @@ export class RenderContext {
 		return {
 			generator: astroStaticPartial.generator,
 			glob: astroStaticPartial.glob,
-			routePattern: this.routePattern,
+			routePattern: this.routeData.route,
 			cookies,
 			get clientAddress() {
 				return renderContext.clientAddress();
@@ -580,34 +576,4 @@ export class RenderContext {
 			duplex: 'half',
 		});
 	}
-}
-
-/**
- * Return the component path without the `srcDir` and `pages`
- * @param component
- */
-function getAstroRoutePattern(component: RouteData['component']): string {
-	let splitComponent = component.split('/');
-	while (true) {
-		const currentPart = splitComponent.shift();
-		if (!currentPart) {
-			break;
-		}
-
-		// "pages" isn't configurable, so it's safe to stop here
-		if (currentPart === 'pages') {
-			break;
-		}
-	}
-
-	const pathWithoutPages = splitComponent.join('/');
-	// This covers cases where routes don't have extensions, so they can be: [slug] or [...slug]
-	if (pathWithoutPages.endsWith(']')) {
-		return pathWithoutPages;
-	}
-	splitComponent = splitComponent.join('/').split('.');
-
-	// this should remove the extension
-	splitComponent.pop();
-	return '/' + splitComponent.join('/');
 }

--- a/packages/astro/test/astro-global.test.js
+++ b/packages/astro/test/astro-global.test.js
@@ -50,8 +50,8 @@ describe('Astro Global', () => {
 		it("Astro.route.pattern has the right value in pages and components", async () => {
 			let html = await fixture.fetch('/blog').then((res) => res.text());
 			let $ = cheerio.load(html);
-			assert.match($("#pattern").text(),  /Astro route pattern: \/index/);
-			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: \/index/);
+			assert.match($("#pattern").text(),  /Astro route pattern: \//);
+			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: \//);
 			html = await fixture.fetch('/blog/omit-markdown-extensions/').then((res) => res.text());
 			$ = cheerio.load(html);
 			assert.match($("#pattern").text(),  /Astro route pattern: \/omit-markdown-extensions/);
@@ -96,8 +96,8 @@ describe('Astro Global', () => {
 		it("Astro.route.pattern has the right value in pages and components", async () => {
 			let html = await fixture.readFile('/index.html');
 			let $ = cheerio.load(html);
-			assert.match($("#pattern").text(),  /Astro route pattern: \/index/);
-			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: \/index/);
+			assert.match($("#pattern").text(),  /Astro route pattern: \//);
+			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: \//);
 
 			html =await fixture.readFile('/omit-markdown-extensions/index.html');
 			$ = cheerio.load(html);
@@ -139,8 +139,8 @@ describe('Astro Global', () => {
 			let response = await app.render(new Request('https://example.com/'));
 			let html = await response.text();
 			let $ = cheerio.load(html);
-			assert.match($("#pattern").text(),  /Astro route pattern: \/index/);
-			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: \/index/);
+			assert.match($("#pattern").text(),  /Astro route pattern: \//);
+			assert.match($("#pattern-middleware").text(),  /Astro route pattern middleware: \//);
 			response = await app.render(new Request('https://example.com/omit-markdown-extensions'));
 			html = await response.text();
 			$ = cheerio.load(html);


### PR DESCRIPTION
## Changes

Turns out that we already had `Astro.routePattern` value. This PR uses it

## Testing

Updated existing tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
