### PR TITLE
[docs] update a link in error reference

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1593,7 +1593,7 @@ export const ActionsWithoutServerOutputError = {
 /**
  * @docs
  * @see
- * - [Actions handler reference](https://docs.astro.build/en/reference/api-reference/#handler-property)
+ * - [Actions handler reference](https://docs.astro.build/en/reference/modules/astro-actions/#handler-property)
  * @description
  * Action handler returned invalid data. Handlers should return serializable data types, and cannot return a Response object.
  */


### PR DESCRIPTION
## Changes

This updates a link in an error message, corresponding to reference content that will be moving in https://github.com/withastro/docs/pull/9687

Created as a draft until that docs PR merges and the link is live.

## Testing

No tests, just docs.

## Docs

Only changes docs and error message shown.