### PR TITLE
feat: add crop support to image services

### DIFF
--- a/packages/astro/components/Image.astro
+++ b/packages/astro/components/Image.astro
@@ -23,6 +23,20 @@ if (typeof props.height === 'string') {
 	props.height = parseInt(props.height);
 }
 
+const { experimentalResponsiveImages } = imageConfig;
+
+const layoutClassMap = {
+	fixed: 'aim-fi',
+	responsive: 'aim-re',
+};
+
+if (experimentalResponsiveImages) {
+	// Apply defaults from imageConfig if not provided
+	props.layout ??= imageConfig.experimentalLayout;
+	props.fit ??= imageConfig.experimentalObjectFit ?? 'cover';
+	props.position ??= imageConfig.experimentalObjectPosition ?? 'center';
+}
+
 const image = await getImage(props);
 
 const additionalAttributes: HTMLAttributes<'img'> = {};
@@ -34,16 +48,7 @@ if (import.meta.env.DEV) {
 	additionalAttributes['data-image-component'] = 'true';
 }
 
-const { experimentalResponsiveImages } = imageConfig;
-
-const layoutClassMap = {
-	fixed: 'aim-fi',
-	responsive: 'aim-re',
-};
-
 const cssFitValues = ['fill', 'contain', 'cover', 'scale-down'];
-const objectFit = props.fit ?? imageConfig.experimentalObjectFit ?? 'cover';
-const objectPosition = props.position ?? imageConfig.experimentalObjectPosition ?? 'center';
 
 // The style prop can't be spread when using define:vars, so we need to extract it here
 // @see https://github.com/withastro/compiler/issues/1050
