### PR TITLE
Support custom mode

### DIFF
--- a/.changeset/sixty-coins-worry.md
+++ b/.changeset/sixty-coins-worry.md
@@ -1,0 +1,29 @@
+---
+'astro': minor
+---
+
+Adds support for passing values other than `"production"` or `"development"` to the `--mode` flag, e.g. `"staging"`, `"testing"`, or any value. This allows to change the value of `import.meta.env.MODE` or the loaded `.env` file, and take advantage of Vite's [mode](https://vite.dev/guide/env-and-mode#modes) feature.
+
+Note that changing the `mode` does not change the kind of code transform handled by Vite and Astro:
+
+- In `astro dev`, Astro will transform code with debug information.
+- In `astro build`, Astro will transform code with the most optimized output and removes debug information.
+- In `astro build --dev` (new flag), Astro will transform code with debug information like in `astro dev`. 
+
+This enables various usecases like:
+
+```bash
+# Run the dev server connected to a "staging" API
+astro dev --mode staging
+
+# Build a site that connects to a "staging" API
+astro build --mode staging
+
+# Build a site that connects to a "production" API with additional debug information
+astro build --dev
+
+# Build a site that connects to a "testing" API
+astro build --mode testing
+```
+
+The different modes can be used to load different `.env` files, e.g. `.env.staging` or `.env.production`, which can have different `API_URL` environment variable values (for example).

--- a/packages/astro/src/cli/build/index.ts
+++ b/packages/astro/src/cli/build/index.ts
@@ -18,6 +18,7 @@ export async function build({ flags }: BuildOptions) {
 						'--force',
 						'Clear the content layer and content collection cache, forcing a full rebuild.',
 					],
+					['--dev', 'Create a development build, similar to code transformed in `astro dev`.'],
 					['--help (-h)', 'See all available flags.'],
 				],
 			},
@@ -28,5 +29,5 @@ export async function build({ flags }: BuildOptions) {
 
 	const inlineConfig = flagsToAstroInlineConfig(flags);
 
-	await _build(inlineConfig);
+	await _build(inlineConfig, { dev: !!flags.dev });
 }

