### PR TITLE
Make @astrojs/tailwind compat with Astro 5

### DIFF
--- a/.changeset/plenty-pandas-repeat.md
+++ b/.changeset/plenty-pandas-repeat.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/tailwind': patch
+---
+
+Make @astrojs/tailwind compat with Astro 5

--- a/packages/integrations/tailwind/package.json
+++ b/packages/integrations/tailwind/package.json
@@ -44,7 +44,7 @@
     "vite": "^5.4.3"
   },
   "peerDependencies": {
-    "astro": "^3.0.0 || ^4.0.0",
+    "astro": "^3.0.0 || ^4.0.0 || ^5.0.0-beta.0",
     "tailwindcss": "^3.0.24"
   },
   "publishConfig": {


### PR DESCRIPTION
## Changes

- Updates the `peerDependency` range so Tailwind can be installed in a 5.0 beta project.

## Testing

- not really

## Docs

N/A, bug fix