### PR TITLE
[CVE 2024-47764] Update package 'cookie'

### DIFF
--- a/.changeset/twenty-spoons-sneeze.md
+++ b/.changeset/twenty-spoons-sneeze.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+This updates Astro's dependency on the [`cookie`](https://npmjs.com/package/cookie) package to a version that is not susceptible to the [CVE 2024-47764](https://nvd.nist.gov/vuln/detail/CVE-2024-47764) vulnerability.

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -137,7 +137,7 @@
     "ci-info": "^4.0.0",
     "clsx": "^2.1.1",
     "common-ancestor-path": "^1.0.1",
-    "cookie": "^0.6.0",
+    "cookie": "^0.7.1",
     "cssesc": "^3.0.0",
     "debug": "^4.3.7",
     "deterministic-object-hash": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -587,8 +587,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       cookie:
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.1
+        version: 0.7.1
       cssesc:
         specifier: ^3.0.0
         version: 3.0.0
@@ -7873,8 +7873,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+  cookie@0.7.1:
+    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
 
   copy-anything@3.0.5:
@@ -13650,7 +13650,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@0.6.0: {}
+  cookie@0.7.1: {}
 
   copy-anything@3.0.5:
     dependencies:


### PR DESCRIPTION
## Changes

This just updates `cookie` to get rid of warnings about [CVE 2024-47764](https://nvd.nist.gov/vuln/detail/CVE-2024-47764).

## Testing

No change required.

## Docs

No change required.

---
Note: It's a cherry-pick of #12132 targeting the Astro 5 branch.