### PR TITLE
Delete empty `server-islands` example

### DIFF
--- a/examples/server-islands/tsconfig.json
+++ b/examples/server-islands/tsconfig.json
@@ -1,5 +1,0 @@
-{
-  "extends": "astro/tsconfigs/strict",
-  "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
-}


### PR DESCRIPTION
## Changes

- Removes `sever-islands/tsconfig.json` in the examples directory.
- Looks like this example was removed in #12196 but #12083 accidentally reintroduced it by adding the `tsconfig.json`.
- Noticed this on https://astro.new/next/templates/ which links to this example, but has no content

## Testing

- n/a

## Docs

- n/a