### PR TITLE
fix: use path for renderer entrypoint

### DIFF
--- a/.changeset/selfish-chicken-retire.md
+++ b/.changeset/selfish-chicken-retire.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an issue which broke MDX rendering if a site had a space in the directory path

--- a/packages/astro/src/integrations/hooks.ts
+++ b/packages/astro/src/integrations/hooks.ts
@@ -184,7 +184,9 @@ export async function runHookConfigSetup({
 					if (!renderer.serverEntrypoint) {
 						throw new Error(`Renderer ${bold(renderer.name)} does not provide a serverEntrypoint.`);
 					}
-
+					if(renderer.serverEntrypoint instanceof URL) {
+						renderer.serverEntrypoint = fileURLToPath(renderer.serverEntrypoint);
+					}
 					if (renderer.name === 'astro:jsx') {
 						astroJSXRenderer = renderer;
 					} else {

--- a/packages/astro/src/integrations/hooks.ts
+++ b/packages/astro/src/integrations/hooks.ts
@@ -184,9 +184,7 @@ export async function runHookConfigSetup({
 					if (!renderer.serverEntrypoint) {
 						throw new Error(`Renderer ${bold(renderer.name)} does not provide a serverEntrypoint.`);
 					}
-					if(renderer.serverEntrypoint instanceof URL) {
-						renderer.serverEntrypoint = fileURLToPath(renderer.serverEntrypoint);
-					}
+
 					if (renderer.name === 'astro:jsx') {
 						astroJSXRenderer = renderer;
 					} else {

--- a/packages/integrations/mdx/src/index.ts
+++ b/packages/integrations/mdx/src/index.ts
@@ -54,7 +54,7 @@ export default function mdx(partialMdxOptions: Partial<MdxOptions> = {}): AstroI
 
 				addRenderer({
 					name: 'astro:jsx',
-					serverEntrypoint: new URL('../dist/server.js', import.meta.url),
+					serverEntrypoint: fileURLToPath(new URL('../dist/server.js', import.meta.url)),
 				});
 				addPageExtension('.mdx');
 				addContentEntryType({


### PR DESCRIPTION
## Changes

#12533 changed the MDX entrypoint to a URL, so that it could be resolved correctly. However this introduced a different bug that meant the entrypoint could not be resolved in dev if there was a space in the path. It's unclear whether this is a Vite bug or ours, but we can fix it by using `fileURLToPath` instead of passing the URL directly. This PR converts any entrypoint URLs to paths.

Fixes #12556

## Testing

This is hard to test in the monorepo, because it needs a space in the path to the *integration* not the site. I tested it by renaming my monorepo folder, but I couldn't work out an easy way to do a test fixture for it.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
