### PR TITLE
Use IE conditional comment placeholders for server island start markers

### DIFF
--- a/.changeset/rich-apes-divide.md
+++ b/.changeset/rich-apes-divide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Server islands: changes the server island HTML placeholder comment so that it is much less likely to get removed by HTML minifiers.

--- a/packages/astro/src/runtime/server/render/server-islands.ts
+++ b/packages/astro/src/runtime/server/render/server-islands.ts
@@ -47,7 +47,7 @@ export function renderServerIsland(
 				}
 			}
 
-			destination.write('<!--server-island-start-->');
+			destination.write('<!--[if astro]>server-island-start<![endif]-->');
 
 			// Render the slots
 			const renderedSlots: Record<string, string> = {};
@@ -88,7 +88,7 @@ if(response.status === 200 && response.headers.get('content-type') === 'text/htm
 	// Swap!
 	while(script.previousSibling &&
 		script.previousSibling.nodeType !== 8 &&
-		script.previousSibling.data !== 'server-island-start') {
+		script.previousSibling.data !== '[if astro]>server-island-start<![endif]') {
 		script.previousSibling.remove();
 	}
 	script.previousSibling?.remove();


### PR DESCRIPTION
## Changes

fixes #11995

cc: @matthewp — we talked about this on Twitter.

Swaps the generic HTML comment placeholders with IE conditional comments. These placeholders have existed for a long time, and are much less likely to be removed by HTML minifiers, because they have traditionally been used to change the behavior of a site.

A similar fix was implemented in [Livewire](https://github.com/livewire/livewire/commit/b666304652006f3491987c92d53724bc14035d6a) to work around Cloudflare HTML minification removing the HTML comment placeholders Livewire was inserting for a similar purpose.

## Testing

No tests changed, since it's just changing the content of an HTML comment. I haven't been able to set up the original commenter's complete environment for a complete fix verification, but I did look at the source code for the minifier library they were using, and that library has code to not remove IE conditional comments.

## Docs

No documentation needed... the feature should just work more reliably now when Astro output is touched by HTML minifiers.