### PR TITLE
Fixes an issue with cssesc in dev mode when setting vite.ssr.noExternal: true

### DIFF
--- a/.changeset/dirty-bags-double.md
+++ b/.changeset/dirty-bags-double.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue with cssesc in dev mode when setting `vite.noExternal: true`

--- a/.changeset/dirty-bags-double.md
+++ b/.changeset/dirty-bags-double.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes an issue with cssesc in dev mode when setting `vite.noExternal: true`
+Fixes an issue with cssesc in dev mode when setting `vite.ssr.noExternal: true`

--- a/packages/astro/src/core/create-vite.ts
+++ b/packages/astro/src/core/create-vite.ts
@@ -71,6 +71,8 @@ const ONLY_DEV_EXTERNAL = [
 	'prismjs/components/index.js',
 	// Imported by `astro/assets` -> `packages/astro/src/core/logger/core.ts`
 	'string-width',
+	// Imported by `astro:transitions` -> packages/astro/src/runtime/server/transition.ts
+	'cssesc',
 ];
 
 /** Return a base vite config as a common starting point for all Vite commands. */


### PR DESCRIPTION
## Changes

silence vite on cssesc import in dev mode.
Fixes #12229

## Testing

Manually tested

## Docs

n.a., bug-fix

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
