### PR TITLE
Improve Zod error messages and user config error messages

### DIFF
--- a/.changeset/heavy-buttons-compare.md
+++ b/.changeset/heavy-buttons-compare.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Improves error message formatting for user config and content collection frontmatter

--- a/packages/astro/src/core/config/schema.ts
+++ b/packages/astro/src/core/config/schema.ts
@@ -566,7 +566,7 @@ export const AstroConfigSchema = z.object({
 				}),
 		})
 		.strict(
-			`Invalid or outdated experimental feature.\nCheck for incorrect spelling or outdated Astro version.\nSee https://docs.astro.build/en/reference/configuration-reference/#experimental-flags for a list of all current experiments.`,
+			`Invalid or outdated experimental feature.\nCheck for incorrect spelling or outdated Astro version.\nSee https://docs.astro.build/en/reference/experimental-flags/ for a list of all current experiments.`,
 		)
 		.default({}),
 	legacy: z

--- a/packages/astro/src/core/config/validate.ts
+++ b/packages/astro/src/core/config/validate.ts
@@ -1,4 +1,5 @@
 import type { AstroConfig } from '../../types/public/config.js';
+import { errorMap } from '../errors/index.js';
 import { createRelativeSchema } from './schema.js';
 
 /** Turn raw config values into normalized values */
@@ -10,5 +11,5 @@ export async function validateConfig(
 	const AstroConfigRelativeSchema = createRelativeSchema(cmd, root);
 
 	// First-Pass Validation
-	return await AstroConfigRelativeSchema.parseAsync(userConfig);
+	return await AstroConfigRelativeSchema.parseAsync(userConfig, { errorMap });
 }

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -232,11 +232,19 @@ function getNetworkLogging(host: string | boolean): 'none' | 'host-to-expose' | 
 }
 
 export function formatConfigErrorMessage(err: ZodError) {
-	const errorList = err.issues.map(
-		(issue) => `  ! ${bold(issue.path.join('.'))}  ${red(issue.message + '.')}`,
+	const errorList = err.issues.map((issue) =>
+		`${red('!')} ${issue.message}`
+			// Bold text wrapped in **...** kind of like Markdown.
+			.replaceAll(/\*\*([^*]+)\*\*/g, red(bold('$1')))
+			// Make text wrapped in backticks blue.
+			.replaceAll(/`([^`]+)`/g, cyan('$1'))
+			// Dim all lines in an issue except for the first
+			.split('\n')
+			.map((line, index) => '  ' + (index > 0 ? dim(line) : line))
+			.join('\n'),
 	);
-	return `${red('[config]')} Astro found issue(s) with your configuration:\n${errorList.join(
-		'\n',
+	return `${red('[config]')} Astro found issue(s) with your configuration:\n\n${errorList.join(
+		'\n\n',
 	)}`;
 }
 

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -237,12 +237,10 @@ export function formatConfigErrorMessage(err: ZodError) {
 	const errorList = err.issues.map((issue) =>
 		`! ${renderErrorMarkdown(issue.message, 'cli')}`
 			// Make text wrapped in backticks blue.
-			.replaceAll(codeRegex, cyan('$1'))
+			.replaceAll(codeRegex, blue('$1'))
+			// Make the first line red and indent the rest.
 			.split('\n')
-			// Dim all lines in an issue except for the first which should be red.
-			.map((line, index) => (index > 0 ? dim(line) : red(line)))
-			// Indent all lines.
-			.map((line) => '  ' + line)
+			.map((line, index) => (index === 0 ? red(line) : '  ' + line))
 			.join('\n'),
 	);
 	return `${red('[config]')} Astro found issue(s) with your configuration:\n\n${errorList.join(

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -231,11 +231,13 @@ function getNetworkLogging(host: string | boolean): 'none' | 'host-to-expose' | 
 	}
 }
 
+const codeRegex = /`([^`]+)`/g;
+
 export function formatConfigErrorMessage(err: ZodError) {
 	const errorList = err.issues.map((issue) =>
 		`! ${renderErrorMarkdown(issue.message, 'cli')}`
 			// Make text wrapped in backticks blue.
-			.replaceAll(/`([^`]+)`/g, cyan('$1'))
+			.replaceAll(codeRegex, cyan('$1'))
 			.split('\n')
 			// Dim all lines in an issue except for the first which should be red.
 			.map((line, index) => (index > 0 ? dim(line) : red(line)))

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -238,9 +238,11 @@ export function formatConfigErrorMessage(err: ZodError) {
 			.replaceAll(/\*\*([^*]+)\*\*/g, bold('$1'))
 			// Make text wrapped in backticks blue.
 			.replaceAll(/`([^`]+)`/g, cyan('$1'))
-			// Dim all lines in an issue except for the first
 			.split('\n')
-			.map((line, index) => '  ' + (index > 0 ? dim(line) : red(line)))
+			// Dim all lines in an issue except for the first which should be red.
+			.map((line, index) => (index > 0 ? dim(line) : red(line)))
+			// Indent all lines.
+			.map((line) => '  ' + line)
 			.join('\n'),
 	);
 	return `${red('[config]')} Astro found issue(s) with your configuration:\n\n${errorList.join(

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -233,14 +233,14 @@ function getNetworkLogging(host: string | boolean): 'none' | 'host-to-expose' | 
 
 export function formatConfigErrorMessage(err: ZodError) {
 	const errorList = err.issues.map((issue) =>
-		`${red('!')} ${issue.message}`
+		`! ${issue.message}`
 			// Bold text wrapped in **...** kind of like Markdown.
-			.replaceAll(/\*\*([^*]+)\*\*/g, red(bold('$1')))
+			.replaceAll(/\*\*([^*]+)\*\*/g, bold('$1'))
 			// Make text wrapped in backticks blue.
 			.replaceAll(/`([^`]+)`/g, cyan('$1'))
 			// Dim all lines in an issue except for the first
 			.split('\n')
-			.map((line, index) => '  ' + (index > 0 ? dim(line) : line))
+			.map((line, index) => '  ' + (index > 0 ? dim(line) : red(line)))
 			.join('\n'),
 	);
 	return `${red('[config]')} Astro found issue(s) with your configuration:\n\n${errorList.join(

--- a/packages/astro/src/core/messages.ts
+++ b/packages/astro/src/core/messages.ts
@@ -233,9 +233,7 @@ function getNetworkLogging(host: string | boolean): 'none' | 'host-to-expose' | 
 
 export function formatConfigErrorMessage(err: ZodError) {
 	const errorList = err.issues.map((issue) =>
-		`! ${issue.message}`
-			// Bold text wrapped in **...** kind of like Markdown.
-			.replaceAll(/\*\*([^*]+)\*\*/g, bold('$1'))
+		`! ${renderErrorMarkdown(issue.message, 'cli')}`
 			// Make text wrapped in backticks blue.
 			.replaceAll(/`([^`]+)`/g, cyan('$1'))
 			.split('\n')

--- a/packages/astro/test/content-collections.test.js
+++ b/packages/astro/test/content-collections.test.js
@@ -267,7 +267,7 @@ describe('Content Collections', () => {
 			} catch (e) {
 				error = e.message;
 			}
-			assert.equal(error.includes('**title**: Expected type `"string"`, received "number"'), true);
+			assert.match(error, /\*\*title\*\*: Expected type `"string"`, received `"number"`/);
 		});
 	});
 	describe('With config.mts', () => {
@@ -281,7 +281,7 @@ describe('Content Collections', () => {
 			} catch (e) {
 				error = e.message;
 			}
-			assert.equal(error.includes('**title**: Expected type `"string"`, received "number"'), true);
+			assert.match(error, /\*\*title\*\*: Expected type `"string"`, received `"number"`/);
 		});
 	});
 
@@ -296,7 +296,7 @@ describe('Content Collections', () => {
 			} catch (e) {
 				error = e.message;
 			}
-			assert.equal(error.includes('**title**: Required'), true);
+			assert.match(error, /\*\*title\*\*: Required/);
 		});
 	});
 

--- a/packages/astro/test/error-map.test.js
+++ b/packages/astro/test/error-map.test.js
@@ -30,7 +30,7 @@ describe('Content Collections - error map', () => {
 			}),
 			{ foo: 1 },
 		);
