### PR TITLE
fix: server island hydration

### DIFF
--- a/.changeset/olive-garlics-marry.md
+++ b/.changeset/olive-garlics-marry.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where a server island hydration script might fail case the island ID misses from the DOM.

--- a/packages/astro/src/runtime/server/render/server-islands.ts
+++ b/packages/astro/src/runtime/server/render/server-islands.ts
@@ -81,8 +81,8 @@ let response = await fetch('${serverIslandUrl}', {
 	method: 'POST',
 	body: JSON.stringify(data),
 });
-
-if(response.status === 200 && response.headers.get('content-type') === 'text/html') {
+if (script) {
+	if(response.status === 200 && response.headers.get('content-type') === 'text/html') {
 	let html = await response.text();
 
 	// Swap!
@@ -97,6 +97,7 @@ if(response.status === 200 && response.headers.get('content-type') === 'text/htm
 	script.before(frag);
 }
 script.remove();
+}
 </script>`);
 		},
 	};


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/astro/issues/12421
Closes PLT-2643

The PR just adds a check if `script` exists, because external libs could mess up with DOM and stuff. 

## Testing

I tested it locally

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
