### PR TITLE
fix: dynamically load zod-to-ts

### DIFF
--- a/.changeset/swift-crabs-exercise.md
+++ b/.changeset/swift-crabs-exercise.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue with some package managers where sites would not build if TypeScript was not installed.

--- a/packages/astro/src/content/types-generator.ts
+++ b/packages/astro/src/content/types-generator.ts
@@ -6,7 +6,6 @@ import { bold, cyan } from 'kleur/colors';
 import { type ViteDevServer, normalizePath } from 'vite';
 import { type ZodSchema, z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
-import { printNode, zodToTs } from 'zod-to-ts';
 import type { AstroSettings, ContentEntryType } from '../@types/astro.js';
 import { AstroError } from '../core/errors/errors.js';
 import { AstroErrorData } from '../core/errors/index.js';
@@ -396,8 +395,17 @@ async function typeForCollection<T extends keyof ContentConfig['collections']>(
 	if (collection?.type === CONTENT_LAYER_TYPE) {
 		const schema = await getContentLayerSchema(collection, collectionKey);
 		if (schema) {
-			const ast = zodToTs(schema);
-			return printNode(ast.node);
+			try {
+				const zodToTs = await import('zod-to-ts');
+				const ast = zodToTs.zodToTs(schema);
+				return zodToTs.printNode(ast.node);
+			} catch (err: any) {
+				// zod-to-ts is sad if we don't have TypeScript installed, but that's fine as we won't be needing types in that case
+				if (err.message.includes("Cannot find package 'typescript'")) {
+					return 'any';
+				}
+				throw err;
+			}
 		}
 	}
 	return 'any';


### PR DESCRIPTION
## Changes

Builds have been failing with sites that don't have TypeScript installed when using some package managers. This is because `zod-to-ts` has a peer dependency on `typescript`. This PR changes typegen to dynamically import `zod-to-ts` inside a try/catch block, and return `any` for types if it fails.

Fixes #12204

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
