### PR TITLE
Ensure that the generated package.json and tsconfig.json end with a newline.

### DIFF
--- a/.changeset/tidy-bugs-yawn.md
+++ b/.changeset/tidy-bugs-yawn.md
@@ -2,4 +2,4 @@
 'create-astro': minor
 ---
 
-The generated package.json and tsconfig.json will have a newline at the end of the file.
+Ensures new line at the end of the generated `package.json` and `tsconfig.json` files

--- a/.changeset/tidy-bugs-yawn.md
+++ b/.changeset/tidy-bugs-yawn.md
@@ -1,0 +1,5 @@
+---
+'create-astro': minor
+---
+
+The generated package.json and tsconfig.json will have a newline at the end of the file.

--- a/packages/create-astro/src/actions/typescript.ts
+++ b/packages/create-astro/src/actions/typescript.ts
@@ -108,7 +108,7 @@ const FILES_TO_UPDATE = {
 			parsedPackageJson.dependencies['@astrojs/check'] = `^${astroCheckVersion}`;
 			parsedPackageJson.dependencies.typescript = `^${typescriptVersion}`;
 
-			await writeFile(file, JSON.stringify(parsedPackageJson, null, indent), 'utf-8');
+			await writeFile(file, JSON.stringify(parsedPackageJson, null, indent) + '\n', 'utf-8');
 		} catch (err) {
 			// if there's no package.json (which is very unlikely), then do nothing
 			if (err && (err as any).code === 'ENOENT') return;
@@ -124,7 +124,7 @@ const FILES_TO_UPDATE = {
 					extends: `astro/tsconfigs/${options.value}`,
 				});
 
-				await writeFile(file, JSON.stringify(result, null, 2));
+				await writeFile(file, JSON.stringify(result, null, 2) + '\n');
 			} else {
 				throw new Error(
 					"There was an error applying the requested TypeScript settings. This could be because the template's tsconfig.json is malformed",
@@ -135,7 +135,7 @@ const FILES_TO_UPDATE = {
 				// If the template doesn't have a tsconfig.json, let's add one instead
 				await writeFile(
 					file,
-					JSON.stringify({ extends: `astro/tsconfigs/${options.value}` }, null, 2),
+					JSON.stringify({ extends: `astro/tsconfigs/${options.value}` }, null, 2) + '\n',
 				);
 			}
 		}

--- a/packages/create-astro/test/typescript.test.js
+++ b/packages/create-astro/test/typescript.test.js
@@ -91,6 +91,7 @@ describe('typescript: setup tsconfig', async () => {
 		assert.deepEqual(JSON.parse(fs.readFileSync(tsconfig, { encoding: 'utf-8' })), {
 			extends: 'astro/tsconfigs/strict',
 		});
+		assert(fs.readFileSync(tsconfig, { encoding: 'utf-8' }).endsWith('\n'), 'The file does not end with a newline');
 	});
 
 	it('exists', async () => {
@@ -100,6 +101,7 @@ describe('typescript: setup tsconfig', async () => {
 		assert.deepEqual(JSON.parse(fs.readFileSync(tsconfig, { encoding: 'utf-8' })), {
 			extends: 'astro/tsconfigs/strict',
 		});
+		assert(fs.readFileSync(tsconfig, { encoding: 'utf-8' }).endsWith('\n'), 'The file does not end with a newline');
 	});
 });
 
@@ -124,6 +126,7 @@ describe('typescript: setup package', async () => {
 		);
 
 		await setupTypeScript('strictest', { cwd: fileURLToPath(root), install: false });
+		assert(fs.readFileSync(packageJson, { encoding: 'utf-8' }).endsWith('\n'), 'The file does not end with a newline');
 		const { scripts, dependencies } = JSON.parse(
 			fs.readFileSync(packageJson, { encoding: 'utf-8' }),
 		);


### PR DESCRIPTION
## Changes

Add new line at the end of generated package.json and tsconfig.json files.

before
```json
{
  "extends": "astro/tsconfigs/strict"
}
```

after
```diff
{
  "extends": "astro/tsconfigs/strict"
}

```

## Testing

### How was this change tested?
- I add a test case that check the file does end with new line.
- I run `node ./astro/packages/create-astro/create-astro.mjs` in my local machine, and check the files end with new line.

## Docs

- Could this affect a user’s behavior? We probably need to update docs!
    - No.
    - Generated files will end with new line.
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
