### PR TITLE
fix: don't strip "slug" from content layer data

### DIFF
--- a/.changeset/funny-wolves-dream.md
+++ b/.changeset/funny-wolves-dream.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Allows "slug" as a field in content layer data

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -167,11 +167,12 @@ export async function getEntryDataAndImages<
 	pluginContext?: PluginContext,
 ): Promise<{ data: TOutputData; imageImports: Array<string> }> {
 	let data: TOutputData;
-	if (collectionConfig.type === 'data') {
-		data = entry.unvalidatedData as TOutputData;
-	} else {
+	// Legacy content collections have 'slug' removed
+	if (collectionConfig.type === 'content') {
 		const { slug, ...unvalidatedData } = entry.unvalidatedData;
 		data = unvalidatedData as TOutputData;
+	} else {
+		data = entry.unvalidatedData as TOutputData;
 	}
 
 	let schema = collectionConfig.schema;

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -168,7 +168,7 @@ export async function getEntryDataAndImages<
 ): Promise<{ data: TOutputData; imageImports: Array<string> }> {
 	let data: TOutputData;
 	// Legacy content collections have 'slug' removed
-	if (collectionConfig.type === 'content') {
+	if (collectionConfig.type === 'content' || (collectionConfig as any)._legacy) {
 		const { slug, ...unvalidatedData } = entry.unvalidatedData;
 		data = unvalidatedData as TOutputData;
 	} else {

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -260,6 +260,10 @@ describe('Content Layer', () => {
 			});
 		});
 
+		it('allows "slug" as a field', async () => {
+			assert.equal(json.increment.data.slug, 'slimy');
+		});
+
 		it('updates the store on new builds', async () => {
 			assert.equal(json.increment.data.lastValue, 1);
 			assert.equal(json.entryWithReference.data.something?.content, 'transform me');

--- a/packages/astro/test/fixtures/content-layer/src/content/config.ts
+++ b/packages/astro/test/fixtures/content-layer/src/content/config.ts
@@ -198,16 +198,22 @@ const images = defineCollection({
 const increment = defineCollection({
 	loader: {
 		name: 'increment-loader',
-		load: async ({ store, refreshContextData }) => {
+		load: async ({ store, refreshContextData, parseData }) => {
 			const entry = store.get<{ lastValue: number }>('value');
 			const lastValue = entry?.data.lastValue ?? 0;
-			store.set({
+			const raw = {
 				id: 'value',
 				data: {
 					lastValue: lastValue + 1,
 					lastUpdated: new Date(),
 					refreshContextData,
+					slug: 'slimy'
 				},
+			}
+			const parsed = await parseData(raw)
+			store.set({
+				id: raw.id,
+				data: parsed,
 			});
 		},
 		// Example of a loader that returns an async schema function
@@ -215,7 +221,8 @@ const increment = defineCollection({
 			z.object({
 				lastValue: z.number(),
 				lastUpdated: z.date(),
-				refreshContextData: z.record(z.unknown()),
+				refreshContextData: z.record(z.unknown()).optional(),
+				slug: z.string().optional(),
 			}),
 	},
 });


### PR DESCRIPTION
## Changes

The backward compat changes had introduced a bug, where content layer collections were having their `slug` field stripped. This PR fixes it so it only happens for legacy collections. This bug is not present in main.

Fixes #12162

## Testing

Added a test

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
