### PR TITLE
Release a beta for Svelte and Vue

### DIFF
--- a/.changeset/heavy-peas-sneeze.md
+++ b/.changeset/heavy-peas-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/svelte': patch
+'@astrojs/vue': patch
+---
+
+Makes compatible with Astro 5

--- a/.changeset/heavy-peas-sneeze.md
+++ b/.changeset/heavy-peas-sneeze.md
@@ -1,6 +1,6 @@
 ---
-'@astrojs/svelte': patch
-'@astrojs/vue': patch
+'@astrojs/svelte': major
+'@astrojs/vue': major
 ---
 
 Updates peer dependency range to support Astro 5

--- a/.changeset/heavy-peas-sneeze.md
+++ b/.changeset/heavy-peas-sneeze.md
@@ -3,4 +3,4 @@
 '@astrojs/vue': patch
 ---
 
-Makes compatible with Astro 5
+Updates peer dependency range to support Astro 5


### PR DESCRIPTION
## Changes

Svelte and Vue peer deps are only looking for Astro 4, by releasing a beta of them, you can now use the beta of them with Astro 5

Fix https://github.com/withastro/astro/issues/12059

## Testing

N/A

## Docs

N/A
