### PR TITLE
fix: throw a useful error if rendering undefined entry

### DIFF
--- a/.changeset/wise-pumas-fry.md
+++ b/.changeset/wise-pumas-fry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Throw a helpful error if attempting to render undefined entry

--- a/.changeset/wise-pumas-fry.md
+++ b/.changeset/wise-pumas-fry.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Throw a helpful error if attempting to render undefined entry
+Adds a helpful error when attempting to render an undefined collection entry

--- a/packages/astro/src/content/runtime.ts
+++ b/packages/astro/src/content/runtime.ts
@@ -436,7 +436,11 @@ function updateImageReferencesInData<T extends Record<string, unknown>>(
 export async function renderEntry(
 	entry: DataEntry | { render: () => Promise<{ Content: AstroComponentFactory }> },
 ) {
-	if (entry && 'render' in entry) {
+	if (!entry) {
+		throw new AstroError(AstroErrorData.RenderUndefinedEntryError);
+	}
+
+	if ('render' in entry) {
 		// This is an old content collection entry, so we use its render method
 		return entry.render();
 	}

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1413,6 +1413,17 @@ export const UnknownContentCollectionError = {
 /**
  * @docs
  * @description
+ * Astro tried to render a content collection entry that was undefined. This can happen if you try to render an entry that does not exist.
+ */
+export const RenderUndefinedEntryError = {
+	name: 'RenderUndefinedEntryError',
+	title: 'Attempted to render an undefined content collection entry.',
+	hint: 'Check if the entry is undefined before passing it to `render()`',
+} satisfies ErrorData;
+
+/**
+ * @docs
+ * @description
  * The `getDataEntryById` and `getEntryBySlug` functions are deprecated and cannot be used with content layer collections. Use the `getEntry` function instead.
  */
 export const GetEntryDeprecationError = {

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -317,5 +317,12 @@ describe('Content Layer', () => {
 			assert.ok(updated.fileLoader[0].data.temperament.includes('Bouncy'));
 			await fixture.resetAllFiles();
 		});
+
+		it('returns an error if we render an undefined entry', async () => {
+			const res = await fixture.fetch('/missing');
+			const text = await res.text();
+			assert.equal(res.status, 500);
+			assert.ok(text.includes('RenderUndefinedEntryError'));
+		});
 	});
 });

--- a/packages/astro/test/fixtures/content-layer/src/pages/missing.astro
+++ b/packages/astro/test/fixtures/content-layer/src/pages/missing.astro
@@ -1,0 +1,14 @@
+---
+import { getEntry, render } from "astro:content"
+// Skipping the broken page in production so the build doesn't fail
+if(import.meta.env.PROD) {
+	return new Response(null, { status: 404 })
+}
+
+const entry = await getEntry("spacecraft", "missing")
+
+const { Content } = await render(entry)
+
+---
+
+<Content />


### PR DESCRIPTION
## Changes
Currently if an undefined entry is passed to `render()` it gives the unhelpful error about attempting to access `deferredRender` on `undefined`. This PR adds an explicit null check which throws a new AstroError if the entry is undefined.

## Testing

Added a new test case and fixture

## Docs

Adds a new error

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
