### PR TITLE
chore: use Biome VCS ignore file

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,137 +1,163 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.3/schema.json",
-	"files": {
-		"ignore": [
-			"vendor",
-			"**/dist/**",
-			"**/smoke/**",
-			"**/fixtures/**",
-			"**/_temp-fixtures/**",
-			"**/vendor/**",
-			"**/.vercel/**",
-			"benchmark/projects/",
-			"benchmark/results/",
-			"benchmark/bench/_template.js",
-		],
-		"include": ["test/**", "e2e/**", "packages/**", "/scripts/**", "benchmark/bench"],
-	},
-	"formatter": {
-		"indentStyle": "tab",
-		"indentWidth": 2,
-		"lineWidth": 100,
-		"ignore": [".changeset", "pnpm-lock.yaml", "*.astro"],
-	},
-	"organizeImports": {
-		"enabled": true,
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": false,
-			"style": {
-				"useNodejsImportProtocol": "error",
-				// Enforce separate type imports for type-only imports to avoid bundling unneeded code
-				"useImportType": "error",
-			},
-			"suspicious": {
-				// This one is specific to catch `console.log`. The rest of logs are permitted
-				"noConsoleLog": "warn",
-			},
-			"correctness": {
-				"noUnusedVariables": "info",
-				"noUnusedFunctionParameters": "info",
-			},
-		},
-	},
-	"javascript": {
-		"formatter": {
-			"trailingCommas": "all",
-			"quoteStyle": "single",
-			"semicolons": "always",
-		},
-	},
-	"json": {
-		"parser": {
-			"allowComments": true,
-			"allowTrailingCommas": true,
-		},
-		"formatter": {
-			"indentStyle": "space",
-			"trailingCommas": "none",
-		},
-	},
-	"overrides": [
-		{
-			// Workaround to format files like npm does
-			"include": ["package.json"],
-			"json": {
-				"formatter": {
-					"lineWidth": 1,
-				},
-			},
-		},
-		{
-			// We don"t want to have node modules in code that should be runtime agnostic
-			"include": ["packages/astro/src/runtime/**/*.ts"],
-			"linter": {
-				"rules": {
-					"correctness": {
-						"noNodejsModules": "error",
-					},
-				},
-			},
-		},
-		{
-			"include": ["*.test.js"],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"noFocusedTests": "error",
-						"noConsole": "off",
-					},
-				},
-			},
-		},
-		{
-			"include": ["*.astro", "client.d.ts"],
-			"linter": {
-				"rules": {
-					"correctness": {
-						"noUnusedVariables": "off",
-					},
-				},
-			},
-		},
-		{
-			"include": ["packages/integrations/**/*.ts"],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"noConsole": {
-							"level": "error",
-							"options": {
-								"allow": ["warn", "error", "info", "debug"],
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			"include": [
-				"packages/db/**/cli/**/*.ts",
-				"benchmark/**/*.js",
-				"packages/astro/src/cli/**/*.ts",
-				"packages/astro/astro.js",
-			],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"noConsole": "off",
-						"noConsoleLog": "off",
-					},
-				},
-			},
-		},
-	],
+  "$schema": "https://biomejs.dev/schemas/1.9.3/schema.json",
+  "files": {
+    "ignore": [
+      "**/smoke/**",
+      "**/fixtures/**",
+      "**/_temp-fixtures/**",
+      "**/vendor/**"
+    ],
+    "include": [
+      "test/**",
+      "e2e/**",
+      "packages/**",
+      "scripts/**",
+      "benchmark/bench"
+    ]
+  },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "formatter": {
+    "indentStyle": "tab",
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "ignore": [
+      ".changeset",
+      "pnpm-lock.yaml",
+      "*.astro"
+    ]
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": false,
+      "style": {
+        "useNodejsImportProtocol": "error",
+        // Enforce separate type imports for type-only imports to avoid bundling unneeded code
+        "useImportType": "error"
+      },
+      "suspicious": {
+        // This one is specific to catch `console.log`. The rest of logs are permitted
+        "noConsoleLog": "warn"
+      },
+      "correctness": {
+        "noUnusedVariables": "info",
+        "noUnusedFunctionParameters": "info"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "trailingCommas": "all",
+      "quoteStyle": "single",
+      "semicolons": "always"
+    }
+  },
+  "json": {
+    "parser": {
+      "allowComments": true,
+      "allowTrailingCommas": true
+    },
+    "formatter": {
+      "indentStyle": "space",
+      "trailingCommas": "none"
+    }
+  },
+  "overrides": [
+    {
+      // Workaround to format files like npm does
+      "include": [
+        "package.json",
+        "biome.jsonc"
+      ],
+      "json": {
+        "formatter": {
+          "lineWidth": 1
+        }
+      }
+    },
+    {
+      // We don"t want to have node modules in code that should be runtime agnostic
+      "include": [
+        "packages/astro/src/runtime/**/*.ts"
+      ],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noNodejsModules": "error"
+          }
+        }
+      }
+    },
+    {
+      "include": [
+        "*.test.js"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noFocusedTests": "error",
+            "noConsole": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": [
+        "*.astro",
+        "client.d.ts"
+      ],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedVariables": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": [
+        "packages/integrations/**/*.ts"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": {
+              "level": "error",
+              "options": {
+                "allow": [
+                  "warn",
+                  "error",
+                  "info",
+                  "debug"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "include": [
+        "packages/db/**/cli/**/*.ts",
+        "benchmark/**/*.js",
+        "packages/astro/src/cli/**/*.ts",
+        "packages/astro/astro.js"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off",
+            "noConsoleLog": "off"
+          }
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Changes

Biome can integrate with the top level VCS ignore file, so we don't need to repeat folders inside the configuration file.

I also aligned the configuration formatting with the the rest of JSON files 

## Testing

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
