### PR TITLE
feat(markdown): add support for `shiki` option `langAlias`

### DIFF
--- a/.changeset/dirty-socks-sip.md
+++ b/.changeset/dirty-socks-sip.md
@@ -3,7 +3,7 @@
 'astro': minor
 ---
 
-Adds a `markdown.shikiConfig.langAlias` option that allows [aliasing a non-supported code language to a known language](https://shiki.style/guide/load-lang#custom-language-aliases). This is useful when the language of your code samples is not [a built-in Shiki language](https://shiki.style/languages), but you want your Markdown source to display an accurate language while also displaying syntax highlighting.
+Adds a `markdown.shikiConfig.langAlias` option that allows [aliasing a non-supported code language to a known language](https://shiki.style/guide/load-lang#custom-language-aliases). This is useful when the language of your code samples is not [a built-in Shiki language](https://shiki.style/languages), but you want your Markdown source to contain an accurate language while also displaying syntax highlighting.
 
 The following example configures Shiki to highlight `cjs` code blocks using the `javascript` syntax highlighter:
 

--- a/.changeset/dirty-socks-sip.md
+++ b/.changeset/dirty-socks-sip.md
@@ -1,0 +1,32 @@
+---
+'@astrojs/markdown-remark': minor
+'astro': minor
+---
+
+Adds a configuration called https://shiki.style/guide/load-lang#custom-language-aliases, that allows a non-supported code language to a known language.
+ 
+The below example will tell shiki to highlight the code blocks `cjs` using the `javascript` syntax highlighting.  
+
+```js
+import { defineConfig } from "astro/config";
+
+export default defineConfig({
+  markdown: {
+    shikiConfig: {
+      langAlias: {
+        cjs: "javascript"
+      }
+    }
+  }
+})
+```
+
+``````md
+```cjs
+"use strict"
+
+function commonJs() {
+    return "I am a commonjs file"
+}
+```
+``````

--- a/.changeset/dirty-socks-sip.md
+++ b/.changeset/dirty-socks-sip.md
@@ -3,9 +3,9 @@
 'astro': minor
 ---
 
-Adds a [`markdown.shikiConfig.langAlias` option](https://shiki.style/guide/load-lang#custom-language-aliases) that allows aliasing a non-supported code language to a known language.
+Adds a `markdown.shikiConfig.langAlias` option that allows [aliasing a non-supported code language to a known language](https://shiki.style/guide/load-lang#custom-language-aliases). This is useful when the language of your code samples is not [a built-in Shiki language](https://shiki.style/languages), but you want your Markdown source to display an accurate language while also displaying syntax highlighting.
 
-For example, the below configuration tells shiki to highlight `cjs` code blocks using the `javascript` syntax highlighter:
+The following example configures Shiki to highlight `cjs` code blocks using the `javascript` syntax highlighter:
 
 ```js
 import { defineConfig } from 'astro/config';
@@ -20,6 +20,8 @@ export default defineConfig({
   },
 });
 ```
+
+Then in your Markdown, you can use the alias as the language for a code block for syntax highlighting:
 
 ````md
 ```cjs

--- a/.changeset/dirty-socks-sip.md
+++ b/.changeset/dirty-socks-sip.md
@@ -3,40 +3,30 @@
 'astro': minor
 ---
 
-Adds a configuration called https://shiki.style/guide/load-lang#custom-language-aliases, that allows a non-supported code language to a known language.
+Adds a [`markdown.shikiConfig.langAlias` option](https://shiki.style/guide/load-lang#custom-language-aliases) that allows aliasing a non-supported code language to a known language.
 
-This option requires `langs` to be defined with the correct values. The option will tell shiki which language to load when mapping the alias.
-
-The below example will tell shiki to highlight the code blocks `cjs` using the `javascript` syntax highlighting, The `langs` list will contain the `javascript` language.  
+For example, the below configuration tells shiki to highlight `cjs` code blocks using the `javascript` syntax highlighter:
 
 ```js
-import { defineConfig } from "astro/config";
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   markdown: {
     shikiConfig: {
       langAlias: {
-        cjs: "javascript"
+        cjs: 'javascript',
       },
-      langs: ['javascript']
-    }
-  }
-})
+    },
+  },
+});
 ```
 
-``````md
+````md
 ```cjs
