### PR TITLE
Remove Studio Commands from help output for astro cli

### DIFF
--- a/.changeset/heavy-pianos-breathe.md
+++ b/.changeset/heavy-pianos-breathe.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Remove Studio Commands from help output for astro cli

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -40,11 +40,6 @@ async function printAstroHelp() {
 				['preferences', 'Configure user preferences.'],
 				['telemetry', 'Configure telemetry settings.'],
 			],
-			'Studio Commands': [
-				['login', 'Authenticate your machine with Astro Studio.'],
-				['logout', 'End your authenticated session with Astro Studio.'],
-				['link', 'Link this project directory to an Astro Studio project.'],
-			],
 			'Global Flags': [
 				['--config <path>', 'Specify your config file.'],
 				['--root <path>', 'Specify your project root folder.'],


### PR DESCRIPTION
## Changes

Remove Studio Commands from help output for astro cli, Because we no longer recommend using Astro Studio

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

This section is not in the [Cli Reference of our docs](http://localhost:4321/en/reference/cli-reference/)

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
