### PR TITLE
refactor(build): don't emit `middleware.mjs`

### DIFF
--- a/packages/astro/src/core/middleware/vite-plugin.ts
+++ b/packages/astro/src/core/middleware/vite-plugin.ts
@@ -13,7 +13,6 @@ export const MIDDLEWARE_MODULE_ID = '\0astro-internal:middleware';
 const NOOP_MIDDLEWARE = '\0noop-middleware';
 
 export function vitePluginMiddleware({ settings }: { settings: AstroSettings }): VitePlugin {
-	let isCommandBuild = false;
 	let resolvedMiddlewareId: string | undefined = undefined;
 	const hasIntegrationMiddleware =
 		settings.middlewares.pre.length > 0 || settings.middlewares.post.length > 0;
@@ -21,9 +20,6 @@ export function vitePluginMiddleware({ settings }: { settings: AstroSettings }):
 
 	return {
 		name: '@astro/plugin-middleware',
-		config(_, { command }) {
-			isCommandBuild = command === 'build';
-		},
 		async resolveId(id) {
 			if (id === MIDDLEWARE_MODULE_ID) {
 				const middlewareId = await this.resolve(
@@ -52,15 +48,6 @@ export function vitePluginMiddleware({ settings }: { settings: AstroSettings }):
 			} else if (id === MIDDLEWARE_MODULE_ID) {
 				if (!userMiddlewareIsPresent && settings.config.i18n?.routing === 'manual') {
 					throw new AstroError(MissingMiddlewareForInternationalization);
-				}
-				// In the build, tell Vite to emit this file
-				if (isCommandBuild) {
-					this.emitFile({
-						type: 'chunk',
-						preserveSignature: 'strict',
-						fileName: 'middleware.mjs',
-						id,
-					});
 				}
 
 				const preMiddleware = createMiddlewareImports(settings.middlewares.pre, 'pre');
@@ -124,7 +111,7 @@ export function vitePluginMiddlewareBuild(
 
 		writeBundle(_, bundle) {
 			for (const [chunkName, chunk] of Object.entries(bundle)) {
-				if (chunk.type !== 'asset' && chunk.fileName === 'middleware.mjs') {
+				if (chunk.type !== 'asset' && chunk.facadeModuleId === MIDDLEWARE_MODULE_ID) {
 					const outputDirectory = getOutputDirectory(opts.settings.config);
 					internals.middlewareEntryPoint = new URL(chunkName, outputDirectory);
 				}


### PR DESCRIPTION
## Changes

This PR refactors our build by removing the necessity of having a file called `middleware.mjs`. We were emitting `middleware.mjs` in order to have a predictable way to load the middleware file; however, since we started emitting the middleware chunk as a virtual module, we were emitting two files: `middleware.mjs` that simply do an export of `onRequest` from the middleware chunk.

`middleware.mjs` isn't needed anymore, and we directly import the chunk that rollup generates after the build.

## Testing

This is an internal refactor; existing CI should pass, and no changeset is needed.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
