### PR TITLE
Fix mts reloads

### DIFF
--- a/.changeset/mean-bags-shave.md
+++ b/.changeset/mean-bags-shave.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixed .mts astro config files not reloading automatically

--- a/.changeset/mean-bags-shave.md
+++ b/.changeset/mean-bags-shave.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixed .mts astro config files not reloading automatically
+Fixes a bug where `astro.config.mts` and `astro.config.cts` weren't reloading the dev server upon modifications.

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -30,7 +30,7 @@ async function createRestartedContainer(
 	return newContainer;
 }
 
-const configRE = /.*astro.config.(?:mjs|cjs|js|ts)$/;
+const configRE = /.*astro.config.(?:mjs|mts|cjs|js|ts)$/;
 
 function shouldRestartContainer(
 	{ settings, inlineConfig, restartInFlight }: Container,

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -30,7 +30,7 @@ async function createRestartedContainer(
 	return newContainer;
 }
 
-const configRE = /.*astro.config.(?:mjs|mts|cjs|js|ts)$/;
+const configRE = /.*astro.config.(?:mjs|mts|cjs|cts|js|ts)$/;
 
 function shouldRestartContainer(
 	{ settings, inlineConfig, restartInFlight }: Container,


### PR DESCRIPTION
## Changes

- Adds the .mts file extension to the configRE regex so it restarts when the `astro.config.mts` file changes
- Fixes #12159

## Testing

Manually tested

## Docs

N/A
