### PR TITLE
fix(@astrojs/rss): prevent an error when `pubDate` is missing

### DIFF
--- a/.changeset/ninety-dolls-reply.md
+++ b/.changeset/ninety-dolls-reply.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': patch
+---
+
+Fixes an error that occurred when the optional `pubDate` property was missing in an item.

--- a/.changeset/plenty-kings-swim.md
+++ b/.changeset/plenty-kings-swim.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/rss': patch
+---
+
+Fixes an error where docs incorrectly stated the `title`, `link` and `pubDate` properties of RSS items was required.

--- a/packages/astro-rss/README.md
+++ b/packages/astro-rss/README.md
@@ -198,19 +198,19 @@ const item = {
 
 ### `title`
 
-Type: `string (required)`
+Type: `string (optional)`
 
-The title of the item in the feed.
+The title of the item in the feed. Optional only if a description is set. Otherwise, required.
 
 ### `link`
 
-Type: `string (required)`
+Type: `string (optional)`
 
 The URL of the item on the web.
 
 ### `pubDate`
 
-Type: `Date (required)`
+Type: `Date (optional)`
 
 Indicates when the item was published.
 
@@ -218,7 +218,7 @@ Indicates when the item was published.
 
 Type: `string (optional)`
 
-A synopsis of your item when you are publishing the full content of the item in the `content` field. The `description` may alternatively be the full content of the item in the feed if you are not using the `content` field (entity-coded HTML is permitted).
+A synopsis of your item when you are publishing the full content of the item in the `content` field. The `description` may alternatively be the full content of the item in the feed if you are not using the `content` field (entity-coded HTML is permitted). Optional only if a title is set. Otherwise, required.
 
 ### `content`
 

--- a/packages/astro-rss/src/schema.ts
+++ b/packages/astro-rss/src/schema.ts
@@ -5,9 +5,9 @@ export const rssSchema = z.object({
 	description: z.string().optional(),
 	pubDate: z
 		.union([z.string(), z.number(), z.date()])
-		.optional()
-		.transform((value) => (value === undefined ? value : new Date(value)))
-		.refine((value) => (value === undefined ? value : !isNaN(value.getTime()))),
+		.transform((value) => new Date(value))
+		.refine((value) => !isNaN(value.getTime()))
+		.optional(),
 	customData: z.string().optional(),
 	categories: z.array(z.string()).optional(),
 	author: z.string().optional(),

--- a/packages/astro-rss/test/rss.test.js
+++ b/packages/astro-rss/test/rss.test.js
@@ -10,6 +10,7 @@ import {
 	phpFeedItem,
 	phpFeedItemWithContent,
 	phpFeedItemWithCustomData,
+	phpFeedItemWithoutDate,
 	site,
 	title,
 	web1FeedItem,
@@ -24,6 +25,8 @@ import {
 const validXmlResult = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title><![CDATA[${title}]]></title><description><![CDATA[${description}]]></description><link>${site}/</link><item><title><![CDATA[${phpFeedItem.title}]]></title><link>${site}${phpFeedItem.link}/</link><guid isPermaLink="true">${site}${phpFeedItem.link}/</guid><description><![CDATA[${phpFeedItem.description}]]></description><pubDate>${new Date(phpFeedItem.pubDate).toUTCString()}</pubDate></item><item><title><![CDATA[${web1FeedItem.title}]]></title><link>${site}${web1FeedItem.link}/</link><guid isPermaLink="true">${site}${web1FeedItem.link}/</guid><description><![CDATA[${web1FeedItem.description}]]></description><pubDate>${new Date(web1FeedItem.pubDate).toUTCString()}</pubDate></item></channel></rss>`;
 // biome-ignore format: keep in one line
 const validXmlWithContentResult = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/"><channel><title><![CDATA[${title}]]></title><description><![CDATA[${description}]]></description><link>${site}/</link><item><title><![CDATA[${phpFeedItemWithContent.title}]]></title><link>${site}${phpFeedItemWithContent.link}/</link><guid isPermaLink="true">${site}${phpFeedItemWithContent.link}/</guid><description><![CDATA[${phpFeedItemWithContent.description}]]></description><pubDate>${new Date(phpFeedItemWithContent.pubDate).toUTCString()}</pubDate><content:encoded><![CDATA[${phpFeedItemWithContent.content}]]></content:encoded></item><item><title><![CDATA[${web1FeedItemWithContent.title}]]></title><link>${site}${web1FeedItemWithContent.link}/</link><guid isPermaLink="true">${site}${web1FeedItemWithContent.link}/</guid><description><![CDATA[${web1FeedItemWithContent.description}]]></description><pubDate>${new Date(web1FeedItemWithContent.pubDate).toUTCString()}</pubDate><content:encoded><![CDATA[${web1FeedItemWithContent.content}]]></content:encoded></item></channel></rss>`;
+// biome-ignore format: keep in one line
+const validXmlResultWithMissingDate = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title><![CDATA[${title}]]></title><description><![CDATA[${description}]]></description><link>${site}/</link><item><title><![CDATA[${phpFeedItemWithoutDate.title}]]></title><link>${site}${phpFeedItemWithoutDate.link}/</link><guid isPermaLink="true">${site}${phpFeedItemWithoutDate.link}/</guid><description><![CDATA[${phpFeedItemWithoutDate.description}]]></description></item><item><title><![CDATA[${phpFeedItem.title}]]></title><link>${site}${phpFeedItem.link}/</link><guid isPermaLink="true">${site}${phpFeedItem.link}/</guid><description><![CDATA[${phpFeedItem.description}]]></description><pubDate>${new Date(phpFeedItem.pubDate).toUTCString()}</pubDate></item></channel></rss>`;
 // biome-ignore format: keep in one line
 const validXmlResultWithAllData = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title><![CDATA[${title}]]></title><description><![CDATA[${description}]]></description><link>${site}/</link><item><title><![CDATA[${phpFeedItem.title}]]></title><link>${site}${phpFeedItem.link}/</link><guid isPermaLink="true">${site}${phpFeedItem.link}/</guid><description><![CDATA[${phpFeedItem.description}]]></description><pubDate>${new Date(phpFeedItem.pubDate).toUTCString()}</pubDate></item><item><title><![CDATA[${web1FeedItemWithAllData.title}]]></title><link>${site}${web1FeedItemWithAllData.link}/</link><guid isPermaLink="true">${site}${web1FeedItemWithAllData.link}/</guid><description><![CDATA[${web1FeedItemWithAllData.description}]]></description><pubDate>${new Date(web1FeedItemWithAllData.pubDate).toUTCString()}</pubDate><category>${web1FeedItemWithAllData.categories[0]}</category><category>${web1FeedItemWithAllData.categories[1]}</category><author>${web1FeedItemWithAllData.author}</author><comments>${web1FeedItemWithAllData.commentsUrl}</comments><source url="${web1FeedItemWithAllData.source.url}">${web1FeedItemWithAllData.source.title}</source><enclosure url="${site}${web1FeedItemWithAllData.enclosure.url}" length="${web1FeedItemWithAllData.enclosure.length}" type="${web1FeedItemWithAllData.enclosure.type}"/></item></channel></rss>`;
 // biome-ignore format: keep in one line
@@ -99,6 +102,17 @@ describe('getRssString', () => {
 		});
 
 		assertXmlDeepEqual(str, validXmlWithContentResult);
+	});
+
+	it('should generate on valid RSSFeedItem array with missing date', async () => {
+		const str = await getRssString({
+			title,
+			description,
+			items: [phpFeedItemWithoutDate, phpFeedItem],
+			site,
+		});
+
+		assertXmlDeepEqual(str, validXmlResultWithMissingDate);
 	});
 
 	it('should generate on valid RSSFeedItem array with all RSS content included', async () => {

--- a/packages/astro-rss/test/test-utils.js
+++ b/packages/astro-rss/test/test-utils.js
@@ -4,12 +4,15 @@ export const title = 'My RSS feed';
 export const description = 'This sure is a nice RSS feed';
 export const site = 'https://example.com';
 
-export const phpFeedItem = {
+export const phpFeedItemWithoutDate = {
 	link: '/php',
 	title: 'Remember PHP?',
-	pubDate: '1994-05-03',
 	description:
 		'PHP is a general-purpose scripting language geared toward web development. It was originally created by Danish-Canadian programmer Rasmus Lerdorf in 1994.',
+};
+export const phpFeedItem = {
+	...phpFeedItemWithoutDate,
+	pubDate: '1994-05-03',
 };
 export const phpFeedItemWithContent = {
 	...phpFeedItem,


### PR DESCRIPTION
This PR fixes an issue reported in [Doc repository](https://github.com/withastro/docs/issues/9575): `pubDate` is optional when generating RSS items since #9610 but if not provided an error is thrown (`Invalid input (items.0.pubDate)`).

I have not created a ticket, but I have [a minimal reproduction](https://stackblitz.com/edit/astro-rss-pubdate-bug?file=src%2Fpages%2Ffeed.xml.ts&on=stackblitz) (just delete one of the pubDate).

## Changes

* I updated the way we declare `pubDate` in `rssSchema` to prevent the validation to fail when `pubDate` is not included in the item.
* I updated the README to replace `required` with `optional` for the items updated in #9610

## Testing

* I added a test and an item without date: it was failing before, now it passes.
* I tested manually with `pnpm link` with the minimal reproduction and the feed is now correctly generated

All previous tests still work!

## Docs

I added two different changesets since there was two issues (the doc + the bug). Otherwise, I don't think we need more documentation, the [current one is already up to date](https://docs.astro.build/en/guides/rss/#generating-items).

/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
