### PR TITLE
Call server island early so it can set headers

### DIFF
--- a/.changeset/rotten-dodos-judge.md
+++ b/.changeset/rotten-dodos-judge.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Call server island early so it can set headers

--- a/packages/astro/src/vite-plugin-astro-server/plugin.ts
+++ b/packages/astro/src/vite-plugin-astro-server/plugin.ts
@@ -4,7 +4,7 @@ import { IncomingMessage } from 'node:http';
 import type * as vite from 'vite';
 import type { SSRManifest, SSRManifestI18n } from '../core/app/types.js';
 import { warnMissingAdapter } from '../core/dev/adapter-validation.js';
-import { createKey } from '../core/encryption.js';
+import { createKey, getEnvironmentKey, hasEnvironmentKey } from '../core/encryption.js';
 import { getViteErrorPayload } from '../core/errors/dev/index.js';
 import { AstroError, AstroErrorData } from '../core/errors/index.js';
 import { patchOverlay } from '../core/errors/overlay.js';
@@ -168,7 +168,7 @@ export function createDevelopmentManifest(settings: AstroSettings): SSRManifest 
 		checkOrigin:
 			(settings.config.security?.checkOrigin && settings.buildOutput === 'server') ?? false,
 		envGetSecretEnabled: false,
-		key: createKey(),
+		key: hasEnvironmentKey() ? getEnvironmentKey() : createKey(),
 		middleware() {
 			return {
 				onRequest: NOOP_MIDDLEWARE_FN,

--- a/packages/astro/test/fixtures/server-islands/ssr/src/components/Island.astro
+++ b/packages/astro/test/fixtures/server-islands/ssr/src/components/Island.astro
@@ -1,4 +1,5 @@
 ---
-
+await new Promise(resolve => setTimeout(resolve, 1));
+Astro.response.headers.set('X-Works', 'true');
 ---
 <h2 id="island">I'm an island</h2>

--- a/packages/astro/test/server-islands.test.js
+++ b/packages/astro/test/server-islands.test.js
@@ -19,11 +19,13 @@ describe('Server islands', () => {
 			let devServer;
 
 			before(async () => {
+				process.env.ASTRO_KEY = 'eKBaVEuI7YjfanEXHuJe/pwZKKt3LkAHeMxvTU7aR0M=';
 				devServer = await fixture.startDevServer();
 			});
 
 			after(async () => {
 				await devServer.stop();
+				delete process.env.ASTRO_KEY;
 			});
 
 			it('omits the islands HTML', async () => {
@@ -34,11 +36,29 @@ describe('Server islands', () => {
 				const serverIslandEl = $('h2#island');
 				assert.equal(serverIslandEl.length, 0);
 			});
+
+			it('island can set headers', async () => {
+				const res = await fixture.fetch('/_server-islands/Island', {
+					method: 'POST',
+					body: JSON.stringify({
+					        componentExport: 'default',
+					        encryptedProps: 'FC8337AF072BE5B1641501E1r8mLIhmIME1AV7UO9XmW9OLD',
+					        slots: {},
+					})
+				});
+				const works = res.headers.get('X-Works');
+				assert.equal(works, 'true', 'able to set header from server island');
+			});
 		});
 
 		describe('prod', () => {
 			before(async () => {
+				process.env.ASTRO_KEY = 'eKBaVEuI7YjfanEXHuJe/pwZKKt3LkAHeMxvTU7aR0M=';
 				await fixture.build();
+			});
+
+			after(async () => {
+				delete process.env.ASTRO_KEY;
 			});
 
 			it('omits the islands HTML', async () => {


### PR DESCRIPTION
## Changes

- Server islands should be able to set headers, specifically their own caching.
- Because we render the island inside of a template it won't be able to do so, because of streaming.
- Fix is to call the component early, so it can render before we start streaming out.

## Testing

- New test added
- Added the ability to use an `ASTRO_KEY` in dev too, needed for the tests, but users might also want the ability for testing as well.

## Docs

N/A, bug fix
