### PR TITLE
fix: don't apply duplicate class to images

### DIFF
--- a/.changeset/silver-hats-agree.md
+++ b/.changeset/silver-hats-agree.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug where the class attribute was rendered twice on the image component

--- a/packages/astro/components/Image.astro
+++ b/packages/astro/components/Image.astro
@@ -47,7 +47,7 @@ if (import.meta.env.DEV) {
 	additionalAttributes['data-image-component'] = 'true';
 }
 
-const attributes = useResponsive
+const { class: className, ...attributes } = useResponsive
 	? applyResponsiveAttributes({
 			layout,
 			image,
@@ -58,4 +58,4 @@ const attributes = useResponsive
 ---
 
 {/* Applying class outside of the spread prevents it from applying unnecessary astro-* classes */}
-<img src={image.src} {...attributes} class={attributes.class} />
+<img src={image.src} {...attributes} class={className} />

--- a/packages/astro/components/Picture.astro
+++ b/packages/astro/components/Picture.astro
@@ -102,7 +102,7 @@ if (fallbackImage.srcSet.values.length > 0) {
 	imgAdditionalAttributes.srcset = fallbackImage.srcSet.attribute;
 }
 
-const attributes = useResponsive
+const { class: className, ...attributes } = useResponsive
 	? applyResponsiveAttributes({
 			layout,
 			image: fallbackImage,
@@ -133,5 +133,5 @@ if (import.meta.env.DEV) {
 		})
 	}
 	{/* Applying class outside of the spread prevents it from applying unnecessary astro-* classes */}
-	<img src={fallbackImage.src} {...attributes} class={attributes.class} />
+	<img src={fallbackImage.src} {...attributes} class={className} />
 </picture>

--- a/packages/astro/test/core-image-layout.test.js
+++ b/packages/astro/test/core-image-layout.test.js
@@ -591,10 +591,9 @@ describe('astro:image:layout', () => {
 			await fixture.build();
 		});
 
-
 		describe('basics', () => {
 			let $;
-			let html
+			let html;
 			before(async () => {
 				html = await fixture.readFile('/index.html');
 				$ = cheerio.load(html);
@@ -680,7 +679,7 @@ describe('astro:image:layout', () => {
 				// We can't use cheerio because it normalises the DOM, so we have to use a regex
 				const matches = html.match(/class="green"/g);
 				assert.equal(matches.length, 1);
-			})
+			});
 
 			it('passes in a parent style', () => {
 				let $img = $('#local-style img');
@@ -697,6 +696,5 @@ describe('astro:image:layout', () => {
 				assert.match(style, /\[data-astro-image\]/);
 			});
 		});
-
 	});
 });


### PR DESCRIPTION
## Changes

Fixes a bug where the class attribute was rendered twice on images during builds

Fixes #12629

## Testing

Adds more tests for images during build, including tests of the raw HTML without cheerio

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