--- a/packages/astro/src/cli/flags.ts
+++ b/packages/astro/src/cli/flags.ts
@@ -10,7 +10,7 @@ export function flagsToAstroInlineConfig(flags: Flags): AstroInlineConfig {
 	return {
 		// Inline-only configs
 		configFile: typeof flags.config === 'string' ? flags.config : undefined,
-		mode: typeof flags.mode === 'string' ? (flags.mode as AstroInlineConfig['mode']) : undefined,
+		mode: typeof flags.mode === 'string' ? flags.mode : undefined,
 		logLevel: flags.verbose ? 'debug' : flags.silent ? 'silent' : undefined,
 		force: flags.force ? true : undefined,
 

--- a/packages/astro/src/config/index.ts
+++ b/packages/astro/src/config/index.ts
@@ -1,4 +1,4 @@
-import type { UserConfig as ViteUserConfig } from 'vite';
+import type { UserConfig as ViteUserConfig, UserConfigFn as ViteUserConfigFn } from 'vite';
 import { Logger } from '../core/logger/core.js';
 import { createRouteManifest } from '../core/routing/index.js';
 import type { AstroInlineConfig, AstroUserConfig } from '../types/public/config.js';
@@ -11,11 +11,11 @@ export function defineConfig(config: AstroUserConfig) {
 export function getViteConfig(
 	userViteConfig: ViteUserConfig,
 	inlineAstroConfig: AstroInlineConfig = {},
-) {
+): ViteUserConfigFn {
 	// Return an async Vite config getter which exposes a resolved `mode` and `command`
-	return async ({ mode, command }: { mode: 'dev'; command: 'serve' | 'build' }) => {
+	return async ({ mode, command }) => {
 		// Vite `command` is `serve | build`, but Astro uses `dev | build`
-		const cmd = command === 'serve' ? 'dev' : command;
+		const cmd = command === 'serve' ? 'dev' : 'build';
 
 		// Use dynamic import to avoid pulling in deps unless used
 		const [
@@ -46,13 +46,12 @@ export function getViteConfig(
 		const devSSRManifest = createDevelopmentManifest(settings);
 		const viteConfig = await createVite(
 			{
-				mode,
 				plugins: [
 					// Initialize the content listener
 					astroContentListenPlugin({ settings, logger, fs }),
 				],
 			},
-			{ settings, logger, mode, sync: false, manifest, ssrManifest: devSSRManifest },
+			{ settings, command: cmd, logger, mode, sync: false, manifest, ssrManifest: devSSRManifest },
 		);
 		await runHookConfigDone({ settings, logger });
 		return mergeConfig(viteConfig, userViteConfig);

--- a/packages/astro/src/content/vite-plugin-content-assets.ts
+++ b/packages/astro/src/content/vite-plugin-content-assets.ts
@@ -21,10 +21,8 @@ import {
 import { hasContentFlag } from './utils.js';
 
 export function astroContentAssetPropagationPlugin({
-	mode,
 	settings,
 }: {
-	mode: string;
 	settings: AstroSettings;
 }): Plugin {
 	let devModuleLoader: ModuleLoader;
@@ -67,9 +65,7 @@ export function astroContentAssetPropagationPlugin({
 			}
 		},
 		configureServer(server) {
-			if (mode === 'dev') {
-				devModuleLoader = createViteLoader(server);
-			}
+			devModuleLoader = createViteLoader(server);
 		},
 		async transform(_, id, options) {
 			if (hasContentFlag(id, PROPAGATED_ASSET_FLAG)) {

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -56,7 +56,7 @@ export function astroContentVirtualModPlugin({
 		name: 'astro-content-virtual-mod-plugin',
 		enforce: 'pre',
 		configResolved(config) {
-			IS_DEV = config.mode === 'development';
+			IS_DEV = !config.isProduction;
 			dataStoreFile = getDataStoreFile(settings, IS_DEV);
 		},
 		async resolveId(id) {

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -114,7 +114,7 @@ export class App {
 		return AppPipeline.create(manifestData, {
 			logger: this.#logger,
 			manifest: this.#manifest,
-			mode: 'production',
+			runtimeMode: 'production',
 			renderers: this.#manifest.renderers,
 			defaultRoutes: createDefaultRoutes(this.#manifest),
 			resolve: async (specifier: string) => {

--- a/packages/astro/src/core/app/pipeline.ts
+++ b/packages/astro/src/core/app/pipeline.ts
@@ -15,7 +15,7 @@ export class AppPipeline extends Pipeline {
 		{
 			logger,
 			manifest,
-			mode,
+			runtimeMode,
 			renderers,
 			resolve,
 			serverLike,
@@ -25,7 +25,7 @@ export class AppPipeline extends Pipeline {
 			AppPipeline,
 			| 'logger'
 			| 'manifest'
-			| 'mode'
+			| 'runtimeMode'
 			| 'renderers'
 			| 'resolve'
 			| 'serverLike'
@@ -36,7 +36,7 @@ export class AppPipeline extends Pipeline {
 		const pipeline = new AppPipeline(
 			logger,
 			manifest,
-			mode,
+			runtimeMode,
 			renderers,
 			resolve,
 			serverLike,

--- a/packages/astro/src/core/base-pipeline.ts
+++ b/packages/astro/src/core/base-pipeline.ts
@@ -32,9 +32,9 @@ export abstract class Pipeline {
 		readonly logger: Logger,
 		readonly manifest: SSRManifest,
 		/**
-		 * "development" or "production"
+		 * "development" or "production" only
 		 */
-		readonly mode: RuntimeMode,
+		readonly runtimeMode: RuntimeMode,
 		readonly renderers: SSRLoadedRenderer[],
 		readonly resolve: (s: string) => Promise<string>,
 		/**
@@ -51,7 +51,7 @@ export abstract class Pipeline {
 		readonly compressHTML = manifest.compressHTML,
 		readonly i18n = manifest.i18n,
 		readonly middleware = manifest.middleware,
-		readonly routeCache = new RouteCache(logger, mode),
+		readonly routeCache = new RouteCache(logger, runtimeMode),
 		/**
 		 * Used for `Astro.site`.
 		 */

--- a/packages/astro/src/core/build/index.ts
+++ b/packages/astro/src/core/build/index.ts
@@ -31,7 +31,14 @@ import { collectPagesData } from './page-data.js';
 import { staticBuild, viteBuild } from './static-build.js';
 import type { StaticBuildOptions } from './types.js';
 import { getTimeStat } from './util.js';
+
 export interface BuildOptions {
+	/**
+	 * Create a development build, similar to code transformed in `astro dev`.
+	 *
+	 * @default false
+	 */
+	dev?: boolean;
 	/**
 	 * Teardown the compiler WASM instance after build. This can improve performance when
 	 * building once, but may cause a performance hit if building multiple times in a row.
@@ -52,7 +59,7 @@ export default async function build(
 	inlineConfig: AstroInlineConfig,
 	options: BuildOptions = {},
 ): Promise<void> {
-	ensureProcessNodeEnv('production');
+	ensureProcessNodeEnv(options.dev ? 'development' : 'production');
 	applyPolyfill();
 	const logger = createNodeLogger(inlineConfig);
 	const { userConfig, astroConfig } = await resolveConfig(inlineConfig, 'build');
@@ -67,29 +74,31 @@ export default async function build(
 	const builder = new AstroBuilder(settings, {
 		...options,
 		logger,
-		mode: inlineConfig.mode,
+		mode: inlineConfig.mode ?? 'production',
+		runtimeMode: options.dev ? 'development' : 'production',
 	});
 	await builder.run();
 }
 
 interface AstroBuilderOptions extends BuildOptions {
 	logger: Logger;
-	mode?: RuntimeMode;
+	mode: string;
+	runtimeMode: RuntimeMode;
 }
 
 class AstroBuilder {
 	private settings: AstroSettings;
 	private logger: Logger;
-	private mode: RuntimeMode = 'production';
+	private mode: string;
+	private runtimeMode: RuntimeMode;
 	private origin: string;
 	private manifest: ManifestData;
 	private timer: Record<string, number>;
 	private teardownCompiler: boolean;
 
 	constructor(settings: AstroSettings, options: AstroBuilderOptions) {
-		if (options.mode) {
-			this.mode = options.mode;
-		}
+		this.mode = options.mode;
+		this.runtimeMode = options.runtimeMode;
 		this.settings = settings;
 		this.logger = options.logger;
 		this.teardownCompiler = options.teardownCompiler ?? true;
@@ -127,7 +136,6 @@ class AstroBuilder {
 
 		const viteConfig = await createVite(
 			{
-				mode: this.mode,
 				server: {
 					hmr: false,
 					middlewareMode: true,
@@ -136,7 +144,7 @@ class AstroBuilder {
 			{
 				settings: this.settings,
 				logger: this.logger,
-				mode: 'build',
+				mode: this.mode,
 				command: 'build',
 				sync: false,
 				manifest: this.manifest,
@@ -145,6 +153,7 @@ class AstroBuilder {
 
 		const { syncInternal } = await import('../sync/index.js');
 		await syncInternal({
+			mode: this.mode,
 			settings: this.settings,
 			logger,
 			fs,
@@ -193,7 +202,7 @@ class AstroBuilder {
 			settings: this.settings,
 			logger: this.logger,
 			manifest: this.manifest,
-			mode: this.mode,
+			runtimeMode: this.runtimeMode,
 			origin: this.origin,
 			pageNames,
 			teardownCompiler: this.teardownCompiler,

--- a/packages/astro/src/core/build/pipeline.ts
+++ b/packages/astro/src/core/build/pipeline.ts
@@ -78,7 +78,7 @@ export class BuildPipeline extends Pipeline {
 		super(
 			options.logger,
 			manifest,
-			options.mode,
+			options.runtimeMode,
 			manifest.renderers,
 			resolve,
 			serverLike,

--- a/packages/astro/src/core/build/static-build.ts
+++ b/packages/astro/src/core/build/static-build.ts
@@ -156,7 +156,6 @@ async function ssrBuild(
 	const { lastVitePlugins, vitePlugins } = await container.runBeforeHook('server', input);
 	const viteBuildConfig: vite.InlineConfig = {
 		...viteConfig,
-		mode: viteConfig.mode || 'production',
 		logLevel: viteConfig.logLevel ?? 'error',
 		build: {
 			target: 'esnext',
@@ -269,7 +268,6 @@ async function clientBuild(
 
 	const viteBuildConfig: vite.InlineConfig = {
 		...viteConfig,
-		mode: viteConfig.mode || 'production',
 		build: {
 			target: 'esnext',
 			...viteConfig.build,

--- a/packages/astro/src/core/build/types.ts
+++ b/packages/astro/src/core/build/types.ts
@@ -30,7 +30,7 @@ export interface StaticBuildOptions {
 	settings: AstroSettings;
 	logger: Logger;
 	manifest: ManifestData;
-	mode: RuntimeMode;
+	runtimeMode: RuntimeMode;
 	origin: string;
 	pageNames: string[];
 	viteConfig: InlineConfig;

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -92,9 +92,9 @@ export async function createContainer({
 
 	warnMissingAdapter(logger, settings);
 
+	const mode = inlineConfig?.mode ?? 'development';
 	const viteConfig = await createVite(
 		{
-			mode: 'development',
 			server: { host, headers, open },
 			optimizeDeps: {
 				include: rendererClientEntries,
@@ -103,7 +103,7 @@ export async function createContainer({
 		{
 			settings,
 			logger,
-			mode: 'dev',
+			mode,
 			command: 'dev',
 			fs,
 			sync: false,
@@ -114,6 +114,7 @@ export async function createContainer({
 
 	await syncInternal({
 		settings,
+		mode,
 		logger,
 		skip: {
 			content: true,

--- a/packages/astro/src/core/render/route-cache.ts
+++ b/packages/astro/src/core/render/route-cache.ts
@@ -88,11 +88,11 @@ interface RouteCacheEntry {
 export class RouteCache {
 	private logger: Logger;
 	private cache: Record<string, RouteCacheEntry> = {};
-	private mode: RuntimeMode;
+	private runtimeMode: RuntimeMode;
 
-	constructor(logger: Logger, mode: RuntimeMode = 'production') {
+	constructor(logger: Logger, runtimeMode: RuntimeMode = 'production') {
 		this.logger = logger;
-		this.mode = mode;
+		this.runtimeMode = runtimeMode;
 	}
 
 	/** Clear the cache. */
@@ -105,7 +105,7 @@ export class RouteCache {
 		// NOTE: This shouldn't be called on an already-cached component.
 		// Warn here so that an unexpected double-call of getStaticPaths()
 		// isn't invisible and developer can track down the issue.
-		if (this.mode === 'production' && this.cache[key]?.staticPaths) {
+		if (this.runtimeMode === 'production' && this.cache[key]?.staticPaths) {
 			this.logger.warn(null, `Internal Warning: route cache overwritten. (${key})`);
 		}
 		this.cache[key] = entry;

--- a/packages/astro/src/env/vite-plugin-env.ts
+++ b/packages/astro/src/env/vite-plugin-env.ts
@@ -14,7 +14,7 @@ import { getEnvFieldType, validateEnvVariable } from './validators.js';
 
 interface AstroEnvPluginParams {
 	settings: AstroSettings;
-	mode: 'dev' | 'build' | string;
+	mode: string;
 	sync: boolean;
 }
 
@@ -27,11 +27,7 @@ export function astroEnv({ settings, mode, sync }: AstroEnvPluginParams): Plugin
 		name: 'astro-env-plugin',
 		enforce: 'pre',
 		buildStart() {
-			const loadedEnv = loadEnv(
-				mode === 'dev' ? 'development' : 'production',
-				fileURLToPath(settings.config.root),
-				'',
-			);
+			const loadedEnv = loadEnv(mode, fileURLToPath(settings.config.root), '');
 			for (const [key, value] of Object.entries(loadedEnv)) {
 				if (value !== undefined) {
 					process.env[key] = value;

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1684,9 +1684,12 @@ export interface AstroInlineOnlyConfig {
 	 */
 	configFile?: string | false;
 	/**
-	 * The mode used when building your site to generate either "development" or "production" code.
+	 * The mode used when building your site. It's passed to Vite that affects how `.env` files are loaded and the value
+	 * of `import.meta.env.MODE`. See the [Vite docs](https://vitejs.dev/guide/env-and-mode.html) for more information.
+	 *
+	 * @default "development" for `astro dev`, "production" for `astro build`
 	 */
-	mode?: RuntimeMode;
+	mode?: string;
 	/**
 	 * The logging level to filter messages logged by Astro.
 	 * - "debug": Log everything, including noisy debugging diagnostics.

--- a/packages/astro/src/vite-plugin-astro-server/pipeline.ts
+++ b/packages/astro/src/vite-plugin-astro-server/pipeline.ts
@@ -45,11 +45,10 @@ export class DevPipeline extends Pipeline {
 		readonly config = settings.config,
 		readonly defaultRoutes = createDefaultRoutes(manifest),
 	) {
-		const mode = 'development';
 		const resolve = createResolve(loader, config.root);
 		const serverLike = settings.buildOutput === 'server';
 		const streaming = true;
-		super(logger, manifest, mode, [], resolve, serverLike, streaming);
+		super(logger, manifest, 'development', [], resolve, serverLike, streaming);
 		manifest.serverIslandMap = settings.serverIslandMap;
 		manifest.serverIslandNameMap = settings.serverIslandNameMap;
 	}
@@ -72,14 +71,14 @@ export class DevPipeline extends Pipeline {
 		const {
 			config: { root },
 			loader,
-			mode,
+			runtimeMode,
 			settings,
 		} = this;
 		const filePath = new URL(`${routeData.component}`, root);
 		const scripts = new Set<SSRElement>();
 
 		// Inject HMR scripts
-		if (isPage(filePath, settings) && mode === 'development') {
+		if (isPage(filePath, settings) && runtimeMode === 'development') {
 			scripts.add({
 				props: { type: 'module', src: '/@vite/client' },
 				children: '',

--- a/packages/astro/test/astro-mode.test.js
+++ b/packages/astro/test/astro-mode.test.js
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { after, afterEach, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+
+describe('--mode', () => {
+	/** @type {import('./test-utils.js').Fixture} */
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/astro-mode/',
+		});
+	});
+
+	afterEach(() => {
+		// Reset so it doesn't interfere with other tests as builds below
+		// will interact with env variables loaded from .env files
+		delete process.env.NODE_ENV;
+		// `astro:env` writes to `process.env` currently which should be avoided,
+		// otherwise consecutive builds can't get the latest `.env` values. Workaround
+		// here for now be resetting it.
+		delete process.env.TITLE;
+	});
+
+	describe('build', () => {
+		before(async () => {
+			await fixture.build();
+		});
+
+		it('works', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			assert.equal($('#env-mode').text(), 'production');
+			assert.equal($('#env-dev').text(), 'false');
+			assert.equal($('#env-prod').text(), 'true');
+			assert.equal($('#env-title').text(), 'production');
+			assert.equal($('#env-astro-title').text(), 'production');
+		});
+	});
+
+	describe('build --mode testing --dev', () => {
+		before(async () => {
+			await fixture.build({ mode: 'testing' }, { dev: true });
+		});
+
+		it('works', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			assert.equal($('#env-mode').text(), 'testing');
+			assert.equal($('#env-dev').text(), 'true');
+			assert.equal($('#env-prod').text(), 'false');
+			assert.equal($('#env-title').text(), '');
+			assert.equal($('#env-astro-title').text(), 'unset');
+		});
+	});
+
+	describe('build --mode staging', () => {
+		before(async () => {
+			await fixture.build({ mode: 'staging' });
+		});
+
+		it('works', async () => {
+			const html = await fixture.readFile('/index.html');
+			const $ = cheerio.load(html);
+			assert.equal($('#env-mode').text(), 'staging');
+			assert.equal($('#env-dev').text(), 'false');
+			assert.equal($('#env-prod').text(), 'true');
+			assert.equal($('#env-title').text(), 'staging');
+			assert.equal($('#env-astro-title').text(), 'staging');
+		});
+	});
+
+	describe('dev', () => {
+		/** @type {import('./test-utils.js').DevServer} */
+		let devServer;
+		before(async () => {
+			devServer = await fixture.startDevServer();
+		});
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('works', async () => {
+			const res = await fixture.fetch('/');
+			assert.equal(res.status, 200);
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal($('#env-mode').text(), 'development');
+			assert.equal($('#env-dev').text(), 'true');
+			assert.equal($('#env-prod').text(), 'false');
+			assert.equal($('#env-title').text(), 'development');
+			assert.equal($('#env-astro-title').text(), 'development');
+		});
+	});
+
+	describe('dev --mode develop', () => {
+		/** @type {import('./test-utils.js').DevServer} */
+		let devServer;
+		before(async () => {
+			devServer = await fixture.startDevServer({ mode: 'develop' });
+		});
+		after(async () => {
+			await devServer.stop();
+		});
+
+		it('works', async () => {
+			const res = await fixture.fetch('/');
+			assert.equal(res.status, 200);
+			const html = await res.text();
+			const $ = cheerio.load(html);
+			assert.equal($('#env-mode').text(), 'develop');
+			assert.equal($('#env-dev').text(), 'true');
+			assert.equal($('#env-prod').text(), 'false');
+			assert.equal($('#env-title').text(), '');
+			assert.equal($('#env-astro-title').text(), 'unset');
+		});
+	});
+});

--- a/packages/astro/test/fixtures/astro-mode/.env.development
+++ b/packages/astro/test/fixtures/astro-mode/.env.development
@@ -1,0 +1,1 @@
+TITLE=development

--- a/packages/astro/test/fixtures/astro-mode/.env.production
+++ b/packages/astro/test/fixtures/astro-mode/.env.production
@@ -1,0 +1,1 @@
+TITLE=production

--- a/packages/astro/test/fixtures/astro-mode/.env.staging
+++ b/packages/astro/test/fixtures/astro-mode/.env.staging
@@ -1,0 +1,1 @@
+TITLE=staging

--- a/packages/astro/test/fixtures/astro-mode/astro.config.mjs
+++ b/packages/astro/test/fixtures/astro-mode/astro.config.mjs
@@ -1,0 +1,14 @@
+import { defineConfig, envField } from 'astro/config';
+
+export default defineConfig({
+	env: {
+		schema: {
+			TITLE: envField.string({
+				context: 'client',
+				access: 'public',
+				optional: true,
+				default: 'unset',
+			}),
+		},
+	},
+});

--- a/packages/astro/test/fixtures/astro-mode/package.json
+++ b/packages/astro/test/fixtures/astro-mode/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/astro-mode",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/astro-mode/src/pages/index.astro
+++ b/packages/astro/test/fixtures/astro-mode/src/pages/index.astro
@@ -1,0 +1,9 @@
+---
+import { TITLE } from 'astro:env/client';
+---
+
+<div id="env-mode">{import.meta.env.MODE}</div>
+<div id="env-dev">{import.meta.env.DEV.toString()}</div>
+<div id="env-prod">{import.meta.env.PROD.toString()}</div>
+<div id="env-title">{import.meta.env.TITLE}</div>
+<div id="env-astro-title">{TITLE}</div>

--- a/packages/astro/test/test-utils.js
+++ b/packages/astro/test/test-utils.js
@@ -162,7 +162,8 @@ export async function loadFixture(inlineConfig) {
 		build: async (extraInlineConfig = {}, options = {}) => {
 			globalContentLayer.dispose();
 			globalContentConfigObserver.set({ status: 'init' });
-			process.env.NODE_ENV = 'production';
+			// Reset NODE_ENV so it can be re-set by `build()`
+			delete process.env.NODE_ENV;
 			return build(mergeConfig(inlineConfig, extraInlineConfig), {
 				teardownCompiler: false,
 				...options,
@@ -175,7 +176,8 @@ export async function loadFixture(inlineConfig) {
 		startDevServer: async (extraInlineConfig = {}) => {
 			globalContentLayer.dispose();
 			globalContentConfigObserver.set({ status: 'init' });
-			process.env.NODE_ENV = 'development';
+			// Reset NODE_ENV so it can be re-set by `dev()`
+			delete process.env.NODE_ENV;
 			devServer = await dev(mergeConfig(inlineConfig, extraInlineConfig));
 			config.server.host = parseAddressToHost(devServer.address.address); // update host
 			config.server.port = devServer.address.port; // update port
@@ -233,7 +235,8 @@ export async function loadFixture(inlineConfig) {
 			}
 		},
 		preview: async (extraInlineConfig = {}) => {
-			process.env.NODE_ENV = 'production';
+			// Reset NODE_ENV so it can be re-set by `preview()`
+			delete process.env.NODE_ENV;
 			const previewServer = await preview(mergeConfig(inlineConfig, extraInlineConfig));
 			config.server.host = parseAddressToHost(previewServer.host); // update host
 			config.server.port = previewServer.port; // update port

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2330,6 +2330,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/astro/test/fixtures/astro-mode:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/astro-not-response:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

Users can know pass custom `--mode` other than `production` and `development`, like `staging` or anything else etc.

#### Within Astro, how do we actually tell in we're in dev or prod state now?

For `astro dev`, it'll always be in the dev state. It's not possible to be in a prod state as it may break existing code, like HMR and stuff (which is also a restriction in Vite)

For `astro build`, it'll be prod state by default, unless the user passes `--dev` which Astro will then switch to a dev state.

In other parts of the codebase, there's also the concept of `runtimeMode` which contains this state as either `"development"` or `"production"` values only.

#### Future coding style

If we want to check the prod or dev state, we should no longer rely on `mode` as that's no longer relevant. We can check via these states instead:

1. `viteResolvedConfig.isProduction`
2. `runtimeMode`
3. `process.env.NODE_ENV === 'production'`
4. `import.meta.env.PROD` and `import.meta.env.DEV`

## Testing

Added a new test to verify that it works.

## Docs

TBA. The `--dev` flag will require docs.
