### PR TITLE
Use default import in astro add

### DIFF
--- a/.changeset/neat-swans-hear.md
+++ b/.changeset/neat-swans-hear.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes `astro add` importing adapters and integrations

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -427,7 +427,11 @@ function addIntegration(mod: ProxifiedModule<any>, integration: IntegrationInfo)
 	const integrationId = toIdent(integration.id);
 
 	if (!mod.imports.$items.some((imp) => imp.local === integrationId)) {
-		mod.imports.$append({ imported: integrationId, from: integration.packageName });
+		mod.imports.$append({
+			imported: 'default',
+			local: integrationId,
+			from: integration.packageName,
+		});
 	}
 
 	config.integrations ??= [];
@@ -448,7 +452,11 @@ export function setAdapter(mod: ProxifiedModule<any>, adapter: IntegrationInfo) 
 	const adapterId = toIdent(adapter.id);
 
 	if (!mod.imports.$items.some((imp) => imp.local === adapterId)) {
-		mod.imports.$append({ imported: adapterId, from: adapter.packageName });
+		mod.imports.$append({
+			imported: 'default',
+			local: adapterId,
+			from: adapter.packageName,
+		});
 	}
 
 	if (!config.output) {


### PR DESCRIPTION
## Changes

Use default import instead of named imports when injecting adapters or integrations

<img width="356" alt="image" src="https://github.com/user-attachments/assets/dcb65c36-1a4b-4a63-b54c-a7f866959222">

<img width="359" alt="image" src="https://github.com/user-attachments/assets/61f63b85-27f5-49d4-a3e9-ed6b5bd2aa44">



## Testing

Tested locally in the screenshots above

## Docs
bug fix