### PR TITLE
fix(i18n): render `404.astro` when i18n is enabled

### DIFF
--- a/.changeset/hot-dingos-dress.md
+++ b/.changeset/hot-dingos-dress.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue where `i18n` is enabled, Astro couldn't render the `404.astro` component when navigating non-existent routes.

--- a/.changeset/hot-dingos-dress.md
+++ b/.changeset/hot-dingos-dress.md
@@ -2,4 +2,4 @@
 'astro': patch
 ---
 
-Fixes an issue where `i18n` is enabled, Astro couldn't render the `404.astro` component when navigating non-existent routes.
+Fixes an issue where with `i18n` enabled, Astro couldn't render the `404.astro` component for non-existent routes.

--- a/packages/astro/src/i18n/middleware.ts
+++ b/packages/astro/src/i18n/middleware.ts
@@ -1,6 +1,6 @@
 import type { APIContext, MiddlewareHandler, SSRManifest } from '../@types/astro.js';
 import type { SSRManifestI18n } from '../core/app/types.js';
-import { ROUTE_TYPE_HEADER } from '../core/constants.js';
+import { REROUTE_DIRECTIVE_HEADER, ROUTE_TYPE_HEADER } from '../core/constants.js';
 import {
 	type MiddlewarePayload,
 	normalizeTheLocale,
@@ -65,6 +65,12 @@ export function createI18nMiddleware(
 	return async (context, next) => {
 		const response = await next();
 		const type = response.headers.get(ROUTE_TYPE_HEADER);
+
+		// This is case where we are internally rendering a 404/500, so we need to bypass checks that were done already
+		const isReroute = response.headers.get(REROUTE_DIRECTIVE_HEADER);
+		if (isReroute === 'no' && typeof i18n.fallback === 'undefined') {
+			return response;
+		}
 		// If the route we're processing is not a page, then we ignore it
 		if (type !== 'page' && type !== 'fallback') {
 			return response;

--- a/packages/astro/src/vite-plugin-astro-server/request.ts
+++ b/packages/astro/src/vite-plugin-astro-server/request.ts
@@ -63,7 +63,6 @@ export async function handleRequest({
 				url,
 				pathname: resolvedPathname,
 				body,
-				origin,
 				pipeline,
 				manifestData,
 				incomingRequest: incomingRequest,

--- a/packages/astro/src/vite-plugin-astro-server/route.ts
+++ b/packages/astro/src/vite-plugin-astro-server/route.ts
@@ -158,7 +158,6 @@ export async function handleRoute({
 	const middleware = (await loadMiddleware(loader)).onRequest;
 	const locals = Reflect.get(incomingRequest, clientLocalsSymbol);
 
-	const filePath: URL | undefined = matchedRoute.filePath;
 	const { preloadedComponent } = matchedRoute;
 	route = matchedRoute.route;
 	// Allows adapters to pass in locals in dev mode.

--- a/packages/astro/test/fixtures/i18n-routing/src/pages/404.astro
+++ b/packages/astro/test/fixtures/i18n-routing/src/pages/404.astro
@@ -7,6 +7,7 @@ const currentLocale = Astro.currentLocale;
 </head>
 <body>
   <h1>404 - Not Found</h1>
+	<h2>Custom 404</h2>
   <p>Current Locale: {currentLocale ? currentLocale : "none"}</p>
 </body>
 </html>

--- a/packages/astro/test/i18n-routing.test.js
+++ b/packages/astro/test/i18n-routing.test.js
@@ -83,6 +83,12 @@ describe('[DEV] i18n routing', () => {
 			assert.equal((await response.text()).includes('Endurance'), true);
 		});
 
+		it('should render the 404.astro file', async () => {
+			const response = await fixture.fetch('/do-not-exist');
+			assert.equal(response.status, 404);
+			assert.match(await response.text(), /Custom 404/);
+		});
+
 		it('should return the correct locale on 404 page for non existing default locale page', async () => {
 			const response = await fixture.fetch('/es/nonexistent-page');
 			assert.equal(response.status, 404);


### PR DESCRIPTION
## Changes

Closes PLT-2671
Closes https://github.com/withastro/astro/issues/12509

The issue was caused by the i18n middleware doing all it's "routing strategy checks" when rendering the `404.astro` component. This should be an expection, because all the "routing strategy checks" were already done when rendering the non-existent route. 

To fix the issue, we have an internal header that we attach to a `Response`. We check that header at the very beginning of the middleware.

**Additional change**

I removed the recursions that we use in development, which **isn't needed**, and it should be things a bit more easy to debug. To remove the recursion, we just create a new `RenderContext` with the `/404` route, and render it.

## Testing

Tested it against the issue of reproduction. Current tests should pass. Added a new test.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
