### PR TITLE
refactor(mdx): add entrypoint as full path file

### DIFF
--- a/.changeset/young-terms-hammer.md
+++ b/.changeset/young-terms-hammer.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/mdx': patch
+---
+
+Fixes a case where the MDX renderer couldn't be loaded when used as a direct dependency of an Astro integration.

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -54,7 +54,7 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 
 				addRenderer({
 					name: 'astro:jsx',
-					serverEntrypoint: '@astrojs/mdx/server.js',
+					serverEntrypoint: new URL('../dist/server.js', import.meta.url),
 				});
 				addPageExtension('.mdx');
 				addContentEntryType({


### PR DESCRIPTION
## Changes

Changes the MDX integration to add the renderer entrypoint as a full path file instead of being a specifier. Astro v5 now accepts `URL` too, so it's a better of passing the correct `URL`

## Testing

The existing CI should pass.
I tested it against [this reproduction](https://github.com/HiDeoo/starlight/tree/hd-astro-v5), by linking `@astrojs/mdx` package directly to my local version, and running `pnpm dev` inside the `/docs` folder. The project compiles and it renders the pages without errors. 

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
