### PR TITLE
Pin `zod-to-json-schema` to previous patch release

### DIFF
--- a/.changeset/clever-bags-jump.md
+++ b/.changeset/clever-bags-jump.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Pins `zod-to-json-schema` to avoid broken patch release being installed

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -183,7 +183,7 @@
     "xxhash-wasm": "^1.0.2",
     "yargs-parser": "^21.1.1",
     "zod": "^3.23.8",
-    "zod-to-json-schema": "^3.23.3",
+    "zod-to-json-schema": "3.23.3",
     "zod-to-ts": "^1.2.0"
   },
   "optionalDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,7 +630,7 @@ importers:
         specifier: ^3.23.8
         version: 3.23.8
       zod-to-json-schema:
-        specifier: ^3.23.3
+        specifier: 3.23.3
         version: 3.23.3(zod@3.23.8)
       zod-to-ts:
         specifier: ^1.2.0


### PR DESCRIPTION
Needed until https://github.com/StefanTerdell/zod-to-json-schema/issues/151 is fixed

## Changes

- Closes #12296 
- Needed until https://github.com/StefanTerdell/zod-to-json-schema/issues/151 is fixed

## Testing

Pinned using a pnpm override in a local project to test that the 0.23.3 release didn’t have this issue

## Docs

n/a