### PR TITLE
fix: check origin in static build

### DIFF
--- a/.changeset/tame-pumpkins-swim.md
+++ b/.changeset/tame-pumpkins-swim.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where the check origin middleware was incorrectly injected when the build output was `"static"`

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -540,7 +540,7 @@ function createBuildManifest(
 				onRequest: middleware,
 			};
 		},
-		checkOrigin: settings.config.security?.checkOrigin ?? false,
+		checkOrigin: (settings.config.security?.checkOrigin && settings.buildOutput === "server") ?? false,
 		key,
 		envGetSecretEnabled: false,
 	};

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -270,7 +270,7 @@ function buildManifest(
 		assets: staticFiles.map(prefixAssetPath),
 		i18n: i18nManifest,
 		buildFormat: settings.config.build.format,
-		checkOrigin: settings.config.security?.checkOrigin ?? false,
+		checkOrigin: (settings.config.security?.checkOrigin && settings.buildOutput === "server") ?? false,
 		serverIslandNameMap: Array.from(settings.serverIslandNameMap),
 		key: encodedKey,
 		envGetSecretEnabled:

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -160,7 +160,7 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 		componentMetadata: new Map(),
 		inlinedScripts: new Map(),
 		i18n: i18nManifest,
-		checkOrigin: settings.config.security?.checkOrigin ?? false,
+		checkOrigin: (settings.config.security?.checkOrigin && settings.buildOutput === "server") ?? false,
 		envGetSecretEnabled: false,
 		key: createKey(),
 		middleware() {

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -60,6 +60,7 @@ export default function createVitePluginAstroServer({
 						await createRouteManifest({ settings, fsMod }, logger), // TODO: Handle partial updates to the manifest
 					);
 					warnMissingAdapter(logger, settings);
+					pipeline.manifest.checkOrigin = settings.config.security.checkOrigin && settings.buildOutput === "server";
 					pipeline.setManifestData(routeManifest);
 				}
 			}


### PR DESCRIPTION
## Changes

The `checkOrigin` manifest flag was always `true`, because it didn't check the `buildOutput` flag.

Fixes https://github.com/withastro/astro/issues/12069

## Testing

CI Should pass. Tested manually using a basic project.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
