### PR TITLE
Remove default throw behavior in astro:env

### DIFF
--- a/.changeset/early-scissors-beg.md
+++ b/.changeset/early-scissors-beg.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Remove default throw behavior in astro:env
+Removes the default throw behavior in `astro:env`

--- a/.changeset/early-scissors-beg.md
+++ b/.changeset/early-scissors-beg.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Remove default throw behavior in astro:env

--- a/packages/astro/src/core/app/pipeline.ts
+++ b/packages/astro/src/core/app/pipeline.ts
@@ -54,7 +54,6 @@ export class AppPipeline extends Pipeline {
 			undefined,
 			undefined,
 			undefined,
-			false,
 			defaultRoutes,
 		);
 		pipeline.#manifestData = manifestData;

--- a/packages/astro/src/core/base-pipeline.ts
+++ b/packages/astro/src/core/base-pipeline.ts
@@ -57,7 +57,6 @@ export abstract class Pipeline {
 		 * Used for `Astro.site`.
 		 */
 		readonly site = manifest.site ? new URL(manifest.site) : undefined,
-		readonly callSetGetEnv = true,
 		/**
 		 * Array of built-in, internal, routes.
 		 * Used to find the route module

--- a/packages/astro/src/core/base-pipeline.ts
+++ b/packages/astro/src/core/base-pipeline.ts
@@ -71,13 +71,6 @@ export abstract class Pipeline {
 				createI18nMiddleware(i18n, manifest.base, manifest.trailingSlash, manifest.buildFormat),
 			);
 		}
-		// In SSR, getSecret should fail by default. Setting it here will run before the
-		// adapter override.
-		if (callSetGetEnv && manifest.experimentalEnvGetSecretEnabled) {
-			setGetEnv(() => {
-				throw new AstroError(AstroErrorData.EnvUnsupportedGetSecret);
-			}, true);
-		}
 	}
 
 	abstract headElements(routeData: RouteData): Promise<HeadElements> | HeadElements;

--- a/packages/astro/src/core/errors/errors-data.ts
+++ b/packages/astro/src/core/errors/errors-data.ts
@@ -1177,17 +1177,6 @@ export const EnvInvalidVariables = {
 /**
  * @docs
  * @description
- * The `astro:env/server` exported function `getSecret()` is not supported by your adapter.
- */
-export const EnvUnsupportedGetSecret = {
-	name: 'EnvUnsupportedGetSecret',
-	title: 'Unsupported astro:env getSecret',
-	message: '`astro:env/server` exported function `getSecret` is not supported by your adapter.',
-} satisfies ErrorData;
-
-/**
- * @docs
- * @description
  * This module is only available server-side.
  */
 export const ServerOnlyModule = {


### PR DESCRIPTION
## Changes

- Removes the default throw for `getEnv`.
- Plan is to move away from having `astro:env` be dependent on timing; if some code runs before `setGetEnv` has been called it currently could result in incorrect or missing environment variables.
- Instead now we always default to the `process.env[key]` approach. Since this is what most adapters need anyways, we don't have to worry about bundling causing issues of code executing in unwanted order.
- Now only Cloudflare needs to ensure it calls `setGetEnv`, and it already has the constraint of not allowing vars to be grabbed at the top level.

## Testing

- manual

## Docs

N/A, bug fix