### PR TITLE
ci: filter paths of when running the benchmark action

### DIFF
--- a/.github/workflows/continuous_benchmark.yml
+++ b/.github/workflows/continuous_benchmark.yml
@@ -19,7 +19,6 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
   FORCE_COLOR: true
-  CODSPEED_TOKEN: ${{ secrets.CODSPEED_TOKEN }}
   CODSPEED: true
 
 jobs:
@@ -52,4 +51,5 @@ jobs:
         timeout-minutes: 30
         with:
           run: pnpm benchmark codspeed
+          token: ${{ secrets.CODSPEED_TOKEN }}
                

--- a/.github/workflows/continuous_benchmark.yml
+++ b/.github/workflows/continuous_benchmark.yml
@@ -5,9 +5,15 @@ on:
   pull_request: 
     branches:
       - main
+    paths:
+      - 'packages/astro/src/**/*.ts'
+      - 'benchmark/**'
   push:
     branches:
       - main
+    paths:
+      - 'packages/astro/src/**/*.ts'
+      - 'benchmark/**'
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
## Changes

This filters the paths for when the benchmarking workflow should be triggered.]

**UPDATE**

[I added the `token` part](https://docs.codspeed.io/integrations/ci/github-actions#2-create-the-benchmarks-workflow), which I completely forgot 😅  
That should fix the runs from third party PRs

## Testing

It should *not* run in this PR I think 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
