### PR TITLE
docs: update `security.checkOrigin` JSDoc comment

### DIFF
--- a/.changeset/fresh-pandas-drive.md
+++ b/.changeset/fresh-pandas-drive.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a type and an example in documenting the `security.checkOrigin` property of Astro config.

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -442,8 +442,8 @@ export interface AstroUserConfig {
 	/**
 	 * @docs
 	 * @name security
-	 * @type {boolean}
-	 * @default `{}`
+	 * @type {Record<"checkOrigin", boolean> | undefined}
+	 * @default `{checkOrigin: true}`
 	 * @version 4.9.0
 	 * @description
 	 *
@@ -451,12 +451,16 @@ export interface AstroUserConfig {
 	 *
 	 * These features only exist for pages rendered on demand (SSR) using `server` mode or pages that opt out of prerendering in `static` mode.
 	 *
+	 * By default, Astro will automatically check that the “origin” header
+	 * matches the URL sent by each request in on-demand rendered pages. You can
+	 * disable this behavior by setting `checkOrigin` to `false`:
+	 *
 	 * ```js
 	 * // astro.config.mjs
 	 * export default defineConfig({
 	 *   output: "server",
 	 *   security: {
-	 *     checkOrigin: true
+	 *     checkOrigin: false
 	 *   }
 	 * })
 	 * ```


### PR DESCRIPTION
## Changes

The default value for `security.checkOrigin` has [changed in v5](https://5-0-0-beta.docs.astro.build/en/guides/upgrade-to/v5/#csrf-protection-is-now-set-by-default), so I updated the JSDoc comment to:
* fix the type of `security` (this is not a boolean if I make no mistake)
* define its default value
* add an example to show how to disable this behavior

## Testing

N/A, it's doc.

## Docs

This is a doc PR. I added a changeset, not sure if it was necessary since it is for v5 (first time I'm publishing to the next branch).
But a review from Team docs could be helpful!
/cc @withastro/maintainers-docs for feedback!
