### PR TITLE
Add server island route to the front of the route list

### DIFF
--- a/.changeset/honest-dots-jump.md
+++ b/.changeset/honest-dots-jump.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes conflict between server islands and on-demand dynamic routes in the form of `/[...rest]` or `/[paramA]/[paramB]`.

--- a/packages/astro/e2e/fixtures/server-islands/src/pages/[conflicting]/[dynamicRoute].astro
+++ b/packages/astro/e2e/fixtures/server-islands/src/pages/[conflicting]/[dynamicRoute].astro
@@ -1,0 +1,14 @@
+---
+export const prerender = false;
+---
+
+<html>
+	<head>
+		<title>Conflicting route</title>
+	</head>
+	<body>
+		This route would conflict with the route generated for server islands.
+		<br />
+		This file is here so the tests break if that happens.
+	</body>
+</html>

--- a/packages/astro/src/core/server-islands/endpoint.ts
+++ b/packages/astro/src/core/server-islands/endpoint.ts
@@ -44,7 +44,7 @@ export function ensureServerIslandRoute(config: ConfigFields, routeManifest: Man
 		return;
 	}
 
-	routeManifest.routes.push(getServerIslandRouteData(config));
+	routeManifest.routes.unshift(getServerIslandRouteData(config));
 }
 
 type RenderOptions = {


### PR DESCRIPTION
## Changes

- Fixes #11793

The route was being added as the last route in the list, making it the lowest priority. The solution would be to either add it before the routes are sorted by priority or make it higher than other routes.

IMO internal routes should come first since they are required for native Astro features to work, so adding it to the front of the list is enough. If we think they should follow the normal route priority then the fix is different (insert the route based on the priority rules).

## Testing

Added a conflicting route on the e2e test fixture to reproduce the problem.

## Docs

Maybe document the prefixes reserved for Astro functionality (`_server-islands/`, `_actions/` and `_astro/`)