### PR TITLE
Fix-component-undefined-svelte-v5

### DIFF
--- a/.changeset/eighty-ligers-punch.md
+++ b/.changeset/eighty-ligers-punch.md
@@ -2,4 +2,4 @@
 '@astrojs/svelte': patch
 ---
 
-- fix: 'component is not defined' error when unmount svelte 5 component
+Fixes an Reference Error that occurred during client transitions

--- a/.changeset/eighty-ligers-punch.md
+++ b/.changeset/eighty-ligers-punch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/svelte': patch
+---
+
+- fix: 'component is not defined' error when unmount svelte 5 component

--- a/packages/integrations/svelte/client-v5.js
+++ b/packages/integrations/svelte/client-v5.js
@@ -23,6 +23,7 @@ export default (element) => {
 		}
 
 		const bootstrap = client !== 'only' ? hydrate : mount;
+		let component = null;
 		if (existingApplications.has(element)) {
 			existingApplications.get(element).$set({
 				...props,
@@ -30,7 +31,7 @@ export default (element) => {
 				$$slots,
 			});
 		} else {
-			const component = bootstrap(Component, {
+			component = bootstrap(Component, {
 				target: element,
 				props: {
 					...props,
@@ -41,6 +42,6 @@ export default (element) => {
 			existingApplications.set(element, component);
 		}
 
-		element.addEventListener('astro:unmount', () => unmount(component), { once: true });
+		element.addEventListener('astro:unmount', () => component && unmount(component), { once: true });
 	};
 };

--- a/packages/integrations/svelte/client-v5.js
+++ b/packages/integrations/svelte/client-v5.js
@@ -23,7 +23,6 @@ export default (element) => {
 		}
 
 		const bootstrap = client !== 'only' ? hydrate : mount;
-		let component = null;
 		if (existingApplications.has(element)) {
 			existingApplications.get(element).$set({
 				...props,
@@ -31,7 +30,7 @@ export default (element) => {
 				$$slots,
 			});
 		} else {
-			component = bootstrap(Component, {
+			const component = bootstrap(Component, {
 				target: element,
 				props: {
 					...props,
@@ -40,8 +39,7 @@ export default (element) => {
 				},
 			});
 			existingApplications.set(element, component);
+			element.addEventListener('astro:unmount', () => unmount(component), { once: true });
 		}
-
-		element.addEventListener('astro:unmount', () => component && unmount(component), { once: true });
 	};
 };


### PR DESCRIPTION
## Changes

Small code enhancement, which is easy to understand.

- Fix 'component is not defined' console error when unmounting svelte 5 component.

Console error: ![Screenshot 2024-10-01 110532](https://github.com/user-attachments/assets/0e198f57-2f66-4787-a5ed-c79f41a63678)
## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Defensive code added and tested locally.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
