### PR TITLE
ci: remove `next` from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - next
   merge_group:
   pull_request:
     paths-ignore:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - "1-legacy"
       - "2-legacy"
       - "3-legacy"
-      - next
+      - "4-legacy"
 
 defaults:
   run:

--- a/.github/workflows/sync-examples.yml
+++ b/.github/workflows/sync-examples.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - main
-      - next
 
 # Automatically cancel in-progress actions on the same branch
 concurrency:


### PR DESCRIPTION
## Changes

This PR removes `next` from our workflows, mainly the release, ci checks and example sync.

It also adds the branch `4-legacy`, which we will use for security fixes regarding v4

## Testing

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
