### PR TITLE
Remove dependency on path-to-regexp

### DIFF
--- a/.changeset/quiet-lemons-collect.md
+++ b/.changeset/quiet-lemons-collect.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Remove dependency on path-to-regexp

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -168,7 +168,6 @@
     "ora": "^8.1.0",
     "p-limit": "^6.1.0",
     "p-queue": "^8.0.1",
-    "path-to-regexp": "^6.2.2",
     "preferred-pm": "^4.0.0",
     "prompts": "^2.4.2",
     "rehype": "^13.0.1",

--- a/packages/astro/src/core/routing/manifest/generator.ts
+++ b/packages/astro/src/core/routing/manifest/generator.ts
@@ -1,7 +1,5 @@
 import type { AstroConfig, RoutePart } from '../../../@types/astro.js';
 
-import { compile } from 'path-to-regexp';
-
 /**
  * Sanitizes the parameters object by normalizing string values and replacing certain characters with their URL-encoded equivalents.
  * @param {Record<string, string | number | undefined>} params - The parameters object to be sanitized.
@@ -24,45 +22,39 @@ export function getRouteGenerator(
 	segments: RoutePart[][],
 	addTrailingSlash: AstroConfig['trailingSlash'],
 ) {
-	const template = segments
-		.map((segment) => {
-			return (
-				'/' +
-				segment
-					.map((part) => {
-						if (part.spread) {
-							return `:${part.content.slice(3)}(.*)?`;
-						} else if (part.dynamic) {
-							return `:${part.content}`;
-						} else {
-							return part.content
-								.normalize()
-								.replace(/\?/g, '%3F')
-								.replace(/#/g, '%23')
-								.replace(/%5B/g, '[')
-								.replace(/%5D/g, ']')
-								.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-						}
-					})
-					.join('')
-			);
-		})
-		.join('');
-
-	// Unless trailingSlash config is set to 'always', don't automatically append it.
-	let trailing: '/' | '' = '';
-	if (addTrailingSlash === 'always' && segments.length) {
-		trailing = '/';
-	}
-	const toPath = compile(template + trailing);
 	return (params: Record<string, string | number | undefined>): string => {
 		const sanitizedParams = sanitizeParams(params);
-		const path = toPath(sanitizedParams);
 
-		// When generating an index from a rest parameter route, `path-to-regexp` will return an
-		// empty string instead "/". This causes an inconsistency with static indexes that may result
-		// in the incorrect routes being rendered.
-		// To fix this, we return "/" when the path is empty.
+		// Unless trailingSlash config is set to 'always', don't automatically append it.
+		let trailing: '/' | '' = '';
+		if (addTrailingSlash === 'always' && segments.length) {
+			trailing = '/';
+		}
+
+		const path = segments
+			.map((segment) => {
+				return (
+					'/' +
+					segment
+						.map((part) => {
+							if (part.spread) {
+								return `${sanitizedParams[part.content.slice(3)] || ''}`;
+							} else if (part.dynamic) {
+								return `${sanitizedParams[part.content] || ''}`;
+							} else {
+								return part.content
+									.normalize()
+									.replace(/\?/g, '%3F')
+									.replace(/#/g, '%23')
+									.replace(/%5B/g, '[')
+									.replace(/%5D/g, ']');
+							}
+						})
+						.join('')
+				);
+			})
+			.join('') + trailing;
+
 		return path || '/';
 	};
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -693,9 +693,6 @@ importers:
       p-queue:
         specifier: ^8.0.1
         version: 8.0.1
-      path-to-regexp:
-        specifier: ^6.2.2
-        version: 6.2.2
       preferred-pm:
         specifier: ^4.0.0
         version: 4.0.0
@@ -9546,9 +9543,6 @@ packages:
     resolution: {integrity: sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  path-to-regexp@6.2.2:
-    resolution: {integrity: sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==}
-
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -15581,8 +15575,6 @@ snapshots:
     dependencies:
       lru-cache: 10.2.0
       minipass: 7.1.2
-
-  path-to-regexp@6.2.2: {}
 
   path-type@4.0.0: {}
 


### PR DESCRIPTION
## Changes

- Remove dependency path-to-regexp
- Replace route placeholders directly in generate function

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
All existing test still run and code is already covered.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
No change to docs necessary as this is only an internal implementation change.
