### PR TITLE
Add test for `astro:route:setup` hook

### DIFF
--- a/packages/astro/test/fixtures/integration-route-setup/astro.config.mjs
+++ b/packages/astro/test/fixtures/integration-route-setup/astro.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from 'astro/config'
+import test from './integration.js'
+import node from '@astrojs/node';
+
+export default defineConfig({
+	output: 'hybrid',
+	adapter: node({ mode: 'standalone' }),
+	integrations: [test()]
+})

--- a/packages/astro/test/fixtures/integration-route-setup/integration.js
+++ b/packages/astro/test/fixtures/integration-route-setup/integration.js
@@ -1,0 +1,12 @@
+export default function () {
+	const routes = (globalThis.TEST_ROUTES_OBJECTS = []);
+
+	return {
+		name: '@astrojs/test-integration',
+		hooks: {
+			'astro:route:setup': ({ route }) => {
+				routes.push(route);
+			},
+		},
+	};
+}

--- a/packages/astro/test/fixtures/integration-route-setup/package.json
+++ b/packages/astro/test/fixtures/integration-route-setup/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@test/integration-route-setup",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/node": "^8.3.3",
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/integration-route-setup/src/pages/no-prerender.astro
+++ b/packages/astro/test/fixtures/integration-route-setup/src/pages/no-prerender.astro
@@ -1,0 +1,5 @@
+---
+export const prerender = false;
+---
+
+<div></div>

--- a/packages/astro/test/fixtures/integration-route-setup/src/pages/prerender.astro
+++ b/packages/astro/test/fixtures/integration-route-setup/src/pages/prerender.astro
@@ -1,0 +1,5 @@
+---
+export const prerender = true;
+---
+
+<div></div>

--- a/packages/astro/test/fixtures/integration-route-setup/src/pages/report.json.js
+++ b/packages/astro/test/fixtures/integration-route-setup/src/pages/report.json.js
@@ -1,0 +1,13 @@
+const routes = (globalThis.TEST_ROUTES_OBJECTS ?? []);
+
+export const GET = () => {
+	// Routes are not garanteed to be loaded in any particular order
+	// sort for test stability.
+	routes.sort((a, b) => a.component.localeCompare(b.component));
+
+	return new Response(JSON.stringify(routes), {
+		headers: {
+			'content-type': 'application/json'
+		},
+	});
+};

--- a/packages/astro/test/integration-route-setup.test.js
+++ b/packages/astro/test/integration-route-setup.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import { loadFixture } from './test-utils.js';
+
+describe('Integration route setup', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ root: './fixtures/integration-route-setup/' });
+		await fixture.build();
+	});
+
+	it('Adds middlewares in dev', async () => {
+		const routeInfo = JSON.parse(await fixture.readFile('client/report.json'));
+
+		assert.deepEqual(routeInfo, [
+			{
+				component: 'src/pages/no-prerender.astro',
+				prerender: false,
+			},
+			{
+				component: 'src/pages/prerender.astro',
+				prerender: true,
+			},
+			{
+				component: 'src/pages/report.json.js',
+			},
+		]);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3316,6 +3316,15 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/integration-route-setup:
+    dependencies:
+      '@astrojs/node':
+        specifier: ^8.3.3
+        version: 8.3.3(astro@packages+astro)
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/integration-server-setup:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

- Add a test for the new `astro:route:setup` hook introduced on #11657

To ensure it doesn't break with future work regarding routing and route data.

## Testing

It's the entire PR 😜