-"use strict"
+'use strict';
 
 function commonJs() {
-    return "I am a commonjs file"
+  return 'I am a commonjs file';
 }
 ```
-``````
-
-Failing to define `langs` will result in an error:
-
-```
-Error [ShikiError]: Failed to parse Markdown file "undefined":
-Language `cjs` not found, you may need to load it first 
-```
+````

--- a/.changeset/dirty-socks-sip.md
+++ b/.changeset/dirty-socks-sip.md
@@ -4,8 +4,10 @@
 ---
 
 Adds a configuration called https://shiki.style/guide/load-lang#custom-language-aliases, that allows a non-supported code language to a known language.
- 
-The below example will tell shiki to highlight the code blocks `cjs` using the `javascript` syntax highlighting.  
+
+This option requires `langs` to be defined with the correct values. The option will tell shiki which language to load when mapping the alias.
+
+The below example will tell shiki to highlight the code blocks `cjs` using the `javascript` syntax highlighting, The `langs` list will contain the `javascript` language.  
 
 ```js
 import { defineConfig } from "astro/config";
@@ -15,7 +17,8 @@ export default defineConfig({
     shikiConfig: {
       langAlias: {
         cjs: "javascript"
-      }
+      },
+      langs: ['javascript']
     }
   }
 })
@@ -30,3 +33,10 @@ function commonJs() {
 }
 ```
 ``````
+
+Failing to define `langs` will result in an error:
+
+```
+Error [ShikiError]: Failed to parse Markdown file "undefined":
+Language `cjs` not found, you may need to load it first 
+```

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -311,6 +311,10 @@ export const AstroConfigSchema = z.object({
 							return langs;
 						})
 						.default([]),
+					langAlias: z
+						.record(z.string(), z.string())
+						.optional()
+						.default(ASTRO_CONFIG_DEFAULTS.markdown.shikiConfig.langAlias!),
 					theme: z
 						.enum(Object.keys(bundledThemes) as [BuiltinTheme, ...BuiltinTheme[]])
 						.or(z.custom<ShikiTheme>())

--- a/packages/markdown/remark/src/index.ts
+++ b/packages/markdown/remark/src/index.ts
@@ -37,6 +37,7 @@ export const markdownConfigDefaults: Required<AstroMarkdownOptions> = {
 		themes: {},
 		wrap: false,
 		transformers: [],
+		langAlias: {},
 	},
 	remarkPlugins: [],
 	rehypePlugins: [],

--- a/packages/markdown/remark/src/shiki.ts
+++ b/packages/markdown/remark/src/shiki.ts
@@ -48,12 +48,7 @@ export async function createShikiHighlighter({
 	langAlias = {},
 }: ShikiConfig = {}): Promise<ShikiHighlighter> {
 	theme = theme === 'css-variables' ? cssVariablesTheme() : theme;
-	const aliasKeys = [];
 
-	for (const [fromLang, toLang] of Object.entries(langAlias)) {
-		langs?.push(toLang);
-		aliasKeys.push(fromLang);
-	}
 	const highlighter = await getHighlighter({
 		langs: ['plaintext', ...langs],
 		langAlias,

--- a/packages/markdown/remark/src/shiki.ts
+++ b/packages/markdown/remark/src/shiki.ts
@@ -45,11 +45,18 @@ export async function createShikiHighlighter({
 	defaultColor,
 	wrap = false,
 	transformers = [],
+	langAlias = {},
 }: ShikiConfig = {}): Promise<ShikiHighlighter> {
 	theme = theme === 'css-variables' ? cssVariablesTheme() : theme;
+	const aliasKeys = [];
 
+	for (const [fromLang, toLang] of Object.entries(langAlias)) {
+		langs?.push(toLang);
+		aliasKeys.push(fromLang);
+	}
 	const highlighter = await getHighlighter({
 		langs: ['plaintext', ...langs],
+		langAlias,
 		themes: Object.values(themes).length ? Object.values(themes) : [theme],
 	});
 

--- a/packages/markdown/remark/src/shiki.ts
+++ b/packages/markdown/remark/src/shiki.ts
@@ -57,14 +57,17 @@ export async function createShikiHighlighter({
 
 	return {
 		async highlight(code, lang = 'plaintext', options) {
+			const resolvedLang = langAlias[lang] ?? lang;
 			const loadedLanguages = highlighter.getLoadedLanguages();
 
-			if (!isSpecialLang(lang) && !loadedLanguages.includes(lang)) {
+			if (!isSpecialLang(lang) && !loadedLanguages.includes(resolvedLang)) {
 				try {
-					await highlighter.loadLanguage(lang as BundledLanguage);
+					await highlighter.loadLanguage(resolvedLang as BundledLanguage);
 				} catch (_err) {
+					const langStr =
+						lang === resolvedLang ? `"${lang}"` : `"${lang}" (aliased to "${resolvedLang}")`;
 					console.warn(
-						`[Shiki] The language "${lang}" doesn't exist, falling back to "plaintext".`,
+						`[Shiki] The language ${langStr} doesn't exist, falling back to "plaintext".`,
 					);
 					lang = 'plaintext';
 				}
