### PR TITLE
chore: remove `eslint-plugin-no-only-tests`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -61,6 +61,16 @@
           "lineWidth": 1
         }
       }
+    },
+    {
+      "include": ["*.test.js"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noFocusedTests": "error"
+          }
+        }
+      }
     }
   ]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,6 @@ import { builtinModules } from 'node:module';
 import tseslint from 'typescript-eslint';
 
 // plugins
-import noOnlyTestsEslint from 'eslint-plugin-no-only-tests';
 import regexpEslint from 'eslint-plugin-regexp';
 const typescriptEslint = tseslint.plugin;
 
@@ -47,7 +46,6 @@ export default [
 		},
 		plugins: {
 			'@typescript-eslint': typescriptEslint,
-			'no-only-tests': noOnlyTestsEslint,
 			regexp: regexpEslint,
 		},
 		rules: {
@@ -62,7 +60,6 @@ export default [
 					ignoreRestSiblings: true,
 				},
 			],
-			'no-only-tests/no-only-tests': 'error',
 			'@typescript-eslint/no-shadow': 'error',
 			'no-console': 'warn',
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@types/node": "^18.17.8",
     "esbuild": "^0.21.5",
     "eslint": "^9.10.0",
-    "eslint-plugin-no-only-tests": "^3.3.0",
     "eslint-plugin-regexp": "^2.6.0",
     "globby": "^14.0.2",
     "only-allow": "^1.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ importers:
       eslint:
         specifier: ^9.10.0
         version: 9.10.0(jiti@1.21.0)
-      eslint-plugin-no-only-tests:
-        specifier: ^3.3.0
-        version: 3.3.0
       eslint-plugin-regexp:
         specifier: ^2.6.0
         version: 2.6.0(eslint@9.10.0(jiti@1.21.0))
@@ -8192,10 +8189,6 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  eslint-plugin-no-only-tests@3.3.0:
-    resolution: {integrity: sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==}
-    engines: {node: '>=5.0.0'}
-
   eslint-plugin-regexp@2.6.0:
     resolution: {integrity: sha512-FCL851+kislsTEQEMioAlpDuK5+E5vs0hi1bF8cFlPlHcEjeRhuAzEsGikXRreE+0j4WhW2uO54MqTjXtYOi3A==}
     engines: {node: ^18 || >=20}
@@ -13795,8 +13788,6 @@ snapshots:
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
-
-  eslint-plugin-no-only-tests@3.3.0: {}
 
   eslint-plugin-regexp@2.6.0(eslint@9.10.0(jiti@1.21.0)):
     dependencies:


### PR DESCRIPTION
## Changes

This PR removes `eslint-plugin-no-only-tests`, which is not needed because Biome already has a rule for that, which is enabled in this PR.

## Testing

I locally checked that using `.only` fails the build

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
