### PR TITLE
Fix sync-examples workflow

### DIFF
--- a/.github/workflows/sync-examples.yml
+++ b/.github/workflows/sync-examples.yml
@@ -52,7 +52,7 @@ jobs:
       # to clone examples that may rely on unreleased code
 
       - name: Sync stable to latest and examples/* branches
-        if: steps.detect.outputs.has-changesets == 'false' && steps.pre.outputs.value == ''
+        if: steps.detect.outputs.has-changesets == 'false' && github.ref == 'refs/heads/main' && steps.pre.outputs.value == ''
         uses: bluwy/auto-branch-sync-action@v1
         with:
           map: |

--- a/.github/workflows/sync-examples.yml
+++ b/.github/workflows/sync-examples.yml
@@ -3,6 +3,9 @@ name: Sync examples
 on:
   workflow_dispatch:
     inputs:
+      checkout-ref:
+        type: string
+        required: false
       skip-unchanged-check:
         type: boolean
         default: false
@@ -31,16 +34,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2 # fetch 2 to compare with previous commit for changes
+          ref: ${{ inputs.checkout-ref }}
 
       - name: Detect changesets
         uses: bluwy/detect-changesets-action@v1
         id: detect
 
+      - name: Get pre mode of changesets
+        id: pre
+        run: |
+          if [ -f ./.changeset/pre.json ]; then
+            pre_value=$(jq -r '.tag' ./.changeset/pre.json)
+            echo "value=$pre_value" >> $GITHUB_OUTPUT
+          fi
+
       # We only do sync if there are no changesets, so we don't accidentally allow users
       # to clone examples that may rely on unreleased code
 
-      - name: Sync from main branch to latest and examples/* branches
-        if: steps.detect.outputs.has-changesets == 'false' && github.ref == 'refs/heads/main'
+      - name: Sync stable to latest and examples/* branches
+        if: steps.detect.outputs.has-changesets == 'false' && steps.pre.outputs.value == ''
         uses: bluwy/auto-branch-sync-action@v1
         with:
           map: |
@@ -49,38 +61,24 @@ jobs:
           skip-unchanged-check: ${{ inputs.skip-unchanged-check == true }}
           dry-run: ${{ inputs.dry-run == true }}
 
-      - name: Check .changeset/pre.json for matching tag
-        if: steps.detect.outputs.has-changesets == 'false' && github.ref == 'refs/heads/next'
-        id: check-pre-mode
-        run: |
-          if [ -f ./.changeset/pre.json ]; then
-            if grep -q '"tag": "alpha"' ./.changeset/pre.json; then
-              echo "alpha=true" >> $GITHUB_OUTPUT
-            elif grep -q '"tag": "beta"' ./.changeset/pre.json; then
-              echo "beta=true" >> $GITHUB_OUTPUT
-            elif grep -q '"tag": "rc"' ./.changeset/pre.json; then
-              echo "rc=true" >> $GITHUB_OUTPUT
-            fi
-          fi
-
-      - name: Sync from next branch to alpha branch
-        if: steps.detect.outputs.has-changesets == 'false' && steps.check-pre-mode.outputs.alpha == 'true'
+      - name: Sync prerelease to alpha branch
+        if: steps.detect.outputs.has-changesets == 'false' && steps.pre.outputs.value == 'alpha'
         uses: bluwy/auto-branch-sync-action@v1
         with:
           map: / -> alpha
           skip-unchanged-check: ${{ inputs.skip-unchanged-check == true }}
           dry-run: ${{ inputs.dry-run == true }}
 
-      - name: Sync from next branch to beta branch
-        if: steps.detect.outputs.has-changesets == 'false' && steps.check-pre-mode.outputs.beta == 'true'
+      - name: Sync prerelease to beta branch
+        if: steps.detect.outputs.has-changesets == 'false' && steps.pre.outputs.value == 'beta'
         uses: bluwy/auto-branch-sync-action@v1
         with:
           map: / -> beta
           skip-unchanged-check: ${{ inputs.skip-unchanged-check == true }}
           dry-run: ${{ inputs.dry-run == true }}
 
-      - name: Sync from next branch to rc branch
-        if: steps.detect.outputs.has-changesets == 'false' && steps.check-pre-mode.outputs.rc == 'true'
+      - name: Sync prerelease to rc branch
+        if: steps.detect.outputs.has-changesets == 'false' && steps.pre.outputs.value == 'rc'
         uses: bluwy/auto-branch-sync-action@v1
         with:
           map: / -> rc


### PR DESCRIPTION
## Changes

- Added `checkout-ref` input so we can sync the examples via a specific commit (we can use the commit before we merge next into main)
- Updated how we detect prereleases to check against `.changeset/pre.json` instead of the branch name
  - The bug before assumed that anything on `main` was stable which isn't always the case

---

There's two ways we can do after this is resolved:

1. Merge this PR, trigger the workflow manually to sync with the commit before we merged next to main, revert https://github.com/withastro/astro/pull/12557, and it'll auto sync main to the `beta` branch instead.
2. Or disable this workflow, merge this PR, and re-enable the workflow on Tuesday again after we revert https://github.com/withastro/astro/pull/12557 and prep the release

To prevent more work and to play it safe, I think no2 is the best for now.

## Testing

n/a. Reading the code I think it'll work later.

## Docs

n/a