### PR TITLE
fix(routing): don't check headers for prenredered pages

### DIFF
--- a/.changeset/gentle-scissors-bow.md
+++ b/.changeset/gentle-scissors-bow.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where the origin check middleware run for prendered pages

--- a/packages/astro/src/core/app/middlewares.ts
+++ b/packages/astro/src/core/app/middlewares.ts
@@ -20,7 +20,11 @@ const FORM_CONTENT_TYPES = [
  */
 export function createOriginCheckMiddleware(): MiddlewareHandler {
 	return defineMiddleware((context, next) => {
-		const { request, url } = context;
+		const { request, url, isPrerendered } = context;
+		// Prerendered pages should be excluded
+		if (isPrerendered) {
+			return next();
+		}
 		const contentType = request.headers.get('content-type');
 		if (contentType) {
 			if (FORM_CONTENT_TYPES.includes(contentType.toLowerCase())) {


### PR DESCRIPTION
## Changes

Closes  https://github.com/withastro/astro/issues/12292
Closes PLT-2601

The check origin header middleware was running for all pages. Now it doesn't for pre-rendered pages.

## Testing

I tested it against the provided reproduction. The warnings aren't there anymore

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
