### PR TITLE
test: fix regression

### DIFF
--- a/packages/astro/test/fixtures/actions/astro.config.mjs
+++ b/packages/astro/test/fixtures/actions/astro.config.mjs
@@ -3,4 +3,8 @@ import { defineConfig } from 'astro/config';
 // https://astro.build/config
 export default defineConfig({
 	output: 'server',
+	// we stub actions coming from another domain for testing purposes
+	security: {
+		checkOrigin: false
+	}
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -627,6 +627,9 @@ importers:
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
+      fastq:
+        specifier: ^1.17.1
+        version: 1.17.1
       flattie:
         specifier: ^1.1.1
         version: 1.1.1


### PR DESCRIPTION
## Changes

Check origin is now on by default, but the actions test needs to check against a particular test code when we hit an external domain

## Testing

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
