### PR TITLE
Examples fixes and preview.astro.new support

### DIFF
--- a/.github/workflows/examples-deploy.yml
+++ b/.github/workflows/examples-deploy.yml
@@ -1,0 +1,25 @@
+name: Redeploy preview.astro.new
+
+on:
+  push:
+    branches: 
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check if examples changed
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            examples:
+              - 'examples/*'
+      - name: Notify Netlify
+        if: ${{ steps.changes.outputs.examples == 'true' }}
+        run: 'curl -X POST -d {} ${{ env.BUILD_HOOK }}'
+        env:
+          BUILD_HOOK: ${{ secrets.NETLIFY_PREVIEWS_BUILD_HOOK }}

--- a/.github/workflows/examples-deploy.yml
+++ b/.github/workflows/examples-deploy.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           filters: |
             examples:
-              - 'examples/*'
+              - 'examples/**'
       - name: Notify Netlify
         if: ${{ steps.changes.outputs.examples == 'true' }}
         run: 'curl -X POST -d {} ${{ env.BUILD_HOOK }}'

--- a/.github/workflows/examples-deploy.yml
+++ b/.github/workflows/examples-deploy.yml
@@ -1,4 +1,4 @@
-# This workflow runs when chanegs to examples are pushed to main.
+# This workflow runs when changes to examples are pushed to main.
 # It calls a build hook on Netlify that will redeploy preview.astro.new with the latest changes.
 
 name: Redeploy preview.astro.new

--- a/.github/workflows/examples-deploy.yml
+++ b/.github/workflows/examples-deploy.yml
@@ -1,6 +1,5 @@
-# This workflow runs when pushing to main.
-# It checks if any of the examples have changed, and if they have, calls a build hook on Netlify
-# that will redeploy preview.astro.new with the latest changes.
+# This workflow runs when chanegs to examples are pushed to main.
+# It calls a build hook on Netlify that will redeploy preview.astro.new with the latest changes.
 
 name: Redeploy preview.astro.new
 
@@ -8,6 +7,8 @@ on:
   push:
     branches: 
       - main
+    paths: 
+      - 'examples/**'
   workflow_dispatch:
 
 jobs:
@@ -15,15 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check if examples changed
-        id: changes
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            examples:
-              - 'examples/**'
-      - name: Notify Netlify
-        if: ${{ steps.changes.outputs.examples == 'true' }}
+      - name: Send a POST request to Netlify to rebuild preview.astro.new
         run: 'curl -X POST -d {} ${{ env.BUILD_HOOK }}'
         env:
           BUILD_HOOK: ${{ secrets.NETLIFY_PREVIEWS_BUILD_HOOK }}

--- a/.github/workflows/examples-deploy.yml
+++ b/.github/workflows/examples-deploy.yml
@@ -1,3 +1,7 @@
+# This workflow runs when pushing to main.
+# It checks if any of the examples have changed, and if they have, calls a build hook on Netlify
+# that will redeploy preview.astro.new with the latest changes.
+
 name: Redeploy preview.astro.new
 
 on:

--- a/examples/blog/src/components/HeaderLink.astro
+++ b/examples/blog/src/components/HeaderLink.astro
@@ -4,10 +4,9 @@ import type { HTMLAttributes } from 'astro/types';
 type Props = HTMLAttributes<'a'>;
 
 const { href, class: className, ...props } = Astro.props;
-
-const { pathname } = Astro.url;
+const pathname = Astro.url.pathname.replace(import.meta.env.BASE_URL, '');
 const subpath = pathname.match(/[^\/]+/g);
-const isActive = href === pathname || href === '/' + subpath?.[0];
+const isActive = href === pathname || href === '/' + (subpath?.[0] || '');
 ---
 
 <a href={href} class:list={[className, { active: isActive }]} {...props}>

--- a/examples/portfolio/src/components/Nav.astro
+++ b/examples/portfolio/src/components/Nav.astro
@@ -19,6 +19,14 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 	{ label: 'dribbble', href: 'https://dribbble.com/me', icon: 'dribbble-logo' },
 	{ label: 'YouTube', href: 'https://www.youtube.com/@me/', icon: 'youtube-logo' },
 ];
+
+/** Test if a link is pointing to the current page. */
+const isCurrentPage = (href: string) => {
+	let pathname = Astro.url.pathname.replace(import.meta.env.BASE_URL, '');
+	if (pathname.at(0) !== '/') pathname = '/' + pathname;
+	if (pathname.at(-1) !== '/') pathname += '/';
+	return pathname === href || (href !== '/' && pathname.startsWith(href));
+};
 ---
 
 <nav>
