### PR TITLE
chore: remove next badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 <div align="center">
 
 [![main](https://github.com/withastro/astro/actions/workflows/ci.yml/badge.svg)](https://github.com/withastro/astro/actions/workflows/ci.yml)
-[![next](https://github.com/withastro/astro/actions/workflows/ci.yml/badge.svg?branch=next)](https://github.com/withastro/astro/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/withastro/astro/blob/main/LICENSE)
 [![npm version](https://badge.fury.io/js/astro.svg)](https://badge.fury.io/js/astro)
 


### PR DESCRIPTION
## Changes

This PR removes the badge of CI `next` from the readme

## Testing
N/A
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
N/A
<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
