### PR TITLE
fix(markdoc): correctly render boolean HTML attributes

### DIFF
--- a/.changeset/twenty-lobsters-think.md
+++ b/.changeset/twenty-lobsters-think.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/markdoc': patch
+---
+
+Correctly renders boolean HTML attributes

--- a/packages/integrations/markdoc/src/html/tagdefs/html.tag.ts
+++ b/packages/integrations/markdoc/src/html/tagdefs/html.tag.ts
@@ -1,6 +1,37 @@
 import type { Config, Schema } from '@markdoc/markdoc';
 import Markdoc from '@markdoc/markdoc';
 
+const booleanAttributes = new Set([
+	'allowfullscreen',
+	'async',
+	'autofocus',
+	'autoplay',
+	'checked',
+	'controls',
+	'default',
+	'defer',
+	'disabled',
+	'disablepictureinpicture',
+	'disableremoteplayback',
+	'download',
+	'formnovalidate',
+	'hidden',
+	'inert',
+	'ismap',
+	'itemscope',
+	'loop',
+	'multiple',
+	'muted',
+	'nomodule',
+	'novalidate',
+	'open',
+	'playsinline',
+	'readonly',
+	'required',
+	'reversed',
+	'selected',
+]);
+
 // local
 import { parseInlineCSSToReactLikeObject } from '../css/parse-inline-css-to-react.js';
 
@@ -17,6 +48,14 @@ export const htmlTag: Schema<Config, never> = {
 
 		// pull out any "unsafe" attributes which need additional processing
 		const { style, ...safeAttributes } = unsafeAttributes as Record<string, unknown>;
+
+		// Convert boolean attributes to boolean literals
+		for (const [key, value] of Object.entries(safeAttributes)) {
+			if (booleanAttributes.has(key)) {
+				// If the attribute exists, ensure its value is a boolean
+				safeAttributes[key] = value === '' || value === true || value === 'true';
+			}
+		}
 
 		// if the inline "style" attribute is present we need to parse the HTML into a react-like React.CSSProperties object
 		if (typeof style === 'string') {

--- a/packages/integrations/markdoc/test/fixtures/render-html/src/content/blog/simple.mdoc
+++ b/packages/integrations/markdoc/test/fixtures/render-html/src/content/blog/simple.mdoc
@@ -9,3 +9,7 @@ This is a simple Markdoc <span class="post-class" style="color: hotpink;">post</
 <p>This is a paragraph!</p>
 
 <p>This is a <span class="inside-p">span</span> inside a paragraph!</p>
+
+<video
+	src="https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExejZnbmN6ODlxOWk2djVmcnFkMjIwbmFnZGFtZ2J4aG52dzVvbjJlaCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/H1vJZzQAiILUUq0FUL/giphy.mp4"
+	autoplay muted></video>

--- a/packages/integrations/markdoc/test/render-html.test.js
+++ b/packages/integrations/markdoc/test/render-html.test.js
@@ -123,6 +123,11 @@ function renderSimpleChecks(html) {
 	const p3 = document.querySelector('article > p:nth-of-type(3)');
 	assert.equal(p3.children.length, 1);
 	assert.equal(p3.textContent, 'This is a span inside a paragraph!');
+
+	const video = document.querySelector('video');
+	assert.ok(video, 'A video element should exist');
+	assert.ok(video.hasAttribute('autoplay'), 'The video element should have the autoplay attribute');
+	assert.ok(video.hasAttribute('muted'), 'The video element should have the muted attribute');
 }
 
 /** @param {string} html */


### PR DESCRIPTION
## Changes

Normalises boolean HTML attributes to boolean literals, because Markdoc treats `''` as falsy.

Fixes #12409

## Testing
Adds a test
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
