### PR TITLE
Improve tinyexec errors

### DIFF
--- a/.changeset/many-eyes-call.md
+++ b/.changeset/many-eyes-call.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves error logs when executing commands

--- a/benchmark/bench/cli-startup.js
+++ b/benchmark/bench/cli-startup.js
@@ -45,7 +45,7 @@ async function benchmarkCommand(command, args, root) {
 
 	for (let i = 0; i < 10; i++) {
 		const start = performance.now();
-		await exec(command, args, { nodeOptions: { cwd: root } });
+		await exec(command, args, { nodeOptions: { cwd: root }, throwOnError: true });
 		durations.push(performance.now() - start);
 	}
 

--- a/benchmark/bench/memory.js
+++ b/benchmark/bench/memory.js
@@ -26,6 +26,7 @@ export async function run(projectDir, outputFile) {
 				ASTRO_TIMER_PATH: outputFilePath,
 			},
 		},
+		throwOnError: true,
 	});
 
 	console.log('Raw results written to', outputFilePath);

--- a/benchmark/bench/render.js
+++ b/benchmark/bench/render.js
@@ -25,6 +25,7 @@ export async function run(projectDir, outputFile) {
 			cwd: root,
 			stdio: 'inherit',
 		},
+		throwOnError: true,
 	});
 
 	console.log('Previewing...');
@@ -33,6 +34,7 @@ export async function run(projectDir, outputFile) {
 			cwd: root,
 			stdio: 'inherit',
 		},
+		throwOnError: true,
 	});
 
 	console.log('Waiting for server ready...');

--- a/benchmark/bench/server-stress.js
+++ b/benchmark/bench/server-stress.js
@@ -24,6 +24,7 @@ export async function run(projectDir, outputFile) {
 			cwd: root,
 			stdio: 'inherit',
 		},
+		throwOnError: true,
 	});
 
 	console.log('Previewing...');

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -29,9 +29,9 @@ import { appendForwardSlash } from '../../core/path.js';
 import { apply as applyPolyfill } from '../../core/polyfill.js';
 import { ensureProcessNodeEnv, parseNpmName } from '../../core/util.js';
 import { eventCliSession, telemetry } from '../../events/index.js';
+import { exec } from '../exec.js';
 import { type Flags, createLoggerFromFlags, flagsToAstroInlineConfig } from '../flags.js';
 import { fetchPackageJson, fetchPackageVersions } from '../install-package.js';
-import { exec } from '../exec.js';
 
 interface AddOptions {
 	flags: Flags;

--- a/packages/astro/src/cli/add/index.ts
+++ b/packages/astro/src/cli/add/index.ts
@@ -10,7 +10,6 @@ import ora from 'ora';
 import preferredPM from 'preferred-pm';
 import prompts from 'prompts';
 import maxSatisfying from 'semver/ranges/max-satisfying.js';
-import { exec } from 'tinyexec';
 import {
 	loadTSConfig,
 	resolveConfig,
@@ -32,6 +31,7 @@ import { ensureProcessNodeEnv, parseNpmName } from '../../core/util.js';
 import { eventCliSession, telemetry } from '../../events/index.js';
 import { type Flags, createLoggerFromFlags, flagsToAstroInlineConfig } from '../flags.js';
 import { fetchPackageJson, fetchPackageVersions } from '../install-package.js';
+import { exec } from '../exec.js';
 
 interface AddOptions {
 	flags: Flags;

--- a/packages/astro/src/cli/docs/open.ts
+++ b/packages/astro/src/cli/docs/open.ts
@@ -1,4 +1,5 @@
-import { type Result, exec } from 'tinyexec';
+import type { Result } from 'tinyexec';
+import { exec } from '../exec.js';
 
 /**
  *  Credit: Azhar22

--- a/packages/astro/src/cli/exec.ts
+++ b/packages/astro/src/cli/exec.ts
@@ -1,4 +1,4 @@
-import { NonZeroExitError, x, type Options } from 'tinyexec';
+import { NonZeroExitError, type Options, x } from 'tinyexec';
 
 /**
  * Improve tinyexec error logging and set `throwOnError` to `true` by default

--- a/packages/astro/src/cli/exec.ts
+++ b/packages/astro/src/cli/exec.ts
@@ -1,0 +1,26 @@
+import { NonZeroExitError, x, type Options } from 'tinyexec';
+
+/**
+ * Improve tinyexec error logging and set `throwOnError` to `true` by default
+ */
+export function exec(command: string, args?: string[], options?: Partial<Options>) {
+	return x(command, args, {
+		throwOnError: true,
+		...options,
+	}).then(
+		(o) => o,
+		(e) => {
+			if (e instanceof NonZeroExitError) {
+				const fullCommand = args?.length
+					? `${command} ${args.map((a) => (a.includes(' ') ? `"${a}"` : a)).join(' ')}`
+					: command;
+				const message = `The command \`${fullCommand}\` exited with code ${e.exitCode}`;
+				const newError = new Error(message, e.cause ? { cause: e.cause } : undefined);
+				(newError as any).stderr = e.output?.stderr;
+				(newError as any).stdout = e.output?.stdout;
+				throw newError;
+			}
+			throw e;
+		},
+	);
+}

--- a/packages/astro/src/cli/install-package.ts
+++ b/packages/astro/src/cli/install-package.ts
@@ -5,9 +5,9 @@ import { bold, cyan, dim, magenta } from 'kleur/colors';
 import ora from 'ora';
 import preferredPM from 'preferred-pm';
 import prompts from 'prompts';
-import { exec } from 'tinyexec';
 import whichPm from 'which-pm';
 import type { Logger } from '../core/logger/core.js';
+import { exec } from './exec.js';
 
 const require = createRequire(import.meta.url);
 

--- a/scripts/smoke/cleanup.js
+++ b/scripts/smoke/cleanup.js
@@ -38,6 +38,7 @@ async function run() {
 
 	await exec('pnpm', ['install'], {
 		nodeOptions: { cwd: fileURLToPath(rootDir), stdio: ['pipe', 'inherit', 'inherit'] },
+		throwOnError: true
 	});
 }
 

--- a/scripts/smoke/index.js
+++ b/scripts/smoke/index.js
@@ -33,7 +33,10 @@ async function run() {
 
 	const directories = [...(await getChildDirectories(smokeDir)), ...(await getChildDirectories(exampleDir))];
 	/** @type {Partial<import('tinyexec').Options>} */
-	const execOptions = { nodeOptions: { cwd: fileURLToPath(rootDir), stdio: 'inherit' }};
+	const execOptions = {
+		nodeOptions: { cwd: fileURLToPath(rootDir), stdio: 'inherit' },
+		throwOnError: true,
+	};
 
 	console.log('🤖', 'Preparing', 'pnpm');
 	


### PR DESCRIPTION
## Changes

close https://github.com/withastro/astro/issues/12241

In all of our tinyexec usage, we need `throwOnError: true` so that non-0 exit code will error out, which is the expected behaviour in most case. I added that in this PR.

However its error logs aren't the user-friendliest, so I wrapped it with a utility to improve it. I'm working to see if I can upstream the changes so we don't have to wrap it ourselves.

## Testing

<!-- How was this change tested? -->
Tested manually. I tweaked the install dependencies command to `npm foobar` (which is expected to fail). Before:

<img width="497" alt="image" src="https://github.com/user-attachments/assets/6b7112e9-ceb1-466c-95ae-44133a6febbb">

After (now it properly surfaces the error):

<img width="660" alt="image" src="https://github.com/user-attachments/assets/940ffed9-dab3-4ab4-92f9-a2c3fb9518cd">


## Docs

n/a. bug fix