### PR TITLE
fix(routing): middleware in dev

### DIFF
--- a/.changeset/spicy-ties-matter.md
+++ b/.changeset/spicy-ties-matter.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where the dev server returns a 404 status code when a user middleware returns a valid `Response`.

--- a/packages/astro/src/core/constants.ts
+++ b/packages/astro/src/core/constants.ts
@@ -32,6 +32,11 @@ export const REWRITE_DIRECTIVE_HEADER_KEY = 'X-Astro-Rewrite';
 export const REWRITE_DIRECTIVE_HEADER_VALUE = 'yes';
 
 /**
+ * This header is set by the no-op Astro middleware.
+ */
+export const NOOP_MIDDLEWARE_HEADER = 'X-Astro-Noop';
+
+/**
  * The name for the header used to help i18n middleware, which only needs to act on "page" and "fallback" route types.
  */
 export const ROUTE_TYPE_HEADER = 'X-Astro-Route-Type';

--- a/packages/astro/src/core/middleware/noop-middleware.ts
+++ b/packages/astro/src/core/middleware/noop-middleware.ts
@@ -1,3 +1,7 @@
 import type { MiddlewareHandler } from '../../@types/astro.js';
+import { NOOP_MIDDLEWARE_HEADER } from '../constants.js';
 
-export const NOOP_MIDDLEWARE_FN: MiddlewareHandler = (_, next) => next();
+export const NOOP_MIDDLEWARE_FN: MiddlewareHandler = (ctx, next) => {
+	ctx.request.headers.set(NOOP_MIDDLEWARE_HEADER, 'true');
+	return next();
+};

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -219,7 +219,9 @@ export async function handleRoute({
 				response.status
 			: // Our internal noop middleware sets a particular header. If the header isn't present, it means that the user have
 				// their own middleware, so we need to return what the user returns
-				!response.headers.has(NOOP_MIDDLEWARE_HEADER)
+				!response.headers.has(NOOP_MIDDLEWARE_HEADER) &&
+					matchedRoute.route.route !== '/404' &&
+					matchedRoute.route.route !== '/500'
 				? response.status
 				: (getStatusByMatchedRoute(matchedRoute) ?? response.status);
 	} catch (err: any) {

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -192,16 +192,11 @@ export async function handleRoute({
 
 	mod = preloadedComponent;
 
-	const isDefaultPrerendered404 =
-		matchedRoute.route.route === '/404' &&
-		matchedRoute.route.prerender &&
-		matchedRoute.route.component === DEFAULT_404_COMPONENT;
-
 	renderContext = await RenderContext.create({
 		locals,
 		pipeline,
 		pathname,
-		middleware: isDefaultPrerendered404 ? undefined : middleware,
+		middleware: isDefaultPrerendered404(matchedRoute.route) ? undefined : middleware,
 		request,
 		routeData: route,
 	});
@@ -214,16 +209,15 @@ export async function handleRoute({
 		response = await renderContext.render(mod);
 		isReroute = response.headers.has(REROUTE_DIRECTIVE_HEADER);
 		isRewrite = response.headers.has(REWRITE_DIRECTIVE_HEADER_KEY);
+		const statusCodedMatched = getStatusByMatchedRoute(matchedRoute);
 		statusCode = isRewrite
 			? // Ignore `matchedRoute` status for rewrites
 				response.status
 			: // Our internal noop middleware sets a particular header. If the header isn't present, it means that the user have
-				// their own middleware, so we need to return what the user returns
-				!response.headers.has(NOOP_MIDDLEWARE_HEADER) &&
-					matchedRoute.route.route !== '/404' &&
-					matchedRoute.route.route !== '/500'
+				// their own middleware, so we need to return what the user returns.
+				!response.headers.has(NOOP_MIDDLEWARE_HEADER) && !isReroute
 				? response.status
-				: (getStatusByMatchedRoute(matchedRoute) ?? response.status);
+				: (statusCodedMatched ?? response.status);
 	} catch (err: any) {
 		const custom500 = getCustom500Route(manifestData);
 		if (!custom500) {
@@ -314,4 +308,8 @@ function getStatusByMatchedRoute(matchedRoute?: MatchedRoute) {
 	if (matchedRoute?.route.route === '/404') return 404;
 	if (matchedRoute?.route.route === '/500') return 500;
 	return undefined;
+}
+
+function isDefaultPrerendered404(route: RouteData) {
+	return route.route === '/404' && route.prerender && route.component === DEFAULT_404_COMPONENT;
 }

--- a/packages/astro/test/fixtures/middleware space/src/middleware.js
+++ b/packages/astro/test/fixtures/middleware space/src/middleware.js
@@ -74,4 +74,13 @@ const third = defineMiddleware(async (context, next) => {
 	return next();
 });
 
-export const onRequest = sequence(first, second, third);
+const fourth = defineMiddleware((context, next) => {
+	if (context.request.url.includes('/no-route-but-200')) {
+		return new Response("It's OK!", {
+			status: 200
+		});
+	}
+	return next()
+})
+
+export const onRequest = sequence(first, second, third, fourth);

--- a/packages/astro/test/middleware.test.js
+++ b/packages/astro/test/middleware.test.js
@@ -70,6 +70,13 @@ describe('Middleware in DEV mode', () => {
 		assert.equal($('title').html(), 'MiddlewareNoDataOrNextCalled');
 	});
 
+	it('should return 200 if the middleware returns a 200 Response', async () => {
+		const response = await fixture.fetch('/no-route-but-200');
+		assert.equal(response.status, 200);
+		const html = await response.text();
+		assert.match(html, /It's OK!/);
+	});
+
 	it('should allow setting cookies', async () => {
 		const res = await fixture.fetch('/');
 		assert.equal(res.headers.get('set-cookie'), 'foo=bar');
@@ -237,6 +244,14 @@ describe('Middleware API in PROD mode, SSR', () => {
 		const html = await response.text();
 		const $ = cheerio.load(html);
 		assert.notEqual($('title').html(), 'MiddlewareNoDataReturned');
+	});
+
+	it('should return 200 if the middleware returns a 200 Response', async () => {
+		const request = new Request('http://example.com/no-route-but-200');
+		const response = await app.render(request);
+		assert.equal(response.status, 200);
+		const html = await response.text();
+		assert.match(html, /It's OK!/);
 	});
 
 	it('should correctly work for API endpoints that return a Response object', async () => {


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/12391
Closes PLT-2627

The middleware is called even when a user doesn't have a route that doesn't match an existing FS route. Users can return a `Response` that isn't a 404.

The dev server didn't know that, so this PR fixes it.

To understand this use case, I decoded to add a tiny logic to our no-op middleware, which is used only when the user doesn't have a middleware. The no-op middleware adds an arbitrary header. If header **isn't present**, it means that the user have their own middleware, so we need to return any status returned by the `.render` function. 

## Testing

Added two new test cases

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
