### PR TITLE
fix: copy server URLs to Vite dev server

### DIFF
--- a/.changeset/dull-moles-talk.md
+++ b/.changeset/dull-moles-talk.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Prevents Vite emitting an error when restarting itself

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -136,7 +136,7 @@ export async function createContainerWithAutomaticRestart({
 		},
 	};
 
-	async function handleServerRestart(logMsg = '') {
+	async function handleServerRestart(logMsg = '', server?: vite.ViteDevServer) {
 		logger.info(null, (logMsg + ' Restarting...').trim());
 		const container = restart.container;
 		const result = await restartContainer(container);
@@ -147,6 +147,11 @@ export async function createContainerWithAutomaticRestart({
 			// Restart success. Add new watches because this is a new container with a new Vite server
 			restart.container = result;
 			setupContainer();
+			if (server) {
+				// Vite expects the resolved URLs to be available
+				server.resolvedUrls = result.viteServer.resolvedUrls;
+			}
+
 			resolveRestart(null);
 		}
 		restartComplete = new Promise<Error | null>((resolve) => {
@@ -171,7 +176,8 @@ export async function createContainerWithAutomaticRestart({
 
 		// Restart the Astro dev server instead of Vite's when the API is called by plugins.
 		// Ignore the `forceOptimize` parameter for now.
-		restart.container.viteServer.restart = () => handleServerRestart();
+		restart.container.viteServer.restart = () =>
+			handleServerRestart('', restart.container.viteServer);
 
 		// Set up shortcuts
 


### PR DESCRIPTION
## Changes

We currently trick Vite into restarting our dev server when it tries to restart its own server by overwriting the vite server's `restart()` method. Our method restarts our own dev server, which includes restarting Vite. The problem is that the calling function expects to still be able to read from the original Vite server instance, but we've created a new one. This causes it to emit a confusing error about missing server URLs. This PR copies across the URLs to the old server, just so that the calling function can read them. 

Fixes #12107

## Testing
Tested manually

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
