### PR TITLE
Update compile.ts Deals with Hydration directive error

### DIFF
--- a/packages/astro/src/vite-plugin-astro/compile.ts
+++ b/packages/astro/src/vite-plugin-astro/compile.ts
@@ -34,6 +34,17 @@ export async function compileAstro({
 
 	try {
 		transformResult = await compile(compileProps);
+
+		// Check for client: hydration directives in the compiled JSX structure
+		const hasHydrationDirective = transformResult.code.includes('client:');
+		if (hasHydrationDirective) {			
+			// Optionally log a warning or error for devs
+			logger.warn(
+				null,
+				`Hydration directive found in ${compileProps.filename}. Astro components should not use client-side rendering.`
+			);			
+		}
+		
 		// Compile all TypeScript to JavaScript.
 		// Also, catches invalid JS/TS in the compiled output before returning.
 		esbuildResult = await transformWithEsbuild(transformResult.code, compileProps.filename, {


### PR DESCRIPTION
## Changes

-The following changes solves issue number 11623.
Closes https://github.com/withastro/astro/issues/11623
-The command npm run build now prints the error message that it printed in Developement.
-Updated compile.ts file in astro\packages\astro\src\vite-plugin-astro\compile.ts line 38-46

before
![image](https://github.com/user-attachments/assets/336948d2-17d7-4b28-a8b8-8b5b8c590ff8)

after
![image](https://github.com/user-attachments/assets/5cdb4bf2-95ec-46ce-9581-9f4df9fe7c24)


## Testing

<!-- How was this change tested? -->
I recreated the error with the guidence of the issue page.  added a Header and called it in the index <Header client:idle /> recreated both dev and production error. then changed the file compile.ts retested it and now get the error I got in dev mode in production
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
I dont belive fixing an error line should need to be in the docs.
<!-- https://github.com/withastro/docs -->
