### PR TITLE
ci: fetch changeset base branch when snapshot

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -63,7 +63,13 @@ jobs:
           ref: ${{ steps.refs.outputs.head_ref }}
           fetch-depth: 0
 
-      - run: git fetch origin main:main
+      - name: Extract base branch from .changeset/config.json
+        id: getBaseBranch
+        run: |
+          baseBranch=$(jq -r '.baseBranch' .changeset/config.json)
+          echo "baseBranch=${baseBranch}" >> $GITHUB_ENV
+
+      - run: git fetch origin ${{ env.baseBranch }}:${{ env.baseBranch }}
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v3
@@ -84,6 +90,8 @@ jobs:
       - name: Bump Package Versions
         id: changesets
         run: |
+          # Snapshots don't work in pre mode. See https://github.com/changesets/changesets/issues/1195
+          pnpm exec changeset pre exit || true
           pnpm exec changeset status --output status.output.json 2>&1
           # Snapshots don't work in pre mode. See https://github.com/changesets/changesets/issues/1195
           pnpm exec changeset pre exit || true

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -67,9 +67,9 @@ jobs:
         id: getBaseBranch
         run: |
           baseBranch=$(jq -r '.baseBranch' .changeset/config.json)
-          echo "baseBranch=${baseBranch}" >> $GITHUB_ENV
+          echo "baseBranch=${baseBranch}" >> $GITHUB_OUTPUT
 
-      - run: git fetch origin ${{ env.baseBranch }}:${{ env.baseBranch }}
+      - run: git fetch origin ${{ steps.getBaseBranch.outputs.baseBranch }}:${{  steps.getBaseBranch.outputs.baseBranch }}
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v3

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -90,8 +90,6 @@ jobs:
       - name: Bump Package Versions
         id: changesets
         run: |
-          # Snapshots don't work in pre mode. See https://github.com/changesets/changesets/issues/1195
-          pnpm exec changeset pre exit || true
           pnpm exec changeset status --output status.output.json 2>&1
           # Snapshots don't work in pre mode. See https://github.com/changesets/changesets/issues/1195
           pnpm exec changeset pre exit || true

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -69,7 +69,7 @@ jobs:
           baseBranch=$(jq -r '.baseBranch' .changeset/config.json)
           echo "baseBranch=${baseBranch}" >> $GITHUB_OUTPUT
 
-      - run: git fetch origin ${{ steps.getBaseBranch.outputs.baseBranch }}:${{  steps.getBaseBranch.outputs.baseBranch }}
+      - run: git fetch origin ${{ steps.getBaseBranch.outputs.baseBranch }}:${{ steps.getBaseBranch.outputs.baseBranch }}
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v3


### PR DESCRIPTION
## Changes

Finds the base branch for the current changeset from the config and fetch that before doing a snapshot. This avoid errors resolving the base.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
