### PR TITLE
use shorthash for data url image to prevent ENAMETOOLONG

### DIFF
--- a/.changeset/dull-worms-own.md
+++ b/.changeset/dull-worms-own.md
@@ -1,5 +1,5 @@
 ---
-'astro': minor
+'astro': patch
 ---
 
-use shorthash for data url image output filename to prevent ENAMETOOLONG
+use shorthash for data url image output filename to prevent ENAMETOOLONG when optimizing images

--- a/.changeset/dull-worms-own.md
+++ b/.changeset/dull-worms-own.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-use shorthash for data url image output filename to prevent ENAMETOOLONG when optimizing images
+Fixes a bug where [data URL images](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data) were not correctly handled. The bug resulted in an `ENAMETOOLONG` error.

--- a/.changeset/dull-worms-own.md
+++ b/.changeset/dull-worms-own.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+use shorthash for data url image output filename to prevent ENAMETOOLONG

--- a/packages/astro/src/assets/utils/transformToPath.ts
+++ b/packages/astro/src/assets/utils/transformToPath.ts
@@ -8,7 +8,11 @@ import { isESMImportedImage } from './imageKind.js';
 export function propsToFilename(filePath: string, transform: ImageTransform, hash: string) {
 	let filename = decodeURIComponent(removeQueryString(filePath));
 	const ext = extname(filename);
-	filename = basename(filename, ext);
+	if (filePath.startsWith('data:')) {
+		filename = shorthash(filePath);
+	} else {
+		filename = basename(filename, ext);
+	}
 	const prefixDirname = isESMImportedImage(transform.src) ? dirname(filePath) : '';
 
 	let outputExt = transform.format ? `.${transform.format}` : ext;

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -1284,9 +1284,9 @@ describe('astro:image', () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 			const src1 = $('#data-url img').attr('src');
-			assert.equal(basename(src1.length) < 32, true);
+			assert.equal(basename(src1).length < 32, true);
 			const src2 = $('#data-url-no-size img').attr('src');
-			assert.equal(basename(src2.length) < 32, true);
+			assert.equal(basename(src2).length < 32, true);
 			assert.equal(src1.split('_')[0], src2.split('_')[0]);
 		});
 

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -1263,4 +1263,55 @@ describe('astro:image', () => {
 			assert.equal(imgData instanceof Buffer, true);
 		});
 	});
+
+	describe('build data url', () => {
+		before(async () => {
+			fixture = await loadFixture({
+				root: './fixtures/core-image-data-url/',
+				image: {
+					remotePatterns: [{
+						protocol: 'data'
+					}]
+				}
+			})
+			
+			await fixture.build()
+		})
+
+		it('uses short hash for data url filename', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			const src1 = $('#data-url img').attr('src');
+			assert.equal(basename(src1.length) < 32, true);
+			const src2 = $('#data-url-no-size img').attr('src');
+			assert.equal(basename(src2.length) < 32, true);
+			assert.equal(src1.split('_')[0], src2.split('_')[0])
+		})
+
+		it('adds file extension for data url images', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			const src = $('#data-url img').attr('src');
+			assert.equal(src.endsWith('.webp'), true);
+		})
+
+		it('writes data url images to dist', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			const src = $('#data-url img').attr('src');
+			assert.equal(src.length > 0, true);
+			const data = await fixture.readFile(src, null);
+			assert.equal(data instanceof Buffer, true);
+		})
+		
+		it('infers size of data url images', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			const img = $('#data-url-no-size img');
+			const width = img.attr('width')
+			const height = img.attr('height')
+			assert.equal(width, '256');
+			assert.equal(height, '144');
+		})
+	})
 });

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -1269,14 +1269,16 @@ describe('astro:image', () => {
 			fixture = await loadFixture({
 				root: './fixtures/core-image-data-url/',
 				image: {
-					remotePatterns: [{
-						protocol: 'data'
-					}]
-				}
-			})
-			
-			await fixture.build()
-		})
+					remotePatterns: [
+						{
+							protocol: 'data',
+						},
+					],
+				},
+			});
+
+			await fixture.build();
+		});
 
 		it('uses short hash for data url filename', async () => {
 			const html = await fixture.readFile('/index.html');
@@ -1285,15 +1287,15 @@ describe('astro:image', () => {
 			assert.equal(basename(src1.length) < 32, true);
 			const src2 = $('#data-url-no-size img').attr('src');
 			assert.equal(basename(src2.length) < 32, true);
-			assert.equal(src1.split('_')[0], src2.split('_')[0])
-		})
+			assert.equal(src1.split('_')[0], src2.split('_')[0]);
+		});
 
 		it('adds file extension for data url images', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 			const src = $('#data-url img').attr('src');
 			assert.equal(src.endsWith('.webp'), true);
-		})
+		});
 
 		it('writes data url images to dist', async () => {
 			const html = await fixture.readFile('/index.html');
@@ -1302,16 +1304,16 @@ describe('astro:image', () => {
 			assert.equal(src.length > 0, true);
 			const data = await fixture.readFile(src, null);
 			assert.equal(data instanceof Buffer, true);
-		})
-		
+		});
+
 		it('infers size of data url images', async () => {
 			const html = await fixture.readFile('/index.html');
 			const $ = cheerio.load(html);
 			const img = $('#data-url-no-size img');
-			const width = img.attr('width')
-			const height = img.attr('height')
+			const width = img.attr('width');
+			const height = img.attr('height');
 			assert.equal(width, '256');
 			assert.equal(height, '144');
-		})
-	})
+		});
+	});
 });

--- a/packages/astro/test/fixtures/core-image-data-url/package.json
+++ b/packages/astro/test/fixtures/core-image-data-url/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/core-image-data-url",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}  

--- a/packages/astro/test/fixtures/core-image-data-url/src/pages/index.astro
+++ b/packages/astro/test/fixtures/core-image-data-url/src/pages/index.astro
@@ -1,0 +1,17 @@
+---
+import { Image } from 'astro:assets';
+const data = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAACQCAQAAABNan0aAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QAAKqNIzIAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQflBAsNKgIhYT8HAAAAXklEQVR42u3BMQEAAADCoPVPbQlPoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4G8gnwABm4i4EAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAyMS0wNC0xMVQxMzo0MjowMiswMDowMNhkaiwAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMjEtMDQtMTFUMTM6NDI6MDIrMDA6MDCpOdKQAAAAAElFTkSuQmCC"
+---
+<html>
+<head>
+
+</head>
+<body>
+	<div id="data-url">
+		<Image src={data} alt="transparent" width="128" height="72" />
+	</div>
+	<div id="data-url-no-size">
+		<Image src={data} inferSize={true} alt="transparent" />
+	</div>
+</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2813,6 +2813,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/core-image-data-url:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/core-image-deletion:
     dependencies:
       '@astrojs/markdoc':


### PR DESCRIPTION
## Changes

currently data: urls are treated like normal urls and `basename` is used to get the filename to generate the cache and output files. however this can result in a very long filename depending on where the slashes (which are part of the base64 data) are, possibly resulting in errors.

to prevent this, can instead use a shorthash of the data url as the filename for data url images processed. so the final output image filename will be `[hash of data url]_[hash].[ext]` instead of `[arbitrary basename of data url]_[hash].[ext]`

## Testing

added text fixture which processes data url images which would cause ENAMETOOLONG

## Docs

should have no effect on user behaviour