### PR TITLE
Fix non-stable versions for astro add

### DIFF
--- a/.changeset/real-nails-tan.md
+++ b/.changeset/real-nails-tan.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix installing non-stable versions of integrations with `astro add`

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -608,7 +608,8 @@ async function resolveRangeToInstallSpecifier(name: string, range: string): Prom
 	if (versions instanceof Error) return name;
 	// Filter out any prerelease versions, but fallback if there are no stable versions
 	const stableVersions = versions.filter((v) => !v.includes('-'));
-	const maxStable = maxSatisfying(stableVersions.length !== 0 ? stableVersions : versions, range);
+	const maxStable = maxSatisfying(stableVersions, range) ?? maxSatisfying(versions, range);
+	if (!maxStable) return name;
 	return `${name}@^${maxStable}`;
 }
 


### PR DESCRIPTION
## Changes

- Fix installing non-stable versions of packages with `astro add`. For example, `astro add node@beta`

## Testing

Manually. No tests exist yet for `astro add`.

## Docs

No change required
