### PR TITLE
fix: Destroy the node http server response stream if there was a caught error

### DIFF
--- a/.changeset/clean-plums-tap.md
+++ b/.changeset/clean-plums-tap.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Destroy the server response stream if async error is thrown

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -154,7 +154,7 @@ export class NodeApp extends App {
 			destination.end();
 			// the error will be logged by the "on end" callback above
 		} catch (err) {
-			destination.end('Internal server error', () => {
+			destination.write('Internal server error', () => {
 				err instanceof Error ? destination.destroy(err) : destination.destroy();
 			});
 		}

--- a/packages/astro/src/core/app/node.ts
+++ b/packages/astro/src/core/app/node.ts
@@ -153,8 +153,10 @@ export class NodeApp extends App {
 			}
 			destination.end();
 			// the error will be logged by the "on end" callback above
-		} catch {
-			destination.end('Internal server error');
+		} catch (err) {
+			destination.end('Internal server error', () => {
+				err instanceof Error ? destination.destroy(err) : destination.destroy();
+			});
 		}
 	}
 }


### PR DESCRIPTION
PR to fix bug described in https://github.com/withastro/astro/issues/8714 that is still an issue

I have made a new reproducer to break the example ssr project if you apply this [https://github.com/imattacus/astro/commit/6ed890780fcdb5b8eeb7be9c1a82c2f1138886bd](https://github.com/imattacus/astro/commit/6ed890780fcdb5b8eeb7be9c1a82c2f1138886bd) patch.
Then build `npm run build` the ssr example, and run it `npm run server`.

Before this fix if you run `curl -i curl --raw -i -v localhost:4321` 
```
$ curl --raw -i -v localhost:4321
* Host localhost:4321 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:4321...
* Connected to localhost (::1) port 4321
> GET / HTTP/1.1
> Host: localhost:4321
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< content-type: text/html
content-type: text/html
< Date: Tue, 29 Oct 2024 15:11:23 GMT
Date: Tue, 29 Oct 2024 15:11:23 GMT
< Connection: keep-alive
Connection: keep-alive
< Keep-Alive: timeout=5
Keep-Alive: timeout=5
< Transfer-Encoding: chunked
Transfer-Encoding: chunked
<

71b
<!DOCTYPE html><html lang="en" data-astro-cid-j7pv25f6> <head><title>Online Store</title><style>@import"https://fonts.googleapis.com/css2?family=Lobster&display=swap";span[data-astro-cid-uctnmiwz]{text-decoration:underline}.cart.svelte-tyuvb9.svelte-tyuvb9{display:flex;align-items:center;text-decoration:none;color:inherit}.cart.svelte-tyuvb9 .svelte-tyuvb9:first-child{margin-right:5px}.cart-icon.svelte-tyuvb9.svelte-tyuvb9{font-size:36px}.count.svelte-tyuvb9.svelte-tyuvb9{font-size:24px}header[data-astro-cid-3ef6ksr2]{margin:1rem 2rem;display:flex;justify-content:space-between}h1[data-astro-cid-3ef6ksr2]{margin:0;font-family:Lobster,cursive;color:#000}a[data-astro-cid-3ef6ksr2],a[data-astro-cid-3ef6ksr2]:visited{color:inherit;text-decoration:none}.right-pane[data-astro-cid-3ef6ksr2]{display:flex}.material-icons[data-astro-cid-3ef6ksr2]{font-size:36px;margin-right:1rem}.container[data-astro-cid-d6puh33w]{width:1248px;margin-left:auto;margin-right:auto}
ul[data-astro-cid-45rsrgu5]{list-style-type:none;margin:0;padding:0;display:flex}figure[data-astro-cid-45rsrgu5]{width:200px;padding:7px;border:1px solid black;display:flex;flex-direction:column}figure[data-astro-cid-45rsrgu5] figcaption[data-astro-cid-45rsrgu5]{text-align:center;line-height:1.6}figure[data-astro-cid-45rsrgu5] img[data-astro-cid-45rsrgu5]{width:100%;height:250px;object-fit:cover}.product[data-astro-cid-45rsrgu5] a[data-astro-cid-45rsrgu5]{display:block;text-decoration:none;color:inherit}.name[data-astro-cid-45rsrgu5]{font-weight:500}.price[data-astro-cid-45rsrgu5]{font-size:90%;color:#787878}h1[data-astro-cid-j7pv25f6]{font-size:36px}.product-listing-title[data-astro-cid-j7pv25f6]{text-align:center}
body{font-family:GT America Standard,Helvetica Neue,Helvetica,Arial,sans-serif}
</style></head> <body data-astro-cid-j7pv25f6>
56
<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
61
<header data-astro-cid-3ef6ksr2> <h1 data-astro-cid-3ef6ksr2><a href="/" data-astro-cid-3ef6ksr2>
30
<span data-astro-cid-uctnmiwz>Online</span>&#32;
2a
<span data-astro-cid-uctnmiwz>Store</span>
ae
</a></h1> <div class="right-pane" data-astro-cid-3ef6ksr2> <a href="/login" data-astro-cid-3ef6ksr2> <span class="material-icons" data-astro-cid-3ef6ksr2> login</span> </a> 1
15
Internal server error
0

* Connection #0 to host localhost left intact
``` 

After this fix
```
$ curl --raw -i -v localhost:4321
* Host localhost:4321 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:4321...
* Connected to localhost (::1) port 4321
> GET / HTTP/1.1
> Host: localhost:4321
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< content-type: text/html
content-type: text/html
< Date: Tue, 29 Oct 2024 15:16:01 GMT
Date: Tue, 29 Oct 2024 15:16:01 GMT
< Connection: keep-alive
Connection: keep-alive
< Keep-Alive: timeout=5
Keep-Alive: timeout=5
< Transfer-Encoding: chunked
Transfer-Encoding: chunked
<

71b
<!DOCTYPE html><html lang="en" data-astro-cid-j7pv25f6> <head><title>Online Store</title><style>@import"https://fonts.googleapis.com/css2?family=Lobster&display=swap";span[data-astro-cid-uctnmiwz]{text-decoration:underline}.cart.svelte-tyuvb9.svelte-tyuvb9{display:flex;align-items:center;text-decoration:none;color:inherit}.cart.svelte-tyuvb9 .svelte-tyuvb9:first-child{margin-right:5px}.cart-icon.svelte-tyuvb9.svelte-tyuvb9{font-size:36px}.count.svelte-tyuvb9.svelte-tyuvb9{font-size:24px}header[data-astro-cid-3ef6ksr2]{margin:1rem 2rem;display:flex;justify-content:space-between}h1[data-astro-cid-3ef6ksr2]{margin:0;font-family:Lobster,cursive;color:#000}a[data-astro-cid-3ef6ksr2],a[data-astro-cid-3ef6ksr2]:visited{color:inherit;text-decoration:none}.right-pane[data-astro-cid-3ef6ksr2]{display:flex}.material-icons[data-astro-cid-3ef6ksr2]{font-size:36px;margin-right:1rem}.container[data-astro-cid-d6puh33w]{width:1248px;margin-left:auto;margin-right:auto}
ul[data-astro-cid-45rsrgu5]{list-style-type:none;margin:0;padding:0;display:flex}figure[data-astro-cid-45rsrgu5]{width:200px;padding:7px;border:1px solid black;display:flex;flex-direction:column}figure[data-astro-cid-45rsrgu5] figcaption[data-astro-cid-45rsrgu5]{text-align:center;line-height:1.6}figure[data-astro-cid-45rsrgu5] img[data-astro-cid-45rsrgu5]{width:100%;height:250px;object-fit:cover}.product[data-astro-cid-45rsrgu5] a[data-astro-cid-45rsrgu5]{display:block;text-decoration:none;color:inherit}.name[data-astro-cid-45rsrgu5]{font-weight:500}.price[data-astro-cid-45rsrgu5]{font-size:90%;color:#787878}h1[data-astro-cid-j7pv25f6]{font-size:36px}.product-listing-title[data-astro-cid-j7pv25f6]{text-align:center}
body{font-family:GT America Standard,Helvetica Neue,Helvetica,Arial,sans-serif}
</style></head> <body data-astro-cid-j7pv25f6>
56
<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
61
<header data-astro-cid-3ef6ksr2> <h1 data-astro-cid-3ef6ksr2><a href="/" data-astro-cid-3ef6ksr2>
30
<span data-astro-cid-uctnmiwz>Online</span>&#32;
2a
<span data-astro-cid-uctnmiwz>Store</span>
ae
</a></h1> <div class="right-pane" data-astro-cid-3ef6ksr2> <a href="/login" data-astro-cid-3ef6ksr2> <span class="material-icons" data-astro-cid-3ef6ksr2> login</span> </a> 1
15
Internal server error
* transfer closed with outstanding read data remaining
* Closing connection
curl: (18) transfer closed with outstanding read data remaining

``` 



## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
I have not added a new test, there is an existing test but it is in the astro adapters repo [here](https://github.com/withastro/adapters/blob/73cba1db1794e9079edaec00950d6d71ecc0f116/packages/node/test/errors.test.js#L66)
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
