### PR TITLE
Adds missing filePath property on content layer entries

### DIFF
--- a/.changeset/afraid-candles-hear.md
+++ b/.changeset/afraid-candles-hear.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Adds missing filePath property on content layer entries

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -497,7 +497,7 @@ async function writeContentFiles({
 				contentTypesStr += `};\n`;
 				break;
 			case CONTENT_LAYER_TYPE:
-				dataTypesStr += `${collectionKey}: Record<string, {\n  id: string;\n  collection: ${collectionKey};\n  data: ${dataType};\n  rendered?: RenderedContent \n}>;\n`;
+				dataTypesStr += `${collectionKey}: Record<string, {\n  id: string;\n  collection: ${collectionKey};\n  data: ${dataType};\n  rendered?: RenderedContent;\n  filePath?: string \n}>;\n`;
 				break;
 			case 'data':
 				if (collectionEntryKeys.length === 0) {


### PR DESCRIPTION
## Changes

Entries can (and often do) have a filePath property. It'd be great if it knew for sure that it existed for loaders that have it, but aalas, that's not how the world works.

## Testing

Tested manually

## Docs

N/A
