### PR TITLE
Fix-component-undefined-svelte-v5 (#12102)

### DIFF
--- a/.changeset/eighty-ligers-punch.md
+++ b/.changeset/eighty-ligers-punch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/svelte': patch
+---
+
+Fixes an Reference Error that occurred during client transitions

--- a/packages/integrations/svelte/client-v5.js
+++ b/packages/integrations/svelte/client-v5.js
@@ -39,8 +39,7 @@ export default (element) => {
 				},
 			});
 			existingApplications.set(element, component);
+			element.addEventListener('astro:unmount', () => unmount(component), { once: true });
 		}
-
-		element.addEventListener('astro:unmount', () => unmount(component), { once: true });
 	};
 };


### PR DESCRIPTION
* - fix: 'component is not defined' error when unmount svelte 5 component

* added changeset

* Moving unmount listener to where the component is defined.

* Update .changeset/eighty-ligers-punch.md


Cherry-picked from dcc1e895abbad1311719803363c933541c0ad984
