### PR TITLE
Export `LoaderContext` types

### DIFF
--- a/.changeset/mean-donkeys-switch.md
+++ b/.changeset/mean-donkeys-switch.md
@@ -1,0 +1,6 @@
+---
+'astro': patch
+---
+
+Exports types for all `LoaderContext` properties from `astro/loaders` to make it easier to use them in custom loaders.
+The `ScopedDataStore` interface (which was previously internal) is renamed to `AstroDataStore`, to reflect the fact that it's the only public API for the data store. 

--- a/.changeset/mean-donkeys-switch.md
+++ b/.changeset/mean-donkeys-switch.md
@@ -3,4 +3,4 @@
 ---
 
 Exports types for all `LoaderContext` properties from `astro/loaders` to make it easier to use them in custom loaders.
-The `ScopedDataStore` interface (which was previously internal) is renamed to `AstroDataStore`, to reflect the fact that it's the only public API for the data store. 
+The `ScopedDataStore` interface (which was previously internal) is renamed to `DataStore`, to reflect the fact that it's the only public API for the data store. 

--- a/packages/astro/src/content/data-store.ts
+++ b/packages/astro/src/content/data-store.ts
@@ -41,7 +41,7 @@ export interface DataEntry<TData extends Record<string, unknown> = Record<string
  * To add or modify data, use {@link MutableDataStore} instead.
  */
 
