### PR TITLE
fix: clear content layer cache if astro version changes

### DIFF
--- a/.changeset/ninety-monkeys-complain.md
+++ b/.changeset/ninety-monkeys-complain.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Clear content layer cache when astro version changes


### PR DESCRIPTION
## Changes

New Astro versions can introduce changes that are incompatible with data stores created by other versions. This PR ensures that if the version has changed, the store will be cleared.

## Testing

Tested manually. I'm not sure how to test this automatically because of the way the version is injected into builds

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
