### PR TITLE
Enhance README: Add clarification to Astro Content Collections link.

### DIFF
--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -42,7 +42,7 @@ Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page
 
 There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
 
-The `src/content/` directory contains "collections" of related Markdown and MDX documents. Use `getCollection()` to retrieve posts from `src/content/blog/`, and type-check your frontmatter using an optional schema. See [Astro's Content Collections docs](https://docs.astro.build/en/guides/content-collections/) to learn more.
+The `src/content/` directory contains "collections" of related Markdown and MDX documents. Use `getCollection()` to retrieve posts from `src/content/blog/`, and type-check your frontmatter using an optional schema. For detailed information, see [Astro's Content Collections docs](https://docs.astro.build/en/guides/content-collections/).
 
 Any static assets, like images, can be placed in the `public/` directory.
 


### PR DESCRIPTION
## Changes
- Added "For detailed information" before the "Astro's Content Collections docs" link in the README.
- This change clarifies the purpose of the link, helping users understand that it provides detailed information about content collections.

## Testing
- The change was reviewed in the markdown preview to ensure the link and additional text display correctly.
- No functional code changes, so no additional testing required.

## Docs
- This change updates the README file to provide better clarity.
- No further documentation changes needed.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why. -->
<!-- https://github.com/withastro/docs -->
