### PR TITLE
fix: re-export unstorage drivers

### DIFF
--- a/.changeset/poor-mangos-fold.md
+++ b/.changeset/poor-mangos-fold.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Adds experimental session support
+Adds experimental session support.

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "publint": "^0.2.12",
     "turbo": "^2.2.3",
     "typescript": "~5.6.3",
-    "typescript-eslint": "^8.13.0"
+    "typescript-eslint": "^8.13.0",
+    "unstorage": "^1.12.0"
   },
   "pnpm": {
     "overrides": {

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -67,6 +67,7 @@
     "./assets/services/noop": "./dist/assets/services/noop.js",
     "./loaders": "./dist/content/loaders/index.js",
     "./content/runtime": "./dist/content/runtime.js",
+    "./internal/storage/drivers/*": "./dist/storage/drivers/*.js",
     "./content/runtime-assets": "./dist/content/runtime-assets.js",
     "./debug": "./components/Debug.astro",
     "./package.json": "./package.json",

--- a/packages/astro/src/core/session.ts
+++ b/packages/astro/src/core/session.ts
@@ -344,7 +344,7 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 	 * Ensures the storage is initialized.
 	 * This is called automatically when a storage operation is needed.
 	 */
-	async #ensureStorage():Promise<Storage> {
+	async #ensureStorage(): Promise<Storage> {
 		if (this.#storage) {
 			return this.#storage;
 		}
@@ -364,7 +364,9 @@ export class AstroSession<TDriver extends SessionDriverName = any> {
 
 		let driver: ((config: SessionConfig<TDriver>['options']) => Driver) | null = null;
 		const entry =
-			builtinDrivers[this.#config.driver as keyof typeof builtinDrivers] || this.#config.driver;
+			this.#config.driver in builtinDrivers
+				? `astro/internal/storage/drivers/${this.#config.driver}`
+				: this.#config.driver;
 		try {
 			// Try to load the driver from the built-in unstorage drivers.
 			// Otherwise, assume it's a custom driver and load by name.

--- a/packages/astro/src/storage/drivers/azureAppConfiguration.js
+++ b/packages/astro/src/storage/drivers/azureAppConfiguration.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/azure-app-configuration";

--- a/packages/astro/src/storage/drivers/azureCosmos.js
+++ b/packages/astro/src/storage/drivers/azureCosmos.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/azure-cosmos";

--- a/packages/astro/src/storage/drivers/azureKeyVault.js
+++ b/packages/astro/src/storage/drivers/azureKeyVault.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/azure-key-vault";

--- a/packages/astro/src/storage/drivers/azureStorageBlob.js
+++ b/packages/astro/src/storage/drivers/azureStorageBlob.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/azure-storage-blob";

--- a/packages/astro/src/storage/drivers/azureStorageTable.js
+++ b/packages/astro/src/storage/drivers/azureStorageTable.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/azure-storage-table";

--- a/packages/astro/src/storage/drivers/cloudflare-kv-binding.js
+++ b/packages/astro/src/storage/drivers/cloudflare-kv-binding.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/cloudflare-kv-binding";

--- a/packages/astro/src/storage/drivers/cloudflare-kv-http.js
+++ b/packages/astro/src/storage/drivers/cloudflare-kv-http.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/cloudflare-kv-http";

--- a/packages/astro/src/storage/drivers/cloudflareKVBinding.js
+++ b/packages/astro/src/storage/drivers/cloudflareKVBinding.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/cloudflare-kv-binding";

--- a/packages/astro/src/storage/drivers/cloudflareKVHTTP.js
+++ b/packages/astro/src/storage/drivers/cloudflareKVHTTP.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/cloudflare-kv-http";

--- a/packages/astro/src/storage/drivers/cloudflareR2Binding.js
+++ b/packages/astro/src/storage/drivers/cloudflareR2Binding.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/cloudflare-r2-binding";

--- a/packages/astro/src/storage/drivers/fs.js
+++ b/packages/astro/src/storage/drivers/fs.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/fs";

--- a/packages/astro/src/storage/drivers/fsLite.js
+++ b/packages/astro/src/storage/drivers/fsLite.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/fs-lite";

--- a/packages/astro/src/storage/drivers/github.js
+++ b/packages/astro/src/storage/drivers/github.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/github";

--- a/packages/astro/src/storage/drivers/http.js
+++ b/packages/astro/src/storage/drivers/http.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/http";

--- a/packages/astro/src/storage/drivers/indexedb.js
+++ b/packages/astro/src/storage/drivers/indexedb.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/indexedb";

--- a/packages/astro/src/storage/drivers/localStorage.js
+++ b/packages/astro/src/storage/drivers/localStorage.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/localstorage";

--- a/packages/astro/src/storage/drivers/lruCache.js
+++ b/packages/astro/src/storage/drivers/lruCache.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/lru-cache";

--- a/packages/astro/src/storage/drivers/memory.js
+++ b/packages/astro/src/storage/drivers/memory.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/memory";

--- a/packages/astro/src/storage/drivers/mongodb.js
+++ b/packages/astro/src/storage/drivers/mongodb.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/mongodb";

--- a/packages/astro/src/storage/drivers/netlifyBlobs.js
+++ b/packages/astro/src/storage/drivers/netlifyBlobs.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/netlify-blobs";

--- a/packages/astro/src/storage/drivers/null.js
+++ b/packages/astro/src/storage/drivers/null.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/null";

--- a/packages/astro/src/storage/drivers/overlay.js
+++ b/packages/astro/src/storage/drivers/overlay.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/overlay";

--- a/packages/astro/src/storage/drivers/planetscale.js
+++ b/packages/astro/src/storage/drivers/planetscale.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/planetscale";

--- a/packages/astro/src/storage/drivers/redis.js
+++ b/packages/astro/src/storage/drivers/redis.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/redis";

--- a/packages/astro/src/storage/drivers/sessionStorage.js
+++ b/packages/astro/src/storage/drivers/sessionStorage.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/session-storage";

--- a/packages/astro/src/storage/drivers/vercelKV.js
+++ b/packages/astro/src/storage/drivers/vercelKV.js
@@ -1,0 +1,2 @@
+// Auto-generated file. Do not edit
+export { default } from "unstorage/drivers/vercel-kv";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       typescript-eslint:
         specifier: ^8.13.0
         version: 8.13.0(eslint@9.14.0(jiti@2.4.0))(typescript@5.6.3)
+      unstorage:
+        specifier: ^1.12.0
+        version: 1.13.1
 
   benchmark:
     dependencies:

--- a/scripts/deps/update-storage-reexports.js
+++ b/scripts/deps/update-storage-reexports.js
@@ -1,0 +1,13 @@
+// @ts-check
+import { builtinDrivers } from 'unstorage';
+import { promises as fs } from 'node:fs';
+
+async function generateStorageReexports() {
+	await fs.mkdir(new URL('../../packages/astro/src/storage/drivers', import.meta.url), { recursive: true });
+	for (const key in builtinDrivers) {
+		const exports = `// Auto-generated file. Do not edit\nexport { default } from "${builtinDrivers[key]}";`;
+		await fs.writeFile(new URL(`../../packages/astro/src/storage/drivers/${key}.js`, import.meta.url), exports);
+	}
+}
+
+generateStorageReexports();


### PR DESCRIPTION
## Changes
Well, this sucks, but dynamic imports directly from unstorage don't work with pnpm. This PR adds a script to auto-generate the re-exports. I've prefixed it with `astro/internal` so that peopel don't think it's a public API.

## Testing

Tested locally with a site using node adapter.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
