### PR TITLE
fix(ssr): duplicate custom headers

### DIFF
--- a/.changeset/proud-wombats-mate.md
+++ b/.changeset/proud-wombats-mate.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where SSR error pages would return duplicated custom headers.

--- a/packages/astro/src/core/app/index.ts
+++ b/packages/astro/src/core/app/index.ts
@@ -436,6 +436,15 @@ export class App {
 			// this function could throw an error...
 			originalResponse.headers.delete('Content-type');
 		} catch {}
+		// we use a map to remove duplicates
+		const mergedHeaders = new Map([
+			...Array.from(newResponse.headers),
+			...Array.from(originalResponse.headers),
+		]);
+		const newHeaders = new Headers();
+		for (const [name, value] of mergedHeaders) {
+			newHeaders.set(name, value);
+		}
 		return new Response(newResponse.body, {
 			status,
 			statusText: status === 200 ? newResponse.statusText : originalResponse.statusText,
@@ -444,10 +453,7 @@ export class App {
 			// If users see something weird, it's because they are setting some headers they should not.
 			//
 			// Although, we don't want it to replace the content-type, because the error page must return `text/html`
-			headers: new Headers([
-				...Array.from(newResponse.headers),
-				...Array.from(originalResponse.headers),
-			]),
+			headers: newHeaders,
 		});
 	}
 

--- a/packages/astro/test/fixtures/ssr-error/package.json
+++ b/packages/astro/test/fixtures/ssr-error/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/ssr",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*"
+  }
+}

--- a/packages/astro/test/fixtures/ssr-error/src/pages/[...slug].astro
+++ b/packages/astro/test/fixtures/ssr-error/src/pages/[...slug].astro
@@ -1,0 +1,8 @@
+---
+return new Response("oops", {
+	status: 500,
+	headers: new Headers({
+		"X-Debug": "1234",
+	}),
+});
+---

--- a/packages/astro/test/fixtures/ssr-error/src/pages/index.astro
+++ b/packages/astro/test/fixtures/ssr-error/src/pages/index.astro
@@ -1,0 +1,6 @@
+<html>
+<head><title>Hello world</title></head>
+<body>
+<h1>Hello world</h1>
+</body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3825,6 +3825,12 @@ importers:
         specifier: ^10.25.0
         version: 10.25.0
 
+  packages/astro/test/fixtures/ssr-error:
+    dependencies:
+      astro:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/astro/test/fixtures/ssr-error-pages:
     dependencies:
       astro:


### PR DESCRIPTION
## Changes

Closes #12419 
Closes PLT-2669

This PR changes the merging strategy of the headers in SSR when we render an error page. It relies on a `Map` to remove the duplicates. 

## Testing

Added a new test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
