### PR TITLE
fix(routing): correct redirects in dev

### DIFF
--- a/.changeset/light-pears-accept.md
+++ b/.changeset/light-pears-accept.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes a bug where configured redirects were incorrectly constructed when reading the file system.
+
+This caused an issue where configuring a redirect in `astro.config.mjs` like `{ /old: /new }`, failed to trigger the correct redirect in the dev server.

--- a/.changeset/three-days-cough.md
+++ b/.changeset/three-days-cough.md
@@ -1,0 +1,7 @@
+---
+'astro': patch
+---
+
+Fixes a bug where the dev server was not providing a consistent user experience for configured redirects.
+
+With the fix, when you configure a redirect in `astro.config.mjs` like this `{ /old: "/new" }`, the dev server return an HTML response that matches the one emitted by a static build. 

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -33,6 +33,7 @@ import { getRedirectLocationOrThrow, routeIsRedirect } from '../redirects/index.
 import { RenderContext } from '../render-context.js';
 import { callGetStaticPaths } from '../render/route-cache.js';
 import { createRequest } from '../request.js';
+import { redirectTemplate } from '../routing/3xx.js';
 import { matchRoute } from '../routing/match.js';
 import { stringifyParams } from '../routing/params.js';
 import { getOutputFilename } from '../util.js';
