### PR TITLE
fix: defer check for schema references to content layer collections

### DIFF
--- a/.changeset/bright-swans-shout.md
+++ b/.changeset/bright-swans-shout.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes error where references in content layer schemas sometimes incorrectly report as missing

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -599,16 +599,9 @@ export function createReference({ lookupMap }: { lookupMap: ContentLookupMap }) 
 							});
 							return;
 						}
+						// We won't throw if the collection is missing, because it may be a content layer collection and the store may not yet be populated.
+						// If it is an object then we're validating later in the build, so we can check the collection at that point.
 
-						// A reference object might refer to an invalid collection, because when we convert it we don't have access to the store.
-						// If it is an object then we're validating later in the pipeline, so we can check the collection at that point.
-						if (!lookupMap[collection] && !collectionIsInStore) {
-							ctx.addIssue({
-								code: ZodIssueCode.custom,
-								message: `**${flattenedErrorPath}:** Reference to ${collection} invalid. Collection does not exist or is empty.`,
-							});
-							return;
-						}
 						return lookup;
 					}
 
@@ -624,8 +617,9 @@ export function createReference({ lookupMap }: { lookupMap: ContentLookupMap }) 
 						return { id: lookup, collection };
 					}
 
-					if (!lookupMap[collection] && store.collections().size === 0) {
+					if (!lookupMap[collection] && store.collections().size < 2) {
 						// If the collection is not in the lookup map or store, it may be a content layer collection and the store may not yet be populated.
+						// The store may still have a single collection, which would be the top level metadata collection.
 						// For now, we can't validate this reference, so we'll optimistically convert it to a reference object which we'll validate
 						// later in the pipeline when we do have access to the store.
 						return { id: lookup, collection };

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -616,10 +616,10 @@ export function createReference({ lookupMap }: { lookupMap: ContentLookupMap }) 
 						}
 						return { id: lookup, collection };
 					}
-
-					if (!lookupMap[collection] && store.collections().size < 2) {
-						// If the collection is not in the lookup map or store, it may be a content layer collection and the store may not yet be populated.
-						// The store may still have a single collection, which would be the top level metadata collection.
+					// If the collection is not in the lookup map or store, it may be a content layer collection and the store may not yet be populated.
+					// If the store has 0 or 1 entries it probably means that the entries have not yet been loaded.
+					// The store may have a single entry even if the collections have not loaded, because the top-level metadata collection is generated early.
+					if (!lookupMap[collection] && store.collections().size <= 1) {
 						// For now, we can't validate this reference, so we'll optimistically convert it to a reference object which we'll validate
 						// later in the pipeline when we do have access to the store.
 						return { id: lookup, collection };


### PR DESCRIPTION
## Changes

When using references in schemas that refer to content layer there was sometimes a race condition causing them to incorrectly report as missing. We already checked for empty collections which may not have loaded yet, but were missing this case where even the stubbed collection had not been created. The fix is just to remove this particular error. It's ok because we still have a check later when querying, which will still give a helpful error message if the collection is missing. I did spend some time trying to see if I can get the collection list early enough to check, but there are too many race conditions and I think this approach is ok.

Fixes #12087

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
