### PR TITLE
fix(build): generated entry

### DIFF
--- a/.changeset/thin-cups-peel.md
+++ b/.changeset/thin-cups-peel.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where the SSR build was emitting the `dist/server/entry.mjs` file with an incorrect import at the top of the file/

--- a/packages/astro/src/core/build/plugins/plugin-ssr.ts
+++ b/packages/astro/src/core/build/plugins/plugin-ssr.ts
@@ -283,7 +283,6 @@ function generateSSRCode(settings: AstroSettings, adapter: AstroAdapter, middlew
 		`import { renderers } from '${RENDERERS_MODULE_ID}';`,
 		`import * as serverEntrypointModule from '${ADAPTER_VIRTUAL_MODULE_ID}';`,
 		`import { manifest as defaultManifest } from '${SSR_MANIFEST_VIRTUAL_MODULE_ID}';`,
-		edgeMiddleware ? `` : `import { onRequest as middleware } from '${middlewareId}';`,
 		settings.config.experimental.serverIslands
 			? `import { serverIslandMap } from '${VIRTUAL_ISLAND_MAP_ID}';`
 			: '',


### PR DESCRIPTION
## Changes

The middleware is now dynamically imported, which means we don't need to have it at the top of `entry.mjs`

Closes PLT-2659

## Testing

I tested locally and checked the emitted file. That import is **unused**, so there's no need for new tests.

Current CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
