### PR TITLE
Actions: fixed error where certain strings could not be parsed

### DIFF
--- a/.changeset/orange-rats-sparkle.md
+++ b/.changeset/orange-rats-sparkle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fixed error where certain strings could not be parsed

--- a/packages/astro/src/actions/runtime/virtual/get-action.ts
+++ b/packages/astro/src/actions/runtime/virtual/get-action.ts
@@ -11,7 +11,7 @@ import type { ActionAccept, ActionClient } from './server.js';
 export async function getAction(
 	path: string,
 ): Promise<ActionClient<unknown, ActionAccept, ZodType>> {
-	const pathKeys = path.replace('/_actions/', '').split('.');
+	const pathKey = decodeURIComponent(path.replace("/_actions/", ""))
 	// @ts-expect-error virtual module
 	let { server: actionLookup } = await import('astro:internal-actions');
 
@@ -20,19 +20,16 @@ export async function getAction(
 			`Expected \`server\` export in actions file to be an object. Received ${typeof actionLookup}.`,
 		);
 	}
-
-	for (const key of pathKeys) {
-		if (!(key in actionLookup)) {
-			throw new AstroError({
-				...ActionNotFoundError,
-				message: ActionNotFoundError.message(pathKeys.join('.')),
-			});
-		}
-		actionLookup = actionLookup[key];
-	}
+	if (!(pathKey in actionLookup)) {
+    throw new AstroError({
+      ...ActionNotFoundError,
+      message: ActionNotFoundError.message(pathKey)
+    })
+  }
+  actionLookup = actionLookup[pathKey];
 	if (typeof actionLookup !== 'function') {
 		throw new TypeError(
-			`Expected handler for action ${pathKeys.join('.')} to be a function. Received ${typeof actionLookup}.`,
+			`Expected handler for action ${pathKey} to be a function. Received ${typeof actionLookup}.`,
 		);
 	}
 	return actionLookup;


### PR DESCRIPTION
## Changes

I have resolved the issue of not being able to handle `.` and spaces as shown in the following issue.

- #11905

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I tested `actions.test.js`, and here are the results:

![aa](https://github.com/user-attachments/assets/a2402961-73ea-4923-97de-8eabe07e6b89)

