### PR TITLE
View Transitions: Fixes Astro's fade animation to prevent flicker during morph transitions

### DIFF
--- a/.changeset/fifty-squids-build.md
+++ b/.changeset/fifty-squids-build.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+View transitions: Fixes Astro's fade animation to prevent flashing during morph transitions.

--- a/packages/astro/components/viewtransitions.css
+++ b/packages/astro/components/viewtransitions.css
@@ -10,12 +10,22 @@
 @keyframes astroFadeIn {
 	from {
 		opacity: 0;
+		mix-blend-mode: plus-lighter;
+	}
+	to {
+		opacity: 1;
+		mix-blend-mode: plus-lighter;
 	}
 }
 
 @keyframes astroFadeOut {
+	from {
+		opacity: 1;
+		mix-blend-mode: plus-lighter;
+	}
 	to {
 		opacity: 0;
+		mix-blend-mode: plus-lighter;
 	}
 }
 


### PR DESCRIPTION
## Changes

Adds `mix-blend-mode: plus-lighter` to Astro's fade transitions 
Fixes #12045

## Testing

manually tested

## Docs

n.a. / bug fix
