### PR TITLE
Fix watchfile multiple dev server restart

### DIFF
--- a/.changeset/famous-timers-move.md
+++ b/.changeset/famous-timers-move.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue in dev server watch file handling that could cause multiple restarts for a single file change.

--- a/packages/astro/src/core/dev/restart.ts
+++ b/packages/astro/src/core/dev/restart.ts
@@ -169,7 +169,9 @@ export async function createContainerWithAutomaticRestart({
 
 		// Restart the Astro dev server instead of Vite's when the API is called by plugins.
 		// Ignore the `forceOptimize` parameter for now.
-		restart.container.viteServer.restart = () => handleServerRestart();
+		restart.container.viteServer.restart = async () => {
+			if (!restart.container.restartInFlight) await handleServerRestart();
+		};
 
 		// Set up shortcuts
 


### PR DESCRIPTION
## Changes

- Fixes an issue in dev server watch file handling that could cause multiple restarts for a single file change.
- This issue was triggered by changes to watched files added by integrations through Astro's `addWatchFile` API. Our override for the Vite restart handler was missing a check for the container's `restartInFlight` flag and caused multiple overlapping restarts.
- This also fixes the repeated `Port 27969 is in use, trying another one...` message that appeared in this case.

## Testing

- Tested locally by running Astro's test suite and on a Starlight site.

## Docs

- Just a bugfix.
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
