### PR TITLE
chore: clarify wording of responsive image props

### DIFF
--- a/packages/astro/src/assets/internal.ts
+++ b/packages/astro/src/assets/internal.ts
@@ -150,6 +150,7 @@ export async function getImage(
 			resolvedOptions.fetchpriority ??= 'auto';
 		}
 		delete resolvedOptions.priority;
+		delete resolvedOptions.densities;
 	}
 
 	const validatedOptions = service.validateOptions

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1899,11 +1899,10 @@ export interface ViteUserConfig extends OriginalViteUserConfig {
 		 * - `position`: Defines the position of the image crop if the aspect ratio is changed. Values match those of CSS `object-position`. Defaults to `center`, or the value of `image.experimentalObjectPosition` if set.
 		 * - `priority`: If set, eagerly loads the image. Otherwise images will be lazy-loaded. Use this for your largest above-the-fold image. Defaults to `false`.
 		 *
-		 * The following `<Image />` component properties should not be used with responsive images as these are automatically generated:
-		 *
-		 * - `densities`
-		 * - `widths`
-		 * - `sizes`
+		 * The `widths` and `sizes` attributes are automatically generated based on the image's dimensions and the layout type, and in most cases should not be set manually. The generated `sizes` attribute for `responsive` and `full-width` images
+		 * is based on the assumption that the image is displayed at close to the full width of the screen when the viewport is smaller than the image's width. If it is significantly different (e.g. if it's in a multi-column layout on small screens) you may need to adjust the `sizes` attribute manually for best results.
+		 * 
+		 * The `densities` attribute is not compatible with responsive images and will be ignored if set.
 		 */
 
 		responsiveImages?: boolean;


### PR DESCRIPTION
## Changes

Improves the wording of the experimental flag docs for responsive images. Currently it says you should not set the sizes or widths values manually. This is true in some cases, but not all. This PR clarifies these, explainign when you might need it. It also ensures that the densities value is ignored if set. This was already listed as not supported, and this just aligns the actual behaviour with the docs.

Thanks @carlcs for the suggestion.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
