### PR TITLE
fix: handle base path with images

### DIFF
--- a/.changeset/wise-parents-agree.md
+++ b/.changeset/wise-parents-agree.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Correctly handles local images when using a base path in SSR

--- a/packages/astro/src/assets/endpoint/node.ts
+++ b/packages/astro/src/assets/endpoint/node.ts
@@ -24,6 +24,12 @@ async function loadLocalImage(src: string, url: URL) {
 		fileUrl = pathToFileURL(removeQueryString(replaceFileSystemReferences(src)));
 	} else {
 		try {
+			// If the _image segment isn't at the start of the path, we have a base
+			const idx = url.pathname.indexOf('/_image');
+			if (idx > 0) {
+				// Remove the base path
+				src = src.slice(idx);
+			}
 			fileUrl = new URL('.' + src, outDir);
 			const filePath = fileURLToPath(fileUrl);
 

--- a/packages/astro/test/core-image.test.js
+++ b/packages/astro/test/core-image.test.js
@@ -820,6 +820,7 @@ describe('astro:image', () => {
 				},
 				adapter: testAdapter(),
 				image: {
+					endpoint: 'astro/assets/endpoint/node',
 					service: testImageService(),
 				},
 				base: '/blog',
@@ -833,6 +834,8 @@ describe('astro:image', () => {
 			const $ = cheerio.load(html);
 			const src = $('#local img').attr('src');
 			assert.equal(src.startsWith('/blog'), true);
+			const img = await app.render(new Request(`https://example.com${src}`));
+			assert.equal(img.status, 200);
 		});
 	});
 


### PR DESCRIPTION
## Changes

Currently the Node image endpoint incorrectly resolves local image paths when a site has a base path configured. This PR ensures that the base path is stripped from the path before attempting to find the image

Fixes #12190

## Testing

Updated the integration tests to check this

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
