### PR TITLE
fix: remove value and writable properties from headers descriptor

### DIFF
--- a/.changeset/tame-hats-fold.md
+++ b/.changeset/tame-hats-fold.md
@@ -1,5 +1,5 @@
 ---
-'astro': major
+'astro': patch
 ---
 
 Fixed an issue where modifying the `Request.headers` prototype during prerendering caused a build error. Removed conflicting value and writable properties from the `headers` descriptor to prevent `Invalid property descriptor` errors.

--- a/.changeset/tame-hats-fold.md
+++ b/.changeset/tame-hats-fold.md
@@ -1,0 +1,5 @@
+---
+'astro': major
+---
+
+Fixed an issue where modifying the `Request.headers` prototype during prerendering caused a build error. Removed conflicting value and writable properties from the `headers` descriptor to prevent `Invalid property descriptor` errors.

--- a/packages/astro/src/core/request.ts
+++ b/packages/astro/src/core/request.ts
@@ -70,9 +70,14 @@ export function createRequest({
 	});
 
 	if (isPrerendered) {
-		// Warn when accessing headers in prerendered pages
-		const _headers = request.headers;
+		// Warn when accessing headers in SSG mode
+		let _headers = request.headers;
 		const headersDesc = Object.getOwnPropertyDescriptor(request, 'headers') || {};
+
+		// We need to delete any existing descriptor's value and writable properties because we're adding getters and setters.
+		delete headersDesc.value;
+		delete headersDesc.writable;
+
 		Object.defineProperty(request, 'headers', {
 			...headersDesc,
 			get() {
@@ -81,6 +86,9 @@ export function createRequest({
 					`\`Astro.request.headers\` is not available on prerendered pages. If you need access to request headers, make sure that the page is server rendered using \`export const prerender = false;\` or by setting \`output\` to \`"server"\` in your Astro config to make all your pages server rendered.`,
 				);
 				return _headers;
+			},
+			set(value: Headers) {
+				_headers = value;
 			},
 		});
 	} else if (clientAddress) {

--- a/packages/astro/src/core/request.ts
+++ b/packages/astro/src/core/request.ts
@@ -72,11 +72,10 @@ export function createRequest({
 	if (isPrerendered) {
 		// Warn when accessing headers in SSG mode
 		let _headers = request.headers;
-		const headersDesc = Object.getOwnPropertyDescriptor(request, 'headers') || {};
 
-		// We need to delete any existing descriptor's value and writable properties because we're adding getters and setters.
-		delete headersDesc.value;
-		delete headersDesc.writable;
+		// We need to remove descriptor's value and writable properties because we're adding getters and setters.
+		const { value, writable, ...headersDesc } =
+			Object.getOwnPropertyDescriptor(request, 'headers') || {};
 
 		Object.defineProperty(request, 'headers', {
 			...headersDesc,
@@ -87,8 +86,8 @@ export function createRequest({
 				);
 				return _headers;
 			},
-			set(value: Headers) {
-				_headers = value;
+			set(newHeaders: Headers) {
+				_headers = newHeaders;
 			},
 		});
 	} else if (clientAddress) {


### PR DESCRIPTION
Fixes #12548 

- Ensure that any existing value and writable properties are deleted from the headers descriptor before adding getters and setters.
- This prevents the error: `Invalid property descriptor. Cannot both specify accessors and a value or writable attribute, #<Object>`

## Changes

- Removed the `value` and `writable` properties from the `headers` descriptor before defining getters and setters for the `headers` property on the `Request` object.
- Updated the `Object.defineProperty` call to prevent the `Invalid property descriptor` error during prerendering.
- Added a setter to `request.headers` to allow updating `_headers` if needed.
  
## Testing

This change was tested by building the Astro project with `prerender = true` and confirming that the build completes without the `Invalid property descriptor` error.

No automated tests have been added since this affects the internal build handling of the `Request` headers property, but manual testing confirms the fix.

## Docs

No documentation changes are needed for this fix, as this is an internal implementation detail that does not affect user-facing API or behavior directly.

/cc @withastro/maintainers-docs for feedback if required.
