### PR TITLE
fix: explicitly check for null props in `serializeSignals`

### DIFF
--- a/.changeset/long-lemons-add.md
+++ b/.changeset/long-lemons-add.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/preact': patch
+---
+
+Preact components no longer throw an error if a property is null.

--- a/packages/astro/test/fixtures/preact-component/src/components/ComponentWithNullProp.jsx
+++ b/packages/astro/test/fixtures/preact-component/src/components/ComponentWithNullProp.jsx
@@ -1,0 +1,7 @@
+import { h } from 'preact';
+
+export default ({ nullProp }) => {
+  return <div id="preact-component-with-null-prop">
+		<p>I have a null prop: {nullProp}</p>
+	</div>
+}

--- a/packages/astro/test/fixtures/preact-component/src/pages/signals.astro
+++ b/packages/astro/test/fixtures/preact-component/src/pages/signals.astro
@@ -3,6 +3,7 @@ import { signal } from '@preact/signals';
 import Signals from '../components/Signals';
 import SignalsInArray from '../components/SignalsInArray';
 import SignalsInObject from '../components/SignalsInObject';
+import ComponentWithNullProp from '../components/ComponentWithNullProp';
 const count = signal(1);
 const secondCount = signal(2);
 ---
@@ -14,6 +15,7 @@ const secondCount = signal(2);
 		<Signals client:load count={count} />
 		<Signals client:load count={count} />
 		<SignalsInArray client:load signalsArray={["I'm not a signal", count, count, 12345, secondCount]} />
-		<SignalsInObject client:load signalsObject={{title:'I am a title', counter: count}} />
+		<SignalsInObject client:load signalsObject={{title:'I am a title', counter: count}}, />
+		<ComponentWithNullProp client:load nullProp={null} />
 	</body>
 </html>

--- a/packages/astro/test/preact-component.test.js
+++ b/packages/astro/test/preact-component.test.js
@@ -140,4 +140,11 @@ describe('Preact component', () => {
 		assert.equal(element.find('h1').text(), 'I am a title');
 		assert.equal(element.find('p').text(), '1');
 	});
+
+	it('Can use null props', async () => {
+		const html = await fixture.readFile('/signals/index.html');
+		const $ = cheerio.load(html);
+
+		assert.equal($('#preact-component-with-null-prop').length, 1);
+	});
 });

--- a/packages/integrations/preact/src/signals.ts
+++ b/packages/integrations/preact/src/signals.ts
@@ -38,7 +38,8 @@ export function serializeSignals(
 	const signals: Signals = {};
 	for (const [key, value] of Object.entries(props)) {
 		const isPropArray = Array.isArray(value);
-		const isPropObject = !isSignal(value) && typeof props[key] === 'object' && !isPropArray;
+		// `typeof null` is 'object' in JS, so we need to check for `null` specifically
+		const isPropObject = !isSignal(value) && typeof props[key] === 'object' && props[key] !== null && !isPropArray; 
 
 		if (isPropObject || isPropArray) {
 			const values = isPropObject ? Object.keys(props[key]) : value;


### PR DESCRIPTION
## Changes

Following up on @ph1p's changes, we discovered our pages were suddenly failing. Example error message: 

```
TypeError [Error]: Cannot convert undefined or null to object
      at Function.keys (<anonymous>)
      at serializeSignals (file:///Users/lukasbachlechner/development/astro/packages/astro/test/fixtures/preact-component/dist/renderers.mjs:49:44)
      at Object.renderToStaticMarkup (file:///Users/lukasbachlechner/development/astro/packages/astro/test/fixtures/preact-component/dist/renderers.mjs:146:3)
      at renderFrameworkComponent (file:///Users/lukasbachlechner/development/astro/packages/astro/test/fixtures/preact-component/dist/chunks/astro/server_B-ybt-25.mjs:1263:53)
      at async renderComponent (file:///Users/lukasbachlechner/development/astro/packages/astro/test/fixtures/preact-component/dist/chunks/astro/server_B-ybt-25.mjs:1441:10)
      at async renderChild (file:///Users/lukasbachlechner/development/astro/packages/astro/test/fixtures/preact-component/dist/chunks/astro/server_B-ybt-25.mjs:904:13) {
    id: 'src/pages/signals.astro'
  }
```

Turns out that we need to explicitly check if `props[key] !== null` because `typeof null` returns `"object"`, so `Object.keys(props[key])` threw this error. Added this line to the `isPropObject` and also added a test case for it.

## Testing

Test added in `astro/test/preact-component.test.js`.

## Docs

No user-facing changes, so none needed.
