### PR TITLE
feat: accept `URL` for entry points

### DIFF
--- a/.changeset/eighty-donkeys-fly.md
+++ b/.changeset/eighty-donkeys-fly.md
@@ -5,11 +5,10 @@
 The following renderer fields and integration fields now accept `URL` as a type:
 
 **Renderers**:
--`AstroRenderer.clientEntrpoint`;
--`AstroRenderer.serverEntrypoint`;
-
+- `AstroRenderer.clientEntrpoint`
+- `AstroRenderer.serverEntrypoint`
 
 **Integrations**:
-- `InjectedRoute.entrypoint`;
-- `AstroIntegrationMiddleware.entrypoint`;
-- `DevToolbarAppEntry.entrypoint`;
+- `InjectedRoute.entrypoint`
+- `AstroIntegrationMiddleware.entrypoint`
+- `DevToolbarAppEntry.entrypoint`

--- a/.changeset/eighty-donkeys-fly.md
+++ b/.changeset/eighty-donkeys-fly.md
@@ -1,0 +1,15 @@
+---
+'astro': minor
+---
+
+The following renderer fields and integration fields now accept `URL` as a type:
+
+**Renderers**:
+-`AstroRenderer.clientEntrpoint`;
+-`AstroRenderer.serverEntrypoint`;
+
+
+**Integrations**:
+- `InjectedRoute.entrypoint`;
+- `AstroIntegrationMiddleware.entrypoint`;
+- `DevToolbarAppEntry.entrypoint`;

--- a/packages/astro/src/core/client-directive/build.ts
+++ b/packages/astro/src/core/client-directive/build.ts
@@ -4,7 +4,11 @@ import { build } from 'esbuild';
 /**
  * Build a client directive entrypoint into code that can directly run in a `<script>` tag.
  */
-export async function buildClientDirectiveEntrypoint(name: string, entrypoint: string, root: URL) {
+export async function buildClientDirectiveEntrypoint(
+	name: string,
+	entrypoint: string | URL,
+	root: URL,
+) {
 	const stringifiedName = JSON.stringify(name);
 	const stringifiedEntrypoint = JSON.stringify(entrypoint);
 

--- a/packages/astro/src/core/middleware/vite-plugin.ts
+++ b/packages/astro/src/core/middleware/vite-plugin.ts
@@ -64,9 +64,6 @@ export function vitePluginMiddleware({ settings }: { settings: AstroSettings }):
 					});
 				}
 
-				console.log('middleware', settings.middlewares.pre);
-				console.log('middleware', settings.middlewares.post);
-
 				const preMiddleware = createMiddlewareImports(settings.middlewares.pre, 'pre');
 				const postMiddleware = createMiddlewareImports(settings.middlewares.post, 'post');
 

--- a/packages/astro/src/core/middleware/vite-plugin.ts
+++ b/packages/astro/src/core/middleware/vite-plugin.ts
@@ -64,6 +64,9 @@ export function vitePluginMiddleware({ settings }: { settings: AstroSettings }):
 					});
 				}
 
+				console.log('middleware', settings.middlewares.pre);
+				console.log('middleware', settings.middlewares.post);
+
 				const preMiddleware = createMiddlewareImports(settings.middlewares.pre, 'pre');
 				const postMiddleware = createMiddlewareImports(settings.middlewares.post, 'post');
 

--- a/packages/astro/src/core/preview/index.ts
+++ b/packages/astro/src/core/preview/index.ts
@@ -67,7 +67,7 @@ export default async function preview(inlineConfig: AstroInlineConfig): Promise<
 	// preview entrypoint of the integration package, relative to the user's project root.
 	const require = createRequire(settings.config.root);
 	const previewEntrypointUrl = pathToFileURL(
-		require.resolve(settings.adapter.previewEntrypoint),
+		require.resolve(settings.adapter.previewEntrypoint.toString()),
 	).href;
 
 	const previewModule = (await import(previewEntrypointUrl)) as Partial<PreviewModule>;

--- a/packages/astro/src/core/render/renderer.ts
+++ b/packages/astro/src/core/render/renderer.ts
@@ -1,4 +1,4 @@
-import type { AstroRenderer } from '../../types/public/integrations.js';
+import type { AstroRenderer } from '../../types/public/index.js';
 import type { SSRLoadedRenderer } from '../../types/public/internal.js';
 import type { ModuleLoader } from '../module-loader/index.js';
 
