### PR TITLE
fix: generate types even without src/content

### DIFF
--- a/.changeset/blue-gorillas-accept.md
+++ b/.changeset/blue-gorillas-accept.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where content types were not generated when first running astro dev unless src/content exists

--- a/packages/astro/test/content-layer.test.js
+++ b/packages/astro/test/content-layer.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { promises as fs } from 'node:fs';
+import { promises as fs, existsSync } from 'node:fs';
 import { sep } from 'node:path';
 import { sep as posixSep } from 'node:path/posix';
 import { after, before, describe, it } from 'node:test';
@@ -311,6 +311,13 @@ describe('Content Layer', () => {
 
 		after(async () => {
 			devServer?.stop();
+		});
+
+
+		it('Generates content types files', async () => {
+			assert.ok(existsSync(new URL('./.astro/content.d.ts', fixture.config.root)));
+			const data = await fs.readFile(new URL('./.astro/types.d.ts', fixture.config.root), 'utf-8');
+			assert.match(data, /<reference path="content.d.ts"/);
 		});
 
 		it('Returns custom loader collection', async () => {


### PR DESCRIPTION
## Changes

Currently we're only referencing the content types in dev if the content dir exists. Since we no longer require that, in many cases this wasn't being generated. This PR changes the logic to ensure it's always created when needed.

Fixes #12555

## Testing
Added a test
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
