### PR TITLE
prevents access to the history state if not set

### DIFF
--- a/.changeset/dirty-teachers-know.md
+++ b/.changeset/dirty-teachers-know.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a potential null access in the clientside router

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -636,7 +636,7 @@ if (inBrowser) {
 				'scroll',
 				() => {
 					if (intervalId !== undefined) return;
-					(lastIndex = history.state.index), (lastY = scrollY), (lastX = scrollX);
+					(lastIndex = history.state?.index), (lastY = scrollY), (lastX = scrollX);
 					intervalId = window.setInterval(scrollInterval, 50);
 				},
 				{ passive: true },


### PR DESCRIPTION
## Changes

do not access properties of the browsers history state if it is not defined 

## Testing

defensive coding, no additional test

## Docs

n.a.