@@ -41,18 +49,7 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 			{
 				textLinks.map(({ label, href }) => (
 					<li>
-						<a
-							aria-current={Astro.url.pathname === href}
-							class:list={[
-								'link',
-								{
-									active:
-										Astro.url.pathname === href ||
-										(href !== '/' && Astro.url.pathname.startsWith(href)),
-								},
-							]}
-							href={href}
-						>
+						<a aria-current={isCurrentPage(href) ? 'page' : null} class="link" href={href}>
 							{label}
 						</a>
 					</li>
@@ -79,18 +76,7 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 			{
 				textLinks.map(({ label, href }) => (
 					<li>
-						<a
-							aria-current={Astro.url.pathname === href}
-							class:list={[
-								'link',
-								{
-									active:
-										Astro.url.pathname === href ||
-										(href !== '/' && Astro.url.pathname.startsWith(href)),
-								},
-							]}
-							href={href}
-						>
+						<a aria-current={isCurrentPage(href) ? 'page' : null} class="link" href={href}>
 							{label}
 						</a>
 					</li>
@@ -234,7 +220,7 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 		text-decoration: none;
 	}
 
-	.link.active {
+	.link[aria-current] {
 		color: var(--gray-0);
 	}
 
@@ -332,7 +318,7 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 			background-color: var(--accent-subtle-overlay);
 		}
 
-		.link.active {
+		.link[aria-current='page'] {
 			color: var(--accent-text-over);
 			background-color: var(--accent-regular);
 		}
@@ -360,7 +346,7 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 		}
 	}
 	@media (forced-colors: active) {
-		.link.active {
+		.link[aria-current='page'] {
 			color: SelectedItem;
 		}
 	}

--- a/examples/with-nanostores/src/layouts/Layout.astro
+++ b/examples/with-nanostores/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import CartFlyout from '../components/CartFlyout';
 import CartFlyoutToggle from '../components/CartFlyoutToggle';
+import { withBase } from '../utils';
 
 interface Props {
 	title: string;
@@ -15,15 +16,15 @@ const { title } = Astro.props;
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<link rel="icon" type="image/svg+xml" href={withBase('/favicon.svg')} />
 		<title>{title}</title>
 	</head>
 	<body>
 		<header>
 			<nav>
-				<a href="/" class="nav-header"
-					><span style="color: var(--astro-blue)">Astro</span> storefront</a
-				>
+				<a href={withBase('/')} class="nav-header">
+					<span style="color: var(--astro-blue)">Astro</span> storefront
+				</a>
 				<CartFlyoutToggle client:load />
 			</nav>
 		</header>

--- a/examples/with-nanostores/src/pages/index.astro
+++ b/examples/with-nanostores/src/pages/index.astro
@@ -3,11 +3,12 @@ import type { CartItemDisplayInfo } from '../cartStore';
 import Layout from '../layouts/Layout.astro';
 import AddToCartForm from '../components/AddToCartForm';
 import FigurineDescription from '../components/FigurineDescription.astro';
+import { withBase } from '../utils';
 
 const item: CartItemDisplayInfo = {
 	id: 'astronaut-figurine',
 	name: 'Astronaut Figurine',
-	imageSrc: '/images/astronaut-figurine.png',
+	imageSrc: withBase('/images/astronaut-figurine.png'),
 };
 ---
 

--- a/examples/with-nanostores/src/utils.ts
+++ b/examples/with-nanostores/src/utils.ts
@@ -1,0 +1,4 @@
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+/** Prefix a URL path with the site’s base path if set. */
+export const withBase = (path: string) => base + path;


### PR DESCRIPTION
## Changes

- This PR (partially) fixes support for `base` in the blog, portfolio, and with-nanostores examples.
  - In the blog and portfolio examples, this fixes the highlighting of the current page in the site navigation components. It doesn’t fix other aspects of these templates to work with base (e.g. image paths etc.) just for simplicity’s sake, but we could in a follow up if we wanted.
  - In the with-nanostores example, this fixes all user-authored links to use a base.
- This improves the deployments to preview.astro.new, which builds each example with `base` and then tries to auto-prefix with base when it can, but there are some edge cases it can’t handle, which this PR fixes
- This PR also adds a new GitHub workflow which runs when pushing to `main`. It checks to see if anything in the `examples/` directory has changed, and if so sends a request to Netlify to redeploy preview.astro.new
- This workflow requires a new `NETLIFY_PREVIEWS_BUILD_HOOK` secret adding to this repo. @ematipico added this ✅ 

## Testing

- Ran the examples locally with and without `base` set

## Docs

n/a bug fix only