### PR TITLE
[error docs] Update error messages that reference src/content/

### DIFF
--- a/.changeset/sharp-worms-sniff.md
+++ b/.changeset/sharp-worms-sniff.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Updates error messages that assume content collections are located in `src/content/` with more generic language

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1431,7 +1431,7 @@ export const GetEntryDeprecationError = {
  * "title" is required.<br/>
  * "date" must be a valid date.
  * @description
- * A Markdown or MDX entry in `src/content/` does not match its collection schema.
+ * A Markdown or MDX entry does not match its collection schema.
  * Make sure that all required fields are present, and that all fields are of the correct type.
  * You can check against the collection schema in your `src/content/config.*` file.
  * See the [Content collections documentation](https://docs.astro.build/en/guides/content-collections/) for more information.
@@ -1455,7 +1455,7 @@ export const InvalidContentEntryFrontmatterError = {
  * @see
  * - [The reserved entry `slug` field](https://docs.astro.build/en/guides/content-collections/)
  * @description
- * An entry in `src/content/` has an invalid `slug`. This field is reserved for generating entry slugs, and must be a string when present.
+ * A collection entry has an invalid `slug`. This field is reserved for generating entry slugs, and must be a string when present.
  */
 export const InvalidContentEntrySlugError = {
 	name: 'InvalidContentEntrySlugError',


### PR DESCRIPTION
## Changes
 
Generalizes two error messages that assume your collections are stored in `src/content/`

## Testing

No tests, docs

## Docs

Only error message docs on `next`.
