### PR TITLE
fix(core): computation of `outDir` for SSR builds

### DIFF
--- a/.changeset/ten-pugs-begin.md
+++ b/.changeset/ten-pugs-begin.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where Astro creates an incorrect folder when `outDir` is defined, and an adapter is used.

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -664,13 +664,13 @@ export function createRelativeSchema(cmd: string, fileProtocolRoot: string) {
 				!config.build.server.toString().startsWith(config.outDir.toString()) &&
 				config.build.server.toString().endsWith('dist/server/')
 			) {
-				config.build.server = new URL('./dist/server/', config.outDir);
+				config.build.server = new URL('./server/', config.outDir);
 			}
 			if (
 				!config.build.client.toString().startsWith(config.outDir.toString()) &&
 				config.build.client.toString().endsWith('dist/client/')
 			) {
-				config.build.client = new URL('./dist/client/', config.outDir);
+				config.build.client = new URL('./client/', config.outDir);
 			}
 
 			// Handle `base` trailing slash based on `trailingSlash` config

--- a/packages/astro/test/fixtures/ssr-locals/.gitignore
+++ b/packages/astro/test/fixtures/ssr-locals/.gitignore
@@ -1,0 +1,1 @@
+custom-dir

--- a/packages/astro/test/ssr-out-dir.test.js
+++ b/packages/astro/test/ssr-out-dir.test.js
@@ -6,8 +6,6 @@ import { loadFixture } from './test-utils.js';
 describe('The build', () => {
 	/** @type {import('./test-utils').Fixture} */
 	let fixture;
-	/** @type {import('./test-utils.js').App} */
-	let app;
 
 	before(async () => {
 		fixture = await loadFixture({
@@ -17,7 +15,6 @@ describe('The build', () => {
 			outDir: 'custom-dir',
 		});
 		await fixture.build();
-		app = await fixture.loadTestAdapterApp();
 	});
 
 	it('should output the files in `custom-dir`', async () => {

--- a/packages/astro/test/ssr-out-dir.test.js
+++ b/packages/astro/test/ssr-out-dir.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import testAdapter from './test-adapter.js';
+import { loadFixture } from './test-utils.js';
+
+describe('The build', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+	/** @type {import('./test-utils.js').App} */
+	let app;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/ssr-locals/',
+			output: 'server',
+			adapter: testAdapter(),
+			outDir: 'custom-dir',
+		});
+		await fixture.build();
+		app = await fixture.loadTestAdapterApp();
+	});
+
+	it('should output the files in `custom-dir`', async () => {
+		try {
+			await fixture.readFile('/server/entry.mjs');
+			assert.ok(true);
+		} catch (e) {
+			assert.fail(e);
+		}
+	});
+});


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/12248
Closes PLT-2594

The bug was happening only for SSR builds.

## Testing

Added a new test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
