### PR TITLE
Lazily initialize the md and mdx processor

### DIFF
--- a/.changeset/heavy-pugs-jam.md
+++ b/.changeset/heavy-pugs-jam.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Initializes the Markdown processor only when there's `.md` files

--- a/.changeset/moody-cougars-taste.md
+++ b/.changeset/moody-cougars-taste.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Initializes the MDX processor only when there's `.mdx` files


### PR DESCRIPTION
## Changes

close https://github.com/withastro/astro/issues/12015

I don't particular understand how the issue happen in the first place, but after reading the code, it looks like there's a perf opportunity to lazily initialize the processors only if there's `.md` or `.mdx` files, so I did that instead and it should also indirectly fix the issue.

## Testing

Existing tests should pass.

## Docs

n/a. refactor.
