### PR TITLE
fix: don't set statusMessage in HTTP/2

### DIFF
--- a/.changeset/strong-pugs-stare.md
+++ b/.changeset/strong-pugs-stare.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Skips setting statusMessage header for HTTP/2 response
+
+HTTP/2 doesn't support status message, so setting this was logging a warning.

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -6,6 +6,7 @@ import { createOutgoingHttpHeaders } from './createOutgoingHttpHeaders.js';
 import { App } from './index.js';
 import type { RenderOptions } from './index.js';
 import type { SSRManifest, SerializedSSRManifest } from './types.js';
+import { Http2ServerResponse } from 'node:http2';
 
 export { apply as applyPolyfills } from '../polyfill.js';
 
@@ -108,7 +109,10 @@ export class NodeApp extends App {
 	 */
 	static async writeResponse(source: Response, destination: ServerResponse) {
 		const { status, headers, body, statusText } = source;
-		destination.statusMessage = statusText;
+		// HTTP/2 doesn't support statusMessage
+		if (!(destination instanceof Http2ServerResponse)) {
+			destination.statusMessage = statusText;
+		}
 		destination.writeHead(status, createOutgoingHttpHeaders(headers));
 		if (!body) return destination.end();
 		try {

--- a/packages/astro/src/vite-plugin-astro-server/response.ts
+++ b/packages/astro/src/vite-plugin-astro-server/response.ts
@@ -1,4 +1,5 @@
 import type http from 'node:http';
+import { Http2ServerResponse } from 'node:http2';
 import type { ErrorWithMetadata } from '../core/errors/index.js';
 import type { ModuleLoader } from '../core/module-loader/index.js';
 
@@ -67,7 +68,10 @@ export async function writeWebResponse(res: http.ServerResponse, webResponse: Re
 	if (headers.has('set-cookie')) {
 		_headers['set-cookie'] = headers.getSetCookie();
 	}
-	res.statusMessage = statusText;
+	// HTTP/2 doesn't support statusMessage
+	if(!(res instanceof Http2ServerResponse)) {
+		res.statusMessage = statusText;
+	}
 	res.writeHead(status, _headers);
 	if (body) {
 		if (Symbol.for('astro.responseBody') in webResponse) {


### PR DESCRIPTION
## Changes

#12105 added support for setting the response statusMessage. However this is not supported by HTTP/2, so a warning was being logged. This PR first checks that the response is not HTTP/2 before setting it.

Fixes #12134

## Testing

Tested manually with `astro-dev-http2` fixture
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
