### PR TITLE
feat: add configuration option to disable CLI telemetry

### DIFF
--- a/.changeset/rich-rivers-cheer.md
+++ b/.changeset/rich-rivers-cheer.md
@@ -1,0 +1,18 @@
+---
+'@astrojs/telemetry': minor
+'astro': minor
+---
+
+Adds a configuration option to disable CLI telemetry for the project
+
+Astro collects optional anonymous telemetry to help us understand how people use the CLI. This change adds a new way to disable telemetry on a per-project basis. Currently you can disable telemetry globally per machine by running `astro telemetry disable` or by setting the environment variable `ASTRO_TELEMETRY_DISABLE`. This change adds a new configuration option to disable telemetry for a specific project, which applies to all users of the project.
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  disableTelemetry: true
+});
+
+```

--- a/packages/astro/src/core/config/config.ts
+++ b/packages/astro/src/core/config/config.ts
@@ -148,6 +148,11 @@ export async function resolveConfig(
 
 	const userConfig = await loadConfig(root, inlineOnlyConfig.configFile, fsMod);
 	const mergedConfig = mergeConfig(userConfig, inlineUserConfig);
+
+	if (mergedConfig.disableTelemetry) {
+		telemetry.disableForSession();
+	}
+
 	// First-Pass Validation
 	let astroConfig: AstroConfig;
 	try {

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -87,6 +87,7 @@ export const ASTRO_CONFIG_DEFAULTS = {
 	security: {
 		checkOrigin: true,
 	},
+	disableTelemetry: false,
 	env: {
 		schema: {},
 		validateSecrets: false,
@@ -509,6 +510,7 @@ export const AstroConfigSchema = z.object({
 		.strict()
 		.optional()
 		.default(ASTRO_CONFIG_DEFAULTS.env),
+	disableTelemetry: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.disableTelemetry),
 	experimental: z
 		.object({
 			clientPrerender: z
@@ -526,10 +528,7 @@ export const AstroConfigSchema = z.object({
 		.default({}),
 	legacy: z
 		.object({
-			collections: z
-				.boolean()
-				.optional()
-				.default(ASTRO_CONFIG_DEFAULTS.legacy.collections),
+			collections: z.boolean().optional().default(ASTRO_CONFIG_DEFAULTS.legacy.collections),
 		})
 		.default({}),
 });

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -901,6 +901,22 @@ export interface AstroUserConfig {
 
 	/**
 	 * @docs
+	 * @name disableTelemetry
+	 * @type {boolean}
+	 * @version 5.0.0
+	 * @default `false`
+	 * @description
+	 * Disable anonymous telemetry collection for this project.
+	 *
+	 * You can also disable telemetry globally by running `astro telemetry disable`.
+	 *
+	 * Visit https://astro.build/telemetry/ for more information about our approach to anonymous telemetry in Astro.
+	 */
+
+	disableTelemetry?: boolean;
+
+	/**
+	 * @docs
 	 * @kind heading
 	 * @name Image Options
 	 */

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -25,6 +25,7 @@ export class AstroTelemetry {
 	private debug = debug('astro:telemetry');
 	private isCI = isCI;
 	private env = process.env;
+	private disabledForSession = false;
 
 	private get astroVersion() {
 		return this.opts.astroVersion;
@@ -85,7 +86,7 @@ export class AstroTelemetry {
 	}
 
 	private get isDisabled(): boolean {
-		if (Boolean(this.ASTRO_TELEMETRY_DISABLED || this.TELEMETRY_DISABLED)) {
+		if (this.ASTRO_TELEMETRY_DISABLED || this.TELEMETRY_DISABLED || this.disabledForSession) {
 			return true;
 		}
 		return this.enabled === false;
@@ -93,6 +94,11 @@ export class AstroTelemetry {
 
 	setEnabled(value: boolean) {
 		this.config.set(KEY.TELEMETRY_ENABLED, value);
+	}
+
+	disableForSession() {
+		this.debug('[notify] telemetry has been disabled for this session');
+		this.disabledForSession = true;
 	}
 
 	clear() {

--- a/packages/telemetry/test/index.test.js
+++ b/packages/telemetry/test/index.test.js
@@ -81,4 +81,15 @@ describe('AstroTelemetry', () => {
 		assert.notEqual(log, undefined);
 		assert.match(logs.join(''), /enabled/);
 	});
+
+	it('respects disabling per session', async () => {
+		const { telemetry, logs } = setup();
+		telemetry.disableForSession();
+		assert.equal(telemetry.isDisabled, true);
+		const result = await telemetry.record(['TEST']);
+		assert.equal(result, undefined);
+		const [log] = logs;
+		assert.notEqual(log, undefined);
+		assert.match(logs.join(''), /disabled/);
+	});
 });


### PR DESCRIPTION
## Changes

This change adds a new configuration option to disable telemetry for the project.

Fixes #11820

## Testing
Adds tests
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Adds a config option

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