@@ -51,7 +56,7 @@ const { style = '', class: className, ...attrs } = { ...additionalAttributes, ..
 ---
 
 {
-	experimentalResponsiveImages ? (
+	experimentalResponsiveImages && props.layout ? (
 		<img
 			src={image.src}
 			{...attrs}
@@ -64,12 +69,13 @@ const { style = '', class: className, ...attrs } = { ...additionalAttributes, ..
 }
 
 <style
-	define:vars={experimentalResponsiveImages && {
-		w: image.attributes.width ?? props.width ?? image.options.width,
-		h: image.attributes.height ?? props.height ?? image.options.height,
-		fit: cssFitValues.includes(objectFit) && objectFit,
-		pos: objectPosition,
-	}}
+	define:vars={experimentalResponsiveImages &&
+		props.layout && {
+			w: image.attributes.width ?? props.width ?? image.options.width,
+			h: image.attributes.height ?? props.height ?? image.options.height,
+			fit: cssFitValues.includes(props.fit) && props.fit,
+			pos: props.position,
+		}}
 >
 	/* Shared by all Astro images */
 	.aim {

--- a/packages/astro/src/assets/consts.ts
+++ b/packages/astro/src/assets/consts.ts
@@ -26,4 +26,4 @@ export const VALID_SUPPORTED_FORMATS = [
 ] as const;
 export const DEFAULT_OUTPUT_FORMAT = 'webp' as const;
 export const VALID_OUTPUT_FORMATS = ['avif', 'png', 'webp', 'jpeg', 'jpg', 'svg'] as const;
-export const DEFAULT_HASH_PROPS = ['src', 'width', 'height', 'format', 'quality'];
+export const DEFAULT_HASH_PROPS = ['src', 'width', 'height', 'format', 'quality', 'fit', 'position'];

--- a/packages/astro/src/assets/consts.ts
+++ b/packages/astro/src/assets/consts.ts
@@ -26,4 +26,12 @@ export const VALID_SUPPORTED_FORMATS = [
 ] as const;
 export const DEFAULT_OUTPUT_FORMAT = 'webp' as const;
 export const VALID_OUTPUT_FORMATS = ['avif', 'png', 'webp', 'jpeg', 'jpg', 'svg'] as const;
-export const DEFAULT_HASH_PROPS = ['src', 'width', 'height', 'format', 'quality', 'fit', 'position'];
+export const DEFAULT_HASH_PROPS = [
+	'src',
+	'width',
+	'height',
+	'format',
+	'quality',
+	'fit',
+	'position',
+];

--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -2,6 +2,12 @@ import { isRemotePath } from '@astrojs/internal-helpers/path';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import type { AstroConfig } from '../types/public/config.js';
 import { DEFAULT_HASH_PROPS } from './consts.js';
+import {
+	DEFAULT_RESOLUTIONS,
+	LIMITED_RESOLUTIONS,
+	getSizesAttribute,
+	getWidths,
+} from './layout.js';
 import { type ImageService, isLocalService } from './services/service.js';
 import {
 	type GetImageResult,
@@ -12,12 +18,6 @@ import {
 } from './types.js';
 import { isESMImportedImage, isRemoteImage, resolveSrc } from './utils/imageKind.js';
 import { inferRemoteSize } from './utils/remoteProbe.js';
-import {
-	DEFAULT_RESOLUTIONS,
-	getSizesAttribute,
-	getWidths,
-	LIMITED_RESOLUTIONS,
-} from './layout.js';
 
 export async function getConfiguredImageService(): Promise<ImageService> {
 	if (!globalThis?.astroAsset?.imageService) {

--- a/packages/astro/src/assets/layout.ts
+++ b/packages/astro/src/assets/layout.ts
@@ -1,4 +1,4 @@
-import type { ImageLayout } from '../types/public/index.js';
+import type { ImageLayout } from './types.js';
 
 // Common screen widths. These will be filtered according to the image size and layout
 export const DEFAULT_RESOLUTIONS = [
@@ -33,9 +33,9 @@ export const LIMITED_RESOLUTIONS = [
 
 /**
  * Gets the breakpoints for an image, based on the layout and width
- * 
+ *
  * The rules are as follows:
- * 
+ *
  * - For full-width layout we return all breakpoints smaller than the original image width
  * - For fixed layout we return 1x and 2x the requested width, unless the original image is smaller than that.
  * - For responsive layout we return all breakpoints smaller than 2x the requested width, unless the original image is smaller than that.

--- a/packages/astro/src/assets/services/service.ts
+++ b/packages/astro/src/assets/services/service.ts
@@ -250,6 +250,8 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 			formats,
 			layout,
 			priority,
+			fit,
+			position,
 			...attributes
 		} = options;
 		return {

--- a/packages/astro/src/assets/services/service.ts
+++ b/packages/astro/src/assets/services/service.ts
@@ -232,6 +232,9 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 			options.fit ??= 'cover';
 			delete options.layout;
 		}
+		if(options.fit === 'none') {
+			delete options.fit;
+		}
 		return options;
 	},
 	getHTMLAttributes(options) {

--- a/packages/astro/src/assets/services/service.ts
+++ b/packages/astro/src/assets/services/service.ts
@@ -232,7 +232,7 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 			options.fit ??= 'cover';
 			delete options.layout;
 		}
-		if(options.fit === 'none') {
+		if (options.fit === 'none') {
 			delete options.fit;
 		}
 		return options;

--- a/packages/astro/src/assets/services/service.ts
+++ b/packages/astro/src/assets/services/service.ts
@@ -2,7 +2,12 @@ import { AstroError, AstroErrorData } from '../../core/errors/index.js';
 import { isRemotePath, joinPaths } from '../../core/path.js';
 import type { AstroConfig } from '../../types/public/config.js';
 import { DEFAULT_HASH_PROPS, DEFAULT_OUTPUT_FORMAT, VALID_SUPPORTED_FORMATS } from '../consts.js';
-import type { ImageOutputFormat, ImageTransform, UnresolvedSrcSetValue } from '../types.js';
+import type {
+	ImageFit,
+	ImageOutputFormat,
+	ImageTransform,
+	UnresolvedSrcSetValue,
+} from '../types.js';
 import { isESMImportedImage } from '../utils/imageKind.js';
 import { isRemoteAllowed } from '../utils/remotePattern.js';
 
@@ -116,6 +121,8 @@ export type BaseServiceTransform = {
 	height?: number;
 	format: string;
 	quality?: string | null;
+	fit?: ImageFit;
+	position?: string;
 };
 
 const sortNumeric = (a: number, b: number) => a - b;
@@ -221,7 +228,10 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 		// Sometimes users will pass number generated from division, which can result in floating point numbers
 		if (options.width) options.width = Math.round(options.width);
 		if (options.height) options.height = Math.round(options.height);
-
+		if (options.layout && options.width && options.height) {
+			options.fit ??= 'cover';
+			delete options.layout;
+		}
 		return options;
 	},
 	getHTMLAttributes(options) {
@@ -344,6 +354,8 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 			h: 'height',
 			q: 'quality',
 			f: 'format',
+			fit: 'fit',
+			position: 'position',
 		};
 
 		Object.entries(params).forEach(([param, key]) => {
@@ -366,6 +378,8 @@ export const baseService: Omit<LocalImageService, 'transform'> = {
 			height: params.has('h') ? parseInt(params.get('h')!) : undefined,
 			format: params.get('f') as ImageOutputFormat,
 			quality: params.get('q'),
+			fit: params.get('fit') as ImageFit,
+			position: params.get('position') ?? undefined,
 		};
 
 		return transform;

--- a/packages/astro/src/assets/services/sharp.ts
+++ b/packages/astro/src/assets/services/sharp.ts
@@ -71,7 +71,12 @@ const sharpService: LocalImageService<SharpImageServiceConfig> = {
 		// always call rotate to adjust for EXIF data orientation
 		result.rotate();
 
-		// If `fit` isn't set then don't use both width and height (old behavior)
+		// If `fit` isn't set then use old behavior:
+		// - Do not use both width and height for resizing, and prioritize width over height
+		// - Allow enlarging images
+
+		const withoutEnlargement = Boolean(transform.fit) && transform.fit !== 'none';
+
 		if (transform.width && transform.height && transform.fit) {
 			const fit: keyof FitEnum = fitMap[transform.fit] ?? transform.fit ?? 'outside';
 			result.resize({
@@ -79,12 +84,18 @@ const sharpService: LocalImageService<SharpImageServiceConfig> = {
 				height: Math.round(transform.height),
 				fit,
 				position: transform.position,
-				withoutEnlargement: true
+				withoutEnlargement,
 			});
 		} else if (transform.height && !transform.width) {
-			result.resize({ height: Math.round(transform.height), withoutEnlargement: Boolean(transform.fit) });
+			result.resize({
+				height: Math.round(transform.height),
+				withoutEnlargement,
+			});
 		} else if (transform.width) {
-			result.resize({ width: Math.round(transform.width), withoutEnlargement: Boolean(transform.fit) });
+			result.resize({
+				width: Math.round(transform.width),
+				withoutEnlargement,
+			});
 		}
 
 		if (transform.format) {

--- a/packages/astro/src/assets/services/sharp.ts
+++ b/packages/astro/src/assets/services/sharp.ts
@@ -40,11 +40,12 @@ async function loadSharp() {
 
 const fitMap: Record<ImageFit, keyof FitEnum> = {
 	fill: 'fill',
-	contain: 'contain',
+	contain: 'inside',
 	cover: 'cover',
 	none: 'outside',
 	'scale-down': 'inside',
-	'': 'outside',
+	'outside': 'outside',
+	'inside': 'inside',
 };
 
 const sharpService: LocalImageService<SharpImageServiceConfig> = {
@@ -55,7 +56,6 @@ const sharpService: LocalImageService<SharpImageServiceConfig> = {
 	getSrcSet: baseService.getSrcSet,
 	async transform(inputBuffer, transformOptions, config) {
 		if (!sharp) sharp = await loadSharp();
-
 		const transform: BaseServiceTransform = transformOptions as BaseServiceTransform;
 
 		// Return SVGs as-is
@@ -75,10 +75,9 @@ const sharpService: LocalImageService<SharpImageServiceConfig> = {
 		// - Do not use both width and height for resizing, and prioritize width over height
 		// - Allow enlarging images
 
-		const withoutEnlargement = Boolean(transform.fit) && transform.fit !== 'none';
-
+		const withoutEnlargement = Boolean(transform.fit);
 		if (transform.width && transform.height && transform.fit) {
-			const fit: keyof FitEnum = fitMap[transform.fit] ?? transform.fit ?? 'outside';
+			const fit: keyof FitEnum = fitMap[transform.fit] ?? 'inside';
 			result.resize({
 				width: Math.round(transform.width),
 				height: Math.round(transform.height),

--- a/packages/astro/src/assets/services/sharp.ts
+++ b/packages/astro/src/assets/services/sharp.ts
@@ -79,11 +79,12 @@ const sharpService: LocalImageService<SharpImageServiceConfig> = {
 				height: Math.round(transform.height),
 				fit,
 				position: transform.position,
+				withoutEnlargement: true
 			});
 		} else if (transform.height && !transform.width) {
-			result.resize({ height: Math.round(transform.height) });
+			result.resize({ height: Math.round(transform.height), withoutEnlargement: Boolean(transform.fit) });
 		} else if (transform.width) {
-			result.resize({ width: Math.round(transform.width) });
+			result.resize({ width: Math.round(transform.width), withoutEnlargement: Boolean(transform.fit) });
 		}
 
 		if (transform.format) {

--- a/packages/astro/src/assets/services/sharp.ts
+++ b/packages/astro/src/assets/services/sharp.ts
@@ -44,8 +44,8 @@ const fitMap: Record<ImageFit, keyof FitEnum> = {
 	cover: 'cover',
 	none: 'outside',
 	'scale-down': 'inside',
-	'outside': 'outside',
-	'inside': 'inside',
+	outside: 'outside',
+	inside: 'inside',
 };
 
 const sharpService: LocalImageService<SharpImageServiceConfig> = {

--- a/packages/astro/src/assets/types.ts
+++ b/packages/astro/src/assets/types.ts
@@ -1,4 +1,3 @@
-import type { ImageLayout } from '../types/public/index.js';
 import type { OmitPreservingIndexSignature, Simplify, WithRequired } from '../type-utils.js';
 import type { VALID_INPUT_FORMATS, VALID_OUTPUT_FORMATS } from './consts.js';
 import type { ImageService } from './services/service.js';
@@ -7,6 +6,8 @@ export type ImageQualityPreset = 'low' | 'mid' | 'high' | 'max' | (string & {});
 export type ImageQuality = ImageQualityPreset | number;
 export type ImageInputFormat = (typeof VALID_INPUT_FORMATS)[number];
 export type ImageOutputFormat = (typeof VALID_OUTPUT_FORMATS)[number] | (string & {});
+export type ImageLayout = 'responsive' | 'fixed' | 'full-width' | 'none';
+export type ImageFit = 'fill' | 'contain' | 'cover' | 'none' | 'scale-down' | (string & {});
 
 export type AssetsGlobalStaticImagesList = Map<
 	string,
@@ -87,6 +88,8 @@ export type ImageTransform = {
 	height?: number | undefined;
 	quality?: ImageQuality | undefined;
 	format?: ImageOutputFormat | undefined;
+	fit?: ImageFit | undefined;
+	position?: string | undefined;
 	[key: string]: any;
 };
 
@@ -157,7 +160,7 @@ type ImageSharedProps<T> = T & {
 
 	layout?: ImageLayout;
 
-	fit?: 'fill' | 'contain' | 'cover' | 'none' | 'scale-down' | (string & {});
+	fit?: ImageFit;
 
 	position?: string;
 } & (

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -13,6 +13,7 @@ import type { REDIRECT_STATUS_CODES } from '../../core/constants.js';
 import type { Logger, LoggerLevel } from '../../core/logger/core.js';
 import type { EnvSchema } from '../../env/schema.js';
 import type { AstroIntegration } from './integrations.js';
+import type { ImageFit, ImageLayout } from '../../assets/types.js';
 
 export type Locales = (string | { codes: string[]; path: string })[];
 
@@ -1091,7 +1092,7 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 * The default object-fit value for responsive images. Can be overridden by the `fit` prop on the image component.
 		 * Requires the `experimental.responsiveImages` flag to be enabled.
 		 */
-		experimentalObjectFit?: 'contain' | 'cover' | 'fill' | 'none' | 'scale-down' | (string & {});
+		experimentalObjectFit?: ImageFit;
 		/**
 		 * @docs
 		 * @name image.experimentalObjectPosition
@@ -1765,8 +1766,6 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		responsiveImages?: boolean;
 	};
 }
-
-export type ImageLayout = 'responsive' | 'fixed' | 'full-width' | 'none';
 
 /**
  * Resolved Astro Config

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -6,6 +6,7 @@ import type {
 	ShikiConfig,
 } from '@astrojs/markdown-remark';
 import type { UserConfig as OriginalViteUserConfig, SSROptions as ViteSSROptions } from 'vite';
+import type { ImageFit, ImageLayout } from '../../assets/types.js';
 import type { RemotePattern } from '../../assets/utils/remotePattern.js';
 import type { AssetsPrefix } from '../../core/app/types.js';
 import type { AstroConfigType } from '../../core/config/schema.js';
@@ -13,7 +14,6 @@ import type { REDIRECT_STATUS_CODES } from '../../core/constants.js';
 import type { Logger, LoggerLevel } from '../../core/logger/core.js';
 import type { EnvSchema } from '../../env/schema.js';
 import type { AstroIntegration } from './integrations.js';
-import type { ImageFit, ImageLayout } from '../../assets/types.js';
 
 export type Locales = (string | { codes: string[]; path: string })[];
 

--- a/packages/astro/test/core-image-layout.test.js
+++ b/packages/astro/test/core-image-layout.test.js
@@ -134,7 +134,7 @@ describe('astro:image:layout', () => {
 				assert.match(style, /\.aim\[/);
 				assert.match(style, /\.aim-re\[/);
 				assert.match(style, /\.aim-fi\[/);
-			})
+			});
 		});
 
 		describe('srcsets', () => {

--- a/packages/astro/test/core-image-layout.test.js
+++ b/packages/astro/test/core-image-layout.test.js
@@ -190,7 +190,7 @@ describe('astro:image:layout', () => {
 			it('generates width and height in image URLs when both are provided', () => {
 				let $img = $('#local-both img');
 				const aspectRatio = 300 / 400;
-				const srcset = parseSrcset($img.attr('srcset'))
+				const srcset = parseSrcset($img.attr('srcset'));
 				for (const { url } of srcset) {
 					const params = new URL(url, 'https://example.com').searchParams;
 					const width = parseInt(params.get('w'));
@@ -204,34 +204,34 @@ describe('astro:image:layout', () => {
 				assert.ok(!fit.attr('fit'));
 				const position = $('#position img');
 				assert.ok(!position.attr('position'));
-			})
+			});
 
 			it('sets a default fit of "cover" when no fit is provided', () => {
 				let $img = $('#fit-default img');
-				const srcset = parseSrcset($img.attr('srcset'))
+				const srcset = parseSrcset($img.attr('srcset'));
 				for (const { url } of srcset) {
 					const params = new URL(url, 'https://example.com').searchParams;
 					assert.equal(params.get('fit'), 'cover');
 				}
-			})
+			});
 
 			it('sets a fit of "contain" when fit="contain" is provided', () => {
 				let $img = $('#fit-contain img');
-				const srcset = parseSrcset($img.attr('srcset'))
+				const srcset = parseSrcset($img.attr('srcset'));
 				for (const { url } of srcset) {
 					const params = new URL(url, 'https://example.com').searchParams;
 					assert.equal(params.get('fit'), 'contain');
 				}
-			})
+			});
 
 			it('sets no fit when fit="none" is provided', () => {
 				let $img = $('#fit-none img');
-				const srcset = parseSrcset($img.attr('srcset'))
+				const srcset = parseSrcset($img.attr('srcset'));
 				for (const { url } of srcset) {
 					const params = new URL(url, 'https://example.com').searchParams;
 					assert.ok(!params.has('fit'));
 				}
-			})
+			});
 		});
 
 		describe('remote images', () => {

--- a/packages/astro/test/core-image-layout.test.js
+++ b/packages/astro/test/core-image-layout.test.js
@@ -5,8 +5,8 @@ import * as cheerio from 'cheerio';
 import parseSrcset from 'parse-srcset';
 import { Logger } from '../dist/core/logger/core.js';
 import { testImageService } from './test-image-service.js';
-import { loadFixture } from './test-utils.js';
 import { testRemoteImageService } from './test-remote-image-service.js';
+import { loadFixture } from './test-utils.js';
 
 describe('astro:image:layout', () => {
 	/** @type {import('./test-utils').Fixture} */
@@ -15,8 +15,6 @@ describe('astro:image:layout', () => {
 	describe('local image service', () => {
 		/** @type {import('./test-utils').DevServer} */
 		let devServer;
-		/** @type {Array<{ type: any, level: 'error', message: string; }>} */
-		let logs = [];
 
 		before(async () => {
 			fixture = await loadFixture({

--- a/packages/astro/test/core-image-layout.test.js
+++ b/packages/astro/test/core-image-layout.test.js
@@ -199,6 +199,13 @@ describe('astro:image:layout', () => {
 				}
 			});
 
+			it('does not pass through fit and position', async () => {
+				const fit = $('#fit-cover img');
+				assert.ok(!fit.attr('fit'));
+				const position = $('#position img');
+				assert.ok(!position.attr('position'));
+			})
+
 			it('sets a default fit of "cover" when no fit is provided', () => {
 				let $img = $('#fit-default img');
 				const srcset = parseSrcset($img.attr('srcset'))

--- a/packages/astro/test/core-image-layout.test.js
+++ b/packages/astro/test/core-image-layout.test.js
@@ -180,6 +180,53 @@ describe('astro:image:layout', () => {
 			});
 		});
 
+		describe('generated URLs', () => {
+			let $;
+			before(async () => {
+				let res = await fixture.fetch('/fit');
+				let html = await res.text();
+				$ = cheerio.load(html);
+			});
+			it('generates width and height in image URLs when both are provided', () => {
+				let $img = $('#local-both img');
+				const aspectRatio = 300 / 400;
+				const srcset = parseSrcset($img.attr('srcset'))
+				for (const { url } of srcset) {
+					const params = new URL(url, 'https://example.com').searchParams;
+					const width = parseInt(params.get('w'));
+					const height = parseInt(params.get('h'));
+					assert.equal(width / height, aspectRatio);
+				}
+			});
+
+			it('sets a default fit of "cover" when no fit is provided', () => {
+				let $img = $('#fit-default img');
+				const srcset = parseSrcset($img.attr('srcset'))
+				for (const { url } of srcset) {
+					const params = new URL(url, 'https://example.com').searchParams;
+					assert.equal(params.get('fit'), 'cover');
+				}
+			})
+
+			it('sets a fit of "contain" when fit="contain" is provided', () => {
+				let $img = $('#fit-contain img');
+				const srcset = parseSrcset($img.attr('srcset'))
+				for (const { url } of srcset) {
+					const params = new URL(url, 'https://example.com').searchParams;
+					assert.equal(params.get('fit'), 'contain');
+				}
+			})
+
+			it('sets no fit when fit="none" is provided', () => {
+				let $img = $('#fit-none img');
+				const srcset = parseSrcset($img.attr('srcset'))
+				for (const { url } of srcset) {
+					const params = new URL(url, 'https://example.com').searchParams;
+					assert.ok(!params.has('fit'));
+				}
+			})
+		});
+
 		describe('remote images', () => {
 			describe('srcset', () => {
 				let $;

--- a/packages/astro/test/core-image-service.test.js
+++ b/packages/astro/test/core-image-service.test.js
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
-import * as cheerio from 'cheerio';
-import { loadFixture } from './test-utils.js';
-import { lookup as probe } from '../dist/assets/utils/vendor/image-size/lookup.js';
 import { removeDir } from '@astrojs/internal-helpers/fs';
+import * as cheerio from 'cheerio';
+import { lookup as probe } from '../dist/assets/utils/vendor/image-size/lookup.js';
+import { loadFixture } from './test-utils.js';
 
 async function getImageDimensionsFromFixture(fixture, path) {
 	/** @type { Response } */
@@ -26,8 +26,6 @@ describe('astro image service', () => {
 	describe('dev image service', () => {
 		/** @type {import('./test-utils').DevServer} */
 		let devServer;
-		/** @type {Array<{ type: any, level: 'error', message: string; }>} */
-		let logs = [];
 
 		before(async () => {
 			fixture = await loadFixture({
@@ -149,7 +147,6 @@ describe('astro image service', () => {
 
 		describe('generated images', () => {
 			let $;
-			let src;
 			before(async () => {
 				const html = await fixture.readFile('/build/index.html');
 				$ = cheerio.load(html);
@@ -204,7 +201,6 @@ describe('astro image service', () => {
 				assert.equal(width, originalWidth);
 				assert.equal(height, originalHeight);
 			});
-
 		});
 	});
 });

--- a/packages/astro/test/core-image-service.test.js
+++ b/packages/astro/test/core-image-service.test.js
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import * as cheerio from 'cheerio';
+import { loadFixture } from './test-utils.js';
+import { lookup as probe } from '../dist/assets/utils/vendor/image-size/lookup.js';
+
+async function getImageDimensionsFromFixture(fixture, path) {
+	/** @type { Response } */
+	const res = await fixture.fetch(path instanceof URL ? path.pathname + path.search : path);
+	const buffer = await res.arrayBuffer();
+	const { width, height } = await probe(new Uint8Array(buffer));
+	return { width, height };
+}
+
+describe('astro image service', () => {
+	/** @type {import('./test-utils').Fixture} */
+	let fixture;
+
+	describe('dev image service', () => {
+		/** @type {import('./test-utils').DevServer} */
+		let devServer;
+		/** @type {Array<{ type: any, level: 'error', message: string; }>} */
+		let logs = [];
+
+		before(async () => { 
+			fixture = await loadFixture({
+				root: './fixtures/core-image-layout/',
+				image: {
+					domains: ['unsplash.com'],
+				},
+			});
+
+			devServer = await fixture.startDevServer({});
+		});
+
+		after(async () => {
+			await devServer.stop();
+		});
+
+		describe('generated images', () => {
+			let $;
+			let src 
+			before(async () => {
+				const res = await fixture.fetch('/fit');
+				const html = await res.text();
+				$ = cheerio.load(html);
+				let $img = $('#local-both img');
+				src = new URL($img.attr('src'), 'http://localhost').href
+			});
+
+			it('generates width and height in image URLs when both are provided', async () => {
+				const url = new URL(src);
+				const { width, height } = await getImageDimensionsFromFixture(fixture, url);
+				assert.equal(width, 300);
+				assert.equal(height, 400);
+			});
+
+			it('generates height in image URLs when only width is provided', async () => {
+				const url = new URL(src);
+				url.searchParams.delete('h');
+				const { width, height } = await getImageDimensionsFromFixture(fixture, url);
+				assert.equal(width, 300);
+				assert.equal(height, 200);
+			});
+
+			it('generates width in image URLs when only height is provided', async () => {
+				const url = new URL(src);
+				url.searchParams.delete('w');
+				url.searchParams.set('h', '400');
+				const { width, height } = await getImageDimensionsFromFixture(fixture, url);
+				assert.equal(width, 600);
+				assert.equal(height, 400);
+			});
+
+			it('preserves aspect ratio when fit=inside', async () => {
+				const url = new URL(src);
+				url.searchParams.set('fit', 'inside');
+				const { width, height } = await getImageDimensionsFromFixture(fixture, url);
+				assert.equal(width, 300);
+				assert.equal(height, 200);
+			});
+
+			it('preserves aspect ratio when fit=scale-down', async () => {
+				const url = new URL(src);
+				url.searchParams.set('fit', 'scale-down');
+				const { width, height } = await getImageDimensionsFromFixture(fixture, url);
+				assert.equal(width, 300);
+				assert.equal(height, 200);
+			});
+
+			it('preserves aspect ratio when fit=outside', async () => {
+				const url = new URL(src);
+				url.searchParams.set('fit', 'outside');
+				const { width, height } = await getImageDimensionsFromFixture(fixture, url);
+				assert.equal(width, 600);
+				assert.equal(height, 400);
+			});
+			const originalWidth = 2316;
+			const originalHeight = 1544;
+			it('does not upscale image if requested size is larger than original', async () => {
+				const url = new URL(src);
+				url.searchParams.set('w', '3000');
+				url.searchParams.set('h', '2000');
+				const { width, height } = await getImageDimensionsFromFixture(fixture, url);
+				assert.equal(width, originalWidth);
+				assert.equal(height, originalHeight);
+			});
+
+			// To match old behavior, we should upscale if the requested size is larger than the original
+			it('does upscale image if requested size is larger than original and fit is unset', async () => {
+				const url = new URL(src);
+				url.searchParams.set('w', '3000');
+				url.searchParams.set('h', '2000');
+				url.searchParams.delete('fit');
+				const { width, height } = await getImageDimensionsFromFixture(fixture, url);
+				assert.equal(width, 3000);
+				assert.equal(height, 2000);
+			})
+
+			// To match old behavior, we should upscale if the requested size is larger than the original
+			it('does not upscale is only one dimension is provided and fit is set', async () => {
+				const url = new URL(src);
+				url.searchParams.set('w', '3000');
+				url.searchParams.delete('h');
+				url.searchParams.set('fit', 'cover');
+				const { width, height } = await getImageDimensionsFromFixture(fixture, url);
+				assert.equal(width, originalWidth);
+				assert.equal(height, originalHeight);
+			})
+		});
+
+	});
+
+});

--- a/packages/astro/test/core-image-service.test.js
+++ b/packages/astro/test/core-image-service.test.js
@@ -22,7 +22,7 @@ describe('astro image service', () => {
 		/** @type {Array<{ type: any, level: 'error', message: string; }>} */
 		let logs = [];
 
-		before(async () => { 
+		before(async () => {
 			fixture = await loadFixture({
 				root: './fixtures/core-image-layout/',
 				image: {
@@ -39,13 +39,13 @@ describe('astro image service', () => {
 
 		describe('generated images', () => {
 			let $;
-			let src 
+			let src;
 			before(async () => {
 				const res = await fixture.fetch('/fit');
 				const html = await res.text();
 				$ = cheerio.load(html);
 				let $img = $('#local-both img');
-				src = new URL($img.attr('src'), 'http://localhost').href
+				src = new URL($img.attr('src'), 'http://localhost').href;
 			});
 
 			it('generates width and height in image URLs when both are provided', async () => {
@@ -115,7 +115,7 @@ describe('astro image service', () => {
 				const { width, height } = await getImageDimensionsFromFixture(fixture, url);
 				assert.equal(width, 3000);
 				assert.equal(height, 2000);
-			})
+			});
 
 			// To match old behavior, we should upscale if the requested size is larger than the original
 			it('does not upscale is only one dimension is provided and fit is set', async () => {
@@ -126,9 +126,7 @@ describe('astro image service', () => {
 				const { width, height } = await getImageDimensionsFromFixture(fixture, url);
 				assert.equal(width, originalWidth);
 				assert.equal(height, originalHeight);
-			})
+			});
 		});
-
 	});
-
 });

--- a/packages/astro/test/fixtures/core-image-layout/src/pages/build.astro
+++ b/packages/astro/test/fixtures/core-image-layout/src/pages/build.astro
@@ -1,0 +1,66 @@
+---
+import { Image } from "astro:assets";
+import penguin from "../assets/penguin.jpg";
+---
+
+<div class="both">
+	<Image src={penguin} alt="a penguin" width={300} height={400}/>
+</div>
+
+<div class="width-only">
+	<Image src={penguin} alt="a penguin" width={300}/>
+</div>
+
+<div class="height-only">
+	<Image src={penguin} alt="a penguin" height={400}/>
+</div>
+
+<div class="fit-contain">
+	<Image 
+		src={penguin} 
+		alt="a penguin" 
+		width={300} 
+		height={400} 
+		fit="contain"
+	/>
+</div>
+
+<div class="fit-scale-down">
+	<Image 
+		src={penguin} 
+		alt="a penguin" 
+		width={300} 
+		height={400} 
+		fit="scale-down"
+	/>
+</div>
+
+<div class="fit-outside">
+	<Image 
+		src={penguin} 
+		alt="a penguin" 
+		width={300} 
+		height={400} 
+		fit="outside"
+	/>
+</div>
+
+<div class="fit-inside">
+	<Image 
+		src={penguin} 
+		alt="a penguin" 
+		width={300} 
+		height={400} 
+		fit="inside"
+	/>
+</div>
+
+<div class="too-large">
+	<Image 
+		src={penguin} 
+		alt="a penguin" 
+		width={3000} 
+		height={2000} 
+		fit="cover"
+	/>
+</div>

--- a/packages/astro/test/fixtures/core-image-layout/src/pages/fit.astro
+++ b/packages/astro/test/fixtures/core-image-layout/src/pages/fit.astro
@@ -1,0 +1,35 @@
+---
+import { Image } from "astro:assets";
+import penguin from "../assets/penguin.jpg";
+---
+
+<div id="local-both">
+	<Image src={penguin} alt="a penguin" width={300} height={400}/>
+</div>
+<div id="fit-default">
+	<Image src={penguin} alt="a penguin" />
+</div>
+<div id="fit-fill">
+	<Image src={penguin} alt="a penguin" fit="fill" />
+</div>
+<div id="fit-contain">
+	<Image src={penguin} alt="a penguin" fit="contain" />
+</div>
+<div id="fit-cover">
+	<Image src={penguin} alt="a penguin" fit="cover" />
+</div>
+<div id="fit-scale-down">
+	<Image src={penguin} alt="a penguin" fit="scale-down" />
+</div>
+<div id="fit-inside">
+	<Image src={penguin} alt="a penguin" fit="inside" />
+</div>
+<div id="fit-none">
+	<Image src={penguin} alt="a penguin" fit="none" />
+</div>
+<div id="fit-unsupported">
+	<Image src={penguin} alt="a penguin" fit="unsupported" />
+</div>
+<div id="position">
+	<Image src={penguin} alt="a penguin" position="top left" />
+</div>

--- a/packages/astro/test/fixtures/core-image-layout/src/pages/fit.astro
+++ b/packages/astro/test/fixtures/core-image-layout/src/pages/fit.astro
@@ -31,5 +31,5 @@ import penguin from "../assets/penguin.jpg";
 	<Image src={penguin} alt="a penguin" fit="unsupported" />
 </div>
 <div id="position">
-	<Image src={penguin} alt="a penguin" position="top left" />
+	<Image src={penguin} alt="a penguin" position="right top" />
 </div>


### PR DESCRIPTION
## Changes

Adds new `fit` and `position` parameter to `ImageTransform`, which tells an image service how to handle images when the requested aspect ratio is different fromt he source. Currently if both width and height are set then height is ignored. Now if `fit` is set then both are used, and cropping is enabled. 

- `fit` sets the behvior for an image service if the requested aspect ratio is different from the source image. Allowed values are CSS `object-fit` values, but it also accepts arbitrary strings that may be understood by a particular image service. 
- `postion` is used when cropping, to choose the point at which to focus the crop. It accepts CSS `object-position` values, but also allows arbitrary strings that may be supported by an image service. For example, the default sharp service support `entropy` for position, which focusses on the point with the most detail.

This PR implements this crop support in the default sharp image service. It also changes the behaviour when fit is set to set `withoutEnlargement`, ensuring the service never returns images that are larger than the source. The styling in the image component means that if the smaller image is returned then the upscaling will happen in the browser, which is more efficient.

## Testing

The PR adds integration tests for the generation of srcsets. It also tests the actual image generation, ensuring the dimensions of the returned images are as expected.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
