### PR TITLE
Fix JPEG image size determination

### DIFF
--- a/.changeset/bright-pants-trade.md
+++ b/.changeset/bright-pants-trade.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fix JPEG image size determination

--- a/packages/astro/src/assets/utils/vendor/image-size/types/jpg.ts
+++ b/packages/astro/src/assets/utils/vendor/image-size/types/jpg.ts
@@ -122,7 +122,7 @@ export const JPG: IImage = {
 
       // Every JPEG block must begin with a 0xFF
       if (input[i] !== 0xff) {
-        input = input.slice(1)
+        input = input.slice(i)
         continue
       }
 

--- a/packages/astro/src/assets/utils/vendor/image-size/types/jpg.ts
+++ b/packages/astro/src/assets/utils/vendor/image-size/types/jpg.ts
@@ -122,6 +122,7 @@ export const JPG: IImage = {
 
       // Every JPEG block must begin with a 0xFF
       if (input[i] !== 0xff) {
+        // Change from upstream: fix non-0xFF blocks skipping
         input = input.slice(i)
         continue
       }


### PR DESCRIPTION
Fixes #12530

## Changes

* Fixed incorrect handling of non-`0xFF` blocks in the JPEG image size calculation. Instead of skipping one byte, the entire block is now skipped, improving performance and accuracy.
* Before this change, the code would incorrectly enter and parse non-`0xFF` blocks, leading to incorrect image size determination. This change ensures that only valid JPEG blocks are processed, skipping unnecessary metadata blocks.

## Testing

This change was tested manually by verifying that the image size calculation is accurate for JPEG images with various metadata blocks. No new tests were added, as the existing tests should cover this scenario.

## Docs

This change does not affect user behavior, so no documentation updates are required. The fix is internal to the JPEG image size calculation logic and does not introduce any new features or APIs.