### PR TITLE
feat: makes it so astro add does not set output server by default

### DIFF
--- a/.changeset/smooth-panthers-heal.md
+++ b/.changeset/smooth-panthers-heal.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+`astro add` no longer automatically sets `output: 'server'`. Since the default value of output now allows for server-rendered pages, it no longer makes sense to default to full server builds when you add an adapter

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -463,10 +463,6 @@ export function setAdapter(
 		});
 	}
 
-	if (!config.output) {
-		config.output = 'server';
-	}
-
 	switch (adapter.id) {
 		case 'node':
 			config.adapter = builders.functionCall(adapterId, { mode: 'standalone' });


### PR DESCRIPTION
## Changes

What the title says

## Testing

N/A. Just a line removed.

## Docs

It's not a breaking change, since this well, you don't depend on this output, but the docs changes related to SSG / SSR will somewhat touch on this.