@@ -122,7 +125,7 @@ export async function createShikiHighlighter({
 							// Add "user-select: none;" for "+"/"-" diff symbols.
 							// Transform `<span class="line"><span style="...">+ something</span></span>
 							// into      `<span class="line"><span style="..."><span style="user-select: none;">+</span> something</span></span>`
-							if (lang === 'diff') {
+							if (resolvedLang === 'diff') {
 								const innerSpanNode = node.children[0];
 								const innerSpanTextNode =
 									innerSpanNode?.type === 'element' && innerSpanNode.children?.[0];

--- a/packages/markdown/remark/src/types.ts
+++ b/packages/markdown/remark/src/types.ts
@@ -2,10 +2,12 @@ import type * as hast from 'hast';
 import type * as mdast from 'mdast';
 import type { Options as RemarkRehypeOptions } from 'remark-rehype';
 import type {
+	BuiltinLanguage,
 	BuiltinTheme,
 	HighlighterCoreOptions,
 	LanguageRegistration,
 	ShikiTransformer,
+	SpecialLanguage,
 	ThemeRegistration,
 	ThemeRegistrationRaw,
 } from 'shiki';

--- a/packages/markdown/remark/src/types.ts
+++ b/packages/markdown/remark/src/types.ts
@@ -2,12 +2,10 @@ import type * as hast from 'hast';
 import type * as mdast from 'mdast';
 import type { Options as RemarkRehypeOptions } from 'remark-rehype';
 import type {
-	BuiltinLanguage,
 	BuiltinTheme,
 	HighlighterCoreOptions,
 	LanguageRegistration,
 	ShikiTransformer,
-	SpecialLanguage,
 	ThemeRegistration,
 	ThemeRegistrationRaw,
 } from 'shiki';
@@ -39,7 +37,7 @@ export type RemarkRehype = RemarkRehypeOptions;
 export type ThemePresets = BuiltinTheme | 'css-variables';
 
 export interface ShikiConfig {
-	langs?: (LanguageRegistration | BuiltinLanguage | SpecialLanguage)[];
+	langs?: LanguageRegistration[];
 	langAlias?: HighlighterCoreOptions['langAlias'];
 	theme?: ThemePresets | ThemeRegistration | ThemeRegistrationRaw;
 	themes?: Record<string, ThemePresets | ThemeRegistration | ThemeRegistrationRaw>;

--- a/packages/markdown/remark/src/types.ts
+++ b/packages/markdown/remark/src/types.ts
@@ -3,6 +3,7 @@ import type * as mdast from 'mdast';
 import type { Options as RemarkRehypeOptions } from 'remark-rehype';
 import type {
 	BuiltinTheme,
+	HighlighterCoreOptions,
 	LanguageRegistration,
 	ShikiTransformer,
 	ThemeRegistration,
@@ -36,7 +37,8 @@ export type RemarkRehype = RemarkRehypeOptions;
 export type ThemePresets = BuiltinTheme | 'css-variables';
 
 export interface ShikiConfig {
-	langs?: LanguageRegistration[];
+	langs?: (LanguageRegistration | string)[];
+	langAlias?: HighlighterCoreOptions['langAlias'];
 	theme?: ThemePresets | ThemeRegistration | ThemeRegistrationRaw;
 	themes?: Record<string, ThemePresets | ThemeRegistration | ThemeRegistrationRaw>;
 	defaultColor?: 'light' | 'dark' | string | false;

--- a/packages/markdown/remark/src/types.ts
+++ b/packages/markdown/remark/src/types.ts
@@ -37,7 +37,7 @@ export type RemarkRehype = RemarkRehypeOptions;
 export type ThemePresets = BuiltinTheme | 'css-variables';
 
 export interface ShikiConfig {
-	langs?: (LanguageRegistration | string)[];
+	langs?: (LanguageRegistration | BuiltinLanguage | SpecialLanguage)[];
 	langAlias?: HighlighterCoreOptions['langAlias'];
 	theme?: ThemePresets | ThemeRegistration | ThemeRegistrationRaw;
 	themes?: Record<string, ThemePresets | ThemeRegistration | ThemeRegistrationRaw>;

--- a/packages/markdown/remark/test/shiki.test.js
+++ b/packages/markdown/remark/test/shiki.test.js
@@ -107,7 +107,7 @@ describe('shiki syntax highlighting', () => {
 			langAlias: {
 				cjs: 'javascript',
 			},
-			langs: ['javascript']
+			langs: ['javascript'],
 		});
 
 		const html = await highlighter.highlight(`let test = "some string"`, 'cjs', {
@@ -123,7 +123,7 @@ describe('shiki syntax highlighting', () => {
 				langAlias: {
 					cjs: 'javascript',
 				},
-				langs: ['javascript']
+				langs: ['javascript'],
 			},
 		});
 

--- a/packages/markdown/remark/test/shiki.test.js
+++ b/packages/markdown/remark/test/shiki.test.js
@@ -107,6 +107,7 @@ describe('shiki syntax highlighting', () => {
 			langAlias: {
 				cjs: 'javascript',
 			},
+			langs: ['javascript']
 		});
 
 		const html = await highlighter.highlight(`let test = "some string"`, 'cjs', {
@@ -122,6 +123,7 @@ describe('shiki syntax highlighting', () => {
 				langAlias: {
 					cjs: 'javascript',
 				},
+				langs: ['javascript']
 			},
 		});
 

--- a/packages/markdown/remark/test/shiki.test.js
+++ b/packages/markdown/remark/test/shiki.test.js
@@ -107,7 +107,6 @@ describe('shiki syntax highlighting', () => {
 			langAlias: {
 				cjs: 'javascript',
 			},
-			langs: ['javascript'],
 		});
 
 		const html = await highlighter.highlight(`let test = "some string"`, 'cjs', {
@@ -123,7 +122,6 @@ describe('shiki syntax highlighting', () => {
 				langAlias: {
 					cjs: 'javascript',
 				},
-				langs: ['javascript'],
 			},
 		});
 

--- a/packages/markdown/remark/test/shiki.test.js
+++ b/packages/markdown/remark/test/shiki.test.js
@@ -101,4 +101,32 @@ describe('shiki syntax highlighting', () => {
 		// Doesn't have `color` or `background-color` properties.
 		assert.doesNotMatch(code, /color:/);
 	});
+
+	it('the highlighter supports lang alias', async () => {
+		const highlighter = await createShikiHighlighter({
+			langAlias: {
+				cjs: 'javascript',
+			},
+		});
+
+		const html = await highlighter.highlight(`let test = "some string"`, 'cjs', {
+			attributes: { 'data-foo': 'bar', autofocus: true },
+		});
+
+		assert.match(html, /data-language="cjs"/);
+	});
+
+	it('the markdown processsor support lang alias', async () => {
+		const processor = await createMarkdownProcessor({
+			shikiConfig: {
+				langAlias: {
+					cjs: 'javascript',
+				},
+			},
+		});
+
+		const { code } = await processor.render('```cjs\nlet foo = "bar"\n```');
+
+		assert.match(code, /data-language="cjs"/);
+	});
 });


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/roadmap/discussions/954

This PR adds support for [`langAlias`](https://shiki.style/guide/load-lang#custom-language-aliases)

## Testing

I added new tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

https://github.com/withastro/docs/pull/9453

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
