### PR TITLE
Added generateId option for file loader

### DIFF
--- a/.changeset/famous-ways-perform.md
+++ b/.changeset/famous-ways-perform.md
@@ -1,0 +1,5 @@
+---
+'astro': minor
+---
+
+Added generateId option for file loader


### PR DESCRIPTION
Background: https://github.com/withastro/roadmap/discussions/1045

## Changes

- Adds a generateId option to the file loader (similar as the glob loader already has)
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
