### PR TITLE
fix: allow content config in underscored dir

### DIFF
--- a/.changeset/bright-keys-sell.md
+++ b/.changeset/bright-keys-sell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where content config was ignored if it was outside of content dir and has a parent dir with an underscore

--- a/packages/astro/src/content/utils.ts
+++ b/packages/astro/src/content/utils.ts
@@ -421,14 +421,14 @@ export function getEntryType(
 	const { ext } = path.parse(entryPath);
 	const fileUrl = pathToFileURL(entryPath);
 
-	if (hasUnderscoreBelowContentDirectoryPath(fileUrl, paths.contentDir)) {
+	if (fileUrl.href === paths.config.url.href) {
+		return 'config';
+	} else if (hasUnderscoreBelowContentDirectoryPath(fileUrl, paths.contentDir)) {
 		return 'ignored';
 	} else if (contentFileExts.includes(ext)) {
 		return 'content';
 	} else if (dataFileExts.includes(ext)) {
 		return 'data';
-	} else if (fileUrl.href === paths.config.url.href) {
-		return 'config';
 	} else {
 		return 'ignored';
 	}


### PR DESCRIPTION
## Changes

Fixes a bug identified by @hideoo. Currently, if a content config file is outside of the content dir and with any parent dir that starts with an underscore it is not loaded. This was not an issue previously because the config had to be in the content dir.

## Testing

Tested with [the repro](https://github.com/HiDeoo/astro-content-config-ts-issue-repro)

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
