### PR TITLE
fix(actions): explicitly import index.ts to fix types when moduleResolution is NodeNext

### DIFF
--- a/.changeset/empty-jobs-impress.md
+++ b/.changeset/empty-jobs-impress.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Explicitly import index.ts to fix types when moduleResolution is NodeNext

--- a/packages/astro/src/actions/integration.ts
+++ b/packages/astro/src/actions/integration.ts
@@ -38,7 +38,7 @@ export default function astroIntegrationActionsRouteHandler({
 				}
 
 				const stringifiedActionsImport = JSON.stringify(
-					viteID(new URL('./actions', params.config.srcDir)),
+					viteID(new URL('./actions/index.ts', params.config.srcDir)),
 				);
 				settings.injectedTypes.push({
 					filename: ACTIONS_TYPES_FILE,


### PR DESCRIPTION
## Changes

This updates the template that generates `.astro/actions.d.ts` file to make sure types work when `moduleResolution: "NodeNext"` is used on tsconfig.json.

## Testing

I haven't added tests because I am not familiar on how to do so for type tests that require a different tsconfig.json.

## Docs

No behavior changes.

---

Closes #12575