### PR TITLE
fix: use correct datastore location in test environment

### DIFF
--- a/.changeset/violet-bugs-enjoy.md
+++ b/.changeset/violet-bugs-enjoy.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes a bug that caused content collections to be returned empty when run in a test environment

--- a/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
+++ b/packages/astro/src/content/vite-plugin-content-virtual-mod.ts
@@ -50,14 +50,12 @@ export function astroContentVirtualModPlugin({
 	settings,
 	fs,
 }: AstroContentVirtualModPluginParams): Plugin {
-	let IS_DEV = false;
 	let dataStoreFile: URL;
 	return {
 		name: 'astro-content-virtual-mod-plugin',
 		enforce: 'pre',
-		configResolved(config) {
-			IS_DEV = !config.isProduction;
-			dataStoreFile = getDataStoreFile(settings, IS_DEV);
+		config(_, env) {
+			dataStoreFile = getDataStoreFile(settings, env.command === 'serve');
 		},
 		async resolveId(id) {
 			if (id === VIRTUAL_MODULE_ID) {

--- a/packages/astro/src/core/dev/dev.ts
+++ b/packages/astro/src/core/dev/dev.ts
@@ -107,7 +107,7 @@ export default async function dev(inlineConfig: AstroInlineConfig): Promise<DevS
 
 	let store: MutableDataStore | undefined;
 	try {
-		const dataStoreFile = getDataStoreFile(restart.container.settings);
+		const dataStoreFile = getDataStoreFile(restart.container.settings, true);
 		if (existsSync(dataStoreFile)) {
 			store = await MutableDataStore.fromFile(dataStoreFile);
 		}


### PR DESCRIPTION
## Changes

The content layer needs to know if it is running in dev, so that it knows whether to find the datastore in the `.astro` folder (so it can be watched for changes) or in `node_modules` (so it is cached between builds in production environments). Previously it was incorrectly detecting this in the Vite plugin by using the `isProduction` flag, which reports as false in a test enviornment. This PR changes it to instead use the `env.command`.

Fixes #12612

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