-		assert.deepEqual(messages(error), ['**foo**: Expected type `"string"`, received "number"']);
+		assert.deepEqual(messages(error), ['**foo**: Expected type `"string"`, received `"number"`']);
 	});
 	it('Returns formatted error for literal mismatch', () => {
 		const error = getParseError(
@@ -39,7 +39,7 @@ describe('Content Collections - error map', () => {
 			}),
 			{ lang: 'es' },
 		);
-		assert.deepEqual(messages(error), ['**lang**: Expected `"en"`, received "es"']);
+		assert.deepEqual(messages(error), ['**lang**: Expected `"en"`, received `"es"`']);
 	});
 	it('Replaces undefined errors with "Required"', () => {
 		const error = getParseError(
@@ -58,7 +58,7 @@ describe('Content Collections - error map', () => {
 		);
 		assert.deepEqual(messages(error), [
 			fixLineEndings(
-				'Did not match union:\n> Expected type `"boolean" | "number"`, received "string"',
+				'Did not match union.\n> Expected type `"boolean" | "number"`, received `"string"`',
 			),
 		]);
 	});
@@ -76,7 +76,7 @@ describe('Content Collections - error map', () => {
 		);
 		assert.deepEqual(messages(error), [
 			fixLineEndings(
-				'Did not match union:\n> **type**: Expected `"tutorial" | "article"`, received "integration-guide"',
+				'Did not match union.\n> **type**: Expected `"tutorial" | "article"`, received `"integration-guide"`',
 			),
 		]);
 	});

--- a/packages/astro/test/legacy-content-collections.test.js
+++ b/packages/astro/test/legacy-content-collections.test.js
@@ -285,7 +285,7 @@ describe('Legacy Content Collections', () => {
 			} catch (e) {
 				error = e.message;
 			}
-			assert.equal(error.includes('**title**: Expected type `"string"`, received "number"'), true);
+			assert.match(error, /\*\*title\*\*: Expected type `"string"`, received `"number"`/);
 		});
 	});
 	describe('With config.mts', () => {
@@ -302,7 +302,7 @@ describe('Legacy Content Collections', () => {
 			} catch (e) {
 				error = e.message;
 			}
-			assert.equal(error.includes('**title**: Expected type `"string"`, received "number"'), true);
+			assert.match(error, /\*\*title\*\*: Expected type `"string"`, received `"number"`/);
 		});
 	});
 

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -24,7 +24,7 @@ describe('Config Validation', () => {
 			formattedError,
 			`[config] Astro found issue(s) with your configuration:
 
-  ! site: Expected type "string", received "number"`,
+! site: Expected type "string", received "number"`,
 		);
 	});
 
@@ -40,9 +40,9 @@ describe('Config Validation', () => {
 			formattedError,
 			`[config] Astro found issue(s) with your configuration:
 
-  ! integrations.0: Expected type "object", received "number"
+! integrations.0: Expected type "object", received "number"
 
-  ! build.format: Did not match union.
+! build.format: Did not match union.
   > Expected "file" | "directory" | "preserve", received "invalid"`,
 		);
 	});

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -23,7 +23,8 @@ describe('Config Validation', () => {
 		assert.equal(
 			formattedError,
 			`[config] Astro found issue(s) with your configuration:
-  ! site  Expected string, received number.`,
+
+  ! site  Expected type "string", received "number"`,
 		);
 	});
 
