### PR TITLE
fix(dev-toolbar): false positive in Audit with a11y check on labels

### DIFF
--- a/.changeset/selfish-toes-carry.md
+++ b/.changeset/selfish-toes-carry.md
@@ -3,3 +3,5 @@
 ---
 
 Fixes a false positive reported by the dev toolbar Audit app where a label was considered missing when associated with a button
+
+The `button` element can be [used with a label](https://www.w3.org/TR/2011/WD-html5-author-20110809/forms.html#category-label) (e.g. to create a switch) and should not be reported as an accessibility issue when used as a child of a `label`.

--- a/.changeset/selfish-toes-carry.md
+++ b/.changeset/selfish-toes-carry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a false positive reported by the dev toolbar Audit app where a label was considered missing when associated with a button

--- a/packages/astro/e2e/dev-toolbar-audits.test.js
+++ b/packages/astro/e2e/dev-toolbar-audits.test.js
@@ -170,4 +170,18 @@ test.describe('Dev Toolbar - Audits', () => {
 		const count = await auditHighlights.count();
 		expect(count).toEqual(0);
 	});
+
+	test('does not warn about label with valid labelable elements', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/a11y-labelable'));
+
+		const toolbar = page.locator('astro-dev-toolbar');
+		const appButton = toolbar.locator('button[data-app-id="astro:audit"]');
+		await appButton.click();
+
+		const auditCanvas = toolbar.locator('astro-dev-toolbar-app-canvas[data-app-id="astro:audit"]');
+		const auditHighlights = auditCanvas.locator('astro-dev-toolbar-highlight');
+
+		const count = await auditHighlights.count();
+		expect(count).toEqual(0);
+	});
 });

--- a/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-labelable.astro
+++ b/packages/astro/e2e/fixtures/dev-toolbar/src/pages/a11y-labelable.astro
@@ -1,0 +1,54 @@
+---
+
+---
+
+<label for="button1">Button label</label>
+<button id="button1" />
+<label>
+	Button label as child
+	<button>Activate?</button>
+</label>
+<label for="input1">Input label</label>
+<input id="input1" />
+<label>
+	Input label as child
+	<input type="text" />
+</label>
+<label for="meter1">Meter label</label>
+<meter id="meter1" min="0" max="100" value="75">75%</meter>
+<label>
+	Meter label as child
+	<meter min="0" max="100" value="75">75%</meter>
+</label>
+<label for="output1">Output label</label>
+<output id="output1">"Hello, world!"</output>
+<label>
+	Output label as child
+	<output>"Hello, world!"</output>
+</label>
+<label for="progress1">Progress label</label>
+<progress id="progress1" max="100" value="70">70%</progress>
+<label>
+	Progress label as child
+	<progress max="100" value="70">70%</progress>
+</label>
+<label for="select1">Select label</label>
+<select id="select1">
+	<option>Option 1</option>
+	<option>Option 2</option>
+	<option>Option 3</option>
+</select>
+<label>
+	Select label as child
+	<select>
+		<option>Option 1</option>
+		<option>Option 2</option>
+		<option>Option 3</option>
+	</select>
+</label>
+<label for="textarea1">Textarea label</label>
+<textarea cols="33" id="textarea1" rows="5" />
+<label>
+	Textarea label as child
+	<textarea cols="33" rows="5" />
+</label>

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -62,7 +62,7 @@ const interactiveElements = [
 	...MAYBE_INTERACTIVE.keys(),
 ];
 
-const labellableElements = ['input', 'meter', 'output', 'progress', 'select', 'textarea'];
+const labellableElements = ['button', 'input', 'meter', 'output', 'progress', 'select', 'textarea'];
 
 const aria_non_interactive_roles = [
 	'alert',


### PR DESCRIPTION
`button` element is [labelable according to MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#labelable) and it can be useful to [create switches](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role) for example. Due to the absence of `button` in `labellableElements`, the Audit app in Dev Toolbar reports a false positive in a11y checks when using `button` as child of a `label`.

Here is a minimal reproduction: https://stackblitz.com/edit/astro-dev-toolbar-audit-label?file=src%2Fpages%2Findex.astro
* When using `id`/`for` it works as expected
* When using `button` as child of `label` the Audit app reports an issue

## Changes

Adds `button` in `labellableElements` used in the `a11y-invalid-label` rule.

## Testing

I'm not sure if there are any tests with the current a11y rules so I didn't add any. I only tested manually: with this change, the false positive disappear.

## Docs

* I added a changeset that is longer than the patch... 😅  feel free to reword!
* Nothing to update on Astro Docs.
