### PR TITLE
fix(@astro/mdx): add components property to RenderResult type definition

### DIFF
--- a/.changeset/twenty-gifts-kick.md
+++ b/.changeset/twenty-gifts-kick.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/mdx': patch
+'astro': patch
+---
+
+Add `components` property to MDXInstance type definition (RenderResult and module import)

--- a/packages/astro/client.d.ts
+++ b/packages/astro/client.d.ts
@@ -289,6 +289,7 @@ declare module '*.mdx' {
 	export const url: MDX['url'];
 	export const getHeadings: MDX['getHeadings'];
 	export const Content: MDX['Content'];
+	export const components: MDX['components'];
 
 	const load: MDX['default'];
 	export default load;

--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -2648,10 +2648,12 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 
 type MD = MarkdownInstance<Record<string, any>>;
 
-export type MDXInstance<T extends Record<string, any>> = Omit<
+export interface MDXInstance<T extends Record<string, any>> extends Omit<
 	MarkdownInstance<T>,
 	'rawContent' | 'compiledContent'
->;
+> {
+	components: Record<string, AstroComponentFactory> | undefined;
+}
 
 export interface MarkdownLayoutProps<T extends Record<string, any>> {
 	frontmatter: {
@@ -2665,10 +2667,12 @@ export interface MarkdownLayoutProps<T extends Record<string, any>> {
 	compiledContent: MarkdownInstance<T>['compiledContent'];
 }
 
-export type MDXLayoutProps<T extends Record<string, any>> = Omit<
+export interface MDXLayoutProps<T extends Record<string, any>> extends Omit<
 	MarkdownLayoutProps<T>,
 	'rawContent' | 'compiledContent'
->;
+> {
+	components: MDXInstance<T>['components'];
+}
 
 export type GetHydrateCallback = () => Promise<() => void | Promise<void>>;
 

--- a/packages/integrations/mdx/template/content-module-types.d.ts
+++ b/packages/integrations/mdx/template/content-module-types.d.ts
@@ -4,6 +4,7 @@ declare module 'astro:content' {
 			Content: import('astro').MarkdownInstance<{}>['Content'];
 			headings: import('astro').MarkdownHeading[];
 			remarkPluginFrontmatter: Record<string, any>;
+			components: import('astro').MDXInstance<{}>['components'];
 		}>;
 	}
 }


### PR DESCRIPTION
## Changes

- Fixes #12244
- Add `components` property to Astro’s `MDXInstance` type definition.
- Add `components` property to RenderResult in the template type definition of `@astro/mdx` integration.


## Testing

Only a type definition change, not sure how to test this properly over here?
Did run `pnpm --filter @astro/mdx run test`: all existing tests passed. 
`pnpm build` passes.
Tested locally on the [minimal reproduction repo](https://github.com/bmenant/astro-render-mdx-components-missing-type-issue).

## Docs

Only a type definition change.