### PR TITLE
fix: add refresh context to schema for loader args

### DIFF
--- a/.changeset/cuddly-shoes-press.md
+++ b/.changeset/cuddly-shoes-press.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where the refresh context data was not passed correctly to content layer loaders

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -80,6 +80,7 @@ const collectionConfigParser = z.union([
 								parseData: z.any(),
 								generateDigest: z.function(z.tuple([z.any()], z.string())),
 								watcher: z.any().optional(),
+								refreshContextData: z.record(z.unknown()).optional(),
 							}),
 						],
 						z.unknown(),

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -290,16 +290,18 @@ describe('Content Layer', () => {
 			const rawJsonResponse = await fixture.fetch('/collections.json');
 			const initialJson = devalue.parse(await rawJsonResponse.text());
 			assert.equal(initialJson.increment.data.lastValue, 1);
+			const now = new Date().toISOString();
 
 			const refreshResponse = await fixture.fetch('/_refresh', {
 				method: 'POST',
-				body: JSON.stringify({}),
+				body: JSON.stringify({ now }),
 			});
 			const refreshData = await refreshResponse.json();
 			assert.equal(refreshData.message, 'Content refreshed successfully');
 			const updatedJsonResponse = await fixture.fetch('/collections.json');
 			const updated = devalue.parse(await updatedJsonResponse.text());
 			assert.equal(updated.increment.data.lastValue, 2);
+			assert.deepEqual(updated.increment.data.refreshContextData, { webhookBody: { now } });
 		});
 
 		it('updates collection when data file is changed', async () => {

--- a/packages/astro/test/fixtures/content-layer/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-layer/src/content/config.ts
@@ -123,7 +123,7 @@ const images = defineCollection({
 const increment = defineCollection({
 	loader: {
 		name: 'increment-loader',
-		load: async ({ store }) => {
+		load: async ({ store, refreshContextData }) => {
 			const entry = store.get<{ lastValue: number }>('value');
 			const lastValue = entry?.data.lastValue ?? 0;
 			store.set({
@@ -131,6 +131,7 @@ const increment = defineCollection({
 				data: {
 					lastValue: lastValue + 1,
 					lastUpdated: new Date(),
+					refreshContextData
 				},
 			});
 		},
@@ -139,6 +140,7 @@ const increment = defineCollection({
 			z.object({
 				lastValue: z.number(),
 				lastUpdated: z.date(),
+				refreshContextData: z.record(z.unknown()),
 			}),
 	},
 });


### PR DESCRIPTION
## Changes

The `refreshContextData` value was missing from the schema for loader args, meaning it was being stripped from the context object

## Testing

Added a test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
