### PR TITLE
Bump path-to-regexp from 6.2.2 to 6.3.0

### DIFF
--- a/.changeset/funny-cars-unite.md
+++ b/.changeset/funny-cars-unite.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Bump path-to-regexp to 6.3.0

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -168,7 +168,7 @@
     "ora": "^8.1.0",
     "p-limit": "^6.1.0",
     "p-queue": "^8.0.1",
-    "path-to-regexp": "^6.2.2",
+    "path-to-regexp": "^6.3.0",
     "preferred-pm": "^4.0.0",
     "prompts": "^2.4.2",
     "rehype": "^13.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -694,8 +694,8 @@ importers:
         specifier: ^8.0.1
         version: 8.0.1
       path-to-regexp:
-        specifier: ^6.2.2
-        version: 6.2.2
+        specifier: ^6.3.0
+        version: 6.3.0
       preferred-pm:
         specifier: ^4.0.0
         version: 4.0.0
@@ -9546,8 +9546,8 @@ packages:
     resolution: {integrity: sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  path-to-regexp@6.2.2:
-    resolution: {integrity: sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==}
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -15582,7 +15582,7 @@ snapshots:
       lru-cache: 10.2.0
       minipass: 7.1.2
 
-  path-to-regexp@6.2.2: {}
+  path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
 


### PR DESCRIPTION
## Changes

Bump `path-to-regexp` from 6.2.2 to 6.3.0.
Fixes `CVE-2024-45296` (see https://github.com/advisories/GHSA-9wv6-86v2-598j).
Resolves #11956.

Related to https://github.com/withastro/astro/issues/11956#issuecomment-2348605338.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Just bumping to newly available patch to fix vulnerability.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

N/A
