### PR TITLE
fix(i18n): default locale in server islands

### DIFF
--- a/.changeset/gorgeous-foxes-divide.md
+++ b/.changeset/gorgeous-foxes-divide.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes and issue where `Astro.currentLocale` always returned the default locale when consumed inside a server island.

--- a/packages/astro/e2e/fixtures/i18n/astro.config.mjs
+++ b/packages/astro/e2e/fixtures/i18n/astro.config.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from 'astro/config';
-
+import nodejs from "@astrojs/node"
 // https://astro.build/config
 export default defineConfig({
 	i18n: {
@@ -17,4 +17,6 @@ export default defineConfig({
 				],
 		}],
 	},
+	output: 'static',
+	adapter: nodejs({ mode: 'standalone' }),
 });

--- a/packages/astro/e2e/fixtures/i18n/components/Greeting.astro
+++ b/packages/astro/e2e/fixtures/i18n/components/Greeting.astro
@@ -1,0 +1,4 @@
+---
+const locale = Astro.currentLocale
+---
+<p data-testid="greeting">Greeting {locale}!</p>

--- a/packages/astro/e2e/fixtures/i18n/package.json
+++ b/packages/astro/e2e/fixtures/i18n/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "astro": "workspace:*"
+    "astro": "workspace:*",
+    "@astrojs/node": "^8.3.4"
   }
 }

--- a/packages/astro/e2e/fixtures/i18n/src/pages/fr/island.astro
+++ b/packages/astro/e2e/fixtures/i18n/src/pages/fr/island.astro
@@ -1,0 +1,5 @@
+---
+import Greeting from "../../../components/Greeting.astro"
+---
+<p>This is a test</p>
+<Greeting server:defer />

--- a/packages/astro/e2e/fixtures/i18n/src/pages/island.astro
+++ b/packages/astro/e2e/fixtures/i18n/src/pages/island.astro
@@ -1,0 +1,6 @@
+---
+import Greeting from "../../components/Greeting.astro"
+---
+
+<p>This is a test</p>
+<Greeting server:defer />

--- a/packages/astro/e2e/i18n.test.js
+++ b/packages/astro/e2e/i18n.test.js
@@ -32,3 +32,21 @@ test.describe('i18n', () => {
 		await expect(p3).toHaveText('Locale: pt-AO');
 	});
 });
+
+test.describe('i18n default locale', () => {
+	test('is "en" when navigating the default locale page', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/island'));
+		let el = page.getByTestId('greeting');
+
+		await expect(el, 'element rendered').toBeVisible();
+		await expect(el).toHaveText('Greeting en!');
+	});
+
+	test('is "fr" when navigating the french page', async ({ page, astro }) => {
+		await page.goto(astro.resolveUrl('/fr/island'));
+		let el = page.getByTestId('greeting');
+
+		await expect(el, 'element rendered').toBeVisible();
+		await expect(el).toHaveText('Greeting fr!');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1038,6 +1038,9 @@ importers:
 
   packages/astro/e2e/fixtures/i18n:
     dependencies:
+      '@astrojs/node':
+        specifier: ^8.3.4
+        version: 8.3.4(astro@packages+astro)
       astro:
         specifier: workspace:*
         version: link:../../..


### PR DESCRIPTION
## Changes

Closes PLT-2606
Closes #12307 

To fix this, when computing `Astro.currentLocale` we check if `RouteData.component` matches the known server island component. 

If so, we use the `referer` header as pathname. Since `referer` can contain an absolute or relative URL, we check if `referer` is parsable, and if so, we retrieve its `pathname`.

## Testing

I created a new e2e test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
