### PR TITLE
fix(assets): fix `getImage` options type

### DIFF
--- a/.changeset/long-monkeys-exercise.md
+++ b/.changeset/long-monkeys-exercise.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes the `getImage` options type so it properly extends `ImageTransform`

--- a/packages/astro/src/assets/types.ts
+++ b/packages/astro/src/assets/types.ts
@@ -1,4 +1,4 @@
-import type { WithRequired } from '../type-utils.js';
+import type { OmitPreservingIndexSignature, Simplify, WithRequired } from '../type-utils.js';
 import type { VALID_INPUT_FORMATS, VALID_OUTPUT_FORMATS } from './consts.js';
 import type { ImageService } from './services/service.js';
 
@@ -66,10 +66,10 @@ export type SrcSetValue = UnresolvedSrcSetValue & {
 /**
  * A yet to be resolved image transform. Used by `getImage`
  */
-export type UnresolvedImageTransform = Omit<ImageTransform, 'src'> & {
+export type UnresolvedImageTransform = Simplify<OmitPreservingIndexSignature<ImageTransform, 'src'> & {
 	src: ImageMetadata | string | Promise<{ default: ImageMetadata }>;
 	inferSize?: boolean;
-} & {
+}> & {
 	[isESMImport]?: never;
 };
 

--- a/packages/astro/src/type-utils.ts
+++ b/packages/astro/src/type-utils.ts
@@ -16,6 +16,11 @@ export type OmitIndexSignature<ObjectType> = {
 		: KeyType]: ObjectType[KeyType];
 };
 
+// This is an alternative `Omit<T, K>` implementation that _doesn't_ remove the index signature of an object.
+export type OmitPreservingIndexSignature<T, K extends PropertyKey> = {
+	[P in keyof T as Exclude<P, K>]: T[P]
+};
+
 // Transform a string into its kebab case equivalent (camelCase -> kebab-case). Useful for CSS-in-JS to CSS.
 export type Kebab<T extends string, A extends string = ''> = T extends `${infer F}${infer R}`
 	? Kebab<R, `${A}${F extends Lowercase<F> ? '' : '-'}${Lowercase<F>}`>


### PR DESCRIPTION
## Changes

This PR fixes #12319

As I mentioned in the issue, there are two ways of fixing the problem:

1. Use a type helper to properly handle `Omit`ting from types containing index signatures.
2. Remove that index signature from the `ImageTransform`.

I went with the first one since I guess that index signature was put there for a reason. :)

I also applied `Simplify`. This is to force TypeScript better resolve properties. Not doing that results in the following error when an empty options objects is passed to `getImage`:

```
Type '{}' is not assignable to type 'UnresolvedImageTransform'.
  Property 'src' is missing in type '{}' but required in type '{ src: string | ImageMetadata | Promise<{ default: ImageMetadata; }>; inferSize?: boolean | undefined; }'.ts(2322)
```

With `Simplify` the error is:

```
Type '{}' is not assignable to type 'UnresolvedImageTransform'.
  Property 'src' is missing in type '{}' but required in type '{ [x: string]: any; width?: number | undefined; widths?: number[] | undefined; densities?: (number | `${number}x`)[] | undefined; height?: number | undefined; quality?: ImageQuality | undefined; format?: ImageOutputFormat | undefined; src: string | ... 1 more ... | Promise<...>; inferSize?: boolean | undefined; }'.
```

The latter is rather verbose, but I'd prefer this over the former's actually misleading message.

## Testing

Not sure how to add non-fragile or hardcoded tests here.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

This is a fix that doesn't require any changes in docs.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
