### PR TITLE
docs: fix Content Layer RFC Link

### DIFF
--- a/.changeset/healthy-donuts-yell.md
+++ b/.changeset/healthy-donuts-yell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an outdated link used to document Content Layer API

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2279,7 +2279,7 @@ export interface AstroUserConfig {
 		 * export const collections = { countries };
 		 * ```
 		 *
-		 * For more advanced loading logic, you can define an object loader. This allows incremental updates and conditional loading while also giving full access to the data store. See the API in [the Content Layer API RFC](https://github.com/withastro/roadmap/blob/content-layer/proposals/0047-content-layer.md#loaders).
+		 * For more advanced loading logic, you can define an object loader. This allows incremental updates and conditional loading while also giving full access to the data store. See the API in [the Content Layer API RFC](https://github.com/withastro/roadmap/blob/content-layer/proposals/0050-content-layer.md#loaders).
 		 *
 		 * #### Migrating an existing content collection to use the Content Layer API
 		 *
@@ -2344,7 +2344,7 @@ export interface AstroUserConfig {
 		 *
 		 * #### Learn more
 		 *
-		 * For a complete overview and the full API reference, see [the Content Layer API RFC](https://github.com/withastro/roadmap/blob/content-layer/proposals/0047-content-layer.md) and [share your feedback](https://github.com/withastro/roadmap/pull/982).
+		 * For a complete overview and the full API reference, see [the Content Layer API RFC](https://github.com/withastro/roadmap/blob/content-layer/proposals/0050-content-layer.md) and [share your feedback](https://github.com/withastro/roadmap/pull/982).
 		 */
 		contentLayer?: boolean;
 	};


### PR DESCRIPTION
## Changes

Updates Content Layer RFC links in `@types/astro.ts`. Previous links led to 404 error...

## Testing

N/A

## Docs

* This is a doc fix already approved in `docs` repo (see https://github.com/withastro/docs/pull/9410) but the update should occur here!
* I don't think we need a changeset for this...
