### PR TITLE
chore: breakdown of benchmarks

### DIFF
--- a/benchmark/bench/codspeed.js
+++ b/benchmark/bench/codspeed.js
@@ -2,7 +2,6 @@ import path from 'node:path';
 import { withCodSpeed } from '@codspeed/tinybench-plugin';
 import { Bench } from 'tinybench';
 import { exec } from 'tinyexec';
-import { renderPages } from '../make-project/render-default.js';
 import { astroBin } from './_util.js';
 
 export async function run({ memory: _memory, render, stress: _stress }) {
@@ -10,40 +9,55 @@ export async function run({ memory: _memory, render, stress: _stress }) {
 		iterations: 10,
 	};
 	const bench = process.env.CODSPEED ? withCodSpeed(new Bench(options)) : new Bench(options);
-	let app;
-	bench.add(
-		'Rendering',
-		async () => {
-			console.info('Start task.');
-			const result = {};
-			for (const fileName of renderPages) {
-				const pathname = '/' + fileName.slice(0, -path.extname(fileName).length);
-				const request = new Request(new URL(pathname, 'http://exmpale.com'));
-				const response = await app.render(request);
-				const html = await response.text();
-				if (!result[pathname]) result[pathname] = [];
-				result[pathname].push(html);
-			}
-			console.info('Finish task.');
-			return result;
+	await exec(astroBin, ['build'], {
+		nodeOptions: {
+			cwd: render.root,
+			stdio: 'inherit',
 		},
-		{
-			async beforeAll() {
-				// build for rendering
-				await exec(astroBin, ['build'], {
-					nodeOptions: {
-						cwd: render.root,
-						stdio: 'inherit',
-					},
-				});
+	});
 
-				const entry = new URL('./dist/server/entry.mjs', `file://${render.root}`);
-				const { manifest, createApp } = await import(entry);
-				app = createApp(manifest);
-				app.manifest = manifest;
-			},
-		},
-	);
+	const entry = new URL('./dist/server/entry.mjs', `file://${render.root}`);
+	const { manifest, createApp } = await import(entry);
+	const streamingApp = createApp(manifest, true);
+	const nonStreamingApp = createApp(manifest, false);
+	bench
+		.add('Rendering: streaming [true], .astro file', async () => {
+			console.info('Start task.');
+			const request = new Request(new URL('http://exmpale.com/astro'));
+			await streamingApp.render(request);
+			console.info('Finish task.');
+		})
+		.add('Rendering: streaming [true], .md file', async () => {
+			console.info('Start task.');
+			const request = new Request(new URL('http://exmpale.com/md'));
+			await streamingApp.render(request);
+			console.info('Finish task.');
+		})
+		.add('Rendering: streaming [true], .mdx file', async () => {
+			console.info('Start task.');
+			const request = new Request(new URL('http://exmpale.com/mdx'));
+			await streamingApp.render(request);
+			console.info('Finish task.');
+		})
+
+		.add('Rendering: streaming [false], .astro file', async () => {
+			console.info('Start task.');
+			const request = new Request(new URL('http://exmpale.com/astro'));
+			await nonStreamingApp.render(request);
+			console.info('Finish task.');
+		})
+		.add('Rendering: streaming [false], .md file', async () => {
+			console.info('Start task.');
+			const request = new Request(new URL('http://exmpale.com/md'));
+			await nonStreamingApp.render(request);
+			console.info('Finish task.');
+		})
+		.add('Rendering: streaming [false], .mdx file', async () => {
+			console.info('Start task.');
+			const request = new Request(new URL('http://exmpale.com/mdx'));
+			await nonStreamingApp.render(request);
+			console.info('Finish task.');
+		});
 
 	await bench.run();
 	console.table(bench.table());

--- a/benchmark/packages/adapter/src/server.ts
+++ b/benchmark/packages/adapter/src/server.ts
@@ -7,11 +7,9 @@ applyPolyfills();
 
 class MyApp extends App {
 	#manifest: SSRManifest | undefined;
-	#streaming: boolean;
 	constructor(manifest: SSRManifest, streaming = false) {
 		super(manifest, streaming);
 		this.#manifest = manifest;
-		this.#streaming = streaming;
 	}
 
 	async render(request: Request) {


### PR DESCRIPTION
## Changes

This PR adds 6 benchmarks to CodSpeed. It moves the building of the project to before running the benchmarks, it creates two apps, one with streaming enabled and one where it's not enabled.

The pet project that we create has three routes: `/astro`, `/md` and `/mdx`, so we already know in advance what **we want** to test.

## Testing

This CI should work and we should see the results already.

CodSpeed will go crazy because we will remove the benchmark we already have, so we must acknowledge the deletion. 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
