### PR TITLE
Fix: prevent island from re-rendering when using transition:persist

### DIFF
--- a/.changeset/seven-bees-love.md
+++ b/.changeset/seven-bees-love.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix: prevent island from re-rendering when using transition:persist (#11854)

--- a/packages/astro/src/transitions/swap-functions.ts
+++ b/packages/astro/src/transitions/swap-functions.ts
@@ -77,7 +77,11 @@ export function swapBodyElement(newElement: Element, oldElement: Element) {
 			// from the old page so that state is preserved.
 			newEl.replaceWith(el);
 			// For islands, copy over the props to allow them to re-render
-			if (newEl.localName === 'astro-island' && shouldCopyProps(el as HTMLElement)) {
+			if (
+				newEl.localName === 'astro-island' &&
+				shouldCopyProps(el as HTMLElement) &&
+				!isSameProps(el, newEl)
+			) {
 				el.setAttribute('ssr', '');
 				el.setAttribute('props', newEl.getAttribute('props')!);
 			}
@@ -131,6 +135,10 @@ const persistedHeadElement = (el: HTMLElement, newDoc: Document): Element | null
 const shouldCopyProps = (el: HTMLElement): boolean => {
 	const persistProps = el.dataset.astroTransitionPersistProps;
 	return persistProps == null || persistProps === 'false';
+};
+
+const isSameProps = (oldEl: Element, newEl: Element) => {
+	return oldEl.getAttribute('props') === newEl.getAttribute('props');
 };
 
 export const swapFunctions = {


### PR DESCRIPTION
This PR addresses the issue described in [#11854](https://github.com/withastro/astro/issues/11854).

**Issue**: In the `swapBodyElement` function, the props attribute of the custom element is being updated even when the new and old values are identical. This unnecessary update triggers rehydration, which can lead to unexpected behavior during transitions.  [swap-functions.ts#L82](https://github.com/withastro/astro/blob/60d8e30008baef46ff46559450e5cd9c1f2500f6/packages/astro/src/transitions/swap-functions.ts#L82)

When navigating to a different page containing the same component (island), the following method is triggered on the custom element `astro-island`:

```
attributeChangedCallback() {
    this.hydrate();
}
```
(Source: [astro-island.ts#L204](https://github.com/withastro/astro/blob/60d8e30008baef46ff46559450e5cd9c1f2500f6/packages/astro/src/runtime/server/astro-island.ts#L204))

## Changes

I introduced a check to compare the `props` attribute values between `el` and `newEl`. The update now only occurs if the values differ. 

_However, since these strings represent serialized objects, there is a potential concern about whether a simple string comparison is sufficient, considering that the property order within the serialized objects might vary._

## Testing

I tested the changes by navigating between pages that contain the same component (island) to ensure that the `props` attribute is not unnecessarily updated, preventing redundant rehydration. The component state now persists correctly across transitions without triggering unnecessary rehydration. 

The testing was conducted using the code available at [https://stackblitz.com/edit/github-jhuzfh-jxxerz](https://stackblitz.com/edit/github-jhuzfh-jxxerz). This environment allowed me to reproduce the issue and verify the effectiveness of the fix.

No new tests were added since this change addresses a specific issue with existing behavior, and the existing test suite sufficiently covers the transition and hydration logic. However, I verified that all existing tests pass, ensuring that there are no regressions caused by this fix.

## Docs

This change does not affect user-facing behavior or API, so no updates to the documentation are needed.