@@ -448,14 +449,7 @@ async function generatePath(
 		// A short delay causes Google to interpret the redirect as temporary.
 		// https://developers.google.com/search/docs/crawling-indexing/301-redirects#metarefresh
 		const delay = response.status === 302 ? 2 : 0;
-		body = `<!doctype html>
-<title>Redirecting to: ${location}</title>
-<meta http-equiv="refresh" content="${delay};url=${location}">
-<meta name="robots" content="noindex">
-<link rel="canonical" href="${location}">
-<body>
-	<a href="${location}">Redirecting from <code>${fromPath}</code> to <code>${location}</code></a>
-</body>`;
+		body = redirectTemplate({ delay, location, from: fromPath });
 		if (config.compressHTML === true) {
 			body = body.replaceAll('\n', '');
 		}

--- a/packages/astro/src/core/build/generate.ts
+++ b/packages/astro/src/core/build/generate.ts
@@ -446,10 +446,7 @@ async function generatePath(
 		const siteURL = config.site;
 		const location = siteURL ? new URL(locationSite, siteURL) : locationSite;
 		const fromPath = new URL(request.url).pathname;
-		// A short delay causes Google to interpret the redirect as temporary.
-		// https://developers.google.com/search/docs/crawling-indexing/301-redirects#metarefresh
-		const delay = response.status === 302 ? 2 : 0;
-		body = redirectTemplate({ delay, location, from: fromPath });
+		body = redirectTemplate({ status: response.status, location, from: fromPath });
 		if (config.compressHTML === true) {
 			body = body.replaceAll('\n', '');
 		}

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -155,7 +155,6 @@ export class RenderContext {
 			}
 			let response: Response;
 
-			console.log('route type', this.routeData.type);
 			switch (this.routeData.type) {
 				case 'endpoint': {
 					response = await renderEndpoint(

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -155,6 +155,7 @@ export class RenderContext {
 			}
 			let response: Response;
 
+			console.log('route type', this.routeData.type);
 			switch (this.routeData.type) {
 				case 'endpoint': {
 					response = await renderEndpoint(

--- a/packages/astro/src/core/routing/3xx.ts
+++ b/packages/astro/src/core/routing/3xx.ts
@@ -1,10 +1,13 @@
 export type RedirectTemplate = {
 	from: string;
 	location: string | URL;
-	delay: 0 | 2;
+	status: number;
 };
 
-export function redirectTemplate({ delay, location, from }: RedirectTemplate) {
+export function redirectTemplate({ status, location, from }: RedirectTemplate) {
+	// A short delay causes Google to interpret the redirect as temporary.
+	// https://developers.google.com/search/docs/crawling-indexing/301-redirects#metarefresh
+	const delay = status === 302 ? 2 : 0;
 	return `<!doctype html>
 <title>Redirecting to: ${location}</title>
 <meta http-equiv="refresh" content="${delay};url=${location}">

--- a/packages/astro/src/core/routing/3xx.ts
+++ b/packages/astro/src/core/routing/3xx.ts
@@ -1,0 +1,16 @@
+export type RedirectTemplate = {
+	from: string;
+	location: string | URL;
+	delay: 0 | 2;
+};
+
+export function redirectTemplate({ delay, location, from }: RedirectTemplate) {
+	return `<!doctype html>
+<title>Redirecting to: ${location}</title>
+<meta http-equiv="refresh" content="${delay};url=${location}">
+<meta name="robots" content="noindex">
+<link rel="canonical" href="${location}">
+<body>
+	<a href="${location}">Redirecting from <code>${from}</code> to <code>${location}</code></a>
+</body>`;
+}

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -500,18 +500,8 @@ export async function createRouteManifest(
 
 	// we remove the file based routes that were deemed redirects
 	const filteredFiledBasedRoutes = fileBasedRoutes.filter((fileBasedRoute) => {
-		let isRedirect = redirectRoutes['normal'].findIndex((rd) => rd.route === fileBasedRoute.route);
-
-		if (isRedirect >= 0) {
-			return false;
-		}
-		isRedirect = redirectRoutes['legacy'].findIndex((rd) => rd.route === fileBasedRoute.route);
-
-		if (isRedirect >= 0) {
-			return false;
-		}
-
-		return true;
+		const isRedirect = redirectRoutes.findIndex((rd) => rd.route === fileBasedRoute.route);
+		return isRedirect < 0;
 	});
 
 	const routes: RouteData[] = [

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -498,8 +498,24 @@ export async function createRouteManifest(
 
 	const redirectRoutes = createRedirectRoutes(params, routeMap, logger);
 
+	// we remove the file based routes that were deemed redirects
+	const filteredFiledBasedRoutes = fileBasedRoutes.filter((fileBasedRoute) => {
+		let isRedirect = redirectRoutes['normal'].findIndex((rd) => rd.route === fileBasedRoute.route);
+
+		if (isRedirect >= 0) {
+			return false;
+		}
+		isRedirect = redirectRoutes['legacy'].findIndex((rd) => rd.route === fileBasedRoute.route);
+
+		if (isRedirect >= 0) {
+			return false;
+		}
+
+		return true;
+	});
+
 	const routes: RouteData[] = [
-		...[...fileBasedRoutes, ...injectedRoutes, ...redirectRoutes].sort(routeComparator),
+		...[...filteredFiledBasedRoutes, ...injectedRoutes, ...redirectRoutes].sort(routeComparator),
 	];
 
 	settings.buildOutput = getPrerenderDefault(config) ? 'static' : 'server';

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -299,7 +299,7 @@ export async function handleRoute({
 			// We try to replicate the same behaviour that we provide during a static build
 			response = new Response(
 				redirectTemplate({
-					delay: response.status === 302 ? 2 : 0,
+					status: response.status,
 					location: response.headers.get('location')!,
 					from: pathname,
 				}),

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -1,7 +1,6 @@
 import type http from 'node:http';
 import {
 	DEFAULT_404_COMPONENT,
-	REDIRECT_STATUS_CODES,
 	REROUTE_DIRECTIVE_HEADER,
 	REWRITE_DIRECTIVE_HEADER_KEY,
 	clientLocalsSymbol,


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/10576
Closes PLT-2584

This PR brings **two** fixes.

1. The first fix was around the construction of `RouteData[]` during the scanning of the file system. When configure redirects, Astro requires to have the _old_ routes in the file system. The old routes are stored as `"page"` routes, but then we have the function that marks them as `"redirect"`. The end product was an array that contained both routes, and the first one was the `"page"`, which was picked first. The fix removes those routes if we have some redirects
2. The second fix provides some UX improvements to our users by returning an HTML response that emulates that one returned by a static build. This means that we return a `200` status code, which is a bit controversial, but it matches the redirect that happens in static HTML file.

## Testing

The current CI should pass. I manually tested the changes in a project.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
