### PR TITLE
fix(actions): pass actionAPIContext to action handler instead of APIContext

### DIFF
--- a/packages/astro/src/actions/runtime/middleware.ts
+++ b/packages/astro/src/actions/runtime/middleware.ts
@@ -99,7 +99,9 @@ async function handlePost({
 	if (contentType && hasContentType(contentType, formContentTypes)) {
 		formData = await request.clone().formData();
 	}
-	const action = baseAction.bind(context);
+
+	const { getActionResult, callAction, props, redirect, ...actionAPIContext } = context;
+	const action = baseAction.bind(actionAPIContext);
 	const actionResult = await action(formData);
 
 	if (context.url.searchParams.get(ACTION_QUERY_PARAMS.actionRedirect) === 'false') {

--- a/packages/astro/src/actions/runtime/route.ts
+++ b/packages/astro/src/actions/runtime/route.ts
@@ -27,7 +27,8 @@ export const POST: APIRoute = async (context) => {
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/415
 		return new Response(null, { status: 415 });
 	}
-	const action = baseAction.bind(context);
+	const { getActionResult, callAction, props, redirect, ...actionAPIContext } = context;
+	const action = baseAction.bind(actionAPIContext);
 	const result = await action(args);
 	const serialized = serializeActionResult(result);
 


### PR DESCRIPTION
closes #12281 

## Changes
- Currently, an incorrect handler is passed to the action handler.
This PR fixes it by passing actionAPIContext to the action handler instead of APIContext

## Testing

Manually tested locally by triggering actions and checking context in handler 

## Docs

Just a internal bug fix so there is no need for docs