@@ -6,7 +6,7 @@ export async function loadRenderer(
 	renderer: AstroRenderer,
 	moduleLoader: ModuleLoader,
 ): Promise<SSRLoadedRenderer | undefined> {
-	const mod = await moduleLoader.import(renderer.serverEntrypoint);
+	const mod = await moduleLoader.import(renderer.serverEntrypoint.toString());
 	if (typeof mod.default !== 'undefined') {
 		return {
 			...renderer,

--- a/packages/astro/src/core/render/renderer.ts
+++ b/packages/astro/src/core/render/renderer.ts
@@ -1,4 +1,4 @@
-import type { AstroRenderer } from '../../types/public/index.js';
+import type { AstroRenderer } from '../../types/public/integrations.js';
 import type { SSRLoadedRenderer } from '../../types/public/internal.js';
 import type { ModuleLoader } from '../module-loader/index.js';
 

--- a/packages/astro/src/core/routing/manifest/create.ts
+++ b/packages/astro/src/core/routing/manifest/create.ts
@@ -281,7 +281,7 @@ function createInjectedRoutes({ settings, cwd }: CreateRouteManifestParams): Rou
 
 	for (const injectedRoute of settings.injectedRoutes) {
 		const { pattern: name, entrypoint, prerender: prerenderInjected } = injectedRoute;
-		const { resolved, component } = resolveInjectedRoute(entrypoint, config.root, cwd);
+		const { resolved, component } = resolveInjectedRoute(entrypoint.toString(), config.root, cwd);
 
 		const segments = removeLeadingForwardSlash(name)
 			.split(path.posix.sep)

--- a/packages/astro/src/integrations/hooks.ts
+++ b/packages/astro/src/integrations/hooks.ts
@@ -236,7 +236,7 @@ export async function runHookConfigSetup({
 							order === 'pre' ? 'before' : 'after'
 						} any application middleware you define.`,
 					);
-					updatedSettings.middlewares[order].push(entrypoint);
+					updatedSettings.middlewares[order].push(entrypoint.toString());
 				},
 				createCodegenDir: () => {
 					const codegenDir = new URL(normalizeCodegenDir(integration.name), settings.dotAstroDir);

--- a/packages/astro/src/integrations/hooks.ts
+++ b/packages/astro/src/integrations/hooks.ts
@@ -236,7 +236,9 @@ export async function runHookConfigSetup({
 							order === 'pre' ? 'before' : 'after'
 						} any application middleware you define.`,
 					);
-					updatedSettings.middlewares[order].push(entrypoint.toString());
+					updatedSettings.middlewares[order].push(
+						typeof entrypoint === 'string' ? entrypoint : fileURLToPath(entrypoint),
+					);
 				},
 				createCodegenDir: () => {
 					const codegenDir = new URL(normalizeCodegenDir(integration.name), settings.dotAstroDir);

--- a/packages/astro/src/runtime/server/hydration.ts
+++ b/packages/astro/src/runtime/server/hydration.ts
@@ -158,7 +158,9 @@ export async function generateHydrateScript(
 	// Add renderer url
 	if (renderer.clientEntrypoint) {
 		island.props['component-export'] = componentExport.value;
-		island.props['renderer-url'] = await result.resolve(decodeURI(renderer.clientEntrypoint));
+		island.props['renderer-url'] = await result.resolve(
+			decodeURI(renderer.clientEntrypoint.toString()),
+		);
 		island.props['props'] = escapeHTML(serializeProps(props, metadata));
 	}
 

--- a/packages/astro/src/toolbar/vite-plugin-dev-toolbar.ts
+++ b/packages/astro/src/toolbar/vite-plugin-dev-toolbar.ts
@@ -66,9 +66,9 @@ export default function astroDevToolbar({ settings, logger }: AstroPluginOptions
 									`safeLoadPlugin(${JSON.stringify(
 										plugin,
 									)}, async () => (await import(${JSON.stringify(
-										typeof plugin === 'string' ? plugin : plugin.entrypoint,
+										typeof plugin === 'string' ? plugin : plugin.entrypoint.toString(),
 									)})).default, ${JSON.stringify(
-										typeof plugin === 'string' ? plugin : plugin.entrypoint,
+										typeof plugin === 'string' ? plugin : plugin.entrypoint.toString(),
 									)})`,
 							)
 							.join(',')}]));

--- a/packages/astro/src/types/public/integrations.ts
+++ b/packages/astro/src/types/public/integrations.ts
@@ -49,16 +49,16 @@ export type ClientDirective = (
 
 export interface ClientDirectiveConfig {
 	name: string;
-	entrypoint: string;
+	entrypoint: string | URL;
 }
 
 export interface AstroRenderer {
 	/** Name of the renderer. */
 	name: string;
 	/** Import entrypoint for the client/browser renderer. */
-	clientEntrypoint?: string;
+	clientEntrypoint?: string | URL;
 	/** Import entrypoint for the server/build/ssr renderer. */
-	serverEntrypoint: string;
+	serverEntrypoint: string | URL;
 }
 
 export type AdapterSupportsKind =
@@ -84,8 +84,8 @@ export interface AstroAdapterFeatures {
 
 export interface AstroAdapter {
 	name: string;
-	serverEntrypoint?: string;
-	previewEntrypoint?: string;
+	serverEntrypoint?: string | URL;
+	previewEntrypoint?: string | URL;
 	exports?: string[];
 	args?: any;
 	adapterFeatures?: AstroAdapterFeatures;
@@ -140,7 +140,7 @@ export type InjectedScriptStage = 'before-hydration' | 'head-inline' | 'page' | 
 
 export interface InjectedRoute {
 	pattern: string;
-	entrypoint: string;
+	entrypoint: string | URL;
 	prerender?: boolean;
 }
 
@@ -155,7 +155,7 @@ export interface InjectedType {
 
 export type AstroIntegrationMiddleware = {
 	order: 'pre' | 'post';
-	entrypoint: string;
+	entrypoint: string | URL;
 };
 
 export type HookParameters<

--- a/packages/astro/src/types/public/toolbar.ts
+++ b/packages/astro/src/types/public/toolbar.ts
@@ -45,7 +45,7 @@ type DevToolbarAppMeta = {
 
 // The param passed to `addDevToolbarApp` in the integration
 export type DevToolbarAppEntry = DevToolbarAppMeta & {
-	entrypoint: string;
+	entrypoint: string | URL;
 };
 
 // Public API for the dev toolbar

--- a/packages/astro/src/virtual-modules/container.ts
+++ b/packages/astro/src/virtual-modules/container.ts
@@ -18,7 +18,7 @@ import type { SSRLoadedRenderer } from '../types/public/internal.js';
 export async function loadRenderers(renderers: AstroRenderer[]) {
 	const loadedRenderers = await Promise.all(
 		renderers.map(async (renderer) => {
-			const mod = await import(renderer.serverEntrypoint);
+			const mod = await import(renderer.serverEntrypoint.toString());
 			if (typeof mod.default !== 'undefined') {
 				return {
 					...renderer,

--- a/packages/astro/src/vite-plugin-integrations-container/index.ts
+++ b/packages/astro/src/vite-plugin-integrations-container/index.ts
@@ -35,7 +35,7 @@ async function resolveEntryPoint(
 	this: PluginContext,
 	route: InjectedRoute,
 ): Promise<ResolvedInjectedRoute> {
-	const resolvedId = await this.resolve(route.entrypoint)
+	const resolvedId = await this.resolve(route.entrypoint.toString())
 		.then((res) => res?.id)
 		.catch(() => undefined);
 	if (!resolvedId) return route;

--- a/packages/astro/test/fixtures/middleware-no-user-middleware/astro.config.mjs
+++ b/packages/astro/test/fixtures/middleware-no-user-middleware/astro.config.mjs
@@ -16,6 +16,11 @@ export default defineConfig({
 						entrypoint: fileURLToPath(new URL('./integration-middleware-post.js', import.meta.url)),
 						order: 'post'
 					});
+
+					addMiddleware({
+						entrypoint: new URL('./integration-middleware-url.js', import.meta.url),
+						order: 'post'
+					});
 				}
 			}
 		}

--- a/packages/astro/test/fixtures/middleware-no-user-middleware/integration-middleware-url.js
+++ b/packages/astro/test/fixtures/middleware-no-user-middleware/integration-middleware-url.js
@@ -2,11 +2,7 @@ import { defineMiddleware } from 'astro:middleware';
 
 export const onRequest = defineMiddleware((context, next) => {
 	if (context.url.pathname === '/url') {
-		return new Response(JSON.stringify({ post: 'works' }), {
-			headers: {
-				'content-type': 'application/json',
-			},
-		});
+		return Response.json({ post: 'works' });
 	}
 
 	return next();

--- a/packages/astro/test/fixtures/middleware-no-user-middleware/integration-middleware-url.js
+++ b/packages/astro/test/fixtures/middleware-no-user-middleware/integration-middleware-url.js
@@ -1,0 +1,13 @@
+import { defineMiddleware } from 'astro:middleware';
+
+export const onRequest = defineMiddleware((context, next) => {
+	if (context.url.pathname === '/url') {
+		return new Response(JSON.stringify({ post: 'works' }), {
+			headers: {
+				'content-type': 'application/json',
+			},
+		});
+	}
+
+	return next();
+});

--- a/packages/astro/test/fixtures/multiple-renderers/renderers/two/index.mjs
+++ b/packages/astro/test/fixtures/multiple-renderers/renderers/two/index.mjs
@@ -7,7 +7,7 @@ export default function() {
 				addRenderer({
 					name: 'renderer-two',
 					clientEntrypoint: null,
-					serverEntrypoint: '@test/astro-renderer-two/server.mjs',
+					serverEntrypoint: new URL('server.mjs', import.meta.url),
 				});
 			}
 		}

--- a/packages/astro/test/fixtures/reuse-injected-entrypoint/astro.config.mjs
+++ b/packages/astro/test/fixtures/reuse-injected-entrypoint/astro.config.mjs
@@ -6,7 +6,7 @@ export default defineConfig({
 		{
 			name: 'astropi',
 			hooks: {
-				'astro:config:setup': async ({ injectRoute }) => {
+				'astro:config:setup': async ({ injectRoute, config }) => {
 					injectRoute({
 						pattern: `/injected-a`,
 						entrypoint: './src/to-inject.astro',
@@ -27,6 +27,11 @@ export default defineConfig({
 						entrypoint: './src/[id].astro',
 						prerender: true,
 					});
+					injectRoute({
+						pattern: `/dynamic-c/[id]`,
+						entrypoint: new URL('./[id].astro', config.srcDir),
+						prerender: true,
+					})
 				},
 			},
 		},

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -102,7 +102,7 @@ describe('Middleware in DEV mode', () => {
 	});
 });
 
-describe.only('Integration hooks with no user middleware', () => {
+describe('Integration hooks with no user middleware', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
 	let devServer;
@@ -129,7 +129,7 @@ describe.only('Integration hooks with no user middleware', () => {
 		assert.equal(json.post, 'works');
 	});
 
-	it.only('Integration middleware marked as "url" runs', async () => {
+	it('Integration middleware marked as "url" runs', async () => {
 		const res = await fixture.fetch('/url');
 		const json = await res.json();
 		assert.equal(json.post, 'works');

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -102,7 +102,7 @@ describe('Middleware in DEV mode', () => {
 	});
 });
 
-describe('Integration hooks with no user middleware', () => {
+describe.only('Integration hooks with no user middleware', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
 	let devServer;
@@ -125,6 +125,12 @@ describe('Integration hooks with no user middleware', () => {
 
 	it('Integration middleware marked as "post" runs', async () => {
 		const res = await fixture.fetch('/post');
+		const json = await res.json();
+		assert.equal(json.post, 'works');
+	});
+
+	it.only('Integration middleware marked as "url" runs', async () => {
+		const res = await fixture.fetch('/url');
 		const json = await res.json();
 		assert.equal(json.post, 'works');
 	});

--- a/packages/astro/test/reuse-injected-entrypoint.test.js
+++ b/packages/astro/test/reuse-injected-entrypoint.test.js
@@ -43,6 +43,12 @@ const routes = [
 		h1: '[id].astro',
 		p: 'id-2',
 	},
+	{
+		description: 'matches /dynamic-c/id-2 to [id].astro when the route is injected with a URL',
+		url: '/dynamic-c/id-2',
+		h1: '[id].astro',
+		p: 'id-2',
+	},
 ];
 
 function appendForwardSlash(path) {


### PR DESCRIPTION
## Changes

Closes PLT-1993

The entrypoints of adapters, integrations and renderers (server and client) can now accept a `URL`. 

This isn't a breaking change and it should ease the life of integration developers. We already encourage them to use `fileURLtoPath` when providing a string.

### Question

Should we use `fileURLToPath` when printing the `URL`? At the moment I used `toString()` because `fileURLToPath` is a Node.js function, and there are cases where we don't have Node.js available.

## Testing

- Renderers: I took and existing test and changed the correct renderer to be loaded using `URL`
- Middleware: I created a new middleware and added a new test case
- Injected routes: added a new test case

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

https://github.com/withastro/docs/pull/9680

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
