### PR TITLE
Handle MDX optimize for root hast node

### DIFF
--- a/.changeset/lovely-dolphins-draw.md
+++ b/.changeset/lovely-dolphins-draw.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Handles nested root hast node when optimizing MDX

--- a/packages/integrations/mdx/src/rehype-optimize-static.ts
+++ b/packages/integrations/mdx/src/rehype-optimize-static.ts
@@ -64,8 +64,14 @@ export const rehypeOptimizeStatic: RehypePlugin<[OptimizeOptions?]> = (options) 
 		 * A non-static node causes all its parents to be non-optimizable
 		 */
 		const isNodeNonStatic = (node: Node) => {
-			// @ts-expect-error Access `.tagName` naively for perf
-			return node.type.startsWith('mdx') || ignoreElementNames.has(node.tagName);
+			return (
+				node.type.startsWith('mdx') ||
+				// @ts-expect-error `node` should never have `type: 'root'`, but in some cases plugins may inject it as children,
+				// which MDX will render as a fragment instead (an MDX fragment is a `mdxJsxFlowElement` type).
+				node.type === 'root' ||
+				// @ts-expect-error Access `.tagName` naively for perf
+				ignoreElementNames.has(node.tagName)
+			);
 		};
 
 		visit(tree as any, {

--- a/packages/integrations/mdx/test/fixtures/mdx-optimize/astro.config.mjs
+++ b/packages/integrations/mdx/test/fixtures/mdx-optimize/astro.config.mjs
@@ -1,9 +1,37 @@
 import mdx from '@astrojs/mdx';
 
 export default {
-	integrations: [mdx({
-		optimize: {
-			ignoreElementNames: ['strong']
-		}
-	})]
-}
+	integrations: [
+		mdx({
+			optimize: {
+				ignoreElementNames: ['strong'],
+			},
+		}),
+	],
+	markdown: {
+		rehypePlugins: [
+			() => {
+				return (tree) => {
+					tree.children.push({
+						type: 'root',
+						children: [
+							{
+								type: 'element',
+								tagName: 'p',
+								properties: {
+									id: 'injected-root-hast',
+								},
+								children: [
+									{
+										type: 'text',
+										value: 'Injected root hast from rehype plugin',
+									},
+								],
+							},
+						],
+					});
+				};
+			},
+		],
+	},
+};

--- a/packages/integrations/mdx/test/mdx-optimize.test.js
+++ b/packages/integrations/mdx/test/mdx-optimize.test.js
@@ -47,4 +47,15 @@ describe('MDX optimize', () => {
 		assert.notEqual(blockquote, null);
 		assert.equal(blockquote.textContent.includes('I like pancakes'), true);
 	});
+
+	it('renders MDX with rehype plugin that incorrectly injects root hast node', async () => {
+		const html = await fixture.readFile('/import/index.html');
+		const { document } = parseHTML(html);
+
+		assert.doesNotMatch(html, /set:html=/);
+		assert.equal(
+			document.getElementById('injected-root-hast').textContent,
+			'Injected root hast from rehype plugin',
+		);
+	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8865,12 +8865,10 @@ packages:
 
   libsql@0.3.19:
     resolution: {integrity: sha512-Aj5cQ5uk/6fHdmeW0TiXK42FqUlwx7ytmMLPSaUQPin5HKKKuUPD62MAbN4OEweGBBI7q1BekoEN4gPUEL6MZA==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   libsql@0.4.1:
     resolution: {integrity: sha512-qZlR9Yu1zMBeLChzkE/cKfoKV3Esp9cn9Vx5Zirn4AVhDWPcjYhKwbtJcMuHehgk3mH+fJr9qW+3vesBWbQpBg==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@2.1.0:


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/11971

The MDX optimizer didn't handle `{ type: 'root', children: [] }` kind of hast node when combining the MDX into an HTML string, which resulted in incorrect output. The fix here is to treat root hast nodes as non-optimizable, like MDX nodes.

## Testing

Added tests

## Docs

n/a. bug fix.