### PR TITLE
Update link in error message

### DIFF
--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1704,7 +1704,7 @@ export const ActionsWithoutServerOutputError = {
 /**
  * @docs
  * @see
- * - [Actions handler reference](https://docs.astro.build/en/reference/api-reference/#handler-property)
+ * - [Actions handler reference](https://docs.astro.build/en/reference/modules/astro-actions/#handler-property)
  * @description
  * Action handler returned invalid data. Handlers should return serializable data types, and cannot return a Response object.
  */


### PR DESCRIPTION
## Changes

This updates a link in an error message to correspond to new API reference docs

## Testing

No tests, just docs.

## Docs

Only affects generating docs