### PR TITLE
Actions: add discriminated union support

### DIFF
--- a/.changeset/mighty-stingrays-press.md
+++ b/.changeset/mighty-stingrays-press.md
@@ -1,0 +1,63 @@
+---
+'astro': patch
+---
+
+Adds support for Zod discriminated unions on Action form inputs. This allows forms with different inputs to be submitted to the same action, using a given input to decide which object should be used for validation.
+
+This example accepts either a `create` or `update` form submission, and uses the `type` field to determine which object to validate against.
+
+```ts
+import { defineAction } from 'astro:actions';
+import { z } from 'astro:schema';
+
+export const server = {
+  changeUser: defineAction({
+    accept: 'form',
+    input: z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal('create'),
+        name: z.string(),
+        email: z.string().email(),
+      }),
+      z.object({
+        type: z.literal('update'),
+        id: z.number(),
+        name: z.string(),
+        email: z.string().email(),
+      }),
+    ]),
+    async handler(input) {
+      if (input.type === 'create') {
+        // input is { type: 'create', name: string, email: string }
+      } else {
+        // input is { type: 'update', id: number, name: string, email: string }
+      }
+    },
+  }),
+}
+```
+
+The corresponding `create` and `update` forms may look like this:
+
+```astro
+---
+import { actions } from 'astro:actions';
+---
+
+<!--Create-->
+<form action={actions.changeUser} method="POST">
+  <input type="hidden" name="type" value="create" />
+  <input type="text" name="name" required />
+  <input type="email" name="email" required />
+  <button type="submit">Create User</button>
+</form>
+
+<!--Update-->
+<form action={actions.changeUser} method="POST">
+  <input type="hidden" name="type" value="update" />
+  <input type="hidden" name="id" value="user-123" />
+  <input type="text" name="name" required />
+  <input type="email" name="email" required />
+  <button type="submit">Update User</button>
+</form>
+```

--- a/packages/astro/test/fixtures/actions/src/actions/index.ts
+++ b/packages/astro/test/fixtures/actions/src/actions/index.ts
@@ -7,6 +7,29 @@ const passwordSchema = z
 	.max(128, 'Password length exceeded. Max 128 chars.');
 
 export const server = {
+	imageUploadInChunks: defineAction({
+		accept: 'form',
+		input: z.discriminatedUnion('type', [
+			z.object({
+				type: z.literal('first-chunk'),
+				image: z.instanceof(File),
+				alt: z.string(),
+			}),
+			z.object({ type: z.literal('rest-chunk'), image: z.instanceof(File), uploadId: z.string() }),
+		]),
+		handler: async (data) => {
+			if (data.type === 'first-chunk') {
+				const uploadId = Math.random().toString(36).slice(2);
+				return {
+					uploadId,
+				};
+			} else {
+				return {
+					uploadId: data.uploadId,
+				};
+			}
+		},
+	}),
 	subscribe: defineAction({
 		input: z.object({ channel: z.string() }),
 		handler: async ({ channel }) => {


### PR DESCRIPTION
## Changes

Adds support for Zod discriminated unions. Implemented from [this roadmap suggestion](https://github.com/withastro/roadmap/issues/898#issuecomment-2178131665) by @arihantverma. Thanks for the suggestion!

- Add check for discriminated union schemas, and unwrap the correct object depending on the union key.

## Testing

- Add test for discriminated unions

## Docs

Changeset for now, will update API reference

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
