### PR TITLE
Fix prefetch sourcemap generation

### DIFF
--- a/.changeset/heavy-walls-rhyme.md
+++ b/.changeset/heavy-walls-rhyme.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes sourcemap generation when prefetch is enabled

--- a/packages/astro/src/prefetch/vite-plugin-prefetch.ts
+++ b/packages/astro/src/prefetch/vite-plugin-prefetch.ts
@@ -45,15 +45,25 @@ export default function astroPrefetch({ settings }: { settings: AstroSettings })
 		},
 		transform(code, id) {
 			// NOTE: Handle replacing the specifiers even if prefetch is disabled so View Transitions
-			// can import the internal module as not hit runtime issues.
+			// can import the internal module and not hit runtime issues.
 			if (id.includes(prefetchInternalModuleFsSubpath)) {
-				return code
-					.replace('__PREFETCH_PREFETCH_ALL__', JSON.stringify(prefetch?.prefetchAll))
-					.replace('__PREFETCH_DEFAULT_STRATEGY__', JSON.stringify(prefetch?.defaultStrategy))
+				// We perform a simple replacement with padding so that the code offset is not changed and
+				// we don't have to generate a sourcemap. This has the assumption that the replaced string
+				// will always be shorter than the search string to work.
+				code = code
 					.replace(
-						'__EXPERIMENTAL_CLIENT_PRERENDER__',
-						JSON.stringify(settings.config.experimental.clientPrerender),
+						'__PREFETCH_PREFETCH_ALL__', // length: 25
+						`${JSON.stringify(prefetch?.prefetchAll)}`.padEnd(25),
+					)
+					.replace(
+						'__PREFETCH_DEFAULT_STRATEGY__', // length: 29
+						`${JSON.stringify(prefetch?.defaultStrategy)}`.padEnd(29),
+					)
+					.replace(
+						'__EXPERIMENTAL_CLIENT_PRERENDER__', // length: 33
+						`${JSON.stringify(settings.config.experimental.clientPrerender)}`.padEnd(33),
 					);
+				return { code, map: null };
 			}
 		},
 	};


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/astro/issues/12306

We need to return a `map` property to not have rollup yelling that's we're generating invalid sourcemap

## Testing

tested the repro manually

## Docs

n/a