### PR TITLE
fix(next): do not override process.env

### DIFF
--- a/.changeset/proud-adults-swim.md
+++ b/.changeset/proud-adults-swim.md
@@ -1,0 +1,26 @@
+---
+'astro': major
+---
+
+Fixes a case where environment variables would not be refreshed.
+
+This fix introduces some changes that are breaking for adapters adding environment variables to `process.env` in order to reach `astro:env`:
+
+```diff
++ import { ENV_SYMBOL } from "astro/env/setup"
+
+function setProcessEnv(config: AstroConfig, env: Record<string, unknown>) {
+	const getEnv = createGetEnv(env);
+
++    (globalThis as any)[ENV_SYMBOL] ??= {};
+	if (config.env.schema) {
+		for (const key of Object.keys(config.env.schema)) {
+			const value = getEnv(key);
+-			if (value !== undefined) {
+-				process.env[key] = value;
+			}
++            (globalThis as any)[ENV_SYMBOL] = value;
+		}
+	}
+}
+```

--- a/packages/astro/src/env/constants.ts
+++ b/packages/astro/src/env/constants.ts
@@ -9,3 +9,5 @@ export const ENV_TYPES_FILE = 'env.d.ts';
 
 const PKG_BASE = new URL('../../', import.meta.url);
 export const MODULE_TEMPLATE_URL = new URL('templates/env.mjs', PKG_BASE);
+
+export const ENV_SYMBOL = Symbol.for('astro:env/dev');

--- a/packages/astro/src/env/runtime.ts
+++ b/packages/astro/src/env/runtime.ts
@@ -1,4 +1,5 @@
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
+import { ENV_SYMBOL } from './constants.js';
 import { invalidVariablesToError } from './errors.js';
 import type { ValidationResultInvalid } from './validators.js';
 export { validateEnvVariable, getEnvFieldType } from './validators.js';
@@ -6,7 +7,10 @@ export { validateEnvVariable, getEnvFieldType } from './validators.js';
 export type GetEnv = (key: string) => string | undefined;
 type OnSetGetEnv = (reset: boolean) => void;
 
-let _getEnv: GetEnv = (key) => process.env[key];
+let _getEnv: GetEnv = (key) => {
+	const env = (globalThis as any)[ENV_SYMBOL] ?? {};
+	return env[key];
+};
 
 export function setGetEnv(fn: GetEnv, reset = false) {
 	_getEnv = fn;

--- a/packages/astro/src/env/setup.ts
+++ b/packages/astro/src/env/setup.ts
@@ -1,1 +1,2 @@
 export { setGetEnv, type GetEnv } from './runtime.js';
+export { ENV_SYMBOL } from './constants.js';

--- a/packages/astro/src/env/vite-plugin-env.ts
+++ b/packages/astro/src/env/vite-plugin-env.ts
@@ -4,6 +4,7 @@ import { type Plugin, loadEnv } from 'vite';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import type { AstroSettings } from '../types/astro.js';
 import {
+	ENV_SYMBOL,
 	MODULE_TEMPLATE_URL,
 	VIRTUAL_MODULES_IDS,
 	VIRTUAL_MODULES_IDS_VALUES,
@@ -32,11 +33,8 @@ export function astroEnv({ settings, mode, sync }: AstroEnvPluginParams): Plugin
 				fileURLToPath(settings.config.root),
 				'',
 			);
-			for (const [key, value] of Object.entries(loadedEnv)) {
-				if (value !== undefined) {
-					process.env[key] = value;
-				}
-			}
+			(globalThis as any)[ENV_SYMBOL] ??= {};
+			Object.assign((globalThis as any)[ENV_SYMBOL], loadedEnv);
 
 			const validatedVariables = validatePublicVariables({
 				schema,

--- a/packages/astro/test/env-secret.test.js
+++ b/packages/astro/test/env-secret.test.js
@@ -3,6 +3,7 @@ import { afterEach, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
+import { ENV_SYMBOL } from '../dist/env/setup.js';
 
 describe('astro:env secret variables', () => {
 	/** @type {Awaited<ReturnType<typeof loadFixture>>} */
@@ -12,13 +13,14 @@ describe('astro:env secret variables', () => {
 
 	afterEach(async () => {
 		await devServer?.stop();
-		if (process.env.KNOWN_SECRET) {
-			delete process.env.KNOWN_SECRET;
+		if (globalThis[ENV_SYMBOL]?.KNOWN_SECRET) {
+			delete globalThis[ENV_SYMBOL].KNOWN_SECRET;
 		}
 	});
 
 	it('works in dev', async () => {
-		process.env.KNOWN_SECRET = '5';
+		globalThis[ENV_SYMBOL] ??= {};
+		globalThis[ENV_SYMBOL].KNOWN_SECRET = '5';
 		fixture = await loadFixture({
 			root: './fixtures/astro-env-server-secret/',
 		});


### PR DESCRIPTION
## Changes

- Fixes a bug that prevents env from being refreshed because of astro:env (we currently override process.env)
- It's breaking for adapters, hence it's a major change against next

## Testing

Should still pass. I'll make a preview release to test adapters

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset, will do docs later

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