@@ -38,8 +39,11 @@ describe('Config Validation', () => {
 		assert.equal(
 			formattedError,
 			`[config] Astro found issue(s) with your configuration:
-  ! integrations.0  Expected object, received number.
-  ! build.format  Invalid input.`,
+
+  ! integrations.0: Expected type "object", received "number"
+
+  ! build.format: Did not match union.
+  > Expected "file" | "directory" | "preserve", received "invalid"`,
 		);
 	});
 
@@ -118,7 +122,10 @@ describe('Config Validation', () => {
 				process.cwd(),
 			).catch((err) => err);
 			assert.equal(configError instanceof z.ZodError, true);
-			assert.equal(configError.errors[0].message, 'Array must contain at least 1 element(s)');
+			assert.equal(
+				configError.errors[0].message,
+				'**i18n.locales.1.codes**: Array must contain at least 1 element(s)',
+			);
 		});
 
 		it('errors if the default locale is not in path', async () => {

--- a/packages/astro/test/units/config/config-validate.test.js
+++ b/packages/astro/test/units/config/config-validate.test.js
@@ -24,7 +24,7 @@ describe('Config Validation', () => {
 			formattedError,
 			`[config] Astro found issue(s) with your configuration:
 
-  ! site  Expected type "string", received "number"`,
+  ! site: Expected type "string", received "number"`,
 		);
 	});
 


### PR DESCRIPTION
## Changes

- Upstreams improvements to the Zod error map that we made in Starlight. We initially copied Astro’s error map and then iterated on it. It’s still similar, just with better handling for complex types like unions, and more consistent formatting (e.g. if you look at the changed tests you’ll see we’d report errors where some stuff was wrapped with backticks and other stuff wasn’t within the same error message and that that is now fixed).

- Updates error handling for user config parse errors to use the error map. With the v5 release, we’re seeing a fair amount of the rather confusing `output Invalid input` error when people leave `output: "hybrid"` in their config and this aims to improve that.

	- This also updates the styling for these messages as they can now contain a bit more useful information. Open to feedback/suggestions on the design there. It reuses the Markdown formatter we already use for error rendering and adds some additional details for this specific context.

- Fixes a broken docs link in one of our error messages.

### Example

Example error message with this change when adding `output: 'hybrid', experimental: { contentLayer: true }` to an astro.config file:

#### Currently

![Error message. The text is cramped together and one error simply reads "output Invalid input"](https://github.com/user-attachments/assets/11f11d05-1552-4855-bc8a-d8497f9839e3)

#### After this PR

![Error message. The text for each issue is spaced out and the same error now reads output: Did not match union.  Expected "static" | "server", received "hybrid"](https://github.com/user-attachments/assets/1682dd85-f93c-4622-a4a1-c200a4250804)



## Testing

- I’ve updated our existing error message tests to test for the updated message format
- I manually ran `astro dev` in the blog example using invalid configurations to test output.

## Docs

n/a — error message improvements only