### PR TITLE
fix: update wrong action error message

### DIFF
--- a/.changeset/seven-elephants-suffer.md
+++ b/.changeset/seven-elephants-suffer.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-update wrong error message
+Update wrong error message

--- a/.changeset/seven-elephants-suffer.md
+++ b/.changeset/seven-elephants-suffer.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+update wrong error message

--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -25,7 +25,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		if (context.request.method === 'POST') {
 			console.warn(
 				yellow('[astro:actions]'),
-				'POST requests should not be sent to prerendered pages. If you\'re using Actions, disable prerendering with `export const prerender = "false".',
+				'POST requests should not be sent to prerendered pages. If you\'re using Actions, disable prerendering with `export const prerender = false`.',
 			);
 		}
 		return next();


### PR DESCRIPTION
## Changes

- update wrong error message.
- If you enter "false" as currently shown, it will not work correctly - you must use a `fasle` of type boolean.

