### PR TITLE
fix(actions): internal symbol check

### DIFF
--- a/.changeset/brown-bulldogs-share.md
+++ b/.changeset/brown-bulldogs-share.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where an incorrect usage of Astro actions was lost when porting the fix from v4 to v5

--- a/packages/astro/src/actions/utils.ts
+++ b/packages/astro/src/actions/utils.ts
@@ -1,7 +1,7 @@
 import type fsMod from 'node:fs';
 import * as eslexer from 'es-module-lexer';
 import type { APIContext } from '../types/public/context.js';
-import type { ActionAPIContext, Locals } from './runtime/utils.js';
+import { ACTION_API_CONTEXT_SYMBOL, type ActionAPIContext, type Locals } from './runtime/utils.js';
 import { deserializeActionResult, getActionQueryString } from './runtime/virtual/shared.js';
 
 export function hasActionPayload(locals: APIContext['locals']): locals is Locals {
@@ -22,6 +22,7 @@ export function createGetActionResult(locals: APIContext['locals']): APIContext[
 
 export function createCallAction(context: ActionAPIContext): APIContext['callAction'] {
 	return (baseAction, input) => {
+		Reflect.set(context, ACTION_API_CONTEXT_SYMBOL, true);
 		const action = baseAction.bind(context);
 		return action(input) as any;
 	};

--- a/packages/astro/test/fixtures/actions/src/pages/invalid.astro
+++ b/packages/astro/test/fixtures/actions/src/pages/invalid.astro
@@ -2,5 +2,5 @@
 import { actions } from "astro:actions";
 
 // this is invalid, it should fail
-const result = await actions.imageUploadInChunks();
+const result = await actions.subscribe({ channel: "hey" });
 ---


### PR DESCRIPTION
## Changes

This PR ports https://github.com/withastro/astro/pull/12402 into `next`. It was incorrectly lost during the merge, plus the actions code changed a lot, so it required some wiring.

## Testing

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
