### PR TITLE
Setup CI for next branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - next
   merge_group:
   pull_request:
     paths-ignore:
@@ -208,6 +209,11 @@ jobs:
         with:
           repository: withastro/docs
           path: smoke/docs
+          # For a commit event on the `next` branch (`ref_name`), use the `5.0.0-beta` branch.
+          # For a pull_request event merging into the `next` branch (`base_ref`), use the `5.0.0-beta` branch.
+          # NOTE: For a pull_request event, the `ref_name` is something like `<pr-number>/merge` than the branch name.
+          # NOTE: Perhaps docs repo should use a consistent `next` branch in the future.
+          ref: ${{ (github.ref_name == 'next' || github.base_ref == 'next') && '5.0.0-beta' || 'main' }}
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile


### PR DESCRIPTION
## Changes

Similar as https://github.com/withastro/astro/pull/12238 but reusing the CI file.

- actions/checkout should be checking out the `next` branch if the event is triggered on the `next` branch
- Use a ternary (kinda) to use the `5.0.0-beta` branch of the docs repo if the PR is against `next`, or the commit event happens on the `next` branch

## Testing

The ternary is the tricky one, but I confirmed it works in my private gh action playground repo.

## Docs

n/a