### PR TITLE
fix: 404 and 500 route matching

### DIFF
--- a/.changeset/purple-swans-argue.md
+++ b/.changeset/purple-swans-argue.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Standardize 404 and 500 route matching via `isRoute404` and `isRoute500` functions

--- a/packages/astro/src/core/util.ts
+++ b/packages/astro/src/core/util.ts
@@ -33,6 +33,16 @@ export function padMultilineString(source: string, n = 2) {
 	return lines.map((l) => ` `.repeat(n) + l).join(`\n`);
 }
 
+export function isRoute404(route: string) {
+	const route404Pattern = /^\/404\/?$/;
+	return route404Pattern.test(route);
+}
+
+export function isRoute500(route: string) {
+	const route500Pattern = /^\/500\/?$/;
+	return route500Pattern.test(route);
+}
+
 const STATUS_CODE_PAGES = new Set(['/404', '/500']);
 
 /**

--- a/packages/astro/src/i18n/index.ts
+++ b/packages/astro/src/i18n/index.ts
@@ -10,6 +10,7 @@ import { shouldAppendForwardSlash } from '../core/build/util.js';
 import { REROUTE_DIRECTIVE_HEADER } from '../core/constants.js';
 import { MissingLocale, i18nNoLocaleFoundInPath } from '../core/errors/errors-data.js';
 import { AstroError } from '../core/errors/index.js';
+import { isRoute404, isRoute500 } from '../core/util.js';
 import { createI18nMiddleware } from './middleware.js';
 import type { RoutingStrategies } from './utils.js';
 
@@ -21,8 +22,9 @@ export function requestHasLocale(locales: Locales) {
 
 export function requestIs404Or500(request: Request, base = '') {
 	const url = new URL(request.url);
+	const pathname = url.pathname.slice(base.length);
 
-	return url.pathname.startsWith(`${base}/404`) || url.pathname.startsWith(`${base}/500`);
+	return isRoute404(pathname) || isRoute500(pathname);
 }
 
 // Checks if the pathname has any locale

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -13,6 +13,7 @@ import { RenderContext } from '../core/render-context.js';
 import { type SSROptions, getProps } from '../core/render/index.js';
 import { createRequest } from '../core/request.js';
 import { matchAllRoutes } from '../core/routing/index.js';
+import { isRoute404, isRoute500 } from '../core/util.js';
 import { getSortedPreloadedMatches } from '../prerender/routing.js';
 import type { DevPipeline } from './pipeline.js';
 import { writeSSRResult, writeWebResponse } from './response.js';
@@ -36,13 +37,11 @@ function isLoggedRequest(url: string) {
 }
 
 function getCustom404Route(manifestData: ManifestData): RouteData | undefined {
-	const route404 = /^\/404\/?$/;
-	return manifestData.routes.find((r) => route404.test(r.route));
+	return manifestData.routes.find((r) => isRoute404(r.route));
 }
 
 function getCustom500Route(manifestData: ManifestData): RouteData | undefined {
-	const route500 = /^\/500\/?$/;
-	return manifestData.routes.find((r) => route500.test(r.route));
+	return manifestData.routes.find((r) => isRoute500(r.route));
 }
 
 export async function matchRoute(


### PR DESCRIPTION
## Changes

- What does this change?

- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

Standardize 404 and 500 route matching via `isRoute404` and `isRoute500` functions. This addresses #11595 .

I'm unsure where are the best places to put the `isRoute404` and `isRoute500` functions, so I put them in `packages/astro/src/core/util.ts` with other util files but that could be moved! They are used in `packages/astro/src/i18n/index.ts` and `packages/astro/src/vite-plugin-astro-server/route.ts`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

No tests were added as no new behavior was added. Ran `pnpm test` on the `astro` package via `pnpm --filter astro run test`.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

n/a, this is a fix in behavior that addresses #11595 