### PR TITLE
Improve Shiki highlighter performance

### DIFF
--- a/.changeset/many-squids-jog.md
+++ b/.changeset/many-squids-jog.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdown-remark': patch
+---
+
+Improve Shiki highlighter performance

--- a/packages/markdown/remark/src/highlight.ts
+++ b/packages/markdown/remark/src/highlight.ts
@@ -1,10 +1,9 @@
 import type { Element, Parent, Root } from 'hast';
-import { fromHtml } from 'hast-util-from-html';
 import { toText } from 'hast-util-to-text';
 import { removePosition } from 'unist-util-remove-position';
 import { visitParents } from 'unist-util-visit-parents';
 
-type Highlighter = (code: string, language: string, options?: { meta?: string }) => Promise<string>;
+type Highlighter = (code: string, language: string, options?: { meta?: string }) => Promise<Root>;
 
 const languagePattern = /\blanguage-(\S+)\b/;
 
@@ -73,15 +72,13 @@ export async function highlightCodeBlocks(tree: Root, highlighter: Highlighter) 
 	for (const { node, language, grandParent, parent } of nodes) {
 		const meta = (node.data as any)?.meta ?? node.properties.metastring ?? undefined;
 		const code = toText(node, { whitespace: 'pre' });
-		// TODO: In Astro 5, have `highlighter()` return hast directly to skip expensive HTML parsing and serialization.
-		const html = await highlighter(code, language, { meta });
+		const replacement = await highlighter(code, language, { meta });
 		// The replacement returns a root node with 1 child, the `<pr>` element replacement.
-		const replacement = fromHtml(html, { fragment: true }).children[0] as Element;
 		// We just generated this node, so any positional information is invalid.
 		removePosition(replacement);
 
 		// We replace the parent in its parent with the new `<pre>` element.
 		const index = grandParent.children.indexOf(parent);
-		grandParent.children[index] = replacement;
+		grandParent.children.splice(index, 1, ...replacement.children);
 	}
 }

--- a/packages/markdown/remark/src/rehype-prism.ts
+++ b/packages/markdown/remark/src/rehype-prism.ts
@@ -2,6 +2,7 @@ import { runHighlighterWithAstro } from '@astrojs/prism/dist/highlighter';
 import type { Root } from 'hast';
 import type { Plugin } from 'unified';
 import { highlightCodeBlocks } from './highlight.js';
+import { fromHtml } from 'hast-util-from-html';
 
 export const rehypePrism: Plugin<[], Root> = () => {
 	return async (tree) => {
@@ -9,7 +10,7 @@ export const rehypePrism: Plugin<[], Root> = () => {
 			let { html, classLanguage } = runHighlighterWithAstro(language, code);
 
 			return Promise.resolve(
-				`<pre class="${classLanguage}" data-language="${language}"><code is:raw class="${classLanguage}">${html}</code></pre>`,
+				fromHtml(`<pre class="${classLanguage}" data-language="${language}"><code is:raw class="${classLanguage}">${html}</code></pre>`)
 			);
 		});
 	};

--- a/packages/markdown/remark/src/shiki.ts
+++ b/packages/markdown/remark/src/shiki.ts
@@ -1,8 +1,8 @@
-import type { Properties } from 'hast';
+import type { Properties, Root } from 'hast';
 import {
 	type BundledLanguage,
 	createCssVariablesTheme,
-	getHighlighter,
+	getSingletonHighlighter,
 	isSpecialLang,
 } from 'shiki';
 import { visit } from 'unist-util-visit';
@@ -20,7 +20,7 @@ export interface ShikiHighlighter {
 			 */
 			meta?: string;
 		},
-	): Promise<string>;
+	): Promise<Root>;
 }
 
 // TODO: Remove this special replacement in Astro 5
@@ -36,7 +36,7 @@ const COLOR_REPLACEMENT_REGEX = new RegExp(
 let _cssVariablesTheme: ReturnType<typeof createCssVariablesTheme>;
 const cssVariablesTheme = () =>
 	_cssVariablesTheme ??
-	(_cssVariablesTheme = createCssVariablesTheme({ variablePrefix: '--astro-code-' }));
+	(_cssVariablesTheme = createCssVariablesTheme({ variablePrefix: '--astro-code-',  }));
 
 export async function createShikiHighlighter({
 	langs = [],
@@ -49,7 +49,7 @@ export async function createShikiHighlighter({
 }: ShikiConfig = {}): Promise<ShikiHighlighter> {
 	theme = theme === 'css-variables' ? cssVariablesTheme() : theme;
 
-	const highlighter = await getHighlighter({
+	const highlighter = await getSingletonHighlighter({
 		langs: ['plaintext', ...langs],
 		langAlias,
 		themes: Object.values(themes).length ? Object.values(themes) : [theme],
@@ -76,7 +76,7 @@ export async function createShikiHighlighter({
 			const themeOptions = Object.values(themes).length ? { themes } : { theme };
 			const inline = options?.inline ?? false;
 
-			return highlighter.codeToHtml(code, {
+			return highlighter.codeToHast(code, {
 				...themeOptions,
 				defaultColor,
 				lang,


### PR DESCRIPTION
## Changes

As the TODO `In Astro 5, have highlighter() return hast directly to skip expensive HTML parsing and serialization.` states.

This PR:
- Allow highlighter to return a HAST tree in `highlightCodeBlocks()`
- Let Shiki outputs HAST tree
- *The Prism highlighter remains unchanged (still using `fromHtml`)

This reduced extra work from the rehype plugin as Shiki directly outputs HAST, calling `highlighter.codeToHtml` and converting it back to HAST tree using `fromHtml()` is unnecessary.

## Testing

no tests added, this PR doesn't change the behavior of highlighters.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

no docs added, this PR doesn't change the behavior of highlighters.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
