### PR TITLE
fix(upgrade): remove the prefix from `targetVersion` while comparing versions

### DIFF
--- a/.changeset/dirty-bees-repair.md
+++ b/.changeset/dirty-bees-repair.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/upgrade': patch
+---
+
+Fixes an issue where `@astrojs/upgrade` announces integration updates for already up to date packages

--- a/packages/upgrade/src/actions/install.ts
+++ b/packages/upgrade/src/actions/install.ts
@@ -90,8 +90,8 @@ function filterPackages(ctx: Pick<Context, 'packages'>) {
 	const devDependencies: PackageInfo[] = [];
 	for (const packageInfo of ctx.packages) {
 		const { currentVersion, targetVersion, isDevDependency } = packageInfo;
-		// Remove prefix from `currentVersion` before comparing
-		if (currentVersion.replace(/^\D+/, '') === targetVersion) {
+		// Remove prefix from version before comparing
+		if (currentVersion.replace(/^\D+/, '') === targetVersion.replace(/^\D+/, '')) {
 			current.push(packageInfo);
 		} else {
 			const arr = isDevDependency ? devDependencies : dependencies;


### PR DESCRIPTION
## Changes
Closes #12455

This change fixes an issue where `@astrojs/upgrade` announces integration updates for already up-to-date packages by removing the prefix from `targetVersion` while comparing. 


https://github.com/user-attachments/assets/41b2cf80-5cc0-4894-a298-497204bc934c



## Testing

Manually Tested

## Docs

N/A bug fix