-export class DataStore {
+export class ImmutableDataStore {
 	protected _collections = new Map<string, Map<string, any>>();
 
 	constructor() {
@@ -92,31 +92,31 @@ export class DataStore {
 			// @ts-expect-error - this is a virtual module
 			const data = await import('astro:data-layer-content');
 			if (data.default instanceof Map) {
-				return DataStore.fromMap(data.default);
+				return ImmutableDataStore.fromMap(data.default);
 			}
 			const map = devalue.unflatten(data.default);
-			return DataStore.fromMap(map);
+			return ImmutableDataStore.fromMap(map);
 		} catch {}
-		return new DataStore();
+		return new ImmutableDataStore();
 	}
 
 	static async fromMap(data: Map<string, Map<string, any>>) {
-		const store = new DataStore();
+		const store = new ImmutableDataStore();
 		store._collections = data;
 		return store;
 	}
 }
 
 function dataStoreSingleton() {
-	let instance: Promise<DataStore> | DataStore | undefined = undefined;
+	let instance: Promise<ImmutableDataStore> | ImmutableDataStore | undefined = undefined;
 	return {
 		get: async () => {
 			if (!instance) {
-				instance = DataStore.fromModule();
+				instance = ImmutableDataStore.fromModule();
 			}
 			return instance;
 		},
-		set: (store: DataStore) => {
+		set: (store: ImmutableDataStore) => {
 			instance = store;
 		},
 	};

--- a/packages/astro/src/content/loaders/types.ts
+++ b/packages/astro/src/content/loaders/types.ts
@@ -3,7 +3,9 @@ import type { ZodSchema } from 'zod';
 import type { AstroIntegrationLogger } from '../../core/logger/core.js';
 import type { AstroConfig } from '../../types/public/config.js';
 import type { ContentEntryType } from '../../types/public/content.js';
-import type { MetaStore, ScopedDataStore } from '../mutable-data-store.js';
+import type { MetaStore, AstroDataStore } from '../mutable-data-store.js';
+
+export type { MetaStore, AstroDataStore };
 
 export interface ParseDataOptions<TData extends Record<string, unknown>> {
 	/** The ID of the entry. Unique per collection */
@@ -18,7 +20,7 @@ export interface LoaderContext {
 	/** The unique name of the collection */
 	collection: string;
 	/** A database abstraction to store the actual data */
-	store: ScopedDataStore;
+	store: AstroDataStore;
 	/**  A simple KV store, designed for things like sync tokens */
 	meta: MetaStore;
 	logger: AstroIntegrationLogger;
@@ -35,6 +37,7 @@ export interface LoaderContext {
 
 	/** If the loader has been triggered by an integration, this may optionally contain extra data set by that integration */
 	refreshContextData?: Record<string, unknown>;
+	/** @internal */
 	entryTypes: Map<string, ContentEntryType>;
 }
 

--- a/packages/astro/src/content/loaders/types.ts
+++ b/packages/astro/src/content/loaders/types.ts
@@ -3,9 +3,9 @@ import type { ZodSchema } from 'zod';
 import type { AstroIntegrationLogger } from '../../core/logger/core.js';
 import type { AstroConfig } from '../../types/public/config.js';
 import type { ContentEntryType } from '../../types/public/content.js';
-import type { AstroDataStore, MetaStore } from '../mutable-data-store.js';
+import type { DataStore, MetaStore } from '../mutable-data-store.js';
 
-export type { AstroDataStore, MetaStore };
+export type { DataStore, MetaStore };
 
 export interface ParseDataOptions<TData extends Record<string, unknown>> {
 	/** The ID of the entry. Unique per collection */
@@ -19,8 +19,8 @@ export interface ParseDataOptions<TData extends Record<string, unknown>> {
 export interface LoaderContext {
 	/** The unique name of the collection */
 	collection: string;
-	/** A database abstraction to store the actual data */
-	store: AstroDataStore;
+	/** A database to store the actual data */
+	store: DataStore;
 	/**  A simple KV store, designed for things like sync tokens */
 	meta: MetaStore;
 	logger: AstroIntegrationLogger;

--- a/packages/astro/src/content/loaders/types.ts
+++ b/packages/astro/src/content/loaders/types.ts
@@ -3,9 +3,9 @@ import type { ZodSchema } from 'zod';
 import type { AstroIntegrationLogger } from '../../core/logger/core.js';
 import type { AstroConfig } from '../../types/public/config.js';
 import type { ContentEntryType } from '../../types/public/content.js';
-import type { MetaStore, AstroDataStore } from '../mutable-data-store.js';
+import type { AstroDataStore, MetaStore } from '../mutable-data-store.js';
 
-export type { MetaStore, AstroDataStore };
+export type { AstroDataStore, MetaStore };
 
 export interface ParseDataOptions<TData extends Record<string, unknown>> {
 	/** The ID of the entry. Unique per collection */

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -4,7 +4,7 @@ import { Traverse } from 'neotraverse/modern';
 import { imageSrcToImportId, importIdToSymbolName } from '../assets/utils/resolveImports.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { IMAGE_IMPORT_PREFIX } from './consts.js';
-import { type DataEntry, DataStore, type RenderedContent } from './data-store.js';
+import { type DataEntry, ImmutableDataStore, type RenderedContent } from './data-store.js';
 import { contentModuleToId } from './utils.js';
 
 const SAVE_DEBOUNCE_MS = 500;
@@ -13,7 +13,7 @@ const SAVE_DEBOUNCE_MS = 500;
  * Extends the DataStore with the ability to change entries and write them to disk.
  * This is kept as a separate class to avoid needing node builtins at runtime, when read-only access is all that is needed.
  */
-export class MutableDataStore extends DataStore {
+export class MutableDataStore extends ImmutableDataStore {
 	#file?: PathLike;
 
 	#assetsFile?: PathLike;
@@ -190,7 +190,7 @@ export default new Map([\n${lines.join(',\n')}]);
 		}
 	}
 
-	scopedStore(collectionName: string): AstroDataStore {
+	scopedStore(collectionName: string): DataStore {
 		return {
 			get: <TData extends Record<string, unknown> = Record<string, unknown>>(key: string) =>
 				this.get<DataEntry<TData>>(collectionName, key),
@@ -329,7 +329,8 @@ export default new Map([\n${lines.join(',\n')}]);
 	}
 }
 
-export interface AstroDataStore {
+// This is the scoped store for a single collection. It's a subset of the MutableDataStore API, and is the only public type.
+export interface DataStore {
 	get: <TData extends Record<string, unknown> = Record<string, unknown>>(
 		key: string,
 	) => DataEntry<TData> | undefined;

--- a/packages/astro/src/content/mutable-data-store.ts
+++ b/packages/astro/src/content/mutable-data-store.ts
@@ -190,7 +190,7 @@ export default new Map([\n${lines.join(',\n')}]);
 		}
 	}
 
-	scopedStore(collectionName: string): ScopedDataStore {
+	scopedStore(collectionName: string): AstroDataStore {
 		return {
 			get: <TData extends Record<string, unknown> = Record<string, unknown>>(key: string) =>
 				this.get<DataEntry<TData>>(collectionName, key),
@@ -329,7 +329,7 @@ export default new Map([\n${lines.join(',\n')}]);
 	}
 }
 
-export interface ScopedDataStore {
+export interface AstroDataStore {
 	get: <TData extends Record<string, unknown> = Record<string, unknown>>(
 		key: string,
 	) => DataEntry<TData> | undefined;


### PR DESCRIPTION
## Changes

The `LoaderContext` object that is passed to custom loaders is exported as a public type, but previously the individual properties used types that weren't public. This PR exports those types. It also changes the confusingly-named `ScopedDataStore` to `DataStore` to reflect the fact that it's the only public data store type.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
