### PR TITLE
Add `css` keyword to Tailwind integration

### DIFF
--- a/.changeset/angry-ducks-kneel.md
+++ b/.changeset/angry-ducks-kneel.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/tailwind': patch
+---
+
+Adds keywords to `package.json` to improve categorization in the Astro integrations catalog

--- a/packages/integrations/tailwind/package.json
+++ b/packages/integrations/tailwind/package.json
@@ -13,7 +13,9 @@
   },
   "keywords": [
     "astro-integration",
-    "astro-component"
+    "withastro",
+    "css",
+    "tailwindcss"
   ],
   "bugs": "https://github.com/withastro/astro/issues",
   "homepage": "https://docs.astro.build/en/guides/integrations-guide/tailwind/",


### PR DESCRIPTION
## Changes

- Adds keywords to the Tailwind integration `package.json` to improve categorization in the Astro integrations catalog
- Currently Tailwind shows up as “uncategorized” but adding the `css` keyword in this PR will mean it gets put in the “CSS + UI” category ([docs](https://docs.astro.build/en/reference/publish-to-npm/#categories))

## Testing

n/a

## Docs

n/a