### PR TITLE
fix(cli): reset `NODE_ENV` to ensure install command run in dev mode

### DIFF
--- a/.changeset/itchy-flowers-report.md
+++ b/.changeset/itchy-flowers-report.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+fix(cli): reset NODE_ENV to ensure install command run in dev mode

--- a/.changeset/itchy-flowers-report.md
+++ b/.changeset/itchy-flowers-report.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-fix(cli): reset NODE_ENV to ensure install command run in dev mode
+Resets `NODE_ENV` to ensure install command run in dev mode

--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -144,7 +144,13 @@ async function installPackage(
 			await exec(
 				installCommand.pm,
 				[installCommand.command, ...installCommand.flags, ...installCommand.dependencies],
-				{ nodeOptions: { cwd: cwd } },
+				{
+					nodeOptions: {
+						cwd,
+						// reset NODE_ENV to ensure install command run in dev mode
+						env: { NODE_ENV: undefined },
+					}
+				},
 			);
 			spinner.succeed();
 


### PR DESCRIPTION
## Changes

- What does this change?
	- When I tried to run `pnpm astro check` in the env mentioned in _testing_ section. The CLI hints me that it will run `pnpm add @astrojs/check typescript` to install necessary dependenies. After installed, it show me error that `Cannot find package 'typescript' imported from node_modules/astro/dist/cli/install-package.js`.
	- After adding logging statement in `install-package.js` file of astro, I surprisingly found that the command is running with `NODE_ENV=production`.
	- Thus, I reset `NODE_ENV` to ensure install command run in dev mode

Before fixing.

<img width="704" alt="image" src="https://github.com/user-attachments/assets/82640e86-35c3-4684-bb54-24abf8d9aecc">

<img width="665" alt="image" src="https://github.com/user-attachments/assets/56ad1636-13c0-40b6-bfd4-c13d23066747">


After fixing. 

<img width="790" alt="image" src="https://github.com/user-attachments/assets/2bf41101-af76-4553-a540-51f2c242ac83">

## Testing

Create an astro project with `typescript` _installed as a devDependency_. and without `@astrojs/check` installed, then run `pnpm astro check`. Compare the results before  PR and after PR.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

No docs is needed as it is a fix for CLI.