### PR TITLE
docs(i18n): fix typo in `fallbackType` JSDoc comment

### DIFF
--- a/.changeset/little-zebras-march.md
+++ b/.changeset/little-zebras-march.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes typo in documenting the `fallbackType` property in i18n routing

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1683,7 +1683,7 @@ export interface AstroUserConfig {
 					 *
 					 * When `i18n.routing.fallback: "rewrite"` is configured, Astro will create pages that render the contents of the fallback page on the original, requested URL.
 					 *
-					 * With the following configuration, if you have the file `src/pages/en/about.astro` but not `src/pages/fr/about.astro`, the `astro build` command will generate `dist/fr/about.html` with the same content as the `dist/en/index.html` page.
+					 * With the following configuration, if you have the file `src/pages/en/about.astro` but not `src/pages/fr/about.astro`, the `astro build` command will generate `dist/fr/about.html` with the same content as the `dist/en/about.html` page.
 					 * Your site visitor will see the English version of the page at `https://example.com/fr/about/` and will not be redirected.
 					 *
 					 * ```js


### PR DESCRIPTION
## Changes

The example provided for `i18n.routing.fallbackType` was using the wrong filename (`dist/en/index.html` should be `dist/en/about.html` since the page is `src/pages/en/about.astro`).

## Testing

No need.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

* No additional documentation needed, this is a small fix in `i18n.routing.fallbackType` documentation
* I added a changeset since this fixes the documentation content

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
