### PR TITLE
Fix SolidJS view transition state persistence

### DIFF
--- a/.changeset/grumpy-bobcats-rush.md
+++ b/.changeset/grumpy-bobcats-rush.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/solid-js': patch
+---
+
+Fix view transition state persistence

--- a/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/view-transitions/astro.config.mjs
@@ -1,6 +1,7 @@
 import nodejs from '@astrojs/node';
 import react from '@astrojs/react';
 import svelte from '@astrojs/svelte';
+import solidjs from '@astrojs/solid-js';
 import vue from '@astrojs/vue';
 import { defineConfig } from 'astro/config';
 
@@ -8,7 +9,11 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({
 	output: 'hybrid',
 	adapter: nodejs({ mode: 'standalone' }),
-	integrations: [react(),vue(),svelte()],
+	integrations: [react( {
+		exclude: ['**/solid/**'],
+	}),vue(),svelte(),solidjs({
+		include: ['**/solid/**'],
+	})],
 	redirects: {
 		'/redirect-two': '/two',
 		'/redirect-external': 'http://example.com/',

--- a/packages/astro/e2e/fixtures/view-transitions/package.json
+++ b/packages/astro/e2e/fixtures/view-transitions/package.json
@@ -7,10 +7,12 @@
     "@astrojs/react": "workspace:*",
     "@astrojs/svelte": "workspace:*",
     "@astrojs/vue": "workspace:*",
+    "@astrojs/solid-js": "workspace:*",
     "astro": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "svelte": "^4.2.19",
-    "vue": "^3.5.3"
+    "vue": "^3.5.3",
+    "solid-js": "^1.8.0"
   }
 }

--- a/packages/astro/e2e/fixtures/view-transitions/src/components/solid/Counter.jsx
+++ b/packages/astro/e2e/fixtures/view-transitions/src/components/solid/Counter.jsx
@@ -1,0 +1,19 @@
+import {createSignal} from "solid-js";
+
+export default function Counter(props) {
+	const [count, setCount] = createSignal(0);
+	const add = () => setCount(count() + 1);
+	const subtract = () => setCount(count() - 1);
+
+	return (
+		<>
+			<div class="counter">
+				<button onClick={subtract} class="decrement">-</button>
+
+				<pre>{props.prefix ?? ''}{count()}{props.postfix ?? ""}</pre>
+				<button onClick={add} class="increment">+</button>
+			</div>
+			<div class="counter-message">{props.children}</div>
+		</>
+	);
+}

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/island-solid-one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/island-solid-one.astro
@@ -1,0 +1,11 @@
+---
+import Layout from '../components/Layout.astro';
+import Counter from '../components/solid/Counter.jsx';
+export const prerender = false;
+
+---
+<Layout>
+	<p id="island-one">Page 1</p>
+	<a id="click-two" href="/island-solid-two">go to 2</a>
+	<Counter prefix="A" client:load transition:persist transition:name="counter" />
+</Layout>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/island-solid-two.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/island-solid-two.astro
@@ -1,0 +1,11 @@
+---
+import Layout from '../components/Layout.astro';
+import Counter from '../components/solid/Counter.jsx';
+export const prerender = false;
+
+---
+<Layout>
+	<p id="island-two">Page 2</p>
+	<a id="click-one" href="/island-solid-one">go to 1</a>
+	<Counter prefix="B" postfix="!" client:load transition:persist transition:name="counter" />
+</Layout>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -544,6 +544,31 @@ test.describe('View Transitions', () => {
 		await expect(pageTitle).toHaveText('Island 2');
 	});
 
+	test('Solid Islands can persist using transition:persist', async ({ page, astro }) => {
+		// Go to page 1
+		await page.goto(astro.resolveUrl('/island-solid-one'));
+		let cnt = page.locator('.counter pre');
+		await expect(cnt).toHaveText('A0');
+
+		await page.click('.increment');
+		await expect(cnt).toHaveText('A1');
+
+		// Navigate to page 2
+		await page.click('#click-two');
+		let p = page.locator('#island-two');
+		await expect(p).toBeVisible();
+		cnt = page.locator('.counter pre');
+		// Count should remain, but the prefix should be updated
+		await expect(cnt).toHaveText('B1!');
+
+		await page.click('#click-one');
+		p = page.locator('#island-one');
+		await expect(p).toBeVisible();
+		cnt = page.locator('.counter pre');
+		// Count should remain, but the postfix should be removed again (to test unsetting props)
+		await expect(cnt).toHaveText('A1');
+	});
+
 	test('transition:persist-props prevents props from changing', async ({ page, astro }) => {
 		// Go to page 1
 		await page.goto(astro.resolveUrl('/island-one?persist'));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1721,6 +1721,9 @@ importers:
       '@astrojs/react':
         specifier: workspace:*
         version: link:../../../../integrations/react
+      '@astrojs/solid-js':
+        specifier: workspace:*
+        version: link:../../../../integrations/solid
       '@astrojs/svelte':
         specifier: workspace:*
         version: link:../../../../integrations/svelte
@@ -1736,6 +1739,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      solid-js:
+        specifier: ^1.8.0
+        version: 1.8.22
       svelte:
         specifier: ^4.2.19
         version: 4.2.19


### PR DESCRIPTION
## Changes

This changes addresses the issue that the state if SolidJS components would not be retained when using `transition:persist`.

It introduces a reactive store to update the props passed to the root component after initialization (similar approach as the React integration is using).

Related to #11854

## Testing

E2E test was added.

## Docs

Only a fix, so no docs update should be needed.
