### PR TITLE
Bugfix/extra whitespace in code

### DIFF
--- a/.changeset/twelve-pens-remain.md
+++ b/.changeset/twelve-pens-remain.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/markdown-remark": patch
+---
+
+Removes trailing new line in code blocks to prevent generating a trailing empty `<span />` tag

--- a/packages/markdown/remark/src/shiki.ts
+++ b/packages/markdown/remark/src/shiki.ts
@@ -103,9 +103,7 @@ export async function createShikiHighlighter({
 			}
 		}
 
-		if (code.endsWith('\n')) {
-			code = code.slice(0, -1);
-		}
+		code = code.replace(/(\r\n|\r|\n)$/, '');
 
 		const themeOptions = Object.values(themes).length ? { themes } : { theme };
 		const inline = options?.inline ?? false;

--- a/packages/markdown/remark/src/shiki.ts
+++ b/packages/markdown/remark/src/shiki.ts
@@ -103,7 +103,7 @@ export async function createShikiHighlighter({
 			}
 		}
 
-		code = code.replace(/(\r\n|\r|\n)$/, '');
+		code = code.replace(/(?:\r\n|\r|\n)$/, '');
 
 		const themeOptions = Object.values(themes).length ? { themes } : { theme };
 		const inline = options?.inline ?? false;

--- a/packages/markdown/remark/src/shiki.ts
+++ b/packages/markdown/remark/src/shiki.ts
@@ -103,6 +103,10 @@ export async function createShikiHighlighter({
 			}
 		}
 
+		if (code.endsWith('\n')) {
+			code = code.slice(0, -1);
+		}
+
 		const themeOptions = Object.values(themes).length ? { themes } : { theme };
 		const inline = options?.inline ?? false;
 


### PR DESCRIPTION
## Changes

This fixes the extra line added in the code blocks as reported in #12515 using the same method as seen in https://github.com/shikijs/shiki/pull/585 as suggested by @bluwy

Now this option is enabled by default, same as seen in shiki, but can be disabled trough a option.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Testing was done manually in my own Astro project and I made sure to run both `pnpm run build` and `pnpm run test` to see that this PR had no impact on one of the actions.

This change also does not include any new tests in the `@astrojs/markdown-remark` package,
since this option works similar to the `wrap` option, which also has no test.

## Docs

A update to the docs will be needed, since this adds a new option to opt out of this behavior.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
/cc @withastro/maintainers-docs for feedback!

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
