### PR TITLE
fix(routing): match against decoded pathname

### DIFF
--- a/.changeset/metal-birds-admire.md
+++ b/.changeset/metal-birds-admire.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where the params weren't correctly computed when rendering URLs with non-English characters

--- a/.changeset/stupid-actors-tan.md
+++ b/.changeset/stupid-actors-tan.md
@@ -1,5 +1,0 @@
----
-'astro': patch
----
-
-Fixes a case where `pathname` wasn't decoded when matching against parameters

--- a/.changeset/stupid-actors-tan.md
+++ b/.changeset/stupid-actors-tan.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where `pathname` wasn't decoded when matching against parameters

--- a/packages/astro/src/core/render/params-and-props.ts
+++ b/packages/astro/src/core/render/params-and-props.ts
@@ -47,7 +47,10 @@ export async function getProps(opts: GetParamsAndPropsOptions): Promise<Props> {
 		base,
 	});
 
-	const params = getParams(route, pathname);
+	// The pathname used here comes from the server, which already encored. 
+	// Since we decided to not mess up with encoding anymore, we need to decode them back so the parameters can match
+	// the ones expected from the users
+	const params = getParams(route, decodeURI(pathname));
 	const matchedStaticPath = findPathItemByKey(staticPaths, params, route, logger);
 	if (!matchedStaticPath && (serverLike ? route.prerender : true)) {
 		throw new AstroError({

--- a/packages/astro/test/fixtures/ssr-params/src/pages/[category].astro
+++ b/packages/astro/test/fixtures/ssr-params/src/pages/[category].astro
@@ -6,6 +6,7 @@ export function getStaticPaths() {
 		{ params: { category: "%2Fsomething" } },
 		{ params: { category: "%3Fsomething" } },
 		{ params: { category: "[page]" } },
+		{ params: { category: "你好" } },
 	]
 }
 ---

--- a/packages/astro/test/params.test.js
+++ b/packages/astro/test/params.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, describe, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import testAdapter from './test-adapter.js';
 import { loadFixture } from './test-utils.js';
@@ -87,6 +87,31 @@ describe('Astro.params in SSR', () => {
 		const html = await response.text();
 		const $ = cheerio.load(html);
 		assert.equal($('.category').text(), '%3Fsomething');
+	});
+});
+
+describe('Astro.params in  dev mode', () => {
+	/** @type {import('./test-utils.js').Fixture} */
+	let fixture;
+	let devServer;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/ssr-params/',
+			adapter: testAdapter(),
+			output: 'server',
+		});
+		devServer = await fixture.startDevServer();
+	});
+
+	after(async () => {
+		await devServer.stop();
+	});
+
+	it('should handle non-english URLs', async () => {
+		const html = await fixture.fetch('/你好').then((res) => res.text());
+		const $ = cheerio.load(html);
+		assert.equal($('.category').text(), '你好');
 	});
 });
 


### PR DESCRIPTION
## Changes

Closes PLT-2596
Closes #12262 

The pathname coming from the server is usually encoded, so we need to decode it when computing the parameters.

## Testing

Added a new test case

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
