### PR TITLE
Fix user-facing type for `i18n.routing.fallbackType`

### DIFF
--- a/.changeset/seven-rice-exercise.md
+++ b/.changeset/seven-rice-exercise.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the user-facing type of the new `i18n.routing.fallbackType` option to be optional

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1703,7 +1703,7 @@ export interface AstroUserConfig {
 					 * })
 					 * ```
 					 */
-					fallbackType: 'redirect' | 'rewrite';
+					fallbackType?: 'redirect' | 'rewrite';
 
 					/**
 					 * @name i18n.routing.strategy


### PR DESCRIPTION
## Changes

The new `i18n.routing.fallbackType` option added in Astro 4.15 is optional, but typed as required. This PR fixes that.

## Testing

Tiny change, so no tests required.

## Docs

n/a — bug fix only