### PR TITLE
fix(routing): actions should redirect the original pathname (#12173)

### DIFF
--- a/.changeset/tough-snakes-reflect.md
+++ b/.changeset/tough-snakes-reflect.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where Astro Actions couldn't redirect to the correct pathname when there was a rewrite involved.

--- a/packages/astro/e2e/actions-blog.test.js
+++ b/packages/astro/e2e/actions-blog.test.js
@@ -136,8 +136,7 @@ test.describe('Astro Actions - Blog', () => {
 		await expect(page).toHaveURL(astro.resolveUrl('/blog/'));
 	});
 
-	// TODO: fix regression #12201 and #12202
-	test.skip('Should redirect to the origin pathname when there is a rewrite', async ({
+	test('Should redirect to the origin pathname when there is a rewrite', async ({
 		page,
 		astro,
 	}) => {

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -1,5 +1,6 @@
 import { yellow } from 'kleur/colors';
 import type { APIContext, MiddlewareNext } from '../../@types/astro.js';
+import { ASTRO_ORIGIN_HEADER } from '../../core/constants.js';
 import { defineMiddleware } from '../../core/middleware/index.js';
 import { ACTION_QUERY_PARAMS } from '../consts.js';
 import { formContentTypes, hasContentType } from './utils.js';
@@ -9,6 +10,7 @@ import {
 	type SerializedActionResult,
 	serializeActionResult,
 } from './virtual/shared.js';
+import {getOriginHeader} from "../../core/routing/rewrite.js";
 
 export type ActionPayload = {
 	actionResult: SerializedActionResult;
@@ -132,6 +134,11 @@ async function redirectWithResult({
 		if (!referer) {
 			throw new Error('Internal: Referer unexpectedly missing from Action POST request.');
 		}
+		return context.redirect(referer);
+	}
+
+	const referer = getOriginHeader(context.request);
+	if (referer) {
 		return context.redirect(referer);
 	}
 

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -1,7 +1,7 @@
 import { yellow } from 'kleur/colors';
 import type { APIContext, MiddlewareNext } from '../../@types/astro.js';
-import { ASTRO_ORIGIN_HEADER } from '../../core/constants.js';
 import { defineMiddleware } from '../../core/middleware/index.js';
+import { getOriginPathname } from '../../core/routing/rewrite.js';
 import { ACTION_QUERY_PARAMS } from '../consts.js';
 import { formContentTypes, hasContentType } from './utils.js';
 import { getAction } from './virtual/get-action.js';
@@ -10,7 +10,6 @@ import {
 	type SerializedActionResult,
 	serializeActionResult,
 } from './virtual/shared.js';
-import {getOriginHeader} from "../../core/routing/rewrite.js";
 
 export type ActionPayload = {
 	actionResult: SerializedActionResult;
@@ -137,7 +136,7 @@ async function redirectWithResult({
 		return context.redirect(referer);
 	}
 
-	const referer = getOriginHeader(context.request);
+	const referer = getOriginPathname(context.request);
 	if (referer) {
 		return context.redirect(referer);
 	}

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { Http2ServerResponse } from 'node:http2';
 import type { RouteData } from '../../@types/astro.js';
+import { clientAddressSymbol } from '../constants.js';
 import { deserializeManifest } from './common.js';
 import { createOutgoingHttpHeaders } from './createOutgoingHttpHeaders.js';
 import { App } from './index.js';
@@ -9,8 +10,6 @@ import type { RenderOptions } from './index.js';
 import type { SSRManifest, SerializedSSRManifest } from './types.js';
 
 export { apply as applyPolyfills } from '../polyfill.js';
-
-const clientAddressSymbol = Symbol.for('astro.clientAddress');
 
 /**
  * Allow the request body to be explicitly overridden. For example, this

--- a/packages/astro/src/core/constants.ts
+++ b/packages/astro/src/core/constants.ts
@@ -29,10 +29,6 @@ export const REROUTE_DIRECTIVE_HEADER = 'X-Astro-Reroute';
  */
 export const REWRITE_DIRECTIVE_HEADER_KEY = 'X-Astro-Rewrite';
 
-/**
- * Header used to track the original URL requested by the user. This information is useful rewrites are involved.
- */
-export const ASTRO_ORIGIN_HEADER = 'X-Astro-Origin';
 export const REWRITE_DIRECTIVE_HEADER_VALUE = 'yes';
 
 /**
@@ -72,6 +68,11 @@ export const clientAddressSymbol = Symbol.for('astro.clientAddress');
  * Use judiciously, as locals are now stored within `RenderContext` by default. Tacking it onto request is no longer necessary.
  */
 export const clientLocalsSymbol = Symbol.for('astro.locals');
+
+/**
+ * Use this symbol to set and retrieve the original pathname of a request. This is useful when working with redirects and rewrites
+ */
+export const originPathnameSymbol = Symbol.for('astro.originPathname');
 
 /**
  * The symbol used as a field on the response object to keep track of streaming.

--- a/packages/astro/src/core/constants.ts
+++ b/packages/astro/src/core/constants.ts
@@ -28,6 +28,11 @@ export const REROUTE_DIRECTIVE_HEADER = 'X-Astro-Reroute';
  * This metadata is used to determine the origin of a Response. If a rewrite has occurred, it should be prioritised over other logic.
  */
 export const REWRITE_DIRECTIVE_HEADER_KEY = 'X-Astro-Rewrite';
+
+/**
+ * Header used to track the original URL requested by the user. This information is useful rewrites are involved.
+ */
+export const ASTRO_ORIGIN_HEADER = 'X-Astro-Origin';
 export const REWRITE_DIRECTIVE_HEADER_VALUE = 'yes';
 
 /**

--- a/packages/astro/src/core/middleware/sequence.ts
+++ b/packages/astro/src/core/middleware/sequence.ts
@@ -2,7 +2,6 @@ import type { APIContext, MiddlewareHandler, RewritePayload } from '../../@types
 import { AstroCookies } from '../cookies/cookies.js';
 import { apiContextRoutesSymbol } from '../render-context.js';
 import { type Pipeline, getParams } from '../render/index.js';
-import { copyRequest } from '../routing/rewrite.js';
 import { defineMiddleware } from './index.js';
 
 // From SvelteKit: https://github.com/sveltejs/kit/blob/master/packages/kit/src/exports/hooks/sequence.js
@@ -37,9 +36,9 @@ export function sequence(...handlers: MiddlewareHandler[]): MiddlewareHandler {
 						if (payload instanceof Request) {
 							newRequest = payload;
 						} else if (payload instanceof URL) {
-							newRequest = copyRequest(payload, handleContext.request);
+							newRequest = new Request(payload, handleContext.request);
 						} else {
-							newRequest = copyRequest(
+							newRequest = new Request(
 								new URL(payload, handleContext.url.origin),
 								handleContext.request,
 							);

--- a/packages/astro/src/core/middleware/sequence.ts
+++ b/packages/astro/src/core/middleware/sequence.ts
@@ -2,6 +2,7 @@ import type { APIContext, MiddlewareHandler, RewritePayload } from '../../@types
 import { AstroCookies } from '../cookies/cookies.js';
 import { apiContextRoutesSymbol } from '../render-context.js';
 import { type Pipeline, getParams } from '../render/index.js';
+import { copyRequest } from '../routing/rewrite.js';
 import { defineMiddleware } from './index.js';
 
 // From SvelteKit: https://github.com/sveltejs/kit/blob/master/packages/kit/src/exports/hooks/sequence.js
@@ -36,9 +37,9 @@ export function sequence(...handlers: MiddlewareHandler[]): MiddlewareHandler {
 						if (payload instanceof Request) {
 							newRequest = payload;
 						} else if (payload instanceof URL) {
-							newRequest = new Request(payload, handleContext.request);
+							newRequest = copyRequest(payload, handleContext.request);
 						} else {
-							newRequest = new Request(
+							newRequest = copyRequest(
 								new URL(payload, handleContext.url.origin),
 								handleContext.request,
 							);

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -20,6 +20,7 @@ import {
 import { renderEndpoint } from '../runtime/server/endpoint.js';
 import { renderPage } from '../runtime/server/index.js';
 import {
+	ASTRO_ORIGIN_HEADER,
 	ASTRO_VERSION,
 	REROUTE_DIRECTIVE_HEADER,
 	REWRITE_DIRECTIVE_HEADER_KEY,
@@ -36,6 +37,7 @@ import { callMiddleware } from './middleware/callMiddleware.js';
 import { sequence } from './middleware/index.js';
 import { renderRedirect } from './redirects/render.js';
 import { type Pipeline, Slots, getParams, getProps } from './render/index.js';
+import {copyRequest, setOriginHeader} from './routing/rewrite.js';
 
 export const apiContextRoutesSymbol = Symbol.for('context.routes');
 
@@ -81,6 +83,7 @@ export class RenderContext {
 			Pick<RenderContext, 'locals' | 'middleware' | 'status' | 'props'>
 		>): Promise<RenderContext> {
 		const pipelineMiddleware = await pipeline.getMiddleware();
+		setOriginHeader(request, pathname)
 		return new RenderContext(
 			pipeline,
 			locals,
@@ -153,7 +156,7 @@ export class RenderContext {
 				if (payload instanceof Request) {
 					this.request = payload;
 				} else {
-					this.request = this.#copyRequest(newUrl, this.request);
+					this.request = copyRequest(newUrl, this.request);
 				}
 				this.isRewriting = true;
 				this.url = new URL(this.request.url);
@@ -253,7 +256,7 @@ export class RenderContext {
 		if (reroutePayload instanceof Request) {
 			this.request = reroutePayload;
 		} else {
-			this.request = this.#copyRequest(newUrl, this.request);
+			this.request = copyRequest(newUrl, this.request);
 		}
 		this.url = new URL(this.request.url);
 		this.cookies = new AstroCookies(this.request);
@@ -566,34 +569,5 @@ export class RenderContext {
 		} = this;
 		if (!i18n) return;
 		return (this.#preferredLocaleList ??= computePreferredLocaleList(request, i18n.locales));
-	}
-
-	/**
-	 * Utility function that creates a new `Request` with a new URL from an old `Request`.
-	 *
-	 * @param newUrl The new `URL`
-	 * @param oldRequest The old `Request`
-	 */
-	#copyRequest(newUrl: URL, oldRequest: Request): Request {
-		if (oldRequest.bodyUsed) {
-			throw new AstroError(AstroErrorData.RewriteWithBodyUsed);
-		}
-		return new Request(newUrl, {
-			method: oldRequest.method,
-			headers: oldRequest.headers,
-			body: oldRequest.body,
-			referrer: oldRequest.referrer,
-			referrerPolicy: oldRequest.referrerPolicy,
-			mode: oldRequest.mode,
-			credentials: oldRequest.credentials,
-			cache: oldRequest.cache,
-			redirect: oldRequest.redirect,
-			integrity: oldRequest.integrity,
-			signal: oldRequest.signal,
-			keepalive: oldRequest.keepalive,
-			// https://fetch.spec.whatwg.org/#dom-request-duplex
-			// @ts-expect-error It isn't part of the types, but undici accepts it and it allows to carry over the body to a new request
-			duplex: 'half',
-		});
 	}
 }

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -20,7 +20,6 @@ import {
 import { renderEndpoint } from '../runtime/server/endpoint.js';
 import { renderPage } from '../runtime/server/index.js';
 import {
-	ASTRO_ORIGIN_HEADER,
 	ASTRO_VERSION,
 	REROUTE_DIRECTIVE_HEADER,
 	REWRITE_DIRECTIVE_HEADER_KEY,
@@ -37,7 +36,7 @@ import { callMiddleware } from './middleware/callMiddleware.js';
 import { sequence } from './middleware/index.js';
 import { renderRedirect } from './redirects/render.js';
 import { type Pipeline, Slots, getParams, getProps } from './render/index.js';
-import {copyRequest, setOriginHeader} from './routing/rewrite.js';
+import { copyRequest, setOriginPathname } from './routing/rewrite.js';
 
 export const apiContextRoutesSymbol = Symbol.for('context.routes');
 
@@ -83,7 +82,7 @@ export class RenderContext {
 			Pick<RenderContext, 'locals' | 'middleware' | 'status' | 'props'>
 		>): Promise<RenderContext> {
 		const pipelineMiddleware = await pipeline.getMiddleware();
-		setOriginHeader(request, pathname)
+		setOriginPathname(request, pathname);
 		return new RenderContext(
 			pipeline,
 			locals,

--- a/packages/astro/src/core/routing/rewrite.ts
+++ b/packages/astro/src/core/routing/rewrite.ts
@@ -1,7 +1,9 @@
 import type { AstroConfig, RewritePayload, RouteData } from '../../@types/astro.js';
 import { shouldAppendForwardSlash } from '../build/util.js';
+import { AstroError, AstroErrorData } from '../errors/index.js';
 import { appendForwardSlash, removeTrailingForwardSlash } from '../path.js';
 import { DEFAULT_404_ROUTE } from './astro-designed-error-pages.js';
+import {ASTRO_ORIGIN_HEADER} from "../constants.js";
 
 export type FindRouteToRewrite = {
 	payload: RewritePayload;
@@ -69,4 +71,45 @@ export function findRouteToRewrite({
 			return { routeData: DEFAULT_404_ROUTE, newUrl, pathname };
 		}
 	}
+}
+
+/**
+ * Utility function that creates a new `Request` with a new URL from an old `Request`.
+ *
+ * @param newUrl The new `URL`
+ * @param oldRequest The old `Request`
+ */
+export function copyRequest(newUrl: URL, oldRequest: Request): Request {
+	if (oldRequest.bodyUsed) {
+		throw new AstroError(AstroErrorData.RewriteWithBodyUsed);
+	}
+	return new Request(newUrl, {
+		method: oldRequest.method,
+		headers: oldRequest.headers,
+		body: oldRequest.body,
+		referrer: oldRequest.referrer,
+		referrerPolicy: oldRequest.referrerPolicy,
+		mode: oldRequest.mode,
+		credentials: oldRequest.credentials,
+		cache: oldRequest.cache,
+		redirect: oldRequest.redirect,
+		integrity: oldRequest.integrity,
+		signal: oldRequest.signal,
+		keepalive: oldRequest.keepalive,
+		// https://fetch.spec.whatwg.org/#dom-request-duplex
+		// @ts-expect-error It isn't part of the types, but undici accepts it and it allows to carry over the body to a new request
+		duplex: 'half',
+	});
+}
+
+export function setOriginHeader(request: Request, pathname: string): void {
+	request.headers.set(ASTRO_ORIGIN_HEADER, encodeURIComponent(pathname));
+}
+
+export function getOriginHeader(request: Request): string | undefined {
+	const origin = request.headers.get(ASTRO_ORIGIN_HEADER);
+	if (origin) {
+		return decodeURIComponent(origin)
+	}
+	return undefined
 }

--- a/packages/astro/src/core/routing/rewrite.ts
+++ b/packages/astro/src/core/routing/rewrite.ts
@@ -1,9 +1,9 @@
 import type { AstroConfig, RewritePayload, RouteData } from '../../@types/astro.js';
 import { shouldAppendForwardSlash } from '../build/util.js';
+import { originPathnameSymbol } from '../constants.js';
 import { AstroError, AstroErrorData } from '../errors/index.js';
 import { appendForwardSlash, removeTrailingForwardSlash } from '../path.js';
 import { DEFAULT_404_ROUTE } from './astro-designed-error-pages.js';
-import {ASTRO_ORIGIN_HEADER} from "../constants.js";
 
 export type FindRouteToRewrite = {
 	payload: RewritePayload;
@@ -102,14 +102,14 @@ export function copyRequest(newUrl: URL, oldRequest: Request): Request {
 	});
 }
 
-export function setOriginHeader(request: Request, pathname: string): void {
-	request.headers.set(ASTRO_ORIGIN_HEADER, encodeURIComponent(pathname));
+export function setOriginPathname(request: Request, pathname: string): void {
+	Reflect.set(request, originPathnameSymbol, encodeURIComponent(pathname));
 }
 
-export function getOriginHeader(request: Request): string | undefined {
-	const origin = request.headers.get(ASTRO_ORIGIN_HEADER);
+export function getOriginPathname(request: Request): string | undefined {
+	const origin = Reflect.get(request, originPathnameSymbol);
 	if (origin) {
-		return decodeURIComponent(origin)
+		return decodeURIComponent(origin);
 	}
-	return undefined
+	return undefined;
 }


### PR DESCRIPTION
## Changes

Second attempt.

Fixes https://github.com/withastro/astro/issues/12146

This time no headers, we use `Reflect`, which is a technique we already use extensively. We should have led with that approach in the first place.

## Testing

The uncommented test should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
