### PR TITLE
feat(db): Add support for libSQL remotes on non-Node runtimes

### DIFF
--- a/packages/db/src/core/cli/commands/execute/index.ts
+++ b/packages/db/src/core/cli/commands/execute/index.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../errors.js';
 import {
 	getLocalVirtualModContents,
-	getStudioVirtualModContents,
+	getRemoteVirtualModContents,
 } from '../../../integration/vite-plugin-db.js';
 import { bundleFile, importBundledFile } from '../../../load-file.js';
 import type { DBConfig } from '../../../types.js';
@@ -41,7 +41,7 @@ export async function cmd({
 	let virtualModContents: string;
 	if (flags.remote) {
 		const appToken = await getManagedRemoteToken(flags.token);
-		virtualModContents = getStudioVirtualModContents({
+		virtualModContents = getRemoteVirtualModContents({
 			tables: dbConfig.tables ?? {},
 			appToken: appToken.token,
 			isBuild: false,

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -31,7 +31,12 @@ import {
 	vitePluginDb,
 } from './vite-plugin-db.js';
 
-function astroDBIntegration(): AstroIntegration {
+type DBOptions = {
+	remoteClient?: 'native' | 'web';
+};
+
+function astroDBIntegration(options?: DBOptions): AstroIntegration {
+	const { remoteClient = 'native' } = options || {};
 	let connectToRemote = false;
 	let configFileDependencies: string[] = [];
 	let root: URL;
@@ -77,17 +82,22 @@ function astroDBIntegration(): AstroIntegration {
 				if (connectToRemote) {
 					appToken = await getManagedRemoteToken();
 					dbPlugin = vitePluginDb({
-						connectToStudio: connectToRemote,
+						connectToRemote: true,
 						appToken: appToken.token,
 						tables,
 						root: config.root,
 						srcDir: config.srcDir,
 						output: config.output,
 						seedHandler,
+						// The web remote client is only used for production builds
+						// in order to be compatible with non-Node server runtimes.
+						// For local development and CLI commands, the native client
+						// is used for greater flexibility.
+						remoteClientMode: command === 'build' ? remoteClient : 'native',
 					});
 				} else {
 					dbPlugin = vitePluginDb({
-						connectToStudio: false,
+						connectToRemote: false,
 						tables,
 						seedFiles,
 						root: config.root,


### PR DESCRIPTION
## Changes

- Add an option to the Astro DB integration to switch the client used for libSQL on production builds to the web client (restricted to Web Standards API instead of using a native Node binding)
- Enables using a libSQL remote on non-Node runtimes like Cloudflare and Deno

## Testing

Thiking about it

## Docs

Don't add or remove this note: https://github.com/withastro/docs/pull/9509#discussion_r1791120727
