### PR TITLE
fix: show file name with invalid frontmatter errors for MDX

### DIFF
--- a/.changeset/wise-bulldogs-jump.md
+++ b/.changeset/wise-bulldogs-jump.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Improves error reporting for invalid frontmatter in MDX files during the ```astro build``` process. The error message now includes the file path where the frontmatter parsing failed.
+Improves error reporting for invalid frontmatter in MDX files during the `astro build` command. The error message now includes the file path where the frontmatter parsing failed.

--- a/.changeset/wise-bulldogs-jump.md
+++ b/.changeset/wise-bulldogs-jump.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Improve mdx files invalid frontmatter errors by displaying file name
+Improves error reporting for invalid frontmatter in MDX files during the ```astro build``` process. The error message now includes the file path where the frontmatter parsing failed.

--- a/.changeset/wise-bulldogs-jump.md
+++ b/.changeset/wise-bulldogs-jump.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improve mdx files invalid frontmatter errors by displaying file name

--- a/packages/astro/src/cli/index.ts
+++ b/packages/astro/src/cli/index.ts
@@ -133,8 +133,8 @@ async function runCommand(cmd: string, flags: yargs.Arguments) {
 		}
 		case 'sync': {
 			const { sync } = await import('./sync/index.js');
-			const exitCode = await sync({ flags });
-			return process.exit(exitCode);
+			await sync({ flags });
+			return;
 		}
 		case 'preferences': {
 			const { preferences } = await import('./preferences/index.js');

--- a/packages/astro/src/cli/sync/index.ts
+++ b/packages/astro/src/cli/sync/index.ts
@@ -22,10 +22,5 @@ export async function sync({ flags }: SyncOptions) {
 		return 0;
 	}
 
-	try {
-		await _sync(flagsToAstroInlineConfig(flags), { telemetry: true });
-		return 0;
-	} catch (_) {
-		return 1;
-	}
+	await _sync(flagsToAstroInlineConfig(flags), { telemetry: true });
 }

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1388,7 +1388,7 @@ export const GenerateContentTypesError = {
 	title: 'Failed to generate content types.',
 	message: (errorMessage: string) =>
 		`\`astro sync\` command failed to generate content collection types: ${errorMessage}`,
-	hint: 'Check your `src/content/config.*` file for typos.',
+	hint: 'This error is often caused by a syntax error inside your content, or your content configuration file. Check your `src/content/config.*` file for typos.',
 } satisfies ErrorData;
 /**
  * @docs

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -298,6 +298,11 @@ export function formatErrorMessage(err: ErrorWithMetadata, showFullStacktrace: b
 		output.push(`    ${cyan(underline(docsLink))}`);
 	}
 
+	if (showFullStacktrace && err.loc) {
+		output.push(`  ${bold('Location:')}`);
+		output.push(`    ${underline(`${err.loc.file}:${err.loc.line ?? 0}:${err.loc.column ?? 0}`)}`);
+	}
+
 	if (err.stack) {
 		output.push(`  ${bold('Stack trace:')}`);
 		output.push(dim(formatErrorStackTrace(err, showFullStacktrace)));

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -25,6 +25,7 @@ import {
 	AstroUserError,
 	createSafeError,
 	isAstroError,
+	type ErrorWithMetadata,
 } from '../errors/index.js';
 import type { Logger } from '../logger/core.js';
 import { formatErrorMessage } from '../messages.js';
@@ -223,7 +224,8 @@ async function syncContentCollections(
 			}
 		}
 	} catch (e) {
-		const safeError = createSafeError(e);
+		const safeError = createSafeError(e) as ErrorWithMetadata;
+		const fileId = safeError.id ?? safeError.loc?.file
 		if (isAstroError(e)) {
 			throw e;
 		}
@@ -232,7 +234,7 @@ async function syncContentCollections(
 			{
 				...AstroErrorData.GenerateContentTypesError,
 				hint,
-				message: AstroErrorData.GenerateContentTypesError.message(safeError.message),
+				message: AstroErrorData.GenerateContentTypesError.message(`${safeError.message} in ${fileId}`),
 			},
 			{ cause: e },
 		);

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -233,7 +233,7 @@ async function syncContentCollections(
 			{
 				...AstroErrorData.GenerateContentTypesError,
 				hint,
-				message: AstroErrorData.GenerateContentTypesError.message(`${safeError.message}`),
+				message: AstroErrorData.GenerateContentTypesError.message(safeError.message),
 				location: safeError.loc,
 			},
 			{ cause: e },

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -225,7 +225,6 @@ async function syncContentCollections(
 		}
 	} catch (e) {
 		const safeError = createSafeError(e) as ErrorWithMetadata;
-		const fileId = safeError.id ?? safeError.loc?.file
 		if (isAstroError(e)) {
 			throw e;
 		}
@@ -234,7 +233,8 @@ async function syncContentCollections(
 			{
 				...AstroErrorData.GenerateContentTypesError,
 				hint,
-				message: AstroErrorData.GenerateContentTypesError.message(`${safeError.message} in ${fileId}`),
+				message: AstroErrorData.GenerateContentTypesError.message(`${safeError.message}`),
+				location: safeError.loc,
 			},
 			{ cause: e },
 		);

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -23,9 +23,9 @@ import {
 	AstroError,
 	AstroErrorData,
 	AstroUserError,
+	type ErrorWithMetadata,
 	createSafeError,
 	isAstroError,
-	type ErrorWithMetadata,
 } from '../errors/index.js';
 import type { Logger } from '../logger/core.js';
 import { formatErrorMessage } from '../messages.js';
@@ -63,17 +63,7 @@ export default async function sync(
 		logger,
 	});
 
-	// Run `astro:config:done`
-	// Actions will throw if there is misconfiguration, so catch here.
-	try {
-		await runHookConfigDone({ settings, logger });
-	} catch (err) {
-		if (err instanceof Error) {
-			const errorMessage = err.toString();
-			logger.error('sync', errorMessage);
-		}
-		throw err;
-	}
+	await runHookConfigDone({ settings, logger });
 
 	return await syncInternal({ settings, logger, fs, force: inlineConfig.force });
 }
@@ -113,51 +103,41 @@ export async function syncInternal({
 
 	const timerStart = performance.now();
 
-	try {
-		if (!skip?.content) {
-			await syncContentCollections(settings, { fs, logger });
-			settings.timer.start('Sync content layer');
-			let store: MutableDataStore | undefined;
-			try {
-				const dataStoreFile = getDataStoreFile(settings);
-				if (existsSync(dataStoreFile)) {
-					store = await MutableDataStore.fromFile(dataStoreFile);
-				}
-			} catch (err: any) {
-				logger.error('content', err.message);
+	if (!skip?.content) {
+		await syncContentCollections(settings, { fs, logger });
+		settings.timer.start('Sync content layer');
+		let store: MutableDataStore | undefined;
+		try {
+			const dataStoreFile = getDataStoreFile(settings);
+			if (existsSync(dataStoreFile)) {
+				store = await MutableDataStore.fromFile(dataStoreFile);
 			}
-			if (!store) {
-				store = new MutableDataStore();
-			}
-			const contentLayer = globalContentLayer.init({
-				settings,
-				logger,
-				store,
-			});
-			await contentLayer.sync();
-			settings.timer.end('Sync content layer');
-		} else if (fs.existsSync(fileURLToPath(getContentPaths(settings.config, fs).contentDir))) {
-			// Content is synced after writeFiles. That means references are not created
-			// To work around it, we create a stub so the reference is created and content
-			// sync will override the empty file
-			settings.injectedTypes.push({
-				filename: CONTENT_TYPES_FILE,
-				content: '',
-			});
+		} catch (err: any) {
+			logger.error('content', err.message);
 		}
-		syncAstroEnv(settings, fs);
-
-		await writeFiles(settings, fs, logger);
-		logger.info('types', `Generated ${dim(getTimeStat(timerStart, performance.now()))}`);
-	} catch (err) {
-		const error = createSafeError(err);
-		logger.error(
-			'types',
-			formatErrorMessage(collectErrorMetadata(error), logger.level() === 'debug') + '\n',
-		);
-		// Will return exit code 1 in CLI
-		throw error;
+		if (!store) {
+			store = new MutableDataStore();
+		}
+		const contentLayer = globalContentLayer.init({
+			settings,
+			logger,
+			store,
+		});
+		await contentLayer.sync();
+		settings.timer.end('Sync content layer');
+	} else if (fs.existsSync(fileURLToPath(getContentPaths(settings.config, fs).contentDir))) {
+		// Content is synced after writeFiles. That means references are not created
+		// To work around it, we create a stub so the reference is created and content
+		// sync will override the empty file
+		settings.injectedTypes.push({
+			filename: CONTENT_TYPES_FILE,
+			content: '',
+		});
 	}
+	syncAstroEnv(settings, fs);
+
+	await writeFiles(settings, fs, logger);
+	logger.info('types', `Generated ${dim(getTimeStat(timerStart, performance.now()))}`);
 }
 
 /**


### PR DESCRIPTION
## Changes

- What does this change?
-`astro build` does not report which file has an invalid frontmatter for MDX files.
This PR fixes that. 

After the fix, the error looks like the below:

![Screenshot 2024-11-02 at 10 15 14 AM](https://github.com/user-attachments/assets/2fb1d323-6f18-4e61-bd71-33aedb7cb806)



Closes #12352 

## Testing

It was manually tested by running a local build.


## Docs

Not needed as it just enhances existing error messages.
