### PR TITLE
chore: update examples to use latest node

### DIFF
--- a/examples/hackernews/package.json
+++ b/examples/hackernews/package.json
@@ -10,7 +10,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/node": "^9.0.0-alpha.1",
+    "@astrojs/node": "^9.0.0",
     "astro": "^5.0.1"
   }
 }

--- a/examples/ssr/package.json
+++ b/examples/ssr/package.json
@@ -11,7 +11,7 @@
     "server": "node dist/server/entry.mjs"
   },
   "dependencies": {
-    "@astrojs/node": "^9.0.0-alpha.1",
+    "@astrojs/node": "^9.0.0",
     "@astrojs/svelte": "^7.0.1",
     "astro": "^5.0.1",
     "svelte": "^5.1.16"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,8 +326,8 @@ importers:
   examples/hackernews:
     dependencies:
       '@astrojs/node':
-        specifier: ^9.0.0-alpha.1
-        version: 9.0.0-alpha.1(astro@packages+astro)
+        specifier: ^9.0.0
+        version: 9.0.0(astro@packages+astro)
       astro:
         specifier: ^5.0.1
         version: link:../../packages/astro
@@ -353,8 +353,8 @@ importers:
   examples/ssr:
     dependencies:
       '@astrojs/node':
-        specifier: ^9.0.0-alpha.1
-        version: 9.0.0-alpha.1(astro@packages+astro)
+        specifier: ^9.0.0
+        version: 9.0.0(astro@packages+astro)
       '@astrojs/svelte':
         specifier: ^7.0.1
         version: link:../../packages/integrations/svelte
@@ -5630,11 +5630,6 @@ packages:
     peerDependencies:
       astro: ^5.0.0
 
-  '@astrojs/node@9.0.0-alpha.1':
-    resolution: {integrity: sha512-5KsaJYuAnKP4tmT/skEWLs4UP6FQhtwIVa26MBU5imiS/aL33cIwmZ7Gl2W0rP/t4Wnz9ehf42lXWXLPekhETw==}
-    peerDependencies:
-      astro: ^5.0.0-alpha.0
-
   '@astrojs/yaml2ts@0.2.1':
     resolution: {integrity: sha512-CBaNwDQJz20E5WxzQh4thLVfhB3JEEGz72wRA+oJp6fQR37QLAqXZJU0mHC+yqMOQ6oj0GfRPJrz6hjf+zm6zA==}
 
@@ -10212,10 +10207,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  send@0.18.0:
-    resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
-    engines: {node: '>= 0.8.0'}
-
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
@@ -11322,14 +11313,6 @@ snapshots:
     dependencies:
       astro: link:packages/astro
       send: 1.1.0
-      server-destroy: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@astrojs/node@9.0.0-alpha.1(astro@packages+astro)':
-    dependencies:
-      astro: link:packages/astro
-      send: 0.18.0
       server-destroy: 1.0.1
     transitivePeerDependencies:
       - supports-color
@@ -16491,24 +16474,6 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.6.3: {}
-
-  send@0.18.0:
-    dependencies:
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      mime: 1.6.0
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   send@0.19.0:
     dependencies:


### PR DESCRIPTION
## Changes

Few examples were using an alpha version of `@astrojs/node`. This PR updates that them.

## Testing

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
