### PR TITLE
fix: pass custom statusText in Response

### DIFF
--- a/.changeset/moody-doors-wink.md
+++ b/.changeset/moody-doors-wink.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Returns custom statusText that has been set in a Response

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -107,7 +107,8 @@ export class NodeApp extends App {
 	 * @param destination NodeJS ServerResponse
 	 */
 	static async writeResponse(source: Response, destination: ServerResponse) {
-		const { status, headers, body } = source;
+		const { status, headers, body, statusText } = source;
+		destination.statusMessage = statusText;
 		destination.writeHead(status, createOutgoingHttpHeaders(headers));
 		if (!body) return destination.end();
 		try {

--- a/packages/astro/src/vite-plugin-astro-server/response.ts
+++ b/packages/astro/src/vite-plugin-astro-server/response.ts
@@ -53,7 +53,7 @@ export function writeHtmlResponse(res: http.ServerResponse, statusCode: number, 
 }
 
 export async function writeWebResponse(res: http.ServerResponse, webResponse: Response) {
-	const { status, headers, body } = webResponse;
+	const { status, headers, body, statusText } = webResponse;
 
 	// Attach any set-cookie headers added via Astro.cookies.set()
 	const setCookieHeaders = Array.from(getSetCookiesFromResponse(webResponse));
@@ -67,7 +67,7 @@ export async function writeWebResponse(res: http.ServerResponse, webResponse: Re
 	if (headers.has('set-cookie')) {
 		_headers['set-cookie'] = headers.getSetCookie();
 	}
-
+	res.statusMessage = statusText;
 	res.writeHead(status, _headers);
 	if (body) {
 		if (Symbol.for('astro.responseBody') in webResponse) {

--- a/packages/astro/test/fixtures/ssr-api-route/src/pages/food.json.js
+++ b/packages/astro/test/fixtures/ssr-api-route/src/pages/food.json.js
@@ -5,14 +5,19 @@ export function GET() {
 			{ name: 'lettuce' },
 			{ name: 'broccoli' },
 			{ name: 'pizza' }
-		])
+		]), {
+			status: 200,
+			statusText: `tasty`,
+		}
 	)
 }
 
 export async function POST({ params, request }) {
 	const body = await request.text();
-	return new Response(body === `some data` ? `ok` : `not ok`, {
-		status: 200,
+	const ok = body === `some data`
+	return new Response( ok ? `ok` : `not ok`, {
+		status: ok ? 200 : 400,
+		statusText: ok ? `ok` : `not ok`,
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded'
 		}

--- a/packages/astro/test/ssr-api-route.test.js
+++ b/packages/astro/test/ssr-api-route.test.js
@@ -33,6 +33,7 @@ describe('API routes in SSR', () => {
 			const request = new Request('http://example.com/food.json');
 			const response = await app.render(request);
 			assert.equal(response.status, 200);
+			assert.equal(response.statusText, 'tasty');
 			const body = await response.json();
 			assert.equal(body.length, 3);
 		});
@@ -76,6 +77,17 @@ describe('API routes in SSR', () => {
 			assert.equal(response.status, 200);
 			const text = await response.text();
 			assert.equal(text, 'ok');
+		});
+
+		it('Can read custom status text from API routes', async () => {
+			const response = await fixture.fetch('/food.json', {
+				method: 'POST',
+				body: `not some data`,
+			});
+			assert.equal(response.status, 400);
+			assert.equal(response.statusText, 'not ok');
+			const text = await response.text();
+			assert.equal(text, 'not ok');
 		});
 
 		it('Can be passed binary data from multipart formdata', async () => {


### PR DESCRIPTION
## Changes

The `Response` spec allows a custom `statusText` to be defined, which should be sent in the HTTP response. Currently we're not passing this in our response. This PR fixes this in dev and NodeApp. Other adapters will use their native Response handling.

Fixes #9401

## Testing

Added test cases

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
