### PR TITLE
Fix Svelte view transition state persistence

### DIFF
--- a/.changeset/warm-birds-cheer.md
+++ b/.changeset/warm-birds-cheer.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/svelte': patch
+---
+
+Fix Svelte component view transition state persistence

--- a/packages/astro/e2e/fixtures/view-transitions/src/components/SvelteCounter.svelte
+++ b/packages/astro/e2e/fixtures/view-transitions/src/components/SvelteCounter.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	let count = 0;
+	export let prefix = "";
 
 	function add() {
 		count += 1;
@@ -11,9 +12,9 @@
 </script>
 
 <div class="counter">
-	<button on:click={subtract}>-</button>
-	<pre>{count}</pre>
-	<button on:click={add}>+</button>
+	<button on:click={subtract} class="decrement">-</button>
+	<pre>{prefix}{count}</pre>
+	<button on:click={add} class="increment">+</button>
 </div>
 <div class="message">
 	<slot />

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/island-svelte-one.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/island-svelte-one.astro
@@ -1,0 +1,11 @@
+---
+import Counter from '../components/SvelteCounter.svelte';
+import Layout from '../components/Layout.astro';
+export const prerender = false;
+
+---
+<Layout>
+	<p id="island-one">Page 1</p>
+	<a id="click-two" href="/island-svelte-two">go to 2</a>
+	<Counter prefix="A" client:load transition:persist transition:name="counter"/>
+</Layout>

--- a/packages/astro/e2e/fixtures/view-transitions/src/pages/island-svelte-two.astro
+++ b/packages/astro/e2e/fixtures/view-transitions/src/pages/island-svelte-two.astro
@@ -1,0 +1,11 @@
+---
+import Counter from '../components/SvelteCounter.svelte';
+import Layout from '../components/Layout.astro';
+export const prerender = false;
+
+---
+<Layout>
+	<p id="island-two">Page 2</p>
+	<a id="click-one" href="/island-svelte-one">go to 1</a>
+	<Counter prefix="B" client:load transition:persist transition:name="counter"/>
+</Layout>

--- a/packages/astro/e2e/view-transitions.test.js
+++ b/packages/astro/e2e/view-transitions.test.js
@@ -544,6 +544,24 @@ test.describe('View Transitions', () => {
 		await expect(pageTitle).toHaveText('Island 2');
 	});
 
+	test('Svelte Islands can persist using transition:persist', async ({ page, astro }) => {
+		// Go to page 1
+		await page.goto(astro.resolveUrl('/island-svelte-one'));
+		let cnt = page.locator('.counter pre');
+		await expect(cnt).toHaveText('A0');
+
+		await page.click('.increment');
+		await expect(cnt).toHaveText('A1');
+
+		// Navigate to page 2
+		await page.click('#click-two');
+		let p = page.locator('#island-two');
+		await expect(p).toBeVisible();
+		cnt = page.locator('.counter pre');
+		// Count should remain, but the prefix should be updated
+		await expect(cnt).toHaveText('B1');
+	});
+
 	test('transition:persist-props prevents props from changing', async ({ page, astro }) => {
 		// Go to page 1
 		await page.goto(astro.resolveUrl('/island-one?persist'));


### PR DESCRIPTION
## Changes

This change fixes view transition state persistence for Svelte components. It keeps track of mounted components and updates props instead of remounting the component.

Related to #11854.

## Testing

E2E test was added

## Docs

This behavior is already documented but was not working until now.
