### PR TITLE
Clean up content layer sync in build and sync api

### DIFF
--- a/.changeset/stupid-teachers-yell.md
+++ b/.changeset/stupid-teachers-yell.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Cleans up content layer sync during builds and programmatic `sync()` calls

--- a/packages/astro/src/core/dev/container.ts
+++ b/packages/astro/src/core/dev/container.ts
@@ -120,6 +120,7 @@ export async function createContainer({
 		logger,
 		skip: {
 			content: true,
+			cleanup: true,
 		},
 		force: inlineConfig?.force,
 		manifest,

--- a/packages/astro/src/core/sync/index.ts
+++ b/packages/astro/src/core/sync/index.ts
@@ -45,6 +45,8 @@ export type SyncOptions = {
 	skip?: {
 		// Must be skipped in dev
 		content?: boolean;
+		// Cleanup can be skipped in dev as some state can be reused on updates
+		cleanup?: boolean;
 	};
 	manifest: ManifestData;
 };
@@ -141,6 +143,10 @@ export async function syncInternal({
 			store,
 		});
 		await contentLayer.sync();
+		if (!skip?.cleanup) {
+			// Free up memory (usually in builds since we only need to use this once)
+			contentLayer.dispose();
+		}
 		settings.timer.end('Sync content layer');
 	} else {
 		const paths = getContentPaths(settings.config, fs);


### PR DESCRIPTION
## Changes

In build (and `sync()` programmatic API), the content layer singleton is disposed since we only usually need to init and sync it once. This could free a bit of memory (but I think not by a lot).

## Testing

Existing tests should pass

## Docs

n/a. refactor