### PR TITLE
Fix `build.client` and `build.server` resolve behaviour

### DIFF
--- a/.changeset/chilly-terms-know.md
+++ b/.changeset/chilly-terms-know.md
@@ -1,0 +1,15 @@
+---
+'astro': major
+---
+
+Updates how the `build.client` and `build.server` option values get resolved. As currently documented, the option values will now correctly resolve relative to the `outDir` option. So if `outDir` is set to `./dist/nested/`, then by default:
+
+- `build.client` will resolve to `<root>/dist/nested/client`
+- `build.server` will resolve to `<root>/dist/nested/server`
+
+Previously the values were incorrectly resolved:
+
+- `build.client` was resolved to `<root>/dist/nested/dist/client`
+- `build.server` was resolved to `<root>/dist/nested/dist/server`
+
+If you were relying on the previous build paths, make sure that it's adapted to the new build paths.

--- a/.changeset/chilly-terms-know.md
+++ b/.changeset/chilly-terms-know.md
@@ -4,12 +4,12 @@
 
 Updates how the `build.client` and `build.server` option values get resolved. As currently documented, the option values will now correctly resolve relative to the `outDir` option. So if `outDir` is set to `./dist/nested/`, then by default:
 
-- `build.client` will resolve to `<root>/dist/nested/client`
-- `build.server` will resolve to `<root>/dist/nested/server`
+- `build.client` will resolve to `<root>/dist/nested/client/`
+- `build.server` will resolve to `<root>/dist/nested/server/`
 
 Previously the values were incorrectly resolved:
 
