### PR TITLE
Fix SVG Component sprite ids

### DIFF
--- a/.changeset/red-paws-juggle.md
+++ b/.changeset/red-paws-juggle.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix SVG Component sprite references

--- a/packages/astro/test/core-image-svg.test.js
+++ b/packages/astro/test/core-image-svg.test.js
@@ -322,8 +322,9 @@ describe('astro:assets - SVG Components', () => {
 				assert.equal($symbol.length, 1);
 				let $use = $('.one svg > use');
 				assert.equal($use.length, 2);
-				let defId = $('.one.def svg > use').attr('id');
-				let useId = $('.one.use svg > use').attr('id');
+				const defId = $('.one.def svg > symbol').attr('id');
+				const useId = $('.one.use svg > use').attr('href').replace('#', '');
+				assert.ok(defId);
 				assert.equal(defId, useId);
 
 				// Second SVG
@@ -333,9 +334,10 @@ describe('astro:assets - SVG Components', () => {
 				assert.equal($symbol.length, 1);
 				$use = $('.two svg > use');
 				assert.equal($use.length, 2);
-				defId = $('.two.def svg > use').attr('id');
-				useId = $('.two.use svg > use').attr('id');
-				assert.equal(defId, useId);
+				const defId2 = $('.two.def svg > symbol').attr('id');
+				const useId2 = $('.two.use svg > use').attr('href').replace('#', '');
+				assert.ok(defId2);
+				assert.equal(defId2, useId2);
 
 				// Third SVG
 				$svg = $('.three svg');
@@ -344,6 +346,12 @@ describe('astro:assets - SVG Components', () => {
 				assert.equal($symbol.length, 1);
 				$use = $('.three svg > use');
 				assert.equal($use.length, 1);
+				const defId3 = $('.three.def svg > symbol').attr('id');
+				assert.ok(defId3);
+
+				// Assert IDs are different
+				assert.equal(new Set([defId, defId2, defId3]).size, 3);
+				assert.equal(new Set([useId, useId2]).size, 2);
 			});
 		});
 


### PR DESCRIPTION
## Changes

This fixes the `id` generation for sprite icons. The previous implementation only ever generated one id per page. This caused the first icon to be used for all icons. Instead we need to increment on each unique icon. 

I was able to accomplish this by checking if a component had rendered already and generating a new id if it hadn't. This now stores the full id per page.

### Before

![image](https://github.com/user-attachments/assets/8001037d-675c-4fd5-a4bc-d3de4acb82a9)

### After

![image](https://github.com/user-attachments/assets/9237dde8-4023-4202-a7cf-b08d3df4d4cb)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
There were a few issues with the previous tests that I have addressed. I also updated the test to ensure that the ids are all unique which I should have asserted previously.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

No docs necessary.

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

--- 

I can't request reviewers  but wanted to tag @ematipico, @natemoo-re and @bluwy since this was related to the changes requested and committed to my previous branch. https://github.com/withastro/astro/pull/12067#discussion_r1824671794