### PR TITLE
perf(astro/assets): avoid downloading original image when using cache

### DIFF
--- a/.changeset/purple-ears-sneeze.md
+++ b/.changeset/purple-ears-sneeze.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+perf(assets): avoid downloading original image when using cache


### PR DESCRIPTION
## Changes

Moves the `loadImage` method call to after the image cache check, improving performance massively and reducing memory consumption for remote images.

| Website | Version | No cache | Cache |
|---------|---------|-----------|--------|
| brpartners.com.br | Before | <img width="895" alt="Before, no cache, 129.47s" src="https://github.com/user-attachments/assets/bd549f4c-9ff1-467e-808e-97f6b464c206"> | <img width="832" alt="Before, cache, 44.23s" src="https://github.com/user-attachments/assets/bfe3f9b9-00fc-415f-8d34-fc8ba571db01"> |
| brpartners.com.br | After | <img width="905" alt="After, no cache, 126.67s" src="https://github.com/user-attachments/assets/d161cec9-fc66-44aa-b8d8-fd83bcb94a12"> | <img width="835" alt="After, cache, 0,56s" src="https://github.com/user-attachments/assets/43df8a18-3dd6-4991-94fd-126f78aa668a"> |
| erika.florist | Before | <img width="816" alt="Before, no cache, 47.20s" src="https://github.com/user-attachments/assets/18e53414-a75d-4d2a-a07f-2d13628045cb"> | <img width="743" alt="Before, cache, 0.54s" src="https://github.com/user-attachments/assets/3b8ab191-957c-4581-9adc-17037fe84a2f"> |
| erika.florist | After | <img width="823" alt="After, no cache, 47.29s" src="https://github.com/user-attachments/assets/a68350de-7587-47b1-bfae-b8de8a6e83e9"> | <img width="740" alt="After, cache, 0,25s" src="https://github.com/user-attachments/assets/52f4bf3e-f9a7-4bf1-bf64-cfbc8043b4e3">

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Manual testing was performed in my [company's](https://brpartners.com.br/) website, with 950 optimized images, and in [erika.florist](erika.florist) website, with 626 images.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
N/A.