### PR TITLE
Restart on lock file changes

### DIFF
--- a/.changeset/good-geese-run.md
+++ b/.changeset/good-geese-run.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Restart dev server on lockfile change

--- a/packages/astro/src/core/config/settings.ts
+++ b/packages/astro/src/core/config/settings.ts
@@ -121,7 +121,15 @@ export async function createSettings(config: AstroConfig, cwd?: string): Promise
 
 	let watchFiles = [];
 	if (cwd) {
-		watchFiles.push(fileURLToPath(new URL('./package.json', pathToFileURL(cwd))));
+		// We don't official support Bun, Yarn Berry, and Yarn 1 should not be used by anyone.
+		// Ok to add other obscure package managers.
+		const packageFiles = ['package.json', 'package-lock.json', 'pnpm-lock.yaml'];
+
+		for(const file of packageFiles) {
+			const rel = `./${file}`;
+			const url = new URL(rel, pathToFileURL(cwd));
+			watchFiles.push(fileURLToPath(url));
+		}
 	}
 
 	if (typeof tsconfig !== 'string') {


### PR DESCRIPTION
## Changes

- Adds common package lock files to the list of files to watch for trigger a dev server restart.

## Testing

- New unit test case added

## Docs

N/A