### PR TITLE
fix: missing body type on content layer entries

### DIFF
--- a/.changeset/thin-trains-fold.md
+++ b/.changeset/thin-trains-fold.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes missing `body` property on CollectionEntry types for content layer entries

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -497,7 +497,7 @@ async function writeContentFiles({
 				contentTypesStr += `};\n`;
 				break;
 			case CONTENT_LAYER_TYPE:
-				dataTypesStr += `${collectionKey}: Record<string, {\n  id: string;\n  collection: ${collectionKey};\n  data: ${dataType};\n  rendered?: RenderedContent;\n  filePath?: string \n}>;\n`;
+				dataTypesStr += `${collectionKey}: Record<string, {\n  id: string;\n  collection: ${collectionKey};\n  data: ${dataType};\n  rendered?: RenderedContent;\n  filePath?: string;\n  body?: string \n}>;\n`;
 				break;
 			case 'data':
 				if (collectionEntryKeys.length === 0) {


### PR DESCRIPTION
## Changes

Similar to filePath, body was missing.

## Testing

Tested manually

## Docs

N/A
