### PR TITLE
fix(routing): incorrect assumption when loading the middleware

### DIFF
--- a/.changeset/nasty-trains-invite.md
+++ b/.changeset/nasty-trains-invite.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes a regression that was introduced by an internal refactor of how the middleware is loaded by the Astro application. The regression was introduced by [#11550](https://github.com/withastro/astro/pull/11550).
+
+When the edge middleware feature is opted in, Astro removes the middleware function from the SSR manifest, and this wasn't taken into account during the refactor.

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -68,7 +68,7 @@ export type SSRManifest = {
 	serverIslandNameMap?: Map<string, string>;
 	key: Promise<CryptoKey>;
 	i18n: SSRManifestI18n | undefined;
-	middleware: () => Promise<AstroMiddlewareInstance> | AstroMiddlewareInstance;
+	middleware?: () => Promise<AstroMiddlewareInstance> | AstroMiddlewareInstance;
 	checkOrigin: boolean;
 	// TODO: remove experimental prefix
 	experimentalEnvGetSecretEnabled: boolean;

--- a/packages/astro/src/core/base-pipeline.ts
+++ b/packages/astro/src/core/base-pipeline.ts
@@ -109,7 +109,10 @@ export abstract class Pipeline {
 	async getMiddleware(): Promise<MiddlewareHandler> {
 		if (this.resolvedMiddleware) {
 			return this.resolvedMiddleware;
-		} else {
+		}
+		// The middleware can be undefined when using edge middleware.
+		// This is set to undefined by the plugin-ssr.ts 
+		else if (this.middleware) {
 			const middlewareInstance = await this.middleware();
 			const onRequest = middlewareInstance.onRequest ?? NOOP_MIDDLEWARE_FN;
 			if (this.manifest.checkOrigin) {
@@ -118,6 +121,9 @@ export abstract class Pipeline {
 				this.resolvedMiddleware = onRequest;
 			}
 			return this.resolvedMiddleware;
+		} else {
+			this.resolvedMiddleware = NOOP_MIDDLEWARE_FN;
+			return this.resolvedMiddleware
 		}
 	}
 }


### PR DESCRIPTION
## Changes

This PR fixes a regression that was introduced by a refactor of mine regarding the edge middleware.

There was an incorrect type inside the manifest. The middleware function needs to be marked undefined, because when we enable the edge middleware, that function isn't present inside the SSR manifest

## Testing

This PR affects some Netlify users. I will create a preview release and ask them to test it

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
