### PR TITLE
feat(sitemap): add missing i18n urls on fallback type `rewrite`

### DIFF
--- a/.changeset/brown-shrimps-confess.md
+++ b/.changeset/brown-shrimps-confess.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/sitemap': patch
+---
+
+Include internationalized URLs when the fallback type is configured as `rewrite`

--- a/packages/integrations/sitemap/src/index.ts
+++ b/packages/integrations/sitemap/src/index.ts
@@ -130,6 +130,26 @@ const createPlugin = (options?: SitemapOptions): AstroIntegration => {
 						return urls;
 					}, []);
 
+					if (
+						opts.i18n &&
+						config.i18n &&
+						config.i18n.routing !== 'manual' &&
+						config.i18n.routing.fallbackType === 'rewrite'
+					) {
+						const { locales, defaultLocale } = opts.i18n;
+						const alternateLocales = Object.keys(locales).filter((locale) => {
+							return locale !== defaultLocale;
+						});
+
+						pageUrls.forEach((url) => {
+							alternateLocales.forEach((locale) => {
+								const newUrl = new URL(url);
+								newUrl.pathname = `/${locale}${newUrl.pathname}`;
+								pageUrls.push(newUrl.href);
+							});
+						});
+					}
+
 					pageUrls = Array.from(new Set([...pageUrls, ...routeUrls, ...(customPages ?? [])]));
 
 					try {

--- a/packages/integrations/sitemap/test/i18n-rewrite.test.js
+++ b/packages/integrations/sitemap/test/i18n-rewrite.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import { loadFixture, readXML } from './test-utils.js';
+
+describe('i18n-rewrite', () => {
+	/** @type {import('./test-utils.js').Fixture} */
+	let fixture;
+	/** @type {string[]} */
+	let urls;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/static/',
+			i18n: {
+				defaultLocale: 'it',
+				locales: ['it', 'de'],
+				routing: {
+					fallbackType: 'rewrite',
+				},
+			},
+		});
+		await fixture.build();
+
+		const data = await readXML(fixture.readFile('/sitemap-0.xml'));
+		urls = data.urlset.url.map((url) => url.loc[0]);
+	});
+
+	it('includes internationalized for getStaticPaths', async () => {
+		assert.equal(urls.includes('http://example.com/de/one/'), true);
+		assert.equal(urls.includes('http://example.com/de/two/'), true);
+	});
+
+	it('includes internationalized for numerical pages', () => {
+		assert.equal(urls.includes('http://example.com/de/123/'), true);
+	});
+
+	it('includes internationalized numerical 404 pages if not for i18n', () => {
+		assert.equal(urls.includes('http://example.com/de/products-by-id/405/'), true);
+		assert.equal(urls.includes('http://example.com/de/products-by-id/404/'), true);
+	});
+});


### PR DESCRIPTION
## Changes

- Include internationalized URLs when the fallback type is configured as `rewrite`

Fixes https://github.com/withastro/astro/issues/12135

## Testing

- Tests have been added to ensure that the internationalized routes are properly integrated.

## Docs

N/A
