### PR TITLE
feat(create-astro): ts-check comment

### DIFF
--- a/.changeset/nasty-dogs-sort.md
+++ b/.changeset/nasty-dogs-sort.md
@@ -1,0 +1,5 @@
+---
+'create-astro': patch
+---
+
+Updates the default Astro config with `// @ts-check` if the Typescript preset is `strict` or `strictest`

--- a/packages/create-astro/src/actions/typescript.ts
+++ b/packages/create-astro/src/actions/typescript.ts
@@ -140,6 +140,21 @@ const FILES_TO_UPDATE = {
 			}
 		}
 	},
+	'astro.config.mjs': async (file: string, options: { value: string }) => {
+		if (!(options.value === 'strict' || options.value === 'strictest')) {
+			return;
+		}
+
+		try {
+			let data = await readFile(file, { encoding: 'utf-8' });
+			data = `// @ts-check\n${data}`;
+			await writeFile(file, data, { encoding: 'utf-8' });
+		} catch (err) {
+			// if there's no astro.config.mjs (which is very unlikely), then do nothing
+			if (err && (err as any).code === 'ENOENT') return;
+			if (err instanceof Error) throw new Error(err.message);
+		}
+	},
 };
 
 export async function setupTypeScript(value: string, ctx: PickedTypeScriptContext) {


### PR DESCRIPTION
## Changes

- Updates the default Astro config with `// @ts-check` if the Typescript preset is `strict` or `strictest`

## Testing

Tested manually

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

I don't think anything is needed

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
