### PR TITLE
Export the RenderResult type

### DIFF
--- a/.changeset/eighty-bags-cross.md
+++ b/.changeset/eighty-bags-cross.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Exports the `RenderResult` type

--- a/packages/astro/templates/content/types.d.ts
+++ b/packages/astro/templates/content/types.d.ts
@@ -1,5 +1,5 @@
 declare module 'astro:content' {
-	interface RenderResult {
+	export interface RenderResult {
 		Content: import('astro/runtime/server/index.js').AstroComponentFactory;
 		headings: import('astro').MarkdownHeading[];
 		remarkPluginFrontmatter: Record<string, any>;


### PR DESCRIPTION
## Changes

Exports `RenderResult` type, which is the return type of `render()`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
