### PR TITLE
Update image error messages

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -461,8 +461,8 @@ export const PageNumberParamNotFound = {
  * @docs
  * @see
  * - [Images](https://docs.astro.build/en/guides/images/)
- * - [Image component](/en/reference/modules/astro-assets/#image-)
- * - [Image component#alt](/en/reference/modules/astro-assets/#alt-required)
+ * - [Image component](https://docs.astro.build/en/reference/modules/astro-assets/#image-)
+ * - [Image component#alt](https://docs.astro.build/en/reference/modules/astro-assets/#alt-required)
  * @description
  * The `alt` property allows you to provide descriptive alt text to users of screen readers and other assistive technologies. In order to ensure your images are accessible, the `Image` component requires that an `alt` be specified.
  *
@@ -496,9 +496,9 @@ export const InvalidImageService = {
  * Missing width and height attributes for `IMAGE_URL`. When using remote images, both dimensions are required in order to avoid cumulative layout shift (CLS).
  * @see
  * - [Images](https://docs.astro.build/en/guides/images/)
- * - [Image component#width-and-height-required](/en/reference/modules/astro-assets/#width-and-height-required-for-images-in-public)
+ * - [Image component#width-and-height-required](https://docs.astro.build/en/reference/modules/astro-assets/#width-and-height-required-for-images-in-public)
  * @description
- * For remote images, `width` and `height` cannot automatically be inferred from the original file. To avoid cumulative layout shift (CLS), either specify these two properties, or set [`inferSize`](/en/reference/modules/astro-assets/#infersize) to `true` to fetch a remote image's original dimensions.
+ * For remote images, `width` and `height` cannot automatically be inferred from the original file. To avoid cumulative layout shift (CLS), either specify these two properties, or set [`inferSize`](https://docs.astro.build/en/reference/modules/astro-assets/#infersize) to `true` to fetch a remote image's original dimensions.
  *
  * If your image is inside your `src` folder, you probably meant to import it instead. See [the Imports guide for more information](https://docs.astro.build/en/guides/imports/#other-assets).
  */

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -461,8 +461,8 @@ export const PageNumberParamNotFound = {
  * @docs
  * @see
  * - [Images](https://docs.astro.build/en/guides/images/)
- * - [Image component](https://docs.astro.build/en/guides/images/#image--astroassets)
- * - [Image component#alt](https://docs.astro.build/en/guides/images/#alt-required)
+ * - [Image component](/en/reference/modules/astro-assets/#image-)
+ * - [Image component#alt](/en/reference/modules/astro-assets/#alt-required)
  * @description
  * The `alt` property allows you to provide descriptive alt text to users of screen readers and other assistive technologies. In order to ensure your images are accessible, the `Image` component requires that an `alt` be specified.
  *
@@ -496,9 +496,9 @@ export const InvalidImageService = {
  * Missing width and height attributes for `IMAGE_URL`. When using remote images, both dimensions are required in order to avoid cumulative layout shift (CLS).
  * @see
  * - [Images](https://docs.astro.build/en/guides/images/)
- * - [Image component#width-and-height-required](https://docs.astro.build/en/guides/images/#width-and-height-required-for-images-in-public)
+ * - [Image component#width-and-height-required](/en/reference/modules/astro-assets/#width-and-height-required-for-images-in-public)
  * @description
- * For remote images, `width` and `height` cannot automatically be inferred from the original file. To avoid cumulative layout shift (CLS), either specify these two properties, or set [`inferSize`](https://docs.astro.build/en/guides/images/#infersize) to `true` to fetch a remote image's original dimensions.
+ * For remote images, `width` and `height` cannot automatically be inferred from the original file. To avoid cumulative layout shift (CLS), either specify these two properties, or set [`inferSize`](/en/reference/modules/astro-assets/#infersize) to `true` to fetch a remote image's original dimensions.
  *
  * If your image is inside your `src` folder, you probably meant to import it instead. See [the Imports guide for more information](https://docs.astro.build/en/guides/imports/#other-assets).
  */
@@ -939,7 +939,6 @@ export const InvalidDynamicRoute = {
  * @docs
  * @see
  * - [Default Image Service](https://docs.astro.build/en/guides/images/#default-image-service)
- * - [Image Component](https://docs.astro.build/en/guides/images/#image--astroassets)
  * - [Image Services API](https://docs.astro.build/en/reference/image-service-reference/)
  * @description
  * Sharp is the default image service used for `astro:assets`. When using a [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) like pnpm, Sharp must be installed manually into your project in order to use image processing.


### PR DESCRIPTION
## Changes

Updates the links in three error messages related to images to correspond with the reorganized content in https://github.com/withastro/docs/pull/9801/

## Testing

Just docs

## Docs

Only affects generating docs errors
