### PR TITLE
fix: include undefined in types for getEntry with content layer

### DIFF
--- a/.changeset/fuzzy-bats-try.md
+++ b/.changeset/fuzzy-bats-try.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Includes "undefined" in types for getEntry

--- a/packages/astro/templates/content/types.d.ts
+++ b/packages/astro/templates/content/types.d.ts
@@ -92,7 +92,9 @@ declare module 'astro:content' {
 		collection: C,
 		id: E,
 	): E extends keyof DataEntryMap[C]
-		? Promise<DataEntryMap[C][E]>
+		? string extends keyof DataEntryMap[C]
+			? Promise<DataEntryMap[C][E]> | undefined
+			: Promise<DataEntryMap[C][E]>
 		: Promise<CollectionEntry<C> | undefined>;
 
 	/** Resolve an array of entry references from the same collection */


### PR DESCRIPTION
## Changes

Currently the types for `getEntry` exclude undefined if the key passed is a key in the type. This works for the old system where there were types for every entry, but now they are types as `Record<string, {//...the type }>`, it means any key will match (because they're all strings), meaning the entries are incorrectly returned as not nullable. This PR changes this so that if the key type is `string` (i.e. the type does not have specific entries), then the return type is nullable.

This is technically a breaking change but I think we can slip it in in 5.0.x

Fixes #12598

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Our migration guide already says that the types for getEntry have been loosened.

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
