### PR TITLE
feat: Allow integrations to change the base for server-islands URLs

### DIFF
--- a/.changeset/famous-beds-tan.md
+++ b/.changeset/famous-beds-tan.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+feat: Allow integrations to change the base for server-islands URLs

--- a/.changeset/famous-beds-tan.md
+++ b/.changeset/famous-beds-tan.md
@@ -1,5 +1,5 @@
 ---
-"astro": patch
+"astro": minor
 ---
 
 feat: Allow integrations to change the base for server-islands URLs

--- a/packages/astro/src/container/index.ts
+++ b/packages/astro/src/container/index.ts
@@ -150,6 +150,7 @@ function createManifest(
 		clientDirectives: manifest?.clientDirectives ?? getDefaultClientDirectives(),
 		renderers: renderers ?? manifest?.renderers ?? [],
 		base: manifest?.base ?? ASTRO_CONFIG_DEFAULTS.base,
+		serverIslandDynamicBase: manifest?.serverIslandDynamicBase,
 		componentMetadata: manifest?.componentMetadata ?? new Map(),
 		inlinedScripts: manifest?.inlinedScripts ?? new Map(),
 		i18n: manifest?.i18n,
@@ -228,6 +229,7 @@ type AstroContainerManifest = Pick<
 	| 'renderers'
 	| 'assetsPrefix'
 	| 'base'
+	| 'serverIslandDynamicBase'
 	| 'routes'
 	| 'assets'
 	| 'entryModules'

--- a/packages/astro/src/core/app/types.ts
+++ b/packages/astro/src/core/app/types.ts
@@ -48,6 +48,7 @@ export type SSRManifest = {
 	routes: RouteInfo[];
 	site?: string;
 	base: string;
+	serverIslandDynamicBase?: string;
 	trailingSlash: 'always' | 'never' | 'ignore';
 	buildFormat: 'file' | 'directory' | 'preserve';
 	compressHTML: boolean;

--- a/packages/astro/src/core/build/plugins/plugin-manifest.ts
+++ b/packages/astro/src/core/build/plugins/plugin-manifest.ts
@@ -259,6 +259,7 @@ function buildManifest(
 		routes,
 		site: settings.config.site,
 		base: settings.config.base,
+		serverIslandDynamicBase: settings.config.serverIslandDynamicBase,
 		trailingSlash: settings.config.trailingSlash,
 		compressHTML: settings.config.compressHTML,
 		assetsPrefix: settings.config.build.assetsPrefix,

--- a/packages/astro/src/core/render-context.ts
+++ b/packages/astro/src/core/render-context.ts
@@ -367,6 +367,7 @@ export class RenderContext {
 		// calling the render() function will populate the object with scripts, styles, etc.
 		const result: SSRResult = {
 			base: manifest.base,
+			serverIslandDynamicBase: manifest.serverIslandDynamicBase,
 			cancelled: false,
 			clientDirectives,
 			inlinedScripts,

--- a/packages/astro/src/runtime/server/render/server-islands.ts
+++ b/packages/astro/src/runtime/server/render/server-islands.ts
@@ -80,8 +80,9 @@ export function renderServerIsland(
 
 			const hostId = crypto.randomUUID();
 
-			const slash = result.base.endsWith('/') ? '' : '/';
-			let serverIslandUrl = `${result.base}${slash}_server-islands/${componentId}${result.trailingSlash === 'always' ? '/' : ''}`;
+			const _base = result.serverIslandDynamicBase ?? result.base;
+			const slash = _base.endsWith('/') ? '' : '/';
+			let serverIslandUrl = `${_base}${slash}_server-islands/${componentId}${result.trailingSlash === 'always' ? '/' : ''}`;
 
 			// Determine if its safe to use a GET request
 			const potentialSearchParams = createSearchParams(

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1978,6 +1978,11 @@ export interface AstroConfig extends AstroConfigType {
 
 	// Private:
 	// This is not configurable directly by the user. But may be configured by an integration.
+	//
+	// Setting this option will change the base path to deploy server islands to.
+	// This changes the path of any server islands that are emitted in the client HTML.
+	// If this is unset, this will fallback to the user supplied `base` config option, and if that is unset,
+	// then a relative URL will be used (ie: `/_server-islands/`).
 	serverIslandDynamicBase?: string;
 }
 /**

--- a/packages/astro/src/types/public/config.ts
+++ b/packages/astro/src/types/public/config.ts
@@ -1975,6 +1975,10 @@ export interface AstroConfig extends AstroConfigType {
 	// This is a more detailed type than zod validation gives us.
 	// TypeScript still confirms zod validation matches this type.
 	integrations: AstroIntegration[];
+
+	// Private:
+	// This is not configurable directly by the user. But may be configured by an integration.
+	serverIslandDynamicBase?: string;
 }
 /**
  * An inline Astro config that takes highest priority when merging with the user config,

--- a/packages/astro/src/types/public/internal.ts
+++ b/packages/astro/src/types/public/internal.ts
@@ -217,6 +217,7 @@ export interface SSRResult {
 	// serverIslandDynamicBase allows users to specify that server islands will be served from a separate domain.
 	// This is an advanced option and won't be used in most cases. This should only be used if the static assets and
 	// SSR server are served on separate domains.
+	// If this is not set, it will use `base` instead.
 	serverIslandDynamicBase?: string;
 	styles: Set<SSRElement>;
 	scripts: Set<SSRElement>;

--- a/packages/astro/src/types/public/internal.ts
+++ b/packages/astro/src/types/public/internal.ts
@@ -214,6 +214,10 @@ export interface SSRResult {
 	 */
 	cancelled: boolean;
 	base: string;
+	// serverIslandDynamicBase allows users to specify that server islands will be served from a separate domain.
+	// This is an advanced option and won't be used in most cases. This should only be used if the static assets and
+	// SSR server are served on separate domains.
+	serverIslandDynamicBase?: string;
 	styles: Set<SSRElement>;
 	scripts: Set<SSRElement>;
 	links: Set<SSRElement>;


### PR DESCRIPTION
> [!NOTE]
> This is moved from https://github.com/withastro/astro/pull/12320 to point to the main branch

See proposal https://github.com/withastro/roadmap/discussions/1043 to see the full reasoning behind this change.

This PR only contains the required changes to enable an integration to be built. However, I created a draft PR that shows an integration and the example that uses it https://github.com/withastro/astro/pull/12304. Please look at that PR to see the full desired impact of this change.

## Changes

- Allow changing the domain that the server islands are hosted on.
- Allow developers to split the "static" part and the "dynamic" part of their website fully.
- Allows developers that cannot give Cloudflare the ability to read their customer's data to still use Astro's great site builder.
- Use a specific integration so we don't pollute the main astro config.

With config:
<img width="611" alt="Screenshot 2024-10-28 at 9 02 01 PM" src="https://github.com/user-attachments/assets/66aa30db-2458-4d60-8782-fa963bfd5486">


Result:
<img width="599" alt="Screenshot 2024-10-25 at 11 00 17 PM" src="https://github.com/user-attachments/assets/954a171f-6e96-4cf9-85e3-2c573047503f">


## Testing

<!-- How was this change tested? -->
A manual test has been run in the separate PR. No automated tests have been added.

I have added an test that ensures that the build output contains the base URL that we specify.

## Docs

Docs are added in https://github.com/withastro/docs/pull/10106 that explain to integration authors this new config option.


