### PR TITLE
ci: Update the next tag when a alpha/beta release is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
           # Needs access to publish to npm
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Update next npm tag
+        if: steps.changesets.outputs.published == 'true' && github.ref == 'refs/heads/next' && contains(steps.changesets.outputs.publishedPackages.*.name, 'astro')
+        run: npm dist-tag astro@${{ steps.changesets.outputs.publishedPackages.astro.version }} next
+
       - name: Generate Announcement
         id: message
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Changes

This makes it so `astro@next` always point to the latest release of the `next` branch. This makes it a bit more easier for users to update between alphas to beta etc as they can always just `npm install astro@next`. In the future, this could also power nightly or canaries versions perhaps.
 
Right now this only updates `astro`, it could be extended to support every integration if we deem it necessary
 
## Testing

It won't work, it's GitHub Actions

## Docs

N/A