### PR TITLE
Fix: The problem getViteConfig() duplicates some config

### DIFF
--- a/.changeset/slimy-sloths-fry.md
+++ b/.changeset/slimy-sloths-fry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix the problem getViteConfig() duplicates some config

--- a/.changeset/slimy-sloths-fry.md
+++ b/.changeset/slimy-sloths-fry.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fix the problem getViteConfig() duplicates some config
+Fixes a problem where using `getViteConfig()` resulted in an incorrect confirmation.

--- a/.changeset/slimy-sloths-fry.md
+++ b/.changeset/slimy-sloths-fry.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes a problem where using `getViteConfig()` resulted in an incorrect confirmation.
+Fixes an issue where using `getViteConfig()` has incorrect and duplicate configuration

--- a/.changeset/slimy-sloths-fry.md
+++ b/.changeset/slimy-sloths-fry.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes an issue where using `getViteConfig()` has incorrect and duplicate configuration
+Fixes an issue where using `getViteConfig()` returns incorrect and duplicate configuration

--- a/packages/astro/src/core/middleware/vite-plugin.ts
+++ b/packages/astro/src/core/middleware/vite-plugin.ts
@@ -23,7 +23,6 @@ export function vitePluginMiddleware({ settings }: { settings: AstroSettings }):
 		name: '@astro/plugin-middleware',
 		config(_, { command }) {
 			isCommandBuild = command === 'build';
-			return {};
 		},
 		async resolveId(id) {
 			if (id === MIDDLEWARE_MODULE_ID) {

--- a/packages/astro/src/core/middleware/vite-plugin.ts
+++ b/packages/astro/src/core/middleware/vite-plugin.ts
@@ -21,9 +21,9 @@ export function vitePluginMiddleware({ settings }: { settings: AstroSettings }):
 
 	return {
 		name: '@astro/plugin-middleware',
-		config(opts, { command }) {
+		config(_, { command }) {
 			isCommandBuild = command === 'build';
-			return opts;
+			return {};
 		},
 		async resolveId(id) {
 			if (id === MIDDLEWARE_MODULE_ID) {

--- a/packages/astro/test/config-vite.test.js
+++ b/packages/astro/test/config-vite.test.js
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 import * as cheerio from 'cheerio';
 import { loadFixture } from './test-utils.js';
+import { getViteConfig } from '../dist/config/index.js'
+import { resolveConfig } from 'vite';
 
 describe('Vite Config', async () => {
 	let fixture;
@@ -20,4 +22,15 @@ describe('Vite Config', async () => {
 		const $ = cheerio.load(html);
 		assert.match($('link').attr('href'), /\/assets\/testing-[a-z\d]+\.css/);
 	});
+});
+
+describe("getViteConfig", () => {
+	it("Does not change the default config.", async () => {
+		const command = "serve";
+		const mode = "test";
+		const configFn = getViteConfig({});
+		const config = await configFn({ command, mode });
+		const resolvedConfig = await resolveConfig(config, command, mode);
+		assert.deepStrictEqual(resolvedConfig.resolve.conditions, ["astro"]);
+	})
 });


### PR DESCRIPTION
## Changes

In the `config` method of `@astro/plugin-middleware`, we modified it to return an empty object instead of the received opts itself.

There was an issue where some configs were duplicated when using `getViteConfig()`.
This was caused by `@astro/plugin-middleware` returning the received `opts` as the config's return value, resulting in `opts` being merged with itself.

https://vite.dev/guide/api-plugin.html#config
> It can return a partial config object that will be deeply merged into existing config, or directly mutate the config (if the default merging cannot achieve the desired result).

In the config, it is recommended to return only the parts you want to change, rather than the entire modified config.
Since @astro/plugin-middleware does not need to change the config itself, it seems correct to modify it to return an empty object as shown above.

Fixes: [When using getViteConfig, the files listed in setupFiles are loaded twice. · Issue #12287 · withastro/astro](https://github.com/withastro/astro/issues/12287)

## Testing

Before the fix, we tested that the return value of Vite's resolveConfig had a resolve.conditions array with duplicate elements like ['astro', 'astro']. After the change, the duplicates were resolved, resulting in ['astro'].

## Docs

It is unlikely users rely on the existing buggy behavior, so updating the docs isn't necessary.
