### PR TITLE
fix: content layer glob deletion

### DIFF
--- a/.changeset/six-pianos-draw.md
+++ b/.changeset/six-pianos-draw.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a case where the Content Layer `glob()` loader would not update when renaming or deleting an entry

--- a/packages/astro/src/content/loaders/glob.ts
+++ b/packages/astro/src/content/loaders/glob.ts
@@ -101,6 +101,7 @@ export function glob(globOptions: GlobOptions): Loader {
 				const existingEntry = store.get(id);
 
 				const digest = generateDigest(contents);
+				const filePath = fileURLToPath(fileUrl);
 
 				if (existingEntry && existingEntry.digest === digest && existingEntry.filePath) {
 					if (existingEntry.deferredRender) {
@@ -112,10 +113,9 @@ export function glob(globOptions: GlobOptions): Loader {
 						store.addAssetImports(existingEntry.assetImports, existingEntry.filePath);
 					}
 
+					fileToIdMap.set(filePath, id);
 					return;
 				}
-
-				const filePath = fileURLToPath(fileUrl);
 
 				const relativePath = posixRelative(fileURLToPath(config.root), filePath);
 

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -323,5 +323,26 @@ describe('Content Layer', () => {
 			assert.equal(res.status, 500);
 			assert.ok(text.includes('RenderUndefinedEntryError'));
 		});
+
+		it('update the store when a file is renamed', async () => {
+			const rawJsonResponse = await fixture.fetch('/collections.json');
+			const initialJson = devalue.parse(await rawJsonResponse.text());
+			assert.equal(initialJson.numbers.map((e) => e.id).includes('src/data/glob-data/three'), true);
+
+			const oldPath = new URL('./data/glob-data/three.json', fixture.config.srcDir);
+			const newPath = new URL('./data/glob-data/four.json', fixture.config.srcDir);
+
+			await fs.rename(oldPath, newPath);
+			await fixture.onNextDataStoreChange();
+
+			try {
+				const updatedJsonResponse = await fixture.fetch('/collections.json');
+				const updated = devalue.parse(await updatedJsonResponse.text());
+				assert.equal(updated.numbers.map((e) => e.id).includes('src/data/glob-data/three'), false);
+				assert.equal(updated.numbers.map((e) => e.id).includes('src/data/glob-data/four'), true);
+			} finally {
+				await fs.rename(newPath, oldPath);
+			}
+		});
 	});
 });

--- a/packages/astro/test/fixtures/content-layer/src/pages/collections.json.js
+++ b/packages/astro/test/fixtures/content-layer/src/pages/collections.json.js
@@ -19,6 +19,9 @@ export async function GET() {
 	const increment = await getEntry('increment', 'value');
 
 	const images = await getCollection('images');
+
+	const numbers = await getCollection('numbers');
+
 	return new Response(
 		devalue.stringify({
 			customLoader,
@@ -29,7 +32,8 @@ export async function GET() {
 			entryWithImagePath,
 			referencedEntry,
 			increment,
-			images
+			images,
+			numbers,
 		})
 	);
 }


### PR DESCRIPTION
## Changes

- Closes #12195
- Closes PLT-2539
- The map was not initialized on load so deleting a non updated entry would not actually delete it from the data store

## Testing

Adds a test case

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A bugfix

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
