### PR TITLE
fix(db): import base virtual module ID

### DIFF
--- a/.changeset/red-emus-repair.md
+++ b/.changeset/red-emus-repair.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/db': patch
+---
+
+Fixes a bug that caused an error to be logged about invalid entrypoints

--- a/packages/db/src/core/integration/index.ts
+++ b/packages/db/src/core/integration/index.ts
@@ -16,7 +16,7 @@ import {
 } from 'vite';
 import parseArgs from 'yargs-parser';
 import { AstroDbError } from '../../runtime/utils.js';
-import { CONFIG_FILE_NAMES, DB_PATH } from '../consts.js';
+import { CONFIG_FILE_NAMES, DB_PATH, VIRTUAL_MODULE_ID } from '../consts.js';
 import { EXEC_DEFAULT_EXPORT_ERROR, EXEC_ERROR } from '../errors.js';
 import { resolveDbConfig } from '../load-file.js';
 import { SEED_DEV_FILE_NAME } from '../queries.js';
@@ -153,7 +153,7 @@ function astroDBIntegration(): AstroIntegration {
 					);
 					// Eager load astro:db module on startup
 					if (seedFiles.get().length || localSeedPaths.find((path) => existsSync(path))) {
-						server.ssrLoadModule(resolved.module).catch((e) => {
+						server.ssrLoadModule(VIRTUAL_MODULE_ID).catch((e) => {
 							logger.error(e instanceof Error ? e.message : String(e));
 						});
 					}


### PR DESCRIPTION
## Changes

In Astro DB we eagerly load the virtual module at startup. Currently we load the resolved virtual module ID, which is prefixed with a null byte. This worked fine previously, but fails in Vite 6/Astro 5. This PR changes the import to use the base virtual module ID (`astro:db`).

Fixes #12474

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
