### PR TITLE
Provide an error message when Actions throws in setup

### DIFF
--- a/.changeset/many-turtles-tie.md
+++ b/.changeset/many-turtles-tie.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Provide error message when Actions throws in setup

--- a/.changeset/many-turtles-tie.md
+++ b/.changeset/many-turtles-tie.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Provide error message when Actions throws in setup
+Fixes a missing error message when actions throws during `astro sync`

--- a/packages/astro/src/core/logger/core.ts
+++ b/packages/astro/src/core/logger/core.ts
@@ -27,6 +27,7 @@ export type LoggerLabel =
 	| 'middleware'
 	| 'preferences'
 	| 'redirects'
+	| 'sync'
 	| 'toolbar'
 	| 'assets'
 	| 'env'

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -61,7 +61,19 @@ export default async function sync(
 		settings,
 		logger,
 	});
-	await runHookConfigDone({ settings, logger });
+
+	// Run `astro:config:done`
+	// Actions will throw if there is misconfiguration, so catch here.
+	try {
+		await runHookConfigDone({ settings, logger });
+	} catch(err) {
+		if(err instanceof Error) {
+			const errorMessage = err.toString();
+			logger.error('sync', errorMessage);
+		}
+		throw err;
+	}
+
 	return await syncInternal({ settings, logger, fs, force: inlineConfig.force });
 }
 


### PR DESCRIPTION
## Changes

- Actions throws in `astro:config:done` if the output is static. This change makes it so that the error surfaces to the user like it should.

## Testing

Did so manually looks like:

```
ActionsWithoutServerOutputError: Actions enabled without setting a server build output. A server is required to create callable backend functions. To deploy routes to a server, add a server adapter to your astro config.
```

## Docs

Bug fix