### PR TITLE
fix(routing): call middleware when rendering `404.astro`

### DIFF
--- a/.changeset/clever-vans-flash.md
+++ b/.changeset/clever-vans-flash.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where the middleware wasn't called when a project uses `404.astro`.

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -1,6 +1,7 @@
 import type http from 'node:http';
 import type { ComponentInstance, ManifestData, RouteData } from '../@types/astro.js';
 import {
+	DEFAULT_404_COMPONENT,
 	REROUTE_DIRECTIVE_HEADER,
 	REWRITE_DIRECTIVE_HEADER_KEY,
 	clientLocalsSymbol,
@@ -192,13 +193,16 @@ export async function handleRoute({
 
 	mod = preloadedComponent;
 
-	const isPrerendered404 = matchedRoute.route.route === '/404' && matchedRoute.route.prerender;
+	const isDefaultPrerendered404 =
+		matchedRoute.route.route === '/404' &&
+		matchedRoute.route.prerender &&
+		matchedRoute.route.component === DEFAULT_404_COMPONENT;
 
 	renderContext = RenderContext.create({
 		locals,
 		pipeline,
 		pathname,
-		middleware: isPrerendered404 ? undefined : middleware,
+		middleware: isDefaultPrerendered404 ? undefined : middleware,
 		request,
 		routeData: route,
 	});

--- a/packages/astro/test/i18n-routing-manual.test.js
+++ b/packages/astro/test/i18n-routing-manual.test.js
@@ -53,9 +53,9 @@ describe('Dev server manual routing', () => {
 		assert.equal(text.includes('Hola.'), true);
 	});
 
-	it('should not redirect prerendered 404 routes in dev', async () => {
+	it('should call the middleware for 404.astro pages', async () => {
 		const response = await fixture.fetch('/redirect-me');
-		assert.equal(response.status, 404);
+		assert.equal(response.status, 200);
 	});
 });
 


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/12033

The middleware **should** be called for prerendered `404.astro`, but it shouldn't be called for our default 404, because it's not a user component.

## Testing

Updated an existing test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