-- `build.client` was resolved to `<root>/dist/nested/dist/client`
-- `build.server` was resolved to `<root>/dist/nested/dist/server`
+- `build.client` was resolved to `<root>/dist/nested/dist/client/`
+- `build.server` was resolved to `<root>/dist/nested/dist/server/`
 
 If you were relying on the previous build paths, make sure that it's adapted to the new build paths.

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -655,8 +655,11 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 		.transform((config) => {
 			// If the user changed `outDir`, we need to also update `build.client` and `build.server`
 			// the be based on the correct `outDir`
-			const outDirPath = fileURLToPath(config.outDir);
-			if (outDirPath !== ASTRO_CONFIG_DEFAULTS.outDir) {
+			if (
+				config.outDir.toString() !==
+				resolveDirAsUrl(ASTRO_CONFIG_DEFAULTS.outDir, fileProtocolRoot).toString()
+			) {
+				const outDirPath = fileURLToPath(config.outDir);
 				config.build.client = resolveDirAsUrl(originalBuildClient, outDirPath);
 				config.build.server = resolveDirAsUrl(originalBuildServer, outDirPath);
 			}

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -9,7 +9,7 @@ import { type BuiltinTheme, bundledThemes } from 'shiki';
 
 import type { OutgoingHttpHeaders } from 'node:http';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { z } from 'zod';
 import { EnvSchema } from '../../env/schema.js';
 import type { AstroUserConfig, ViteUserConfig } from '../../types/public/config.js';
@@ -57,8 +57,8 @@ export const ASTRO_CONFIG_DEFAULTS = {
 	trailingSlash: 'ignore',
 	build: {
 		format: 'directory',
-		client: './dist/client/',
-		server: './dist/server/',
+		client: './client/',
+		server: './server/',
 		assets: '_astro',
 		serverEntry: 'entry.mjs',
 		redirects: true,
@@ -540,6 +540,9 @@ export const AstroConfigSchema = z.object({
 export type AstroConfigType = z.infer<typeof AstroConfigSchema>;
 
 export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
+	let originalBuildClient: string;
+	let originalBuildServer: string;
+
 	// We need to extend the global schema to add transforms that are relative to root.
 	// This is type checked against the global schema to make sure we still match.
 	const AstroConfigRelativeSchema = AstroConfigSchema.extend({
@@ -570,16 +573,30 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 					.union([z.literal('file'), z.literal('directory'), z.literal('preserve')])
 					.optional()
 					.default(ASTRO_CONFIG_DEFAULTS.build.format),
+				// NOTE: `client` and `server` are transformed relative to the default outDir first,
+				// later we'll fix this to be relative to the actual `outDir`
 				client: z
 					.string()
 					.optional()
 					.default(ASTRO_CONFIG_DEFAULTS.build.client)
-					.transform((val) => resolveDirAsUrl(val, fileProtocolRoot)),
+					.transform((val) => {
+						originalBuildClient = val;
+						return resolveDirAsUrl(
+							val,
+							path.resolve(fileProtocolRoot, ASTRO_CONFIG_DEFAULTS.outDir),
+						);
+					}),
 				server: z
 					.string()
 					.optional()
 					.default(ASTRO_CONFIG_DEFAULTS.build.server)
-					.transform((val) => resolveDirAsUrl(val, fileProtocolRoot)),
+					.transform((val) => {
+						originalBuildServer = val;
+						return resolveDirAsUrl(
+							val,
+							path.resolve(fileProtocolRoot, ASTRO_CONFIG_DEFAULTS.outDir),
+						);
+					}),
 				assets: z.string().optional().default(ASTRO_CONFIG_DEFAULTS.build.assets),
 				assetsPrefix: z
 					.string()
@@ -636,19 +653,12 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 		),
 	})
 		.transform((config) => {
-			// If the user changed outDir but not build.server, build.config, adjust so those
-			// are relative to the outDir, as is the expected default.
-			if (
-				!config.build.server.toString().startsWith(config.outDir.toString()) &&
-				config.build.server.toString().endsWith('dist/server/')
-			) {
-				config.build.server = new URL('./dist/server/', config.outDir);
-			}
-			if (
-				!config.build.client.toString().startsWith(config.outDir.toString()) &&
-				config.build.client.toString().endsWith('dist/client/')
-			) {
-				config.build.client = new URL('./dist/client/', config.outDir);
+			// If the user changed `outDir`, we need to also update `build.client` and `build.server`
+			// the be based on the correct `outDir`
+			const outDirPath = fileURLToPath(config.outDir);
+			if (outDirPath !== ASTRO_CONFIG_DEFAULTS.outDir) {
+				config.build.client = resolveDirAsUrl(originalBuildClient, outDirPath);
+				config.build.server = resolveDirAsUrl(originalBuildServer, outDirPath);
 			}
 
 			// Handle `base` trailing slash based on `trailingSlash` config

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -561,7 +561,7 @@ export interface AstroUserConfig {
 		 * @docs
 		 * @name build.client
 		 * @type {string}
-		 * @default `'./dist/client'`
+		 * @default `'./client'`
 		 * @description
 		 * Controls the output directory of your client-side CSS and JavaScript when `output: 'server'` or `output: 'hybrid'` only.
 		 * `outDir` controls where the code is built to.
@@ -582,7 +582,7 @@ export interface AstroUserConfig {
 		 * @docs
 		 * @name build.server
 		 * @type {string}
-		 * @default `'./dist/server'`
+		 * @default `'./server'`
 		 * @description
 		 * Controls the output directory of server JavaScript when building to SSR.
 		 *

--- a/packages/astro/test/astro-assets-prefix.test.js
+++ b/packages/astro/test/astro-assets-prefix.test.js
@@ -15,10 +15,6 @@ describe('Assets Prefix - Static', () => {
 		fixture = await loadFixture({
 			root: './fixtures/astro-assets-prefix/',
 			outDir: './dist/static',
-			build: {
-				client: './dist/static/client',
-				server: './dist/static/server',
-			},
 		});
 		await fixture.build();
 	});
@@ -79,8 +75,6 @@ describe('Assets Prefix - with path prefix', () => {
 			root: './fixtures/astro-assets-prefix/',
 			outDir: './dist/server',
 			build: {
-				client: './dist/server/client',
-				server: './dist/server/server',
 				assetsPrefix: '/starting-slash',
 			},
 		});
@@ -106,10 +100,6 @@ describe('Assets Prefix, server', () => {
 			output: 'server',
 			adapter: testAdapter(),
 			outDir: './dist/server',
-			build: {
-				client: './dist/server/client',
-				server: './dist/server/server',
-			},
 		});
 		await fixture.build();
 		app = await fixture.loadTestAdapterApp();
@@ -169,8 +159,6 @@ describe('Assets Prefix, with path prefix', () => {
 			adapter: testAdapter(),
 			outDir: './dist/server-path-prefix',
 			build: {
-				client: './dist/server-path-prefix/client',
-				server: './dist/server-path-prefix/server',
 				assetsPrefix: '/starting-slash',
 			},
 		});

--- a/packages/astro/test/before-hydration.test.js
+++ b/packages/astro/test/before-hydration.test.js
@@ -15,10 +15,6 @@ describe('Astro Scripts before-hydration', () => {
 				fixture = await loadFixture({
 					root: './fixtures/before-hydration/',
 					outDir: './dist/static-integration',
-					build: {
-						client: './dist/static-integration/client',
-						server: './dist/static-integration/server',
-					},
 					integrations: [
 						preact(),
 						{
@@ -74,10 +70,6 @@ describe('Astro Scripts before-hydration', () => {
 				fixture = await loadFixture({
 					root: './fixtures/before-hydration/',
 					outDir: './dist/static-no-integration',
-					build: {
-						client: './dist/static-no-integration/client',
-						server: './dist/static-no-integration/server',
-					},
 				});
 			});
 
@@ -126,10 +118,6 @@ describe('Astro Scripts before-hydration', () => {
 					output: 'server',
 					adapter: testAdapter(),
 					outDir: './dist/server-integration',
-					build: {
-						client: './dist/server-integration/client',
-						server: './dist/server-integration/server',
-					},
 					integrations: [
 						preact(),
 						{
@@ -169,10 +157,6 @@ describe('Astro Scripts before-hydration', () => {
 					root: './fixtures/before-hydration/',
 					output: 'server',
 					outDir: './dist/static-no-integration',
-					build: {
-						client: './dist/static-no-integration/client',
-						server: './dist/static-no-integration/server',
-					},
 					adapter: testAdapter(),
 				});
 			});

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -814,10 +814,6 @@ describe('astro:image', () => {
 				root: './fixtures/core-image-ssr/',
 				output: 'server',
 				outDir: './dist/server-base-path',
-				build: {
-					client: './dist/server-base-path/client',
-					server: './dist/server-base-path/server',
-				},
 				adapter: testAdapter(),
 				image: {
 					service: testImageService(),
@@ -1100,10 +1096,6 @@ describe('astro:image', () => {
 				root: './fixtures/core-image-ssr/',
 				output: 'server',
 				outDir: './dist/server-dev',
-				build: {
-					client: './dist/server-dev/client',
-					server: './dist/server-dev/server',
-				},
 				adapter: testAdapter(),
 				base: 'some-base',
 				image: {
@@ -1139,10 +1131,6 @@ describe('astro:image', () => {
 				root: './fixtures/core-image-ssr/',
 				output: 'server',
 				outDir: './dist/server-prod',
-				build: {
-					client: './dist/server-prod/client',
-					server: './dist/server-prod/server',
-				},
 				adapter: testAdapter(),
 				image: {
 					endpoint: 'astro/assets/endpoint/node',

--- a/packages/astro/test/css-inline-stylesheets.test.js
+++ b/packages/astro/test/css-inline-stylesheets.test.js
@@ -17,8 +17,6 @@ describe('Setting inlineStylesheets to never in static output', () => {
 			output: 'static',
 			outDir: './dist/static-inline-stylesheets-never',
 			build: {
-				client: './dist/static-inline-stylesheets-never/client',
-				server: './dist/static-inline-stylesheets-never/server',
 				inlineStylesheets: 'never',
 			},
 		});
@@ -58,8 +56,6 @@ describe('Setting inlineStylesheets to never in server output', () => {
 			adapter: testAdapter(),
 			outDir: './dist/server-inline-stylesheets-never',
 			build: {
-				client: './dist/server-inline-stylesheets-never/client',
-				server: './dist/server-inline-stylesheets-never/server',
 				inlineStylesheets: 'never',
 			},
 		});
@@ -100,8 +96,6 @@ describe('Setting inlineStylesheets to auto in static output', () => {
 			output: 'static',
 			outDir: './dist/static-inline-stylesheets-auto',
 			build: {
-				client: './dist/static-inline-stylesheets-auto/client',
-				server: './dist/static-inline-stylesheets-auto/server',
 				inlineStylesheets: 'auto',
 			},
 			vite: {
@@ -148,8 +142,6 @@ describe('Setting inlineStylesheets to auto in server output', () => {
 			adapter: testAdapter(),
 			outDir: './dist/server-inline-stylesheets-auto',
 			build: {
-				client: './dist/server-inline-stylesheets-auto/client',
-				server: './dist/server-inline-stylesheets-auto/server',
 				inlineStylesheets: 'auto',
 			},
 			vite: {
@@ -198,8 +190,6 @@ describe('Setting inlineStylesheets to always in static output', () => {
 			output: 'static',
 			outDir: './dist/static-inline-stylesheets-always',
 			build: {
-				client: './dist/static-inline-stylesheets-always/client',
-				server: './dist/static-inline-stylesheets-always/server',
 				inlineStylesheets: 'always',
 			},
 		});
@@ -238,8 +228,6 @@ describe('Setting inlineStylesheets to always in server output', () => {
 			adapter: testAdapter(),
 			outDir: './dist/server-inline-stylesheets-always',
 			build: {
-				client: './dist/server-inline-stylesheets-always/client',
-				server: './dist/server-inline-stylesheets-always/server',
 				inlineStylesheets: 'always',
 			},
 		});

--- a/packages/astro/test/experimental-content-collections-css-inline-stylesheets.test.js
+++ b/packages/astro/test/experimental-content-collections-css-inline-stylesheets.test.js
@@ -61,8 +61,6 @@ describe('Experimental Content Collections cache - inlineStylesheets to never in
 			adapter: testAdapter(),
 			outDir: './dist/inline-stylesheets-never',
 			build: {
-				client: './dist/inline-stylesheets-never/client',
-				server: './dist/inline-stylesheets-never/server',
 				inlineStylesheets: 'never',
 			},
 			experimental: {
@@ -108,8 +106,6 @@ describe('Experimental Content Collections cache - inlineStylesheets to auto in 
 			output: 'static',
 			outDir: './dist/inline-stylesheets-auto',
 			build: {
-				client: './dist/inline-stylesheets-auto/client',
-				server: './dist/inline-stylesheets-auto/server',
 				inlineStylesheets: 'auto',
 			},
 			vite: {
@@ -210,8 +206,6 @@ describe('Setting inlineStylesheets to always in server output', () => {
 			adapter: testAdapter(),
 			outDir: './dist/inline-stylesheets-always',
 			build: {
-				client: './dist/inline-stylesheets-always/client',
-				server: './dist/inline-stylesheets-always/server',
 				inlineStylesheets: 'always',
 			},
 			experimental: {

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -1337,10 +1337,6 @@ describe('[SSR] i18n routing', () => {
 				root: './fixtures/i18n-routing-prefix-always/',
 				output: 'server',
 				outDir: './dist/pathname-prefix-always-no-redirect',
-				build: {
-					client: './dist/pathname-prefix-always-no-redirect/client',
-					server: './dist/pathname-prefix-always-no-redirect/server',
-				},
 				adapter: testAdapter(),
 				i18n: {
 					routing: {
@@ -1628,10 +1624,6 @@ describe('[SSR] i18n routing', () => {
 					root: './fixtures/i18n-routing/',
 					output: 'server',
 					outDir: './dist/locales-underscore',
-					build: {
-						client: './dist/locales-underscore/client',
-						server: './dist/locales-underscore/server',
-					},
 					adapter: testAdapter(),
 					i18n: {
 						defaultLocale: 'en',
@@ -1902,10 +1894,6 @@ describe('SSR fallback from missing locale index to default locale index', () =>
 			root: './fixtures/i18n-routing-prefix-other-locales/',
 			output: 'server',
 			outDir: './dist/missing-locale-to-default',
-			build: {
-				client: './dist/missing-locale-to-default/client',
-				server: './dist/missing-locale-to-default/server',
-			},
 			adapter: testAdapter(),
 			i18n: {
 				defaultLocale: 'en',
@@ -2003,10 +1991,6 @@ describe('Fallback rewrite SSR', () => {
 			root: './fixtures/i18n-routing-fallback/',
 			output: 'server',
 			outDir: './dist/i18n-routing-fallback',
-			build: {
-				client: './dist/i18n-routing-fallback/client',
-				server: './dist/i18n-routing-fallback/server',
-			},
 			adapter: testAdapter(),
 			i18n: {
 				defaultLocale: 'en',

--- a/packages/astro/test/ssr-prerender.test.js
+++ b/packages/astro/test/ssr-prerender.test.js
@@ -13,10 +13,6 @@ describe('SSR: prerender', () => {
 			root: './fixtures/ssr-prerender/',
 			output: 'server',
 			outDir: './dist/normal',
-			build: {
-				client: './dist/normal/client',
-				server: './dist/normal/server',
-			},
 			adapter: testAdapter(),
 		});
 		await fixture.build();
@@ -93,10 +89,6 @@ describe.skip('Integrations can hook into the prerendering decision', () => {
 			root: './fixtures/ssr-prerender/',
 			output: 'server',
 			outDir: './dist/integration-prerender',
-			build: {
-				client: './dist/integration-prerender/client',
-				server: './dist/integration-prerender/server',
-			},
 			integrations: [testIntegration],
 			adapter: testAdapter(),
 		});

--- a/packages/astro/test/ssr-script.test.js
+++ b/packages/astro/test/ssr-script.test.js
@@ -28,10 +28,6 @@ describe('Inline scripts in SSR', () => {
 			fixture = await loadFixture({
 				...defaultFixtureOptions,
 				outDir: './dist/inline-scripts-without-base-path',
-				build: {
-					client: './dist/inline-scripts-without-base-path/client',
-					server: './dist/inline-scripts-without-base-path/server',
-				},
 			});
 			await fixture.build();
 		});
@@ -50,10 +46,6 @@ describe('Inline scripts in SSR', () => {
 			fixture = await loadFixture({
 				...defaultFixtureOptions,
 				outDir: './dist/inline-scripts-with-base-path',
-				build: {
-					client: './dist/inline-scripts-with-base-path/client',
-					server: './dist/inline-scripts-with-base-path/server',
-				},
 				base,
 			});
 			await fixture.build();
@@ -76,10 +68,6 @@ describe('External scripts in SSR', () => {
 			fixture = await loadFixture({
 				...defaultFixtureOptions,
 				outDir: './dist/external-scripts-without-base-path',
-				build: {
-					client: './dist/external-scripts-without-base-path/client',
-					server: './dist/external-scripts-without-base-path/server',
-				},
 				vite: {
 					build: {
 						assetsInlineLimit: 0,
@@ -101,10 +89,6 @@ describe('External scripts in SSR', () => {
 			fixture = await loadFixture({
 				...defaultFixtureOptions,
 				outDir: './dist/external-scripts-with-base-path',
-				build: {
-					client: './dist/external-scripts-with-base-path/client',
-					server: './dist/external-scripts-with-base-path/server',
-				},
 				vite: {
 					build: {
 						assetsInlineLimit: 0,
@@ -128,8 +112,6 @@ describe('External scripts in SSR', () => {
 				...defaultFixtureOptions,
 				outDir: './dist/with-assets-prefix',
 				build: {
-					client: './dist/with-assets-prefix/client',
-					server: './dist/with-assets-prefix/server',
 					assetsPrefix: 'https://cdn.example.com',
 				},
 				vite: {
@@ -153,10 +135,6 @@ describe('External scripts in SSR', () => {
 			fixture = await loadFixture({
 				...defaultFixtureOptions,
 				outDir: './dist/with-rollup-output-file-names',
-				build: {
-					client: './dist/with-rollup-output-file-names/client',
-					server: './dist/with-rollup-output-file-names/server',
-				},
 				vite: {
 					build: {
 						assetsInlineLimit: 0,
@@ -185,10 +163,6 @@ describe('External scripts in SSR', () => {
 			fixture = await loadFixture({
 				...defaultFixtureOptions,
 				outDir: './dist/with-rollup-output-file-names-and-base',
-				build: {
-					client: './dist/with-rollup-output-file-names-and-base/client',
-					server: './dist/with-rollup-output-file-names-and-base/server',
-				},
 				vite: {
 					build: {
 						assetsInlineLimit: 0,
@@ -219,8 +193,6 @@ describe('External scripts in SSR', () => {
 				...defaultFixtureOptions,
 				outDir: './dist/with-rollup-output-file-names-and-assets-prefix',
 				build: {
-					client: './dist/with-rollup-output-file-names-and-assets-prefix/client',
-					server: './dist/with-rollup-output-file-names-and-assets-prefix/server',
 					assetsPrefix: 'https://cdn.example.com',
 				},
 				vite: {


### PR DESCRIPTION
## Changes

Ensure that `build.client` and `build.server` will actually resolve relative to the `outDir` as currently documented. The changesets have extra information of the previous behaviour.

## Testing

Existing tests should pass. I also remove the previously set `build.client` and `build.server` options as the workaround is no longer needed.

## Docs

Added changesets explaining the breaking change.