### PR TITLE
Fix setOnSetGetEnv parameter name

### DIFF
--- a/.changeset/bright-bananas-run.md
+++ b/.changeset/bright-bananas-run.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Fixes accidental internal `setOnSetGetEnv` parameter rename that caused runtime errors

--- a/packages/astro/templates/env/module.mjs
+++ b/packages/astro/templates/env/module.mjs
@@ -26,6 +26,8 @@ const _internalGetSecret = (key) => {
 };
 
 // used while generating the virtual module
-setOnSetGetEnv((_reset) => {
+// biome-ignore lint/correctness/noUnusedFunctionParameters: `reset` is used by the generated code
+// biome-ignore lint/correctness/noUnusedVariables: `reset` is used by the generated code
+setOnSetGetEnv((reset) => {
 	// @@ON_SET_GET_ENV@@
 });


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/12210

The parameter name should be prefixed with an underscore as it's used here:

https://github.com/withastro/astro/blob/ed1adf97e3fba7e71e1b0793efd08c6f8f1ebb3b/packages/astro/src/env/vite-plugin-env.ts#L165-L168

## Testing

Existing tests should pass. Probably should add a test for this, but I'm not sure how at the moment.

## Docs

n/a